### PR TITLE
feat: add active runs ps view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,34 +1,48 @@
 # AGENTS.md
 
+## Rules
+
+- After every code change, run `biome format` on each modified file supported by Biome before finishing.
+
 ## Commands
+
 - Use Bun for everything. Root scripts are the source of truth:
-  - `bun run dev` -> runs only `apps/looperd`
-  - `bun run build` -> builds `apps/looperd`, then `apps/cli`, then `apps/web`
-  - `bun run typecheck` -> `bun x tsc -b --noEmit` across all three apps
-  - `bun run lint` -> `bun x @biomejs/biome check .`
-  - `bun run test` -> `bun test`
+  - `bun run dev` — runs `apps/looperd` only.
+  - `bun run build` — builds `apps/looperd`, then `apps/cli`, then `apps/web`.
+  - `bun run typecheck` — runs `bun x tsc -b --noEmit` across all three apps.
+  - `bun run lint` — runs `bun x @biomejs/biome check .`.
+  - `bun run test` — runs `bun test`.
 - Package-scoped commands:
   - `bun run --cwd apps/looperd dev|build|typecheck`
   - `bun run --cwd apps/cli dev|build|typecheck|test`
   - `bun run --cwd apps/web dev|build|typecheck`
-- Focused tests: run Bun against the file you changed, e.g. `bun test apps/looperd/src/config/load.test.ts` or `bun test tests/smoke.test.ts`.
+- Focused tests: run Bun against the changed file directly, e.g. `bun test apps/looperd/src/config/load.test.ts` or `bun test tests/smoke.test.ts`.
 
-## Repo shape
-- Bun workspace monorepo: `apps/*`.
-- `apps/looperd` is the real product. Entry flow is `src/index.ts` -> `bootstrapLooperd()` -> runtime -> Bun HTTP API server + SQLite store.
-- `apps/cli` is the `looper` bin. It talks to looperd over HTTP and reuses the same config loading pattern.
-- `apps/web` is currently a placeholder (`src/index.ts` only logs a message). Do not assume there is a real web app yet.
+## Repo structure
 
-## Config and runtime gotchas
-- Default daemon config path is `~/.looper/config.json`.
-- Config precedence is: defaults -> config file -> env -> CLI flags.
-- looperd fails fast on config validation errors and requires writable runtime paths.
-- Tool paths for `bun`, `git`, `gh`, and `osascript` are auto-detected with `Bun.which()` unless explicitly configured.
-- If `notifications.osascript.enabled` is true, `osascript` must resolve or startup fails.
-- Default runtime artifacts live under `~/.looper/` (`looper.sqlite`, `backups/`, `logs/`).
+- Bun workspace monorepo rooted at `apps/*`.
+- `apps/looperd` — primary application. Entry: `src/index.ts` → `bootstrapLooperd()` → runtime → Bun HTTP API server + SQLite store.
+- `apps/cli` — the `looper` binary. Communicates with looperd over HTTP; reuses the same config-loading pattern.
+- `apps/web` — placeholder only (`src/index.ts` logs a message). No functional web app exists.
 
-## Verified agent-facing conventions
-- TypeScript uses project references from the root `tsconfig.json`; prefer root `bun run typecheck` when changes cross packages, and it is intentionally `--noEmit` to avoid regenerating `*.tsbuildinfo`.
-- Formatting/linting is Biome with spaces; use Biome-compatible edits and do not hand-format against another style.
-- Generated/build output lives in `apps/*/dist/` and is ignored by git/Biome; do not edit `dist`.
-- CI lives in `.github/workflows/ci.yml` and runs on PR updates: `bun install --frozen-lockfile`, then `bun run lint`, `bun run typecheck`, `bun run test`, and `bun run build`.
+## Configuration & runtime
+
+- Default daemon config path: `~/.looper/config.json`.
+- Precedence: defaults → config file → env → CLI flags.
+- looperd fails fast on config-validation errors and requires writable runtime paths.
+- Tool paths (`bun`, `git`, `gh`, `osascript`) are auto-detected via `Bun.which()` unless explicitly configured.
+- When `notifications.osascript.enabled` is true, `osascript` must resolve or startup fails.
+- Default runtime artifacts: `~/.looper/` (`looper.sqlite`, `backups/`, `logs/`).
+
+## Conventions
+
+- TypeScript uses project references from the root `tsconfig.json`. Prefer `bun run typecheck` at the root when changes cross packages. The `--noEmit` flag is intentional — do not regenerate `*.tsbuildinfo`.
+- Formatting and linting use Biome (spaces). Make Biome-compatible edits only; do not hand-format to another style.
+- Build output lives in `apps/*/dist/` and is git/Biome-ignored. Do not edit `dist`.
+- CI (`.github/workflows/ci.yml`) runs on PR updates: `bun install --frozen-lockfile` → `bun run lint` → `bun run typecheck` → `bun run test` → `bun run build`.
+
+## Review guidelines
+
+- Report every issue found. Do not prioritize, triage, or omit.
+- Continue reviewing after finding issues. Early termination is a defect.
+- Review systematically across correctness, performance, maintainability, and style.

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -263,47 +263,47 @@ describe("runCli", () => {
     const lines: string[] = [];
     const requests: string[] = [];
     const exitCode = await runCli(["ps", "--json"], {
-        stdout: (line) => lines.push(line),
-        loadConfigImpl: async () => createConfig() as never,
-        fetchImpl: async (input) => {
-          requests.push(String(input));
-          return new Response(
-            JSON.stringify({
-              ok: true,
-              requestId: "req_ps_json",
-              data: {
-                items: [
-                  {
-                    runId: "run_1",
-                    loopId: "loop_1",
-                    projectId: "project_1",
-                    type: "worker",
-                    status: "running",
-                    currentStep: "execute",
-                    startedAt: "2026-04-11T12:00:00.000Z",
-                    target: {
-                      type: "task",
-                      taskId: "task_1",
-                      label: "Ship CLI",
-                    },
-                    agent: {
-                      active: true,
-                      activeCount: 1,
-                      executionId: "agent_1",
-                      vendor: "opencode",
-                      pid: 1234,
-                      startedAt: "2026-04-11T12:00:01.000Z",
-                      lastHeartbeatAt: "2026-04-11T12:00:02.000Z",
-                      heartbeatCount: 3,
-                      status: "running",
-                    },
+      stdout: (line) => lines.push(line),
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input) => {
+        requests.push(String(input));
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_ps_json",
+            data: {
+              items: [
+                {
+                  runId: "run_1",
+                  loopId: "loop_1",
+                  projectId: "project_1",
+                  type: "worker",
+                  status: "running",
+                  currentStep: "execute",
+                  startedAt: "2026-04-11T12:00:00.000Z",
+                  target: {
+                    type: "task",
+                    taskId: "task_1",
+                    label: "Ship CLI",
                   },
-                ],
-              },
-            }),
-          );
-        },
-      });
+                  agent: {
+                    active: true,
+                    activeCount: 1,
+                    executionId: "agent_1",
+                    vendor: "opencode",
+                    pid: 1234,
+                    startedAt: "2026-04-11T12:00:01.000Z",
+                    lastHeartbeatAt: "2026-04-11T12:00:02.000Z",
+                    heartbeatCount: 3,
+                    status: "running",
+                  },
+                },
+              ],
+            },
+          }),
+        );
+      },
+    });
 
     expect(exitCode).toBe(0);
     expect(requests[0]).toContain("/api/v1/runs/active");
@@ -318,45 +318,45 @@ describe("runCli", () => {
 
     try {
       const exitCode = await runCli(["ps"], {
-          stdout: (line) => lines.push(line),
-          loadConfigImpl: async () => createConfig() as never,
-          fetchImpl: async () =>
-            new Response(
-              JSON.stringify({
-                ok: true,
-                requestId: "req_ps_table",
-                data: {
-                  items: [
-                    {
-                      runId: "run_worker_1",
-                      loopId: "loop_worker_1",
-                      projectId: "project_1",
-                      type: "worker",
-                      status: "running",
-                      currentStep: "execute",
-                      startedAt: "2026-04-11T12:00:00.000Z",
-                      target: {
-                        type: "task",
-                        taskId: "task_1",
-                        label: "Ship CLI",
-                      },
-                      agent: {
-                        active: true,
-                        activeCount: 2,
-                        executionId: "agent_2",
-                        vendor: "opencode",
-                        pid: 2222,
-                        startedAt: "2026-04-11T12:00:01.000Z",
-                        lastHeartbeatAt: "2026-04-11T12:00:02.000Z",
-                        heartbeatCount: 4,
-                        status: "running",
-                      },
+        stdout: (line) => lines.push(line),
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_ps_table",
+              data: {
+                items: [
+                  {
+                    runId: "run_worker_1",
+                    loopId: "loop_worker_1",
+                    projectId: "project_1",
+                    type: "worker",
+                    status: "running",
+                    currentStep: "execute",
+                    startedAt: "2026-04-11T12:00:00.000Z",
+                    target: {
+                      type: "task",
+                      taskId: "task_1",
+                      label: "Ship CLI",
                     },
-                  ],
-                },
-              }),
-            ),
-        });
+                    agent: {
+                      active: true,
+                      activeCount: 2,
+                      executionId: "agent_2",
+                      vendor: "opencode",
+                      pid: 2222,
+                      startedAt: "2026-04-11T12:00:01.000Z",
+                      lastHeartbeatAt: "2026-04-11T12:00:02.000Z",
+                      heartbeatCount: 4,
+                      status: "running",
+                    },
+                  },
+                ],
+              },
+            }),
+          ),
+      });
 
       expect(exitCode).toBe(0);
       expect(lines[0]).toContain("type");
