### PR TITLE
Surface codex stderr in default looper logs output

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2178,10 +2178,20 @@ func loopLogsStreamState(resp loopLogsResponse, stderr bool) (string, string) {
 		return "", ""
 	}
 	content := resp.Agent.Stdout
-	if stderr {
+	if stderr || shouldDefaultLoopLogsStreamToStderr(resp) {
 		content = resp.Agent.Stderr
 	}
 	return resp.Agent.ExecutionID, content
+}
+
+func shouldDefaultLoopLogsStreamToStderr(resp loopLogsResponse) bool {
+	if resp.Agent == nil {
+		return false
+	}
+	if strings.TrimSpace(resp.Agent.Vendor) != "codex" {
+		return false
+	}
+	return strings.TrimSpace(resp.Agent.Stdout) == "" && strings.TrimSpace(resp.Agent.Stderr) != ""
 }
 
 func appendedLogChunk(previousExecutionID, previousContent, currentExecutionID, currentContent string) string {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2866,6 +2866,101 @@ func TestHandlerLoopLogsFollowStreamsSnapshotAndChunk(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedRunRouteData(t, fixture.runtime)
+
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	if err := fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
+		ID:              "agent_exec_1",
+		ProjectID:       stringPtr("project_1"),
+		LoopID:          stringPtr("loop_1"),
+		RunID:           stringPtr("run_1"),
+		Vendor:          "codex",
+		Status:          "running",
+		PID:             int64Ptr(1234),
+		HeartbeatCount:  1,
+		LastHeartbeatAt: stringPtr(nowISO),
+		StartedAt:       nowISO,
+		OutputJSON:      stringPtr(`{"stdout":"","stderr":"codex line1\n"}`),
+		CreatedAt:       nowISO,
+		UpdatedAt:       nowISO,
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(agent_exec_1) error = %v", err)
+	}
+
+	server := httptest.NewServer(NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime}))
+	defer server.Close()
+
+	response, err := http.Get(server.URL + "/api/v1/loops/loop_1/logs?follow=1")
+	if err != nil {
+		t.Fatalf("http.Get() error = %v", err)
+	}
+	defer response.Body.Close()
+
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		updatedRun, getRunErr := fixture.runtime.Services().Repositories.Runs.GetByID(context.Background(), "run_1")
+		if getRunErr != nil || updatedRun == nil {
+			return
+		}
+		run := *updatedRun
+		completedAt := fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString)
+		run.Status = "success"
+		run.EndedAt = &completedAt
+		run.UpdatedAt = completedAt
+		_ = fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), run)
+
+		updatedExec, getExecErr := fixture.runtime.Services().Repositories.AgentExecutions.GetLatestByRunID(context.Background(), "run_1")
+		if getExecErr != nil || updatedExec == nil {
+			return
+		}
+		exec := *updatedExec
+		exec.Status = "completed"
+		exec.EndedAt = &completedAt
+		exec.OutputJSON = stringPtr(`{"stdout":"","stderr":"codex line1\ncodex line2\n"}`)
+		exec.UpdatedAt = completedAt
+		_ = fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), exec)
+	}()
+
+	bodyCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		body, readErr := io.ReadAll(response.Body)
+		if readErr != nil {
+			errCh <- readErr
+			return
+		}
+		bodyCh <- body
+	}()
+
+	var body []byte
+	select {
+	case body = <-bodyCh:
+	case err := <-errCh:
+		t.Fatalf("io.ReadAll() error = %v", err)
+	case <-time.After(5 * time.Second):
+		_ = response.Body.Close()
+		t.Fatal("timed out waiting for loop logs follow stream")
+	}
+	text := string(body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.StatusCode)
+	}
+	if !strings.Contains(text, "event: snapshot") {
+		t.Fatalf("stream body = %q, want snapshot event", text)
+	}
+	if !strings.Contains(text, "\"stderr\":\"codex line1\\n\"") {
+		t.Fatalf("stream body = %q, want codex stderr in snapshot", text)
+	}
+	if !strings.Contains(text, "event: chunk") || !strings.Contains(text, "\"content\":\"codex line2\\n\"") {
+		t.Fatalf("stream body = %q, want chunk with appended codex stderr output", text)
+	}
+	if !strings.Contains(text, "event: end") {
+		t.Fatalf("stream body = %q, want end event", text)
+	}
+}
+
 func TestHandlerLoopLogsFollowEmitsEndForTerminalSnapshot(t *testing.T) {
 	fixture := newTestFixture(t)
 	seedRunRouteData(t, fixture.runtime)

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -446,6 +446,45 @@ func TestLogsWithoutJSONPrintsHeaderAndTail(t *testing.T) {
 	}
 }
 
+func TestLogsWithoutJSONDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/loops/loop_1/logs"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_logs", map[string]any{
+			"seq":        12,
+			"loopId":     "loop_1",
+			"loopType":   "reviewer",
+			"loopStatus": "running",
+			"run":        map[string]any{"runId": "run_1", "currentStep": "review"},
+			"agent": map[string]any{
+				"vendor": "codex",
+				"pid":    1234,
+				"status": "running",
+				"stdout": "",
+				"stderr": "codex line1\ncodex line2\n",
+			},
+		}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "logs", "loop_1", "--tail", "2", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([logs loop_1 --tail 2]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([logs loop_1 --tail 2]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Loop #12 · reviewer · running", "Run run_1 · step: review", "Agent: codex · pid 1234 · running", "codex line1", "codex line2"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([logs loop_1 --tail 2]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
 func TestLogsFollowStreamsNewOutput(t *testing.T) {
 	t.Parallel()
 
@@ -475,6 +514,44 @@ func TestLogsFollowStreamsNewOutput(t *testing.T) {
 		t.Fatalf("Run([logs loop_1 --follow]) stderr = %q, want empty string", stderr)
 	}
 	for _, want := range []string{"Loop #12 · reviewer · running", "Run run_1 · step: review", "Agent: openai · pid 1234 · running", "line1", "line2"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([logs loop_1 --follow]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
+func TestLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/loops/loop_1/logs"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		if got := r.URL.Query().Get("follow"); got != "1" {
+			t.Fatalf("follow query = %q, want 1", got)
+		}
+		if got := r.URL.Query().Get("stderr"); got != "" {
+			t.Fatalf("stderr query = %q, want empty string", got)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "event: snapshot\n")
+		_, _ = io.WriteString(w, "data: {\"seq\":12,\"loopType\":\"reviewer\",\"loopStatus\":\"running\",\"run\":{\"runId\":\"run_1\",\"status\":\"running\",\"currentStep\":\"review\"},\"agent\":{\"executionId\":\"exec_1\",\"vendor\":\"codex\",\"pid\":1234,\"status\":\"running\",\"stdout\":\"\",\"stderr\":\"codex line1\\n\"}}\n\n")
+		_, _ = io.WriteString(w, "event: chunk\n")
+		_, _ = io.WriteString(w, "data: {\"runId\":\"run_1\",\"currentStep\":\"review\",\"executionId\":\"exec_1\",\"vendor\":\"codex\",\"pid\":1234,\"status\":\"running\",\"content\":\"codex line2\\n\"}\n\n")
+		_, _ = io.WriteString(w, "event: end\n")
+		_, _ = io.WriteString(w, "data: {\"reason\":\"run_completed\"}\n\n")
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "logs", "loop_1", "--follow", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([logs loop_1 --follow]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([logs loop_1 --follow]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Loop #12 · reviewer · running", "Run run_1 · step: review", "Agent: codex · pid 1234 · running", "codex line1", "codex line2"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("Run([logs loop_1 --follow]) stdout = %q, want to contain %q", stdout, want)
 		}

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -375,7 +375,20 @@ func loopLogsSelectedContent(data loopLogsOutput, stderr bool) string {
 	if stderr {
 		return data.Agent.Stderr
 	}
+	if shouldDefaultLoopLogsToStderr(data) {
+		return data.Agent.Stderr
+	}
 	return data.Agent.Stdout
+}
+
+func shouldDefaultLoopLogsToStderr(data loopLogsOutput) bool {
+	if data.Agent == nil {
+		return false
+	}
+	if strings.TrimSpace(data.Agent.Vendor) != "codex" {
+		return false
+	}
+	return strings.TrimSpace(data.Agent.Stdout) == "" && strings.TrimSpace(data.Agent.Stderr) != ""
 }
 
 func loopLogsInitialContent(data loopLogsOutput, stderr bool, full bool, tail string) (string, error) {


### PR DESCRIPTION
## Summary
- default human `looper logs` output to codex `stderr` when codex produced no `stdout` but did produce `stderr`
- apply the same fallback to streamed `looper logs --follow` chunks so live codex runs no longer look silent by default
- add CLI and handler regression coverage for the codex stderr fallback path

## Validation
- `go test ./internal/cliapp ./internal/api`
- `env GOCACHE=/tmp/looper-go-cache go vet ./...`
- `env GOCACHE=/tmp/looper-go-cache go build ./...`
- `env GOCACHE=/tmp/looper-go-cache go test ./...`  *(fails in this sandbox because existing tests use `httptest.NewServer` and config paths outside writable roots; focused changed-package tests passed)*

Closes #66