### PR TITLE
Use detached worktrees for fixer PR updates

### DIFF
--- a/apps/looperd/src/fixer/index.test.ts
+++ b/apps/looperd/src/fixer/index.test.ts
@@ -210,6 +210,16 @@ class FakeGitGateway implements FixerGitGateway {
   public cleanupCalls = 0;
   public lastExpectedRemoteHeadSha?: string;
   public pushError?: string;
+  public lastCreateWorktreeInput?: {
+    projectId: string;
+    repoPath: string;
+    worktreeRoot: string;
+    branch: string;
+    baseBranch: string;
+    prNumber: number;
+    protectedBranches?: string[];
+    checkoutMode?: "branch" | "detached";
+  };
 
   constructor(
     private readonly options: {
@@ -236,8 +246,10 @@ class FakeGitGateway implements FixerGitGateway {
     baseBranch: string;
     prNumber: number;
     protectedBranches?: string[];
+    checkoutMode?: "branch" | "detached";
   }) {
     this.createWorktreeCalls += 1;
+    this.lastCreateWorktreeInput = _input;
     return {
       worktreePath: this.options.worktreePath ?? "/tmp/looper-fixer-worktree",
       branch: _input.branch,
@@ -483,6 +495,7 @@ describe("FixerLoopRunner", () => {
     }
     expect(agent.starts).toHaveLength(1);
     expect(git.createWorktreeCalls).toBe(1);
+    expect(git.lastCreateWorktreeInput?.checkoutMode).toBe("detached");
     expect(git.prepareCalls).toBe(1);
     expect(git.pushCalls).toBe(1);
     expect(git.lastExpectedRemoteHeadSha).toBe("abc123");

--- a/apps/looperd/src/fixer/index.ts
+++ b/apps/looperd/src/fixer/index.ts
@@ -85,6 +85,7 @@ export interface FixerGitGateway {
     baseBranch: string;
     prNumber: number;
     protectedBranches?: string[];
+    checkoutMode?: "branch" | "detached";
   }): Promise<{
     worktreePath: string;
     branch: string;
@@ -816,6 +817,7 @@ export class FixerLoopRunner {
         detail?.baseRefName,
         input.project.baseBranch,
       ]),
+      checkoutMode: "detached",
     });
     const prepared = await this.options.git.prepareWorktree({
       worktreePath: worktree.worktreePath,

--- a/apps/looperd/src/infra/git.test.ts
+++ b/apps/looperd/src/infra/git.test.ts
@@ -373,6 +373,135 @@ describe("GitWorktreeGateway", () => {
     store.close();
   });
 
+  test("recreates a stored attached worktree when it is on the wrong branch", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
+    cleanupPaths.push(rootDir);
+    const repoPath = join(rootDir, "repo");
+    const worktreeRoot = join(rootDir, "worktrees");
+    await mkdir(repoPath, { recursive: true });
+
+    await runGit(["init", "-b", "main"], repoPath);
+    await runGit(["config", "user.email", "test@example.com"], repoPath);
+    await runGit(["config", "user.name", "Looper Test"], repoPath);
+    await writeFile(join(repoPath, "README.md"), "hello\n");
+    await runGit(["add", "README.md"], repoPath);
+    await runGit(["commit", "-m", "init"], repoPath);
+    await runGit(["checkout", "-b", "feature/fixer"], repoPath);
+    await runGit(["checkout", "-b", "feature/other"], repoPath);
+    await runGit(["checkout", "main"], repoPath);
+
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+    });
+    store.initialize({ autoMigrate: true });
+    const now = "2026-04-11T12:00:00.000Z";
+    store.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath,
+      baseBranch: "main",
+      archived: false,
+      metadataJson: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const gateway = new GitWorktreeGateway({ gitPath: "git", store });
+    const worktree = await gateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+    });
+    await runGit(["checkout", "feature/other"], worktree.worktreePath);
+
+    const restored = await gateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+    });
+
+    expect(restored.worktreePath).toBe(worktree.worktreePath);
+    expect(
+      (
+        await runGit(["branch", "--show-current"], restored.worktreePath)
+      ).trim(),
+    ).toBe("feature/fixer");
+
+    store.close();
+  });
+
+  test("restores detached worktree from its expected path when store row is missing", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
+    cleanupPaths.push(rootDir);
+    const repoPath = join(rootDir, "repo");
+    const worktreeRoot = join(rootDir, "worktrees");
+    await mkdir(repoPath, { recursive: true });
+
+    await runGit(["init", "-b", "main"], repoPath);
+    await runGit(["config", "user.email", "test@example.com"], repoPath);
+    await runGit(["config", "user.name", "Looper Test"], repoPath);
+    await writeFile(join(repoPath, "README.md"), "hello\n");
+    await runGit(["add", "README.md"], repoPath);
+    await runGit(["commit", "-m", "init"], repoPath);
+    await runGit(["checkout", "-b", "feature/fixer"], repoPath);
+    await runGit(["checkout", "main"], repoPath);
+
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+    });
+    store.initialize({ autoMigrate: true });
+    const now = "2026-04-11T12:00:00.000Z";
+    store.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath,
+      baseBranch: "main",
+      archived: false,
+      metadataJson: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const gateway = new GitWorktreeGateway({ gitPath: "git", store });
+    const detached = await gateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+      checkoutMode: "detached",
+    });
+    const statelessGateway = new GitWorktreeGateway({ gitPath: "git" });
+
+    const restored = await statelessGateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+      checkoutMode: "detached",
+    });
+
+    expect(normalizeForTest(restored.worktreePath)).toBe(
+      normalizeForTest(detached.worktreePath),
+    );
+    expect(
+      (
+        await runGit(["branch", "--show-current"], restored.worktreePath)
+      ).trim(),
+    ).toBe("");
+
+    store.close();
+  });
+
   test("ignores stored worktrees that belong to a different repo path", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
     cleanupPaths.push(rootDir);

--- a/apps/looperd/src/infra/git.test.ts
+++ b/apps/looperd/src/infra/git.test.ts
@@ -305,6 +305,74 @@ describe("GitWorktreeGateway", () => {
     store.close();
   });
 
+  test("recreates a detached worktree when branch checkout mode is requested", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
+    cleanupPaths.push(rootDir);
+    const repoPath = join(rootDir, "repo");
+    const worktreeRoot = join(rootDir, "worktrees");
+    await mkdir(repoPath, { recursive: true });
+
+    await runGit(["init", "-b", "main"], repoPath);
+    await runGit(["config", "user.email", "test@example.com"], repoPath);
+    await runGit(["config", "user.name", "Looper Test"], repoPath);
+    await writeFile(join(repoPath, "README.md"), "hello\n");
+    await runGit(["add", "README.md"], repoPath);
+    await runGit(["commit", "-m", "init"], repoPath);
+    await runGit(["checkout", "-b", "feature/fixer"], repoPath);
+    await runGit(["checkout", "main"], repoPath);
+
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+    });
+    store.initialize({ autoMigrate: true });
+    const now = "2026-04-11T12:00:00.000Z";
+    store.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath,
+      baseBranch: "main",
+      archived: false,
+      metadataJson: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const gateway = new GitWorktreeGateway({ gitPath: "git", store });
+    const detached = await gateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+      checkoutMode: "detached",
+    });
+
+    expect(
+      (
+        await runGit(["branch", "--show-current"], detached.worktreePath)
+      ).trim(),
+    ).toBe("");
+
+    const attached = await gateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+    });
+
+    expect(attached.worktreePath).toBe(detached.worktreePath);
+    expect(
+      (
+        await runGit(["branch", "--show-current"], attached.worktreePath)
+      ).trim(),
+    ).toBe("feature/fixer");
+
+    store.close();
+  });
+
   test("ignores stored worktrees that belong to a different repo path", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
     cleanupPaths.push(rootDir);

--- a/apps/looperd/src/infra/git.test.ts
+++ b/apps/looperd/src/infra/git.test.ts
@@ -154,6 +154,89 @@ describe("GitWorktreeGateway", () => {
     store.close();
   });
 
+  test("keeps the primary checkout clean when a detached fixer worktree commits", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
+    cleanupPaths.push(rootDir);
+    const repoPath = join(rootDir, "repo");
+    const worktreeRoot = join(rootDir, "worktrees");
+    const remotePath = join(rootDir, "remote.git");
+    await mkdir(repoPath, { recursive: true });
+    await mkdir(remotePath, { recursive: true });
+
+    await runGit(["init", "-b", "main"], repoPath);
+    await runGit(["init", "--bare"], remotePath);
+    await runGit(["config", "user.email", "test@example.com"], repoPath);
+    await runGit(["config", "user.name", "Looper Test"], repoPath);
+    await runGit(["remote", "add", "origin", remotePath], repoPath);
+    await writeFile(join(repoPath, "README.md"), "hello\n");
+    await runGit(["add", "README.md"], repoPath);
+    await runGit(["commit", "-m", "init"], repoPath);
+    await runGit(["push", "-u", "origin", "main"], repoPath);
+    await runGit(["checkout", "-b", "feature/fixer"], repoPath);
+    await writeFile(join(repoPath, "fix.txt"), "remote change\n");
+    await runGit(["add", "fix.txt"], repoPath);
+    await runGit(["commit", "-m", "feature"], repoPath);
+    await runGit(["push", "-u", "origin", "feature/fixer"], repoPath);
+
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+    });
+    store.initialize({ autoMigrate: true });
+    const now = "2026-04-11T12:00:00.000Z";
+    store.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath,
+      baseBranch: "main",
+      archived: false,
+      metadataJson: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const gateway = new GitWorktreeGateway({ gitPath: "git", store });
+    const worktree = await gateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+      checkoutMode: "detached",
+    });
+
+    expect(
+      (
+        await runGit(["branch", "--show-current"], worktree.worktreePath)
+      ).trim(),
+    ).toBe("");
+
+    await writeFile(
+      join(worktree.worktreePath, "README.md"),
+      "hello updated\n",
+    );
+    const baseHeadSha = (await runGit(["rev-parse", "HEAD"], repoPath)).trim();
+    await gateway.commit({
+      worktreePath: worktree.worktreePath,
+      message: "fixer: address PR #42 follow-up items",
+    });
+    await gateway.push({
+      worktreePath: worktree.worktreePath,
+      branch: "feature/fixer",
+      expectedRemoteHeadSha: baseHeadSha,
+    });
+
+    expect((await runGit(["rev-parse", "HEAD"], repoPath)).trim()).toBe(
+      baseHeadSha,
+    );
+    expect((await runGit(["status", "--porcelain"], repoPath)).trim()).toBe("");
+    expect(
+      (await runGit(["diff", "--cached", "--name-only"], repoPath)).trim(),
+    ).toBe("");
+
+    store.close();
+  });
+
   test("does not treat the primary checkout as a restorable worktree", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
     cleanupPaths.push(rootDir);

--- a/apps/looperd/src/infra/git.test.ts
+++ b/apps/looperd/src/infra/git.test.ts
@@ -237,6 +237,143 @@ describe("GitWorktreeGateway", () => {
     store.close();
   });
 
+  test("recreates an attached branch worktree when detached mode is requested", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
+    cleanupPaths.push(rootDir);
+    const repoPath = join(rootDir, "repo");
+    const worktreeRoot = join(rootDir, "worktrees");
+    await mkdir(repoPath, { recursive: true });
+
+    await runGit(["init", "-b", "main"], repoPath);
+    await runGit(["config", "user.email", "test@example.com"], repoPath);
+    await runGit(["config", "user.name", "Looper Test"], repoPath);
+    await writeFile(join(repoPath, "README.md"), "hello\n");
+    await runGit(["add", "README.md"], repoPath);
+    await runGit(["commit", "-m", "init"], repoPath);
+    await runGit(["checkout", "-b", "feature/fixer"], repoPath);
+    await runGit(["checkout", "main"], repoPath);
+
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+    });
+    store.initialize({ autoMigrate: true });
+    const now = "2026-04-11T12:00:00.000Z";
+    store.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath,
+      baseBranch: "main",
+      archived: false,
+      metadataJson: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const gateway = new GitWorktreeGateway({ gitPath: "git", store });
+    const attached = await gateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+    });
+
+    expect(
+      (
+        await runGit(["branch", "--show-current"], attached.worktreePath)
+      ).trim(),
+    ).toBe("feature/fixer");
+
+    const detached = await gateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+      checkoutMode: "detached",
+    });
+
+    expect(detached.worktreePath).toBe(attached.worktreePath);
+    expect(
+      (
+        await runGit(["branch", "--show-current"], detached.worktreePath)
+      ).trim(),
+    ).toBe("");
+
+    store.close();
+  });
+
+  test("ignores stored worktrees that belong to a different repo path", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
+    cleanupPaths.push(rootDir);
+    const repoPath = join(rootDir, "repo");
+    const otherRepoPath = join(rootDir, "other-repo");
+    const worktreeRoot = join(rootDir, "worktrees");
+    const strayWorktreePath = join(rootDir, "stray-worktree");
+    await mkdir(repoPath, { recursive: true });
+    await mkdir(otherRepoPath, { recursive: true });
+    await mkdir(strayWorktreePath, { recursive: true });
+
+    await runGit(["init", "-b", "main"], repoPath);
+    await runGit(["config", "user.email", "test@example.com"], repoPath);
+    await runGit(["config", "user.name", "Looper Test"], repoPath);
+    await writeFile(join(repoPath, "README.md"), "hello\n");
+    await runGit(["add", "README.md"], repoPath);
+    await runGit(["commit", "-m", "init"], repoPath);
+
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+    });
+    store.initialize({ autoMigrate: true });
+    const now = "2026-04-11T12:00:00.000Z";
+    store.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath,
+      baseBranch: "main",
+      archived: false,
+      metadataJson: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    store.worktrees.upsert({
+      id: "wrong-repo-record",
+      projectId: "project_1",
+      repoPath: otherRepoPath,
+      worktreePath: strayWorktreePath,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      status: "active",
+      headSha: null,
+      metadataJson: JSON.stringify({ recovered: false }),
+      createdAt: now,
+      updatedAt: now,
+      cleanedAt: null,
+    });
+
+    const gateway = new GitWorktreeGateway({ gitPath: "git", store });
+    const worktree = await gateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+      checkoutMode: "detached",
+    });
+
+    expect(worktree.worktreePath).not.toBe(strayWorktreePath);
+    expect(
+      normalizeForTest(
+        store.worktrees.getByBranch("project_1", "feature/fixer")?.repoPath,
+      ),
+    ).toBe(normalizeForTest(repoPath));
+
+    store.close();
+  });
+
   test("does not treat the primary checkout as a restorable worktree", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
     cleanupPaths.push(rootDir);
@@ -344,3 +481,7 @@ describe("GitWorktreeGateway", () => {
     store.close();
   });
 });
