### PR TITLE
Fail worker and fixer runs on invalid agent completion

### DIFF
--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -1168,6 +1168,7 @@ func (e smokeAgentExecution) Wait(ctx context.Context) (worker.AgentResult, erro
 		Status:       result.Status,
 		Summary:      result.Summary,
 		Stdout:       result.Stdout,
+		ParseStatus:  result.ParseStatus,
 		ChangedFiles: append([]string{}, result.ChangedFiles...),
 		Commits:      append([]string{}, result.Commits...),
 	}, nil

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1835,6 +1835,8 @@ func shouldResumeFromPrepare(status string, failedStep FixerStep, checkpoint fix
 	switch failedStep {
 	case stepRepair, stepReconcileCommits, stepValidate, stepPush:
 		return true
+	case stepResolveComments, stepRecheck:
+		return validateCompletedRepairCheckpoint(checkpoint.Repair) != nil
 	default:
 		return false
 	}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -920,6 +920,9 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	if !strings.EqualFold(result.Status, "completed") {
 		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, "Fixer agent "+result.Status), kind: FailureRetryableTransient}
 	}
+	if result.ParseStatus != "parsed" {
+		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Fixer agent completed without valid structured result (parse status: %s)", firstNonEmpty(result.ParseStatus, "missing"))), kind: FailureRetryableTransient}
+	}
 	checkpoint.Repair = &checkpointRepair{AgentExecutionID: executionID, Summary: result.Summary, HeadSHA: detailHeadSHA(checkpoint.Detail), ParseStatus: result.ParseStatus, CompletedAt: r.nowISO()}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -420,6 +420,19 @@ type loopError struct {
 	kind    QueueFailureKind
 }
 
+func validateCompletedRepairCheckpoint(repair *checkpointRepair) error {
+	if repair == nil {
+		return nil
+	}
+	if repair.ParseStatus == "parsed" {
+		return nil
+	}
+	return &loopError{
+		message: firstNonEmpty(repair.Summary, fmt.Sprintf("Fixer agent completed without valid structured result (parse status: %s)", firstNonEmpty(repair.ParseStatus, "missing"))),
+		kind:    FailureRetryableTransient,
+	}
+}
+
 func (e *loopError) Error() string { return e.message }
 
 func New(options Options) *Runner {
@@ -885,6 +898,9 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		return checkpoint, nil
 	}
 	if checkpoint.Repair != nil {
+		if err := validateCompletedRepairCheckpoint(checkpoint.Repair); err != nil {
+			return checkpoint, err
+		}
 		return checkpoint, nil
 	}
 	if len(checkpoint.FixItems) == 0 {
@@ -920,8 +936,8 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	if !strings.EqualFold(result.Status, "completed") {
 		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, "Fixer agent "+result.Status), kind: FailureRetryableTransient}
 	}
-	if result.ParseStatus != "parsed" {
-		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Fixer agent completed without valid structured result (parse status: %s)", firstNonEmpty(result.ParseStatus, "missing"))), kind: FailureRetryableTransient}
+	if err := validateCompletedRepairCheckpoint(&checkpointRepair{Summary: result.Summary, ParseStatus: result.ParseStatus}); err != nil {
+		return checkpoint, err
 	}
 	checkpoint.Repair = &checkpointRepair{AgentExecutionID: executionID, Summary: result.Summary, HeadSHA: detailHeadSHA(checkpoint.Detail), ParseStatus: result.ParseStatus, CompletedAt: r.nowISO()}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -669,6 +669,37 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	}); err != nil {
 		return ProcessResult{}, err
 	}
+	if err := validateFixerResumeCheckpoint(resumedRun.StartStep, checkpoint); err != nil {
+		failure := r.classifyFailure(err)
+		latest := r.getLatestCheckpoint(ctx, run, checkpoint)
+		if latest.ResumePolicy == "" {
+			latest.ResumePolicy = "replay_step"
+		}
+		if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
+			return ProcessResult{}, err
+		}
+		failedQueue, err := r.failQueueItem(ctx, queueItem, failure.kind, failure.message)
+		if err != nil {
+			return ProcessResult{}, err
+		}
+		if _, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
+			updated.LastRunAt = stringPtr(r.nowISO())
+			if failedQueue != nil && failedQueue.Status == "queued" {
+				updated.Status = "queued"
+				updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
+			} else {
+				if failure.kind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+					updated.Status = "paused"
+				} else {
+					updated.Status = "failed"
+				}
+				updated.NextRunAt = nil
+			}
+		}); err != nil {
+			return ProcessResult{}, err
+		}
+		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
+	}
 	r.appendEvent(ctx, eventInput{eventType: "loop.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "loop", entityID: loop.ID, payload: map[string]any{"queueItemId": queueItem.ID, "resumed": resumedRun.Resumed, "startStep": string(resumedRun.StartStep)}})
 	r.appendEvent(ctx, eventInput{eventType: "run.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep)}})
 	r.logInfo("fixer loop started", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep), "resumed": resumedRun.Resumed})
@@ -1187,9 +1218,6 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 				startStep = next
 			}
 		}
-	}
-	if err := validateFixerResumeCheckpoint(startStep, resumedCheckpoint); err != nil {
-		return resumedRunContext{}, err
 	}
 	resumed := latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && startStep != stepDiscoverPR
 	initialCheckpoint := fixerCheckpoint{ResumePolicy: "replay_step"}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -698,6 +698,9 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		}); err != nil {
 			return ProcessResult{}, err
 		}