@@ -383,17 +383,17 @@ describe("runCli", () => {
   test("prints ps empty state", async () => {
     const lines: string[] = [];
     const exitCode = await runCli(["ps"], {
-        stdout: (line) => lines.push(line),
-        loadConfigImpl: async () => createConfig() as never,
-        fetchImpl: async () =>
-          new Response(
-            JSON.stringify({
-              ok: true,
-              requestId: "req_ps_empty",
-              data: { items: [] },
-            }),
-          ),
-      });
+      stdout: (line) => lines.push(line),
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_ps_empty",
+            data: { items: [] },
+          }),
+        ),
+    });
 
     expect(exitCode).toBe(0);
     expect(lines).toEqual(["No running loops."]);
@@ -404,19 +404,19 @@ describe("runCli", () => {
     const exitCode = await runCli(
       ["ps", "--type", "reviewer", "--project", "project_1"],
       {
-          stdout: () => {},
-          loadConfigImpl: async () => createConfig() as never,
-          fetchImpl: async (input) => {
-            requests.push(String(input));
-            return new Response(
-              JSON.stringify({
-                ok: true,
-                requestId: "req_ps_query",
-                data: { items: [] },
-              }),
-            );
-          },
+        stdout: () => {},
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async (input) => {
+          requests.push(String(input));
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_ps_query",
+              data: { items: [] },
+            }),
+          );
         },
+      },
     );
 
     expect(exitCode).toBe(0);

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -18,6 +18,20 @@ function createConfig() {
   };
 }
 
+async function withPatchedObjectEntries<T>(
+  fallback: Record<string, unknown>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const original = Object.entries;
+  Object.entries = ((value: unknown) =>
+    original(value ?? fallback)) as typeof Object.entries;
+  try {
+    return await fn();
+  } finally {
+    Object.entries = original;
+  }
+}
+
 describe("runCli", () => {
   test("renders status as json", async () => {
     const lines: string[] = [];
@@ -257,5 +271,178 @@ describe("runCli", () => {
     expect(output).toContain("running");
     expect(output).toContain("paused");
     expect(output).toContain("queued");
+  });
+
+  test("prints active runs as json for ps --json", async () => {
+    const lines: string[] = [];
+    const requests: string[] = [];
+    const exitCode = await withPatchedObjectEntries({ json: true }, async () =>
+      runCli(["ps", "--json"], {
+        stdout: (line) => lines.push(line),
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async (input) => {
+          requests.push(String(input));
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_ps_json",
+              data: {
+                items: [
+                  {
+                    runId: "run_1",
+                    loopId: "loop_1",
+                    projectId: "project_1",
+                    type: "worker",
+                    status: "running",
+                    currentStep: "execute",
+                    startedAt: "2026-04-11T12:00:00.000Z",
+                    target: {
+                      type: "task",
+                      taskId: "task_1",
+                      label: "Ship CLI",
+                    },
+                    agent: {
+                      active: true,
+                      activeCount: 1,
+                      executionId: "agent_1",
+                      vendor: "opencode",
+                      pid: 1234,
+                      startedAt: "2026-04-11T12:00:01.000Z",
+                      lastHeartbeatAt: "2026-04-11T12:00:02.000Z",
+                      heartbeatCount: 3,
+                      status: "running",
+                    },
+                  },
+                ],
+              },
+            }),
+          );
+        },
+      }),
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests[0]).toContain("/api/v1/runs/active");
+    expect(lines.join("\n")).toContain('"runId": "run_1"');
+    expect(lines.join("\n")).toContain('"activeCount": 1');
+  });
+
+  test("renders ps table with expected column order and values", async () => {
+    const lines: string[] = [];
+    const originalNow = Date.now;
+    Date.now = () => Date.parse("2026-04-11T12:05:00.000Z");
+
+    try {
+      const exitCode = await withPatchedObjectEntries({}, async () =>
+        runCli(["ps"], {
+          stdout: (line) => lines.push(line),
+          loadConfigImpl: async () => createConfig() as never,
+          fetchImpl: async () =>
+            new Response(
+              JSON.stringify({
+                ok: true,
+                requestId: "req_ps_table",
+                data: {
+                  items: [
+                    {
+                      runId: "run_worker_1",
+                      loopId: "loop_worker_1",
+                      projectId: "project_1",
+                      type: "worker",
+                      status: "running",
+                      currentStep: "execute",
+                      startedAt: "2026-04-11T12:00:00.000Z",
+                      target: {
+                        type: "task",
+                        taskId: "task_1",
+                        label: "Ship CLI",
+                      },
+                      agent: {
+                        active: true,
+                        activeCount: 2,
+                        executionId: "agent_2",
+                        vendor: "opencode",
+                        pid: 2222,
+                        startedAt: "2026-04-11T12:00:01.000Z",
+                        lastHeartbeatAt: "2026-04-11T12:00:02.000Z",
+                        heartbeatCount: 4,
+                        status: "running",
+                      },
+                    },
+                  ],
+                },
+              }),
+            ),
+        }),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(lines[0]).toContain("type");
+      expect(lines[0]).toContain("target");
+      expect(lines[0]).toContain("run");
+      expect(lines[0]).toContain("step");
+      expect(lines[0]).toContain("agent");
+      expect(lines[0]).toContain("pid");
+      expect(lines[0]).toContain("status");
+      expect(lines[0]).toContain("age");
+      expect(lines[2]).toContain("worker");
+      expect(lines[2]).toContain("Ship CLI");
+      expect(lines[2]).toContain("run_worker_1");
+      expect(lines[2]).toContain("execute");
+      expect(lines[2]).toContain("opencode");
+      expect(lines[2]).toContain("2222");
+      expect(lines[2]).toContain("running");
+      expect(lines[2]).toContain("5m");
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  test("prints ps empty state", async () => {
+    const lines: string[] = [];
+    const exitCode = await withPatchedObjectEntries({}, async () =>
+      runCli(["ps"], {
+        stdout: (line) => lines.push(line),
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_ps_empty",
+              data: { items: [] },
+            }),
+          ),
+      }),
+    );
+
+    expect(exitCode).toBe(0);
+    expect(lines).toEqual(["No running loops."]);
+  });
+
+  test("composes ps query params from --type and --project", async () => {
+    const requests: string[] = [];
+    const exitCode = await withPatchedObjectEntries(
+      { type: "reviewer", project: "project_1" },
+      () =>
+        runCli(["ps", "--type", "reviewer", "--project", "project_1"], {
+          stdout: () => {},
+          loadConfigImpl: async () => createConfig() as never,
+          fetchImpl: async (input) => {
+            requests.push(String(input));
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                requestId: "req_ps_query",
+                data: { items: [] },
+              }),
+            );
+          },
+        }),
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests[0]).toContain(
+      "/api/v1/runs/active?type=reviewer&projectId=project_1",
+    );
   });
 });

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -18,20 +18,6 @@ function createConfig() {
   };
 }
 
