### PR TITLE
Allow issue workers to derive prompts and open PRs directly

### DIFF
--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -656,52 +656,28 @@ describe("createLooperdApi", () => {
       }),
     );
     const missingIssueBody = (await missingIssueResponse.json()) as {
-      error: { code: string; message: string };
-    };
-    expect(missingIssueResponse.status).toBe(400);
-    expect(missingIssueBody.error.code).toBe("VALIDATION_FAILED");
-    expect(missingIssueBody.error.message).toContain(
-      "issueNumber requires planner-derived specPath",
-    );
-
-    store.loops.upsert({
-      id: "loop_planner_issue_999",
-      seq: 200,
-      projectId: "project_2",
-      type: "planner",
-      targetType: "issue",
-      targetId: "issue:acme/looper:999",
-      repo: "acme/looper",
-      prNumber: null,
-      status: "running",
-      configJson: null,
-      metadataJson: JSON.stringify({}),
-      lastRunAt: "2026-04-11T12:06:00.000Z",
-      nextRunAt: "2026-04-11T12:06:00.000Z",
-      createdAt: "2026-04-11T12:06:00.000Z",
-      updatedAt: "2026-04-11T12:06:00.000Z",
-    });
-
-    const missingPlannerSpecResponse = await api.handle(
-      new Request("http://localhost/api/v1/workers", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          projectId: "project_2",
-          repo: "acme/looper",
-          issueNumber: 999,
-        }),
-      }),
-    );
-    const missingPlannerSpecBody =
-      (await missingPlannerSpecResponse.json()) as {
-        error: { code: string; message: string };
+      data: {
+        id: string;
+        status: string;
+        issueNumber: number;
+        prNumber?: number;
+        specPath?: string;
       };
-    expect(missingPlannerSpecResponse.status).toBe(400);
-    expect(missingPlannerSpecBody.error.code).toBe("VALIDATION_FAILED");
-    expect(missingPlannerSpecBody.error.message).toContain(
-      "issueNumber requires planner-derived specPath",
-    );
+    };
+    expect(missingIssueResponse.status).toBe(200);
+    expect(missingIssueBody.data.status).toBe("running");
+    expect(missingIssueBody.data.issueNumber).toBe(999);
+    expect(missingIssueBody.data.prNumber).toBeNull();
+    expect(missingIssueBody.data.specPath).toBeNull();
+    expect(
+      store.queue.findActiveByDedupe(`worker:${missingIssueBody.data.id}`),
+    ).toMatchObject({
+      loopId: missingIssueBody.data.id,
+      type: "worker",
+      targetType: "project",
+      targetId: "project_2",
+      status: "queued",
+    });
 
     const createLoopResponse = await api.handle(
       new Request("http://localhost/api/v1/loops", {

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -656,13 +656,6 @@ async function buildWorkersCreateResponse(
           repo,
           issueNumber,
         });
-  if (issueNumber != null && !planner?.specPath) {
-    throw new ApiError(
-      "VALIDATION_FAILED",
-      400,
-      `issueNumber requires planner-derived specPath; run planner for ${repo}#${issueNumber} first`,
-    );
-  }
   const effectivePrNumber =
     pullRequestTarget?.prNumber ?? planner?.prNumber ?? null;
   const effectiveSpecPath = specPath ?? planner?.specPath ?? null;
@@ -682,6 +675,7 @@ async function buildWorkersCreateResponse(
     specPath: effectiveSpecPath,
     repo,
     baseBranch,
+    ...(issueNumber ? { issueNumber } : {}),
     ...(effectivePrNumber ? { prNumber: effectivePrNumber } : {}),
   };
   const loop = createLoopRecord({

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -575,6 +575,64 @@ describe("WorkerLoopRunner", () => {
     fixture.store.close();
   });
 
+  test("does not reuse an existing PR when the base branch differs", async () => {
+    const fixture = await createFixture();
+    const git = new FakeGitGateway(fixture.worktreeRoot);
+    const github = new FakeGitHubGateway();
+    github.listOpenPullRequests = async (input) => {
+      github.listOpenPullRequestCalls.push({
+        label: input.label,
+        limit: input.limit,
+      });
+      return [
+        {
+          number: 303,
+          title: "Wrong-base PR",
+          url: "https://example.test/acme/looper/pull/303",
+          state: "OPEN",
+          isDraft: false,
+          reviewDecision: undefined,
+          labels: [],
+          headRefName: "looper/worker/loop-worker-1",
+          baseRefName: "develop",
+          author: "octocat",
+          reviewRequests: [],
+        },
+      ];
+    };
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Implemented slice and opened PR", ["abc123"]),
+    ]);
+    const runner = new WorkerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      validationRunner: async (): Promise<WorkerValidationResult> => ({
+        passed: true,
+        summary: "ok",
+        output: "ok",
+      }),
+      openPrStrategy: "all_done",
+    });
+
+    const claimed = fixture.queue.claimNext("worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed worker queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+    expect(result.status).toBe("success");
+    expect(result.pullRequestNumber).toBe(101);
+    expect(github.createPullRequestCalls).toHaveLength(1);
+    expect(fixture.store.loops.getById("loop_worker_1")?.prNumber).toBe(101);
+
+    fixture.store.close();
+  });
+
   test("hydrates worker input from issue details and opens a PR without planner", async () => {
     const fixture = await createFixture();
     const nowIso = fixture.now.toISOString();

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -500,7 +500,7 @@ describe("WorkerLoopRunner", () => {
     expect(result.status).toBe("success");
     expect(result.pullRequestNumber).toBe(101);
     expect(agent.starts).toHaveLength(1);
-    expect(agent.starts[0]?.prompt).toContain(
+    expect(agent.starts[0]?.prompt).not.toContain(
       "use the GitHub CLI (`gh`) to create the pull request yourself",
     );
     expect(git.createWorktreeCalls).toBe(1);
@@ -509,6 +509,40 @@ describe("WorkerLoopRunner", () => {
     expect(fixture.store.loops.getById("loop_worker_1")?.status).toBe(
       "completed",
     );
+    fixture.store.close();
+  });
+
+  test("prompts agent to create PR only when looperd validation is disabled", async () => {
+    const fixture = await createFixture();
+    const git = new FakeGitGateway(fixture.worktreeRoot);
+    const github = new FakeGitHubGateway();
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Implemented slice and committed changes", [
+        "abc123",
+      ]),
+    ]);
+    const runner = new WorkerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      openPrStrategy: "all_done",
+    });
+
+    const claimed = fixture.queue.claimNext("worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed worker queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+    expect(result.status).toBe("success");
+    expect(agent.starts[0]?.prompt).toContain(
+      "use the GitHub CLI (`gh`) to create the pull request yourself",
+    );
+
     fixture.store.close();
   });
 

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -516,21 +516,27 @@ describe("WorkerLoopRunner", () => {
     const fixture = await createFixture();
     const git = new FakeGitGateway(fixture.worktreeRoot);
     const github = new FakeGitHubGateway();
-    github.listOpenPullRequests = async () => [
-      {
-        number: 202,
-        title: "Agent-created PR",
-        url: "https://example.test/acme/looper/pull/202",
-        state: "OPEN",
-        isDraft: false,
-        reviewDecision: undefined,
-        labels: [],
-        headRefName: "looper/worker/loop-worker-1",
-        baseRefName: "main",
-        author: "octocat",
-        reviewRequests: [],
-      },
-    ];
+    github.listOpenPullRequests = async (input) => {
+      github.listOpenPullRequestCalls.push({
+        label: input.label,
+        limit: input.limit,
+      });
+      return [
+        {
+          number: 202,
+          title: "Agent-created PR",
+          url: "https://example.test/acme/looper/pull/202",
+          state: "OPEN",
+          isDraft: false,
+          reviewDecision: undefined,
+          labels: [],
+          headRefName: "looper/worker/loop-worker-1",
+          baseRefName: "main",
+          author: "octocat",
+          reviewRequests: [],
+        },
+      ];
+    };
     const agent = new FakeAgentExecutor([
       completedAgentResult("Implemented slice and opened PR", ["abc123"]),
     ]);
@@ -560,7 +566,7 @@ describe("WorkerLoopRunner", () => {
     expect(result.pullRequestNumber).toBe(202);
     expect(git.pushCalls).toBe(1);
     expect(github.createPullRequestCalls).toHaveLength(0);
-    expect(github.listOpenPullRequestCalls[0]?.limit).toBeUndefined();
+    expect(github.listOpenPullRequestCalls[0]?.limit).toBe(1000);
     expect(fixture.store.loops.getById("loop_worker_1")?.prNumber).toBe(202);
     expect(
       fixture.store.loops.getById("loop_worker_1")?.metadataJson,
@@ -693,6 +699,121 @@ describe("WorkerLoopRunner", () => {
       "Add worker issue fallback",
     );
     expect(github.createPullRequestCalls[0]?.body).toContain("Closes #123");
+
+    fixture.store.close();
+  });
+
+  test("truncates long issue-derived branch slugs", async () => {
+    const fixture = await createFixture();
+    const nowIso = fixture.now.toISOString();
+    const longTitle = `Implement ${"supercalifragilisticexpialidocious".repeat(6)}`;
+    fixture.store.loops.upsert({
+      ...(fixture.store.loops.getById("loop_worker_1") ?? {
+        id: "loop_worker_1",
+        seq: 1,
+        projectId: "project_1",
+        type: "worker",
+        targetType: "project",
+        targetId: "project_1",
+        repo: "acme/looper",
+        prNumber: null,
+        status: "queued",
+        configJson: null,
+        metadataJson: null,
+        lastRunAt: null,
+        nextRunAt: nowIso,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+      }),
+      metadataJson: JSON.stringify({
+        worker: {
+          title: "Implement acme/looper#124",
+          repo: "acme/looper",
+          baseBranch: "main",
+          issueNumber: 124,
+        },
+      }),
+      updatedAt: nowIso,
+    });
+    fixture.store.queue.upsert({
+      ...(fixture.store.queue.findActiveByDedupe("worker:loop_worker_1") ?? {
+        id: "queue_issue_mode_long",
+        projectId: "project_1",
+        loopId: "loop_worker_1",
+        type: "worker",
+        targetType: "project",
+        targetId: "project_1",
+        repo: "acme/looper",
+        prNumber: null,
+        dedupeKey: "worker:loop_worker_1",
+        priority: 0,
+        status: "queued",
+        availableAt: nowIso,
+        attempts: 0,
+        maxAttempts: 3,
+        claimedBy: null,
+        claimedAt: null,
+        startedAt: null,
+        finishedAt: null,
+        lockKey: "worker:loop_worker_1",
+        payloadJson: null,
+        lastError: null,
+        lastErrorKind: null,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+      }),
+      payloadJson: JSON.stringify({
+        title: "Implement acme/looper#124",
+        repo: "acme/looper",
+        baseBranch: "main",
+        issueNumber: 124,
+      }),
+      updatedAt: nowIso,
+    });
+
+    const git = new FakeGitGateway(fixture.worktreeRoot);
+    const github = new FakeGitHubGateway();
+    github.viewIssue = async (input) => ({
+      number: input.issueNumber,
+      title: longTitle,
+      body: "Long title branch test.",
+      url: `https://example.test/${input.repo}/issues/${input.issueNumber}`,
+      state: "OPEN",
+      author: "octocat",
+      assignees: [],
+      labels: [],
+    });
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Implemented issue fallback", ["abc123"]),
+    ]);
+    const runner = new WorkerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      validationRunner: async (): Promise<WorkerValidationResult> => ({
+        passed: true,
+        summary: "ok",
+        output: "ok",
+      }),
+      openPrStrategy: "all_done",
+    });
+
+    const claimed = fixture.queue.claimNext("worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed worker queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+    expect(result.status).toBe("success");
+    const headBranch = github.createPullRequestCalls[0]?.headBranch;
+    expect(headBranch).toBeDefined();
+    expect(headBranch?.length ?? 0).toBeLessThanOrEqual(80);
+    expect(headBranch).toMatch(/^looper\/worker\/124-/);
+    expect(headBranch).toContain("-loop-worker-1");
 
     fixture.store.close();
   });

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -150,7 +150,8 @@ class FakeGitGateway implements WorkerGitGateway {
 }
 
 class FakeGitHubGateway implements WorkerGitHubGateway {
-  public listOpenPullRequestCalls: Array<{ label?: string }> = [];
+  public listOpenPullRequestCalls: Array<{ label?: string; limit?: number }> =
+    [];
   public viewIssueCalls: Array<{
     repo: string;
     issueNumber: number;
@@ -183,7 +184,10 @@ class FakeGitHubGateway implements WorkerGitHubGateway {
   }): Promise<
     Awaited<ReturnType<WorkerGitHubGateway["listOpenPullRequests"]>>
   > {
-    this.listOpenPullRequestCalls.push({ label: input.label });
+    this.listOpenPullRequestCalls.push({
+      label: input.label,
+      limit: input.limit,
+    });
     return [];
   }
 
@@ -556,6 +560,7 @@ describe("WorkerLoopRunner", () => {
     expect(result.pullRequestNumber).toBe(202);
     expect(git.pushCalls).toBe(1);
     expect(github.createPullRequestCalls).toHaveLength(0);
+    expect(github.listOpenPullRequestCalls[0]?.limit).toBeUndefined();
     expect(fixture.store.loops.getById("loop_worker_1")?.prNumber).toBe(202);
     expect(
       fixture.store.loops.getById("loop_worker_1")?.metadataJson,
@@ -1191,11 +1196,51 @@ describe("WorkerLoopRunner", () => {
     expect(agent.starts[0]?.prompt).not.toContain(
       "use the GitHub CLI (`gh`) to create the pull request yourself",
     );
+    expect(github.listOpenPullRequestCalls).toHaveLength(0);
     expect(git.pushCalls).toBe(0);
     expect(github.createPullRequestCalls).toHaveLength(0);
     expect(fixture.store.loops.getById("loop_worker_1")?.status).toBe(
       "completed",
     );
+
+    fixture.store.close();
+  });
+
+  test("skips GitHub PR lookup when manual PR opening is configured", async () => {
+    const fixture = await createFixture();
+    const git = new FakeGitGateway(fixture.worktreeRoot);
+    const github = new FakeGitHubGateway();
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Implemented slice and committed changes", [
+        "abc123",
+      ]),
+    ]);
+    const runner = new WorkerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      validationRunner: async (): Promise<WorkerValidationResult> => ({
+        passed: true,
+        summary: "ok",
+        output: "ok",
+      }),
+      openPrStrategy: "manual",
+    });
+
+    const claimed = fixture.queue.claimNext("worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed worker queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+    expect(result.status).toBe("skipped");
+    expect(result.summary).toContain("PR opening is manual");
+    expect(github.listOpenPullRequestCalls).toHaveLength(0);
+    expect(github.createPullRequestCalls).toHaveLength(0);
 
     fixture.store.close();
   });

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -623,7 +623,7 @@ describe("WorkerLoopRunner", () => {
     expect(git.pushCalls).toBe(1);
     expect(github.createPullRequestCalls).toHaveLength(1);
     expect(github.createPullRequestCalls[0]?.headBranch).toBe(
-      "looper/worker/123-add-worker-issue-fallback",
+      "looper/worker/123-add-worker-issue-fallback-loop-worker-1",
     );
     expect(github.createPullRequestCalls[0]?.title).toBe(
       "Add worker issue fallback",

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -151,6 +151,11 @@ class FakeGitGateway implements WorkerGitGateway {
 
 class FakeGitHubGateway implements WorkerGitHubGateway {
   public listOpenPullRequestCalls: Array<{ label?: string }> = [];
+  public viewIssueCalls: Array<{
+    repo: string;
+    issueNumber: number;
+    cwd?: string;
+  }> = [];
   public createPullRequestCalls: Array<{
     repo: string;
     headBranch: string;
@@ -205,6 +210,24 @@ class FakeGitHubGateway implements WorkerGitHubGateway {
       comments: [],
       reviews: [],
       checks: [{ conclusion: "SUCCESS" }],
+    };
+  }
+
+  public async viewIssue(input: {
+    repo: string;
+    issueNumber: number;
+    cwd?: string;
+  }) {
+    this.viewIssueCalls.push(input);
+    return {
+      number: input.issueNumber,
+      title: "Add worker issue fallback",
+      body: "Use the issue body as worker prompt when no planner exists.",
+      url: `https://example.test/${input.repo}/issues/${input.issueNumber}`,
+      state: "OPEN",
+      author: "octocat",
+      assignees: [],
+      labels: [],
     };
   }
 
@@ -479,6 +502,134 @@ describe("WorkerLoopRunner", () => {
     expect(fixture.store.loops.getById("loop_worker_1")?.status).toBe(
       "completed",
     );
+    fixture.store.close();
+  });
+
+  test("hydrates worker input from issue details and opens a PR without planner", async () => {
+    const fixture = await createFixture();
+    const nowIso = fixture.now.toISOString();
+    fixture.store.loops.upsert({
+      ...(fixture.store.loops.getById("loop_worker_1") ?? {
+        id: "loop_worker_1",
+        seq: 1,
+        projectId: "project_1",
+        type: "worker",
+        targetType: "project",
+        targetId: "project_1",
+        repo: "acme/looper",
+        prNumber: null,
+        status: "queued",
+        configJson: null,
+        metadataJson: null,
+        lastRunAt: null,
+        nextRunAt: nowIso,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+      }),
+      targetType: "project",
+      targetId: "project_1",
+      repo: "acme/looper",
+      prNumber: null,
+      metadataJson: JSON.stringify({
+        worker: {
+          title: "Implement acme/looper#123",
+          repo: "acme/looper",
+          baseBranch: "main",
+          issueNumber: 123,
+        },
+      }),
+      updatedAt: nowIso,
+    });
+    fixture.store.queue.upsert({
+      ...(fixture.store.queue.findActiveByDedupe("worker:loop_worker_1") ?? {
+        id: "queue_issue_mode",
+        projectId: "project_1",
+        loopId: "loop_worker_1",
+        type: "worker",
+        targetType: "project",
+        targetId: "project_1",
+        repo: "acme/looper",
+        prNumber: null,
+        dedupeKey: "worker:loop_worker_1",
+        priority: 0,
+        status: "queued",
+        availableAt: nowIso,
+        attempts: 0,
+        maxAttempts: 3,
+        claimedBy: null,
+        claimedAt: null,
+        startedAt: null,
+        finishedAt: null,
+        lockKey: "worker:loop_worker_1",
+        payloadJson: null,
+        lastError: null,
+        lastErrorKind: null,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+      }),
+      targetType: "project",
+      targetId: "project_1",
+      repo: "acme/looper",
+      prNumber: null,
+      lockKey: "worker:loop_worker_1",
+      payloadJson: JSON.stringify({
+        title: "Implement acme/looper#123",
+        repo: "acme/looper",
+        baseBranch: "main",
+        issueNumber: 123,
+      }),
+      updatedAt: nowIso,
+    });
+
+    const git = new FakeGitGateway(fixture.worktreeRoot);
+    const github = new FakeGitHubGateway();
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Implemented issue fallback", ["abc123"]),
+    ]);
+    const runner = new WorkerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      validationRunner: async (): Promise<WorkerValidationResult> => ({
+        passed: true,
+        summary: "ok",
+        output: "ok",
+      }),
+      openPrStrategy: "all_done",
+    });
+
+    const claimed = fixture.queue.claimNext("worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed worker queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+    expect(result.status).toBe("success");
+    expect(github.viewIssueCalls).toEqual([
+      {
+        repo: "acme/looper",
+        issueNumber: 123,
+        cwd: fixture.repoPath,
+      },
+    ]);
+    expect(agent.starts).toHaveLength(1);
+    expect(agent.starts[0]?.prompt).toContain(
+      "Implement GitHub issue acme/looper#123: Add worker issue fallback",
+    );
+    expect(git.pushCalls).toBe(1);
+    expect(github.createPullRequestCalls).toHaveLength(1);
+    expect(github.createPullRequestCalls[0]?.headBranch).toBe(
+      "looper/worker/123-add-worker-issue-fallback",
+    );
+    expect(github.createPullRequestCalls[0]?.title).toBe(
+      "Add worker issue fallback",
+    );
+    expect(github.createPullRequestCalls[0]?.body).toContain("Closes #123");
+
     fixture.store.close();
   });
 

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -496,12 +496,71 @@ describe("WorkerLoopRunner", () => {
     expect(result.status).toBe("success");
     expect(result.pullRequestNumber).toBe(101);
     expect(agent.starts).toHaveLength(1);
+    expect(agent.starts[0]?.prompt).toContain(
+      "use the GitHub CLI (`gh`) to create the pull request yourself",
+    );
     expect(git.createWorktreeCalls).toBe(1);
     expect(git.pushCalls).toBe(1);
     expect(github.createPullRequestCalls).toHaveLength(1);
     expect(fixture.store.loops.getById("loop_worker_1")?.status).toBe(
       "completed",
     );
+    fixture.store.close();
+  });
+
+  test("records agent-created pull requests without creating a duplicate", async () => {
+    const fixture = await createFixture();
+    const git = new FakeGitGateway(fixture.worktreeRoot);
+    const github = new FakeGitHubGateway();
+    github.listOpenPullRequests = async () => [
+      {
+        number: 202,
+        title: "Agent-created PR",
+        url: "https://example.test/acme/looper/pull/202",
+        state: "OPEN",
+        isDraft: false,
+        reviewDecision: undefined,
+        labels: [],
+        headRefName: "looper/worker/loop-worker-1",
+        baseRefName: "main",
+        author: "octocat",
+        reviewRequests: [],
+      },
+    ];
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Implemented slice and opened PR", ["abc123"]),
+    ]);
+    const runner = new WorkerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      validationRunner: async (): Promise<WorkerValidationResult> => ({
+        passed: true,
+        summary: "ok",
+        output: "ok",
+      }),
+      openPrStrategy: "all_done",
+    });
+
+    const claimed = fixture.queue.claimNext("worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed worker queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+    expect(result.status).toBe("success");
+    expect(result.pullRequestNumber).toBe(202);
+    expect(git.pushCalls).toBe(1);
+    expect(github.createPullRequestCalls).toHaveLength(0);
+    expect(fixture.store.loops.getById("loop_worker_1")?.prNumber).toBe(202);
+    expect(
+      fixture.store.loops.getById("loop_worker_1")?.metadataJson,
+    ).toContain("https://example.test/acme/looper/pull/202");
+
     fixture.store.close();
   });
 
