### PR TITLE
Add cwd project resolution for work and plan

### DIFF
--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -129,6 +129,82 @@ describe("runCli", () => {
     expect(requests[0]?.body).not.toContain('"title":');
   });
 
+  test("detects worker project from cwd when --project is omitted", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(
+      ["work", "--issue", "123", "--repo", "acme/looper"],
+      {
+        cwd: "/tmp/repos/looper/packages/cli",
+        stdout: () => {},
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async (input, init) => {
+          const url = String(input);
+          requests.push({
+            url,
+            body: init?.body as string | null,
+          });
+
+          if (url.endsWith("/api/v1/projects")) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                requestId: "req_projects_1",
+                data: {
+                  items: [
+                    { id: "project_other", repoPath: "/tmp/repos/other" },
+                    { id: "project_1", repoPath: "/tmp/repos/looper" },
+                  ],
+                },
+              }),
+            );
+          }
+
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_work_cwd_1",
+              data: {
+                id: "loop_2",
+                title: "Implement acme/looper#123",
+                status: "running",
+              },
+            }),
+          );
+        },
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.url).toContain("/api/v1/projects");
+    expect(requests[1]?.url).toContain("/api/v1/workers");
+    expect(requests[1]?.body).toContain('"projectId":"project_1"');
+  });
+
+  test("errors when worker cwd does not match a project and --project is omitted", async () => {
+    const errors: string[] = [];
+    const exitCode = await runCli(["work", "--issue", "123"], {
+      cwd: "/tmp/repos/missing",
+      stderr: (line) => errors.push(line),
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_projects_2",
+            data: {
+              items: [{ id: "project_1", repoPath: "/tmp/repos/looper" }],
+            },
+          }),
+        ),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors.at(-1)).toContain(
+      "--project is required (no project matched cwd /tmp/repos/missing)",
+    );
+  });
+
   test("rejects invalid worker issue number", async () => {
     const errors: string[] = [];
     const exitCode = await runCli(
@@ -256,6 +332,52 @@ describe("runCli", () => {
     expect(exitCode).toBe(0);
     expect(requests[0]?.url).toContain("/api/v1/planners");
     expect(requests[0]?.body).toContain('"issueNumber":123');
+  });
+
+  test("detects planner project from cwd when --project is omitted", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["plan", "--issue", "123"], {
+      cwd: "/tmp/repos/looper",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body as string | null,
+        });
+
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_projects_3",
+              data: {
+                items: [{ id: "project_1", repoPath: "/tmp/repos/looper" }],
+              },
+            }),
+          );
+        }
+
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_plan_cwd_1",
+            data: {
+              id: "loop_plan_1",
+              issueNumber: 123,
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.url).toContain("/api/v1/projects");
+    expect(requests[1]?.url).toContain("/api/v1/planners");
+    expect(requests[1]?.body).toContain('"projectId":"project_1"');
   });
 
   test("adds project and requests discovery", async () => {

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -205,6 +205,83 @@ describe("runCli", () => {
     );
   });
 
+  test("normalizes /private-prefixed cwd aliases when detecting worker project", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(
+      ["work", "--issue", "123", "--repo", "acme/looper"],
+      {
+        cwd: "/private/tmp/repos/looper/packages/cli",
+        stdout: () => {},
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async (input, init) => {
+          const url = String(input);
+          requests.push({
+            url,
+            body: init?.body as string | null,
+          });
+
+          if (url.endsWith("/api/v1/projects")) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                requestId: "req_projects_private_1",
+                data: {
+                  items: [{ id: "project_1", repoPath: "/tmp/repos/looper" }],
+                },
+              }),
+            );
+          }
+
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_work_private_1",
+              data: {
+                id: "loop_private_1",
+                title: "Implement acme/looper#123",
+                status: "running",
+              },
+            }),
+          );
+        },
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.body).toContain('"projectId":"project_1"');
+  });
+
+  test("errors when worker cwd matches multiple equally specific projects", async () => {
+    const errors: string[] = [];
+    const exitCode = await runCli(
+      ["work", "--issue", "123", "--repo", "acme/looper"],
+      {
+        cwd: "/tmp/repos/looper/packages/cli",
+        stderr: (line) => errors.push(line),
+        loadConfigImpl: async () => createConfig() as never,
+        fetchImpl: async () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_projects_ambiguous_1",
+              data: {
+                items: [
+                  { id: "project_1", repoPath: "/tmp/repos/looper" },
+                  { id: "project_2", repoPath: "/tmp/repos/looper" },
+                ],
+              },
+            }),
+          ),
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(errors.at(-1)).toContain(
+      "--project is required (multiple projects matched cwd /tmp/repos/looper/packages/cli)",
+    );
+  });
+
   test("rejects invalid worker issue number", async () => {
     const errors: string[] = [];
     const exitCode = await runCli(
@@ -378,6 +455,33 @@ describe("runCli", () => {
     expect(requests[0]?.url).toContain("/api/v1/projects");
     expect(requests[1]?.url).toContain("/api/v1/planners");
     expect(requests[1]?.body).toContain('"projectId":"project_1"');
+  });
+
+  test("errors when planner cwd matches multiple equally specific projects", async () => {
+    const errors: string[] = [];
+    const exitCode = await runCli(["plan", "--issue", "123"], {
+      cwd: "/tmp/repos/looper",
+      stderr: (line) => errors.push(line),
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_projects_ambiguous_2",
+            data: {
+              items: [
+                { id: "project_1", repoPath: "/tmp/repos/looper" },
+                { id: "project_2", repoPath: "/tmp/repos/looper" },
+              ],
+            },
+          }),
+        ),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors.at(-1)).toContain(
+      "--project is required (multiple projects matched cwd /tmp/repos/looper)",
+    );
   });
 
   test("adds project and requests discovery", async () => {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, join, resolve, sep } from "node:path";
 import { cac } from "cac";
 
 import {
@@ -43,6 +43,7 @@ interface CliContext {
   readFileImpl: (path: string, encoding: "utf8") => Promise<string>;
   showHelp: (commandName?: string) => void;
   env: Record<string, string | undefined>;
+  cwd: string;
   isStdoutTty: boolean;
   launchShell: (cwd: string) => Promise<number>;
 }
@@ -196,6 +197,7 @@ export async function runCli(
       readFileImpl: deps.readFileImpl ?? readFile,
       showHelp: () => {},
       env,
+      cwd,
       isStdoutTty: deps.isStdoutTty ?? Boolean(process.stdout.isTTY),
       launchShell: async (shellCwd) =>
         (deps.launchShellImpl ?? launchInteractiveShell)({
@@ -841,7 +843,7 @@ async function runWorkCreate(context: CliContext) {
   const data = await context.client.post<Record<string, unknown>>(
     "/api/v1/workers",
     {
-      projectId: requireFlag(context.args, "project"),
+      projectId: await resolveCommandProjectId(context),
       ...(issueNumber == null
         ? { title: requireFlag(context.args, "title") }
         : hasFlag(context.args, "title")
@@ -879,7 +881,7 @@ async function runPlannerCreate(context: CliContext) {
   const data = await context.client.post<Record<string, unknown>>(
     "/api/v1/planners",
     {
-      projectId: requireFlag(context.args, "project"),
+      projectId: await resolveCommandProjectId(context),
       issueNumber,
     },
   );
@@ -1284,6 +1286,40 @@ function requireFlag(args: ParsedArgs, name: string): string {
     throw new Error(`--${name} is required`);
   }
   return value;
+}
+
+async function resolveCommandProjectId(context: CliContext): Promise<string> {
+  const explicitProjectId = getFlag(context.args, "project");
+  if (explicitProjectId && explicitProjectId !== "true") {
+    return explicitProjectId;
+  }
+
+  const cwd = resolve(context.cwd);
+  const data = await context.client.get<{
+    items: Array<{ id: string; repoPath: string }>;
+  }>("/api/v1/projects");
+  const matches = data.items.filter((project) =>
+    isWithinProjectRepo(cwd, project.repoPath),
+  );
+
+  if (matches.length === 0) {
+    throw new Error(`--project is required (no project matched cwd ${cwd})`);
+  }
+
+  matches.sort((left, right) => right.repoPath.length - left.repoPath.length);
+  const match = matches[0];
+  if (!match) {
+    throw new Error(`--project is required (no project matched cwd ${cwd})`);
+  }
+
+  return match.id;
+}
+
+function isWithinProjectRepo(cwd: string, repoPath: string): boolean {
+  const normalizedRepoPath = resolve(repoPath);
+  return (
+    cwd === normalizedRepoPath || cwd.startsWith(`${normalizedRepoPath}${sep}`)
+  );
 }
 
 function parsePullRequestRef(value: string): PullRequestRef {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1294,7 +1294,7 @@ async function resolveCommandProjectId(context: CliContext): Promise<string> {
     return explicitProjectId;
   }
 
-  const cwd = resolve(context.cwd);
+  const cwd = normalizeComparablePath(context.cwd);
   const data = await context.client.get<{
     items: Array<{ id: string; repoPath: string }>;
   }>("/api/v1/projects");
@@ -1306,20 +1306,43 @@ async function resolveCommandProjectId(context: CliContext): Promise<string> {
     throw new Error(`--project is required (no project matched cwd ${cwd})`);
   }
 
-  matches.sort((left, right) => right.repoPath.length - left.repoPath.length);
-  const match = matches[0];
+  const rankedMatches = matches
+    .map((project) => ({
+      project,
+      normalizedRepoPath: normalizeComparablePath(project.repoPath),
+    }))
+    .sort(
+      (left, right) =>
+        right.normalizedRepoPath.length - left.normalizedRepoPath.length,
+    );
+  const match = rankedMatches[0];
   if (!match) {
     throw new Error(`--project is required (no project matched cwd ${cwd})`);
   }
 
-  return match.id;
+  const ambiguousMatch = rankedMatches.find(
+    (candidate) =>
+      candidate.project.id !== match.project.id &&
+      candidate.normalizedRepoPath.length === match.normalizedRepoPath.length,
+  );
+  if (ambiguousMatch) {
+    throw new Error(
+      `--project is required (multiple projects matched cwd ${cwd})`,
+    );
+  }
+
+  return match.project.id;
 }
 
 function isWithinProjectRepo(cwd: string, repoPath: string): boolean {
-  const normalizedRepoPath = resolve(repoPath);
+  const normalizedRepoPath = normalizeComparablePath(repoPath);
   return (
     cwd === normalizedRepoPath || cwd.startsWith(`${normalizedRepoPath}${sep}`)
   );
+}
+
+function normalizeComparablePath(path: string): string {
+  return resolve(path).replace(/^\/private/, "");
 }
 
 function parsePullRequestRef(value: string): PullRequestRef {


### PR DESCRIPTION
## Summary
- add CLI fallback to resolve `work` and `plan` project ids from the current working directory when `--project` is omitted
- keep explicit `--project` behavior unchanged and return a clearer error when cwd does not match any registered project
- cover worker and planner cwd resolution with focused CLI tests