### PR TITLE
Allow issue workers to start without planner loops

### DIFF
--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -666,7 +666,7 @@ describe("createLooperdApi", () => {
 
     store.loops.upsert({
       id: "loop_planner_issue_999",
-      seq: 100,
+      seq: 200,
       projectId: "project_2",
       type: "planner",
       targetType: "issue",

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -656,28 +656,52 @@ describe("createLooperdApi", () => {
       }),
     );
     const missingIssueBody = (await missingIssueResponse.json()) as {
-      data: {
-        id: string;
-        status: string;
-        issueNumber: number;
-        prNumber?: number;
-        specPath?: string;
-      };
+      error: { code: string; message: string };
     };
-    expect(missingIssueResponse.status).toBe(200);
-    expect(missingIssueBody.data.status).toBe("running");
-    expect(missingIssueBody.data.issueNumber).toBe(999);
-    expect(missingIssueBody.data.prNumber).toBeNull();
-    expect(missingIssueBody.data.specPath).toBeNull();
-    expect(
-      store.queue.findActiveByDedupe(`worker:${missingIssueBody.data.id}`),
-    ).toMatchObject({
-      loopId: missingIssueBody.data.id,
-      type: "worker",
-      targetType: "project",
-      targetId: "project_2",
-      status: "queued",
+    expect(missingIssueResponse.status).toBe(400);
+    expect(missingIssueBody.error.code).toBe("VALIDATION_FAILED");
+    expect(missingIssueBody.error.message).toContain(
+      "issueNumber requires planner-derived specPath",
+    );
+
+    store.loops.upsert({
+      id: "loop_planner_issue_999",
+      seq: 100,
+      projectId: "project_2",
+      type: "planner",
+      targetType: "issue",
+      targetId: "issue:acme/looper:999",
+      repo: "acme/looper",
+      prNumber: null,
+      status: "running",
+      configJson: null,
+      metadataJson: JSON.stringify({}),
+      lastRunAt: "2026-04-11T12:06:00.000Z",
+      nextRunAt: "2026-04-11T12:06:00.000Z",
+      createdAt: "2026-04-11T12:06:00.000Z",
+      updatedAt: "2026-04-11T12:06:00.000Z",
     });
+
+    const missingPlannerSpecResponse = await api.handle(
+      new Request("http://localhost/api/v1/workers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          projectId: "project_2",
+          repo: "acme/looper",
+          issueNumber: 999,
+        }),
+      }),
+    );
+    const missingPlannerSpecBody =
+      (await missingPlannerSpecResponse.json()) as {
+        error: { code: string; message: string };
+      };
+    expect(missingPlannerSpecResponse.status).toBe(400);
+    expect(missingPlannerSpecBody.error.code).toBe("VALIDATION_FAILED");
+    expect(missingPlannerSpecBody.error.message).toContain(
+      "issueNumber requires planner-derived specPath",
+    );
 
     const createLoopResponse = await api.handle(
       new Request("http://localhost/api/v1/loops", {

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -649,13 +649,35 @@ describe("createLooperdApi", () => {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          projectId: "project_1",
+          projectId: "project_2",
           repo: "acme/looper",
           issueNumber: 999,
         }),
       }),
     );
-    expect(missingIssueResponse.status).toBe(404);
+    const missingIssueBody = (await missingIssueResponse.json()) as {
+      data: {
+        id: string;
+        status: string;
+        issueNumber: number;
+        prNumber?: number;
+        specPath?: string;
+      };
+    };
+    expect(missingIssueResponse.status).toBe(200);
+    expect(missingIssueBody.data.status).toBe("running");
+    expect(missingIssueBody.data.issueNumber).toBe(999);
+    expect(missingIssueBody.data.prNumber).toBeNull();
+    expect(missingIssueBody.data.specPath).toBeNull();
+    expect(
+      store.queue.findActiveByDedupe(`worker:${missingIssueBody.data.id}`),
+    ).toMatchObject({
+      loopId: missingIssueBody.data.id,
+      type: "worker",
+      targetType: "project",
+      targetId: "project_2",
+      status: "queued",
+    });
 
     const createLoopResponse = await api.handle(
       new Request("http://localhost/api/v1/loops", {

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -651,7 +651,7 @@ async function buildWorkersCreateResponse(
   const planner =
     issueNumber == null
       ? null
-      : findPlannerLoopForIssue(context, {
+      : maybeFindPlannerLoopForIssue(context, {
           projectId,
           repo,
           issueNumber,
@@ -1848,14 +1848,14 @@ function requirePullRequestTarget(
   return { prNumber: snapshot.prNumber };
 }
 
-function findPlannerLoopForIssue(
+function maybeFindPlannerLoopForIssue(
   context: LooperdApiContext,
   input: {
     projectId: string;
     repo: string;
     issueNumber: number;
   },
-): { prNumber: number; specPath: string | null } {
+): { prNumber: number | null; specPath: string | null } | null {
   const targetId = `issue:${input.repo}:${input.issueNumber}`;
   const loop = context.store.loops
     .list()
@@ -1867,22 +1867,11 @@ function findPlannerLoopForIssue(
         candidate.targetId === targetId,
     );
   if (!loop) {
-    throw new ApiError(
-      "PLANNER_NOT_FOUND",
-      404,
-      `No planner loop found for ${input.repo}#${input.issueNumber}`,
-    );
+    return null;
   }
 
   const metadata = parseMetadata(loop.metadataJson);
-  const prNumber = loop.prNumber ?? readNumber(metadata.prNumber);
-  if (!prNumber) {
-    throw new ApiError(
-      "PLANNER_PR_NOT_READY",
-      409,
-      `Planner spec PR is not ready for ${input.repo}#${input.issueNumber}`,
-    );
-  }
+  const prNumber = loop.prNumber ?? readNumber(metadata.prNumber) ?? null;
 
   return {
     prNumber,

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -656,6 +656,13 @@ async function buildWorkersCreateResponse(
           repo,
           issueNumber,
         });
+  if (issueNumber != null && !planner?.specPath) {
+    throw new ApiError(
+      "VALIDATION_FAILED",
+      400,
+      `issueNumber requires planner-derived specPath; run planner for ${repo}#${issueNumber} first`,
+    );
+  }
   const effectivePrNumber =
     pullRequestTarget?.prNumber ?? planner?.prNumber ?? null;
   const effectiveSpecPath = specPath ?? planner?.specPath ?? null;


### PR DESCRIPTION
## Summary
- let workers started with `looper work --issue` run even when no planner loop exists
- keep reusing planner-derived `prNumber` and `specPath` when a planner is available
- add server coverage for issue-based worker creation without a planner dependency