+		if failedQueue == nil || failedQueue.Status != "queued" {
+			r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &latest)
+		}
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 	}
 	r.appendEvent(ctx, eventInput{eventType: "loop.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "loop", entityID: loop.ID, payload: map[string]any{"queueItemId": queueItem.ID, "resumed": resumedRun.Resumed, "startStep": string(resumedRun.StartStep)}})

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1188,6 +1188,9 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 			}
 		}
 	}
+	if err := validateFixerResumeCheckpoint(startStep, resumedCheckpoint); err != nil {
+		return resumedRunContext{}, err
+	}
 	resumed := latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && startStep != stepDiscoverPR
 	initialCheckpoint := fixerCheckpoint{ResumePolicy: "replay_step"}
 	if resumed {
@@ -1608,6 +1611,15 @@ func previousFixerStep(step FixerStep) FixerStep {
 		}
 	}
 	return ""
+}
+
+func validateFixerResumeCheckpoint(startStep FixerStep, checkpoint fixerCheckpoint) error {
+	switch startStep {
+	case stepReconcileCommits, stepValidate, stepPush, stepResolveComments, stepRecheck:
+		return validateCompletedRepairCheckpoint(checkpoint.Repair)
+	default:
+		return nil
+	}
 }
 
 func asFixerStep(value string) FixerStep {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -305,6 +305,84 @@ func TestRunRepairStepFailsResumedCompletedCheckpointWithoutParsedResult(t *test
 	}
 }
 
+func TestCreateRunContextRewindsToPrepareWhenPostRepairResumeCheckpointParseStatusIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	nowISO := fixture.nowISO()
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:         "loop_fixer_rewind_invalid_repair",
+		Seq:        1,
+		ProjectID:  "project_1",
+		Type:       "fixer",
+		TargetType: "pull_request",
+		TargetID:   &loopTarget,
+		Repo:       &repo,
+		PRNumber:   &prNumber,
+		Status:     "queued",
+		CreatedAt:  nowISO,
+		UpdatedAt:  nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
+		ClaimedLockKey: "pr:acme/looper:42",
+		FixItems:       []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}},
+		Worktree:       &checkpointWorktree{Path: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "head-1", BaseHeadSHA: "base-1", PreparedAt: nowISO},
+		Repair:         &checkpointRepair{Summary: "upstream server_error", ParseStatus: "", CompletedAt: nowISO},
+		Validation:     &ValidationResult{Passed: true, Summary: "stale"},
+		Push:           &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", PushedAt: nowISO},
+		ResolvedComments: &checkpointResolvedComments{
+			Items: []checkpointResolvedComment{{FixItemID: "c1", ThreadID: "t1", Status: "resolved", UpdatedAt: nowISO}},
+		},
+		Recheck: &checkpointRecheck{RemainingFixItems: []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}},
+	})
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:                "run_failed_after_recheck",
+		LoopID:            "loop_fixer_rewind_invalid_repair",
+		Status:            "failed",
+		CurrentStep:       stringPtr(string(stepRecheck)),
+		LastCompletedStep: stringPtr(string(stepResolveComments)),
+		CheckpointJSON:    &checkpointJSON,
+		StartedAt:         nowISO,
+		CreatedAt:         nowISO,
+		UpdatedAt:         nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_fixer_rewind_invalid_repair")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil {
+		t.Fatal("loop = nil, want fixer loop")
+	}
+
+	resumed, err := runner.createRunContext(context.Background(), *loop)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if !resumed.Resumed || resumed.StartStep != stepPrepareWorktree {
+		t.Fatalf("resumed = %#v, want prepare-worktree rewind", resumed)
+	}
+	if resumed.Checkpoint.Repair != nil {
+		t.Fatalf("Repair = %#v, want cleared repair checkpoint", resumed.Checkpoint.Repair)
+	}
+	if resumed.Checkpoint.Validation != nil || resumed.Checkpoint.Push != nil || resumed.Checkpoint.ResolvedComments != nil || resumed.Checkpoint.Recheck != nil {
+		t.Fatalf("checkpoint = %#v, want post-repair checkpoints cleared", resumed.Checkpoint)
+	}
+	if resumed.Checkpoint.Worktree == nil || resumed.Checkpoint.Worktree.PreparedAt != "" {
+		t.Fatalf("Worktree = %#v, want worktree retained but marked for reprepare", resumed.Checkpoint.Worktree)
+	}
+	if resumed.Run.LastCompletedStep == nil || *resumed.Run.LastCompletedStep != string(stepCollectFixes) {
+		t.Fatalf("run.LastCompletedStep = %#v, want collect-fixes", resumed.Run.LastCompletedStep)
+	}
+}
+
 func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -213,6 +213,67 @@ func TestProcessClaimedItemCompletesSuccessfulFlow(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemFailsWhenRepairCompletionResultMissing(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+		},
+	}
+	validationCalls := 0
+	git := &fakeGitGateway{
+		createResult:  CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "upstream server_error", ParseStatus: "missing"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: func(context.Context, ValidationInput) (ValidationResult, error) {
+		validationCalls++
+		return ValidationResult{Passed: true, Summary: "ok"}, nil
+	}, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient || !contains(result.Summary, "server_error") {
+		t.Fatalf("result = %#v, want retryable failed result with upstream error", result)
+	}
+	if validationCalls != 0 {
+		t.Fatalf("validationCalls = %d, want repair failure to stop before validation", validationCalls)
+	}
+	if len(git.pushCalls) != 0 || len(github.resolveCalls) != 0 {
+		t.Fatalf("push calls=%d resolve calls=%d, want 0/0 after invalid repair completion", len(git.pushCalls), len(github.resolveCalls))
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued loop for retryable failure", loop)
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	if run == nil || run.Status != "failed" || run.CurrentStep == nil || *run.CurrentStep != string(stepRepair) {
+		t.Fatalf("run = %#v, want failed run at repair step", run)
+	}
+	if run.LastCompletedStep != nil && *run.LastCompletedStep == string(stepRecheck) {
+		t.Fatalf("run = %#v, want downstream steps to remain incomplete", run)
+	}
+}
+
 func TestProcessClaimedItemRestartsFromDiscoverAfterRemoteHeadChangeAtPush(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -309,6 +309,7 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	t.Parallel()
 
 	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{}
 	repo := "acme/looper"
 	prNumber := int64(42)
 	loopTarget := "pr:acme/looper:42"
@@ -328,8 +329,12 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
+		Worktree: &checkpointWorktree{
+			Path:   filepath.Join(t.TempDir(), "wt-42"),
+			Branch: "feature/fix-42",
+		},
 		Repair: &checkpointRepair{
 			Summary:     "upstream server_error",
 			ParseStatus: "",
@@ -399,6 +404,12 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	}
 	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
 		t.Fatalf("loop = %#v, want failed terminal loop", loop)
+	}
+	if len(git.cleanupCalls) != 1 {
+		t.Fatalf("len(git.cleanupCalls) = %d, want 1", len(git.cleanupCalls))
+	}
+	if git.cleanupCalls[0].WorktreePath == "" || git.cleanupCalls[0].Branch != "feature/fix-42" {
+		t.Fatalf("cleanup call = %#v, want persisted worktree cleanup", git.cleanupCalls[0])
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -305,6 +305,72 @@ func TestRunRepairStepFailsResumedCompletedCheckpointWithoutParsedResult(t *test
 	}
 }
 
+func TestCreateRunContextFailsWhenResumeStartsAfterRepairWithoutParsedResult(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	nowISO := fixture.nowISO()
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:         "loop_fixer_resume_parse_status",
+		Seq:        1,
+		ProjectID:  "project_1",
+		Type:       "fixer",
+		TargetType: "pull_request",
+		TargetID:   &loopTarget,
+		Repo:       &repo,
+		PRNumber:   &prNumber,
+		Status:     "queued",
+		CreatedAt:  nowISO,
+		UpdatedAt:  nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
+		Repair: &checkpointRepair{
+			Summary:     "upstream server_error",
+			ParseStatus: "",
+		},
+	})
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:                "run_failed_after_repair",
+		LoopID:            "loop_fixer_resume_parse_status",
+		Status:            "failed",
+		LastCompletedStep: stringPtr(string(stepRepair)),
+		CheckpointJSON:    &checkpointJSON,
+		StartedAt:         nowISO,
+		CreatedAt:         nowISO,
+		UpdatedAt:         nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_fixer_resume_parse_status")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil {
+		t.Fatal("loop = nil, want loop record")
+	}
+
+	_, err = runner.createRunContext(context.Background(), *loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want parse-status failure")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableTransient)
+	}
+	if !contains(err.Error(), "server_error") {
+		t.Fatalf("error = %q, want upstream summary", err.Error())
+	}
+}
+
 func TestProcessClaimedItemRestartsFromDiscoverAfterRemoteHeadChangeAtPush(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -305,7 +305,7 @@ func TestRunRepairStepFailsResumedCompletedCheckpointWithoutParsedResult(t *test
 	}
 }
 
