### PR TITLE
Improve worker completion feedback with end-state notifications

### DIFF
--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -87,6 +87,18 @@ type agentExecutionNotificationInput struct {
 	DedupeKey   string
 }
 
+type workerRunCompletedNotificationInput struct {
+	ProjectID         string
+	LoopID            string
+	RunID             string
+	Subtitle          string
+	Status            string
+	Summary           string
+	FailureKind       worker.QueueFailureKind
+	PullRequestNumber int64
+	PullRequestURL    string
+}
+
 type plannerGitHubAdapter struct{ gateway *githubinfra.Gateway }
 
 func (a plannerGitHubAdapter) ListOpenIssues(ctx context.Context, input planner.ListOpenIssuesInput) ([]planner.IssueSummary, error) {
@@ -456,6 +468,45 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 		})
 		return nil
 	}
+	notifyWorkerRunCompleted := func(ctx context.Context, input workerRunCompletedNotificationInput) error {
+		payload := notify.SystemNotificationPayload{
+			ProjectID:  input.ProjectID,
+			LoopID:     input.LoopID,
+			RunID:      input.RunID,
+			Subtitle:   input.Subtitle,
+			EntityType: "run",
+			EntityID:   input.RunID,
+		}
+		switch {
+		case input.Status == "failed" && input.FailureKind == worker.FailureManualIntervention:
+			payload.Level = "action_required"
+			payload.Title = "Looper Worker Needs Attention"
+			payload.Body = input.Summary
+			payload.DedupeKey = fmt.Sprintf("runtime.worker.action_required:%s", input.RunID)
+		case input.Status == "failed":
+			payload.Level = "failure"
+			payload.Title = "Looper Worker Failed"
+			payload.Body = input.Summary
+			payload.DedupeKey = fmt.Sprintf("runtime.worker.failed:%s", input.RunID)
+		case input.Status == "skipped":
+			payload.Level = "action_required"
+			payload.Title = "Looper Worker Needs Attention"
+			payload.Body = input.Summary
+			payload.DedupeKey = fmt.Sprintf("runtime.worker.action_required:%s", input.RunID)
+		case input.PullRequestNumber > 0:
+			payload.Level = "action_required"
+			payload.Title = "Looper Worker Opened a PR"
+			payload.Body = fmt.Sprintf("PR #%d is ready: %s", input.PullRequestNumber, runtimeFirstNonEmpty(input.PullRequestURL, input.Summary))
+			payload.DedupeKey = fmt.Sprintf("runtime.worker.pr_ready:%s", input.RunID)
+		default:
+			payload.Level = "success"
+			payload.Title = "Looper Worker Completed"
+			payload.Body = runtimeFirstNonEmpty(input.Summary, "Worker completed successfully")
+			payload.DedupeKey = fmt.Sprintf("runtime.worker.completed:%s", input.RunID)
+		}
+		notificationGateway.Notify(ctx, payload)
+		return nil
+	}
 
 	var plannerRunner plannerScheduler
 	var reviewerRunner reviewerScheduler
@@ -532,8 +583,8 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 		OpenPRStrategy:   cfg.Defaults.OpenPRStrategy,
 		RetryBaseDelay:   retryBaseDelay,
 		RetryMaxAttempts: int64(cfg.Scheduler.RetryMaxAttempts),
-		OnAgentExecutionStarted: func(ctx context.Context, input worker.AgentExecutionStartedInput) error {
-			return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Worker", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
+		OnRunCompleted: func(ctx context.Context, input worker.RunCompletedInput) error {
+			return notifyWorkerRunCompleted(ctx, workerRunCompletedNotificationInput{ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Subtitle: input.Subtitle, Status: input.Status, Summary: input.Summary, FailureKind: input.FailureKind, PullRequestNumber: input.PullRequestNumber, PullRequestURL: input.PullRequestURL})
 		},
 	})
 
@@ -769,6 +820,15 @@ func wrapSchedulerQueueError(queueType string, err error) error {
 		return nil
 	}
 	return fmt.Errorf("%s processing failed: %w", queueType, err)