-async function withPatchedObjectEntries<T>(
-  fallback: Record<string, unknown>,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const original = Object.entries;
-  Object.entries = ((value: unknown) =>
-    original(value ?? fallback)) as typeof Object.entries;
-  try {
-    return await fn();
-  } finally {
-    Object.entries = original;
-  }
-}
-
 describe("runCli", () => {
   test("renders status as json", async () => {
     const lines: string[] = [];
@@ -276,8 +262,7 @@ describe("runCli", () => {
   test("prints active runs as json for ps --json", async () => {
     const lines: string[] = [];
     const requests: string[] = [];
-    const exitCode = await withPatchedObjectEntries({ json: true }, async () =>
-      runCli(["ps", "--json"], {
+    const exitCode = await runCli(["ps", "--json"], {
         stdout: (line) => lines.push(line),
         loadConfigImpl: async () => createConfig() as never,
         fetchImpl: async (input) => {
@@ -318,8 +303,7 @@ describe("runCli", () => {
             }),
           );
         },
-      }),
-    );
+      });
 
     expect(exitCode).toBe(0);
     expect(requests[0]).toContain("/api/v1/runs/active");
@@ -333,8 +317,7 @@ describe("runCli", () => {
     Date.now = () => Date.parse("2026-04-11T12:05:00.000Z");
 
     try {
-      const exitCode = await withPatchedObjectEntries({}, async () =>
-        runCli(["ps"], {
+      const exitCode = await runCli(["ps"], {
           stdout: (line) => lines.push(line),
           loadConfigImpl: async () => createConfig() as never,
           fetchImpl: async () =>
@@ -373,8 +356,7 @@ describe("runCli", () => {
                 },
               }),
             ),
-        }),
-      );
+        });
 
       expect(exitCode).toBe(0);
       expect(lines[0]).toContain("type");
@@ -400,8 +382,7 @@ describe("runCli", () => {
 
   test("prints ps empty state", async () => {
     const lines: string[] = [];
-    const exitCode = await withPatchedObjectEntries({}, async () =>
-      runCli(["ps"], {
+    const exitCode = await runCli(["ps"], {
         stdout: (line) => lines.push(line),
         loadConfigImpl: async () => createConfig() as never,
         fetchImpl: async () =>
@@ -412,8 +393,7 @@ describe("runCli", () => {
               data: { items: [] },
             }),
           ),
-      }),
-    );
+      });
 
     expect(exitCode).toBe(0);
     expect(lines).toEqual(["No running loops."]);
@@ -421,10 +401,9 @@ describe("runCli", () => {
 
   test("composes ps query params from --type and --project", async () => {
     const requests: string[] = [];
-    const exitCode = await withPatchedObjectEntries(
-      { type: "reviewer", project: "project_1" },
-      () =>
-        runCli(["ps", "--type", "reviewer", "--project", "project_1"], {
+    const exitCode = await runCli(
+      ["ps", "--type", "reviewer", "--project", "project_1"],
+      {
           stdout: () => {},
           loadConfigImpl: async () => createConfig() as never,
           fetchImpl: async (input) => {
@@ -437,7 +416,7 @@ describe("runCli", () => {
               }),
             );
           },
-        }),
+        },
     );
 
     expect(exitCode).toBe(0);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -404,7 +404,7 @@ function outputCommandHelp(
 function createContext(
   runtime: CliRuntime,
   positionals: string[],
-  options: Record<string, unknown>,
+  options?: Record<string, unknown>,
 ): CliContext {
   return {
     ...runtime,
@@ -414,11 +414,11 @@ function createContext(
 
 function buildParsedArgs(
   positionals: string[],
-  options: Record<string, unknown>,
+  options?: Record<string, unknown>,
 ): ParsedArgs {
   const flags = new Map<string, string[]>();
 
-  for (const [name, value] of Object.entries(options)) {
+  for (const [name, value] of Object.entries(options ?? {})) {
     if (value === undefined || value === false || name === "--") {
       continue;
     }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -69,6 +69,39 @@ interface PullRequestRef {
   prNumber: number;
 }
 
+interface ActiveRunItem {
+  runId: string;
+  loopId: string;
+  projectId: string;
+  type: string;
+  status: string;
+  currentStep: string | null;
+  startedAt: string;
+  target:
+    | {
+        type: "task";
+        taskId: string;
+        label: string;
+      }
+    | {
+        type: "pull_request";
+        repo: string;
+        prNumber: number;
+        label: string;
+      };
+  agent: {
+    active: true;
+    activeCount: number;
+    executionId: string;
+    vendor: string;
+    pid: number | null;
+    startedAt: string;
+    lastHeartbeatAt: string | null;
+    heartbeatCount: number;
+    status: string;
+  } | null;
+}
+
 const CONFIG_FLAGS = new Set([
   "config",
   "host",
@@ -215,6 +248,8 @@ async function dispatch(context: CliContext): Promise<void> {
       }
       context.showHelp("run");
       return;
+    case "ps":
+      return runPs(context);
     default:
       break;
   }
@@ -304,6 +339,16 @@ function createCli(runtime: CliRuntime) {
     .example((name) => `  $ ${name} pr show acme/looper#42`)
     .action(async (args, options) => {
       await dispatch(createContext(runtime, ["pr", ...args], options));
+    });
+
+  cli
+    .command("ps", "Show running loops")
+    .option("--type <type>", "Filter by loop type")
+    .option("--project <projectId>", "Filter by project id")
+    .example((name) => `  $ ${name} ps`)
+    .example((name) => `  $ ${name} ps --type reviewer --project project_1`)
+    .action(async (_args, options) => {
+      await dispatch(createContext(runtime, ["ps"], options));
     });
 
   cli
@@ -890,6 +935,76 @@ async function runRunList(context: CliContext) {
       startedAt: run.startedAt as string,
     })),
   );
+}
+
+async function runPs(context: CliContext) {
+  const searchParams = new URLSearchParams();
+  const type = getFlag(context.args, "type");
+  const projectId = getFlag(context.args, "project");
+
+  if (type) {
+    searchParams.set("type", type);
+  }
+  if (projectId) {
+    searchParams.set("projectId", projectId);
+  }
+
+  const query = searchParams.toString();
+  const path = query ? `/api/v1/runs/active?${query}` : "/api/v1/runs/active";
+  const data = await context.client.get<{ items: ActiveRunItem[] }>(path);
+
+  if (hasFlag(context.args, "json")) {
+    return printJson(context.write, data);
+  }
+
+  if (data.items.length === 0) {
+    context.write("No running loops.");
+    return;
+  }
+
+  printTable(
+    context.write,
+    data.items.map((item) => ({
+      type: item.type,
+      target: item.target.label,
+      run: item.runId,
+      step: item.currentStep ?? "-",
+      agent: item.agent?.vendor ?? "-",
+      pid: item.agent?.pid ?? "-",
+      status: item.status,
+      age: formatRelativeAge(item.startedAt),
+    })),
+  );
+}
+
+function formatRelativeAge(startedAt: string): string {
+  const started = Date.parse(startedAt);
+  if (Number.isNaN(started)) {
+    return "-";
+  }
+
+  const diffMs = Math.max(Date.now() - started, 0);
+  const totalMinutes = Math.floor(diffMs / 60_000);
+  if (totalMinutes < 1) {
+    return "<1m";
+  }
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m`;
+  }
+
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) {
+    const remainingMinutes = totalMinutes % 60;
+    return remainingMinutes === 0
+      ? `${totalHours}h`
+      : `${totalHours}h${remainingMinutes}m`;
+  }
+
+  const totalDays = Math.floor(totalHours / 24);
+  const remainingHours = totalHours % 24;
+  return remainingHours === 0
+    ? `${totalDays}d`
+    : `${totalDays}d${remainingHours}h`;
 }
 
 function emitTaskResult(

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -347,7 +347,7 @@ function createCli(runtime: CliRuntime) {
     .option("--project <projectId>", "Filter by project id")
     .example((name) => `  $ ${name} ps`)
     .example((name) => `  $ ${name} ps --type reviewer --project project_1`)
-    .action(async (_args, options) => {
+    .action(async (options) => {
       await dispatch(createContext(runtime, ["ps"], options));
     });
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -404,7 +404,7 @@ function outputCommandHelp(
 function createContext(
   runtime: CliRuntime,
   positionals: string[],
-  options?: Record<string, unknown>,
+  options: Record<string, unknown>,
 ): CliContext {
   return {
     ...runtime,
@@ -414,11 +414,11 @@ function createContext(
 
 function buildParsedArgs(
   positionals: string[],
-  options?: Record<string, unknown>,
+  options: Record<string, unknown>,
 ): ParsedArgs {
   const flags = new Map<string, string[]>();
 
-  for (const [name, value] of Object.entries(options ?? {})) {
+  for (const [name, value] of Object.entries(options)) {
     if (value === undefined || value === false || name === "--") {
       continue;
     }

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -664,4 +664,370 @@ describe("createLooperdApi", () => {
     store.close();
     await rm(rootDir, { recursive: true, force: true });
   });
+
+  test("returns an empty active-runs list when no runs are running", async () => {
+    const { api, store, rootDir } = await createFixture();
+
+    const existingRun = store.runs.getById("run_1");
+    if (!existingRun) {
+      throw new Error("expected run_1 to exist");
+    }
+    store.runs.upsert({
+      ...existingRun,
+      status: "completed",
+      endedAt: "2026-04-11T12:10:00.000Z",
+      updatedAt: "2026-04-11T12:10:00.000Z",
+    });
+
+    const response = await api.handle(
+      new Request("http://localhost/api/v1/runs/active"),
+    );
+    const body = (await response.json()) as {
+      data: { items: Array<Record<string, unknown>> };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.data.items).toEqual([]);
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test("returns active runs with target/agent shapes, collapse rules, and filters", async () => {
+    const { api, store, rootDir } = await createFixture();
+
+    store.loops.upsert({
+      id: "loop_worker_1",
+      projectId: "project_1",
+      type: "worker",
+      targetType: "task",
+      targetId: "task:task_2",
+      repo: null,
+      prNumber: null,
+      status: "running",
+      configJson: null,
+      metadataJson: null,
+      lastRunAt: "2026-04-11T12:01:00.000Z",
+      nextRunAt: "2026-04-11T12:01:00.000Z",
+      createdAt: "2026-04-11T12:01:00.000Z",
+      updatedAt: "2026-04-11T12:01:00.000Z",
+    });
+    store.tasks.upsert({
+      id: "task_2",
+      projectId: "project_1",
+      title: "Implement ps command",
+      description: null,
+      status: "in_progress",
+      loopId: "loop_worker_1",
+      repo: null,
+      prNumber: null,
+      metadataJson: null,
+      createdAt: "2026-04-11T12:01:00.000Z",
+      updatedAt: "2026-04-11T12:01:00.000Z",
+    });
+    store.runs.upsert({
+      id: "run_worker_1",
+      loopId: "loop_worker_1",
+      status: "running",
+      currentStep: "execute",
+      lastCompletedStep: null,
+      checkpointJson: null,
+      summary: null,
+      errorMessage: null,
+      startedAt: "2026-04-11T12:01:00.000Z",
+      lastHeartbeatAt: "2026-04-11T12:01:30.000Z",
+      endedAt: null,
+      createdAt: "2026-04-11T12:01:00.000Z",
+      updatedAt: "2026-04-11T12:01:30.000Z",
+    });
+
+    store.loops.upsert({
+      id: "loop_fixer_1",
+      projectId: "project_1",
+      type: "fixer",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:43",
+      repo: "acme/looper",
+      prNumber: 43,
+      status: "running",
+      configJson: null,
+      metadataJson: null,
+      lastRunAt: "2026-04-11T12:02:00.000Z",
+      nextRunAt: "2026-04-11T12:02:00.000Z",
+      createdAt: "2026-04-11T12:02:00.000Z",
+      updatedAt: "2026-04-11T12:02:00.000Z",
+    });
+    store.runs.upsert({
+      id: "run_fixer_1",
+      loopId: "loop_fixer_1",
+      status: "running",
+      currentStep: "fix",
+      lastCompletedStep: null,
+      checkpointJson: null,
+      summary: null,
+      errorMessage: null,
+      startedAt: "2026-04-11T12:02:00.000Z",
+      lastHeartbeatAt: "2026-04-11T12:02:30.000Z",
+      endedAt: null,
+      createdAt: "2026-04-11T12:02:00.000Z",
+      updatedAt: "2026-04-11T12:02:30.000Z",
+    });
+
+    // fallback label should use task id when task title is unavailable
+    store.loops.upsert({
+      id: "loop_worker_fallback",
+      projectId: "project_1",
+      type: "worker",
+      targetType: "task",
+      targetId: "task:task_fallback",
+      repo: null,
+      prNumber: null,
+      status: "running",
+      configJson: null,
+      metadataJson: null,
+      lastRunAt: "2026-04-11T12:03:00.000Z",
+      nextRunAt: "2026-04-11T12:03:00.000Z",
+      createdAt: "2026-04-11T12:03:00.000Z",
+      updatedAt: "2026-04-11T12:03:00.000Z",
+    });
+    store.runs.upsert({
+      id: "run_worker_fallback",
+      loopId: "loop_worker_fallback",
+      status: "running",
+      currentStep: "plan",
+      lastCompletedStep: null,
+      checkpointJson: null,
+      summary: null,
+      errorMessage: null,
+      startedAt: "2026-04-11T12:03:00.000Z",
+      lastHeartbeatAt: "2026-04-11T12:03:30.000Z",
+      endedAt: null,
+      createdAt: "2026-04-11T12:03:00.000Z",
+      updatedAt: "2026-04-11T12:03:30.000Z",
+    });
+
+    // null-runId active execution is ignored
+    store.agentExecutions.upsert({
+      id: "agent_exec_null_run",
+      projectId: "project_1",
+      loopId: "loop_worker_1",
+      runId: null,
+      taskId: "task_2",
+      vendor: "opencode",
+      status: "running",
+      pid: 99901,
+      commandJson: "{}",
+      cwd: "/tmp/looper",
+      summary: null,
+      parseStatus: null,
+      completionSignal: null,
+      heartbeatCount: 1,
+      lastHeartbeatAt: "2026-04-11T12:02:00.000Z",
+      outputJson: null,
+      errorMessage: null,
+      startedAt: "2026-04-11T12:02:00.000Z",
+      endedAt: null,
+      metadataJson: null,
+      createdAt: "2026-04-11T12:02:00.000Z",
+      updatedAt: "2026-04-11T12:02:00.000Z",
+    });
+
+    // duplicate active executions collapse to one agent summary with activeCount
+    store.agentExecutions.upsert({
+      id: "agent_exec_worker_old",
+      projectId: "project_1",
+      loopId: "loop_worker_1",
+      runId: "run_worker_1",
+      taskId: "task_2",
+      vendor: "opencode",
+      status: "running",
+      pid: 11111,
+      commandJson: "{}",
+      cwd: "/tmp/looper",
+      summary: null,
+      parseStatus: null,
+      completionSignal: null,
+      heartbeatCount: 2,
+      lastHeartbeatAt: "2026-04-11T12:01:40.000Z",
+      outputJson: null,
+      errorMessage: null,
+      startedAt: "2026-04-11T12:01:10.000Z",
+      endedAt: null,
+      metadataJson: null,
+      createdAt: "2026-04-11T12:01:10.000Z",
+      updatedAt: "2026-04-11T12:01:40.000Z",
+    });
+    store.agentExecutions.upsert({
+      id: "agent_exec_worker_new",
+      projectId: "project_1",
+      loopId: "loop_worker_1",
+      runId: "run_worker_1",
+      taskId: "task_2",
+      vendor: "opencode",
+      status: "running",
+      pid: 22222,
+      commandJson: "{}",
+      cwd: "/tmp/looper",
+      summary: null,
+      parseStatus: null,
+      completionSignal: null,
+      heartbeatCount: 5,
+      lastHeartbeatAt: "2026-04-11T12:01:50.000Z",
+      outputJson: null,
+      errorMessage: null,
+      startedAt: "2026-04-11T12:01:20.000Z",
+      endedAt: null,
+      metadataJson: null,
+      createdAt: "2026-04-11T12:01:20.000Z",
+      updatedAt: "2026-04-11T12:01:50.000Z",
+    });
+    store.agentExecutions.upsert({
+      id: "agent_exec_fixer",
+      projectId: "project_1",
+      loopId: "loop_fixer_1",
+      runId: "run_fixer_1",
+      taskId: null,
+      vendor: "opencode",
+      status: "running",
+      pid: 33333,
+      commandJson: "{}",
+      cwd: "/tmp/looper",
+      summary: null,
+      parseStatus: null,
+      completionSignal: null,
+      heartbeatCount: 3,
+      lastHeartbeatAt: "2026-04-11T12:02:40.000Z",
+      outputJson: null,
+      errorMessage: null,
+      startedAt: "2026-04-11T12:02:10.000Z",
+      endedAt: null,
+      metadataJson: null,
+      createdAt: "2026-04-11T12:02:10.000Z",
+      updatedAt: "2026-04-11T12:02:40.000Z",
+    });
+
+    const response = await api.handle(
+      new Request("http://localhost/api/v1/runs/active"),
+    );
+    const body = (await response.json()) as {
+      data: {
+        items: Array<{
+          runId: string;
+          type: string;
+          currentStep: string | null;
+          target: { type: string; label: string; taskId?: string };
+          agent: {
+            executionId: string;
+            activeCount: number;
+            pid: number | null;
+          } | null;
+        }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.data.items.map((item) => item.runId)).toEqual([
+      "run_worker_1",
+      "run_fixer_1",
+      "run_1",
+      "run_worker_fallback",
+    ]);
+
+    const reviewer = body.data.items.find((item) => item.runId === "run_1");
+    expect(reviewer).toMatchObject({
+      type: "reviewer",
+      currentStep: "review",
+      target: {
+        type: "pull_request",
+        label: "acme/looper#42",
+      },
+      agent: null,
+    });
+
+    const worker = body.data.items.find(
+      (item) => item.runId === "run_worker_1",
+    );
+    expect(worker).toMatchObject({
+      type: "worker",
+      currentStep: "execute",
+      target: {
+        type: "task",
+        taskId: "task_2",
+        label: "Implement ps command",
+      },
+      agent: {
+        executionId: "agent_exec_worker_new",
+        activeCount: 2,
+        pid: 22222,
+      },
+    });
+
+    const fixer = body.data.items.find((item) => item.runId === "run_fixer_1");
+    expect(fixer).toMatchObject({
+      type: "fixer",
+      currentStep: "fix",
+      target: {
+        type: "pull_request",
+        label: "acme/looper#43",
+      },
+      agent: {
+        executionId: "agent_exec_fixer",
+        activeCount: 1,
+        pid: 33333,
+      },
+    });
+
+    const fallbackTaskTarget = body.data.items.find(
+      (item) => item.runId === "run_worker_fallback",
+    );
+    expect(fallbackTaskTarget?.target).toMatchObject({
+      type: "task",
+      taskId: "task_fallback",
+      label: "task_fallback",
+    });
+
+    const typeFiltered = await api.handle(
+      new Request("http://localhost/api/v1/runs/active?type=worker"),
+    );
+    const typeFilteredBody = (await typeFiltered.json()) as {
+      data: { items: Array<{ runId: string }> };
+    };
+    expect(typeFilteredBody.data.items.map((item) => item.runId)).toEqual([
+      "run_worker_1",
+      "run_worker_fallback",
+    ]);
+
+    const projectFiltered = await api.handle(
+      new Request("http://localhost/api/v1/runs/active?projectId=project_1"),
+    );
+    const projectFilteredBody = (await projectFiltered.json()) as {
+      data: { items: Array<{ runId: string }> };
+    };
+    expect(projectFilteredBody.data.items).toHaveLength(4);
+
+    const taskFiltered = await api.handle(
+      new Request("http://localhost/api/v1/runs/active?taskId=task_2"),
+    );
+    const taskFilteredBody = (await taskFiltered.json()) as {
+      data: { items: Array<{ runId: string }> };
+    };
+    expect(taskFilteredBody.data.items.map((item) => item.runId)).toEqual([
+      "run_worker_1",
+    ]);
+
+    const prFiltered = await api.handle(
+      new Request(
+        "http://localhost/api/v1/runs/active?repo=acme%2Flooper&prNumber=43",
+      ),
+    );
+    const prFilteredBody = (await prFiltered.json()) as {
+      data: { items: Array<{ runId: string }> };
+    };
+    expect(prFilteredBody.data.items.map((item) => item.runId)).toEqual([
+      "run_fixer_1",
+    ]);
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
 });

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -14,9 +14,12 @@ import type { ProjectManager } from "../projects/index";
 import { SchedulerQueue } from "../scheduler/index";
 import type { Store } from "../storage/store";
 import type {
+  AgentExecutionRecord,
   EventLogRecord,
+  LoopRecord,
   PullRequestSnapshotRecord,
   RunRecord,
+  TaskRecord,
 } from "../storage/types";
 
 export interface ApiResponse<T> {
@@ -133,6 +136,10 @@ export function createLooperdApi(context: LooperdApiContext): LooperdApi {
           case pathname === "/api/v1/runs":
             assertMethod(request, ["GET"], pathname);
             data = buildRunsResponse(context, url.searchParams);
+            break;
+          case pathname === "/api/v1/runs/active":
+            assertMethod(request, ["GET"], pathname);
+            data = buildActiveRunsResponse(context, url.searchParams);
             break;
           default:
             throw new ApiError(
@@ -705,6 +712,266 @@ function buildRunsResponse(
       ? context.store.runs.listByLoop(loopId)
       : context.store.runs.list(),
   };
+}
+
+interface ActiveRunsQuery {
+  type?: string;
+  projectId?: string;
+  taskId?: string;
+  repo?: string;
+  prNumber?: number;
+}
+
+interface ActiveRunAgentSummary {
+  active: true;
+  activeCount: number;
+  executionId: string;
+  vendor: string;
+  pid: number | null;
+  startedAt: string;
+  lastHeartbeatAt: string | null;
+  heartbeatCount: number;
+  status: string;
+}
+
+interface ActiveRunView {
+  runId: string;
+  loopId: string;
+  projectId: string;
+  type: string;
+  status: string;
+  currentStep: string | null;
+  startedAt: string;
+  target:
+    | {
+        type: "task";
+        taskId: string;
+        label: string;
+      }
+    | {
+        type: "pull_request";
+        repo: string;
+        prNumber: number;
+        label: string;
+      };
+  agent: ActiveRunAgentSummary | null;
+}
+
+function buildActiveRunsResponse(
+  context: LooperdApiContext,
+  searchParams: URLSearchParams,
+) {
+  const query = readActiveRunsQuery(searchParams);
+  const items = buildActiveRunViews(context).filter((item) =>
+    matchesActiveRunsQuery(item, query),
+  );
+
+  return { items };
+}
+
+function buildActiveRunViews(context: LooperdApiContext): ActiveRunView[] {
+  const activeRuns = context.store.runs.listByStatus("running");
+  const activeAgentByRunId = buildActiveAgentByRunId(
+    context.store.agentExecutions.listActive(),
+  );
+
+  return activeRuns
+    .map((run) => {
+      const loop = context.store.loops.getById(run.loopId);
+      if (!loop) {
+        return null;
+      }
+
+      const target = tryBuildActiveRunTarget(context, loop);
+      if (!target) {
+        return null;
+      }
+
+      return {
+        runId: run.id,
+        loopId: run.loopId,
+        projectId: loop.projectId,
+        type: loop.type,
+        status: run.status,
+        currentStep: run.currentStep ?? null,
+        startedAt: run.startedAt,
+        target,
+        agent: activeAgentByRunId.get(run.id) ?? null,
+      } satisfies ActiveRunView;
+    })
+    .filter((item): item is ActiveRunView => item !== null)
+    .sort(compareActiveRunViews);
+}
+
+function buildActiveAgentByRunId(
+  executions: AgentExecutionRecord[],
+): Map<string, ActiveRunAgentSummary> {
+  const grouped = new Map<string, AgentExecutionRecord[]>();
+
+  for (const execution of executions) {
+    if (!execution.runId) {
+      continue;
+    }
+
+    const bucket = grouped.get(execution.runId) ?? [];
+    bucket.push(execution);
+    grouped.set(execution.runId, bucket);
+  }
+
+  return new Map(
+    Array.from(grouped.entries()).map(([runId, bucket]) => {
+      const sorted = [...bucket].sort((left, right) =>
+        compareIsoDesc(left.startedAt, right.startedAt),
+      );
+      const primary = sorted[0];
+      if (!primary) {
+        throw new Error(`Missing active execution for run ${runId}`);
+      }
+
+      return [
+        runId,
+        {
+          active: true,
+          activeCount: bucket.length,
+          executionId: primary.id,
+          vendor: primary.vendor,
+          pid: primary.pid ?? null,
+          startedAt: primary.startedAt,
+          lastHeartbeatAt: primary.lastHeartbeatAt ?? null,
+          heartbeatCount: primary.heartbeatCount,
+          status: primary.status,
+        } satisfies ActiveRunAgentSummary,
+      ];
+    }),
+  );
+}
+
+function tryBuildActiveRunTarget(
+  context: LooperdApiContext,
+  loop: LoopRecord,
+): ActiveRunView["target"] | null {
+  if (loop.targetType === "task") {
+    const taskId =
+      loop.targetId?.startsWith("task:") === true
+        ? loop.targetId.slice("task:".length)
+        : loop.targetId;
+    if (!taskId) {
+      return null;
+    }
+
+    const task = context.store.tasks.getById(taskId);
+
+    return {
+      type: "task",
+      taskId,
+      label: task?.title?.trim() || taskId,
+    };
+  }
+
+  if (!loop.repo || !loop.prNumber) {
+    return null;
+  }
+
+  return {
+    type: "pull_request",
+    repo: loop.repo,
+    prNumber: loop.prNumber,
+    label: `${loop.repo}#${loop.prNumber}`,
+  };
+}
+
+function readActiveRunsQuery(searchParams: URLSearchParams): ActiveRunsQuery {
+  const type = searchParams.get("type")?.trim() || undefined;
+  const projectId = searchParams.get("projectId")?.trim() || undefined;
+  const taskId = searchParams.get("taskId")?.trim() || undefined;
+  const repo = searchParams.get("repo")?.trim() || undefined;
+  const prNumberValue = searchParams.get("prNumber")?.trim();
+  const prNumber = prNumberValue
+    ? readSearchParamPositiveInteger(prNumberValue, "prNumber")
+    : undefined;
+
+  if ((repo && prNumber === undefined) || (!repo && prNumber !== undefined)) {
+    throw new ApiError(
+      "VALIDATION_FAILED",
+      400,
+      "repo and prNumber must be provided together",
+    );
+  }
+
+  return { type, projectId, taskId, repo, prNumber };
+}
+
+function readSearchParamPositiveInteger(
+  value: string,
+  fieldName: string,
+): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new ApiError(
+      "VALIDATION_FAILED",
+      400,
+      `${fieldName} must be a positive integer`,
+    );
+  }
+
+  return parsed;
+}
+
+function matchesActiveRunsQuery(
+  item: ActiveRunView,
+  query: ActiveRunsQuery,
+): boolean {
+  if (query.type && item.type !== query.type) {
+    return false;
+  }
+
+  if (query.projectId && item.projectId !== query.projectId) {
+    return false;
+  }
+
+  if (query.taskId) {
+    if (item.target.type !== "task" || item.target.taskId !== query.taskId) {
+      return false;
+    }
+  }
+
+  if (query.repo || query.prNumber !== undefined) {
+    if (
+      item.target.type !== "pull_request" ||
+      item.target.repo !== query.repo ||
+      item.target.prNumber !== query.prNumber
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function compareActiveRunViews(
+  left: ActiveRunView,
+  right: ActiveRunView,
+): number {
+  const leftHasActiveAgent = left.agent ? 1 : 0;
+  const rightHasActiveAgent = right.agent ? 1 : 0;
+  if (leftHasActiveAgent !== rightHasActiveAgent) {
+    return rightHasActiveAgent - leftHasActiveAgent;
+  }
+
+  const startedAtComparison = compareIsoAsc(left.startedAt, right.startedAt);
+  if (startedAtComparison !== 0) {
+    return startedAtComparison;
+  }
+
+  return left.runId.localeCompare(right.runId);
+}
+
+function compareIsoAsc(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+function compareIsoDesc(left: string, right: string): number {
+  return right.localeCompare(left);
 }
 
 async function buildProjectsRouteResponse(

--- a/apps/looperd/src/storage/sqlite/sqlite-store.test.ts
+++ b/apps/looperd/src/storage/sqlite/sqlite-store.test.ts
@@ -527,4 +527,92 @@ describe("SqliteStore", () => {
 
     store.close();
   });
+
+  test("lists runs by status in stable newest-first order", async () => {
+    const fixture = await createStoreFixture();
+    const store = new SqliteStore({ dbPath: fixture.dbPath });
+    store.initialize({ autoMigrate: true });
+
+    store.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath: "/tmp/looper",
+      baseBranch: "main",
+      archived: false,
+      metadataJson: null,
+      createdAt: "2026-04-11T11:59:00.000Z",
+      updatedAt: "2026-04-11T11:59:00.000Z",
+    });
+    store.loops.upsert({
+      id: "loop_1",
+      projectId: "project_1",
+      type: "worker",
+      targetType: "task",
+      targetId: "task:task_1",
+      repo: null,
+      prNumber: null,
+      status: "running",
+      configJson: null,
+      metadataJson: null,
+      lastRunAt: null,
+      nextRunAt: "2026-04-11T12:00:00.000Z",
+      createdAt: "2026-04-11T11:59:30.000Z",
+      updatedAt: "2026-04-11T11:59:30.000Z",
+    });
+
+    store.runs.upsert({
+      id: "run_old_running",
+      loopId: "loop_1",
+      status: "running",
+      currentStep: "step_old",
+      lastCompletedStep: null,
+      checkpointJson: null,
+      summary: null,
+      errorMessage: null,
+      startedAt: "2026-04-11T12:00:00.000Z",
+      lastHeartbeatAt: "2026-04-11T12:00:00.000Z",
+      endedAt: null,
+      createdAt: "2026-04-11T12:00:00.000Z",
+      updatedAt: "2026-04-11T12:00:00.000Z",
+    });
+    store.runs.upsert({
+      id: "run_new_running",
+      loopId: "loop_1",
+      status: "running",
+      currentStep: "step_new",
+      lastCompletedStep: null,
+      checkpointJson: null,
+      summary: null,
+      errorMessage: null,
+      startedAt: "2026-04-11T12:05:00.000Z",
+      lastHeartbeatAt: "2026-04-11T12:05:00.000Z",
+      endedAt: null,
+      createdAt: "2026-04-11T12:05:00.000Z",
+      updatedAt: "2026-04-11T12:05:00.000Z",
+    });
+    store.runs.upsert({
+      id: "run_done",
+      loopId: "loop_1",
+      status: "completed",
+      currentStep: "done",
+      lastCompletedStep: "done",
+      checkpointJson: null,
+      summary: null,
+      errorMessage: null,
+      startedAt: "2026-04-11T12:10:00.000Z",
+      lastHeartbeatAt: "2026-04-11T12:10:00.000Z",
+      endedAt: "2026-04-11T12:12:00.000Z",
+      createdAt: "2026-04-11T12:10:00.000Z",
+      updatedAt: "2026-04-11T12:12:00.000Z",
+    });
+
+    const running = store.runs.listByStatus("running");
+    expect(running.map((run) => run.id)).toEqual([
+      "run_new_running",
+      "run_old_running",
+    ]);
+    expect(running.every((run) => run.status === "running")).toBe(true);
+
+    store.close();
+  });
 });

--- a/apps/looperd/src/storage/sqlite/sqlite-store.ts
+++ b/apps/looperd/src/storage/sqlite/sqlite-store.ts
@@ -183,6 +183,14 @@ export class SqliteStore implements Store {
         .all() as Record<string, unknown>[];
       return rows.map(mapRun);
     },
+    listByStatus: (status: RunRecord["status"]): RunRecord[] => {
+      const rows = this.coordinator.db
+        .query(
+          "SELECT * FROM runs WHERE status = ?1 ORDER BY started_at DESC, id DESC",
+        )
+        .all(status) as Record<string, unknown>[];
+      return rows.map(mapRun);
+    },
     listByLoop: (loopId: string): RunRecord[] => {
       const rows = this.coordinator.db
         .query("SELECT * FROM runs WHERE loop_id = ?1 ORDER BY started_at DESC")

--- a/apps/looperd/src/storage/store.ts
+++ b/apps/looperd/src/storage/store.ts
@@ -35,6 +35,7 @@ export interface Store {
     upsert(record: RunRecord): void;
     getById(id: string): RunRecord | null;
     list(): RunRecord[];
+    listByStatus(status: RunRecord["status"]): RunRecord[];
     listByLoop(loopId: string): RunRecord[];
   };
 

--- a/specs/2026-04-11-running-task-ps/checklist.md
+++ b/specs/2026-04-11-running-task-ps/checklist.md
@@ -1,0 +1,110 @@
+# Running Task PS Implementation Checklist
+
+## Phase 1: API Contract & Data Access
+
+- [ ] 新增 active runs 聚合接口约定
+  - [ ] 路由定为 `GET /api/v1/runs/active`
+  - [ ] 明确它是 `runs` 资源下的聚合视图，不引入新的 `process` 领域对象
+  - [ ] 明确 query 参数：`type`、`projectId`、`taskId`、`repo`、`prNumber`
+  - [ ] 明确返回字段：`runId`、`loopId`、`projectId`、`type`、`status`、`currentStep`、`startedAt`、`target`、`agent`
+
+- [ ] 扩展 `runs` store 查询能力
+  - [ ] 增加 `listByStatus(status: string)`
+  - [ ] SQLite store 增加对应查询实现
+  - [ ] 保持返回顺序稳定，便于上层排序/测试
+
+- [ ] 明确 active agent join 规则
+  - [ ] 使用 `agentExecutions.listActive()` 作为数据源
+  - [ ] `runId` 为空的 active execution 在 join 时直接跳过
+  - [ ] 多个 active execution 绑定同一 run 时，选择最新 `startedAt` 作为主展示对象
+  - [ ] 同时返回 `agent.activeCount` 以暴露异常并存情况
+
+## Phase 2: Server Aggregation
+
+- [ ] 在 `apps/looperd/src/server/index.ts` 增加 `/api/v1/runs/active` 路由
+  - [ ] 仅支持 `GET`
+  - [ ] 读取并校验 query 参数
+  - [ ] 调用聚合 builder 返回 `items`
+
+- [ ] 实现 active run view 聚合逻辑
+  - [ ] 从 `runs.listByStatus("running")` 读取 active runs
+  - [ ] 按 `run.loopId` join `loop`
+  - [ ] 从 `loop.type` 派生响应里的 `type`
+  - [ ] 按 target 类型构造 `target` 结构
+  - [ ] task target 优先展示 task title，缺失时回退 task id
+  - [ ] PR target 展示为 `<repo>#<prNumber>`
+  - [ ] 挂载 active agent 摘要（vendor / pid / startedAt / lastHeartbeatAt / heartbeatCount / activeCount）
+
+- [ ] 实现过滤逻辑
+  - [ ] `type`
+  - [ ] `projectId`
+  - [ ] `taskId`
+  - [ ] `repo + prNumber`
+
+- [ ] 实现排序逻辑
+  - [ ] 有活跃 agent execution 的 run 排前面
+  - [ ] 同组内按 `run.startedAt` 升序
+
+## Phase 3: CLI Command
+
+- [ ] 在 `apps/cli/src/index.ts` 增加顶级命令 `looper ps`
+  - [ ] 命令接入现有 CLI router
+  - [ ] 增加 help / example 文案
+  - [ ] 保持与现有 `run list` / `loop list` 风格一致
+
+- [ ] 支持 Phase 1 flags
+  - [ ] `--json`
+  - [ ] `--type <worker|reviewer|fixer>`
+  - [ ] `--project <projectId>`
+
+- [ ] 实现 CLI 输出
+  - [ ] 调用 `GET /api/v1/runs/active`
+  - [ ] 表格列输出：`type` / `target` / `run` / `step` / `agent` / `pid` / `status` / `age`
+  - [ ] `age` 由 CLI 基于 `startedAt` 计算相对时长
+  - [ ] 无活跃任务时输出 `No running loops.`
+  - [ ] 无 active agent 时 `agent` / `pid` 列显示 `-`
+
+## Phase 4: Tests
+
+- [ ] Store 测试
+  - [ ] `runs.listByStatus("running")` 只返回目标状态 run
+  - [ ] 返回顺序稳定
+
+- [ ] API 测试
+  - [ ] 无 active run 时返回空列表
+  - [ ] 有 active worker / reviewer / fixer 时正确返回 type + target + currentStep
+  - [ ] active agent execution 正确 join 到 run
+  - [ ] 当前 step 无 agent 时返回空 agent 展示对象或 `null`
+  - [ ] active execution `runId` 为空时被安全跳过
+  - [ ] 多个 active execution 绑定同一 run 时只返回一条 run 记录，并带 `activeCount`
+  - [ ] `type` / `projectId` / `taskId` / `repo+prNumber` 过滤正确
+  - [ ] task target 缺 title 时正确回退到 id
+
+- [ ] CLI 测试
+  - [ ] `looper ps --json` 输出结构化结果
+  - [ ] 默认表格输出列顺序正确
+  - [ ] 空态输出为 `No running loops.`
+  - [ ] `--type` / `--project` 正确拼 query 参数
+
+## MVP Cut Line
+
+MVP 必须完成：
+
+- [ ] `GET /api/v1/runs/active`
+- [ ] `runs.listByStatus(status)`
+- [ ] active run + active agent 聚合视图
+- [ ] `looper ps`
+- [ ] `--json`
+- [ ] `--type` / `--project`
+- [ ] 空态输出
+- [ ] 基础 API / CLI 测试
+
+后续再做：
+
+- [ ] `--task`
+- [ ] `--pr`
+- [ ] `--watch`
+- [ ] `looper ps -a`
+- [ ] queued footer / `--queued`
+- [ ] `looper ps --stuck`
+- [ ] SSE-based watch

--- a/specs/2026-04-11-running-task-ps/checklist.md
+++ b/specs/2026-04-11-running-task-ps/checklist.md
@@ -2,102 +2,102 @@
 
 ## Phase 1: API Contract & Data Access
 
-- [ ] 新增 active runs 聚合接口约定
-  - [ ] 路由定为 `GET /api/v1/runs/active`
-  - [ ] 明确它是 `runs` 资源下的聚合视图，不引入新的 `process` 领域对象
-  - [ ] 明确 query 参数：`type`、`projectId`、`taskId`、`repo`、`prNumber`
-  - [ ] 明确返回字段：`runId`、`loopId`、`projectId`、`type`、`status`、`currentStep`、`startedAt`、`target`、`agent`
+- [x] 新增 active runs 聚合接口约定
+  - [x] 路由定为 `GET /api/v1/runs/active`
+  - [x] 明确它是 `runs` 资源下的聚合视图，不引入新的 `process` 领域对象
+  - [x] 明确 query 参数：`type`、`projectId`、`taskId`、`repo`、`prNumber`
+  - [x] 明确返回字段：`runId`、`loopId`、`projectId`、`type`、`status`、`currentStep`、`startedAt`、`target`、`agent`
 
-- [ ] 扩展 `runs` store 查询能力
-  - [ ] 增加 `listByStatus(status: string)`
-  - [ ] SQLite store 增加对应查询实现
-  - [ ] 保持返回顺序稳定，便于上层排序/测试
+- [x] 扩展 `runs` store 查询能力
+  - [x] 增加 `listByStatus(status: string)`
+  - [x] SQLite store 增加对应查询实现
+  - [x] 保持返回顺序稳定，便于上层排序/测试
 
-- [ ] 明确 active agent join 规则
-  - [ ] 使用 `agentExecutions.listActive()` 作为数据源
-  - [ ] `runId` 为空的 active execution 在 join 时直接跳过
-  - [ ] 多个 active execution 绑定同一 run 时，选择最新 `startedAt` 作为主展示对象
-  - [ ] 同时返回 `agent.activeCount` 以暴露异常并存情况
+- [x] 明确 active agent join 规则
+  - [x] 使用 `agentExecutions.listActive()` 作为数据源
+  - [x] `runId` 为空的 active execution 在 join 时直接跳过
+  - [x] 多个 active execution 绑定同一 run 时，选择最新 `startedAt` 作为主展示对象
+  - [x] 同时返回 `agent.activeCount` 以暴露异常并存情况
 
 ## Phase 2: Server Aggregation
 
-- [ ] 在 `apps/looperd/src/server/index.ts` 增加 `/api/v1/runs/active` 路由
-  - [ ] 仅支持 `GET`
-  - [ ] 读取并校验 query 参数
-  - [ ] 调用聚合 builder 返回 `items`
+- [x] 在 `apps/looperd/src/server/index.ts` 增加 `/api/v1/runs/active` 路由
+  - [x] 仅支持 `GET`
+  - [x] 读取并校验 query 参数
+  - [x] 调用聚合 builder 返回 `items`
 
-- [ ] 实现 active run view 聚合逻辑
-  - [ ] 从 `runs.listByStatus("running")` 读取 active runs
-  - [ ] 按 `run.loopId` join `loop`
-  - [ ] 从 `loop.type` 派生响应里的 `type`
-  - [ ] 按 target 类型构造 `target` 结构
-  - [ ] task target 优先展示 task title，缺失时回退 task id
-  - [ ] PR target 展示为 `<repo>#<prNumber>`
-  - [ ] 挂载 active agent 摘要（vendor / pid / startedAt / lastHeartbeatAt / heartbeatCount / activeCount）
+- [x] 实现 active run view 聚合逻辑
+  - [x] 从 `runs.listByStatus("running")` 读取 active runs
+  - [x] 按 `run.loopId` join `loop`
+  - [x] 从 `loop.type` 派生响应里的 `type`
+  - [x] 按 target 类型构造 `target` 结构
+  - [x] task target 优先展示 task title，缺失时回退 task id
+  - [x] PR target 展示为 `<repo>#<prNumber>`
+  - [x] 挂载 active agent 摘要（vendor / pid / startedAt / lastHeartbeatAt / heartbeatCount / activeCount）
 
-- [ ] 实现过滤逻辑
-  - [ ] `type`
-  - [ ] `projectId`
-  - [ ] `taskId`
-  - [ ] `repo + prNumber`
+- [x] 实现过滤逻辑
+  - [x] `type`
+  - [x] `projectId`
+  - [x] `taskId`
+  - [x] `repo + prNumber`
 
-- [ ] 实现排序逻辑
-  - [ ] 有活跃 agent execution 的 run 排前面
-  - [ ] 同组内按 `run.startedAt` 升序
+- [x] 实现排序逻辑
+  - [x] 有活跃 agent execution 的 run 排前面
+  - [x] 同组内按 `run.startedAt` 升序
 
 ## Phase 3: CLI Command
 
-- [ ] 在 `apps/cli/src/index.ts` 增加顶级命令 `looper ps`
-  - [ ] 命令接入现有 CLI router
-  - [ ] 增加 help / example 文案
-  - [ ] 保持与现有 `run list` / `loop list` 风格一致
+- [x] 在 `apps/cli/src/index.ts` 增加顶级命令 `looper ps`
+  - [x] 命令接入现有 CLI router
+  - [x] 增加 help / example 文案
+  - [x] 保持与现有 `run list` / `loop list` 风格一致
 
-- [ ] 支持 Phase 1 flags
-  - [ ] `--json`
-  - [ ] `--type <worker|reviewer|fixer>`
-  - [ ] `--project <projectId>`
+- [x] 支持 Phase 1 flags
+  - [x] `--json`
+  - [x] `--type <worker|reviewer|fixer>`
+  - [x] `--project <projectId>`
 
-- [ ] 实现 CLI 输出
-  - [ ] 调用 `GET /api/v1/runs/active`
-  - [ ] 表格列输出：`type` / `target` / `run` / `step` / `agent` / `pid` / `status` / `age`
-  - [ ] `age` 由 CLI 基于 `startedAt` 计算相对时长
-  - [ ] 无活跃任务时输出 `No running loops.`
-  - [ ] 无 active agent 时 `agent` / `pid` 列显示 `-`
+- [x] 实现 CLI 输出
+  - [x] 调用 `GET /api/v1/runs/active`
+  - [x] 表格列输出：`type` / `target` / `run` / `step` / `agent` / `pid` / `status` / `age`
+  - [x] `age` 由 CLI 基于 `startedAt` 计算相对时长
+  - [x] 无活跃任务时输出 `No running loops.`
+  - [x] 无 active agent 时 `agent` / `pid` 列显示 `-`
 
 ## Phase 4: Tests
 
-- [ ] Store 测试
-  - [ ] `runs.listByStatus("running")` 只返回目标状态 run
-  - [ ] 返回顺序稳定
+- [x] Store 测试
+  - [x] `runs.listByStatus("running")` 只返回目标状态 run
+  - [x] 返回顺序稳定
 
-- [ ] API 测试
-  - [ ] 无 active run 时返回空列表
-  - [ ] 有 active worker / reviewer / fixer 时正确返回 type + target + currentStep
-  - [ ] active agent execution 正确 join 到 run
-  - [ ] 当前 step 无 agent 时返回空 agent 展示对象或 `null`
-  - [ ] active execution `runId` 为空时被安全跳过
-  - [ ] 多个 active execution 绑定同一 run 时只返回一条 run 记录，并带 `activeCount`
-  - [ ] `type` / `projectId` / `taskId` / `repo+prNumber` 过滤正确
-  - [ ] task target 缺 title 时正确回退到 id
+- [x] API 测试
+  - [x] 无 active run 时返回空列表
+  - [x] 有 active worker / reviewer / fixer 时正确返回 type + target + currentStep
+  - [x] active agent execution 正确 join 到 run
+  - [x] 当前 step 无 agent 时返回空 agent 展示对象或 `null`
+  - [x] active execution `runId` 为空时被安全跳过
+  - [x] 多个 active execution 绑定同一 run 时只返回一条 run 记录，并带 `activeCount`
+  - [x] `type` / `projectId` / `taskId` / `repo+prNumber` 过滤正确
+  - [x] task target 缺 title 时正确回退到 id
 
-- [ ] CLI 测试
-  - [ ] `looper ps --json` 输出结构化结果
-  - [ ] 默认表格输出列顺序正确
-  - [ ] 空态输出为 `No running loops.`
-  - [ ] `--type` / `--project` 正确拼 query 参数
+- [x] CLI 测试
+  - [x] `looper ps --json` 输出结构化结果
+  - [x] 默认表格输出列顺序正确
+  - [x] 空态输出为 `No running loops.`
+  - [x] `--type` / `--project` 正确拼 query 参数
 
 ## MVP Cut Line
 
 MVP 必须完成：
 
-- [ ] `GET /api/v1/runs/active`
-- [ ] `runs.listByStatus(status)`
-- [ ] active run + active agent 聚合视图
-- [ ] `looper ps`
-- [ ] `--json`
-- [ ] `--type` / `--project`
-- [ ] 空态输出
-- [ ] 基础 API / CLI 测试
+- [x] `GET /api/v1/runs/active`
+- [x] `runs.listByStatus(status)`
+- [x] active run + active agent 聚合视图
+- [x] `looper ps`
+- [x] `--json`
+- [x] `--type` / `--project`
+- [x] 空态输出
+- [x] 基础 API / CLI 测试
 
 后续再做：
 

--- a/specs/2026-04-11-running-task-ps/spec.md
+++ b/specs/2026-04-11-running-task-ps/spec.md
@@ -1,0 +1,394 @@
+# 运行中任务速览（`looper ps`）方案
+
+## 1. 背景
+
+当前已经有：
+
+- `looper loop list`
+- `looper run list`
+- `looper task status/show`
+- `looper pr list/status`
+
+但缺少一个“只看现在谁正在跑”的快速入口。
+
+用户想回答的问题通常不是：
+
+- 系统里一共有多少 loop / run
+
+而是：
+
+- 现在有没有 Worker 在干活
+- 哪个 PR 正在被 Reviewer / Fixer 处理
+- 当前卡在哪个 step
+- 背后有没有真实 agent 进程在跑，PID 是多少，跑了多久
+
+因此需要一个类似 `docker ps` 的命令，默认只展示**当前运行中的执行单元**。
+
+---
+
+## 2. 方案结论
+
+新增一个顶级命令：
+
+```bash
+looper ps
+```
+
+它默认展示**当前处于 running 状态的 loop run**，并附带该 run 关联的活跃 agent execution 摘要。
+
+设计原则：
+
+1. **默认只看 active**，不把历史记录混进来
+2. **展示单位以 loop run 为主**，而不是只看 agent process
+3. **如果存在活跃 agent execution，则把 agent 信息并排展示**
+4. **一屏可扫读**，优先解决“现在谁在跑”而不是“完整审计”
+5. 详细历史继续留给 `run list` / `task show` / `pr status`
+
+---
+
+## 3. 为什么展示单位选 `run`，不是只看 agent execution
+
+如果只列 `agent_executions`：
+
+- 能看到 PID / vendor / heartbeat
+- 但看不到完整业务语义
+- 不能覆盖 `validate` / `push` / `resolve-comments` 这类程序化 step
+
+而用户真正关心的是“哪个 Worker / Reviewer / Fixer 正在推进什么目标”。
+
+所以 `looper ps` 应以 **active run** 为主表，再附加：
+
+- loop 类型（worker / reviewer / fixer）
+- target（task / PR）
+- current step
+- 当前 step 是否由 agent 驱动
+- agent pid / vendor / heartbeat / startedAt
+
+这样既保留“docker ps 式总览”，又不丢业务上下文。
+
+---
+
+## 4. CLI 设计
+
+## 4.1 主命令
+
+```bash
+looper ps
+```
+
+默认输出建议：
+
+| type | target | run | step | agent | pid | status | age |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| worker | task_12 | run_101 | implement | codex | 81234 | running | 12m |
+| reviewer | repo#42 | run_102 | review | claude | 81288 | running | 4m |
+| fixer | repo#42 | run_103 | validate | - | - | running | 1m |
+
+字段说明：
+
+- `type`: `worker` / `reviewer` / `fixer`
+- `target`: task id 或 `repo#prNumber`
+- `run`: run id
+- `step`: 当前 step
+- `agent`: 活跃 agent vendor；无则 `-`
+- `pid`: 活跃 agent pid；无则 `-`
+- `status`: run status，第一阶段只会主要看到 `running`
+- `age`: 从 run.startedAt 到现在的时长
+
+## 4.2 推荐 flags
+
+第一阶段建议支持：
+
+- `--json`：返回结构化数据
+- `--type <worker|reviewer|fixer>`：按 loop type 过滤
+- `--project <projectId>`：按项目过滤
+- `--task <taskId>`：按 task 过滤
+- `--pr <repo>#<number>`：按 PR 过滤
+- `--watch`：每 2 秒刷新一次（可选，若首版想控 scope 可后置）
+- `-a, --all`：展示最近一小段非活跃 run（第二阶段）
+
+建议分阶段：
+
+- **Phase 1**：`looper ps`、`--json`、`--type`、`--project`
+- **Phase 2**：`--task`、`--pr`、`--watch`
+- **Phase 3**：`--all`
+
+## 4.3 命名选择
+
+建议直接使用顶级命令 `looper ps`，而不是：
+
+- `looper run active`
+- `looper agent list-active`
+- `looper status --running`
+
+原因：
+
+- `ps` 心智模型最短
+- 与用户提出的 `docker ps` 诉求一致
+- 适合作为“高频速览入口”
+
+同时不替代已有命令：
+
+- `looper ps` = 当前运行态速览
+- `looper run list` = 历史 run 列表
+- `looper task/pr status` = 单目标详情
+
+---
+
+## 5. 服务端接口设计
+
+建议新增聚合接口：
+
+```txt
+GET /api/v1/runs/active
+```
+
+这里返回的是 **active run view**，本质上仍然是 `runs` 资源的聚合视图，而不是新增一个叫 `process` 的领域对象。
+
+这样可以保持与现有模型一致：
+
+- `RunRecord`
+- `LoopRecord`
+- `AgentExecutionRecord`
+
+CLI 命令仍然叫：
+
+```bash
+looper ps
+```
+
+也就是：**CLI 用 `ps` 作为交互名称，API 仍用 `runs` 作为领域边界。**
+
+返回形态建议：
+
+```json
+{
+  "items": [
+    {
+      "runId": "run_101",
+      "loopId": "loop_1",
+      "projectId": "proj_1",
+      "type": "worker",
+      "status": "running",
+      "currentStep": "implement",
+      "startedAt": "2026-04-11T10:00:00.000Z",
+      "target": {
+        "type": "task",
+        "taskId": "task_12",
+        "label": "task_12"
+      },
+      "agent": {
+        "active": true,
+        "executionId": "agent_exec_1",
+        "vendor": "codex",
+        "pid": 81234,
+        "startedAt": "2026-04-11T10:01:10.000Z",
+        "lastHeartbeatAt": "2026-04-11T10:11:58.000Z",
+        "heartbeatCount": 31,
+        "status": "running"
+      }
+    }
+  ]
+}
+```
+
+查询参数建议：
+
+- `active=true`（默认）
+- `type=worker|reviewer|fixer`
+- `projectId=...`
+- `taskId=...`
+- `repo=...&prNumber=...`
+
+不建议第一阶段直接只返回原始 `/api/v1/runs` 记录，因为：
+
+1. `runs` 目前只返回原始 run record
+2. CLI 还需要 join loop / target / agent execution 才能形成可读视图
+3. 让 CLI 拼装会导致逻辑分散到多个客户端
+
+因此更合适的做法是由 looperd 提供一个**已聚合好的 active run view**，并把它挂在 `runs` 资源下。
+
+---
+
+## 6. 数据拼装逻辑
+
+服务端聚合时，建议基于以下事实：
+
+- `runs` 是当前 loop 执行态主记录
+- `loops` 持有 loop type 和 target 信息
+- `tasks` / `pull_requests` 提供 target 语义
+- `agent_executions.listActive()` 能提供当前活跃 agent 进程
+
+建议同时为 `runs` store 增加：
+
+- `listByStatus(status: string)`
+
+避免第一阶段通过 `runs.list()` 全量扫描历史记录后再过滤 `running`。
+
+建议聚合算法：
+
+1. 取 `runs.listByStatus("running")` 的记录
+2. 按 `run.loopId` 关联 `loop`
+3. 根据 `loop.targetType` 生成 `target.label`
+   - task: 优先展示 task title，其次再回退 task id
+   - PR: `<repo>#<prNumber>`
+4. 取 `agent_executions.listActive()`，按 `runId` 建索引
+5. 为每个 active run 附加最多一个“主活跃 agent execution”
+
+补充约束：
+
+- 响应中的 `type` 来自关联的 `loop.type`，不是 `run` 自身字段
+- `age` 不应由服务端返回预格式化字符串，而应由 CLI 基于 `startedAt` 计算相对时长
+
+关于“一条 run 是否会对应多个活跃 agent execution”：
+
+- 第一阶段按系统现状应视为**不应发生**
+- 若实际出现多个活跃 execution，接口应：
+  - 仍返回该 run 一条记录
+  - 选择最新 `startedAt` 的 execution 作为主展示对象
+  - 同时返回 `agent.activeCount`
+
+关于 `agentExecution.runId` 为空的情况：
+
+- `AgentExecutionRecord.runId` 当前是 nullable
+- 如果某个 active execution 还没有可靠绑定到 `runId`，则本接口 join 时应直接跳过
+- 不应因为这类瞬时中间态导致 `/api/v1/runs/active` 失败
+
+这样可以容忍异常态，又不让 CLI 表格爆炸。
+
+---
+
+## 7. 输出排序与可读性
+
+`looper ps` 默认排序建议：
+
+1. 有活跃 agent execution 的 run 排前面
+2. 同组内按 `run.startedAt` 升序（跑最久的在前）
+
+原因：
+
+- 先让用户看到真正占着 agent 进程的任务
+- 再让用户优先关注长时间运行项
+
+当没有任何运行中任务时，输出：
+
+```txt
+No running loops.
+```
+
+不要输出空表。
+
+---
+
+## 8. 与现有命令的职责边界
+
+## 8.1 不替代 `run list`
+
+`run list` 保留“run 审计列表”角色；它可以继续偏原始。
+
+`ps` 是高频操作视图，强调：
+
+- active only
+- 更强语义化 target
+- 附加 agent 状态
+
+## 8.2 不替代 `status`
+
+`looper status` 仍然负责系统级健康、调度、总体统计。
+
+`looper run list` 仍然负责 run 历史审计。
+
+`looper ps` 负责回答：
+
+- “现在谁在跑？”
+
+补充：如果用户还想看“还有哪些工作在排队”，第一阶段仍优先查看 `looper status`；后续可给 `ps` 增加 queued footer 或 `--queued`。
+
+## 8.3 为未来 Web UI 复用
+
+`/api/v1/runs/active` 后续可直接供 Web UI 的“Running Now”面板使用。
+
+因为 `apps/web` 目前还是占位实现，所以第一阶段先做 API + CLI 即可。
+
+---
+
+## 9. 实现范围建议
+
+## Phase 1（推荐先做）
+
+目标：先把“当前运行中任务一眼看清”做出来。
+
+包含：
+
+- 新增 `GET /api/v1/runs/active`
+- 新增 `looper ps`
+- 支持 `--json`
+- 支持 `--type`、`--project`
+- 表格输出 + 空态输出
+- 基础测试
+
+不包含：
+
+- TUI / curses 风格刷新
+- 复杂 watch 交互
+- 历史 exited/failed 列表
+- 杀进程 / 取消任务动作
+
+## Phase 2
+
+- `--task`
+- `--pr`
+- `--watch`
+- 表格中增加 heartbeat lag / branch / repo 等可选列
+
+## Phase 3
+
+- `looper ps -a`
+- 支持最近完成 / 失败项
+- 支持 “stuck” 判断（如 heartbeat 超时高亮）
+
+---
+
+## 10. 测试建议
+
+至少覆盖：
+
+1. 没有 active run 时返回空列表
+2. 有 active worker/reviewer/fixer 时能正确展示 type + target + step
+3. 有活跃 agent execution 时能正确 join vendor/pid/heartbeat
+4. run 在 running，但当前 step 无 agent 时，agent 列显示 `-`
+5. `--type` / `projectId` 过滤正确
+6. 多个 active agent execution 异常并存时，仍能稳定返回单条 run 记录
+7. active agent execution 的 `runId` 为空时被安全跳过
+8. task target 优先展示 title，缺失时回退 id
+
+---
+
+## 11. 后续可扩展点
+
+如果后面要继续向 `docker ps` 靠拢，可以逐步增加：
+
+- `COMMAND`：显示 agent command 摘要
+- `NAMES`：显示更友好的 loop label
+- `UPTIME`：区分 run uptime 与 agent uptime
+- `STATE`：`running / waiting-agent / validating / pushing / stuck`
+- queued footer / `--queued`
+- `looper logs --run <id>` 快速跳日志
+- `looper cancel <run-id>` 或 `looper kill <agent-exec-id>`
+- `looper ps --stuck`
+- `--watch` 后续可考虑 SSE，而不是只做轮询
+
+但这些都不应阻塞第一阶段落地。
+
+---
+
+## 12. 最终建议
+
+建议按以下最小闭环推进：
+
+1. looperd 新增 `/api/v1/runs/active` 聚合视图
+2. CLI 新增 `looper ps`
+3. 默认只展示 running runs
+4. 每行同时展示 loop 语义 + agent 摘要
+
+这样能用最小改动解决当前痛点，并为后续 Web “Running Now”面板复用同一数据模型。


### PR DESCRIPTION
## Summary
- add `GET /api/v1/runs/active` with active run + agent aggregation, filtering, and sorting
- add `looper ps` with JSON and table output for running work
- cover the new store, API, and CLI behavior with focused tests and update the implementation checklist

## Validation
- bun test apps/looperd/src/storage/sqlite/sqlite-store.test.ts apps/looperd/src/server/index.test.ts apps/cli/src/index.test.ts
- bun run typecheck
- bun x @biomejs/biome check \"apps/cli/src/index.ts\" \"apps/cli/src/index.test.ts\" \"apps/looperd/src/server/index.ts\" \"apps/looperd/src/server/index.test.ts\" \"apps/looperd/src/storage/sqlite/sqlite-store.ts\" \"apps/looperd/src/storage/store.ts\" \"apps/looperd/src/storage/sqlite/sqlite-store.test.ts\"