+
+function normalizeForTest(path: string | null | undefined): string | null {
+  return path ? path.replace(/^\/private/, "") : null;
+}

--- a/apps/looperd/src/infra/git.test.ts
+++ b/apps/looperd/src/infra/git.test.ts
@@ -502,6 +502,78 @@ describe("GitWorktreeGateway", () => {
     store.close();
   });
 
+  test("recreates worktree when stored row points at a deleted path", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
+    cleanupPaths.push(rootDir);
+    const repoPath = join(rootDir, "repo");
+    const worktreeRoot = join(rootDir, "worktrees");
+    await mkdir(repoPath, { recursive: true });
+
+    await runGit(["init", "-b", "main"], repoPath);
+    await runGit(["config", "user.email", "test@example.com"], repoPath);
+    await runGit(["config", "user.name", "Looper Test"], repoPath);
+    await writeFile(join(repoPath, "README.md"), "hello\n");
+    await runGit(["add", "README.md"], repoPath);
+    await runGit(["commit", "-m", "init"], repoPath);
+
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+    });
+    store.initialize({ autoMigrate: true });
+    const now = "2026-04-11T12:00:00.000Z";
+    store.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath,
+      baseBranch: "main",
+      archived: false,
+      metadataJson: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const missingWorktreePath = join(
+      worktreeRoot,
+      "looper-fix-project_1-pr-42",
+    );
+    store.worktrees.upsert({
+      id: "missing-record",
+      projectId: "project_1",
+      repoPath,
+      worktreePath: missingWorktreePath,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      status: "active",
+      headSha: null,
+      metadataJson: JSON.stringify({ recovered: false }),
+      createdAt: now,
+      updatedAt: now,
+      cleanedAt: null,
+    });
+
+    const gateway = new GitWorktreeGateway({ gitPath: "git", store });
+    const recreated = await gateway.createWorktree({
+      projectId: "project_1",
+      repoPath,
+      worktreeRoot,
+      branch: "feature/fixer",
+      baseBranch: "main",
+      prNumber: 42,
+      checkoutMode: "detached",
+    });
+
+    expect(normalizeForTest(recreated.worktreePath)).toBe(
+      normalizeForTest(missingWorktreePath),
+    );
+    expect(
+      (
+        await runGit(["branch", "--show-current"], recreated.worktreePath)
+      ).trim(),
+    ).toBe("");
+
+    store.close();
+  });
+
   test("ignores stored worktrees that belong to a different repo path", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "looper-git-"));
     cleanupPaths.push(rootDir);

