### PR TITLE
Mark worker issue runs as claimed on GitHub

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2519,6 +2519,9 @@ func (h *Handler) buildWorkersCreateResponse(r *http.Request) (workerCreateRespo
 	if effectivePRNumber != nil {
 		targetType = string(domain.LoopTargetTypePullRequest)
 		targetID = fmt.Sprintf("pr:%s:%d", *repo, *effectivePRNumber)
+	} else if issueNumber != nil {
+		targetType = string(domain.LoopTargetTypeIssue)
+		targetID = fmt.Sprintf("issue:%s:%d", *repo, *issueNumber)
 	}
 
 	workerPayload := struct {
@@ -2562,6 +2565,8 @@ func (h *Handler) buildWorkersCreateResponse(r *http.Request) (workerCreateRespo
 		target := domain.LoopTarget{TargetType: domain.LoopTargetTypeProject, ProjectID: projectID}
 		if effectivePRNumber != nil {
 			target = domain.LoopTarget{TargetType: domain.LoopTargetTypePullRequest, Repo: *repo, PRNumber: *effectivePRNumber}
+		} else if issueNumber != nil {
+			target = domain.LoopTarget{TargetType: domain.LoopTargetTypeIssue, Repo: *repo, IssueNumber: *issueNumber}
 		}
 		existing, listErr := repos.Loops.List(r.Context())
 		if listErr != nil {
@@ -2597,6 +2602,9 @@ func (h *Handler) buildWorkersCreateResponse(r *http.Request) (workerCreateRespo
 		if effectivePRNumber != nil {
 			dedupeKey = fmt.Sprintf("worker:%s:%s:%d", projectID, *repo, *effectivePRNumber)
 			lockKey = fmt.Sprintf("pr:%s:%d", *repo, *effectivePRNumber)
+		} else if issueNumber != nil {
+			dedupeKey = fmt.Sprintf("worker:%s:%s:%d", projectID, *repo, *issueNumber)
+			lockKey = fmt.Sprintf("issue:%s:%d", *repo, *issueNumber)
 		}
 		payloadJSON := string(queuePayloadJSONBytes)
 		queueRecord := storage.QueueItemRecord{
@@ -3353,7 +3361,19 @@ func buildQueuedLoopQueueRecordCompat(record storage.LoopRecord, target domain.L
 		queueRecord.Priority = storage.QueuePriorityWorker
 		lockKey := fmt.Sprintf("worker:%s", record.ID)
 		queueRecord.DedupeKey = fmt.Sprintf("worker:%s", record.ID)
-		if target.TargetType == domain.LoopTargetTypePullRequest {
+		if target.TargetType == domain.LoopTargetTypeIssue {
+			repo := strings.TrimSpace(derefString(record.Repo))
+			issueNumber := target.IssueNumber
+			if repo == "" || issueNumber <= 0 {
+				return storage.QueueItemRecord{}, false, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("%s loop requires repo and issueNumber", record.Type)}
+			}
+			lockKey = fmt.Sprintf("issue:%s:%d", repo, issueNumber)
+			queueRecord.TargetType = string(domain.LoopTargetTypeIssue)
+			queueRecord.TargetID = lockKey
+			queueRecord.Repo = &repo
+			queueRecord.PRNumber = nil
+			queueRecord.DedupeKey = fmt.Sprintf("worker:%s:%s:%d", record.ProjectID, repo, issueNumber)
+		} else if target.TargetType == domain.LoopTargetTypePullRequest {
 			repo := strings.TrimSpace(derefString(record.Repo))
 			if repo == "" || record.PRNumber == nil {
 				return storage.QueueItemRecord{}, false, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("%s loop requires repo and prNumber", record.Type)}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2388,7 +2388,7 @@ func TestHandlerWorkerCreateUsesOnlyNewestMatchingPlannerLoop(t *testing.T) {
 	if loop == nil {
 		t.Fatal("Loops.GetByID() = nil, want created worker loop")
 	}
-	assertEqual(t, loop.TargetType, "project")
+	assertEqual(t, loop.TargetType, "issue")
 	if loop.PRNumber != nil {
 		t.Fatalf("loop.PRNumber = %#v, want nil", loop.PRNumber)
 	}
@@ -2407,10 +2407,13 @@ func TestHandlerWorkerCreateUsesOnlyNewestMatchingPlannerLoop(t *testing.T) {
 	if queueItem == nil || queueItem.PayloadJSON == nil {
 		t.Fatalf("worker queue payload missing for loop %s", loopID)
 	}
-	assertEqual(t, queueItem.TargetType, "project")
-	assertEqual(t, queueItem.TargetID, "project:project_1")
+	assertEqual(t, queueItem.TargetType, "issue")
+	assertEqual(t, queueItem.TargetID, "issue:acme/looper:77")
 	if queueItem.PRNumber != nil {
 		t.Fatalf("queueItem.PRNumber = %#v, want nil", queueItem.PRNumber)
+	}
+	if queueItem.LockKey == nil || *queueItem.LockKey != "issue:acme/looper:77" {
+		t.Fatalf("queueItem.LockKey = %#v, want issue lock key", queueItem.LockKey)
 	}
 	payload := parseJSONMap(t, []byte(*queueItem.PayloadJSON))
 	assertEqual(t, payload["specPath"], "specs/newer-closed.md")

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -1168,6 +1168,7 @@ func (e smokeAgentExecution) Wait(ctx context.Context) (worker.AgentResult, erro
 		Status:       result.Status,
 		Summary:      result.Summary,
 		Stdout:       result.Stdout,
+		ParseStatus:  result.ParseStatus,
 		ChangedFiles: append([]string{}, result.ChangedFiles...),
 		Commits:      append([]string{}, result.Commits...),
 	}, nil

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -81,6 +81,25 @@ type IssueSummary struct {
 
 type IssueDetail = IssueSummary
 
+type IssueCommentInput struct {
+	Repo        string
+	IssueNumber int64
+	Body        string
+	CWD         string
+}
+
+type IssueCommentResult struct {
+	ID  int64
+	URL string
+}
+
+type UpdateIssueCommentInput struct {
+	Repo      string
+	CommentID int64
+	Body      string
+	CWD       string
+}
+
 type SubmitReviewInput struct {
 	Repo     string
 	PRNumber int64
@@ -297,6 +316,23 @@ func (g *Gateway) ViewIssue(ctx context.Context, input ViewIssueInput) (IssueDet
 		Assignees: extractActorLogins(row["assignees"]),
 		Labels:    extractLabelNames(row["labels"]),
 	}, nil
+}
+
+func (g *Gateway) CreateIssueComment(ctx context.Context, input IssueCommentInput) (IssueCommentResult, error) {
+	result, err := g.runGh(ctx, input.CWD, "", "api", fmt.Sprintf("repos/%s/issues/%d/comments", input.Repo, input.IssueNumber), "--method", "POST", "-f", "body="+input.Body)
+	if err != nil {
+		return IssueCommentResult{}, err
+	}
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return IssueCommentResult{}, err
+	}
+	return IssueCommentResult{ID: asInt64(row["id"]), URL: asString(row["html_url"])}, nil
+}
+
+func (g *Gateway) UpdateIssueComment(ctx context.Context, input UpdateIssueCommentInput) error {
+	_, err := g.runGh(ctx, input.CWD, "", "api", fmt.Sprintf("repos/%s/issues/comments/%d", input.Repo, input.CommentID), "--method", "PATCH", "-f", "body="+input.Body)
+	return err
 }
 
 func (g *Gateway) ViewPullRequest(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -32,6 +32,12 @@ case "$*" in
   "issue view"*)
     printf '{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","author":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}'
     ;;
+  "api repos/acme/looper/issues/8/comments --method POST -f body=Looper started")
+    printf '{"id":91,"html_url":"https://example.test/issues/8#issuecomment-91"}'
+    ;;
+  "api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished")
+    printf '{}'
+    ;;
   "pr view"*)
     printf '{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"state":"UNRESOLVED"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}'
     ;;
@@ -99,6 +105,13 @@ esac
 	if err != nil {
 		t.Fatalf("ViewIssue() error = %v", err)
 	}
+	comment, err := gateway.CreateIssueComment(context.Background(), IssueCommentInput{Repo: "acme/looper", IssueNumber: 8, Body: "Looper started"})
+	if err != nil {
+		t.Fatalf("CreateIssueComment() error = %v", err)
+	}
+	if err := gateway.UpdateIssueComment(context.Background(), UpdateIssueCommentInput{Repo: "acme/looper", CommentID: 91, Body: "Looper finished"}); err != nil {
+		t.Fatalf("UpdateIssueComment() error = %v", err)
+	}
 	snapshot, err := gateway.CapturePullRequestSnapshot(context.Background(), CapturePullRequestSnapshotInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
 	if err != nil {
 		t.Fatalf("CapturePullRequestSnapshot() error = %v", err)
@@ -158,6 +171,9 @@ esac
 	if issueDetail.Number != 8 {
 		t.Fatalf("issueDetail.Number = %d, want 8", issueDetail.Number)
 	}
+	if comment.ID != 91 || comment.URL != "https://example.test/issues/8#issuecomment-91" {
+		t.Fatalf("comment = %#v, want parsed issue comment metadata", comment)
+	}
 	if snapshot.HeadSHA != "abc123" {
 		t.Fatalf("snapshot.HeadSHA = %q, want abc123", snapshot.HeadSHA)
 	}
@@ -190,6 +206,8 @@ esac
 		"pr list --repo acme/looper --state open --limit 30 --label phase-1",
 		"issue list --repo acme/looper --state open --limit 30 --assignee reviewer --label phase-1",
 		"issue view 8 --repo acme/looper",
+		"api repos/acme/looper/issues/8/comments --method POST -f body=Looper started",
+		"api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished",
 		"label create phase-1 --repo acme/looper --color 5319e7 --description Managed by looper --force",
 		"label create ready --repo acme/looper --color 5319e7 --description Managed by looper --force",
 		"api repos/acme/looper/issues/42/labels --method POST -f labels[]=phase-1 -f labels[]=ready",

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -961,7 +961,22 @@ func buildRecoveryQueueItem(loop storage.LoopRecord, nowISO string, maxAttempts 
 		queueRecord.Priority = storage.QueuePriorityWorker
 		lockKey := fmt.Sprintf("worker:%s", loop.ID)
 		queueRecord.DedupeKey = fmt.Sprintf("worker:%s", loop.ID)
-		if loop.TargetType == string(domain.LoopTargetTypePullRequest) {
+		if loop.TargetType == string(domain.LoopTargetTypeIssue) {
+			repo := strings.TrimSpace(derefString(loop.Repo))
+			issueNumber, err := parseIssueNumberFromTargetID(queueRecord.TargetID)
+			if err != nil || repo == "" {
+				if err == nil {
+					err = fmt.Errorf("worker loop requires repo and issue target")
+				}
+				return storage.QueueItemRecord{}, false, err
+			}
+			lockKey = fmt.Sprintf("issue:%s:%d", repo, issueNumber)
+			queueRecord.TargetType = string(domain.LoopTargetTypeIssue)
+			queueRecord.TargetID = lockKey
+			queueRecord.Repo = &repo
+			queueRecord.PRNumber = nil
+			queueRecord.DedupeKey = fmt.Sprintf("worker:%s:%s:%d", loop.ProjectID, repo, issueNumber)
+		} else if loop.TargetType == string(domain.LoopTargetTypePullRequest) {
 			repo := strings.TrimSpace(derefString(loop.Repo))
 			if repo == "" || loop.PRNumber == nil {
 				return storage.QueueItemRecord{}, false, fmt.Errorf("worker loop requires repo and prNumber")

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -398,6 +398,18 @@ func (a workerGitHubAdapter) ViewIssue(ctx context.Context, input worker.ViewIss
 	return worker.IssueDetail{Number: issue.Number, Title: issue.Title, Body: issue.Body, URL: issue.URL}, nil
 }
 
+func (a workerGitHubAdapter) CreateIssueComment(ctx context.Context, input worker.IssueCommentInput) (worker.IssueCommentResult, error) {
+	comment, err := a.gateway.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: input.Repo, IssueNumber: input.IssueNumber, Body: input.Body, CWD: input.CWD})
+	if err != nil {
+		return worker.IssueCommentResult{}, err
+	}
+	return worker.IssueCommentResult{ID: comment.ID, URL: comment.URL}, nil
+}
+
+func (a workerGitHubAdapter) UpdateIssueComment(ctx context.Context, input worker.UpdateIssueCommentInput) error {
+	return a.gateway.UpdateIssueComment(ctx, githubinfra.UpdateIssueCommentInput{Repo: input.Repo, CommentID: input.CommentID, Body: input.Body, CWD: input.CWD})
+}
+
 func (a workerGitHubAdapter) CreatePullRequest(ctx context.Context, input worker.CreatePullRequestInput) (worker.CreatePullRequestResult, error) {
 	pr, err := a.gateway.CreatePullRequest(ctx, githubinfra.CreatePullRequestInput{Repo: input.Repo, HeadBranch: input.HeadBranch, BaseBranch: input.BaseBranch, Title: input.Title, Body: input.Body, CWD: input.CWD})
 	if err != nil {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -464,7 +464,7 @@ func (a workerAgentExecutionAdapter) Wait(ctx context.Context) (worker.AgentResu
 	if err != nil {
 		return worker.AgentResult{}, err
 	}
-	return worker.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, ChangedFiles: result.ChangedFiles, Commits: result.Commits}, nil
+	return worker.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, ParseStatus: result.ParseStatus, ChangedFiles: result.ChangedFiles, Commits: result.Commits}, nil
 }
 
 func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, asyncRunner func() schedulerAsyncRunner, now func() time.Time) RunSchedulerTickFunc {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -639,11 +639,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			}); err != nil {
 				return ProcessResult{}, err
 			}
-			terminalStatus := issueClaimStatusFailed
-			if failure.kind == FailureManualIntervention {
-				terminalStatus = issueClaimStatusPaused
-			}
-			r.syncIssueClaim(ctx, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem}, &latest, terminalStatus, failure.message)
+			r.syncIssueClaim(ctx, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem}, &latest, issueClaimStatusForFailure(latest, failedQueue, failure.kind), failure.message)
 			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 		}
 		if step == stepPrepareWork {
@@ -1450,6 +1446,19 @@ func shouldNotifyCompletedRun(kind QueueFailureKind, failedQueue *storage.QueueI
 		return true
 	}
 	return failedQueue != nil && failedQueue.Status != "queued" && failedQueue.Status != "cancelled"
+}
+
+func issueClaimStatusForFailure(checkpoint workerCheckpoint, failedQueue *storage.QueueItemRecord, kind QueueFailureKind) string {
+	if failedQueue != nil && failedQueue.Status == "queued" {
+		if checkpoint.PullRequest != nil && strings.TrimSpace(checkpoint.PullRequest.URL) != "" {
+			return issueClaimStatusPRLinked
+		}
+		return issueClaimStatusRunning
+	}
+	if kind == FailureManualIntervention {
+		return issueClaimStatusPaused
+	}
+	return issueClaimStatusFailed
 }
 
 func statusForCheckpoint(checkpoint workerCheckpoint) string {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -88,6 +88,25 @@ type IssueDetail struct {
 	URL    string
 }
 
+type IssueCommentInput struct {
+	Repo        string
+	IssueNumber int64
+	Body        string
+	CWD         string
+}
+
+type IssueCommentResult struct {
+	ID  int64
+	URL string
+}
+
+type UpdateIssueCommentInput struct {
+	Repo      string
+	CommentID int64
+	Body      string
+	CWD       string
+}
+
 type CreatePullRequestInput struct {
 	Repo       string
 	HeadBranch string
@@ -139,6 +158,8 @@ type GitHubGateway interface {
 	ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error)
 	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
 	ViewIssue(context.Context, ViewIssueInput) (IssueDetail, error)
+	CreateIssueComment(context.Context, IssueCommentInput) (IssueCommentResult, error)
+	UpdateIssueComment(context.Context, UpdateIssueCommentInput) error
 	CreatePullRequest(context.Context, CreatePullRequestInput) (CreatePullRequestResult, error)
 	RemovePullRequestLabels(context.Context, PullRequestLabelsInput) error
 	AddPullRequestReviewers(context.Context, PullRequestReviewersInput) error
@@ -329,15 +350,24 @@ type workerInput struct {
 }
 
 type workerCheckpoint struct {
-	ResumePolicy   string               `json:"resumePolicy,omitempty"`
-	Work           *workerInput         `json:"work,omitempty"`
-	ClaimedLockKey string               `json:"claimedLockKey,omitempty"`
-	Worktree       *checkpointWorktree  `json:"worktree,omitempty"`
-	Plan           *checkpointPlan      `json:"plan,omitempty"`
-	Execution      *checkpointExecution `json:"execution,omitempty"`
-	Validation     *ValidationResult    `json:"validation,omitempty"`
-	PullRequest    *checkpointPullPR    `json:"pullRequest,omitempty"`
-	SkipReason     string               `json:"skipReason,omitempty"`
+	ResumePolicy   string                `json:"resumePolicy,omitempty"`
+	Work           *workerInput          `json:"work,omitempty"`
+	ClaimedLockKey string                `json:"claimedLockKey,omitempty"`
+	IssueClaim     *checkpointIssueClaim `json:"issueClaim,omitempty"`
+	Worktree       *checkpointWorktree   `json:"worktree,omitempty"`
+	Plan           *checkpointPlan       `json:"plan,omitempty"`
+	Execution      *checkpointExecution  `json:"execution,omitempty"`
+	Validation     *ValidationResult     `json:"validation,omitempty"`
+	PullRequest    *checkpointPullPR     `json:"pullRequest,omitempty"`
+	SkipReason     string                `json:"skipReason,omitempty"`
+}
+
+type checkpointIssueClaim struct {
+	Repo        string `json:"repo,omitempty"`
+	IssueNumber int64  `json:"issueNumber,omitempty"`
+	CommentID   int64  `json:"commentId,omitempty"`
+	CommentURL  string `json:"commentUrl,omitempty"`
+	Status      string `json:"status,omitempty"`
 }
 
 type checkpointWorktree struct {
@@ -609,6 +639,11 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			}); err != nil {
 				return ProcessResult{}, err
 			}
+			terminalStatus := issueClaimStatusFailed
+			if failure.kind == FailureManualIntervention {
+				terminalStatus = issueClaimStatusPaused
+			}
+			r.syncIssueClaim(ctx, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem}, &latest, terminalStatus, failure.message)
 			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 		}
 		if step == stepPrepareWork {
@@ -642,6 +677,11 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if checkpoint.SkipReason != "" {
 		status = "skipped"
 	}
+	finalIssueClaimStatus := issueClaimStatusSuccess
+	if checkpoint.SkipReason != "" {
+		finalIssueClaimStatus = issueClaimStatusPaused
+	}
+	r.syncIssueClaim(ctx, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem}, &checkpoint, finalIssueClaimStatus, summary)
 	r.notifyRunCompleted(ctx, buildRunCompletedInput(*project, *loop, run, checkpoint, statusForCheckpoint(checkpoint), "", summary))
 	return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary, PullRequestNumber: pullRequestNumber(checkpoint.PullRequest)}, nil
 }
@@ -675,6 +715,8 @@ func (r *Runner) runPrepareWorkStep(ctx context.Context, input stepInput) (worke
 	if lockKey == "" {
 		if work.ExecutionMode == "push-existing" && work.Repo != "" && work.PRNumber > 0 {
 			lockKey = fmt.Sprintf("pr:%s:%d", work.Repo, work.PRNumber)
+		} else if work.IssueNumber > 0 {
+			lockKey = buildIssueLockKey(issueLookupRepo(work), work.IssueNumber)
 		} else {
 			lockKey = fmt.Sprintf("worker:%s", input.Loop.ID)
 		}
@@ -695,6 +737,7 @@ func (r *Runner) runPrepareWorkStep(ctx context.Context, input stepInput) (worke
 	checkpoint.ClaimedLockKey = lockKey
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	checkpoint.SkipReason = ""
+	r.syncIssueClaim(ctx, input, &checkpoint, issueClaimStatusRunning, "")
 	return checkpoint, nil
 }
 
@@ -873,6 +916,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		prURL := stringFromAnyDefault(parseJSONObject(input.Loop.MetadataJSON)["prUrl"])
 		checkpoint.PullRequest = &checkpointPullPR{Number: work.PRNumber, URL: prURL}
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		r.syncIssueClaim(ctx, input, &checkpoint, issueClaimStatusPRLinked, "")
 		return checkpoint, nil
 	}
 	if r.openPRStrategy == config.OpenPRStrategyManual {
@@ -901,6 +945,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		}
 		checkpoint.PullRequest = &checkpointPullPR{Number: existing.Number, URL: existing.URL}
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		r.syncIssueClaim(ctx, input, &checkpoint, issueClaimStatusPRLinked, "")
 		return checkpoint, nil
 	}
 	if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
@@ -913,6 +958,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		}
 		checkpoint.PullRequest = &checkpointPullPR{Number: existing.Number, URL: existing.URL}
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		r.syncIssueClaim(ctx, input, &checkpoint, issueClaimStatusPRLinked, "")
 		return checkpoint, nil
 	}
 	created, err := r.github.CreatePullRequest(ctx, CreatePullRequestInput{Repo: work.Repo, HeadBranch: worktree.Branch, BaseBranch: work.BaseBranch, Title: work.Title, Body: buildPullRequestBody(work, checkpoint.Plan, checkpoint.Execution), CWD: input.Project.RepoPath})
@@ -929,6 +975,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 	}
 	checkpoint.PullRequest = &pr
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
+	r.syncIssueClaim(ctx, input, &checkpoint, issueClaimStatusPRLinked, "")
 	return checkpoint, nil
 }
 
