### PR TITLE
fix: auto-close linked issues from worker PRs

### DIFF
--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -8,8 +8,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -290,10 +292,12 @@ type ProcessResult struct {
 }
 
 type workerInput struct {
-	Title         string   `json:"title,omitempty"`
-	Prompt        string   `json:"prompt,omitempty"`
-	SpecPath      string   `json:"specPath,omitempty"`
-	Repo          string   `json:"repo,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Prompt   string `json:"prompt,omitempty"`
+	SpecPath string `json:"specPath,omitempty"`
+	Repo     string `json:"repo,omitempty"`
+	// IssueRepo is the source issue repository, which may differ from Repo for cross-repo closing references.
+	IssueRepo     string   `json:"issueRepo,omitempty"`
 	BaseBranch    string   `json:"baseBranch,omitempty"`
 	ExecutionMode string   `json:"executionMode,omitempty"`
 	IssueNumber   int64    `json:"issueNumber,omitempty"`
@@ -914,7 +918,10 @@ func (r *Runner) resolveWorkerInput(ctx context.Context, project storage.Project
 	projectMetadata := parseJSONObject(project.MetadataJSON)
 	repo := firstNonEmpty(stringFromAnyDefault(source["repo"]), derefString(loop.Repo), stringFromAnyDefault(projectMetadata["repo"]))
 	baseBranch := firstNonEmpty(stringFromAnyDefault(source["baseBranch"]), stringFromAnyDefault(metadata["baseBranch"]), derefString(project.BaseBranch), "main")
-	work := workerInput{Title: firstNonEmpty(stringFromAnyDefault(source["title"]), "Worker run"), Prompt: stringFromAnyDefault(source["prompt"]), SpecPath: stringFromAnyDefault(source["specPath"]), Repo: repo, BaseBranch: baseBranch, ExecutionMode: executionMode, IssueNumber: int64FromAny(source["issueNumber"]), IssueURL: stringFromAnyDefault(source["issueUrl"]), PRNumber: int64FromAny(source["prNumber"]), Branch: stringFromAnyDefault(source["branch"]), HeadSHA: stringFromAnyDefault(source["headSha"]), Reviewers: stringSliceFromAny(source["reviewers"])}
+	work := workerInput{Title: firstNonEmpty(stringFromAnyDefault(source["title"]), "Worker run"), Prompt: stringFromAnyDefault(source["prompt"]), SpecPath: stringFromAnyDefault(source["specPath"]), Repo: repo, IssueRepo: stringFromAnyDefault(source["issueRepo"]), BaseBranch: baseBranch, ExecutionMode: executionMode, IssueNumber: int64FromAny(source["issueNumber"]), IssueURL: stringFromAnyDefault(source["issueUrl"]), PRNumber: int64FromAny(source["prNumber"]), Branch: stringFromAnyDefault(source["branch"]), HeadSHA: stringFromAnyDefault(source["headSha"]), Reviewers: stringSliceFromAny(source["reviewers"])}
+	if work.IssueNumber > 0 && strings.TrimSpace(work.IssueRepo) == "" {
+		work.IssueRepo = work.Repo
+	}
 	if work.Repo == "" {
 		return workerInput{}, &loopError{message: "worker.repo is required", kind: FailureNonRetryable}
 	}
@@ -1290,9 +1297,50 @@ func buildAgentPullRequestInstruction(work workerInput) string {
 		fmt.Sprintf("Target base branch: %s.", work.BaseBranch),
 	}
 	if work.IssueNumber > 0 {
-		parts = append(parts, fmt.Sprintf("Include `Closes #%d` in the PR body.", work.IssueNumber))
+		parts = append(parts, fmt.Sprintf("Include `Closes %s` in the PR body.", formatIssueClosingReference(work.Repo, work.IssueRepo, work.IssueNumber)))
 	}
 	return strings.Join(parts, "\n")