--- a/apps/looperd/src/infra/git.ts
+++ b/apps/looperd/src/infra/git.ts
@@ -209,26 +209,28 @@ export class GitWorktreeGateway {
       (!input.worktreeRoot ||
         isWithinRoot(stored.worktreePath, input.worktreeRoot))
     ) {
-      const storedCheckoutMatches = await this.matchesRestoreCheckoutMode(
-        stored.worktreePath,
-        input,
-      );
-      if (
-        (await this.isHealthyWorktree(stored.worktreePath)) &&
-        storedCheckoutMatches
-      ) {
-        const nowIso = this.now().toISOString();
-        const restored = {
-          ...stored,
-          headSha: await this.getHeadSha(stored.worktreePath),
-          status: "active" as const,
-          updatedAt: nowIso,
-        };
-        this.options.store?.worktrees.upsert(restored);
-        return restored;
-      }
+      const storedHealthy = await this.isHealthyWorktree(stored.worktreePath);
+      if (!storedHealthy) {
+        await this.tryRemoveWorktree(input.repoPath, stored.worktreePath);
+      } else {
+        const storedCheckoutMatches = await this.matchesRestoreCheckoutMode(
+          stored.worktreePath,
+          input,
+        );
+        if (storedCheckoutMatches) {
+          const nowIso = this.now().toISOString();
+          const restored = {
+            ...stored,
+            headSha: await this.getHeadSha(stored.worktreePath),
+            status: "active" as const,
+            updatedAt: nowIso,
+          };
+          this.options.store?.worktrees.upsert(restored);
+          return restored;
+        }
 
-      await this.tryRemoveWorktree(input.repoPath, stored.worktreePath);
+        await this.tryRemoveWorktree(input.repoPath, stored.worktreePath);
+      }
     }
 
     const worktrees = await this.listWorktrees(input.repoPath);