+}
+
+func runtimeFirstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func boolPtr(value bool) *bool {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -469,6 +469,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 		return nil
 	}
 	notifyWorkerRunCompleted := func(ctx context.Context, input workerRunCompletedNotificationInput) error {
+		workerNotificationKeyID := runtimeFirstNonEmpty(input.RunID, input.LoopID)
 		payload := notify.SystemNotificationPayload{
 			ProjectID:  input.ProjectID,
 			LoopID:     input.LoopID,
@@ -482,17 +483,17 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			payload.Level = "action_required"
 			payload.Title = "Looper Worker Needs Attention"
 			payload.Body = input.Summary
-			payload.DedupeKey = fmt.Sprintf("runtime.worker.action_required:%s", input.RunID)
+			payload.DedupeKey = fmt.Sprintf("runtime.worker.action_required:%s", workerNotificationKeyID)
 		case input.Status == "failed":
 			payload.Level = "failure"
 			payload.Title = "Looper Worker Failed"
 			payload.Body = input.Summary
-			payload.DedupeKey = fmt.Sprintf("runtime.worker.failed:%s", input.RunID)
+			payload.DedupeKey = fmt.Sprintf("runtime.worker.failed:%s", workerNotificationKeyID)
 		case input.Status == "skipped":
 			payload.Level = "action_required"
 			payload.Title = "Looper Worker Needs Attention"
 			payload.Body = input.Summary
-			payload.DedupeKey = fmt.Sprintf("runtime.worker.action_required:%s", input.RunID)
+			payload.DedupeKey = fmt.Sprintf("runtime.worker.action_required:%s", workerNotificationKeyID)
 		case input.PullRequestNumber > 0:
 			payload.Level = "action_required"
 			payload.Title = "Looper Worker Opened a PR"

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -618,7 +618,6 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if _, err := r.completeRun(ctx, run, "success", summary, "", checkpoint); err != nil {
 		return ProcessResult{}, err
 	}
-	r.notifyRunCompleted(ctx, buildRunCompletedInput(*project, *loop, run, checkpoint, statusForCheckpoint(checkpoint), "", summary))
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
 		return ProcessResult{}, err
 	}
@@ -633,6 +632,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if checkpoint.SkipReason != "" {
 		status = "skipped"
 	}
+	r.notifyRunCompleted(ctx, buildRunCompletedInput(*project, *loop, run, checkpoint, statusForCheckpoint(checkpoint), "", summary))
 	return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary, PullRequestNumber: pullRequestNumber(checkpoint.PullRequest)}, nil
 }
 