+}
+
+func formatIssueClosingReference(prRepo, issueRepo string, issueNumber int64) string {
+	if issueNumber <= 0 {
+		return ""
+	}
+	issueRepo = strings.TrimSpace(issueRepo)
+	if issueRepo == "" || strings.EqualFold(strings.TrimSpace(prRepo), issueRepo) {
+		return fmt.Sprintf("#%d", issueNumber)
+	}
+	return fmt.Sprintf("%s#%d", issueRepo, issueNumber)
+}
+
+func formatIssueReference(issueRepo string, issueNumber int64) string {
+	if issueNumber <= 0 {
+		return ""
+	}
+	issueRepo = strings.TrimSpace(issueRepo)
+	if issueRepo == "" {
+		return fmt.Sprintf("#%d", issueNumber)
+	}
+	return fmt.Sprintf("%s#%d", issueRepo, issueNumber)
+}
+
+func issueRepoFromURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	host := strings.ToLower(parsed.Host)
+	if host != "github.com" && host != "www.github.com" {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 4 || !strings.EqualFold(parts[2], "issues") {
+		return ""
+	}
+	if _, err := strconv.ParseInt(parts[3], 10, 64); err != nil {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
 }
 
 func readSpecBlock(projectRepoPath, specPath string) (string, error) {
@@ -1321,10 +1369,10 @@ func buildPullRequestBody(work workerInput, plan *checkpointPlan, execution *che
 		lines = append(lines, "", "## Agent Summary", execution.Summary)
 	}
 	if work.IssueNumber > 0 {
-		lines = append(lines, "", fmt.Sprintf("Issue: %s#%d", work.Repo, work.IssueNumber))
+		lines = append(lines, "", "Issue: "+formatIssueReference(firstNonEmpty(work.IssueRepo, work.Repo), work.IssueNumber))
 	}
 	if work.IssueURL != "" {
-		lines = append(lines, fmt.Sprintf("Issue URL: %s", work.IssueURL))
+		lines = append(lines, "", fmt.Sprintf("Issue URL: %s", work.IssueURL))
 	}
 	if work.SpecPath != "" {
 		lines = append(lines, "", fmt.Sprintf("Spec: %s", work.SpecPath))
@@ -1333,7 +1381,7 @@ func buildPullRequestBody(work workerInput, plan *checkpointPlan, execution *che
 		lines = append(lines, "", fmt.Sprintf("Prompt: %s", work.Prompt))
 	}
 	if work.IssueNumber > 0 {
-		lines = append(lines, "", fmt.Sprintf("Closes #%d", work.IssueNumber))
+		lines = append(lines, "", "Closes "+formatIssueClosingReference(work.Repo, work.IssueRepo, work.IssueNumber))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -1344,6 +1392,7 @@ func hydrateWorkerInputFromIssue(work workerInput, issue IssueDetail) workerInpu
 		work.Title = issue.Title
 	}
 	work.Prompt = buildIssuePrompt(work.Repo, issue)
+	work.IssueRepo = firstNonEmpty(work.IssueRepo, issueRepoFromURL(issue.URL), work.Repo)
 	work.IssueURL = issue.URL
 	return work
 }

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1341,7 +1341,7 @@ func issueRepoFromURL(raw string) string {
 }
 
 func issueLookupRepo(work workerInput) string {
-	return firstNonEmpty(strings.TrimSpace(work.IssueRepo), issueRepoFromURL(work.IssueURL))
+	return firstNonEmpty(strings.TrimSpace(work.IssueRepo), issueRepoFromURL(work.IssueURL), work.Repo)
 }
 
 func resolvedIssueRepo(work workerInput, issue IssueDetail) string {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -932,7 +932,7 @@ func (r *Runner) resolveWorkerInput(ctx context.Context, project storage.Project
 		return workerInput{}, &loopError{message: "worker.prompt or worker.specPath is required", kind: FailureNonRetryable}
 	}
 	if work.ExecutionMode == "create-pr" && work.IssueNumber > 0 && work.Prompt == "" && work.SpecPath == "" && r.github != nil {
-		issue, err := r.github.ViewIssue(ctx, ViewIssueInput{Repo: work.Repo, IssueNumber: work.IssueNumber, CWD: project.RepoPath})
+		issue, err := r.github.ViewIssue(ctx, ViewIssueInput{Repo: firstNonEmpty(work.IssueRepo, work.Repo), IssueNumber: work.IssueNumber, CWD: project.RepoPath})
 		if err != nil {
 			return workerInput{}, err
 		}

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -929,7 +929,7 @@ func (r *Runner) resolveWorkerInput(ctx context.Context, project storage.Project
 		return workerInput{}, &loopError{message: "worker.prompt or worker.specPath is required", kind: FailureNonRetryable}
 	}
 	if work.ExecutionMode == "create-pr" && work.IssueNumber > 0 && work.Prompt == "" && work.SpecPath == "" && r.github != nil {
-		issue, err := r.github.ViewIssue(ctx, ViewIssueInput{Repo: strings.TrimSpace(work.IssueRepo), IssueNumber: work.IssueNumber, CWD: project.RepoPath})
+		issue, err := r.github.ViewIssue(ctx, ViewIssueInput{Repo: issueLookupRepo(work), IssueNumber: work.IssueNumber, CWD: project.RepoPath})
 		if err != nil {
 			return workerInput{}, err
 		}
@@ -1340,6 +1340,14 @@ func issueRepoFromURL(raw string) string {
 	return parts[0] + "/" + parts[1]
 }
 
+func issueLookupRepo(work workerInput) string {
+	return firstNonEmpty(strings.TrimSpace(work.IssueRepo), issueRepoFromURL(work.IssueURL))
+}
+
+func resolvedIssueRepo(work workerInput, issue IssueDetail) string {
+	return firstNonEmpty(strings.TrimSpace(work.IssueRepo), issueRepoFromURL(issue.URL), issueRepoFromURL(work.IssueURL), work.Repo)
+}
+
 func readSpecBlock(projectRepoPath, specPath string) (string, error) {
 	if specPath == "" {
 		return "", nil
@@ -1388,9 +1396,9 @@ func hydrateWorkerInputFromIssue(work workerInput, issue IssueDetail) workerInpu
 	if work.Title == "Worker run" || work.Title == fallbackTitle {
 		work.Title = issue.Title
 	}
-	work.IssueRepo = firstNonEmpty(strings.TrimSpace(work.IssueRepo), issueRepoFromURL(issue.URL), work.Repo)
+	work.IssueRepo = resolvedIssueRepo(work, issue)
 	work.Prompt = buildIssuePrompt(work.IssueRepo, issue)
-	work.IssueURL = issue.URL
+	work.IssueURL = firstNonEmpty(issue.URL, work.IssueURL)
 	return work
 }
 

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1326,8 +1326,7 @@ func issueRepoFromURL(raw string) string {
 	if err != nil {
 		return ""
 	}
-	host := strings.ToLower(parsed.Host)
-	if host != "github.com" && host != "www.github.com" {
+	if parsed.Host == "" {
 		return ""
 	}
 	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -919,9 +919,6 @@ func (r *Runner) resolveWorkerInput(ctx context.Context, project storage.Project
 	repo := firstNonEmpty(stringFromAnyDefault(source["repo"]), derefString(loop.Repo), stringFromAnyDefault(projectMetadata["repo"]))
 	baseBranch := firstNonEmpty(stringFromAnyDefault(source["baseBranch"]), stringFromAnyDefault(metadata["baseBranch"]), derefString(project.BaseBranch), "main")
 	work := workerInput{Title: firstNonEmpty(stringFromAnyDefault(source["title"]), "Worker run"), Prompt: stringFromAnyDefault(source["prompt"]), SpecPath: stringFromAnyDefault(source["specPath"]), Repo: repo, IssueRepo: stringFromAnyDefault(source["issueRepo"]), BaseBranch: baseBranch, ExecutionMode: executionMode, IssueNumber: int64FromAny(source["issueNumber"]), IssueURL: stringFromAnyDefault(source["issueUrl"]), PRNumber: int64FromAny(source["prNumber"]), Branch: stringFromAnyDefault(source["branch"]), HeadSHA: stringFromAnyDefault(source["headSha"]), Reviewers: stringSliceFromAny(source["reviewers"])}
-	if work.IssueNumber > 0 && strings.TrimSpace(work.IssueRepo) == "" {
-		work.IssueRepo = work.Repo
-	}
 	if work.Repo == "" {
 		return workerInput{}, &loopError{message: "worker.repo is required", kind: FailureNonRetryable}
 	}
@@ -932,7 +929,7 @@ func (r *Runner) resolveWorkerInput(ctx context.Context, project storage.Project
 		return workerInput{}, &loopError{message: "worker.prompt or worker.specPath is required", kind: FailureNonRetryable}
 	}
 	if work.ExecutionMode == "create-pr" && work.IssueNumber > 0 && work.Prompt == "" && work.SpecPath == "" && r.github != nil {
-		issue, err := r.github.ViewIssue(ctx, ViewIssueInput{Repo: firstNonEmpty(work.IssueRepo, work.Repo), IssueNumber: work.IssueNumber, CWD: project.RepoPath})
+		issue, err := r.github.ViewIssue(ctx, ViewIssueInput{Repo: strings.TrimSpace(work.IssueRepo), IssueNumber: work.IssueNumber, CWD: project.RepoPath})
 		if err != nil {
 			return workerInput{}, err
 		}
@@ -1391,8 +1388,8 @@ func hydrateWorkerInputFromIssue(work workerInput, issue IssueDetail) workerInpu
 	if work.Title == "Worker run" || work.Title == fallbackTitle {
 		work.Title = issue.Title
 	}
-	work.Prompt = buildIssuePrompt(work.Repo, issue)
-	work.IssueRepo = firstNonEmpty(work.IssueRepo, issueRepoFromURL(issue.URL), work.Repo)
+	work.IssueRepo = firstNonEmpty(strings.TrimSpace(work.IssueRepo), issueRepoFromURL(issue.URL), work.Repo)
+	work.Prompt = buildIssuePrompt(work.IssueRepo, issue)
 	work.IssueURL = issue.URL
 	return work
 }

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -197,7 +197,7 @@ func TestResolveWorkerInputUsesIssueRepoForIssueHydration(t *testing.T) {
 	}
 }
 
-func TestResolveWorkerInputDefersIssueRepoFallbackUntilAfterHydration(t *testing.T) {
+func TestResolveWorkerInputFallsBackToWorkerRepoForIssueHydration(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{issueDetail: IssueDetail{Number: 27, Title: "Cross-repo issue", URL: "https://github.com/powerformer/looper/issues/27"}}
@@ -227,8 +227,8 @@ func TestResolveWorkerInputDefersIssueRepoFallbackUntilAfterHydration(t *testing
 	if len(github.viewIssueCalls) != 1 {
 		t.Fatalf("len(github.viewIssueCalls) = %d, want 1", len(github.viewIssueCalls))
 	}
-	if github.viewIssueCalls[0].Repo != "" {
-		t.Fatalf("ViewIssue repo = %q, want empty repo before hydration inference", github.viewIssueCalls[0].Repo)
+	if github.viewIssueCalls[0].Repo != "acme/looper" {
+		t.Fatalf("ViewIssue repo = %q, want worker repo fallback for hydration lookup", github.viewIssueCalls[0].Repo)
 	}
 	if work.IssueRepo != "powerformer/looper" {
 		t.Fatalf("work.IssueRepo = %q, want powerformer/looper", work.IssueRepo)

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -139,6 +139,20 @@ func TestHydrateWorkerInputFromIssueInfersIssueRepoFromURL(t *testing.T) {
 	}
 }
 
+func TestHydrateWorkerInputFromIssueUsesSourceIssueURLWhenIssueURLMissing(t *testing.T) {
+	t.Parallel()
+	work := hydrateWorkerInputFromIssue(workerInput{Repo: "acme/looper", IssueNumber: 27, IssueURL: "https://github.com/powerformer/looper/issues/27"}, IssueDetail{Number: 27, Title: "Issue title"})
+	if work.IssueRepo != "powerformer/looper" {
+		t.Fatalf("IssueRepo = %q, want powerformer/looper", work.IssueRepo)
+	}
+	if !strings.Contains(work.Prompt, "Implement GitHub issue powerformer/looper#27") {
+		t.Fatalf("Prompt = %q, want issue repo inferred from source issue URL", work.Prompt)
+	}
+	if work.IssueURL != "https://github.com/powerformer/looper/issues/27" {
+		t.Fatalf("IssueURL = %q, want source issue URL preserved", work.IssueURL)
+	}
+}
+
 func TestResolveWorkerInputUsesIssueRepoForIssueHydration(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -221,6 +235,50 @@ func TestResolveWorkerInputDefersIssueRepoFallbackUntilAfterHydration(t *testing
 	}
 	if !strings.Contains(work.Prompt, "Implement GitHub issue powerformer/looper#27") {
 		t.Fatalf("Prompt = %q, want resolved issue repo in prompt", work.Prompt)
+	}
+}
+
+func TestResolveWorkerInputUsesIssueURLRepoForIssueHydrationLookup(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{issueDetail: IssueDetail{Number: 27, Title: "Cross-repo issue"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	queueItem, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	payload := `{"title":"Implement worker loop","repo":"acme/looper","issueNumber":27,"issueUrl":"https://github.com/powerformer/looper/issues/27","baseBranch":"main"}`
+	loopMetadata := `{"worker":{"title":"Implement worker loop","repo":"acme/looper","issueNumber":27,"issueUrl":"https://github.com/powerformer/looper/issues/27","baseBranch":"main"}}`
+	loop.MetadataJSON = &loopMetadata
+	queueItem.PayloadJSON = &payload
+
+	work, err := runner.resolveWorkerInput(context.Background(), *project, *loop, *queueItem, workerCheckpoint{})
+	if err != nil {
+		t.Fatalf("resolveWorkerInput() error = %v", err)
+	}
+	if len(github.viewIssueCalls) != 1 {
+		t.Fatalf("len(github.viewIssueCalls) = %d, want 1", len(github.viewIssueCalls))
+	}
+	if github.viewIssueCalls[0].Repo != "powerformer/looper" {
+		t.Fatalf("ViewIssue repo = %q, want powerformer/looper inferred from issue URL", github.viewIssueCalls[0].Repo)
+	}
+	if work.IssueRepo != "powerformer/looper" {
+		t.Fatalf("work.IssueRepo = %q, want powerformer/looper", work.IssueRepo)
+	}
+	if !strings.Contains(work.Prompt, "Implement GitHub issue powerformer/looper#27") {
+		t.Fatalf("Prompt = %q, want resolved issue repo in prompt", work.Prompt)
+	}
+	if strings.Contains(work.Prompt, "Implement GitHub issue acme/looper#27") {
+		t.Fatalf("Prompt = %q, want prompt to avoid worker repo issue reference", work.Prompt)
 	}
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -136,6 +136,44 @@ func TestHydrateWorkerInputFromIssueInfersIssueRepoFromURL(t *testing.T) {
 	}
 }
 
+func TestResolveWorkerInputUsesIssueRepoForIssueHydration(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{issueDetail: IssueDetail{Number: 27, Title: "Cross-repo issue", URL: "https://github.com/powerformer/looper/issues/27"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	queueItem, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	payload := `{"title":"Implement worker loop","repo":"acme/looper","issueRepo":"powerformer/looper","issueNumber":27,"baseBranch":"main"}`
+	loopMetadata := `{"worker":{"title":"Implement worker loop","repo":"acme/looper","issueRepo":"powerformer/looper","issueNumber":27,"baseBranch":"main"}}`
+	loop.MetadataJSON = &loopMetadata
+	queueItem.PayloadJSON = &payload
+
+	work, err := runner.resolveWorkerInput(context.Background(), *project, *loop, *queueItem, workerCheckpoint{})
+	if err != nil {
+		t.Fatalf("resolveWorkerInput() error = %v", err)
+	}
+	if len(github.viewIssueCalls) != 1 {
+		t.Fatalf("len(github.viewIssueCalls) = %d, want 1", len(github.viewIssueCalls))
+	}
+	if github.viewIssueCalls[0].Repo != "powerformer/looper" {
+		t.Fatalf("ViewIssue repo = %q, want powerformer/looper", github.viewIssueCalls[0].Repo)
+	}
+	if work.IssueRepo != "powerformer/looper" {
+		t.Fatalf("work.IssueRepo = %q, want powerformer/looper", work.IssueRepo)
+	}
+}
+
 func TestProcessClaimedItemResumesFromOpenPRAfterRetryableFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -562,6 +600,7 @@ type fakeGitHubGateway struct {
 	openPRIndex     int
 	prDetail        PullRequestDetail
 	issueDetail     IssueDetail
+	viewIssueCalls  []ViewIssueInput
 	createPRResult  CreatePullRequestResult
 	createPRErrors  []error
 	createPRCalls   []CreatePullRequestInput
@@ -600,6 +639,7 @@ func (f *fakeGitHubGateway) ViewPullRequest(_ context.Context, input ViewPullReq
 }
 
 func (f *fakeGitHubGateway) ViewIssue(_ context.Context, input ViewIssueInput) (IssueDetail, error) {
+	f.viewIssueCalls = append(f.viewIssueCalls, input)
 	detail := f.issueDetail
 	if detail.Number == 0 {
 		detail.Number = input.IssueNumber

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -128,7 +128,10 @@ func TestHydrateWorkerInputFromIssueInfersIssueRepoFromURL(t *testing.T) {
 	if !strings.Contains(work.Prompt, "Implement GitHub issue powerformer/looper#27") {
 		t.Fatalf("Prompt = %q, want issue repo in prompt", work.Prompt)
 	}
-	if issueRepoFromURL("https://gitlab.com/powerformer/looper/issues/27") != "" {
+	if issueRepoFromURL("https://ghe.example.com/powerformer/looper/issues/27") != "powerformer/looper" {
+		t.Fatal("issueRepoFromURL() should infer issue repo from GitHub Enterprise URLs")
+	}
+	if issueRepoFromURL("https://gitlab.com/powerformer/looper/-/issues/27") != "" {
 		t.Fatal("issueRepoFromURL() should ignore non-GitHub hosts")
 	}
 	if issueRepoFromURL("https://github.com/powerformer/looper/issues/not-a-number") != "" {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -125,6 +125,9 @@ func TestHydrateWorkerInputFromIssueInfersIssueRepoFromURL(t *testing.T) {
 	if work.IssueRepo != "powerformer/looper" {
 		t.Fatalf("IssueRepo = %q, want powerformer/looper", work.IssueRepo)
 	}
+	if !strings.Contains(work.Prompt, "Implement GitHub issue powerformer/looper#27") {
+		t.Fatalf("Prompt = %q, want issue repo in prompt", work.Prompt)
+	}
 	if issueRepoFromURL("https://gitlab.com/powerformer/looper/issues/27") != "" {
 		t.Fatal("issueRepoFromURL() should ignore non-GitHub hosts")
 	}
@@ -171,6 +174,53 @@ func TestResolveWorkerInputUsesIssueRepoForIssueHydration(t *testing.T) {
 	}
 	if work.IssueRepo != "powerformer/looper" {
 		t.Fatalf("work.IssueRepo = %q, want powerformer/looper", work.IssueRepo)
+	}
+	if !strings.Contains(work.Prompt, "Implement GitHub issue powerformer/looper#27") {
+		t.Fatalf("Prompt = %q, want resolved issue repo in prompt", work.Prompt)
+	}
+	if strings.Contains(work.Prompt, "Implement GitHub issue acme/looper#27") {
+		t.Fatalf("Prompt = %q, want prompt to avoid worker repo issue reference", work.Prompt)
+	}
+}
+
+func TestResolveWorkerInputDefersIssueRepoFallbackUntilAfterHydration(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{issueDetail: IssueDetail{Number: 27, Title: "Cross-repo issue", URL: "https://github.com/powerformer/looper/issues/27"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	queueItem, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	payload := `{"title":"Implement worker loop","repo":"acme/looper","issueNumber":27,"baseBranch":"main"}`
+	loopMetadata := `{"worker":{"title":"Implement worker loop","repo":"acme/looper","issueNumber":27,"baseBranch":"main"}}`
+	loop.MetadataJSON = &loopMetadata
+	queueItem.PayloadJSON = &payload
+
+	work, err := runner.resolveWorkerInput(context.Background(), *project, *loop, *queueItem, workerCheckpoint{})
+	if err != nil {
+		t.Fatalf("resolveWorkerInput() error = %v", err)
+	}
+	if len(github.viewIssueCalls) != 1 {
+		t.Fatalf("len(github.viewIssueCalls) = %d, want 1", len(github.viewIssueCalls))
+	}
+	if github.viewIssueCalls[0].Repo != "" {
+		t.Fatalf("ViewIssue repo = %q, want empty repo before hydration inference", github.viewIssueCalls[0].Repo)
+	}
+	if work.IssueRepo != "powerformer/looper" {
+		t.Fatalf("work.IssueRepo = %q, want powerformer/looper", work.IssueRepo)
+	}
+	if !strings.Contains(work.Prompt, "Implement GitHub issue powerformer/looper#27") {
+		t.Fatalf("Prompt = %q, want resolved issue repo in prompt", work.Prompt)
 	}
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -94,6 +94,48 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	}
 }
 
+func TestBuildPullRequestBodyUsesCrossRepoClosingReference(t *testing.T) {
+	t.Parallel()
+	body := buildPullRequestBody(workerInput{Repo: "acme/looper", IssueRepo: "powerformer/looper", IssueNumber: 27, IssueURL: "https://github.com/powerformer/looper/issues/27"}, &checkpointPlan{Items: []string{"Add linked issue auto-close support"}}, &checkpointExecution{Summary: "done"})
+	if !strings.Contains(body, "Issue: powerformer/looper#27") {
+		t.Fatalf("body = %q, want issue repo reference", body)
+	}
+	if !strings.Contains(body, "Closes powerformer/looper#27") {
+		t.Fatalf("body = %q, want cross-repo closing reference", body)
+	}
+	if strings.Contains(body, "Closes #27") {
+		t.Fatalf("body = %q, want fully qualified cross-repo closing reference only", body)
+	}
+}
+
+func TestBuildPullRequestBodyUsesBareClosingReferenceForSameRepo(t *testing.T) {
+	t.Parallel()
+	body := buildPullRequestBody(workerInput{Repo: "powerformer/looper", IssueRepo: "powerformer/looper", IssueNumber: 27}, nil, nil)
+	if !strings.Contains(body, "Closes #27") {
+		t.Fatalf("body = %q, want same-repo closing reference", body)
+	}
+	if strings.Contains(body, "Closes powerformer/looper#27") {
+		t.Fatalf("body = %q, want unqualified same-repo closing reference", body)
+	}
+}
+
+func TestHydrateWorkerInputFromIssueInfersIssueRepoFromURL(t *testing.T) {
+	t.Parallel()
+	work := hydrateWorkerInputFromIssue(workerInput{Repo: "acme/looper", IssueNumber: 27}, IssueDetail{Number: 27, Title: "Issue title", URL: "https://github.com/powerformer/looper/issues/27"})
+	if work.IssueRepo != "powerformer/looper" {
+		t.Fatalf("IssueRepo = %q, want powerformer/looper", work.IssueRepo)
+	}
+	if issueRepoFromURL("https://gitlab.com/powerformer/looper/issues/27") != "" {
+		t.Fatal("issueRepoFromURL() should ignore non-GitHub hosts")
+	}
+	if issueRepoFromURL("https://github.com/powerformer/looper/issues/not-a-number") != "" {
+		t.Fatal("issueRepoFromURL() should ignore invalid issue URLs")
+	}
+	if !strings.Contains(buildAgentPullRequestInstruction(work), "Closes powerformer/looper#27") {
+		t.Fatalf("instruction = %q, want cross-repo closing reference", buildAgentPullRequestInstruction(work))
+	}
+}
+
 func TestProcessClaimedItemResumesFromOpenPRAfterRetryableFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)


### PR DESCRIPTION
## Summary
- preserve issue-linked worker PR body content while appending an auto-closing `Closes ...` line
- qualify closing references with `owner/repo#number` when the source issue repo differs from the PR repo
- add worker tests for same-repo and cross-repo issue reference formatting