@@ -958,6 +1005,9 @@ func (r *Runner) resolveWorkerInput(ctx context.Context, project storage.Project
 	repo := firstNonEmpty(stringFromAnyDefault(source["repo"]), derefString(loop.Repo), stringFromAnyDefault(projectMetadata["repo"]))
 	baseBranch := firstNonEmpty(stringFromAnyDefault(source["baseBranch"]), stringFromAnyDefault(metadata["baseBranch"]), derefString(project.BaseBranch), "main")
 	work := workerInput{Title: firstNonEmpty(stringFromAnyDefault(source["title"]), "Worker run"), Prompt: stringFromAnyDefault(source["prompt"]), SpecPath: stringFromAnyDefault(source["specPath"]), Repo: repo, IssueRepo: stringFromAnyDefault(source["issueRepo"]), BaseBranch: baseBranch, ExecutionMode: executionMode, IssueNumber: int64FromAny(source["issueNumber"]), IssueURL: stringFromAnyDefault(source["issueUrl"]), PRNumber: int64FromAny(source["prNumber"]), Branch: stringFromAnyDefault(source["branch"]), HeadSHA: stringFromAnyDefault(source["headSha"]), Reviewers: stringSliceFromAny(source["reviewers"])}
+	if work.IssueNumber == 0 && loop.TargetType == "issue" {
+		work.IssueNumber = parseIssueNumberFromTargetID(derefString(loop.TargetID))
+	}
 	if work.Repo == "" {
 		return workerInput{}, &loopError{message: "worker.repo is required", kind: FailureNonRetryable}
 	}
@@ -1025,7 +1075,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	}
 	resumed := latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && startStep != stepPrepareWork
 	nowISO := r.nowISO()
