### PR TITLE
Fix planner publish flow, planner naming, and reviewer rediscovery

### DIFF
--- a/apps/looperd/src/infra/github.test.ts
+++ b/apps/looperd/src/infra/github.test.ts
@@ -29,11 +29,23 @@ describe("GhCliGitHubGateway", () => {
   "pr list"*)
     printf '[{"number":42,"title":"Review me","url":"https://example.test/pr/42","state":"OPEN","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","author":{"login":"octocat"},"reviewRequests":[{"__typename":"User","login":"OctoCat"},{"__typename":"Team","slug":"platform"}]}]'
     ;;
+  "label create"*)
+    printf '{}'
+    ;;
   "issue list"*)
     printf '[{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","author":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}]'
     ;;
   "issue view"*)
     printf '{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","author":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}'
+    ;;
+  "api repos/acme/looper/issues/42/labels --method POST -f labels[]=phase-1 -f labels[]=ready")
+    printf '{}'
+    ;;
+  "api repos/acme/looper/issues/42/labels/needs-work --method DELETE")
+    printf '{}'
+    ;;
+  "api repos/acme/looper/pulls/42/requested_reviewers --method POST -f reviewers[]=reviewer")
+    printf '{}'
     ;;
   "pr view"*)
     printf '{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pr/42","state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"state":"UNRESOLVED"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}'
