### PR TITLE
Move default worktree roots under ~/.looper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ node_modules/
 dist/
 apps/*/dist/
 *.tsbuildinfo
-.looper-worktrees/

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Selected CLI config flags:
 - `looperd` fails fast on invalid config.
 - Runtime paths must be writable.
 - If `notifications.osascript.enabled` is `true`, `osascript` must resolve.
+- Default daemon-managed worktrees now live under `~/.looper/worktrees/<project-id>/`; if you still have legacy repo-local `.looper-worktrees/` entries, prune any stale `.git/worktrees/*/gitdir` references before deleting those old directories.
 - SQLite migrations are loaded from the built output when present, otherwise from source.
 
 ## Development notes

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -8,11 +8,11 @@ import {
   getDefaultProjectWorktreeRoot,
   getDefaultWorktreeRoot,
 } from "./index";
-import { toProjectWorktreeDirectoryName } from "./project-id";
+import { toRepoWorktreeDirectoryName } from "./project-id";
 
 describe("config defaults", () => {
   const repoPath = join(homedir(), "src", "looper");
-  const repoDirectoryName = toProjectWorktreeDirectoryName(repoPath);
+  const repoDirectoryName = toRepoWorktreeDirectoryName(repoPath);
 
   test("uses ~/.looper for runtime artifacts and worktree roots", () => {
     const config = createDefaultLooperConfig("/tmp/workspace");
@@ -169,6 +169,26 @@ describe("config defaults", () => {
       getDefaultProjectWorktreeRoot(
         "project_1",
         join(homedir(), "src", "repo-b"),
+      ),
+    );
+  });
+
+  test("hashes repository identity when deriving default project worktree roots", () => {
+    const deepRepoPath = join(
+      homedir(),
+      "src",
+      "very".repeat(20),
+      "deep".repeat(20),
+      "repo",
+    );
+
+    expect(getDefaultProjectWorktreeRoot("project_1", deepRepoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        toRepoWorktreeDirectoryName(deepRepoPath),
+        "project_1",
       ),
     );
   });

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createDefaultLooperConfig,
+  getDefaultProjectWorktreeRoot,
+  getDefaultWorktreeRoot,
+} from "./index";
+
+describe("config defaults", () => {
+  test("uses ~/.looper for runtime artifacts and worktree roots", () => {
+    const config = createDefaultLooperConfig("/tmp/workspace");
+
+    expect(config.storage.dbPath).toBe(
+      join(homedir(), ".looper", "looper.sqlite"),
+    );
+    expect(config.storage.backupDir).toBe(
+      join(homedir(), ".looper", "backups"),
+    );
+    expect(config.daemon.logDir).toBe(join(homedir(), ".looper", "logs"));
+    expect(getDefaultWorktreeRoot()).toBe(
+      join(homedir(), ".looper", "worktrees"),
+    );
+    expect(getDefaultProjectWorktreeRoot("project_1")).toBe(
+      join(homedir(), ".looper", "worktrees", "project_1"),
+    );
+  });
+});

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -27,15 +27,15 @@ describe("config defaults", () => {
     );
   });
 
-  test("rejects unsafe project ids when deriving project worktree roots", () => {
-    expect(() => getDefaultProjectWorktreeRoot("../tmp")).toThrow(
-      'Invalid project id "../tmp": must not contain path separators, dot segments, or be an absolute path',
+  test("sanitizes legacy project ids when deriving project worktree roots", () => {
+    expect(getDefaultProjectWorktreeRoot("../tmp")).toBe(
+      join(homedir(), ".looper", "worktrees", "legacy-id-Li4vdG1w"),
     );
-    expect(() => getDefaultProjectWorktreeRoot("..")).toThrow(
-      'Invalid project id "..": must not contain path separators, dot segments, or be an absolute path',
+    expect(getDefaultProjectWorktreeRoot("..")).toBe(
+      join(homedir(), ".looper", "worktrees", "legacy-id-Li4"),
     );
-    expect(() => getDefaultProjectWorktreeRoot("/var/tmp/x")).toThrow(
-      'Invalid project id "/var/tmp/x": must not contain path separators, dot segments, or be an absolute path',
+    expect(getDefaultProjectWorktreeRoot("/var/tmp/x")).toBe(
+      join(homedir(), ".looper", "worktrees", "legacy-id-L3Zhci90bXAveA"),
     );
   });
 });

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -8,8 +8,12 @@ import {
   getDefaultProjectWorktreeRoot,
   getDefaultWorktreeRoot,
 } from "./index";
+import { toProjectWorktreeDirectoryName } from "./project-id";
 
 describe("config defaults", () => {
+  const repoPath = join(homedir(), "src", "looper");
+  const repoDirectoryName = toProjectWorktreeDirectoryName(repoPath);
+
   test("uses ~/.looper for runtime artifacts and worktree roots", () => {
     const config = createDefaultLooperConfig("/tmp/workspace");
 
@@ -23,52 +27,101 @@ describe("config defaults", () => {
     expect(getDefaultWorktreeRoot()).toBe(
       join(homedir(), ".looper", "worktrees"),
     );
-    expect(getDefaultProjectWorktreeRoot("project_1")).toBe(
-      join(homedir(), ".looper", "worktrees", "project_1"),
+    expect(getDefaultProjectWorktreeRoot("project_1", repoPath)).toBe(
+      join(homedir(), ".looper", "worktrees", repoDirectoryName, "project_1"),
     );
   });
 
   test("sanitizes legacy project ids when deriving project worktree roots", () => {
-    expect(getDefaultProjectWorktreeRoot("../tmp")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-2e2e2f746d70"),
-    );
-    expect(getDefaultProjectWorktreeRoot("..")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-2e2e"),
-    );
-    expect(getDefaultProjectWorktreeRoot("/var/tmp/x")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-2f7661722f746d702f78"),
-    );
-    expect(getDefaultProjectWorktreeRoot("legacy-id-Li4vdG1w")).toBe(
+    expect(getDefaultProjectWorktreeRoot("../tmp", repoPath)).toBe(
       join(
         homedir(),
         ".looper",
         "worktrees",
+        repoDirectoryName,
+        "legacy-id-2e2e2f746d70",
+      ),
+    );
+    expect(getDefaultProjectWorktreeRoot("..", repoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        repoDirectoryName,
+        "legacy-id-2e2e",
+      ),
+    );
+    expect(getDefaultProjectWorktreeRoot("/var/tmp/x", repoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        repoDirectoryName,
+        "legacy-id-2f7661722f746d702f78",
+      ),
+    );
+    expect(getDefaultProjectWorktreeRoot("legacy-id-Li4vdG1w", repoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        repoDirectoryName,
         "legacy-id-6c65676163792d69642d4c69347664473177",
       ),
     );
   });
 
   test("canonicalizes mixed-case project ids when deriving project worktree roots", () => {
-    expect(getDefaultProjectWorktreeRoot("foo")).toBe(
-      join(homedir(), ".looper", "worktrees", "foo"),
+    expect(getDefaultProjectWorktreeRoot("foo", repoPath)).toBe(
+      join(homedir(), ".looper", "worktrees", repoDirectoryName, "foo"),
     );
-    expect(getDefaultProjectWorktreeRoot("Foo")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-466f6f"),
+    expect(getDefaultProjectWorktreeRoot("Foo", repoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        repoDirectoryName,
+        "legacy-id-466f6f",
+      ),
     );
-    expect(getDefaultProjectWorktreeRoot("FOO")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-464f4f"),
+    expect(getDefaultProjectWorktreeRoot("FOO", repoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        repoDirectoryName,
+        "legacy-id-464f4f",
+      ),
     );
   });
 
   test("sanitizes Windows-invalid canonical project ids when deriving project worktree roots", () => {
-    expect(getDefaultProjectWorktreeRoot("con")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-636f6e"),
+    expect(getDefaultProjectWorktreeRoot("con", repoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        repoDirectoryName,
+        "legacy-id-636f6e",
+      ),
     );
-    expect(getDefaultProjectWorktreeRoot("nul.txt")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-6e756c2e747874"),
+    expect(getDefaultProjectWorktreeRoot("nul.txt", repoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        repoDirectoryName,
+        "legacy-id-6e756c2e747874",
+      ),
     );
-    expect(getDefaultProjectWorktreeRoot("project.")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-70726f6a6563742e"),
+    expect(getDefaultProjectWorktreeRoot("project.", repoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        repoDirectoryName,
+        "legacy-id-70726f6a6563742e",
+      ),
     );
   });
 
@@ -78,8 +131,14 @@ describe("config defaults", () => {
       .update(projectId)
       .digest("hex");
 
-    expect(getDefaultProjectWorktreeRoot(projectId)).toBe(
-      join(homedir(), ".looper", "worktrees", `legacy-id-${hashedProjectId}`),
+    expect(getDefaultProjectWorktreeRoot(projectId, repoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        repoDirectoryName,
+        `legacy-id-${hashedProjectId}`,
+      ),
     );
   });
 
@@ -89,8 +148,28 @@ describe("config defaults", () => {
       .update(projectId)
       .digest("hex");
 
-    expect(getDefaultProjectWorktreeRoot(projectId)).toBe(
-      join(homedir(), ".looper", "worktrees", `legacy-id-${hashedProjectId}`),
+    expect(getDefaultProjectWorktreeRoot(projectId, repoPath)).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        repoDirectoryName,
+        `legacy-id-${hashedProjectId}`,
+      ),
+    );
+  });
+
+  test("scopes default project worktree roots by repository identity", () => {
+    expect(
+      getDefaultProjectWorktreeRoot(
+        "project_1",
+        join(homedir(), "src", "repo-a"),
+      ),
+    ).not.toBe(
+      getDefaultProjectWorktreeRoot(
+        "project_1",
+        join(homedir(), "src", "repo-b"),
+      ),
     );
   });
 });

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -56,6 +57,28 @@ describe("config defaults", () => {
     );
     expect(getDefaultProjectWorktreeRoot("FOO")).toBe(
       join(homedir(), ".looper", "worktrees", "legacy-id-464f4f"),
+    );
+  });
+
+  test("hashes long canonical project ids when deriving project worktree roots", () => {
+    const projectId = "a".repeat(256);
+    const hashedProjectId = createHash("sha256")
+      .update(projectId)
+      .digest("hex");
+
+    expect(getDefaultProjectWorktreeRoot(projectId)).toBe(
+      join(homedir(), ".looper", "worktrees", `legacy-id-${hashedProjectId}`),
+    );
+  });
+
+  test("hashes long legacy project ids when deriving project worktree roots", () => {
+    const projectId = "A".repeat(123);
+    const hashedProjectId = createHash("sha256")
+      .update(projectId)
+      .digest("hex");
+
+    expect(getDefaultProjectWorktreeRoot(projectId)).toBe(
+      join(homedir(), ".looper", "worktrees", `legacy-id-${hashedProjectId}`),
     );
   });
 });

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   createDefaultLooperConfig,

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -29,21 +29,33 @@ describe("config defaults", () => {
 
   test("sanitizes legacy project ids when deriving project worktree roots", () => {
     expect(getDefaultProjectWorktreeRoot("../tmp")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-Li4vdG1w"),
+      join(homedir(), ".looper", "worktrees", "legacy-id-2e2e2f746d70"),
     );
     expect(getDefaultProjectWorktreeRoot("..")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-Li4"),
+      join(homedir(), ".looper", "worktrees", "legacy-id-2e2e"),
     );
     expect(getDefaultProjectWorktreeRoot("/var/tmp/x")).toBe(
-      join(homedir(), ".looper", "worktrees", "legacy-id-L3Zhci90bXAveA"),
+      join(homedir(), ".looper", "worktrees", "legacy-id-2f7661722f746d702f78"),
     );
     expect(getDefaultProjectWorktreeRoot("legacy-id-Li4vdG1w")).toBe(
       join(
         homedir(),
         ".looper",
         "worktrees",
-        "legacy-id-bGVnYWN5LWlkLUxpNHZkRzF3",
+        "legacy-id-6c65676163792d69642d4c69347664473177",
       ),
+    );
+  });
+
+  test("canonicalizes mixed-case project ids when deriving project worktree roots", () => {
+    expect(getDefaultProjectWorktreeRoot("foo")).toBe(
+      join(homedir(), ".looper", "worktrees", "foo"),
+    );
+    expect(getDefaultProjectWorktreeRoot("Foo")).toBe(
+      join(homedir(), ".looper", "worktrees", "legacy-id-466f6f"),
+    );
+    expect(getDefaultProjectWorktreeRoot("FOO")).toBe(
+      join(homedir(), ".looper", "worktrees", "legacy-id-464f4f"),
     );
   });
 });

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import {
   createDefaultLooperConfig,
@@ -191,5 +193,23 @@ describe("config defaults", () => {
         "project_1",
       ),
     );
+  });
+
+  test("canonicalizes equivalent repository paths before hashing worktree roots", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-defaults-"));
+    const repoPath = join(rootDir, "repo");
+    const repoAliasPath = join(rootDir, "repo-alias");
+
+    await mkdir(repoPath, { recursive: true });
+    await symlink(repoPath, repoAliasPath);
+
+    expect(toRepoWorktreeDirectoryName(`${repoPath}/`)).toBe(
+      toRepoWorktreeDirectoryName(repoPath),
+    );
+    expect(toRepoWorktreeDirectoryName(repoAliasPath)).toBe(
+      toRepoWorktreeDirectoryName(repoPath),
+    );
+
+    await rm(rootDir, { recursive: true, force: true });
   });
 });

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -26,4 +26,16 @@ describe("config defaults", () => {
       join(homedir(), ".looper", "worktrees", "project_1"),
     );
   });
+
+  test("rejects unsafe project ids when deriving project worktree roots", () => {
+    expect(() => getDefaultProjectWorktreeRoot("../tmp")).toThrow(
+      'Invalid project id "../tmp": must not contain path separators, dot segments, or be an absolute path',
+    );
+    expect(() => getDefaultProjectWorktreeRoot("..")).toThrow(
+      'Invalid project id "..": must not contain path separators, dot segments, or be an absolute path',
+    );
+    expect(() => getDefaultProjectWorktreeRoot("/var/tmp/x")).toThrow(
+      'Invalid project id "/var/tmp/x": must not contain path separators, dot segments, or be an absolute path',
+    );
+  });
 });

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -37,5 +37,13 @@ describe("config defaults", () => {
     expect(getDefaultProjectWorktreeRoot("/var/tmp/x")).toBe(
       join(homedir(), ".looper", "worktrees", "legacy-id-L3Zhci90bXAveA"),
     );
+    expect(getDefaultProjectWorktreeRoot("legacy-id-Li4vdG1w")).toBe(
+      join(
+        homedir(),
+        ".looper",
+        "worktrees",
+        "legacy-id-bGVnYWN5LWlkLUxpNHZkRzF3",
+      ),
+    );
   });
 });

--- a/apps/looperd/src/config/defaults.test.ts
+++ b/apps/looperd/src/config/defaults.test.ts
@@ -60,6 +60,18 @@ describe("config defaults", () => {
     );
   });
 
+  test("sanitizes Windows-invalid canonical project ids when deriving project worktree roots", () => {
+    expect(getDefaultProjectWorktreeRoot("con")).toBe(
+      join(homedir(), ".looper", "worktrees", "legacy-id-636f6e"),
+    );
+    expect(getDefaultProjectWorktreeRoot("nul.txt")).toBe(
+      join(homedir(), ".looper", "worktrees", "legacy-id-6e756c2e747874"),
+    );
+    expect(getDefaultProjectWorktreeRoot("project.")).toBe(
+      join(homedir(), ".looper", "worktrees", "legacy-id-70726f6a6563742e"),
+    );
+  });
+
   test("hashes long canonical project ids when deriving project worktree roots", () => {
     const projectId = "a".repeat(256);
     const hashedProjectId = createHash("sha256")

--- a/apps/looperd/src/config/defaults.ts
+++ b/apps/looperd/src/config/defaults.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { assertValidProjectId } from "./project-id";
+import { toProjectWorktreeDirectoryName } from "./project-id";
 import type { LooperConfig } from "./types";
 
 const LOOPER_HOME = join(homedir(), ".looper");
@@ -72,8 +72,7 @@ export function getDefaultWorktreeRoot(): string {
 }
 
 export function getDefaultProjectWorktreeRoot(projectId: string): string {
-  assertValidProjectId(projectId);
-  return join(DEFAULT_WORKTREE_ROOT, projectId);
+  return join(DEFAULT_WORKTREE_ROOT, toProjectWorktreeDirectoryName(projectId));
 }
 
 export function getDefaultConfigPath(): string {

--- a/apps/looperd/src/config/defaults.ts
+++ b/apps/looperd/src/config/defaults.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { assertValidProjectId } from "./project-id";
 import type { LooperConfig } from "./types";
 
 const LOOPER_HOME = join(homedir(), ".looper");
@@ -71,6 +72,7 @@ export function getDefaultWorktreeRoot(): string {
 }
 
 export function getDefaultProjectWorktreeRoot(projectId: string): string {
+  assertValidProjectId(projectId);
   return join(DEFAULT_WORKTREE_ROOT, projectId);
 }
 

--- a/apps/looperd/src/config/defaults.ts
+++ b/apps/looperd/src/config/defaults.ts
@@ -1,7 +1,10 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { toProjectWorktreeDirectoryName } from "./project-id";
+import {
+  toProjectWorktreeDirectoryName,
+  toRepoWorktreeDirectoryName,
+} from "./project-id";
 import type { LooperConfig } from "./types";
 
 function getLooperHome(): string {
@@ -80,7 +83,7 @@ export function getDefaultProjectWorktreeRoot(
 ): string {
   return join(
     getDefaultWorktreeRoot(),
-    toProjectWorktreeDirectoryName(repoIdentity),
+    toRepoWorktreeDirectoryName(repoIdentity),
     toProjectWorktreeDirectoryName(projectId),
   );
 }

--- a/apps/looperd/src/config/defaults.ts
+++ b/apps/looperd/src/config/defaults.ts
@@ -4,10 +4,13 @@ import { join } from "node:path";
 import { toProjectWorktreeDirectoryName } from "./project-id";
 import type { LooperConfig } from "./types";
 
-const LOOPER_HOME = join(homedir(), ".looper");
-const DEFAULT_WORKTREE_ROOT = join(LOOPER_HOME, "worktrees");
+function getLooperHome(): string {
+  return join(homedir(), ".looper");
+}
 
 export function createDefaultLooperConfig(cwd = process.cwd()): LooperConfig {
+  const looperHome = getLooperHome();
+
   return {
     server: {
       host: "127.0.0.1",
@@ -16,8 +19,8 @@ export function createDefaultLooperConfig(cwd = process.cwd()): LooperConfig {
     },
     storage: {
       mode: "sqlite",
-      dbPath: join(LOOPER_HOME, "looper.sqlite"),
-      backupDir: join(LOOPER_HOME, "backups"),
+      dbPath: join(looperHome, "looper.sqlite"),
+      backupDir: join(looperHome, "backups"),
     },
     scheduler: {
       pollIntervalSeconds: 30,
@@ -45,7 +48,7 @@ export function createDefaultLooperConfig(cwd = process.cwd()): LooperConfig {
     tools: {},
     daemon: {
       mode: "foreground",
-      logDir: join(LOOPER_HOME, "logs"),
+      logDir: join(looperHome, "logs"),
       workingDirectory: cwd,
       environment: {},
     },
@@ -68,13 +71,16 @@ export function createDefaultLooperConfig(cwd = process.cwd()): LooperConfig {
 }
 
 export function getDefaultWorktreeRoot(): string {
-  return DEFAULT_WORKTREE_ROOT;
+  return join(getLooperHome(), "worktrees");
 }
 
 export function getDefaultProjectWorktreeRoot(projectId: string): string {
-  return join(DEFAULT_WORKTREE_ROOT, toProjectWorktreeDirectoryName(projectId));
+  return join(
+    getDefaultWorktreeRoot(),
+    toProjectWorktreeDirectoryName(projectId),
+  );
 }
 
 export function getDefaultConfigPath(): string {
-  return join(LOOPER_HOME, "config.json");
+  return join(getLooperHome(), "config.json");
 }

--- a/apps/looperd/src/config/defaults.ts
+++ b/apps/looperd/src/config/defaults.ts
@@ -3,9 +3,10 @@ import { join } from "node:path";
 
 import type { LooperConfig } from "./types";
 
-export function createDefaultLooperConfig(cwd = process.cwd()): LooperConfig {
-  const looperHome = join(homedir(), ".looper");
+const LOOPER_HOME = join(homedir(), ".looper");
+const DEFAULT_WORKTREE_ROOT = join(LOOPER_HOME, "worktrees");
 
+export function createDefaultLooperConfig(cwd = process.cwd()): LooperConfig {
   return {
     server: {
       host: "127.0.0.1",
@@ -14,8 +15,8 @@ export function createDefaultLooperConfig(cwd = process.cwd()): LooperConfig {
     },
     storage: {
       mode: "sqlite",
-      dbPath: join(looperHome, "looper.sqlite"),
-      backupDir: join(looperHome, "backups"),
+      dbPath: join(LOOPER_HOME, "looper.sqlite"),
+      backupDir: join(LOOPER_HOME, "backups"),
     },
     scheduler: {
       pollIntervalSeconds: 30,
@@ -43,7 +44,7 @@ export function createDefaultLooperConfig(cwd = process.cwd()): LooperConfig {
     tools: {},
     daemon: {
       mode: "foreground",
-      logDir: join(looperHome, "logs"),
+      logDir: join(LOOPER_HOME, "logs"),
       workingDirectory: cwd,
       environment: {},
     },
@@ -65,6 +66,14 @@ export function createDefaultLooperConfig(cwd = process.cwd()): LooperConfig {
   };
 }
 
+export function getDefaultWorktreeRoot(): string {
+  return DEFAULT_WORKTREE_ROOT;
+}
+
+export function getDefaultProjectWorktreeRoot(projectId: string): string {
+  return join(DEFAULT_WORKTREE_ROOT, projectId);
+}
+
 export function getDefaultConfigPath(): string {
-  return join(homedir(), ".looper", "config.json");
+  return join(LOOPER_HOME, "config.json");
 }

--- a/apps/looperd/src/config/defaults.ts
+++ b/apps/looperd/src/config/defaults.ts
@@ -74,9 +74,13 @@ export function getDefaultWorktreeRoot(): string {
   return join(getLooperHome(), "worktrees");
 }
 
-export function getDefaultProjectWorktreeRoot(projectId: string): string {
+export function getDefaultProjectWorktreeRoot(
+  projectId: string,
+  repoIdentity: string,
+): string {
   return join(
     getDefaultWorktreeRoot(),
+    toProjectWorktreeDirectoryName(repoIdentity),
     toProjectWorktreeDirectoryName(projectId),
   );
 }

--- a/apps/looperd/src/config/index.ts
+++ b/apps/looperd/src/config/index.ts
@@ -1,4 +1,9 @@
-export { createDefaultLooperConfig, getDefaultConfigPath } from "./defaults";
+export {
+  createDefaultLooperConfig,
+  getDefaultConfigPath,
+  getDefaultProjectWorktreeRoot,
+  getDefaultWorktreeRoot,
+} from "./defaults";
 export { loadLooperConfig } from "./load";
 export { detectToolPaths } from "./tools";
 export {

--- a/apps/looperd/src/config/index.ts
+++ b/apps/looperd/src/config/index.ts
@@ -6,6 +6,7 @@ export {
 } from "./defaults";
 export {
   assertValidProjectId,
+  deriveProjectIdFromRepoPath,
   getConfigProjectIdValidationMessage,
   getProjectIdValidationMessage,
   InvalidProjectIdError,

--- a/apps/looperd/src/config/index.ts
+++ b/apps/looperd/src/config/index.ts
@@ -4,6 +4,12 @@ export {
   getDefaultProjectWorktreeRoot,
   getDefaultWorktreeRoot,
 } from "./defaults";
+export {
+  assertValidProjectId,
+  getProjectIdValidationMessage,
+  InvalidProjectIdError,
+  isValidProjectId,
+} from "./project-id";
 export { loadLooperConfig } from "./load";
 export { detectToolPaths } from "./tools";
 export {

--- a/apps/looperd/src/config/index.ts
+++ b/apps/looperd/src/config/index.ts
@@ -9,6 +9,8 @@ export {
   getProjectIdValidationMessage,
   InvalidProjectIdError,
   isValidProjectId,
+  normalizeDerivedProjectId,
+  toRepoWorktreeDirectoryName,
 } from "./project-id";
 export { loadLooperConfig } from "./load";
 export { detectToolPaths } from "./tools";

--- a/apps/looperd/src/config/index.ts
+++ b/apps/looperd/src/config/index.ts
@@ -6,8 +6,10 @@ export {
 } from "./defaults";
 export {
   assertValidProjectId,
+  getConfigProjectIdValidationMessage,
   getProjectIdValidationMessage,
   InvalidProjectIdError,
+  isValidConfiguredProjectId,
   isValidProjectId,
   normalizeDerivedProjectId,
   toRepoWorktreeDirectoryName,

--- a/apps/looperd/src/config/load.test.ts
+++ b/apps/looperd/src/config/load.test.ts
@@ -3,7 +3,12 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { ConfigValidationError, loadLooperConfig } from "./index";
+import {
+  ConfigValidationError,
+  createDefaultLooperConfig,
+  loadLooperConfig,
+  validateLooperConfig,
+} from "./index";
 
 async function createFixture(): Promise<{
   rootDir: string;
@@ -219,7 +224,86 @@ describe("loadLooperConfig", () => {
         {
           path: "projects[0].id",
           message:
-            "must not contain path separators, dot segments, or be an absolute path",
+            "must not contain path separators, dot segments, be an absolute path, or start with legacy-id-",
+        },
+      ],
+    });
+  });
+
+  test("rejects project ids that use the reserved legacy-id prefix", async () => {
+    const fixture = await createFixture();
+    cleanupPaths.push(fixture.rootDir);
+
+    await writeFile(
+      fixture.configPath,
+      JSON.stringify({
+        daemon: {
+          logDir: fixture.logDir,
+          workingDirectory: fixture.writableDir,
+        },
+        storage: { dbPath: fixture.dbPath },
+        notifications: {
+          osascript: { enabled: false, throttleWindowSeconds: 60 },
+        },
+        tools: {
+          bunPath: "/file/bun",
+          gitPath: "/file/git",
+          ghPath: "/file/gh",
+        },
+        projects: [
+          {
+            id: "legacy-id-Li4vdG1w",
+            name: "bad-project",
+            repoPath: fixture.writableDir,
+          },
+        ],
+      }),
+    );
+
+    await expect(
+      loadLooperConfig({
+        argv: ["--config", fixture.configPath],
+        cwd: fixture.rootDir,
+        env: {},
+      }),
+    ).rejects.toMatchObject({
+      issues: [
+        {
+          path: "projects[0].id",
+          message:
+            "must not contain path separators, dot segments, be an absolute path, or start with legacy-id-",
+        },
+      ],
+    });
+  });
+
+  test("rejects configs when the default worktree root cannot be created", async () => {
+    const fixture = await createFixture();
+    cleanupPaths.push(fixture.rootDir);
+
+    const blockingRoot = join(fixture.rootDir, "blocked-root");
+    await writeFile(blockingRoot, "not-a-directory");
+
+    const config = createDefaultLooperConfig(fixture.rootDir);
+    config.daemon.logDir = fixture.logDir;
+    config.daemon.workingDirectory = fixture.writableDir;
+    config.storage.dbPath = fixture.dbPath;
+    config.notifications.osascript.enabled = false;
+    config.tools = {
+      bunPath: "/file/bun",
+      gitPath: "/file/git",
+      ghPath: "/file/gh",
+    };
+
+    await expect(
+      validateLooperConfig(config, {
+        defaultWorktreeRoot: join(blockingRoot, "worktrees"),
+      }),
+    ).rejects.toMatchObject({
+      issues: [
+        {
+          path: "defaults.worktreeRoot",
+          message: `${blockingRoot} is not a directory`,
         },
       ],
     });

--- a/apps/looperd/src/config/load.test.ts
+++ b/apps/looperd/src/config/load.test.ts
@@ -229,13 +229,13 @@ describe("loadLooperConfig", () => {
         {
           path: "projects[0].id",
           message:
-            "must not contain path separators, dot segments, be an absolute path, or start with legacy-id-",
+            "must not contain path separators, dot segments, or be an absolute path",
         },
       ],
     });
   });
 
-  test("rejects project ids that use the reserved legacy-id prefix", async () => {
+  test("allows legacy project ids in config for upgrade compatibility", async () => {
     const fixture = await createFixture();
     cleanupPaths.push(fixture.rootDir);
 
@@ -258,28 +258,20 @@ describe("loadLooperConfig", () => {
         projects: [
           {
             id: "legacy-id-Li4vdG1w",
-            name: "bad-project",
+            name: "legacy-project",
             repoPath: fixture.writableDir,
           },
         ],
       }),
     );
 
-    await expect(
-      loadLooperConfig({
-        argv: ["--config", fixture.configPath],
-        cwd: fixture.rootDir,
-        env: {},
-      }),
-    ).rejects.toMatchObject({
-      issues: [
-        {
-          path: "projects[0].id",
-          message:
-            "must not contain path separators, dot segments, be an absolute path, or start with legacy-id-",
-        },
-      ],
+    const loaded = await loadLooperConfig({
+      argv: ["--config", fixture.configPath],
+      cwd: fixture.rootDir,
+      env: {},
     });
+
+    expect(loaded.config.projects[0]?.id).toBe("legacy-id-Li4vdG1w");
   });
 
   test("rejects configs when the default worktree root cannot be created", async () => {

--- a/apps/looperd/src/config/load.test.ts
+++ b/apps/looperd/src/config/load.test.ts
@@ -177,4 +177,51 @@ describe("loadLooperConfig", () => {
       }),
     ).rejects.toThrow("Unknown looperd argument: --hostfoo");
   });
+
+  test("rejects project ids that would escape the default worktree root", async () => {
+    const fixture = await createFixture();
+    cleanupPaths.push(fixture.rootDir);
+
+    await writeFile(
+      fixture.configPath,
+      JSON.stringify({
+        daemon: {
+          logDir: fixture.logDir,
+          workingDirectory: fixture.writableDir,
+        },
+        storage: { dbPath: fixture.dbPath },
+        notifications: {
+          osascript: { enabled: false, throttleWindowSeconds: 60 },
+        },
+        tools: {
+          bunPath: "/file/bun",
+          gitPath: "/file/git",
+          ghPath: "/file/gh",
+        },
+        projects: [
+          {
+            id: "../../tmp",
+            name: "bad-project",
+            repoPath: fixture.writableDir,
+          },
+        ],
+      }),
+    );
+
+    await expect(
+      loadLooperConfig({
+        argv: ["--config", fixture.configPath],
+        cwd: fixture.rootDir,
+        env: {},
+      }),
+    ).rejects.toMatchObject({
+      issues: [
+        {
+          path: "projects[0].id",
+          message:
+            "must not contain path separators, dot segments, or be an absolute path",
+        },
+      ],
+    });
+  });
 });

--- a/apps/looperd/src/config/project-id.ts
+++ b/apps/looperd/src/config/project-id.ts
@@ -1,8 +1,9 @@
 import { posix, win32 } from "node:path";
 
 const PROJECT_ID_SEPARATOR_PATTERN = /[\\/]/;
+const LEGACY_PROJECT_ID_PREFIX = "legacy-id-";
 const INVALID_PROJECT_ID_MESSAGE =
-  "must not contain path separators, dot segments, or be an absolute path";
+  "must not contain path separators, dot segments, be an absolute path, or start with legacy-id-";
 
 export class InvalidProjectIdError extends Error {
   constructor(projectId: string) {
@@ -16,6 +17,7 @@ export function isValidProjectId(projectId: string): boolean {
     projectId.length > 0 &&
     projectId !== "." &&
     projectId !== ".." &&
+    !projectId.startsWith(LEGACY_PROJECT_ID_PREFIX) &&
     !PROJECT_ID_SEPARATOR_PATTERN.test(projectId) &&
     !posix.isAbsolute(projectId) &&
     !win32.isAbsolute(projectId)
@@ -40,5 +42,5 @@ export function toProjectWorktreeDirectoryName(projectId: string): string {
   const encodedProjectId =
     Buffer.from(projectId).toString("base64url") || "empty";
 
-  return `legacy-id-${encodedProjectId}`;
+  return `${LEGACY_PROJECT_ID_PREFIX}${encodedProjectId}`;
 }

--- a/apps/looperd/src/config/project-id.ts
+++ b/apps/looperd/src/config/project-id.ts
@@ -2,6 +2,7 @@ import { posix, win32 } from "node:path";
 
 const PROJECT_ID_SEPARATOR_PATTERN = /[\\/]/;
 const LEGACY_PROJECT_ID_PREFIX = "legacy-id-";
+const CANONICAL_PROJECT_DIRECTORY_NAME_PATTERN = /^[a-z0-9._-]+$/;
 const INVALID_PROJECT_ID_MESSAGE =
   "must not contain path separators, dot segments, be an absolute path, or start with legacy-id-";
 
@@ -35,12 +36,14 @@ export function assertValidProjectId(projectId: string): void {
 }
 
 export function toProjectWorktreeDirectoryName(projectId: string): string {
-  if (isValidProjectId(projectId)) {
+  if (
+    isValidProjectId(projectId) &&
+    CANONICAL_PROJECT_DIRECTORY_NAME_PATTERN.test(projectId)
+  ) {
     return projectId;
   }
 
-  const encodedProjectId =
-    Buffer.from(projectId).toString("base64url") || "empty";
+  const encodedProjectId = Buffer.from(projectId).toString("hex") || "empty";
 
   return `${LEGACY_PROJECT_ID_PREFIX}${encodedProjectId}`;
 }

--- a/apps/looperd/src/config/project-id.ts
+++ b/apps/looperd/src/config/project-id.ts
@@ -32,6 +32,17 @@ export function normalizeDerivedProjectId(projectId: string): string {
   return `${AUTO_DERIVED_LEGACY_PROJECT_ID_PREFIX}${projectId}`;
 }
 
+export function deriveProjectIdFromRepoPath(repoPath: string): string {
+  const segments = repoPath.split(/[\\/]+/).filter(Boolean);
+  const lastSegment = segments.at(-1) ?? "project";
+  const normalized = lastSegment
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return normalized || "project";
+}
+
 export class InvalidProjectIdError extends Error {
   constructor(projectId: string) {
     super(`Invalid project id \"${projectId}\": ${INVALID_PROJECT_ID_MESSAGE}`);

