### PR TITLE
Bump CLI and looperd version to 0.2.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerformer/looper",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "type": "module",
   "bin": {

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -668,7 +668,7 @@ describe("runCli", () => {
       runCommandImpl: async ({ command, args, timeoutMs }) => {
         runCommandCalls.push({ command, args, timeoutMs });
         if (command === "/Users/tester/.looper/bin/looperd") {
-          return { stdout: "0.1.0\n", stderr: "", exitCode: 0 };
+          return { stdout: "0.2.0\n", stderr: "", exitCode: 0 };
         }
 
         return { stdout: "", stderr: "not found", exitCode: 1 };
@@ -683,7 +683,7 @@ describe("runCli", () => {
       timeoutMs: 5_000,
     });
     expect(lines.join("\n")).toContain("daemonVersion");
-    expect(lines.join("\n")).toContain("0.1.0");
+    expect(lines.join("\n")).toContain("0.2.0");
     expect(lines.join("\n")).toContain("/Users/tester/.looper/bin/looperd");
   });
 
@@ -834,7 +834,7 @@ describe("runCli", () => {
       },
       runCommandImpl: async ({ command }) => {
         if (command === "/Users/tester/.looper/bin/looperd") {
-          return { stdout: "0.1.0\n", stderr: "", exitCode: 0 };
+          return { stdout: "0.2.0\n", stderr: "", exitCode: 0 };
         }
 
         return { stdout: "", stderr: "not found", exitCode: 1 };
@@ -843,7 +843,7 @@ describe("runCli", () => {
 
     expect(exitCode).toBe(0);
     expect(lines.join("\n")).toContain("cliCurrent");
-    expect(lines.join("\n")).toContain("0.1.0");
+    expect(lines.join("\n")).toContain("0.2.0");
     expect(lines.join("\n")).toContain("0.2.0");
     expect(lines.join("\n")).toContain("0.3.0");
     expect(lines.join("\n")).toContain("installed-binary");
@@ -904,7 +904,7 @@ describe("runCli", () => {
           "https://api.github.com/repos/powerformer/looper/releases/latest"
         ) {
           return new Response(
-            JSON.stringify({ tag_name: "v0.2.0", assets: [] }),
+            JSON.stringify({ tag_name: "v0.3.0", assets: [] }),
           );
         }
 
@@ -912,7 +912,7 @@ describe("runCli", () => {
       },
       runCommandImpl: async ({ command }) => {
         if (command === "/Users/tester/.looper/bin/looperd") {
-          return { stdout: "0.1.0\n", stderr: "", exitCode: 0 };
+          return { stdout: "0.2.0\n", stderr: "", exitCode: 0 };
         }
 
         return { stdout: "", stderr: "not found", exitCode: 1 };
@@ -932,8 +932,8 @@ describe("runCli", () => {
     expect(installCalls).toHaveLength(1);
     expect(installCalls[0]?.homeDir).toBe("/Users/tester");
     expect(installCalls[0]?.force).toBe(true);
-    expect(installCalls[0]?.tag).toBe("v0.2.0");
-    expect(lines.join("\n")).toContain("Upgraded looperd 0.1.0 → 0.2.0");
+    expect(installCalls[0]?.tag).toBe("v0.3.0");
+    expect(lines.join("\n")).toContain("Upgraded looperd 0.2.0 → 0.3.0");
     expect(lines.join("\n")).toContain("looper daemon restart");
   });
 

--- a/apps/looperd/src/generated/version.ts
+++ b/apps/looperd/src/generated/version.ts
@@ -6,7 +6,7 @@ export interface LooperdBuildMetadata {
   buildTimestamp: string | null;
 }
 
-export const LOOPERD_VERSION = "0.1.0";
+export const LOOPERD_VERSION = "0.2.0";
 export const LOOPERD_BUILD_METADATA: LooperdBuildMetadata = {
   versionSource: "apps/cli/package.json",
   gitCommitSha: null,

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/cli": {
       "name": "@powerformer/looper",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "looper": "dist/index.js",
       },

--- a/specs/2026-04-15-cli-daemon-distribution/checklist.md
+++ b/specs/2026-04-15-cli-daemon-distribution/checklist.md
@@ -149,7 +149,7 @@
 
 - `bun test apps/looperd/src/storage/sqlite/migrate.test.ts apps/cli/src/index.test.ts` 通过，补齐 Phase 11 缺失单测
 - `bun run typecheck` 与 `bun run build` 通过
-- 本地 tarball 全局安装 smoke：`npm install -g --prefix <tmp> apps/cli/powerformer-looper-0.1.0.tgz` 后 `looper --help` 正常
+- 本地 tarball 全局安装 smoke：`npm install -g --prefix <tmp> apps/cli/powerformer-looper-0.2.0.tgz` 后 `looper --help` 正常
 - 手动安装 compiled `looperd-darwin-x64` 到 `~/.looper/bin/looperd` 后，`looper daemon start`、`looper daemon status --json`、`looper status --json` 均正常
 - GitHub Release download 逻辑由 `apps/cli/src/daemon-release.test.ts` 与 `apps/cli/src/daemon-install.test.ts` 覆盖；仓库当前尚无公开 release 可做真实 smoke
 


### PR DESCRIPTION
## Summary
- bump the published CLI package version from 0.1.0 to 0.2.0 and sync the generated looperd version metadata
- update CLI tests to treat 0.2.0 as the current installed version and keep upgrade expectations pointed at the next release
- refresh the distribution checklist tarball example to the new package version

## Testing
- bun test apps/cli/src/index.test.ts