@@ -140,13 +152,19 @@ esac\n`,
     );
     expect(log).toContain("issue view 8 --repo acme/looper");
     expect(log).toContain(
-      "pr edit 42 --repo acme/looper --add-label phase-1,ready",
+      "label create phase-1 --repo acme/looper --color 5319e7 --description Managed by looper --force",
     );
     expect(log).toContain(
-      "pr edit 42 --repo acme/looper --remove-label needs-work",
+      "label create ready --repo acme/looper --color 5319e7 --description Managed by looper --force",
     );
     expect(log).toContain(
-      "pr edit 42 --repo acme/looper --add-reviewer reviewer",
+      "api repos/acme/looper/issues/42/labels --method POST -f labels[]=phase-1 -f labels[]=ready",
+    );
+    expect(log).toContain(
+      "api repos/acme/looper/issues/42/labels/needs-work --method DELETE",
+    );
+    expect(log).toContain(
+      "api repos/acme/looper/pulls/42/requested_reviewers --method POST -f reviewers[]=reviewer",
     );
     expect(log).toContain("threadId=thread-1");
   });

--- a/apps/looperd/src/infra/github.test.ts
+++ b/apps/looperd/src/infra/github.test.ts
@@ -238,4 +238,39 @@ esac
       }),
     ).rejects.toThrow("Command exited with code 1");
   });
+
+  test("ignores missing label errors when removing pull request labels", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-gh-"));
+    cleanupPaths.push(rootDir);
+
+    const scriptPath = join(rootDir, "gh");
+    await writeFile(
+      scriptPath,
+      `#!/bin/sh
+case "$*" in
+  "api repos/acme/looper/issues/42/labels/looper%3Aspec-ready --method DELETE")
+    printf 'gh: HTTP 404: label does not exist (https://api.github.com/...)' >&2
+    exit 1
+    ;;
+  *)
+    printf '{}'
+    ;;
+esac
+`,
+    );
+    await chmod(scriptPath, 0o755);
+
+    const gateway = new GhCliGitHubGateway({
+      ghPath: scriptPath,
+      cwd: rootDir,
+    });
+
+    await expect(
+      gateway.removePullRequestLabels({
+        repo: "acme/looper",
+        prNumber: 42,
+        labels: ["looper:spec-ready"],
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/looperd/src/infra/github.ts
+++ b/apps/looperd/src/infra/github.ts
@@ -19,6 +19,7 @@ export interface GitHubPullRequestSummary {
   labels: string[];
   headRefName?: string;
   baseRefName?: string;
+  headSha?: string;
   author?: string;
   reviewRequests: string[];
 }
@@ -112,6 +113,7 @@ export class GhCliGitHubGateway {
         "labels",
         "headRefName",
         "baseRefName",
+        "headRefOid",
         "author",
         "reviewRequests",
       ].join(","),
@@ -129,6 +131,7 @@ export class GhCliGitHubGateway {
       labels: extractLabelNames(item.labels),
       headRefName: asOptionalString(item.headRefName),
       baseRefName: asOptionalString(item.baseRefName),
+      headSha: asOptionalString(item.headRefOid),
       author: extractAuthor(item.author),
       reviewRequests: extractReviewRequestLogins(item.reviewRequests),
     }));

--- a/apps/looperd/src/infra/github.ts
+++ b/apps/looperd/src/infra/github.ts
@@ -400,15 +400,22 @@ export class GhCliGitHubGateway {
     }
 
     for (const label of input.labels) {
-      await this.runGh(
-        [
-          "api",
-          `repos/${input.repo}/issues/${input.prNumber}/labels/${encodeURIComponent(label)}`,
-          "--method",
-          "DELETE",
-        ],
-        input.cwd,
-      );
+      try {
+        await this.runGh(
+          [
+            "api",
+            `repos/${input.repo}/issues/${input.prNumber}/labels/${encodeURIComponent(label)}`,
+            "--method",
+            "DELETE",
+          ],
+          input.cwd,
+        );
+      } catch (error) {
+        if (isMissingPullRequestLabelDelete(error)) {
+          continue;
+        }
+        throw error;
+      }
     }
   }
 
@@ -870,4 +877,13 @@ function parsePrNumberFromUrl(url: string): number | undefined {
 
   const value = Number(match[1]);
   return Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function isMissingPullRequestLabelDelete(error: unknown): boolean {
+  if (!(error instanceof CommandExecutionError)) {
+    return false;
+  }
+
+  const output = `${error.result.stdout}\n${error.result.stderr}`.toLowerCase();
+  return output.includes("404") && output.includes("label");
 }

--- a/apps/looperd/src/infra/github.ts
+++ b/apps/looperd/src/infra/github.ts
@@ -373,15 +373,14 @@ export class GhCliGitHubGateway {
       return;
     }
 
+    await this.ensureLabelsExist(input.repo, input.labels, input.cwd);
     await this.runGh(
       [
-        "pr",
-        "edit",
-        String(input.prNumber),
-        "--repo",
-        input.repo,
-        "--add-label",
-        input.labels.join(","),
+        "api",
+        `repos/${input.repo}/issues/${input.prNumber}/labels`,
+        "--method",
+        "POST",
+        ...input.labels.flatMap((label) => ["-f", `labels[]=${label}`]),
       ],
       input.cwd,
     );
@@ -397,18 +396,17 @@ export class GhCliGitHubGateway {
       return;
     }
 
-    await this.runGh(
-      [
-        "pr",
-        "edit",
-        String(input.prNumber),
-        "--repo",
-        input.repo,
-        "--remove-label",
-        input.labels.join(","),
-      ],
-      input.cwd,
-    );
+    for (const label of input.labels) {
+      await this.runGh(
+        [
+          "api",
+          `repos/${input.repo}/issues/${input.prNumber}/labels/${encodeURIComponent(label)}`,
+          "--method",
+          "DELETE",
+        ],
+        input.cwd,
+      );
+    }
   }
 
   public async addPullRequestReviewers(input: {
@@ -423,13 +421,14 @@ export class GhCliGitHubGateway {
 
     await this.runGh(
       [
-        "pr",
-        "edit",
-        String(input.prNumber),
-        "--repo",
-        input.repo,
-        "--add-reviewer",
-        input.reviewers.join(","),
+        "api",
+        `repos/${input.repo}/pulls/${input.prNumber}/requested_reviewers`,
+        "--method",
+        "POST",
+        ...input.reviewers.flatMap((reviewer) => [
+          "-f",
+          `reviewers[]=${reviewer}`,
+        ]),
       ],
       input.cwd,
     );
@@ -611,6 +610,34 @@ export class GhCliGitHubGateway {
       cwd: cwd ?? this.options.cwd,
     });
   }
+
+  private async ensureLabelsExist(
+    repo: string,
+    labels: string[],
+    cwd?: string,
+  ): Promise<void> {
+    const uniqueLabels = labels.filter(
+      (label, index, values) => values.indexOf(label) === index,
+    );
+
+    for (const label of uniqueLabels) {
+      await this.runGh(
+        [
+          "label",
+          "create",
+          label,
+          "--repo",
+          repo,
+          "--color",
+          resolveLabelColor(label),
+          "--description",
+          resolveLabelDescription(label),
+          "--force",
+        ],
+        cwd,
+      );
+    }
+  }
 }
 
 interface ReviewThreadNode {
@@ -685,6 +712,36 @@ function parseRepo(repo: string): { owner: string; name: string } {
     throw new Error(`Invalid GitHub repo: ${repo}`);
   }
   return { owner, name };
+}
+
+function resolveLabelColor(label: string): string {
+  switch (label.trim().toLowerCase()) {
+    case "looper:plan":
+      return "5319e7";
+    case "looper:spec-reviewing":
+      return "1d76db";
+    case "looper:spec-ready":
+      return "0e8a16";
+    case "looper:needs-human":
+      return "d93f0b";
+    default:
+      return "5319e7";
+  }
+}
+
+function resolveLabelDescription(label: string): string {
+  switch (label.trim().toLowerCase()) {
+    case "looper:plan":
+      return "Picked up automatically by planner";
+    case "looper:spec-reviewing":
+      return "Spec PR is under review";
+    case "looper:spec-ready":
+      return "Spec PR is ready for implementation";
+    case "looper:needs-human":
+      return "Looper requires manual intervention";
+    default:
+      return "Managed by looper";
+  }
 }
 
 function asObject(value: string): Record<string, unknown> {

--- a/apps/looperd/src/planner/index.test.ts
+++ b/apps/looperd/src/planner/index.test.ts
@@ -338,7 +338,7 @@ describe("PlannerLoopRunner", () => {
     expect(result.queueItems[0]?.dedupeKey).toBe("planner:acme/looper:123");
     expect(fixture.store.loops.list()[0]?.targetType).toBe("issue");
     expect(fixture.store.loops.list()[0]?.metadataJson).toContain(
-      "specs/123-add-planner-flow/spec.md",
+      "specs/2026-04-12-add-planner-flow.md",
     );
 
     fixture.store.close();
@@ -425,12 +425,12 @@ describe("PlannerLoopRunner", () => {
     expect(git.pushCalls).toBe(1);
     expect(agent.starts).toHaveLength(1);
     expect(agent.starts[0]?.prompt).toContain(
-      "Spec path: specs/123-add-planner-flow/spec.md",
+      "Spec path: specs/2026-04-12-add-planner-flow.md",
     );
     expect(agent.starts[0]?.prompt).toContain("AGENTS.md:");
     expect(github.createPullRequestCalls).toHaveLength(1);
     expect(github.createPullRequestCalls[0]?.body).toContain(
-      "Spec: specs/123-add-planner-flow/spec.md",
+      "Spec: specs/2026-04-12-add-planner-flow.md",
     );
     expect(github.addLabelCalls).toEqual([
       {
@@ -449,7 +449,9 @@ describe("PlannerLoopRunner", () => {
     expect(fixture.store.loops.getById("loop_planner_missing")).toBeNull();
     const loop = fixture.store.loops.list()[0];
     expect(loop?.prNumber).toBe(77);
-    expect(loop?.metadataJson).toContain("specs/123-add-planner-flow/spec.md");
+    expect(loop?.metadataJson).toContain(
+      "specs/2026-04-12-add-planner-flow.md",
+    );
 
     fixture.store.close();
   });
@@ -468,7 +470,7 @@ describe("PlannerLoopRunner", () => {
       status: "queued",
       configJson: null,
       metadataJson: JSON.stringify({
-        specPath: "specs/123-add-planner-flow/spec.md",
+        specPath: "specs/2026-04-12-add-planner-flow.md",
         prUrl: "https://example.test/acme/looper/pull/77",
       }),
       lastRunAt: null,
@@ -494,7 +496,7 @@ describe("PlannerLoopRunner", () => {
           assignees: ["octocat"],
           labels: ["looper:plan"],
           currentUserLogin: "octocat",
-          specPath: "specs/123-add-planner-flow/spec.md",
+          specPath: "specs/2026-04-12-add-planner-flow.md",
           requestedReviewers: ["review-bot"],
         },
         worktree: {
@@ -502,12 +504,12 @@ describe("PlannerLoopRunner", () => {
           path: fixture.worktreeRoot,
           branch: "looper/planner/123-add-planner-flow",
           baseBranch: "main",
-          specPath: "specs/123-add-planner-flow/spec.md",
+          specPath: "specs/2026-04-12-add-planner-flow.md",
         },
         writeSpec: {
           status: "completed",
           summary: "Spec committed",
-          changedFiles: ["specs/123-add-planner-flow/spec.md"],
+          changedFiles: ["specs/2026-04-12-add-planner-flow.md"],
           commits: ["abc123"],
           stdout: "Spec committed\n",
         },
@@ -516,7 +518,7 @@ describe("PlannerLoopRunner", () => {
           pullRequest: {
             number: 77,
             url: "https://example.test/acme/looper/pull/77",
-            body: "Spec: specs/123-add-planner-flow/spec.md",
+            body: "Spec: specs/2026-04-12-add-planner-flow.md",
           },
           labelsAdded: [],
           reviewersAdded: [],
@@ -672,7 +674,7 @@ describe("PlannerLoopRunner", () => {
       status: "paused",
       configJson: null,
       metadataJson: JSON.stringify({
-        specPath: "specs/123-add-planner-flow/spec.md",
+        specPath: "specs/2026-04-12-add-planner-flow.md",
       }),
       lastRunAt: nowIso,
       nextRunAt: null,
@@ -690,7 +692,7 @@ describe("PlannerLoopRunner", () => {
       status: "completed",
       configJson: null,
       metadataJson: JSON.stringify({
-        specPath: "specs/124-add-planner-flow/spec.md",
+        specPath: "specs/2026-04-12-add-another-planner-flow.md",
       }),
       lastRunAt: nowIso,
       nextRunAt: null,
@@ -770,6 +772,64 @@ describe("PlannerLoopRunner", () => {
     const runs = fixture.store.runs.listByLoop(result.loopId);
     expect(runs[0]?.status).toBe("failed");
     expect(fixture.store.loops.getById(result.loopId)?.status).toBe("queued");
+
+    fixture.store.close();
+  });
+
+  test("truncates planner spec paths and branch slugs to four words", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway({
+      issues: [
+        {
+          number: 123,
+          title:
+            "Let agents create their own git commits with looperd as fallback",
+          body: "Implement planning loop",
+          url: "https://example.test/acme/looper/issues/123",
+          assignees: ["octocat"],
+          labels: ["looper:plan"],
+        },
+      ],
+      currentUserLogin: "octocat",
+    });
+    const git = new FakeGitGateway(fixture.worktreeRoot);
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Spec committed"),
+    ]);
+    const runner = new PlannerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverIssues();
+    const claimed = fixture.queue.claimNext("planner-1");
+    if (!claimed) {
+      throw new Error("Expected planner queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(agent.starts[0]?.prompt).toContain(
+      "Spec path: specs/2026-04-12-let-agents-create-their.md",
+    );
+
+    const latestRun = fixture.store.runs.listByLoop(result.loopId)[0];
+    const checkpoint = latestRun?.checkpointJson
+      ? JSON.parse(latestRun.checkpointJson)
+      : null;
+
+    expect(checkpoint?.worktree?.branch).toBe(
+      "looper/planner/123-let-agents-create-their",
+    );
+    expect(checkpoint?.issue?.specPath).toBe(
+      "specs/2026-04-12-let-agents-create-their.md",
+    );
 
     fixture.store.close();
   });

--- a/apps/looperd/src/planner/index.test.ts
+++ b/apps/looperd/src/planner/index.test.ts
@@ -338,7 +338,54 @@ describe("PlannerLoopRunner", () => {
     expect(result.queueItems[0]?.dedupeKey).toBe("planner:acme/looper:123");
     expect(fixture.store.loops.list()[0]?.targetType).toBe("issue");
     expect(fixture.store.loops.list()[0]?.metadataJson).toContain(
-      "specs/2026-04-12-add-planner-flow.md",
+      "specs/2026-04-12-123-add-planner-flow.md",
+    );
+
+    fixture.store.close();
+  });
+
+  test("builds unique spec paths for same-title issues", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway({
+      issues: [
+        {
+          number: 123,
+          title: "Add planner flow",
+          assignees: ["octocat"],
+          labels: ["looper:plan"],
+        },
+        {
+          number: 124,
+          title: "Add planner flow",
+          assignees: ["octocat"],
+          labels: ["looper:plan"],
+        },
+      ],
+      currentUserLogin: "octocat",
+    });
+    const runner = new PlannerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git: new FakeGitGateway(fixture.worktreeRoot),
+      github,
+      agentExecutor: new FakeAgentExecutor([
+        completedAgentResult("wrote spec"),
+      ]),
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    const result = await runner.discoverIssues();
+
+    expect(result.createdLoopIds).toHaveLength(2);
+    const loopMetadata = fixture.store.loops
+      .list()
+      .map((loop) => loop.metadataJson ?? "");
+    expect(loopMetadata).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("specs/2026-04-12-123-add-planner-flow.md"),
+        expect.stringContaining("specs/2026-04-12-124-add-planner-flow.md"),
+      ]),
     );
 
     fixture.store.close();
@@ -425,12 +472,12 @@ describe("PlannerLoopRunner", () => {
     expect(git.pushCalls).toBe(1);
     expect(agent.starts).toHaveLength(1);
     expect(agent.starts[0]?.prompt).toContain(
-      "Spec path: specs/2026-04-12-add-planner-flow.md",
+      "Spec path: specs/2026-04-12-123-add-planner-flow.md",
     );
     expect(agent.starts[0]?.prompt).toContain("AGENTS.md:");
     expect(github.createPullRequestCalls).toHaveLength(1);
     expect(github.createPullRequestCalls[0]?.body).toContain(
-      "Spec: specs/2026-04-12-add-planner-flow.md",
+      "Spec: specs/2026-04-12-123-add-planner-flow.md",
     );
     expect(github.addLabelCalls).toEqual([
       {
@@ -450,7 +497,7 @@ describe("PlannerLoopRunner", () => {
     const loop = fixture.store.loops.list()[0];
     expect(loop?.prNumber).toBe(77);
     expect(loop?.metadataJson).toContain(
-      "specs/2026-04-12-add-planner-flow.md",
+      "specs/2026-04-12-123-add-planner-flow.md",
     );
 
     fixture.store.close();
@@ -470,7 +517,7 @@ describe("PlannerLoopRunner", () => {
       status: "queued",
       configJson: null,
       metadataJson: JSON.stringify({
-        specPath: "specs/2026-04-12-add-planner-flow.md",
+        specPath: "specs/2026-04-12-123-add-planner-flow.md",
         prUrl: "https://example.test/acme/looper/pull/77",
       }),
       lastRunAt: null,
@@ -496,7 +543,7 @@ describe("PlannerLoopRunner", () => {
           assignees: ["octocat"],
           labels: ["looper:plan"],
           currentUserLogin: "octocat",
-          specPath: "specs/2026-04-12-add-planner-flow.md",
+          specPath: "specs/2026-04-12-123-add-planner-flow.md",
           requestedReviewers: ["review-bot"],
         },
         worktree: {
@@ -504,12 +551,12 @@ describe("PlannerLoopRunner", () => {
           path: fixture.worktreeRoot,
           branch: "looper/planner/123-add-planner-flow",
           baseBranch: "main",
-          specPath: "specs/2026-04-12-add-planner-flow.md",
+          specPath: "specs/2026-04-12-123-add-planner-flow.md",
         },
         writeSpec: {
           status: "completed",
           summary: "Spec committed",
-          changedFiles: ["specs/2026-04-12-add-planner-flow.md"],
+          changedFiles: ["specs/2026-04-12-123-add-planner-flow.md"],
           commits: ["abc123"],
           stdout: "Spec committed\n",
         },
@@ -518,7 +565,7 @@ describe("PlannerLoopRunner", () => {
           pullRequest: {
             number: 77,
             url: "https://example.test/acme/looper/pull/77",
-            body: "Spec: specs/2026-04-12-add-planner-flow.md",
+            body: "Spec: specs/2026-04-12-123-add-planner-flow.md",
           },
           labelsAdded: [],
           reviewersAdded: [],
@@ -674,7 +721,7 @@ describe("PlannerLoopRunner", () => {
       status: "paused",
       configJson: null,
       metadataJson: JSON.stringify({
-        specPath: "specs/2026-04-12-add-planner-flow.md",
+        specPath: "specs/2026-04-12-123-add-planner-flow.md",
       }),
       lastRunAt: nowIso,
       nextRunAt: null,
@@ -692,7 +739,7 @@ describe("PlannerLoopRunner", () => {
       status: "completed",
       configJson: null,
       metadataJson: JSON.stringify({
-        specPath: "specs/2026-04-12-add-another-planner-flow.md",
+        specPath: "specs/2026-04-12-124-add-another-planner-flow.md",
       }),
       lastRunAt: nowIso,
       nextRunAt: null,
@@ -816,7 +863,7 @@ describe("PlannerLoopRunner", () => {
 
     expect(result.status).toBe("success");
     expect(agent.starts[0]?.prompt).toContain(
-      "Spec path: specs/2026-04-12-let-agents-create-their.md",
+      "Spec path: specs/2026-04-12-123-let-agents-create-their.md",
     );
 
     const latestRun = fixture.store.runs.listByLoop(result.loopId)[0];
@@ -828,7 +875,7 @@ describe("PlannerLoopRunner", () => {
       "looper/planner/123-let-agents-create-their",
     );
     expect(checkpoint?.issue?.specPath).toBe(
-      "specs/2026-04-12-let-agents-create-their.md",
+      "specs/2026-04-12-123-let-agents-create-their.md",
     );
 
     fixture.store.close();

--- a/apps/looperd/src/planner/index.ts
+++ b/apps/looperd/src/planner/index.ts
@@ -546,7 +546,7 @@ export class PlannerLoopRunner {
           assignees: detail.assignees,
           labels: detail.labels,
           currentUserLogin,
-          specPath: buildSpecPath(issueNumber, detail.title),
+          specPath: buildSpecPath(this.now(), detail.title),
           requestedReviewers: [],
         },
         claimedLockKey: lockKey,
@@ -569,7 +569,7 @@ export class PlannerLoopRunner {
           assignees: detail.assignees,
           labels: detail.labels,
           currentUserLogin,
-          specPath: buildSpecPath(issueNumber, detail.title),
+          specPath: buildSpecPath(this.now(), detail.title),
           requestedReviewers: [],
         },
         claimedLockKey: lockKey,
@@ -589,7 +589,7 @@ export class PlannerLoopRunner {
         assignees: detail.assignees,
         labels: detail.labels,
         currentUserLogin,
-        specPath: buildSpecPath(issueNumber, detail.title),
+        specPath: buildSpecPath(this.now(), detail.title),
         requestedReviewers: this.resolveRequestedReviewers({
           project: input.project,
           loop: input.loop,
@@ -615,7 +615,10 @@ export class PlannerLoopRunner {
     const configuredRoot = readString(projectMetadata.worktreeRoot);
     const worktreeRoot =
       configuredRoot ?? join(input.project.repoPath, ".looper-worktrees");
-    const branch = `looper/planner/${issue.issueNumber}-${slugify(issue.title || "issue")}`;
+    const branch = buildPlannerBranch(
+      issue.issueNumber,
+      issue.title || "issue",
+    );
     const worktree = await this.options.git.createWorktree({
       projectId: input.project.id,
       repoPath: input.project.repoPath,
@@ -1044,7 +1047,7 @@ export class PlannerLoopRunner {
       issueUrl: input.issue.url,
       issueNumber: input.issue.number,
       currentUserLogin: input.currentUserLogin,
-      specPath: buildSpecPath(input.issue.number, input.issue.title),
+      specPath: buildSpecPath(this.now(), input.issue.title),
     };
     const nowIso = this.nowIso();
     if (existing) {
@@ -1349,8 +1352,24 @@ function slugify(value: string): string {
   return slug || "issue";
 }
 
-function buildSpecPath(issueNumber: number, title: string): string {
-  return `specs/${issueNumber}-${slugify(title)}/spec.md`;
+function buildPlannerSlug(title: string, maxWords = 4): string {
+  const words = slugify(title)
+    .split("-")
+    .filter((word) => word.length > 0)
+    .slice(0, maxWords);
+  return words.join("-") || "issue";
+}
+
+function formatDatePrefix(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function buildPlannerBranch(issueNumber: number, title: string): string {
+  return `looper/planner/${issueNumber}-${buildPlannerSlug(title)}`;
+}
+
+function buildSpecPath(now: Date, title: string): string {
+  return `specs/${formatDatePrefix(now)}-${buildPlannerSlug(title)}.md`;
 }
 
 async function buildPlannerPrompt(input: {

--- a/apps/looperd/src/planner/index.ts
+++ b/apps/looperd/src/planner/index.ts
@@ -546,7 +546,7 @@ export class PlannerLoopRunner {
           assignees: detail.assignees,
           labels: detail.labels,
           currentUserLogin,
-          specPath: buildSpecPath(this.now(), detail.title),
+          specPath: buildSpecPath(this.now(), issueNumber, detail.title),
           requestedReviewers: [],
         },
         claimedLockKey: lockKey,
@@ -569,7 +569,7 @@ export class PlannerLoopRunner {
           assignees: detail.assignees,
           labels: detail.labels,
           currentUserLogin,
-          specPath: buildSpecPath(this.now(), detail.title),
+          specPath: buildSpecPath(this.now(), issueNumber, detail.title),
           requestedReviewers: [],
         },
         claimedLockKey: lockKey,
@@ -589,7 +589,7 @@ export class PlannerLoopRunner {
         assignees: detail.assignees,
         labels: detail.labels,
         currentUserLogin,
-        specPath: buildSpecPath(this.now(), detail.title),
+        specPath: buildSpecPath(this.now(), issueNumber, detail.title),
         requestedReviewers: this.resolveRequestedReviewers({
           project: input.project,
           loop: input.loop,
@@ -1047,7 +1047,7 @@ export class PlannerLoopRunner {
       issueUrl: input.issue.url,
       issueNumber: input.issue.number,
       currentUserLogin: input.currentUserLogin,
-      specPath: buildSpecPath(this.now(), input.issue.title),
+      specPath: buildSpecPath(this.now(), input.issueNumber, input.issue.title),
     };
     const nowIso = this.nowIso();
     if (existing) {
@@ -1368,8 +1368,8 @@ function buildPlannerBranch(issueNumber: number, title: string): string {
   return `looper/planner/${issueNumber}-${buildPlannerSlug(title)}`;
 }
 
-function buildSpecPath(now: Date, title: string): string {
-  return `specs/${formatDatePrefix(now)}-${buildPlannerSlug(title)}.md`;
+function buildSpecPath(now: Date, issueNumber: number, title: string): string {
+  return `specs/${formatDatePrefix(now)}-${issueNumber}-${buildPlannerSlug(title)}.md`;
 }
 
 async function buildPlannerPrompt(input: {

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -109,6 +109,7 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
         isDraft: this.options.isDraft ?? false,
         reviewDecision: this.options.reviewDecision,
         labels: [...this.currentLabels],
+        headSha: this.options.headSha ?? "abc123",
         author: "octocat",
         reviewRequests: this.options.reviewRequests ?? ["octocat"],
       },
@@ -119,6 +120,7 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
         isDraft: true,
         reviewDecision: undefined,
         labels: [],
+        headSha: "draft123",
         author: "octocat",
         reviewRequests: this.options.reviewRequests ?? ["octocat"],
       },
@@ -970,6 +972,57 @@ describe("ReviewerLoopRunner", () => {
     expect(fixture.store.runs.listByLoop(loopId)[0]?.summary).toContain(
       "already-reviewed head",
     );
+
+    fixture.store.close();
+  });
+
+  test("does not enqueue discovery work for PRs already reviewed at the same head", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway({
+      headSha: "abc123",
+      labels: ["looper:spec-reviewing"],
+      reviewRequests: [],
+      currentUserLogin: "someone-else",
+    });
+    const agent = new FakeAgentExecutor([completedAgentResult("unused")]);
+    const nowIso = fixture.now.toISOString();
+
+    fixture.store.loops.upsert({
+      id: "loop_existing",
+      projectId: "project_1",
+      type: "reviewer",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:42",
+      repo: "acme/looper",
+      prNumber: 42,
+      status: "completed",
+      configJson: null,
+      metadataJson: JSON.stringify({ lastPublishedHeadSha: "abc123" }),
+      lastRunAt: nowIso,
+      nextRunAt: null,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    const discovery = await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+
+    expect(discovery.queueItems).toHaveLength(0);
+    expect(discovery.createdLoopIds).toHaveLength(0);
+    expect(discovery.skipped).toBe(3);
+    expect(fixture.queue.listScheduled()).toHaveLength(0);
+    expect(fixture.store.loops.getById("loop_existing")?.status).toBe("queued");
 
     fixture.store.close();
   });

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -226,6 +226,29 @@ export class ReviewerLoopRunner {
         createdLoopIds.push(loop.record.id);
       }
 
+      const loopMetadata = parseJsonObject(loop.record.metadataJson);
+      const lastPublishedHeadSha = readString(
+        loopMetadata.lastPublishedHeadSha,
+      );
+      if (
+        !loop.created &&
+        lastPublishedHeadSha &&
+        pullRequest.headSha &&
+        lastPublishedHeadSha === pullRequest.headSha
+      ) {
+        skipped += 1;
+        this.options.logger.info(
+          "reviewer discovery skipped already-reviewed head",
+          {
+            projectId: project.id,
+            repo: input.repo,
+            prNumber: pullRequest.number,
+            headSha: pullRequest.headSha,
+          },
+        );
+        return;
+      }
+
       queueItems.push(
         this.options.scheduler.enqueue({
           projectId: project.id,


### PR DESCRIPTION
## Summary
- switch PR label/reviewer mutations from `gh pr edit` to REST-backed `gh api` calls and auto-provision looper-managed labels
- fix planner publish retries that were failing on deprecated GitHub CLI GraphQL behavior during PR updates
- shorten planner-generated branch names and spec paths to use `specs/{date}-{slug}.md` with a four-word slug cap
- stop reviewer discovery from re-enqueueing PRs that were already reviewed at the current head SHA, avoiding no-op review loops that can block fixer work

## Testing
- bun test apps/looperd/src/infra/github.test.ts apps/looperd/src/planner/index.test.ts
- bun test apps/looperd/src/infra/github.test.ts apps/looperd/src/reviewer/index.test.ts