### PR TITLE
Stop forcing unsupported looperd compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,6 @@ jobs:
 
       - name: Compile looperd for ${{ matrix.target }}
         env:
-          LOOPER_FORCE_COMPILE: "1"
           LOOPER_BUILD_GIT_SHA: ${{ github.sha }}
         run: |
           export LOOPER_BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
## Summary
- stop overriding the darwin-arm64 standalone compile guard in the release workflow
- let the existing compile safety check block release publication instead of shipping a known-bad looperd binary

## Testing
- not run (workflow-only change)