### PR TITLE
fix: hide stopped loops from active runs

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1713,6 +1713,9 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 		if !ok {
 			continue
 		}
+		if loop.Status != string(domain.LoopStatusRunning) {
+			continue
+		}
 		target, ok, err := h.tryBuildActiveRunTarget(ctx, loop)
 		if err != nil {
 			return nil, err

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1713,9 +1713,6 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 		if !ok {
 			continue
 		}
-		if loop.Status != string(domain.LoopStatusRunning) {
-			continue
-		}
 		target, ok, err := h.tryBuildActiveRunTarget(ctx, loop)
 		if err != nil {
 			return nil, err

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2823,7 +2823,7 @@ func TestActiveRunsIncludesRunningLoopWithoutRun(t *testing.T) {
 	assertEqual(t, target["label"], "acme/looper#43")
 }
 
-func TestActiveRunsExcludesPausedLoopWithStaleRunningRun(t *testing.T) {
+func TestActiveRunsIncludesPausedLoopWithRunningRun(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)
 
@@ -2877,12 +2877,16 @@ func TestActiveRunsExcludesPausedLoopWithStaleRunningRun(t *testing.T) {
 	}
 	body := parseJSONMap(t, recorder.Body.Bytes())
 	items := body["data"].(map[string]any)["items"].([]any)
-	if len(items) != 0 {
-		t.Fatalf("len(items) = %d, want 0", len(items))
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
 	}
+	item := items[0].(map[string]any)
+	assertEqual(t, item["loopId"], "loop_paused")
+	assertEqual(t, item["runId"], "run_stale")
+	assertEqual(t, item["status"], "running")
 }
 
-func TestActiveRunDetailExcludesPausedLoopWithStaleRunningRun(t *testing.T) {
+func TestActiveRunDetailIncludesPausedLoopWithRunningRun(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)
 
@@ -2931,12 +2935,14 @@ func TestActiveRunDetailExcludesPausedLoopWithStaleRunningRun(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active/8", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
-	if recorder.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404", recorder.Code)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
 	}
 	body := parseJSONMap(t, recorder.Body.Bytes())
-	errorMap := body["error"].(map[string]any)
-	assertEqual(t, errorMap["code"], "ACTIVE_RUN_NOT_FOUND")
+	data := body["data"].(map[string]any)
+	assertEqual(t, data["loopId"], "loop_paused")
+	assertEqual(t, data["runId"], "run_stale")
+	assertEqual(t, data["status"], "running")
 }
 
 func TestActiveRunDetailIncludesRunningLoopWithoutRun(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2823,6 +2823,122 @@ func TestActiveRunsIncludesRunningLoopWithoutRun(t *testing.T) {
 	assertEqual(t, target["label"], "acme/looper#43")
 }
 
+func TestActiveRunsExcludesPausedLoopWithStaleRunningRun(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID:        "project_1",
+		Name:      "Looper",
+		RepoPath:  "/tmp/repos/looper",
+		Archived:  false,
+		CreatedAt: nowISO,
+		UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:         "loop_paused",
+		Seq:        8,
+		ProjectID:  "project_1",
+		Type:       "reviewer",
+		TargetType: "pull_request",
+		TargetID:   stringPtr("pr:acme/looper:52"),
+		Repo:       stringPtr("acme/looper"),
+		PRNumber:   int64Ptr(52),
+		Status:     "paused",
+		LastRunAt:  stringPtr(nowISO),
+		CreatedAt:  nowISO,
+		UpdatedAt:  nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	if err := fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:              "run_stale",
+		LoopID:          "loop_paused",
+		Status:          "running",
+		CurrentStep:     stringPtr("review"),
+		StartedAt:       nowISO,
+		LastHeartbeatAt: stringPtr(nowISO),
+		CreatedAt:       nowISO,
+		UpdatedAt:       nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 0 {
+		t.Fatalf("len(items) = %d, want 0", len(items))
+	}
+}
+
+func TestActiveRunDetailExcludesPausedLoopWithStaleRunningRun(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID:        "project_1",
+		Name:      "Looper",
+		RepoPath:  "/tmp/repos/looper",
+		Archived:  false,
+		CreatedAt: nowISO,
+		UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:         "loop_paused",
+		Seq:        8,
+		ProjectID:  "project_1",
+		Type:       "reviewer",
+		TargetType: "pull_request",
+		TargetID:   stringPtr("pr:acme/looper:52"),
+		Repo:       stringPtr("acme/looper"),
+		PRNumber:   int64Ptr(52),
+		Status:     "paused",
+		LastRunAt:  stringPtr(nowISO),
+		CreatedAt:  nowISO,
+		UpdatedAt:  nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	if err := fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:              "run_stale",
+		LoopID:          "loop_paused",
+		Status:          "running",
+		CurrentStep:     stringPtr("review"),
+		StartedAt:       nowISO,
+		LastHeartbeatAt: stringPtr(nowISO),
+		CreatedAt:       nowISO,
+		UpdatedAt:       nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active/8", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	errorMap := body["error"].(map[string]any)
+	assertEqual(t, errorMap["code"], "ACTIVE_RUN_NOT_FOUND")
+}
+
 func TestActiveRunDetailIncludesRunningLoopWithoutRun(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -296,26 +296,23 @@ printf '{}'
 
 func writeExecutable(t *testing.T, path, contents string) {
 	t.Helper()
-	tempFile, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
 	if err != nil {
-		t.Fatalf("os.CreateTemp(%s) error = %v", filepath.Dir(path), err)
+		t.Fatalf("os.OpenFile(%s) error = %v", path, err)
 	}
-	tempPath := tempFile.Name()
-	defer func() {
-		_ = os.Remove(tempPath)
-	}()
-	if _, err := tempFile.WriteString(contents); err != nil {
-		_ = tempFile.Close()
-		t.Fatalf("tempFile.WriteString(%s) error = %v", tempPath, err)
+	if _, err := file.WriteString(contents); err != nil {
+		_ = file.Close()
+		t.Fatalf("file.WriteString(%s) error = %v", path, err)
 	}
-	if err := tempFile.Close(); err != nil {
-		t.Fatalf("tempFile.Close(%s) error = %v", tempPath, err)
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		t.Fatalf("file.Sync(%s) error = %v", path, err)
 	}
-	if err := os.Chmod(tempPath, 0o755); err != nil {
-		t.Fatalf("os.Chmod(%s) error = %v", tempPath, err)
+	if err := file.Close(); err != nil {
+		t.Fatalf("file.Close(%s) error = %v", path, err)
 	}
-	if err := os.Rename(tempPath, path); err != nil {
-		t.Fatalf("os.Rename(%s, %s) error = %v", tempPath, path, err)
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("os.Chmod(%s) error = %v", path, err)
 	}
 }
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -296,23 +296,12 @@ printf '{}'
 
 func writeExecutable(t *testing.T, path, contents string) {
 	t.Helper()
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
-	if err != nil {
-		t.Fatalf("os.OpenFile(%s) error = %v", path, err)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(contents), 0o755); err != nil {
+		t.Fatalf("os.WriteFile(%s) error = %v", tmpPath, err)
 	}
-	if _, err := file.WriteString(contents); err != nil {
-		_ = file.Close()
-		t.Fatalf("file.WriteString(%s) error = %v", path, err)
-	}
-	if err := file.Sync(); err != nil {
-		_ = file.Close()
-		t.Fatalf("file.Sync(%s) error = %v", path, err)
-	}
-	if err := file.Close(); err != nil {
-		t.Fatalf("file.Close(%s) error = %v", path, err)
-	}
-	if err := os.Chmod(path, 0o755); err != nil {
-		t.Fatalf("os.Chmod(%s) error = %v", path, err)
+	if err := os.Rename(tmpPath, path); err != nil {
+		t.Fatalf("os.Rename(%s, %s) error = %v", tmpPath, path, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- hide paused loops from `/api/v1/runs/active` so `looper ps` stops reporting a loop as running after `looper stop` succeeds
- add list and detail regression tests for paused loops that still have a stale `running` run record
- validated with `go vet ./...`, `go test ./...`, and `go build ./...`

Closes #52
