### PR TITLE
Show subcommands in CLI help output

### DIFF
--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -18,7 +18,82 @@ function createConfig() {
   };
 }
 
+async function captureHelpOutput(args: string[]) {
+  const result = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "-e",
+      [
+        `import { runCli } from ${JSON.stringify(new URL("./index.ts", import.meta.url).href)};`,
+        `const exitCode = await runCli(${JSON.stringify(args)}, {`,
+        `  loadConfigImpl: async () => (${JSON.stringify(createConfig())}),`,
+        "});",
+        "process.exit(exitCode);",
+      ].join("\n"),
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    exitCode: result.exitCode,
+    output: result.stdout.toString(),
+    error: result.stderr.toString(),
+  };
+}
+
 describe("runCli", () => {
+  test("shows subcommands in help output for every command group", async () => {
+    const commandGroups = [
+      {
+        args: ["project", "--help"],
+        subcommands: ["list  List projects", "add   Add a project"],
+      },
+      {
+        args: ["config", "--help"],
+        subcommands: ["show  Show active config"],
+      },
+      {
+        args: ["daemon", "--help"],
+        subcommands: ["status  Show daemon status", "logs    Show daemon logs"],
+      },
+      {
+        args: ["loop", "--help"],
+        subcommands: [
+          "list   List loops",
+          "start  Start a loop",
+          "pause  Pause a loop",
+        ],
+      },
+      {
+        args: ["pr", "--help"],
+        subcommands: [
+          "list    List pull requests",
+          "show    Show a pull request",
+          "status  Show pull request status",
+        ],
+      },
+      {
+        args: ["run", "--help"],
+        subcommands: ["list  List runs"],
+      },
+    ];
+
+    for (const commandGroup of commandGroups) {
+      const { exitCode, output, error } = await captureHelpOutput(
+        commandGroup.args,
+      );
+
+      expect(exitCode).toBe(0);
+      expect(error).toBe("");
+      expect(output).toContain("Subcommands:");
+
+      for (const subcommand of commandGroup.subcommands) {
+        expect(output).toContain(subcommand);
+      }
+    }
+  });
+
   test("renders status as json", async () => {
     const lines: string[] = [];
     const exitCode = await runCli(["status", "--json"], {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -78,6 +78,39 @@ interface PullRequestRef {
   prNumber: number;
 }
 
+interface HelpSection {
+  title?: string;
+  body: string;
+}
+
+interface CommandGroupSubcommand {
+  name: string;
+  description: string;
+}
+
+const COMMAND_GROUP_SUBCOMMANDS: Record<string, CommandGroupSubcommand[]> = {
+  project: [
+    { name: "list", description: "List projects" },
+    { name: "add", description: "Add a project" },
+  ],
+  config: [{ name: "show", description: "Show active config" }],
+  daemon: [
+    { name: "status", description: "Show daemon status" },
+    { name: "logs", description: "Show daemon logs" },
+  ],
+  loop: [
+    { name: "list", description: "List loops" },
+    { name: "start", description: "Start a loop" },
+    { name: "pause", description: "Pause a loop" },
+  ],
+  pr: [
+    { name: "list", description: "List pull requests" },
+    { name: "show", description: "Show a pull request" },
+    { name: "status", description: "Show pull request status" },
+  ],
+  run: [{ name: "list", description: "List runs" }],
+};
+
 interface ProjectSummary {
   id: string;
   repoPath: string;
@@ -473,9 +506,50 @@ function createCli(runtime: CliRuntime) {
       await dispatch(createContext(runtime, ["run", ...args], options));
     });
 
-  cli.help();
+  cli.help((sections) => {
+    return addCommandGroupSubcommandSection(sections, cli.matchedCommand?.name);
+  });
 
   return cli;
+}
+
+function addCommandGroupSubcommandSection(
+  sections: HelpSection[],
+  commandName?: string,
+): HelpSection[] {
+  if (!commandName) {
+    return sections;
+  }
+
+  const subcommands = COMMAND_GROUP_SUBCOMMANDS[commandName];
+  if (!subcommands?.length) {
+    return sections;
+  }
+
+  const longestSubcommandName = Math.max(
+    ...subcommands.map((subcommand) => subcommand.name.length),
+  );
+  const subcommandsSection: HelpSection = {
+    title: "Subcommands",
+    body: subcommands
+      .map(
+        (subcommand) =>
+          `  ${subcommand.name.padEnd(longestSubcommandName)}  ${subcommand.description}`,
+      )
+      .join("\n"),
+  };
+  const usageSectionIndex = sections.findIndex(
+    (section) => section.title === "Usage",
+  );
+  const nextSections = [...sections];
+
+  if (usageSectionIndex === -1) {
+    nextSections.push(subcommandsSection);
+    return nextSections;
+  }
+
+  nextSections.splice(usageSectionIndex + 1, 0, subcommandsSection);
+  return nextSections;
 }
 
 function addGlobalOptions(cli: ReturnType<typeof cac>) {


### PR DESCRIPTION
## Summary
- add a help-section hook that injects subcommand listings for every CLI command group
- define descriptions for each supported group subcommand so help output is self-discoverable
- cover the help output for all command groups with CLI tests

## Validation
- /Users/mrc/.bun/bin/bun test apps/cli/src/index.test.ts
- /Users/mrc/.bun/bin/bun run --cwd apps/cli typecheck
- /Users/mrc/.bun/bin/bun run lint
- /Users/mrc/.bun/bin/bun run --cwd apps/cli build