-func TestCreateRunContextFailsWhenResumeStartsAfterRepairWithoutParsedResult(t *testing.T) {
+func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testing.T) {
 	t.Parallel()
 
 	fixture := newRunnerFixture(t)
@@ -347,27 +347,58 @@ func TestCreateRunContextFailsWhenResumeStartsAfterRepairWithoutParsedResult(t *
 	}); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
+	projectID := "project_1"
+	loopID := "loop_fixer_resume_parse_status"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID:          "queue_fixer_resume_parse_status",
+		ProjectID:   &projectID,
+		LoopID:      &loopID,
+		Type:        "fixer",
+		TargetType:  "pull_request",
+		TargetID:    loopTarget,
+		Repo:        &repo,
+		PRNumber:    &prNumber,
+		DedupeKey:   "fixer:acme/looper:42:resume-parse",
+		Priority:    1,
+		Status:      "queued",
+		AvailableAt: nowISO,
+		MaxAttempts: 1,
+		CreatedAt:   nowISO,
+		UpdatedAt:   nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil {
+		t.Fatalf("ClaimNextOfType() error = %v", err)
+	}
+	if claim == nil {
+		t.Fatal("claim = nil, want claimed queue item")
+	}
+
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "failed" || result.FailureKind != FailureRetryableTransient {
+		t.Fatalf("result = %#v, want failed retryable_transient result", result)
+	}
+
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_fixer_resume_parse_status")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "failed" {
+		t.Fatalf("queue = %#v, want failed terminal queue item", queue)
+	}
+
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_fixer_resume_parse_status")
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil {
-		t.Fatal("loop = nil, want loop record")
-	}
-
-	_, err = runner.createRunContext(context.Background(), *loop)
-	if err == nil {
-		t.Fatal("createRunContext() error = nil, want parse-status failure")
-	}
-	var loopErr *loopError
-	if !errors.As(err, &loopErr) {
-		t.Fatalf("error = %T, want *loopError", err)
-	}
-	if loopErr.kind != FailureRetryableTransient {
-		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableTransient)
-	}
-	if !contains(err.Error(), "server_error") {
-		t.Fatalf("error = %q, want upstream summary", err.Error())
+	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want failed terminal loop", loop)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -2,6 +2,7 @@ package fixer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -271,6 +272,36 @@ func TestProcessClaimedItemFailsWhenRepairCompletionResultMissing(t *testing.T) 
 	}
 	if run.LastCompletedStep != nil && *run.LastCompletedStep == string(stepRecheck) {
 		t.Fatalf("run = %#v, want downstream steps to remain incomplete", run)
+	}
+}
+
+func TestRunRepairStepFailsResumedCompletedCheckpointWithoutParsedResult(t *testing.T) {
+	t.Parallel()
+
+	runner := New(Options{})
+	checkpoint, err := runner.runRepairStep(context.Background(), stepInput{
+		Checkpoint: fixerCheckpoint{
+			Repair: &checkpointRepair{
+				Summary:     "upstream server_error",
+				ParseStatus: "",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatalf("runRepairStep() error = nil, want parse-status failure")
+	}
+	if checkpoint.Repair == nil {
+		t.Fatal("checkpoint.Repair = nil, want checkpoint preserved")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableTransient)
+	}
+	if !contains(err.Error(), "server_error") {
+		t.Fatalf("error = %q, want upstream summary", err.Error())
 	}
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -452,7 +452,7 @@ func (a workerAgentExecutionAdapter) Wait(ctx context.Context) (worker.AgentResu
 	if err != nil {
 		return worker.AgentResult{}, err
 	}
-	return worker.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, ChangedFiles: result.ChangedFiles, Commits: result.Commits}, nil
+	return worker.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, ParseStatus: result.ParseStatus, ChangedFiles: result.ChangedFiles, Commits: result.Commits}, nil
 }
 
 func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, asyncRunner func() schedulerAsyncRunner, now func() time.Time) RunSchedulerTickFunc {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -204,6 +204,7 @@ type AgentResult struct {
 	Status       string
 	Summary      string
 	Stdout       string
+	ParseStatus  string
 	ChangedFiles []string
 	Commits      []string
 }
@@ -356,6 +357,7 @@ type checkpointPlan struct {
 type checkpointExecution struct {
 	Status       string   `json:"status,omitempty"`
 	Summary      string   `json:"summary,omitempty"`
+	ParseStatus  string   `json:"parseStatus,omitempty"`
 	ChangedFiles []string `json:"changedFiles,omitempty"`
 	Commits      []string `json:"commits,omitempty"`
 	Stdout       string   `json:"stdout,omitempty"`
@@ -819,7 +821,10 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 	if result.Status != "completed" {
 		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Worker agent %s", result.Status)), kind: FailureRetryableTransient}
 	}
-	checkpoint.Execution = &checkpointExecution{Status: result.Status, Summary: result.Summary, ChangedFiles: append([]string(nil), result.ChangedFiles...), Commits: append([]string(nil), result.Commits...), Stdout: result.Stdout}
+	if result.ParseStatus != "parsed" {
+		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Worker agent completed without valid structured result (parse status: %s)", firstNonEmpty(result.ParseStatus, "missing"))), kind: FailureRetryableTransient}
+	}
+	checkpoint.Execution = &checkpointExecution{Status: result.Status, Summary: result.Summary, ParseStatus: result.ParseStatus, ChangedFiles: append([]string(nil), result.ChangedFiles...), Commits: append([]string(nil), result.Commits...), Stdout: result.Stdout}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -576,6 +576,42 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	}); err != nil {
 		return ProcessResult{}, err
 	}
+	if err := validateWorkerResumeCheckpoint(resumedRun.StartStep, checkpoint); err != nil {
+		failure := r.classifyFailure(err)
+		latest := r.getLatestCheckpoint(ctx, run, checkpoint)
+		if latest.ResumePolicy == "" {
+			latest.ResumePolicy = "replay_step"
+		}
+		if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
+			return ProcessResult{}, err
+		}
+		failedQueue, err := r.failQueueItem(ctx, queueItem, failure.kind, failure.message)
+		if err != nil {
+			return ProcessResult{}, err
+		}
+		if shouldNotifyCompletedRun(failure.kind, failedQueue) {
+			r.notifyRunCompleted(ctx, buildRunCompletedInput(*project, *loop, run, latest, "failed", failure.kind, failure.message))
+		}
+		if _, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
+			updated.LastRunAt = stringPtr(r.nowISO())
+			if updated.Status == "paused" {
+				updated.NextRunAt = nil
+			} else if failedQueue != nil && failedQueue.Status == "queued" {
+				updated.Status = "queued"
+				updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
+			} else {
+				if failure.kind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+					updated.Status = "paused"
+				} else {
+					updated.Status = "failed"
+				}
+				updated.NextRunAt = nil
+			}
+		}); err != nil {
+			return ProcessResult{}, err
+		}
+		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
+	}
 
 	for _, step := range stepsFrom(resumedRun.StartStep) {
 		run, err = r.persistStepStarted(ctx, run, step, checkpoint)
@@ -1043,9 +1079,6 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		if next := nextWorkerStep(lastCompletedStep); next != "" {
 			startStep = next
 		}
-	}
-	if err := validateWorkerResumeCheckpoint(startStep, checkpoint); err != nil {
-		return resumedRunContext{}, err
 	}
 	resumed := latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && startStep != stepPrepareWork
 	nowISO := r.nowISO()

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1064,6 +1064,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	}
 	checkpoint := workerCheckpoint{}
 	var lastCompletedStep WorkerStep
