### PR TITLE
Avoid treating plain PR comments as review threads

### DIFF
--- a/apps/looperd/src/infra/github.test.ts
+++ b/apps/looperd/src/infra/github.test.ts
@@ -203,6 +203,42 @@ esac
     ).rejects.toBeInstanceOf(ReviewThreadNotFoundError);
   });
 
+  test("does not treat plain pull request comments as review threads", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "looper-gh-"));
+    cleanupPaths.push(rootDir);
+
+    const scriptPath = join(rootDir, "gh");
+    await writeFile(
+      scriptPath,
+      `#!/bin/sh
+case "$*" in
+  "pr view"*)
+    printf '{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pr/42","state":"OPEN","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","author":{"login":"octocat"},"reviewRequests":[],"comments":[{"id":"IC_comment","body":"@codex review"}],"reviews":[],"statusCheckRollup":[]}'
+    ;;
+  *"reviewThreads"*)
+    printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
+    ;;
+  *)
+    printf '{}'
+    ;;
+esac
+`,
+    );
+    await chmod(scriptPath, 0o755);
+
+    const gateway = new GhCliGitHubGateway({
+      ghPath: scriptPath,
+      cwd: rootDir,
+    });
+
+    const detail = await gateway.viewPullRequest({
+      repo: "acme/looper",
+      prNumber: 42,
+    });
+
+    expect(detail.comments).toEqual([]);
+  });
+
   test("surfaces permission errors when resolving review thread", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "looper-gh-"));
     cleanupPaths.push(rootDir);

--- a/apps/looperd/src/infra/github.ts
+++ b/apps/looperd/src/infra/github.ts
@@ -284,10 +284,7 @@ export class GhCliGitHubGateway {
       author: extractAuthor(parsed.author),
       reviewRequests: extractReviewRequestLogins(parsed.reviewRequests),
       hasConflicts: asOptionalString(parsed.mergeStateStatus) === "DIRTY",
-      comments:
-        reviewThreads.length > 0
-          ? reviewThreads
-          : asArrayValue(parsed.comments),
+      comments: reviewThreads,
       reviews: asArrayValue(parsed.reviews),
       checks: asArrayValue(parsed.statusCheckRollup),
     };


### PR DESCRIPTION
## Summary
- stop falling back to plain `gh pr view` comments when review thread queries return no threads
- ensure fixer and spec review logic only operate on actual review threads
- add a regression test covering PRs with plain comments but no review threads

## Validation
- bun test apps/looperd/src/infra/github.test.ts