### PR TITLE
Run reviewer in a dedicated worktree instead of switching branches in cwd

### DIFF
--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -65,6 +65,7 @@ type RestoreWorktreeInput struct {
 type PrepareWorktreeInput struct {
 	WorktreePath    string
 	Branch          string
+	Ref             string
 	ExpectedHeadSHA string
 	Remote          string
 }
@@ -503,17 +504,27 @@ func (g *Gateway) PrepareWorktree(ctx context.Context, input PrepareWorktreeInpu
 	if strings.TrimSpace(remote) == "" {
 		remote = "origin"
 	}
-	if err := g.runGit(ctx, input.WorktreePath, nil, "fetch", remote, input.Branch); err != nil {
+	targetSpec := strings.TrimSpace(input.Ref)
+	resetRef := "FETCH_HEAD"
+	errorRef := targetSpec
+	if targetSpec == "" {
+		targetSpec = strings.TrimSpace(input.Branch)
+		resetRef = remote + "/" + targetSpec
+		errorRef = targetSpec
+	}
+	if targetSpec == "" {
+		return PrepareWorktreeResult{}, fmt.Errorf("branch or ref is required")
+	}
+	if err := g.runGit(ctx, input.WorktreePath, nil, "fetch", remote, targetSpec); err != nil {
 		return PrepareWorktreeResult{}, err
 	}
 
-	remoteRef := remote + "/" + input.Branch
-	remoteHeadSHA, err := g.getRevision(ctx, input.WorktreePath, remoteRef)
+	remoteHeadSHA, err := g.getRevision(ctx, input.WorktreePath, resetRef)
 	if err != nil {
 		return PrepareWorktreeResult{}, err
 	}
 	if input.ExpectedHeadSHA != "" && remoteHeadSHA != input.ExpectedHeadSHA {
-		return PrepareWorktreeResult{}, &RemoteHeadChangedError{Branch: input.Branch, ExpectedHeadSHA: input.ExpectedHeadSHA, ActualHeadSHA: remoteHeadSHA}
+		return PrepareWorktreeResult{}, &RemoteHeadChangedError{Branch: errorRef, ExpectedHeadSHA: input.ExpectedHeadSHA, ActualHeadSHA: remoteHeadSHA}
 	}
 
 	statusBeforeReset, err := g.readStatus(ctx, input.WorktreePath)
@@ -529,7 +540,7 @@ func (g *Gateway) PrepareWorktree(ctx context.Context, input PrepareWorktreeInpu
 		return PrepareWorktreeResult{}, err
 	}
 	if remoteHeadSHA != "" && localHeadSHA != remoteHeadSHA {
-		if err := g.runGit(ctx, input.WorktreePath, nil, "reset", "--hard", remoteRef); err != nil {
+		if err := g.runGit(ctx, input.WorktreePath, nil, "reset", "--hard", resetRef); err != nil {
 			return PrepareWorktreeResult{}, err
 		}
 	}

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -448,6 +448,38 @@ func TestGatewayPrepareWorktreeDetectsRemoteHeadChanges(t *testing.T) {
 	}
 }
 
+func TestGatewayPrepareWorktreeSupportsExplicitRef(t *testing.T) {
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createRemoteRepo(t, "feature/fixer")
+	gateway := fixture.gateway()
+
+	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       "reviewer/pr-42",
+		BaseBranch:   "main",
+		PRNumber:     42,
+		CheckoutMode: CheckoutModeDetached,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	prepared, err := gateway.PrepareWorktree(ctx, PrepareWorktreeInput{WorktreePath: worktree.WorktreePath, Branch: "reviewer/pr-42", Ref: "refs/heads/feature/fixer"})
+	if err != nil {
+		t.Fatalf("PrepareWorktree() error = %v", err)
+	}
+	if !prepared.Clean {
+		t.Fatal("PrepareWorktree().Clean = false, want true")
+	}
+	remoteHeadSHA := stringsTrimSpace(runGit(t, fixture.repoPath, "rev-parse", "refs/remotes/origin/feature/fixer"))
+	if prepared.HeadSHA != remoteHeadSHA {
+		t.Fatalf("PrepareWorktree().HeadSHA = %q, want %q", prepared.HeadSHA, remoteHeadSHA)
+	}
+}
+
 func TestGatewayBranchExistsTreatsOnlyExitCode1AsMissing(t *testing.T) {
 	t.Parallel()
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/powerformer/looper/internal/agent"
 	"github.com/powerformer/looper/internal/bootstrap"
+	"github.com/powerformer/looper/internal/config"
 	"github.com/powerformer/looper/internal/eventlog"
 	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/storage"
@@ -21,6 +22,7 @@ const (
 	stepFilter   ReviewerStep = "filter"
 	stepClaim    ReviewerStep = "claim"
 	stepSnapshot ReviewerStep = "snapshot"
+	stepWorktree ReviewerStep = "worktree"
 	stepReview   ReviewerStep = "review"
 	stepPublish  ReviewerStep = "publish"
 )
@@ -30,6 +32,7 @@ var reviewerStepSequence = []ReviewerStep{
 	stepFilter,
 	stepClaim,
 	stepSnapshot,
+	stepWorktree,
 	stepReview,
 	stepPublish,
 }
@@ -81,11 +84,50 @@ type PullRequestDetail struct {
 	Labels         []string
 	HeadSHA        string
 	BaseSHA        string
+	HeadRefName    string
+	BaseRefName    string
 	Author         string
 	ReviewRequests []string
 	ChecksSummary  string
 	Diff           string
 	Comments       []map[string]any
+}
+
+type CreateWorktreeInput struct {
+	ProjectID         string
+	RepoPath          string
+	WorktreeRoot      string
+	Branch            string
+	BaseBranch        string
+	PRNumber          int64
+	ProtectedBranches []string
+	CheckoutMode      string
+}
+
+type CreateWorktreeResult struct {
+	WorktreePath string
+	Branch       string
+	HeadSHA      string
+}
+
+type PrepareWorktreeInput struct {
+	WorktreePath    string
+	Branch          string
+	ExpectedHeadSHA string
+	Remote          string
+}
+
+type PrepareWorktreeResult struct {
+	HeadSHA string
+	Clean   bool
+}
+
+type CleanupWorktreeInput struct {
+	ProjectID         string
+	RepoPath          string
+	WorktreePath      string
+	Branch            string
+	ProtectedBranches []string
 }
 
 type transientFailure interface{ Temporary() bool }
@@ -170,6 +212,12 @@ type GitHubGateway interface {
 	RemovePullRequestLabels(context.Context, PullRequestLabelsInput) error
 }
 
+type GitGateway interface {
+	CreateWorktree(context.Context, CreateWorktreeInput) (CreateWorktreeResult, error)
+	PrepareWorktree(context.Context, PrepareWorktreeInput) (PrepareWorktreeResult, error)
+	CleanupWorktree(context.Context, CleanupWorktreeInput) error
+}
+
 type AgentRunInput struct {
 	ExecutionID      string
 	ProjectID        string
@@ -213,6 +261,7 @@ type Options struct {
 	DB                      *sql.DB
 	Repos                   *storage.Repositories
 	GitHub                  GitHubGateway
+	Git                     GitGateway
 	AgentExecutor           AgentExecutor
 	Logger                  bootstrap.Logger
 	Now                     func() time.Time
@@ -228,6 +277,7 @@ type Runner struct {
 	db                      *sql.DB
 	repos                   *storage.Repositories
 	github                  GitHubGateway
+	git                     GitGateway
 	agentExecutor           AgentExecutor
 	logger                  bootstrap.Logger
 	now                     func() time.Time
@@ -265,6 +315,7 @@ type reviewerCheckpoint struct {
 	Detail         *checkpointDetail        `json:"detail,omitempty"`
 	ClaimedLockKey string                   `json:"claimedLockKey,omitempty"`
 	Snapshot       *checkpointSnapshot      `json:"snapshot,omitempty"`
+	Worktree       *checkpointWorktree      `json:"worktree,omitempty"`
 	PendingReview  *pendingReviewCheckpoint `json:"pendingReview,omitempty"`
 	SkipReason     string                   `json:"skipReason,omitempty"`
 }
@@ -277,7 +328,18 @@ type checkpointDetail struct {
 	Labels         []string `json:"labels,omitempty"`
 	HeadSHA        string   `json:"headSha,omitempty"`
 	BaseSHA        string   `json:"baseSha,omitempty"`
+	HeadRefName    string   `json:"headRefName,omitempty"`
+	BaseRefName    string   `json:"baseRefName,omitempty"`
 	Author         string   `json:"author,omitempty"`
+}
+
+type checkpointWorktree struct {
+	Path       string `json:"path,omitempty"`
+	Branch     string `json:"branch,omitempty"`
+	BaseBranch string `json:"baseBranch,omitempty"`
+	HeadSHA    string `json:"headSha,omitempty"`
+	PreparedAt string `json:"preparedAt,omitempty"`
+	CleanedAt  string `json:"cleanedAt,omitempty"`
 }
 
 type checkpointSnapshot struct {
@@ -361,6 +423,7 @@ func New(options Options) *Runner {
 		db:                      options.DB,
 		repos:                   options.Repos,
 		github:                  options.GitHub,
+		git:                     options.Git,
 		agentExecutor:           options.AgentExecutor,
 		logger:                  options.Logger,
 		now:                     now,
@@ -658,6 +721,9 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			if loopErr != nil {
 				return ProcessResult{}, loopErr
 			}
+			if failedQueue == nil || failedQueue.Status != "queued" {
+				r.cleanupReviewerWorktreeIfTerminal(context.Background(), *project, &latest)
+			}
 			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 		}
 		if step == stepClaim {
@@ -691,6 +757,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	}); err != nil {
 		return ProcessResult{}, err
 	}
+	r.cleanupReviewerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
 	status := "success"
 	if checkpoint.SkipReason != "" {
 		status = "skipped"
@@ -718,6 +785,8 @@ func (r *Runner) executeStep(ctx context.Context, step ReviewerStep, input stepI
 		return r.runClaimStep(ctx, input)
 	case stepSnapshot:
 		return r.runSnapshotStep(ctx, input)
+	case stepWorktree:
+		return r.runPrepareWorktreeStep(ctx, input)
 	case stepReview:
 		return r.runReviewStep(ctx, input)
 	case stepPublish:
@@ -733,7 +802,7 @@ func (r *Runner) runDiscoverStep(ctx context.Context, input stepInput) (reviewer
 		return input.Checkpoint, err
 	}
 	checkpoint := input.Checkpoint
-	checkpoint.Detail = &checkpointDetail{Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, Author: detail.Author}
+	checkpoint.Detail = &checkpointDetail{Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, Author: detail.Author}
 	checkpoint.ResumePolicy = "replay_step"
 	return checkpoint, nil
 }
@@ -795,17 +864,83 @@ func (r *Runner) runSnapshotStep(ctx context.Context, input stepInput) (reviewer
 	return checkpoint, nil
 }
 
-func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCheckpoint, error) {
-	if input.Checkpoint.PendingReview != nil {
-		return input.Checkpoint, nil
+func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (reviewerCheckpoint, error) {
+	checkpoint := input.Checkpoint
+	if checkpoint.SkipReason != "" {
+		return checkpoint, nil
 	}
-	if input.Checkpoint.Snapshot == nil {
-		return input.Checkpoint, &loopError{message: "Missing PR snapshot checkpoint for review step", kind: FailureRetryableTransient}
+	if checkpoint.Worktree != nil && checkpoint.Worktree.PreparedAt != "" {
+		return checkpoint, nil
+	}
+	if r.git == nil {
+		return checkpoint, fmt.Errorf("reviewer git gateway is not configured")
+	}
+	if checkpoint.Detail == nil {
+		return checkpoint, &loopError{message: "Missing PR detail checkpoint for worktree step", kind: FailureRetryableTransient}
+	}
+	if checkpoint.Snapshot == nil {
+		return checkpoint, &loopError{message: "Missing PR snapshot checkpoint for worktree step", kind: FailureRetryableTransient}
+	}
+	branch := strings.TrimSpace(checkpoint.Detail.HeadRefName)
+	if branch == "" {
+		return checkpoint, &loopError{message: fmt.Sprintf("Missing pull request head ref for %s#%d", input.Repo, input.PRNumber), kind: FailureManualIntervention}
+	}
+	baseBranch := firstNonEmpty(strings.TrimSpace(checkpoint.Detail.BaseRefName), derefString(input.Project.BaseBranch), "main")
+	projectMetadata := parseJSONObject(input.Project.MetadataJSON)
+	worktreeRoot, _ := stringFromAny(projectMetadata["worktreeRoot"])
+	if worktreeRoot == "" {
+		resolvedRoot, err := config.DefaultProjectWorktreeRoot(input.Project.ID, input.Project.RepoPath)
+		if err != nil {
+			return checkpoint, err
+		}
+		worktreeRoot = resolvedRoot
+	}
+	protectedBranches := make([]string, 0, 2)
+	if candidate := strings.TrimSpace(checkpoint.Detail.BaseRefName); candidate != "" {
+		protectedBranches = append(protectedBranches, candidate)
+	}
+	if candidate := strings.TrimSpace(derefString(input.Project.BaseBranch)); candidate != "" {
+		protectedBranches = append(protectedBranches, candidate)
+	}
+	created, err := r.git.CreateWorktree(ctx, CreateWorktreeInput{ProjectID: input.Project.ID, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, Branch: branch, BaseBranch: baseBranch, ProtectedBranches: protectedBranches, CheckoutMode: "detached"})
+	if err != nil {
+		return checkpoint, err
+	}
+	prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{WorktreePath: created.WorktreePath, Branch: branch, ExpectedHeadSHA: checkpoint.Snapshot.HeadSHA})
+	if err != nil {
+		return checkpoint, err
+	}
+	if !prepared.Clean {
+		return checkpoint, &loopError{message: fmt.Sprintf("Reviewer worktree is dirty for branch %s; manual intervention required", branch), kind: FailureManualIntervention}
+	}
+	checkpoint.Worktree = &checkpointWorktree{Path: created.WorktreePath, Branch: branch, BaseBranch: baseBranch, HeadSHA: prepared.HeadSHA, PreparedAt: r.nowISO()}
+	checkpoint.ResumePolicy = "advance_from_checkpoint"
+	return checkpoint, nil
+}
+
+func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCheckpoint, error) {
+	checkpoint := input.Checkpoint
+	var err error
+	if checkpoint.PendingReview != nil {
+		return checkpoint, nil
+	}
+	if checkpoint.Snapshot == nil {
+		return checkpoint, &loopError{message: "Missing PR snapshot checkpoint for review step", kind: FailureRetryableTransient}
+	}
+	if checkpoint.Worktree == nil {
+		checkpoint, err = r.runPrepareWorktreeStep(ctx, input)
+		if err != nil {
+			return input.Checkpoint, err
+		}
+	}
+	worktree, err := requireWorktree(checkpoint)
+	if err != nil {
+		return checkpoint, err
 	}
 	executionID := eventlog.NewEventID("agent")
-	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: buildReviewPrompt(input.Repo, input.PRNumber, input.Checkpoint), WorkingDirectory: input.Project.RepoPath, Timeout: r.agentTimeout, Metadata: map[string]any{"loopType": "reviewer", "repo": input.Repo, "prNumber": input.PRNumber}, IdempotencyKey: fmt.Sprintf("reviewer:%s:%s", input.Loop.ID, input.Checkpoint.Snapshot.HeadSHA)})
+	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: buildReviewPrompt(input.Repo, input.PRNumber, checkpoint), WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, Metadata: map[string]any{"loopType": "reviewer", "repo": input.Repo, "prNumber": input.PRNumber}, IdempotencyKey: fmt.Sprintf("reviewer:%s:%s", input.Loop.ID, checkpoint.Snapshot.HeadSHA)})
 	if err != nil {
-		return input.Checkpoint, err
+		return checkpoint, err
 	}
 	if r.onAgentExecutionStarted != nil {
 		if err := r.onAgentExecutionStarted(ctx, AgentExecutionStartedInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Subtitle: fmt.Sprintf("%s#%d", input.Repo, input.PRNumber), Body: "Review started", DedupeKey: "runtime.agent.started:reviewer:" + input.Run.ID}); err != nil && r.logger != nil {
@@ -816,11 +951,11 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	result, err := execution.Wait(ctx)
 	if err != nil {
 		_ = r.tryRemoveReaction(ctx, input, "eyes")
-		return input.Checkpoint, err
+		return checkpoint, err
 	}
 	if result.Status != "completed" {
 		_ = r.tryRemoveReaction(ctx, input, "eyes")
-		return input.Checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Reviewer agent %s", result.Status)), kind: FailureRetryableTransient}
+		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Reviewer agent %s", result.Status)), kind: FailureRetryableTransient}
 	}
 	feedback := parseReviewFeedback(result)
 	if !feedback.Clean && len(feedback.Comments) == 0 {
@@ -829,10 +964,9 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		if result.ParseStatus == "invalid_json" {
 			kind = FailureNonRetryable
 		}
-		return input.Checkpoint, &loopError{message: "Reviewer agent produced no actionable review comments", kind: kind}
+		return checkpoint, &loopError{message: "Reviewer agent produced no actionable review comments", kind: kind}
 	}
-	checkpoint := input.Checkpoint
-	checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: input.Checkpoint.Snapshot.HeadSHA, Event: ternaryReviewEvent(feedback.Clean), Body: feedback.Body, Summary: result.Summary, Comments: feedback.Comments, Clean: feedback.Clean}
+	checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, Event: ternaryReviewEvent(feedback.Clean), Body: feedback.Body, Summary: result.Summary, Comments: feedback.Comments, Clean: feedback.Clean}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }
@@ -1517,6 +1651,28 @@ func normalizePendingReviewCheckpoint(pending pendingReviewCheckpoint) pendingRe
 		pending.Comments = []reviewFeedbackComment{}
 	}
 	return pending
+}
+
+func (r *Runner) cleanupReviewerWorktreeIfTerminal(ctx context.Context, project storage.ProjectRecord, checkpoint *reviewerCheckpoint) {
+	if r.git == nil || checkpoint == nil || checkpoint.Worktree == nil || checkpoint.Worktree.Path == "" || checkpoint.Worktree.Branch == "" || checkpoint.Worktree.CleanedAt != "" {
+		return
+	}
+	protectedBranches := []string{}
+	if baseBranch := strings.TrimSpace(derefString(project.BaseBranch)); baseBranch != "" {
+		protectedBranches = append(protectedBranches, baseBranch)
+	}
+	if err := r.git.CleanupWorktree(ctx, CleanupWorktreeInput{ProjectID: project.ID, RepoPath: project.RepoPath, WorktreePath: checkpoint.Worktree.Path, Branch: checkpoint.Worktree.Branch, ProtectedBranches: protectedBranches}); err != nil {
+		r.logWarn("reviewer worktree cleanup failed", map[string]any{"projectId": project.ID, "worktreePath": checkpoint.Worktree.Path, "branch": checkpoint.Worktree.Branch, "error": err.Error()})
+		return
+	}
+	checkpoint.Worktree.CleanedAt = r.nowISO()
+}
+
+func requireWorktree(checkpoint reviewerCheckpoint) (*checkpointWorktree, error) {
+	if checkpoint.Worktree == nil {
+		return nil, &loopError{message: "Missing reviewer worktree checkpoint for review step", kind: FailureRetryableTransient}
+	}
+	return checkpoint.Worktree, nil
 }
 
 func (p pendingReviewCheckpoint) clone() *pendingReviewCheckpoint {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -113,6 +114,7 @@ type CreateWorktreeResult struct {
 type PrepareWorktreeInput struct {
 	WorktreePath    string
 	Branch          string
+	Ref             string
 	ExpectedHeadSHA string
 	Remote          string
 }
@@ -869,7 +871,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 	if checkpoint.SkipReason != "" {
 		return checkpoint, nil
 	}
-	if checkpoint.Worktree != nil && checkpoint.Worktree.PreparedAt != "" {
+	if reviewerWorktreePrepared(checkpoint) {
 		return checkpoint, nil
 	}
 	if r.git == nil {
@@ -881,11 +883,9 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 	if checkpoint.Snapshot == nil {
 		return checkpoint, &loopError{message: "Missing PR snapshot checkpoint for worktree step", kind: FailureRetryableTransient}
 	}
-	branch := strings.TrimSpace(checkpoint.Detail.HeadRefName)
-	if branch == "" {
-		return checkpoint, &loopError{message: fmt.Sprintf("Missing pull request head ref for %s#%d", input.Repo, input.PRNumber), kind: FailureManualIntervention}
-	}
+	branch := reviewerWorktreeBranch(input.PRNumber, checkpoint)
 	baseBranch := firstNonEmpty(strings.TrimSpace(checkpoint.Detail.BaseRefName), derefString(input.Project.BaseBranch), "main")
+	prRef := pullRequestHeadRef(input.PRNumber)
 	projectMetadata := parseJSONObject(input.Project.MetadataJSON)
 	worktreeRoot, _ := stringFromAny(projectMetadata["worktreeRoot"])
 	if worktreeRoot == "" {
@@ -906,7 +906,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 	if err != nil {
 		return checkpoint, err
 	}
-	prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{WorktreePath: created.WorktreePath, Branch: branch, ExpectedHeadSHA: checkpoint.Snapshot.HeadSHA})
+	prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{WorktreePath: created.WorktreePath, Branch: branch, Ref: prRef, ExpectedHeadSHA: checkpoint.Snapshot.HeadSHA})
 	if err != nil {
 		return checkpoint, err
 	}
@@ -927,7 +927,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	if checkpoint.Snapshot == nil {
 		return checkpoint, &loopError{message: "Missing PR snapshot checkpoint for review step", kind: FailureRetryableTransient}
 	}
-	if checkpoint.Worktree == nil {
+	if reviewerWorktreeNeedsPrepare(checkpoint) {
 		checkpoint, err = r.runPrepareWorktreeStep(ctx, input)
 		if err != nil {
 			return input.Checkpoint, err
@@ -1673,6 +1673,43 @@ func requireWorktree(checkpoint reviewerCheckpoint) (*checkpointWorktree, error)
 		return nil, &loopError{message: "Missing reviewer worktree checkpoint for review step", kind: FailureRetryableTransient}
 	}
 	return checkpoint.Worktree, nil
+}
+
+func reviewerWorktreePrepared(checkpoint reviewerCheckpoint) bool {
+	if reviewerWorktreeNeedsPrepare(checkpoint) {
+		return false
+	}
+	return checkpoint.Worktree.PreparedAt != ""
+}
+
+func reviewerWorktreeNeedsPrepare(checkpoint reviewerCheckpoint) bool {
+	if checkpoint.Worktree == nil {
+		return true
+	}
+	worktree := checkpoint.Worktree
+	if strings.TrimSpace(worktree.Path) == "" || strings.TrimSpace(worktree.Branch) == "" || worktree.CleanedAt != "" {
+		return true
+	}
+	_, err := os.Stat(worktree.Path)
+	return err != nil
+}
+
+func reviewerWorktreeBranch(prNumber int64, checkpoint reviewerCheckpoint) string {
+	if checkpoint.Detail != nil {
+		if branch := strings.TrimSpace(checkpoint.Detail.HeadRefName); branch != "" {
+			return branch
+		}
+	}
+	if checkpoint.Worktree != nil {
+		if branch := strings.TrimSpace(checkpoint.Worktree.Branch); branch != "" {
+			return branch
+		}
+	}
+	return fmt.Sprintf("pr-%d-head", prNumber)
+}
+
+func pullRequestHeadRef(prNumber int64) string {
+	return fmt.Sprintf("refs/pull/%d/head", prNumber)
 }
 
 func (p pendingReviewCheckpoint) clone() *pendingReviewCheckpoint {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1695,11 +1695,6 @@ func reviewerWorktreeNeedsPrepare(checkpoint reviewerCheckpoint) bool {
 }
 
 func reviewerWorktreeBranch(prNumber int64, checkpoint reviewerCheckpoint) string {
-	if checkpoint.Detail != nil {
-		if branch := strings.TrimSpace(checkpoint.Detail.HeadRefName); branch != "" {
-			return branch
-		}
-	}
 	if checkpoint.Worktree != nil {
 		if branch := strings.TrimSpace(checkpoint.Worktree.Branch); branch != "" {
 			return branch

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -906,6 +906,16 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 	if err != nil {
 		return checkpoint, err
 	}
+	checkpoint.Worktree = &checkpointWorktree{Path: created.WorktreePath, Branch: branch, BaseBranch: baseBranch}
+	if input.Run.ID != "" {
+		step := asReviewerStep(derefString(input.Run.CurrentStep))
+		if step == "" {
+			step = stepWorktree
+		}
+		if err := r.persistCheckpoint(ctx, input.Run.ID, step, checkpoint); err != nil {
+			return checkpoint, err
+		}
+	}
 	prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{WorktreePath: created.WorktreePath, Branch: branch, Ref: prRef, ExpectedHeadSHA: checkpoint.Snapshot.HeadSHA})
 	if err != nil {
 		return checkpoint, err
@@ -913,7 +923,8 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 	if !prepared.Clean {
 		return checkpoint, &loopError{message: fmt.Sprintf("Reviewer worktree is dirty for branch %s; manual intervention required", branch), kind: FailureManualIntervention}
 	}
-	checkpoint.Worktree = &checkpointWorktree{Path: created.WorktreePath, Branch: branch, BaseBranch: baseBranch, HeadSHA: prepared.HeadSHA, PreparedAt: r.nowISO()}
+	checkpoint.Worktree.HeadSHA = prepared.HeadSHA
+	checkpoint.Worktree.PreparedAt = r.nowISO()
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }
@@ -927,7 +938,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	if checkpoint.Snapshot == nil {
 		return checkpoint, &loopError{message: "Missing PR snapshot checkpoint for review step", kind: FailureRetryableTransient}
 	}
-	if reviewerWorktreeNeedsPrepare(checkpoint) {
+	if !reviewerWorktreePrepared(checkpoint) {
 		checkpoint, err = r.runPrepareWorktreeStep(ctx, input)
 		if err != nil {
 			return input.Checkpoint, err
@@ -1151,6 +1162,9 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 			initialCheckpoint = reviewerCheckpoint{ResumePolicy: "replay_step"}
 		} else {
 			initialCheckpoint.ResumePolicy = "advance_from_checkpoint"
+			if startStep == stepReview && initialCheckpoint.Worktree != nil {
+				initialCheckpoint.Worktree.PreparedAt = ""
+			}
 		}
 	}
 	nowISO := r.nowISO()

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -902,7 +902,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 	if candidate := strings.TrimSpace(derefString(input.Project.BaseBranch)); candidate != "" {
 		protectedBranches = append(protectedBranches, candidate)
 	}
-	created, err := r.git.CreateWorktree(ctx, CreateWorktreeInput{ProjectID: input.Project.ID, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, Branch: branch, BaseBranch: baseBranch, ProtectedBranches: protectedBranches, CheckoutMode: "detached"})
+	created, err := r.git.CreateWorktree(ctx, CreateWorktreeInput{ProjectID: input.Project.ID, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, Branch: branch, BaseBranch: baseBranch, PRNumber: input.PRNumber, ProtectedBranches: protectedBranches, CheckoutMode: "detached"})
 	if err != nil {
 		return checkpoint, err
 	}
@@ -931,6 +931,9 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		checkpoint, err = r.runPrepareWorktreeStep(ctx, input)
 		if err != nil {
 			return input.Checkpoint, err
+		}
+		if err := r.persistCheckpoint(ctx, input.Run.ID, stepReview, checkpoint); err != nil {
+			return checkpoint, err
 		}
 	}
 	worktree, err := requireWorktree(checkpoint)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -552,6 +552,96 @@ func TestRunReviewStepPersistsRepreparedWorktreeBeforeAgentStart(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemRetryAfterReviewFailureRepreparesWorktree(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{worktreePath: filepath.Join(t.TempDir(), "reviewer-worktree")}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed", Summary: "agent failed"}, {Status: "completed", Summary: "Looks good", Stdout: `{"verdict":"clean","body":"","comments":[]}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	firstClaim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || firstClaim == nil {
+		t.Fatalf("first ClaimNextOfType() = (%#v, %v), want claimed item", firstClaim, err)
+	}
+	firstResult, err := runner.ProcessClaimedItem(context.Background(), *firstClaim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(first) error = %v", err)
+	}
+	if firstResult.Status != "failed" || firstResult.FailureKind != FailureRetryableTransient {
+		t.Fatalf("first result = %#v, want retryable_transient failure", firstResult)
+	}
+
+	fixture.advance(5 * time.Second)
+	retryClaim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || retryClaim == nil {
+		t.Fatalf("retry ClaimNextOfType() = (%#v, %v), want claimed item", retryClaim, err)
+	}
+	retryResult, err := runner.ProcessClaimedItem(context.Background(), *retryClaim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(retry) error = %v", err)
+	}
+	if retryResult.Status != "success" {
+		t.Fatalf("retry result = %#v, want success", retryResult)
+	}
+	if len(git.createCalls) != 2 || len(git.prepareCalls) != 2 {
+		t.Fatalf("createCalls=%d prepareCalls=%d, want 2 each", len(git.createCalls), len(git.prepareCalls))
+	}
+	if len(agent.starts) != 2 {
+		t.Fatalf("len(agent.starts) = %d, want 2", len(agent.starts))
+	}
+}
+
+func TestRunPrepareWorktreeStepPersistsCreatedWorktreeBeforeManualIntervention(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	clean := false
+	git := &fakeGitGateway{worktreePath: filepath.Join(t.TempDir(), "reviewer-worktree"), prepareClean: &clean}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	prNumber := int64(42)
+	loopTarget := "pr:42"
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_1", LoopID: "loop_1", Status: "running", CurrentStep: stringPtr(string(stepWorktree)), CheckpointJSON: stringPtr(mustMarshalJSON(reviewerCheckpoint{})), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	_, err = runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project:  *project,
+		Run:      run,
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadSHA: "abc123", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+		},
+	})
+	if err == nil || !contains(err.Error(), "manual intervention required") {
+		t.Fatalf("runPrepareWorktreeStep() error = %v, want manual intervention required", err)
+	}
+	persistedRun, err := fixture.repos.Runs.GetByID(context.Background(), run.ID)
+	if err != nil || persistedRun == nil {
+		t.Fatalf("Runs.GetByID() = (%#v, %v), want run", persistedRun, err)
+	}
+	persistedCheckpoint := parseCheckpoint(persistedRun.CheckpointJSON)
+	if persistedCheckpoint.Worktree == nil || persistedCheckpoint.Worktree.Path != git.worktreePath {
+		t.Fatalf("persisted checkpoint worktree = %#v, want created worktree", persistedCheckpoint.Worktree)
+	}
+	if persistedCheckpoint.Worktree.PreparedAt != "" {
+		t.Fatalf("persisted checkpoint preparedAt = %q, want empty before failed prepare", persistedCheckpoint.Worktree.PreparedAt)
+	}
+}
+
 func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -368,6 +368,9 @@ func TestProcessClaimedItemRunsReviewerInDedicatedWorktree(t *testing.T) {
 	if git.createCalls[0].Branch != "pr-42-head" {
 		t.Fatalf("create branch = %q, want PR-scoped branch", git.createCalls[0].Branch)
 	}
+	if git.createCalls[0].PRNumber != 42 {
+		t.Fatalf("create PR number = %d, want 42", git.createCalls[0].PRNumber)
+	}
 	if len(git.prepareCalls) != 1 {
 		t.Fatalf("len(git.prepareCalls) = %d, want 1", len(git.prepareCalls))
 	}
@@ -423,6 +426,9 @@ func TestRunPrepareWorktreeStepFallsBackWhenCheckpointLacksHeadRef(t *testing.T)
 	}
 	if git.createCalls[0].Branch != "pr-42-head" {
 		t.Fatalf("create branch = %q, want fallback branch", git.createCalls[0].Branch)
+	}
+	if git.createCalls[0].PRNumber != 42 {
+		t.Fatalf("create PR number = %d, want 42", git.createCalls[0].PRNumber)
 	}
 	if len(git.prepareCalls) != 1 {
 		t.Fatalf("len(git.prepareCalls) = %d, want 1", len(git.prepareCalls))
@@ -492,6 +498,57 @@ func TestRunReviewStepRepreparesMissingReviewerWorktree(t *testing.T) {
 	}
 	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.worktreePath {
 		t.Fatalf("checkpoint worktree = %#v, want recreated worktree path", checkpoint.Worktree)
+	}
+}
+
+func TestRunReviewStepPersistsRepreparedWorktreeBeforeAgentStart(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{worktreePath: filepath.Join(t.TempDir(), "reviewer-worktree")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	prNumber := int64(42)
+	loopTarget := "pr:42"
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	initialCheckpoint := reviewerCheckpoint{
+		Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+		Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+		Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "deleted-worktree"), Branch: "feature/review-me", PreparedAt: fixture.nowISO()},
+	}
+	checkpointJSON := mustMarshalJSON(initialCheckpoint)
+	run := storage.RunRecord{ID: "run_1", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepReview)), CheckpointJSON: &checkpointJSON, StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	checkpoint, err := runner.runReviewStep(context.Background(), stepInput{
+		Project:    *project,
+		Loop:       loop,
+		Run:        run,
+		Repo:       "acme/looper",
+		PRNumber:   prNumber,
+		Checkpoint: initialCheckpoint,
+	})
+	if err == nil || !contains(err.Error(), "no queued agent result") {
+		t.Fatalf("runReviewStep() error = %v, want no queued agent result", err)
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.worktreePath {
+		t.Fatalf("checkpoint worktree = %#v, want recreated worktree path", checkpoint.Worktree)
+	}
+	persistedRun, err := fixture.repos.Runs.GetByID(context.Background(), run.ID)
+	if err != nil || persistedRun == nil {
+		t.Fatalf("Runs.GetByID() = (%#v, %v), want run", persistedRun, err)
+	}
+	persistedCheckpoint := parseCheckpoint(persistedRun.CheckpointJSON)
+	if persistedCheckpoint.Worktree == nil || persistedCheckpoint.Worktree.Path != git.worktreePath {
+		t.Fatalf("persisted checkpoint worktree = %#v, want recreated worktree path", persistedCheckpoint.Worktree)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -3,6 +3,7 @@ package reviewer
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -385,6 +386,87 @@ func TestProcessClaimedItemRunsReviewerInDedicatedWorktree(t *testing.T) {
 	}
 }
 
+func TestRunPrepareWorktreeStepFallsBackWhenCheckpointLacksHeadRef(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+
+	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project:  *project,
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadSHA: "abc123", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPrepareWorktreeStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if git.createCalls[0].Branch != "pr-42-head" {
+		t.Fatalf("create branch = %q, want fallback branch", git.createCalls[0].Branch)
+	}
+	if len(git.prepareCalls) != 1 {
+		t.Fatalf("len(git.prepareCalls) = %d, want 1", len(git.prepareCalls))
+	}
+	if git.prepareCalls[0].Ref != "refs/pull/42/head" {
+		t.Fatalf("prepare ref = %q, want PR head ref", git.prepareCalls[0].Ref)
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Branch != "pr-42-head" {
+		t.Fatalf("checkpoint worktree = %#v, want fallback branch", checkpoint.Worktree)
+	}
+}
+
+func TestRunReviewStepRepreparesMissingReviewerWorktree(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{worktreePath: filepath.Join(t.TempDir(), "reviewer-worktree")}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `{"verdict":"clean","body":"","comments":[]}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+
+	checkpoint, err := runner.runReviewStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     storage.LoopRecord{ID: "loop_1"},
+		Run:      storage.RunRecord{ID: "run_1"},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "deleted-worktree"), Branch: "feature/review-me", PreparedAt: fixture.nowISO()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runReviewStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 || len(git.prepareCalls) != 1 {
+		t.Fatalf("createCalls=%d prepareCalls=%d, want 1 each", len(git.createCalls), len(git.prepareCalls))
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
+	}
+	if agent.starts[0].WorkingDirectory != git.worktreePath {
+		t.Fatalf("agent working dir = %q, want %q", agent.starts[0].WorkingDirectory, git.worktreePath)
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.worktreePath {
+		t.Fatalf("checkpoint worktree = %#v, want recreated worktree path", checkpoint.Worktree)
+	}
+}
+
 func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -711,6 +793,9 @@ func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeI
 	if path == "" {
 		path = filepath.Join("/tmp", "reviewer-worktree")
 		f.worktreePath = path
+	}
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return CreateWorktreeResult{}, err
 	}
 	return CreateWorktreeResult{WorktreePath: path, Branch: input.Branch, HeadSHA: "abc123"}, nil
 }

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -365,8 +365,17 @@ func TestProcessClaimedItemRunsReviewerInDedicatedWorktree(t *testing.T) {
 	if len(git.createCalls) != 1 {
 		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
 	}
+	if git.createCalls[0].Branch != "pr-42-head" {
+		t.Fatalf("create branch = %q, want PR-scoped branch", git.createCalls[0].Branch)
+	}
 	if len(git.prepareCalls) != 1 {
 		t.Fatalf("len(git.prepareCalls) = %d, want 1", len(git.prepareCalls))
+	}
+	if git.prepareCalls[0].Branch != "pr-42-head" {
+		t.Fatalf("prepare branch = %q, want PR-scoped branch", git.prepareCalls[0].Branch)
+	}
+	if git.prepareCalls[0].Ref != "refs/pull/42/head" {
+		t.Fatalf("prepare ref = %q, want PR head ref", git.prepareCalls[0].Ref)
 	}
 	if len(agent.starts) != 1 {
 		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
@@ -423,6 +432,25 @@ func TestRunPrepareWorktreeStepFallsBackWhenCheckpointLacksHeadRef(t *testing.T)
 	}
 	if checkpoint.Worktree == nil || checkpoint.Worktree.Branch != "pr-42-head" {
 		t.Fatalf("checkpoint worktree = %#v, want fallback branch", checkpoint.Worktree)
+	}
+}
+
+func TestReviewerWorktreeBranchIgnoresHeadRefName(t *testing.T) {
+	t.Parallel()
+
+	branch := reviewerWorktreeBranch(42, reviewerCheckpoint{
+		Detail:   &checkpointDetail{HeadRefName: "patch-1"},
+		Worktree: &checkpointWorktree{Branch: "pr-42-head"},
+	})
+	if branch != "pr-42-head" {
+		t.Fatalf("reviewerWorktreeBranch() = %q, want existing PR-scoped branch", branch)
+	}
+
+	branch = reviewerWorktreeBranch(42, reviewerCheckpoint{
+		Detail: &checkpointDetail{HeadRefName: "main"},
+	})
+	if branch != "pr-42-head" {
+		t.Fatalf("reviewerWorktreeBranch() = %q, want PR-scoped fallback", branch)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -15,7 +15,7 @@ func TestDiscoverPullRequestsCreatesLoopAndQueue(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
 
 	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
 	if err != nil {
@@ -47,7 +47,7 @@ func TestDiscoverPullRequestsPreservesPausedLoop(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
 
 	nowISO := fixture.nowISO()
 	repo := "acme/looper"
@@ -83,7 +83,7 @@ func TestDiscoverPullRequestsPreservesPausedLoop(t *testing.T) {
 func TestEnqueueScopesReviewerDedupeKeyToLoop(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
 
 	project2ID := "project_2"
 	loop1ID := "loop_1"
@@ -137,7 +137,7 @@ func TestProcessClaimedItemRetriesPublishFromCheckpointWithoutRerunningReview(t 
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{submitFailuresRemaining: 1}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Please add tests"}]}`}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
 		t.Fatalf("DiscoverPullRequests() error = %v", err)
@@ -214,7 +214,7 @@ func TestProcessClaimedItemResumeReacquiresPullRequestLock(t *testing.T) {
 	fixture.repos.Locks.SetNow(fixture.now)
 	github := &fakeGitHubGateway{submitFailuresRemaining: 1}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Please add tests"}]}`}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
 		t.Fatalf("DiscoverPullRequests() error = %v", err)
@@ -266,7 +266,7 @@ func TestProcessClaimedItemRestartsFromDiscoverWhenHeadChangesBeforePublish(t *t
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{changeHeadOnSecondView: true}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Review old head", Stdout: `{"verdict":"actionable","body":"Review old head","comments":[{"body":"Review old head"}]}`}, {Status: "completed", Summary: "Review new head", Stdout: `{"verdict":"actionable","body":"Review new head","comments":[{"body":"Review new head"}]}`}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
 		t.Fatalf("DiscoverPullRequests() error = %v", err)
@@ -312,7 +312,7 @@ func TestProcessClaimedItemNotifiesWhenReviewAgentStarts(t *testing.T) {
 	github := &fakeGitHubGateway{}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `{"verdict":"clean","body":"","comments":[]}`}}}
 	notifications := make([]AgentExecutionStartedInput, 0, 1)
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, OnAgentExecutionStarted: func(_ context.Context, input AgentExecutionStartedInput) error {
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, OnAgentExecutionStarted: func(_ context.Context, input AgentExecutionStartedInput) error {
 		notifications = append(notifications, input)
 		return nil
 	}})
@@ -339,6 +339,52 @@ func TestProcessClaimedItemNotifiesWhenReviewAgentStarts(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemRunsReviewerInDedicatedWorktree(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{}
+	git := &fakeGitGateway{}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `{"verdict":"clean","body":"","comments":[]}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claimed, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success", result)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if len(git.prepareCalls) != 1 {
+		t.Fatalf("len(git.prepareCalls) = %d, want 1", len(git.prepareCalls))
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
+	}
+	if len(git.cleanupCalls) != 1 {
+		t.Fatalf("len(git.cleanupCalls) = %d, want 1", len(git.cleanupCalls))
+	}
+	if agent.starts[0].WorkingDirectory != git.worktreePath {
+		t.Fatalf("agent working dir = %q, want %q", agent.starts[0].WorkingDirectory, git.worktreePath)
+	}
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	if agent.starts[0].WorkingDirectory == project.RepoPath {
+		t.Fatalf("agent working dir = repo path %q, want dedicated worktree", project.RepoPath)
+	}
+}
+
 func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -352,7 +398,7 @@ func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	`); err != nil {
 		t.Fatalf("create trigger error = %v", err)
 	}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
 	discovery, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
 	if err != nil {
 		t.Fatalf("DiscoverPullRequests() error = %v", err)
@@ -382,7 +428,7 @@ func TestProcessClaimedItemReturnsWhenCompleteRunFails(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{submitFailuresRemaining: 1}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Please add tests"}]}`}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
 		t.Fatalf("DiscoverPullRequests() error = %v", err)
@@ -479,7 +525,7 @@ func TestProcessClaimedItemPreservesPausedLoopOnRetryableFailureAfterPause(t *te
 		}
 		return context.DeadlineExceeded
 	}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
 		t.Fatalf("DiscoverPullRequests() error = %v", err)
@@ -591,7 +637,7 @@ func (g *fakeGitHubGateway) ViewPullRequest(context.Context, ViewPullRequestInpu
 	if g.changeHeadOnSecondView && g.viewCalls >= 2 {
 		headSHA = "new-head"
 	}
-	return PullRequestDetail{Number: 42, Title: "Review me", Body: "PR body", State: "OPEN", Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, BaseSHA: "base123", Author: "octocat", ReviewRequests: []string{"octocat"}, ChecksSummary: "SUCCESS", Diff: "diff --git a/a.ts b/a.ts"}, nil
+	return PullRequestDetail{Number: 42, Title: "Review me", Body: "PR body", State: "OPEN", Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, BaseSHA: "base123", HeadRefName: "feature/review-me", BaseRefName: "main", Author: "octocat", ReviewRequests: []string{"octocat"}, ChecksSummary: "SUCCESS", Diff: "diff --git a/a.ts b/a.ts"}, nil
 }
 
 func (g *fakeGitHubGateway) CapturePullRequestSnapshot(_ context.Context, input CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
@@ -648,6 +694,38 @@ func (g *fakeGitHubGateway) RemovePullRequestLabels(_ context.Context, input Pul
 		}
 	}
 	g.labels = remaining
+	return nil
+}
+
+type fakeGitGateway struct {
+	worktreePath string
+	createCalls  []CreateWorktreeInput
+	prepareCalls []PrepareWorktreeInput
+	cleanupCalls []CleanupWorktreeInput
+	prepareClean *bool
+}
+
+func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeInput) (CreateWorktreeResult, error) {
+	f.createCalls = append(f.createCalls, input)
+	path := f.worktreePath
+	if path == "" {
+		path = filepath.Join("/tmp", "reviewer-worktree")
+		f.worktreePath = path
+	}
+	return CreateWorktreeResult{WorktreePath: path, Branch: input.Branch, HeadSHA: "abc123"}, nil
+}
+
+func (f *fakeGitGateway) PrepareWorktree(_ context.Context, input PrepareWorktreeInput) (PrepareWorktreeResult, error) {
+	f.prepareCalls = append(f.prepareCalls, input)
+	clean := true
+	if f.prepareClean != nil {
+		clean = *f.prepareClean
+	}
+	return PrepareWorktreeResult{HeadSHA: input.ExpectedHeadSHA, Clean: clean}, nil
+}
+
+func (f *fakeGitGateway) CleanupWorktree(_ context.Context, input CleanupWorktreeInput) error {
+	f.cleanupCalls = append(f.cleanupCalls, input)
 	return nil
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -185,7 +185,7 @@ func (a reviewerGitHubAdapter) ViewPullRequest(ctx context.Context, input review
 	if err != nil {
 		return reviewer.PullRequestDetail{}, err
 	}
-	return reviewer.PullRequestDetail{Number: detail.Number, Title: detail.Title, Body: detail.Body, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: detail.Labels, HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, Author: detail.Author, ReviewRequests: detail.ReviewRequests, ChecksSummary: summarizeCheckStates(detail.Checks), Comments: detail.Comments}, nil
+	return reviewer.PullRequestDetail{Number: detail.Number, Title: detail.Title, Body: detail.Body, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: detail.Labels, HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, Author: detail.Author, ReviewRequests: detail.ReviewRequests, ChecksSummary: summarizeCheckStates(detail.Checks), Comments: detail.Comments}, nil
 }
 
 func (a reviewerGitHubAdapter) CapturePullRequestSnapshot(ctx context.Context, input reviewer.CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
@@ -222,6 +222,28 @@ func (a reviewerGitHubAdapter) RemovePullRequestLabels(ctx context.Context, inpu
 
 type reviewerAgentExecutorAdapter struct{ executor *agent.ConfiguredExecutor }
 type reviewerAgentExecutionAdapter struct{ execution agent.Execution }
+
+type reviewerGitAdapter struct{ gateway *gitinfra.Gateway }
+
+func (a reviewerGitAdapter) CreateWorktree(ctx context.Context, input reviewer.CreateWorktreeInput) (reviewer.CreateWorktreeResult, error) {
+	worktree, err := a.gateway.CreateWorktree(ctx, gitinfra.CreateWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, Branch: input.Branch, BaseBranch: input.BaseBranch, PRNumber: input.PRNumber, ProtectedBranches: input.ProtectedBranches, CheckoutMode: gitinfra.CheckoutMode(input.CheckoutMode)})
+	if err != nil {
+		return reviewer.CreateWorktreeResult{}, err
+	}
+	return reviewer.CreateWorktreeResult{WorktreePath: worktree.WorktreePath, Branch: worktree.Branch, HeadSHA: derefString(worktree.HeadSHA)}, nil
+}
+
+func (a reviewerGitAdapter) PrepareWorktree(ctx context.Context, input reviewer.PrepareWorktreeInput) (reviewer.PrepareWorktreeResult, error) {
+	result, err := a.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{WorktreePath: input.WorktreePath, Branch: input.Branch, ExpectedHeadSHA: input.ExpectedHeadSHA, Remote: input.Remote})
+	if err != nil {
+		return reviewer.PrepareWorktreeResult{}, err
+	}
+	return reviewer.PrepareWorktreeResult{HeadSHA: result.HeadSHA, Clean: result.Clean}, nil
+}
+
+func (a reviewerGitAdapter) CleanupWorktree(ctx context.Context, input reviewer.CleanupWorktreeInput) error {
+	return a.gateway.CleanupWorktree(ctx, gitinfra.CleanupWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreePath: input.WorktreePath, Branch: input.Branch, ProtectedBranches: input.ProtectedBranches})
+}
 
 func (a reviewerAgentExecutorAdapter) Start(ctx context.Context, input reviewer.AgentRunInput) (reviewer.AgentExecution, error) {
 	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
@@ -492,6 +514,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 		DB:               coordinator.DB(),
 		Repos:            repos,
 		GitHub:           reviewerGitHubAdapter{gateway: githubGateway},
+		Git:              reviewerGitAdapter{gateway: gitGateway},
 		AgentExecutor:    reviewerAgentExecutorAdapter{executor: agentExecutor},
 		Logger:           logger,
 		Now:              now,

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -234,7 +234,7 @@ func (a reviewerGitAdapter) CreateWorktree(ctx context.Context, input reviewer.C
 }
 
 func (a reviewerGitAdapter) PrepareWorktree(ctx context.Context, input reviewer.PrepareWorktreeInput) (reviewer.PrepareWorktreeResult, error) {
-	result, err := a.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{WorktreePath: input.WorktreePath, Branch: input.Branch, ExpectedHeadSHA: input.ExpectedHeadSHA, Remote: input.Remote})
+	result, err := a.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{WorktreePath: input.WorktreePath, Branch: input.Branch, Ref: input.Ref, ExpectedHeadSHA: input.ExpectedHeadSHA, Remote: input.Remote})
 	if err != nil {
 		return reviewer.PrepareWorktreeResult{}, err
 	}


### PR DESCRIPTION
## Summary
- run reviewer agents from a detached dedicated worktree instead of the project repo cwd
- capture PR head/base refs for reviewer worktree setup, add cleanup on terminal runs, and keep old in-flight review steps resumable
- cover the new isolated execution path in reviewer runner tests

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #53 