+	var failedStep WorkerStep
 	if latestRun != nil {
 		checkpoint, err = parseCheckpoint(latestRun.CheckpointJSON)
 		if err != nil {
@@ -1073,20 +1074,32 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		if derefString(latestRun.LastCompletedStep) != "" && lastCompletedStep == "" {
 			return resumedRunContext{}, fmt.Errorf("unknown worker last completed step %q", derefString(latestRun.LastCompletedStep))
 		}
+		failedStep = asWorkerStep(derefString(latestRun.CurrentStep))
 	}
 	startStep := stepPrepareWork
+	resumedCheckpoint := checkpoint
 	if latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && lastCompletedStep != "" {
-		if next := nextWorkerStep(lastCompletedStep); next != "" {
+		if shouldReplayExecuteOnResume(latestRun.Status, failedStep, checkpoint) {
+			startStep = stepExecute
+			resumedCheckpoint = rewindCheckpointForExecuteRetry(checkpoint)
+		} else if next := nextWorkerStep(lastCompletedStep); next != "" {
 			startStep = next
 		}
 	}
 	resumed := latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && startStep != stepPrepareWork
 	nowISO := r.nowISO()
-	encoded := mustMarshalJSON(workerCheckpoint{ResumePolicy: ternary(resumed, "advance_from_checkpoint", "replay_step"), Work: checkpoint.Work, ClaimedLockKey: checkpoint.ClaimedLockKey, Worktree: checkpoint.Worktree, Plan: checkpoint.Plan, Execution: checkpoint.Execution, Validation: checkpoint.Validation, PullRequest: checkpoint.PullRequest, SkipReason: checkpoint.SkipReason})
+	encoded := mustMarshalJSON(workerCheckpoint{ResumePolicy: ternary(resumed, "advance_from_checkpoint", "replay_step"), Work: resumedCheckpoint.Work, ClaimedLockKey: resumedCheckpoint.ClaimedLockKey, Worktree: resumedCheckpoint.Worktree, Plan: resumedCheckpoint.Plan, Execution: resumedCheckpoint.Execution, Validation: resumedCheckpoint.Validation, PullRequest: resumedCheckpoint.PullRequest, SkipReason: resumedCheckpoint.SkipReason})
 	run := storage.RunRecord{ID: eventlog.NewEventID("run"), LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(startStep)), LastCompletedStep: nil, CheckpointJSON: &encoded, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
-	if resumed && lastCompletedStep != "" {
-		value := string(lastCompletedStep)
-		run.LastCompletedStep = &value
+	if resumed {
+		if shouldReplayExecuteOnResume(latestRun.Status, failedStep, checkpoint) {
+			if prev := previousWorkerStep(startStep); prev != "" {
+				value := string(prev)
+				run.LastCompletedStep = &value
+			}
+		} else if lastCompletedStep != "" {
+			value := string(lastCompletedStep)
+			run.LastCompletedStep = &value
+		}
 	}
 	if err := r.repos.Runs.Upsert(ctx, run); err != nil {
 		return resumedRunContext{}, err
@@ -1418,6 +1431,15 @@ func nextWorkerStep(step WorkerStep) WorkerStep {
 	return ""
 }
 
+func previousWorkerStep(step WorkerStep) WorkerStep {
+	for i, candidate := range workerStepSequence {
+		if candidate == step && i > 0 {
+			return workerStepSequence[i-1]
+		}
+	}
+	return ""
+}
+
 func validateWorkerResumeCheckpoint(startStep WorkerStep, checkpoint workerCheckpoint) error {
 	switch startStep {
 	case stepValidate, stepOpenPR:
@@ -1452,6 +1474,26 @@ func requireWork(checkpoint workerCheckpoint) (workerInput, error) {
 		return workerInput{}, &loopError{message: "missing worker input checkpoint", kind: FailureRetryableTransient}
 	}
 	return *checkpoint.Work, nil
+}
+
+func shouldReplayExecuteOnResume(status string, failedStep WorkerStep, checkpoint workerCheckpoint) bool {
+	if status != "failed" && status != "interrupted" {
+		return false
+	}
+	switch failedStep {
+	case stepValidate, stepOpenPR:
+	default:
+		return false
+	}
+	return validateCompletedExecutionCheckpoint(checkpoint.Execution) != nil
+}
+
+func rewindCheckpointForExecuteRetry(checkpoint workerCheckpoint) workerCheckpoint {
+	checkpoint.Execution = nil
+	checkpoint.Validation = nil
+	checkpoint.PullRequest = nil
+	checkpoint.SkipReason = ""
+	return checkpoint
 }
 
 func requireWorktree(checkpoint workerCheckpoint) (checkpointWorktree, error) {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1044,6 +1044,9 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 			startStep = next
 		}
 	}
+	if err := validateWorkerResumeCheckpoint(startStep, checkpoint); err != nil {
+		return resumedRunContext{}, err
+	}
 	resumed := latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && startStep != stepPrepareWork
 	nowISO := r.nowISO()
 	encoded := mustMarshalJSON(workerCheckpoint{ResumePolicy: ternary(resumed, "advance_from_checkpoint", "replay_step"), Work: checkpoint.Work, ClaimedLockKey: checkpoint.ClaimedLockKey, Worktree: checkpoint.Worktree, Plan: checkpoint.Plan, Execution: checkpoint.Execution, Validation: checkpoint.Validation, PullRequest: checkpoint.PullRequest, SkipReason: checkpoint.SkipReason})
@@ -1380,6 +1383,15 @@ func nextWorkerStep(step WorkerStep) WorkerStep {
 		}
 	}
 	return ""
+}
+
+func validateWorkerResumeCheckpoint(startStep WorkerStep, checkpoint workerCheckpoint) error {
+	switch startStep {
+	case stepValidate, stepOpenPR:
+		return validateCompletedExecutionCheckpoint(checkpoint.Execution)
+	default:
+		return nil
+	}
 }
 
 func asWorkerStep(value string) WorkerStep {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -388,6 +388,19 @@ type loopError struct {
 	kind    QueueFailureKind
 }
 
+func validateCompletedExecutionCheckpoint(execution *checkpointExecution) error {
+	if execution == nil || execution.Status != "completed" {
+		return nil
+	}
+	if execution.ParseStatus == "parsed" {
+		return nil
+	}
+	return &loopError{
+		message: firstNonEmpty(execution.Summary, fmt.Sprintf("Worker agent completed without valid structured result (parse status: %s)", firstNonEmpty(execution.ParseStatus, "missing"))),
+		kind:    FailureRetryableTransient,
+	}
+}
+
 func (e *loopError) Error() string { return e.message }
 
 func New(options Options) *Runner {
@@ -787,6 +800,9 @@ func (r *Runner) runPlanStep(input stepInput) (workerCheckpoint, error) {
 func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerCheckpoint, error) {
 	checkpoint := input.Checkpoint
 	if checkpoint.Execution != nil && checkpoint.Execution.Status == "completed" {
+		if err := validateCompletedExecutionCheckpoint(checkpoint.Execution); err != nil {
+			return checkpoint, err
+		}
 		return checkpoint, nil
 	}
 	if !r.allowAutoCommit {
@@ -821,8 +837,8 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 	if result.Status != "completed" {
 		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Worker agent %s", result.Status)), kind: FailureRetryableTransient}
 	}
-	if result.ParseStatus != "parsed" {
-		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Worker agent completed without valid structured result (parse status: %s)", firstNonEmpty(result.ParseStatus, "missing"))), kind: FailureRetryableTransient}
+	if err := validateCompletedExecutionCheckpoint(&checkpointExecution{Status: result.Status, Summary: result.Summary, ParseStatus: result.ParseStatus}); err != nil {
+		return checkpoint, err
 	}
 	checkpoint.Execution = &checkpointExecution{Status: result.Status, Summary: result.Summary, ParseStatus: result.ParseStatus, ChangedFiles: append([]string(nil), result.ChangedFiles...), Commits: append([]string(nil), result.Commits...), Stdout: result.Stdout}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -205,6 +205,54 @@ func TestRunExecuteStepFailsResumedCompletedCheckpointWithoutParsedResult(t *tes
 	}
 }
 
+func TestCreateRunContextFailsWhenResumeStartsAfterExecuteWithoutParsedResult(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	checkpointJSON := mustMarshalJSON(workerCheckpoint{
+		Execution: &checkpointExecution{
+			Status:      "completed",
+			Summary:     "upstream server_error",
+			ParseStatus: "",
+		},
+	})
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:                "run_failed_after_execute",
+		LoopID:            "loop_worker_1",
+		Status:            "failed",
+		LastCompletedStep: stringPtr(string(stepExecute)),
+		CheckpointJSON:    &checkpointJSON,
+		StartedAt:         fixture.nowISO(),
+		CreatedAt:         fixture.nowISO(),
+		UpdatedAt:         fixture.nowISO(),
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil {
+		t.Fatal("loop = nil, want loop record")
+	}
+
+	_, err = runner.createRunContext(context.Background(), *loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want parse-status failure")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableTransient)
+	}
+	if !strings.Contains(err.Error(), "server_error") {
+		t.Fatalf("error = %q, want upstream summary", err.Error())
+	}
+}
+
 func TestBuildPullRequestBodyUsesCrossRepoClosingReference(t *testing.T) {
 	t.Parallel()
 	body := buildPullRequestBody(workerInput{Repo: "acme/looper", IssueRepo: "powerformer/looper", IssueNumber: 27, IssueURL: "https://github.com/powerformer/looper/issues/27"}, &checkpointPlan{Items: []string{"Add linked issue auto-close support"}}, &checkpointExecution{Summary: "done"})

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -205,6 +205,69 @@ func TestRunExecuteStepFailsResumedCompletedCheckpointWithoutParsedResult(t *tes
 	}
 }
 
+func TestCreateRunContextReplaysExecuteWhenResumeCheckpointParseStatusIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	checkpointJSON := mustMarshalJSON(workerCheckpoint{
+		Work:           &workerInput{Title: "Worker task"},
+		ClaimedLockKey: "worker:loop_worker_1",
+		Worktree:       &checkpointWorktree{ID: "wt_1", Path: filepath.Join(t.TempDir(), "wt"), Branch: "feature/test"},
+		Plan:           &checkpointPlan{Summary: "plan"},
+		Execution:      &checkpointExecution{Status: "completed", Summary: "upstream server_error"},
+		Validation:     &ValidationResult{Passed: true, Summary: "stale"},
+		PullRequest:    &checkpointPullPR{Number: 101, URL: "https://example/pr/101"},
+		SkipReason:     "stale skip reason",
+	})
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:                "run_failed_after_validate",
+		LoopID:            "loop_worker_1",
+		Status:            "failed",
+		CurrentStep:       stringPtr(string(stepValidate)),
+		LastCompletedStep: stringPtr(string(stepExecute)),
+		CheckpointJSON:    &checkpointJSON,
+		StartedAt:         fixture.nowISO(),
+		CreatedAt:         fixture.nowISO(),
+		UpdatedAt:         fixture.nowISO(),
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil {
+		t.Fatal("loop = nil, want worker loop")
+	}
+
+	resumed, err := runner.createRunContext(context.Background(), *loop)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if !resumed.Resumed || resumed.StartStep != stepExecute {
+		t.Fatalf("resumed = %#v, want resumed execute replay", resumed)
+	}
+	if resumed.Checkpoint.Execution != nil {
+		t.Fatalf("Execution = %#v, want cleared execution checkpoint", resumed.Checkpoint.Execution)
+	}
+	if resumed.Checkpoint.Validation != nil {
+		t.Fatalf("Validation = %#v, want cleared validation checkpoint", resumed.Checkpoint.Validation)
+	}
+	if resumed.Checkpoint.PullRequest != nil {
+		t.Fatalf("PullRequest = %#v, want cleared pull request checkpoint", resumed.Checkpoint.PullRequest)
+	}
+	if resumed.Checkpoint.SkipReason != "" {
+		t.Fatalf("SkipReason = %q, want cleared skip reason", resumed.Checkpoint.SkipReason)
+	}
+	if resumed.Checkpoint.Worktree == nil || resumed.Checkpoint.Plan == nil {
+		t.Fatalf("checkpoint = %#v, want preserved worktree and plan", resumed.Checkpoint)
+	}
+	if resumed.Run.LastCompletedStep == nil || *resumed.Run.LastCompletedStep != string(stepPlan) {
+		t.Fatalf("run.LastCompletedStep = %#v, want plan", resumed.Run.LastCompletedStep)
+	}
+}
+
 func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -44,7 +44,7 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
 		queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
@@ -115,6 +115,61 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	}
 	if lock != nil {
 		t.Fatalf("lock = %#v, want prepare-work lock released after successful run", lock)
+	}
+}
+
+func TestProcessClaimedItemFailsWhenAgentCompletionResultMissing(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "upstream server_error", Stdout: "server_error", ParseStatus: "missing"}}}
+	validationCalls := 0
+	completed := make([]RunCompletedInput, 0, 1)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, ValidationRunner: func(context.Context, ValidationInput) (ValidationResult, error) {
+		validationCalls++
+		return ValidationResult{Passed: true, Summary: "ok"}, nil
+	}, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
+		completed = append(completed, input)
+		return nil
+	}})
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient || !strings.Contains(result.Summary, "server_error") {
+		t.Fatalf("result = %#v, want retryable failed result with upstream error", result)
+	}
+	if validationCalls != 0 {
+		t.Fatalf("validationCalls = %d, want execute failure to stop before validation", validationCalls)
+	}
+	if len(git.pushCalls) != 0 || len(github.createPRCalls) != 0 {
+		t.Fatalf("push calls=%d createPR calls=%d, want 0/0 after invalid agent completion", len(git.pushCalls), len(github.createPRCalls))
+	}
+	if len(completed) != 0 {
+		t.Fatalf("len(completed) = %d, want no completion notification for retryable failure", len(completed))
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued loop for retryable failure", loop)
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	if run == nil || run.Status != "failed" || run.CurrentStep == nil || *run.CurrentStep != string(stepExecute) {
+		t.Fatalf("run = %#v, want failed run at execute step", run)
+	}
+	if run.LastCompletedStep != nil && *run.LastCompletedStep == string(stepOpenPR) {
+		t.Fatalf("run = %#v, want open-pr to remain incomplete", run)
 	}
 }
 
