### PR TITLE
fix worker issue-linked PR auto-close when reusing planner PRs

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2678,6 +2678,7 @@ func (h *Handler) maybeFindPlannerLoopForIssue(ctx context.Context, input findPl
 		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
 	targetID := fmt.Sprintf("issue:%s:%d", input.Repo, input.IssueNumber)
+	var fallback *workerPlannerMatch
 	for _, loop := range loopsList {
 		if loop.ProjectID != input.ProjectID || loop.Type != string(domain.LoopTypePlanner) || loop.TargetType != string(domain.LoopTargetTypeIssue) || derefString(loop.TargetID) != targetID {
 			continue
@@ -2687,9 +2688,29 @@ func (h *Handler) maybeFindPlannerLoopForIssue(ctx context.Context, input findPl
 		if prNumber == nil {
 			prNumber = int64MetadataPtr(metadata, "prNumber")
 		}
-		return &workerPlannerMatch{PRNumber: prNumber, SpecPath: stringMetadataPtr(metadata, "specPath")}, nil
+		match := &workerPlannerMatch{PRNumber: prNumber, SpecPath: stringMetadataPtr(metadata, "specPath")}
+		if prNumber == nil || !h.isPlannerPullRequestOpen(ctx, input.ProjectID, input.Repo, *prNumber) {
+			if fallback == nil {
+				fallback = &workerPlannerMatch{PRNumber: nil, SpecPath: match.SpecPath}
+			}
+			continue
+		}
+		return match, nil
 	}
-	return nil, nil
+	return fallback, nil
+}
+
+func (h *Handler) isPlannerPullRequestOpen(ctx context.Context, projectID, repo string, prNumber int64) bool {
+	if prNumber <= 0 {
+		return false
+	}
+	snapshot, err := h.context.Runtime.Services().Repositories.PullRequestSnapshots.GetLatestByProject(ctx, projectID, repo, prNumber)
+	if err != nil || snapshot == nil {
+		return false
+	}
+	payload := parseJSONObject(snapshot.PayloadJSON)
+	detail, _ := payload["detail"].(map[string]any)
+	return strings.EqualFold(stringFromAnyDefault(detail["state"]), "open")
 }
 
 func deriveWorkerTitle(prompt, specPath, repo *string, prNumber, issueNumber *int64) string {
@@ -3508,6 +3529,14 @@ func stringMetadataPtr(metadata map[string]any, key string) *string {
 
 	result := text
 	return &result
+}
+
+func stringFromAnyDefault(value any) string {
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return text
 }
 
 func normalizeOptionalString(value *string) *string {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2710,7 +2710,8 @@ func (h *Handler) isPlannerPullRequestOpen(ctx context.Context, projectID, repo 
 	}
 	payload := parseJSONObject(snapshot.PayloadJSON)
 	detail, _ := payload["detail"].(map[string]any)
-	return strings.EqualFold(stringFromAnyDefault(detail["state"]), "open")
+	state := firstNonEmptyString(readStringAny(detail["state"]), readStringAny(detail["State"]))
+	return state != nil && strings.EqualFold(*state, "open")
 }
 
 func deriveWorkerTitle(prompt, specPath, repo *string, prNumber, issueNumber *int64) string {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2678,7 +2678,6 @@ func (h *Handler) maybeFindPlannerLoopForIssue(ctx context.Context, input findPl
 		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
 	targetID := fmt.Sprintf("issue:%s:%d", input.Repo, input.IssueNumber)
-	var fallback *workerPlannerMatch
 	for _, loop := range loopsList {
 		if loop.ProjectID != input.ProjectID || loop.Type != string(domain.LoopTypePlanner) || loop.TargetType != string(domain.LoopTargetTypeIssue) || derefString(loop.TargetID) != targetID {
 			continue
@@ -2690,14 +2689,11 @@ func (h *Handler) maybeFindPlannerLoopForIssue(ctx context.Context, input findPl
 		}
 		match := &workerPlannerMatch{PRNumber: prNumber, SpecPath: stringMetadataPtr(metadata, "specPath")}
 		if prNumber == nil || !h.isPlannerPullRequestOpen(ctx, input.ProjectID, input.Repo, *prNumber) {
-			if fallback == nil {
-				fallback = &workerPlannerMatch{PRNumber: nil, SpecPath: match.SpecPath}
-			}
-			continue
+			return &workerPlannerMatch{PRNumber: nil, SpecPath: match.SpecPath}, nil
 		}
 		return match, nil
 	}
-	return fallback, nil
+	return nil, nil
 }
 
 func (h *Handler) isPlannerPullRequestOpen(ctx context.Context, projectID, repo string, prNumber int64) bool {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2688,7 +2688,14 @@ func (h *Handler) maybeFindPlannerLoopForIssue(ctx context.Context, input findPl
 			prNumber = int64MetadataPtr(metadata, "prNumber")
 		}
 		match := &workerPlannerMatch{PRNumber: prNumber, SpecPath: stringMetadataPtr(metadata, "specPath")}
-		if prNumber == nil || !h.isPlannerPullRequestOpen(ctx, input.ProjectID, input.Repo, *prNumber) {
+		if prNumber == nil {
+			return &workerPlannerMatch{PRNumber: nil, SpecPath: match.SpecPath}, nil
+		}
+		isOpen, known, err := h.getPlannerPullRequestOpenState(ctx, input.ProjectID, input.Repo, *prNumber)
+		if err != nil {
+			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		if known && !isOpen {
 			return &workerPlannerMatch{PRNumber: nil, SpecPath: match.SpecPath}, nil
 		}
 		return match, nil
@@ -2697,17 +2704,28 @@ func (h *Handler) maybeFindPlannerLoopForIssue(ctx context.Context, input findPl
 }
 
 func (h *Handler) isPlannerPullRequestOpen(ctx context.Context, projectID, repo string, prNumber int64) bool {
+	isOpen, known, err := h.getPlannerPullRequestOpenState(ctx, projectID, repo, prNumber)
+	return err == nil && known && isOpen
+}
+
+func (h *Handler) getPlannerPullRequestOpenState(ctx context.Context, projectID, repo string, prNumber int64) (bool, bool, error) {
 	if prNumber <= 0 {
-		return false
+		return false, true, nil
 	}
 	snapshot, err := h.context.Runtime.Services().Repositories.PullRequestSnapshots.GetLatestByProject(ctx, projectID, repo, prNumber)
-	if err != nil || snapshot == nil {
-		return false
+	if err != nil {
+		return false, false, err
+	}
+	if snapshot == nil {
+		return false, false, nil
 	}
 	payload := parseJSONObject(snapshot.PayloadJSON)
 	detail, _ := payload["detail"].(map[string]any)
 	state := firstNonEmptyString(readStringAny(detail["state"]), readStringAny(detail["State"]))
-	return state != nil && strings.EqualFold(*state, "open")
+	if state == nil {
+		return false, false, nil
+	}
+	return strings.EqualFold(*state, "open"), true, nil
 }
 
 func deriveWorkerTitle(prompt, specPath, repo *string, prNumber, issueNumber *int64) string {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2358,6 +2358,52 @@ func TestSerializePullRequestListItemUsesProvidedLoopMatches(t *testing.T) {
 	}
 }
 
+func TestIsPlannerPullRequestOpenReadsStructMarshaledStateKey(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID:        "project_1",
+		Name:      "Looper",
+		RepoPath:  "/tmp/repos/looper",
+		Archived:  false,
+		CreatedAt: nowISO,
+		UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	payloadBytes, err := json.Marshal(map[string]any{
+		"detail": struct {
+			State string
+		}{
+			State: "OPEN",
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	payloadJSON := string(payloadBytes)
+
+	if err := fixture.runtime.Services().Repositories.PullRequestSnapshots.Upsert(context.Background(), storage.PullRequestSnapshotRecord{
+		ID:          "prs_planner_open",
+		ProjectID:   "project_1",
+		Repo:        "acme/looper",
+		PRNumber:    42,
+		HeadSHA:     "abc123",
+		PayloadJSON: &payloadJSON,
+		CapturedAt:  nowISO,
+		CreatedAt:   nowISO,
+	}); err != nil {
+		t.Fatalf("PullRequestSnapshots.Upsert() error = %v", err)
+	}
+
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+	if !h.isPlannerPullRequestOpen(context.Background(), "project_1", "acme/looper", 42) {
+		t.Fatal("isPlannerPullRequestOpen() = false, want true")
+	}
+}
+
 func TestHandlerWorkersCreateAllowsConcurrentProjectWorkers(t *testing.T) {
 	fixture := newTestFixture(t)
 	seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2419,6 +2419,80 @@ func TestHandlerWorkerCreateUsesOnlyNewestMatchingPlannerLoop(t *testing.T) {
 	}
 }
 
+func TestHandlerWorkerCreatePreservesPlannerPRWhenSnapshotIsMissing(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	issueTargetID := "issue:acme/looper:77"
+	prNumber := int64(42)
+	metadata := `{"prNumber":42,"specPath":"specs/planner.md"}`
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:           "loop_planner_missing_snapshot",
+		Seq:          1,
+		ProjectID:    "project_1",
+		Type:         "planner",
+		TargetType:   "issue",
+		TargetID:     &issueTargetID,
+		Repo:         stringPtr("acme/looper"),
+		PRNumber:     &prNumber,
+		Status:       "running",
+		MetadataJSON: &metadata,
+		CreatedAt:    nowISO,
+		UpdatedAt:    nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_planner_missing_snapshot) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workers", bytes.NewReader([]byte(`{"projectId":"project_1","repo":"acme/looper","issueNumber":77,"baseBranch":"main"}`)))
+	req.Header.Set("x-request-id", "fixture-request-id")
+	req.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	loopID := data["id"].(string)
+
+	loop, err := fixture.runtime.Services().Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil {
+		t.Fatal("Loops.GetByID() = nil, want created worker loop")
+	}
+	assertEqual(t, loop.TargetType, "pull_request")
+	if loop.PRNumber == nil || *loop.PRNumber != prNumber {
+		t.Fatalf("loop.PRNumber = %#v, want %d", loop.PRNumber, prNumber)
+	}
+
+	queueItems, err := fixture.runtime.Services().Repositories.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	var queueItem *storage.QueueItemRecord
+	for i := range queueItems {
+		if queueItems[i].LoopID != nil && *queueItems[i].LoopID == loopID {
+			queueItem = &queueItems[i]
+			break
+		}
+	}
+	if queueItem == nil || queueItem.PayloadJSON == nil {
+		t.Fatalf("worker queue payload missing for loop %s", loopID)
+	}
+	assertEqual(t, queueItem.TargetType, "pull_request")
+	assertEqual(t, queueItem.TargetID, "pr:acme/looper:42")
+	if queueItem.PRNumber == nil || *queueItem.PRNumber != prNumber {
+		t.Fatalf("queueItem.PRNumber = %#v, want %d", queueItem.PRNumber, prNumber)
+	}
+	payload := parseJSONMap(t, []byte(*queueItem.PayloadJSON))
+	assertEqual(t, payload["specPath"], "specs/planner.md")
+	assertEqual(t, payload["prNumber"], float64(prNumber))
+}
+
 func TestHandlerPullRequestStatusUsesLatestRunAcrossLoops(t *testing.T) {
 	fixture := newTestFixture(t)
 	seedEventAndPullRequestRouteData(t, fixture.runtime)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2281,6 +2281,144 @@ func TestHandlerCreateLoopWorkerEnqueuesSchedulableManualLoop(t *testing.T) {
 	assertEqual(t, triggered, 1)
 }
 
+func TestHandlerWorkerCreateUsesOnlyNewestMatchingPlannerLoop(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	olderISO := fixture.now.Add(-time.Minute).UTC().Format(javaScriptISOString)
+	newerISO := fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString)
+	issueTargetID := "issue:acme/looper:77"
+	openPayloadBytes, err := json.Marshal(map[string]any{
+		"detail": map[string]any{
+			"state": "OPEN",
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(open payload) error = %v", err)
+	}
+	openPayloadJSON := string(openPayloadBytes)
+	closedPayloadBytes, err := json.Marshal(map[string]any{
+		"detail": map[string]any{
+			"state": "CLOSED",
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(closed payload) error = %v", err)
+	}
+	closedPayloadJSON := string(closedPayloadBytes)
+	olderPRNumber := int64(42)
+	newerPRNumber := int64(43)
+	olderMetadata := `{"prNumber":42,"specPath":"specs/older-open.md"}`
+	newerMetadata := `{"prNumber":43,"specPath":"specs/newer-closed.md"}`
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:           "loop_planner_older_open",
+		Seq:          1,
+		ProjectID:    "project_1",
+		Type:         "planner",
+		TargetType:   "issue",
+		TargetID:     &issueTargetID,
+		Repo:         stringPtr("acme/looper"),
+		PRNumber:     &olderPRNumber,
+		Status:       "completed",
+		MetadataJSON: &olderMetadata,
+		CreatedAt:    olderISO,
+		UpdatedAt:    olderISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_planner_older_open) error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:           "loop_planner_newer_closed",
+		Seq:          2,
+		ProjectID:    "project_1",
+		Type:         "planner",
+		TargetType:   "issue",
+		TargetID:     &issueTargetID,
+		Repo:         stringPtr("acme/looper"),
+		PRNumber:     &newerPRNumber,
+		Status:       "completed",
+		MetadataJSON: &newerMetadata,
+		CreatedAt:    newerISO,
+		UpdatedAt:    newerISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_planner_newer_closed) error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.PullRequestSnapshots.Upsert(context.Background(), storage.PullRequestSnapshotRecord{
+		ID:          "prs_planner_older_open",
+		ProjectID:   "project_1",
+		Repo:        "acme/looper",
+		PRNumber:    olderPRNumber,
+		HeadSHA:     "head-older-open",
+		PayloadJSON: &openPayloadJSON,
+		CapturedAt:  olderISO,
+		CreatedAt:   nowISO,
+	}); err != nil {
+		t.Fatalf("PullRequestSnapshots.Upsert(prs_planner_older_open) error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.PullRequestSnapshots.Upsert(context.Background(), storage.PullRequestSnapshotRecord{
+		ID:          "prs_planner_newer_closed",
+		ProjectID:   "project_1",
+		Repo:        "acme/looper",
+		PRNumber:    newerPRNumber,
+		HeadSHA:     "head-newer-closed",
+		PayloadJSON: &closedPayloadJSON,
+		CapturedAt:  newerISO,
+		CreatedAt:   nowISO,
+	}); err != nil {
+		t.Fatalf("PullRequestSnapshots.Upsert(prs_planner_newer_closed) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workers", bytes.NewReader([]byte(`{"projectId":"project_1","repo":"acme/looper","issueNumber":77,"baseBranch":"main"}`)))
+	req.Header.Set("x-request-id", "fixture-request-id")
+	req.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(2 * time.Minute) }}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	loopID := data["id"].(string)
+
+	loop, err := fixture.runtime.Services().Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil {
+		t.Fatal("Loops.GetByID() = nil, want created worker loop")
+	}
+	assertEqual(t, loop.TargetType, "project")
+	if loop.PRNumber != nil {
+		t.Fatalf("loop.PRNumber = %#v, want nil", loop.PRNumber)
+	}
+
+	queueItems, err := fixture.runtime.Services().Repositories.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	var queueItem *storage.QueueItemRecord
+	for i := range queueItems {
+		if queueItems[i].LoopID != nil && *queueItems[i].LoopID == loopID {
+			queueItem = &queueItems[i]
+			break
+		}
+	}
+	if queueItem == nil || queueItem.PayloadJSON == nil {
+		t.Fatalf("worker queue payload missing for loop %s", loopID)
+	}
+	assertEqual(t, queueItem.TargetType, "project")
+	assertEqual(t, queueItem.TargetID, "project:project_1")
+	if queueItem.PRNumber != nil {
+		t.Fatalf("queueItem.PRNumber = %#v, want nil", queueItem.PRNumber)
+	}
+	payload := parseJSONMap(t, []byte(*queueItem.PayloadJSON))
+	assertEqual(t, payload["specPath"], "specs/newer-closed.md")
+	if _, ok := payload["prNumber"]; ok {
+		t.Fatalf("payload[\"prNumber\"] present = %#v, want omitted", payload["prNumber"])
+	}
+}
+
 func TestHandlerPullRequestStatusUsesLatestRunAcrossLoops(t *testing.T) {
 	fixture := newTestFixture(t)
 	seedEventAndPullRequestRouteData(t, fixture.runtime)


### PR DESCRIPTION
## What changed

- only reuse a planner PR for `looper work --issue` when the planner PR snapshot is still open
- fall back to issue-backed worker behavior when the planner loop exists but its linked PR is closed or missing
- add the missing local string helper needed by the new PR-state check in the API handler

## Why

The worker create path could upgrade issue-backed work onto a planner PR even when that planner PR was no longer open. In that case the worker ran in `push-existing` mode and skipped the normal create-PR body path, which meant the issue auto-close body logic never ran.

## Impact

Issue-backed workers should stop reusing stale planner PRs and should preserve the normal create-PR flow needed for closing references.

Closes #62

## Validation

- `go test ./internal/api`