@@ -1225,9 +1225,11 @@ func (r *Runner) notifyRecoveredRunCompleted(ctx context.Context, queueItem stor
 	runID := ""
 	checkpoint := workerCheckpoint{}
 	if latestRun, runErr := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID); runErr == nil && latestRun != nil {
-		runID = latestRun.ID
-		if parsed, parseErr := parseCheckpoint(latestRun.CheckpointJSON); parseErr == nil {
-			checkpoint = parsed
+		if runMatchesQueueAttempt(queueItem, *latestRun) {
+			runID = latestRun.ID
+			if parsed, parseErr := parseCheckpoint(latestRun.CheckpointJSON); parseErr == nil {
+				checkpoint = parsed
+			}
 		}
 	}
 	r.notifyRunCompleted(ctx, RunCompletedInput{
@@ -1241,6 +1243,13 @@ func (r *Runner) notifyRecoveredRunCompleted(ctx context.Context, queueItem stor
 		PullRequestNumber: pullRequestNumber(checkpoint.PullRequest),
 		PullRequestURL:    pullRequestURL(checkpoint.PullRequest),
 	})
+}
+
+func runMatchesQueueAttempt(queueItem storage.QueueItemRecord, run storage.RunRecord) bool {
+	if queueItem.ClaimedAt == nil || *queueItem.ClaimedAt == "" {
+		return run.Status == "running"
+	}
+	return run.StartedAt >= *queueItem.ClaimedAt
 }
 
 func buildRunCompletedInput(project storage.ProjectRecord, loop storage.LoopRecord, run storage.RunRecord, checkpoint workerCheckpoint, status string, failureKind QueueFailureKind, summary string) RunCompletedInput {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -241,6 +241,20 @@ type AgentExecutionStartedInput struct {
 
 type AgentExecutionStartedFunc func(context.Context, AgentExecutionStartedInput) error
 
+type RunCompletedInput struct {
+	ProjectID         string
+	LoopID            string
+	RunID             string
+	Subtitle          string
+	Status            string
+	Summary           string
+	FailureKind       QueueFailureKind
+	PullRequestNumber int64
+	PullRequestURL    string
+}
+
+type RunCompletedFunc func(context.Context, RunCompletedInput) error
+
 type Options struct {
 	DB                      *sql.DB
 	Repos                   *storage.Repositories
@@ -259,6 +273,7 @@ type Options struct {
 	RetryBaseDelay          time.Duration
 	RetryMaxAttempts        int64
 	OnAgentExecutionStarted AgentExecutionStartedFunc
+	OnRunCompleted          RunCompletedFunc
 }
 
 type Runner struct {
@@ -279,6 +294,7 @@ type Runner struct {
 	retryBaseDelay          time.Duration
 	retryMaxAttempts        int64
 	onAgentExecutionStarted AgentExecutionStartedFunc
+	onRunCompleted          RunCompletedFunc
 }
 
 type ProcessResult struct {
@@ -411,6 +427,7 @@ func New(options Options) *Runner {
 		retryBaseDelay:          retryBaseDelay,
 		retryMaxAttempts:        retryMaxAttempts,
 		onAgentExecutionStarted: options.OnAgentExecutionStarted,
+		onRunCompleted:          options.OnRunCompleted,
 	}
 }
 
@@ -441,6 +458,9 @@ func (r *Runner) recoverClaimedItem(ctx context.Context, queueItem storage.Queue
 	}
 	if err := r.reconcileRecoveredLoop(ctx, queueItem, failedQueue, failure.kind); err != nil {
 		return nil, err
+	}
+	if shouldNotifyCompletedRun(failure.kind, failedQueue) {
+		r.notifyRecoveredRunCompleted(ctx, queueItem, failure)
 	}
 	return &ProcessResult{LoopID: derefString(queueItem.LoopID), QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 }
@@ -558,6 +578,9 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			if err != nil {
 				return ProcessResult{}, err
 			}
+			if shouldNotifyCompletedRun(failure.kind, failedQueue) {
+				r.notifyRunCompleted(ctx, buildRunCompletedInput(*project, *loop, run, latest, "failed", failure.kind, failure.message))
+			}
 			if _, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
 				updated.LastRunAt = stringPtr(r.nowISO())
 				if updated.Status == "paused" {
@@ -595,6 +618,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if _, err := r.completeRun(ctx, run, "success", summary, "", checkpoint); err != nil {
 		return ProcessResult{}, err
 	}
+	r.notifyRunCompleted(ctx, buildRunCompletedInput(*project, *loop, run, checkpoint, statusForCheckpoint(checkpoint), "", summary))
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
 		return ProcessResult{}, err
 	}
@@ -1180,6 +1204,88 @@ func (r *Runner) buildSuccessSummary(loop storage.LoopRecord, checkpoint workerC
 		return fmt.Sprintf("Opened pull request for worker %s: %s", loop.ID, checkpoint.PullRequest.URL)
 	}
 	return fmt.Sprintf("Completed worker %s", loop.ID)
+}
+
+func (r *Runner) notifyRunCompleted(ctx context.Context, input RunCompletedInput) {
+	if r.onRunCompleted != nil {
+		if err := r.onRunCompleted(ctx, input); err != nil && r.logger != nil {
+			r.logger.Warn("worker completion notification failed", map[string]any{"loopId": input.LoopID, "runId": input.RunID, "error": err.Error()})
+		}
+	}
+}
+
+func (r *Runner) notifyRecoveredRunCompleted(ctx context.Context, queueItem storage.QueueItemRecord, failure *loopError) {
+	if queueItem.LoopID == nil {
+		return
+	}
+	loop, err := r.repos.Loops.GetByID(ctx, *queueItem.LoopID)
+	if err != nil || loop == nil {
+		return
+	}
+	runID := ""
+	checkpoint := workerCheckpoint{}
+	if latestRun, runErr := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID); runErr == nil && latestRun != nil {
+		runID = latestRun.ID
+		if parsed, parseErr := parseCheckpoint(latestRun.CheckpointJSON); parseErr == nil {
+			checkpoint = parsed
+		}
+	}
+	r.notifyRunCompleted(ctx, RunCompletedInput{
+		ProjectID:         loop.ProjectID,
+		LoopID:            loop.ID,
+		RunID:             runID,
+		Subtitle:          runNotificationSubtitle(*loop, checkpoint),
+		Status:            "failed",
+		Summary:           failure.message,
+		FailureKind:       failure.kind,
+		PullRequestNumber: pullRequestNumber(checkpoint.PullRequest),
+		PullRequestURL:    pullRequestURL(checkpoint.PullRequest),
+	})
+}
+
+func buildRunCompletedInput(project storage.ProjectRecord, loop storage.LoopRecord, run storage.RunRecord, checkpoint workerCheckpoint, status string, failureKind QueueFailureKind, summary string) RunCompletedInput {
+	return RunCompletedInput{
+		ProjectID:         project.ID,
+		LoopID:            loop.ID,
+		RunID:             run.ID,
+		Subtitle:          runNotificationSubtitle(loop, checkpoint),
+		Status:            status,
+		Summary:           summary,
+		FailureKind:       failureKind,
+		PullRequestNumber: pullRequestNumber(checkpoint.PullRequest),
+		PullRequestURL:    pullRequestURL(checkpoint.PullRequest),
+	}
+}
+
+func runNotificationSubtitle(loop storage.LoopRecord, checkpoint workerCheckpoint) string {
+	if checkpoint.Work != nil && strings.TrimSpace(checkpoint.Work.Title) != "" {
+		return checkpoint.Work.Title
+	}
+	if loop.TargetType != "" && loop.TargetID != nil && strings.TrimSpace(*loop.TargetID) != "" {
+		return *loop.TargetID
+	}
+	return loop.ID
+}
+
+func shouldNotifyCompletedRun(kind QueueFailureKind, failedQueue *storage.QueueItemRecord) bool {
+	if kind == FailureManualIntervention {
+		return true
+	}
+	return failedQueue != nil && failedQueue.Status != "queued" && failedQueue.Status != "cancelled"
+}
+
+func statusForCheckpoint(checkpoint workerCheckpoint) string {
+	if checkpoint.SkipReason != "" {
+		return "skipped"
+	}
+	return "success"
+}
+
+func pullRequestURL(pr *checkpointPullPR) string {
+	if pr == nil {
+		return ""
+	}
+	return strings.TrimSpace(pr.URL)
 }
 
 func (r *Runner) canAgentCreatePR(work workerInput) bool {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -47,6 +47,20 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
+		queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+		if err != nil {
+			t.Fatalf("Queue.GetByID() in notification callback error = %v", err)
+		}
+		if queue == nil || queue.Status != "completed" {
+			t.Fatalf("queue during notification = %#v, want completed queue item", queue)
+		}
+		loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+		if err != nil {
+			t.Fatalf("Loops.GetByID() in notification callback error = %v", err)
+		}
+		if loop == nil || loop.Status != "completed" || loop.NextRunAt != nil {
+			t.Fatalf("loop during notification = %#v, want completed loop", loop)
+		}
 		completed = append(completed, input)
 		return nil
 	}})
@@ -566,6 +580,47 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	}
 	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
 		t.Fatalf("loop = %#v, want failed terminal loop", loop)
