### PR TITLE
Support manual reviewer tasks from PR refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,15 @@ The CLI connects to `looperd` over HTTP and supports commands under:
 - `config show`
 - `daemon status|logs`
 - `loop list|start|pause`
+- `review <pr> [--loop]`
 - `work`
 - `pr list|show|status`
 - `run list`
+
+Manual review examples:
+
+- `looper review 123` — create a one-shot reviewer task for PR `123` in the current project
+- `looper review powerformer/looper#123 --loop` — keep re-reviewing that PR as new commits are pushed
 
 ### `apps/web`
 

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -379,6 +379,111 @@ describe("runCli", () => {
     expect(requests[1]).toContain("POST http://127.0.0.1:4310/api/v1/loops");
   });
 
+  test("creates manual review task from repo-qualified PR reference", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["review", "acme/looper#42", "--loop"], {
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({ url, body: init?.body as string | null });
+
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_projects_review_1",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_review_1",
+            data: {
+              id: "loop_review_1",
+              projectId: "project_1",
+              repo: "acme/looper",
+              prNumber: 42,
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests[0]?.url).toContain("/api/v1/projects");
+    expect(requests[1]?.url).toContain("/api/v1/loops");
+    expect(requests[1]?.body).toContain('"projectId":"project_1"');
+    expect(requests[1]?.body).toContain('"repo":"acme/looper"');
+    expect(requests[1]?.body).toContain('"prNumber":42');
+    expect(requests[1]?.body).toContain('"followUpdates":true');
+    expect(requests[1]?.body).toContain('"manual":true');
+  });
+
+  test("creates manual review task from local project PR number", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["review", "42"], {
+      cwd: "/tmp/repos/looper/packages/cli",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({ url, body: init?.body as string | null });
+
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_projects_review_2",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_review_2",
+            data: {
+              id: "loop_review_2",
+              projectId: "project_1",
+              repo: "acme/looper",
+              prNumber: 42,
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests[0]?.url).toContain("/api/v1/projects");
+    expect(requests[1]?.body).toContain('"projectId":"project_1"');
+    expect(requests[1]?.body).toContain('"repo":"acme/looper"');
+    expect(requests[1]?.body).toContain('"prNumber":42');
+    expect(requests[1]?.body).toContain('"followUpdates":false');
+  });
+
   test("creates planner work item from issue number", async () => {
     const requests: Array<{ url: string; body?: string | null }> = [];
     const exitCode = await runCli(

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -484,6 +484,62 @@ describe("runCli", () => {
     expect(requests[1]?.body).toContain('"followUpdates":false');
   });
 
+  test("uses explicit project for local PR number review targets", async () => {
+    const requests: Array<{ url: string; body?: string | null }> = [];
+    const exitCode = await runCli(["review", "42", "--project", "project_2"], {
+      cwd: "/tmp/outside-repo",
+      stdout: () => {},
+      loadConfigImpl: async () => createConfig() as never,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({ url, body: init?.body as string | null });
+
+        if (url.endsWith("/api/v1/projects")) {
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              requestId: "req_projects_review_3",
+              data: {
+                items: [
+                  {
+                    id: "project_1",
+                    repoPath: "/tmp/repos/looper",
+                    repo: "acme/looper",
+                  },
+                  {
+                    id: "project_2",
+                    repoPath: "/tmp/repos/other",
+                    repo: "acme/other",
+                  },
+                ],
+              },
+            }),
+          );
+        }
+
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            requestId: "req_review_3",
+            data: {
+              id: "loop_review_3",
+              projectId: "project_2",
+              repo: "acme/other",
+              prNumber: 42,
+              status: "running",
+            },
+          }),
+        );
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(requests[0]?.url).toContain("/api/v1/projects");
+    expect(requests[1]?.body).toContain('"projectId":"project_2"');
+    expect(requests[1]?.body).toContain('"repo":"acme/other"');
+    expect(requests[1]?.body).toContain('"prNumber":42');
+  });
+
   test("creates planner work item from issue number", async () => {
     const requests: Array<{ url: string; body?: string | null }> = [];
     const exitCode = await runCli(

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1363,7 +1363,11 @@ async function resolveReviewTarget(
     };
   }
 
-  const projectId = resolveProjectId(context, projects);
+  const projectId = resolveExplicitOrCurrentProjectId(
+    context,
+    projects,
+    explicitProjectId,
+  );
   const project = projects.find((candidate) => candidate.id === projectId);
   if (!project?.repo) {
     throw new Error(`project ${projectId} is missing a configured repo`);
@@ -1374,6 +1378,24 @@ async function resolveReviewTarget(
     repo: project.repo,
     prNumber: parsed.prNumber,
   };
+}
+
+function resolveExplicitOrCurrentProjectId(
+  context: CliContext,
+  projects: ProjectSummary[],
+  explicitProjectId?: string,
+): string {
+  if (explicitProjectId && explicitProjectId !== "true") {
+    const explicitProject = projects.find(
+      (project) => project.id === explicitProjectId,
+    );
+    if (!explicitProject) {
+      throw new Error(`project not found: ${explicitProjectId}`);
+    }
+    return explicitProject.id;
+  }
+
+  return resolveProjectId(context, projects);
 }
 
 async function listProjects(context: CliContext): Promise<ProjectSummary[]> {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -78,6 +78,12 @@ interface PullRequestRef {
   prNumber: number;
 }
 
+interface ProjectSummary {
+  id: string;
+  repoPath: string;
+  repo: string | null;
+}
+
 interface ActiveRunItem {
   seq: number;
   runId: string;
@@ -293,6 +299,8 @@ async function dispatch(context: CliContext): Promise<void> {
       }
       context.showHelp("pr");
       return;
+    case "review":
+      return runReviewCreate(context);
     case "run":
       if (subcommand === "list") {
         return runRunList(context);
@@ -404,6 +412,16 @@ function createCli(runtime: CliRuntime) {
     .example((name) => `  $ ${name} pr show acme/looper#42`)
     .action(async (args, options) => {
       await dispatch(createContext(runtime, ["pr", ...args], options));
+    });
+
+  cli
+    .command("review <pr>", "Create a reviewer task for a pull request")
+    .option("--project <projectId>", "Project id")
+    .option("--loop", "Keep reviewing when new commits are pushed")
+    .example((name) => `  $ ${name} review 123`)
+    .example((name) => `  $ ${name} review acme/looper#42 --loop`)
+    .action(async (pr, options) => {
+      await dispatch(createContext(runtime, ["review", pr], options));
     });
 
   cli
@@ -777,6 +795,42 @@ async function runLoopStart(context: CliContext) {
     ["id", data.id as string],
     ["type", data.type as string],
     ["status", data.status as string],
+  ]);
+}
+
+async function runReviewCreate(context: CliContext) {
+  const refText = context.args.positionals[1];
+  if (!refText) {
+    throw new Error("Usage: looper review <pr> [--loop]");
+  }
+
+  const target = await resolveReviewTarget(context, refText);
+  const data = await context.client.post<Record<string, unknown>>(
+    "/api/v1/loops",
+    {
+      projectId: target.projectId,
+      type: "reviewer",
+      targetType: "pull_request",
+      repo: target.repo,
+      prNumber: target.prNumber,
+      status: "running",
+      metadata: {
+        followUpdates: hasFlag(context.args, "loop"),
+        manual: true,
+      },
+    },
+  );
+
+  if (hasFlag(context.args, "json")) {
+    return printJson(context.write, data);
+  }
+
+  printSection(context.write, "Reviewer started", [
+    ["id", data.id as string],
+    ["projectId", data.projectId as string],
+    ["pr", `${data.repo}#${data.prNumber}`],
+    ["status", data.status as string],
+    ["loop", String(hasFlag(context.args, "loop"))],
   ]);
 }
 
@@ -1288,17 +1342,96 @@ function requireFlag(args: ParsedArgs, name: string): string {
   return value;
 }
 
+async function resolveReviewTarget(
+  context: CliContext,
+  value: string,
+): Promise<{ projectId: string; repo: string; prNumber: number }> {
+  const explicitProjectId = getFlag(context.args, "project");
+  const projects = await listProjects(context);
+  const parsed = parseOptionalRepoPullRequestRef(value);
+
+  if (parsed.repo) {
+    const project = resolveProjectForRepo(
+      projects,
+      parsed.repo,
+      explicitProjectId,
+    );
+    return {
+      projectId: project.id,
+      repo: parsed.repo,
+      prNumber: parsed.prNumber,
+    };
+  }
+
+  const projectId = resolveProjectId(context, projects);
+  const project = projects.find((candidate) => candidate.id === projectId);
+  if (!project?.repo) {
+    throw new Error(`project ${projectId} is missing a configured repo`);
+  }
+
+  return {
+    projectId,
+    repo: project.repo,
+    prNumber: parsed.prNumber,
+  };
+}
+
+async function listProjects(context: CliContext): Promise<ProjectSummary[]> {
+  const data = await context.client.get<{ items: ProjectSummary[] }>(
+    "/api/v1/projects",
+  );
+  return data.items;
+}
+
+function resolveProjectForRepo(
+  projects: ProjectSummary[],
+  repo: string,
+  explicitProjectId?: string,
+): ProjectSummary {
+  if (explicitProjectId && explicitProjectId !== "true") {
+    const explicitProject = projects.find(
+      (project) => project.id === explicitProjectId,
+    );
+    if (!explicitProject) {
+      throw new Error(`project not found: ${explicitProjectId}`);
+    }
+    if (explicitProject.repo !== repo) {
+      throw new Error(
+        `project ${explicitProjectId} is configured for ${explicitProject.repo ?? "no repo"}, not ${repo}`,
+      );
+    }
+    return explicitProject;
+  }
+
+  const matches = projects.filter((project) => project.repo === repo);
+  if (matches.length === 0) {
+    throw new Error(
+      `--project is required (no project configured for repo ${repo})`,
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `--project is required (multiple projects are configured for repo ${repo})`,
+    );
+  }
+  return matches[0] as ProjectSummary;
+}
+
 async function resolveCommandProjectId(context: CliContext): Promise<string> {
   const explicitProjectId = getFlag(context.args, "project");
   if (explicitProjectId && explicitProjectId !== "true") {
     return explicitProjectId;
   }
 
+  return resolveProjectId(context, await listProjects(context));
+}
+
+function resolveProjectId(
+  context: CliContext,
+  projects: ProjectSummary[],
+): string {
   const cwd = normalizeComparablePath(context.cwd);
-  const data = await context.client.get<{
-    items: Array<{ id: string; repoPath: string }>;
-  }>("/api/v1/projects");
-  const matches = data.items.filter((project) =>
+  const matches = projects.filter((project) =>
     isWithinProjectRepo(cwd, project.repoPath),
   );
 
@@ -1361,6 +1494,26 @@ function parsePullRequestRef(value: string): PullRequestRef {
     repo,
     prNumber: Number(prNumber),
   };
+}
+
+function parseOptionalRepoPullRequestRef(value: string): {
+  repo?: string;
+  prNumber: number;
+} {
+  const trimmed = value.trim();
+  const repoQualified = /^(?<repo>[^#]+)#(?<prNumber>\d+)$/.exec(trimmed);
+  if (repoQualified?.groups?.repo && repoQualified.groups.prNumber) {
+    return {
+      repo: repoQualified.groups.repo,
+      prNumber: Number(repoQualified.groups.prNumber),
+    };
+  }
+
+  if (/^\d+$/.test(trimmed)) {
+    return { prNumber: Number(trimmed) };
+  }
+
+  throw new Error(`Invalid pull request reference: ${value}`);
 }
 
 function deriveProjectId(repoPath: string): string {

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -1029,4 +1029,59 @@ describe("ReviewerLoopRunner", () => {
 
     fixture.store.close();
   });
+
+  test("re-enqueues manual follow-up loops when a PR head changes", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway({
+      headSha: "new-head",
+      reviewRequests: [],
+      currentUserLogin: "someone-else",
+    });
+    const agent = new FakeAgentExecutor([completedAgentResult("unused")]);
+    const nowIso = fixture.now.toISOString();
+
+    fixture.store.loops.upsert({
+      id: "loop_manual_followup",
+      seq: 1,
+      projectId: "project_1",
+      type: "reviewer",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:42",
+      repo: "acme/looper",
+      prNumber: 42,
+      status: "completed",
+      configJson: null,
+      metadataJson: JSON.stringify({
+        followUpdates: true,
+        manual: true,
+        lastPublishedHeadSha: "abc123",
+      }),
+      lastRunAt: nowIso,
+      nextRunAt: null,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    const discovery = await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+
+    expect(discovery.queueItems).toHaveLength(1);
+    expect(fixture.queue.listScheduled()).toHaveLength(1);
+    expect(fixture.store.loops.getById("loop_manual_followup")?.status).toBe(
+      "queued",
+    );
+
+    fixture.store.close();
+  });
 });

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -1158,7 +1158,7 @@ describe("ReviewerLoopRunner", () => {
     });
 
     expect(discovery.queueItems).toHaveLength(1);
-    expect(discovery.skipped).toBe(2);
+    expect(discovery.skipped).toBe(3);
     expect(fixture.queue.listScheduled()).toHaveLength(1);
     expect(
       fixture.store.loops.getById("loop_manual_followup_valid")?.status,

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -1090,6 +1090,61 @@ describe("ReviewerLoopRunner", () => {
     fixture.store.close();
   });
 
+  test("does not re-enqueue paused manual follow-up loops", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway({
+      headSha: "new-head",
+      reviewRequests: [],
+      currentUserLogin: "someone-else",
+    });
+    const agent = new FakeAgentExecutor([completedAgentResult("unused")]);
+    const nowIso = fixture.now.toISOString();
+
+    fixture.store.loops.upsert({
+      id: "loop_manual_followup_paused",
+      seq: 1,
+      projectId: "project_1",
+      type: "reviewer",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:42",
+      repo: "acme/looper",
+      prNumber: 42,
+      status: "paused",
+      configJson: null,
+      metadataJson: JSON.stringify({
+        followUpdates: true,
+        manual: true,
+        lastPublishedHeadSha: "abc123",
+      }),
+      lastRunAt: nowIso,
+      nextRunAt: null,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    const discovery = await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+
+    expect(discovery.queueItems).toHaveLength(0);
+    expect(fixture.queue.listScheduled()).toHaveLength(0);
+    expect(fixture.store.loops.getById("loop_manual_followup_paused")?.status).toBe(
+      "paused",
+    );
+
+    fixture.store.close();
+  });
+
   test("discovery skips invalid follow-up PR fetch failures without aborting", async () => {
     const fixture = await createFixture();
     const github = new FakeGitHubGateway({

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -1138,9 +1138,9 @@ describe("ReviewerLoopRunner", () => {
 
     expect(discovery.queueItems).toHaveLength(0);
     expect(fixture.queue.listScheduled()).toHaveLength(0);
-    expect(fixture.store.loops.getById("loop_manual_followup_paused")?.status).toBe(
-      "paused",
-    );
+    expect(
+      fixture.store.loops.getById("loop_manual_followup_paused")?.status,
+    ).toBe("paused");
 
     fixture.store.close();
   });

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -78,6 +78,7 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
   public submitFailuresRemaining = 0;
   public addLabelFailuresRemaining = 0;
   public nextReviewDecisionAfterSubmit: string | undefined;
+  public failingViewPullRequestNumbers = new Set<number>();
   private readonly currentLabels: string[];
 
   constructor(
@@ -141,12 +142,16 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
     return this.options.currentUserLogin ?? "octocat";
   }
 
-  public async viewPullRequest() {
+  public async viewPullRequest(input: { prNumber: number }) {
+    if (this.failingViewPullRequestNumbers.has(input.prNumber)) {
+      throw new Error(`PR not accessible: ${input.prNumber}`);
+    }
+
     return {
-      number: 42,
+      number: input.prNumber,
       title: "Review me",
       body: "PR body",
-      url: "https://example.test/pr/42",
+      url: `https://example.test/pr/${input.prNumber}`,
       state: this.options.state ?? "OPEN",
       isDraft: this.options.isDraft ?? false,
       reviewDecision: this.options.reviewDecision,
@@ -1081,6 +1086,86 @@ describe("ReviewerLoopRunner", () => {
     expect(fixture.store.loops.getById("loop_manual_followup")?.status).toBe(
       "queued",
     );
+
+    fixture.store.close();
+  });
+
+  test("discovery skips invalid follow-up PR fetch failures without aborting", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway({
+      headSha: "new-head",
+      reviewRequests: [],
+      currentUserLogin: "someone-else",
+    });
+    github.failingViewPullRequestNumbers.add(77);
+    const agent = new FakeAgentExecutor([completedAgentResult("unused")]);
+    const nowIso = fixture.now.toISOString();
+
+    fixture.store.loops.upsert({
+      id: "loop_manual_followup_valid",
+      seq: 1,
+      projectId: "project_1",
+      type: "reviewer",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:42",
+      repo: "acme/looper",
+      prNumber: 42,
+      status: "completed",
+      configJson: null,
+      metadataJson: JSON.stringify({
+        followUpdates: true,
+        manual: true,
+        lastPublishedHeadSha: "abc123",
+      }),
+      lastRunAt: nowIso,
+      nextRunAt: null,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+    fixture.store.loops.upsert({
+      id: "loop_manual_followup_invalid",
+      seq: 2,
+      projectId: "project_1",
+      type: "reviewer",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:77",
+      repo: "acme/looper",
+      prNumber: 77,
+      status: "completed",
+      configJson: null,
+      metadataJson: JSON.stringify({
+        followUpdates: true,
+        manual: true,
+      }),
+      lastRunAt: nowIso,
+      nextRunAt: null,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    const discovery = await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+
+    expect(discovery.queueItems).toHaveLength(1);
+    expect(discovery.skipped).toBe(2);
+    expect(fixture.queue.listScheduled()).toHaveLength(1);
+    expect(
+      fixture.store.loops.getById("loop_manual_followup_valid")?.status,
+    ).toBe("queued");
+    expect(
+      fixture.store.loops.getById("loop_manual_followup_invalid")?.status,
+    ).toBe("completed");
 
     fixture.store.close();
   });

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -1225,7 +1225,8 @@ export class ReviewerLoopRunner {
         loop.type !== "reviewer" ||
         loop.projectId !== projectId ||
         loop.repo !== repo ||
-        loop.prNumber == null
+        loop.prNumber == null ||
+        loop.status === "paused"
       ) {
         return false;
       }

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -305,11 +305,27 @@ export class ReviewerLoopRunner {
       }
       seen.add(dedupe);
 
-      const detail = await this.options.github.viewPullRequest({
-        repo: input.repo,
-        prNumber: loop.prNumber,
-        cwd: project.repoPath,
-      });
+      let detail: GitHubPullRequestDetail;
+      try {
+        detail = await this.options.github.viewPullRequest({
+          repo: input.repo,
+          prNumber: loop.prNumber,
+          cwd: project.repoPath,
+        });
+      } catch (error) {
+        skipped += 1;
+        this.options.logger.warn(
+          "reviewer discovery skipped follow-up PR fetch failure",
+          {
+            projectId: project.id,
+            repo: input.repo,
+            prNumber: loop.prNumber,
+            loopId: loop.id,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        continue;
+      }
       if (detail.isDraft || normalizePrState(detail.state) !== "open") {
         skipped += 1;
         continue;

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -209,18 +209,17 @@ export class ReviewerLoopRunner {
     let skipped = 0;
     const seen = new Set<string>();
 
-    const enqueuePullRequest = (pullRequest: GitHubPullRequestSummary) => {
-      const dedupe = `${input.repo}#${pullRequest.number}`;
-      if (seen.has(dedupe)) {
-        return;
-      }
-      seen.add(dedupe);
-
-      const loop = this.ensureLoopForPullRequest({
-        projectId: project.id,
-        repo: input.repo,
-        prNumber: pullRequest.number,
-      });
+    const enqueueLoopRecord = (
+      pullRequest: Pick<GitHubPullRequestSummary, "number" | "headSha">,
+      loopRecord?: LoopRecord,
+    ) => {
+      const loop = loopRecord
+        ? this.refreshLoopForPullRequest(loopRecord)
+        : this.ensureLoopForPullRequest({
+            projectId: project.id,
+            repo: input.repo,
+            prNumber: pullRequest.number,
+          });
 
       if (loop.created) {
         createdLoopIds.push(loop.record.id);
@@ -263,6 +262,16 @@ export class ReviewerLoopRunner {
       );
     };
 
+    const enqueuePullRequest = (pullRequest: GitHubPullRequestSummary) => {
+      const dedupe = `${input.repo}#${pullRequest.number}`;
+      if (seen.has(dedupe)) {
+        return;
+      }
+      seen.add(dedupe);
+
+      enqueueLoopRecord(pullRequest);
+    };
+
     for (const pullRequest of openPullRequests) {
       if (
         pullRequest.isDraft ||
@@ -287,6 +296,26 @@ export class ReviewerLoopRunner {
       }
 
       enqueuePullRequest(pullRequest);
+    }
+
+    for (const loop of this.listFollowUpLoops(project.id, input.repo)) {
+      const dedupe = `${input.repo}#${loop.prNumber}`;
+      if (seen.has(dedupe) || loop.prNumber == null) {
+        continue;
+      }
+      seen.add(dedupe);
+
+      const detail = await this.options.github.viewPullRequest({
+        repo: input.repo,
+        prNumber: loop.prNumber,
+        cwd: project.repoPath,
+      });
+      if (detail.isDraft || normalizePrState(detail.state) !== "open") {
+        skipped += 1;
+        continue;
+      }
+
+      enqueueLoopRecord(detail, loop);
     }
 
     return { queueItems, createdLoopIds, skipped };
@@ -1157,6 +1186,37 @@ export class ReviewerLoopRunner {
       },
     });
     return { record: loop, created: true };
+  }
+
+  private refreshLoopForPullRequest(loop: LoopRecord): {
+    record: LoopRecord;
+    created: boolean;
+  } {
+    const nowIso = this.nowIso();
+    const updated = {
+      ...loop,
+      status: loop.status === "running" ? loop.status : "queued",
+      nextRunAt: nowIso,
+      updatedAt: nowIso,
+    };
+    this.options.store.loops.upsert(updated);
+    return { record: updated, created: false };
+  }
+
+  private listFollowUpLoops(projectId: string, repo: string): LoopRecord[] {
+    return this.options.store.loops.list().filter((loop) => {
+      if (
+        loop.type !== "reviewer" ||
+        loop.projectId !== projectId ||
+        loop.repo !== repo ||
+        loop.prNumber == null
+      ) {
+        return false;
+      }
+
+      const metadata = parseJsonObject(loop.metadataJson);
+      return metadata.followUpdates === true;
+    });
   }
 
   private updateLoop(

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -755,7 +755,9 @@ describe("createLooperdApi", () => {
       };
     expect(createPausedReviewerResponse.status).toBe(200);
     expect(createPausedReviewerBody.data.status).toBe("paused");
-    expect(store.queue.findActiveByDedupe("reviewer:acme/looper:44")).toBeNull();
+    expect(
+      store.queue.findActiveByDedupe("reviewer:acme/looper:44"),
+    ).toBeNull();
 
     const createPlannerResponse = await api.handle(
       new Request("http://localhost/api/v1/planners", {

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -701,6 +701,39 @@ describe("createLooperdApi", () => {
     expect(createLoopBody.data.prNumber).toBe(43);
     expect(createLoopBody.data.status).toBe("running");
 
+    const createReviewerResponse = await api.handle(
+      new Request("http://localhost/api/v1/loops", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          projectId: "project_1",
+          type: "reviewer",
+          targetType: "pull_request",
+          repo: "acme/looper",
+          prNumber: 43,
+          metadata: { followUpdates: true, manual: true },
+        }),
+      }),
+    );
+    const createReviewerBody = (await createReviewerResponse.json()) as {
+      data: { id: string; metadataJson: string | null; status: string };
+    };
+    expect(createReviewerResponse.status).toBe(200);
+    expect(createReviewerBody.data.status).toBe("running");
+    expect(createReviewerBody.data.metadataJson).toContain(
+      '"followUpdates":true',
+    );
+    expect(
+      store.queue.findActiveByDedupe("reviewer:acme/looper:43"),
+    ).toMatchObject({
+      loopId: createReviewerBody.data.id,
+      type: "reviewer",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:43",
+      prNumber: 43,
+      status: "queued",
+    });
+
     const createPlannerResponse = await api.handle(
       new Request("http://localhost/api/v1/planners", {
         method: "POST",

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -734,6 +734,29 @@ describe("createLooperdApi", () => {
       status: "queued",
     });
 
+    const createPausedReviewerResponse = await api.handle(
+      new Request("http://localhost/api/v1/loops", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          projectId: "project_1",
+          type: "reviewer",
+          targetType: "pull_request",
+          repo: "acme/looper",
+          prNumber: 44,
+          status: "paused",
+          metadata: { followUpdates: true, manual: true },
+        }),
+      }),
+    );
+    const createPausedReviewerBody =
+      (await createPausedReviewerResponse.json()) as {
+        data: { id: string; status: string };
+      };
+    expect(createPausedReviewerResponse.status).toBe(200);
+    expect(createPausedReviewerBody.data.status).toBe("paused");
+    expect(store.queue.findActiveByDedupe("reviewer:acme/looper:44")).toBeNull();
+
     const createPlannerResponse = await api.handle(
       new Request("http://localhost/api/v1/planners", {
         method: "POST",

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -1158,6 +1158,8 @@ async function buildLoopsCreateResponse(
   const type = readRequiredString(body, "type");
   const targetType = readRequiredString(body, "targetType");
   const status = readOptionalString(body, "status") ?? "running";
+  const metadata = readOptionalObject(body, "metadata");
+  const now = new Date().toISOString();
 
   if (
     (type === "reviewer" || type === "fixer") &&
@@ -1180,10 +1182,40 @@ async function buildLoopsCreateResponse(
     prNumber: readOptionalPositiveInteger(body, "prNumber") ?? undefined,
     issueNumber: readOptionalPositiveInteger(body, "issueNumber") ?? undefined,
     status,
-    now: new Date().toISOString(),
+    now,
+    metadataJson: metadata ? JSON.stringify(metadata) : null,
   });
 
+  enqueueLoopCreate(context, loop, now);
+
   return loop;
+}
+
+function enqueueLoopCreate(
+  context: LooperdApiContext,
+  loop: LoopRecord,
+  now: string,
+): void {
+  const scheduler = new SchedulerQueue({
+    store: context.store,
+    retryMaxAttempts: context.config.scheduler.retryMaxAttempts,
+    retryBaseDelayMs: context.config.scheduler.retryBaseDelayMs,
+    now: () => new Date(now),
+  });
+
+  if (loop.type === "reviewer" && loop.repo && loop.prNumber) {
+    scheduler.enqueue({
+      projectId: loop.projectId,
+      loopId: loop.id,
+      type: "reviewer",
+      targetType: "pull_request",
+      targetId: `pr:${loop.repo}:${loop.prNumber}`,
+      repo: loop.repo,
+      prNumber: loop.prNumber,
+      dedupeKey: `reviewer:${loop.repo}:${loop.prNumber}`,
+      lockKey: createPrLockKey(loop.repo, loop.prNumber),
+    });
+  }
 }
 
 function createLoopRecord(input: {
@@ -1479,6 +1511,26 @@ function readOptionalString(
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function readOptionalObject(
+  body: Record<string, unknown>,
+  fieldName: string,
+): Record<string, unknown> | null {
+  const value = body[fieldName];
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new ApiError(
+      "VALIDATION_FAILED",
+      400,
+      `${fieldName} must be an object`,
+    );
+  }
+
+  return value as Record<string, unknown>;
 }
 
 function readOptionalPositiveInteger(

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -1203,7 +1203,12 @@ function enqueueLoopCreate(
     now: () => new Date(now),
   });
 
-  if (loop.type === "reviewer" && loop.repo && loop.prNumber) {
+  if (
+    loop.type === "reviewer" &&
+    loop.status === "running" &&
+    loop.repo &&
+    loop.prNumber
+  ) {
     scheduler.enqueue({
       projectId: loop.projectId,
       loopId: loop.id,


### PR DESCRIPTION
## Summary
- add `looper review <pr>` with support for local and repo-qualified pull request references
- allow manual reviewer loop creation to enqueue immediately and optionally follow later PR updates with `--loop`
- update reviewer/server/CLI tests plus README examples for the new review flow

Closes #10.