### PR TITLE
Improve worker and planner CLI entrypoints

### DIFF
--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -162,6 +162,55 @@ describe("runCli", () => {
     expect(requests[1]?.body).toContain('"projectId":"project_inferred"');
   });
 
+  test("fails work create when --repo has no matching project instead of falling back to cwd", async () => {
+    let workerRequestCount = 0;
+    const exitCode = await runCli(
+      [
+        "work",
+        "--spec",
+        "spec.md",
+        "--prompt",
+        "Implement CLI flow",
+        "--repo",
+        "acme/other",
+        "--base-branch",
+        "main",
+      ],
+      {
+        cwd: "/tmp/repos/looper/packages/cli",
+        stdout: () => {},
+        stderr: () => {},
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async (input) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/projects")) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                requestId: "req_projects_missing_repo_hint",
+                data: {
+                  items: [
+                    {
+                      id: "project_cwd",
+                      repoPath: "/tmp/repos/looper",
+                      repo: "acme/looper",
+                    },
+                  ],
+                },
+              }),
+            );
+          }
+
+          workerRequestCount += 1;
+          return new Response(JSON.stringify({ ok: true, requestId: "unexpected" }));
+        },
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(workerRequestCount).toBe(0);
+  });
+
   test("creates worker from numeric --pr input", async () => {
     const requests: Array<{ url: string; body?: string | null }> = [];
     const exitCode = await runCli(["work", "--pr", "42"], {

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -604,6 +604,44 @@ describe("runCli", () => {
     expect(requests[1]?.body).toContain('"issueNumber":123');
   });
 
+  test("fails planner creation when qualified issue repo has no matching project", async () => {
+    let plannerRequestCount = 0;
+    const exitCode = await runCli(["plan", "acme/other#123"], {
+      cwd: "/tmp/repos/looper",
+      stdout: () => {},
+      stderr: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_plan_projects_missing_qualified_repo",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+
+        plannerRequestCount += 1;
+        return new Response(
+          JSON.stringify({ ok: true, requestId: "unexpected" }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(plannerRequestCount).toBe(0);
+  });
+
   test("adds project and requests discovery", async () => {
     const requests: Array<{ url: string; body?: string | null }> = [];
     const exitCode = await runCli(["project", "add", "/tmp/repos/looper"], {

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -162,6 +162,64 @@ describe("runCli", () => {
     expect(requests[1]?.body).toContain('"projectId":"project_inferred"');
   });
 
+  test("fails work create when cwd matches multiple projects equally", async () => {
+    let workerRequestCount = 0;
+    const exitCode = await runCli(
+      [
+        "work",
+        "--spec",
+        "spec.md",
+        "--prompt",
+        "Implement CLI flow",
+        "--repo",
+        "acme/looper",
+        "--base-branch",
+        "main",
+      ],
+      {
+        cwd: "/tmp/repos/looper",
+        stdout: () => {},
+        stderr: () => {},
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async (input) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/projects")) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                requestId: "req_projects_ambiguous_cwd",
+                data: {
+                  items: [
+                    {
+                      id: "project_1",
+                      repoPath: "/tmp/repos/project-one",
+                      repo: "acme/looper",
+                      worktreeRoot: "/tmp/repos/looper",
+                    },
+                    {
+                      id: "project_2",
+                      repoPath: "/tmp/repos/project-two",
+                      repo: "acme/looper-alt",
+                      worktreeRoot: "/tmp/repos/looper",
+                    },
+                  ],
+                },
+              }),
+            );
+          }
+
+          workerRequestCount += 1;
+          return new Response(
+            JSON.stringify({ ok: true, requestId: "unexpected" }),
+          );
+        },
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(workerRequestCount).toBe(0);
+  });
+
   test("fails work create when --repo has no matching project instead of falling back to cwd", async () => {
     let workerRequestCount = 0;
     const exitCode = await runCli(
@@ -716,6 +774,51 @@ describe("runCli", () => {
                     id: "project_1",
                     repoPath: "/tmp/repos/looper",
                     repo: "acme/looper",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+
+        plannerRequestCount += 1;
+        return new Response(
+          JSON.stringify({ ok: true, requestId: "unexpected" }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(plannerRequestCount).toBe(0);
+  });
+
+  test("fails planner creation when cwd matches multiple projects equally", async () => {
+    let plannerRequestCount = 0;
+    const exitCode = await runCli(["plan", "123"], {
+      cwd: "/tmp/repos/looper",
+      stdout: () => {},
+      stderr: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_plan_projects_ambiguous_cwd",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/project-one",
+                    repo: "acme/looper",
+                    worktreeRoot: "/tmp/repos/looper",
+                  },
+                  {
+                    id: "project_2",
+                    repoPath: "/tmp/repos/project-two",
+                    repo: "acme/looper-alt",
+                    worktreeRoot: "/tmp/repos/looper",
                   },
                 ],
               },

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -202,7 +202,9 @@ describe("runCli", () => {
           }
 
           workerRequestCount += 1;
-          return new Response(JSON.stringify({ ok: true, requestId: "unexpected" }));
+          return new Response(
+            JSON.stringify({ ok: true, requestId: "unexpected" }),
+          );
         },
       },
     );

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -60,10 +60,22 @@ describe("runCli", () => {
         stdout: () => {},
         loadConfigImpl: async () => createConfig() as never,
         fetchImpl: async (input, init) => {
+          const url = String(input);
           requests.push({
-            url: String(input),
+            url,
             body: init?.body as string | null,
           });
+          if (url.endsWith("/api/v1/projects")) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                requestId: "req_projects_create_mode",
+                data: {
+                  items: [{ id: "project_1", repoPath: "/tmp/project" }],
+                },
+              }),
+            );
+          }
           return new Response(
             JSON.stringify({
               ok: true,
@@ -76,10 +88,270 @@ describe("runCli", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(requests).toHaveLength(1);
-    expect(requests[0]?.url).toContain("/api/v1/workers");
-    expect(requests[0]?.body).toContain('"prompt":"Implement CLI flow"');
-    expect(requests[0]?.body).toContain('"specPath":"spec.md"');
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.url).toContain("/api/v1/workers");
+    expect(requests[1]?.body).toContain('"prompt":"Implement CLI flow"');
+    expect(requests[1]?.body).toContain('"specPath":"spec.md"');
+  });
+
+  test("infers project from cwd for work create mode", async () => {
+    const requests: Array<{
+      method: string;
+      url: string;
+      body?: string | null;
+    }> = [];
+    const exitCode = await runCli(
+      [
+        "work",
+        "--spec",
+        "spec.md",
+        "--prompt",
+        "Implement CLI flow",
+        "--repo",
+        "acme/looper",
+        "--base-branch",
+        "main",
+      ],
+      {
+        cwd: "/tmp/repos/looper/packages/cli",
+        stdout: () => {},
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async (input, init) => {
+          const url = String(input);
+          requests.push({
+            method: init?.method ?? "GET",
+            url,
+            body: init?.body as string | null,
+          });
+
+          if (url.endsWith("/api/v1/projects")) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                requestId: "req_projects_1",
+                data: {
+                  items: [
+                    {
+                      id: "project_inferred",
+                      repoPath: "/tmp/repos/looper",
+                    },
+                  ],
+                },
+              }),
+            );
+          }
+
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_worker_inferred",
+              data: {
+                id: "loop_2",
+                title: "Implement CLI flow",
+                status: "running",
+              },
+            }),
+          );
+        },
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests[0]?.url).toContain("/api/v1/projects");
+    expect(requests[1]?.url).toContain("/api/v1/workers");
+    expect(requests[1]?.body).toContain('"projectId":"project_inferred"');
+  });
+
+  test("creates worker from numeric --pr input", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["work", "--pr", "42"], {
+      cwd: "/tmp/repos/looper",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body as string | null,
+        });
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_projects_2",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_worker_pr",
+            data: {
+              id: "loop_worker_pr",
+              title: "Implement acme/looper#42",
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests[1]?.url).toContain("/api/v1/workers");
+    expect(requests[1]?.body).toContain('"repo":"acme/looper"');
+    expect(requests[1]?.body).toContain('"prNumber":42');
+  });
+
+  test("creates worker from qualified --pr input", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["work", "--pr", "acme/looper#42"], {
+      cwd: "/tmp/repos/looper",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body as string | null,
+        });
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_projects_qualified_pr",
+              data: {
+                items: [{ id: "project_1", repoPath: "/tmp/repos/looper" }],
+              },
+            }),
+          );
+        }
+
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_worker_qualified_pr",
+            data: {
+              id: "loop_worker_pr_qualified",
+              title: "Implement acme/looper#42",
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests[1]?.body).toContain('"repo":"acme/looper"');
+    expect(requests[1]?.body).toContain('"prNumber":42');
+  });
+
+  test("creates worker from numeric --issue input", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["work", "--issue", "123"], {
+      cwd: "/tmp/repos/looper",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body as string | null,
+        });
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_projects_3",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_worker_issue",
+            data: {
+              id: "loop_worker_issue",
+              title: "Implement acme/looper#123",
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests[1]?.url).toContain("/api/v1/workers");
+    expect(requests[1]?.body).toContain('"repo":"acme/looper"');
+    expect(requests[1]?.body).toContain('"issueNumber":123');
+  });
+
+  test("creates worker from qualified --issue input", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["work", "--issue", "acme/looper#123"], {
+      cwd: "/tmp/repos/looper",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body as string | null,
+        });
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_projects_qualified_issue",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_worker_qualified_issue",
+            data: {
+              id: "loop_worker_issue_qualified",
+              title: "Implement acme/looper#123",
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests[1]?.body).toContain('"repo":"acme/looper"');
+    expect(requests[1]?.body).toContain('"issueNumber":123');
   });
 
   test("creates reviewer loop from PR reference", async () => {
@@ -125,36 +397,102 @@ describe("runCli", () => {
     expect(requests[1]).toContain("POST http://127.0.0.1:4310/api/v1/loops");
   });
 
-  test("creates planner work item from issue number", async () => {
+  test("creates planner work item from numeric issue reference", async () => {
     const requests: Array<{ url: string; body?: string | null }> = [];
-    const exitCode = await runCli(
-      ["plan", "--project", "project_1", "--issue", "123"],
-      {
-        stdout: () => {},
-        loadConfigImpl: async () => createConfig() as never,
-        fetchImpl: async (input, init) => {
-          requests.push({
-            url: String(input),
-            body: init?.body as string | null,
-          });
+    const exitCode = await runCli(["plan", "123"], {
+      cwd: "/tmp/repos/looper",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body as string | null,
+        });
+        if (url.endsWith("/api/v1/projects")) {
           return new Response(
             JSON.stringify({
               ok: true,
-              requestId: "req_plan_1",
+              requestId: "req_plan_projects_1",
               data: {
-                id: "loop_plan_1",
-                issueNumber: 123,
-                status: "running",
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                ],
               },
             }),
           );
-        },
+        }
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_plan_1",
+            data: {
+              id: "loop_plan_1",
+              issueNumber: 123,
+              status: "running",
+            },
+          }),
+        );
       },
-    );
+    });
 
     expect(exitCode).toBe(0);
-    expect(requests[0]?.url).toContain("/api/v1/planners");
-    expect(requests[0]?.body).toContain('"issueNumber":123');
+    expect(requests[1]?.url).toContain("/api/v1/planners");
+    expect(requests[1]?.body).toContain('"projectId":"project_1"');
+    expect(requests[1]?.body).toContain('"issueNumber":123');
+  });
+
+  test("creates planner work item from qualified issue reference", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["plan", "acme/looper#123"], {
+      cwd: "/tmp/elsewhere",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body as string | null,
+        });
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_plan_projects_2",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_plan_2",
+            data: {
+              id: "loop_plan_2",
+              issueNumber: 123,
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests[1]?.url).toContain("/api/v1/planners");
+    expect(requests[1]?.body).toContain('"projectId":"project_1"');
+    expect(requests[1]?.body).toContain('"issueNumber":123');
   });
 
   test("adds project and requests discovery", async () => {

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -354,6 +354,61 @@ describe("runCli", () => {
     expect(requests[1]?.body).toContain('"issueNumber":123');
   });
 
+  test("prefers qualified issue repo over cwd project", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["work", "--issue", "acme/other#123"], {
+      cwd: "/tmp/repos/looper",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body as string | null,
+        });
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_projects_qualified_issue_repo_priority",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                  {
+                    id: "project_2",
+                    repoPath: "/tmp/repos/other",
+                    repo: "acme/other",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_worker_qualified_issue_repo_priority",
+            data: {
+              id: "loop_worker_issue_repo_priority",
+              title: "Implement acme/other#123",
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests[1]?.body).toContain('"projectId":"project_2"');
+    expect(requests[1]?.body).toContain('"repo":"acme/other"');
+    expect(requests[1]?.body).toContain('"issueNumber":123');
+  });
+
   test("creates reviewer loop from PR reference", async () => {
     const requests: string[] = [];
     const exitCode = await runCli(
@@ -492,6 +547,60 @@ describe("runCli", () => {
     expect(exitCode).toBe(0);
     expect(requests[1]?.url).toContain("/api/v1/planners");
     expect(requests[1]?.body).toContain('"projectId":"project_1"');
+    expect(requests[1]?.body).toContain('"issueNumber":123');
+  });
+
+  test("prefers qualified planner issue repo over cwd project", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["plan", "acme/other#123"], {
+      cwd: "/tmp/repos/looper",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body as string | null,
+        });
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_plan_projects_repo_priority",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                  {
+                    id: "project_2",
+                    repoPath: "/tmp/repos/other",
+                    repo: "acme/other",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_plan_repo_priority",
+            data: {
+              id: "loop_plan_repo_priority",
+              issueNumber: 123,
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests[1]?.url).toContain("/api/v1/planners");
+    expect(requests[1]?.body).toContain('"projectId":"project_2"');
     expect(requests[1]?.body).toContain('"issueNumber":123');
   });
 

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -162,7 +162,7 @@ describe("runCli", () => {
     expect(requests[1]?.body).toContain('"projectId":"project_inferred"');
   });
 
-  test("fails work create when cwd matches multiple projects equally", async () => {
+  test("prefers a unique --repo match over an ambiguous cwd match", async () => {
     let workerRequestCount = 0;
     const exitCode = await runCli(
       [
@@ -210,14 +210,22 @@ describe("runCli", () => {
 
           workerRequestCount += 1;
           return new Response(
-            JSON.stringify({ ok: true, requestId: "unexpected" }),
+            JSON.stringify({
+              ok: true,
+              requestId: "req_worker_repo_match",
+              data: {
+                id: "loop_repo_match",
+                title: "Implement CLI flow",
+                status: "running",
+              },
+            }),
           );
         },
       },
     );
 
-    expect(exitCode).toBe(1);
-    expect(workerRequestCount).toBe(0);
+    expect(exitCode).toBe(0);
+    expect(workerRequestCount).toBe(1);
   });
 
   test("fails work create when --repo has no matching project instead of falling back to cwd", async () => {

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -604,6 +604,47 @@ describe("runCli", () => {
     expect(requests[1]?.body).toContain('"issueNumber":123');
   });
 
+  test("rejects explicit project when qualified issue repo does not match", async () => {
+    let workerRequestCount = 0;
+    const exitCode = await runCli(
+      ["work", "--issue", "acme/other#123", "--project", "project_1"],
+      {
+        cwd: "/tmp/repos/looper",
+        stdout: () => {},
+        stderr: () => {},
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async (input) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/projects")) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                requestId: "req_projects_explicit_mismatch_issue",
+                data: {
+                  items: [
+                    {
+                      id: "project_1",
+                      repoPath: "/tmp/repos/looper",
+                      repo: "acme/looper",
+                    },
+                  ],
+                },
+              }),
+            );
+          }
+
+          workerRequestCount += 1;
+          return new Response(
+            JSON.stringify({ ok: true, requestId: "unexpected" }),
+          );
+        },
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(workerRequestCount).toBe(0);
+  });
+
   test("fails planner creation when qualified issue repo has no matching project", async () => {
     let plannerRequestCount = 0;
     const exitCode = await runCli(["plan", "acme/other#123"], {
@@ -637,6 +678,47 @@ describe("runCli", () => {
         );
       },
     });
+
+    expect(exitCode).toBe(1);
+    expect(plannerRequestCount).toBe(0);
+  });
+
+  test("rejects explicit project when qualified planner issue repo does not match", async () => {
+    let plannerRequestCount = 0;
+    const exitCode = await runCli(
+      ["plan", "acme/other#123", "--project", "project_1"],
+      {
+        cwd: "/tmp/repos/looper",
+        stdout: () => {},
+        stderr: () => {},
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async (input) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/projects")) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                requestId: "req_plan_projects_explicit_mismatch",
+                data: {
+                  items: [
+                    {
+                      id: "project_1",
+                      repoPath: "/tmp/repos/looper",
+                      repo: "acme/looper",
+                    },
+                  ],
+                },
+              }),
+            );
+          }
+
+          plannerRequestCount += 1;
+          return new Response(
+            JSON.stringify({ ok: true, requestId: "unexpected" }),
+          );
+        },
+      },
+    );
 
     expect(exitCode).toBe(1);
     expect(plannerRequestCount).toBe(0);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -865,11 +865,6 @@ async function resolveProjectForWork(
     return project;
   }
 