+	}
+}
+
+func TestRecoverClaimedItemDoesNotReusePreviousRunID(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	priorStartedAt := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC).Format(time.RFC3339Nano)
+	claimedAt := time.Date(2024, time.January, 2, 3, 5, 5, 0, time.UTC).Format(time.RFC3339Nano)
+	loopTarget := "project:project_1"
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_prior_run", Seq: 2, ProjectID: "project_1", Type: "worker", TargetType: "project", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := `{"work":{"title":"Older worker run"}}`
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_prior", LoopID: "loop_worker_prior_run", Status: "success", CheckpointJSON: &checkpointJSON, StartedAt: priorStartedAt, EndedAt: &priorStartedAt, CreatedAt: priorStartedAt, UpdatedAt: priorStartedAt}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	loopID := "loop_worker_prior_run"
+	payload := `{"title":"Recover worker loop","prompt":"Do the thing","repo":"acme/looper","baseBranch":"main"}`
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_prior_run", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: loopTarget, Repo: stringPtr("acme/looper"), DedupeKey: "worker:loop_worker_prior_run", Priority: 1, Status: "running", AvailableAt: nowISO, ClaimedAt: &claimedAt, Attempts: 0, MaxAttempts: 1, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	completed := make([]RunCompletedInput, 0, 1)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
+		completed = append(completed, input)
+		return nil
+	}})
+
+	result, err := runner.recoverClaimedItem(context.Background(), storage.QueueItemRecord{ID: "queue_worker_prior_run", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: loopTarget, Repo: stringPtr("acme/looper"), DedupeKey: "worker:loop_worker_prior_run", Priority: 1, Status: "running", AvailableAt: nowISO, ClaimedAt: &claimedAt, Attempts: 0, MaxAttempts: 1, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}, fmt.Errorf("project lookup failed"))
+	if err != nil {
+		t.Fatalf("recoverClaimedItem() error = %v", err)
+	}
+	if result == nil || result.Status != "failed" || result.FailureKind != FailureNonRetryable {
+		t.Fatalf("result = %#v, want failed non-retryable recovery", result)
+	}
+	if len(completed) != 1 {
+		t.Fatalf("completed = %#v, want one recovery notification", completed)
+	}
+	if completed[0].RunID != "" {
+		t.Fatalf("completed[0].RunID = %q, want empty run ID for recovery before new run creation", completed[0].RunID)
 	}
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -45,7 +45,11 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+	completed := make([]RunCompletedInput, 0, 1)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
+		completed = append(completed, input)
+		return nil
+	}})
 
 	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
 	if err != nil || claim == nil {
@@ -60,6 +64,12 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	}
 	if len(agent.starts) != 1 || len(git.pushCalls) != 1 || len(github.createPRCalls) != 1 {
 		t.Fatalf("agent starts=%d push=%d createPR=%d, want 1/1/1", len(agent.starts), len(git.pushCalls), len(github.createPRCalls))
+	}
+	if len(completed) != 1 {
+		t.Fatalf("len(completed) = %d, want 1", len(completed))
+	}
+	if completed[0].Status != "success" || completed[0].PullRequestNumber != 101 || completed[0].PullRequestURL != "https://example/pr/101" {
+		t.Fatalf("completed[0] = %#v, want success with PR details", completed[0])
 	}
 	if !strings.Contains(agent.starts[0].Prompt, `__LOOPER_RESULT__={"summary":"<one-sentence summary>"}`) {
 		t.Fatalf("prompt = %q, want canonical completion instruction", agent.starts[0].Prompt)
@@ -291,7 +301,11 @@ func TestProcessClaimedItemResumesFromOpenPRAfterRetryableFailure(t *testing.T) 
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}, createPRErrors: []error{fmt.Errorf("temporary create pr failure")}}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+	started := make([]AgentExecutionStartedInput, 0, 1)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, OnAgentExecutionStarted: func(_ context.Context, input AgentExecutionStartedInput) error {
+		started = append(started, input)
+		return nil
+	}})
 
 	claim1, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
 	first, err := runner.ProcessClaimedItem(context.Background(), *claim1)
