### PR TITLE
Add looper work --issue CLI support

### DIFF
--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -82,6 +82,91 @@ describe("runCli", () => {
     expect(requests[0]?.body).toContain('"specPath":"spec.md"');
   });
 
+  test("creates worker work item from issue number", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(
+      [
+        "work",
+        "--project",
+        "project_1",
+        "--issue",
+        "123",
+        "--repo",
+        "acme/looper",
+        "--base-branch",
+        "main",
+      ],
+      {
+        stdout: () => {},
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async (input, init) => {
+          requests.push({
+            url: String(input),
+            body: init?.body as string | null,
+          });
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_2_issue",
+              data: {
+                id: "loop_2",
+                title: "Implement acme/looper#123",
+                status: "running",
+              },
+            }),
+          );
+        },
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toContain("/api/v1/workers");
+    expect(requests[0]?.body).toContain('"projectId":"project_1"');
+    expect(requests[0]?.body).toContain('"issueNumber":123');
+    expect(requests[0]?.body).toContain('"repo":"acme/looper"');
+    expect(requests[0]?.body).toContain('"baseBranch":"main"');
+    expect(requests[0]?.body).not.toContain('"title":');
+  });
+
+  test("rejects invalid worker issue number", async () => {
+    const errors: string[] = [];
+    const exitCode = await runCli(
+      ["work", "--project", "project_1", "--issue", "123abc"],
+      {
+        stderr: (line) => errors.push(line),
+        loadConfigImpl: async () => createConfig() as never,
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(errors.at(-1)).toContain("--issue must be a positive integer");
+  });
+
+  test("rejects combining worker issue with prompt or spec", async () => {
+    const errors: string[] = [];
+    const exitCode = await runCli(
+      [
+        "work",
+        "--project",
+        "project_1",
+        "--issue",
+        "123",
+        "--prompt",
+        "Implement CLI flow",
+      ],
+      {
+        stderr: (line) => errors.push(line),
+        loadConfigImpl: async () => createConfig() as never,
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(errors.at(-1)).toContain(
+      "--issue cannot be combined with --prompt or --spec",
+    );
+  });
+
   test("creates reviewer loop from PR reference", async () => {
     const requests: string[] = [];
     const exitCode = await runCli(

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -167,6 +167,22 @@ describe("runCli", () => {
     );
   });
 
+  test("rejects valueless title in worker issue mode", async () => {
+    const errors: string[] = [];
+    const exitCode = await runCli(
+      ["work", "--project", "project_1", "--issue", "123", "--title"],
+      {
+        stderr: (line) => errors.push(line),
+        loadConfigImpl: async () => createConfig() as never,
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(errors.at(-1)).toContain(
+      "option `--title <title>` value is missing",
+    );
+  });
+
   test("creates reviewer loop from PR reference", async () => {
     const requests: string[] = [];
     const exitCode = await runCli(

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -844,8 +844,8 @@ async function runWorkCreate(context: CliContext) {
       projectId: requireFlag(context.args, "project"),
       ...(issueNumber == null
         ? { title: requireFlag(context.args, "title") }
-        : getFlag(context.args, "title") != null
-          ? { title: getFlag(context.args, "title") }
+        : hasFlag(context.args, "title")
+          ? { title: requireFlag(context.args, "title") }
           : {}),
       ...(getFlag(context.args, "prompt") != null
         ? { prompt: getFlag(context.args, "prompt") }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -373,6 +373,7 @@ function createCli(runtime: CliRuntime) {
     .option("--project <projectId>", "Project id")
     .option("--title <title>", "Task title")
     .option("--prompt <text>", "Implementation prompt")
+    .option("--issue <number>", "Issue number")
     .option("--spec <path>", "Spec path")
     .option("--repo <repo>", "Repository slug")
     .option("--base-branch <branch>", "Base branch")
@@ -380,6 +381,7 @@ function createCli(runtime: CliRuntime) {
       (name) =>
         `  $ ${name} work --project project_1 --title "Ship CLI" --spec specs/ship-cli.md`,
     )
+    .example((name) => `  $ ${name} work --project project_1 --issue 123`)
     .action(async (options) => {
       await dispatch(createContext(runtime, ["work"], options));
     });
@@ -819,13 +821,39 @@ async function runLoopPause(context: CliContext) {
 }
 
 async function runWorkCreate(context: CliContext) {
+  const issueNumberValue = getFlag(context.args, "issue");
+  let issueNumber: number | undefined;
+  if (issueNumberValue != null) {
+    if (
+      getFlag(context.args, "prompt") != null ||
+      getFlag(context.args, "spec") != null
+    ) {
+      throw new Error("--issue cannot be combined with --prompt or --spec");
+    }
+
+    const parsedIssueNumber = Number(issueNumberValue);
+    if (!Number.isInteger(parsedIssueNumber) || parsedIssueNumber <= 0) {
+      throw new Error("--issue must be a positive integer");
+    }
+    issueNumber = parsedIssueNumber;
+  }
+
   const data = await context.client.post<Record<string, unknown>>(
     "/api/v1/workers",
     {
       projectId: requireFlag(context.args, "project"),
-      title: requireFlag(context.args, "title"),
-      prompt: getFlag(context.args, "prompt"),
-      specPath: getFlag(context.args, "spec"),
+      ...(issueNumber == null
+        ? { title: requireFlag(context.args, "title") }
+        : getFlag(context.args, "title") != null
+          ? { title: getFlag(context.args, "title") }
+          : {}),
+      ...(getFlag(context.args, "prompt") != null
+        ? { prompt: getFlag(context.args, "prompt") }
+        : {}),
+      ...(issueNumber == null ? {} : { issueNumber }),
+      ...(getFlag(context.args, "spec") != null
+        ? { specPath: getFlag(context.args, "spec") }
+        : {}),
       repo: getFlag(context.args, "repo"),
       baseBranch: getFlag(context.args, "base-branch"),
     },


### PR DESCRIPTION
## Summary
- add `--issue` to `looper work` and forward it to the worker creation API
- make `--title` optional for issue-based worker runs while rejecting invalid/conflicting flag combinations in the CLI
- add CLI tests for happy path and new issue flag validation behavior