### PR TITLE
Improve reviewer feedback style and PR reaction signaling

### DIFF
--- a/apps/looperd/src/infra/github.test.ts
+++ b/apps/looperd/src/infra/github.test.ts
@@ -47,6 +47,21 @@ describe("GhCliGitHubGateway", () => {
   "api repos/acme/looper/pulls/42/requested_reviewers --method POST -f reviewers[]=reviewer")
     printf '{}'
     ;;
+  "api repos/acme/looper/pulls/42/reviews --method POST --input -")
+    printf '{}'
+    ;;
+  "pr comment 42 --repo acme/looper --body High-level follow-up")
+    printf '{}'
+    ;;
+  "api repos/acme/looper/issues/42/reactions --method POST -H Accept: application/vnd.github+json -f content=eyes")
+    printf '{}'
+    ;;
+  "api repos/acme/looper/issues/42/reactions -H Accept: application/vnd.github+json")
+    printf '[{"id":7,"content":"eyes","user":{"login":"reviewer"}}]'
+    ;;
+  "api repos/acme/looper/issues/42/reactions/7 --method DELETE -H Accept: application/vnd.github+json")
+    printf '{}'
+    ;;
   "pr view"*)
     printf '{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pr/42","state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"state":"UNRESOLVED"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}'
     ;;