-	encoded := mustMarshalJSON(workerCheckpoint{ResumePolicy: ternary(resumed, "advance_from_checkpoint", "replay_step"), Work: checkpoint.Work, ClaimedLockKey: checkpoint.ClaimedLockKey, Worktree: checkpoint.Worktree, Plan: checkpoint.Plan, Execution: checkpoint.Execution, Validation: checkpoint.Validation, PullRequest: checkpoint.PullRequest, SkipReason: checkpoint.SkipReason})
+	encoded := mustMarshalJSON(workerCheckpoint{ResumePolicy: ternary(resumed, "advance_from_checkpoint", "replay_step"), Work: checkpoint.Work, ClaimedLockKey: checkpoint.ClaimedLockKey, IssueClaim: checkpoint.IssueClaim, Worktree: checkpoint.Worktree, Plan: checkpoint.Plan, Execution: checkpoint.Execution, Validation: checkpoint.Validation, PullRequest: checkpoint.PullRequest, SkipReason: checkpoint.SkipReason})
 	run := storage.RunRecord{ID: eventlog.NewEventID("run"), LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(startStep)), LastCompletedStep: nil, CheckpointJSON: &encoded, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
 	if resumed && lastCompletedStep != "" {
 		value := string(lastCompletedStep)
@@ -1072,6 +1122,25 @@ func (r *Runner) persistStepCompleted(ctx context.Context, run storage.RunRecord
 		return storage.RunRecord{}, err
 	}
 	return updated, nil
+}
+
+func (r *Runner) persistCheckpoint(ctx context.Context, runID string, checkpoint workerCheckpoint) error {
+	if r.repos == nil || r.repos.Runs == nil {
+		return fmt.Errorf("runs repository is not configured")
+	}
+	run, err := r.repos.Runs.GetByID(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if run == nil {
+		return fmt.Errorf("run not found: %s", runID)
+	}
+	nowISO := r.nowISO()
+	encoded := mustMarshalJSON(checkpoint)
+	run.CheckpointJSON = &encoded
+	run.LastHeartbeatAt = &nowISO
+	run.UpdatedAt = nowISO
+	return r.repos.Runs.Upsert(ctx, *run)
 }
 
 func (r *Runner) completeRun(ctx context.Context, run storage.RunRecord, status, summary, errorMessage string, checkpoint workerCheckpoint) (storage.RunRecord, error) {
@@ -1219,6 +1288,91 @@ func (r *Runner) buildSuccessSummary(loop storage.LoopRecord, checkpoint workerC
 		return fmt.Sprintf("Opened pull request for worker %s: %s", loop.ID, checkpoint.PullRequest.URL)
 	}
 	return fmt.Sprintf("Completed worker %s", loop.ID)
+}
+
+const (
+	issueClaimStatusRunning  = "running"
+	issueClaimStatusPRLinked = "pr_linked"
+	issueClaimStatusSuccess  = "success"
+	issueClaimStatusFailed   = "failed"
+	issueClaimStatusPaused   = "paused"
+)
+
+func (r *Runner) syncIssueClaim(ctx context.Context, input stepInput, checkpoint *workerCheckpoint, status, summary string) {
+	if checkpoint == nil || checkpoint.Work == nil || checkpoint.Work.IssueNumber <= 0 || r.github == nil {
+		return
+	}
+	repo := issueLookupRepo(*checkpoint.Work)
+	if repo == "" {
+		return
+	}
+	body := buildIssueClaimCommentBody(input.Loop.ID, input.Run.ID, *checkpoint.Work, status, checkpoint.PullRequest, summary)
+	claim := checkpoint.IssueClaim
+	if claim == nil {
+		claim = &checkpointIssueClaim{Repo: repo, IssueNumber: checkpoint.Work.IssueNumber}
+		checkpoint.IssueClaim = claim
+	}
+	claim.Repo = repo
+	claim.IssueNumber = checkpoint.Work.IssueNumber
+	if claim.CommentID == 0 {
+		created, err := r.github.CreateIssueComment(ctx, IssueCommentInput{Repo: repo, IssueNumber: checkpoint.Work.IssueNumber, Body: body, CWD: input.Project.RepoPath})
+		if err != nil {
+			r.logWarn("worker issue claim comment create failed", map[string]any{"loopId": input.Loop.ID, "repo": repo, "issueNumber": checkpoint.Work.IssueNumber, "error": err.Error()})
+			return
+		}
+		claim.CommentID = created.ID
+		claim.CommentURL = created.URL
+		claim.Status = status
+		if err := r.persistCheckpoint(ctx, input.Run.ID, *checkpoint); err != nil {
+			r.logWarn("worker issue claim checkpoint persist failed", map[string]any{"loopId": input.Loop.ID, "runId": input.Run.ID, "error": err.Error()})
+		}
+		return
+	}
+	if err := r.github.UpdateIssueComment(ctx, UpdateIssueCommentInput{Repo: repo, CommentID: claim.CommentID, Body: body, CWD: input.Project.RepoPath}); err != nil {
+		r.logWarn("worker issue claim comment update failed", map[string]any{"loopId": input.Loop.ID, "repo": repo, "issueNumber": checkpoint.Work.IssueNumber, "commentId": claim.CommentID, "error": err.Error()})
+		return
+	}
+	claim.Status = status
+	if err := r.persistCheckpoint(ctx, input.Run.ID, *checkpoint); err != nil {
+		r.logWarn("worker issue claim checkpoint persist failed", map[string]any{"loopId": input.Loop.ID, "runId": input.Run.ID, "error": err.Error()})
+	}
+}
+
+func buildIssueClaimCommentBody(loopID, runID string, work workerInput, status string, pr *checkpointPullPR, summary string) string {
+	lines := []string{
+		fmt.Sprintf("<!-- looper:issue-claim loop:%s run:%s issue:%s -->", loopID, runID, formatIssueReference(issueLookupRepo(work), work.IssueNumber)),
+	}
+	switch status {
+	case issueClaimStatusPRLinked:
+		lines = append(lines, "Looper is working on this issue.")
+		if pr != nil && pr.URL != "" {
+			lines = append(lines, "", "Linked pull request: "+pr.URL)
+		}
+	case issueClaimStatusSuccess:
+		lines = append(lines, "Looper finished work on this issue.")
+		if pr != nil && pr.URL != "" {
+			lines = append(lines, "", "Pull request: "+pr.URL)
+		}
+	case issueClaimStatusFailed:
+		lines = append(lines, "Looper stopped work on this issue with a failure.")
+		if summary != "" {
+			lines = append(lines, "", "Latest status: "+summary)
+		}
+	case issueClaimStatusPaused:
+		lines = append(lines, "Looper paused work on this issue.")
+		if summary != "" {
+			lines = append(lines, "", "Latest status: "+summary)
+		}
+	default:
+		lines = append(lines, "Looper has claimed this issue and started work.")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (r *Runner) logWarn(message string, payload map[string]any) {
+	if r.logger != nil {
+		r.logger.Warn(message, payload)
+	}
 }
 
 func (r *Runner) notifyRunCompleted(ctx context.Context, input RunCompletedInput) {
@@ -1393,6 +1547,22 @@ func requireWorktree(checkpoint workerCheckpoint) (checkpointWorktree, error) {
 		return checkpointWorktree{}, &loopError{message: "missing worker worktree checkpoint", kind: FailureRetryableTransient}
 	}
 	return *checkpoint.Worktree, nil
+}
+
+func parseIssueNumberFromTargetID(targetID string) int64 {
+	parts := strings.Split(strings.TrimSpace(targetID), ":")
+	if len(parts) != 3 || parts[0] != "issue" {
+		return 0
+	}
+	value, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil || value <= 0 {
+		return 0
+	}
+	return value
+}
+
+func buildIssueLockKey(repo string, issueNumber int64) string {
+	return fmt.Sprintf("issue:%s:%d", strings.TrimSpace(repo), issueNumber)
 }
 
 func buildWorkerPrompt(repoRootPath string, work workerInput, plan *checkpointPlan, allowAgentPRCreation bool) (string, error) {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -225,6 +225,7 @@ type AgentResult struct {
 	Status       string
 	Summary      string
 	Stdout       string
+	ParseStatus  string
 	ChangedFiles []string
 	Commits      []string
 }
@@ -386,6 +387,7 @@ type checkpointPlan struct {
 type checkpointExecution struct {
 	Status       string   `json:"status,omitempty"`
 	Summary      string   `json:"summary,omitempty"`
+	ParseStatus  string   `json:"parseStatus,omitempty"`
 	ChangedFiles []string `json:"changedFiles,omitempty"`
 	Commits      []string `json:"commits,omitempty"`
 	Stdout       string   `json:"stdout,omitempty"`
@@ -414,6 +416,19 @@ type stepInput struct {
 type loopError struct {
 	message string
 	kind    QueueFailureKind
+}
+
+func validateCompletedExecutionCheckpoint(execution *checkpointExecution) error {
+	if execution == nil || execution.Status != "completed" {
+		return nil
+	}
+	if execution.ParseStatus == "parsed" {
+		return nil
+	}
+	return &loopError{
+		message: firstNonEmpty(execution.Summary, fmt.Sprintf("Worker agent completed without valid structured result (parse status: %s)", firstNonEmpty(execution.ParseStatus, "missing"))),
+		kind:    FailureRetryableTransient,
+	}
 }
 
 func (e *loopError) Error() string { return e.message }
@@ -590,6 +605,42 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		updated.NextRunAt = nil
 	}); err != nil {
 		return ProcessResult{}, err
+	}
+	if err := validateWorkerResumeCheckpoint(resumedRun.StartStep, checkpoint); err != nil {
+		failure := r.classifyFailure(err)
+		latest := r.getLatestCheckpoint(ctx, run, checkpoint)
+		if latest.ResumePolicy == "" {
+			latest.ResumePolicy = "replay_step"
+		}
+		if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
+			return ProcessResult{}, err
+		}
+		failedQueue, err := r.failQueueItem(ctx, queueItem, failure.kind, failure.message)
+		if err != nil {
+			return ProcessResult{}, err
+		}
+		if shouldNotifyCompletedRun(failure.kind, failedQueue) {
+			r.notifyRunCompleted(ctx, buildRunCompletedInput(*project, *loop, run, latest, "failed", failure.kind, failure.message))
+		}
+		if _, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
+			updated.LastRunAt = stringPtr(r.nowISO())
+			if updated.Status == "paused" {
+				updated.NextRunAt = nil
+			} else if failedQueue != nil && failedQueue.Status == "queued" {
+				updated.Status = "queued"
+				updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
+			} else {
+				if failure.kind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+					updated.Status = "paused"
+				} else {
+					updated.Status = "failed"
+				}
+				updated.NextRunAt = nil
+			}
+		}); err != nil {
+			return ProcessResult{}, err
+		}
+		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 	}
 
 	for _, step := range stepsFrom(resumedRun.StartStep) {
@@ -824,6 +875,9 @@ func (r *Runner) runPlanStep(input stepInput) (workerCheckpoint, error) {
 func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerCheckpoint, error) {
 	checkpoint := input.Checkpoint
 	if checkpoint.Execution != nil && checkpoint.Execution.Status == "completed" {
+		if err := validateCompletedExecutionCheckpoint(checkpoint.Execution); err != nil {
+			return checkpoint, err
+		}
 		return checkpoint, nil
 	}
 	if !r.allowAutoCommit {
@@ -858,7 +912,10 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 	if result.Status != "completed" {
 		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Worker agent %s", result.Status)), kind: FailureRetryableTransient}
 	}
-	checkpoint.Execution = &checkpointExecution{Status: result.Status, Summary: result.Summary, ChangedFiles: append([]string(nil), result.ChangedFiles...), Commits: append([]string(nil), result.Commits...), Stdout: result.Stdout}
+	if err := validateCompletedExecutionCheckpoint(&checkpointExecution{Status: result.Status, Summary: result.Summary, ParseStatus: result.ParseStatus}); err != nil {
+		return checkpoint, err
+	}
+	checkpoint.Execution = &checkpointExecution{Status: result.Status, Summary: result.Summary, ParseStatus: result.ParseStatus, ChangedFiles: append([]string(nil), result.ChangedFiles...), Commits: append([]string(nil), result.Commits...), Stdout: result.Stdout}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }
@@ -1053,6 +1110,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	}
 	checkpoint := workerCheckpoint{}
 	var lastCompletedStep WorkerStep
+	var failedStep WorkerStep
 	if latestRun != nil {
 		checkpoint, err = parseCheckpoint(latestRun.CheckpointJSON)
 		if err != nil {
@@ -1062,20 +1120,32 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		if derefString(latestRun.LastCompletedStep) != "" && lastCompletedStep == "" {
 			return resumedRunContext{}, fmt.Errorf("unknown worker last completed step %q", derefString(latestRun.LastCompletedStep))
 		}
+		failedStep = asWorkerStep(derefString(latestRun.CurrentStep))
 	}
 	startStep := stepPrepareWork
+	resumedCheckpoint := checkpoint
 	if latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && lastCompletedStep != "" {
-		if next := nextWorkerStep(lastCompletedStep); next != "" {
+		if shouldReplayExecuteOnResume(latestRun.Status, failedStep, checkpoint) {
+			startStep = stepExecute
+			resumedCheckpoint = rewindCheckpointForExecuteRetry(checkpoint)
+		} else if next := nextWorkerStep(lastCompletedStep); next != "" {
 			startStep = next
 		}
 	}
 	resumed := latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && startStep != stepPrepareWork
 	nowISO := r.nowISO()
-	encoded := mustMarshalJSON(workerCheckpoint{ResumePolicy: ternary(resumed, "advance_from_checkpoint", "replay_step"), Work: checkpoint.Work, ClaimedLockKey: checkpoint.ClaimedLockKey, IssueClaim: checkpoint.IssueClaim, Worktree: checkpoint.Worktree, Plan: checkpoint.Plan, Execution: checkpoint.Execution, Validation: checkpoint.Validation, PullRequest: checkpoint.PullRequest, SkipReason: checkpoint.SkipReason})
+	encoded := mustMarshalJSON(workerCheckpoint{ResumePolicy: ternary(resumed, "advance_from_checkpoint", "replay_step"), Work: resumedCheckpoint.Work, ClaimedLockKey: resumedCheckpoint.ClaimedLockKey, Worktree: resumedCheckpoint.Worktree, Plan: resumedCheckpoint.Plan, Execution: resumedCheckpoint.Execution, Validation: resumedCheckpoint.Validation, PullRequest: resumedCheckpoint.PullRequest, SkipReason: resumedCheckpoint.SkipReason})
 	run := storage.RunRecord{ID: eventlog.NewEventID("run"), LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(startStep)), LastCompletedStep: nil, CheckpointJSON: &encoded, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
-	if resumed && lastCompletedStep != "" {
-		value := string(lastCompletedStep)
-		run.LastCompletedStep = &value
+	if resumed {
+		if shouldReplayExecuteOnResume(latestRun.Status, failedStep, checkpoint) {
+			if prev := previousWorkerStep(startStep); prev != "" {
+				value := string(prev)
+				run.LastCompletedStep = &value
+			}
+		} else if lastCompletedStep != "" {
+			value := string(lastCompletedStep)
+			run.LastCompletedStep = &value
+		}
 	}
 	if err := r.repos.Runs.Upsert(ctx, run); err != nil {
 		return resumedRunContext{}, err
@@ -1305,6 +1375,12 @@ func (r *Runner) syncIssueClaim(ctx context.Context, input stepInput, checkpoint
 	body := buildIssueClaimCommentBody(input.Loop.ID, input.Run.ID, *checkpoint.Work, status, checkpoint.PullRequest, summary)
 	claim := checkpoint.IssueClaim
 	if claim == nil {
+		claim = r.findPreviousIssueClaim(ctx, input.Loop.ID, input.Run.ID, repo, checkpoint.Work.IssueNumber)
+		if claim != nil {
+			checkpoint.IssueClaim = claim
+		}
+	}
+	if claim == nil {
 		claim = &checkpointIssueClaim{Repo: repo, IssueNumber: checkpoint.Work.IssueNumber}
 		checkpoint.IssueClaim = claim
 	}
@@ -1332,6 +1408,31 @@ func (r *Runner) syncIssueClaim(ctx context.Context, input stepInput, checkpoint
 	if err := r.persistCheckpoint(ctx, input.Run.ID, *checkpoint); err != nil {
 		r.logWarn("worker issue claim checkpoint persist failed", map[string]any{"loopId": input.Loop.ID, "runId": input.Run.ID, "error": err.Error()})
 	}
+}
+
+func (r *Runner) findPreviousIssueClaim(ctx context.Context, loopID, currentRunID, repo string, issueNumber int64) *checkpointIssueClaim {
+	if r.repos == nil || r.repos.Runs == nil {
+		return nil
+	}
+	runs, err := r.repos.Runs.ListByLoop(ctx, loopID)
+	if err != nil {
+		return nil
+	}
+	for i := len(runs) - 1; i >= 0; i-- {
+		if runs[i].ID == currentRunID {
+			continue
+		}
+		checkpoint, err := parseCheckpoint(runs[i].CheckpointJSON)
+		if err != nil || checkpoint.IssueClaim == nil || checkpoint.IssueClaim.CommentID == 0 {
+			continue
+		}
+		if checkpoint.IssueClaim.IssueNumber != issueNumber || !strings.EqualFold(checkpoint.IssueClaim.Repo, repo) {
+			continue
+		}
+		claim := *checkpoint.IssueClaim
+		return &claim
+	}
+	return nil
 }
 
 func buildIssueClaimCommentBody(loopID, runID string, work workerInput, status string, pr *checkpointPullPR, summary string) string {
@@ -1524,6 +1625,24 @@ func nextWorkerStep(step WorkerStep) WorkerStep {
 	return ""
 }
 
+func previousWorkerStep(step WorkerStep) WorkerStep {
+	for i, candidate := range workerStepSequence {
+		if candidate == step && i > 0 {
+			return workerStepSequence[i-1]
+		}
+	}
+	return ""
+}
+
+func validateWorkerResumeCheckpoint(startStep WorkerStep, checkpoint workerCheckpoint) error {
+	switch startStep {
+	case stepValidate, stepOpenPR:
+		return validateCompletedExecutionCheckpoint(checkpoint.Execution)
+	default:
+		return nil
+	}
+}
+
 func asWorkerStep(value string) WorkerStep {
 	for _, candidate := range workerStepSequence {
 		if string(candidate) == value {
@@ -1549,6 +1668,26 @@ func requireWork(checkpoint workerCheckpoint) (workerInput, error) {
 		return workerInput{}, &loopError{message: "missing worker input checkpoint", kind: FailureRetryableTransient}
 	}
 	return *checkpoint.Work, nil
+}
+
+func shouldReplayExecuteOnResume(status string, failedStep WorkerStep, checkpoint workerCheckpoint) bool {
+	if status != "failed" && status != "interrupted" {
+		return false
+	}
+	switch failedStep {
+	case stepValidate, stepOpenPR:
+	default:
+		return false
+	}
+	return validateCompletedExecutionCheckpoint(checkpoint.Execution) != nil
+}
+
+func rewindCheckpointForExecuteRetry(checkpoint workerCheckpoint) workerCheckpoint {
+	checkpoint.Execution = nil
+	checkpoint.Validation = nil
+	checkpoint.PullRequest = nil
+	checkpoint.SkipReason = ""
+	return checkpoint
 }
 
 func requireWorktree(checkpoint workerCheckpoint) (checkpointWorktree, error) {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -383,6 +383,12 @@ func TestProcessClaimedItemResumesFromOpenPRAfterRetryableFailure(t *testing.T) 
 	if first.Status != "failed" || first.FailureKind != FailureRetryableAfterResume {
 		t.Fatalf("first = %#v, want retryable_after_resume failure", first)
 	}
+	if len(github.updateIssueCommentCalls) != 1 {
+		t.Fatalf("len(github.updateIssueCommentCalls) after retryable failure = %d, want 1 non-terminal refresh", len(github.updateIssueCommentCalls))
+	}
+	if body := github.updateIssueCommentCalls[0].Body; !strings.Contains(body, "started work") || strings.Contains(body, "stopped work") || strings.Contains(body, "paused work") {
+		t.Fatalf("retryable issue comment body = %q, want in-progress status without terminal failure text", body)
+	}
 	fixture.advance(5 * time.Second)
 	claim2, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
 	second, err := runner.ProcessClaimedItem(context.Background(), *claim2)

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -43,7 +43,7 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
-	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}
+	github := &fakeGitHubGateway{issueCommentResult: IssueCommentResult{ID: 501, URL: "https://example/issues/27#issuecomment-501"}, createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
@@ -78,6 +78,24 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	}
 	if len(agent.starts) != 1 || len(git.pushCalls) != 1 || len(github.createPRCalls) != 1 {
 		t.Fatalf("agent starts=%d push=%d createPR=%d, want 1/1/1", len(agent.starts), len(git.pushCalls), len(github.createPRCalls))
+	}
+	if len(github.createIssueCommentCalls) != 1 {
+		t.Fatalf("len(github.createIssueCommentCalls) = %d, want 1", len(github.createIssueCommentCalls))
+	}
+	if len(github.updateIssueCommentCalls) != 2 {
+		t.Fatalf("len(github.updateIssueCommentCalls) = %d, want 2", len(github.updateIssueCommentCalls))
+	}
+	if github.createIssueCommentCalls[0].Repo != "acme/looper" || github.createIssueCommentCalls[0].IssueNumber != 27 {
+		t.Fatalf("issue comment call = %#v, want acme/looper#27", github.createIssueCommentCalls[0])
+	}
+	if !strings.Contains(github.createIssueCommentCalls[0].Body, "started work") {
+		t.Fatalf("create issue comment body = %q, want running marker text", github.createIssueCommentCalls[0].Body)
+	}
+	if !strings.Contains(github.updateIssueCommentCalls[0].Body, "Linked pull request: https://example/pr/101") {
+		t.Fatalf("open-pr issue comment body = %q, want linked PR", github.updateIssueCommentCalls[0].Body)
+	}
+	if !strings.Contains(github.updateIssueCommentCalls[1].Body, "finished work") {
+		t.Fatalf("terminal issue comment body = %q, want success marker text", github.updateIssueCommentCalls[1].Body)
 	}
 	if len(completed) != 1 {
 		t.Fatalf("len(completed) = %d, want 1", len(completed))
@@ -115,6 +133,42 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	}
 	if lock != nil {
 		t.Fatalf("lock = %#v, want prepare-work lock released after successful run", lock)
+	}
+}
+
+func TestProcessClaimedItemUsesIssueScopedLockForIssueWork(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{
+		DB:              fixture.coordinator.DB(),
+		Repos:           fixture.repos,
+		GitHub:          &fakeGitHubGateway{issueCommentResult: IssueCommentResult{ID: 501}},
+		Git:             &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}},
+		AgentExecutor:   &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done"}}},
+		Logger:          fixture.logger,
+		Now:             fixture.now,
+		AllowAutoCommit: true,
+		AllowAutoPush:   false,
+		OpenPRStrategy:  config.OpenPRStrategyAllDone,
+	})
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped after manual PR gating", result)
+	}
+	lock, err := fixture.repos.Locks.Get(context.Background(), "issue:acme/looper:27")
+	if err != nil {
+		t.Fatalf("Locks.Get() error = %v", err)
+	}
+	if lock != nil {
+		t.Fatalf("lock = %#v, want issue lock released", lock)
 	}
 }
 
@@ -313,7 +367,7 @@ func TestProcessClaimedItemResumesFromOpenPRAfterRetryableFailure(t *testing.T) 
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
-	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}, createPRErrors: []error{fmt.Errorf("temporary create pr failure")}}
+	github := &fakeGitHubGateway{issueCommentResult: IssueCommentResult{ID: 501}, createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}, createPRErrors: []error{fmt.Errorf("temporary create pr failure")}}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
 	started := make([]AgentExecutionStartedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, OnAgentExecutionStarted: func(_ context.Context, input AgentExecutionStartedInput) error {
@@ -349,6 +403,9 @@ func TestProcessClaimedItemResumesFromOpenPRAfterRetryableFailure(t *testing.T) 
 	}
 	if len(github.createPRCalls) != 2 {
 		t.Fatalf("len(github.createPRCalls) = %d, want 2", len(github.createPRCalls))
+	}
+	if len(github.createIssueCommentCalls) != 1 {
+		t.Fatalf("len(github.createIssueCommentCalls) = %d, want 1 running marker across resume", len(github.createIssueCommentCalls))
 	}
 }
 
@@ -400,7 +457,7 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
-	github := &fakeGitHubGateway{}
+	github := &fakeGitHubGateway{issueCommentResult: IssueCommentResult{ID: 501}}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, ValidationRunner: func(context.Context, ValidationInput) (ValidationResult, error) {
@@ -423,6 +480,9 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 	}
 	if completed[0].Status != "failed" || completed[0].FailureKind != FailureManualIntervention || completed[0].Summary != "Validation failed" {
 		t.Fatalf("completed[0] = %#v, want manual intervention completion notice", completed[0])
+	}
+	if len(github.updateIssueCommentCalls) == 0 || !strings.Contains(github.updateIssueCommentCalls[len(github.updateIssueCommentCalls)-1].Body, "paused work") {
+		t.Fatalf("terminal issue comment updates = %#v, want paused marker body", github.updateIssueCommentCalls)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
 	if err != nil {
@@ -766,7 +826,7 @@ func TestProcessClaimedItemPullRequestLoopRequiresSpecPath(t *testing.T) {
 func TestProcessClaimedItemFindsExistingPRAfterPush(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	branch := buildWorkerBranchName(workerInput{Title: "Implement worker loop", Repo: "acme/looper", BaseBranch: "main", ExecutionMode: "create-pr"}, "loop_worker_1")
+	branch := buildWorkerBranchName(workerInput{Title: "Implement worker loop", Repo: "acme/looper", BaseBranch: "main", ExecutionMode: "create-pr", IssueNumber: 27}, "loop_worker_1")
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: branch, BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{openPRResponses: [][]PullRequestSummary{{}, {{Number: 201, URL: "https://example/pr/201", State: "OPEN", HeadRefName: branch, BaseRefName: "main"}}}}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
@@ -881,15 +941,16 @@ func newRunnerFixture(t *testing.T) *runnerFixture {
 	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(t.TempDir(), "repo"), BaseBranch: &baseBranch, MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Projects.Upsert() error = %v", err)
 	}
-	loopTarget := "project:project_1"
-	loopMetadata := `{"worker":{"title":"Implement worker loop","prompt":"Do the thing","repo":"acme/looper","baseBranch":"main"}}`
-	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_1", Seq: 1, ProjectID: "project_1", Type: "worker", TargetType: "project", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), Status: "queued", MetadataJSON: &loopMetadata, NextRunAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+	loopTarget := "issue:acme/looper:27"
+	loopMetadata := `{"worker":{"title":"Implement worker loop","repo":"acme/looper","issueNumber":27,"baseBranch":"main"}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_1", Seq: 1, ProjectID: "project_1", Type: "worker", TargetType: "issue", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), Status: "queued", MetadataJSON: &loopMetadata, NextRunAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	projectID := "project_1"
 	loopID := "loop_worker_1"
-	payload := `{"title":"Implement worker loop","prompt":"Do the thing","repo":"acme/looper","baseBranch":"main"}`
-	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_1", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: "project:project_1", Repo: stringPtr("acme/looper"), DedupeKey: "worker:loop_worker_1", Priority: 1, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+	payload := `{"title":"Implement worker loop","repo":"acme/looper","issueNumber":27,"baseBranch":"main"}`
+	lockKey := "issue:acme/looper:27"
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_1", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "issue", TargetID: lockKey, Repo: stringPtr("acme/looper"), DedupeKey: "worker:project_1:acme/looper:27", Priority: 1, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, LockKey: &lockKey, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
 	fixture := &runnerFixture{coordinator: coordinator, repos: repos, logger: &testLogger{}, current: now}
@@ -904,18 +965,21 @@ func (f *runnerFixture) nowISO() string {
 func (f *runnerFixture) advance(delta time.Duration) { f.current = f.current.Add(delta) }
 
 type fakeGitHubGateway struct {
-	openPRs         []PullRequestSummary
-	openPRResponses [][]PullRequestSummary
-	openPRIndex     int
-	prDetail        PullRequestDetail
-	issueDetail     IssueDetail
-	viewIssueCalls  []ViewIssueInput
-	createPRResult  CreatePullRequestResult
-	createPRErrors  []error
-	createPRCalls   []CreatePullRequestInput
-	removeLabels    []PullRequestLabelsInput
-	reviewerCalls   []PullRequestReviewersInput
-	createPRIndex   int
+	openPRs                 []PullRequestSummary
+	openPRResponses         [][]PullRequestSummary
+	openPRIndex             int
+	prDetail                PullRequestDetail
+	issueDetail             IssueDetail
+	viewIssueCalls          []ViewIssueInput
+	createIssueCommentCalls []IssueCommentInput
+	updateIssueCommentCalls []UpdateIssueCommentInput
+	issueCommentResult      IssueCommentResult
+	createPRResult          CreatePullRequestResult
+	createPRErrors          []error
+	createPRCalls           []CreatePullRequestInput
+	removeLabels            []PullRequestLabelsInput
+	reviewerCalls           []PullRequestReviewersInput
+	createPRIndex           int
 }
 
 func (f *fakeGitHubGateway) ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
@@ -957,6 +1021,19 @@ func (f *fakeGitHubGateway) ViewIssue(_ context.Context, input ViewIssueInput) (
 		detail.Title = "Issue"
 	}
 	return detail, nil
+}
+
+func (f *fakeGitHubGateway) CreateIssueComment(_ context.Context, input IssueCommentInput) (IssueCommentResult, error) {
+	f.createIssueCommentCalls = append(f.createIssueCommentCalls, input)
+	if f.issueCommentResult.ID == 0 {
+		return IssueCommentResult{ID: 1}, nil
+	}
+	return f.issueCommentResult, nil
+}
+
+func (f *fakeGitHubGateway) UpdateIssueComment(_ context.Context, input UpdateIssueCommentInput) error {
+	f.updateIssueCommentCalls = append(f.updateIssueCommentCalls, input)
+	return nil
 }
 
 func (f *fakeGitHubGateway) CreatePullRequest(_ context.Context, input CreatePullRequestInput) (CreatePullRequestResult, error) {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -43,8 +44,8 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
-	github := &fakeGitHubGateway{issueCommentResult: IssueCommentResult{ID: 501, URL: "https://example/issues/27#issuecomment-501"}, createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
 		queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
@@ -78,24 +79,6 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	}
 	if len(agent.starts) != 1 || len(git.pushCalls) != 1 || len(github.createPRCalls) != 1 {
 		t.Fatalf("agent starts=%d push=%d createPR=%d, want 1/1/1", len(agent.starts), len(git.pushCalls), len(github.createPRCalls))
-	}
-	if len(github.createIssueCommentCalls) != 1 {
-		t.Fatalf("len(github.createIssueCommentCalls) = %d, want 1", len(github.createIssueCommentCalls))
-	}
-	if len(github.updateIssueCommentCalls) != 2 {
-		t.Fatalf("len(github.updateIssueCommentCalls) = %d, want 2", len(github.updateIssueCommentCalls))
-	}
-	if github.createIssueCommentCalls[0].Repo != "acme/looper" || github.createIssueCommentCalls[0].IssueNumber != 27 {
-		t.Fatalf("issue comment call = %#v, want acme/looper#27", github.createIssueCommentCalls[0])
-	}
-	if !strings.Contains(github.createIssueCommentCalls[0].Body, "started work") {
-		t.Fatalf("create issue comment body = %q, want running marker text", github.createIssueCommentCalls[0].Body)
-	}
-	if !strings.Contains(github.updateIssueCommentCalls[0].Body, "Linked pull request: https://example/pr/101") {
-		t.Fatalf("open-pr issue comment body = %q, want linked PR", github.updateIssueCommentCalls[0].Body)
-	}
-	if !strings.Contains(github.updateIssueCommentCalls[1].Body, "finished work") {
-		t.Fatalf("terminal issue comment body = %q, want success marker text", github.updateIssueCommentCalls[1].Body)
 	}
 	if len(completed) != 1 {
 		t.Fatalf("len(completed) = %d, want 1", len(completed))
@@ -136,21 +119,21 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	}
 }
 
-func TestProcessClaimedItemUsesIssueScopedLockForIssueWork(t *testing.T) {
+func TestProcessClaimedItemFailsWhenAgentCompletionResultMissing(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	runner := New(Options{
-		DB:              fixture.coordinator.DB(),
-		Repos:           fixture.repos,
-		GitHub:          &fakeGitHubGateway{issueCommentResult: IssueCommentResult{ID: 501}},
-		Git:             &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}},
-		AgentExecutor:   &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done"}}},
-		Logger:          fixture.logger,
-		Now:             fixture.now,
-		AllowAutoCommit: true,
-		AllowAutoPush:   false,
-		OpenPRStrategy:  config.OpenPRStrategyAllDone,
-	})
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "upstream server_error", Stdout: "server_error", ParseStatus: "missing"}}}
+	validationCalls := 0
+	completed := make([]RunCompletedInput, 0, 1)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, ValidationRunner: func(context.Context, ValidationInput) (ValidationResult, error) {
+		validationCalls++
+		return ValidationResult{Passed: true, Summary: "ok"}, nil
+	}, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
+		completed = append(completed, input)
+		return nil
+	}})
 
 	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
 	if err != nil || claim == nil {
@@ -160,15 +143,197 @@ func TestProcessClaimedItemUsesIssueScopedLockForIssueWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "skipped" {
-		t.Fatalf("result = %#v, want skipped after manual PR gating", result)
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient || !strings.Contains(result.Summary, "server_error") {
+		t.Fatalf("result = %#v, want retryable failed result with upstream error", result)
 	}
-	lock, err := fixture.repos.Locks.Get(context.Background(), "issue:acme/looper:27")
+	if validationCalls != 0 {
+		t.Fatalf("validationCalls = %d, want execute failure to stop before validation", validationCalls)
+	}
+	if len(git.pushCalls) != 0 || len(github.createPRCalls) != 0 {
+		t.Fatalf("push calls=%d createPR calls=%d, want 0/0 after invalid agent completion", len(git.pushCalls), len(github.createPRCalls))
+	}
+	if len(completed) != 0 {
+		t.Fatalf("len(completed) = %d, want no completion notification for retryable failure", len(completed))
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
 	if err != nil {
-		t.Fatalf("Locks.Get() error = %v", err)
+		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if lock != nil {
-		t.Fatalf("lock = %#v, want issue lock released", lock)
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued loop for retryable failure", loop)
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	if run == nil || run.Status != "failed" || run.CurrentStep == nil || *run.CurrentStep != string(stepExecute) {
+		t.Fatalf("run = %#v, want failed run at execute step", run)
+	}
+	if run.LastCompletedStep != nil && *run.LastCompletedStep == string(stepOpenPR) {
+		t.Fatalf("run = %#v, want open-pr to remain incomplete", run)
+	}
+}
+
+func TestRunExecuteStepFailsResumedCompletedCheckpointWithoutParsedResult(t *testing.T) {
+	t.Parallel()
+
+	runner := New(Options{})
+	checkpoint, err := runner.runExecuteStep(context.Background(), stepInput{
+		Checkpoint: workerCheckpoint{
+			Execution: &checkpointExecution{
+				Status:      "completed",
+				Summary:     "upstream server_error",
+				ParseStatus: "",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatalf("runExecuteStep() error = nil, want parse-status failure")
+	}
+	if checkpoint.Execution == nil || checkpoint.Execution.Status != "completed" {
+		t.Fatalf("checkpoint.Execution = %#v, want completed checkpoint preserved", checkpoint.Execution)
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableTransient)
+	}
+	if !strings.Contains(err.Error(), "server_error") {
+		t.Fatalf("error = %q, want upstream summary", err.Error())
+	}
+}
+
+func TestCreateRunContextReplaysExecuteWhenResumeCheckpointParseStatusIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	checkpointJSON := mustMarshalJSON(workerCheckpoint{
+		Work:           &workerInput{Title: "Worker task"},
+		ClaimedLockKey: "worker:loop_worker_1",
+		Worktree:       &checkpointWorktree{ID: "wt_1", Path: filepath.Join(t.TempDir(), "wt"), Branch: "feature/test"},
+		Plan:           &checkpointPlan{Summary: "plan"},
+		Execution:      &checkpointExecution{Status: "completed", Summary: "upstream server_error"},
+		Validation:     &ValidationResult{Passed: true, Summary: "stale"},
+		PullRequest:    &checkpointPullPR{Number: 101, URL: "https://example/pr/101"},
+		SkipReason:     "stale skip reason",
+	})
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:                "run_failed_after_validate",
+		LoopID:            "loop_worker_1",
+		Status:            "failed",
+		CurrentStep:       stringPtr(string(stepValidate)),
+		LastCompletedStep: stringPtr(string(stepExecute)),
+		CheckpointJSON:    &checkpointJSON,
+		StartedAt:         fixture.nowISO(),
+		CreatedAt:         fixture.nowISO(),
+		UpdatedAt:         fixture.nowISO(),
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil {
+		t.Fatal("loop = nil, want worker loop")
+	}
+
+	resumed, err := runner.createRunContext(context.Background(), *loop)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if !resumed.Resumed || resumed.StartStep != stepExecute {
+		t.Fatalf("resumed = %#v, want resumed execute replay", resumed)
+	}
+	if resumed.Checkpoint.Execution != nil {
+		t.Fatalf("Execution = %#v, want cleared execution checkpoint", resumed.Checkpoint.Execution)
+	}
+	if resumed.Checkpoint.Validation != nil {
+		t.Fatalf("Validation = %#v, want cleared validation checkpoint", resumed.Checkpoint.Validation)
+	}
+	if resumed.Checkpoint.PullRequest != nil {
+		t.Fatalf("PullRequest = %#v, want cleared pull request checkpoint", resumed.Checkpoint.PullRequest)
+	}
+	if resumed.Checkpoint.SkipReason != "" {
+		t.Fatalf("SkipReason = %q, want cleared skip reason", resumed.Checkpoint.SkipReason)
+	}
+	if resumed.Checkpoint.Worktree == nil || resumed.Checkpoint.Plan == nil {
+		t.Fatalf("checkpoint = %#v, want preserved worktree and plan", resumed.Checkpoint)
+	}
+	if resumed.Run.LastCompletedStep == nil || *resumed.Run.LastCompletedStep != string(stepPlan) {
+		t.Fatalf("run.LastCompletedStep = %#v, want plan", resumed.Run.LastCompletedStep)
+	}
+}
+
+func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	checkpointJSON := mustMarshalJSON(workerCheckpoint{
+		Execution: &checkpointExecution{
+			Status:      "completed",
+			Summary:     "upstream server_error",
+			ParseStatus: "",
+		},
+	})
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:                "run_failed_after_execute",
+		LoopID:            "loop_worker_1",
+		Status:            "failed",
+		LastCompletedStep: stringPtr(string(stepExecute)),
+		CheckpointJSON:    &checkpointJSON,
+		StartedAt:         fixture.nowISO(),
+		CreatedAt:         fixture.nowISO(),
+		UpdatedAt:         fixture.nowISO(),
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil {
+		t.Fatal("queue = nil, want queue record")
+	}
+	queue.MaxAttempts = 1
+	if err := fixture.repos.Queue.Upsert(context.Background(), *queue); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	if err != nil {
+		t.Fatalf("ClaimNextOfType() error = %v", err)
+	}
+	if claim == nil {
+		t.Fatal("claim = nil, want claimed queue item")
+	}
+
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "failed" || result.FailureKind != FailureRetryableTransient {
+		t.Fatalf("result = %#v, want failed retryable_transient result", result)
+	}
+
+	queue, err = fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "failed" {
+		t.Fatalf("queue = %#v, want failed terminal queue item", queue)
+	}
+
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want failed terminal loop", loop)
 	}
 }
 
@@ -367,8 +532,8 @@ func TestProcessClaimedItemResumesFromOpenPRAfterRetryableFailure(t *testing.T) 
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
-	github := &fakeGitHubGateway{issueCommentResult: IssueCommentResult{ID: 501}, createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}, createPRErrors: []error{fmt.Errorf("temporary create pr failure")}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}, createPRErrors: []error{fmt.Errorf("temporary create pr failure")}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	started := make([]AgentExecutionStartedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, OnAgentExecutionStarted: func(_ context.Context, input AgentExecutionStartedInput) error {
 		started = append(started, input)
@@ -463,8 +628,8 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
-	github := &fakeGitHubGateway{issueCommentResult: IssueCommentResult{ID: 501}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	github := &fakeGitHubGateway{}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, ValidationRunner: func(context.Context, ValidationInput) (ValidationResult, error) {
 		return ValidationResult{Passed: false, Summary: "Validation failed"}, nil
@@ -509,7 +674,7 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 func TestProcessClaimedItemPreservesPausedLoopOnRetryableFailureAfterPause(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}, wait: func(ctx context.Context) error {
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}, wait: func(ctx context.Context) error {
 		loopID := ""
 		items, err := fixture.repos.Queue.List(ctx)
 		if err != nil {
@@ -694,7 +859,7 @@ func TestProcessClaimedItemSkippedFlowEmitsCompletionNotification(t *testing.T) 
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: false, OpenPRStrategy: config.OpenPRStrategyAllDone, OnRunCompleted: func(_ context.Context, input RunCompletedInput) error {
 		completed = append(completed, input)
@@ -718,7 +883,7 @@ func TestProcessClaimedItemSkipsAutoPROpenWhenGitHubCLIUnavailable(t *testing.T)
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	completed := make([]RunCompletedInput, 0, 1)
 	githubCLIAvailable := false
 	runner := New(Options{
@@ -760,7 +925,7 @@ func TestProcessClaimedItemRechecksGitHubCLIAvailabilityAtRunTime(t *testing.T) 
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	checkCalls := 0
 	runner := New(Options{
 		DB:                 fixture.coordinator.DB(),
@@ -835,7 +1000,7 @@ func TestProcessClaimedItemFindsExistingPRAfterPush(t *testing.T) {
 	branch := buildWorkerBranchName(workerInput{Title: "Implement worker loop", Repo: "acme/looper", BaseBranch: "main", ExecutionMode: "create-pr", IssueNumber: 27}, "loop_worker_1")
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: branch, BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{openPRResponses: [][]PullRequestSummary{{}, {{Number: 201, URL: "https://example/pr/201", State: "OPEN", HeadRefName: branch, BaseRefName: "main"}}}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
 
 	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
@@ -856,7 +1021,7 @@ func TestProcessClaimedItemFailsWhenCreatedPRNumberIsMissing(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
 	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 0, URL: "https://example/pr/unparsed"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
 
 	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
@@ -876,6 +1041,42 @@ func TestProcessClaimedItemFailsWhenCreatedPRNumberIsMissing(t *testing.T) {
 	}
 	if loop == nil || (loop.MetadataJSON != nil && strings.Contains(*loop.MetadataJSON, `"prNumber":0`)) {
 		t.Fatalf("loop = %#v, want no persisted PR number 0", loop)
+	}
+}
+
+func TestProcessClaimedItemUsesIssueScopedLockForIssueWork(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{
+		DB:              fixture.coordinator.DB(),
+		Repos:           fixture.repos,
+		GitHub:          &fakeGitHubGateway{issueCommentResult: IssueCommentResult{ID: 501}},
+		Git:             &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}},
+		AgentExecutor:   &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", ParseStatus: "parsed"}}},
+		Logger:          fixture.logger,
+		Now:             fixture.now,
+		AllowAutoCommit: true,
+		AllowAutoPush:   false,
+		OpenPRStrategy:  config.OpenPRStrategyAllDone,
+	})
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped after manual PR gating", result)
+	}
+	lock, err := fixture.repos.Locks.Get(context.Background(), "issue:acme/looper:27")
+	if err != nil {
+		t.Fatalf("Locks.Get() error = %v", err)
+	}
+	if lock != nil {
+		t.Fatalf("lock = %#v, want issue lock released", lock)
 	}
 }
 
@@ -1107,7 +1308,7 @@ type fakeAgentExecutor struct {
 
 func (f *fakeAgentExecutor) Start(_ context.Context, input AgentRunInput) (AgentExecution, error) {
 	f.starts = append(f.starts, input)
-	result := AgentResult{Status: "completed", Summary: "done"}
+	result := AgentResult{Status: "completed", Summary: "done", ParseStatus: "parsed"}
 	if f.index < len(f.results) {
 		result = f.results[f.index]
 	}


### PR DESCRIPTION
## Summary
- make worker loops and recovery queue items use issue-scoped targets and `issue:<repo>:<n>` locks for `work --issue` flows
- add best-effort GitHub issue claim comments that are created when execution actually starts, then edited in place when a PR is linked and when the worker reaches a terminal state
- extend the GitHub gateway and runtime adapters with issue comment create/update support, and cover the new worker lifecycle with gateway, runtime, API, and worker tests

## Why
`looper work --issue <n>` already had internal loop/run state, but it did not expose any GitHub-side visibility that the issue had been claimed. This change keeps the internal lock/checkpoint state authoritative while adding a short-lived advisory marker that prevents duplicate-looking work and gives humans a clear in-progress signal before a PR appears.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #60