### PR TITLE
fix: retry recovery after PR head changes

### DIFF
--- a/apps/looperd/src/fixer/index.test.ts
+++ b/apps/looperd/src/fixer/index.test.ts
@@ -1215,6 +1215,93 @@ describe("FixerLoopRunner", () => {
     fixture.store.close();
   });
 
+  test("restarts from discover-pr after push remote-head changes to refresh expected head", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway({
+      views: [
+        {
+          comments: [{ id: "c1", threadId: "thread-1", state: "UNRESOLVED" }],
+          checks: [],
+          headSha: "abc123",
+        },
+        {
+          comments: [{ id: "c1", threadId: "thread-1", state: "UNRESOLVED" }],
+          checks: [],
+          headSha: "abc123",
+        },
+        {
+          comments: [{ id: "c1", threadId: "thread-1", state: "UNRESOLVED" }],
+          checks: [],
+          headSha: "new-head",
+        },
+        {
+          comments: [{ id: "c1", threadId: "thread-1", state: "UNRESOLVED" }],
+          checks: [],
+          headSha: "commit-1",
+        },
+        { comments: [], checks: [], headSha: "commit-1" },
+        { comments: [], checks: [], headSha: "commit-1" },
+      ],
+    });
+    const git = new FakeGitGateway({
+      pushError:
+        "Remote head changed for feature/fixer: expected abc123, got new-head",
+    });
+    git.prepareWorktree = async (input) => {
+      git.prepareCalls += 1;
+      if (git.prepareCalls === 2 && input.expectedHeadSha !== "new-head") {
+        throw new RemoteHeadChangedError(
+          input.branch,
+          input.expectedHeadSha,
+          "new-head",
+        );
+      }
+      return { headSha: input.expectedHeadSha, clean: true };
+    };
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("fixed-on-old-head"),
+      completedAgentResult("fixed-on-new-head"),
+    ]);
+    const runner = new FixerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      git,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      validationRunner: async (): Promise<FixerValidationResult> => ({
+        passed: true,
+        summary: "ok",
+      }),
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const firstClaim = fixture.queue.claimNext("fixer-1");
+    if (!firstClaim) throw new Error("Expected first fixer claim");
+
+    const first = await runner.processClaimedItem(firstClaim);
+    expect(first.status).toBe("failed");
+    expect(first.failureKind).toBe("retryable_after_resume");
+    expect(agent.starts).toHaveLength(1);
+
+    fixture.now.setTime(new Date("2026-04-11T12:00:05.000Z").getTime());
+    git.pushError = undefined;
+    const retryClaim = fixture.queue.claimNext("fixer-1");
+    if (!retryClaim) throw new Error("Expected retry fixer claim");
+
+    const retry = await runner.processClaimedItem(retryClaim);
+    expect(retry.status).toBe("success");
+    expect(agent.starts).toHaveLength(2);
+    expect(git.prepareCalls).toBe(2);
+    expect(github.viewCalls).toBeGreaterThanOrEqual(4);
+
+    fixture.store.close();
+  });
+
   test("retries resolve-comments head changes from discover-pr with fresh PR detail", async () => {
     const fixture = await createFixture();
     const github = new FakeGitHubGateway({

--- a/apps/looperd/src/fixer/index.ts
+++ b/apps/looperd/src/fixer/index.ts
@@ -2097,6 +2097,10 @@ function shouldRestartFromDiscovery(input: {
     return true;
   }
 
+  if (input.failedStep === "push") {
+    return (input.failureSummary ?? "").includes("Remote head changed");
+  }
+
   if (input.failedStep !== "resolve-comments") {
     return false;
   }

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -66,6 +66,7 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
     body?: string;
   }> = [];
   public submitFailuresRemaining = 0;
+  public viewFailuresRemaining = 0;
 
   constructor(
     private readonly options: {
@@ -115,6 +116,11 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
   }
 
   public async viewPullRequest() {
+    if (this.viewFailuresRemaining > 0) {
+      this.viewFailuresRemaining -= 1;
+      throw new Error("temporary GitHub lookup failure");
+    }
+
     return {
       number: 42,
       title: "Review me",
@@ -465,6 +471,77 @@ describe("ReviewerLoopRunner", () => {
     ).toMatchObject({
       lastPublishedHeadSha: "abc123",
     });
+
+    fixture.store.close();
+  });
+
+  test("retries publish when PR head recheck fails before submit", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    const originalViewPullRequest = github.viewPullRequest.bind(github);
+    let viewCalls = 0;
+    github.viewPullRequest = async () => {
+      viewCalls += 1;
+      if (viewCalls === 2) {
+        throw new Error("temporary GitHub lookup failure");
+      }
+
+      return originalViewPullRequest();
+    };
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Please add tests"),
+    ]);
+    const logs = createCapturingLogger();
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: logs.logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const firstClaim = fixture.queue.claimNext("reviewer-worker-1");
+    if (!firstClaim) {
+      throw new Error("Expected first reviewer claim");
+    }
+    const firstResult = await runner.processClaimedItem(firstClaim);
+
+    expect(firstResult.status).toBe("failed");
+    expect(firstResult.failureKind).toBe("retryable_after_resume");
+    expect(firstResult.summary).toBe("temporary GitHub lookup failure");
+    expect(agent.starts).toHaveLength(1);
+    expect(github.submitCalls).toHaveLength(0);
+
+    const firstRun = fixture.store.runs.listByLoop(firstResult.loopId)[0];
+    const firstCheckpoint = JSON.parse(firstRun?.checkpointJson ?? "{}");
+    expect(firstRun?.lastCompletedStep).toBe("review");
+    expect(firstCheckpoint.pendingReview.body).toContain("Please add tests");
+    const failedLog = logs.entries.find(
+      (entry) =>
+        entry.level === "error" && entry.message === "reviewer run failed",
+    );
+    expect(failedLog?.context).toMatchObject({
+      failureKind: "retryable_after_resume",
+      currentStep: "publish",
+    });
+
+    fixture.now.setTime(new Date("2026-04-11T12:00:05.000Z").getTime());
+    const retryClaim = fixture.queue.claimNext("reviewer-worker-1");
+    if (!retryClaim) {
+      throw new Error("Expected retry reviewer claim");
+    }
+    const retryResult = await runner.processClaimedItem(retryClaim);
+
+    expect(retryResult.status).toBe("success");
+    expect(retryResult.failureKind).toBeUndefined();
+    expect(agent.starts).toHaveLength(1);
+    expect(github.submitCalls).toHaveLength(1);
+    expect(github.submitCalls[0]?.body).toContain("Please add tests");
 
     fixture.store.close();
   });

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -469,6 +469,102 @@ describe("ReviewerLoopRunner", () => {
     fixture.store.close();
   });
 
+  test("restarts from discover when PR head changes before publish", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    let viewCalls = 0;
+    github.viewPullRequest = async () => {
+      viewCalls += 1;
+      const headSha = viewCalls >= 2 ? "new-head" : "abc123";
+      return {
+        number: 42,
+        title: "Review me",
+        body: "PR body",
+        url: "https://example.test/pr/42",
+        state: "OPEN",
+        isDraft: false,
+        reviewDecision: undefined,
+        headRefName: "feature",
+        baseRefName: "main",
+        headSha,
+        baseSha: "base123",
+        author: "octocat",
+        reviewRequests: ["octocat"],
+        comments: [],
+        reviews: [],
+        checks: [{ conclusion: "SUCCESS" }],
+      };
+    };
+    github.capturePullRequestSnapshot = async (input) => ({
+      id: `snapshot:${input.prNumber}:${input.capturedAt}`,
+      projectId: input.projectId,
+      repo: input.repo,
+      prNumber: input.prNumber,
+      headSha: viewCalls >= 2 ? "new-head" : "abc123",
+      baseSha: "base123",
+      title: "Review me",
+      body: "PR body",
+      author: "octocat",
+      diffRef: "gh:diff",
+      checksSummary: "SUCCESS",
+      unresolvedThreadCount: 0,
+      reviewState: null,
+      payloadJson: JSON.stringify({ diff: "diff --git a/a.ts b/a.ts" }),
+      capturedAt: input.capturedAt ?? "2026-04-11T12:00:00.000Z",
+      createdAt: input.capturedAt ?? "2026-04-11T12:00:00.000Z",
+    });
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Review old head"),
+      completedAgentResult("Review new head"),
+    ]);
+    const logs = createCapturingLogger();
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: logs.logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const firstClaim = fixture.queue.claimNext("reviewer-worker-1");
+    if (!firstClaim) {
+      throw new Error("Expected first reviewer claim");
+    }
+    const firstResult = await runner.processClaimedItem(firstClaim);
+
+    expect(firstResult.status).toBe("failed");
+    expect(firstResult.failureKind).toBe("retryable_after_resume");
+    expect(firstResult.summary).toContain("PR head changed before publish");
+    expect(agent.starts).toHaveLength(1);
+    expect(github.submitCalls).toHaveLength(0);
+
+    fixture.now.setTime(new Date("2026-04-11T12:00:05.000Z").getTime());
+    const retryClaim = fixture.queue.claimNext("reviewer-worker-1");
+    if (!retryClaim) {
+      throw new Error("Expected retry reviewer claim");
+    }
+    const retryResult = await runner.processClaimedItem(retryClaim);
+
+    expect(retryResult.status).toBe("success");
+    expect(agent.starts).toHaveLength(2);
+    expect(github.submitCalls).toHaveLength(1);
+    expect(github.submitCalls[0]?.body).toContain("Review new head");
+    expect(
+      JSON.parse(
+        fixture.store.loops.getById(retryResult.loopId)?.metadataJson ?? "{}",
+      ),
+    ).toMatchObject({
+      lastPublishedHeadSha: "new-head",
+    });
+
+    fixture.store.close();
+  });
+
   test("auto-discovery enqueues only when current user is requested", async () => {
     const fixture = await createFixture();
     const github = new FakeGitHubGateway({

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -792,19 +792,19 @@ export class ReviewerLoopRunner {
       input.queueItem.prNumber,
       "queueItem.prNumber",
     );
-    const detail = await this.options.github.viewPullRequest({
-      repo,
-      prNumber,
-      cwd: input.project.repoPath,
-    });
-    if (detail.headSha && detail.headSha !== pendingReview.headSha) {
-      throw new ReviewerLoopError(
-        `PR head changed before publish: expected ${pendingReview.headSha}, got ${detail.headSha}`,
-        "retryable_after_resume",
-      );
-    }
-
     try {
+      const detail = await this.options.github.viewPullRequest({
+        repo,
+        prNumber,
+        cwd: input.project.repoPath,
+      });
+      if (detail.headSha && detail.headSha !== pendingReview.headSha) {
+        throw new ReviewerLoopError(
+          `PR head changed before publish: expected ${pendingReview.headSha}, got ${detail.headSha}`,
+          "retryable_after_resume",
+        );
+      }
+
       await this.options.github.submitReview({
         repo,
         prNumber,

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -787,12 +787,24 @@ export class ReviewerLoopRunner {
         ? "COMMENT"
         : pendingReview.event;
 
-    try {
-      const repo = requireString(input.queueItem.repo, "queueItem.repo");
-      const prNumber = requireNumber(
-        input.queueItem.prNumber,
-        "queueItem.prNumber",
+    const repo = requireString(input.queueItem.repo, "queueItem.repo");
+    const prNumber = requireNumber(
+      input.queueItem.prNumber,
+      "queueItem.prNumber",
+    );
+    const detail = await this.options.github.viewPullRequest({
+      repo,
+      prNumber,
+      cwd: input.project.repoPath,
+    });
+    if (detail.headSha && detail.headSha !== pendingReview.headSha) {
+      throw new ReviewerLoopError(
+        `PR head changed before publish: expected ${pendingReview.headSha}, got ${detail.headSha}`,
+        "retryable_after_resume",
       );
+    }
+
+    try {
       await this.options.github.submitReview({
         repo,
         prNumber,
@@ -846,11 +858,22 @@ export class ReviewerLoopRunner {
     const nowIso = this.nowIso();
     const checkpoint = parseCheckpoint(latestRun?.checkpointJson);
     const lastCompletedStep = asReviewerStep(latestRun?.lastCompletedStep);
+    const failedStep = asReviewerStep(latestRun?.currentStep);
+    const restartFromDiscover = shouldRestartFromDiscover({
+      latestRunStatus: latestRun?.status,
+      failedStep,
+      failureSummary: latestRun?.summary ?? latestRun?.errorMessage,
+    });
+    const resumedStep = lastCompletedStep
+      ? (nextReviewerStep(lastCompletedStep) ?? "discover")
+      : "discover";
     const startStep =
       latestRun &&
       (latestRun.status === "failed" || latestRun.status === "interrupted") &&
-      lastCompletedStep
-        ? (nextReviewerStep(lastCompletedStep) ?? "discover")
+      (restartFromDiscover || lastCompletedStep)
+        ? restartFromDiscover
+          ? "discover"
+          : resumedStep
         : "discover";
     const resumed =
       Boolean(latestRun) &&
@@ -862,10 +885,21 @@ export class ReviewerLoopRunner {
       loopId: loop.id,
       status: "running",
       currentStep: startStep,
-      lastCompletedStep: resumed ? (lastCompletedStep ?? null) : null,
+      lastCompletedStep: resumed
+        ? restartFromDiscover
+          ? null
+          : (lastCompletedStep ?? null)
+        : null,
       checkpointJson: JSON.stringify(
         resumed
-          ? { ...checkpoint, resumePolicy: "advance_from_checkpoint" }
+          ? {
+              ...(restartFromDiscover
+                ? { resumePolicy: "replay_step" }
+                : checkpoint),
+              resumePolicy: restartFromDiscover
+                ? "replay_step"
+                : "advance_from_checkpoint",
+            }
           : { resumePolicy: "replay_step" },
       ),
       summary: null,
@@ -1084,6 +1118,24 @@ export class ReviewerLoopRunner {
   private nowIso(): string {
     return this.now().toISOString();
   }
+}
+
+function shouldRestartFromDiscover(input: {
+  latestRunStatus?: string | null;
+  failedStep: ReviewerStep | null;
+  failureSummary?: string | null;
+}): boolean {
+  if (
+    input.latestRunStatus !== "failed" &&
+    input.latestRunStatus !== "interrupted"
+  ) {
+    return false;
+  }
+
+  return (
+    input.failedStep === "publish" &&
+    (input.failureSummary ?? "").includes("PR head changed before publish")
+  );
 }
 
 function buildPullRequestTargetId(repo: string, prNumber: number): string {


### PR DESCRIPTION
## Summary
- restart fixer from PR discovery after push remote-head changes so retries refresh the expected head before rebuilding the worktree
- revalidate reviewer PR head before publish and restart from discovery when the head changed so reviews are regenerated against the latest snapshot
- add regression coverage for the fixer and reviewer retry paths; worker behavior remains unchanged because it pushes a worker-owned branch

## Testing
- bun test apps/looperd/src/fixer/index.test.ts
- bun test apps/looperd/src/reviewer/index.test.ts apps/looperd/src/worker/index.test.ts