@@ -314,7 +369,7 @@ func TestProcessClaimedItemResumesFromOpenPRAfterRetryableFailure(t *testing.T) 
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}, createPRErrors: []error{fmt.Errorf("temporary create pr failure")}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	started := make([]AgentExecutionStartedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, OnAgentExecutionStarted: func(_ context.Context, input AgentExecutionStartedInput) error {
 		started = append(started, input)
@@ -401,7 +456,7 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, ValidationRunner: func(context.Context, ValidationInput) (ValidationResult, error) {
 		return ValidationResult{Passed: false, Summary: "Validation failed"}, nil
@@ -443,7 +498,7 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 func TestProcessClaimedItemPreservesPausedLoopOnRetryableFailureAfterPause(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}, wait: func(ctx context.Context) error {
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}, wait: func(ctx context.Context) error {
 		loopID := ""
 		items, err := fixture.repos.Queue.List(ctx)
 		if err != nil {
@@ -628,7 +683,7 @@ func TestProcessClaimedItemSkippedFlowEmitsCompletionNotification(t *testing.T) 
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: false, OpenPRStrategy: config.OpenPRStrategyAllDone, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
 		completed = append(completed, input)
@@ -652,7 +707,7 @@ func TestProcessClaimedItemSkipsAutoPROpenWhenGitHubCLIUnavailable(t *testing.T)
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	githubCLIAvailable := false
 	runner := New(Options{
@@ -694,7 +749,7 @@ func TestProcessClaimedItemRechecksGitHubCLIAvailabilityAtRunTime(t *testing.T) 
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	checkCalls := 0
 	runner := New(Options{
 		DB:                 fixture.coordinator.DB(),
@@ -769,7 +824,7 @@ func TestProcessClaimedItemFindsExistingPRAfterPush(t *testing.T) {
 	branch := buildWorkerBranchName(workerInput{Title: "Implement worker loop", Repo: "acme/looper", BaseBranch: "main", ExecutionMode: "create-pr"}, "loop_worker_1")
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: branch, BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{openPRResponses: [][]PullRequestSummary{{}, {{Number: 201, URL: "https://example/pr/201", State: "OPEN", HeadRefName: branch, BaseRefName: "main"}}}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
 
 	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
@@ -790,7 +845,7 @@ func TestProcessClaimedItemFailsWhenCreatedPRNumberIsMissing(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 0, URL: "https://example/pr/unparsed"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
 
 	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
@@ -1024,7 +1079,7 @@ type fakeAgentExecutor struct {
 
 func (f *fakeAgentExecutor) Start(_ context.Context, input AgentRunInput) (AgentExecution, error) {
 	f.starts = append(f.starts, input)
-	result := AgentResult{Status: "completed", Summary: "done"}
+	result := AgentResult{Status: "completed", Summary: "done", ParseStatus: "parsed"}
 	if f.index < len(f.results) {
 		result = f.results[f.index]
 	}

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -170,6 +171,37 @@ func TestProcessClaimedItemFailsWhenAgentCompletionResultMissing(t *testing.T) {
 	}
 	if run.LastCompletedStep != nil && *run.LastCompletedStep == string(stepOpenPR) {
 		t.Fatalf("run = %#v, want open-pr to remain incomplete", run)
+	}
+}
+
+func TestRunExecuteStepFailsResumedCompletedCheckpointWithoutParsedResult(t *testing.T) {
+	t.Parallel()
+
+	runner := New(Options{})
+	checkpoint, err := runner.runExecuteStep(context.Background(), stepInput{
+		Checkpoint: workerCheckpoint{
+			Execution: &checkpointExecution{
+				Status:      "completed",
+				Summary:     "upstream server_error",
+				ParseStatus: "",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatalf("runExecuteStep() error = nil, want parse-status failure")
+	}
+	if checkpoint.Execution == nil || checkpoint.Execution.Status != "completed" {
+		t.Fatalf("checkpoint.Execution = %#v, want completed checkpoint preserved", checkpoint.Execution)
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableTransient)
+	}
+	if !strings.Contains(err.Error(), "server_error") {
+		t.Fatalf("error = %q, want upstream summary", err.Error())
 	}
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -205,7 +205,7 @@ func TestRunExecuteStepFailsResumedCompletedCheckpointWithoutParsedResult(t *tes
 	}
 }
 
-func TestCreateRunContextFailsWhenResumeStartsAfterExecuteWithoutParsedResult(t *testing.T) {
+func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testing.T) {
 	t.Parallel()
 
 	fixture := newRunnerFixture(t)
@@ -229,27 +229,48 @@ func TestCreateRunContextFailsWhenResumeStartsAfterExecuteWithoutParsedResult(t 
 	}); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil {
+		t.Fatal("queue = nil, want queue record")
+	}
+	queue.MaxAttempts = 1
+	if err := fixture.repos.Queue.Upsert(context.Background(), *queue); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	if err != nil {
+		t.Fatalf("ClaimNextOfType() error = %v", err)
+	}
+	if claim == nil {
+		t.Fatal("claim = nil, want claimed queue item")
+	}
+
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "failed" || result.FailureKind != FailureRetryableTransient {
+		t.Fatalf("result = %#v, want failed retryable_transient result", result)
+	}
+
+	queue, err = fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "failed" {
+		t.Fatalf("queue = %#v, want failed terminal queue item", queue)
+	}
+
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil {
-		t.Fatal("loop = nil, want loop record")
-	}
-
-	_, err = runner.createRunContext(context.Background(), *loop)
-	if err == nil {
-		t.Fatal("createRunContext() error = nil, want parse-status failure")
-	}
-	var loopErr *loopError
-	if !errors.As(err, &loopErr) {
-		t.Fatalf("error = %T, want *loopError", err)
-	}
-	if loopErr.kind != FailureRetryableTransient {
-		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableTransient)
-	}
-	if !strings.Contains(err.Error(), "server_error") {
-		t.Fatalf("error = %q, want upstream summary", err.Error())
+	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want failed terminal loop", loop)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fail worker execute and fixer repair steps unless the agent execution both finishes with `status=completed` and produces a parsed `__LOOPER_RESULT__`
- carry worker `parseStatus` through the runtime adapter/checkpoint so worker runs can distinguish upstream `server_error` / missing structured output from real success
- add regression coverage to prove worker and fixer flows stop before downstream validation, push, comment resolution, or PR opening when agent output is missing or invalid

## Why
Upstream `server_error` cases were being recorded as completed runs because the runners only checked the outer execution status. When the agent process exited without a valid structured result, Looper could continue through success-only paths and emit misleading completion notifications.

## Validation
- `go test ./internal/worker ./internal/fixer ./internal/runtime`
- `env GOCACHE=/tmp/looper-go-cache go vet ./...`
- `env GOCACHE=/tmp/looper-go-cache go build ./...`
- `env GOCACHE=/tmp/looper-go-cache go test ./...` *(environment-limited in this sandbox: `httptest` listener binds are not permitted here, and config tests expect writable paths under `~/.looper`)*

Closes #65