@@ -1129,6 +1188,9 @@ describe("WorkerLoopRunner", () => {
     const result = await runner.processClaimedItem(claimed);
     expect(result.status).toBe("skipped");
     expect(result.summary).toContain("Auto push disabled");
+    expect(agent.starts[0]?.prompt).not.toContain(
+      "use the GitHub CLI (`gh`) to create the pull request yourself",
+    );
     expect(git.pushCalls).toBe(0);
     expect(github.createPullRequestCalls).toHaveLength(0);
     expect(fixture.store.loops.getById("loop_worker_1")?.status).toBe(

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -10,6 +10,7 @@ import { appendCompletionInstruction } from "../infra/agent-prompt";
 import { CommandExecutionError, runCommand } from "../infra/command";
 import { ProtectedBranchError } from "../infra/git";
 import type {
+  GitHubIssueDetail,
   GitHubPullRequestDetail,
   GitHubPullRequestSummary,
 } from "../infra/github";
@@ -78,6 +79,11 @@ export interface WorkerGitHubGateway {
     prNumber: number;
     cwd?: string;
   }): Promise<GitHubPullRequestDetail>;
+  viewIssue(input: {
+    repo: string;
+    issueNumber: number;
+    cwd?: string;
+  }): Promise<GitHubIssueDetail>;
   createPullRequest(input: {
     repo: string;
     headBranch: string;
@@ -160,6 +166,8 @@ interface WorkerInput {
   repo: string;
   baseBranch: string;
   executionMode: "create-pr" | "push-existing";
+  issueNumber?: number;
+  issueUrl?: string;
   prNumber?: number;
   branch?: string;
   headSha?: string;
@@ -511,6 +519,19 @@ export class WorkerLoopRunner {
         input.loop.metadataJson,
         input.loop,
       );
+    if (
+      work.executionMode === "create-pr" &&
+      work.issueNumber &&
+      !work.prompt &&
+      !work.specPath
+    ) {
+      const issue = await this.options.github.viewIssue({
+        repo: work.repo,
+        issueNumber: work.issueNumber,
+        cwd: input.project.repoPath,
+      });
+      work = hydrateWorkerInputFromIssue(work, issue);
+    }
     if (input.loop.targetType === "pull_request") {
       const repo = input.loop.repo ?? input.queueItem.repo;
       const prNumber = input.loop.prNumber ?? input.queueItem.prNumber;
@@ -602,7 +623,7 @@ export class WorkerLoopRunner {
     const branch =
       work.executionMode === "push-existing"
         ? (work.branch ?? `pr-${work.prNumber}`)
-        : `looper/worker/${slugify(input.loop.id)}`;
+        : buildWorkerBranchName(work, input.loop.id);
     const worktree = await this.options.git.createWorktree({
       projectId: input.project.id,
       repoPath: input.project.repoPath,
@@ -897,7 +918,12 @@ export class WorkerLoopRunner {
       (executionMode === "push-existing"
         ? (readString(parseJsonObject(loop?.metadataJson).baseBranch) ?? "main")
         : null);
-    if (executionMode === "create-pr" && !prompt && !specPath) {
+    if (
+      executionMode === "create-pr" &&
+      !prompt &&
+      !specPath &&
+      !readNumber(source.issueNumber)
+    ) {
       throw new WorkerLoopError(
         "worker.prompt or worker.specPath is required",
         "non_retryable",
@@ -920,6 +946,8 @@ export class WorkerLoopRunner {
       prompt,
       specPath,
       executionMode,
+      issueNumber: readNumber(source.issueNumber),
+      issueUrl: readString(source.issueUrl) ?? undefined,
       prNumber: readNumber(source.prNumber),
       branch: readString(source.branch) ?? undefined,
       headSha: readString(source.headSha) ?? undefined,
@@ -1409,11 +1437,62 @@ function buildPullRequestBody(input: {
     input.executionSummary
       ? `\n## Agent Summary\n${input.executionSummary}`
       : null,
+    input.work.issueNumber
+      ? `\nIssue: ${input.work.repo}#${input.work.issueNumber}`
+      : null,
+    input.work.issueUrl ? `Issue URL: ${input.work.issueUrl}` : null,
     input.work.specPath ? `\nSpec: ${input.work.specPath}` : null,
     input.work.prompt ? `\nPrompt: ${input.work.prompt}` : null,
+    input.work.issueNumber ? `\nCloses #${input.work.issueNumber}` : null,
   ]
     .filter((value): value is string => Boolean(value))
     .join("\n");
+}
+
+function hydrateWorkerInputFromIssue(
+  work: WorkerInput,
+  issue: GitHubIssueDetail,
+): WorkerInput {
+  const fallbackTitle = buildDefaultIssueWorkerTitle(work.repo, issue.number);
+  return {
+    ...work,
+    title:
+      work.title === "Worker run" || work.title === fallbackTitle
+        ? issue.title
+        : work.title,
+    prompt: buildIssuePrompt(work.repo, issue),
+    issueUrl: issue.url,
+  };
+}
+
+function buildIssuePrompt(repo: string, issue: GitHubIssueDetail): string {
+  return [
+    `Implement GitHub issue ${repo}#${issue.number}: ${issue.title}`,
+    issue.body ? `Issue body:\n${issue.body}` : null,
+    issue.url ? `Issue URL: ${issue.url}` : null,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join("\n\n");
+}
+
+function buildWorkerBranchName(work: WorkerInput, loopId: string): string {
+  if (work.issueNumber) {
+    return `looper/worker/${work.issueNumber}-${buildWorkerSlug(work.title)}`;
+  }
+
+  return `looper/worker/${slugify(loopId)}`;
+}
+
+function buildWorkerSlug(title: string): string {
+  const words = slugify(title).split("-").filter(Boolean).slice(0, 8).join("-");
+  return words || "update";
+}
+
+function buildDefaultIssueWorkerTitle(
+  repo: string,
+  issueNumber: number,
+): string {
+  return `Implement ${repo}#${issueNumber}`;
 }
 
 function buildPullRequestTargetId(repo: string, prNumber: number): string {

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -716,10 +716,7 @@ export class WorkerLoopRunner {
       repoRootPath: worktree.path,
       work,
       plan: input.checkpoint.plan?.items ?? [],
-      allowAgentPrCreation:
-        work.executionMode === "create-pr" &&
-        this.openPrStrategy !== "manual" &&
-        this.allowAutoPush,
+      allowAgentPrCreation: this.canAgentCreatePr(work),
     });
     const executionId = randomUUID();
     const execution = await this.options.agentExecutor.start({
@@ -974,6 +971,16 @@ export class WorkerLoopRunner {
       reviewers: input.work.reviewers ?? [],
       cwd: input.cwd,
     });
+  }
+
+  private canAgentCreatePr(work: WorkerInput): boolean {
+    return (
+      work.executionMode === "create-pr" &&
+      this.openPrStrategy !== "manual" &&
+      this.allowAutoPush &&
+      this.validationCommands.length === 0 &&
+      !this.options.validationRunner
+    );
   }
 
   private async findOpenPullRequestForBranch(input: {

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -1477,7 +1477,7 @@ function buildIssuePrompt(repo: string, issue: GitHubIssueDetail): string {
 
 function buildWorkerBranchName(work: WorkerInput, loopId: string): string {
   if (work.issueNumber) {
-    return `looper/worker/${work.issueNumber}-${buildWorkerSlug(work.title)}`;
+    return `looper/worker/${work.issueNumber}-${buildWorkerSlug(work.title)}-${slugify(loopId)}`;
   }
 
   return `looper/worker/${slugify(loopId)}`;

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -38,6 +38,9 @@ const WORKER_STEP_SEQUENCE = [
   "open-pr",
 ] as const;
 
+const WORKER_BRANCH_SLUG_MAX_LENGTH = 48;
+const WORKER_PR_DEDUPE_LOOKUP_LIMIT = 1000;
+
 export type WorkerStep = (typeof WORKER_STEP_SEQUENCE)[number];
 
 export interface WorkerGitGateway {
@@ -979,6 +982,7 @@ export class WorkerLoopRunner {
     const pullRequests = await this.options.github.listOpenPullRequests({
       repo: input.repo,
       cwd: input.cwd,
+      limit: WORKER_PR_DEDUPE_LOOKUP_LIMIT,
     });
     return (
       pullRequests.find(
@@ -1620,7 +1624,10 @@ function buildWorkerBranchName(work: WorkerInput, loopId: string): string {
 
 function buildWorkerSlug(title: string): string {
   const words = slugify(title).split("-").filter(Boolean).slice(0, 8).join("-");
-  return words || "update";
+  return (
+    words.slice(0, WORKER_BRANCH_SLUG_MAX_LENGTH).replace(/-+$/g, "") ||
+    "update"
+  );
 }
 
 function buildDefaultIssueWorkerTitle(

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -862,6 +862,7 @@ export class WorkerLoopRunner {
       const existingPullRequest = await this.findOpenPullRequestForBranch({
         repo: work.repo,
         branch: worktree.branch,
+        baseBranch: work.baseBranch,
         cwd: input.project.repoPath,
       });
       if (existingPullRequest) {
@@ -897,6 +898,7 @@ export class WorkerLoopRunner {
       const discoveredPullRequest = await this.findOpenPullRequestForBranch({
         repo: work.repo,
         branch: worktree.branch,
+        baseBranch: work.baseBranch,
         cwd: input.project.repoPath,
       });
       if (discoveredPullRequest) {
@@ -977,6 +979,7 @@ export class WorkerLoopRunner {
   private async findOpenPullRequestForBranch(input: {
     repo: string;
     branch: string;
+    baseBranch: string;
     cwd: string;
   }): Promise<GitHubPullRequestSummary | null> {
     const pullRequests = await this.options.github.listOpenPullRequests({
@@ -988,7 +991,8 @@ export class WorkerLoopRunner {
       pullRequests.find(
         (pullRequest) =>
           normalizePrState(pullRequest.state) === "open" &&
-          pullRequest.headRefName === input.branch,
+          pullRequest.headRefName === input.branch &&
+          pullRequest.baseRefName === input.baseBranch,
       ) ?? null
     );
   }

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -840,6 +840,21 @@ export class WorkerLoopRunner {
         );
       }
     }
+    if (this.openPrStrategy === "manual") {
+      return {
+        ...input.checkpoint,
+        skipReason: `Worker completed; PR opening is manual for ${input.loop.id}`,
+        resumePolicy: "manual_intervention",
+      };
+    }
+    if (!this.allowAutoPush) {
+      return {
+        ...input.checkpoint,
+        skipReason: `Auto push disabled; manual PR opening required for worker ${input.loop.id}`,
+        resumePolicy: "manual_intervention",
+      };
+    }
+
     try {
       const existingPullRequest = await this.findOpenPullRequestForBranch({
         repo: work.repo,
@@ -847,13 +862,11 @@ export class WorkerLoopRunner {
         cwd: input.project.repoPath,
       });
       if (existingPullRequest) {
-        if (this.allowAutoPush) {
-          await this.options.git.push({
-            worktreePath: worktree.path,
-            branch: worktree.branch,
-            protectedBranches: [work.baseBranch],
-          });
-        }
+        await this.options.git.push({
+          worktreePath: worktree.path,
+          branch: worktree.branch,
+          protectedBranches: [work.baseBranch],
+        });
         await this.assignReviewersIfNeeded({
           work,
           pullRequest: existingPullRequest,
@@ -871,20 +884,6 @@ export class WorkerLoopRunner {
             url: existingPullRequest.url ?? "",
           },
           resumePolicy: "advance_from_checkpoint",
-        };
-      }
-      if (this.openPrStrategy === "manual") {
-        return {
-          ...input.checkpoint,
-          skipReason: `Worker completed; PR opening is manual for ${input.loop.id}`,
-          resumePolicy: "manual_intervention",
-        };
-      }
-      if (!this.allowAutoPush) {
-        return {
-          ...input.checkpoint,
-          skipReason: `Auto push disabled; manual PR opening required for worker ${input.loop.id}`,
-          resumePolicy: "manual_intervention",
         };
       }
       await this.options.git.push({
@@ -980,7 +979,6 @@ export class WorkerLoopRunner {
     const pullRequests = await this.options.github.listOpenPullRequests({
       repo: input.repo,
       cwd: input.cwd,
-      limit: 100,
     });
     return (
       pullRequests.find(

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -713,6 +713,10 @@ export class WorkerLoopRunner {
       repoRootPath: worktree.path,
       work,
       plan: input.checkpoint.plan?.items ?? [],
+      allowAgentPrCreation:
+        work.executionMode === "create-pr" &&
+        this.openPrStrategy !== "manual" &&
+        this.allowAutoPush,
     });
     const executionId = randomUUID();
     const execution = await this.options.agentExecutor.start({
@@ -836,27 +840,83 @@ export class WorkerLoopRunner {
         );
       }
     }
-    if (this.openPrStrategy === "manual") {
-      return {
-        ...input.checkpoint,
-        skipReason: `Worker completed; PR opening is manual for ${input.loop.id}`,
-        resumePolicy: "manual_intervention",
-      };
-    }
-    if (!this.allowAutoPush) {
-      return {
-        ...input.checkpoint,
-        skipReason: `Auto push disabled; manual PR opening required for worker ${input.loop.id}`,
-        resumePolicy: "manual_intervention",
-      };
-    }
-
     try {
+      const existingPullRequest = await this.findOpenPullRequestForBranch({
+        repo: work.repo,
+        branch: worktree.branch,
+        cwd: input.project.repoPath,
+      });
+      if (existingPullRequest) {
+        if (this.allowAutoPush) {
+          await this.options.git.push({
+            worktreePath: worktree.path,
+            branch: worktree.branch,
+            protectedBranches: [work.baseBranch],
+          });
+        }
+        await this.assignReviewersIfNeeded({
+          work,
+          pullRequest: existingPullRequest,
+          cwd: input.project.repoPath,
+        });
+        this.persistPullRequestReference(
+          input.loop,
+          work.repo,
+          existingPullRequest,
+        );
+        return {
+          ...input.checkpoint,
+          pullRequest: {
+            number: existingPullRequest.number,
+            url: existingPullRequest.url ?? "",
+          },
+          resumePolicy: "advance_from_checkpoint",
+        };
+      }
+      if (this.openPrStrategy === "manual") {
+        return {
+          ...input.checkpoint,
+          skipReason: `Worker completed; PR opening is manual for ${input.loop.id}`,
+          resumePolicy: "manual_intervention",
+        };
+      }
+      if (!this.allowAutoPush) {
+        return {
+          ...input.checkpoint,
+          skipReason: `Auto push disabled; manual PR opening required for worker ${input.loop.id}`,
+          resumePolicy: "manual_intervention",
+        };
+      }
       await this.options.git.push({
         worktreePath: worktree.path,
         branch: worktree.branch,
         protectedBranches: [work.baseBranch],
       });
+      const discoveredPullRequest = await this.findOpenPullRequestForBranch({
+        repo: work.repo,
+        branch: worktree.branch,
+        cwd: input.project.repoPath,
+      });
+      if (discoveredPullRequest) {
+        await this.assignReviewersIfNeeded({
+          work,
+          pullRequest: discoveredPullRequest,
+          cwd: input.project.repoPath,
+        });
+        this.persistPullRequestReference(
+          input.loop,
+          work.repo,
+          discoveredPullRequest,
+        );
+        return {
+          ...input.checkpoint,
+          pullRequest: {
+            number: discoveredPullRequest.number,
+            url: discoveredPullRequest.url ?? "",
+          },
+          resumePolicy: "advance_from_checkpoint",
+        };
+      }
       const pullRequest = await this.options.github.createPullRequest({
         repo: work.repo,
         headBranch: worktree.branch,
@@ -869,15 +929,13 @@ export class WorkerLoopRunner {
         }),
         cwd: input.project.repoPath,
       });
+      await this.assignReviewersIfNeeded({
+        work,
+        pullRequest,
+        cwd: input.project.repoPath,
+      });
 
-      this.updateLoop(input.loop, {
-        repo: work.repo,
-        prNumber: pullRequest.number ?? null,
-      });
-      this.updateLoopMetadata(input.loop.id, {
-        prUrl: pullRequest.url,
-        prNumber: pullRequest.number ?? null,
-      });
+      this.persistPullRequestReference(input.loop, work.repo, pullRequest);
 
       return {
         ...input.checkpoint,
@@ -890,6 +948,47 @@ export class WorkerLoopRunner {
         "retryable_after_resume",
       );
     }
+  }
+
+  private async assignReviewersIfNeeded(input: {
+    work: WorkerInput;
+    pullRequest: {
+      number?: number;
+    };
+    cwd: string;
+  }): Promise<void> {
+    if (
+      (input.work.reviewers ?? []).length === 0 ||
+      !input.pullRequest.number
+    ) {
+      return;
+    }
+
+    await this.options.github.addPullRequestReviewers({
+      repo: input.work.repo,
+      prNumber: input.pullRequest.number,
+      reviewers: input.work.reviewers ?? [],
+      cwd: input.cwd,
+    });
+  }
+
+  private async findOpenPullRequestForBranch(input: {
+    repo: string;
+    branch: string;
+    cwd: string;
+  }): Promise<GitHubPullRequestSummary | null> {
+    const pullRequests = await this.options.github.listOpenPullRequests({
+      repo: input.repo,
+      cwd: input.cwd,
+      limit: 100,
+    });
+    return (
+      pullRequests.find(
+        (pullRequest) =>
+          normalizePrState(pullRequest.state) === "open" &&
+          pullRequest.headRefName === input.branch,
+      ) ?? null
+    );
   }
 
   private resolveWorkerInput(
@@ -1282,6 +1381,24 @@ export class WorkerLoopRunner {
   private nowIso(): string {
     return this.now().toISOString();
   }
+
+  private persistPullRequestReference(
+    loop: LoopRecord,
+    repo: string,
+    pullRequest: {
+      number?: number;
+      url?: string;
+    },
+  ): void {
+    this.updateLoop(loop, {
+      repo,
+      prNumber: pullRequest.number ?? null,
+    });
+    this.updateLoopMetadata(loop.id, {
+      prUrl: pullRequest.url ?? null,
+      prNumber: pullRequest.number ?? null,
+    });
+  }
 }
 
 function nextWorkerStep(step: WorkerStep): WorkerStep | null {
@@ -1378,6 +1495,7 @@ async function buildWorkerPrompt(input: {
   repoRootPath: string;
   work: WorkerInput;
   plan: string[];
+  allowAgentPrCreation: boolean;
 }): Promise<string> {
   const specBlock = await readSpecBlock(
     input.repoRootPath,
@@ -1400,11 +1518,30 @@ async function buildWorkerPrompt(input: {
             "\n",
           )
         : null,
-      "Make the necessary code changes, validate them, and leave the branch ready for PR creation.",
+      input.allowAgentPrCreation
+        ? buildAgentPullRequestInstruction(input.work)
+        : null,
+      input.allowAgentPrCreation
+        ? "Make the necessary code changes, validate them, and ensure the branch and pull request are left in a consistent state."
+        : "Make the necessary code changes, validate them, and leave the branch ready for PR creation.",
     ]
       .filter((value): value is string => Boolean(value))
       .join("\n\n"),
   );
+}
+
+function buildAgentPullRequestInstruction(work: WorkerInput): string {
+  return [
+    "When the implementation is ready and validation passes, use the GitHub CLI (`gh`) to create the pull request yourself.",
+    "Before creating a PR, check whether one already exists for the current branch and avoid duplicates.",
+    "Write a concise, accurate PR title and a structured body that explains the actual changes and why they were made.",
+    work.issueNumber
+      ? `Include \`Closes #${work.issueNumber}\` in the PR body.`
+      : null,
+    `Target base branch: ${work.baseBranch}.`,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join("\n");
 }
 
 async function readSpecBlock(


### PR DESCRIPTION
## Summary
- let `looper work --issue` start even when no planner loop exists and persist the issue number in worker payloads
- hydrate worker runs from the GitHub issue title/body when no planner spec is available, then continue through the existing create-PR flow
- add coverage for issue-driven worker execution, branch naming, and PR body linking back to the source issue