@@ -312,6 +326,9 @@ func TestProcessClaimedItemResumesFromOpenPRAfterRetryableFailure(t *testing.T) 
 	}
 	if len(agent.starts) != 1 {
 		t.Fatalf("len(agent.starts) = %d, want 1 (execute should not rerun)", len(agent.starts))
+	}
+	if len(started) != 1 {
+		t.Fatalf("len(started) = %d, want 1 (start notification should not repeat on resume)", len(started))
 	}
 	if len(git.createCalls) != 1 {
 		t.Fatalf("len(git.createCalls) = %d, want 1 (worktree should not rerun)", len(git.createCalls))
@@ -371,8 +388,12 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	completed := make([]RunCompletedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, ValidationRunner: func(context.Context, ValidationInput) (ValidationResult, error) {
 		return ValidationResult{Passed: false, Summary: "Validation failed"}, nil
+	}, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
+		completed = append(completed, input)
+		return nil
 	}})
 
 	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
@@ -382,6 +403,12 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 	}
 	if result.Status != "failed" || result.FailureKind != FailureManualIntervention {
 		t.Fatalf("result = %#v, want manual_intervention failure", result)
+	}
+	if len(completed) != 1 {
+		t.Fatalf("len(completed) = %d, want 1", len(completed))
+	}
+	if completed[0].Status != "failed" || completed[0].FailureKind != FailureManualIntervention || completed[0].Summary != "Validation failed" {
+		t.Fatalf("completed[0] = %#v, want manual intervention completion notice", completed[0])
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
 	if err != nil {
@@ -510,7 +537,11 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_running", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: loopTarget, Repo: stringPtr("acme/looper"), DedupeKey: "worker:loop_worker_running", Priority: 1, Status: "running", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 1, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	completed := make([]RunCompletedInput, 0, 1)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
+		completed = append(completed, input)
+		return nil
+	}})
 
 	result, err := runner.recoverClaimedItem(context.Background(), storage.QueueItemRecord{ID: "queue_worker_running", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: loopTarget, Repo: stringPtr("acme/looper"), DedupeKey: "worker:loop_worker_running", Priority: 1, Status: "running", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 1, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}, fmt.Errorf("persist step failed"))
 	if err != nil {
@@ -518,6 +549,9 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	}
 	if result == nil || result.Status != "failed" || result.FailureKind != FailureNonRetryable {
 		t.Fatalf("result = %#v, want failed non-retryable recovery", result)
+	}
+	if len(completed) != 1 || completed[0].Status != "failed" || completed[0].FailureKind != FailureNonRetryable {
+		t.Fatalf("completed = %#v, want terminal recovery notification", completed)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_running")
 	if err != nil {
@@ -532,6 +566,30 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	}
 	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
 		t.Fatalf("loop = %#v, want failed terminal loop", loop)
+	}
+}
+
+func TestProcessClaimedItemSkippedFlowEmitsCompletionNotification(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	completed := make([]RunCompletedInput, 0, 1)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: false, OpenPRStrategy: config.OpenPRStrategyAllDone, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
+		completed = append(completed, input)
+		return nil
+	}})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" || !strings.Contains(result.Summary, "manual PR opening required") {
+		t.Fatalf("result = %#v, want skipped manual intervention summary", result)
+	}
+	if len(completed) != 1 || completed[0].Status != "skipped" || !strings.Contains(completed[0].Summary, "manual PR opening required") {
+		t.Fatalf("completed = %#v, want skipped completion notification", completed)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add worker end-state notifications for success, PR-ready, failure, and needs-attention outcomes
- stop wiring worker start notifications by default so end-state signals carry the user-facing feedback loop
- cover completion, skipped, manual-intervention, and recovery notification paths with worker tests

## Testing
- go test ./internal/worker ./internal/runtime
- go test ./...
- go build ./...

Closes #50