--- a/apps/looperd/src/infra/git.ts
+++ b/apps/looperd/src/infra/git.ts
@@ -29,6 +29,7 @@ interface RestoreWorktreeInput {
   branch: string;
   worktreeRoot?: string;
   checkoutMode?: "branch" | "detached";
+  expectedWorktreePath?: string;
 }
 
 export interface PrepareWorktreeResult {
@@ -106,6 +107,7 @@ export class GitWorktreeGateway {
       branch: input.branch,
       worktreeRoot: input.worktreeRoot,
       checkoutMode,
+      expectedWorktreePath: worktreePath,
     });
 
     if (existing) {
@@ -207,11 +209,13 @@ export class GitWorktreeGateway {
       (!input.worktreeRoot ||
         isWithinRoot(stored.worktreePath, input.worktreeRoot))
     ) {
+      const storedCheckoutMatches = await this.matchesRestoreCheckoutMode(
+        stored.worktreePath,
+        input,
+      );
       if (
         (await this.isHealthyWorktree(stored.worktreePath)) &&
-        (input.checkoutMode === "detached"
-          ? await this.isDetachedWorktree(stored.worktreePath)
-          : !(await this.isDetachedWorktree(stored.worktreePath)))
+        storedCheckoutMatches
       ) {
         const nowIso = this.now().toISOString();
         const restored = {
@@ -229,10 +233,12 @@ export class GitWorktreeGateway {
 
     const worktrees = await this.listWorktrees(input.repoPath);
     const match = worktrees.find((worktree) => {
-      if (input.checkoutMode === "detached") {
-        return false;
-      }
-      if (worktree.branch !== input.branch) {
+      if (
+        input.checkoutMode === "detached"
+          ? normalizeComparablePath(worktree.path) !==
+            normalizeComparablePath(input.expectedWorktreePath ?? worktree.path)
+          : worktree.branch !== input.branch
+      ) {
         return false;
       }
       if (
@@ -255,6 +261,11 @@ export class GitWorktreeGateway {
     }
 
     if (!(await this.isHealthyWorktree(match.path))) {
+      await this.tryRemoveWorktree(input.repoPath, match.path);
+      return null;
+    }
+
+    if (!(await this.matchesRestoreCheckoutMode(match.path, input))) {
       await this.tryRemoveWorktree(input.repoPath, match.path);
       return null;
     }
@@ -552,6 +563,26 @@ export class GitWorktreeGateway {
       worktreePath,
     );
     return result.stdout.trim() === "HEAD";
+  }
+
+  private async getCurrentBranch(worktreePath: string): Promise<string | null> {
+    const result = await this.runGit(
+      ["rev-parse", "--abbrev-ref", "HEAD"],
+      worktreePath,
+    );
+    const branch = result.stdout.trim();
+    return branch === "HEAD" ? null : branch || null;
+  }
+
+  private async matchesRestoreCheckoutMode(
+    worktreePath: string,
+    input: RestoreWorktreeInput,
+  ): Promise<boolean> {
+    if ((input.checkoutMode ?? "branch") === "detached") {
+      return this.isDetachedWorktree(worktreePath);
+    }
+
+    return (await this.getCurrentBranch(worktreePath)) === input.branch;
   }
 
   private async tryRemoveWorktree(

--- a/apps/looperd/src/infra/git.ts
+++ b/apps/looperd/src/infra/git.ts
@@ -23,6 +23,14 @@ export interface CreateWorktreeInput {
   checkoutMode?: "branch" | "detached";
 }
 
+interface RestoreWorktreeInput {
+  projectId: string;
+  repoPath: string;
+  branch: string;
+  worktreeRoot?: string;
+  checkoutMode?: "branch" | "detached";
+}
+
 export interface PrepareWorktreeResult {
   headSha?: string;
   clean: boolean;
@@ -91,18 +99,19 @@ export class GitWorktreeGateway {
       input.worktreeRoot,
       buildWorktreeDirectoryName(input),
     );
+    const checkoutMode = input.checkoutMode ?? "branch";
     const existing = await this.restoreWorktree({
       projectId: input.projectId,
       repoPath: input.repoPath,
       branch: input.branch,
       worktreeRoot: input.worktreeRoot,
+      checkoutMode,
     });
 
     if (existing) {
       return existing;
     }
 
-    const checkoutMode = input.checkoutMode ?? "branch";
     if (checkoutMode === "detached") {
       await this.runGit(
         [
@@ -181,12 +190,9 @@ export class GitWorktreeGateway {
     return parseGitHubRepoFromRemoteUrl(result.stdout.trim());
   }
 
-  public async restoreWorktree(input: {
-    projectId: string;
-    repoPath: string;
-    branch: string;
-    worktreeRoot?: string;
-  }): Promise<WorktreeRecord | null> {
+  public async restoreWorktree(
+    input: RestoreWorktreeInput,
+  ): Promise<WorktreeRecord | null> {
     const stored = this.options.store?.worktrees.getByBranch(
       input.projectId,
       input.branch,
@@ -194,12 +200,18 @@ export class GitWorktreeGateway {
     if (
       stored &&
       stored.status !== "cleaned" &&
+      normalizeComparablePath(stored.repoPath) ===
+        normalizeComparablePath(input.repoPath) &&
       normalizeComparablePath(stored.worktreePath) !==
         normalizeComparablePath(input.repoPath) &&
       (!input.worktreeRoot ||
         isWithinRoot(stored.worktreePath, input.worktreeRoot))
     ) {
-      if (await this.isHealthyWorktree(stored.worktreePath)) {
+      if (
+        (await this.isHealthyWorktree(stored.worktreePath)) &&
+        (input.checkoutMode !== "detached" ||
+          (await this.isDetachedWorktree(stored.worktreePath)))
+      ) {
         const nowIso = this.now().toISOString();
         const restored = {
           ...stored,
@@ -216,6 +228,9 @@ export class GitWorktreeGateway {
 
     const worktrees = await this.listWorktrees(input.repoPath);
     const match = worktrees.find((worktree) => {
+      if (input.checkoutMode === "detached") {
+        return false;
+      }
       if (worktree.branch !== input.branch) {
         return false;
       }
@@ -528,6 +543,14 @@ export class GitWorktreeGateway {
     } catch {
       return false;
     }
+  }
+
+  private async isDetachedWorktree(worktreePath: string): Promise<boolean> {
+    const result = await this.runGit(
+      ["rev-parse", "--abbrev-ref", "HEAD"],
+      worktreePath,
+    );
+    return result.stdout.trim() === "HEAD";
   }
 
   private async tryRemoveWorktree(

--- a/apps/looperd/src/infra/git.ts
+++ b/apps/looperd/src/infra/git.ts
@@ -209,8 +209,9 @@ export class GitWorktreeGateway {
     ) {
       if (
         (await this.isHealthyWorktree(stored.worktreePath)) &&
-        (input.checkoutMode !== "detached" ||
-          (await this.isDetachedWorktree(stored.worktreePath)))
+        (input.checkoutMode === "detached"
+          ? await this.isDetachedWorktree(stored.worktreePath)
+          : !(await this.isDetachedWorktree(stored.worktreePath)))
       ) {
         const nowIso = this.now().toISOString();
         const restored = {

--- a/apps/looperd/src/infra/git.ts
+++ b/apps/looperd/src/infra/git.ts
@@ -20,6 +20,7 @@ export interface CreateWorktreeInput {
   baseBranch: string;
   prNumber?: number;
   protectedBranches?: string[];
+  checkoutMode?: "branch" | "detached";
 }
 
 export interface PrepareWorktreeResult {
@@ -101,21 +102,39 @@ export class GitWorktreeGateway {
       return existing;
     }
 
-    const branchExists = await this.branchExists(input.repoPath, input.branch);
-    await this.runGit(
-      branchExists
-        ? ["worktree", "add", "--force", worktreePath, input.branch]
-        : [
-            "worktree",
-            "add",
-            "--force",
-            "-b",
-            input.branch,
-            worktreePath,
-            input.baseBranch,
-          ],
-      input.repoPath,
-    );
+    const checkoutMode = input.checkoutMode ?? "branch";
+    if (checkoutMode === "detached") {
+      await this.runGit(
+        [
+          "worktree",
+          "add",
+          "--force",
+          "--detach",
+          worktreePath,
+          await this.resolveDetachedStartPoint(input),
+        ],
+        input.repoPath,
+      );
+    } else {
+      const branchExists = await this.branchExists(
+        input.repoPath,
+        input.branch,
+      );
+      await this.runGit(
+        branchExists
+          ? ["worktree", "add", "--force", worktreePath, input.branch]
+          : [
+              "worktree",
+              "add",
+              "--force",
+              "-b",
+              input.branch,
+              worktreePath,
+              input.baseBranch,
+            ],
+        input.repoPath,
+      );
+    }
 
     const headSha = await this.getHeadSha(worktreePath);
     const nowIso = this.now().toISOString();
@@ -168,6 +187,33 @@ export class GitWorktreeGateway {
     branch: string;
     worktreeRoot?: string;
   }): Promise<WorktreeRecord | null> {
+    const stored = this.options.store?.worktrees.getByBranch(
+      input.projectId,
+      input.branch,
+    );
+    if (
+      stored &&
+      stored.status !== "cleaned" &&
+      normalizeComparablePath(stored.worktreePath) !==
+        normalizeComparablePath(input.repoPath) &&
+      (!input.worktreeRoot ||
+        isWithinRoot(stored.worktreePath, input.worktreeRoot))
+    ) {
+      if (await this.isHealthyWorktree(stored.worktreePath)) {
+        const nowIso = this.now().toISOString();
+        const restored = {
+          ...stored,
+          headSha: await this.getHeadSha(stored.worktreePath),
+          status: "active" as const,
+          updatedAt: nowIso,
+        };
+        this.options.store?.worktrees.upsert(restored);
+        return restored;
+      }
+
+      await this.tryRemoveWorktree(input.repoPath, stored.worktreePath);
+    }
+
     const worktrees = await this.listWorktrees(input.repoPath);
     const match = worktrees.find((worktree) => {
       if (worktree.branch !== input.branch) {
@@ -417,6 +463,43 @@ export class GitWorktreeGateway {
     } catch {
       return false;
     }
+  }
+
+  private async remoteBranchExists(
+    repoPath: string,
+    remote: string,
+    branch: string,
+  ): Promise<boolean> {
+    try {
+      await this.runGit(
+        ["show-ref", "--verify", `refs/remotes/${remote}/${branch}`],
+        repoPath,
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async resolveDetachedStartPoint(
+    input: CreateWorktreeInput,
+  ): Promise<string> {
+    const remote = "origin";
+    try {
+      await this.runGit(["fetch", remote, input.branch], input.repoPath);
+    } catch {
+      // fall back to any local branch/base branch that is available
+    }
+
+    if (await this.remoteBranchExists(input.repoPath, remote, input.branch)) {
+      return `${remote}/${input.branch}`;
+    }
+
+    if (await this.branchExists(input.repoPath, input.branch)) {
+      return input.branch;
+    }
+
+    return input.baseBranch;
   }
 
   private async isAncestor(


### PR DESCRIPTION
## Summary
- make fixer create detached worktrees so its commits do not advance shared local branch refs
- restore detached fixer worktrees from stored records and resolve detached start points from remote or local refs
- add regression coverage that verifies detached fixer commits leave the primary checkout clean and that fixer requests detached checkout mode