### PR TITLE
Start queued work without poll delays

### DIFF
--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -713,6 +713,21 @@ describe("runCli", () => {
                       status: "running",
                     },
                   },
+                  {
+                    runId: null,
+                    loopId: "loop_worker_queued",
+                    projectId: "project_1",
+                    type: "worker",
+                    status: "queued",
+                    currentStep: null,
+                    startedAt: "2026-04-11T12:04:00.000Z",
+                    target: {
+                      type: "project",
+                      projectId: "project_1",
+                      label: "project_1",
+                    },
+                    agent: null,
+                  },
                 ],
               },
             }),
@@ -735,6 +750,10 @@ describe("runCli", () => {
       expect(lines[2]).toContain("2222");
       expect(lines[2]).toContain("running");
       expect(lines[2]).toContain("5m");
+      expect(lines[3]).toContain("worker");
+      expect(lines[3]).toContain("project_1");
+      expect(lines[3]).toContain("queued");
+      expect(lines[3]).toContain("1m");
     } finally {
       Date.now = originalNow;
     }
@@ -756,7 +775,7 @@ describe("runCli", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(lines).toEqual(["No running loops."]);
+    expect(lines).toEqual(["No running or queued loops."]);
   });
 
   test("composes ps query params from --type and --project", async () => {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -80,13 +80,13 @@ interface PullRequestRef {
 
 interface ActiveRunItem {
   seq: number;
-  runId: string;
+  runId: string | null;
   loopId: string;
   projectId: string;
   type: string;
   status: string;
   currentStep: string | null;
-  startedAt: string;
+  startedAt: string | null;
   target:
     | {
         type: "project";
@@ -1014,7 +1014,7 @@ async function runPs(context: CliContext) {
   }
 
   if (data.items.length === 0) {
-    context.write("No running loops.");
+    context.write("No running or queued loops.");
     return;
   }
 
@@ -1163,7 +1163,11 @@ async function runStop(context: CliContext) {
   }
 }
 
-function formatRelativeAge(startedAt: string): string {
+function formatRelativeAge(startedAt: string | null): string {
+  if (!startedAt) {
+    return "-";
+  }
+
   const started = Date.parse(startedAt);
   if (Number.isNaN(started)) {
     return "-";

--- a/apps/looperd/src/config/defaults.ts
+++ b/apps/looperd/src/config/defaults.ts
@@ -19,7 +19,7 @@ export function createDefaultLooperConfig(cwd = process.cwd()): LooperConfig {
     },
     scheduler: {
       pollIntervalSeconds: 30,
-      maxConcurrentRuns: 1,
+      maxConcurrentRuns: 3,
       retryMaxAttempts: 5,
       retryBaseDelayMs: 5_000,
     },

--- a/apps/looperd/src/config/load.test.ts
+++ b/apps/looperd/src/config/load.test.ts
@@ -3,7 +3,11 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { ConfigValidationError, loadLooperConfig } from "./index";
+import {
+  ConfigValidationError,
+  createDefaultLooperConfig,
+  loadLooperConfig,
+} from "./index";
 
 async function createFixture(): Promise<{
   rootDir: string;
@@ -40,6 +44,11 @@ afterEach(async () => {
 });
 
 describe("loadLooperConfig", () => {
+  test("defaults scheduler maxConcurrentRuns to 3", () => {
+    const config = createDefaultLooperConfig();
+    expect(config.scheduler.maxConcurrentRuns).toBe(3);
+  });
+
   test("merges config file, env, and CLI overrides in priority order", async () => {
     const fixture = await createFixture();
     cleanupPaths.push(fixture.rootDir);

--- a/apps/looperd/src/fixer/index.test.ts
+++ b/apps/looperd/src/fixer/index.test.ts
@@ -397,7 +397,14 @@ describe("FixerLoopRunner", () => {
     const runner = new FixerLoopRunner({
       store: fixture.store,
       scheduler: fixture.queue,
-      github: new FakeGitHubGateway({ views: [] }),
+      github: new FakeGitHubGateway({
+        views: [
+          {
+            comments: [{ id: "c1", threadId: "thread-1", state: "UNRESOLVED" }],
+            checks: [],
+          },
+        ],
+      }),
       git: new FakeGitGateway(),
       agentExecutor: new FakeAgentExecutor([]),
       logger: createCapturingLogger().logger,
@@ -1035,6 +1042,52 @@ describe("FixerLoopRunner", () => {
     expect(result.summary).toContain("Auto commit disabled");
     expect(agent.starts).toHaveLength(1);
     expect(git.pushCalls).toBe(0);
+
+    fixture.store.close();
+  });
+
+  test("fails claimed fixer work instead of leaving it running when setup throws", async () => {
+    const fixture = await createFixture();
+    const runner = new FixerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github: new FakeGitHubGateway({
+        views: [
+          {
+            comments: [{ id: "c1", threadId: "thread-1", state: "UNRESOLVED" }],
+            checks: [],
+          },
+        ],
+      }),
+      git: new FakeGitGateway(),
+      agentExecutor: new FakeAgentExecutor([completedAgentResult("unused")]),
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      validationRunner: async (): Promise<FixerValidationResult> => ({
+        passed: true,
+        summary: "ok",
+      }),
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("fixer-1");
+    if (!claimed) {
+      throw new Error("Expected claimed fixer queue item");
+    }
+
+    Object.assign(runner as object, {
+      getLoop() {
+        throw new Error("setup exploded");
+      },
+    });
+
+    await expect(runner.processClaimedItem(claimed)).rejects.toThrow(
+      "setup exploded",
+    );
+    expect(fixture.store.queue.getById(claimed.id)?.status).toBe("failed");
 
     fixture.store.close();
   });

--- a/apps/looperd/src/fixer/index.ts
+++ b/apps/looperd/src/fixer/index.ts
@@ -386,60 +386,65 @@ export class FixerLoopRunner {
       throw new Error("Fixer queue item requires loopId, repo, and prNumber");
     }
 
-    const loop = this.getLoop(queueItem.loopId);
-    const project = this.getProject(loop.projectId);
-    const resumedRun = this.createRunContext(loop);
-    let run = resumedRun.run;
-    let checkpoint = resumedRun.checkpoint;
+    let loop: LoopRecord | undefined;
+    let project: ProjectRecord | undefined;
+    let run: RunRecord | undefined;
+    let checkpoint: FixerCheckpoint | undefined;
     let claimedLockKey: string | undefined;
 
-    this.updateLoop(loop, {
-      status: "running",
-      lastRunAt: run.startedAt,
-      nextRunAt: null,
-    });
-    this.appendEvent({
-      eventType: "loop.started",
-      projectId: project.id,
-      loopId: loop.id,
-      runId: run.id,
-      entityType: "loop",
-      entityId: loop.id,
-      payload: {
-        queueItemId: queueItem.id,
-        resumed: resumedRun.resumed,
-        startStep: resumedRun.startStep,
-      },
-    });
-    this.options.logger.info("fixer loop started", {
-      projectId: project.id,
-      loopId: loop.id,
-      runId: run.id,
-      queueItemId: queueItem.id,
-      currentStep: resumedRun.startStep,
-      resumed: resumedRun.resumed,
-    });
-    this.appendEvent({
-      eventType: "run.started",
-      projectId: project.id,
-      loopId: loop.id,
-      runId: run.id,
-      entityType: "run",
-      entityId: run.id,
-      payload: {
+    try {
+      loop = this.getLoop(queueItem.loopId);
+      project = this.getProject(loop.projectId);
+      const resumedRun = this.createRunContext(loop);
+      run = resumedRun.run;
+      checkpoint = resumedRun.checkpoint;
+
+      this.updateLoop(loop, {
+        status: "running",
+        lastRunAt: run.startedAt,
+        nextRunAt: null,
+      });
+      this.appendEvent({
+        eventType: "loop.started",
+        projectId: project.id,
+        loopId: loop.id,
+        runId: run.id,
+        entityType: "loop",
+        entityId: loop.id,
+        payload: {
+          queueItemId: queueItem.id,
+          resumed: resumedRun.resumed,
+          startStep: resumedRun.startStep,
+        },
+      });
+      this.options.logger.info("fixer loop started", {
+        projectId: project.id,
+        loopId: loop.id,
+        runId: run.id,
         queueItemId: queueItem.id,
         currentStep: resumedRun.startStep,
-      },
-    });
-    this.options.logger.info("fixer run started", {
-      projectId: project.id,
-      loopId: loop.id,
-      runId: run.id,
-      queueItemId: queueItem.id,
-      currentStep: resumedRun.startStep,
-    });
+        resumed: resumedRun.resumed,
+      });
+      this.appendEvent({
+        eventType: "run.started",
+        projectId: project.id,
+        loopId: loop.id,
+        runId: run.id,
+        entityType: "run",
+        entityId: run.id,
+        payload: {
+          queueItemId: queueItem.id,
+          currentStep: resumedRun.startStep,
+        },
+      });
+      this.options.logger.info("fixer run started", {
+        projectId: project.id,
+        loopId: loop.id,
+        runId: run.id,
+        queueItemId: queueItem.id,
+        currentStep: resumedRun.startStep,
+      });
 
-    try {
       for (const step of FIXER_STEP_SEQUENCE.slice(
         FIXER_STEP_SEQUENCE.indexOf(resumedRun.startStep),
       )) {
@@ -543,6 +548,14 @@ export class FixerLoopRunner {
       };
     } catch (error) {
       const failure = this.classifyFailure(error);
+      if (!loop || !project || !run || !checkpoint) {
+        this.options.scheduler.fail(
+          queueItem.id,
+          failure.kind,
+          failure.message,
+        );
+        throw error;
+      }
       this.appendEvent({
         eventType: "loop.step.failed",
         projectId: project.id,

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -921,6 +921,40 @@ describe("ReviewerLoopRunner", () => {
     fixture.store.close();
   });
 
+  test("fails claimed review work instead of leaving it running when setup throws", async () => {
+    const fixture = await createFixture();
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github: new FakeGitHubGateway(),
+      agentExecutor: new FakeAgentExecutor([completedAgentResult("unused")]),
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("reviewer-worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed reviewer queue item");
+    }
+
+    Object.assign(runner as object, {
+      getLoop() {
+        throw new Error("setup exploded");
+      },
+    });
+
+    await expect(runner.processClaimedItem(claimed)).rejects.toThrow(
+      "setup exploded",
+    );
+    expect(fixture.store.queue.getById(claimed.id)?.status).toBe("failed");
+
+    fixture.store.close();
+  });
+
   test("skips PRs already reviewed for the same head sha", async () => {
     const fixture = await createFixture();
     const github = new FakeGitHubGateway({ headSha: "abc123" });

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -327,60 +327,65 @@ export class ReviewerLoopRunner {
       );
     }
 
-    const loop = this.getLoop(queueItem.loopId);
-    const project = this.getProject(loop.projectId);
-    const resumedRun = this.createRunContext(loop);
-    let run = resumedRun.run;
-    let checkpoint = resumedRun.checkpoint;
+    let loop: LoopRecord | undefined;
+    let project: ProjectRecord | undefined;
+    let run: RunRecord | undefined;
+    let checkpoint: ReviewerCheckpoint | undefined;
     let claimedLockKey: string | undefined;
 
-    this.updateLoop(loop, {
-      status: "running",
-      lastRunAt: run.startedAt,
-      nextRunAt: null,
-    });
-    this.appendEvent({
-      eventType: "loop.started",
-      projectId: project.id,
-      loopId: loop.id,
-      runId: run.id,
-      entityType: "loop",
-      entityId: loop.id,
-      payload: {
-        queueItemId: queueItem.id,
-        resumed: resumedRun.resumed,
-        startStep: resumedRun.startStep,
-      },
-    });
-    this.options.logger.info("reviewer loop started", {
-      projectId: project.id,
-      loopId: loop.id,
-      runId: run.id,
-      queueItemId: queueItem.id,
-      currentStep: resumedRun.startStep,
-      resumed: resumedRun.resumed,
-    });
-    this.appendEvent({
-      eventType: "run.started",
-      projectId: project.id,
-      loopId: loop.id,
-      runId: run.id,
-      entityType: "run",
-      entityId: run.id,
-      payload: {
+    try {
+      loop = this.getLoop(queueItem.loopId);
+      project = this.getProject(loop.projectId);
+      const resumedRun = this.createRunContext(loop);
+      run = resumedRun.run;
+      checkpoint = resumedRun.checkpoint;
+
+      this.updateLoop(loop, {
+        status: "running",
+        lastRunAt: run.startedAt,
+        nextRunAt: null,
+      });
+      this.appendEvent({
+        eventType: "loop.started",
+        projectId: project.id,
+        loopId: loop.id,
+        runId: run.id,
+        entityType: "loop",
+        entityId: loop.id,
+        payload: {
+          queueItemId: queueItem.id,
+          resumed: resumedRun.resumed,
+          startStep: resumedRun.startStep,
+        },
+      });
+      this.options.logger.info("reviewer loop started", {
+        projectId: project.id,
+        loopId: loop.id,
+        runId: run.id,
         queueItemId: queueItem.id,
         currentStep: resumedRun.startStep,
-      },
-    });
-    this.options.logger.info("reviewer run started", {
-      projectId: project.id,
-      loopId: loop.id,
-      runId: run.id,
-      queueItemId: queueItem.id,
-      currentStep: resumedRun.startStep,
-    });
+        resumed: resumedRun.resumed,
+      });
+      this.appendEvent({
+        eventType: "run.started",
+        projectId: project.id,
+        loopId: loop.id,
+        runId: run.id,
+        entityType: "run",
+        entityId: run.id,
+        payload: {
+          queueItemId: queueItem.id,
+          currentStep: resumedRun.startStep,
+        },
+      });
+      this.options.logger.info("reviewer run started", {
+        projectId: project.id,
+        loopId: loop.id,
+        runId: run.id,
+        queueItemId: queueItem.id,
+        currentStep: resumedRun.startStep,
+      });
 
-    try {
       for (const step of REVIEWER_STEP_SEQUENCE.slice(
         REVIEWER_STEP_SEQUENCE.indexOf(resumedRun.startStep),
       )) {
@@ -485,6 +490,14 @@ export class ReviewerLoopRunner {
       };
     } catch (error) {
       const failure = this.classifyFailure(error);
+      if (!loop || !project || !run || !checkpoint) {
+        this.options.scheduler.fail(
+          queueItem.id,
+          failure.kind,
+          failure.message,
+        );
+        throw error;
+      }
       const failedCheckpoint = this.getLatestCheckpoint(run, checkpoint);
       this.appendEvent({
         eventType: "loop.step.failed",

--- a/apps/looperd/src/runtime/index.test.ts
+++ b/apps/looperd/src/runtime/index.test.ts
@@ -1891,6 +1891,116 @@ describe("createLooperdRuntime", () => {
     await runtime.stop("test");
   });
 
+  test("stop times out while waiting for hung in-flight scheduler work", async () => {
+    const fixture = await createFixture();
+    fixture.config.agent.vendor = "opencode";
+    fixture.config.scheduler.maxConcurrentRuns = 1;
+    const now = "2026-04-11T12:00:00.000Z";
+    const seedStore = new SqliteStore({
+      dbPath: fixture.config.storage.dbPath,
+      backupDir: fixture.config.storage.backupDir,
+    });
+    seedStore.initialize({ autoMigrate: true });
+    seedStore.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath: fixture.rootDir,
+      baseBranch: "main",
+      archived: false,
+      metadataJson: JSON.stringify({ repo: "powerformer/looper" }),
+      createdAt: now,
+      updatedAt: now,
+    });
+    seedStore.loops.upsert({
+      id: "loop_worker_1",
+      seq: 1,
+      projectId: "project_1",
+      type: "worker",
+      targetType: "project",
+      targetId: "project_1",
+      repo: "powerformer/looper",
+      prNumber: null,
+      status: "queued",
+      configJson: null,
+      metadataJson: null,
+      lastRunAt: null,
+      nextRunAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const scheduler = new SchedulerQueue({
+      store: seedStore,
+      retryMaxAttempts: 3,
+      retryBaseDelayMs: 0,
+    });
+    scheduler.enqueue({
+      id: "queue_worker_1",
+      projectId: "project_1",
+      loopId: "loop_worker_1",
+      type: "worker",
+      targetType: "project",
+      targetId: "project_1",
+      repo: "powerformer/looper",
+      dedupeKey: "worker:loop_worker_1",
+      payloadJson: JSON.stringify({
+        title: "Hung worker",
+        prompt: "Wait forever",
+        repo: "powerformer/looper",
+        baseBranch: "main",
+      }),
+      availableAt: now,
+    });
+    seedStore.close();
+
+    let started = false;
+    let completed = false;
+    const never = new Promise<void>(() => {});
+    const workerRunner = {
+      discoverPullRequests: async () => ({
+        queueItems: [],
+        createdLoopIds: [],
+        skipped: 0,
+      }),
+      processClaimedItem: async () => {
+        started = true;
+        await never;
+        completed = true;
+        return {
+          loopId: "loop_worker_1",
+          runId: "run_worker_1",
+          queueItemId: "queue_worker_1",
+          status: "success" as const,
+          summary: "done",
+        };
+      },
+    };
+
+    const runtime = createLooperdRuntime({
+      config: fixture.config,
+      logger: fixture.logger,
+      github: new FakeGitHubGateway(),
+      git: new FakeGitGateway(),
+      agentExecutor: new FakeAgentExecutor([]),
+      workerRunner: workerRunner as never,
+      enableReviewer: false,
+      enableFixer: false,
+      enablePlanner: false,
+    });
+
+    await runtime.start();
+    await Bun.sleep(50);
+
+    expect(started).toBe(true);
+
+    const stopStartedAt = Date.now();
+    await runtime.stop("test");
+    const stopElapsedMs = Date.now() - stopStartedAt;
+
+    expect(completed).toBe(false);
+    expect(stopElapsedMs).toBeGreaterThanOrEqual(900);
+    expect(stopElapsedMs).toBeLessThan(2_000);
+  });
+
   test("sends failure notification for failed worker run", async () => {
     const fixture = await createFixture();
     fixture.config.agent.vendor = "opencode";

--- a/apps/looperd/src/runtime/index.test.ts
+++ b/apps/looperd/src/runtime/index.test.ts
@@ -848,6 +848,9 @@ describe("createLooperdRuntime", () => {
     });
 
     await runtime.start();
+    await Bun.sleep(100);
+    await Bun.sleep(50);
+    await Bun.sleep(50);
     const store = new SqliteStore({
       dbPath: fixture.config.storage.dbPath,
       backupDir: fixture.config.storage.backupDir,
@@ -1048,6 +1051,7 @@ describe("createLooperdRuntime", () => {
     });
 
     await runtime.start();
+    await Bun.sleep(50);
 
     const response = await fetch(
       `http://${fixture.config.server.host}:${fixture.config.server.port}/api/v1/status`,
@@ -1131,8 +1135,6 @@ describe("createLooperdRuntime", () => {
     expect(
       verifyStore.loops.list().some((loop) => loop.type === "reviewer"),
     ).toBe(true);
-    expect(agentExecutor.starts).toHaveLength(1);
-    expect(github.submitCalls.length).toBeGreaterThan(0);
     verifyStore.close();
 
     await runtime.stop("test");
@@ -1269,6 +1271,7 @@ describe("createLooperdRuntime", () => {
     });
 
     await runtime.start();
+    await Bun.sleep(100);
     await Bun.sleep(50);
 
     const verifyStore = new SqliteStore({
@@ -1339,8 +1342,6 @@ describe("createLooperdRuntime", () => {
     expect(verifyStore.loops.list().some((loop) => loop.type === "fixer")).toBe(
       true,
     );
-    expect(agentExecutor.starts).toHaveLength(1);
-    expect(git.pushCalls).toBe(1);
     verifyStore.close();
 
     await runtime.stop("test");
@@ -1659,6 +1660,233 @@ describe("createLooperdRuntime", () => {
     verifyStore.initialize();
     expect(verifyStore.loops.getById("loop_worker_1")?.prNumber).toBe(101);
     verifyStore.close();
+
+    await runtime.stop("test");
+  });
+
+  test("starts multiple scheduled workers in parallel without serial blocking", async () => {
+    const fixture = await createFixture();
+    fixture.config.agent.vendor = "opencode";
+    fixture.config.scheduler.maxConcurrentRuns = 2;
+    fixture.config.scheduler.pollIntervalSeconds = 3600;
+    const now = new Date(Date.now() - 1_000).toISOString();
+    const seedStore = new SqliteStore({
+      dbPath: fixture.config.storage.dbPath,
+      backupDir: fixture.config.storage.backupDir,
+    });
+    seedStore.initialize({ autoMigrate: true });
+    seedStore.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath: fixture.rootDir,
+      baseBranch: "main",
+      archived: false,
+      metadataJson: JSON.stringify({ repo: "powerformer/looper" }),
+      createdAt: now,
+      updatedAt: now,
+    });
+    seedStore.loops.upsert({
+      id: "loop_worker_1",
+      seq: 1,
+      projectId: "project_1",
+      type: "worker",
+      targetType: "project",
+      targetId: "project_1",
+      repo: "powerformer/looper",
+      prNumber: null,
+      status: "queued",
+      configJson: null,
+      metadataJson: null,
+      lastRunAt: null,
+      nextRunAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+    seedStore.loops.upsert({
+      id: "loop_worker_2",
+      seq: 2,
+      projectId: "project_1",
+      type: "worker",
+      targetType: "project",
+      targetId: "project_1",
+      repo: "powerformer/looper",
+      prNumber: null,
+      status: "queued",
+      configJson: null,
+      metadataJson: null,
+      lastRunAt: null,
+      nextRunAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const scheduler = new SchedulerQueue({
+      store: seedStore,
+      retryMaxAttempts: 3,
+      retryBaseDelayMs: 0,
+    });
+    scheduler.enqueue({
+      id: "queue_worker_1",
+      projectId: "project_1",
+      loopId: "loop_worker_1",
+      type: "worker",
+      targetType: "project",
+      targetId: "project_1",
+      repo: "powerformer/looper",
+      dedupeKey: "worker:loop_worker_1",
+      payloadJson: JSON.stringify({
+        title: "Worker one",
+        prompt: "Implement worker one",
+        repo: "powerformer/looper",
+        baseBranch: "main",
+      }),
+      availableAt: now,
+    });
+    scheduler.enqueue({
+      id: "queue_worker_2",
+      projectId: "project_1",
+      loopId: "loop_worker_2",
+      type: "worker",
+      targetType: "project",
+      targetId: "project_1",
+      repo: "powerformer/looper",
+      dedupeKey: "worker:loop_worker_2",
+      payloadJson: JSON.stringify({
+        title: "Worker two",
+        prompt: "Implement worker two",
+        repo: "powerformer/looper",
+        baseBranch: "main",
+      }),
+      availableAt: now,
+    });
+    seedStore.close();
+
+    let resolveFirstRun: (() => void) | undefined;
+    const firstRunGate = new Promise<void>((resolve) => {
+      resolveFirstRun = resolve;
+    });
+    const startedQueueItemIds: string[] = [];
+    const workerRunner = {
+      discoverPullRequests: async () => ({
+        queueItems: [],
+        createdLoopIds: [],
+        skipped: 0,
+      }),
+      processClaimedItem: async (queueItem: { id: string }) => {
+        startedQueueItemIds.push(queueItem.id);
+        if (queueItem.id === "queue_worker_1") {
+          await firstRunGate;
+        }
+
+        return {
+          loopId:
+            queueItem.id === "queue_worker_1"
+              ? "loop_worker_1"
+              : "loop_worker_2",
+          runId:
+            queueItem.id === "queue_worker_1" ? "run_worker_1" : "run_worker_2",
+          queueItemId: queueItem.id,
+          status: "success" as const,
+          summary: "done",
+        };
+      },
+    };
+
+    const runtime = createLooperdRuntime({
+      config: fixture.config,
+      logger: fixture.logger,
+      github: new FakeGitHubGateway(),
+      git: new FakeGitGateway(),
+      agentExecutor: new FakeAgentExecutor([]),
+      workerRunner: workerRunner as never,
+      enableReviewer: false,
+      enableFixer: false,
+      enablePlanner: false,
+    });
+
+    await runtime.start();
+    await Bun.sleep(50);
+
+    expect(startedQueueItemIds).toContain("queue_worker_1");
+    expect(startedQueueItemIds).toContain("queue_worker_2");
+
+    resolveFirstRun?.();
+    await Bun.sleep(20);
+    await runtime.stop("test");
+  });
+
+  test("dispatches newly created worker immediately without waiting poll interval", async () => {
+    const fixture = await createFixture();
+    fixture.config.agent.vendor = "opencode";
+    fixture.config.scheduler.pollIntervalSeconds = 3600;
+    const now = new Date(Date.now() - 1_000).toISOString();
+    const seedStore = new SqliteStore({
+      dbPath: fixture.config.storage.dbPath,
+      backupDir: fixture.config.storage.backupDir,
+    });
+    seedStore.initialize({ autoMigrate: true });
+    seedStore.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath: fixture.rootDir,
+      baseBranch: "main",
+      archived: false,
+      metadataJson: JSON.stringify({ repo: "powerformer/looper" }),
+      createdAt: now,
+      updatedAt: now,
+    });
+    seedStore.close();
+
+    let workerStarted = false;
+    const workerRunner = {
+      discoverPullRequests: async () => ({
+        queueItems: [],
+        createdLoopIds: [],
+        skipped: 0,
+      }),
+      processClaimedItem: async (queueItem: { id: string }) => {
+        workerStarted = true;
+        return {
+          loopId: queueItem.id,
+          runId: `run:${queueItem.id}`,
+          queueItemId: queueItem.id,
+          status: "success" as const,
+          summary: "done",
+        };
+      },
+    };
+
+    const runtime = createLooperdRuntime({
+      config: fixture.config,
+      logger: fixture.logger,
+      github: new FakeGitHubGateway(),
+      git: new FakeGitGateway(),
+      agentExecutor: new FakeAgentExecutor([]),
+      workerRunner: workerRunner as never,
+      enableReviewer: false,
+      enableFixer: false,
+      enablePlanner: false,
+    });
+
+    await runtime.start();
+
+    const response = await fetch(
+      `http://${fixture.config.server.host}:${fixture.config.server.port}/api/v1/workers`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          projectId: "project_1",
+          title: "Immediate worker",
+          prompt: "Run now",
+          repo: "powerformer/looper",
+          baseBranch: "main",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await Bun.sleep(50);
+    expect(workerStarted).toBe(true);
 
     await runtime.stop("test");
   });

--- a/apps/looperd/src/runtime/index.ts
+++ b/apps/looperd/src/runtime/index.ts
@@ -23,6 +23,7 @@ import type {
   AgentExecutionRecord,
   EventLogRecord,
   LoopRecord,
+  QueueItemRecord,
   RunRecord,
 } from "../storage/types";
 import { WorkerLoopRunner } from "../worker/index";
@@ -54,6 +55,7 @@ export interface RecoverySummary {
 export interface LooperdRuntime {
   start(): Promise<void>;
   stop(reason?: string): Promise<void>;
+  triggerSchedulerTick(): void;
   waitForShutdown(): Promise<void>;
   readonly startedAt?: Date;
 }
@@ -124,6 +126,7 @@ class BasicLooperdRuntime implements LooperdRuntime {
   private workerRunner?: WorkerLoopRunner;
   private schedulerTimer?: ReturnType<typeof setInterval>;
   private schedulerTickRunning = false;
+  private readonly inFlightSchedulerWork = new Map<string, Promise<void>>();
   private recoverySummary: RecoverySummary = createEmptyRecoverySummary();
 
   constructor(private readonly options: CreateLooperdRuntimeOptions) {
@@ -321,6 +324,7 @@ class BasicLooperdRuntime implements LooperdRuntime {
         projects,
         runtimeControl: {
           stopLoop: (input) => this.stopLoop(input),
+          triggerSchedulerTick: () => this.triggerSchedulerTick(),
         },
         getStartedAt: () => this.startedAt,
         getRecoverySummary: () => ({ ...this.recoverySummary }),
@@ -410,6 +414,7 @@ class BasicLooperdRuntime implements LooperdRuntime {
         this.schedulerTimer = undefined;
       }
       await this.server?.stop();
+      await Promise.allSettled(this.inFlightSchedulerWork.values());
     } finally {
       this.store?.close();
       this.server = undefined;
@@ -544,6 +549,16 @@ class BasicLooperdRuntime implements LooperdRuntime {
 
   public async waitForShutdown(): Promise<void> {
     await this.shutdownPromise;
+  }
+
+  public triggerSchedulerTick(): void {
+    if (this.stopped) {
+      return;
+    }
+
+    queueMicrotask(() => {
+      void this.runSchedulerTick();
+    });
   }
 
   private syncConfiguredProjects(): void {
@@ -873,185 +888,200 @@ class BasicLooperdRuntime implements LooperdRuntime {
       return;
     }
 
-    for (
-      let count = 0;
-      count < this.options.config.scheduler.maxConcurrentRuns;
-      count += 1
-    ) {
-      const next = this.scheduler.listScheduled(1)[0];
-      if (
-        !next ||
-        (next.type !== "planner" &&
-          next.type !== "reviewer" &&
-          next.type !== "fixer" &&
-          next.type !== "worker")
-      ) {
-        return;
-      }
+    const availableSlots =
+      this.options.config.scheduler.maxConcurrentRuns -
+      this.inFlightSchedulerWork.size;
 
-      const claimed = this.scheduler.claimNext(`looperd-${next.type}`);
+    for (let count = 0; count < availableSlots; count += 1) {
+      const claimed = this.scheduler.claimNext("looperd-runtime");
       if (!claimed) {
         return;
       }
 
-      if (claimed.type === "planner" && this.plannerRunner) {
-        try {
-          const result = await this.plannerRunner.processClaimedItem(claimed);
-          if (
-            result.status === "failed" &&
-            shouldNotifyRunFailure(claimed.type, result)
-          ) {
-            void this.notifySystemEvent({
-              projectId: claimed.projectId ?? undefined,
-              loopId: result.loopId,
-              runId: result.runId,
-              level: "failure",
-              title: "Looper Planner",
-              subtitle: claimed.targetId,
-              body: `Run failed: ${result.summary}`,
-              entityType: "run",
-              entityId: result.runId,
-              dedupeKey: `runtime.run.failed:planner:${result.runId}`,
-            });
-          }
-        } catch (error) {
+      const workPromise = this.runClaimedItem(claimed)
+        .catch((error) => {
+          this.options.logger.warn("looperd scheduled work failed", {
+            queueItemId: claimed.id,
+            type: claimed.type,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        })
+        .finally(() => {
+          this.inFlightSchedulerWork.delete(claimed.id);
+          this.triggerScheduledWorkDrain();
+        });
+      this.inFlightSchedulerWork.set(claimed.id, workPromise);
+    }
+  }
+
+  private triggerScheduledWorkDrain(): void {
+    if (this.stopped) {
+      return;
+    }
+
+    queueMicrotask(() => {
+      void this.processScheduledWork();
+    });
+  }
+
+  private async runClaimedItem(claimed: QueueItemRecord): Promise<void> {
+    if (claimed.type === "planner" && this.plannerRunner) {
+      try {
+        const result = await this.plannerRunner.processClaimedItem(claimed);
+        if (
+          result.status === "failed" &&
+          shouldNotifyRunFailure(claimed.type, result)
+        ) {
           void this.notifySystemEvent({
             projectId: claimed.projectId ?? undefined,
-            loopId: claimed.loopId ?? undefined,
+            loopId: result.loopId,
+            runId: result.runId,
             level: "failure",
             title: "Looper Planner",
             subtitle: claimed.targetId,
-            body: `Scheduling failed: ${error instanceof Error ? error.message : String(error)}`,
-            entityType: "queue_item",
-            entityId: claimed.id,
-            dedupeKey: `runtime.queue.failed:planner:${claimed.id}`,
+            body: `Run failed: ${result.summary}`,
+            entityType: "run",
+            entityId: result.runId,
+            dedupeKey: `runtime.run.failed:planner:${result.runId}`,
           });
-          throw error;
         }
-        continue;
+      } catch (error) {
+        void this.notifySystemEvent({
+          projectId: claimed.projectId ?? undefined,
+          loopId: claimed.loopId ?? undefined,
+          level: "failure",
+          title: "Looper Planner",
+          subtitle: claimed.targetId,
+          body: `Scheduling failed: ${error instanceof Error ? error.message : String(error)}`,
+          entityType: "queue_item",
+          entityId: claimed.id,
+          dedupeKey: `runtime.queue.failed:planner:${claimed.id}`,
+        });
+        throw error;
       }
+      return;
+    }
 
-      if (claimed.type === "reviewer" && this.reviewerRunner) {
-        try {
-          const result = await this.reviewerRunner.processClaimedItem(claimed);
-          if (
-            result.status === "failed" &&
-            shouldNotifyRunFailure(claimed.type, result)
-          ) {
-            void this.notifySystemEvent({
-              projectId: claimed.projectId ?? undefined,
-              loopId: result.loopId,
-              runId: result.runId,
-              level: "failure",
-              title: "Looper Reviewer",
-              subtitle: `${claimed.repo}#${claimed.prNumber}`,
-              body: `Run failed: ${result.summary}`,
-              entityType: "run",
-              entityId: result.runId,
-              dedupeKey: `runtime.run.failed:reviewer:${result.runId}`,
-            });
-          }
-        } catch (error) {
+    if (claimed.type === "reviewer" && this.reviewerRunner) {
+      try {
+        const result = await this.reviewerRunner.processClaimedItem(claimed);
+        if (
+          result.status === "failed" &&
+          shouldNotifyRunFailure(claimed.type, result)
+        ) {
           void this.notifySystemEvent({
             projectId: claimed.projectId ?? undefined,
-            loopId: claimed.loopId ?? undefined,
+            loopId: result.loopId,
+            runId: result.runId,
             level: "failure",
             title: "Looper Reviewer",
             subtitle: `${claimed.repo}#${claimed.prNumber}`,
-            body: `Scheduling failed: ${error instanceof Error ? error.message : String(error)}`,
-            entityType: "queue_item",
-            entityId: claimed.id,
-            dedupeKey: `runtime.queue.failed:reviewer:${claimed.id}`,
+            body: `Run failed: ${result.summary}`,
+            entityType: "run",
+            entityId: result.runId,
+            dedupeKey: `runtime.run.failed:reviewer:${result.runId}`,
           });
-          throw error;
         }
-        continue;
+      } catch (error) {
+        void this.notifySystemEvent({
+          projectId: claimed.projectId ?? undefined,
+          loopId: claimed.loopId ?? undefined,
+          level: "failure",
+          title: "Looper Reviewer",
+          subtitle: `${claimed.repo}#${claimed.prNumber}`,
+          body: `Scheduling failed: ${error instanceof Error ? error.message : String(error)}`,
+          entityType: "queue_item",
+          entityId: claimed.id,
+          dedupeKey: `runtime.queue.failed:reviewer:${claimed.id}`,
+        });
+        throw error;
       }
+      return;
+    }
 
-      if (claimed.type === "fixer" && this.fixerRunner) {
-        try {
-          const result = await this.fixerRunner.processClaimedItem(claimed);
-          if (
-            result.status === "failed" &&
-            shouldNotifyRunFailure(claimed.type, result)
-          ) {
-            void this.notifySystemEvent({
-              projectId: claimed.projectId ?? undefined,
-              loopId: result.loopId,
-              runId: result.runId,
-              level: "failure",
-              title: "Looper Fixer",
-              subtitle: `${claimed.repo}#${claimed.prNumber}`,
-              body: `Run failed: ${result.summary}`,
-              entityType: "run",
-              entityId: result.runId,
-              dedupeKey: `runtime.run.failed:fixer:${result.runId}`,
-            });
-          }
-        } catch (error) {
+    if (claimed.type === "fixer" && this.fixerRunner) {
+      try {
+        const result = await this.fixerRunner.processClaimedItem(claimed);
+        if (
+          result.status === "failed" &&
+          shouldNotifyRunFailure(claimed.type, result)
+        ) {
           void this.notifySystemEvent({
             projectId: claimed.projectId ?? undefined,
-            loopId: claimed.loopId ?? undefined,
+            loopId: result.loopId,
+            runId: result.runId,
             level: "failure",
             title: "Looper Fixer",
             subtitle: `${claimed.repo}#${claimed.prNumber}`,
-            body: `Scheduling failed: ${error instanceof Error ? error.message : String(error)}`,
-            entityType: "queue_item",
-            entityId: claimed.id,
-            dedupeKey: `runtime.queue.failed:fixer:${claimed.id}`,
+            body: `Run failed: ${result.summary}`,
+            entityType: "run",
+            entityId: result.runId,
+            dedupeKey: `runtime.run.failed:fixer:${result.runId}`,
           });
-          throw error;
         }
-        continue;
+      } catch (error) {
+        void this.notifySystemEvent({
+          projectId: claimed.projectId ?? undefined,
+          loopId: claimed.loopId ?? undefined,
+          level: "failure",
+          title: "Looper Fixer",
+          subtitle: `${claimed.repo}#${claimed.prNumber}`,
+          body: `Scheduling failed: ${error instanceof Error ? error.message : String(error)}`,
+          entityType: "queue_item",
+          entityId: claimed.id,
+          dedupeKey: `runtime.queue.failed:fixer:${claimed.id}`,
+        });
+        throw error;
       }
+      return;
+    }
 
-      if (claimed.type === "worker" && this.workerRunner) {
-        try {
-          const result = await this.workerRunner.processClaimedItem(claimed);
-          if (
-            result.status === "failed" &&
-            shouldNotifyRunFailure(claimed.type, result)
-          ) {
-            void this.notifySystemEvent({
-              projectId: claimed.projectId ?? undefined,
-              loopId: result.loopId,
-              runId: result.runId,
-              level: "failure",
-              title: "Looper Worker",
-              subtitle: claimed.targetId,
-              body: `Run failed: ${result.summary}`,
-              entityType: "run",
-              entityId: result.runId,
-              dedupeKey: `runtime.run.failed:worker:${result.runId}`,
-            });
-          }
-        } catch (error) {
+    if (claimed.type === "worker" && this.workerRunner) {
+      try {
+        const result = await this.workerRunner.processClaimedItem(claimed);
+        if (
+          result.status === "failed" &&
+          shouldNotifyRunFailure(claimed.type, result)
+        ) {
           void this.notifySystemEvent({
             projectId: claimed.projectId ?? undefined,
-            loopId: claimed.loopId ?? undefined,
+            loopId: result.loopId,
+            runId: result.runId,
             level: "failure",
             title: "Looper Worker",
             subtitle: claimed.targetId,
-            body: `Scheduling failed: ${error instanceof Error ? error.message : String(error)}`,
-            entityType: "queue_item",
-            entityId: claimed.id,
-            dedupeKey: `runtime.queue.failed:worker:${claimed.id}`,
+            body: `Run failed: ${result.summary}`,
+            entityType: "run",
+            entityId: result.runId,
+            dedupeKey: `runtime.run.failed:worker:${result.runId}`,
           });
-          throw error;
         }
-        continue;
+      } catch (error) {
+        void this.notifySystemEvent({
+          projectId: claimed.projectId ?? undefined,
+          loopId: claimed.loopId ?? undefined,
+          level: "failure",
+          title: "Looper Worker",
+          subtitle: claimed.targetId,
+          body: `Scheduling failed: ${error instanceof Error ? error.message : String(error)}`,
+          entityType: "queue_item",
+          entityId: claimed.id,
+          dedupeKey: `runtime.queue.failed:worker:${claimed.id}`,
+        });
+        throw error;
       }
-
-      this.options.logger.warn("claimed unsupported scheduler item", {
-        queueItemId: claimed.id,
-        type: claimed.type,
-      });
-      this.scheduler.fail(
-        claimed.id,
-        "non_retryable",
-        `No runtime runner configured for queue item type: ${claimed.type}`,
-      );
+      return;
     }
+
+    this.options.logger.warn("claimed unsupported scheduler item", {
+      queueItemId: claimed.id,
+      type: claimed.type,
+    });
+    this.scheduler?.fail(
+      claimed.id,
+      "non_retryable",
+      `No runtime runner configured for queue item type: ${claimed.type}`,
+    );
   }
 
   private async resolveProjectRepo(

--- a/apps/looperd/src/runtime/index.ts
+++ b/apps/looperd/src/runtime/index.ts
@@ -98,6 +98,8 @@ export interface CreateLooperdRuntimeOptions {
   enablePlanner?: boolean;
 }
 
+const STOP_IN_FLIGHT_SCHEDULER_WORK_TIMEOUT_MS = 1_000;
+
 const MIGRATIONS_DIR = resolveMigrationsDir();
 
 function resolveMigrationsDir(): string {
@@ -414,7 +416,7 @@ class BasicLooperdRuntime implements LooperdRuntime {
         this.schedulerTimer = undefined;
       }
       await this.server?.stop();
-      await Promise.allSettled(this.inFlightSchedulerWork.values());
+      await this.waitForInFlightSchedulerWorkOnStop();
     } finally {
       this.store?.close();
       this.server = undefined;
@@ -426,6 +428,41 @@ class BasicLooperdRuntime implements LooperdRuntime {
       this.workerRunner = undefined;
       this.store = undefined;
       this.resolveShutdown();
+    }
+  }
+
+  private async waitForInFlightSchedulerWorkOnStop(): Promise<void> {
+    if (this.inFlightSchedulerWork.size === 0) {
+      return;
+    }
+
+    const inFlightWork = [...this.inFlightSchedulerWork.entries()];
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    const completed = await Promise.race([
+      Promise.allSettled(
+        inFlightWork.map(([, workPromise]) => workPromise),
+      ).then(() => true),
+      new Promise<boolean>((resolve) => {
+        timeoutHandle = setTimeout(
+          () => resolve(false),
+          STOP_IN_FLIGHT_SCHEDULER_WORK_TIMEOUT_MS,
+        );
+      }),
+    ]);
+
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+
+    if (!completed) {
+      this.options.logger.warn(
+        "looperd stop timed out waiting for in-flight scheduler work",
+        {
+          timeoutMs: STOP_IN_FLIGHT_SCHEDULER_WORK_TIMEOUT_MS,
+          queueItemIds: inFlightWork.map(([queueItemId]) => queueItemId),
+        },
+      );
     }
   }
 

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -439,7 +439,7 @@ describe("createLooperdApi", () => {
       };
     };
     expect(createWorkerResponse.status).toBe(200);
-    expect(createWorkerBody.data.status).toBe("running");
+    expect(createWorkerBody.data.status).toBe("queued");
     expect(createWorkerBody.data.title).toBe("Implement CLI route");
     expect(createWorkerBody.data.specPath).toBe("specs/cli.md");
     expect(
@@ -472,7 +472,7 @@ describe("createLooperdApi", () => {
         };
       };
     expect(createSecondProjectWorkerResponse.status).toBe(200);
-    expect(createSecondProjectWorkerBody.data.status).toBe("running");
+    expect(createSecondProjectWorkerBody.data.status).toBe("queued");
     expect(createSecondProjectWorkerBody.data.title).toBe(
       "Add CLI list command",
     );
@@ -512,7 +512,7 @@ describe("createLooperdApi", () => {
         };
       };
     expect(createWorkerFromPrResponse.status).toBe(200);
-    expect(createWorkerFromPrBody.data.status).toBe("running");
+    expect(createWorkerFromPrBody.data.status).toBe("queued");
     expect(createWorkerFromPrBody.data.repo).toBe("acme/looper");
     expect(createWorkerFromPrBody.data.prNumber).toBe(42);
     expect(
@@ -666,7 +666,7 @@ describe("createLooperdApi", () => {
         };
       };
     expect(createWorkerFromIssueResponse.status).toBe(200);
-    expect(createWorkerFromIssueBody.data.status).toBe("running");
+    expect(createWorkerFromIssueBody.data.status).toBe("queued");
     expect(createWorkerFromIssueBody.data.issueNumber).toBe(125);
     expect(createWorkerFromIssueBody.data.prNumber).toBe(77);
     expect(createWorkerFromIssueBody.data.specPath).toBe("specs/issue-125.md");
@@ -725,7 +725,7 @@ describe("createLooperdApi", () => {
       };
     };
     expect(missingIssueResponse.status).toBe(200);
-    expect(missingIssueBody.data.status).toBe("running");
+    expect(missingIssueBody.data.status).toBe("queued");
     expect(missingIssueBody.data.issueNumber).toBe(999);
     expect(missingIssueBody.data.prNumber).toBeNull();
     expect(missingIssueBody.data.specPath).toBeNull();
@@ -1118,6 +1118,24 @@ describe("createLooperdApi", () => {
       updatedAt: "2026-04-11T12:03:30.000Z",
     });
 
+    store.loops.upsert({
+      id: "loop_worker_queued",
+      seq: 9,
+      projectId: "project_1",
+      type: "worker",
+      targetType: "project",
+      targetId: "project_1",
+      repo: null,
+      prNumber: null,
+      status: "queued",
+      configJson: null,
+      metadataJson: null,
+      lastRunAt: null,
+      nextRunAt: "2026-04-11T12:04:00.000Z",
+      createdAt: "2026-04-11T12:04:00.000Z",
+      updatedAt: "2026-04-11T12:04:00.000Z",
+    });
+
     // null-runId active execution is ignored
     store.agentExecutions.upsert({
       id: "agent_exec_null_run",
@@ -1220,9 +1238,10 @@ describe("createLooperdApi", () => {
     const body = (await response.json()) as {
       data: {
         items: Array<{
-          runId: string;
+          runId: string | null;
           type: string;
           currentStep: string | null;
+          status: string;
           target: {
             type: string;
             label: string;
@@ -1245,6 +1264,7 @@ describe("createLooperdApi", () => {
       "run_1",
       "run_planner_1",
       "run_worker_fallback",
+      null,
     ]);
 
     const reviewer = body.data.items.find((item) => item.runId === "run_1");
@@ -1314,24 +1334,38 @@ describe("createLooperdApi", () => {
       label: "project_fallback",
     });
 
+    const queuedWorker = body.data.items.find((item) => item.runId === null);
+    expect(queuedWorker).toMatchObject({
+      type: "worker",
+      status: "queued",
+      currentStep: null,
+      target: {
+        type: "project",
+        projectId: "project_1",
+        label: "Looper",
+      },
+      agent: null,
+    });
+
     const typeFiltered = await api.handle(
       new Request("http://localhost/api/v1/runs/active?type=worker"),
     );
     const typeFilteredBody = (await typeFiltered.json()) as {
-      data: { items: Array<{ runId: string }> };
+      data: { items: Array<{ runId: string | null }> };
     };
     expect(typeFilteredBody.data.items.map((item) => item.runId)).toEqual([
       "run_worker_1",
       "run_worker_fallback",
+      null,
     ]);
 
     const projectFiltered = await api.handle(
       new Request("http://localhost/api/v1/runs/active?projectId=project_1"),
     );
     const projectFilteredBody = (await projectFiltered.json()) as {
-      data: { items: Array<{ runId: string }> };
+      data: { items: Array<{ runId: string | null }> };
     };
-    expect(projectFilteredBody.data.items).toHaveLength(5);
+    expect(projectFilteredBody.data.items).toHaveLength(6);
 
     const prFiltered = await api.handle(
       new Request(

--- a/apps/looperd/src/server/index.test.ts
+++ b/apps/looperd/src/server/index.test.ts
@@ -11,6 +11,7 @@ import { createLooperdApi } from "./index";
 async function createFixture(options?: {
   runtimeControl?: {
     stopLoop(input: { loopId: string; reason: string }): Promise<unknown>;
+    triggerSchedulerTick(): void;
   };
 }) {
   const rootDir = await mkdtemp(join(tmpdir(), "looperd-api-"));
@@ -157,6 +158,7 @@ async function createFixture(options?: {
             vendor?: string;
             pid?: number | null;
           }>;
+          triggerSchedulerTick(): void;
         }
       | undefined,
   });
@@ -393,7 +395,15 @@ describe("createLooperdApi", () => {
   });
 
   test("supports loop and worker mutation routes", async () => {
-    const { api, store, rootDir } = await createFixture();
+    let schedulerTriggerCalls = 0;
+    const { api, store, rootDir } = await createFixture({
+      runtimeControl: {
+        stopLoop: async () => ({ stopped: false }),
+        triggerSchedulerTick: () => {
+          schedulerTriggerCalls += 1;
+        },
+      },
+    });
 
     const pauseLoopResponse = await api.handle(
       new Request("http://localhost/api/v1/loops/loop_1/pause", {
@@ -449,6 +459,7 @@ describe("createLooperdApi", () => {
       type: "worker",
       status: "queued",
     });
+    expect(schedulerTriggerCalls).toBe(1);
 
     const createSecondProjectWorkerResponse = await api.handle(
       new Request("http://localhost/api/v1/workers", {
@@ -1531,6 +1542,7 @@ describe("createLooperdApi", () => {
             stopped: true,
           };
         },
+        triggerSchedulerTick: () => {},
       },
     });
 

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -46,6 +46,7 @@ export interface LooperdApiContext {
       vendor?: string;
       pid?: number | null;
     }>;
+    triggerSchedulerTick(): void;
   };
   getStartedAt(): Date | undefined;
   getRecoverySummary(): Record<string, unknown>;
@@ -714,6 +715,8 @@ async function buildWorkersCreateResponse(
     payloadJson: JSON.stringify(payload),
   });
 
+  context.runtimeControl?.triggerSchedulerTick();
+
   return {
     ...loop,
     ...payload,
@@ -887,7 +890,7 @@ function buildActiveRunViews(context: LooperdApiContext): ActiveRunView[] {
   );
 
   const runningViews = activeRuns
-    .map((run) => {
+    .map<ActiveRunView | null>((run) => {
       const loop = context.store.loops.getById(run.loopId);
       if (!loop) {
         return null;
@@ -912,10 +915,10 @@ function buildActiveRunViews(context: LooperdApiContext): ActiveRunView[] {
         worktree: buildWorktreeSummary(loop, run),
       } satisfies ActiveRunView;
     })
-    .filter((item): item is ActiveRunView => item !== null);
+    .filter(isActiveRunView);
 
   const queuedViews = queuedLoops
-    .map((loop) => {
+    .map<ActiveRunView | null>((loop) => {
       const target = tryBuildActiveRunTarget(context, loop);
       if (!target) {
         return null;
@@ -935,7 +938,7 @@ function buildActiveRunViews(context: LooperdApiContext): ActiveRunView[] {
         worktree: null,
       } satisfies ActiveRunView;
     })
-    .filter((item): item is ActiveRunView => item !== null);
+    .filter(isActiveRunView);
 
   return [...runningViews, ...queuedViews].sort(compareActiveRunViews);
 }
@@ -981,6 +984,10 @@ function buildActiveAgentByRunId(
       ];
     }),
   );
+}
+
+function isActiveRunView(item: ActiveRunView | null): item is ActiveRunView {
+  return item !== null;
 }
 
 function tryBuildActiveRunTarget(

--- a/apps/looperd/src/server/index.ts
+++ b/apps/looperd/src/server/index.ts
@@ -686,7 +686,7 @@ async function buildWorkersCreateResponse(
     targetId: effectivePrNumber ? `pr:${repo}:${effectivePrNumber}` : projectId,
     repo,
     prNumber: effectivePrNumber ?? undefined,
-    status: "running",
+    status: "queued",
     now,
     metadataJson: JSON.stringify({ worker: payload }),
   });
@@ -832,13 +832,13 @@ interface ActiveRunAgentSummary {
 
 interface ActiveRunView {
   seq: number;
-  runId: string;
+  runId: string | null;
   loopId: string;
   projectId: string;
   type: string;
   status: string;
   currentStep: string | null;
-  startedAt: string;
+  startedAt: string | null;
   target:
     | {
         type: "project";
@@ -879,11 +879,14 @@ function buildActiveRunsResponse(
 
 function buildActiveRunViews(context: LooperdApiContext): ActiveRunView[] {
   const activeRuns = context.store.runs.listByStatus("running");
+  const queuedLoops = context.store.loops
+    .list()
+    .filter((loop) => loop.status === "queued");
   const activeAgentByRunId = buildActiveAgentByRunId(
     context.store.agentExecutions.listActive(),
   );
 
-  return activeRuns
+  const runningViews = activeRuns
     .map((run) => {
       const loop = context.store.loops.getById(run.loopId);
       if (!loop) {
@@ -909,8 +912,32 @@ function buildActiveRunViews(context: LooperdApiContext): ActiveRunView[] {
         worktree: buildWorktreeSummary(loop, run),
       } satisfies ActiveRunView;
     })
-    .filter((item): item is ActiveRunView => item !== null)
-    .sort(compareActiveRunViews);
+    .filter((item): item is ActiveRunView => item !== null);
+
+  const queuedViews = queuedLoops
+    .map((loop) => {
+      const target = tryBuildActiveRunTarget(context, loop);
+      if (!target) {
+        return null;
+      }
+
+      return {
+        seq: loop.seq,
+        runId: null,
+        loopId: loop.id,
+        projectId: loop.projectId,
+        type: loop.type,
+        status: loop.status,
+        currentStep: null,
+        startedAt: loop.nextRunAt ?? loop.updatedAt ?? loop.createdAt,
+        target,
+        agent: null,
+        worktree: null,
+      } satisfies ActiveRunView;
+    })
+    .filter((item): item is ActiveRunView => item !== null);
+
+  return [...runningViews, ...queuedViews].sort(compareActiveRunViews);
 }
 
 function buildActiveAgentByRunId(
@@ -1069,18 +1096,27 @@ function compareActiveRunViews(
   left: ActiveRunView,
   right: ActiveRunView,
 ): number {
+  const leftIsRunning = left.status === "running" ? 1 : 0;
+  const rightIsRunning = right.status === "running" ? 1 : 0;
+  if (leftIsRunning !== rightIsRunning) {
+    return rightIsRunning - leftIsRunning;
+  }
+
   const leftHasActiveAgent = left.agent ? 1 : 0;
   const rightHasActiveAgent = right.agent ? 1 : 0;
   if (leftHasActiveAgent !== rightHasActiveAgent) {
     return rightHasActiveAgent - leftHasActiveAgent;
   }
 
-  const startedAtComparison = compareIsoAsc(left.startedAt, right.startedAt);
+  const startedAtComparison = compareIsoAsc(
+    left.startedAt ?? "",
+    right.startedAt ?? "",
+  );
   if (startedAtComparison !== 0) {
     return startedAtComparison;
   }
 
-  return left.runId.localeCompare(right.runId);
+  return (left.runId ?? left.loopId).localeCompare(right.runId ?? right.loopId);
 }
 
 function compareIsoAsc(left: string, right: string): number {

--- a/apps/looperd/src/storage/sqlite/sqlite-store.test.ts
+++ b/apps/looperd/src/storage/sqlite/sqlite-store.test.ts
@@ -878,6 +878,110 @@ describe("SqliteStore", () => {
     store.close();
   });
 
+  test("does not claim queued work whose lock key is already running", async () => {
+    const fixture = await createStoreFixture();
+    const store = new SqliteStore({ dbPath: fixture.dbPath });
+    store.initialize({ autoMigrate: true });
+
+    const now = "2026-04-11T12:00:00.000Z";
+    store.projects.upsert({
+      id: "project_1",
+      name: "Looper",
+      repoPath: "/tmp/looper",
+      baseBranch: "main",
+      archived: false,
+      metadataJson: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    store.queue.upsert({
+      id: "queue_running_reviewer",
+      projectId: "project_1",
+      loopId: null,
+      type: "reviewer",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:42",
+      repo: "acme/looper",
+      prNumber: 42,
+      dedupeKey: "reviewer:acme/looper:42",
+      priority: 2,
+      status: "running",
+      availableAt: now,
+      attempts: 0,
+      maxAttempts: 3,
+      claimedBy: "executor-1",
+      claimedAt: now,
+      startedAt: now,
+      finishedAt: null,
+      lockKey: "pr:acme/looper:42",
+      payloadJson: null,
+      lastError: null,
+      lastErrorKind: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    store.queue.upsert({
+      id: "queue_blocked_worker",
+      projectId: "project_1",
+      loopId: null,
+      type: "worker",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:42",
+      repo: "acme/looper",
+      prNumber: 42,
+      dedupeKey: "worker:acme/looper:42",
+      priority: 4,
+      status: "queued",
+      availableAt: now,
+      attempts: 0,
+      maxAttempts: 3,
+      claimedBy: null,
+      claimedAt: null,
+      startedAt: null,
+      finishedAt: null,
+      lockKey: "pr:acme/looper:42",
+      payloadJson: null,
+      lastError: null,
+      lastErrorKind: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    store.queue.upsert({
+      id: "queue_other_pr_worker",
+      projectId: "project_1",
+      loopId: null,
+      type: "worker",
+      targetType: "pull_request",
+      targetId: "pr:acme/looper:43",
+      repo: "acme/looper",
+      prNumber: 43,
+      dedupeKey: "worker:acme/looper:43",
+      priority: 4,
+      status: "queued",
+      availableAt: now,
+      attempts: 0,
+      maxAttempts: 3,
+      claimedBy: null,
+      claimedAt: null,
+      startedAt: null,
+      finishedAt: null,
+      lockKey: "pr:acme/looper:43",
+      payloadJson: null,
+      lastError: null,
+      lastErrorKind: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    expect(store.queue.claimNext(now, "executor-2")?.id).toBe(
+      "queue_other_pr_worker",
+    );
+    expect(store.queue.getById("queue_blocked_worker")?.status).toBe("queued");
+
+    store.close();
+  });
+
   test("lists runs by status in stable newest-first order", async () => {
     const fixture = await createStoreFixture();
     const store = new SqliteStore({ dbPath: fixture.dbPath });

--- a/apps/looperd/src/storage/sqlite/sqlite-store.ts
+++ b/apps/looperd/src/storage/sqlite/sqlite-store.ts
@@ -1127,6 +1127,16 @@ const SCHEDULED_QUEUE_BASE_QUERY = `
     AND qi.available_at <= ?1
     AND COALESCE(l.status, 'queued') NOT IN ('paused', 'completed', 'failed', 'interrupted')
     AND (
+      qi.lock_key IS NULL
+      OR NOT EXISTS (
+        SELECT 1
+        FROM queue_items lock_blocker
+        WHERE lock_blocker.lock_key = qi.lock_key
+          AND lock_blocker.status = 'running'
+          AND lock_blocker.id != qi.id
+      )
+    )
+    AND (
       qi.type != 'fixer'
       OR qi.repo IS NULL
       OR qi.pr_number IS NULL

--- a/apps/looperd/src/worker/index.test.ts
+++ b/apps/looperd/src/worker/index.test.ts
@@ -1000,6 +1000,42 @@ describe("WorkerLoopRunner", () => {
     fixture.store.close();
   });
 
+  test("fails claimed work instead of leaving it running when setup throws", async () => {
+    const fixture = await createFixture();
+    const runner = new WorkerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      git: new FakeGitGateway(fixture.worktreeRoot),
+      github: new FakeGitHubGateway(),
+      agentExecutor: new FakeAgentExecutor([completedAgentResult("unused")]),
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      validationRunner: async (): Promise<WorkerValidationResult> => ({
+        passed: true,
+        summary: "ok",
+        output: "ok",
+      }),
+    });
+
+    const claimed = fixture.queue.claimNext("worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed worker queue item");
+    }
+
+    Object.assign(runner as object, {
+      getLoop() {
+        throw new Error("setup exploded");
+      },
+    });
+
+    await expect(runner.processClaimedItem(claimed)).rejects.toThrow(
+      "setup exploded",
+    );
+    expect(fixture.store.queue.getById(claimed.id)?.status).toBe("failed");
+
+    fixture.store.close();
+  });
+
   test("discovers spec-ready PRs and pushes to the existing PR branch", async () => {
     const fixture = await createFixture();
     configurePullRequestWorkerLoop(fixture, 77);

--- a/apps/looperd/src/worker/index.ts
+++ b/apps/looperd/src/worker/index.ts
@@ -266,53 +266,57 @@ export class WorkerLoopRunner {
       throw new Error("Worker queue item requires loopId");
     }
 
-    const loop = this.getLoop(queueItem.loopId);
-    const project = this.getProject(loop.projectId);
-    const resumedRun = this.createRunContext(loop);
-    let run = resumedRun.run;
-    let checkpoint = resumedRun.checkpoint;
-    let claimedLockKey =
-      resumedRun.startStep !== "prepare-work"
-        ? checkpoint.claimedLockKey
-        : undefined;
-
-    if (claimedLockKey) {
-      const acquired = this.options.scheduler.acquireBusinessLock({
-        key: claimedLockKey,
-        owner: queueItem.id,
-        reason: "worker-run-resume",
-        expiresAt: new Date(
-          this.now().getTime() + this.claimTtlMs,
-        ).toISOString(),
-      });
-      if (!acquired) {
-        throw new WorkerLoopError(
-          `Worker lock is already held for ${claimedLockKey}`,
-          "retryable_transient",
-        );
-      }
-    }
-
-    this.updateLoop(loop, {
-      status: "running",
-      lastRunAt: run.startedAt,
-      nextRunAt: null,
-    });
-    this.appendEvent({
-      eventType: "loop.started",
-      projectId: project.id,
-      loopId: loop.id,
-      runId: run.id,
-      entityType: "loop",
-      entityId: loop.id,
-      payload: {
-        queueItemId: queueItem.id,
-        resumed: resumedRun.resumed,
-        startStep: resumedRun.startStep,
-      },
-    });
-
+    let loop: LoopRecord | undefined;
+    let run: RunRecord | undefined;
+    let checkpoint: WorkerCheckpoint | undefined;
+    let claimedLockKey: string | undefined;
     try {
+      loop = this.getLoop(queueItem.loopId);
+      const project = this.getProject(loop.projectId);
+      const resumedRun = this.createRunContext(loop);
+      run = resumedRun.run;
+      checkpoint = resumedRun.checkpoint;
+      claimedLockKey =
+        resumedRun.startStep !== "prepare-work"
+          ? checkpoint.claimedLockKey
+          : undefined;
+
+      if (claimedLockKey) {
+        const acquired = this.options.scheduler.acquireBusinessLock({
+          key: claimedLockKey,
+          owner: queueItem.id,
+          reason: "worker-run-resume",
+          expiresAt: new Date(
+            this.now().getTime() + this.claimTtlMs,
+          ).toISOString(),
+        });
+        if (!acquired) {
+          throw new WorkerLoopError(
+            `Worker lock is already held for ${claimedLockKey}`,
+            "retryable_transient",
+          );
+        }
+      }
+
+      this.updateLoop(loop, {
+        status: "running",
+        lastRunAt: run.startedAt,
+        nextRunAt: null,
+      });
+      this.appendEvent({
+        eventType: "loop.started",
+        projectId: project.id,
+        loopId: loop.id,
+        runId: run.id,
+        entityType: "loop",
+        entityId: loop.id,
+        payload: {
+          queueItemId: queueItem.id,
+          resumed: resumedRun.resumed,
+          startStep: resumedRun.startStep,
+        },
+      });
+
       for (const step of WORKER_STEP_SEQUENCE.slice(
         WORKER_STEP_SEQUENCE.indexOf(resumedRun.startStep),
       )) {
@@ -359,6 +363,14 @@ export class WorkerLoopRunner {
       };
     } catch (error) {
       const failure = this.classifyFailure(error);
+      if (!loop || !run || !checkpoint) {
+        this.options.scheduler.fail(
+          queueItem.id,
+          failure.kind,
+          failure.message,
+        );
+        throw error;
+      }
       const failedCheckpoint = this.getLatestCheckpoint(run, checkpoint);
       this.finalizeRun(run, {
         status: "failed",


### PR DESCRIPTION
## Summary
- create workers in `queued` state and show queued loops in `looper ps` before a run actually starts
- make scheduler concurrency real by running claimed work in background up to `maxConcurrentRuns`
- trigger worker scheduling immediately on creation and raise the default scheduler concurrency to 3