### PR TITLE
feat: support looper logs --follow streaming

### DIFF
--- a/cmd/looper/main.go
+++ b/cmd/looper/main.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"slices"
+	"syscall"
 
 	"github.com/powerformer/looper/internal/cliapp"
 	"github.com/powerformer/looper/internal/version"
@@ -36,7 +38,9 @@ func runWithDeps(args []string, stdout, stderr io.Writer, deps runDeps) int {
 
 	ctx := deps.ctx
 	if ctx == nil {
-		ctx = context.Background()
+		var stop context.CancelFunc
+		ctx, stop = signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
 	}
 
 	newApp := deps.newApp

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -30,9 +31,10 @@ import (
 )
 
 const (
-	requestIDHeaderName = "x-request-id"
-	apiBasePath         = "/api/v1"
-	javaScriptISOString = "2006-01-02T15:04:05.000Z"
+	requestIDHeaderName        = "x-request-id"
+	apiBasePath                = "/api/v1"
+	javaScriptISOString        = "2006-01-02T15:04:05.000Z"
+	loopLogsFollowPollInterval = 200 * time.Millisecond
 )
 
 var nonProjectIDPattern = regexp.MustCompile(`[^a-z0-9]+`)
@@ -245,6 +247,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.HasPrefix(path, apiBasePath+"/loops/") {
+		if isFollowLoopLogsRequest(r, path) {
+			if err := h.streamLoopLogsRoute(w, r, path, requestID); err != nil {
+				var typed apiError
+				if !asAPIError(err, &typed) {
+					typed = internalServerError(err)
+				}
+				h.writeError(w, requestID, typed)
+			}
+			return
+		}
 		payload, err := h.buildLoopRouteResponse(r, path)
 		if err != nil {
 			var typed apiError
@@ -316,6 +328,16 @@ type apiError struct {
 	status  int
 	message string
 	details any
+}
+
+type loopLogsFollowChunkEvent struct {
+	RunID       *string `json:"runId,omitempty"`
+	CurrentStep *string `json:"currentStep,omitempty"`
+	ExecutionID *string `json:"executionId,omitempty"`
+	Vendor      *string `json:"vendor,omitempty"`
+	PID         *int64  `json:"pid,omitempty"`
+	Status      *string `json:"status,omitempty"`
+	Content     string  `json:"content"`
 }
 
 func (e apiError) Error() string {
@@ -2024,6 +2046,169 @@ func (h *Handler) buildLoopRouteResponse(r *http.Request, path string) (any, err
 	default:
 		return nil, apiError{code: pkgapi.ErrorCodeRouteNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Unknown route: %s", path)}
 	}
+}
+
+func isFollowLoopLogsRequest(r *http.Request, path string) bool {
+	if r.Method != http.MethodGet || !strings.HasSuffix(path, "/logs") {
+		return false
+	}
+	value := strings.TrimSpace(r.URL.Query().Get("follow"))
+	return value == "1" || strings.EqualFold(value, "true")
+}
+
+func (h *Handler) streamLoopLogsRoute(w http.ResponseWriter, r *http.Request, path string, requestID string) error {
+	parts := strings.Split(strings.TrimPrefix(path, apiBasePath+"/loops/"), "/")
+	selector, err := urlPathSegment(parts, 0)
+	if err != nil {
+		return err
+	}
+	if len(parts) != 2 || strings.TrimSpace(parts[1]) != "logs" {
+		return apiError{code: pkgapi.ErrorCodeRouteNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Unknown route: %s", path)}
+	}
+
+	loop, err := h.resolveLoop(r.Context(), selector)
+	if err != nil {
+		return err
+	}
+
+	return h.streamLoopLogs(w, r, requestID, loop, queryBool(r.URL.Query(), "stderr"))
+}
+
+func (h *Handler) streamLoopLogs(w http.ResponseWriter, r *http.Request, requestID string, loop storage.LoopRecord, stderr bool) error {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Streaming is not supported by this response writer"}
+	}
+
+	current, err := h.buildLoopLogsResponse(r.Context(), loop)
+	if err != nil {
+		return err
+	}
+
+	w.Header().Set(requestIDHeaderName, requestID)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	if err := writeSSEEvent(w, flusher, "snapshot", current); err != nil {
+		return nil
+	}
+
+	observedRunID := ""
+	if current.Run != nil {
+		observedRunID = current.Run.RunID
+	}
+	previousExecutionID, previousContent := loopLogsStreamState(current, stderr)
+	if shouldTerminateLoopLogsFollow(current, observedRunID) {
+		return nil
+	}
+
+	ticker := time.NewTicker(loopLogsFollowPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		current, err = h.buildLoopLogsResponse(r.Context(), loop)
+		if err != nil {
+			continue
+		}
+		if observedRunID == "" && current.Run != nil {
+			observedRunID = current.Run.RunID
+		}
+
+		nextExecutionID, nextContent := loopLogsStreamState(current, stderr)
+		chunk := appendedLogChunk(previousExecutionID, previousContent, nextExecutionID, nextContent)
+		if chunk != "" {
+			event := loopLogsFollowChunkEvent{Content: chunk}
+			if current.Run != nil {
+				event.RunID = &current.Run.RunID
+				event.CurrentStep = current.Run.CurrentStep
+			}
+			if current.Agent != nil {
+				event.ExecutionID = &current.Agent.ExecutionID
+				event.Vendor = &current.Agent.Vendor
+				event.PID = current.Agent.PID
+				event.Status = &current.Agent.Status
+			}
+			if err := writeSSEEvent(w, flusher, "chunk", event); err != nil {
+				return nil
+			}
+		}
+
+		previousExecutionID, previousContent = nextExecutionID, nextContent
+		if shouldTerminateLoopLogsFollow(current, observedRunID) {
+			_ = writeSSEEvent(w, flusher, "end", map[string]string{"reason": "run_completed"})
+			return nil
+		}
+	}
+}
+
+func queryBool(values url.Values, key string) bool {
+	value := strings.TrimSpace(values.Get(key))
+	return value == "1" || strings.EqualFold(value, "true")
+}
+
+func writeSSEEvent(w io.Writer, flusher http.Flusher, event string, payload any) error {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\n", event); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", encoded); err != nil {
+		return err
+	}
+	flusher.Flush()
+	return nil
+}
+
+func loopLogsStreamState(resp loopLogsResponse, stderr bool) (string, string) {
+	if resp.Agent == nil {
+		return "", ""
+	}
+	content := resp.Agent.Stdout
+	if stderr {
+		content = resp.Agent.Stderr
+	}
+	return resp.Agent.ExecutionID, content
+}
+
+func appendedLogChunk(previousExecutionID, previousContent, currentExecutionID, currentContent string) string {
+	if currentExecutionID == "" {
+		return ""
+	}
+	if previousExecutionID == "" || currentExecutionID != previousExecutionID {
+		return currentContent
+	}
+	if currentContent == previousContent {
+		return ""
+	}
+	if strings.HasPrefix(currentContent, previousContent) {
+		return currentContent[len(previousContent):]
+	}
+	return currentContent
+}
+
+func shouldTerminateLoopLogsFollow(resp loopLogsResponse, observedRunID string) bool {
+	if observedRunID == "" {
+		if resp.Run == nil {
+			return !domain.IsActiveLoopStatus(domain.LoopStatus(resp.LoopStatus))
+		}
+		observedRunID = resp.Run.RunID
+	}
+	if resp.Run == nil {
+		return true
+	}
+	if resp.Run.RunID != observedRunID {
+		return true
+	}
+	return domain.IsTerminalRunStatus(domain.RunStatus(resp.Run.Status))
 }
 
 type createLoopRequest struct {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2121,6 +2121,10 @@ func (h *Handler) streamLoopLogs(w http.ResponseWriter, r *http.Request, request
 		if observedRunID == "" && current.Run != nil {
 			observedRunID = current.Run.RunID
 		}
+		if shouldTerminateLoopLogsFollowBeforeChunk(current, observedRunID) {
+			_ = writeSSEEvent(w, flusher, "end", map[string]string{"reason": "run_completed"})
+			return nil
+		}
 
 		nextExecutionID, nextContent := loopLogsStreamState(current, stderr)
 		chunk := appendedLogChunk(previousExecutionID, previousContent, nextExecutionID, nextContent)
@@ -2210,6 +2214,19 @@ func shouldTerminateLoopLogsFollow(resp loopLogsResponse, observedRunID string) 
 		return true
 	}
 	return domain.IsTerminalRunStatus(domain.RunStatus(resp.Run.Status))
+}
+
+func shouldTerminateLoopLogsFollowBeforeChunk(resp loopLogsResponse, observedRunID string) bool {
+	if !shouldTerminateLoopLogsFollow(resp, observedRunID) {
+		return false
+	}
+	if observedRunID == "" {
+		return resp.Run == nil
+	}
+	if resp.Run == nil {
+		return true
+	}
+	return resp.Run.RunID != observedRunID
 }
 
 type createLoopRequest struct {
@@ -3078,6 +3095,12 @@ func (h *Handler) mutateLoopStatus(ctx context.Context, loopID string, status do
 
 func (h *Handler) buildLoopLogsResponse(ctx context.Context, loop storage.LoopRecord) (loopLogsResponse, error) {
 	services := h.context.Runtime.Services()
+	if latestLoop, err := services.Repositories.Loops.GetByID(ctx, loop.ID); err != nil {
+		return loopLogsResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	} else if latestLoop != nil {
+		loop = *latestLoop
+	}
+
 	latestRun, err := services.Repositories.Runs.GetLatestByLoopID(ctx, loop.ID)
 	if err != nil {
 		return loopLogsResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2100,6 +2100,7 @@ func (h *Handler) streamLoopLogs(w http.ResponseWriter, r *http.Request, request
 	}
 	previousExecutionID, previousContent := loopLogsStreamState(current, stderr)
 	if shouldTerminateLoopLogsFollow(current, observedRunID) {
+		_ = writeSSEEvent(w, flusher, "end", map[string]string{"reason": "run_completed"})
 		return nil
 	}
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2513,6 +2513,101 @@ func TestHandlerRunRoutesMatchFrozenSuccessArtifacts(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopLogsFollowStreamsSnapshotAndChunk(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedRunRouteData(t, fixture.runtime)
+
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	if err := fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
+		ID:              "agent_exec_1",
+		ProjectID:       stringPtr("project_1"),
+		LoopID:          stringPtr("loop_1"),
+		RunID:           stringPtr("run_1"),
+		Vendor:          "openai",
+		Status:          "running",
+		PID:             int64Ptr(1234),
+		HeartbeatCount:  1,
+		LastHeartbeatAt: stringPtr(nowISO),
+		StartedAt:       nowISO,
+		OutputJSON:      stringPtr(`{"stdout":"line1\n","stderr":""}`),
+		CreatedAt:       nowISO,
+		UpdatedAt:       nowISO,
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(agent_exec_1) error = %v", err)
+	}
+
+	server := httptest.NewServer(NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime}))
+	defer server.Close()
+
+	response, err := http.Get(server.URL + "/api/v1/loops/loop_1/logs?follow=1")
+	if err != nil {
+		t.Fatalf("http.Get() error = %v", err)
+	}
+	defer response.Body.Close()
+
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		updatedRun, getRunErr := fixture.runtime.Services().Repositories.Runs.GetByID(context.Background(), "run_1")
+		if getRunErr != nil || updatedRun == nil {
+			return
+		}
+		run := *updatedRun
+		completedAt := fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString)
+		run.Status = "success"
+		run.EndedAt = &completedAt
+		run.UpdatedAt = completedAt
+		_ = fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), run)
+
+		updatedExec, getExecErr := fixture.runtime.Services().Repositories.AgentExecutions.GetLatestByRunID(context.Background(), "run_1")
+		if getExecErr != nil || updatedExec == nil {
+			return
+		}
+		exec := *updatedExec
+		exec.Status = "completed"
+		exec.EndedAt = &completedAt
+		exec.OutputJSON = stringPtr(`{"stdout":"line1\nline2\n","stderr":""}`)
+		exec.UpdatedAt = completedAt
+		_ = fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), exec)
+	}()
+
+	bodyCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		body, readErr := io.ReadAll(response.Body)
+		if readErr != nil {
+			errCh <- readErr
+			return
+		}
+		bodyCh <- body
+	}()
+
+	var body []byte
+	select {
+	case body = <-bodyCh:
+	case err := <-errCh:
+		t.Fatalf("io.ReadAll() error = %v", err)
+	case <-time.After(5 * time.Second):
+		_ = response.Body.Close()
+		t.Fatal("timed out waiting for loop logs follow stream")
+	}
+	text := string(body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.StatusCode)
+	}
+	if got := response.Header.Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	if !strings.Contains(text, "event: snapshot") {
+		t.Fatalf("stream body = %q, want snapshot event", text)
+	}
+	if !strings.Contains(text, "event: chunk") || !strings.Contains(text, "\"content\":\"line2\\n\"") {
+		t.Fatalf("stream body = %q, want chunk with appended output", text)
+	}
+	if !strings.Contains(text, "event: end") {
+		t.Fatalf("stream body = %q, want end event", text)
+	}
+}
+
 func seedWorkerPlannerArtifactsData(t *testing.T, rt *looperdruntime.Runtime, now time.Time) {
 	t.Helper()
 	nowISO := now.UTC().Format(javaScriptISOString)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2608,6 +2608,50 @@ func TestHandlerLoopLogsFollowStreamsSnapshotAndChunk(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopLogsFollowEmitsEndForTerminalSnapshot(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedRunRouteData(t, fixture.runtime)
+
+	completedAt := fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString)
+	run, err := fixture.runtime.Services().Repositories.Runs.GetByID(context.Background(), "run_1")
+	if err != nil {
+		t.Fatalf("Runs.GetByID(run_1) error = %v", err)
+	}
+	if run == nil {
+		t.Fatal("run_1 missing from fixture")
+	}
+	run.Status = "success"
+	run.EndedAt = &completedAt
+	run.UpdatedAt = completedAt
+	if err := fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), *run); err != nil {
+		t.Fatalf("Runs.Upsert(run_1) error = %v", err)
+	}
+
+	server := httptest.NewServer(NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime}))
+	defer server.Close()
+
+	response, err := http.Get(server.URL + "/api/v1/loops/loop_1/logs?follow=1")
+	if err != nil {
+		t.Fatalf("http.Get() error = %v", err)
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error = %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "event: snapshot") {
+		t.Fatalf("stream body = %q, want snapshot event", text)
+	}
+	if !strings.Contains(text, "event: end") {
+		t.Fatalf("stream body = %q, want end event", text)
+	}
+	if strings.Contains(text, "event: chunk") {
+		t.Fatalf("stream body = %q, did not expect chunk event for terminal snapshot", text)
+	}
+}
+
 func seedWorkerPlannerArtifactsData(t *testing.T, rt *looperdruntime.Runtime, now time.Time) {
 	t.Helper()
 	nowISO := now.UTC().Format(javaScriptISOString)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2652,6 +2652,176 @@ func TestHandlerLoopLogsFollowEmitsEndForTerminalSnapshot(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopLogsFollowDoesNotStreamNextRunChunks(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedRunRouteData(t, fixture.runtime)
+
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	if err := fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
+		ID:              "agent_exec_1",
+		ProjectID:       stringPtr("project_1"),
+		LoopID:          stringPtr("loop_1"),
+		RunID:           stringPtr("run_1"),
+		Vendor:          "openai",
+		Status:          "running",
+		PID:             int64Ptr(1234),
+		HeartbeatCount:  1,
+		LastHeartbeatAt: stringPtr(nowISO),
+		StartedAt:       nowISO,
+		OutputJSON:      stringPtr(`{"stdout":"line1\n","stderr":""}`),
+		CreatedAt:       nowISO,
+		UpdatedAt:       nowISO,
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(agent_exec_1) error = %v", err)
+	}
+
+	server := httptest.NewServer(NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime}))
+	defer server.Close()
+
+	response, err := http.Get(server.URL + "/api/v1/loops/loop_1/logs?follow=1")
+	if err != nil {
+		t.Fatalf("http.Get() error = %v", err)
+	}
+	defer response.Body.Close()
+
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		completedAt := fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString)
+
+		updatedRun, getRunErr := fixture.runtime.Services().Repositories.Runs.GetByID(context.Background(), "run_1")
+		if getRunErr != nil || updatedRun == nil {
+			return
+		}
+		run := *updatedRun
+		run.Status = "success"
+		run.EndedAt = &completedAt
+		run.UpdatedAt = completedAt
+		_ = fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), run)
+
+		nextStartedAt := fixture.now.Add(2 * time.Minute).UTC().Format(javaScriptISOString)
+		_ = fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), storage.RunRecord{
+			ID:                "run_2",
+			LoopID:            "loop_1",
+			Status:            "running",
+			CurrentStep:       stringPtr("review"),
+			LastCompletedStep: stringPtr("snapshot"),
+			StartedAt:         nextStartedAt,
+			LastHeartbeatAt:   stringPtr(nextStartedAt),
+			CreatedAt:         nextStartedAt,
+			UpdatedAt:         nextStartedAt,
+		})
+		_ = fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
+			ID:              "agent_exec_2",
+			ProjectID:       stringPtr("project_1"),
+			LoopID:          stringPtr("loop_1"),
+			RunID:           stringPtr("run_2"),
+			Vendor:          "openai",
+			Status:          "running",
+			PID:             int64Ptr(5678),
+			HeartbeatCount:  1,
+			LastHeartbeatAt: stringPtr(nextStartedAt),
+			StartedAt:       nextStartedAt,
+			OutputJSON:      stringPtr(`{"stdout":"run2-line1\n","stderr":""}`),
+			CreatedAt:       nextStartedAt,
+			UpdatedAt:       nextStartedAt,
+		})
+	}()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error = %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "event: snapshot") {
+		t.Fatalf("stream body = %q, want snapshot event", text)
+	}
+	if !strings.Contains(text, "event: end") {
+		t.Fatalf("stream body = %q, want end event", text)
+	}
+	if strings.Contains(text, "run2-line1\\n") {
+		t.Fatalf("stream body = %q, did not expect next run chunk", text)
+	}
+	if strings.Contains(text, "event: chunk") {
+		t.Fatalf("stream body = %q, did not expect chunk event from next run", text)
+	}
+}
+
+func TestHandlerLoopLogsFollowEmitsEndWhenLoopTerminatesBeforeRunStarts(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedRunRouteData(t, fixture.runtime)
+
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:         "loop_no_run",
+		Seq:        2,
+		ProjectID:  "project_1",
+		Type:       "reviewer",
+		TargetType: "pull_request",
+		TargetID:   stringPtr("pr:acme/looper:99"),
+		Repo:       stringPtr("acme/looper"),
+		PRNumber:   int64Ptr(99),
+		Status:     "running",
+		CreatedAt:  nowISO,
+		UpdatedAt:  nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_no_run) error = %v", err)
+	}
+
+	server := httptest.NewServer(NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime}))
+	defer server.Close()
+
+	response, err := http.Get(server.URL + "/api/v1/loops/loop_no_run/logs?follow=1")
+	if err != nil {
+		t.Fatalf("http.Get() error = %v", err)
+	}
+	defer response.Body.Close()
+
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		loop, getLoopErr := fixture.runtime.Services().Repositories.Loops.GetByID(context.Background(), "loop_no_run")
+		if getLoopErr != nil || loop == nil {
+			return
+		}
+		updatedAt := fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString)
+		updatedLoop := *loop
+		updatedLoop.Status = "completed"
+		updatedLoop.UpdatedAt = updatedAt
+		_ = fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), updatedLoop)
+	}()
+
+	bodyCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		body, readErr := io.ReadAll(response.Body)
+		if readErr != nil {
+			errCh <- readErr
+			return
+		}
+		bodyCh <- body
+	}()
+
+	var body []byte
+	select {
+	case body = <-bodyCh:
+	case err := <-errCh:
+		t.Fatalf("io.ReadAll() error = %v", err)
+	case <-time.After(5 * time.Second):
+		_ = response.Body.Close()
+		t.Fatal("timed out waiting for loop logs follow stream")
+	}
+
+	text := string(body)
+	if !strings.Contains(text, "event: snapshot") {
+		t.Fatalf("stream body = %q, want snapshot event", text)
+	}
+	if !strings.Contains(text, "event: end") {
+		t.Fatalf("stream body = %q, want end event", text)
+	}
+	if strings.Contains(text, "event: chunk") {
+		t.Fatalf("stream body = %q, did not expect chunk event", text)
+	}
+}
+
 func seedWorkerPlannerArtifactsData(t *testing.T, rt *looperdruntime.Runtime, now time.Time) {
 	t.Helper()
 	nowISO := now.UTC().Format(javaScriptISOString)

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -276,10 +276,12 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					boolFlag("stderr", "Show stderr instead of stdout"),
 					stringFlag("tail", "count", "Show the last N lines"),
 					boolFlag("full", "Show the full output"),
+					boolFlag("follow", "Stream new log output until the run exits (human output only)"),
 				},
 				exampleLines: []string{
 					"$ looper logs 12",
 					"$ looper logs 12 --stderr --tail 50",
+					"$ looper logs 12 --follow",
 				},
 			}),
 			newCommand(commandSpec{use: "stop <id>", short: "Stop an active loop", args: cobra.ExactArgs(1), runE: runtime.stopLoop, exampleLines: []string{"$ looper stop 12"}}),

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -476,6 +477,34 @@ func TestLogsFollowStreamsNewOutput(t *testing.T) {
 	for _, want := range []string{"Loop #12 · reviewer · running", "Run run_1 · step: review", "Agent: openai · pid 1234 · running", "line1", "line2"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("Run([logs loop_1 --follow]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
+func TestLogsFollowHandlesLargeSnapshotPayload(t *testing.T) {
+	t.Parallel()
+
+	largeOutput := strings.Repeat("x", 1024*1024+128) + "\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "event: snapshot\n")
+		_, _ = fmt.Fprintf(w, "data: {\"seq\":12,\"loopType\":\"reviewer\",\"loopStatus\":\"success\",\"run\":{\"runId\":\"run_1\",\"status\":\"success\",\"currentStep\":\"review\"},\"agent\":{\"executionId\":\"exec_1\",\"vendor\":\"openai\",\"pid\":1234,\"status\":\"completed\",\"stdout\":%q,\"stderr\":\"\"}}\n\n", largeOutput)
+		_, _ = io.WriteString(w, "event: end\n")
+		_, _ = io.WriteString(w, "data: {\"reason\":\"run_completed\"}\n\n")
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "logs", "loop_1", "--follow", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([logs loop_1 --follow]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([logs loop_1 --follow]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Loop #12 · reviewer · success", "Run run_1 · step: review", "Agent: openai · pid 1234 · completed", largeOutput[:64], largeOutput[len(largeOutput)-65 : len(largeOutput)-1]} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([logs loop_1 --follow]) stdout missing expected content %q", want)
 		}
 	}
 }

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -24,11 +25,16 @@ import (
 
 func runApp(t *testing.T, args ...string) (int, string, string) {
 	t.Helper()
+	return runAppWithContext(t, context.Background(), args...)
+}
+
+func runAppWithContext(t *testing.T, ctx context.Context, args ...string) (int, string, string) {
+	t.Helper()
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	app := New(Deps{Stdout: stdout, Stderr: stderr})
-	exitCode := app.Run(context.Background(), args)
+	exitCode := app.Run(ctx, args)
 
 	return exitCode, stdout.String(), stderr.String()
 }
@@ -436,6 +442,101 @@ func TestLogsWithoutJSONPrintsHeaderAndTail(t *testing.T) {
 	}
 	if strings.Contains(stdout, "line1") {
 		t.Fatalf("Run([logs loop_1 --tail 2]) stdout = %q, did not expect trimmed line", stdout)
+	}
+}
+
+func TestLogsFollowStreamsNewOutput(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/loops/loop_1/logs"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		if got := r.URL.Query().Get("follow"); got != "1" {
+			t.Fatalf("follow query = %q, want 1", got)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "event: snapshot\n")
+		_, _ = io.WriteString(w, "data: {\"seq\":12,\"loopType\":\"reviewer\",\"loopStatus\":\"running\",\"run\":{\"runId\":\"run_1\",\"status\":\"running\",\"currentStep\":\"review\"},\"agent\":{\"executionId\":\"exec_1\",\"vendor\":\"openai\",\"pid\":1234,\"status\":\"running\",\"stdout\":\"line1\\n\",\"stderr\":\"\"}}\n\n")
+		_, _ = io.WriteString(w, "event: chunk\n")
+		_, _ = io.WriteString(w, "data: {\"runId\":\"run_1\",\"currentStep\":\"review\",\"executionId\":\"exec_1\",\"vendor\":\"openai\",\"pid\":1234,\"status\":\"running\",\"content\":\"line2\\n\"}\n\n")
+		_, _ = io.WriteString(w, "event: end\n")
+		_, _ = io.WriteString(w, "data: {\"reason\":\"run_completed\"}\n\n")
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "logs", "loop_1", "--follow", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([logs loop_1 --follow]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([logs loop_1 --follow]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Loop #12 · reviewer · running", "Run run_1 · step: review", "Agent: openai · pid 1234 · running", "line1", "line2"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([logs loop_1 --follow]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
+func TestLogsFollowRejectsJSON(t *testing.T) {
+	t.Parallel()
+
+	exitCode, _, stderr := runApp(t, "logs", "loop_1", "--follow", "--json")
+	if exitCode == 0 {
+		t.Fatal("Run([logs loop_1 --follow --json]) exit code = 0, want non-zero")
+	}
+	if !strings.Contains(stderr, "--json cannot be combined with --follow") {
+		t.Fatalf("Run([logs loop_1 --follow --json]) stderr = %q, want follow/json error", stderr)
+	}
+}
+
+func TestLogsFollowStopsOnContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "event: snapshot\n")
+		_, _ = io.WriteString(w, "data: {\"seq\":12,\"loopType\":\"reviewer\",\"loopStatus\":\"running\",\"run\":{\"runId\":\"run_1\",\"status\":\"running\",\"currentStep\":\"review\"},\"agent\":{\"executionId\":\"exec_1\",\"vendor\":\"openai\",\"pid\":1234,\"status\":\"running\",\"stdout\":\"\",\"stderr\":\"\"}}\n\n")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	exitCode, stdout, stderr := runAppWithContext(t, ctx, "logs", "loop_1", "--follow", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([logs loop_1 --follow]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([logs loop_1 --follow]) stderr = %q, want empty string", stderr)
+	}
+	if !strings.Contains(stdout, "Waiting for log output...") {
+		t.Fatalf("Run([logs loop_1 --follow]) stdout = %q, want waiting message", stdout)
+	}
+}
+
+func TestLogsHelpIncludesFollowFlag(t *testing.T) {
+	t.Parallel()
+
+	exitCode, stdout, stderr := runApp(t, "logs", "--help")
+	if exitCode != 0 {
+		t.Fatalf("Run([logs --help]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([logs --help]) stderr = %q, want empty string", stderr)
+	}
+	if !strings.Contains(stdout, "--follow") {
+		t.Fatalf("Run([logs --help]) stdout = %q, want --follow flag", stdout)
 	}
 }
 

--- a/internal/cliapp/daemon_client.go
+++ b/internal/cliapp/daemon_client.go
@@ -52,28 +52,38 @@ func (c *DaemonAPIClient) Get(ctx context.Context, path string, out any) error {
 	return c.request(ctx, http.MethodGet, path, nil, out)
 }
 
+func (c *DaemonAPIClient) Stream(ctx context.Context, path string, accept string) (*http.Response, error) {
+	request, err := c.buildRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(accept) != "" {
+		request.Header.Set("Accept", accept)
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("looperd is not reachable: %w", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		defer response.Body.Close()
+		if decodeErr := decodeAPIResponse(response, nil); decodeErr != nil {
+			return nil, decodeErr
+		}
+		return nil, &DaemonAPIError{Message: fmt.Sprintf("Request failed with status %d", response.StatusCode), Status: response.StatusCode}
+	}
+
+	return response, nil
+}
+
 func (c *DaemonAPIClient) Post(ctx context.Context, path string, body any, out any) error {
 	return c.request(ctx, http.MethodPost, path, body, out)
 }
 
 func (c *DaemonAPIClient) request(ctx context.Context, method, path string, body any, out any) error {
-	var requestBody io.Reader
-	if body != nil {
-		payload, err := json.Marshal(body)
-		if err != nil {
-			return fmt.Errorf("marshal request body: %w", err)
-		}
-		requestBody = bytes.NewReader(payload)
-	}
-
-	request, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, requestBody)
+	request, err := c.buildRequest(ctx, method, path, body)
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
-	}
-
-	request.Header.Set("Content-Type", "application/json")
-	if c.token != "" {
-		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+		return err
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -83,6 +93,29 @@ func (c *DaemonAPIClient) request(ctx context.Context, method, path string, body
 	defer response.Body.Close()
 
 	return decodeAPIResponse(response, out)
+}
+
+func (c *DaemonAPIClient) buildRequest(ctx context.Context, method, path string, body any) (*http.Request, error) {
+	var requestBody io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request body: %w", err)
+		}
+		requestBody = bytes.NewReader(payload)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	}
+
+	return request, nil
 }
 
 func decodeAPIResponse(response *http.Response, out any) error {

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -136,14 +136,16 @@ type loopLogsOutput struct {
 	LoopStatus string `json:"loopStatus"`
 	Run        *struct {
 		RunID       string  `json:"runId"`
+		Status      string  `json:"status"`
 		CurrentStep *string `json:"currentStep"`
 	} `json:"run"`
 	Agent *struct {
-		Vendor string `json:"vendor"`
-		PID    *int64 `json:"pid"`
-		Status string `json:"status"`
-		Stdout string `json:"stdout"`
-		Stderr string `json:"stderr"`
+		ExecutionID string `json:"executionId"`
+		Vendor      string `json:"vendor"`
+		PID         *int64 `json:"pid"`
+		Status      string `json:"status"`
+		Stdout      string `json:"stdout"`
+		Stderr      string `json:"stderr"`
 	} `json:"agent"`
 }
 
@@ -299,64 +301,117 @@ func writeHumanActiveRuns(w io.Writer, payload json.RawMessage) error {
 }
 
 func writeHumanLoopLogs(w io.Writer, payload json.RawMessage, stderr bool, full bool, tail string) error {
+	data, err := decodeLoopLogsOutput(payload)
+	if err != nil {
+		return err
+	}
+	return writeHumanLoopLogsSnapshot(w, data, stderr, full, tail, false)
+}
+
+func decodeLoopLogsOutput(payload json.RawMessage) (loopLogsOutput, error) {
 	var data loopLogsOutput
 	if err := json.Unmarshal(payload, &data); err != nil {
-		return fmt.Errorf("decode loop logs response: %w", err)
+		return loopLogsOutput{}, fmt.Errorf("decode loop logs response: %w", err)
+	}
+	return data, nil
+}
+
+func writeHumanLoopLogsSnapshot(w io.Writer, data loopLogsOutput, stderr bool, full bool, tail string, follow bool) error {
+	if err := writeHumanLoopLogsHeader(w, data); err != nil {
+		return err
+	}
+	if data.Agent == nil {
+		message := "No agent output for the current step."
+		if follow && loopLogsCanContinue(data) {
+			message = "Waiting for agent output..."
+		}
+		_, err := fmt.Fprintln(w, message)
+		return err
+	}
+	if err := writeHumanLoopLogsRunAgent(w, data); err != nil {
+		return err
 	}
 
-	stream := ""
-	if data.Agent != nil {
-		if stderr {
-			stream = data.Agent.Stderr
-		} else {
-			stream = data.Agent.Stdout
+	content, err := loopLogsInitialContent(data, stderr, full, tail)
+	if err != nil {
+		return err
+	}
+	if content == "" {
+		message := "No output captured."
+		if follow && loopLogsCanContinue(data) {
+			message = "Waiting for log output..."
 		}
+		_, err := fmt.Fprintln(w, message)
+		return err
 	}
 
-	var tailCount *int
-	if !full {
-		parsed, err := parseOptionalPositiveInt(tail, "--tail")
-		if err != nil {
-			return err
-		}
-		if parsed == nil {
-			defaultTail := 100
-			tailCount = &defaultTail
-		} else {
-			converted := int(*parsed)
-			tailCount = &converted
-		}
-	}
+	return writeLoopLogContent(w, content)
+}
 
+func writeHumanLoopLogsHeader(w io.Writer, data loopLogsOutput) error {
 	if _, err := fmt.Fprintf(w, "Loop #%d · %s · %s\n", data.Seq, data.LoopType, data.LoopStatus); err != nil {
 		return err
 	}
 	if data.Run != nil {
-		if _, err := fmt.Fprintf(w, "Run %s · step: %s\n", data.Run.RunID, formatScalar(data.Run.CurrentStep)); err != nil {
-			return err
-		}
-	} else if _, err := fmt.Fprintln(w, "Run - · step: -"); err != nil {
+		_, err := fmt.Fprintf(w, "Run %s · step: %s\n", data.Run.RunID, formatScalar(data.Run.CurrentStep))
 		return err
 	}
+	_, err := fmt.Fprintln(w, "Run - · step: -")
+	return err
+}
 
+func writeHumanLoopLogsRunAgent(w io.Writer, data loopLogsOutput) error {
 	if data.Agent == nil {
-		_, err := fmt.Fprintln(w, "No agent output for the current step.")
-		return err
+		return nil
 	}
+	_, err := fmt.Fprintf(w, "Agent: %s · pid %s · %s\n\n", data.Agent.Vendor, formatScalar(data.Agent.PID), data.Agent.Status)
+	return err
+}
 
-	if _, err := fmt.Fprintf(w, "Agent: %s · pid %s · %s\n\n", data.Agent.Vendor, formatScalar(data.Agent.PID), data.Agent.Status); err != nil {
-		return err
+func loopLogsSelectedContent(data loopLogsOutput, stderr bool) string {
+	if data.Agent == nil {
+		return ""
 	}
+	if stderr {
+		return data.Agent.Stderr
+	}
+	return data.Agent.Stdout
+}
 
-	content := stream
-	if tailCount != nil {
-		content = tailText(content, *tailCount)
+func loopLogsInitialContent(data loopLogsOutput, stderr bool, full bool, tail string) (string, error) {
+	content := loopLogsSelectedContent(data, stderr)
+	if full {
+		return content, nil
 	}
-	if content == "" {
-		_, err := fmt.Fprintln(w, "No output captured.")
-		return err
+	parsed, err := parseOptionalPositiveInt(tail, "--tail")
+	if err != nil {
+		return "", err
 	}
+	count := 100
+	if parsed != nil {
+		count = int(*parsed)
+	}
+	return tailText(content, count), nil
+}
 
+func loopLogsCanContinue(data loopLogsOutput) bool {
+	if data.Run == nil {
+		switch data.LoopStatus {
+		case "idle", "queued", "running", "paused":
+			return true
+		default:
+			return false
+		}
+	}
+	switch data.Run.Status {
+	case "queued", "running":
+		return true
+	default:
+		return false
+	}
+}
+
+func writeLoopLogContent(w io.Writer, content string) error {
 	for _, line := range strings.Split(content, "\n") {
 		if _, err := fmt.Fprintln(w, line); err != nil {
 			return err

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -231,6 +231,13 @@ func (r *commandRuntime) activeRuns(cmd *cobra.Command, args []string) error {
 }
 
 func (r *commandRuntime) loopLogs(cmd *cobra.Command, args []string) error {
+	if getBoolFlag(cmd, "follow") {
+		if getBoolFlag(cmd, "json") {
+			return fmt.Errorf("--json cannot be combined with --follow")
+		}
+		return r.followLoopLogs(cmd, strings.TrimSpace(args[0]))
+	}
+
 	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
 		return r.getJSON(ctx, "/api/v1/loops/"+url.PathEscape(strings.TrimSpace(args[0]))+"/logs")
 	}, func(w io.Writer, payload json.RawMessage) error {

--- a/internal/cliapp/logs_follow.go
+++ b/internal/cliapp/logs_follow.go
@@ -1,0 +1,157 @@
+package cliapp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type loopLogsFollowChunk struct {
+	RunID       *string `json:"runId,omitempty"`
+	CurrentStep *string `json:"currentStep,omitempty"`
+	ExecutionID *string `json:"executionId,omitempty"`
+	Vendor      *string `json:"vendor,omitempty"`
+	PID         *int64  `json:"pid,omitempty"`
+	Status      *string `json:"status,omitempty"`
+	Content     string  `json:"content"`
+}
+
+func (r *commandRuntime) followLoopLogs(cmd *cobra.Command, loopID string) error {
+	if _, err := parseOptionalPositiveInt(getStringFlag(cmd, "tail"), "--tail"); err != nil {
+		return err
+	}
+
+	client, err := r.apiClient()
+	if err != nil {
+		return err
+	}
+
+	query := url.Values{}
+	query.Set("follow", "1")
+	if getBoolFlag(cmd, "stderr") {
+		query.Set("stderr", "1")
+	}
+
+	response, err := client.Stream(cmd.Context(), "/api/v1/loops/"+url.PathEscape(loopID)+"/logs?"+query.Encode(), "text/event-stream")
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
+	}
+	defer response.Body.Close()
+
+	scanner := bufio.NewScanner(response.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lastExecutionID := ""
+	lastRunID := ""
+	sawEnd := false
+
+	for {
+		eventName, payload, err := readServerSentEvent(scanner)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
+			if sawEnd && errors.Is(err, io.EOF) {
+				return nil
+			}
+			if errors.Is(err, io.EOF) {
+				return fmt.Errorf("log stream terminated unexpectedly")
+			}
+			return err
+		}
+
+		switch eventName {
+		case "snapshot":
+			data, decodeErr := decodeLoopLogsOutput(json.RawMessage(payload))
+			if decodeErr != nil {
+				return decodeErr
+			}
+			if err := writeHumanLoopLogsSnapshot(cmd.OutOrStdout(), data, getBoolFlag(cmd, "stderr"), getBoolFlag(cmd, "full"), getStringFlag(cmd, "tail"), true); err != nil {
+				return err
+			}
+			if data.Agent != nil {
+				lastExecutionID = data.Agent.ExecutionID
+			}
+			if data.Run != nil {
+				lastRunID = data.Run.RunID
+			}
+		case "chunk":
+			var chunk loopLogsFollowChunk
+			if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+				return fmt.Errorf("decode loop logs stream chunk: %w", err)
+			}
+			if chunk.ExecutionID != nil && *chunk.ExecutionID != "" && *chunk.ExecutionID != lastExecutionID {
+				if lastExecutionID != "" || lastRunID != "" {
+					if _, err := fmt.Fprintln(cmd.OutOrStdout()); err != nil {
+						return err
+					}
+				}
+				if chunk.RunID != nil && *chunk.RunID != lastRunID {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Run %s · step: %s\n", *chunk.RunID, formatScalar(chunk.CurrentStep)); err != nil {
+						return err
+					}
+					lastRunID = *chunk.RunID
+				}
+				if chunk.RunID != nil && lastRunID == "" {
+					lastRunID = *chunk.RunID
+				}
+				if chunk.Vendor != nil && chunk.Status != nil {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Agent: %s · pid %s · %s\n\n", *chunk.Vendor, formatScalar(chunk.PID), *chunk.Status); err != nil {
+						return err
+					}
+				}
+				lastExecutionID = *chunk.ExecutionID
+			}
+			if _, err := io.WriteString(cmd.OutOrStdout(), chunk.Content); err != nil {
+				return err
+			}
+		case "end":
+			sawEnd = true
+			return nil
+		}
+	}
+}
+
+func readServerSentEvent(scanner *bufio.Scanner) (string, string, error) {
+	eventName := "message"
+	dataLines := make([]string, 0, 1)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if len(dataLines) == 0 {
+				continue
+			}
+			return eventName, strings.Join(dataLines, "\n"), nil
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if strings.HasPrefix(line, "event:") {
+			eventName = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			data := strings.TrimPrefix(line, "data:")
+			data = strings.TrimPrefix(data, " ")
+			dataLines = append(dataLines, data)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", "", err
+	}
+	if len(dataLines) > 0 {
+		return eventName, strings.Join(dataLines, "\n"), nil
+	}
+	return "", "", io.EOF
+}

--- a/internal/cliapp/logs_follow.go
+++ b/internal/cliapp/logs_follow.go
@@ -48,14 +48,13 @@ func (r *commandRuntime) followLoopLogs(cmd *cobra.Command, loopID string) error
 	}
 	defer response.Body.Close()
 
-	scanner := bufio.NewScanner(response.Body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	reader := bufio.NewReader(response.Body)
 	lastExecutionID := ""
 	lastRunID := ""
 	sawEnd := false
 
 	for {
-		eventName, payload, err := readServerSentEvent(scanner)
+		eventName, payload, err := readServerSentEvent(reader)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
@@ -121,14 +120,32 @@ func (r *commandRuntime) followLoopLogs(cmd *cobra.Command, loopID string) error
 	}
 }
 
-func readServerSentEvent(scanner *bufio.Scanner) (string, string, error) {
+func readServerSentEvent(reader *bufio.Reader) (string, string, error) {
 	eventName := "message"
 	dataLines := make([]string, 0, 1)
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			line = strings.TrimRight(line, "\r\n")
+			if errors.Is(err, io.EOF) {
+				if line == "" {
+					if len(dataLines) > 0 {
+						return eventName, strings.Join(dataLines, "\n"), nil
+					}
+					return "", "", io.EOF
+				}
+			} else {
+				return "", "", err
+			}
+		} else {
+			line = strings.TrimRight(line, "\r\n")
+		}
 		if line == "" {
 			if len(dataLines) == 0 {
+				if errors.Is(err, io.EOF) {
+					return "", "", io.EOF
+				}
 				continue
 			}
 			return eventName, strings.Join(dataLines, "\n"), nil
@@ -145,13 +162,8 @@ func readServerSentEvent(scanner *bufio.Scanner) (string, string, error) {
 			data = strings.TrimPrefix(data, " ")
 			dataLines = append(dataLines, data)
 		}
+		if errors.Is(err, io.EOF) {
+			return eventName, strings.Join(dataLines, "\n"), nil
+		}
 	}
-
-	if err := scanner.Err(); err != nil {
-		return "", "", err
-	}
-	if len(dataLines) > 0 {
-		return eventName, strings.Join(dataLines, "\n"), nil
-	}
-	return "", "", io.EOF
 }


### PR DESCRIPTION
## Summary
- add a loop logs follow stream in looperd and consume it from the CLI to tail live stdout/stderr output
- preserve existing tail/full/stderr semantics for the initial backlog, reject --json with --follow, and add clean stream shutdown handling
- cover follow mode with CLI and daemon tests and wire CLI cancellation through SIGINT/SIGTERM-aware contexts

## Testing
- go vet ./...
- go test ./...
- go build ./...

Closes #23
