### PR TITLE
Detect PR merge conflicts in fixer discovery

### DIFF
--- a/apps/looperd/src/infra/github.test.ts
+++ b/apps/looperd/src/infra/github.test.ts
@@ -48,7 +48,7 @@ describe("GhCliGitHubGateway", () => {
     printf '{}'
     ;;
   "pr view"*)
-    printf '{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pr/42","state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"state":"UNRESOLVED"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}'
+    printf '{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pr/42","state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"state":"UNRESOLVED"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}'
     ;;
   "pr diff"*)
     printf 'diff --git a/a.ts b/a.ts\n'
@@ -129,6 +129,7 @@ esac\n`,
       prNumber: 42,
     });
     expect(detail.reviewRequests).toEqual(["reviewer"]);
+    expect(detail.hasConflicts).toBe(true);
     expect(detail.comments).toEqual([
       {
         id: "comment-1",

--- a/apps/looperd/src/infra/github.ts
+++ b/apps/looperd/src/infra/github.ts
@@ -28,6 +28,7 @@ export interface GitHubPullRequestDetail extends GitHubPullRequestSummary {
   body?: string;
   headSha?: string;
   baseSha?: string;
+  hasConflicts?: boolean;
   comments: unknown[];
   reviews: unknown[];
   checks: unknown[];
@@ -259,6 +260,7 @@ export class GhCliGitHubGateway {
           "comments",
           "reviews",
           "statusCheckRollup",
+          "mergeStateStatus",
         ].join(","),
       ],
       input.cwd,
@@ -281,6 +283,7 @@ export class GhCliGitHubGateway {
       baseSha: asOptionalString(parsed.baseRefOid),
       author: extractAuthor(parsed.author),
       reviewRequests: extractReviewRequestLogins(parsed.reviewRequests),
+      hasConflicts: asOptionalString(parsed.mergeStateStatus) === "DIRTY",
       comments:
         reviewThreads.length > 0
           ? reviewThreads


### PR DESCRIPTION
## Summary
- include `mergeStateStatus` in GitHub PR detail fetches and map `DIRTY` to `hasConflicts`
- let fixer discovery see conflicted PRs as actionable work items
- add a gateway regression test covering conflict propagation from `gh pr view`

## Validation
- bun test apps/looperd/src/infra/github.test.ts
- bun test apps/looperd/src/fixer/index.test.ts