--- a/apps/looperd/src/config/project-id.ts
+++ b/apps/looperd/src/config/project-id.ts
@@ -5,6 +5,8 @@ const PROJECT_ID_SEPARATOR_PATTERN = /[\\/]/;
 const LEGACY_PROJECT_ID_PREFIX = "legacy-id-";
 const CANONICAL_PROJECT_DIRECTORY_NAME_PATTERN = /^[a-z0-9._-]+$/;
 const MAX_PROJECT_WORKTREE_DIRECTORY_NAME_LENGTH = 255;
+const WINDOWS_RESERVED_PROJECT_DIRECTORY_BASENAME_PATTERN =
+  /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/;
 const INVALID_PROJECT_ID_MESSAGE =
   "must not contain path separators, dot segments, be an absolute path, or start with legacy-id-";
 
@@ -43,11 +45,21 @@ export function assertValidProjectId(projectId: string): void {
   }
 }
 
+function isWindowsInvalidCanonicalProjectDirectoryName(
+  directoryName: string,
+): boolean {
+  return (
+    directoryName.endsWith(".") ||
+    WINDOWS_RESERVED_PROJECT_DIRECTORY_BASENAME_PATTERN.test(directoryName)
+  );
+}
+
 export function toProjectWorktreeDirectoryName(projectId: string): string {
   if (
     isValidProjectId(projectId) &&
     CANONICAL_PROJECT_DIRECTORY_NAME_PATTERN.test(projectId) &&
-    projectId.length <= MAX_PROJECT_WORKTREE_DIRECTORY_NAME_LENGTH
+    projectId.length <= MAX_PROJECT_WORKTREE_DIRECTORY_NAME_LENGTH &&
+    !isWindowsInvalidCanonicalProjectDirectoryName(projectId)
   ) {
     return projectId;
   }

--- a/apps/looperd/src/config/project-id.ts
+++ b/apps/looperd/src/config/project-id.ts
@@ -1,10 +1,18 @@
+import { createHash } from "node:crypto";
 import { posix, win32 } from "node:path";
 
 const PROJECT_ID_SEPARATOR_PATTERN = /[\\/]/;
 const LEGACY_PROJECT_ID_PREFIX = "legacy-id-";
 const CANONICAL_PROJECT_DIRECTORY_NAME_PATTERN = /^[a-z0-9._-]+$/;
+const MAX_PROJECT_WORKTREE_DIRECTORY_NAME_LENGTH = 255;
 const INVALID_PROJECT_ID_MESSAGE =
   "must not contain path separators, dot segments, be an absolute path, or start with legacy-id-";
+
+function toHashedProjectWorktreeDirectoryName(projectId: string): string {
+  const hashedProjectId = createHash("sha256").update(projectId).digest("hex");
+
+  return `${LEGACY_PROJECT_ID_PREFIX}${hashedProjectId}`;
+}
 
 export class InvalidProjectIdError extends Error {
   constructor(projectId: string) {
@@ -38,12 +46,20 @@ export function assertValidProjectId(projectId: string): void {
 export function toProjectWorktreeDirectoryName(projectId: string): string {
   if (
     isValidProjectId(projectId) &&
-    CANONICAL_PROJECT_DIRECTORY_NAME_PATTERN.test(projectId)
+    CANONICAL_PROJECT_DIRECTORY_NAME_PATTERN.test(projectId) &&
+    projectId.length <= MAX_PROJECT_WORKTREE_DIRECTORY_NAME_LENGTH
   ) {
     return projectId;
   }
 
   const encodedProjectId = Buffer.from(projectId).toString("hex") || "empty";
 
-  return `${LEGACY_PROJECT_ID_PREFIX}${encodedProjectId}`;
+  if (
+    LEGACY_PROJECT_ID_PREFIX.length + encodedProjectId.length <=
+    MAX_PROJECT_WORKTREE_DIRECTORY_NAME_LENGTH
+  ) {
+    return `${LEGACY_PROJECT_ID_PREFIX}${encodedProjectId}`;
+  }
+
+  return toHashedProjectWorktreeDirectoryName(projectId);
 }

--- a/apps/looperd/src/config/project-id.ts
+++ b/apps/looperd/src/config/project-id.ts
@@ -1,0 +1,33 @@
+import { posix, win32 } from "node:path";
+
+const PROJECT_ID_SEPARATOR_PATTERN = /[\\/]/;
+const INVALID_PROJECT_ID_MESSAGE =
+  "must not contain path separators, dot segments, or be an absolute path";
+
+export class InvalidProjectIdError extends Error {
+  constructor(projectId: string) {
+    super(`Invalid project id \"${projectId}\": ${INVALID_PROJECT_ID_MESSAGE}`);
+    this.name = "InvalidProjectIdError";
+  }
+}
+
+export function isValidProjectId(projectId: string): boolean {
+  return (
+    projectId.length > 0 &&
+    projectId !== "." &&
+    projectId !== ".." &&
+    !PROJECT_ID_SEPARATOR_PATTERN.test(projectId) &&
+    !posix.isAbsolute(projectId) &&
+    !win32.isAbsolute(projectId)
+  );
+}
+
+export function getProjectIdValidationMessage(): string {
+  return INVALID_PROJECT_ID_MESSAGE;
+}
+
+export function assertValidProjectId(projectId: string): void {
+  if (!isValidProjectId(projectId)) {
+    throw new InvalidProjectIdError(projectId);
+  }
+}

--- a/apps/looperd/src/config/project-id.ts
+++ b/apps/looperd/src/config/project-id.ts
@@ -3,6 +3,7 @@ import { posix, win32 } from "node:path";
 
 const PROJECT_ID_SEPARATOR_PATTERN = /[\\/]/;
 const LEGACY_PROJECT_ID_PREFIX = "legacy-id-";
+const AUTO_DERIVED_LEGACY_PROJECT_ID_PREFIX = "project_";
 const CANONICAL_PROJECT_DIRECTORY_NAME_PATTERN = /^[a-z0-9._-]+$/;
 const MAX_PROJECT_WORKTREE_DIRECTORY_NAME_LENGTH = 255;
 const WINDOWS_RESERVED_PROJECT_DIRECTORY_BASENAME_PATTERN =
@@ -25,7 +26,7 @@ export function normalizeDerivedProjectId(projectId: string): string {
     return projectId;
   }
 
-  return `project-${projectId}`;
+  return `${AUTO_DERIVED_LEGACY_PROJECT_ID_PREFIX}${projectId}`;
 }
 
 export class InvalidProjectIdError extends Error {

--- a/apps/looperd/src/config/project-id.ts
+++ b/apps/looperd/src/config/project-id.ts
@@ -16,6 +16,18 @@ function toHashedProjectWorktreeDirectoryName(projectId: string): string {
   return `${LEGACY_PROJECT_ID_PREFIX}${hashedProjectId}`;
 }
 
+export function toRepoWorktreeDirectoryName(repoIdentity: string): string {
+  return `repo-${createHash("sha256").update(repoIdentity).digest("hex")}`;
+}
+
+export function normalizeDerivedProjectId(projectId: string): string {
+  if (!projectId.startsWith(LEGACY_PROJECT_ID_PREFIX)) {
+    return projectId;
+  }
+
+  return `project-${projectId}`;
+}
+
 export class InvalidProjectIdError extends Error {
   constructor(projectId: string) {
     super(`Invalid project id \"${projectId}\": ${INVALID_PROJECT_ID_MESSAGE}`);

--- a/apps/looperd/src/config/project-id.ts
+++ b/apps/looperd/src/config/project-id.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import { posix, win32 } from "node:path";
+import { realpathSync } from "node:fs";
+import { normalize, posix, resolve, win32 } from "node:path";
 
 const PROJECT_ID_SEPARATOR_PATTERN = /[\\/]/;
 const LEGACY_PROJECT_ID_PREFIX = "legacy-id-";
@@ -10,6 +11,8 @@ const WINDOWS_RESERVED_PROJECT_DIRECTORY_BASENAME_PATTERN =
   /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/;
 const INVALID_PROJECT_ID_MESSAGE =
   "must not contain path separators, dot segments, be an absolute path, or start with legacy-id-";
+const CONFIG_PROJECT_ID_MESSAGE =
+  "must not contain path separators, dot segments, or be an absolute path";
 
 function toHashedProjectWorktreeDirectoryName(projectId: string): string {
   const hashedProjectId = createHash("sha256").update(projectId).digest("hex");
@@ -18,7 +21,7 @@ function toHashedProjectWorktreeDirectoryName(projectId: string): string {
 }
 
 export function toRepoWorktreeDirectoryName(repoIdentity: string): string {
-  return `repo-${createHash("sha256").update(repoIdentity).digest("hex")}`;
+  return `repo-${createHash("sha256").update(canonicalizeRepoIdentity(repoIdentity)).digest("hex")}`;
 }
 
 export function normalizeDerivedProjectId(projectId: string): string {
@@ -52,9 +55,34 @@ export function getProjectIdValidationMessage(): string {
   return INVALID_PROJECT_ID_MESSAGE;
 }
 
+export function getConfigProjectIdValidationMessage(): string {
+  return CONFIG_PROJECT_ID_MESSAGE;
+}
+
 export function assertValidProjectId(projectId: string): void {
   if (!isValidProjectId(projectId)) {
     throw new InvalidProjectIdError(projectId);
+  }
+}
+
+export function isValidConfiguredProjectId(projectId: string): boolean {
+  return (
+    projectId.length > 0 &&
+    projectId !== "." &&
+    projectId !== ".." &&
+    !PROJECT_ID_SEPARATOR_PATTERN.test(projectId) &&
+    !posix.isAbsolute(projectId) &&
+    !win32.isAbsolute(projectId)
+  );
+}
+
+function canonicalizeRepoIdentity(repoIdentity: string): string {
+  const resolved = normalize(resolve(repoIdentity));
+
+  try {
+    return normalize(realpathSync.native(resolved));
+  } catch {
+    return resolved;
   }
 }
 

--- a/apps/looperd/src/config/project-id.ts
+++ b/apps/looperd/src/config/project-id.ts
@@ -31,3 +31,14 @@ export function assertValidProjectId(projectId: string): void {
     throw new InvalidProjectIdError(projectId);
   }
 }
+
+export function toProjectWorktreeDirectoryName(projectId: string): string {
+  if (isValidProjectId(projectId)) {
+    return projectId;
+  }
+
+  const encodedProjectId =
+    Buffer.from(projectId).toString("base64url") || "empty";
+
+  return `legacy-id-${encodedProjectId}`;
+}

--- a/apps/looperd/src/config/validate.ts
+++ b/apps/looperd/src/config/validate.ts
@@ -1,6 +1,7 @@
-import { constants, access } from "node:fs/promises";
+import { constants, access, stat } from "node:fs/promises";
 import { dirname } from "node:path";
 
+import { getDefaultWorktreeRoot } from "./defaults";
 import { getProjectIdValidationMessage, isValidProjectId } from "./project-id";
 import {
   AGENT_VENDORS,
@@ -37,7 +38,14 @@ async function ensureWritablePath(
 
   while (true) {
     try {
-      await access(writableAnchor, constants.F_OK);
+      const anchorStat = await stat(writableAnchor);
+      if (!anchorStat.isDirectory()) {
+        issues.push({
+          path: field,
+          message: `${writableAnchor} is not a directory`,
+        });
+        return;
+      }
       break;
     } catch {
       const parent = dirname(writableAnchor);
@@ -65,6 +73,7 @@ async function ensureWritablePath(
 
 export async function validateLooperConfig(
   config: LooperConfig,
+  options: { defaultWorktreeRoot?: string } = {},
 ): Promise<void> {
   const issues: ValidationIssue[] = [];
 
@@ -337,6 +346,12 @@ export async function validateLooperConfig(
         "directory",
         issues,
         "daemon.workingDirectory",
+      ),
+      ensureWritablePath(
+        options.defaultWorktreeRoot ?? getDefaultWorktreeRoot(),
+        "directory",
+        issues,
+        "defaults.worktreeRoot",
       ),
     ]);
   }

--- a/apps/looperd/src/config/validate.ts
+++ b/apps/looperd/src/config/validate.ts
@@ -2,7 +2,10 @@ import { constants, access, stat } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import { getDefaultWorktreeRoot } from "./defaults";
-import { getProjectIdValidationMessage, isValidProjectId } from "./project-id";
+import {
+  getConfigProjectIdValidationMessage,
+  isValidConfiguredProjectId,
+} from "./project-id";
 import {
   AGENT_VENDORS,
   AUTH_MODES,
@@ -298,10 +301,10 @@ export async function validateLooperConfig(
         path: `${prefix}.id`,
         message: "must be a non-empty string",
       });
-    } else if (!isValidProjectId(project.id)) {
+    } else if (!isValidConfiguredProjectId(project.id)) {
       issues.push({
         path: `${prefix}.id`,
-        message: getProjectIdValidationMessage(),
+        message: getConfigProjectIdValidationMessage(),
       });
     } else if (projectIds.has(project.id)) {
       issues.push({

--- a/apps/looperd/src/config/validate.ts
+++ b/apps/looperd/src/config/validate.ts
@@ -12,6 +12,7 @@ import {
   OPEN_PR_STRATEGIES,
   type ValidationIssue,
 } from "./types";
+import { getProjectIdValidationMessage, isValidProjectId } from "./project-id";
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
@@ -287,6 +288,11 @@ export async function validateLooperConfig(
       issues.push({
         path: `${prefix}.id`,
         message: "must be a non-empty string",
+      });
+    } else if (!isValidProjectId(project.id)) {
+      issues.push({
+        path: `${prefix}.id`,
+        message: getProjectIdValidationMessage(),
       });
     } else if (projectIds.has(project.id)) {
       issues.push({

--- a/apps/looperd/src/config/validate.ts
+++ b/apps/looperd/src/config/validate.ts
@@ -1,6 +1,7 @@
 import { constants, access } from "node:fs/promises";
 import { dirname } from "node:path";
 
+import { getProjectIdValidationMessage, isValidProjectId } from "./project-id";
 import {
   AGENT_VENDORS,
   AUTH_MODES,
@@ -12,7 +13,6 @@ import {
   OPEN_PR_STRATEGIES,
   type ValidationIssue,
 } from "./types";
-import { getProjectIdValidationMessage, isValidProjectId } from "./project-id";
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;

--- a/apps/looperd/src/fixer/index.test.ts
+++ b/apps/looperd/src/fixer/index.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { Logger } from "../bootstrap/logger";
+import { getDefaultProjectWorktreeRoot } from "../config/index";
 import type { AgentResult, AgentRunInput } from "../infra/agent";
 import { RemoteHeadChangedError } from "../infra/git";
 import { SchedulerQueue } from "../scheduler/index";
@@ -495,6 +496,9 @@ describe("FixerLoopRunner", () => {
     }
     expect(agent.starts).toHaveLength(1);
     expect(git.createWorktreeCalls).toBe(1);
+    expect(git.lastCreateWorktreeInput?.worktreeRoot).toBe(
+      getDefaultProjectWorktreeRoot("project_1"),
+    );
     expect(git.lastCreateWorktreeInput?.checkoutMode).toBe("detached");
     expect(git.prepareCalls).toBe(1);
     expect(git.pushCalls).toBe(1);

--- a/apps/looperd/src/fixer/index.test.ts
+++ b/apps/looperd/src/fixer/index.test.ts
@@ -497,7 +497,7 @@ describe("FixerLoopRunner", () => {
     expect(agent.starts).toHaveLength(1);
     expect(git.createWorktreeCalls).toBe(1);
     expect(git.lastCreateWorktreeInput?.worktreeRoot).toBe(
-      getDefaultProjectWorktreeRoot("project_1"),
+      getDefaultProjectWorktreeRoot("project_1", fixture.repoPath),
     );
     expect(git.lastCreateWorktreeInput?.checkoutMode).toBe("detached");
     expect(git.prepareCalls).toBe(1);

--- a/apps/looperd/src/fixer/index.ts
+++ b/apps/looperd/src/fixer/index.ts
@@ -791,7 +791,7 @@ export class FixerLoopRunner {
     const projectMetadata = parseJsonObject(input.project.metadataJson);
     const worktreeRoot =
       readString(projectMetadata.worktreeRoot) ??
-      getDefaultProjectWorktreeRoot(input.project.id);
+      getDefaultProjectWorktreeRoot(input.project.id, input.project.repoPath);
     if (shouldRebuildWorktree(input.checkpoint)) {
       const previousWorktree = input.checkpoint.worktree;
       if (previousWorktree?.path && previousWorktree.branch) {

--- a/apps/looperd/src/fixer/index.ts
+++ b/apps/looperd/src/fixer/index.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { join } from "node:path";
 
 import type { Logger } from "../bootstrap/logger";
+import { getDefaultProjectWorktreeRoot } from "../config/index";
 import type { AgentResult, AgentRunInput } from "../infra/agent";
 import { appendCompletionInstruction } from "../infra/agent-prompt";
 import { CommandExecutionError, runCommand } from "../infra/command";
@@ -790,7 +791,7 @@ export class FixerLoopRunner {
     const projectMetadata = parseJsonObject(input.project.metadataJson);
     const worktreeRoot =
       readString(projectMetadata.worktreeRoot) ??
-      join(input.project.repoPath, ".looper-worktrees");
+      getDefaultProjectWorktreeRoot(input.project.id);
     if (shouldRebuildWorktree(input.checkpoint)) {
       const previousWorktree = input.checkpoint.worktree;
       if (previousWorktree?.path && previousWorktree.branch) {

--- a/apps/looperd/src/planner/index.test.ts
+++ b/apps/looperd/src/planner/index.test.ts
@@ -567,7 +567,7 @@ describe("PlannerLoopRunner", () => {
 
     expect(result.status).toBe("success");
     expect(git.lastCreateWorktreeInput?.worktreeRoot).toBe(
-      getDefaultProjectWorktreeRoot("project_1"),
+      getDefaultProjectWorktreeRoot("project_1", fixture.repoPath),
     );
 
     fixture.store.close();

--- a/apps/looperd/src/planner/index.test.ts
+++ b/apps/looperd/src/planner/index.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { Logger } from "../bootstrap/logger";
+import { getDefaultProjectWorktreeRoot } from "../config/index";
 import type { AgentResult, AgentRunInput } from "../infra/agent";
 import { SchedulerQueue } from "../scheduler/index";
 import { SqliteStore } from "../storage/sqlite/sqlite-store";
@@ -189,6 +190,14 @@ class FakeGitHubGateway implements PlannerGitHubGateway {
 class FakeGitGateway implements PlannerGitGateway {
   public createWorktreeCalls = 0;
   public pushCalls = 0;
+  public lastCreateWorktreeInput?: {
+    projectId: string;
+    repoPath: string;
+    worktreeRoot: string;
+    branch: string;
+    baseBranch: string;
+    protectedBranches?: string[];
+  };
 
   constructor(private readonly worktreeRoot: string) {}
 
@@ -201,6 +210,7 @@ class FakeGitGateway implements PlannerGitGateway {
     protectedBranches?: string[];
   }): Promise<WorktreeRecord> {
     this.createWorktreeCalls += 1;
+    this.lastCreateWorktreeInput = input;
     const worktreePath = join(
       this.worktreeRoot,
       input.branch.replace(/[^a-zA-Z0-9._-]+/g, "-"),
@@ -469,6 +479,9 @@ describe("PlannerLoopRunner", () => {
     expect(result.status).toBe("success");
     expect(result.pullRequestNumber).toBe(77);
     expect(git.createWorktreeCalls).toBe(1);
+    expect(git.lastCreateWorktreeInput?.worktreeRoot).toBe(
+      fixture.worktreeRoot,
+    );
     expect(git.pushCalls).toBe(1);
     expect(agent.starts).toHaveLength(1);
     expect(agent.starts[0]?.prompt).toContain(
@@ -498,6 +511,63 @@ describe("PlannerLoopRunner", () => {
     expect(loop?.prNumber).toBe(77);
     expect(loop?.metadataJson).toContain(
       "specs/2026-04-12-123-add-planner-flow.md",
+    );
+
+    fixture.store.close();
+  });
+
+  test("uses the config default worktree root when project metadata omits one", async () => {
+    const fixture = await createFixture();
+    const project = fixture.store.projects.getById("project_1");
+    if (!project) {
+      throw new Error("Expected project fixture");
+    }
+    fixture.store.projects.upsert({
+      ...project,
+      metadataJson: JSON.stringify({
+        repo: "acme/looper",
+        reviewers: ["review-bot"],
+      }),
+      updatedAt: fixture.now.toISOString(),
+    });
+
+    const github = new FakeGitHubGateway({
+      issues: [
+        {
+          number: 123,
+          title: "Add planner flow",
+          body: "Implement planning loop",
+          url: "https://example.test/acme/looper/issues/123",
+          assignees: ["octocat"],
+          labels: ["looper:plan"],
+        },
+      ],
+      currentUserLogin: "octocat",
+    });
+    const git = new FakeGitGateway(fixture.worktreeRoot);
+    const runner = new PlannerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git,
+      github,
+      agentExecutor: new FakeAgentExecutor([
+        completedAgentResult("Spec committed"),
+      ]),
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverIssues();
+    const claimed = fixture.queue.claimNext("planner-1");
+    if (!claimed) {
+      throw new Error("Expected planner queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(git.lastCreateWorktreeInput?.worktreeRoot).toBe(
+      getDefaultProjectWorktreeRoot("project_1"),
     );
 
     fixture.store.close();

--- a/apps/looperd/src/planner/index.ts
+++ b/apps/looperd/src/planner/index.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { Logger } from "../bootstrap/logger";
+import { getDefaultProjectWorktreeRoot } from "../config/index";
 import type { AgentResult, AgentRunInput } from "../infra/agent";
 import { appendCompletionInstruction } from "../infra/agent-prompt";
 import { CommandExecutionError } from "../infra/command";
@@ -614,7 +615,7 @@ export class PlannerLoopRunner {
     const projectMetadata = parseJsonObject(input.project.metadataJson);
     const configuredRoot = readString(projectMetadata.worktreeRoot);
     const worktreeRoot =
-      configuredRoot ?? join(input.project.repoPath, ".looper-worktrees");
+      configuredRoot ?? getDefaultProjectWorktreeRoot(input.project.id);
     const branch = buildPlannerBranch(
       issue.issueNumber,
       issue.title || "issue",

--- a/apps/looperd/src/planner/index.ts
+++ b/apps/looperd/src/planner/index.ts
@@ -615,7 +615,8 @@ export class PlannerLoopRunner {
     const projectMetadata = parseJsonObject(input.project.metadataJson);
     const configuredRoot = readString(projectMetadata.worktreeRoot);
     const worktreeRoot =
-      configuredRoot ?? getDefaultProjectWorktreeRoot(input.project.id);
+      configuredRoot ??
+      getDefaultProjectWorktreeRoot(input.project.id, input.project.repoPath);
     const branch = buildPlannerBranch(
       issue.issueNumber,
       issue.title || "issue",

--- a/apps/looperd/src/projects/index.test.ts
+++ b/apps/looperd/src/projects/index.test.ts
@@ -208,4 +208,44 @@ describe("ProjectManager", () => {
     store.close();
     await rm(rootDir, { recursive: true, force: true });
   });
+
+  test("normalizes derived legacy-prefixed ids for new projects", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-projects-"));
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+      backupDir: join(rootDir, "backups"),
+    });
+    store.initialize({ autoMigrate: true });
+
+    const manager = new ProjectManager({
+      store,
+      logger: createLogger(),
+      now: () => new Date("2026-04-11T12:00:00.000Z"),
+      git: {
+        detectGitHubRepo: async () => null,
+        listWorktrees: async () => [],
+      },
+      github: {
+        listOpenPullRequests: async () => [],
+        capturePullRequestSnapshot: async () => {
+          throw new Error("not implemented");
+        },
+      },
+    });
+
+    const result = await manager.addProject({
+      id: "legacy-id-example",
+      name: "legacy-id-example",
+      repoPath: join(rootDir, "legacy-id-example"),
+      baseBranch: "main",
+    });
+
+    expect(result.project.id).toBe("project_legacy-id-example");
+    expect(store.projects.getById("project_legacy-id-example")?.repoPath).toBe(
+      join(rootDir, "legacy-id-example"),
+    );
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
 });

--- a/apps/looperd/src/projects/index.test.ts
+++ b/apps/looperd/src/projects/index.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { InvalidProjectIdError } from "../config/index";
 import { SqliteStore } from "../storage/sqlite/sqlite-store";
 import { ProjectManager } from "./index";
 
@@ -101,6 +102,42 @@ describe("ProjectManager", () => {
     expect(
       store.pullRequestSnapshots.getLatest("powerformer/looper", 1)?.title,
     ).toBe("PR 1");
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test("rejects unsafe project ids", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-projects-"));
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+      backupDir: join(rootDir, "backups"),
+    });
+    store.initialize({ autoMigrate: true });
+
+    const manager = new ProjectManager({
+      store,
+      logger: createLogger(),
+      git: {
+        detectGitHubRepo: async () => null,
+        listWorktrees: async () => [],
+      },
+      github: {
+        listOpenPullRequests: async () => [],
+        capturePullRequestSnapshot: async () => {
+          throw new Error("not implemented");
+        },
+      },
+    });
+
+    await expect(
+      manager.addProject({
+        id: "../tmp",
+        name: "looper",
+        repoPath: join(rootDir, "repo"),
+        baseBranch: "main",
+      }),
+    ).rejects.toBeInstanceOf(InvalidProjectIdError);
 
     store.close();
     await rm(rootDir, { recursive: true, force: true });

--- a/apps/looperd/src/projects/index.test.ts
+++ b/apps/looperd/src/projects/index.test.ts
@@ -238,6 +238,7 @@ describe("ProjectManager", () => {
       name: "legacy-id-example",
       repoPath: join(rootDir, "legacy-id-example"),
       baseBranch: "main",
+      idSource: "derived",
     });
 
     expect(result.project.id).toBe("project_legacy-id-example");
@@ -289,6 +290,7 @@ describe("ProjectManager", () => {
       name: "new name",
       repoPath: join(rootDir, "legacy-id-example"),
       baseBranch: "develop",
+      idSource: "derived",
     });
 
     expect(result.project.id).toBe("legacy-id-example");
@@ -297,6 +299,58 @@ describe("ProjectManager", () => {
     expect(result.project.baseBranch).toBe("develop");
     expect(store.projects.list()).toHaveLength(1);
     expect(store.projects.getById("project_legacy-id-example")).toBeNull();
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test("rejects derived legacy-id collisions with explicit normalized ids", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-projects-"));
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+      backupDir: join(rootDir, "backups"),
+    });
+    store.initialize({ autoMigrate: true });
+
+    store.projects.upsert({
+      id: "project_legacy-id-foo",
+      name: "explicit project",
+      repoPath: join(rootDir, "explicit-project"),
+      baseBranch: "main",
+      archived: false,
+      metadataJson: JSON.stringify({ source: "api" }),
+      createdAt: "2026-04-10T12:00:00.000Z",
+      updatedAt: "2026-04-10T12:00:00.000Z",
+    });
+
+    const manager = new ProjectManager({
+      store,
+      logger: createLogger(),
+      now: () => new Date("2026-04-11T12:00:00.000Z"),
+      git: {
+        detectGitHubRepo: async () => null,
+        listWorktrees: async () => [],
+      },
+      github: {
+        listOpenPullRequests: async () => [],
+        capturePullRequestSnapshot: async () => {
+          throw new Error("not implemented");
+        },
+      },
+    });
+
+    await expect(
+      manager.addProject({
+        id: "legacy-id-foo",
+        name: "legacy-id-foo",
+        repoPath: join(rootDir, "legacy-id-foo"),
+        baseBranch: "main",
+        idSource: "derived",
+      }),
+    ).rejects.toThrow("Derived project id collides");
+    expect(store.projects.getById("project_legacy-id-foo")?.repoPath).toBe(
+      join(rootDir, "explicit-project"),
+    );
 
     store.close();
     await rm(rootDir, { recursive: true, force: true });

--- a/apps/looperd/src/projects/index.test.ts
+++ b/apps/looperd/src/projects/index.test.ts
@@ -248,4 +248,57 @@ describe("ProjectManager", () => {
     store.close();
     await rm(rootDir, { recursive: true, force: true });
   });
+
+  test("updates existing derived legacy-prefixed ids in place", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-projects-"));
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+      backupDir: join(rootDir, "backups"),
+    });
+    store.initialize({ autoMigrate: true });
+
+    store.projects.upsert({
+      id: "legacy-id-example",
+      name: "old name",
+      repoPath: join(rootDir, "old-repo"),
+      baseBranch: "main",
+      archived: false,
+      metadataJson: JSON.stringify({ source: "api" }),
+      createdAt: "2026-04-10T12:00:00.000Z",
+      updatedAt: "2026-04-10T12:00:00.000Z",
+    });
+
+    const manager = new ProjectManager({
+      store,
+      logger: createLogger(),
+      now: () => new Date("2026-04-11T12:00:00.000Z"),
+      git: {
+        detectGitHubRepo: async () => null,
+        listWorktrees: async () => [],
+      },
+      github: {
+        listOpenPullRequests: async () => [],
+        capturePullRequestSnapshot: async () => {
+          throw new Error("not implemented");
+        },
+      },
+    });
+
+    const result = await manager.addProject({
+      id: "legacy-id-example",
+      name: "new name",
+      repoPath: join(rootDir, "legacy-id-example"),
+      baseBranch: "develop",
+    });
+
+    expect(result.project.id).toBe("legacy-id-example");
+    expect(result.project.name).toBe("new name");
+    expect(result.project.repoPath).toBe(join(rootDir, "legacy-id-example"));
+    expect(result.project.baseBranch).toBe("develop");
+    expect(store.projects.list()).toHaveLength(1);
+    expect(store.projects.getById("project_legacy-id-example")).toBeNull();
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
 });

--- a/apps/looperd/src/projects/index.test.ts
+++ b/apps/looperd/src/projects/index.test.ts
@@ -139,6 +139,15 @@ describe("ProjectManager", () => {
       }),
     ).rejects.toBeInstanceOf(InvalidProjectIdError);
 
+    await expect(
+      manager.addProject({
+        id: "legacy-id-Li4vdG1w",
+        name: "looper",
+        repoPath: join(rootDir, "repo"),
+        baseBranch: "main",
+      }),
+    ).rejects.toBeInstanceOf(InvalidProjectIdError);
+
     store.close();
     await rm(rootDir, { recursive: true, force: true });
   });

--- a/apps/looperd/src/projects/index.test.ts
+++ b/apps/looperd/src/projects/index.test.ts
@@ -151,4 +151,61 @@ describe("ProjectManager", () => {
     store.close();
     await rm(rootDir, { recursive: true, force: true });
   });
+
+  test("allows updating an existing project with a legacy id", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-projects-"));
+    const store = new SqliteStore({
+      dbPath: join(rootDir, "state", "looper.sqlite"),
+      backupDir: join(rootDir, "backups"),
+    });
+    store.initialize({ autoMigrate: true });
+
+    store.projects.upsert({
+      id: "legacy-id-Li4vdG1w",
+      name: "old name",
+      repoPath: join(rootDir, "old-repo"),
+      baseBranch: "main",
+      archived: false,
+      metadataJson: JSON.stringify({ source: "api" }),
+      createdAt: "2026-04-10T12:00:00.000Z",
+      updatedAt: "2026-04-10T12:00:00.000Z",
+    });
+
+    const manager = new ProjectManager({
+      store,
+      logger: createLogger(),
+      now: () => new Date("2026-04-11T12:00:00.000Z"),
+      git: {
+        detectGitHubRepo: async () => null,
+        listWorktrees: async () => [],
+      },
+      github: {
+        listOpenPullRequests: async () => [],
+        capturePullRequestSnapshot: async () => {
+          throw new Error("not implemented");
+        },
+      },
+    });
+
+    const result = await manager.addProject({
+      id: "legacy-id-Li4vdG1w",
+      name: "new name",
+      repoPath: join(rootDir, "new-repo"),
+      baseBranch: "develop",
+      worktreeRoot: join(rootDir, "worktrees"),
+    });
+
+    expect(result.project.id).toBe("legacy-id-Li4vdG1w");
+    expect(result.project.name).toBe("new name");
+    expect(result.project.repoPath).toBe(join(rootDir, "new-repo"));
+    expect(result.project.baseBranch).toBe("develop");
+    expect(JSON.parse(result.project.metadataJson ?? "{}")).toEqual({
+      repo: null,
+      worktreeRoot: join(rootDir, "worktrees"),
+      source: "api",
+    });
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
 });

--- a/apps/looperd/src/projects/index.ts
+++ b/apps/looperd/src/projects/index.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { Logger } from "../bootstrap/logger";
+import { assertValidProjectId } from "../config/index";
 import type { GitHubPullRequestSummary } from "../infra/index";
 import type { Store } from "../storage/store";
 import type {
@@ -66,6 +67,7 @@ export class ProjectManager {
   }
 
   public async addProject(input: AddProjectInput): Promise<AddProjectResult> {
+    assertValidProjectId(input.id);
     const warnings: string[] = [];
     const nowIso = this.now().toISOString();
     const existing = this.options.store.projects.getById(input.id);

--- a/apps/looperd/src/projects/index.ts
+++ b/apps/looperd/src/projects/index.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
+import { basename } from "node:path";
 
 import type { Logger } from "../bootstrap/logger";
-import { assertValidProjectId } from "../config/index";
+import {
+  assertValidProjectId,
+  normalizeDerivedProjectId,
+} from "../config/index";
 import type { GitHubPullRequestSummary } from "../infra/index";
 import type { Store } from "../storage/store";
 import type {
@@ -67,9 +71,10 @@ export class ProjectManager {
   }
 
   public async addProject(input: AddProjectInput): Promise<AddProjectResult> {
-    const existing = this.options.store.projects.getById(input.id);
+    const projectId = this.normalizeProjectId(input.id, input.repoPath);
+    const existing = this.options.store.projects.getById(projectId);
     if (!existing) {
-      assertValidProjectId(input.id);
+      assertValidProjectId(projectId);
     }
     const warnings: string[] = [];
     const nowIso = this.now().toISOString();
@@ -78,7 +83,12 @@ export class ProjectManager {
       input.repoPath,
       warnings,
     );
-    const project = this.upsertProject(input, detectedRepo, existing, nowIso);
+    const project = this.upsertProject(
+      { ...input, id: projectId },
+      detectedRepo,
+      existing,
+      nowIso,
+    );
 
     const discoveredWorktrees = await this.discoverWorktrees(project, warnings);
     const discoveredPullRequests = await this.discoverPullRequests(
@@ -94,6 +104,18 @@ export class ProjectManager {
       discoveredWorktrees,
       warnings,
     };
+  }
+
+  private normalizeProjectId(projectId: string, repoPath: string): string {
+    if (!projectId.startsWith("legacy-id-")) {
+      return projectId;
+    }
+
+    if (projectId !== deriveProjectId(repoPath)) {
+      return projectId;
+    }
+
+    return normalizeDerivedProjectId(projectId);
   }
 
   private upsertProject(
@@ -242,6 +264,15 @@ export class ProjectManager {
       return 0;
     }
   }
+}
+
+function deriveProjectId(repoPath: string): string {
+  const normalized = basename(repoPath)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return normalized || "project";
 }
 
 function parseMetadata(metadataJson?: string | null): Record<string, unknown> {

--- a/apps/looperd/src/projects/index.ts
+++ b/apps/looperd/src/projects/index.ts
@@ -71,9 +71,13 @@ export class ProjectManager {
   }
 
   public async addProject(input: AddProjectInput): Promise<AddProjectResult> {
-    const projectId = this.normalizeProjectId(input.id, input.repoPath);
-    const existing = this.options.store.projects.getById(projectId);
-    if (!existing) {
+    const existing = this.options.store.projects.getById(input.id);
+    const projectId = existing
+      ? existing.id
+      : this.normalizeProjectId(input.id, input.repoPath);
+    const normalizedExisting =
+      existing ?? this.options.store.projects.getById(projectId);
+    if (!normalizedExisting) {
       assertValidProjectId(projectId);
     }
     const warnings: string[] = [];
@@ -86,7 +90,7 @@ export class ProjectManager {
     const project = this.upsertProject(
       { ...input, id: projectId },
       detectedRepo,
-      existing,
+      normalizedExisting,
       nowIso,
     );
 

--- a/apps/looperd/src/projects/index.ts
+++ b/apps/looperd/src/projects/index.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { basename } from "node:path";
 
 import type { Logger } from "../bootstrap/logger";
 import {
   assertValidProjectId,
+  deriveProjectIdFromRepoPath,
   normalizeDerivedProjectId,
 } from "../config/index";
 import type { GitHubPullRequestSummary } from "../infra/index";
@@ -43,6 +43,7 @@ export interface AddProjectInput {
   name: string;
   repoPath: string;
   baseBranch: string;
+  idSource?: "explicit" | "derived";
   worktreeRoot?: string | null;
   repo?: string | null;
 }
@@ -63,6 +64,15 @@ export interface ProjectManagerOptions {
   now?: () => Date;
 }
 
+export class ProjectIdCollisionError extends Error {
+  constructor(projectId: string) {
+    super(
+      `Derived project id collides with an existing explicit project: ${projectId}`,
+    );
+    this.name = "ProjectIdCollisionError";
+  }
+}
+
 export class ProjectManager {
   private readonly now: () => Date;
 
@@ -72,11 +82,9 @@ export class ProjectManager {
 
   public async addProject(input: AddProjectInput): Promise<AddProjectResult> {
     const existing = this.options.store.projects.getById(input.id);
-    const projectId = existing
-      ? existing.id
-      : this.normalizeProjectId(input.id, input.repoPath);
+    const projectId = existing ? existing.id : this.normalizeProjectId(input);
     const normalizedExisting =
-      existing ?? this.options.store.projects.getById(projectId);
+      existing ?? this.getNormalizedExisting(input, projectId);
     if (!normalizedExisting) {
       assertValidProjectId(projectId);
     }
@@ -110,16 +118,41 @@ export class ProjectManager {
     };
   }
 
-  private normalizeProjectId(projectId: string, repoPath: string): string {
-    if (!projectId.startsWith("legacy-id-")) {
-      return projectId;
+  private normalizeProjectId(input: AddProjectInput): string {
+    if (input.idSource !== "derived") {
+      return input.id;
     }
 
-    if (projectId !== deriveProjectId(repoPath)) {
-      return projectId;
+    if (input.id !== deriveProjectIdFromRepoPath(input.repoPath)) {
+      return input.id;
     }
 
-    return normalizeDerivedProjectId(projectId);
+    if (!input.id.startsWith("legacy-id-")) {
+      return input.id;
+    }
+
+    return normalizeDerivedProjectId(input.id);
+  }
+
+  private getNormalizedExisting(
+    input: AddProjectInput,
+    projectId: string,
+  ): ProjectRecord | null {
+    if (projectId === input.id) {
+      return null;
+    }
+
+    const existing = this.options.store.projects.getById(projectId);
+    if (!existing) {
+      return null;
+    }
+
+    const metadata = parseMetadata(existing.metadataJson);
+    if (metadata.normalizedDerivedId === true) {
+      return existing;
+    }
+
+    throw new ProjectIdCollisionError(projectId);
   }
 
   private upsertProject(
@@ -129,8 +162,14 @@ export class ProjectManager {
     nowIso: string,
   ): ProjectRecord {
     const metadata = parseMetadata(existing?.metadataJson);
+    const derivedProjectId = deriveProjectIdFromRepoPath(input.repoPath);
     const nextMetadata = {
       ...metadata,
+      normalizedDerivedId:
+        metadata.normalizedDerivedId === true ||
+        (input.idSource === "derived" &&
+          derivedProjectId.startsWith("legacy-id-") &&
+          input.id === normalizeDerivedProjectId(derivedProjectId)),
       repo,
       worktreeRoot: input.worktreeRoot ?? metadata.worktreeRoot ?? null,
       source: existing ? (metadata.source ?? "api") : "api",
@@ -268,15 +307,6 @@ export class ProjectManager {
       return 0;
     }
   }
-}
-
-function deriveProjectId(repoPath: string): string {
-  const normalized = basename(repoPath)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
-  return normalized || "project";
 }
 
 function parseMetadata(metadataJson?: string | null): Record<string, unknown> {

--- a/apps/looperd/src/projects/index.ts
+++ b/apps/looperd/src/projects/index.ts
@@ -163,13 +163,14 @@ export class ProjectManager {
   ): ProjectRecord {
     const metadata = parseMetadata(existing?.metadataJson);
     const derivedProjectId = deriveProjectIdFromRepoPath(input.repoPath);
+    const normalizedDerivedId =
+      metadata.normalizedDerivedId === true ||
+      (input.idSource === "derived" &&
+        derivedProjectId.startsWith("legacy-id-") &&
+        input.id === normalizeDerivedProjectId(derivedProjectId));
     const nextMetadata = {
       ...metadata,
-      normalizedDerivedId:
-        metadata.normalizedDerivedId === true ||
-        (input.idSource === "derived" &&
-          derivedProjectId.startsWith("legacy-id-") &&
-          input.id === normalizeDerivedProjectId(derivedProjectId)),
+      ...(normalizedDerivedId ? { normalizedDerivedId: true } : {}),
       repo,
       worktreeRoot: input.worktreeRoot ?? metadata.worktreeRoot ?? null,
       source: existing ? (metadata.source ?? "api") : "api",

--- a/apps/looperd/src/projects/index.ts
+++ b/apps/looperd/src/projects/index.ts
@@ -67,10 +67,12 @@ export class ProjectManager {
   }
 
   public async addProject(input: AddProjectInput): Promise<AddProjectResult> {
-    assertValidProjectId(input.id);
+    const existing = this.options.store.projects.getById(input.id);
+    if (!existing) {
+      assertValidProjectId(input.id);
+    }
     const warnings: string[] = [];
     const nowIso = this.now().toISOString();
-    const existing = this.options.store.projects.getById(input.id);
     const detectedRepo = await this.detectRepo(
       input.repo ?? null,
       input.repoPath,

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -978,9 +978,55 @@ describe("createLooperdApi", () => {
     };
 
     expect(response.status).toBe(200);
-    expect(body.data.id).toBe("project-legacy-id-example");
+    expect(body.data.id).toBe("project_legacy-id-example");
     expect(body.data.name).toBe("Looper");
     expect(body.data.repoPath).toBe("/tmp/repos/legacy-id-example");
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test("keeps derived legacy-id project ids distinct from normalized repo names", async () => {
+    const { api, store, rootDir } = await createFixture();
+
+    const legacyResponse = await api.handle(
+      new Request("http://localhost/api/v1/projects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          repoPath: "/tmp/repos/legacy-id-foo",
+          name: "Legacy repo",
+        }),
+      }),
+    );
+    const legacyBody = (await legacyResponse.json()) as {
+      data: { id: string; repoPath: string };
+    };
+
+    const normalizedResponse = await api.handle(
+      new Request("http://localhost/api/v1/projects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          repoPath: "/tmp/repos/project-legacy-id-foo",
+          name: "Normalized repo",
+        }),
+      }),
+    );
+    const normalizedBody = (await normalizedResponse.json()) as {
+      data: { id: string; repoPath: string };
+    };
+
+    expect(legacyResponse.status).toBe(200);
+    expect(normalizedResponse.status).toBe(200);
+    expect(legacyBody.data.id).toBe("project_legacy-id-foo");
+    expect(normalizedBody.data.id).toBe("project-legacy-id-foo");
+    expect(store.projects.getById("project_legacy-id-foo")?.repoPath).toBe(
+      "/tmp/repos/legacy-id-foo",
+    );
+    expect(store.projects.getById("project-legacy-id-foo")?.repoPath).toBe(
+      "/tmp/repos/project-legacy-id-foo",
+    );
 
     store.close();
     await rm(rootDir, { recursive: true, force: true });

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -886,7 +886,7 @@ describe("createLooperdApi", () => {
   });
 
   test("supports project add route", async () => {
-    const { api, store, rootDir } = await createFixture();
+    const { store, rootDir } = await createFixture();
     const apiWithProjects = createLooperdApi({
       config: createDefaultLooperConfig(rootDir),
       logger: await createLogger(
@@ -1030,9 +1030,46 @@ describe("createLooperdApi", () => {
   });
 
   test("normalizes derived legacy-id project ids through the API", async () => {
-    const { api, store, rootDir } = await createFixture();
+    const { store, rootDir } = await createFixture();
+    const apiWithProjects = createLooperdApi({
+      config: createDefaultLooperConfig(rootDir),
+      logger: await createLogger(
+        createDefaultLooperConfig(rootDir).logging,
+        `${rootDir}/logs-projects-derived-id`,
+      ),
+      store,
+      projects: {
+        addProject: async (input: {
+          id: string;
+          name: string;
+          repoPath: string;
+          baseBranch: string;
+        }) => {
+          const project = {
+            id: input.id,
+            name: input.name,
+            repoPath: input.repoPath,
+            baseBranch: input.baseBranch,
+            archived: false,
+            metadataJson: JSON.stringify({ repo: null, worktreeRoot: null }),
+            createdAt: "2026-04-11T12:00:00.000Z",
+            updatedAt: "2026-04-11T12:00:00.000Z",
+          };
+          store.projects.upsert(project);
+          return {
+            project,
+            repo: null,
+            discoveredPullRequests: 0,
+            discoveredWorktrees: 0,
+            warnings: [],
+          };
+        },
+      } as never,
+      getStartedAt: () => new Date("2026-04-11T12:00:00.000Z"),
+      getRecoverySummary: () => ({ expiredLocksReleased: 1 }),
+    });
 
-    const response = await api.handle(
+    const response = await apiWithProjects.handle(
       new Request("http://localhost/api/v1/projects", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -1056,9 +1093,46 @@ describe("createLooperdApi", () => {
   });
 
   test("keeps derived legacy-id project ids distinct from normalized repo names", async () => {
-    const { api, store, rootDir } = await createFixture();
+    const { store, rootDir } = await createFixture();
+    const apiWithProjects = createLooperdApi({
+      config: createDefaultLooperConfig(rootDir),
+      logger: await createLogger(
+        createDefaultLooperConfig(rootDir).logging,
+        `${rootDir}/logs-projects-distinct-derived-id`,
+      ),
+      store,
+      projects: {
+        addProject: async (input: {
+          id: string;
+          name: string;
+          repoPath: string;
+          baseBranch: string;
+        }) => {
+          const project = {
+            id: input.id,
+            name: input.name,
+            repoPath: input.repoPath,
+            baseBranch: input.baseBranch,
+            archived: false,
+            metadataJson: JSON.stringify({ repo: null, worktreeRoot: null }),
+            createdAt: "2026-04-11T12:00:00.000Z",
+            updatedAt: "2026-04-11T12:00:00.000Z",
+          };
+          store.projects.upsert(project);
+          return {
+            project,
+            repo: null,
+            discoveredPullRequests: 0,
+            discoveredWorktrees: 0,
+            warnings: [],
+          };
+        },
+      } as never,
+      getStartedAt: () => new Date("2026-04-11T12:00:00.000Z"),
+      getRecoverySummary: () => ({ expiredLocksReleased: 1 }),
+    });
 
-    const legacyResponse = await api.handle(
+    const legacyResponse = await apiWithProjects.handle(
       new Request("http://localhost/api/v1/projects", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -1072,7 +1146,7 @@ describe("createLooperdApi", () => {
       data: { id: string; repoPath: string };
     };
 
-    const normalizedResponse = await api.handle(
+    const normalizedResponse = await apiWithProjects.handle(
       new Request("http://localhost/api/v1/projects", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -1102,7 +1176,7 @@ describe("createLooperdApi", () => {
   });
 
   test("rejects reviewer/fixer create and start when no coding agent is configured", async () => {
-    const { api, store, rootDir } = await createFixture();
+    const { store, rootDir } = await createFixture();
     store.loops.upsert({
       id: "loop_fixer_no_agent",
       seq: 4,

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -1029,8 +1029,9 @@ describe("createLooperdApi", () => {
     await rm(rootDir, { recursive: true, force: true });
   });
 
-  test("normalizes derived legacy-id project ids through the API", async () => {
+  test("derives legacy-looking project ids without pre-normalizing through the API", async () => {
     const { store, rootDir } = await createFixture();
+    let derivedId: string | undefined;
     const apiWithProjects = createLooperdApi({
       config: createDefaultLooperConfig(rootDir),
       logger: await createLogger(
@@ -1045,6 +1046,7 @@ describe("createLooperdApi", () => {
           repoPath: string;
           baseBranch: string;
         }) => {
+          derivedId = input.id;
           const project = {
             id: input.id,
             name: input.name,
@@ -1084,7 +1086,8 @@ describe("createLooperdApi", () => {
     };
 
     expect(response.status).toBe(200);
-    expect(body.data.id).toBe("project_legacy-id-example");
+    expect(derivedId).toBe("legacy-id-example");
+    expect(body.data.id).toBe("legacy-id-example");
     expect(body.data.name).toBe("Looper");
     expect(body.data.repoPath).toBe("/tmp/repos/legacy-id-example");
 
@@ -1162,9 +1165,9 @@ describe("createLooperdApi", () => {
 
     expect(legacyResponse.status).toBe(200);
     expect(normalizedResponse.status).toBe(200);
-    expect(legacyBody.data.id).toBe("project_legacy-id-foo");
+    expect(legacyBody.data.id).toBe("legacy-id-foo");
     expect(normalizedBody.data.id).toBe("project-legacy-id-foo");
-    expect(store.projects.getById("project_legacy-id-foo")?.repoPath).toBe(
+    expect(store.projects.getById("legacy-id-foo")?.repoPath).toBe(
       "/tmp/repos/legacy-id-foo",
     );
     expect(store.projects.getById("project-legacy-id-foo")?.repoPath).toBe(

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -1045,6 +1045,7 @@ describe("createLooperdApi", () => {
           name: string;
           repoPath: string;
           baseBranch: string;
+          idSource?: "explicit" | "derived";
         }) => {
           derivedId = input.id;
           const project = {
@@ -1090,6 +1091,75 @@ describe("createLooperdApi", () => {
     expect(body.data.id).toBe("legacy-id-example");
     expect(body.data.name).toBe("Looper");
     expect(body.data.repoPath).toBe("/tmp/repos/legacy-id-example");
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test("derives project ids with the same mixed-separator parser used by project normalization", async () => {
+    const { store, rootDir } = await createFixture();
+    let derivedId = "";
+    let idSource: "explicit" | "derived" | undefined;
+    const apiWithProjects = createLooperdApi({
+      config: createDefaultLooperConfig(rootDir),
+      logger: await createLogger(
+        createDefaultLooperConfig(rootDir).logging,
+        `${rootDir}/logs-projects-mixed-separators`,
+      ),
+      store,
+      projects: {
+        addProject: async (input: {
+          id: string;
+          name: string;
+          repoPath: string;
+          baseBranch: string;
+          idSource?: "explicit" | "derived";
+        }) => {
+          derivedId = input.id;
+          idSource = input.idSource;
+          const project = {
+            id: input.id,
+            name: input.name,
+            repoPath: input.repoPath,
+            baseBranch: input.baseBranch,
+            archived: false,
+            metadataJson: JSON.stringify({ repo: null, worktreeRoot: null }),
+            createdAt: "2026-04-11T12:00:00.000Z",
+            updatedAt: "2026-04-11T12:00:00.000Z",
+          };
+          store.projects.upsert(project);
+          return {
+            project,
+            repo: null,
+            discoveredPullRequests: 0,
+            discoveredWorktrees: 0,
+            warnings: [],
+          };
+        },
+      } as never,
+      getStartedAt: () => new Date("2026-04-11T12:00:00.000Z"),
+      getRecoverySummary: () => ({ expiredLocksReleased: 1 }),
+    });
+
+    const response = await apiWithProjects.handle(
+      new Request("http://localhost/api/v1/projects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          repoPath: "/tmp/repos\\legacy-id-example",
+          name: "Looper",
+        }),
+      }),
+    );
+    const body = (await response.json()) as {
+      data: { id: string; name: string; repoPath: string };
+    };
+
+    expect(response.status).toBe(200);
+    expect(derivedId).toBe("legacy-id-example");
+    expect(idSource).toBe("derived");
+    expect(body.data.id).toBe("legacy-id-example");
+    expect(body.data.repoPath).toBe("/tmp/repos\\legacy-id-example");
 
     store.close();
     await rm(rootDir, { recursive: true, force: true });

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -917,6 +917,49 @@ describe("createLooperdApi", () => {
     await rm(rootDir, { recursive: true, force: true });
   });
 
+  test("rejects reserved legacy-id project ids through the API", async () => {
+    const { store, rootDir } = await createFixture();
+    const apiWithProjects = createLooperdApi({
+      config: createDefaultLooperConfig(rootDir),
+      logger: await createLogger(
+        createDefaultLooperConfig(rootDir).logging,
+        `${rootDir}/logs-projects-invalid-legacy-id`,
+      ),
+      store,
+      projects: {
+        addProject: async () => {
+          throw new InvalidProjectIdError("legacy-id-Li4vdG1w");
+        },
+      } as never,
+      getStartedAt: () => new Date("2026-04-11T12:00:00.000Z"),
+      getRecoverySummary: () => ({ expiredLocksReleased: 1 }),
+    });
+
+    const response = await apiWithProjects.handle(
+      new Request("http://localhost/api/v1/projects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          repoPath: "/tmp/repos/looper",
+          id: "legacy-id-Li4vdG1w",
+          name: "Looper",
+        }),
+      }),
+    );
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+    expect(body.error.message).toContain(
+      'Invalid project id "legacy-id-Li4vdG1w"',
+    );
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
   test("rejects reviewer/fixer create and start when no coding agent is configured", async () => {
     const { api, store, rootDir } = await createFixture();
     store.loops.upsert({

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -5,8 +5,8 @@ import { join } from "node:path";
 
 import { createLogger } from "../bootstrap/logger";
 import {
-  createDefaultLooperConfig,
   InvalidProjectIdError,
+  createDefaultLooperConfig,
 } from "../config/index";
 import { SqliteStore } from "../storage/sqlite/sqlite-store";
 import { createLooperdApi } from "./index";

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { createLogger } from "../bootstrap/logger";
-import { createDefaultLooperConfig } from "../config/index";
+import {
+  createDefaultLooperConfig,
+  InvalidProjectIdError,
+} from "../config/index";
 import { SqliteStore } from "../storage/sqlite/sqlite-store";
 import { createLooperdApi } from "./index";
 
@@ -868,6 +871,47 @@ describe("createLooperdApi", () => {
     expect(body.data.id).toBe("looper");
     expect(body.data.repo).toBe("powerformer/looper");
     expect(body.data.discoveredPullRequests).toBe(1);
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test("rejects unsafe project ids through the API", async () => {
+    const { store, rootDir } = await createFixture();
+    const apiWithProjects = createLooperdApi({
+      config: createDefaultLooperConfig(rootDir),
+      logger: await createLogger(
+        createDefaultLooperConfig(rootDir).logging,
+        `${rootDir}/logs-projects-invalid-id`,
+      ),
+      store,
+      projects: {
+        addProject: async () => {
+          throw new InvalidProjectIdError("../../tmp");
+        },
+      } as never,
+      getStartedAt: () => new Date("2026-04-11T12:00:00.000Z"),
+      getRecoverySummary: () => ({ expiredLocksReleased: 1 }),
+    });
+
+    const response = await apiWithProjects.handle(
+      new Request("http://localhost/api/v1/projects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          repoPath: "/tmp/repos/looper",
+          id: "../../tmp",
+          name: "Looper",
+        }),
+      }),
+    );
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+    expect(body.error.message).toContain('Invalid project id "../../tmp"');
 
     store.close();
     await rm(rootDir, { recursive: true, force: true });

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -960,6 +960,32 @@ describe("createLooperdApi", () => {
     await rm(rootDir, { recursive: true, force: true });
   });
 
+  test("normalizes derived legacy-id project ids through the API", async () => {
+    const { api, store, rootDir } = await createFixture();
+
+    const response = await api.handle(
+      new Request("http://localhost/api/v1/projects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          repoPath: "/tmp/repos/legacy-id-example",
+          name: "Looper",
+        }),
+      }),
+    );
+    const body = (await response.json()) as {
+      data: { id: string; name: string; repoPath: string };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.data.id).toBe("project-legacy-id-example");
+    expect(body.data.name).toBe("Looper");
+    expect(body.data.repoPath).toBe("/tmp/repos/legacy-id-example");
+
+    store.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
   test("rejects reviewer/fixer create and start when no coding agent is configured", async () => {
     const { api, store, rootDir } = await createFixture();
     store.loops.upsert({

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 
 import type { Logger } from "../bootstrap/logger";
-import { InvalidProjectIdError, type LooperConfig } from "../config/index";
+import {
+  InvalidProjectIdError,
+  normalizeDerivedProjectId,
+  type LooperConfig,
+} from "../config/index";
 import {
   assertUniqueActiveLoop,
   createLoop,
@@ -1955,7 +1959,7 @@ function deriveProjectIdFromPath(repoPath: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 
-  return normalized || "project";
+  return normalizeDerivedProjectId(normalized || "project");
 }
 
 function serializeEvent(event: EventLogRecord) {

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -3,8 +3,8 @@ import { randomUUID } from "node:crypto";
 import type { Logger } from "../bootstrap/logger";
 import {
   InvalidProjectIdError,
-  deriveProjectIdFromRepoPath,
   type LooperConfig,
+  deriveProjectIdFromRepoPath,
 } from "../config/index";
 import {
   assertUniqueActiveLoop,
@@ -14,7 +14,10 @@ import {
   defineProjectLoopTarget,
   definePullRequestLoopTarget,
 } from "../domain/index";
-import { ProjectIdCollisionError, type ProjectManager } from "../projects/index";
+import {
+  ProjectIdCollisionError,
+  type ProjectManager,
+} from "../projects/index";
 import { SchedulerQueue } from "../scheduler/index";
 import type { Store } from "../storage/store";
 import type {

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { Logger } from "../bootstrap/logger";
-import type { LooperConfig } from "../config/index";
+import { InvalidProjectIdError, type LooperConfig } from "../config/index";
 import {
   assertUniqueActiveLoop,
   createLoop,
@@ -1989,6 +1989,10 @@ function isCodingAgentConfigured(config: LooperConfig): boolean {
 function toApiError(error: unknown): ApiError {
   if (error instanceof ApiError) {
     return error;
+  }
+
+  if (error instanceof InvalidProjectIdError) {
+    return new ApiError("VALIDATION_FAILED", 400, error.message);
   }
 
   return new ApiError(

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -3,8 +3,8 @@ import { randomUUID } from "node:crypto";
 import type { Logger } from "../bootstrap/logger";
 import {
   InvalidProjectIdError,
-  normalizeDerivedProjectId,
   type LooperConfig,
+  normalizeDerivedProjectId,
 } from "../config/index";
 import {
   assertUniqueActiveLoop,

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 
 import type { Logger } from "../bootstrap/logger";
-import { InvalidProjectIdError, type LooperConfig } from "../config/index";
+import {
+  InvalidProjectIdError,
+  deriveProjectIdFromRepoPath,
+  type LooperConfig,
+} from "../config/index";
 import {
   assertUniqueActiveLoop,
   createLoop,
@@ -10,7 +14,7 @@ import {
   defineProjectLoopTarget,
   definePullRequestLoopTarget,
 } from "../domain/index";
-import type { ProjectManager } from "../projects/index";
+import { ProjectIdCollisionError, type ProjectManager } from "../projects/index";
 import { SchedulerQueue } from "../scheduler/index";
 import type { Store } from "../storage/store";
 import type {
@@ -1157,8 +1161,8 @@ async function buildProjectsRouteResponse(
 
   const body = await parseJsonBody(request);
   const repoPath = readRequiredString(body, "repoPath");
-  const id =
-    readOptionalString(body, "id") ?? deriveProjectIdFromPath(repoPath);
+  const providedId = readOptionalString(body, "id");
+  const id = providedId ?? deriveProjectIdFromRepoPath(repoPath);
   const name = readOptionalString(body, "name") ?? id;
   const baseBranch =
     readOptionalString(body, "baseBranch") ??
@@ -1169,6 +1173,7 @@ async function buildProjectsRouteResponse(
     name,
     repoPath,
     baseBranch,
+    idSource: providedId ? "explicit" : "derived",
     worktreeRoot: readOptionalString(body, "worktreeRoot"),
     repo: readOptionalString(body, "repo"),
   });
@@ -2047,17 +2052,6 @@ function buildWorkerPullRequestLockKey(repo: string, prNumber: number): string {
   return createPrLockKey(repo, prNumber);
 }
 
-function deriveProjectIdFromPath(repoPath: string): string {
-  const segments = repoPath.split(/[\\/]+/).filter(Boolean);
-  const lastSegment = segments.at(-1) ?? "project";
-  const normalized = lastSegment
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
-  return normalized || "project";
-}
-
 function serializeEvent(event: EventLogRecord) {
   return {
     ...event,
@@ -2093,6 +2087,10 @@ function toApiError(error: unknown): ApiError {
 
   if (error instanceof InvalidProjectIdError) {
     return new ApiError("VALIDATION_FAILED", 400, error.message);
+  }
+
+  if (error instanceof ProjectIdCollisionError) {
+    return new ApiError("PROJECT_ID_CONFLICT", 409, error.message);
   }
 
   return new ApiError(

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -1,11 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { Logger } from "../bootstrap/logger";
-import {
-  InvalidProjectIdError,
-  type LooperConfig,
-  normalizeDerivedProjectId,
-} from "../config/index";
+import { InvalidProjectIdError, type LooperConfig } from "../config/index";
 import {
   assertUniqueActiveLoop,
   createLoop,
@@ -2059,7 +2055,7 @@ function deriveProjectIdFromPath(repoPath: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 
-  return normalizeDerivedProjectId(normalized || "project");
+  return normalized || "project";
 }
 
 function serializeEvent(event: EventLogRecord) {

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -568,7 +568,7 @@ describe("WorkerLoopRunner", () => {
 
     expect(result.status).toBe("success");
     expect(git.lastCreateWorktreeInput?.worktreeRoot).toBe(
-      getDefaultProjectWorktreeRoot("project_1"),
+      getDefaultProjectWorktreeRoot("project_1", fixture.repoPath),
     );
 
     fixture.store.close();

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { Logger } from "../bootstrap/logger";
+import { getDefaultProjectWorktreeRoot } from "../config/index";
 import type { AgentResult, AgentRunInput } from "../infra/agent";
 import { SchedulerQueue } from "../scheduler/index";
 import { SqliteStore } from "../storage/sqlite/sqlite-store";
@@ -104,6 +105,15 @@ async function createFixture() {
 class FakeGitGateway implements WorkerGitGateway {
   public createWorktreeCalls = 0;
   public pushCalls = 0;
+  public lastCreateWorktreeInput?: {
+    projectId: string;
+    repoPath: string;
+    worktreeRoot: string;
+    branch: string;
+    baseBranch: string;
+    prNumber?: number;
+    protectedBranches?: string[];
+  };
 
   constructor(private readonly worktreeRoot: string) {}
 
@@ -116,6 +126,7 @@ class FakeGitGateway implements WorkerGitGateway {
     protectedBranches?: string[];
   }): Promise<WorktreeRecord> {
     this.createWorktreeCalls += 1;
+    this.lastCreateWorktreeInput = input;
     const worktreePath = join(
       this.worktreeRoot,
       input.branch.replace(/[^a-zA-Z0-9._-]+/g, "-"),
@@ -504,11 +515,62 @@ describe("WorkerLoopRunner", () => {
       "use the GitHub CLI (`gh`) to create the pull request yourself",
     );
     expect(git.createWorktreeCalls).toBe(1);
+    expect(git.lastCreateWorktreeInput?.worktreeRoot).toBe(
+      fixture.worktreeRoot,
+    );
     expect(git.pushCalls).toBe(1);
     expect(github.createPullRequestCalls).toHaveLength(1);
     expect(fixture.store.loops.getById("loop_worker_1")?.status).toBe(
       "completed",
     );
+    fixture.store.close();
+  });
+
+  test("uses the config default worktree root when project metadata omits one", async () => {
+    const fixture = await createFixture();
+    const project = fixture.store.projects.getById("project_1");
+    if (!project) {
+      throw new Error("Expected project fixture");
+    }
+    fixture.store.projects.upsert({
+      ...project,
+      metadataJson: null,
+      updatedAt: fixture.now.toISOString(),
+    });
+
+    const git = new FakeGitGateway(fixture.worktreeRoot);
+    const runner = new WorkerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git,
+      github: new FakeGitHubGateway(),
+      agentExecutor: new FakeAgentExecutor([
+        completedAgentResult("Implemented slice and committed changes", [
+          "abc123",
+        ]),
+      ]),
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      validationRunner: async (): Promise<WorkerValidationResult> => ({
+        passed: true,
+        summary: "ok",
+        output: "ok",
+      }),
+      openPrStrategy: "all_done",
+    });
+
+    const claimed = fixture.queue.claimNext("worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed worker queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(git.lastCreateWorktreeInput?.worktreeRoot).toBe(
+      getDefaultProjectWorktreeRoot("project_1"),
+    );
+
     fixture.store.close();
   });
 

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -3,7 +3,10 @@ import { readFile } from "node:fs/promises";
 import { isAbsolute, join } from "node:path";
 
 import type { Logger } from "../bootstrap/logger";
-import type { OpenPrStrategy } from "../config/index";
+import {
+  type OpenPrStrategy,
+  getDefaultProjectWorktreeRoot,
+} from "../config/index";
 import { createPrLockKey } from "../domain/index";
 import type { AgentResult, AgentRunInput } from "../infra/agent";
 import { appendCompletionInstruction } from "../infra/agent-prompt";
@@ -622,7 +625,7 @@ export class WorkerLoopRunner {
     const projectMetadata = parseJsonObject(input.project.metadataJson);
     const configuredRoot = readString(projectMetadata.worktreeRoot);
     const worktreeRoot =
-      configuredRoot ?? join(input.project.repoPath, ".looper-worktrees");
+      configuredRoot ?? getDefaultProjectWorktreeRoot(input.project.id);
     const branch =
       work.executionMode === "push-existing"
         ? (work.branch ?? `pr-${work.prNumber}`)

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -625,7 +625,8 @@ export class WorkerLoopRunner {
     const projectMetadata = parseJsonObject(input.project.metadataJson);
     const configuredRoot = readString(projectMetadata.worktreeRoot);
     const worktreeRoot =
-      configuredRoot ?? getDefaultProjectWorktreeRoot(input.project.id);
+      configuredRoot ??
+      getDefaultProjectWorktreeRoot(input.project.id, input.project.repoPath);
     const branch =
       work.executionMode === "push-existing"
         ? (work.branch ?? `pr-${work.prNumber}`)


### PR DESCRIPTION
## Summary
- centralize the default worktree root in the config defaults layer and resolve fallback worktrees under `~/.looper/worktrees/<project-id>`
- remove the repo-local `.looper-worktrees` fallback from fixer, planner, and worker flows while preserving explicit project `worktreeRoot` overrides
- update tests, remove the repo `.gitignore` entry, and document how to clean up legacy repo-local worktree metadata

## Validation
- `bun run lint`
- `bun test apps/looperd/src/config/defaults.test.ts apps/looperd/src/planner/index.test.ts apps/looperd/src/worker/index.test.ts apps/looperd/src/fixer/index.test.ts`
- `bun run --cwd apps/looperd typecheck`

Closes #20