@@ -97,6 +112,36 @@ esac\n`,
       event: "COMMENT",
       body: "Looks good",
     });
+    await gateway.submitReview({
+      repo: "acme/looper",
+      prNumber: 42,
+      event: "COMMENT",
+      body: "Needs work",
+      commitId: "abc123",
+      comments: [
+        {
+          body: "Please handle the null case.",
+          path: "src/a.ts",
+          line: 12,
+          side: "RIGHT",
+        },
+      ],
+    });
+    await gateway.addPullRequestComment({
+      repo: "acme/looper",
+      prNumber: 42,
+      body: "High-level follow-up",
+    });
+    await gateway.addPullRequestReaction({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "eyes",
+    });
+    await gateway.removePullRequestReaction({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "eyes",
+    });
     await gateway.resolveReviewThread({
       repo: "acme/looper",
       threadId: "thread-1",
@@ -144,6 +189,18 @@ esac\n`,
     const log = await readFile(logPath, "utf8");
     expect(log).toContain(
       "pr review 42 --repo acme/looper --comment --body Looks good",
+    );
+    expect(log).toContain(
+      "api repos/acme/looper/pulls/42/reviews --method POST --input -",
+    );
+    expect(log).toContain(
+      "pr comment 42 --repo acme/looper --body High-level follow-up",
+    );
+    expect(log).toContain(
+      "api repos/acme/looper/issues/42/reactions --method POST -H Accept: application/vnd.github+json -f content=eyes",
+    );
+    expect(log).toContain(
+      "api repos/acme/looper/issues/42/reactions/7 --method DELETE -H Accept: application/vnd.github+json",
     );
     expect(log).toContain(
       "pr list --repo acme/looper --state open --limit 30 --label phase-1",

--- a/apps/looperd/src/infra/github.ts
+++ b/apps/looperd/src/infra/github.ts
@@ -52,6 +52,31 @@ export interface SubmitReviewInput {
   prNumber: number;
   event: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
   body?: string;
+  commitId?: string;
+  comments?: GitHubReviewComment[];
+  cwd?: string;
+}
+
+export interface GitHubReviewComment {
+  body: string;
+  path: string;
+  line: number;
+  side: "LEFT" | "RIGHT";
+  startLine?: number;
+  startSide?: "LEFT" | "RIGHT";
+}
+
+export interface PullRequestReactionInput {
+  repo: string;
+  prNumber: number;
+  content: "+1" | "eyes";
+  cwd?: string;
+}
+
+export interface PullRequestCommentInput {
+  repo: string;
+  prNumber: number;
+  body: string;
   cwd?: string;
 }
 
@@ -353,6 +378,35 @@ export class GhCliGitHubGateway {
   }
 
   public async submitReview(input: SubmitReviewInput): Promise<void> {
+    if ((input.comments?.length ?? 0) > 0) {
+      const payload = {
+        event: input.event,
+        body: input.body,
+        commit_id: input.commitId,
+        comments: input.comments?.map((comment) => ({
+          body: comment.body,
+          path: comment.path,
+          line: comment.line,
+          side: comment.side,
+          start_line: comment.startLine,
+          start_side: comment.startSide,
+        })),
+      };
+      await this.runGh(
+        [
+          "api",
+          `repos/${input.repo}/pulls/${input.prNumber}/reviews`,
+          "--method",
+          "POST",
+          "--input",
+          "-",
+        ],
+        input.cwd,
+        JSON.stringify(payload),
+      );
+      return;
+    }
+
     const args = [
       "pr",
       "review",
@@ -367,6 +421,84 @@ export class GhCliGitHubGateway {
     }
 
     await this.runGh(args, input.cwd);
+  }
+
+  public async addPullRequestComment(
+    input: PullRequestCommentInput,
+  ): Promise<void> {
+    await this.runGh(
+      [
+        "pr",
+        "comment",
+        String(input.prNumber),
+        "--repo",
+        input.repo,
+        "--body",
+        input.body,
+      ],
+      input.cwd,
+    );
+  }
+
+  public async addPullRequestReaction(
+    input: PullRequestReactionInput,
+  ): Promise<void> {
+    await this.runGh(
+      [
+        "api",
+        `repos/${input.repo}/issues/${input.prNumber}/reactions`,
+        "--method",
+        "POST",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-f",
+        `content=${input.content}`,
+      ],
+      input.cwd,
+    );
+  }
+
+  public async removePullRequestReaction(
+    input: PullRequestReactionInput,
+  ): Promise<void> {
+    const currentLogin = await this.getCurrentUserLogin({ cwd: input.cwd });
+    if (!currentLogin) {
+      return;
+    }
+
+    const reactionsResult = await this.runGh(
+      [
+        "api",
+        `repos/${input.repo}/issues/${input.prNumber}/reactions`,
+        "-H",
+        "Accept: application/vnd.github+json",
+      ],
+      input.cwd,
+    );
+    const reactions = asObjectArray(reactionsResult.stdout)
+      .map((value) => normalizeReaction(value))
+      .filter((value): value is GitHubReaction => Boolean(value));
+
+    for (const reaction of reactions) {
+      if (
+        reaction.content !== input.content ||
+        reaction.userLogin.toLowerCase() !== currentLogin.toLowerCase()
+      ) {
+        continue;
+      }
+
+      await this.runGh(
+        [
+          "api",
+          `repos/${input.repo}/issues/${input.prNumber}/reactions/${reaction.id}`,
+          "--method",
+          "DELETE",
+          "-H",
+          "Accept: application/vnd.github+json",
+        ],
+        input.cwd,
+      );
+    }
   }
 
   public async addPullRequestLabels(input: {
@@ -616,11 +748,12 @@ export class GhCliGitHubGateway {
     };
   }
 
-  private async runGh(args: string[], cwd?: string) {
+  private async runGh(args: string[], cwd?: string, stdin?: string) {
     return runCommand({
       command: this.options.ghPath,
       args,
       cwd: cwd ?? this.options.cwd,
+      stdin,
     });
   }
 
@@ -664,6 +797,12 @@ interface ReviewThreadComment {
   state: "RESOLVED" | "UNRESOLVED";
   isResolved: boolean;
   body?: string;
+}
+
+interface GitHubReaction {
+  id: number;
+  content: string;
+  userLogin: string;
 }
 
 function summarizeChecks(checks: unknown[]): string | null {
@@ -717,6 +856,22 @@ function normalizeReviewThread(value: unknown): ReviewThreadComment | null {
     isResolved,
     body: asOptionalString(commentNode?.body),
   };
+}
+
+function normalizeReaction(value: unknown): GitHubReaction | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const reaction = value as Record<string, unknown>;
+  const id = Number(reaction.id);
+  const content = asOptionalString(reaction.content);
+  const userLogin = extractAuthor(reaction.user);
+  if (!Number.isInteger(id) || id <= 0 || !content || !userLogin) {
+    return null;
+  }
+
+  return { id, content, userLogin };
 }
 
 function parseRepo(repo: string): { owner: string; name: string } {

--- a/apps/looperd/src/infra/index.ts
+++ b/apps/looperd/src/infra/index.ts
@@ -15,8 +15,11 @@ export {
   GhCliGitHubGateway,
   type CreatePullRequestInput,
   type CreatePullRequestResult,
+  type GitHubReviewComment,
   type GitHubPullRequestDetail,
   type GitHubPullRequestSummary,
+  type PullRequestCommentInput,
+  type PullRequestReactionInput,
   type SubmitReviewInput,
 } from "./github";
 export {

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -623,7 +623,17 @@ describe("ReviewerLoopRunner", () => {
     github.submitFailuresRemaining = 1;
     github.nextReviewDecisionAfterSubmit = "APPROVED";
     const agent = new FakeAgentExecutor([
-      completedAgentResult("Spec looks ready to implement"),
+      {
+        ...completedAgentResult("Spec looks ready to implement"),
+        rawLogs: {
+          stdout: `${JSON.stringify({
+            verdict: "clean",
+            body: "Spec looks ready to implement",
+            comments: [],
+          })}\n`,
+          stderr: "",
+        },
+      },
     ]);
     const runner = new ReviewerLoopRunner({
       store: fixture.store,
@@ -652,7 +662,7 @@ describe("ReviewerLoopRunner", () => {
       throw new Error("Expected failed reviewer run");
     }
     const failedCheckpoint = JSON.parse(failedRun.checkpointJson ?? "{}");
-    failedCheckpoint.pendingReview.event = "APPROVE";
+    expect(failedCheckpoint.pendingReview.event).toBe("APPROVE");
     fixture.store.runs.upsert({
       ...failedRun,
       checkpointJson: JSON.stringify(failedCheckpoint),

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import type { Logger } from "../bootstrap/logger";
 import type { AgentResult, AgentRunInput } from "../infra/agent";
+import { CommandExecutionError } from "../infra/command";
 import { SchedulerQueue } from "../scheduler/index";
 import { SqliteStore } from "../storage/sqlite/sqlite-store";
 import type { PullRequestSnapshotRecord } from "../storage/types";
@@ -105,7 +106,9 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
   public removeReactionFailuresRemaining = 0;
   public nextReviewDecisionAfterSubmit: string | undefined;
   public failingViewPullRequestNumbers = new Set<number>();
+  public failInlineReviewAnchorCallNumbers = new Set<number>();
   public failPullRequestCommentCallNumbers = new Set<number>();
+  private submitCallCount = 0;
   private addPullRequestCommentCallCount = 0;
   private readonly currentLabels: string[];
 
@@ -237,7 +240,20 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
       startSide?: "LEFT" | "RIGHT";
     }>;
   }): Promise<void> {
+    this.submitCallCount += 1;
     this.submitCalls.push(input);
+    if (
+      (input.comments?.length ?? 0) > 0 &&
+      this.failInlineReviewAnchorCallNumbers.has(this.submitCallCount)
+    ) {
+      throw new CommandExecutionError("Command exited with code 1", {
+        exitCode: 1,
+        stdout: "",
+        stderr:
+          'gh: Validation Failed (HTTP 422)\n{"message":"Validation Failed","errors":["Pull request review thread line must be part of the diff"]}',
+        durationMs: 1,
+      });
+    }
     if (this.submitFailuresRemaining > 0) {
       this.submitFailuresRemaining -= 1;
       throw new Error("temporary GitHub failure");
@@ -1582,6 +1598,111 @@ describe("ReviewerLoopRunner", () => {
         repo: "acme/looper",
         prNumber: 42,
         body: "Second comment",
+      },
+    ]);
+
+    fixture.store.close();
+  });
+
+  test("falls back to top-level comments when GitHub rejects inline anchors", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    github.failInlineReviewAnchorCallNumbers.add(1);
+    github.failPullRequestCommentCallNumbers.add(2);
+    const agent = new FakeAgentExecutor([
+      {
+        ...completedAgentResult("Detailed review"),
+        rawLogs: {
+          stdout: `${JSON.stringify({
+            verdict: "actionable",
+            body: "Overall review summary",
+            comments: [
+              {
+                body: "Please handle the null case.",
+                path: "src/a.ts",
+                line: 12,
+                side: "RIGHT",
+              },
+              { body: "Add a regression test." },
+            ],
+          })}\n`,
+          stderr: "",
+        },
+      },
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const firstClaim = fixture.queue.claimNext("reviewer-worker-1");
+    if (!firstClaim) {
+      throw new Error("Expected first reviewer claim");
+    }
+
+    const firstResult = await runner.processClaimedItem(firstClaim);
+
+    expect(firstResult.status).toBe("failed");
+    expect(firstResult.failureKind).toBe("retryable_after_resume");
+    expect(github.submitCalls).toHaveLength(2);
+    expect(github.submitCalls[0]).toMatchObject({
+      repo: "acme/looper",
+      prNumber: 42,
+      event: "COMMENT",
+      body: "Overall review summary",
+      commitId: "abc123",
+      comments: [
+        {
+          body: "Please handle the null case.",
+          path: "src/a.ts",
+          line: 12,
+          side: "RIGHT",
+        },
+      ],
+    });
+    expect(github.submitCalls[1]).toMatchObject({
+      repo: "acme/looper",
+      prNumber: 42,
+      event: "COMMENT",
+      body: "Overall review summary",
+    });
+    expect(github.prComments).toEqual([
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "Inline comment fallback (src/a.ts:12):\n\nPlease handle the null case.",
+      },
+    ]);
+
+    fixture.now.setTime(new Date("2026-04-11T12:00:05.000Z").getTime());
+    github.failPullRequestCommentCallNumbers.clear();
+    const retryClaim = fixture.queue.claimNext("reviewer-worker-1");
+    if (!retryClaim) {
+      throw new Error("Expected retry reviewer claim");
+    }
+
+    const retryResult = await runner.processClaimedItem(retryClaim);
+
+    expect(retryResult.status).toBe("success");
+    expect(github.submitCalls).toHaveLength(2);
+    expect(github.prComments).toEqual([
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "Inline comment fallback (src/a.ts:12):\n\nPlease handle the null case.",
+      },
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "Add a regression test.",
       },
     ]);
 

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -1165,6 +1165,59 @@ describe("ReviewerLoopRunner", () => {
     fixture.store.close();
   });
 
+  test("posts clean review summary as comment when auto-approve is disabled and body is omitted", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    const agent = new FakeAgentExecutor([
+      {
+        ...completedAgentResult("No actionable issues found"),
+        rawLogs: {
+          stdout: `${JSON.stringify({
+            verdict: "clean",
+            comments: [],
+          })}\n`,
+          stderr: "",
+        },
+      },
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("reviewer-worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed reviewer queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(github.submitCalls).toEqual([
+      expect.objectContaining({
+        repo: "acme/looper",
+        prNumber: 42,
+        event: "COMMENT",
+        body: "No actionable issues found",
+      }),
+    ]);
+    expect(github.addedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "+1",
+    });
+
+    fixture.store.close();
+  });
+
   test("treats clean verdict with comments as actionable feedback", async () => {
     const fixture = await createFixture();
     const github = new FakeGitHubGateway();

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -64,6 +64,15 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
     prNumber: number;
     event: string;
     body?: string;
+    commitId?: string;
+    comments?: Array<{
+      body: string;
+      path: string;
+      line: number;
+      side: "LEFT" | "RIGHT";
+      startLine?: number;
+      startSide?: "LEFT" | "RIGHT";
+    }>;
   }> = [];
   public addedLabels: Array<{
     repo: string;
@@ -74,6 +83,21 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
     repo: string;
     prNumber: number;
     labels: string[];
+  }> = [];
+  public prComments: Array<{
+    repo: string;
+    prNumber: number;
+    body: string;
+  }> = [];
+  public addedReactions: Array<{
+    repo: string;
+    prNumber: number;
+    content: "+1" | "eyes";
+  }> = [];
+  public removedReactions: Array<{
+    repo: string;
+    prNumber: number;
+    content: "+1" | "eyes";
   }> = [];
   public submitFailuresRemaining = 0;
   public addLabelFailuresRemaining = 0;
@@ -199,6 +223,15 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
     prNumber: number;
     event: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
     body?: string;
+    commitId?: string;
+    comments?: Array<{
+      body: string;
+      path: string;
+      line: number;
+      side: "LEFT" | "RIGHT";
+      startLine?: number;
+      startSide?: "LEFT" | "RIGHT";
+    }>;
   }): Promise<void> {
     this.submitCalls.push(input);
     if (this.submitFailuresRemaining > 0) {
@@ -252,6 +285,45 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
       }
     }
   }
+
+  public async addPullRequestComment(input: {
+    repo: string;
+    prNumber: number;
+    body: string;
+    cwd?: string;
+  }): Promise<void> {
+    this.prComments.push({
+      repo: input.repo,
+      prNumber: input.prNumber,
+      body: input.body,
+    });
+  }
+
+  public async addPullRequestReaction(input: {
+    repo: string;
+    prNumber: number;
+    content: "+1" | "eyes";
+    cwd?: string;
+  }): Promise<void> {
+    this.addedReactions.push({
+      repo: input.repo,
+      prNumber: input.prNumber,
+      content: input.content,
+    });
+  }
+
+  public async removePullRequestReaction(input: {
+    repo: string;
+    prNumber: number;
+    content: "+1" | "eyes";
+    cwd?: string;
+  }): Promise<void> {
+    this.removedReactions.push({
+      repo: input.repo,
+      prNumber: input.prNumber,
+      content: input.content,
+    });
+  }
 }
 
 class FakeAgentExecutor {
@@ -279,7 +351,14 @@ function completedAgentResult(summary: string): AgentResult {
     artifacts: [],
     changedFiles: [],
     commits: [],
-    rawLogs: { stdout: `${summary}\n`, stderr: "" },
+    rawLogs: {
+      stdout: `${JSON.stringify({
+        verdict: "actionable",
+        body: summary,
+        comments: [{ body: summary }],
+      })}\n`,
+      stderr: "",
+    },
     parseStatus: "parsed",
     completionSignal: "done",
     heartbeatCount: 1,
@@ -392,6 +471,16 @@ describe("ReviewerLoopRunner", () => {
     const result = await runner.processClaimedItem(claimed);
     expect(result.status).toBe("success");
     expect(github.submitCalls).toHaveLength(1);
+    expect(github.addedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "eyes",
+    });
+    expect(github.removedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "eyes",
+    });
     expect(agent.starts).toHaveLength(1);
     expect(
       fixture.store.pullRequestSnapshots.getLatest("acme/looper", 42)?.headSha,
@@ -514,6 +603,11 @@ describe("ReviewerLoopRunner", () => {
     ]);
     expect(github.removedLabels).toEqual([]);
     expect(github.addedLabels).toEqual([]);
+    expect(github.removedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "eyes",
+    });
 
     fixture.store.close();
   });
@@ -630,7 +724,9 @@ describe("ReviewerLoopRunner", () => {
     const firstRun = fixture.store.runs.listByLoop(firstResult.loopId)[0];
     const firstCheckpoint = JSON.parse(firstRun?.checkpointJson ?? "{}");
     expect(firstRun?.lastCompletedStep).toBe("review");
-    expect(firstCheckpoint.pendingReview.body).toContain("Please add tests");
+    expect(firstCheckpoint.pendingReview.comments[0].body).toContain(
+      "Please add tests",
+    );
     expect(fixture.store.queue.getById(firstClaim.id)?.status).toBe("queued");
     const failedLog = logs.entries.find(
       (entry) =>
@@ -843,6 +939,134 @@ describe("ReviewerLoopRunner", () => {
       ),
     ).toMatchObject({
       lastPublishedHeadSha: "new-head",
+    });
+
+    fixture.store.close();
+  });
+
+  test("posts inline comments, top-level comments, and reactions from structured output", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    const agent = new FakeAgentExecutor([
+      {
+        ...completedAgentResult("Detailed review"),
+        rawLogs: {
+          stdout: `${JSON.stringify({
+            verdict: "actionable",
+            body: "Overall review summary",
+            comments: [
+              {
+                body: "This branch misses a nil guard before dereferencing the config.",
+                path: "src/config.ts",
+                line: 27,
+                side: "RIGHT",
+              },
+              {
+                body: "Consider extracting the validation policy into a shared helper so future callers do not drift.",
+              },
+            ],
+          })}\n`,
+          stderr: "",
+        },
+      },
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("reviewer-worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed reviewer queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(github.submitCalls[0]).toMatchObject({
+      body: "Overall review summary",
+      commitId: "abc123",
+      comments: [
+        {
+          body: "This branch misses a nil guard before dereferencing the config.",
+          path: "src/config.ts",
+          line: 27,
+          side: "RIGHT",
+        },
+      ],
+    });
+    expect(github.prComments).toEqual([
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "Consider extracting the validation policy into a shared helper so future callers do not drift.",
+      },
+    ]);
+    expect(github.removedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "eyes",
+    });
+
+    fixture.store.close();
+  });
+
+  test("adds thumbs-up reaction for clean reviews without posting feedback", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    const agent = new FakeAgentExecutor([
+      {
+        ...completedAgentResult("No actionable issues found"),
+        rawLogs: {
+          stdout: `${JSON.stringify({
+            verdict: "clean",
+            body: "No actionable issues found.",
+            comments: [],
+          })}\n`,
+          stderr: "",
+        },
+      },
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("reviewer-worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed reviewer queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(github.submitCalls).toEqual([]);
+    expect(github.prComments).toEqual([]);
+    expect(github.addedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "+1",
+    });
+    expect(github.removedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "eyes",
     });
 
     fixture.store.close();

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -1275,7 +1275,71 @@ describe("ReviewerLoopRunner", () => {
     fixture.store.close();
   });
 
-  test("ignores malformed multiline inline comment ranges", async () => {
+  test("treats malformed clean inline comments as actionable feedback", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    const agent = new FakeAgentExecutor([
+      {
+        ...completedAgentResult("Detailed review"),
+        rawLogs: {
+          stdout: `${JSON.stringify({
+            verdict: "clean",
+            body: "Overall review summary",
+            comments: [
+              {
+                body: "Fix null guard",
+                path: "src/config.ts",
+                line: 12,
+              },
+            ],
+          })}\n`,
+          stderr: "",
+        },
+      },
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("reviewer-worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed reviewer queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(github.submitCalls[0]).toMatchObject({
+      event: "COMMENT",
+      body: "Overall review summary",
+      comments: [],
+    });
+    expect(github.prComments).toEqual([
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "Fix null guard",
+      },
+    ]);
+    expect(github.addedReactions).not.toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "+1",
+    });
+
+    fixture.store.close();
+  });
+
+  test("downgrades malformed multiline inline comment ranges to top-level comments", async () => {
     const fixture = await createFixture();
     const github = new FakeGitHubGateway();
     const agent = new FakeAgentExecutor([
@@ -1329,6 +1393,11 @@ describe("ReviewerLoopRunner", () => {
       comments: [],
     });
     expect(github.prComments).toEqual([
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "Broken multiline range",
+      },
       {
         repo: "acme/looper",
         prNumber: 42,

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -1271,6 +1271,11 @@ describe("ReviewerLoopRunner", () => {
       prNumber: 42,
       content: "+1",
     });
+    expect(github.removedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "+1",
+    });
 
     fixture.store.close();
   });
@@ -1458,7 +1463,13 @@ describe("ReviewerLoopRunner", () => {
       ]),
     );
     expect(github.addedReactions).toEqual([]);
-    expect(github.removedReactions).toEqual([]);
+    expect(github.removedReactions).toEqual([
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        content: "eyes",
+      },
+    ]);
 
     fixture.store.close();
   });

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -101,8 +101,12 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
   }> = [];
   public submitFailuresRemaining = 0;
   public addLabelFailuresRemaining = 0;
+  public addReactionFailuresRemaining = 0;
+  public removeReactionFailuresRemaining = 0;
   public nextReviewDecisionAfterSubmit: string | undefined;
   public failingViewPullRequestNumbers = new Set<number>();
+  public failPullRequestCommentCallNumbers = new Set<number>();
+  private addPullRequestCommentCallCount = 0;
   private readonly currentLabels: string[];
 
   constructor(
@@ -292,6 +296,14 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
     body: string;
     cwd?: string;
   }): Promise<void> {
+    this.addPullRequestCommentCallCount += 1;
+    if (
+      this.failPullRequestCommentCallNumbers.has(
+        this.addPullRequestCommentCallCount,
+      )
+    ) {
+      throw new Error("temporary PR comment failure");
+    }
     this.prComments.push({
       repo: input.repo,
       prNumber: input.prNumber,
@@ -305,6 +317,10 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
     content: "+1" | "eyes";
     cwd?: string;
   }): Promise<void> {
+    if (this.addReactionFailuresRemaining > 0) {
+      this.addReactionFailuresRemaining -= 1;
+      throw new Error("temporary add reaction failure");
+    }
     this.addedReactions.push({
       repo: input.repo,
       prNumber: input.prNumber,
@@ -318,6 +334,10 @@ class FakeGitHubGateway implements ReviewerGitHubGateway {
     content: "+1" | "eyes";
     cwd?: string;
   }): Promise<void> {
+    if (this.removeReactionFailuresRemaining > 0) {
+      this.removeReactionFailuresRemaining -= 1;
+      throw new Error("temporary remove reaction failure");
+    }
     this.removedReactions.push({
       repo: input.repo,
       prNumber: input.prNumber,
@@ -372,13 +392,14 @@ function completedAgentResult(summary: string): AgentResult {
 
 function createCapturingLogger() {
   const entries: Array<{
-    level: "info" | "error";
+    level: "info" | "warn" | "error";
     message: string;
     context?: Record<string, unknown>;
   }> = [];
   const logger: Logger = {
     debug: () => {},
-    warn: () => {},
+    warn: (message, context) =>
+      entries.push({ level: "warn", message, context }),
     info: (message, context) =>
       entries.push({ level: "info", message, context }),
     error: (message, context) =>
@@ -1029,7 +1050,68 @@ describe("ReviewerLoopRunner", () => {
     fixture.store.close();
   });
 
-  test("adds thumbs-up reaction for clean reviews without posting feedback", async () => {
+  test("adds thumbs-up reaction for clean reviews and auto-approves when allowed", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    const agent = new FakeAgentExecutor([
+      {
+        ...completedAgentResult("No actionable issues found"),
+        rawLogs: {
+          stdout: `${JSON.stringify({
+            verdict: "clean",
+            body: "No actionable issues found.",
+            comments: [],
+          })}\n`,
+          stderr: "",
+        },
+      },
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+      allowAutoApprove: true,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("reviewer-worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed reviewer queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(github.submitCalls).toEqual([
+      expect.objectContaining({
+        repo: "acme/looper",
+        prNumber: 42,
+        event: "APPROVE",
+        body: "No actionable issues found.",
+      }),
+    ]);
+    expect(github.prComments).toEqual([]);
+    expect(github.addedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "+1",
+    });
+    expect(github.removedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "eyes",
+    });
+
+    fixture.store.close();
+  });
+
+  test("posts clean review body as comment when auto-approve is disabled", async () => {
     const fixture = await createFixture();
     const github = new FakeGitHubGateway();
     const agent = new FakeAgentExecutor([
@@ -1066,18 +1148,328 @@ describe("ReviewerLoopRunner", () => {
     const result = await runner.processClaimedItem(claimed);
 
     expect(result.status).toBe("success");
-    expect(github.submitCalls).toEqual([]);
-    expect(github.prComments).toEqual([]);
+    expect(github.submitCalls).toEqual([
+      expect.objectContaining({
+        repo: "acme/looper",
+        prNumber: 42,
+        event: "COMMENT",
+        body: "No actionable issues found.",
+      }),
+    ]);
     expect(github.addedReactions).toContainEqual({
       repo: "acme/looper",
       prNumber: 42,
       content: "+1",
     });
-    expect(github.removedReactions).toContainEqual({
+
+    fixture.store.close();
+  });
+
+  test("treats clean verdict with comments as actionable feedback", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    const agent = new FakeAgentExecutor([
+      {
+        ...completedAgentResult("Needs changes"),
+        rawLogs: {
+          stdout: `${JSON.stringify({
+            verdict: "clean",
+            body: "Needs changes",
+            comments: [{ body: "Please add a nil guard here." }],
+          })}\n`,
+          stderr: "",
+        },
+      },
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("reviewer-worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed reviewer queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(github.submitCalls[0]).toMatchObject({
+      event: "COMMENT",
+      body: "Needs changes",
+    });
+    expect(github.prComments).toEqual([
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "Please add a nil guard here.",
+      },
+    ]);
+    expect(github.addedReactions).not.toContainEqual({
       repo: "acme/looper",
       prNumber: 42,
-      content: "eyes",
+      content: "+1",
     });
+
+    fixture.store.close();
+  });
+
+  test("ignores malformed multiline inline comment ranges", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    const agent = new FakeAgentExecutor([
+      {
+        ...completedAgentResult("Detailed review"),
+        rawLogs: {
+          stdout: `${JSON.stringify({
+            verdict: "actionable",
+            body: "Overall review summary",
+            comments: [
+              {
+                body: "Broken multiline range",
+                path: "src/config.ts",
+                line: 26,
+                side: "RIGHT",
+                startLine: 27,
+                startSide: "LEFT",
+              },
+              {
+                body: "Top-level follow-up",
+              },
+            ],
+          })}\n`,
+          stderr: "",
+        },
+      },
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("reviewer-worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed reviewer queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(github.submitCalls[0]).toMatchObject({
+      body: "Overall review summary",
+      comments: [],
+    });
+    expect(github.prComments).toEqual([
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "Top-level follow-up",
+      },
+    ]);
+
+    fixture.store.close();
+  });
+
+  test("continues when reviewer reactions fail", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    github.addReactionFailuresRemaining = 2;
+    github.removeReactionFailuresRemaining = 1;
+    const logs = createCapturingLogger();
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Please add tests"),
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: logs.logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("reviewer-worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed reviewer queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("success");
+    expect(github.submitCalls).toHaveLength(1);
+    expect(logs.entries).toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "reviewer run completed",
+      }),
+    );
+    expect(logs.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: "warn",
+          message: "reviewer reaction add failed",
+        }),
+        expect.objectContaining({
+          level: "warn",
+          message: "reviewer reaction removal failed",
+        }),
+      ]),
+    );
+    expect(github.addedReactions).toEqual([]);
+    expect(github.removedReactions).toEqual([]);
+
+    fixture.store.close();
+  });
+
+  test("resumes publish safely after top-level comment posting partially succeeds", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    github.failPullRequestCommentCallNumbers.add(2);
+    const agent = new FakeAgentExecutor([
+      {
+        ...completedAgentResult("Detailed review"),
+        rawLogs: {
+          stdout: `${JSON.stringify({
+            verdict: "actionable",
+            body: "Overall review summary",
+            comments: [{ body: "First comment" }, { body: "Second comment" }],
+          })}\n`,
+          stderr: "",
+        },
+      },
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const firstClaim = fixture.queue.claimNext("reviewer-worker-1");
+    if (!firstClaim) {
+      throw new Error("Expected first reviewer claim");
+    }
+
+    const firstResult = await runner.processClaimedItem(firstClaim);
+
+    expect(firstResult.status).toBe("failed");
+    expect(firstResult.failureKind).toBe("retryable_after_resume");
+    expect(github.submitCalls).toHaveLength(1);
+    expect(github.prComments).toEqual([
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "First comment",
+      },
+    ]);
+
+    github.failPullRequestCommentCallNumbers.clear();
+    fixture.now.setTime(new Date("2026-04-11T12:00:05.000Z").getTime());
+    const retryClaim = fixture.queue.claimNext("reviewer-worker-1");
+    if (!retryClaim) {
+      throw new Error("Expected retry reviewer claim");
+    }
+
+    const retryResult = await runner.processClaimedItem(retryClaim);
+
+    expect(retryResult.status).toBe("success");
+    expect(github.submitCalls).toHaveLength(1);
+    expect(github.prComments).toEqual([
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "First comment",
+      },
+      {
+        repo: "acme/looper",
+        prNumber: 42,
+        body: "Second comment",
+      },
+    ]);
+
+    fixture.store.close();
+  });
+
+  test("defaults missing checkpoint review fields when resuming publish", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    github.submitFailuresRemaining = 1;
+    const agent = new FakeAgentExecutor([
+      completedAgentResult("Please add tests"),
+    ]);
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: agent,
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const firstClaim = fixture.queue.claimNext("reviewer-worker-1");
+    if (!firstClaim) {
+      throw new Error("Expected first reviewer claim");
+    }
+
+    const firstResult = await runner.processClaimedItem(firstClaim);
+    expect(firstResult.status).toBe("failed");
+
+    const failedRun = fixture.store.runs.listByLoop(firstResult.loopId)[0];
+    if (!failedRun) {
+      throw new Error("Expected failed reviewer run");
+    }
+    const failedCheckpoint = JSON.parse(failedRun.checkpointJson ?? "{}");
+    failedCheckpoint.pendingReview = {
+      headSha: failedCheckpoint.pendingReview.headSha,
+      event: failedCheckpoint.pendingReview.event,
+      body: failedCheckpoint.pendingReview.body,
+      summary: failedCheckpoint.pendingReview.summary,
+    };
+    fixture.store.runs.upsert({
+      ...failedRun,
+      checkpointJson: JSON.stringify(failedCheckpoint),
+    });
+
+    fixture.now.setTime(new Date("2026-04-11T12:00:05.000Z").getTime());
+    const retryClaim = fixture.queue.claimNext("reviewer-worker-1");
+    if (!retryClaim) {
+      throw new Error("Expected retry reviewer claim");
+    }
+
+    const retryResult = await runner.processClaimedItem(retryClaim);
+
+    expect(retryResult.status).toBe("success");
+    expect(github.submitCalls).toHaveLength(2);
 
     fixture.store.close();
   });

--- a/apps/looperd/src/reviewer/index.test.ts
+++ b/apps/looperd/src/reviewer/index.test.ts
@@ -1463,6 +1463,45 @@ describe("ReviewerLoopRunner", () => {
     fixture.store.close();
   });
 
+  test("removes eyes reaction when review step exits before publish", async () => {
+    const fixture = await createFixture();
+    const github = new FakeGitHubGateway();
+    const runner = new ReviewerLoopRunner({
+      store: fixture.store,
+      scheduler: fixture.queue,
+      github,
+      agentExecutor: new FakeAgentExecutor([]),
+      logger: createCapturingLogger().logger,
+      now: () => fixture.now,
+    });
+
+    await runner.discoverPullRequests({
+      projectId: "project_1",
+      repo: "acme/looper",
+    });
+    const claimed = fixture.queue.claimNext("reviewer-worker-1");
+    if (!claimed) {
+      throw new Error("Expected claimed reviewer queue item");
+    }
+
+    const result = await runner.processClaimedItem(claimed);
+
+    expect(result.status).toBe("failed");
+    expect(github.addedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "eyes",
+    });
+    expect(github.removedReactions).toContainEqual({
+      repo: "acme/looper",
+      prNumber: 42,
+      content: "eyes",
+    });
+    expect(github.submitCalls).toHaveLength(0);
+
+    fixture.store.close();
+  });
+
   test("resumes publish safely after top-level comment posting partially succeeds", async () => {
     const fixture = await createFixture();
     const github = new FakeGitHubGateway();

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -993,13 +993,6 @@ export class ReviewerLoopRunner {
           normalizedPendingReview.summary?.trim() ||
           undefined
         : normalizedPendingReview.body;
-    const inlineComments = normalizedPendingReview.comments.filter(
-      isInlineReviewComment,
-    );
-    const topLevelComments = normalizedPendingReview.comments.filter(
-      (comment) => !isInlineReviewComment(comment),
-    );
-
     const repo = requireString(input.queueItem.repo, "queueItem.repo");
     const prNumber = requireNumber(
       input.queueItem.prNumber,
@@ -1044,17 +1037,68 @@ export class ReviewerLoopRunner {
       } else {
         if (
           !normalizedPendingReview.publishState.reviewSubmitted &&
-          (inlineComments.length > 0 || normalizedPendingReview.body)
+          (normalizedPendingReview.comments.some(isInlineReviewComment) ||
+            normalizedPendingReview.body)
         ) {
-          await this.options.github.submitReview({
-            repo,
-            prNumber,
-            event: reviewEvent,
-            body: normalizedPendingReview.body,
-            commitId: normalizedPendingReview.headSha,
-            comments: inlineComments.map(toGitHubReviewComment),
-            cwd: input.project.repoPath,
-          });
+          const inlineComments = normalizedPendingReview.comments.filter(
+            isInlineReviewComment,
+          );
+          try {
+            await this.options.github.submitReview({
+              repo,
+              prNumber,
+              event: reviewEvent,
+              body: normalizedPendingReview.body,
+              commitId: normalizedPendingReview.headSha,
+              comments: inlineComments.map(toGitHubReviewComment),
+              cwd: input.project.repoPath,
+            });
+          } catch (error) {
+            if (
+              inlineComments.length === 0 ||
+              !isInlineReviewAnchorFailure(error)
+            ) {
+              throw error;
+            }
+
+            this.options.logger.warn(
+              "reviewer inline anchors rejected; falling back to top-level comments",
+              {
+                projectId: input.project.id,
+                loopId: input.loop.id,
+                runId: input.run.id,
+                repo,
+                prNumber,
+                inlineCommentCount: inlineComments.length,
+              },
+            );
+
+            normalizedPendingReview.comments =
+              normalizedPendingReview.comments.map((comment) =>
+                isInlineReviewComment(comment)
+                  ? downgradeInlineCommentToTopLevel(comment)
+                  : comment,
+              );
+            this.persistPendingReviewCheckpoint(
+              input.run,
+              input.checkpoint,
+              normalizedPendingReview,
+            );
+
+            const fallbackBody =
+              normalizedPendingReview.body?.trim() ||
+              normalizedPendingReview.summary?.trim() ||
+              undefined;
+            if (fallbackBody) {
+              await this.options.github.submitReview({
+                repo,
+                prNumber,
+                event: reviewEvent,
+                body: fallbackBody,
+                cwd: input.project.repoPath,
+              });
+            }
+          }
           normalizedPendingReview.publishState.reviewSubmitted = true;
           this.persistPendingReviewCheckpoint(
             input.run,
@@ -1062,10 +1106,16 @@ export class ReviewerLoopRunner {
             normalizedPendingReview,
           );
         }
-        while (
-          normalizedPendingReview.publishState.topLevelCommentsPosted <
-          topLevelComments.length
-        ) {
+        while (true) {
+          const topLevelComments = normalizedPendingReview.comments.filter(
+            (comment) => !isInlineReviewComment(comment),
+          );
+          if (
+            normalizedPendingReview.publishState.topLevelCommentsPosted >=
+            topLevelComments.length
+          ) {
+            break;
+          }
           const comment =
             topLevelComments[
               normalizedPendingReview.publishState.topLevelCommentsPosted
@@ -1822,6 +1872,55 @@ function toGitHubReviewComment(
     startLine: comment.startLine,
     startSide: comment.startSide,
   };
+}
+
+function downgradeInlineCommentToTopLevel(
+  comment: ReviewFeedbackComment,
+): ReviewFeedbackComment {
+  const location = formatInlineCommentLocation(comment);
+  return {
+    body: location
+      ? `Inline comment fallback (${location}):\n\n${comment.body}`
+      : comment.body,
+  };
+}
+
+function formatInlineCommentLocation(
+  comment: ReviewFeedbackComment,
+): string | null {
+  if (!comment.path) {
+    return null;
+  }
+
+  if (
+    typeof comment.startLine === "number" &&
+    Number.isFinite(comment.startLine) &&
+    comment.startLine !== comment.line
+  ) {
+    return `${comment.path}:${comment.startLine}-${comment.line}`;
+  }
+
+  if (typeof comment.line === "number" && Number.isFinite(comment.line)) {
+    return `${comment.path}:${comment.line}`;
+  }
+
+  return comment.path;
+}
+
+function isInlineReviewAnchorFailure(error: unknown): boolean {
+  if (!(error instanceof CommandExecutionError)) {
+    return false;
+  }
+
+  const output = `${error.result.stdout}\n${error.result.stderr}`.toLowerCase();
+  return (
+    output.includes("validation failed") &&
+    output.includes("pull request review thread") &&
+    (output.includes("line") ||
+      output.includes("path") ||
+      output.includes("diff") ||
+      output.includes("side"))
+  );
 }
 
 function normalizePendingReviewCheckpoint(

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -1745,7 +1745,7 @@ function normalizeReviewFeedbackComment(
       startSide === side) ||
     (startLine && line && startLine > line)
   ) {
-    return null;
+    return { body };
   }
 
   return {

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -171,6 +171,10 @@ interface ReviewerCheckpoint {
     summary?: string;
     comments: ReviewFeedbackComment[];
     clean: boolean;
+    publishState?: {
+      reviewSubmitted?: boolean;
+      topLevelCommentsPosted?: number;
+    };
   };
   skipReason?: string;
 }
@@ -188,6 +192,19 @@ interface ParsedReviewFeedback {
   body?: string;
   comments: ReviewFeedbackComment[];
   clean: boolean;
+}
+
+interface NormalizedPendingReviewCheckpoint {
+  headSha: string;
+  event: ReviewEvent;
+  body?: string;
+  summary?: string;
+  comments: ReviewFeedbackComment[];
+  clean: boolean;
+  publishState: {
+    reviewSubmitted: boolean;
+    topLevelCommentsPosted: number;
+  };
 }
 
 interface ResumedRunContext {
@@ -857,11 +874,14 @@ export class ReviewerLoopRunner {
     });
 
     const executionId = randomUUID();
-    await this.options.github.addPullRequestReaction({
+    await this.tryAddPullRequestReaction({
       repo,
       prNumber,
       content: "eyes",
       cwd: input.project.repoPath,
+      projectId: input.project.id,
+      loopId: input.loop.id,
+      runId: input.run.id,
     });
     const execution = await this.options.agentExecutor.start({
       executionId,
@@ -939,21 +959,25 @@ export class ReviewerLoopRunner {
       );
     }
 
+    const normalizedPendingReview =
+      normalizePendingReviewCheckpoint(pendingReview);
     const loopMetadata = parseJsonObject(input.loop.metadataJson);
     const lastPublishedHeadSha = readString(loopMetadata.lastPublishedHeadSha);
-    if (lastPublishedHeadSha === pendingReview.headSha) {
+    if (lastPublishedHeadSha === normalizedPendingReview.headSha) {
       return {
         ...input.checkpoint,
-        skipReason: `Skipped already-published review for head ${pendingReview.headSha}`,
+        skipReason: `Skipped already-published review for head ${normalizedPendingReview.headSha}`,
       };
     }
 
     const reviewEvent =
-      pendingReview.event === "APPROVE" && !this.allowAutoApprove
+      normalizedPendingReview.event === "APPROVE" && !this.allowAutoApprove
         ? "COMMENT"
-        : pendingReview.event;
-    const inlineComments = pendingReview.comments.filter(isInlineReviewComment);
-    const topLevelComments = pendingReview.comments.filter(
+        : normalizedPendingReview.event;
+    const inlineComments = normalizedPendingReview.comments.filter(
+      isInlineReviewComment,
+    );
+    const topLevelComments = normalizedPendingReview.comments.filter(
       (comment) => !isInlineReviewComment(comment),
     );
 
@@ -979,55 +1003,92 @@ export class ReviewerLoopRunner {
     }
 
     try {
-      if (pendingReview.clean) {
-        if (reviewEvent === "APPROVE") {
+      if (normalizedPendingReview.clean) {
+        if (
+          !normalizedPendingReview.publishState.reviewSubmitted &&
+          (reviewEvent === "APPROVE" || Boolean(normalizedPendingReview.body))
+        ) {
           await this.options.github.submitReview({
             repo,
             prNumber,
             event: reviewEvent,
-            body: pendingReview.body,
+            body: normalizedPendingReview.body,
             cwd: input.project.repoPath,
           });
+          normalizedPendingReview.publishState.reviewSubmitted = true;
+          this.persistPendingReviewCheckpoint(
+            input.run,
+            input.checkpoint,
+            normalizedPendingReview,
+          );
         }
-        await this.options.github.addPullRequestReaction({
-          repo,
-          prNumber,
-          content: "+1",
-          cwd: input.project.repoPath,
-        });
-        await this.options.github.removePullRequestReaction({
-          repo,
-          prNumber,
-          content: "eyes",
-          cwd: input.project.repoPath,
-        });
       } else {
-        if (inlineComments.length > 0 || pendingReview.body) {
+        if (
+          !normalizedPendingReview.publishState.reviewSubmitted &&
+          (inlineComments.length > 0 || normalizedPendingReview.body)
+        ) {
           await this.options.github.submitReview({
             repo,
             prNumber,
             event: reviewEvent,
-            body: pendingReview.body,
-            commitId: pendingReview.headSha,
+            body: normalizedPendingReview.body,
+            commitId: normalizedPendingReview.headSha,
             comments: inlineComments.map(toGitHubReviewComment),
             cwd: input.project.repoPath,
           });
+          normalizedPendingReview.publishState.reviewSubmitted = true;
+          this.persistPendingReviewCheckpoint(
+            input.run,
+            input.checkpoint,
+            normalizedPendingReview,
+          );
         }
-        for (const comment of topLevelComments) {
+        while (
+          normalizedPendingReview.publishState.topLevelCommentsPosted <
+          topLevelComments.length
+        ) {
+          const comment =
+            topLevelComments[
+              normalizedPendingReview.publishState.topLevelCommentsPosted
+            ];
+          if (!comment) {
+            break;
+          }
           await this.options.github.addPullRequestComment({
             repo,
             prNumber,
             body: comment.body,
             cwd: input.project.repoPath,
           });
+          normalizedPendingReview.publishState.topLevelCommentsPosted += 1;
+          this.persistPendingReviewCheckpoint(
+            input.run,
+            input.checkpoint,
+            normalizedPendingReview,
+          );
         }
-        await this.options.github.removePullRequestReaction({
+      }
+
+      if (normalizedPendingReview.clean) {
+        await this.tryAddPullRequestReaction({
           repo,
           prNumber,
-          content: "eyes",
+          content: "+1",
           cwd: input.project.repoPath,
+          projectId: input.project.id,
+          loopId: input.loop.id,
+          runId: input.run.id,
         });
       }
+      await this.tryRemovePullRequestReaction({
+        repo,
+        prNumber,
+        content: "eyes",
+        cwd: input.project.repoPath,
+        projectId: input.project.id,
+        loopId: input.loop.id,
+        runId: input.run.id,
+      });
 
       let postSubmitDetail = detail;
       if (
@@ -1077,9 +1138,9 @@ export class ReviewerLoopRunner {
     this.updateLoop(input.loop, {
       metadataJson: JSON.stringify({
         ...loopMetadata,
-        lastPublishedHeadSha: pendingReview.headSha,
+        lastPublishedHeadSha: normalizedPendingReview.headSha,
         lastReviewEvent: reviewEvent,
-        lastReviewSummary: pendingReview.summary ?? null,
+        lastReviewSummary: normalizedPendingReview.summary ?? null,
         lastPublishedAt: this.nowIso(),
       }),
     });
@@ -1097,7 +1158,7 @@ export class ReviewerLoopRunner {
         repo: input.queueItem.repo,
         prNumber: input.queueItem.prNumber,
         event: reviewEvent,
-        headSha: pendingReview.headSha,
+        headSha: normalizedPendingReview.headSha,
       },
     });
 
@@ -1245,6 +1306,66 @@ export class ReviewerLoopRunner {
       parseCheckpoint(persistedRun?.checkpointJson ?? run.checkpointJson) ??
       fallback
     );
+  }
+
+  private persistPendingReviewCheckpoint(
+    run: RunRecord,
+    checkpoint: ReviewerCheckpoint,
+    pendingReview: NonNullable<ReviewerCheckpoint["pendingReview"]>,
+  ): void {
+    this.persistStepStarted(run, "publish", {
+      ...checkpoint,
+      pendingReview,
+      resumePolicy: "advance_from_checkpoint",
+    });
+  }
+
+  private async tryAddPullRequestReaction(input: {
+    repo: string;
+    prNumber: number;
+    content: "+1" | "eyes";
+    cwd: string;
+    projectId: string;
+    loopId: string;
+    runId: string;
+  }): Promise<void> {
+    try {
+      await this.options.github.addPullRequestReaction(input);
+    } catch (error) {
+      this.options.logger.warn("reviewer reaction add failed", {
+        projectId: input.projectId,
+        loopId: input.loopId,
+        runId: input.runId,
+        repo: input.repo,
+        prNumber: input.prNumber,
+        content: input.content,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async tryRemovePullRequestReaction(input: {
+    repo: string;
+    prNumber: number;
+    content: "+1" | "eyes";
+    cwd: string;
+    projectId: string;
+    loopId: string;
+    runId: string;
+  }): Promise<void> {
+    try {
+      await this.options.github.removePullRequestReaction(input);
+    } catch (error) {
+      this.options.logger.warn("reviewer reaction removal failed", {
+        projectId: input.projectId,
+        loopId: input.loopId,
+        runId: input.runId,
+        repo: input.repo,
+        prNumber: input.prNumber,
+        content: input.content,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private ensureLoopForPullRequest(input: {
@@ -1577,7 +1698,7 @@ function parseStructuredReviewOutput(
             Boolean(comment),
           )
       : [];
-    const clean = verdict === "clean";
+    const clean = verdict === "clean" && comments.length === 0;
     if (!clean && comments.length === 0) {
       return null;
     }
@@ -1606,9 +1727,17 @@ function normalizeReviewFeedbackComment(
   const side = normalizeReviewSide(comment.side);
   const startLine = readPositiveInteger(comment.startLine);
   const startSide = normalizeReviewSide(comment.startSide);
+  const hasRangeStart = startLine !== undefined || startSide !== undefined;
   if (
     (path && (!line || !side)) ||
-    (!path && (line || side || startLine || startSide))
+    (!path && (line || side || startLine || startSide)) ||
+    (hasRangeStart && (!startLine || !startSide)) ||
+    (startLine &&
+      startSide &&
+      line &&
+      startLine === line &&
+      startSide === side) ||
+    (startLine && line && startLine > line)
   ) {
     return null;
   }
@@ -1666,6 +1795,30 @@ function toGitHubReviewComment(
   };
 }
 
+function normalizePendingReviewCheckpoint(
+  pendingReview: ReviewerCheckpoint["pendingReview"],
+): NormalizedPendingReviewCheckpoint {
+  if (!pendingReview) {
+    throw new Error("pendingReview is required");
+  }
+
+  return {
+    ...pendingReview,
+    comments: Array.isArray(pendingReview.comments)
+      ? pendingReview.comments
+      : [],
+    clean: pendingReview.clean === true,
+    publishState: {
+      reviewSubmitted: pendingReview.publishState?.reviewSubmitted === true,
+      topLevelCommentsPosted:
+        typeof pendingReview.publishState?.topLevelCommentsPosted ===
+          "number" && pendingReview.publishState.topLevelCommentsPosted >= 0
+          ? pendingReview.publishState.topLevelCommentsPosted
+          : 0,
+    },
+  };
+}
+
 function summarizeLogs(stdout: string): string {
   return stdout
     .split("\n")
@@ -1708,8 +1861,9 @@ function buildReviewPrompt(input: {
         "Return detailed GitHub review feedback as raw JSON with this exact shape:",
         '{"verdict":"clean"|"actionable","body":"optional overall summary","comments":[{"body":"required comment text","path":"src/file.ts optional for inline comments","line":123,"side":"RIGHT","startLine":120,"startSide":"RIGHT"}]}',
         "Use verdict=actionable whenever there is any actionable advice.",
-        "Prefer inline comments for specific code-level feedback when you can anchor them confidently to the diff using the changed file path and diff line numbers.",
+        "Prefer inline comments for specific code-level feedback when you can anchor them confidently to the diff using the changed file path and the file line numbers shown in the PR diff (not deprecated diff positions).",
         "Use top-level comments without path/line only for architectural, cross-cutting, or otherwise unanchorable feedback.",
+        "For multiline inline comments, `startLine`/`startSide` must identify the first line of the range and `line`/`side` the last line; omit `startLine`/`startSide` for single-line comments.",
         "Write substantially more detail than a brief summary; every comment should explain the problem, why it matters, and the concrete change to make.",
         "Do not approve. If the review is clean, return verdict=clean with comments=[].",
       ].join("\n"),

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -883,61 +883,74 @@ export class ReviewerLoopRunner {
       loopId: input.loop.id,
       runId: input.run.id,
     });
-    const execution = await this.options.agentExecutor.start({
-      executionId,
-      projectId: input.project.id,
-      loopId: input.loop.id,
-      runId: input.run.id,
-      prompt,
-      workingDirectory: input.project.repoPath,
-      timeoutMs: this.agentTimeoutMs,
-      metadata: {
-        loopType: "reviewer",
-        repo: input.queueItem.repo,
-        prNumber: input.queueItem.prNumber,
-      },
-      idempotencyKey: `reviewer:${input.loop.id}:${snapshot.headSha}`,
-    });
-    await this.options.onAgentExecutionStarted?.({
-      executionId,
-      projectId: input.project.id,
-      loopId: input.loop.id,
-      runId: input.run.id,
-      subtitle: `${repo}#${prNumber}`,
-      body: "Review started",
-      dedupeKey: `runtime.agent.started:reviewer:${input.run.id}`,
-    });
-    const result = await execution.wait();
+    try {
+      const execution = await this.options.agentExecutor.start({
+        executionId,
+        projectId: input.project.id,
+        loopId: input.loop.id,
+        runId: input.run.id,
+        prompt,
+        workingDirectory: input.project.repoPath,
+        timeoutMs: this.agentTimeoutMs,
+        metadata: {
+          loopType: "reviewer",
+          repo: input.queueItem.repo,
+          prNumber: input.queueItem.prNumber,
+        },
+        idempotencyKey: `reviewer:${input.loop.id}:${snapshot.headSha}`,
+      });
+      await this.options.onAgentExecutionStarted?.({
+        executionId,
+        projectId: input.project.id,
+        loopId: input.loop.id,
+        runId: input.run.id,
+        subtitle: `${repo}#${prNumber}`,
+        body: "Review started",
+        dedupeKey: `runtime.agent.started:reviewer:${input.run.id}`,
+      });
+      const result = await execution.wait();
 
-    if (result.status !== "completed") {
-      throw new ReviewerLoopError(
-        result.summary ?? `Reviewer agent ${result.status}`,
-        "retryable_transient",
-      );
+      if (result.status !== "completed") {
+        throw new ReviewerLoopError(
+          result.summary ?? `Reviewer agent ${result.status}`,
+          "retryable_transient",
+        );
+      }
+
+      const reviewFeedback = parseReviewFeedback(result);
+      if (!reviewFeedback.clean && reviewFeedback.comments.length === 0) {
+        throw new ReviewerLoopError(
+          "Reviewer agent produced no actionable review comments",
+          result.parseStatus === "invalid_json"
+            ? "non_retryable"
+            : "retryable_transient",
+        );
+      }
+
+      return {
+        ...input.checkpoint,
+        pendingReview: {
+          headSha: snapshot.headSha,
+          event: reviewFeedback.clean ? "APPROVE" : "COMMENT",
+          body: reviewFeedback.body,
+          summary: result.summary,
+          comments: reviewFeedback.comments,
+          clean: reviewFeedback.clean,
+        },
+        resumePolicy: "advance_from_checkpoint",
+      };
+    } catch (error) {
+      await this.tryRemovePullRequestReaction({
+        repo,
+        prNumber,
+        content: "eyes",
+        cwd: input.project.repoPath,
+        projectId: input.project.id,
+        loopId: input.loop.id,
+        runId: input.run.id,
+      });
+      throw error;
     }
-
-    const reviewFeedback = parseReviewFeedback(result);
-    if (!reviewFeedback.clean && reviewFeedback.comments.length === 0) {
-      throw new ReviewerLoopError(
-        "Reviewer agent produced no actionable review comments",
-        result.parseStatus === "invalid_json"
-          ? "non_retryable"
-          : "retryable_transient",
-      );
-    }
-
-    return {
-      ...input.checkpoint,
-      pendingReview: {
-        headSha: snapshot.headSha,
-        event: reviewFeedback.clean ? "APPROVE" : "COMMENT",
-        body: reviewFeedback.body,
-        summary: result.summary,
-        comments: reviewFeedback.comments,
-        clean: reviewFeedback.clean,
-      },
-      resumePolicy: "advance_from_checkpoint",
-    };
   }
 
   private async runPublishStep(input: {

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -1098,6 +1098,16 @@ export class ReviewerLoopRunner {
           loopId: input.loop.id,
           runId: input.run.id,
         });
+      } else {
+        await this.tryRemovePullRequestReaction({
+          repo,
+          prNumber,
+          content: "+1",
+          cwd: input.project.repoPath,
+          projectId: input.project.id,
+          loopId: input.loop.id,
+          runId: input.run.id,
+        });
       }
       await this.tryRemovePullRequestReaction({
         repo,

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -7,6 +7,7 @@ import { CommandExecutionError } from "../infra/command";
 import type {
   GitHubPullRequestDetail,
   GitHubPullRequestSummary,
+  GitHubReviewComment,
   SubmitReviewInput,
 } from "../infra/github";
 import {
@@ -60,6 +61,24 @@ export interface ReviewerGitHubGateway {
     capturedAt?: string;
   }): Promise<PullRequestSnapshotRecord>;
   submitReview(input: SubmitReviewInput): Promise<void>;
+  addPullRequestComment(input: {
+    repo: string;
+    prNumber: number;
+    body: string;
+    cwd?: string;
+  }): Promise<void>;
+  addPullRequestReaction(input: {
+    repo: string;
+    prNumber: number;
+    content: "+1" | "eyes";
+    cwd?: string;
+  }): Promise<void>;
+  removePullRequestReaction(input: {
+    repo: string;
+    prNumber: number;
+    content: "+1" | "eyes";
+    cwd?: string;
+  }): Promise<void>;
   addPullRequestLabels(input: {
     repo: string;
     prNumber: number;
@@ -148,10 +167,27 @@ interface ReviewerCheckpoint {
   pendingReview?: {
     headSha: string;
     event: ReviewEvent;
-    body: string;
+    body?: string;
     summary?: string;
+    comments: ReviewFeedbackComment[];
+    clean: boolean;
   };
   skipReason?: string;
+}
+
+interface ReviewFeedbackComment {
+  body: string;
+  path?: string;
+  line?: number;
+  side?: "LEFT" | "RIGHT";
+  startLine?: number;
+  startSide?: "LEFT" | "RIGHT";
+}
+
+interface ParsedReviewFeedback {
+  body?: string;
+  comments: ReviewFeedbackComment[];
+  clean: boolean;
 }
 
 interface ResumedRunContext {
@@ -821,6 +857,12 @@ export class ReviewerLoopRunner {
     });
 
     const executionId = randomUUID();
+    await this.options.github.addPullRequestReaction({
+      repo,
+      prNumber,
+      content: "eyes",
+      cwd: input.project.repoPath,
+    });
     const execution = await this.options.agentExecutor.start({
       executionId,
       projectId: input.project.id,
@@ -854,10 +896,10 @@ export class ReviewerLoopRunner {
       );
     }
 
-    const reviewBody = toReviewBody(result);
-    if (!reviewBody) {
+    const reviewFeedback = parseReviewFeedback(result);
+    if (!reviewFeedback.clean && reviewFeedback.comments.length === 0) {
       throw new ReviewerLoopError(
-        "Reviewer agent produced an empty review body",
+        "Reviewer agent produced no actionable review comments",
         result.parseStatus === "invalid_json"
           ? "non_retryable"
           : "retryable_transient",
@@ -869,8 +911,10 @@ export class ReviewerLoopRunner {
       pendingReview: {
         headSha: snapshot.headSha,
         event: "COMMENT",
-        body: reviewBody,
+        body: reviewFeedback.body,
         summary: result.summary,
+        comments: reviewFeedback.comments,
+        clean: reviewFeedback.clean,
       },
       resumePolicy: "advance_from_checkpoint",
     };
@@ -908,6 +952,10 @@ export class ReviewerLoopRunner {
       pendingReview.event === "APPROVE" && !this.allowAutoApprove
         ? "COMMENT"
         : pendingReview.event;
+    const inlineComments = pendingReview.comments.filter(isInlineReviewComment);
+    const topLevelComments = pendingReview.comments.filter(
+      (comment) => !isInlineReviewComment(comment),
+    );
 
     const repo = requireString(input.queueItem.repo, "queueItem.repo");
     const prNumber = requireNumber(
@@ -931,13 +979,55 @@ export class ReviewerLoopRunner {
     }
 
     try {
-      await this.options.github.submitReview({
-        repo,
-        prNumber,
-        event: reviewEvent,
-        body: pendingReview.body,
-        cwd: input.project.repoPath,
-      });
+      if (pendingReview.clean) {
+        if (reviewEvent === "APPROVE") {
+          await this.options.github.submitReview({
+            repo,
+            prNumber,
+            event: reviewEvent,
+            body: pendingReview.body,
+            cwd: input.project.repoPath,
+          });
+        }
+        await this.options.github.addPullRequestReaction({
+          repo,
+          prNumber,
+          content: "+1",
+          cwd: input.project.repoPath,
+        });
+        await this.options.github.removePullRequestReaction({
+          repo,
+          prNumber,
+          content: "eyes",
+          cwd: input.project.repoPath,
+        });
+      } else {
+        if (inlineComments.length > 0 || pendingReview.body) {
+          await this.options.github.submitReview({
+            repo,
+            prNumber,
+            event: reviewEvent,
+            body: pendingReview.body,
+            commitId: pendingReview.headSha,
+            comments: inlineComments.map(toGitHubReviewComment),
+            cwd: input.project.repoPath,
+          });
+        }
+        for (const comment of topLevelComments) {
+          await this.options.github.addPullRequestComment({
+            repo,
+            prNumber,
+            body: comment.body,
+            cwd: input.project.repoPath,
+          });
+        }
+        await this.options.github.removePullRequestReaction({
+          repo,
+          prNumber,
+          content: "eyes",
+          cwd: input.project.repoPath,
+        });
+      }
 
       let postSubmitDetail = detail;
       if (
@@ -1446,6 +1536,136 @@ function toReviewBody(result: AgentResult): string | null {
   return candidate.length > 0 ? candidate : null;
 }
 
+function parseReviewFeedback(result: AgentResult): ParsedReviewFeedback {
+  const rawOutput = extractReviewOutput(result.rawLogs.stdout);
+  const parsed = parseStructuredReviewOutput(rawOutput);
+  if (parsed) {
+    return parsed;
+  }
+
+  const fallbackBody = toReviewBody(result);
+  return {
+    body: fallbackBody ?? undefined,
+    comments: fallbackBody ? [{ body: fallbackBody }] : [],
+    clean: false,
+  };
+}
+
+function extractReviewOutput(stdout: string): string {
+  return stdout
+    .split(/\r?\n/)
+    .filter((line) => !line.startsWith("__LOOPER_RESULT__="))
+    .join("\n")
+    .trim();
+}
+
+function parseStructuredReviewOutput(
+  output: string,
+): ParsedReviewFeedback | null {
+  if (!output) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    const verdict = readString(parsed.verdict)?.toLowerCase();
+    const body = normalizeOptionalBody(parsed.body);
+    const comments = Array.isArray(parsed.comments)
+      ? parsed.comments
+          .map((comment) => normalizeReviewFeedbackComment(comment))
+          .filter((comment): comment is ReviewFeedbackComment =>
+            Boolean(comment),
+          )
+      : [];
+    const clean = verdict === "clean";
+    if (!clean && comments.length === 0) {
+      return null;
+    }
+
+    return { body, comments, clean };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeReviewFeedbackComment(
+  value: unknown,
+): ReviewFeedbackComment | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const comment = value as Record<string, unknown>;
+  const body = readString(comment.body)?.trim();
+  if (!body) {
+    return null;
+  }
+
+  const path = readString(comment.path)?.trim();
+  const line = readPositiveInteger(comment.line);
+  const side = normalizeReviewSide(comment.side);
+  const startLine = readPositiveInteger(comment.startLine);
+  const startSide = normalizeReviewSide(comment.startSide);
+  if (
+    (path && (!line || !side)) ||
+    (!path && (line || side || startLine || startSide))
+  ) {
+    return null;
+  }
+
+  return {
+    body,
+    path,
+    line,
+    side,
+    startLine,
+    startSide,
+  };
+}
+
+function normalizeOptionalBody(value: unknown): string | undefined {
+  const body = readString(value)?.trim();
+  return body && body.length > 0 ? body : undefined;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function normalizeReviewSide(value: unknown): "LEFT" | "RIGHT" | undefined {
+  const side = readString(value)?.trim().toUpperCase();
+  return side === "LEFT" || side === "RIGHT" ? side : undefined;
+}
+
+function isInlineReviewComment(
+  comment: ReviewFeedbackComment,
+): comment is ReviewFeedbackComment & {
+  path: string;
+  line: number;
+  side: "LEFT" | "RIGHT";
+} {
+  return Boolean(comment.path && comment.line && comment.side);
+}
+
+function toGitHubReviewComment(
+  comment: ReviewFeedbackComment & {
+    path: string;
+    line: number;
+    side: "LEFT" | "RIGHT";
+  },
+): GitHubReviewComment {
+  return {
+    body: comment.body,
+    path: comment.path,
+    line: comment.line,
+    side: comment.side,
+    startLine: comment.startLine,
+    startSide: comment.startSide,
+  };
+}
+
 function summarizeLogs(stdout: string): string {
   return stdout
     .split("\n")
@@ -1484,7 +1704,15 @@ function buildReviewPrompt(input: {
         ? `Unresolved threads: ${input.snapshot.unresolvedThreadCount}`
         : null,
       diff ? `Diff:\n${diff}` : null,
-      "Return concise GitHub review feedback. Do not approve; provide comment-ready feedback text.",
+      [
+        "Return detailed GitHub review feedback as raw JSON with this exact shape:",
+        '{"verdict":"clean"|"actionable","body":"optional overall summary","comments":[{"body":"required comment text","path":"src/file.ts optional for inline comments","line":123,"side":"RIGHT","startLine":120,"startSide":"RIGHT"}]}',
+        "Use verdict=actionable whenever there is any actionable advice.",
+        "Prefer inline comments for specific code-level feedback when you can anchor them confidently to the diff using the changed file path and diff line numbers.",
+        "Use top-level comments without path/line only for architectural, cross-cutting, or otherwise unanchorable feedback.",
+        "Write substantially more detail than a brief summary; every comment should explain the problem, why it matters, and the concrete change to make.",
+        "Do not approve. If the review is clean, return verdict=clean with comments=[].",
+      ].join("\n"),
     ]
       .filter((value): value is string => Boolean(value))
       .join("\n\n"),

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -974,6 +974,12 @@ export class ReviewerLoopRunner {
       normalizedPendingReview.event === "APPROVE" && !this.allowAutoApprove
         ? "COMMENT"
         : normalizedPendingReview.event;
+    const reviewBody =
+      normalizedPendingReview.clean && reviewEvent === "COMMENT"
+        ? normalizedPendingReview.body?.trim() ||
+          normalizedPendingReview.summary?.trim() ||
+          undefined
+        : normalizedPendingReview.body;
     const inlineComments = normalizedPendingReview.comments.filter(
       isInlineReviewComment,
     );
@@ -1006,13 +1012,13 @@ export class ReviewerLoopRunner {
       if (normalizedPendingReview.clean) {
         if (
           !normalizedPendingReview.publishState.reviewSubmitted &&
-          (reviewEvent === "APPROVE" || Boolean(normalizedPendingReview.body))
+          (reviewEvent === "APPROVE" || Boolean(reviewBody))
         ) {
           await this.options.github.submitReview({
             repo,
             prNumber,
             event: reviewEvent,
-            body: normalizedPendingReview.body,
+            body: reviewBody,
             cwd: input.project.repoPath,
           });
           normalizedPendingReview.publishState.reviewSubmitted = true;

--- a/apps/looperd/src/reviewer/index.ts
+++ b/apps/looperd/src/reviewer/index.ts
@@ -910,7 +910,7 @@ export class ReviewerLoopRunner {
       ...input.checkpoint,
       pendingReview: {
         headSha: snapshot.headSha,
-        event: "COMMENT",
+        event: reviewFeedback.clean ? "APPROVE" : "COMMENT",
         body: reviewFeedback.body,
         summary: result.summary,
         comments: reviewFeedback.comments,

--- a/apps/looperd/src/runtime/index.test.ts
+++ b/apps/looperd/src/runtime/index.test.ts
@@ -180,6 +180,12 @@ class FakeGitHubGateway {
     this.submitCalls.push(input);
   }
 
+  public async addPullRequestComment(): Promise<void> {}
+
+  public async addPullRequestReaction(): Promise<void> {}
+
+  public async removePullRequestReaction(): Promise<void> {}
+
   public async createPullRequest(): Promise<{ number?: number; url: string }> {
     this.createPullRequestCalls += 1;
     return {

--- a/apps/looperd/src/runtime/index.ts
+++ b/apps/looperd/src/runtime/index.ts
@@ -73,8 +73,11 @@ export interface CreateLooperdRuntimeOptions {
     | "resolveReviewThread"
     | "capturePullRequestSnapshot"
     | "submitReview"
+    | "addPullRequestComment"
+    | "addPullRequestReaction"
     | "createPullRequest"
     | "addPullRequestLabels"
+    | "removePullRequestReaction"
     | "removePullRequestLabels"
     | "addPullRequestReviewers"
   >;


### PR DESCRIPTION
## Summary
- add structured reviewer output handling so actionable findings become inline review comments when they can be anchored to the diff, with top-level PR comments reserved for broader feedback
- update reviewer publishing to signal review lifecycle on the PR with 👀 at review start, 👍 for clean outcomes, and 👀 removal after feedback is posted
- extend GitHub gateway coverage and reviewer tests for review comments, PR comments, and reaction flows

## Validation
- `/Users/mrc/.bun/bin/bun test apps/looperd/src/reviewer/index.test.ts`
- `/Users/mrc/.bun/bin/bun test apps/looperd/src/infra/github.test.ts`
- `/Users/mrc/.bun/bin/bun test apps/looperd/src/runtime/index.test.ts`
- `/Users/mrc/.bun/bin/bun run typecheck` *(currently fails in pre-existing `apps/cli/src/index.ts` issues unrelated to this change)*