-  const projectFromCwd = inferProjectFromCwd(context.cwd, projects);
-  if (projectFromCwd) {
-    return projectFromCwd;
-  }
-
   if (hint?.repo) {
     const matches = projects.filter((project) => project.repo === hint.repo);
     if (matches.length === 1) {
@@ -883,6 +878,11 @@ async function resolveProjectForWork(
         `Multiple projects match repo ${hint.repo}; pass --project <projectId>`,
       );
     }
+  }
+
+  const projectFromCwd = inferProjectFromCwd(context.cwd, projects);
+  if (projectFromCwd) {
+    return projectFromCwd;
   }
 
   throw new Error(

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -801,6 +801,7 @@ async function buildWorkCreateBody(context: CliContext) {
     const ref = parseOptionalRepoNumberRef(pr, "pull request");
     const project = await resolveProjectForWork(context, {
       repo: ref.repo ?? repo,
+      requireRepoMatch: Boolean(ref.repo),
     });
     const resolvedRepo = ref.repo ?? repo ?? project.repo;
     if (!resolvedRepo) {
@@ -821,6 +822,7 @@ async function buildWorkCreateBody(context: CliContext) {
     const ref = parseOptionalRepoNumberRef(issue, "issue");
     const project = await resolveProjectForWork(context, {
       repo: ref.repo ?? repo,
+      requireRepoMatch: Boolean(ref.repo),
     });
     const resolvedRepo = ref.repo ?? repo ?? project.repo;
     if (!resolvedRepo) {
@@ -851,7 +853,7 @@ async function buildWorkCreateBody(context: CliContext) {
 
 async function resolveProjectForWork(
   context: CliContext,
-  hint?: { repo?: string },
+  hint?: { repo?: string; requireRepoMatch?: boolean },
 ): Promise<ProjectSummary> {
   const projects = await listProjects(context);
   const explicitProjectId = getFlag(context.args, "project");
@@ -876,6 +878,11 @@ async function resolveProjectForWork(
     if (matches.length > 1) {
       throw new Error(
         `Multiple projects match repo ${hint.repo}; pass --project <projectId>`,
+      );
+    }
+    if (hint.requireRepoMatch) {
+      throw new Error(
+        `Project not found for repo ${hint.repo}; pass --project <projectId>`,
       );
     }
   }
@@ -959,6 +966,7 @@ async function runPlannerCreate(context: CliContext) {
   const issueRef = parseOptionalRepoNumberRef(issueText, "issue");
   const project = await resolveProjectForWork(context, {
     repo: issueRef.repo ?? repo,
+    requireRepoMatch: Boolean(issueRef.repo),
   });
 
   const data = await context.client.post<Record<string, unknown>>(

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -864,6 +864,16 @@ async function resolveProjectForWork(
     if (!project) {
       throw new Error(`Project not found: ${explicitProjectId}`);
     }
+    if (
+      hint?.repo &&
+      hint.requireRepoMatch &&
+      project.repo !== null &&
+      project.repo !== hint.repo
+    ) {
+      throw new Error(
+        `Project ${explicitProjectId} is for repo ${project.repo}, but ${hint.repo} was requested`,
+      );
+    }
     return project;
   }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -899,11 +899,9 @@ async function resolveProjectForWork(
       return projectFromCwd;
     }
 
-    if (hint.requireRepoMatch) {
-      throw new Error(
-        `Project not found for repo ${hint.repo}; pass --project <projectId>`,
-      );
-    }
+    throw new Error(
+      `Project not found for repo ${hint.repo}; pass --project <projectId>`,
+    );
   }
 
   const projectFromCwd = inferProjectFromCwd(context.cwd, projects);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -958,7 +958,21 @@ function inferProjectFromCwd(
     .filter((project) => project.matchLength >= 0)
     .sort((left, right) => right.matchLength - left.matchLength);
 
-  return matches[0]?.project ?? null;
+  const bestMatch = matches[0];
+  if (!bestMatch) {
+    return null;
+  }
+
+  const equallySpecificMatches = matches.filter(
+    (match) => match.matchLength === bestMatch.matchLength,
+  );
+  if (equallySpecificMatches.length > 1) {
+    throw new Error(
+      "Multiple projects match the current working directory; pass --project <projectId>",
+    );
+  }
+
+  return bestMatch.project;
 }
 
 function pathMatchLength(candidatePath: string, rootPath: string): number {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import { cac } from "cac";
 
 import {
@@ -33,6 +33,7 @@ interface CliContext {
   args: ParsedArgs;
   write: Writer;
   writeError: Writer;
+  cwd: string;
   config: LoadedCliConfig;
   client: ApiClient;
   readFileImpl: (path: string, encoding: "utf8") => Promise<string>;
@@ -65,8 +66,15 @@ interface ParsedArgs {
 }
 
 interface PullRequestRef {
-  repo: string;
+  repo?: string;
   prNumber: number;
+}
+
+interface ProjectSummary {
+  id: string;
+  repoPath: string;
+  repo?: string | null;
+  worktreeRoot?: string | null;
 }
 
 interface ActiveRunItem {
@@ -147,6 +155,7 @@ export async function runCli(
     const runtime: CliRuntime = {
       write,
       writeError,
+      cwd,
       config,
       client,
       readFileImpl: deps.readFileImpl ?? readFile,
@@ -313,27 +322,39 @@ function createCli(runtime: CliRuntime) {
 
   cli
     .command("work", "Create a worker run")
-    .option("--project <projectId>", "Project id")
+    .option(
+      "--project <projectId>",
+      "Project id (auto-detected from cwd when omitted)",
+    )
     .option("--title <title>", "Task title")
     .option("--prompt <text>", "Implementation prompt")
     .option("--spec <path>", "Spec path")
+    .option("--pr <ref>", "Start work on an existing spec PR")
+    .option("--issue <ref>", "Start work from a planner issue")
     .option("--repo <repo>", "Repository slug")
     .option("--base-branch <branch>", "Base branch")
     .example(
       (name) =>
         `  $ ${name} work --project project_1 --title "Ship CLI" --spec specs/ship-cli.md`,
     )
+    .example((name) => `  $ ${name} work --pr 42`)
+    .example((name) => `  $ ${name} work --pr acme/looper#42`)
+    .example((name) => `  $ ${name} work --issue 123`)
+    .example((name) => `  $ ${name} work --issue acme/looper#123`)
     .action(async (options) => {
       await dispatch(createContext(runtime, ["work"], options));
     });
 
   cli
-    .command("plan", "Create a planner run")
-    .option("--project <projectId>", "Project id")
-    .option("--issue <number>", "Issue number")
-    .example((name) => `  $ ${name} plan --project project_1 --issue 123`)
-    .action(async (options) => {
-      await dispatch(createContext(runtime, ["plan"], options));
+    .command("plan <issue>", "Create a planner run")
+    .option(
+      "--project <projectId>",
+      "Project id (auto-detected from cwd when omitted)",
+    )
+    .example((name) => `  $ ${name} plan 123`)
+    .example((name) => `  $ ${name} plan acme/looper#123`)
+    .action(async (issue, options) => {
+      await dispatch(createContext(runtime, ["plan", issue], options));
     });
 
   cli
@@ -696,14 +717,15 @@ async function buildLoopCreateBody(context: CliContext) {
 
   if (pr) {
     const ref = parsePullRequestRef(pr);
+    const repo = requireRepoFromRef(ref, "pull request");
     const snapshot = await context.client.get<Record<string, unknown>>(
-      `/api/v1/pull-requests/${encodeURIComponent(ref.repo)}/${ref.prNumber}`,
+      `/api/v1/pull-requests/${encodeURIComponent(repo)}/${ref.prNumber}`,
     );
     return {
       projectId: snapshot.projectId,
       type,
       targetType: "pull_request",
-      repo: ref.repo,
+      repo,
       prNumber: ref.prNumber,
       status: "running",
     };
@@ -733,16 +755,10 @@ async function runLoopPause(context: CliContext) {
 }
 
 async function runWorkCreate(context: CliContext) {
+  const body = await buildWorkCreateBody(context);
   const data = await context.client.post<Record<string, unknown>>(
     "/api/v1/workers",
-    {
-      projectId: requireFlag(context.args, "project"),
-      title: requireFlag(context.args, "title"),
-      prompt: getFlag(context.args, "prompt"),
-      specPath: getFlag(context.args, "spec"),
-      repo: getFlag(context.args, "repo"),
-      baseBranch: getFlag(context.args, "base-branch"),
-    },
+    body,
   );
 
   if (hasFlag(context.args, "json")) {
@@ -756,17 +772,200 @@ async function runWorkCreate(context: CliContext) {
   ]);
 }
 
-async function runPlannerCreate(context: CliContext) {
-  const issueNumber = Number(requireFlag(context.args, "issue"));
-  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
-    throw new Error("--issue must be a positive integer");
+async function buildWorkCreateBody(context: CliContext) {
+  const prompt = getFlag(context.args, "prompt");
+  const specPath = getFlag(context.args, "spec");
+  const pr = getFlag(context.args, "pr");
+  const issue = getFlag(context.args, "issue");
+  const modeCount =
+    Number(Boolean(pr)) +
+    Number(Boolean(issue)) +
+    Number(Boolean(prompt || specPath));
+
+  if (modeCount === 0) {
+    throw new Error(
+      "work requires one of: --prompt/--spec, --pr <repo>#<number>, or --issue <number>",
+    );
   }
+  if (modeCount > 1) {
+    throw new Error(
+      "work accepts only one input mode at a time: create-pr, --pr, or --issue",
+    );
+  }
+
+  const title = getFlag(context.args, "title");
+  const repo = getFlag(context.args, "repo");
+  const baseBranch = getFlag(context.args, "base-branch");
+
+  if (pr) {
+    const ref = parseOptionalRepoNumberRef(pr, "pull request");
+    const project = await resolveProjectForWork(context, {
+      repo: ref.repo ?? repo,
+    });
+    const resolvedRepo = ref.repo ?? repo ?? project.repo;
+    if (!resolvedRepo) {
+      throw new Error(
+        "Could not determine repo for pull request; pass --pr <repo>#<number>, --repo <repo>, or --project <projectId>",
+      );
+    }
+    return {
+      projectId: project.id,
+      title,
+      repo: resolvedRepo,
+      prNumber: ref.prNumber,
+      baseBranch,
+    };
+  }
+
+  if (issue) {
+    const ref = parseOptionalRepoNumberRef(issue, "issue");
+    const project = await resolveProjectForWork(context, {
+      repo: ref.repo ?? repo,
+    });
+    const resolvedRepo = ref.repo ?? repo ?? project.repo;
+    if (!resolvedRepo) {
+      throw new Error(
+        "Could not determine repo for issue; pass --issue <repo>#<number>, --repo <repo>, or --project <projectId>",
+      );
+    }
+    return {
+      projectId: project.id,
+      title,
+      issueNumber: ref.prNumber,
+      repo: resolvedRepo,
+      baseBranch,
+    };
+  }
+
+  const project = await resolveProjectForWork(context, { repo });
+
+  return {
+    projectId: project.id,
+    title,
+    prompt,
+    specPath,
+    repo,
+    baseBranch,
+  };
+}
+
+async function resolveProjectForWork(
+  context: CliContext,
+  hint?: { repo?: string },
+): Promise<ProjectSummary> {
+  const projects = await listProjects(context);
+  const explicitProjectId = getFlag(context.args, "project");
+  if (explicitProjectId) {
+    const project = projects.find(
+      (candidate) => candidate.id === explicitProjectId,
+    );
+    if (!project) {
+      throw new Error(`Project not found: ${explicitProjectId}`);
+    }
+    return project;
+  }
+
+  const projectFromCwd = inferProjectFromCwd(context.cwd, projects);
+  if (projectFromCwd) {
+    return projectFromCwd;
+  }
+
+  if (hint?.repo) {
+    const matches = projects.filter((project) => project.repo === hint.repo);
+    if (matches.length === 1) {
+      const project = matches[0];
+      if (project) {
+        return project;
+      }
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `Multiple projects match repo ${hint.repo}; pass --project <projectId>`,
+      );
+    }
+  }
+
+  throw new Error(
+    "Could not infer project from the current working directory; pass --project <projectId>",
+  );
+}
+
+async function listProjects(context: CliContext): Promise<ProjectSummary[]> {
+  const data = await context.client.get<{
+    items: Array<Record<string, unknown>>;
+  }>("/api/v1/projects");
+
+  const projects: ProjectSummary[] = [];
+  for (const project of data.items) {
+    if (
+      typeof project.id !== "string" ||
+      typeof project.repoPath !== "string"
+    ) {
+      continue;
+    }
+
+    projects.push({
+      id: project.id,
+      repoPath: project.repoPath,
+      repo: typeof project.repo === "string" ? project.repo : null,
+      worktreeRoot:
+        typeof project.worktreeRoot === "string" ? project.worktreeRoot : null,
+    });
+  }
+
+  return projects;
+}
+
+function inferProjectFromCwd(
+  cwdValue: string,
+  projects: ProjectSummary[],
+): ProjectSummary | null {
+  const cwd = resolve(cwdValue);
+  const matches = projects
+    .map((project) => ({
+      project,
+      matchLength: Math.max(
+        pathMatchLength(cwd, project.repoPath),
+        typeof project.worktreeRoot === "string"
+          ? pathMatchLength(cwd, project.worktreeRoot)
+          : -1,
+      ),
+    }))
+    .filter((project) => project.matchLength >= 0)
+    .sort((left, right) => right.matchLength - left.matchLength);
+
+  return matches[0]?.project ?? null;
+}
+
+function pathMatchLength(candidatePath: string, rootPath: string): number {
+  const absoluteRoot = resolve(rootPath);
+  const relation = relative(absoluteRoot, candidatePath);
+  if (
+    relation === "" ||
+    (!relation.startsWith("..") && !isAbsolute(relation))
+  ) {
+    return absoluteRoot.length;
+  }
+
+  return -1;
+}
+
+async function runPlannerCreate(context: CliContext) {
+  const issueText = context.args.positionals[1];
+  if (!issueText) {
+    throw new Error("Usage: looper plan <issue|repo#issue>");
+  }
+  const repo = getFlag(context.args, "repo");
+  const issueRef = parseOptionalRepoNumberRef(issueText, "issue");
+  const project = await resolveProjectForWork(context, {
+    repo: issueRef.repo ?? repo,
+  });
 
   const data = await context.client.post<Record<string, unknown>>(
     "/api/v1/planners",
     {
-      projectId: requireFlag(context.args, "project"),
-      issueNumber,
+      projectId: project.id,
+      issueNumber: issueRef.prNumber,
     },
   );
 
@@ -808,8 +1007,9 @@ async function runPrShow(context: CliContext) {
     throw new Error("Usage: looper pr show <repo>#<number>");
   }
   const ref = parsePullRequestRef(refText);
+  const repo = requireRepoFromRef(ref, "pull request");
   const data = await context.client.get<Record<string, unknown>>(
-    `/api/v1/pull-requests/${encodeURIComponent(ref.repo)}/${ref.prNumber}`,
+    `/api/v1/pull-requests/${encodeURIComponent(repo)}/${ref.prNumber}`,
   );
 
   if (hasFlag(context.args, "json")) {
@@ -831,8 +1031,9 @@ async function runPrStatus(context: CliContext) {
     throw new Error("Usage: looper pr status <repo>#<number>");
   }
   const ref = parsePullRequestRef(refText);
+  const repo = requireRepoFromRef(ref, "pull request");
   const data = await context.client.get<Record<string, unknown>>(
-    `/api/v1/pull-requests/${encodeURIComponent(ref.repo)}/${ref.prNumber}/status`,
+    `/api/v1/pull-requests/${encodeURIComponent(repo)}/${ref.prNumber}/status`,
   );
 
   if (hasFlag(context.args, "json")) {
@@ -995,21 +1196,51 @@ function requireFlag(args: ParsedArgs, name: string): string {
 }
 
 function parsePullRequestRef(value: string): PullRequestRef {
-  const match = /^(?<repo>[^#]+)#(?<prNumber>\d+)$/.exec(value);
-  if (!match?.groups) {
+  const parsed = parseOptionalRepoNumberRef(value, "pull request");
+  if (!parsed.repo) {
     throw new Error(`Invalid pull request reference: ${value}`);
   }
 
-  const repo = match.groups.repo;
-  const prNumber = match.groups.prNumber;
-  if (!repo || !prNumber) {
-    throw new Error(`Invalid pull request reference: ${value}`);
+  return parsed;
+}
+
+function parseOptionalRepoNumberRef(
+  value: string,
+  label: "pull request" | "issue",
+): PullRequestRef {
+  const qualifiedMatch = /^(?<repo>[^#]+)#(?<number>\d+)$/.exec(value);
+  if (qualifiedMatch?.groups) {
+    const repo = qualifiedMatch.groups.repo;
+    const numberValue = qualifiedMatch.groups.number;
+    if (!repo || !numberValue) {
+      throw new Error(`Invalid ${label} reference: ${value}`);
+    }
+
+    return {
+      repo,
+      prNumber: Number(numberValue),
+    };
   }
 
-  return {
-    repo,
-    prNumber: Number(prNumber),
-  };
+  const numberValue = Number(value);
+  if (Number.isInteger(numberValue) && numberValue > 0) {
+    return {
+      prNumber: numberValue,
+    };
+  }
+
+  throw new Error(`Invalid ${label} reference: ${value}`);
+}
+
+function requireRepoFromRef(
+  ref: PullRequestRef,
+  label: "pull request" | "issue",
+): string {
+  if (!ref.repo) {
+    throw new Error(`Missing repo for ${label} reference`);
+  }
+
+  return ref.repo;
 }
 
 function deriveProjectId(repoPath: string): string {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -880,6 +880,15 @@ async function resolveProjectForWork(
         `Multiple projects match repo ${hint.repo}; pass --project <projectId>`,
       );
     }
+
+    const projectFromCwd = inferProjectFromCwd(context.cwd, projects);
+    if (
+      projectFromCwd &&
+      (projectFromCwd.repo == null || projectFromCwd.repo === hint.repo)
+    ) {
+      return projectFromCwd;
+    }
+
     if (hint.requireRepoMatch) {
       throw new Error(
         `Project not found for repo ${hint.repo}; pass --project <projectId>`,

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -507,6 +507,41 @@ describe("createLooperdApi", () => {
       status: "queued",
     });
 
+    store.pullRequestSnapshots.upsert({
+      id: "snapshot_2",
+      projectId: "project_2",
+      repo: "acme/looper",
+      prNumber: 42,
+      headSha: "def456",
+      baseSha: "base123",
+      title: "Runtime foundation",
+      body: "Adds recovery and API",
+      author: "octocat",
+      diffRef: null,
+      checksSummary: "green",
+      unresolvedThreadCount: 1,
+      reviewState: "changes_requested",
+      payloadJson: JSON.stringify({ title: "Runtime foundation" }),
+      capturedAt: "2026-04-11T12:05:00.000Z",
+      createdAt: "2026-04-11T12:05:00.000Z",
+    });
+
+    const ambiguousPrWorkerResponse = await api.handle(
+      new Request("http://localhost/api/v1/workers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          repo: "acme/looper",
+          prNumber: 42,
+        }),
+      }),
+    );
+    const ambiguousPrWorkerBody = (await ambiguousPrWorkerResponse.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(ambiguousPrWorkerResponse.status).toBe(409);
+    expect(ambiguousPrWorkerBody.error.code).toBe("PROJECT_AMBIGUOUS");
+
     store.loops.upsert({
       id: "loop_planner_issue_125",
       projectId: "project_1",

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -451,9 +451,53 @@ describe("createLooperdApi", () => {
     expect(createWorkerFromPrBody.data.repo).toBe("acme/looper");
     expect(createWorkerFromPrBody.data.prNumber).toBe(42);
     expect(
-      store.queue.findActiveByDedupe("worker:acme/looper:42"),
+      store.queue.findActiveByDedupe("worker:project_1:acme/looper:42"),
     ).toMatchObject({
       loopId: createWorkerFromPrBody.data.id,
+      type: "worker",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:42",
+      prNumber: 42,
+      status: "queued",
+    });
+
+    store.projects.upsert({
+      id: "project_2",
+      name: "Looper mirror",
+      repoPath: "/tmp/looper-mirror",
+      baseBranch: "main",
+      archived: false,
+      metadataJson: JSON.stringify({ repo: "acme/looper" }),
+      createdAt: "2026-04-11T12:04:00.000Z",
+      updatedAt: "2026-04-11T12:04:00.000Z",
+    });
+
+    const createWorkerFromSamePrSecondProjectResponse = await api.handle(
+      new Request("http://localhost/api/v1/workers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          projectId: "project_2",
+          repo: "acme/looper",
+          prNumber: 42,
+        }),
+      }),
+    );
+    const createWorkerFromSamePrSecondProjectBody =
+      (await createWorkerFromSamePrSecondProjectResponse.json()) as {
+        data: {
+          id: string;
+          status: string;
+          repo: string;
+          prNumber: number;
+        };
+      };
+    expect(createWorkerFromSamePrSecondProjectResponse.status).toBe(200);
+    expect(
+      store.queue.findActiveByDedupe("worker:project_2:acme/looper:42"),
+    ).toMatchObject({
+      loopId: createWorkerFromSamePrSecondProjectBody.data.id,
+      projectId: "project_2",
       type: "worker",
       targetType: "pull_request",
       targetId: "pr:acme/looper:42",
@@ -507,7 +551,7 @@ describe("createLooperdApi", () => {
     expect(createWorkerFromIssueBody.data.prNumber).toBe(77);
     expect(createWorkerFromIssueBody.data.specPath).toBe("specs/issue-125.md");
     expect(
-      store.queue.findActiveByDedupe("worker:acme/looper:77"),
+      store.queue.findActiveByDedupe("worker:project_1:acme/looper:77"),
     ).toMatchObject({
       loopId: createWorkerFromIssueBody.data.id,
       type: "worker",

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -458,6 +458,7 @@ describe("createLooperdApi", () => {
       targetType: "pull_request",
       targetId: "pr:acme/looper:42",
       prNumber: 42,
+      lockKey: "worker-pr:project_1:acme/looper:42",
       status: "queued",
     });
 
@@ -502,6 +503,7 @@ describe("createLooperdApi", () => {
       targetType: "pull_request",
       targetId: "pr:acme/looper:42",
       prNumber: 42,
+      lockKey: "worker-pr:project_2:acme/looper:42",
       status: "queued",
     });
 
@@ -558,6 +560,7 @@ describe("createLooperdApi", () => {
       targetType: "pull_request",
       targetId: "pr:acme/looper:77",
       prNumber: 77,
+      lockKey: "worker-pr:project_1:acme/looper:77",
       status: "queued",
     });
 

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -458,7 +458,7 @@ describe("createLooperdApi", () => {
       targetType: "pull_request",
       targetId: "pr:acme/looper:42",
       prNumber: 42,
-      lockKey: "worker-pr:project_1:acme/looper:42",
+      lockKey: "pr:acme/looper:42",
       status: "queued",
     });
 
@@ -503,7 +503,7 @@ describe("createLooperdApi", () => {
       targetType: "pull_request",
       targetId: "pr:acme/looper:42",
       prNumber: 42,
-      lockKey: "worker-pr:project_2:acme/looper:42",
+      lockKey: "pr:acme/looper:42",
       status: "queued",
     });
 
@@ -560,7 +560,7 @@ describe("createLooperdApi", () => {
       targetType: "pull_request",
       targetId: "pr:acme/looper:77",
       prNumber: 77,
-      lockKey: "worker-pr:project_1:acme/looper:77",
+      lockKey: "pr:acme/looper:77",
       status: "queued",
     });
 

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -426,6 +426,97 @@ describe("createLooperdApi", () => {
       status: "queued",
     });
 
+    const createWorkerFromPrResponse = await api.handle(
+      new Request("http://localhost/api/v1/workers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          projectId: "project_1",
+          repo: "acme/looper",
+          prNumber: 42,
+        }),
+      }),
+    );
+    const createWorkerFromPrBody =
+      (await createWorkerFromPrResponse.json()) as {
+        data: {
+          id: string;
+          status: string;
+          repo: string;
+          prNumber: number;
+        };
+      };
+    expect(createWorkerFromPrResponse.status).toBe(200);
+    expect(createWorkerFromPrBody.data.status).toBe("running");
+    expect(createWorkerFromPrBody.data.repo).toBe("acme/looper");
+    expect(createWorkerFromPrBody.data.prNumber).toBe(42);
+    expect(
+      store.queue.findActiveByDedupe("worker:acme/looper:42"),
+    ).toMatchObject({
+      loopId: createWorkerFromPrBody.data.id,
+      type: "worker",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:42",
+      prNumber: 42,
+      status: "queued",
+    });
+
+    store.loops.upsert({
+      id: "loop_planner_issue_125",
+      projectId: "project_1",
+      type: "planner",
+      targetType: "issue",
+      targetId: "issue:acme/looper:125",
+      repo: "acme/looper",
+      prNumber: 77,
+      status: "running",
+      configJson: null,
+      metadataJson: JSON.stringify({
+        prNumber: 77,
+        specPath: "specs/issue-125.md",
+      }),
+      lastRunAt: "2026-04-11T12:03:00.000Z",
+      nextRunAt: "2026-04-11T12:03:00.000Z",
+      createdAt: "2026-04-11T12:03:00.000Z",
+      updatedAt: "2026-04-11T12:03:00.000Z",
+    });
+
+    const createWorkerFromIssueResponse = await api.handle(
+      new Request("http://localhost/api/v1/workers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          projectId: "project_1",
+          issueNumber: 125,
+        }),
+      }),
+    );
+    const createWorkerFromIssueBody =
+      (await createWorkerFromIssueResponse.json()) as {
+        data: {
+          id: string;
+          status: string;
+          issueNumber: number;
+          prNumber: number;
+          specPath: string;
+        };
+      };
+    expect(createWorkerFromIssueResponse.status).toBe(200);
+    expect(createWorkerFromIssueBody.data.status).toBe("running");
+    expect(createWorkerFromIssueBody.data.issueNumber).toBe(125);
+    expect(createWorkerFromIssueBody.data.prNumber).toBe(77);
+    expect(createWorkerFromIssueBody.data.specPath).toBe("specs/issue-125.md");
+    expect(
+      store.queue.findActiveByDedupe("worker:acme/looper:77"),
+    ).toMatchObject({
+      loopId: createWorkerFromIssueBody.data.id,
+      type: "worker",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:77",
+      prNumber: 77,
+      status: "queued",
+    });
+
     const validationResponse = await api.handle(
       new Request("http://localhost/api/v1/workers", {
         method: "POST",
@@ -434,6 +525,32 @@ describe("createLooperdApi", () => {
       }),
     );
     expect(validationResponse.status).toBe(400);
+
+    const missingPrResponse = await api.handle(
+      new Request("http://localhost/api/v1/workers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          projectId: "project_1",
+          repo: "acme/looper",
+          prNumber: 999,
+        }),
+      }),
+    );
+    expect(missingPrResponse.status).toBe(404);
+
+    const missingIssueResponse = await api.handle(
+      new Request("http://localhost/api/v1/workers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          projectId: "project_1",
+          repo: "acme/looper",
+          issueNumber: 999,
+        }),
+      }),
+    );
+    expect(missingIssueResponse.status).toBe(404);
 
     const createLoopResponse = await api.handle(
       new Request("http://localhost/api/v1/loops", {

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -1586,12 +1586,23 @@ function resolveWorkerProject(
   }
 
   if (input.repo && input.prNumber) {
-    const snapshot = context.store.pullRequestSnapshots.getLatest(
-      input.repo,
-      input.prNumber,
+    const snapshots = context.store.pullRequestSnapshots.list().filter(
+      (snapshot) =>
+        snapshot.repo === input.repo && snapshot.prNumber === input.prNumber,
     );
-    if (snapshot) {
-      const project = context.store.projects.getById(snapshot.projectId);
+    const projectIds = [
+      ...new Set(snapshots.map((snapshot) => snapshot.projectId)),
+    ];
+    if (projectIds.length > 1) {
+      throw new ApiError(
+        "PROJECT_AMBIGUOUS",
+        409,
+        `Multiple projects match pull request ${input.repo}#${input.prNumber}; pass projectId explicitly`,
+      );
+    }
+    const projectId = projectIds[0];
+    if (projectId) {
+      const project = context.store.projects.getById(projectId);
       if (project) {
         return project;
       }

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -631,7 +631,7 @@ async function buildWorkersCreateResponse(
       ? buildWorkerPullRequestDedupeKey(projectId, repo, effectivePrNumber)
       : `worker:${loop.id}`,
     lockKey: effectivePrNumber
-      ? buildPullRequestLockKey(repo, effectivePrNumber)
+      ? buildWorkerPullRequestLockKey(projectId, repo, effectivePrNumber)
       : `worker:${loop.id}`,
     payloadJson: JSON.stringify(payload),
   });
@@ -1752,8 +1752,12 @@ function buildWorkerPullRequestDedupeKey(
   return `worker:${projectId}:${repo}:${prNumber}`;
 }
 
-function buildPullRequestLockKey(repo: string, prNumber: number): string {
-  return `pr:${repo}:${prNumber}`;
+function buildWorkerPullRequestLockKey(
+  projectId: string,
+  repo: string,
+  prNumber: number,
+): string {
+  return `worker-pr:${projectId}:${repo}:${prNumber}`;
 }
 
 function deriveProjectIdFromPath(repoPath: string): string {

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -1586,10 +1586,12 @@ function resolveWorkerProject(
   }
 
   if (input.repo && input.prNumber) {
-    const snapshots = context.store.pullRequestSnapshots.list().filter(
-      (snapshot) =>
-        snapshot.repo === input.repo && snapshot.prNumber === input.prNumber,
-    );
+    const snapshots = context.store.pullRequestSnapshots
+      .list()
+      .filter(
+        (snapshot) =>
+          snapshot.repo === input.repo && snapshot.prNumber === input.prNumber,
+      );
     const projectIds = [
       ...new Set(snapshots.map((snapshot) => snapshot.projectId)),
     ];

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -1643,7 +1643,17 @@ function requirePullRequestTarget(
       `Pull request not found: ${input.repo}#${input.prNumber}`,
     );
   }
-  if (snapshot.projectId !== input.projectId) {
+  const project = context.store.projects.getById(input.projectId);
+  if (!project) {
+    throw new ApiError(
+      "PROJECT_NOT_FOUND",
+      404,
+      `Project not found: ${input.projectId}`,
+    );
+  }
+
+  const projectMetadata = parseMetadata(project.metadataJson);
+  if (readString(projectMetadata.repo) !== input.repo) {
     throw new ApiError(
       "PULL_REQUEST_PROJECT_MISMATCH",
       409,

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -521,29 +521,39 @@ async function buildWorkersCreateResponse(
   }
 
   const body = await parseJsonBody(request);
-  const projectId = readRequiredString(body, "projectId");
-  const project = context.store.projects.getById(projectId);
-  if (!project) {
-    throw new ApiError(
-      "PROJECT_NOT_FOUND",
-      404,
-      `Project not found: ${projectId}`,
-    );
-  }
-
+  const requestedProjectId = readOptionalString(body, "projectId");
+  const requestedRepo = readOptionalString(body, "repo");
   const prompt = readOptionalString(body, "prompt");
   const specPath = readOptionalString(body, "specPath");
-  if (!prompt && !specPath) {
+  const prNumber = readOptionalPositiveInteger(body, "prNumber");
+  const issueNumber = readOptionalPositiveInteger(body, "issueNumber");
+  const modeCount =
+    Number(Boolean(prNumber)) +
+    Number(Boolean(issueNumber)) +
+    Number(Boolean(prompt || specPath));
+  if (modeCount === 0) {
     throw new ApiError(
       "VALIDATION_FAILED",
       400,
-      "prompt or specPath is required",
+      "prompt or specPath is required unless prNumber or issueNumber is provided",
+    );
+  }
+  if (modeCount > 1) {
+    throw new ApiError(
+      "VALIDATION_FAILED",
+      400,
+      "worker accepts exactly one input mode: prompt/specPath, prNumber, or issueNumber",
     );
   }
 
+  const project = resolveWorkerProject(context, {
+    projectId: requestedProjectId,
+    repo: requestedRepo,
+    prNumber,
+  });
+  const projectId = project.id;
   const projectMetadata = parseMetadata(project.metadataJson);
-  const repo =
-    readOptionalString(body, "repo") ?? readString(projectMetadata.repo);
+  const repo = requestedRepo ?? readString(projectMetadata.repo);
   const baseBranch =
     readOptionalString(body, "baseBranch") ?? project.baseBranch ?? null;
   if (!repo) {
@@ -553,48 +563,83 @@ async function buildWorkersCreateResponse(
     throw new ApiError("VALIDATION_FAILED", 400, "baseBranch is required");
   }
 
+  const pullRequestTarget =
+    prNumber == null
+      ? null
+      : requirePullRequestTarget(context, {
+          projectId,
+          repo,
+          prNumber,
+        });
+  const planner =
+    issueNumber == null
+      ? null
+      : findPlannerLoopForIssue(context, {
+          projectId,
+          repo,
+          issueNumber,
+        });
+  const effectivePrNumber =
+    pullRequestTarget?.prNumber ?? planner?.prNumber ?? null;
+  const effectiveSpecPath = specPath ?? planner?.specPath ?? null;
   const title =
     readOptionalString(body, "title") ??
-    deriveWorkerTitle({ prompt, specPath });
+    deriveWorkerTitle({
+      prompt,
+      specPath: effectiveSpecPath,
+      repo,
+      prNumber: effectivePrNumber,
+      issueNumber,
+    });
   const now = new Date().toISOString();
   const payload = {
     title,
     prompt,
-    specPath,
+    specPath: effectiveSpecPath,
     repo,
     baseBranch,
+    ...(effectivePrNumber ? { prNumber: effectivePrNumber } : {}),
   };
   const loop = createLoopRecord({
     context,
     projectId,
     type: "worker",
-    targetType: "project",
-    targetId: projectId,
+    targetType: effectivePrNumber ? "pull_request" : "project",
+    targetId: effectivePrNumber ? `pr:${repo}:${effectivePrNumber}` : projectId,
+    repo,
+    prNumber: effectivePrNumber ?? undefined,
     status: "running",
     now,
     metadataJson: JSON.stringify({ worker: payload }),
   });
 
-  new SchedulerQueue({
+  const scheduler = new SchedulerQueue({
     store: context.store,
     retryMaxAttempts: context.config.scheduler.retryMaxAttempts,
     retryBaseDelayMs: context.config.scheduler.retryBaseDelayMs,
     now: () => new Date(now),
-  }).enqueue({
+  });
+  scheduler.enqueue({
     projectId,
     loopId: loop.id,
     type: "worker",
-    targetType: "project",
-    targetId: projectId,
+    targetType: effectivePrNumber ? "pull_request" : "project",
+    targetId: effectivePrNumber ? `pr:${repo}:${effectivePrNumber}` : projectId,
     repo,
-    dedupeKey: `worker:${loop.id}`,
-    lockKey: `worker:${loop.id}`,
+    ...(effectivePrNumber ? { prNumber: effectivePrNumber } : {}),
+    dedupeKey: effectivePrNumber
+      ? buildWorkerPullRequestDedupeKey(repo, effectivePrNumber)
+      : `worker:${loop.id}`,
+    lockKey: effectivePrNumber
+      ? buildPullRequestLockKey(repo, effectivePrNumber)
+      : `worker:${loop.id}`,
     payloadJson: JSON.stringify(payload),
   });
 
   return {
     ...loop,
     ...payload,
+    ...(issueNumber ? { issueNumber } : {}),
   };
 }
 
@@ -1519,15 +1564,156 @@ function parseMetadata(metadataJson?: string | null): Record<string, unknown> {
     : {};
 }
 
+function resolveWorkerProject(
+  context: LooperdApiContext,
+  input: {
+    projectId: string | null;
+    repo: string | null;
+    prNumber: number | null;
+  },
+) {
+  if (input.projectId) {
+    const project = context.store.projects.getById(input.projectId);
+    if (!project) {
+      throw new ApiError(
+        "PROJECT_NOT_FOUND",
+        404,
+        `Project not found: ${input.projectId}`,
+      );
+    }
+    return project;
+  }
+
+  if (input.repo && input.prNumber) {
+    const snapshot = context.store.pullRequestSnapshots.getLatest(
+      input.repo,
+      input.prNumber,
+    );
+    if (snapshot) {
+      const project = context.store.projects.getById(snapshot.projectId);
+      if (project) {
+        return project;
+      }
+    }
+  }
+
+  if (input.repo) {
+    const matches = context.store.projects.list().filter((project) => {
+      const metadata = parseMetadata(project.metadataJson);
+      return readString(metadata.repo) === input.repo;
+    });
+    if (matches.length === 1) {
+      const project = matches[0];
+      if (project) {
+        return project;
+      }
+    }
+    if (matches.length > 1) {
+      throw new ApiError(
+        "PROJECT_AMBIGUOUS",
+        409,
+        `Multiple projects match repo ${input.repo}; pass projectId explicitly`,
+      );
+    }
+  }
+
+  throw new ApiError(
+    "VALIDATION_FAILED",
+    400,
+    "projectId is required unless it can be resolved from repo/prNumber",
+  );
+}
+
+function requirePullRequestTarget(
+  context: LooperdApiContext,
+  input: {
+    projectId: string;
+    repo: string;
+    prNumber: number;
+  },
+): { prNumber: number } {
+  const snapshot = context.store.pullRequestSnapshots.getLatest(
+    input.repo,
+    input.prNumber,
+  );
+  if (!snapshot) {
+    throw new ApiError(
+      "PULL_REQUEST_NOT_FOUND",
+      404,
+      `Pull request not found: ${input.repo}#${input.prNumber}`,
+    );
+  }
+  if (snapshot.projectId !== input.projectId) {
+    throw new ApiError(
+      "PULL_REQUEST_PROJECT_MISMATCH",
+      409,
+      `Pull request ${input.repo}#${input.prNumber} does not belong to project ${input.projectId}`,
+    );
+  }
+
+  return { prNumber: snapshot.prNumber };
+}
+
+function findPlannerLoopForIssue(
+  context: LooperdApiContext,
+  input: {
+    projectId: string;
+    repo: string;
+    issueNumber: number;
+  },
+): { prNumber: number; specPath: string | null } {
+  const targetId = `issue:${input.repo}:${input.issueNumber}`;
+  const loop = context.store.loops
+    .list()
+    .find(
+      (candidate) =>
+        candidate.projectId === input.projectId &&
+        candidate.type === "planner" &&
+        candidate.targetType === "issue" &&
+        candidate.targetId === targetId,
+    );
+  if (!loop) {
+    throw new ApiError(
+      "PLANNER_NOT_FOUND",
+      404,
+      `No planner loop found for ${input.repo}#${input.issueNumber}`,
+    );
+  }
+
+  const metadata = parseMetadata(loop.metadataJson);
+  const prNumber = loop.prNumber ?? readNumber(metadata.prNumber);
+  if (!prNumber) {
+    throw new ApiError(
+      "PLANNER_PR_NOT_READY",
+      409,
+      `Planner spec PR is not ready for ${input.repo}#${input.issueNumber}`,
+    );
+  }
+
+  return {
+    prNumber,
+    specPath: readString(metadata.specPath),
+  };
+}
+
 function readString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0
     ? value.trim()
     : null;
 }
 
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : null;
+}
+
 function deriveWorkerTitle(input: {
   prompt: string | null;
   specPath: string | null;
+  repo: string | null;
+  prNumber: number | null;
+  issueNumber: number | null;
 }): string {
   if (input.prompt) {
     return input.prompt.slice(0, 80);
@@ -1537,7 +1723,26 @@ function deriveWorkerTitle(input: {
     return `Implement ${input.specPath}`;
   }
 
+  if (input.prNumber && input.repo) {
+    return `Implement ${input.repo}#${input.prNumber}`;
+  }
+
+  if (input.issueNumber && input.repo) {
+    return `Implement ${input.repo}#${input.issueNumber}`;
+  }
+
   return "Worker run";
+}
+
+function buildWorkerPullRequestDedupeKey(
+  repo: string,
+  prNumber: number,
+): string {
+  return `worker:${repo}:${prNumber}`;
+}
+
+function buildPullRequestLockKey(repo: string, prNumber: number): string {
+  return `pr:${repo}:${prNumber}`;
 }
 
 function deriveProjectIdFromPath(repoPath: string): string {

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -5,6 +5,7 @@ import type { LooperConfig } from "../config/index";
 import {
   assertUniqueActiveLoop,
   createLoop,
+  createPrLockKey,
   defineIssueLoopTarget,
   defineProjectLoopTarget,
   definePullRequestLoopTarget,
@@ -631,7 +632,7 @@ async function buildWorkersCreateResponse(
       ? buildWorkerPullRequestDedupeKey(projectId, repo, effectivePrNumber)
       : `worker:${loop.id}`,
     lockKey: effectivePrNumber
-      ? buildWorkerPullRequestLockKey(projectId, repo, effectivePrNumber)
+      ? buildWorkerPullRequestLockKey(repo, effectivePrNumber)
       : `worker:${loop.id}`,
     payloadJson: JSON.stringify(payload),
   });
@@ -1752,12 +1753,8 @@ function buildWorkerPullRequestDedupeKey(
   return `worker:${projectId}:${repo}:${prNumber}`;
 }
 
-function buildWorkerPullRequestLockKey(
-  projectId: string,
-  repo: string,
-  prNumber: number,
-): string {
-  return `worker-pr:${projectId}:${repo}:${prNumber}`;
+function buildWorkerPullRequestLockKey(repo: string, prNumber: number): string {
+  return createPrLockKey(repo, prNumber);
 }
 
 function deriveProjectIdFromPath(repoPath: string): string {

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -628,7 +628,7 @@ async function buildWorkersCreateResponse(
     repo,
     ...(effectivePrNumber ? { prNumber: effectivePrNumber } : {}),
     dedupeKey: effectivePrNumber
-      ? buildWorkerPullRequestDedupeKey(repo, effectivePrNumber)
+      ? buildWorkerPullRequestDedupeKey(projectId, repo, effectivePrNumber)
       : `worker:${loop.id}`,
     lockKey: effectivePrNumber
       ? buildPullRequestLockKey(repo, effectivePrNumber)
@@ -1735,10 +1735,11 @@ function deriveWorkerTitle(input: {
 }
 
 function buildWorkerPullRequestDedupeKey(
+  projectId: string,
   repo: string,
   prNumber: number,
 ): string {
-  return `worker:${repo}:${prNumber}`;
+  return `worker:${projectId}:${repo}:${prNumber}`;
 }
 
 function buildPullRequestLockKey(repo: string, prNumber: number): string {

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -359,7 +359,7 @@ describe("WorkerLoopRunner", () => {
         claimedAt: null,
         startedAt: null,
         finishedAt: null,
-        lockKey: `worker-pr:project_1:acme/looper:${prNumber}`,
+        lockKey: `pr:acme/looper:${prNumber}`,
         payloadJson: null,
         lastError: null,
         lastErrorKind: null,
@@ -371,7 +371,7 @@ describe("WorkerLoopRunner", () => {
       targetId: `pr:acme/looper:${prNumber}`,
       repo: "acme/looper",
       prNumber,
-      lockKey: `worker-pr:project_1:acme/looper:${prNumber}`,
+      lockKey: `pr:acme/looper:${prNumber}`,
       payloadJson: null,
       updatedAt: fixture.now.toISOString(),
     });
@@ -778,7 +778,7 @@ describe("WorkerLoopRunner", () => {
     const fixture = await createFixture();
     configurePullRequestWorkerLoop(fixture, 79);
     fixture.queue.acquireBusinessLock({
-      key: "worker-pr:project_1:acme/looper:79",
+      key: "pr:acme/looper:79",
       owner: "other-worker",
       reason: "test-lock",
       expiresAt: new Date(fixture.now.getTime() + 60_000).toISOString(),

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -359,7 +359,7 @@ describe("WorkerLoopRunner", () => {
         claimedAt: null,
         startedAt: null,
         finishedAt: null,
-        lockKey: `pr:acme/looper:${prNumber}`,
+        lockKey: `worker-pr:project_1:acme/looper:${prNumber}`,
         payloadJson: null,
         lastError: null,
         lastErrorKind: null,
@@ -371,7 +371,7 @@ describe("WorkerLoopRunner", () => {
       targetId: `pr:acme/looper:${prNumber}`,
       repo: "acme/looper",
       prNumber,
-      lockKey: `pr:acme/looper:${prNumber}`,
+      lockKey: `worker-pr:project_1:acme/looper:${prNumber}`,
       payloadJson: null,
       updatedAt: fixture.now.toISOString(),
     });
@@ -778,7 +778,7 @@ describe("WorkerLoopRunner", () => {
     const fixture = await createFixture();
     configurePullRequestWorkerLoop(fixture, 79);
     fixture.queue.acquireBusinessLock({
-      key: "pr:acme/looper:79",
+      key: "worker-pr:project_1:acme/looper:79",
       owner: "other-worker",
       reason: "test-lock",
       expiresAt: new Date(fixture.now.getTime() + 60_000).toISOString(),

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -452,6 +452,7 @@ export class WorkerLoopRunner {
           repo: input.repo,
           prNumber: pullRequest.number,
           dedupeKey: buildWorkerPullRequestDedupeKey(
+            project.id,
             input.repo,
             pullRequest.number,
           ),
@@ -1415,10 +1416,11 @@ function buildPullRequestTargetId(repo: string, prNumber: number): string {
 }
 
 function buildWorkerPullRequestDedupeKey(
+  projectId: string,
   repo: string,
   prNumber: number,
 ): string {
-  return `worker:${repo}:${prNumber}`;
+  return `worker:${projectId}:${repo}:${prNumber}`;
 }
 
 function buildPullRequestLockKey(repo: string, prNumber: number): string {

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -456,7 +456,11 @@ export class WorkerLoopRunner {
             input.repo,
             pullRequest.number,
           ),
-          lockKey: buildPullRequestLockKey(input.repo, pullRequest.number),
+          lockKey: buildWorkerPullRequestLockKey(
+            project.id,
+            input.repo,
+            pullRequest.number,
+          ),
         }),
       );
     }
@@ -549,7 +553,11 @@ export class WorkerLoopRunner {
     const lockKey =
       input.queueItem.lockKey ??
       (work.executionMode === "push-existing" && work.prNumber
-        ? buildPullRequestLockKey(work.repo, work.prNumber)
+        ? buildWorkerPullRequestLockKey(
+            input.project.id,
+            work.repo,
+            work.prNumber,
+          )
         : `worker:${input.loop.id}`);
     const acquired = this.options.scheduler.acquireBusinessLock({
       key: lockKey,
@@ -1423,8 +1431,12 @@ function buildWorkerPullRequestDedupeKey(
   return `worker:${projectId}:${repo}:${prNumber}`;
 }
 
-function buildPullRequestLockKey(repo: string, prNumber: number): string {
-  return `pr:${repo}:${prNumber}`;
+function buildWorkerPullRequestLockKey(
+  projectId: string,
+  repo: string,
+  prNumber: number,
+): string {
+  return `worker-pr:${projectId}:${repo}:${prNumber}`;
 }
 
 function normalizePrState(value: string | undefined): "open" | "other" {

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join } from "node:path";
 
 import type { Logger } from "../bootstrap/logger";
 import type { OpenPrStrategy } from "../config/index";
+import { createPrLockKey } from "../domain/index";
 import type { AgentResult, AgentRunInput } from "../infra/agent";
 import { appendCompletionInstruction } from "../infra/agent-prompt";
 import { CommandExecutionError, runCommand } from "../infra/command";
@@ -457,7 +458,6 @@ export class WorkerLoopRunner {
             pullRequest.number,
           ),
           lockKey: buildWorkerPullRequestLockKey(
-            project.id,
             input.repo,
             pullRequest.number,
           ),
@@ -553,11 +553,7 @@ export class WorkerLoopRunner {
     const lockKey =
       input.queueItem.lockKey ??
       (work.executionMode === "push-existing" && work.prNumber
-        ? buildWorkerPullRequestLockKey(
-            input.project.id,
-            work.repo,
-            work.prNumber,
-          )
+        ? buildWorkerPullRequestLockKey(work.repo, work.prNumber)
         : `worker:${input.loop.id}`);
     const acquired = this.options.scheduler.acquireBusinessLock({
       key: lockKey,
@@ -1431,12 +1427,8 @@ function buildWorkerPullRequestDedupeKey(
   return `worker:${projectId}:${repo}:${prNumber}`;
 }
 
-function buildWorkerPullRequestLockKey(
-  projectId: string,
-  repo: string,
-  prNumber: number,
-): string {
-  return `worker-pr:${projectId}:${repo}:${prNumber}`;
+function buildWorkerPullRequestLockKey(repo: string, prNumber: number): string {
+  return createPrLockKey(repo, prNumber);
 }
 
 function normalizePrState(value: string | undefined): "open" | "other" {


### PR DESCRIPTION
## Summary
- let `looper work` auto-detect the project from the current directory and start worker runs from prompts/specs, pull requests, or planner issues
- let `looper plan` accept issue references directly and reuse project inference instead of requiring an explicit project id
- update the looperd worker API and tests so worker runs can resolve PR/issue targets, dedupe per PR, and reuse planner-generated spec PR metadata