### PR TITLE
feat: add install, upgrade, and versioning flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,7 +304,12 @@ jobs:
           assert m["version"] == os.environ["EXPECTED_VERSION"], f"version mismatch: {m['version']}"
           assert m["channel"] == os.environ["EXPECTED_CHANNEL"], f"channel mismatch: {m['channel']}"
           assert m["apiVersion"] == "v1", f"apiVersion mismatch: {m['apiVersion']}"
-          assert m["schemaVersion"] == "0007_agent_execution_run_index", f"schemaVersion mismatch: {m['schemaVersion']}"
+          migration_files = sorted(
+              name for name in os.listdir("internal/storage/migrations")
+              if name.endswith(".sql")
+          )
+          expected_schema_version = migration_files[-1].removesuffix(".sql")
+          assert m["schemaVersion"] == expected_schema_version, f"schemaVersion mismatch: {m['schemaVersion']}"
           assert m["minCliForDaemon"], "minCliForDaemon missing"
           assert m["minDaemonForCli"], "minDaemonForCli missing"
           required = {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
 
     outputs:
       release-version: ${{ steps.release-version.outputs.value }}
+      release-channel: ${{ steps.release-version.outputs.channel }}
+      release-prerelease: ${{ steps.release-version.outputs.prerelease }}
+      release-timestamp: ${{ steps.release-version.outputs.released }}
 
     steps:
       - name: Check out repository
@@ -41,29 +44,37 @@ jobs:
       - name: Test
         run: go test ./...
 
+      - name: Read release version and channel from tag
+        id: release-version
+        run: |
+          tag_name="${{ github.ref_name }}"
+          if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Tag must match vMAJOR.MINOR.PATCH[-PRERELEASE]: ${tag_name}" >&2
+            exit 1
+          fi
+          release_version="${tag_name#v}"
+          channel="stable"
+          prerelease="false"
+          if [[ "$release_version" == *-* ]]; then
+            channel="beta"
+            prerelease="true"
+          fi
+          released="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "value=${release_version}" >> "$GITHUB_OUTPUT"
+          echo "channel=${channel}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
+          echo "released=${released}" >> "$GITHUB_OUTPUT"
+
       - name: Build
         env:
           LOOPER_BUILD_GIT_SHA: ${{ github.sha }}
+          LOOPER_BUILD_VERSION: ${{ steps.release-version.outputs.value }}
+          LOOPER_BUILD_VERSION_SOURCE: git-tag:${{ github.ref_name }}
+          LOOPER_BUILD_CHANNEL: ${{ steps.release-version.outputs.channel }}
+          LOOPER_BUILD_API_VERSION: v1
         run: |
           export LOOPER_BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           go build -ldflags "$(go run ./tools/go-build-flags)" ./...
-
-      - name: Read Go release version
-        id: release-version
-        run: |
-          release_version="$(go run ./cmd/looper --version)"
-          echo "value=${release_version}" >> "$GITHUB_OUTPUT"
-
-      - name: Verify tag matches Go release version
-        env:
-          TAG_NAME: ${{ github.ref_name }}
-          RELEASE_VERSION: ${{ steps.release-version.outputs.value }}
-        run: |
-          expected_tag="v${RELEASE_VERSION}"
-          if [ "$TAG_NAME" != "$expected_tag" ]; then
-            echo "Release tag ${TAG_NAME} does not match Go release version ${RELEASE_VERSION}." >&2
-            exit 1
-          fi
 
   create-draft-release:
     needs: prepare-go-release
@@ -76,6 +87,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: Looper ${{ github.ref_name }}
           draft: true
+          prerelease: ${{ needs.prepare-go-release.outputs.release-prerelease }}
           generate_release_notes: true
 
   build-looper:
@@ -112,6 +124,10 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           LOOPER_BUILD_GIT_SHA: ${{ github.sha }}
+          LOOPER_BUILD_VERSION: ${{ needs.prepare-go-release.outputs.release-version }}
+          LOOPER_BUILD_VERSION_SOURCE: git-tag:${{ github.ref_name }}
+          LOOPER_BUILD_CHANNEL: ${{ needs.prepare-go-release.outputs.release-channel }}
+          LOOPER_BUILD_API_VERSION: v1
         run: |
           export LOOPER_BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           mkdir -p dist/release
@@ -119,6 +135,17 @@ jobs:
 
       - name: Verify built binary exists
         run: test -f "dist/release/${{ matrix.artifact-name }}"
+
+      - name: Verify looper binary version
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare-go-release.outputs.release-version }}
+        run: |
+          artifact_path="dist/release/${{ matrix.artifact-name }}"
+          actual_version=$("$artifact_path" --version)
+          if [ "$actual_version" != "$EXPECTED_VERSION" ]; then
+            echo "Expected $artifact_path --version to print ${EXPECTED_VERSION}, got ${actual_version}." >&2
+            exit 1
+          fi
 
       - name: Generate and verify SHA-256 checksum
         working-directory: dist/release
@@ -169,6 +196,10 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           LOOPER_BUILD_GIT_SHA: ${{ github.sha }}
+          LOOPER_BUILD_VERSION: ${{ needs.prepare-go-release.outputs.release-version }}
+          LOOPER_BUILD_VERSION_SOURCE: git-tag:${{ github.ref_name }}
+          LOOPER_BUILD_CHANNEL: ${{ needs.prepare-go-release.outputs.release-channel }}
+          LOOPER_BUILD_API_VERSION: v1
         run: |
           export LOOPER_BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           mkdir -p dist/release
@@ -207,6 +238,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Download compiled artifacts
         uses: actions/download-artifact@v4
         with:
@@ -232,12 +271,59 @@ jobs:
             exit 1
           fi
 
+      - name: Generate release manifest
+        run: |
+          go run ./tools/release-manifest \
+            -tag "${{ github.ref_name }}" \
+            -version "${{ needs.prepare-go-release.outputs.release-version }}" \
+            -released "${{ needs.prepare-go-release.outputs.release-timestamp }}" \
+            -channel "${{ needs.prepare-go-release.outputs.release-channel }}" \
+            -api-version v1 \
+            -min-cli-for-daemon "0.2.0" \
+            -min-daemon-for-cli "0.2.0" \
+            -assets-dir release-assets \
+            -required-assets "looper-darwin-arm64,looper-darwin-x64,looperd-darwin-arm64,looperd-darwin-x64" \
+            -output release-assets/manifest.json
+
+      - name: Validate release manifest fields
+        env:
+          EXPECTED_TAG: ${{ github.ref_name }}
+          EXPECTED_VERSION: ${{ needs.prepare-go-release.outputs.release-version }}
+          EXPECTED_CHANNEL: ${{ needs.prepare-go-release.outputs.release-channel }}
+        run: |
+          python3 - <<'PY'
+          import json, os
+          with open("release-assets/manifest.json", "r", encoding="utf-8") as f:
+              m = json.load(f)
+          assert m["manifestVersion"] == 1, f"manifestVersion mismatch: {m['manifestVersion']}"
+          assert m["tag"] == os.environ["EXPECTED_TAG"], f"tag mismatch: {m['tag']}"
+          assert m["version"] == os.environ["EXPECTED_VERSION"], f"version mismatch: {m['version']}"
+          assert m["channel"] == os.environ["EXPECTED_CHANNEL"], f"channel mismatch: {m['channel']}"
+          assert m["apiVersion"] == "v1", f"apiVersion mismatch: {m['apiVersion']}"
+          assert m["schemaVersion"] == "0007_agent_execution_run_index", f"schemaVersion mismatch: {m['schemaVersion']}"
+          assert m["minCliForDaemon"], "minCliForDaemon missing"
+          assert m["minDaemonForCli"], "minDaemonForCli missing"
+          required = {
+              "looper-darwin-arm64",
+              "looper-darwin-x64",
+              "looperd-darwin-arm64",
+              "looperd-darwin-x64",
+          }
+          assert required.issubset(set(m["artifacts"].keys())), "manifest missing artifacts"
+          for name in required:
+              artifact = m["artifacts"][name]
+              assert artifact["url"].endswith(f"/{os.environ['EXPECTED_TAG']}/{name}"), f"artifact URL mismatch for {name}: {artifact['url']}"
+              sha = artifact["sha256"]
+              assert len(sha) == 64 and all(c in "0123456789abcdef" for c in sha), f"artifact sha mismatch for {name}: {sha}"
+          PY
+
       - name: Publish GitHub release with assets
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: Looper ${{ github.ref_name }}
           draft: false
+          prerelease: ${{ needs.prepare-go-release.outputs.release-prerelease }}
           generate_release_notes: true
           files: |
             release-assets/looper-darwin-arm64
@@ -248,3 +334,4 @@ jobs:
             release-assets/looperd-darwin-arm64.sha256
             release-assets/looperd-darwin-x64
             release-assets/looperd-darwin-x64.sha256
+            release-assets/manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  LOOPER_BUILD_MIN_CLI_FOR_DAEMON: "0.2.0"
+  LOOPER_BUILD_MIN_DAEMON_FOR_CLI: "0.2.0"
+
 jobs:
   prepare-go-release:
     runs-on: ubuntu-latest
@@ -279,8 +283,8 @@ jobs:
             -released "${{ needs.prepare-go-release.outputs.release-timestamp }}" \
             -channel "${{ needs.prepare-go-release.outputs.release-channel }}" \
             -api-version v1 \
-            -min-cli-for-daemon "0.2.0" \
-            -min-daemon-for-cli "0.2.0" \
+            -min-cli-for-daemon "$LOOPER_BUILD_MIN_CLI_FOR_DAEMON" \
+            -min-daemon-for-cli "$LOOPER_BUILD_MIN_DAEMON_FOR_CLI" \
             -assets-dir release-assets \
             -required-assets "looper-darwin-arm64,looper-darwin-x64,looperd-darwin-arm64,looperd-darwin-x64" \
             -output release-assets/manifest.json

--- a/README.md
+++ b/README.md
@@ -1,170 +1,65 @@
 # looper
 
-Looper ships as Go binaries for the supported CLI + daemon workflows.
+Looper is a Go-based CLI + daemon for planner / reviewer / fixer / worker workflows.
 
-This repository currently contains:
+This repository contains:
 
-- `cmd/looperd` — the supported `looperd` daemon binary
-- `cmd/looper` — the supported `looper` CLI binary
+- `cmd/looperd` — the supported daemon binary
+- `cmd/looper` — the supported CLI binary
 - `internal/` and `pkg/` — the active Go implementation
-
-The current product is the Go daemon + CLI.
-
-## Requirements
-
-For the default supported install path:
-
-- macOS (`darwin-arm64` or `darwin-x64`)
-- `git`
-- `gh`
-
-For source development:
-
-- Go `1.22`
-- `git`
-- `gh`
-- `osascript` if macOS notifications stay enabled
-
-`looperd` auto-detects tool paths from `PATH`, but startup validation fails if required tools cannot be resolved.
 
 ## Installation
 
-Looper now uses Go binaries as the default supported implementation.
-
-Recommended path:
+Quick start:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/install.sh | sh
+looper bootstrap --yes --project-path /path/to/repo --agent-vendor opencode
 ```
 
-That installer:
+Detailed install, upgrade, uninstall, requirements, and source-build instructions: [docs/installation.md](docs/installation.md).
 
-- detects the current macOS architecture
-- downloads the matching `looper` release artifact
-- verifies the published `sha256`
-- installs `looper` into a user-writable location
+## Usage
 
-GitHub Releases continue to publish standalone Go binaries for both `looper` and `looperd` on `darwin-arm64` and `darwin-x64`.
+For the user-facing workflow guide, see [docs/users-guide.md](docs/users-guide.md).
 
-Linux daemon artifacts are not supported in this phase.
-
-### Install the CLI
-
-Fallback manual path:
-
-1. Download the matching `looper` release artifact for your macOS architecture from GitHub Releases.
-2. Rename it to `looper` if needed.
-3. Place it on your `PATH`, for example `/usr/local/bin/looper` or `~/.local/bin/looper`.
-
-### First-Run Setup
-
-Recommended path:
+Typical flow:
 
 ```bash
-looper bootstrap
-looper status
+looper plan --project myproj --issue 123
+looper review owner/repo#42 --loop
+looper work --issue 123
 ```
 
-`looper bootstrap` initializes the runtime directories, creates or updates config, optionally registers a project, installs the managed daemon, starts it, and verifies health.
+Notes:
 
-Manual daemon fallback/debug commands:
+- when you run commands inside a registered repo, `looper` can often infer the current project, so `--project` is often optional for `review` and `work`
+- use `--project` when the current directory is outside the repo, or when multiple projects could match
+- for the full planner / reviewer / fixer / worker flow, GitHub label usage, and assign-based automation, see the guide above
 
-```bash
-looper daemon install
-looper daemon start
-looper daemon status
-```
+## Common commands
 
-The managed daemon install command:
+- `looper bootstrap`
+- `looper status`
+- `looper version`
+- `looper project list|add`
+- `looper plan --project <id> --issue <number>`
+- `looper review <pr> [--loop]`
+- `looper work --issue <number>`
+- `looper pr list|show|status`
+- `looper daemon install|start|stop|restart|status`
+- `looper ps`, `looper logs <id>`, `looper jump <id>`
+- `looper stop <id>`
 
-- detects the current macOS architecture
-- downloads the matching GitHub Release artifact
-- installs it to `~/.looper/bin/looperd`
+## Configuration
 
-Current release binaries are unsigned. If macOS Gatekeeper blocks the first launch, you may need to allow the binary manually in System Settings.
+For configuration details, defaults, environment overrides, CLI flags, auth notes, and troubleshooting, see [docs/configuration.md](docs/configuration.md).
 
-Manual fallback:
+Useful pointers:
 
-- download the matching `looperd` release artifact yourself
-- place it at `~/.looper/bin/looperd` or somewhere on your `PATH`
-
-Daemon lookup order is fixed to `~/.looper/bin/looperd`, then `$PATH`.
-
-Phase 1 process management is intentionally minimal. `looper daemon start` writes a pid file and launches the daemon, but it does not provide full background supervision.
-
-### Verify the install
-
-In another shell, verify the install and daemon connection:
-
-```bash
-looper status
-looper daemon status
-```
-
-### Uninstall
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/uninstall.sh | sh
-```
-
-The uninstall script removes the CLI binary, the managed daemon binary, and updater state. It asks before deleting config, the SQLite DB, backups, logs, and worktrees.
-
-### Upgrade
-
-Unified upgrade entrypoint:
-
-```bash
-looper upgrade
-looper upgrade --check
-looper upgrade --cli
-looper upgrade --daemon
-```
-
-Current phase behavior:
-
-- `looper upgrade --check` shows current/latest CLI and daemon versions
-- `looper upgrade` is the unified entrypoint: it attempts CLI self-upgrade when safe, then upgrades the managed daemon
-- `looper upgrade --cli` upgrades the `looper` binary only when the current install looks like a release-binary install
-- `looper upgrade --daemon` installs or upgrades the managed daemon binary
-- Homebrew and dev / `go install` installs refuse CLI self-upgrade and print the matching manual command instead
-- after a daemon upgrade, restart manually with `looper daemon restart`
-- manifest-gated upgrade, rollback, and channel switching are not implemented in this phase yet
-
-### From source
-
-If you want to develop the supported Go binaries from source, clone the repo:
-
-```bash
-git clone https://github.com/powerformer/looper.git
-cd looper
-```
-
-Then build or run the Go binaries:
-
-```bash
-go build ./cmd/looper
-go build ./cmd/looperd
-go run ./cmd/looperd
-```
-
-In another shell, run the CLI from source:
-
-```bash
-go run ./cmd/looper -- status
-```
-
-### Compatibility and version policy
-
-- CLI and daemon are published from the same git tag and should normally share the same version.
-- Short-lived version skew is allowed when the HTTP API remains compatible; the current expectation is that newer CLI builds should keep working with same-major daemons.
-- Management endpoints stay under `/api/v1/*` in the current phase, and minor releases should not introduce breaking protocol changes.
-- If the daemon is running, the CLI reads its current version from `/api/v1/status`; otherwise it falls back to `looperd --version`.
-- `looper upgrade --check` reads the latest CLI and daemon versions from GitHub Releases metadata. If the daemon is not running, the CLI falls back to the installed daemon binary version; if no binary is found, daemon current version is reported as not installed.
-- The CLI does not currently inject upgrade prompts into every command when the daemon is old; use `looper upgrade --check` to inspect drift and `looper upgrade` / `looper upgrade --daemon` to update the managed binary.
-- Full major-version upgrade confirmation is not implemented in this phase yet. If a future release needs breaking management API changes, it should move to a new API version such as `/api/v2/*` instead of silently breaking `/api/v1`.
-- Release builds are tag-driven (`vX.Y.Z` / `vX.Y.Z-rc.N`) and inject binary version metadata via ldflags; local default builds use `0.0.0-dev`.
-- The release workflow now publishes `manifest.json` alongside binaries/checksums as the machine-readable release contract (channel/apiVersion/schemaVersion/min-compatibility + artifact URL/sha256/size).
-
+- default config path: `~/.looper/config.json`
+- config precedence: defaults → config file → environment → CLI flags
+- if daemon auth is set to `local-token`, the CLI uses `LOOPER_TOKEN`
 
 ## Development commands
 
@@ -176,115 +71,14 @@ From the repo root:
 - `go vet ./...`
 - `go test ./...`
 
-## Project structure
-
-### `cmd/looperd`
-
-Supported daemon entrypoint. Responsibilities include:
-
-- loading and validating config
-- starting the SQLite-backed runtime
-- serving the HTTP API
-- recovery on startup
-- writing logs and notifications
-
-### `cmd/looper`
-
-Supported CLI entrypoint. The CLI connects to `looperd` over HTTP and supports commands under:
-
-- `project list|add`
-- `ps`
-- `jump`
-- `logs`
-- `stop`
-- `status`
-- `plan`
-- `config show`
-- `daemon install|start|restart|status|logs`
-- `loop list|start|pause`
-- `review <pr> [--loop]`
-- `upgrade`
-- `work`
-- `pr list|show|status`
-- `run list`
-
-Manual review examples:
-
-- `looper review 123` — create a one-shot reviewer task for PR `123` in the current project
-- `looper review powerformer/looper#123 --loop` — keep re-reviewing that PR as new commits are pushed
-
-## Configuration
-
-For a full configuration guide with examples, field reference, env overrides, and CLI flags, see [docs/configuration.md](docs/configuration.md).
-
-Default config path:
-
-- `~/.looper/config.json`
-
-Config precedence:
-
-1. built-in defaults
-2. config file
-3. environment variables
-4. CLI flags
-
-Important defaults verified in code:
-
-- host: `127.0.0.1`
-- port: `4310`
-- storage DB: `~/.looper/looper.sqlite`
-- backup dir: `~/.looper/backups`
-- log dir: `~/.looper/logs`
-- daemon mode: `foreground`
-- agent vendor: `opencode`
-- base branch: `main`
-
-Selected looperd environment overrides:
-
-- `LOOPER_CONFIG`
-- `LOOPER_HOST`
-- `LOOPER_PORT`
-- `LOOPER_DB_PATH`
-- `LOOPER_LOG_DIR`
-- `LOOPER_DAEMON_MODE`
-- `LOOPER_WORKING_DIRECTORY`
-- `LOOPER_GIT_PATH`
-- `LOOPER_GH_PATH`
-- `LOOPER_OSASCRIPT_PATH`
-- `LOOPER_OSASCRIPT_ENABLED`
-- `LOOPER_IN_APP_NOTIFICATIONS`
-- `LOOPER_ALLOW_AUTO_COMMIT`
-- `LOOPER_ALLOW_AUTO_PUSH`
-- `LOOPER_ALLOW_AUTO_APPROVE`
-
-CLI-only environment override:
-
-- `LOOPER_TOKEN` — auth token sent by the CLI when talking to a token-protected daemon
-
-Selected CLI config flags:
-
-- `--config`
-- `--host`
-- `--port`
-- `--db-path`
-- `--log-dir`
-- `--daemon-mode`
-- `--git-path`
-- `--gh-path`
-- `--osascript-path`
-- `--allow-auto-commit`
-- `--allow-auto-push`
-- `--allow-auto-approve`
-
 ## Runtime notes
 
-- `looperd` fails fast on invalid config.
-- Runtime paths must be writable.
-- If `notifications.osascript.enabled` is `true`, `osascript` must resolve.
-- Managed daemon installs live at `~/.looper/bin/looperd`.
-- Default daemon-managed worktrees now live under `~/.looper/worktrees/<project-id>/`; if you still have legacy repo-local `.looper-worktrees/` entries, prune any stale `.git/worktrees/*/gitdir` references before deleting those old directories.
-- SQLite migrations are embedded in the daemon binary/build output for normal runtime execution; directory-based migration loading is only used in explicit test/injection paths.
+- `looperd` fails fast on invalid config
+- runtime paths must be writable
+- if `notifications.osascript.enabled` is `true`, `osascript` must resolve
+- managed daemon installs live at `~/.looper/bin/looperd`
+- default daemon-managed worktrees live under `~/.looper/worktrees/<project-id>/`
 
 ## Development notes
 
-- Build output lives in `dist/`; do not edit generated files.
+- build output lives in `dist/`; do not edit generated files

--- a/README.md
+++ b/README.md
@@ -56,19 +56,26 @@ Fallback manual path:
 2. Rename it to `looper` if needed.
 3. Place it on your `PATH`, for example `/usr/local/bin/looper` or `~/.local/bin/looper`.
 
-### Install the daemon
+### First-Run Setup
 
 Recommended path:
 
-Until `looper bootstrap` lands, first-run setup remains:
+```bash
+looper bootstrap
+looper status
+```
+
+`looper bootstrap` initializes the runtime directories, creates or updates config, optionally registers a project, installs the managed daemon, starts it, and verifies health.
+
+Manual daemon fallback/debug commands:
 
 ```bash
 looper daemon install
 looper daemon start
-looper status
+looper daemon status
 ```
 
-This command:
+The managed daemon install command:
 
 - detects the current macOS architecture
 - downloads the matching GitHub Release artifact

--- a/README.md
+++ b/README.md
@@ -107,17 +107,21 @@ The uninstall script removes the CLI binary, the managed daemon binary, and upda
 Unified upgrade entrypoint:
 
 ```bash
+looper upgrade
 looper upgrade --check
+looper upgrade --cli
 looper upgrade --daemon
 ```
 
 Current phase behavior:
 
 - `looper upgrade --check` shows current/latest CLI and daemon versions
+- `looper upgrade` is the unified entrypoint: it attempts CLI self-upgrade when safe, then upgrades the managed daemon
+- `looper upgrade --cli` upgrades the `looper` binary only when the current install looks like a release-binary install
 - `looper upgrade --daemon` installs or upgrades the managed daemon binary
-- full `looper upgrade` for CLI + daemon together is not implemented yet
+- Homebrew and dev / `go install` installs refuse CLI self-upgrade and print the matching manual command instead
 - after a daemon upgrade, restart manually with `looper daemon restart`
-- replace the `looper` CLI binary manually when a newer GitHub Release is available
+- manifest-gated upgrade, rollback, and channel switching are not implemented in this phase yet
 
 ### From source
 
@@ -149,8 +153,8 @@ go run ./cmd/looper -- status
 - Management endpoints stay under `/api/v1/*` in the current phase, and minor releases should not introduce breaking protocol changes.
 - If the daemon is running, the CLI reads its current version from `/api/v1/status`; otherwise it falls back to `looperd --version`.
 - `looper upgrade --check` reads the latest CLI and daemon versions from GitHub Releases metadata. If the daemon is not running, the CLI falls back to the installed daemon binary version; if no binary is found, daemon current version is reported as not installed.
-- The CLI does not currently inject upgrade prompts into every command when the daemon is old; use `looper upgrade --check` to inspect drift and `looper upgrade --daemon` to update the managed binary.
-- Full major-version upgrade confirmation is not implemented in this phase because full `looper upgrade` is not implemented yet. If a future release needs breaking management API changes, it should move to a new API version such as `/api/v2/*` instead of silently breaking `/api/v1`.
+- The CLI does not currently inject upgrade prompts into every command when the daemon is old; use `looper upgrade --check` to inspect drift and `looper upgrade` / `looper upgrade --daemon` to update the managed binary.
+- Full major-version upgrade confirmation is not implemented in this phase yet. If a future release needs breaking management API changes, it should move to a new API version such as `/api/v2/*` instead of silently breaking `/api/v1`.
 
 
 ## Development commands

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ go run ./cmd/looper -- status
 - `looper upgrade --check` reads the latest CLI and daemon versions from GitHub Releases metadata. If the daemon is not running, the CLI falls back to the installed daemon binary version; if no binary is found, daemon current version is reported as not installed.
 - The CLI does not currently inject upgrade prompts into every command when the daemon is old; use `looper upgrade --check` to inspect drift and `looper upgrade` / `looper upgrade --daemon` to update the managed binary.
 - Full major-version upgrade confirmation is not implemented in this phase yet. If a future release needs breaking management API changes, it should move to a new API version such as `/api/v2/*` instead of silently breaking `/api/v1`.
+- Release builds are tag-driven (`vX.Y.Z` / `vX.Y.Z-rc.N`) and inject binary version metadata via ldflags; local default builds use `0.0.0-dev`.
+- The release workflow now publishes `manifest.json` alongside binaries/checksums as the machine-readable release contract (channel/apiVersion/schemaVersion/min-compatibility + artifact URL/sha256/size).
 
 
 ## Development commands

--- a/README.md
+++ b/README.md
@@ -29,18 +29,28 @@ For source development:
 
 ## Installation
 
-Looper now uses Go binaries as the default supported implementation:
+Looper now uses Go binaries as the default supported implementation.
 
-- install the `looper` CLI from GitHub Releases
-- install `looperd` separately as a managed macOS binary with `looper daemon install`
+Recommended path:
 
-GitHub Releases publish standalone Go binaries for both `looper` and `looperd` on `darwin-arm64` and `darwin-x64`.
+```bash
+curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/install.sh | sh
+```
+
+That installer:
+
+- detects the current macOS architecture
+- downloads the matching `looper` release artifact
+- verifies the published `sha256`
+- installs `looper` into a user-writable location
+
+GitHub Releases continue to publish standalone Go binaries for both `looper` and `looperd` on `darwin-arm64` and `darwin-x64`.
 
 Linux daemon artifacts are not supported in this phase.
 
 ### Install the CLI
 
-Recommended path:
+Fallback manual path:
 
 1. Download the matching `looper` release artifact for your macOS architecture from GitHub Releases.
 2. Rename it to `looper` if needed.
@@ -50,8 +60,12 @@ Recommended path:
 
 Recommended path:
 
+Until `looper bootstrap` lands, first-run setup remains:
+
 ```bash
 looper daemon install
+looper daemon start
+looper status
 ```
 
 This command:
@@ -69,12 +83,6 @@ Manual fallback:
 
 Daemon lookup order is fixed to `~/.looper/bin/looperd`, then `$PATH`.
 
-### Start the daemon
-
-```bash
-looper daemon start
-```
-
 Phase 1 process management is intentionally minimal. `looper daemon start` writes a pid file and launches the daemon, but it does not provide full background supervision.
 
 ### Verify the install
@@ -85,6 +93,14 @@ In another shell, verify the install and daemon connection:
 looper status
 looper daemon status
 ```
+
+### Uninstall
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/uninstall.sh | sh
+```
+
+The uninstall script removes the CLI binary, the managed daemon binary, and updater state. It asks before deleting config, the SQLite DB, backups, logs, and worktrees.
 
 ### Upgrade
 

--- a/cmd/looper/main_test.go
+++ b/cmd/looper/main_test.go
@@ -148,3 +148,22 @@ func TestRunWithDepsVersionShortCircuitsBeforeAppConstruction(t *testing.T) {
 		t.Fatalf("stderr = %q, want empty string", got)
 	}
 }
+
+func TestRunUsesDefaultCLIAppFactoryForVersionCommand(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	exitCode := run([]string{"version"}, stdout, stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("run([version]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("run([version]) stderr = %q, want empty string", got)
+	}
+	if got, want := stdout.String(), version.Value+"\n"; got != want {
+		t.Fatalf("run([version]) stdout = %q, want %q", got, want)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,8 @@ Relative config paths are resolved from the current working directory used to st
 
 In the simplest setup, you can rely on defaults and only create a config file when you need to customize behavior.
 
+`agent.vendor` does not have a built-in default. If you want planner / reviewer / fixer / worker loops to run, set it explicitly.
+
 Example minimal `~/.looper/config.json`:
 
 ```json
@@ -78,7 +80,7 @@ Example minimal `~/.looper/config.json`:
   },
   "agent": {
     "vendor": "opencode",
-    "model": "gpt-5.4",
+    "model": "your-model-if-needed",
     "params": {
       "reasoning": "medium"
     },
@@ -172,6 +174,8 @@ Default storage paths:
 - `params`: free-form vendor-specific parameters
 - `env`: environment variables passed to the agent process
 
+`vendor` is required for agent-driven loops. If it is omitted, the daemon can still run, but planner / reviewer / fixer / worker loops cannot be created or started.
+
 ### `logging`
 
 - `level`: one of `debug`, `info`, `warn`, `error`
@@ -187,6 +191,11 @@ When `looperd.log` would exceed `maxSizeMB`, `looperd` rotates it to `looperd.lo
 - `osascript.soundForLevels`: subset of `action_required`, `failure`
 - `osascript.throttleWindowSeconds`: positive integer
 
+Default behavior:
+
+- on macOS, `notifications.osascript.enabled` defaults to `true`
+- on non-macOS platforms, it defaults to `false`
+
 If `notifications.osascript.enabled` is `true`, `tools.osascriptPath` must resolve.
 
 ### `tools`
@@ -201,15 +210,17 @@ If these are omitted, `looperd` tries to detect them from `PATH`. Startup valida
 
 - `mode`: `foreground` or `launchd`
 - `logDir`: daemon log directory
+- `shutdownTimeoutMs`: graceful shutdown timeout in milliseconds
 - `workingDirectory`: working directory used by the daemon
-- `environment`: extra environment variables for the daemon process
+- `environment`: reserved daemon environment map; currently part of the config surface, but not a primary user-facing runtime control in the documented flow
 
-Current packaged install and CLI management flows document `foreground` as the active Phase 1 path. `launchd` remains part of the configuration surface, but full launchd-oriented lifecycle management is not the primary documented install flow here.
+Current packaged install and CLI management flows use `foreground` as the primary documented path. `launchd` remains part of the configuration surface, but it is not the primary documented install flow.
 
 Defaults:
 
 - `mode`: `foreground`
 - `logDir`: `~/.looper/logs`
+- `shutdownTimeoutMs`: `1000`
 - `workingDirectory`: current working directory when config is loaded
 
 ### `package`
@@ -292,11 +303,19 @@ Boolean environment variables accept:
 Example:
 
 ```bash
-LOOPER_CONFIG="$HOME/.looper/config.json" \
+LOOPER_CONFIG="$HOME/custom-looper/config.json" \
 LOOPER_PORT=4321 \
 LOOPER_ALLOW_AUTO_PUSH=false \
 looperd
 ```
+
+Example precedence:
+
+- if the config file sets port `4310`
+- and `LOOPER_PORT=5000` is exported
+- and `looperd --port 6000` is passed
+
+then the daemon uses port `6000`.
 
 ## CLI flag overrides
 
@@ -319,7 +338,7 @@ Example:
 
 ```bash
 looperd \
-  --config "$HOME/.looper/config.json" \
+  --config "$HOME/custom-looper/config.json" \
   --port 4321 \
   --allow-auto-push=false
 ```
@@ -355,6 +374,8 @@ That means if you set `projects` in the config file, the entire projects array c
 4. Set `agent.vendor`
 5. Start the daemon with your installed `looperd` (or `go run ./cmd/looperd` while developing)
 6. Run `looper config show` to inspect the effective config
+
+If you enable `server.authMode=local-token`, also export `LOOPER_TOKEN` before using the CLI.
 
 ## Troubleshooting
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,140 @@
+# Installation and Upgrade Guide
+
+This document contains the detailed install, upgrade, uninstall, and source-build flows for Looper.
+
+## Requirements
+
+For the default supported install path:
+
+- macOS (`darwin-arm64` or `darwin-x64`)
+- `git`
+- `gh`
+
+For source development:
+
+- Go `1.22`
+- `git`
+- `gh`
+- `osascript` if macOS notifications stay enabled
+
+`looperd` auto-detects tool paths from `PATH`, but startup validation fails if required tools cannot be resolved.
+
+## Install
+
+Looper uses Go binaries as the default supported implementation.
+
+The quickest first-time setup is:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/install.sh | sh
+looper bootstrap --yes --project-path /path/to/repo --agent-vendor opencode
+```
+
+`looper bootstrap` creates an initial config, installs or reuses the managed daemon, optionally registers a project, and starts the daemon.
+
+### Install the CLI manually
+
+1. Download the matching `looper` release artifact for your macOS architecture from GitHub Releases.
+2. Rename it to `looper` if needed.
+3. Place it on your `PATH`, for example `/usr/local/bin/looper` or `~/.local/bin/looper`.
+
+GitHub Releases publish standalone Go binaries for both `looper` and `looperd` on `darwin-arm64` and `darwin-x64`.
+
+Linux is not currently supported for the managed daemon flow.
+
+### Install the daemon manually
+
+If you prefer the manual daemon flow instead of `looper bootstrap`:
+
+```bash
+looper daemon install
+looper daemon start
+looper status
+```
+
+This flow:
+
+- detects the current macOS architecture
+- downloads the matching GitHub Release artifact
+- installs it to `~/.looper/bin/looperd`
+
+Current release binaries are unsigned. If macOS Gatekeeper blocks the first launch, you may need to allow the binary manually in System Settings.
+
+Manual fallback:
+
+- download the matching `looperd` release artifact yourself
+- place it at `~/.looper/bin/looperd` or somewhere on your `PATH`
+
+Daemon lookup order is fixed to `~/.looper/bin/looperd`, then `$PATH`.
+
+`looper daemon start` writes a pid file and launches the daemon, but it does not provide full background supervision.
+
+## Verify the install
+
+In another shell:
+
+```bash
+looper status
+looper daemon status
+```
+
+## Upgrade
+
+Unified upgrade entrypoint:
+
+```bash
+looper upgrade
+looper upgrade --check
+looper upgrade --cli
+looper upgrade --daemon
+```
+
+Current behavior:
+
+- `looper upgrade --check` shows current/latest CLI and daemon versions
+- `looper upgrade` attempts CLI self-upgrade when safe, then upgrades the managed daemon
+- `looper upgrade --cli` upgrades the `looper` binary only when the current install looks like a release-binary install
+- `looper upgrade --daemon` installs or upgrades the managed daemon binary
+- Homebrew and dev / `go install` installs refuse CLI self-upgrade and print the matching manual command instead
+- after a daemon upgrade, restart manually with `looper daemon restart`
+- manifest-gated upgrade, rollback, and channel switching are not implemented yet
+
+## Compatibility and version policy
+
+- CLI and daemon are published from the same git tag and should normally share the same version
+- short-lived version skew is allowed while the HTTP API remains compatible
+- management endpoints stay under `/api/v1/*`
+- if the daemon is running, the CLI reads its current version from `/api/v1/status`; otherwise it falls back to `looperd --version`
+- `looper upgrade --check` reads the latest CLI and daemon versions from GitHub Releases metadata
+- release builds are tag-driven (`vX.Y.Z` / `vX.Y.Z-rc.N`); local default builds use `0.0.0-dev`
+
+## Uninstall
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/uninstall.sh | sh
+```
+
+The uninstall script removes the CLI binary, the managed daemon binary, and updater state. It asks before deleting config, the SQLite DB, backups, logs, and worktrees.
+
+## From source
+
+Clone the repo:
+
+```bash
+git clone https://github.com/powerformer/looper.git
+cd looper
+```
+
+Then build or run the Go binaries:
+
+```bash
+go build ./cmd/looper
+go build ./cmd/looperd
+go run ./cmd/looperd
+```
+
+In another shell, run the CLI from source:
+
+```bash
+go run ./cmd/looper -- status
+```

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1,0 +1,361 @@
+# Looper Quick User Guide
+
+This guide is for everyday users. It focuses on how to use `planner`, `reviewer`, `fixer`, and `worker`, and how they interact with GitHub issues and PRs.
+
+## 1. Prerequisites
+
+Make sure these work first:
+
+```bash
+looper status
+looper project list
+gh auth status
+```
+
+If the project is not registered in Looper yet:
+
+```bash
+looper project add /path/to/repo --id myproj --repo owner/repo
+```
+
+Also make sure:
+
+- `looperd` is running
+- your local repo can `git fetch` and `git push`
+- `gh` is authenticated with the target GitHub account
+- `config.agent.vendor` is set (for example via `looper bootstrap --agent-vendor opencode`)
+
+## 2. Project auto-detection from the current directory
+
+Looper can often infer the target project from your current working directory.
+
+In practice, this means that if you run commands from inside a registered project repo, you can usually omit `--project`.
+
+This works best when:
+
+- your current directory is inside exactly one registered project repo
+- that project has a configured GitHub repo mapping
+
+If no project matches the current directory, or multiple projects match, pass `--project` explicitly.
+
+## 3. What each role does
+
+| Role | Purpose | Common entrypoint |
+| --- | --- | --- |
+| `planner` | Generates a spec from an issue and opens a spec PR | `looper plan --project <id> --issue <num>` |
+| `reviewer` | Reviews a PR or spec PR and publishes GitHub reviews | `looper review <repo>#<pr> [--loop]` or `looper review <pr> [--loop]` from inside the repo |
+| `fixer` | Fixes PR issues based on review comments and tries to resolve threads | `looper loop start --type fixer --pr <repo>#<pr>` |
+| `worker` | Implements the actual work from a spec or issue, and can reuse an existing PR | `looper work --issue <num>` or `looper work --project <id> --issue <num>` |
+
+## 4. Recommended flow
+
+### Overview
+
+1. Create a GitHub issue
+2. Add the `looper:plan` label
+3. Assign the issue to the currently authenticated `gh` user
+4. Start `planner` so it creates a spec PR
+5. Let `reviewer` review the spec PR
+6. Let `fixer` address review comments until the review is clean
+7. The PR gets the `looper:spec-ready` label
+8. `worker` takes over that PR and continues implementation
+
+This is the smoothest current Looper workflow.
+
+## 5. Planner: from issue to spec PR
+
+### Start it manually
+
+```bash
+looper plan --project myproj --issue 123
+```
+
+This creates a `planner` loop targeting that issue.
+
+For `plan`, it is safest to pass `--project` explicitly.
+
+### Auto-discovery conditions
+
+For planner auto-discovery, an issue must:
+
+- have the `looper:plan` label
+- be assigned to the current GitHub user
+- belong to a repo that maps uniquely to a local project
+
+So the most common GitHub-side trigger is:
+
+1. create an issue
+2. add `looper:plan`
+3. assign it to yourself
+
+### What planner does
+
+Planner will:
+
+- create a worktree
+- write the spec file
+- push a spec PR
+- add the `looper:spec-reviewing` label to that PR
+- request reviewers when appropriate
+
+## 6. Reviewer: review a spec PR or a normal PR
+
+### One-time review
+
+```bash
+looper review owner/repo#42
+```
+
+If you are already inside the registered repo, this usually also works:
+
+```bash
+looper review 42
+```
+
+### Continuous review
+
+```bash
+looper review owner/repo#42 --loop
+```
+
+Use this when new commits are expected to keep landing on the PR.
+
+### Reviewer auto-discovery rules
+
+Reviewer mainly watches two kinds of PRs:
+
+- open PRs where the current GitHub user was requested as a reviewer
+- open PRs labeled `looper:spec-reviewing`
+
+So for a spec PR, reviewer can find it even if no explicit review request was added, as long as the PR has `looper:spec-reviewing`.
+
+### What happens after reviewer finishes
+
+If reviewer considers the spec review clean, it will:
+
+- remove `looper:spec-reviewing`
+- add `looper:spec-ready`
+
+"Clean" means:
+
+- there are no unresolved review threads
+- the review decision is not `CHANGES_REQUESTED`
+
+## 7. Fixer: repair a PR based on review feedback
+
+The most direct way to use fixer is to start it for a specific PR:
+
+```bash
+looper loop start --type fixer --pr owner/repo#42
+```
+
+Fixer will:
+
+- read pending review comments and threads on the PR
+- create a worktree and apply fixes
+- run validation
+- push back to the same PR branch
+- try to resolve handled review threads
+
+If the PR is still in the spec review phase and the review becomes clean, fixer can also move the labels from:
+
+- `looper:spec-reviewing` → `looper:spec-ready`
+
+In practice, `reviewer` and `fixer` often alternate until the spec PR is ready for `worker`.
+
+## 8. Worker: do the actual implementation
+
+### Start from an issue
+
+```bash
+looper work --project myproj --issue 123
+```
+
+This is the recommended entrypoint.
+
+If you are already inside the target repo, you can usually omit `--project`:
+
+```bash
+looper work --issue 123
+```
+
+If that issue already has a related planner loop, worker will try to reuse planner output, including:
+
+- `specPath`
+- an existing open PR
+
+That means issue → planner → worker can flow through without manually copying the spec path.
+
+### Start directly from a spec
+
+```bash
+looper work --project myproj --title "Implement feature" --spec specs/2026-04-23-123-my-feature.md
+```
+
+### What happens when worker takes over a `spec-ready` PR
+
+When worker starts against a PR target, it first removes:
+
+- `looper:spec-ready`
+
+That signals the PR has been claimed for implementation.
+
+## 9. How the GitHub label system works
+
+These are the most important labels right now:
+
+| Label | Used on | Meaning |
+| --- | --- | --- |
+| `looper:plan` | issue | This issue is eligible for planner auto-pickup |
+| `looper:spec-reviewing` | PR | This PR is in the spec review phase |
+| `looper:spec-ready` | PR | The spec is approved and ready for worker |
+| `looper:needs-human` | PR | Reserved for manual intervention cases |
+
+Treat these as stage signals, not just descriptive labels.
+
+## 10. How assign and review-request trigger automation
+
+The two most important assignment-related rules are:
+
+### Planner
+
+For planner auto-discovery, the issue must:
+
+- be assigned to the current GitHub user
+- also have `looper:plan`
+
+So:
+
+> Adding only the label is not enough. The issue also needs to be assigned to the right person.
+
+### Reviewer
+
+Reviewer automatically pays attention to:
+
+- PRs where the current GitHub user has a review request
+
+Also, any PR labeled `looper:spec-reviewing` can be discovered by reviewer.
+
+## 11. Common GitHub / PR commands
+
+Inspect PRs:
+
+```bash
+looper pr list
+looper pr show owner/repo#42
+looper pr status owner/repo#42
+```
+
+Create a reviewer task:
+
+```bash
+looper review owner/repo#42
+looper review owner/repo#42 --loop
+looper review 42 --loop
+```
+
+Start fixer for an existing PR:
+
+```bash
+looper loop start --type fixer --pr owner/repo#42
+```
+
+## 12. How to inspect current activity
+
+```bash
+looper ps
+looper logs 12 --follow
+looper jump 12
+looper stop 12
+```
+
+Typical usage:
+
+- `looper ps`: see which loops are currently running
+- `looper logs <id> --follow`: stream logs live
+- `looper jump <id>`: print the shell command for the loop's worktree; use `eval "$(looper jump 12)"` to actually change directories, or pass `--print-path` to print just the path
+- `looper stop <id>`: stop an active loop
+
+## 13. Minimal end-to-end example
+
+### Option A: start from an issue
+
+1. Create GitHub issue `#123`
+2. Add the `looper:plan` label
+3. Assign it to the current `gh` user
+4. Run:
+
+```bash
+looper plan --project myproj --issue 123
+```
+
+5. Wait for planner to open a spec PR
+6. Run reviewer:
+
+```bash
+looper review owner/repo#<spec-pr>
+```
+
+7. If comments appear, start fixer:
+
+```bash
+looper loop start --type fixer --pr owner/repo#<spec-pr>
+```
+
+8. Once the PR reaches `looper:spec-ready`, start worker:
+
+```bash
+looper work --issue 123
+```
+
+### Option B: manage an existing PR directly
+
+```bash
+looper review owner/repo#42 --loop
+looper loop start --type fixer --pr owner/repo#42
+```
+
+This is useful when you already have a PR and only want Looper to handle the review/fix cycle.
+
+## 14. Quick decision guide
+
+- You have an issue but no spec yet: use `planner`
+- You have a PR that needs review: use `reviewer`
+- A PR already has review comments to address: use `fixer`
+- The spec is ready and implementation should begin: use `worker`
+
+As a rule of thumb:
+
+- inside a registered repo, you can usually omit `--project` for `review` and `work`
+- use `--project` when you are outside the repo, or when Looper cannot infer the project uniquely
+- for `plan`, prefer passing `--project`
+
+## 15. Authentication
+
+Looper uses `gh` for GitHub access, so `gh auth status` should succeed before you start planner / reviewer / fixer / worker workflows.
+
+If the daemon is configured with `server.authMode=local-token`, the CLI also needs a matching local token. In that setup, export `LOOPER_TOKEN` before running CLI commands.
+
+Example:
+
+```bash
+export LOOPER_TOKEN=replace-me
+looper status
+```
+
+This is separate from GitHub authentication.
+
+## 16. One important clarification
+
+In the current implementation, "automatic triggering" is closer to:
+
+- the daemon continuously polling GitHub state
+- loops discovering targets based on labels, assignees, and review requests
+
+It is not a GitHub webhook-driven instant trigger.
+
+So if you want the automation chain to work reliably, the most important things are:
+
+- keep `looperd` running
+- keep `gh` working
+- set labels and assignments correctly

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -503,10 +503,34 @@ type statusService struct {
 
 type statusBinary struct {
 	Name             string   `json:"name"`
+	Path             string   `json:"path,omitempty"`
 	InstallDir       string   `json:"installDir"`
 	CurrentTarget    string   `json:"currentTarget"`
 	ArtifactName     *string  `json:"artifactName"`
 	SupportedTargets []string `json:"supportedTargets"`
+}
+
+func daemonExecutablePath() string {
+	executablePath, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	executablePath = strings.TrimSpace(executablePath)
+	if executablePath == "" {
+		return ""
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(executablePath)
+	if err != nil {
+		return executablePath
+	}
+
+	resolvedPath = strings.TrimSpace(resolvedPath)
+	if resolvedPath == "" {
+		return executablePath
+	}
+
+	return resolvedPath
 }
 
 type statusStorage struct {
@@ -659,6 +683,7 @@ func (h *Handler) buildStatusResponse(ctx context.Context) (statusResponse, erro
 			Recovery:   h.recoverySummary(),
 			Binary: statusBinary{
 				Name:             "looperd",
+				Path:             daemonExecutablePath(),
 				InstallDir:       installDir,
 				CurrentTarget:    currentTarget,
 				ArtifactName:     artifactName,

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -75,12 +75,17 @@ func TestHandlerStatusSuccessContainsExpectedSections(t *testing.T) {
 
 	data := body["data"].(map[string]any)
 	service := data["service"].(map[string]any)
+	binaryInfo := service["binary"].(map[string]any)
 	storageInfo := data["storage"].(map[string]any)
 	scheduler := data["scheduler"].(map[string]any)
 	loops := data["loops"].(map[string]any)
 
 	assertEqual(t, service["healthy"], true)
 	assertEqual(t, service["daemonMode"], "foreground")
+	binaryPath, ok := binaryInfo["path"].(string)
+	if !ok || strings.TrimSpace(binaryPath) == "" {
+		t.Fatalf("service.binary.path missing/invalid: %#v", binaryInfo["path"])
+	}
 	assertEqual(t, storageInfo["healthy"], true)
 	queuedItems, queuedOK := scheduler["queuedItems"].(float64)
 	runningItems, runningOK := scheduler["runningItems"].(float64)
@@ -4068,7 +4073,7 @@ func responseFixtureMatches(actual, expected any) bool {
 		case "<uuid>":
 			got, ok := actual.(string)
 			return ok && strings.Count(got, "-") == 4 && strings.TrimSpace(got) != ""
-		case "<generated-timestamp>", "<current-target>":
+		case "<generated-timestamp>", "<current-target>", "<daemon-executable-path>":
 			got, ok := actual.(string)
 			return ok && strings.TrimSpace(got) != ""
 		case "<artifact-name>":

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -14,23 +14,24 @@ import (
 )
 
 type Deps struct {
-	Stdin         io.Reader
-	Stdout        io.Writer
-	Stderr        io.Writer
-	HTTPClient    *http.Client
-	HomeDir       string
-	Platform      string
-	Arch          string
-	LookPath      config.LookPathFunc
-	RunCommand    runCommandFunc
-	SpawnDetached spawnDetachedFunc
-	KillProcess   killProcessFunc
-	ReadFile      readFileFunc
-	WriteFile     writeFileFunc
-	RemoveFile    removeFileFunc
-	MkdirAll      mkdirAllFunc
-	Sleep         sleepFunc
-	Getwd         getwdFunc
+	Stdin          io.Reader
+	Stdout         io.Writer
+	Stderr         io.Writer
+	HTTPClient     *http.Client
+	HomeDir        string
+	Platform       string
+	Arch           string
+	LookPath       config.LookPathFunc
+	RunCommand     runCommandFunc
+	SpawnDetached  spawnDetachedFunc
+	KillProcess    killProcessFunc
+	ReadFile       readFileFunc
+	WriteFile      writeFileFunc
+	RemoveFile     removeFileFunc
+	MkdirAll       mkdirAllFunc
+	Sleep          sleepFunc
+	Getwd          getwdFunc
+	ExecutablePath string
 }
 
 type App struct {
@@ -175,10 +176,12 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				runE:  runtime.upgrade,
 				localFlags: []flagSpec{
 					boolFlag("check", "Check available CLI and daemon updates"),
+					boolFlag("cli", "Upgrade the looper CLI binary when self-upgrade is allowed"),
 					boolFlag("daemon", "Install or upgrade the managed daemon binary"),
 				},
 				exampleLines: []string{
 					"$ looper upgrade --check",
+					"$ looper upgrade --cli",
 					"$ looper upgrade --daemon",
 				},
 			}),

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -151,7 +151,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 			newCommand(commandSpec{
 				use:             "daemon",
 				short:           "Daemon commands",
-				helpSubcommands: []helpSubcommand{{name: "install", description: "Install the managed daemon binary"}, {name: "status", description: "Show daemon status"}, {name: "start", description: "Start the daemon"}, {name: "restart", description: "Restart the daemon"}, {name: "logs", description: "Show daemon logs"}},
+				helpSubcommands: []helpSubcommand{{name: "install", description: "Install the managed daemon binary"}, {name: "status", description: "Show daemon status"}, {name: "start", description: "Start the daemon"}, {name: "stop", description: "Stop the daemon"}, {name: "restart", description: "Restart the daemon"}, {name: "logs", description: "Show daemon logs"}},
 				helpWhenNoArgs:  true,
 				persistentFlags: []flagSpec{
 					stringFlag("lines", "count", "Line count"),
@@ -160,6 +160,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				exampleLines: []string{
 					"$ looper daemon install",
 					"$ looper daemon start",
+					"$ looper daemon stop",
 					"$ looper daemon restart",
 					"$ looper daemon status",
 					"$ looper daemon logs --lines 50",
@@ -168,6 +169,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					newCommand(commandSpec{use: "install", short: "Install the managed daemon binary", runE: runtime.daemonInstall}),
 					newCommand(commandSpec{use: "status", short: "Show daemon status", runE: runtime.daemonStatus}),
 					newCommand(commandSpec{use: "start", short: "Start the daemon", runE: runtime.daemonStart}),
+					newCommand(commandSpec{use: "stop", short: "Stop the daemon", runE: runtime.daemonStop}),
 					newCommand(commandSpec{use: "restart", short: "Restart the daemon", runE: runtime.daemonRestart}),
 					newCommand(commandSpec{use: "logs", short: "Show daemon logs", runE: runtime.daemonLogs}),
 				},

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/powerformer/looper/internal/config"
+	"github.com/powerformer/looper/internal/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -93,7 +94,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 	root := newCommand(commandSpec{
 		use:             "looper",
 		short:           "Looper command-line interface",
-		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
+		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
 		helpWhenNoArgs:  true,
 		subcommands: []*cobra.Command{
 			newCommand(commandSpec{use: "status", short: "Show service status", runE: runtime.status}),
@@ -114,6 +115,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					"$ looper bootstrap --yes --project-path /path/to/repo --agent-vendor opencode",
 				},
 			}),
+			newCommand(commandSpec{use: "version", short: "Show Looper version", runE: runtime.version}),
 			newCommand(commandSpec{
 				use:             "project",
 				short:           "Project commands",
@@ -396,6 +398,9 @@ func renderHelp(w io.Writer, cmd *cobra.Command, listedSubcommands []helpSubcomm
 	var output strings.Builder
 
 	_, _ = fmt.Fprintf(&output, "Usage:\n  %s\n", cmd.UseLine())
+	if cmd.Parent() == nil {
+		_, _ = fmt.Fprintf(&output, "\nVersion:\n  %s\n", version.Current().Version)
+	}
 
 	subcommands := listedSubcommands
 	if len(subcommands) == 0 {

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -8,17 +8,20 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/powerformer/looper/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 type Deps struct {
+	Stdin         io.Reader
 	Stdout        io.Writer
 	Stderr        io.Writer
 	HTTPClient    *http.Client
 	HomeDir       string
 	Platform      string
 	Arch          string
+	LookPath      config.LookPathFunc
 	RunCommand    runCommandFunc
 	SpawnDetached spawnDetachedFunc
 	KillProcess   killProcessFunc
@@ -89,10 +92,27 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 	root := newCommand(commandSpec{
 		use:             "looper",
 		short:           "Looper command-line interface",
-		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
+		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
 		helpWhenNoArgs:  true,
 		subcommands: []*cobra.Command{
 			newCommand(commandSpec{use: "status", short: "Show service status", runE: runtime.status}),
+			newCommand(commandSpec{
+				use:   "bootstrap",
+				short: "Run first-time setup",
+				runE:  runtime.bootstrap,
+				localFlags: []flagSpec{
+					boolFlag("yes", "Run non-interactively with defaults"),
+					boolFlag("force", "Reinstall the managed daemon binary even if it already exists"),
+					stringFlag("agent-vendor", "vendor", "Agent vendor for generated config"),
+					stringFlag("project-path", "path", "Add a default project from a local repository path"),
+					boolFlag("enable-local-token", "Enable server.authMode=local-token for generated config"),
+					boolFlag("disable-osascript", "Disable osascript notifications for generated config"),
+				},
+				exampleLines: []string{
+					"$ looper bootstrap",
+					"$ looper bootstrap --yes --project-path /path/to/repo --agent-vendor opencode",
+				},
+			}),
 			newCommand(commandSpec{
 				use:             "project",
 				short:           "Project commands",
@@ -305,6 +325,9 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 	addFlags(root.PersistentFlags(), globalFlags())
 	root.SetOut(a.stdout())
 	root.SetErr(a.stderr())
+	if a.deps.Stdin != nil {
+		root.SetIn(a.deps.Stdin)
+	}
 	root.SilenceErrors = true
 	root.SilenceUsage = true
 	root.CompletionOptions.DisableDefaultCmd = true

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -94,7 +94,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 	root := newCommand(commandSpec{
 		use:             "looper",
 		short:           "Looper command-line interface",
-		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
+		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
 		helpWhenNoArgs:  true,
 		subcommands: []*cobra.Command{
 			newCommand(commandSpec{use: "status", short: "Show service status", runE: runtime.status}),
@@ -264,6 +264,19 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				exampleLines: []string{
 					"$ looper review 123",
 					"$ looper review acme/looper#42 --loop",
+				},
+			}),
+			newCommand(commandSpec{
+				use:   "feedback [message...]",
+				short: "Submit feedback as a GitHub issue",
+				args:  cobra.ArbitraryArgs,
+				runE:  runtime.feedback,
+				localFlags: []flagSpec{
+					stringFlag("title", "title", "Issue title hint"),
+				},
+				exampleLines: []string{
+					"$ looper feedback The CLI should include feedback support",
+					"$ looper feedback --title \"CLI UX\" add an interactive mode",
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -113,6 +113,79 @@ func TestRootHelpIncludesGlobalFlagsWithFrozenSyntax(t *testing.T) {
 	}
 }
 
+func TestRootHelpIncludesFeedbackSubcommand(t *testing.T) {
+	t.Parallel()
+
+	exitCode, stdout, stderr := runApp(t, "--help")
+	if exitCode != 0 {
+		t.Fatalf("Run([--help]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([--help]) stderr = %q, want empty string", stderr)
+	}
+	if !strings.Contains(stdout, "feedback") || !strings.Contains(stdout, "Submit feedback as a GitHub issue") {
+		t.Fatalf("Run([--help]) stdout = %q, want feedback subcommand", stdout)
+	}
+}
+
+func TestFeedbackCommandRunsAgentAndPrintsIssueURL(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(t.TempDir(), "fake-agent.sh")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"printf 'agent started\\n'",
+		"printf 'https://github.com/powerformer/looper/issues/42\\n'",
+		"printf 'https://github.com/powerformer/looper/issues/321\\n'",
+		"printf '%s{\"summary\":\"created issue\"}\\n' \"$LOOPER_COMPLETION_MARKER\"",
+	}, "\n")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake agent script: %v", err)
+	}
+
+	configPath := writeCLIConfigWithAgent(t, "http://127.0.0.1:1", string(config.AgentVendorOpenCode), map[string]any{"command": scriptPath})
+
+	exitCode, stdout, stderr := runApp(t, "feedback", "Great", "tool", "--title", "CLI Feedback", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([feedback ...]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([feedback ...]) stderr = %q, want empty string", stderr)
+	}
+	if got, want := stdout, "https://github.com/powerformer/looper/issues/321\n"; got != want {
+		t.Fatalf("Run([feedback ...]) stdout = %q, want %q", got, want)
+	}
+
+	exitCode, stdout, stderr = runApp(t, "feedback", "Great", "tool", "--title", "CLI Feedback", "--json", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([feedback ... --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([feedback ... --json]) stderr = %q, want empty string", stderr)
+	}
+	assertJSONContains(t, stdout, "repo", "powerformer/looper")
+	assertJSONContains(t, stdout, "titleHint", "CLI Feedback")
+	assertJSONContains(t, stdout, "message", "Great tool")
+	assertJSONContains(t, stdout, "issueUrl", "https://github.com/powerformer/looper/issues/321")
+	assertJSONContains(t, stdout, "summary", "created issue")
+}
+
+func TestFeedbackCommandRequiresMessage(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeCLIConfigWithAgent(t, "http://127.0.0.1:1", string(config.AgentVendorOpenCode), map[string]any{"command": "/bin/true"})
+	exitCode, stdout, stderr := runApp(t, "feedback", "--title", "Only title", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatalf("Run([feedback --title ...]) exit code = %d, want non-zero", exitCode)
+	}
+	if stdout != "" {
+		t.Fatalf("Run([feedback --title ...]) stdout = %q, want empty string", stdout)
+	}
+	if !strings.Contains(stderr, "feedback message is required") {
+		t.Fatalf("Run([feedback --title ...]) stderr = %q, want missing message error", stderr)
+	}
+}
+
 func TestVersionCommandPrintsCurrentVersion(t *testing.T) {
 	t.Parallel()
 
@@ -1317,6 +1390,32 @@ func writeCLIConfig(t *testing.T, baseURL string, localToken string) string {
 	}
 
 	raw, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	return configPath
+}
+
+func writeCLIConfigWithAgent(t *testing.T, baseURL string, vendor string, params map[string]any) string {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	configPayload := map[string]any{
+		"server": map[string]any{
+			"baseUrl":  baseURL,
+			"authMode": "none",
+		},
+		"agent": map[string]any{
+			"vendor": vendor,
+			"params": params,
+		},
+	}
+
+	raw, err := json.Marshal(configPayload)
 	if err != nil {
 		t.Fatalf("marshal config: %v", err)
 	}

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/powerformer/looper/internal/config"
 	gitinfra "github.com/powerformer/looper/internal/infra/git"
 	looperdruntime "github.com/powerformer/looper/internal/runtime"
+	"github.com/powerformer/looper/internal/version"
 	"github.com/powerformer/looper/internal/worker"
 	pkgapi "github.com/powerformer/looper/pkg/api"
 )
@@ -90,6 +91,9 @@ func TestRootHelpIncludesGlobalFlagsWithFrozenSyntax(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("Run([--help]) stderr = %q, want empty string", stderr)
 	}
+	if !strings.Contains(stdout, "Version:\n  "+version.Current().Version) {
+		t.Fatalf("Run([--help]) stdout = %q, want version section", stdout)
+	}
 
 	for _, syntax := range []string{
 		"--json",
@@ -107,6 +111,43 @@ func TestRootHelpIncludesGlobalFlagsWithFrozenSyntax(t *testing.T) {
 			t.Fatalf("Run([--help]) stdout = %q, want to contain %q", stdout, syntax)
 		}
 	}
+}
+
+func TestVersionCommandPrintsCurrentVersion(t *testing.T) {
+	t.Parallel()
+
+	exitCode, stdout, stderr := runApp(t, "version")
+	if exitCode != 0 {
+		t.Fatalf("Run([version]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([version]) stderr = %q, want empty string", stderr)
+	}
+	if got, want := stdout, version.Current().Version+"\n"; got != want {
+		t.Fatalf("Run([version]) stdout = %q, want %q", got, want)
+	}
+}
+
+func TestVersionCommandJSONPrintsBuildMetadata(t *testing.T) {
+	t.Parallel()
+
+	exitCode, stdout, stderr := runApp(t, "version", "--json")
+	if exitCode != 0 {
+		t.Fatalf("Run([version --json]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([version --json]) stderr = %q, want empty string", stderr)
+	}
+	assertJSONContains(t, stdout, "version", version.Current().Version)
+	assertJSONContains(t, stdout, "metadata", map[string]any{
+		"versionSource":   version.Current().Metadata.VersionSource,
+		"channel":         version.Current().Metadata.Channel,
+		"apiVersion":      version.Current().Metadata.APIVersion,
+		"minCliForDaemon": nil,
+		"minDaemonForCli": nil,
+		"gitCommitSha":    nil,
+		"buildTimestamp":  nil,
+	})
 }
 
 func TestNestedCommandParsingReachesLeafCommands(t *testing.T) {

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -50,7 +50,7 @@ func TestCommandGroupHelpListsExpectedSubcommands(t *testing.T) {
 	}{
 		{args: []string{"project", "--help"}, subcommands: []string{"list  List projects", "add   Add a project"}},
 		{args: []string{"config", "--help"}, subcommands: []string{"show  Show active config"}},
-		{args: []string{"daemon", "--help"}, subcommands: []string{"install  Install the managed daemon binary", "status   Show daemon status", "start    Start the daemon", "restart  Restart the daemon", "logs     Show daemon logs"}},
+		{args: []string{"daemon", "--help"}, subcommands: []string{"install  Install the managed daemon binary", "status   Show daemon status", "start    Start the daemon", "stop     Stop the daemon", "restart  Restart the daemon", "logs     Show daemon logs"}},
 		{args: []string{"loop", "--help"}, subcommands: []string{"list   List loops", "start  Start a loop", "pause  Pause a loop"}},
 		{args: []string{"pr", "--help"}, subcommands: []string{"list    List pull requests", "show    Show a pull request", "status  Show pull request status"}},
 		{args: []string{"run", "--help"}, subcommands: []string{"list  List runs"}},

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -601,11 +601,18 @@ func (r *commandRuntime) bootstrapAPIReachable(ctx context.Context, client *Daem
 	if isBootstrapProbeContextError(healthErr) {
 		return false, healthErr
 	}
+	if !isBootstrapProbeReachabilityError(healthErr) {
+		return false, healthErr
+	}
 	return false, nil
 }
 
 func isBootstrapProbeContextError(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func isBootstrapProbeReachabilityError(err error) bool {
+	return strings.HasPrefix(err.Error(), "looperd is not reachable:")
 }
 
 func (r *commandRuntime) waitForBootstrapHealth(ctx context.Context, client *DaemonAPIClient) (bool, error) {

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -591,11 +591,21 @@ func (r *commandRuntime) bootstrapAPIReachable(ctx context.Context, client *Daem
 	if err == nil {
 		return true, nil
 	}
+	if isBootstrapProbeContextError(err) {
+		return false, err
+	}
 	_, healthErr := r.getJSONWithClient(ctx, client, "/api/v1/healthz")
 	if healthErr == nil {
 		return true, nil
 	}
+	if isBootstrapProbeContextError(healthErr) {
+		return false, healthErr
+	}
 	return false, nil
+}
+
+func isBootstrapProbeContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func (r *commandRuntime) waitForBootstrapHealth(ctx context.Context, client *DaemonAPIClient) (bool, error) {

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -97,7 +98,7 @@ func (r *commandRuntime) runBootstrap(ctx context.Context, cmd *cobra.Command, o
 	}
 	result.Notes = append(result.Notes, planNotes...)
 
-	preflightNotes, err := r.bootstrapPreflight(ctx, &planned)
+	preflightNotes, err := r.bootstrapPreflight(ctx, configPath, &planned)
 	if err != nil {
 		return bootstrapResult{}, err
 	}
@@ -132,7 +133,7 @@ func (r *commandRuntime) runBootstrap(ctx context.Context, cmd *cobra.Command, o
 		return bootstrapResult{}, err
 	}
 	if !apiReachable {
-		if err := r.daemonStart(cmd, nil); err != nil {
+		if err := r.daemonStartForBootstrap(cmd); err != nil {
 			return bootstrapResult{}, err
 		}
 		apiReachable, err = r.waitForBootstrapHealth(ctx, client)
@@ -250,22 +251,15 @@ func (r *commandRuntime) planBootstrapConfig(cmd *cobra.Command, cwd string, opt
 	return plan, nil, nil
 }
 
-func (r *commandRuntime) bootstrapPreflight(ctx context.Context, plan *bootstrapConfigPlan) ([]string, error) {
+func (r *commandRuntime) bootstrapPreflight(ctx context.Context, configPath string, plan *bootstrapConfigPlan) ([]string, error) {
 	if _, err := resolveLooperdTarget(r.platform(), r.arch()); err != nil {
 		return nil, err
 	}
 
-	configured := config.ToolPathsConfig{}
-	if value := strings.TrimSpace(extractToolPathOverride(ExtractConfigArgs(r.argv), "git-path")); value != "" {
-		configured.GitPath = stringPtr(value)
+	configured, err := r.bootstrapConfiguredToolPaths(configPath)
+	if err != nil {
+		return nil, err
 	}
-	if value := strings.TrimSpace(extractToolPathOverride(ExtractConfigArgs(r.argv), "gh-path")); value != "" {
-		configured.GHPath = stringPtr(value)
-	}
-	if value := strings.TrimSpace(extractToolPathOverride(ExtractConfigArgs(r.argv), "osascript-path")); value != "" {
-		configured.OsascriptPath = stringPtr(value)
-	}
-
 	detected := config.DetectToolPaths(configured, r.lookPath())
 	missing := make([]string, 0)
 	if detected.Paths.GitPath == nil || strings.TrimSpace(*detected.Paths.GitPath) == "" {
@@ -290,6 +284,68 @@ func (r *commandRuntime) bootstrapPreflight(ctx context.Context, plan *bootstrap
 		}
 	}
 	return notes, nil
+}
+
+func (r *commandRuntime) daemonStartForBootstrap(cmd *cobra.Command) error {
+	if !getBoolFlag(cmd, "json") {
+		return r.daemonStart(cmd, nil)
+	}
+
+	originalOut := cmd.OutOrStdout()
+	cmd.SetOut(io.Discard)
+	defer cmd.SetOut(originalOut)
+	return r.daemonStart(cmd, nil)
+}
+
+func (r *commandRuntime) bootstrapConfiguredToolPaths(configPath string) (config.ToolPathsConfig, error) {
+	configured := config.ToolPathsConfig{}
+	if partial, err := readBootstrapPartialConfigIfPresent(configPath); err != nil {
+		return config.ToolPathsConfig{}, err
+	} else if partial.Tools != nil {
+		configured.GitPath = cloneBootstrapStringPtr(partial.Tools.GitPath)
+		configured.GHPath = cloneBootstrapStringPtr(partial.Tools.GHPath)
+		configured.OsascriptPath = cloneBootstrapStringPtr(partial.Tools.OsascriptPath)
+	}
+
+	if value, ok := os.LookupEnv("LOOPER_GIT_PATH"); ok {
+		configured.GitPath = stringPtr(value)
+	}
+	if value, ok := os.LookupEnv("LOOPER_GH_PATH"); ok {
+		configured.GHPath = stringPtr(value)
+	}
+	if value, ok := os.LookupEnv("LOOPER_OSASCRIPT_PATH"); ok {
+		configured.OsascriptPath = stringPtr(value)
+	}
+
+	args := ExtractConfigArgs(r.argv)
+	if value := strings.TrimSpace(extractToolPathOverride(args, "git-path")); value != "" {
+		configured.GitPath = stringPtr(value)
+	}
+	if value := strings.TrimSpace(extractToolPathOverride(args, "gh-path")); value != "" {
+		configured.GHPath = stringPtr(value)
+	}
+	if value := strings.TrimSpace(extractToolPathOverride(args, "osascript-path")); value != "" {
+		configured.OsascriptPath = stringPtr(value)
+	}
+	return configured, nil
+}
+
+func readBootstrapPartialConfigIfPresent(path string) (config.PartialConfig, error) {
+	partial, err := readBootstrapPartialConfig(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return config.PartialConfig{}, nil
+		}
+		return config.PartialConfig{}, err
+	}
+	return partial, nil
+}
+
+func cloneBootstrapStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	return stringPtr(*value)
 }
 
 func extractToolPathOverride(args []string, flag string) string {

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -565,16 +565,11 @@ func bootstrapLocalToken() string {
 }
 
 func (r *commandRuntime) ensureBootstrapDaemon(ctx context.Context, force bool) (string, bool, error) {
-	release, err := r.fetchReleaseMetadata(ctx, "")
-	if err != nil {
-		return "", false, err
-	}
-	latestVersion := strings.TrimPrefix(strings.TrimSpace(release.TagName), "v")
 	installed, err := r.readManagedDaemonVersion(ctx)
 	if err != nil {
 		return "", false, err
 	}
-	if !force && installed != nil && installed.Version == latestVersion {
+	if !force && installed != nil {
 		return "already-installed", false, nil
 	}
 	reinstall := force || installed != nil

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -1,0 +1,614 @@
+package cliapp
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/powerformer/looper/internal/config"
+	"github.com/spf13/cobra"
+)
+
+const bootstrapHealthCheckTimeout = 5 * time.Second
+
+type bootstrapResult struct {
+	ConfigPath         string   `json:"configPath"`
+	ConfigCreated      bool     `json:"configCreated"`
+	ProjectAdded       bool     `json:"projectAdded"`
+	ManagedDaemonPath  string   `json:"managedDaemonPath"`
+	DaemonInstalled    bool     `json:"daemonInstalled"`
+	DaemonInstallState string   `json:"daemonInstallState"`
+	DaemonRunning      bool     `json:"daemonRunning"`
+	APIReachable       bool     `json:"apiReachable"`
+	NextSteps          []string `json:"nextSteps"`
+	Notes              []string `json:"notes,omitempty"`
+}
+
+type bootstrapOptions struct {
+	Yes              bool
+	Force            bool
+	AgentVendor      string
+	ProjectPath      string
+	EnableLocalToken bool
+	DisableOsascript bool
+}
+
+type bootstrapConfigPlan struct {
+	AgentVendor      *config.AgentVendor
+	EnableOsascript  bool
+	EnableLocalToken bool
+	ProjectPath      string
+}
+
+func (r *commandRuntime) bootstrap(cmd *cobra.Command, args []string) error {
+	_ = args
+
+	ctx := cmd.Context()
+	opts := bootstrapOptions{
+		Yes:              getBoolFlag(cmd, "yes"),
+		Force:            getBoolFlag(cmd, "force"),
+		AgentVendor:      strings.TrimSpace(getStringFlag(cmd, "agent-vendor")),
+		ProjectPath:      strings.TrimSpace(getStringFlag(cmd, "project-path")),
+		EnableLocalToken: getBoolFlag(cmd, "enable-local-token"),
+		DisableOsascript: getBoolFlag(cmd, "disable-osascript"),
+	}
+
+	result, err := r.runBootstrap(ctx, cmd, opts)
+	if err != nil {
+		return err
+	}
+
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), result)
+	}
+
+	return writeHumanBootstrapResult(cmd.OutOrStdout(), result)
+}
+
+func (r *commandRuntime) runBootstrap(ctx context.Context, cmd *cobra.Command, opts bootstrapOptions) (bootstrapResult, error) {
+	cwd, err := r.getwd()
+	if err != nil {
+		return bootstrapResult{}, fmt.Errorf("determine current working directory: %w", err)
+	}
+
+	configPath, err := r.resolveBootstrapConfigPath(cwd)
+	if err != nil {
+		return bootstrapResult{}, err
+	}
+	managedDaemonPath, err := r.managedDaemonBinaryPath()
+	if err != nil {
+		return bootstrapResult{}, err
+	}
+
+	result := bootstrapResult{ConfigPath: configPath, ManagedDaemonPath: managedDaemonPath}
+	planned, planNotes, err := r.planBootstrapConfig(cmd, cwd, opts)
+	if err != nil {
+		return bootstrapResult{}, err
+	}
+	result.Notes = append(result.Notes, planNotes...)
+
+	preflightNotes, err := r.bootstrapPreflight(ctx, &planned)
+	if err != nil {
+		return bootstrapResult{}, err
+	}
+	result.Notes = append(result.Notes, preflightNotes...)
+
+	if err := r.ensureBootstrapDirectories(); err != nil {
+		return bootstrapResult{}, err
+	}
+
+	configCreated, projectAdded, err := r.ensureBootstrapConfig(configPath, cwd, planned)
+	if err != nil {
+		return bootstrapResult{}, err
+	}
+	result.ConfigCreated = configCreated
+	result.ProjectAdded = projectAdded
+
+	installState, installed, err := r.ensureBootstrapDaemon(ctx, opts.Force)
+	if err != nil {
+		return bootstrapResult{}, err
+	}
+	result.DaemonInstallState = installState
+	result.DaemonInstalled = installed
+
+	loaded, err := r.loadConfig()
+	if err != nil {
+		return bootstrapResult{}, err
+	}
+	client := r.apiClientFromLoaded(loaded)
+
+	apiReachable, err := r.bootstrapAPIReachable(ctx, client)
+	if err != nil {
+		return bootstrapResult{}, err
+	}
+	if !apiReachable {
+		if err := r.daemonStart(cmd, nil); err != nil {
+			return bootstrapResult{}, err
+		}
+		apiReachable, err = r.waitForBootstrapHealth(ctx, client)
+		if err != nil {
+			return bootstrapResult{}, err
+		}
+	}
+
+	result.APIReachable = apiReachable
+	result.DaemonRunning = apiReachable
+	result.NextSteps = bootstrapNextSteps(planned.ProjectPath)
+	return result, nil
+}
+
+func (r *commandRuntime) resolveBootstrapConfigPath(cwd string) (string, error) {
+	if override := strings.TrimSpace(extractConfigPathOverride(ExtractConfigArgs(r.argv))); override != "" {
+		return config.ResolveConfigPath(override, cwd), nil
+	}
+	if override, ok := os.LookupEnv("LOOPER_CONFIG"); ok && strings.TrimSpace(override) != "" {
+		return config.ResolveConfigPath(strings.TrimSpace(override), cwd), nil
+	}
+	defaultConfigPath, err := config.DefaultConfigPath()
+	if err != nil {
+		return "", fmt.Errorf("determine default config path: %w", err)
+	}
+	return defaultConfigPath, nil
+}
+
+func extractConfigPathOverride(args []string) string {
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if !strings.HasPrefix(arg, "--config") {
+			continue
+		}
+		if _, value, ok := strings.Cut(arg, "="); ok {
+			return value
+		}
+		if index+1 < len(args) {
+			return args[index+1]
+		}
+	}
+	return ""
+}
+
+func (r *commandRuntime) planBootstrapConfig(cmd *cobra.Command, cwd string, opts bootstrapOptions) (bootstrapConfigPlan, []string, error) {
+	plan := bootstrapConfigPlan{EnableOsascript: runtime.GOOS == "darwin", EnableLocalToken: opts.EnableLocalToken}
+	if opts.DisableOsascript {
+		plan.EnableOsascript = false
+	}
+	if opts.AgentVendor != "" {
+		vendor := config.AgentVendor(opts.AgentVendor)
+		if !isSupportedBootstrapVendor(vendor) {
+			return bootstrapConfigPlan{}, nil, fmt.Errorf("unsupported --agent-vendor %q", opts.AgentVendor)
+		}
+		plan.AgentVendor = &vendor
+	}
+	if opts.ProjectPath != "" {
+		resolved, err := filepath.Abs(opts.ProjectPath)
+		if err != nil {
+			return bootstrapConfigPlan{}, nil, fmt.Errorf("resolve --project-path: %w", err)
+		}
+		plan.ProjectPath = resolved
+	}
+
+	configPath, err := r.resolveBootstrapConfigPath(cwd)
+	if err != nil {
+		return bootstrapConfigPlan{}, nil, err
+	}
+	if _, err := os.Stat(configPath); err == nil {
+		return plan, nil, nil
+	} else if !os.IsNotExist(err) {
+		return bootstrapConfigPlan{}, nil, fmt.Errorf("check config path %s: %w", configPath, err)
+	}
+
+	if opts.Yes {
+		return plan, nil, nil
+	}
+
+	reader := bufio.NewReader(cmd.InOrStdin())
+	if plan.AgentVendor == nil {
+		vendor, err := promptBootstrapVendor(reader, cmd.OutOrStdout())
+		if err != nil {
+			return bootstrapConfigPlan{}, nil, err
+		}
+		plan.AgentVendor = vendor
+	}
+	if !opts.DisableOsascript {
+		enabled, err := promptBootstrapBool(reader, cmd.OutOrStdout(), "Enable osascript notifications", plan.EnableOsascript)
+		if err != nil {
+			return bootstrapConfigPlan{}, nil, err
+		}
+		plan.EnableOsascript = enabled
+	}
+	if !opts.EnableLocalToken {
+		enabled, err := promptBootstrapBool(reader, cmd.OutOrStdout(), "Enable local-token API auth", false)
+		if err != nil {
+			return bootstrapConfigPlan{}, nil, err
+		}
+		plan.EnableLocalToken = enabled
+	}
+	if plan.ProjectPath == "" {
+		projectPath, err := promptBootstrapString(reader, cmd.OutOrStdout(), "Default project path (optional)", "")
+		if err != nil {
+			return bootstrapConfigPlan{}, nil, err
+		}
+		if strings.TrimSpace(projectPath) != "" {
+			resolved, err := filepath.Abs(strings.TrimSpace(projectPath))
+			if err != nil {
+				return bootstrapConfigPlan{}, nil, fmt.Errorf("resolve project path: %w", err)
+			}
+			plan.ProjectPath = resolved
+		}
+	}
+
+	return plan, nil, nil
+}
+
+func (r *commandRuntime) bootstrapPreflight(ctx context.Context, plan *bootstrapConfigPlan) ([]string, error) {
+	if _, err := resolveLooperdTarget(r.platform(), r.arch()); err != nil {
+		return nil, err
+	}
+
+	configured := config.ToolPathsConfig{}
+	if value := strings.TrimSpace(extractToolPathOverride(ExtractConfigArgs(r.argv), "git-path")); value != "" {
+		configured.GitPath = stringPtr(value)
+	}
+	if value := strings.TrimSpace(extractToolPathOverride(ExtractConfigArgs(r.argv), "gh-path")); value != "" {
+		configured.GHPath = stringPtr(value)
+	}
+	if value := strings.TrimSpace(extractToolPathOverride(ExtractConfigArgs(r.argv), "osascript-path")); value != "" {
+		configured.OsascriptPath = stringPtr(value)
+	}
+
+	detected := config.DetectToolPaths(configured, r.lookPath())
+	missing := make([]string, 0)
+	if detected.Paths.GitPath == nil || strings.TrimSpace(*detected.Paths.GitPath) == "" {
+		missing = append(missing, "git")
+	}
+	if detected.Paths.GHPath == nil || strings.TrimSpace(*detected.Paths.GHPath) == "" {
+		missing = append(missing, "gh")
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("bootstrap preflight failed: missing required tools: %s. Install them manually (for example: brew install git gh) and rerun `looper bootstrap`", strings.Join(missing, ", "))
+	}
+
+	notes := make([]string, 0)
+	if plan.EnableOsascript && (detected.Paths.OsascriptPath == nil || strings.TrimSpace(*detected.Paths.OsascriptPath) == "") {
+		plan.EnableOsascript = false
+		notes = append(notes, "osascript was not detected; notifications.osascript.enabled will remain disabled")
+	}
+	if detected.Paths.GHPath != nil {
+		result, err := r.runCommand(ctx, *detected.Paths.GHPath, []string{"auth", "status"}, 3*time.Second)
+		if err != nil || result.ExitCode != 0 {
+			notes = append(notes, "gh auth status is not ready yet; run `gh auth login` if you plan to use GitHub integration")
+		}
+	}
+	return notes, nil
+}
+
+func extractToolPathOverride(args []string, flag string) string {
+	prefix := "--" + flag
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if !strings.HasPrefix(arg, prefix) {
+			continue
+		}
+		if _, value, ok := strings.Cut(arg, "="); ok {
+			return value
+		}
+		if index+1 < len(args) {
+			return args[index+1]
+		}
+	}
+	return ""
+}
+
+func (r *commandRuntime) lookPath() config.LookPathFunc {
+	if r.app.deps.LookPath != nil {
+		return config.LookPathFunc(r.app.deps.LookPath)
+	}
+	return config.LookPathFunc(execLookPath)
+}
+
+var execLookPath = func(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
+func (r *commandRuntime) ensureBootstrapDirectories() error {
+	homeDir, err := r.homeDir()
+	if err != nil {
+		return err
+	}
+	for _, path := range []string{
+		filepath.Join(homeDir, ".looper", "bin"),
+		filepath.Join(homeDir, ".looper", "backups"),
+		filepath.Join(homeDir, ".looper", "logs"),
+	} {
+		if err := r.mkdirAll(path, 0o755); err != nil {
+			return fmt.Errorf("create %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func (r *commandRuntime) ensureBootstrapConfig(configPath string, cwd string, plan bootstrapConfigPlan) (bool, bool, error) {
+	if err := r.mkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return false, false, fmt.Errorf("create config directory: %w", err)
+	}
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		cfg, err := config.DefaultConfig(cwd)
+		if err != nil {
+			return false, false, fmt.Errorf("build default config: %w", err)
+		}
+		applyBootstrapPlan(&cfg, plan)
+		if err := writeBootstrapConfig(configPath, cfg); err != nil {
+			return false, false, err
+		}
+		return true, plan.ProjectPath != "", nil
+	} else if err != nil {
+		return false, false, fmt.Errorf("check config path %s: %w", configPath, err)
+	}
+
+	loaded, err := config.LoadFile(config.LoadFileOptions{Args: ExtractConfigArgs(r.argv), CWD: cwd, LookPath: r.lookPath()})
+	if err != nil {
+		return false, false, err
+	}
+
+	if plan.ProjectPath == "" {
+		return false, false, nil
+	}
+	if hasBootstrapProject(loaded.Config.Projects, plan.ProjectPath) {
+		return false, false, nil
+	}
+	loaded.Config.Projects = append(loaded.Config.Projects, buildBootstrapProject(plan.ProjectPath, loaded.Config.Defaults.BaseBranch))
+	if err := writeBootstrapConfig(configPath, loaded.Config); err != nil {
+		return false, false, err
+	}
+	return false, true, nil
+}
+
+func applyBootstrapPlan(cfg *config.Config, plan bootstrapConfigPlan) {
+	if plan.AgentVendor != nil {
+		vendor := *plan.AgentVendor
+		cfg.Agent.Vendor = &vendor
+	}
+	cfg.Notifications.Osascript.Enabled = plan.EnableOsascript
+	if plan.EnableLocalToken {
+		authMode := config.AuthModeLocalToken
+		cfg.Server.AuthMode = authMode
+		token := bootstrapLocalToken()
+		cfg.Server.LocalToken = &token
+	}
+	if plan.ProjectPath != "" {
+		cfg.Projects = append(cfg.Projects, buildBootstrapProject(plan.ProjectPath, cfg.Defaults.BaseBranch))
+	}
+}
+
+func writeBootstrapConfig(path string, cfg config.Config) error {
+	if err := config.Validate(cfg); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal bootstrap config: %w", err)
+	}
+	raw = append(raw, '\n')
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		return fmt.Errorf("write bootstrap config: %w", err)
+	}
+	return nil
+}
+
+func hasBootstrapProject(projects []config.ProjectRefConfig, projectPath string) bool {
+	for _, project := range projects {
+		if samePath(project.RepoPath, projectPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func samePath(left string, right string) bool {
+	leftClean := filepath.Clean(left)
+	rightClean := filepath.Clean(right)
+	return leftClean == rightClean
+}
+
+func buildBootstrapProject(projectPath string, baseBranch string) config.ProjectRefConfig {
+	projectID := deriveBootstrapProjectID(projectPath)
+	projectName := filepath.Base(projectPath)
+	if projectName == "." || projectName == string(filepath.Separator) || strings.TrimSpace(projectName) == "" {
+		projectName = projectID
+	}
+	return config.ProjectRefConfig{
+		ID:         projectID,
+		Name:       projectName,
+		RepoPath:   projectPath,
+		BaseBranch: stringPtr(baseBranch),
+	}
+}
+
+func deriveBootstrapProjectID(projectPath string) string {
+	base := strings.ToLower(filepath.Base(projectPath))
+	var builder strings.Builder
+	lastHyphen := false
+	for _, r := range base {
+		allowed := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if allowed {
+			builder.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+		if !lastHyphen {
+			builder.WriteRune('-')
+			lastHyphen = true
+		}
+	}
+	derived := strings.Trim(builder.String(), "-")
+	if derived == "" {
+		return "project"
+	}
+	return derived
+}
+
+func bootstrapLocalToken() string {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return fmt.Sprintf("bootstrap-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(raw)
+}
+
+func (r *commandRuntime) ensureBootstrapDaemon(ctx context.Context, force bool) (string, bool, error) {
+	release, err := r.fetchReleaseMetadata(ctx, "")
+	if err != nil {
+		return "", false, err
+	}
+	latestVersion := strings.TrimPrefix(strings.TrimSpace(release.TagName), "v")
+	installed, err := r.readManagedDaemonVersion(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	if !force && installed != nil && installed.Version == latestVersion {
+		return "already-installed", false, nil
+	}
+	reinstall := force || installed != nil
+	result, err := r.installManagedDaemon(ctx, reinstall, "")
+	if err != nil {
+		return "", false, fmt.Errorf("install managed daemon: %w", err)
+	}
+	if result.Skipped {
+		return "already-installed", false, nil
+	}
+	if reinstall {
+		return "reinstalled", true, nil
+	}
+	return "installed", true, nil
+}
+
+func (r *commandRuntime) bootstrapAPIReachable(ctx context.Context, client *DaemonAPIClient) (bool, error) {
+	_, err := r.getJSONWithClient(ctx, client, "/api/v1/status")
+	if err == nil {
+		return true, nil
+	}
+	_, healthErr := r.getJSONWithClient(ctx, client, "/api/v1/healthz")
+	if healthErr == nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (r *commandRuntime) waitForBootstrapHealth(ctx context.Context, client *DaemonAPIClient) (bool, error) {
+	deadline := time.Now().Add(bootstrapHealthCheckTimeout)
+	for time.Now().Before(deadline) {
+		reachable, err := r.bootstrapAPIReachable(ctx, client)
+		if err != nil {
+			return false, err
+		}
+		if reachable {
+			return true, nil
+		}
+		r.sleep(250 * time.Millisecond)
+	}
+	return false, fmt.Errorf("looperd did not become healthy after bootstrap; rerun `looper bootstrap` to retry startup")
+}
+
+func bootstrapNextSteps(projectPath string) []string {
+	steps := []string{"looper status"}
+	if strings.TrimSpace(projectPath) == "" {
+		steps = append(steps, "looper project add /path/to/repo")
+	}
+	return steps
+}
+
+func writeHumanBootstrapResult(w io.Writer, result bootstrapResult) error {
+	printSection(w, "Bootstrap complete", [][2]any{{"configPath", result.ConfigPath}, {"configCreated", result.ConfigCreated}, {"projectAdded", result.ProjectAdded}, {"managedDaemonPath", result.ManagedDaemonPath}, {"daemonInstallState", result.DaemonInstallState}, {"apiReachable", result.APIReachable}})
+	if len(result.Notes) > 0 {
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, "Notes:")
+		for _, note := range result.Notes {
+			_, _ = fmt.Fprintf(w, "- %s\n", note)
+		}
+	}
+	if len(result.NextSteps) > 0 {
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, "Next steps:")
+		for _, step := range result.NextSteps {
+			_, _ = fmt.Fprintf(w, "- %s\n", step)
+		}
+	}
+	return nil
+}
+
+func promptBootstrapVendor(reader *bufio.Reader, w io.Writer) (*config.AgentVendor, error) {
+	answer, err := promptBootstrapString(reader, w, "Agent vendor [claude-code/codex/opencode/cursor-cli]", "")
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(answer) == "" {
+		return nil, nil
+	}
+	vendor := config.AgentVendor(strings.TrimSpace(answer))
+	if !isSupportedBootstrapVendor(vendor) {
+		return nil, fmt.Errorf("unsupported agent vendor %q", answer)
+	}
+	return &vendor, nil
+}
+
+func promptBootstrapBool(reader *bufio.Reader, w io.Writer, label string, defaultValue bool) (bool, error) {
+	defaultText := "y/N"
+	if defaultValue {
+		defaultText = "Y/n"
+	}
+	answer, err := promptBootstrapString(reader, w, label+" ["+defaultText+"]", "")
+	if err != nil {
+		return false, err
+	}
+	trimmed := strings.ToLower(strings.TrimSpace(answer))
+	if trimmed == "" {
+		return defaultValue, nil
+	}
+	if trimmed == "y" || trimmed == "yes" {
+		return true, nil
+	}
+	if trimmed == "n" || trimmed == "no" {
+		return false, nil
+	}
+	return false, fmt.Errorf("invalid answer %q", answer)
+}
+
+func promptBootstrapString(reader *bufio.Reader, w io.Writer, label string, defaultValue string) (string, error) {
+	if defaultValue != "" {
+		if _, err := fmt.Fprintf(w, "%s [%s]: ", label, defaultValue); err != nil {
+			return "", err
+		}
+	} else {
+		if _, err := fmt.Fprintf(w, "%s: ", label); err != nil {
+			return "", err
+		}
+	}
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return defaultValue, nil
+	}
+	return trimmed, nil
+}
+
+func isSupportedBootstrapVendor(vendor config.AgentVendor) bool {
+	switch vendor {
+	case config.AgentVendorClaudeCode, config.AgentVendorCodex, config.AgentVendorOpenCode, config.AgentVendorCursorCLI:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -355,7 +355,7 @@ func (r *commandRuntime) ensureBootstrapConfig(configPath string, cwd string, pl
 		return false, false, fmt.Errorf("check config path %s: %w", configPath, err)
 	}
 
-	loaded, err := config.LoadFile(config.LoadFileOptions{Args: ExtractConfigArgs(r.argv), CWD: cwd, LookPath: r.lookPath()})
+	partial, err := readBootstrapPartialConfig(configPath)
 	if err != nil {
 		return false, false, err
 	}
@@ -363,11 +363,30 @@ func (r *commandRuntime) ensureBootstrapConfig(configPath string, cwd string, pl
 	if plan.ProjectPath == "" {
 		return false, false, nil
 	}
-	if hasBootstrapProject(loaded.Config.Projects, plan.ProjectPath) {
+	normalized, err := config.Normalize(cwd, partial)
+	if err != nil {
+		return false, false, err
+	}
+	if err := config.Validate(normalized); err != nil {
+		return false, false, err
+	}
+	if hasBootstrapProject(normalized.Projects, plan.ProjectPath) {
 		return false, false, nil
 	}
-	loaded.Config.Projects = append(loaded.Config.Projects, buildBootstrapProject(plan.ProjectPath, loaded.Config.Defaults.BaseBranch))
-	if err := writeBootstrapConfig(configPath, loaded.Config); err != nil {
+	projects := []config.ProjectRefConfig{}
+	if partial.Projects != nil {
+		projects = append(projects, (*partial.Projects)...)
+	}
+	projects = append(projects, buildBootstrapProject(plan.ProjectPath, normalized.Defaults.BaseBranch))
+	partial.Projects = &projects
+	updated, err := config.Normalize(cwd, partial)
+	if err != nil {
+		return false, false, err
+	}
+	if err := config.Validate(updated); err != nil {
+		return false, false, err
+	}
+	if err := writeBootstrapPartialConfig(configPath, partial); err != nil {
 		return false, false, err
 	}
 	return false, true, nil
@@ -395,6 +414,30 @@ func writeBootstrapConfig(path string, cfg config.Config) error {
 		return err
 	}
 	raw, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal bootstrap config: %w", err)
+	}
+	raw = append(raw, '\n')
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		return fmt.Errorf("write bootstrap config: %w", err)
+	}
+	return nil
+}
+
+func readBootstrapPartialConfig(path string) (config.PartialConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return config.PartialConfig{}, fmt.Errorf("read bootstrap config: %w", err)
+	}
+	var partial config.PartialConfig
+	if err := json.Unmarshal(raw, &partial); err != nil {
+		return config.PartialConfig{}, fmt.Errorf("parse bootstrap config: %w", err)
+	}
+	return partial, nil
+}
+
+func writeBootstrapPartialConfig(path string, partial config.PartialConfig) error {
+	raw, err := json.MarshalIndent(partial, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal bootstrap config: %w", err)
 	}

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -297,6 +298,30 @@ func TestBootstrapPreflightHonorsConfigAndEnvToolOverrides(t *testing.T) {
 
 	if _, err := runtime.bootstrapPreflight(context.Background(), configPath, &plan); err != nil {
 		t.Fatalf("bootstrapPreflight() error = %v", err)
+	}
+}
+
+func TestWaitForBootstrapHealthPropagatesCancellation(t *testing.T) {
+	t.Parallel()
+
+	app := New(Deps{
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			_ = req
+			return nil, context.Canceled
+		}),
+		Sleep: func(duration time.Duration) {
+			t.Fatalf("Sleep(%s) called after bootstrap probe cancellation", duration)
+		},
+	})
+	runtime := newCommandRuntime(app, nil)
+	client := NewDaemonAPIClient(DaemonAPIClientOptions{BaseURL: "http://127.0.0.1", HTTPClient: app.deps.HTTPClient})
+
+	reachable, err := runtime.waitForBootstrapHealth(context.Background(), client)
+	if reachable {
+		t.Fatal("waitForBootstrapHealth(...) reachable = true, want false")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForBootstrapHealth(...) error = %v, want context.Canceled", err)
 	}
 }
 

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -468,6 +468,78 @@ func TestBootstrapIdempotentWhenConfigProjectAndDaemonAlreadyHealthy(t *testing.
 	}
 }
 
+func TestBootstrapIdempotentSkipsGitHubWhenManagedDaemonInstalled(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	cwd := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "bootstrap-offline.json")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if err := os.WriteFile(configPath, []byte(`{"server":{"baseUrl":"http://daemon.test","authMode":"none"}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(configPath) error = %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		Getwd: func() (string, error) {
+			return cwd, nil
+		},
+		LookPath: func(file string) (string, error) {
+			switch file {
+			case "git", "gh":
+				return "/usr/bin/" + file, nil
+			default:
+				return "", fmt.Errorf("not found")
+			}
+		},
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "http://daemon.test/api/v1/status":
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true}}}`), nil
+			case "http://daemon.test/api/v1/healthz":
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_health","data":{"healthy":true}}}`), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "/usr/bin/gh" && strings.Join(args, " ") == "auth status" {
+				return commandExecutionResult{ExitCode: 0}, nil
+			}
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 0, Stdout: "0.1.0\n"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			_ = command
+			_ = args
+			_ = cwd
+			_ = env
+			return 0, fmt.Errorf("spawn should not be called")
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"bootstrap", "--yes", "--json", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([bootstrap --yes --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([bootstrap --yes --json]) stderr = %q, want empty string", stderr.String())
+	}
+	assertJSONContains(t, stdout.String(), "daemonInstallState", "already-installed")
+	assertJSONContains(t, stdout.String(), "daemonInstalled", false)
+}
+
 func TestBootstrapAddsProjectWithoutPersistingRuntimeOverrides(t *testing.T) {
 	homeDir := t.TempDir()
 	cwd := t.TempDir()

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -325,6 +325,44 @@ func TestWaitForBootstrapHealthPropagatesCancellation(t *testing.T) {
 	}
 }
 
+func TestWaitForBootstrapHealthPropagatesDaemonAPIProbeError(t *testing.T) {
+	t.Parallel()
+
+	app := New(Deps{
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/api/v1/status":
+				return nil, fmt.Errorf("connection refused")
+			case "/api/v1/healthz":
+				return jsonResponse(t, http.StatusUnauthorized, `{"ok":false,"requestId":"req_401","error":{"code":"UNAUTHORIZED","message":"unauthorized"}}`), nil
+			default:
+				t.Fatalf("unexpected request path %q", req.URL.Path)
+				return nil, nil
+			}
+		}),
+		Sleep: func(duration time.Duration) {
+			t.Fatalf("Sleep(%s) called after daemon API probe error", duration)
+		},
+	})
+	runtime := newCommandRuntime(app, nil)
+	client := NewDaemonAPIClient(DaemonAPIClientOptions{BaseURL: "http://127.0.0.1", HTTPClient: app.deps.HTTPClient})
+
+	reachable, err := runtime.waitForBootstrapHealth(context.Background(), client)
+	if reachable {
+		t.Fatal("waitForBootstrapHealth(...) reachable = true, want false")
+	}
+	var apiErr *DaemonAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("waitForBootstrapHealth(...) error type = %T, want *DaemonAPIError", err)
+	}
+	if got, want := apiErr.Status, http.StatusUnauthorized; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if got, want := apiErr.Message, "unauthorized"; got != want {
+		t.Fatalf("message = %q, want %q", got, want)
+	}
+}
+
 func TestBootstrapPreflightFailsWhenRequiredToolsMissing(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -1,0 +1,330 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBootstrapYesInstallsStartsAndPrintsNextSteps(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	cwd := t.TempDir()
+	projectPath := filepath.Join(cwd, "repo")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(projectPath) error = %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "bootstrap.json")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	binary := []byte("looperd-binary")
+	checksum := sha256.Sum256(binary)
+	checksumText := hex.EncodeToString(checksum[:]) + "  looperd-darwin-arm64\n"
+
+	var daemonStarted atomic.Bool
+	var spawnCalls atomic.Int32
+	var statusCalls atomic.Int32
+
+	app := New(Deps{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		Getwd: func() (string, error) {
+			return cwd, nil
+		},
+		LookPath: func(file string) (string, error) {
+			switch file {
+			case "git", "gh", "osascript":
+				return "/usr/bin/" + file, nil
+			default:
+				return "", fmt.Errorf("not found")
+			}
+		},
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v1.2.3","assets":[{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looperd-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, binary), nil
+			case "https://example.invalid/looperd-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, checksumText), nil
+			}
+
+			switch req.URL.Path {
+			case "/api/v1/status", "/api/v1/healthz":
+				statusCalls.Add(1)
+				if !daemonStarted.Load() {
+					return nil, fmt.Errorf("daemon offline")
+				}
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true}}}`), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "/usr/bin/gh" && strings.Join(args, " ") == "auth status" {
+				return commandExecutionResult{ExitCode: 0}, nil
+			}
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				if _, err := os.Stat(managedPath); err != nil {
+					return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+				}
+				return commandExecutionResult{ExitCode: 0, Stdout: "1.2.3\n"}, nil
+			}
+			if command == "ps" && len(args) == 4 && args[0] == "-p" && args[2] == "-o" && args[3] == "command=" {
+				return commandExecutionResult{ExitCode: 0, Stdout: managedPath + "\n"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			_ = args
+			_ = cwd
+			_ = env
+			if command != managedPath {
+				return 0, fmt.Errorf("unexpected command %q", command)
+			}
+			spawnCalls.Add(1)
+			daemonStarted.Store(true)
+			return 4321, nil
+		},
+		KillProcess: func(pid int, signal int) error {
+			if pid == 4321 && signal == 0 {
+				return nil
+			}
+			return fmt.Errorf("unexpected kill(%d, %d)", pid, signal)
+		},
+		Sleep: func(duration time.Duration) {
+			_ = duration
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"bootstrap", "--yes", "--project-path", projectPath, "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([bootstrap --yes]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([bootstrap --yes]) stderr = %q, want empty string", stderr.String())
+	}
+	if spawnCalls.Load() != 1 {
+		t.Fatalf("spawnDetached calls = %d, want 1", spawnCalls.Load())
+	}
+	if statusCalls.Load() < 2 {
+		t.Fatalf("status checks = %d, want at least 2", statusCalls.Load())
+	}
+
+	for _, rel := range []string{".looper/bin", ".looper/backups", ".looper/logs"} {
+		path := filepath.Join(homeDir, rel)
+		if info, err := os.Stat(path); err != nil || !info.IsDir() {
+			t.Fatalf("expected runtime directory %q to exist, err=%v", path, err)
+		}
+	}
+
+	rawConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(configPath) error = %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(rawConfig, &decoded); err != nil {
+		t.Fatalf("Unmarshal(config) error = %v", err)
+	}
+	projects, ok := decoded["projects"].([]any)
+	if !ok || len(projects) == 0 {
+		t.Fatalf("config projects = %#v, want non-empty array", decoded["projects"])
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"Bootstrap complete", "configCreated", "yes", "projectAdded", "daemonInstallState", "installed", "apiReachable", "yes", "Next steps:", "- looper status"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want to contain %q", out, want)
+		}
+	}
+	if strings.Contains(out, "looper project add /path/to/repo") {
+		t.Fatalf("stdout = %q, did not expect manual project-add step", out)
+	}
+}
+
+func TestBootstrapPreflightFailsWhenRequiredToolsMissing(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "bootstrap.json")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	app := New(Deps{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		Getwd: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		LookPath: func(file string) (string, error) {
+			if file == "osascript" {
+				return "/usr/bin/osascript", nil
+			}
+			return "", fmt.Errorf("not found")
+		},
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected network request %q", req.URL.String())
+			return nil, nil
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"bootstrap", "--yes", "--config", configPath})
+	if exitCode != 1 {
+		t.Fatalf("Run([bootstrap --yes]) exit code = %d, want 1", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run([bootstrap --yes]) stdout = %q, want empty string", stdout.String())
+	}
+	for _, want := range []string{"bootstrap preflight failed", "missing required tools: git, gh", "Install them manually", "brew install git gh"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want to contain %q", stderr.String(), want)
+		}
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("config path exists unexpectedly after preflight failure: %v", err)
+	}
+}
+
+func TestBootstrapIdempotentWhenConfigProjectAndDaemonAlreadyHealthy(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	cwd := t.TempDir()
+	projectPath := filepath.Join(cwd, "repo")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(projectPath) error = %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "bootstrap-existing.json")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+
+	existingConfig := map[string]any{
+		"server": map[string]any{"baseUrl": "http://daemon.test", "authMode": "none"},
+		"projects": []map[string]any{{
+			"id":         "repo",
+			"name":       "repo",
+			"repoPath":   projectPath,
+			"baseBranch": "main",
+		}},
+	}
+	raw, err := json.Marshal(existingConfig)
+	if err != nil {
+		t.Fatalf("Marshal(existingConfig) error = %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(configPath) error = %v", err)
+	}
+	before := string(raw)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	var spawnCalls atomic.Int32
+	var installAssetCalls atomic.Int32
+
+	app := New(Deps{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		Getwd: func() (string, error) {
+			return cwd, nil
+		},
+		LookPath: func(file string) (string, error) {
+			switch file {
+			case "git", "gh", "osascript":
+				return "/usr/bin/" + file, nil
+			default:
+				return "", fmt.Errorf("not found")
+			}
+		},
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v1.2.3","assets":[]}`), nil
+			case "https://example.invalid/looperd-darwin-arm64", "https://example.invalid/looperd-darwin-arm64.sha256":
+				installAssetCalls.Add(1)
+				t.Fatalf("unexpected daemon asset download request %q", req.URL.String())
+				return nil, nil
+			}
+			if req.URL.String() == "http://daemon.test/api/v1/status" {
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true}}}`), nil
+			}
+			if req.URL.String() == "http://daemon.test/api/v1/healthz" {
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_health","data":{"healthy":true}}}`), nil
+			}
+			t.Fatalf("unexpected request URL %q", req.URL.String())
+			return nil, nil
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "/usr/bin/gh" && strings.Join(args, " ") == "auth status" {
+				return commandExecutionResult{ExitCode: 0}, nil
+			}
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 0, Stdout: "1.2.3\n"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			_ = command
+			_ = args
+			_ = cwd
+			_ = env
+			spawnCalls.Add(1)
+			return 0, fmt.Errorf("spawn should not be called in idempotent flow")
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"bootstrap", "--yes", "--project-path", projectPath, "--json", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([bootstrap --yes --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([bootstrap --yes --json]) stderr = %q, want empty string", stderr.String())
+	}
+	if spawnCalls.Load() != 0 {
+		t.Fatalf("spawnDetached calls = %d, want 0", spawnCalls.Load())
+	}
+	if installAssetCalls.Load() != 0 {
+		t.Fatalf("daemon asset download calls = %d, want 0", installAssetCalls.Load())
+	}
+
+	assertJSONContains(t, stdout.String(), "configCreated", false)
+	assertJSONContains(t, stdout.String(), "projectAdded", false)
+	assertJSONContains(t, stdout.String(), "daemonInstallState", "already-installed")
+	assertJSONContains(t, stdout.String(), "daemonInstalled", false)
+	assertJSONContains(t, stdout.String(), "daemonRunning", true)
+	assertJSONContains(t, stdout.String(), "apiReachable", true)
+	assertJSONContains(t, stdout.String(), "nextSteps", []any{"looper status"})
+
+	afterRaw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(configPath) error = %v", err)
+	}
+	if string(afterRaw) != before {
+		t.Fatalf("config changed unexpectedly\nbefore=%s\nafter=%s", before, string(afterRaw))
+	}
+}

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -161,6 +161,145 @@ func TestBootstrapYesInstallsStartsAndPrintsNextSteps(t *testing.T) {
 	}
 }
 
+func TestBootstrapJSONSuppressesDaemonStartOutput(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	cwd := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "bootstrap.json")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	binary := []byte("looperd-binary")
+	checksum := sha256.Sum256(binary)
+	checksumText := hex.EncodeToString(checksum[:]) + "  looperd-darwin-arm64\n"
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	var daemonStarted atomic.Bool
+
+	app := New(Deps{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		Getwd: func() (string, error) {
+			return cwd, nil
+		},
+		LookPath: func(file string) (string, error) {
+			switch file {
+			case "git", "gh", "osascript":
+				return "/usr/bin/" + file, nil
+			default:
+				return "", fmt.Errorf("not found")
+			}
+		},
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v1.2.3","assets":[{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looperd-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, binary), nil
+			case "https://example.invalid/looperd-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, checksumText), nil
+			}
+			switch req.URL.Path {
+			case "/api/v1/status", "/api/v1/healthz":
+				if !daemonStarted.Load() {
+					return nil, fmt.Errorf("daemon offline")
+				}
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true}}}`), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "/usr/bin/gh" && strings.Join(args, " ") == "auth status" {
+				return commandExecutionResult{ExitCode: 0}, nil
+			}
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				if _, err := os.Stat(managedPath); err != nil {
+					return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+				}
+				return commandExecutionResult{ExitCode: 0, Stdout: "1.2.3\n"}, nil
+			}
+			if command == "ps" && len(args) == 4 && args[0] == "-p" && args[2] == "-o" && args[3] == "command=" {
+				return commandExecutionResult{ExitCode: 0, Stdout: managedPath + "\n"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			_ = args
+			_ = cwd
+			_ = env
+			if command != managedPath {
+				return 0, fmt.Errorf("unexpected command %q", command)
+			}
+			daemonStarted.Store(true)
+			return 4321, nil
+		},
+		KillProcess: func(pid int, signal int) error {
+			if pid == 4321 && signal == 0 {
+				return nil
+			}
+			return fmt.Errorf("unexpected kill(%d, %d)", pid, signal)
+		},
+		Sleep: func(duration time.Duration) {
+			_ = duration
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"bootstrap", "--yes", "--json", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([bootstrap --yes --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([bootstrap --yes --json]) stderr = %q, want empty string", stderr.String())
+	}
+	var decoded bootstrapResult
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout is not valid bootstrap JSON: %v\nraw=%q", err, stdout.String())
+	}
+	if !decoded.DaemonRunning || !decoded.APIReachable {
+		t.Fatalf("bootstrap JSON daemon state = running:%v reachable:%v, want true/true", decoded.DaemonRunning, decoded.APIReachable)
+	}
+	if strings.Contains(stdout.String(), "Started looperd") || strings.Contains(stdout.String(), "PID file:") {
+		t.Fatalf("stdout contains daemon start chatter: %q", stdout.String())
+	}
+}
+
+func TestBootstrapPreflightHonorsConfigAndEnvToolOverrides(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "bootstrap.json")
+	if err := os.WriteFile(configPath, []byte(`{"tools":{"gitPath":"/config/git","ghPath":"/config/gh"}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(configPath) error = %v", err)
+	}
+	t.Setenv("LOOPER_GH_PATH", "/env/gh")
+
+	app := New(Deps{
+		Platform: "darwin",
+		Arch:     "arm64",
+		LookPath: func(file string) (string, error) {
+			return "", fmt.Errorf("%s not on PATH", file)
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command != "/env/gh" || strings.Join(args, " ") != "auth status" {
+				t.Fatalf("RunCommand(%q, %#v), want env gh auth status", command, args)
+			}
+			return commandExecutionResult{ExitCode: 0}, nil
+		},
+	})
+	runtime := newCommandRuntime(app, []string{"bootstrap", "--yes"})
+	plan := bootstrapConfigPlan{}
+
+	if _, err := runtime.bootstrapPreflight(context.Background(), configPath, &plan); err != nil {
+		t.Fatalf("bootstrapPreflight() error = %v", err)
+	}
+}
+
 func TestBootstrapPreflightFailsWhenRequiredToolsMissing(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -328,3 +328,111 @@ func TestBootstrapIdempotentWhenConfigProjectAndDaemonAlreadyHealthy(t *testing.
 		t.Fatalf("config changed unexpectedly\nbefore=%s\nafter=%s", before, string(afterRaw))
 	}
 }
+
+func TestBootstrapAddsProjectWithoutPersistingRuntimeOverrides(t *testing.T) {
+	homeDir := t.TempDir()
+	cwd := t.TempDir()
+	projectPath := filepath.Join(cwd, "repo")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(projectPath) error = %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "bootstrap-partial.json")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+
+	before := `{"server":{"baseUrl":"http://daemon.test","authMode":"none"},"defaults":{"baseBranch":"trunk"}}`
+	if err := os.WriteFile(configPath, []byte(before), 0o644); err != nil {
+		t.Fatalf("WriteFile(configPath) error = %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	app := New(Deps{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		Getwd: func() (string, error) {
+			return cwd, nil
+		},
+		LookPath: func(file string) (string, error) {
+			switch file {
+			case "git", "gh", "osascript":
+				return "/detected/" + file, nil
+			default:
+				return "", fmt.Errorf("not found")
+			}
+		},
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v1.2.3","assets":[]}`), nil
+			case "http://daemon.test/api/v1/status":
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true}}}`), nil
+			case "http://daemon.test/api/v1/healthz":
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_health","data":{"healthy":true}}}`), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "/detected/gh" && strings.Join(args, " ") == "auth status" {
+				return commandExecutionResult{ExitCode: 0}, nil
+			}
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 0, Stdout: "1.2.3\n"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			_ = command
+			_ = args
+			_ = cwd
+			_ = env
+			return 0, fmt.Errorf("spawn should not be called")
+		},
+	})
+
+	t.Setenv("LOOPER_PORT", "9999")
+	exitCode := app.Run(context.Background(), []string{"--host", "0.0.0.0", "--git-path", "/override/git", "bootstrap", "--yes", "--project-path", projectPath, "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([bootstrap]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([bootstrap]) stderr = %q, want empty string", stderr.String())
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(configPath) error = %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal(config) error = %v\nraw=%s", err, string(raw))
+	}
+	server := decoded["server"].(map[string]any)
+	if _, ok := server["host"]; ok {
+		t.Fatalf("persisted server.host from CLI override: %s", string(raw))
+	}
+	if _, ok := server["port"]; ok {
+		t.Fatalf("persisted server.port from env override: %s", string(raw))
+	}
+	if _, ok := decoded["tools"]; ok {
+		t.Fatalf("persisted detected or overridden tools: %s", string(raw))
+	}
+	if _, ok := decoded["storage"]; ok {
+		t.Fatalf("persisted default-only storage config: %s", string(raw))
+	}
+	projects, ok := decoded["projects"].([]any)
+	if !ok || len(projects) != 1 {
+		t.Fatalf("projects = %#v, want one project", decoded["projects"])
+	}
+	project := projects[0].(map[string]any)
+	if project["baseBranch"] != "trunk" {
+		t.Fatalf("project.baseBranch = %v, want trunk", project["baseBranch"])
+	}
+}

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -316,8 +316,13 @@ func (r *commandRuntime) apiClientFromLoaded(loaded config.LoadedFileConfig) *Da
 }
 
 func (r *commandRuntime) detectDaemonVersionState(ctx context.Context, statusPayload json.RawMessage) (*daemonVersionState, error) {
-	if version := extractDaemonVersion(statusPayload); version != "" {
-		return &daemonVersionState{Version: version, Source: "api"}, nil
+	serviceBinary := extractDaemonServiceBinary(statusPayload)
+	if serviceBinary.Version != "" {
+		state := &daemonVersionState{Version: serviceBinary.Version, Source: "api"}
+		if serviceBinary.Path != "" {
+			state.BinaryPath = stringPtr(serviceBinary.Path)
+		}
+		return state, nil
 	}
 
 	managedVersion, err := r.readManagedDaemonVersion(ctx)
@@ -331,20 +336,36 @@ func (r *commandRuntime) detectDaemonVersionState(ctx context.Context, statusPay
 	return r.readPathDaemonVersion(ctx)
 }
 
-func extractDaemonVersion(payload json.RawMessage) string {
+type daemonServiceBinary struct {
+	Version string
+	Path    string
+}
+
+func extractDaemonServiceBinary(payload json.RawMessage) daemonServiceBinary {
 	if len(payload) == 0 {
-		return ""
+		return daemonServiceBinary{}
 	}
 
 	var decoded struct {
 		Service struct {
 			Version string `json:"version"`
+			Binary  struct {
+				Path string `json:"path"`
+			} `json:"binary"`
 		} `json:"service"`
 	}
 	if err := json.Unmarshal(payload, &decoded); err != nil {
-		return ""
+		return daemonServiceBinary{}
 	}
-	return strings.TrimSpace(decoded.Service.Version)
+
+	return daemonServiceBinary{
+		Version: strings.TrimSpace(decoded.Service.Version),
+		Path:    strings.TrimSpace(decoded.Service.Binary.Path),
+	}
+}
+
+func extractDaemonVersion(payload json.RawMessage) string {
+	return extractDaemonServiceBinary(payload).Version
 }
 
 type resolvedDaemonBinary struct {

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -192,51 +192,81 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 func (r *commandRuntime) daemonRestart(cmd *cobra.Command, args []string) error {
 	_ = args
 
-	pidFilePath, err := r.resolveDaemonPIDFilePath()
-	if err != nil {
-		return err
-	}
-
-	existingPID, ok := r.readPIDFile(pidFilePath)
-	if !ok {
-		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "No daemon pid file found; starting daemon."); err != nil {
-			return err
-		}
-		return r.daemonStart(cmd, nil)
-	}
-
-	if !r.isProcessAlive(existingPID) {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Daemon pid %d is stale; starting daemon.\n", existingPID); err != nil {
-			return err
-		}
-		r.removePIDFile(pidFilePath)
-		return r.daemonStart(cmd, nil)
-	}
-
-	isLooperd, err := r.isLooperdProcess(cmd.Context(), existingPID)
-	if err != nil {
-		return err
-	}
-	if !isLooperd {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Daemon pid %d does not appear to be looperd; treating pid file as stale.\n", existingPID); err != nil {
-			return err
-		}
-		r.removePIDFile(pidFilePath)
-		return r.daemonStart(cmd, nil)
-	}
-
-	if err := r.killProcess(existingPID, int(syscall.SIGTERM)); err != nil {
-		return fmt.Errorf("stop looperd pid %d: %w", existingPID, err)
-	}
-	if err := r.waitForProcessExit(existingPID, 2*time.Second, 100*time.Millisecond); err != nil {
-		return err
-	}
-	r.removePIDFile(pidFilePath)
-	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Stopped looperd pid %d\n", existingPID); err != nil {
+	if _, err := r.stopDaemonProcess(cmd.Context(), cmd.OutOrStdout(), true); err != nil {
 		return err
 	}
 
 	return r.daemonStart(cmd, nil)
+}
+
+func (r *commandRuntime) daemonStop(cmd *cobra.Command, args []string) error {
+	_ = args
+
+	_, err := r.stopDaemonProcess(cmd.Context(), cmd.OutOrStdout(), false)
+	return err
+}
+
+func (r *commandRuntime) stopDaemonProcess(ctx context.Context, out io.Writer, startIfMissing bool) (bool, error) {
+	pidFilePath, err := r.resolveDaemonPIDFilePath()
+	if err != nil {
+		return false, err
+	}
+
+	existingPID, ok := r.readPIDFile(pidFilePath)
+	if !ok {
+		if startIfMissing {
+			if _, err := fmt.Fprintln(out, "No daemon pid file found; starting daemon."); err != nil {
+				return false, err
+			}
+			return false, nil
+		}
+		if _, err := fmt.Fprintln(out, "No daemon pid file found; nothing to stop."); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	if !r.isProcessAlive(existingPID) {
+		if startIfMissing {
+			if _, err := fmt.Fprintf(out, "Daemon pid %d is stale; starting daemon.\n", existingPID); err != nil {
+				return false, err
+			}
+			r.removePIDFile(pidFilePath)
+			return false, nil
+		}
+		r.removePIDFile(pidFilePath)
+		if _, err := fmt.Fprintf(out, "Removed stale daemon pid file for pid %d\n", existingPID); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	isLooperd, err := r.isLooperdProcess(ctx, existingPID)
+	if err != nil {
+		return false, err
+	}
+	if !isLooperd {
+		if _, err := fmt.Fprintf(out, "Daemon pid %d does not appear to be looperd; treating pid file as stale.\n", existingPID); err != nil {
+			return false, err
+		}
+		r.removePIDFile(pidFilePath)
+		if startIfMissing {
+			return false, nil
+		}
+		return false, nil
+	}
+
+	if err := r.killProcess(existingPID, int(syscall.SIGTERM)); err != nil {
+		return false, fmt.Errorf("stop looperd pid %d: %w", existingPID, err)
+	}
+	if err := r.waitForProcessExit(existingPID, 2*time.Second, 100*time.Millisecond); err != nil {
+		return false, err
+	}
+	r.removePIDFile(pidFilePath)
+	if _, err := fmt.Fprintf(out, "Stopped looperd pid %d\n", existingPID); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (r *commandRuntime) daemonLogs(cmd *cobra.Command, args []string) error {

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -68,6 +68,55 @@ func TestDaemonStatusJSONFallsBackToBinaryVersion(t *testing.T) {
 	assertJSONContains(t, stdout.String(), "health", map[string]any{"status": "ok"})
 }
 
+func TestDaemonStatusJSONUsesAPIVersionAndBinaryPath(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/status":
+			writeEnvelope(t, w, pkgapi.Success("req_status", map[string]any{
+				"service": map[string]any{
+					"version": "0.6.0",
+					"binary": map[string]any{
+						"path": "/opt/looper/bin/looperd",
+					},
+				},
+			}))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeDaemonCLIConfig(t, server.URL)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = command
+			_ = args
+			_ = timeout
+			t.Fatal("RunCommand should not be called when API version is available")
+			return commandExecutionResult{}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "status", "--json", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon status --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([daemon status --json]) stderr = %q, want empty string", stderr.String())
+	}
+	assertJSONContains(t, stdout.String(), "apiReachable", true)
+	assertJSONContains(t, stdout.String(), "daemonVersion", "0.6.0")
+	assertJSONContains(t, stdout.String(), "daemonVersionSource", "api")
+	assertJSONContains(t, stdout.String(), "daemonBinaryPath", "/opt/looper/bin/looperd")
+}
+
 func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -348,6 +348,110 @@ func TestDaemonRestartStopsExistingPIDAndStartsReplacement(t *testing.T) {
 	}
 }
 
+func TestDaemonStopStopsExistingPIDAndRemovesPIDFile(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	removeCalls := make([]string, 0)
+	killCalls := make([]struct {
+		pid    int
+		signal int
+	}, 0)
+	alive1234 := true
+
+	app := New(Deps{
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: homeDir,
+		ReadFile: func(path string) ([]byte, error) {
+			if strings.HasSuffix(path, filepath.Join(".looper", "looperd.pid")) {
+				return []byte("1234\n"), nil
+			}
+			return nil, os.ErrNotExist
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "ps" && len(args) >= 2 && args[1] == "1234" {
+				return commandExecutionResult{Stdout: managedPath + "\n", ExitCode: 0}, nil
+			}
+			return commandExecutionResult{ExitCode: 1}, nil
+		},
+		KillProcess: func(pid int, signal int) error {
+			killCalls = append(killCalls, struct {
+				pid    int
+				signal int
+			}{pid: pid, signal: signal})
+			if pid == 1234 && signal == 0 {
+				if !alive1234 {
+					return os.ErrProcessDone
+				}
+				return nil
+			}
+			if pid == 1234 && signal == 15 {
+				alive1234 = false
+				return nil
+			}
+			return nil
+		},
+		RemoveFile: func(path string) error {
+			removeCalls = append(removeCalls, path)
+			return nil
+		},
+		Sleep: func(duration time.Duration) {
+			_ = duration
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "stop"})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon stop]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([daemon stop]) stderr = %q, want empty string", stderr.String())
+	}
+	if len(removeCalls) == 0 || !strings.HasSuffix(removeCalls[0], filepath.Join(".looper", "looperd.pid")) {
+		t.Fatalf("removeCalls = %#v, want pid file removal", removeCalls)
+	}
+	if !strings.Contains(stdout.String(), "Stopped looperd pid 1234") {
+		t.Fatalf("stdout = %q, want stop confirmation", stdout.String())
+	}
+	if len(killCalls) < 3 {
+		t.Fatalf("killCalls = %#v, want liveness probe, SIGTERM, and exit probe", killCalls)
+	}
+	if killCalls[1].pid != 1234 || killCalls[1].signal != 15 {
+		t.Fatalf("killCalls = %#v, want SIGTERM for pid 1234", killCalls)
+	}
+}
+
+func TestDaemonStopWithoutPIDFileReportsNothingToStop(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		ReadFile: func(path string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "stop"})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon stop]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([daemon stop]) stderr = %q, want empty string", stderr.String())
+	}
+	if got, want := stdout.String(), "No daemon pid file found; nothing to stop.\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
 func TestDaemonStartReturnsProcessInspectionFailureForExistingPID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/feedback.go
+++ b/internal/cliapp/feedback.go
@@ -1,0 +1,164 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/powerformer/looper/internal/agent"
+	"github.com/spf13/cobra"
+)
+
+const feedbackRepo = "powerformer/looper"
+
+const feedbackCommandTimeout = 5 * time.Minute
+
+var feedbackIssueURLPattern = regexp.MustCompile(`https://github\.com/` + regexp.QuoteMeta(feedbackRepo) + `/issues/\d+`)
+
+type feedbackOutput struct {
+	Repo      string `json:"repo"`
+	TitleHint string `json:"titleHint"`
+	Message   string `json:"message"`
+	IssueURL  string `json:"issueUrl"`
+	Summary   string `json:"summary"`
+}
+
+func (r *commandRuntime) feedback(cmd *cobra.Command, args []string) error {
+	message := strings.TrimSpace(strings.Join(args, " "))
+	if message == "" {
+		return fmt.Errorf("feedback message is required")
+	}
+	titleHint := strings.TrimSpace(getStringFlag(cmd, "title"))
+
+	loaded, err := r.loadConfig()
+	if err != nil {
+		return err
+	}
+	if loaded.Config.Agent.Vendor == nil || strings.TrimSpace(string(*loaded.Config.Agent.Vendor)) == "" {
+		return fmt.Errorf("feedback requires agent.vendor to be configured")
+	}
+
+	prompt := buildFeedbackPrompt(titleHint, message)
+	agentCfg := agent.ExecutorConfig{
+		Vendor: *loaded.Config.Agent.Vendor,
+		Model:  loaded.Config.Agent.Model,
+		Params: loaded.Config.Agent.Params,
+		Env:    loaded.Config.Agent.Env,
+	}
+	command, commandArgs := agent.ResolveSpawn(agentCfg, prompt)
+
+	cwd, err := r.getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+
+	runCtx, cancel := context.WithTimeout(cmd.Context(), feedbackCommandTimeout)
+	defer cancel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	process := exec.CommandContext(runCtx, command, commandArgs...)
+	process.Dir = cwd
+	process.Stdout = stdout
+	process.Stderr = stderr
+	process.Env = os.Environ()
+	for key, value := range loaded.Config.Agent.Env {
+		process.Env = append(process.Env, key+"="+value)
+	}
+	process.Env = append(process.Env,
+		"LOOPER_PROMPT="+prompt,
+		"LOOPER_COMPLETION_MARKER="+agent.CompletionMarkerPrefix,
+	)
+
+	if err := process.Run(); err != nil {
+		return feedbackRunError(err, stdout.String(), stderr.String())
+	}
+
+	issueURL := extractFeedbackIssueURL(stdout.String(), stderr.String())
+	summary := parseFeedbackCompletionSummary(stdout.String(), stderr.String())
+	if issueURL == "" && summary == "" {
+		return fmt.Errorf("feedback agent completed without reporting an issue URL or summary")
+	}
+
+	output := feedbackOutput{
+		Repo:      feedbackRepo,
+		TitleHint: titleHint,
+		Message:   message,
+		IssueURL:  issueURL,
+		Summary:   summary,
+	}
+
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), output)
+	}
+	if issueURL != "" {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), issueURL)
+		return err
+	}
+	if summary != "" {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), summary)
+		return err
+	}
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), "Feedback submitted successfully.")
+	return err
+}
+
+func buildFeedbackPrompt(titleHint, message string) string {
+	sections := []string{
+		"Create a new GitHub issue in the repository powerformer/looper for the user feedback below.",
+		"Write the issue title and body in English.",
+		"Use the local GitHub CLI (`gh`) if needed.",
+	}
+	if titleHint != "" {
+		sections = append(sections, "Preferred title hint: "+titleHint)
+	}
+	sections = append(sections,
+		"Feedback message:\n"+message,
+		"After creating the issue, print the issue URL (https://github.com/powerformer/looper/issues/<number>) before the final completion marker line.",
+	)
+	return agent.AppendCompletionInstruction(strings.Join(sections, "\n\n"))
+}
+
+func extractFeedbackIssueURL(stdout, stderr string) string {
+	joined := strings.TrimSpace(stdout + "\n" + stderr)
+	if joined == "" {
+		return ""
+	}
+	matches := feedbackIssueURLPattern.FindAllString(joined, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[len(matches)-1]
+}
+
+func parseFeedbackCompletionSummary(stdout, stderr string) string {
+	lines := strings.Split(strings.TrimSpace(stdout+"\n"+stderr), "\n")
+	for index := len(lines) - 1; index >= 0; index-- {
+		line := strings.TrimSpace(lines[index])
+		if !strings.HasPrefix(line, agent.CompletionMarkerPrefix) {
+			continue
+		}
+		payload := strings.TrimPrefix(line, agent.CompletionMarkerPrefix)
+		parsed := map[string]any{}
+		if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+			return ""
+		}
+		summary, _ := parsed["summary"].(string)
+		return strings.TrimSpace(summary)
+	}
+	return ""
+}
+
+func feedbackRunError(err error, stdout string, stderr string) error {
+	summary := parseFeedbackCompletionSummary(stdout, stderr)
+	if summary != "" {
+		return fmt.Errorf("run feedback agent: %w (%s)", err, summary)
+	}
+	return fmt.Errorf("run feedback agent: %w", err)
+}

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/powerformer/looper/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -35,6 +36,16 @@ func (r *commandRuntime) configShow(cmd *cobra.Command, args []string) error {
 	}, func(w io.Writer, payload json.RawMessage) error {
 		return writeJSON(w, payload)
 	})
+}
+
+func (r *commandRuntime) version(cmd *cobra.Command, args []string) error {
+	_ = args
+	info := version.Current()
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), info)
+	}
+	_, err := fmt.Fprintln(cmd.OutOrStdout(), info.Version)
+	return err
 }
 
 func (r *commandRuntime) projectList(cmd *cobra.Command, args []string) error {

--- a/internal/cliapp/semver.go
+++ b/internal/cliapp/semver.go
@@ -1,0 +1,107 @@
+package cliapp
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type semver struct {
+	major      int
+	minor      int
+	patch      int
+	preRelease string
+}
+
+func parseSemver(value string) (semver, error) {
+	trimmed := strings.TrimSpace(value)
+	trimmed = strings.TrimPrefix(trimmed, "v")
+	if trimmed == "" {
+		return semver{}, fmt.Errorf("empty version")
+	}
+
+	base := trimmed
+	preRelease := ""
+	if idx := strings.Index(base, "+"); idx >= 0 {
+		base = base[:idx]
+	}
+	if idx := strings.Index(base, "-"); idx >= 0 {
+		preRelease = base[idx+1:]
+		base = base[:idx]
+	}
+
+	parts := strings.Split(base, ".")
+	if len(parts) != 3 {
+		return semver{}, fmt.Errorf("invalid semver %q", value)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return semver{}, fmt.Errorf("invalid semver major %q", value)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return semver{}, fmt.Errorf("invalid semver minor %q", value)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return semver{}, fmt.Errorf("invalid semver patch %q", value)
+	}
+
+	return semver{major: major, minor: minor, patch: patch, preRelease: preRelease}, nil
+}
+
+func compareSemver(current string, latest string) (int, error) {
+	c, err := parseSemver(current)
+	if err != nil {
+		return 0, err
+	}
+	l, err := parseSemver(latest)
+	if err != nil {
+		return 0, err
+	}
+
+	if c.major != l.major {
+		if c.major < l.major {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if c.minor != l.minor {
+		if c.minor < l.minor {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if c.patch != l.patch {
+		if c.patch < l.patch {
+			return -1, nil
+		}
+		return 1, nil
+	}
+
+	if c.preRelease == l.preRelease {
+		return 0, nil
+	}
+	if c.preRelease == "" {
+		return 1, nil
+	}
+	if l.preRelease == "" {
+		return -1, nil
+	}
+	if c.preRelease < l.preRelease {
+		return -1, nil
+	}
+	if c.preRelease > l.preRelease {
+		return 1, nil
+	}
+	return 0, nil
+}
+
+func isSemverUpgradeAvailable(current string, latest string) (bool, error) {
+	cmp, err := compareSemver(current, latest)
+	if err != nil {
+		return false, err
+	}
+	return cmp < 0, nil
+}

--- a/internal/cliapp/semver.go
+++ b/internal/cliapp/semver.go
@@ -89,13 +89,78 @@ func compareSemver(current string, latest string) (int, error) {
 	if l.preRelease == "" {
 		return -1, nil
 	}
-	if c.preRelease < l.preRelease {
-		return -1, nil
+	return compareSemverPrerelease(c.preRelease, l.preRelease), nil
+}
+
+func compareSemverPrerelease(current string, latest string) int {
+	currentParts := strings.Split(current, ".")
+	latestParts := strings.Split(latest, ".")
+	maxParts := len(currentParts)
+	if len(latestParts) > maxParts {
+		maxParts = len(latestParts)
 	}
-	if c.preRelease > l.preRelease {
-		return 1, nil
+
+	for i := 0; i < maxParts; i++ {
+		if i >= len(currentParts) {
+			return -1
+		}
+		if i >= len(latestParts) {
+			return 1
+		}
+		cmp := compareSemverPrereleaseIdentifier(currentParts[i], latestParts[i])
+		if cmp != 0 {
+			return cmp
+		}
 	}
-	return 0, nil
+	return 0
+}
+
+func compareSemverPrereleaseIdentifier(current string, latest string) int {
+	currentNumeric := isSemverPrereleaseNumber(current)
+	latestNumeric := isSemverPrereleaseNumber(latest)
+	if currentNumeric && latestNumeric {
+		if len(current) < len(latest) {
+			return -1
+		}
+		if len(current) > len(latest) {
+			return 1
+		}
+		if current < latest {
+			return -1
+		}
+		if current > latest {
+			return 1
+		}
+		return 0
+	}
+	if currentNumeric {
+		return -1
+	}
+	if latestNumeric {
+		return 1
+	}
+	if current < latest {
+		return -1
+	}
+	if current > latest {
+		return 1
+	}
+	return 0
+}
+
+func isSemverPrereleaseNumber(value string) bool {
+	if value == "" {
+		return false
+	}
+	if len(value) > 1 && value[0] == '0' {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func isSemverUpgradeAvailable(current string, latest string) (bool, error) {

--- a/internal/cliapp/semver_test.go
+++ b/internal/cliapp/semver_test.go
@@ -16,6 +16,10 @@ func TestIsSemverUpgradeAvailable(t *testing.T) {
 		{name: "newer current", current: "0.4.0", latest: "0.3.0", want: false},
 		{name: "stable newer than prerelease", current: "0.3.0", latest: "0.3.0-rc.1", want: false},
 		{name: "prerelease older than stable", current: "0.3.0-rc.1", latest: "0.3.0", want: true},
+		{name: "numeric prerelease newer", current: "0.3.0-rc.2", latest: "0.3.0-rc.10", want: true},
+		{name: "numeric prerelease older", current: "0.3.0-rc.10", latest: "0.3.0-rc.2", want: false},
+		{name: "numeric identifier lower precedence than text", current: "0.3.0-1", latest: "0.3.0-alpha", want: true},
+		{name: "longer prerelease newer when prefix equal", current: "0.3.0-alpha", latest: "0.3.0-alpha.1", want: true},
 	}
 
 	for _, testCase := range tests {

--- a/internal/cliapp/semver_test.go
+++ b/internal/cliapp/semver_test.go
@@ -1,0 +1,34 @@
+package cliapp
+
+import "testing"
+
+func TestIsSemverUpgradeAvailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+		want    bool
+	}{
+		{name: "equal", current: "0.2.1", latest: "0.2.1", want: false},
+		{name: "older current", current: "0.2.1", latest: "0.3.0", want: true},
+		{name: "newer current", current: "0.4.0", latest: "0.3.0", want: false},
+		{name: "stable newer than prerelease", current: "0.3.0", latest: "0.3.0-rc.1", want: false},
+		{name: "prerelease older than stable", current: "0.3.0-rc.1", latest: "0.3.0", want: true},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := isSemverUpgradeAvailable(testCase.current, testCase.latest)
+			if err != nil {
+				t.Fatalf("isSemverUpgradeAvailable(%q, %q) error = %v", testCase.current, testCase.latest, err)
+			}
+			if got != testCase.want {
+				t.Fatalf("isSemverUpgradeAvailable(%q, %q) = %v, want %v", testCase.current, testCase.latest, got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/cliapp/testdata/golden/daemon-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/daemon-help.stdout.golden
@@ -5,6 +5,7 @@ Subcommands:
   install  Install the managed daemon binary
   status   Show daemon status
   start    Start the daemon
+  stop     Stop the daemon
   restart  Restart the daemon
   logs     Show daemon logs
 
@@ -27,6 +28,7 @@ Global Flags:
 Examples:
 $ looper daemon install
 $ looper daemon start
+$ looper daemon stop
 $ looper daemon restart
 $ looper daemon status
 $ looper daemon logs --lines 50

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -2,21 +2,22 @@ Usage:
   looper [flags]
 
 Subcommands:
-  status   Show service status
-  project  Project commands
-  config   Config commands
-  daemon   Daemon commands
-  upgrade  Check or upgrade Looper installations
-  loop     Loop commands
-  work     Create a worker run
-  plan     Create a planner run
-  pr       Pull request commands
-  review   Create a reviewer task for a pull request
-  ps       Show running loops
-  jump     Print shell command for a loop worktree
-  logs     Show logs for a loop
-  stop     Stop an active loop
-  run      Run commands
+  status     Show service status
+  bootstrap  Run first-time setup
+  project    Project commands
+  config     Config commands
+  daemon     Daemon commands
+  upgrade    Check or upgrade Looper installations
+  loop       Loop commands
+  work       Create a worker run
+  plan       Create a planner run
+  pr         Pull request commands
+  review     Create a reviewer task for a pull request
+  ps         Show running loops
+  jump       Print shell command for a loop worktree
+  logs       Show logs for a loop
+  stop       Stop an active loop
+  run        Run commands
 
 Flags:
   --config <path>             Config path

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -17,6 +17,7 @@ Subcommands:
   plan       Create a planner run
   pr         Pull request commands
   review     Create a reviewer task for a pull request
+  feedback   Submit feedback as a GitHub issue
   ps         Show running loops
   jump       Print shell command for a loop worktree
   logs       Show logs for a loop

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -1,9 +1,13 @@
 Usage:
   looper [flags]
 
+Version:
+  0.0.0-dev
+
 Subcommands:
   status     Show service status
   bootstrap  Run first-time setup
+  version    Show Looper version
   project    Project commands
   config     Config commands
   daemon     Daemon commands

--- a/internal/cliapp/testdata/golden/upgrade-check.stdout.golden
+++ b/internal/cliapp/testdata/golden/upgrade-check.stdout.golden
@@ -1,5 +1,5 @@
 Upgrade check
-  cliCurrent            : 0.2.1
+  cliCurrent            : 0.0.0-dev
   cliLatest             : 0.3.0
   cliUpdateAvailable    : yes
   daemonCurrent         : 0.2.1

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -532,9 +532,6 @@ func detectCLIInstallSource(execPath string) cliInstallSource {
 	if strings.Contains(path, "/cellar/") || strings.Contains(path, "/homebrew/") {
 		return cliInstallSourceHomebrew
 	}
-	if strings.Contains(path, "/go/bin/") || strings.Contains(path, "/go-build/") || strings.Contains(path, "/tmp/") {
-		return cliInstallSourceDev
-	}
 	base := strings.ToLower(filepath.Base(path))
 	if base != "looper" {
 		return cliInstallSourceUnknown
@@ -544,6 +541,9 @@ func detectCLIInstallSource(execPath string) cliInstallSource {
 	}
 	if isInstallerSelectedUserBinPath(execPath) {
 		return cliInstallSourceRelease
+	}
+	if strings.Contains(path, "/go/bin/") || strings.Contains(path, "/go-build/") || strings.Contains(path, "/tmp/") {
+		return cliInstallSourceDev
 	}
 	return cliInstallSourceUnknown
 }

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -71,6 +71,11 @@ type cliUpgradeOutput struct {
 	RefusedGuidance *string `json:"refusedGuidance,omitempty"`
 }
 
+type unifiedUpgradeOutput struct {
+	CLI    cliUpgradeOutput    `json:"cli"`
+	Daemon daemonUpgradeOutput `json:"daemon"`
+}
+
 type cliInstallSource string
 
 const (
@@ -188,23 +193,28 @@ func (r *commandRuntime) collectUpgradeCheckSummary(ctx context.Context) (upgrad
 }
 
 func (r *commandRuntime) upgradeDaemon(cmd *cobra.Command) error {
+	_, err := r.upgradeDaemonWithOutput(cmd, true)
+	return err
+}
+
+func (r *commandRuntime) upgradeDaemonWithOutput(cmd *cobra.Command, emitOutput bool) (daemonUpgradeOutput, error) {
 	ctx := cmd.Context()
 	statusPayload, err := r.currentDaemonStatusPayload(ctx)
 	if err != nil {
-		return err
+		return daemonUpgradeOutput{}, err
 	}
 	managedDaemon, err := r.readManagedUpgradeDaemonVersion(ctx)
 	if err != nil {
-		return err
+		return daemonUpgradeOutput{}, err
 	}
 	pathDaemon, err := r.readPathUpgradeDaemonVersion(ctx)
 	if err != nil {
-		return err
+		return daemonUpgradeOutput{}, err
 	}
 	current := selectUpgradeDaemonVersionState(statusPayload, managedDaemon, pathDaemon)
 	latestRelease, err := r.fetchLatestDaemonRelease(ctx)
 	if err != nil {
-		return err
+		return daemonUpgradeOutput{}, err
 	}
 
 	var currentVersion *string
@@ -219,7 +229,7 @@ func (r *commandRuntime) upgradeDaemon(cmd *cobra.Command) error {
 	if !needsUpgrade {
 		available, err := isSemverUpgradeAvailable(*currentVersion, latestRelease.Version)
 		if err != nil {
-			return fmt.Errorf("compare daemon versions: %w", err)
+			return daemonUpgradeOutput{}, fmt.Errorf("compare daemon versions: %w", err)
 		}
 		needsUpgrade = available
 	}
@@ -234,23 +244,26 @@ func (r *commandRuntime) upgradeDaemon(cmd *cobra.Command) error {
 		} else if current != nil {
 			output.BinaryPath = current.BinaryPath
 		}
-		if getBoolFlag(cmd, "json") {
-			return writeJSON(cmd.OutOrStdout(), output)
+		if emitOutput && getBoolFlag(cmd, "json") {
+			return output, writeJSON(cmd.OutOrStdout(), output)
+		}
+		if !emitOutput {
+			return output, nil
 		}
 
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looperd is already up to date (%s)\n", *currentVersion); err != nil {
-			return err
+			return daemonUpgradeOutput{}, err
 		}
 		if output.BinaryPath != nil {
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Managed binary: %s\n", *output.BinaryPath)
-			return err
+			return output, err
 		}
-		return nil
+		return output, nil
 	}
 
 	result, err := r.installManagedDaemon(ctx, true, latestRelease.Tag)
 	if err != nil {
-		return fmt.Errorf("Failed to upgrade looperd: %w", err)
+		return daemonUpgradeOutput{}, fmt.Errorf("Failed to upgrade looperd: %w", err)
 	}
 
 	output := daemonUpgradeOutput{
@@ -261,33 +274,36 @@ func (r *commandRuntime) upgradeDaemon(cmd *cobra.Command) error {
 		DownloadedFrom:  result.DownloadedFrom,
 		Skipped:         boolPtr(result.Skipped),
 	}
-	if getBoolFlag(cmd, "json") {
-		return writeJSON(cmd.OutOrStdout(), output)
+	if emitOutput && getBoolFlag(cmd, "json") {
+		return output, writeJSON(cmd.OutOrStdout(), output)
+	}
+	if !emitOutput {
+		return output, nil
 	}
 
 	if managedDaemon == nil && pathDaemon != nil {
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Installed managed looperd %s to %s (previously using %s)\n", latestRelease.Version, result.InstallPath, *pathDaemon.BinaryPath); err != nil {
-			return err
+			return daemonUpgradeOutput{}, err
 		}
 	} else if managedDaemon == nil {
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Installed looperd %s to %s\n", latestRelease.Version, result.InstallPath); err != nil {
-			return err
+			return daemonUpgradeOutput{}, err
 		}
 	} else {
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Upgraded looperd %s → %s at %s\n", managedDaemon.Version, latestRelease.Version, result.InstallPath); err != nil {
-			return err
+			return daemonUpgradeOutput{}, err
 		}
 	}
 	if result.DownloadedFrom != nil {
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Downloaded from %s\n", *result.DownloadedFrom); err != nil {
-			return err
+			return daemonUpgradeOutput{}, err
 		}
 	}
 	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Restart the daemon to use the new version:"); err != nil {
-		return err
+		return daemonUpgradeOutput{}, err
 	}
 	_, err = fmt.Fprintln(cmd.OutOrStdout(), "  looper daemon restart")
-	return err
+	return output, err
 }
 
 func (r *commandRuntime) fetchLatestCLIVersion(ctx context.Context) (string, error) {
@@ -367,24 +383,41 @@ func normalizeVersion(value string) string {
 }
 
 func (r *commandRuntime) upgradeUnified(cmd *cobra.Command) error {
-	_, cliErr := r.upgradeCLI(cmd)
+	jsonOutput := getBoolFlag(cmd, "json")
+	cliOutput, cliErr := r.upgradeCLIWithOutput(cmd, !jsonOutput)
 	if cliErr != nil {
 		var refused *cliUpgradeRefusedError
 		if !errors.As(cliErr, &refused) {
 			return cliErr
 		}
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "CLI self-upgrade skipped: %s\n", refused.message); err != nil {
+		if !jsonOutput {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "CLI self-upgrade skipped: %s\n", refused.message); err != nil {
+				return err
+			}
+		}
+	}
+
+	if !jsonOutput {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Proceeding with daemon upgrade..."); err != nil {
 			return err
 		}
 	}
 
-	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Proceeding with daemon upgrade..."); err != nil {
+	daemonOutput, err := r.upgradeDaemonWithOutput(cmd, !jsonOutput)
+	if err != nil {
 		return err
 	}
-	return r.upgradeDaemon(cmd)
+	if jsonOutput {
+		return writeJSON(cmd.OutOrStdout(), unifiedUpgradeOutput{CLI: cliOutput, Daemon: daemonOutput})
+	}
+	return nil
 }
 
 func (r *commandRuntime) upgradeCLI(cmd *cobra.Command) (cliUpgradeOutput, error) {
+	return r.upgradeCLIWithOutput(cmd, true)
+}
+
+func (r *commandRuntime) upgradeCLIWithOutput(cmd *cobra.Command, emitOutput bool) (cliUpgradeOutput, error) {
 	ctx := cmd.Context()
 	latestRelease, err := r.fetchReleaseMetadata(ctx, "")
 	if err != nil {
@@ -404,7 +437,7 @@ func (r *commandRuntime) upgradeCLI(cmd *cobra.Command) (cliUpgradeOutput, error
 	if installSource != cliInstallSourceRelease {
 		refused := true
 		result := cliUpgradeOutput{Changed: false, CurrentVersion: version.Current().Version, LatestVersion: latestVersion, BinaryPath: stringPtr(execPath), InstallSource: string(installSource), Refused: &refused, RefusedGuidance: &guidance}
-		if getBoolFlag(cmd, "json") {
+		if emitOutput && getBoolFlag(cmd, "json") {
 			if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
 				return cliUpgradeOutput{}, err
 			}
@@ -419,12 +452,12 @@ func (r *commandRuntime) upgradeCLI(cmd *cobra.Command) (cliUpgradeOutput, error
 	if !available {
 		skipped := true
 		result := cliUpgradeOutput{Changed: false, CurrentVersion: version.Current().Version, LatestVersion: latestVersion, BinaryPath: stringPtr(execPath), InstallSource: string(installSource), Skipped: &skipped}
-		if getBoolFlag(cmd, "json") {
+		if emitOutput && getBoolFlag(cmd, "json") {
 			if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
 				return cliUpgradeOutput{}, err
 			}
 		}
-		if !getBoolFlag(cmd, "json") {
+		if emitOutput && !getBoolFlag(cmd, "json") {
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looper is already up to date (%s)\n", version.Current().Version); err != nil {
 				return cliUpgradeOutput{}, err
 			}
@@ -462,10 +495,13 @@ func (r *commandRuntime) upgradeCLI(cmd *cobra.Command) (cliUpgradeOutput, error
 
 	prevPath := execPath + ".prev"
 	result := cliUpgradeOutput{Changed: true, CurrentVersion: version.Current().Version, LatestVersion: latestVersion, BinaryPath: stringPtr(execPath), PreviousBinary: stringPtr(prevPath), DownloadedFrom: stringPtr(binaryAsset.BrowserDownloadURL), InstallSource: string(installSource)}
-	if getBoolFlag(cmd, "json") {
+	if emitOutput && getBoolFlag(cmd, "json") {
 		if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
 			return cliUpgradeOutput{}, err
 		}
+		return result, nil
+	}
+	if !emitOutput {
 		return result, nil
 	}
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Upgraded looper %s → %s at %s\n", version.Current().Version, latestVersion, execPath); err != nil {
@@ -495,7 +531,29 @@ func detectCLIInstallSource(execPath string) cliInstallSource {
 	if strings.HasSuffix(path, "/.local/bin/looper") || strings.HasSuffix(path, "/usr/local/bin/looper") || strings.HasSuffix(path, "/.looper/bin/looper") {
 		return cliInstallSourceRelease
 	}
+	if isInstallerSelectedUserBinPath(execPath) {
+		return cliInstallSourceRelease
+	}
 	return cliInstallSourceUnknown
+}
+
+func isInstallerSelectedUserBinPath(execPath string) bool {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		return false
+	}
+	execDir := filepath.Clean(filepath.Dir(execPath))
+	homeDir = filepath.Clean(homeDir)
+	if execDir == homeDir || !strings.HasPrefix(execDir, homeDir+string(os.PathSeparator)) {
+		return false
+	}
+
+	for _, entry := range filepath.SplitList(os.Getenv("PATH")) {
+		if filepath.Clean(entry) == execDir {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *commandRuntime) executablePath() (string, error) {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -607,9 +607,14 @@ func findLooperReleaseAssets(release githubReleasePayload, target string) (githu
 }
 
 func replaceBinaryAtomically(installPath string, binaryBytes []byte) error {
+	return replaceBinaryAtomicallyWithRename(installPath, binaryBytes, os.Rename)
+}
+
+func replaceBinaryAtomicallyWithRename(installPath string, binaryBytes []byte, rename func(string, string) error) error {
 	installDir := filepath.Dir(installPath)
 	tempInstallPath := installPath + ".new"
 	prevPath := installPath + ".prev"
+	previousPreserved := false
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		return fmt.Errorf("create install directory: %w", err)
 	}
@@ -623,13 +628,19 @@ func replaceBinaryAtomically(installPath string, binaryBytes []byte) error {
 	}
 	if _, err := os.Stat(installPath); err == nil {
 		_ = os.Remove(prevPath)
-		if err := os.Rename(installPath, prevPath); err != nil {
+		if err := rename(installPath, prevPath); err != nil {
 			_ = removeTempInstallFile(tempInstallPath)
 			return fmt.Errorf("preserve previous looper binary: %w", err)
 		}
+		previousPreserved = true
 	}
-	if err := os.Rename(tempInstallPath, installPath); err != nil {
+	if err := rename(tempInstallPath, installPath); err != nil {
 		_ = removeTempInstallFile(tempInstallPath)
+		if previousPreserved {
+			if restoreErr := rename(prevPath, installPath); restoreErr != nil {
+				return fmt.Errorf("replace looper binary: %w (failed to restore previous binary from %s: %v)", err, prevPath, restoreErr)
+			}
+		}
 		return fmt.Errorf("replace looper binary: %w", err)
 	}
 	return nil

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -2,10 +2,14 @@ package cliapp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/powerformer/looper/internal/version"
@@ -54,14 +58,55 @@ type daemonUpgradeOutput struct {
 	Skipped         *bool   `json:"skipped,omitempty"`
 }
 
+type cliUpgradeOutput struct {
+	Changed         bool    `json:"changed"`
+	CurrentVersion  string  `json:"currentVersion"`
+	LatestVersion   string  `json:"latestVersion"`
+	BinaryPath      *string `json:"binaryPath,omitempty"`
+	PreviousBinary  *string `json:"previousBinary,omitempty"`
+	DownloadedFrom  *string `json:"downloadedFrom,omitempty"`
+	InstallSource   string  `json:"installSource"`
+	Skipped         *bool   `json:"skipped,omitempty"`
+	Refused         *bool   `json:"refused,omitempty"`
+	RefusedGuidance *string `json:"refusedGuidance,omitempty"`
+}
+
+type cliInstallSource string
+
+const (
+	cliInstallSourceRelease  cliInstallSource = "release-binary"
+	cliInstallSourceHomebrew cliInstallSource = "homebrew"
+	cliInstallSourceDev      cliInstallSource = "dev"
+	cliInstallSourceUnknown  cliInstallSource = "unknown"
+)
+
+type cliUpgradeRefusedError struct {
+	message string
+}
+
+func (e *cliUpgradeRefusedError) Error() string {
+	return e.message
+}
+
 func (r *commandRuntime) upgrade(cmd *cobra.Command, args []string) error {
 	_ = args
 
 	check := getBoolFlag(cmd, "check")
+	cliOnly := getBoolFlag(cmd, "cli")
 	daemonOnly := getBoolFlag(cmd, "daemon")
 
-	if check && daemonOnly {
-		return fmt.Errorf("--check and --daemon cannot be combined")
+	selectedPaths := 0
+	if check {
+		selectedPaths++
+	}
+	if cliOnly {
+		selectedPaths++
+	}
+	if daemonOnly {
+		selectedPaths++
+	}
+	if selectedPaths > 1 {
+		return fmt.Errorf("--check, --cli, and --daemon cannot be combined")
 	}
 
 	if check {
@@ -79,7 +124,12 @@ func (r *commandRuntime) upgrade(cmd *cobra.Command, args []string) error {
 		return r.upgradeDaemon(cmd)
 	}
 
-	return fmt.Errorf("Full `looper upgrade` (CLI + daemon) is not implemented yet. Use `looper upgrade --check` or `looper upgrade --daemon`.")
+	if cliOnly {
+		_, err := r.upgradeCLI(cmd)
+		return err
+	}
+
+	return r.upgradeUnified(cmd)
 }
 
 func (r *commandRuntime) collectUpgradeCheckSummary(ctx context.Context) (upgradeCheckSummary, error) {
@@ -109,16 +159,24 @@ func (r *commandRuntime) collectUpgradeCheckSummary(ctx context.Context) (upgrad
 
 	summary := upgradeCheckSummary{
 		CLI: upgradeCLISummary{
-			CurrentVersion:  version.Current().Version,
-			LatestVersion:   latestCLIVersion,
-			UpdateAvailable: normalizeVersion(version.Current().Version) != normalizeVersion(latestCLIVersion),
+			CurrentVersion: version.Current().Version,
+			LatestVersion:  latestCLIVersion,
 		},
 		Daemon: upgradeDaemonSummary{LatestVersion: latestDaemonRelease.Version, Source: "not-installed"},
 	}
+	cliUpgradeAvailable, err := isSemverUpgradeAvailable(version.Current().Version, latestCLIVersion)
+	if err != nil {
+		return upgradeCheckSummary{}, fmt.Errorf("compare CLI versions: %w", err)
+	}
+	summary.CLI.UpdateAvailable = cliUpgradeAvailable
 
 	if currentDaemon != nil {
 		summary.Daemon.CurrentVersion = stringPtr(currentDaemon.Version)
-		summary.Daemon.UpdateAvailable = normalizeVersion(currentDaemon.Version) != normalizeVersion(latestDaemonRelease.Version)
+		daemonUpgradeAvailable, err := isSemverUpgradeAvailable(currentDaemon.Version, latestDaemonRelease.Version)
+		if err != nil {
+			return upgradeCheckSummary{}, fmt.Errorf("compare daemon versions: %w", err)
+		}
+		summary.Daemon.UpdateAvailable = daemonUpgradeAvailable
 		summary.Daemon.Installed = currentDaemon.Source == "installed-binary"
 		summary.Daemon.Source = currentDaemon.Source
 		summary.Daemon.BinaryPath = currentDaemon.BinaryPath
@@ -157,7 +215,14 @@ func (r *commandRuntime) upgradeDaemon(cmd *cobra.Command) error {
 	}
 
 	needsInstall := managedDaemon == nil
-	needsUpgrade := needsInstall || currentVersion == nil || normalizeVersion(*currentVersion) != normalizeVersion(latestRelease.Version)
+	needsUpgrade := needsInstall || currentVersion == nil
+	if !needsUpgrade {
+		available, err := isSemverUpgradeAvailable(*currentVersion, latestRelease.Version)
+		if err != nil {
+			return fmt.Errorf("compare daemon versions: %w", err)
+		}
+		needsUpgrade = available
+	}
 	if !needsUpgrade {
 		output := daemonUpgradeOutput{
 			Changed:        false,
@@ -299,6 +364,217 @@ func (r *commandRuntime) readUpgradeDaemonVersion(ctx context.Context, command s
 
 func normalizeVersion(value string) string {
 	return strings.TrimPrefix(strings.TrimSpace(value), "v")
+}
+
+func (r *commandRuntime) upgradeUnified(cmd *cobra.Command) error {
+	_, cliErr := r.upgradeCLI(cmd)
+	if cliErr != nil {
+		var refused *cliUpgradeRefusedError
+		if !errors.As(cliErr, &refused) {
+			return cliErr
+		}
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "CLI self-upgrade skipped: %s\n", refused.message); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Proceeding with daemon upgrade..."); err != nil {
+		return err
+	}
+	return r.upgradeDaemon(cmd)
+}
+
+func (r *commandRuntime) upgradeCLI(cmd *cobra.Command) (cliUpgradeOutput, error) {
+	ctx := cmd.Context()
+	latestRelease, err := r.fetchReleaseMetadata(ctx, "")
+	if err != nil {
+		return cliUpgradeOutput{}, err
+	}
+	latestVersion := normalizeVersion(latestRelease.TagName)
+	if latestVersion == "" {
+		return cliUpgradeOutput{}, fmt.Errorf("latest looper release metadata is missing tag_name")
+	}
+
+	execPath, err := r.executablePath()
+	if err != nil {
+		return cliUpgradeOutput{}, fmt.Errorf("resolve current looper path: %w", err)
+	}
+	installSource := detectCLIInstallSource(execPath)
+	guidance := cliRefusalGuidance(installSource, execPath)
+	if installSource != cliInstallSourceRelease {
+		refused := true
+		result := cliUpgradeOutput{Changed: false, CurrentVersion: version.Current().Version, LatestVersion: latestVersion, BinaryPath: stringPtr(execPath), InstallSource: string(installSource), Refused: &refused, RefusedGuidance: &guidance}
+		if getBoolFlag(cmd, "json") {
+			if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
+				return cliUpgradeOutput{}, err
+			}
+		}
+		return result, &cliUpgradeRefusedError{message: guidance}
+	}
+
+	available, err := isSemverUpgradeAvailable(version.Current().Version, latestVersion)
+	if err != nil {
+		return cliUpgradeOutput{}, fmt.Errorf("compare CLI versions: %w", err)
+	}
+	if !available {
+		skipped := true
+		result := cliUpgradeOutput{Changed: false, CurrentVersion: version.Current().Version, LatestVersion: latestVersion, BinaryPath: stringPtr(execPath), InstallSource: string(installSource), Skipped: &skipped}
+		if getBoolFlag(cmd, "json") {
+			if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
+				return cliUpgradeOutput{}, err
+			}
+		}
+		if !getBoolFlag(cmd, "json") {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looper is already up to date (%s)\n", version.Current().Version); err != nil {
+				return cliUpgradeOutput{}, err
+			}
+		}
+		return result, nil
+	}
+
+	target, err := resolveLooperTarget(r.platform(), r.arch())
+	if err != nil {
+		return cliUpgradeOutput{}, err
+	}
+	binaryAsset, checksumAsset, err := findLooperReleaseAssets(latestRelease, target)
+	if err != nil {
+		return cliUpgradeOutput{}, err
+	}
+	binaryBytes, err := r.downloadBinary(ctx, binaryAsset.BrowserDownloadURL)
+	if err != nil {
+		return cliUpgradeOutput{}, fmt.Errorf("failed to download looper binary: %w", err)
+	}
+	checksumText, err := r.downloadChecksum(ctx, checksumAsset.BrowserDownloadURL)
+	if err != nil {
+		return cliUpgradeOutput{}, fmt.Errorf("failed to download looper checksum: %w", err)
+	}
+	expectedChecksum, err := parseChecksum(checksumText)
+	if err != nil {
+		return cliUpgradeOutput{}, err
+	}
+	actualChecksum := sha256.Sum256(binaryBytes)
+	if hex.EncodeToString(actualChecksum[:]) != expectedChecksum {
+		return cliUpgradeOutput{}, fmt.Errorf("downloaded looper checksum mismatch: expected %s, received %s", expectedChecksum, hex.EncodeToString(actualChecksum[:]))
+	}
+	if err := replaceBinaryAtomically(execPath, binaryBytes); err != nil {
+		return cliUpgradeOutput{}, err
+	}
+
+	prevPath := execPath + ".prev"
+	result := cliUpgradeOutput{Changed: true, CurrentVersion: version.Current().Version, LatestVersion: latestVersion, BinaryPath: stringPtr(execPath), PreviousBinary: stringPtr(prevPath), DownloadedFrom: stringPtr(binaryAsset.BrowserDownloadURL), InstallSource: string(installSource)}
+	if getBoolFlag(cmd, "json") {
+		if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
+			return cliUpgradeOutput{}, err
+		}
+		return result, nil
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Upgraded looper %s → %s at %s\n", version.Current().Version, latestVersion, execPath); err != nil {
+		return cliUpgradeOutput{}, err
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Previous binary kept at %s\n", prevPath); err != nil {
+		return cliUpgradeOutput{}, err
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Downloaded from %s\n", binaryAsset.BrowserDownloadURL); err != nil {
+		return cliUpgradeOutput{}, err
+	}
+	return result, nil
+}
+
+func detectCLIInstallSource(execPath string) cliInstallSource {
+	path := strings.ToLower(execPath)
+	if strings.Contains(path, "/cellar/") || strings.Contains(path, "/homebrew/") {
+		return cliInstallSourceHomebrew
+	}
+	if strings.Contains(path, "/go/bin/") || strings.Contains(path, "/go-build/") || strings.Contains(path, "/tmp/") {
+		return cliInstallSourceDev
+	}
+	base := strings.ToLower(filepath.Base(path))
+	if base != "looper" {
+		return cliInstallSourceUnknown
+	}
+	if strings.HasSuffix(path, "/.local/bin/looper") || strings.HasSuffix(path, "/usr/local/bin/looper") || strings.HasSuffix(path, "/.looper/bin/looper") {
+		return cliInstallSourceRelease
+	}
+	return cliInstallSourceUnknown
+}
+
+func (r *commandRuntime) executablePath() (string, error) {
+	if value := strings.TrimSpace(r.app.deps.ExecutablePath); value != "" {
+		return value, nil
+	}
+	return os.Executable()
+}
+
+func cliRefusalGuidance(source cliInstallSource, execPath string) string {
+	switch source {
+	case cliInstallSourceHomebrew:
+		return "this looper binary looks Homebrew-managed. Upgrade with `brew upgrade looper` (or your tap formula)."
+	case cliInstallSourceDev:
+		return "this looper binary looks like a dev/go-install build. Reinstall with `go install ./cmd/looper` (or rebuild locally)."
+	default:
+		return fmt.Sprintf("cannot safely self-upgrade looper from %q. Reinstall from a release binary or use your package manager.", execPath)
+	}
+}
+
+func resolveLooperTarget(platform string, arch string) (string, error) {
+	if platform == "darwin" && arch == "arm64" {
+		return "darwin-arm64", nil
+	}
+	if platform == "darwin" && (arch == "amd64" || arch == "x64") {
+		return "darwin-x64", nil
+	}
+	return "", fmt.Errorf("unsupported platform/arch for looper upgrade: %s-%s. Supported targets: darwin-arm64, darwin-x64", platform, arch)
+}
+
+func findLooperReleaseAssets(release githubReleasePayload, target string) (githubReleaseAsset, githubReleaseAsset, error) {
+	binaryName := "looper-" + target
+	checksumName := binaryName + ".sha256"
+	var binaryAsset githubReleaseAsset
+	var checksumAsset githubReleaseAsset
+	for _, asset := range release.Assets {
+		if asset.Name == binaryName {
+			binaryAsset = asset
+		}
+		if asset.Name == checksumName {
+			checksumAsset = asset
+		}
+	}
+	if strings.TrimSpace(binaryAsset.BrowserDownloadURL) == "" {
+		return githubReleaseAsset{}, githubReleaseAsset{}, fmt.Errorf("release is missing asset %q", binaryName)
+	}
+	if strings.TrimSpace(checksumAsset.BrowserDownloadURL) == "" {
+		return githubReleaseAsset{}, githubReleaseAsset{}, fmt.Errorf("release is missing asset %q", checksumName)
+	}
+	return binaryAsset, checksumAsset, nil
+}
+
+func replaceBinaryAtomically(installPath string, binaryBytes []byte) error {
+	installDir := filepath.Dir(installPath)
+	tempInstallPath := installPath + ".new"
+	prevPath := installPath + ".prev"
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		return fmt.Errorf("create install directory: %w", err)
+	}
+	if err := os.WriteFile(tempInstallPath, binaryBytes, 0o755); err != nil {
+		_ = removeTempInstallFile(tempInstallPath)
+		return fmt.Errorf("write staged binary: %w", err)
+	}
+	if err := os.Chmod(tempInstallPath, 0o755); err != nil {
+		_ = removeTempInstallFile(tempInstallPath)
+		return fmt.Errorf("chmod staged binary: %w", err)
+	}
+	if _, err := os.Stat(installPath); err == nil {
+		_ = os.Remove(prevPath)
+		if err := os.Rename(installPath, prevPath); err != nil {
+			_ = removeTempInstallFile(tempInstallPath)
+			return fmt.Errorf("preserve previous looper binary: %w", err)
+		}
+	}
+	if err := os.Rename(tempInstallPath, installPath); err != nil {
+		_ = removeTempInstallFile(tempInstallPath)
+		return fmt.Errorf("replace looper binary: %w", err)
+	}
+	return nil
 }
 
 func writeHumanUpgradeSummary(w io.Writer, summary upgradeCheckSummary) error {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -557,10 +557,30 @@ func isInstallerSelectedUserBinPath(execPath string) bool {
 }
 
 func (r *commandRuntime) executablePath() (string, error) {
-	if value := strings.TrimSpace(r.app.deps.ExecutablePath); value != "" {
-		return value, nil
+	resolve := func(path string) string {
+		resolvedPath, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return path
+		}
+		resolvedPath = strings.TrimSpace(resolvedPath)
+		if resolvedPath == "" {
+			return path
+		}
+		return resolvedPath
 	}
-	return os.Executable()
+
+	if value := strings.TrimSpace(r.app.deps.ExecutablePath); value != "" {
+		return resolve(value), nil
+	}
+	path, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return path, nil
+	}
+	return resolve(path), nil
 }
 
 func cliRefusalGuidance(source cliInstallSource, execPath string) string {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -649,8 +649,18 @@ func writeHumanUpgradeSummary(w io.Writer, summary upgradeCheckSummary) error {
 }
 
 func selectUpgradeDaemonVersionState(statusPayload json.RawMessage, managedDaemon *upgradeDaemonVersionState, pathDaemon *upgradeDaemonVersionState) *upgradeDaemonVersionState {
-	if versionText := extractDaemonVersion(statusPayload); versionText != "" {
-		return &upgradeDaemonVersionState{Version: versionText, Source: "api"}
+	serviceBinary := extractDaemonServiceBinary(statusPayload)
+	if serviceBinary.Version != "" {
+		state := &upgradeDaemonVersionState{Version: serviceBinary.Version, Source: "api"}
+		if serviceBinary.Path != "" {
+			state.BinaryPath = stringPtr(serviceBinary.Path)
+			if managedDaemon != nil && managedDaemon.BinaryPath != nil && serviceBinary.Path == *managedDaemon.BinaryPath {
+				state.Source = managedDaemon.Source
+			} else if pathDaemon != nil && pathDaemon.BinaryPath != nil && serviceBinary.Path == *pathDaemon.BinaryPath {
+				state.Source = pathDaemon.Source
+			}
+		}
+		return state
 	}
 	if managedDaemon != nil {
 		return managedDaemon

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -539,11 +539,11 @@ func detectCLIInstallSource(execPath string) cliInstallSource {
 	if strings.HasSuffix(path, "/.local/bin/looper") || strings.HasSuffix(path, "/usr/local/bin/looper") || strings.HasSuffix(path, "/.looper/bin/looper") {
 		return cliInstallSourceRelease
 	}
-	if isInstallerSelectedUserBinPath(execPath) {
-		return cliInstallSourceRelease
-	}
 	if strings.Contains(path, "/go/bin/") || strings.Contains(path, "/go-build/") || strings.Contains(path, "/tmp/") {
 		return cliInstallSourceDev
+	}
+	if isInstallerSelectedUserBinPath(execPath) {
+		return cliInstallSourceRelease
 	}
 	return cliInstallSourceUnknown
 }

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -464,6 +464,17 @@ func (r *commandRuntime) upgradeCLIWithOutput(cmd *cobra.Command, emitOutput boo
 		}
 		return result, nil
 	}
+	if err := preflightSelfUpgradeReplace(execPath); err != nil {
+		refused := true
+		guidance := cliSelfUpgradeWriteGuidance(execPath, err)
+		result := cliUpgradeOutput{Changed: false, CurrentVersion: version.Current().Version, LatestVersion: latestVersion, BinaryPath: stringPtr(execPath), InstallSource: string(installSource), Refused: &refused, RefusedGuidance: &guidance}
+		if emitOutput && getBoolFlag(cmd, "json") {
+			if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
+				return cliUpgradeOutput{}, err
+			}
+		}
+		return result, &cliUpgradeRefusedError{message: guidance}
+	}
 
 	target, err := resolveLooperTarget(r.platform(), r.arch())
 	if err != nil {
@@ -592,6 +603,36 @@ func cliRefusalGuidance(source cliInstallSource, execPath string) string {
 	default:
 		return fmt.Sprintf("cannot safely self-upgrade looper from %q. Reinstall from a release binary or use your package manager.", execPath)
 	}
+}
+
+func cliSelfUpgradeWriteGuidance(execPath string, err error) string {
+	return fmt.Sprintf("cannot self-upgrade looper at %q because the install location is not writable: %v. Reinstall looper into a user-writable directory or use your package manager for this installation.", execPath, err)
+}
+
+func preflightSelfUpgradeReplace(installPath string) error {
+	installDir := filepath.Dir(installPath)
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		return fmt.Errorf("prepare install directory %q: %w", installDir, err)
+	}
+	tempFile, err := os.CreateTemp(installDir, ".looper-upgrade-check-*")
+	if err != nil {
+		return fmt.Errorf("create test file in %q: %w", installDir, err)
+	}
+	tempPath := tempFile.Name()
+	if err := tempFile.Close(); err != nil {
+		_ = removeTempInstallFile(tempPath)
+		return fmt.Errorf("close test file in %q: %w", installDir, err)
+	}
+	renamedPath := tempPath + ".rename"
+	_ = os.Remove(renamedPath)
+	if err := os.Rename(tempPath, renamedPath); err != nil {
+		_ = removeTempInstallFile(tempPath)
+		return fmt.Errorf("rename test file in %q: %w", installDir, err)
+	}
+	if err := removeTempInstallFile(renamedPath); err != nil {
+		return fmt.Errorf("remove test file in %q: %w", installDir, err)
+	}
+	return nil
 }
 
 func resolveLooperTarget(platform string, arch string) (string, error) {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -419,15 +419,6 @@ func (r *commandRuntime) upgradeCLI(cmd *cobra.Command) (cliUpgradeOutput, error
 
 func (r *commandRuntime) upgradeCLIWithOutput(cmd *cobra.Command, emitOutput bool) (cliUpgradeOutput, error) {
 	ctx := cmd.Context()
-	latestRelease, err := r.fetchReleaseMetadata(ctx, "")
-	if err != nil {
-		return cliUpgradeOutput{}, err
-	}
-	latestVersion := normalizeVersion(latestRelease.TagName)
-	if latestVersion == "" {
-		return cliUpgradeOutput{}, fmt.Errorf("latest looper release metadata is missing tag_name")
-	}
-
 	execPath, err := r.executablePath()
 	if err != nil {
 		return cliUpgradeOutput{}, fmt.Errorf("resolve current looper path: %w", err)
@@ -436,13 +427,22 @@ func (r *commandRuntime) upgradeCLIWithOutput(cmd *cobra.Command, emitOutput boo
 	guidance := cliRefusalGuidance(installSource, execPath)
 	if installSource != cliInstallSourceRelease {
 		refused := true
-		result := cliUpgradeOutput{Changed: false, CurrentVersion: version.Current().Version, LatestVersion: latestVersion, BinaryPath: stringPtr(execPath), InstallSource: string(installSource), Refused: &refused, RefusedGuidance: &guidance}
+		result := cliUpgradeOutput{Changed: false, CurrentVersion: version.Current().Version, BinaryPath: stringPtr(execPath), InstallSource: string(installSource), Refused: &refused, RefusedGuidance: &guidance}
 		if emitOutput && getBoolFlag(cmd, "json") {
 			if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
 				return cliUpgradeOutput{}, err
 			}
 		}
 		return result, &cliUpgradeRefusedError{message: guidance}
+	}
+
+	latestRelease, err := r.fetchReleaseMetadata(ctx, "")
+	if err != nil {
+		return cliUpgradeOutput{}, err
+	}
+	latestVersion := normalizeVersion(latestRelease.TagName)
+	if latestVersion == "" {
+		return cliUpgradeOutput{}, fmt.Errorf("latest looper release metadata is missing tag_name")
 	}
 
 	available, err := isSemverUpgradeAvailable(version.Current().Version, latestVersion)

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -364,6 +364,47 @@ func TestUpgradeCLIRefusesHomebrewInstallWithGuidance(t *testing.T) {
 	}
 }
 
+func TestUpgradeCLIRefusesHomebrewSymlinkWithGuidance(t *testing.T) {
+	t.Parallel()
+
+	homebrewRoot := t.TempDir()
+	targetPath := filepath.Join(homebrewRoot, "usr", "local", "Cellar", "looper", "0.2.1", "bin", "looper")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(target dir) error = %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("os.WriteFile(target) error = %v", err)
+	}
+
+	symlinkPath := filepath.Join(homebrewRoot, "usr", "local", "bin", "looper")
+	if err := os.MkdirAll(filepath.Dir(symlinkPath), 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(symlink dir) error = %v", err)
+	}
+	if err := os.Symlink(targetPath, symlinkPath); err != nil {
+		t.Skipf("os.Symlink() unavailable: %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		ExecutablePath: symlinkPath,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected request before Homebrew refusal: %q", req.URL.String())
+			return nil, nil
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"upgrade", "--cli"})
+	if exitCode != 1 {
+		t.Fatalf("Run([upgrade --cli]) exit code = %d, want 1", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "brew upgrade looper") {
+		t.Fatalf("stderr = %q, want brew guidance", stderr.String())
+	}
+}
+
 func TestDetectCLIInstallSourceTreatsInstallerSelectedUserBinAsRelease(t *testing.T) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil || homeDir == "" {

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -153,6 +153,40 @@ func TestSelectUpgradeDaemonVersionStatePreservesAPIBinaryPath(t *testing.T) {
 	}
 }
 
+func TestReplaceBinaryAtomicallyRestoresPreviousOnFinalRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	installPath := filepath.Join(dir, "looper")
+	original := []byte("original")
+	if err := os.WriteFile(installPath, original, 0o755); err != nil {
+		t.Fatalf("WriteFile(installPath) error = %v", err)
+	}
+
+	var renameCalls int
+	err := replaceBinaryAtomicallyWithRename(installPath, []byte("new"), func(oldPath string, newPath string) error {
+		renameCalls++
+		if renameCalls == 2 {
+			return fmt.Errorf("injected final rename failure")
+		}
+		return os.Rename(oldPath, newPath)
+	})
+	if err == nil {
+		t.Fatal("replaceBinaryAtomicallyWithRename() error = nil, want failure")
+	}
+	if !strings.Contains(err.Error(), "replace looper binary") {
+		t.Fatalf("error = %v, want replace context", err)
+	}
+	restored, readErr := os.ReadFile(installPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(installPath) error = %v", readErr)
+	}
+	if string(restored) != string(original) {
+		t.Fatalf("restored binary = %q, want %q", string(restored), string(original))
+	}
+	if _, statErr := os.Stat(installPath + ".new"); !os.IsNotExist(statErr) {
+		t.Fatalf("staged binary still exists or stat failed: %v", statErr)
+	}
+}
+
 func TestUpgradeRejectsCombiningCheckAndDaemon(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -77,24 +77,98 @@ func TestUpgradeRejectsCombiningCheckAndDaemon(t *testing.T) {
 	if exitCode != 1 {
 		t.Fatalf("Run([upgrade --check --daemon]) exit code = %d, want 1", exitCode)
 	}
-	if !strings.Contains(stderr.String(), "--check and --daemon cannot be combined") {
+	if !strings.Contains(stderr.String(), "--check, --cli, and --daemon cannot be combined") {
 		t.Fatalf("stderr = %q, want combination error", stderr.String())
 	}
 }
 
-func TestUpgradeWithoutFlagsExplainsNotImplemented(t *testing.T) {
+func TestUpgradeWithoutFlagsContinuesWithDaemonWhenCLISelfUpgradeRefused(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	binary := []byte{1, 2, 3, 4}
+	checksumText := "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a  looperd-darwin-arm64\n"
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		Platform:       "darwin",
+		Arch:           "arm64",
+		ExecutablePath: "/opt/homebrew/Cellar/looper/0.2.1/bin/looper",
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "http://127.0.0.1:4321/api/v1/status":
+				return nil, fmt.Errorf("daemon offline")
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.3.0","assets":[{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://api.github.com/repos/powerformer/looper/releases/tags/v0.3.0":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.3.0","assets":[{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looperd-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, binary), nil
+			case "https://example.invalid/looperd-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, checksumText), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+			}
+			if command == looperdBinaryName && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"upgrade", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([upgrade]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "CLI self-upgrade skipped") {
+		t.Fatalf("stdout = %q, want CLI refusal guidance", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Proceeding with daemon upgrade") {
+		t.Fatalf("stdout = %q, want daemon continuation note", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Installed looperd 0.3.0") {
+		t.Fatalf("stdout = %q, want daemon install message", stdout.String())
+	}
+}
+
+func TestUpgradeCLIRefusesHomebrewInstallWithGuidance(t *testing.T) {
 	t.Parallel()
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	app := New(Deps{Stdout: stdout, Stderr: stderr})
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		ExecutablePath: "/opt/homebrew/Cellar/looper/0.2.1/bin/looper",
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() == "https://api.github.com/repos/powerformer/looper/releases/latest" {
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.3.0","assets":[]}`), nil
+			}
+			t.Fatalf("unexpected request URL %q", req.URL.String())
+			return nil, nil
+		}),
+	})
 
-	exitCode := app.Run(context.Background(), []string{"upgrade"})
+	exitCode := app.Run(context.Background(), []string{"upgrade", "--cli"})
 	if exitCode != 1 {
-		t.Fatalf("Run([upgrade]) exit code = %d, want 1", exitCode)
+		t.Fatalf("Run([upgrade --cli]) exit code = %d, want 1", exitCode)
 	}
-	if !strings.Contains(stderr.String(), "Full `looper upgrade` (CLI + daemon) is not implemented yet") {
-		t.Fatalf("stderr = %q, want bare-upgrade guidance", stderr.String())
+	if !strings.Contains(stderr.String(), "brew upgrade looper") {
+		t.Fatalf("stderr = %q, want brew guidance", stderr.String())
 	}
 }
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -350,10 +350,7 @@ func TestUpgradeCLIRefusesHomebrewInstallWithGuidance(t *testing.T) {
 		Stderr:         stderr,
 		ExecutablePath: "/opt/homebrew/Cellar/looper/0.2.1/bin/looper",
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.String() == "https://api.github.com/repos/powerformer/looper/releases/latest" {
-				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.3.0","assets":[]}`), nil
-			}
-			t.Fatalf("unexpected request URL %q", req.URL.String())
+			t.Fatalf("unexpected request before Homebrew refusal: %q", req.URL.String())
 			return nil, nil
 		}),
 	})

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -405,6 +405,45 @@ func TestUpgradeCLIRefusesHomebrewSymlinkWithGuidance(t *testing.T) {
 	}
 }
 
+func TestUpgradeCLIPreflightsInstallPathBeforeDownload(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	blockingPath := filepath.Join(root, ".looper")
+	if err := os.WriteFile(blockingPath, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("WriteFile(blockingPath) error = %v", err)
+	}
+	execPath := filepath.Join(root, ".looper", "bin", "looper")
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		ExecutablePath: execPath,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.3.0","assets":[{"name":"looper-darwin-arm64","browser_download_url":"https://example.invalid/looper-darwin-arm64"},{"name":"looper-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looper-darwin-arm64.sha256"}]}`), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"upgrade", "--cli"})
+	if exitCode != 1 {
+		t.Fatalf("Run([upgrade --cli]) exit code = %d, want 1", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "install location is not writable") {
+		t.Fatalf("stderr = %q, want writable guidance", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "download") {
+		t.Fatalf("stderr = %q, did not expect download failure", stderr.String())
+	}
+}
+
 func TestDetectCLIInstallSourceTreatsInstallerSelectedUserBinAsRelease(t *testing.T) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil || homeDir == "" {

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -458,6 +458,20 @@ func TestDetectCLIInstallSourceTreatsInstallerSelectedUserBinAsRelease(t *testin
 	}
 }
 
+func TestDetectCLIInstallSourceTreatsGoBinAsDevBeforeUserBinRelease(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		t.Skipf("cannot resolve user home directory: %v", err)
+	}
+	goBin := filepath.Join(homeDir, "go", "bin")
+	t.Setenv("PATH", goBin)
+
+	got := detectCLIInstallSource(filepath.Join(goBin, "looper"))
+	if got != cliInstallSourceDev {
+		t.Fatalf("detectCLIInstallSource(go PATH bin) = %q, want %q", got, cliInstallSourceDev)
+	}
+}
+
 func TestUpgradeDaemonPrintsRestartHint(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -67,6 +67,92 @@ func TestUpgradeCheckPrintsSummary(t *testing.T) {
 	}
 }
 
+func TestUpgradeCheckUsesManagedProvenanceFromStatusAPI(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	app := New(Deps{
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: homeDir,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "http://127.0.0.1:4321/api/v1/status":
+				return jsonResponse(t, http.StatusOK, `{"success":true,"data":{"service":{"version":"0.2.1","binary":{"path":"`+managedPath+`"}}}}`), nil
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.3.0","assets":[]}`), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{Stdout: "0.2.1\n", ExitCode: 0}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"upgrade", "--check", "--json", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([upgrade --check --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([upgrade --check --json]) stderr = %q, want empty string", stderr.String())
+	}
+	var decoded struct {
+		Daemon struct {
+			CurrentVersion string `json:"currentVersion"`
+			Installed      bool   `json:"installed"`
+			Source         string `json:"source"`
+			BinaryPath     string `json:"binaryPath"`
+		} `json:"daemon"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal stdout JSON: %v\nraw=%q", err, stdout.String())
+	}
+	if decoded.Daemon.CurrentVersion != "0.2.1" {
+		t.Fatalf("daemon.currentVersion = %q, want 0.2.1", decoded.Daemon.CurrentVersion)
+	}
+	if !decoded.Daemon.Installed {
+		t.Fatal("daemon.installed = false, want true")
+	}
+	if decoded.Daemon.Source != "installed-binary" {
+		t.Fatalf("daemon.source = %q, want installed-binary", decoded.Daemon.Source)
+	}
+	if decoded.Daemon.BinaryPath != managedPath {
+		t.Fatalf("daemon.binaryPath = %q, want %q", decoded.Daemon.BinaryPath, managedPath)
+	}
+}
+
+func TestSelectUpgradeDaemonVersionStatePreservesAPIBinaryPath(t *testing.T) {
+	t.Parallel()
+
+	managedPath := "/tmp/.looper/bin/looperd"
+	state := selectUpgradeDaemonVersionState(
+		json.RawMessage(`{"service":{"version":"0.2.1","binary":{"path":"`+managedPath+`"}}}`),
+		&upgradeDaemonVersionState{Version: "0.2.1", Source: "installed-binary", BinaryPath: stringPtr(managedPath)},
+		nil,
+	)
+	if state == nil {
+		t.Fatal("selectUpgradeDaemonVersionState() = nil, want state")
+	}
+	if state.Source != "installed-binary" {
+		t.Fatalf("state.Source = %q, want installed-binary", state.Source)
+	}
+	if state.BinaryPath == nil || *state.BinaryPath != managedPath {
+		t.Fatalf("state.BinaryPath = %v, want %q", state.BinaryPath, managedPath)
+	}
+}
+
 func TestUpgradeRejectsCombiningCheckAndDaemon(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -145,6 +146,80 @@ func TestUpgradeWithoutFlagsContinuesWithDaemonWhenCLISelfUpgradeRefused(t *test
 	}
 }
 
+func TestUpgradeWithoutFlagsWritesSingleJSONDocument(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(homeDir, ".looper", "worktrees"), 0o755); err != nil {
+		t.Fatalf("create test worktree root: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	binary := []byte{1, 2, 3, 4}
+	checksumText := "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a  looperd-darwin-arm64\n"
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		Platform:       "darwin",
+		Arch:           "arm64",
+		ExecutablePath: "/opt/homebrew/Cellar/looper/0.2.1/bin/looper",
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "http://127.0.0.1:4321/api/v1/status":
+				return nil, fmt.Errorf("daemon offline")
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.3.0","assets":[{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://api.github.com/repos/powerformer/looper/releases/tags/v0.3.0":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.3.0","assets":[{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looperd-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, binary), nil
+			case "https://example.invalid/looperd-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, checksumText), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+			}
+			if command == looperdBinaryName && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"upgrade", "--json", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([upgrade --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([upgrade --json]) stderr = %q, want empty string", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Proceeding with daemon upgrade") {
+		t.Fatalf("stdout = %q, want JSON without human progress text", stdout.String())
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal stdout JSON: %v\nraw=%q", err, stdout.String())
+	}
+	if _, ok := decoded["cli"].(map[string]any); !ok {
+		t.Fatalf("stdout JSON missing cli object: %#v", decoded)
+	}
+	if _, ok := decoded["daemon"].(map[string]any); !ok {
+		t.Fatalf("stdout JSON missing daemon object: %#v", decoded)
+	}
+}
+
 func TestUpgradeCLIRefusesHomebrewInstallWithGuidance(t *testing.T) {
 	t.Parallel()
 
@@ -169,6 +244,20 @@ func TestUpgradeCLIRefusesHomebrewInstallWithGuidance(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "brew upgrade looper") {
 		t.Fatalf("stderr = %q, want brew guidance", stderr.String())
+	}
+}
+
+func TestDetectCLIInstallSourceTreatsInstallerSelectedUserBinAsRelease(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		t.Skipf("cannot resolve user home directory: %v", err)
+	}
+	userBin := filepath.Join(homeDir, "bin")
+	t.Setenv("PATH", userBin)
+
+	got := detectCLIInstallSource(filepath.Join(userBin, "looper"))
+	if got != cliInstallSourceRelease {
+		t.Fatalf("detectCLIInstallSource(user PATH bin) = %q, want %q", got, cliInstallSourceRelease)
 	}
 }
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -352,8 +352,19 @@ printf '{}'
 func writeExecutable(t *testing.T, path, contents string) {
 	t.Helper()
 	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(contents), 0o755); err != nil {
-		t.Fatalf("os.WriteFile(%s) error = %v", tmpPath, err)
+	file, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		t.Fatalf("os.OpenFile(%s) error = %v", tmpPath, err)
+	}
+	if _, err := file.WriteString(contents); err != nil {
+		_ = file.Close()
+		t.Fatalf("write %s error = %v", tmpPath, err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close %s error = %v", tmpPath, err)
+	}
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		t.Fatalf("os.Chmod(%s) error = %v", tmpPath, err)
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		t.Fatalf("os.Rename(%s, %s) error = %v", tmpPath, path, err)

--- a/internal/release/manifest.go
+++ b/internal/release/manifest.go
@@ -1,0 +1,207 @@
+package release
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/powerformer/looper/internal/storage"
+)
+
+const ManifestVersion = 1
+
+var releaseTagPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$`)
+
+type Manifest struct {
+	ManifestVersion int                 `json:"manifestVersion"`
+	Version         string              `json:"version"`
+	Tag             string              `json:"tag"`
+	Released        string              `json:"released"`
+	Channel         string              `json:"channel"`
+	APIVersion      string              `json:"apiVersion"`
+	SchemaVersion   string              `json:"schemaVersion"`
+	MinCliForDaemon string              `json:"minCliForDaemon"`
+	MinDaemonForCli string              `json:"minDaemonForCli"`
+	Artifacts       map[string]Artifact `json:"artifacts"`
+}
+
+type Artifact struct {
+	URL    string `json:"url"`
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
+type BuildManifestInput struct {
+	Tag               string
+	Version           string
+	Released          time.Time
+	Channel           string
+	APIVersion        string
+	SchemaVersion     string
+	MinCliForDaemon   string
+	MinDaemonForCli   string
+	Repo              string
+	AssetsDir         string
+	RequiredArtifacts []string
+}
+
+func BuildManifest(input BuildManifestInput) (Manifest, error) {
+	tag := strings.TrimSpace(input.Tag)
+	if !releaseTagPattern.MatchString(tag) {
+		return Manifest{}, fmt.Errorf("tag must match vMAJOR.MINOR.PATCH[-PRERELEASE]: %q", tag)
+	}
+
+	version := strings.TrimSpace(input.Version)
+	if version == "" {
+		version = strings.TrimPrefix(tag, "v")
+	}
+
+	if input.Released.IsZero() {
+		return Manifest{}, fmt.Errorf("released time is required")
+	}
+
+	apiVersion := strings.TrimSpace(input.APIVersion)
+	if apiVersion == "" {
+		return Manifest{}, fmt.Errorf("apiVersion is required")
+	}
+
+	schemaVersion := strings.TrimSpace(input.SchemaVersion)
+	if schemaVersion == "" {
+		return Manifest{}, fmt.Errorf("schemaVersion is required")
+	}
+
+	minCliForDaemon := strings.TrimSpace(input.MinCliForDaemon)
+	if minCliForDaemon == "" {
+		return Manifest{}, fmt.Errorf("minCliForDaemon is required")
+	}
+
+	minDaemonForCli := strings.TrimSpace(input.MinDaemonForCli)
+	if minDaemonForCli == "" {
+		return Manifest{}, fmt.Errorf("minDaemonForCli is required")
+	}
+
+	repo := strings.TrimSpace(input.Repo)
+	if repo == "" {
+		return Manifest{}, fmt.Errorf("repo is required")
+	}
+
+	channel := strings.TrimSpace(input.Channel)
+	if channel == "" {
+		if strings.Contains(version, "-") {
+			channel = "beta"
+		} else {
+			channel = "stable"
+		}
+	}
+
+	assets, err := collectArtifacts(strings.TrimSpace(input.AssetsDir), repo, tag)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if len(input.RequiredArtifacts) == 0 {
+		return Manifest{}, fmt.Errorf("at least one required artifact is required")
+	}
+
+	for _, name := range input.RequiredArtifacts {
+		if _, ok := assets[name]; !ok {
+			return Manifest{}, fmt.Errorf("missing required artifact: %s", name)
+		}
+	}
+
+	return Manifest{
+		ManifestVersion: ManifestVersion,
+		Version:         version,
+		Tag:             tag,
+		Released:        input.Released.UTC().Format(time.RFC3339),
+		Channel:         channel,
+		APIVersion:      apiVersion,
+		SchemaVersion:   schemaVersion,
+		MinCliForDaemon: minCliForDaemon,
+		MinDaemonForCli: minDaemonForCli,
+		Artifacts:       assets,
+	}, nil
+}
+
+func CurrentSchemaVersion() string {
+	if len(storage.EmbeddedMigrations) == 0 {
+		return ""
+	}
+	return storage.EmbeddedMigrations[len(storage.EmbeddedMigrations)-1].ID
+}
+
+func EncodeManifest(manifest Manifest) ([]byte, error) {
+	encoded, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(encoded, '\n'), nil
+}
+
+func collectArtifacts(assetsDir, repo, tag string) (map[string]Artifact, error) {
+	if assetsDir == "" {
+		return nil, fmt.Errorf("assets directory is required")
+	}
+	entries, err := os.ReadDir(assetsDir)
+	if err != nil {
+		return nil, fmt.Errorf("read assets directory: %w", err)
+	}
+
+	artifactNames := make([]string, 0)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || strings.HasSuffix(name, ".sha256") || strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".minisig") {
+			continue
+		}
+		artifactNames = append(artifactNames, name)
+	}
+	sort.Strings(artifactNames)
+
+	artifacts := make(map[string]Artifact, len(artifactNames))
+	for _, artifactName := range artifactNames {
+		path := filepath.Join(assetsDir, artifactName)
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("stat artifact %s: %w", artifactName, err)
+		}
+
+		shaPath := path + ".sha256"
+		shaBytes, err := os.ReadFile(shaPath)
+		if err != nil {
+			return nil, fmt.Errorf("read checksum for %s: %w", artifactName, err)
+		}
+		sha := parseSHA256(string(shaBytes))
+		if sha == "" {
+			return nil, fmt.Errorf("invalid checksum format for %s", artifactName)
+		}
+
+		artifacts[artifactName] = Artifact{
+			URL:    fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, tag, artifactName),
+			SHA256: sha,
+			Size:   info.Size(),
+		}
+	}
+
+	return artifacts, nil
+}
+
+func parseSHA256(raw string) string {
+	fields := strings.Fields(raw)
+	if len(fields) == 0 {
+		return ""
+	}
+	hash := strings.ToLower(strings.TrimSpace(fields[0]))
+	if len(hash) != 64 {
+		return ""
+	}
+	for _, char := range hash {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return ""
+		}
+	}
+	return hash
+}

--- a/internal/release/manifest_test.go
+++ b/internal/release/manifest_test.go
@@ -1,0 +1,157 @@
+package release
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBuildManifestCollectsArtifactsAndDerivesDefaults(t *testing.T) {
+	assetsDir := t.TempDir()
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64"), []byte("looper"))
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64.sha256"), []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  looper-darwin-arm64\n"))
+	writeFile(t, filepath.Join(assetsDir, "looperd-darwin-arm64"), []byte("looperd"))
+	writeFile(t, filepath.Join(assetsDir, "looperd-darwin-arm64.sha256"), []byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  looperd-darwin-arm64\n"))
+
+	manifest, err := BuildManifest(BuildManifestInput{
+		Tag:               "v1.2.3-rc.1",
+		Released:          time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC),
+		APIVersion:        "v1",
+		SchemaVersion:     "12",
+		MinCliForDaemon:   "0.2.0",
+		MinDaemonForCli:   "0.2.0",
+		Repo:              "powerformer/looper",
+		AssetsDir:         assetsDir,
+		RequiredArtifacts: []string{"looper-darwin-arm64", "looperd-darwin-arm64"},
+	})
+	if err != nil {
+		t.Fatalf("BuildManifest(...) error = %v", err)
+	}
+
+	if manifest.Version != "1.2.3-rc.1" {
+		t.Fatalf("manifest.Version = %q, want %q", manifest.Version, "1.2.3-rc.1")
+	}
+	if manifest.Channel != "beta" {
+		t.Fatalf("manifest.Channel = %q, want %q", manifest.Channel, "beta")
+	}
+	if manifest.Artifacts["looper-darwin-arm64"].SHA256 != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("looper sha = %q, want %q", manifest.Artifacts["looper-darwin-arm64"].SHA256, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	}
+	if manifest.Artifacts["looperd-darwin-arm64"].URL != "https://github.com/powerformer/looper/releases/download/v1.2.3-rc.1/looperd-darwin-arm64" {
+		t.Fatalf("looperd URL = %q", manifest.Artifacts["looperd-darwin-arm64"].URL)
+	}
+}
+
+func TestBuildManifestFailsWhenRequiredArtifactMissing(t *testing.T) {
+	assetsDir := t.TempDir()
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64"), []byte("looper"))
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64.sha256"), []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  looper-darwin-arm64\n"))
+
+	_, err := BuildManifest(BuildManifestInput{
+		Tag:               "v1.2.3",
+		Released:          time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC),
+		APIVersion:        "v1",
+		SchemaVersion:     "12",
+		Repo:              "powerformer/looper",
+		AssetsDir:         assetsDir,
+		RequiredArtifacts: []string{"looper-darwin-arm64", "looperd-darwin-arm64"},
+	})
+	if err == nil {
+		t.Fatal("BuildManifest(...) error = nil, want missing required artifact")
+	}
+}
+
+func TestBuildManifestRejectsInvalidTag(t *testing.T) {
+	assetsDir := t.TempDir()
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64"), []byte("looper"))
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64.sha256"), []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  looper-darwin-arm64\n"))
+
+	_, err := BuildManifest(BuildManifestInput{
+		Tag:               "vfoo",
+		Released:          time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC),
+		APIVersion:        "v1",
+		SchemaVersion:     "0007_agent_execution_run_index",
+		MinCliForDaemon:   "0.2.0",
+		MinDaemonForCli:   "0.2.0",
+		Repo:              "powerformer/looper",
+		AssetsDir:         assetsDir,
+		RequiredArtifacts: []string{"looper-darwin-arm64"},
+	})
+	if err == nil {
+		t.Fatal("BuildManifest(...) error = nil, want invalid tag error")
+	}
+}
+
+func TestBuildManifestRejectsInvalidChecksum(t *testing.T) {
+	assetsDir := t.TempDir()
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64"), []byte("looper"))
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64.sha256"), []byte("not-a-sha  looper-darwin-arm64\n"))
+
+	_, err := BuildManifest(BuildManifestInput{
+		Tag:               "v1.2.3",
+		Released:          time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC),
+		APIVersion:        "v1",
+		SchemaVersion:     "0007_agent_execution_run_index",
+		MinCliForDaemon:   "0.2.0",
+		MinDaemonForCli:   "0.2.0",
+		Repo:              "powerformer/looper",
+		AssetsDir:         assetsDir,
+		RequiredArtifacts: []string{"looper-darwin-arm64"},
+	})
+	if err == nil {
+		t.Fatal("BuildManifest(...) error = nil, want invalid checksum error")
+	}
+}
+
+func TestCurrentSchemaVersionUsesLatestEmbeddedMigration(t *testing.T) {
+	if got, want := CurrentSchemaVersion(), "0007_agent_execution_run_index"; got != want {
+		t.Fatalf("CurrentSchemaVersion() = %q, want %q", got, want)
+	}
+}
+
+func TestEncodeManifestProducesStableJSONShape(t *testing.T) {
+	manifest := Manifest{
+		ManifestVersion: 1,
+		Version:         "1.2.3",
+		Tag:             "v1.2.3",
+		Released:        "2026-04-22T12:00:00Z",
+		Channel:         "stable",
+		APIVersion:      "v1",
+		SchemaVersion:   "12",
+		MinCliForDaemon: "0.2.0",
+		MinDaemonForCli: "0.2.0",
+		Artifacts: map[string]Artifact{
+			"looper-darwin-arm64": {
+				URL:    "https://example.test/looper",
+				SHA256: "abc",
+				Size:   1,
+			},
+		},
+	}
+
+	encoded, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest(...) error = %v", err)
+	}
+
+	decoded := map[string]any{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(...) error = %v", err)
+	}
+
+	if decoded["channel"] != "stable" {
+		t.Fatalf("channel = %v, want stable", decoded["channel"])
+	}
+	if decoded["apiVersion"] != "v1" {
+		t.Fatalf("apiVersion = %v, want v1", decoded["apiVersion"])
+	}
+}
+
+func writeFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("os.WriteFile(%q) error = %v", path, err)
+	}
+}

--- a/internal/version/buildflags.go
+++ b/internal/version/buildflags.go
@@ -3,29 +3,57 @@ package version
 import "strings"
 
 const (
-	packageImportPath    = "github.com/powerformer/looper/internal/version"
-	buildGitSHAEnvVar    = "LOOPER_BUILD_GIT_SHA"
-	buildTimestampEnvVar = "LOOPER_BUILD_TIMESTAMP"
+	packageImportPath          = "github.com/powerformer/looper/internal/version"
+	buildVersionEnvVar         = "LOOPER_BUILD_VERSION"
+	buildVersionSourceEnvVar   = "LOOPER_BUILD_VERSION_SOURCE"
+	buildChannelEnvVar         = "LOOPER_BUILD_CHANNEL"
+	buildAPIVersionEnvVar      = "LOOPER_BUILD_API_VERSION"
+	buildMinCliForDaemonEnvVar = "LOOPER_BUILD_MIN_CLI_FOR_DAEMON"
+	buildMinDaemonForCliEnvVar = "LOOPER_BUILD_MIN_DAEMON_FOR_CLI"
+	buildGitSHAEnvVar          = "LOOPER_BUILD_GIT_SHA"
+	buildTimestampEnvVar       = "LOOPER_BUILD_TIMESTAMP"
 )
 
 type BuildOverrides struct {
-	Version        string
-	VersionSource  string
-	GitCommitSHA   string
-	BuildTimestamp string
+	Version         string
+	VersionSource   string
+	Channel         string
+	APIVersion      string
+	MinCliForDaemon string
+	MinDaemonForCli string
+	GitCommitSHA    string
+	BuildTimestamp  string
 }
 
 func DefaultBuildOverrides() BuildOverrides {
 	return BuildOverrides{
-		Version:        defaultVersion,
-		VersionSource:  defaultVersionSource,
-		GitCommitSHA:   "",
-		BuildTimestamp: "",
+		Version:         defaultVersion,
+		VersionSource:   defaultVersionSource,
+		Channel:         defaultChannel,
+		APIVersion:      defaultAPIVersion,
+		MinCliForDaemon: "",
+		MinDaemonForCli: "",
+		GitCommitSHA:    "",
+		BuildTimestamp:  "",
 	}
 }
 
 func BuildOverridesFromEnv(lookupEnv func(string) string) BuildOverrides {
 	overrides := DefaultBuildOverrides()
+	if v := strings.TrimSpace(lookupEnv(buildVersionEnvVar)); v != "" {
+		overrides.Version = v
+	}
+	if v := strings.TrimSpace(lookupEnv(buildVersionSourceEnvVar)); v != "" {
+		overrides.VersionSource = v
+	}
+	if v := strings.TrimSpace(lookupEnv(buildChannelEnvVar)); v != "" {
+		overrides.Channel = v
+	}
+	if v := strings.TrimSpace(lookupEnv(buildAPIVersionEnvVar)); v != "" {
+		overrides.APIVersion = v
+	}
+	overrides.MinCliForDaemon = strings.TrimSpace(lookupEnv(buildMinCliForDaemonEnvVar))
+	overrides.MinDaemonForCli = strings.TrimSpace(lookupEnv(buildMinDaemonForCliEnvVar))
 	overrides.GitCommitSHA = strings.TrimSpace(lookupEnv(buildGitSHAEnvVar))
 	overrides.BuildTimestamp = strings.TrimSpace(lookupEnv(buildTimestampEnvVar))
 	return overrides
@@ -35,6 +63,10 @@ func LDFlags(overrides BuildOverrides) string {
 	return strings.Join([]string{
 		ldflagAssignment("Value", overrides.Version),
 		ldflagAssignment("VersionSource", overrides.VersionSource),
+		ldflagAssignment("Channel", overrides.Channel),
+		ldflagAssignment("APIVersion", overrides.APIVersion),
+		ldflagAssignment("MinCliForDaemon", overrides.MinCliForDaemon),
+		ldflagAssignment("MinDaemonForCli", overrides.MinDaemonForCli),
 		ldflagAssignment("GitCommitSHA", overrides.GitCommitSHA),
 		ldflagAssignment("BuildTimestamp", overrides.BuildTimestamp),
 	}, " ")

--- a/internal/version/buildflags_test.go
+++ b/internal/version/buildflags_test.go
@@ -19,6 +19,22 @@ func TestDefaultBuildOverrides(t *testing.T) {
 		t.Fatalf("DefaultBuildOverrides().VersionSource = %q, want %q", overrides.VersionSource, defaultVersionSource)
 	}
 
+	if overrides.Channel != defaultChannel {
+		t.Fatalf("DefaultBuildOverrides().Channel = %q, want %q", overrides.Channel, defaultChannel)
+	}
+
+	if overrides.APIVersion != defaultAPIVersion {
+		t.Fatalf("DefaultBuildOverrides().APIVersion = %q, want %q", overrides.APIVersion, defaultAPIVersion)
+	}
+
+	if overrides.MinCliForDaemon != "" {
+		t.Fatalf("DefaultBuildOverrides().MinCliForDaemon = %q, want empty string", overrides.MinCliForDaemon)
+	}
+
+	if overrides.MinDaemonForCli != "" {
+		t.Fatalf("DefaultBuildOverrides().MinDaemonForCli = %q, want empty string", overrides.MinDaemonForCli)
+	}
+
 	if overrides.GitCommitSHA != "" {
 		t.Fatalf("DefaultBuildOverrides().GitCommitSHA = %q, want empty string", overrides.GitCommitSHA)
 	}
@@ -31,6 +47,18 @@ func TestDefaultBuildOverrides(t *testing.T) {
 func TestBuildOverridesFromEnvUsesOptionalBuildMetadata(t *testing.T) {
 	overrides := BuildOverridesFromEnv(func(name string) string {
 		switch name {
+		case buildVersionEnvVar:
+			return "  1.2.3  "
+		case buildVersionSourceEnvVar:
+			return "  git-tag:v1.2.3  "
+		case buildChannelEnvVar:
+			return "  stable  "
+		case buildAPIVersionEnvVar:
+			return "  v1  "
+		case buildMinCliForDaemonEnvVar:
+			return "  0.2.0  "
+		case buildMinDaemonForCliEnvVar:
+			return "  0.2.0  "
 		case buildGitSHAEnvVar:
 			return "  abc123  "
 		case buildTimestampEnvVar:
@@ -40,12 +68,28 @@ func TestBuildOverridesFromEnvUsesOptionalBuildMetadata(t *testing.T) {
 		}
 	})
 
-	if overrides.Version != defaultVersion {
-		t.Fatalf("BuildOverridesFromEnv(...).Version = %q, want %q", overrides.Version, defaultVersion)
+	if overrides.Version != "1.2.3" {
+		t.Fatalf("BuildOverridesFromEnv(...).Version = %q, want %q", overrides.Version, "1.2.3")
 	}
 
-	if overrides.VersionSource != defaultVersionSource {
-		t.Fatalf("BuildOverridesFromEnv(...).VersionSource = %q, want %q", overrides.VersionSource, defaultVersionSource)
+	if overrides.VersionSource != "git-tag:v1.2.3" {
+		t.Fatalf("BuildOverridesFromEnv(...).VersionSource = %q, want %q", overrides.VersionSource, "git-tag:v1.2.3")
+	}
+
+	if overrides.Channel != "stable" {
+		t.Fatalf("BuildOverridesFromEnv(...).Channel = %q, want %q", overrides.Channel, "stable")
+	}
+
+	if overrides.APIVersion != "v1" {
+		t.Fatalf("BuildOverridesFromEnv(...).APIVersion = %q, want %q", overrides.APIVersion, "v1")
+	}
+
+	if overrides.MinCliForDaemon != "0.2.0" {
+		t.Fatalf("BuildOverridesFromEnv(...).MinCliForDaemon = %q, want %q", overrides.MinCliForDaemon, "0.2.0")
+	}
+
+	if overrides.MinDaemonForCli != "0.2.0" {
+		t.Fatalf("BuildOverridesFromEnv(...).MinDaemonForCli = %q, want %q", overrides.MinDaemonForCli, "0.2.0")
 	}
 
 	if overrides.GitCommitSHA != "abc123" {
@@ -59,13 +103,17 @@ func TestBuildOverridesFromEnvUsesOptionalBuildMetadata(t *testing.T) {
 
 func TestLDFlagsMatchesVersionVariables(t *testing.T) {
 	ldflags := LDFlags(BuildOverrides{
-		Version:        "1.2.3",
-		VersionSource:  "internal/version/version.go",
-		GitCommitSHA:   "abc123",
-		BuildTimestamp: "2026-04-17T00:00:00Z",
+		Version:         "1.2.3",
+		VersionSource:   "internal/version/version.go",
+		Channel:         "stable",
+		APIVersion:      "v1",
+		MinCliForDaemon: "0.2.0",
+		MinDaemonForCli: "0.2.0",
+		GitCommitSHA:    "abc123",
+		BuildTimestamp:  "2026-04-17T00:00:00Z",
 	})
 
-	const want = "-X github.com/powerformer/looper/internal/version.Value=1.2.3 -X github.com/powerformer/looper/internal/version.VersionSource=internal/version/version.go -X github.com/powerformer/looper/internal/version.GitCommitSHA=abc123 -X github.com/powerformer/looper/internal/version.BuildTimestamp=2026-04-17T00:00:00Z"
+	const want = "-X github.com/powerformer/looper/internal/version.Value=1.2.3 -X github.com/powerformer/looper/internal/version.VersionSource=internal/version/version.go -X github.com/powerformer/looper/internal/version.Channel=stable -X github.com/powerformer/looper/internal/version.APIVersion=v1 -X github.com/powerformer/looper/internal/version.MinCliForDaemon=0.2.0 -X github.com/powerformer/looper/internal/version.MinDaemonForCli=0.2.0 -X github.com/powerformer/looper/internal/version.GitCommitSHA=abc123 -X github.com/powerformer/looper/internal/version.BuildTimestamp=2026-04-17T00:00:00Z"
 	if ldflags != want {
 		t.Fatalf("LDFlags(...) = %q, want %q", ldflags, want)
 	}
@@ -82,10 +130,14 @@ func TestLDFlagsInjectIntoBuiltBinary(t *testing.T) {
 		outputPath,
 		"-ldflags",
 		LDFlags(BuildOverrides{
-			Version:        "9.9.9",
-			VersionSource:  "internal/version/version.go",
-			GitCommitSHA:   "deadbeef",
-			BuildTimestamp: "2026-04-17T12:34:56Z",
+			Version:         "9.9.9",
+			VersionSource:   "internal/version/version.go",
+			Channel:         "stable",
+			APIVersion:      "v1",
+			MinCliForDaemon: "0.2.0",
+			MinDaemonForCli: "0.2.0",
+			GitCommitSHA:    "deadbeef",
+			BuildTimestamp:  "2026-04-17T12:34:56Z",
 		}),
 		"./tools/print-version-json",
 	)
@@ -104,7 +156,7 @@ func TestLDFlagsInjectIntoBuiltBinary(t *testing.T) {
 	}
 
 	got := strings.TrimSpace(string(runOutput))
-	const want = `{"version":"9.9.9","metadata":{"versionSource":"internal/version/version.go","gitCommitSha":"deadbeef","buildTimestamp":"2026-04-17T12:34:56Z"}}`
+	const want = `{"version":"9.9.9","metadata":{"versionSource":"internal/version/version.go","channel":"stable","apiVersion":"v1","minCliForDaemon":"0.2.0","minDaemonForCli":"0.2.0","gitCommitSha":"deadbeef","buildTimestamp":"2026-04-17T12:34:56Z"}}`
 	if got != want {
 		t.Fatalf("built helper output = %s, want %s", got, want)
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,23 +1,33 @@
 package version
 
 const (
-	defaultVersion       = "0.2.1"
+	defaultVersion       = "0.0.0-dev"
 	defaultVersionSource = "internal/version/version.go"
+	defaultChannel       = "dev"
+	defaultAPIVersion    = "v1"
 )
 
 // These variables are shared by all Go binaries and can be overridden at build
 // time with -ldflags.
 var (
-	Value          = defaultVersion
-	VersionSource  = defaultVersionSource
-	GitCommitSHA   = ""
-	BuildTimestamp = ""
+	Value           = defaultVersion
+	VersionSource   = defaultVersionSource
+	Channel         = defaultChannel
+	APIVersion      = defaultAPIVersion
+	MinCliForDaemon = ""
+	MinDaemonForCli = ""
+	GitCommitSHA    = ""
+	BuildTimestamp  = ""
 )
 
 type BuildMetadata struct {
-	VersionSource  string  `json:"versionSource"`
-	GitCommitSHA   *string `json:"gitCommitSha"`
-	BuildTimestamp *string `json:"buildTimestamp"`
+	VersionSource   string  `json:"versionSource"`
+	Channel         string  `json:"channel"`
+	APIVersion      string  `json:"apiVersion"`
+	MinCliForDaemon *string `json:"minCliForDaemon"`
+	MinDaemonForCli *string `json:"minDaemonForCli"`
+	GitCommitSHA    *string `json:"gitCommitSha"`
+	BuildTimestamp  *string `json:"buildTimestamp"`
 }
 
 type Info struct {
@@ -29,9 +39,13 @@ func Current() Info {
 	return Info{
 		Version: Value,
 		Metadata: BuildMetadata{
-			VersionSource:  VersionSource,
-			GitCommitSHA:   stringPtrOrNil(GitCommitSHA),
-			BuildTimestamp: stringPtrOrNil(BuildTimestamp),
+			VersionSource:   VersionSource,
+			Channel:         Channel,
+			APIVersion:      APIVersion,
+			MinCliForDaemon: stringPtrOrNil(MinCliForDaemon),
+			MinDaemonForCli: stringPtrOrNil(MinDaemonForCli),
+			GitCommitSHA:    stringPtrOrNil(GitCommitSHA),
+			BuildTimestamp:  stringPtrOrNil(BuildTimestamp),
 		},
 	}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -8,18 +8,30 @@ import (
 func TestCurrentUsesSharedBuildMetadata(t *testing.T) {
 	originalValue := Value
 	originalSource := VersionSource
+	originalChannel := Channel
+	originalAPIVersion := APIVersion
+	originalMinCli := MinCliForDaemon
+	originalMinDaemon := MinDaemonForCli
 	originalCommit := GitCommitSHA
 	originalTimestamp := BuildTimestamp
 
 	t.Cleanup(func() {
 		Value = originalValue
 		VersionSource = originalSource
+		Channel = originalChannel
+		APIVersion = originalAPIVersion
+		MinCliForDaemon = originalMinCli
+		MinDaemonForCli = originalMinDaemon
 		GitCommitSHA = originalCommit
 		BuildTimestamp = originalTimestamp
 	})
 
 	Value = "1.2.3"
 	VersionSource = "internal/version/version.go"
+	Channel = "stable"
+	APIVersion = "v1"
+	MinCliForDaemon = "0.2.0"
+	MinDaemonForCli = "0.2.0"
 	GitCommitSHA = "abc123"
 	BuildTimestamp = "2026-04-17T00:00:00Z"
 
@@ -31,6 +43,22 @@ func TestCurrentUsesSharedBuildMetadata(t *testing.T) {
 
 	if info.Metadata.VersionSource != "internal/version/version.go" {
 		t.Fatalf("Current().Metadata.VersionSource = %q, want %q", info.Metadata.VersionSource, "internal/version/version.go")
+	}
+
+	if info.Metadata.Channel != "stable" {
+		t.Fatalf("Current().Metadata.Channel = %q, want %q", info.Metadata.Channel, "stable")
+	}
+
+	if info.Metadata.APIVersion != "v1" {
+		t.Fatalf("Current().Metadata.APIVersion = %q, want %q", info.Metadata.APIVersion, "v1")
+	}
+
+	if info.Metadata.MinCliForDaemon == nil || *info.Metadata.MinCliForDaemon != "0.2.0" {
+		t.Fatalf("Current().Metadata.MinCliForDaemon = %v, want %q", info.Metadata.MinCliForDaemon, "0.2.0")
+	}
+
+	if info.Metadata.MinDaemonForCli == nil || *info.Metadata.MinDaemonForCli != "0.2.0" {
+		t.Fatalf("Current().Metadata.MinDaemonForCli = %v, want %q", info.Metadata.MinDaemonForCli, "0.2.0")
 	}
 
 	if info.Metadata.GitCommitSHA == nil || *info.Metadata.GitCommitSHA != "abc123" {
@@ -45,18 +73,30 @@ func TestCurrentUsesSharedBuildMetadata(t *testing.T) {
 func TestCurrentDefaultsToPackageVersionMetadata(t *testing.T) {
 	originalValue := Value
 	originalSource := VersionSource
+	originalChannel := Channel
+	originalAPIVersion := APIVersion
+	originalMinCli := MinCliForDaemon
+	originalMinDaemon := MinDaemonForCli
 	originalCommit := GitCommitSHA
 	originalTimestamp := BuildTimestamp
 
 	t.Cleanup(func() {
 		Value = originalValue
 		VersionSource = originalSource
+		Channel = originalChannel
+		APIVersion = originalAPIVersion
+		MinCliForDaemon = originalMinCli
+		MinDaemonForCli = originalMinDaemon
 		GitCommitSHA = originalCommit
 		BuildTimestamp = originalTimestamp
 	})
 
 	Value = defaultVersion
 	VersionSource = defaultVersionSource
+	Channel = defaultChannel
+	APIVersion = defaultAPIVersion
+	MinCliForDaemon = ""
+	MinDaemonForCli = ""
 	GitCommitSHA = ""
 	BuildTimestamp = ""
 
@@ -77,23 +117,51 @@ func TestCurrentDefaultsToPackageVersionMetadata(t *testing.T) {
 	if info.Metadata.BuildTimestamp != nil {
 		t.Fatalf("Current().Metadata.BuildTimestamp = %v, want nil", info.Metadata.BuildTimestamp)
 	}
+
+	if info.Metadata.Channel != defaultChannel {
+		t.Fatalf("Current().Metadata.Channel = %q, want %q", info.Metadata.Channel, defaultChannel)
+	}
+
+	if info.Metadata.APIVersion != defaultAPIVersion {
+		t.Fatalf("Current().Metadata.APIVersion = %q, want %q", info.Metadata.APIVersion, defaultAPIVersion)
+	}
+
+	if info.Metadata.MinCliForDaemon != nil {
+		t.Fatalf("Current().Metadata.MinCliForDaemon = %v, want nil", info.Metadata.MinCliForDaemon)
+	}
+
+	if info.Metadata.MinDaemonForCli != nil {
+		t.Fatalf("Current().Metadata.MinDaemonForCli = %v, want nil", info.Metadata.MinDaemonForCli)
+	}
 }
 
 func TestCurrentJSONMatchesStatusMetadataShape(t *testing.T) {
 	originalValue := Value
 	originalSource := VersionSource
+	originalChannel := Channel
+	originalAPIVersion := APIVersion
+	originalMinCli := MinCliForDaemon
+	originalMinDaemon := MinDaemonForCli
 	originalCommit := GitCommitSHA
 	originalTimestamp := BuildTimestamp
 
 	t.Cleanup(func() {
 		Value = originalValue
 		VersionSource = originalSource
+		Channel = originalChannel
+		APIVersion = originalAPIVersion
+		MinCliForDaemon = originalMinCli
+		MinDaemonForCli = originalMinDaemon
 		GitCommitSHA = originalCommit
 		BuildTimestamp = originalTimestamp
 	})
 
 	Value = defaultVersion
 	VersionSource = defaultVersionSource
+	Channel = defaultChannel
+	APIVersion = defaultAPIVersion
+	MinCliForDaemon = ""
+	MinDaemonForCli = ""
 	GitCommitSHA = ""
 	BuildTimestamp = ""
 
@@ -102,7 +170,7 @@ func TestCurrentJSONMatchesStatusMetadataShape(t *testing.T) {
 		t.Fatalf("json.Marshal(Current()) error = %v", err)
 	}
 
-	const want = `{"version":"0.2.1","metadata":{"versionSource":"internal/version/version.go","gitCommitSha":null,"buildTimestamp":null}}`
+	const want = `{"version":"0.0.0-dev","metadata":{"versionSource":"internal/version/version.go","channel":"dev","apiVersion":"v1","minCliForDaemon":null,"minDaemonForCli":null,"gitCommitSha":null,"buildTimestamp":null}}`
 	if string(encoded) != want {
 		t.Fatalf("json.Marshal(Current()) = %s, want %s", encoded, want)
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -178,7 +178,10 @@ if [ "$install_dir" = "$HOME/.local/bin" ] && ! in_path_dir "$install_dir"; then
 fi
 
 log ""
-log "Current first-run flow:"
+log "Next steps:"
+log "  looper bootstrap"
+log "  looper status"
+log ""
+log "Manual daemon fallback/debug commands:"
 log "  looper daemon install"
 log "  looper daemon start"
-log "  looper status"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,184 @@
+#!/bin/sh
+
+set -eu
+
+OWNER="${LOOPER_GITHUB_OWNER:-powerformer}"
+REPO="${LOOPER_GITHUB_REPO:-looper}"
+VERSION="${LOOPER_VERSION:-latest}"
+
+log() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+detect_target() {
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  [ "$os" = "Darwin" ] || fail "unsupported platform: $os (supported: macOS)"
+
+  case "$arch" in
+    arm64|aarch64) printf 'darwin-arm64\n' ;;
+    x86_64|amd64) printf 'darwin-x64\n' ;;
+    *) fail "unsupported architecture: $arch (supported: arm64, x86_64)" ;;
+  esac
+}
+
+in_path_dir() {
+  candidate="$1"
+  old_ifs=$IFS
+  IFS=:
+  for entry in $PATH; do
+    [ "$entry" = "$candidate" ] && IFS=$old_ifs && return 0
+  done
+  IFS=$old_ifs
+  return 1
+}
+
+guess_profile() {
+  shell_name="${SHELL##*/}"
+  case "$shell_name" in
+    zsh) printf '%s/.zprofile\n' "$HOME" ;;
+    bash) printf '%s/.bash_profile\n' "$HOME" ;;
+    *) printf '%s/.profile\n' "$HOME" ;;
+  esac
+}
+
+confirm() {
+  prompt="$1"
+  if [ ! -t 0 ]; then
+    return 1
+  fi
+  printf '%s [y/N] ' "$prompt" >&2
+  read -r answer || return 1
+  case "$answer" in
+    y|Y|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+append_path_export() {
+  profile="$1"
+  export_line='export PATH="$HOME/.local/bin:$PATH"'
+  mkdir -p "$(dirname "$profile")"
+  touch "$profile"
+  if grep -F "$export_line" "$profile" >/dev/null 2>&1; then
+    return 0
+  fi
+  {
+    printf '\n# Added by looper installer\n'
+    printf '%s\n' "$export_line"
+  } >>"$profile"
+}
+
+pick_install_dir() {
+  if [ -n "${LOOPER_INSTALL_DIR:-}" ]; then
+    printf '%s\n' "$LOOPER_INSTALL_DIR"
+    return 0
+  fi
+
+  old_ifs=$IFS
+  IFS=:
+  for entry in $PATH; do
+    case "$entry" in
+      "$HOME"/*)
+        if [ -d "$entry" ] && [ -w "$entry" ]; then
+          IFS=$old_ifs
+          printf '%s\n' "$entry"
+          return 0
+        fi
+        ;;
+    esac
+  done
+  IFS=$old_ifs
+
+  printf '%s/.local/bin\n' "$HOME"
+}
+
+build_download_base() {
+  tag="$1"
+  if [ "$tag" = "latest" ]; then
+    printf 'https://github.com/%s/%s/releases/latest/download\n' "$OWNER" "$REPO"
+  else
+    printf 'https://github.com/%s/%s/releases/download/%s\n' "$OWNER" "$REPO" "$tag"
+  fi
+}
+
+verify_checksum() {
+  file="$1"
+  expected="$2"
+  if command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+  elif command -v openssl >/dev/null 2>&1; then
+    actual="$(openssl dgst -sha256 "$file" | awk '{print $NF}')"
+  else
+    fail "missing checksum tool (need shasum, sha256sum, or openssl)"
+  fi
+
+  [ "$actual" = "$expected" ] || fail "checksum mismatch: expected $expected, got $actual"
+}
+
+need_cmd curl
+need_cmd grep
+
+target="$(detect_target)"
+asset="looper-$target"
+download_base="$(build_download_base "$VERSION")"
+binary_url="$download_base/$asset"
+checksum_url="$download_base/$asset.sha256"
+
+install_dir="$(pick_install_dir)"
+mkdir -p "$install_dir"
+
+profile_updated=0
+if [ "$install_dir" = "$HOME/.local/bin" ] && ! in_path_dir "$install_dir"; then
+  profile="$(guess_profile)"
+  if confirm "~/.local/bin is not on PATH. Add it to $(basename "$profile")?"; then
+    append_path_export "$profile"
+    profile_updated=1
+  fi
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT INT TERM HUP
+
+tmp_binary="$tmp_dir/looper"
+tmp_checksum="$tmp_dir/$asset.sha256"
+
+log "Downloading $binary_url"
+curl -fsSL "$binary_url" -o "$tmp_binary"
+curl -fsSL "$checksum_url" -o "$tmp_checksum"
+
+expected_checksum="$(awk '{print $1}' "$tmp_checksum")"
+[ -n "$expected_checksum" ] || fail "invalid checksum file: $checksum_url"
+
+verify_checksum "$tmp_binary" "$expected_checksum"
+
+chmod 0755 "$tmp_binary"
+install_path="$install_dir/looper"
+mv "$tmp_binary" "$install_path"
+
+log "Installed looper to $install_path"
+if [ "$profile_updated" -eq 1 ]; then
+  log "Added ~/.local/bin to PATH in $(guess_profile)"
+fi
+
+if [ "$install_dir" = "$HOME/.local/bin" ] && ! in_path_dir "$install_dir"; then
+  log "Open a new shell or run: export PATH=\"$HOME/.local/bin:\$PATH\""
+fi
+
+log ""
+log "Current first-run flow:"
+log "  looper daemon install"
+log "  looper daemon start"
+log "  looper status"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -27,15 +27,33 @@ remove_if_exists() {
   fi
 }
 
+is_installer_owned_cli_path() {
+  path="$1"
+  case "$path" in
+    "$HOME/.local/bin/looper"|"$HOME/.looper/bin/looper") return 0 ;;
+    /opt/homebrew/*|/usr/local/Homebrew/*|"$HOME/go/bin/looper"|"$HOME/.cargo/bin/looper"|"$HOME/.asdf/"*|"$HOME/.local/share/mise/"*) return 1 ;;
+    *) return 1 ;;
+  esac
+}
+
 cli_path="${LOOPER_INSTALL_PATH:-}"
-if [ -z "$cli_path" ] && command -v looper >/dev/null 2>&1; then
+explicit_cli_path=0
+if [ -n "$cli_path" ]; then
+  explicit_cli_path=1
+elif command -v looper >/dev/null 2>&1; then
   cli_path="$(command -v looper)"
 fi
 
 looper_home="$HOME/.looper"
 
 if [ -n "$cli_path" ]; then
-  remove_if_exists "$cli_path"
+  if is_installer_owned_cli_path "$cli_path"; then
+    remove_if_exists "$cli_path"
+  elif [ "$explicit_cli_path" -eq 1 ] && confirm "Remove CLI binary at $cli_path? This path is not recognized as installer-owned."; then
+    remove_if_exists "$cli_path"
+  else
+    log "Skipped CLI binary at $cli_path (not recognized as installer-owned; set LOOPER_INSTALL_PATH and confirm to remove)"
+  fi
 fi
 
 remove_if_exists "$looper_home/bin/looperd"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+set -eu
+
+log() {
+  printf '%s\n' "$*"
+}
+
+confirm() {
+  prompt="$1"
+  if [ ! -t 0 ]; then
+    return 1
+  fi
+  printf '%s [y/N] ' "$prompt" >&2
+  read -r answer || return 1
+  case "$answer" in
+    y|Y|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+remove_if_exists() {
+  path="$1"
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    rm -rf "$path"
+    log "Removed $path"
+  fi
+}
+
+cli_path="${LOOPER_INSTALL_PATH:-}"
+if [ -z "$cli_path" ] && command -v looper >/dev/null 2>&1; then
+  cli_path="$(command -v looper)"
+fi
+
+looper_home="$HOME/.looper"
+
+if [ -n "$cli_path" ]; then
+  remove_if_exists "$cli_path"
+fi
+
+remove_if_exists "$looper_home/bin/looperd"
+remove_if_exists "$looper_home/bin/looperd.prev"
+remove_if_exists "$looper_home/state"
+remove_if_exists "$looper_home/run/upgrade.lock"
+
+if confirm "Also remove config, database, backups, logs, and worktrees under $looper_home?"; then
+  remove_if_exists "$looper_home/config.json"
+  remove_if_exists "$looper_home/looper.sqlite"
+  remove_if_exists "$looper_home/backups"
+  remove_if_exists "$looper_home/logs"
+  remove_if_exists "$looper_home/worktrees"
+fi
+
+log "Looper uninstall complete"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -27,11 +27,29 @@ remove_if_exists() {
   fi
 }
 
+in_path_dir() {
+  candidate="$1"
+  old_ifs=$IFS
+  IFS=:
+  for entry in $PATH; do
+    [ "$entry" = "$candidate" ] && IFS=$old_ifs && return 0
+  done
+  IFS=$old_ifs
+  return 1
+}
+
 is_installer_owned_cli_path() {
   path="$1"
+  dir="${path%/*}"
   case "$path" in
     "$HOME/.local/bin/looper"|"$HOME/.looper/bin/looper") return 0 ;;
     /opt/homebrew/*|/usr/local/Homebrew/*|"$HOME/go/bin/looper"|"$HOME/.cargo/bin/looper"|"$HOME/.asdf/"*|"$HOME/.local/share/mise/"*) return 1 ;;
+    "$HOME"/*/looper)
+      if in_path_dir "$dir"; then
+        return 0
+      fi
+      return 1
+      ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -43,6 +43,7 @@ is_installer_owned_cli_path() {
   dir="${path%/*}"
   case "$path" in
     "$HOME/.local/bin/looper"|"$HOME/.looper/bin/looper") return 0 ;;
+    "$HOME"/go/bin/looper|"$HOME"/*/go/bin/looper) return 1 ;;
     /opt/homebrew/*|/usr/local/Homebrew/*) return 1 ;;
     "$HOME"/*/looper)
       if in_path_dir "$dir"; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -43,7 +43,7 @@ is_installer_owned_cli_path() {
   dir="${path%/*}"
   case "$path" in
     "$HOME/.local/bin/looper"|"$HOME/.looper/bin/looper") return 0 ;;
-    /opt/homebrew/*|/usr/local/Homebrew/*|"$HOME/go/bin/looper"|"$HOME/.cargo/bin/looper"|"$HOME/.asdf/"*|"$HOME/.local/share/mise/"*) return 1 ;;
+    /opt/homebrew/*|/usr/local/Homebrew/*) return 1 ;;
     "$HOME"/*/looper)
       if in_path_dir "$dir"; then
         return 0

--- a/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
+++ b/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
@@ -15,7 +15,8 @@
     "<uuid>": "Runtime-generated UUID.",
     "<generated-timestamp>": "Runtime-generated ISO-8601 timestamp.",
     "<current-target>": "Current looperd build target for the running platform.",
-    "<artifact-name>": "Compiled looperd artifact name for the current target."
+    "<artifact-name>": "Compiled looperd artifact name for the current target.",
+    "<daemon-executable-path>": "Resolved executable path of the running looperd process."
   },
   "routes": [
     {
@@ -66,6 +67,7 @@
             },
             "binary": {
               "name": "looperd",
+              "path": "<daemon-executable-path>",
               "installDir": "<home>/.looper/bin",
               "currentTarget": "<current-target>",
               "artifactName": "<artifact-name>",

--- a/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
+++ b/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
@@ -49,9 +49,13 @@
         "data": {
           "service": {
             "healthy": true,
-            "version": "0.2.1",
+            "version": "0.0.0-dev",
             "build": {
               "versionSource": "internal/version/version.go",
+              "channel": "dev",
+              "apiVersion": "v1",
+              "minCliForDaemon": null,
+              "minDaemonForCli": null,
               "gitCommitSha": null,
               "buildTimestamp": null
             },

--- a/specs/2026-04-22-install-upgrade-strategy/checklist.md
+++ b/specs/2026-04-22-install-upgrade-strategy/checklist.md
@@ -1,0 +1,194 @@
+# Install / Upgrade Strategy Checklist
+
+## Phase 0 - 锁定用户模型与支持边界
+
+- [ ] 明确 Looper 的用户安装入口是 `looper`，不是分别安装 CLI / daemon
+- [ ] 明确 release 渠道只面向用户直接分发 `looper`
+- [ ] 明确 `looperd` 继续由 CLI 负责安装与升级编排
+- [ ] 明确当前主支持矩阵仍是 macOS `darwin-arm64` / `darwin-x64`
+- [ ] 明确 `go install` 仅为开发者路径，不作为普通用户推荐安装方式
+- [ ] 明确 `foreground` 仍是当前受支持默认 daemon 模式
+- [ ] 明确 `launchd` 作为下一阶段正式托管模式演进方向
+- [ ] 明确最低支持的 macOS 版本
+- [ ] 明确安装脚本的长期稳定 URL 策略
+- [ ] 明确 manifest 的发现地址与托管方式
+- [ ] 明确签名方案采用 `minisign` 还是 `cosign`
+- [ ] 明确更新 channel 是一次性 flag 还是持久化配置
+- [ ] 明确 telemetry 策略（推荐无 telemetry）
+- [ ] 明确 Product Version / API Version / Schema Version / Build Metadata 的分层模型
+- [ ] 明确 GitHub Release 是正式产品版本发布载体
+- [ ] 明确 pre-1.0 阶段的 SemVer 规则（MINOR 可 break，PATCH 不可伪装 break）
+- [ ] 明确 `--channel` 在 v1 中默认是一次性 flag，不持久化
+- [ ] 明确源码默认版本切换为 `0.0.0-dev` 的迁移方案
+
+## Phase 1 - 补齐用户可达的安装入口
+
+- [ ] 新增 `scripts/install.sh`
+- [ ] 安装脚本支持架构检测
+- [ ] 安装脚本支持下载匹配的 `looper` artifact
+- [ ] 安装脚本支持 checksum 校验
+- [ ] 安装脚本默认安装到用户可写 PATH（且保证用户安装后可直接执行）
+- [ ] 若目标 PATH 不可见，安装脚本经确认后更新 shell profile 或给出替代路径
+- [ ] 安装脚本安装完成后输出清晰 next steps
+- [ ] 新增 `scripts/uninstall.sh`
+- [ ] README 将安装脚本设为默认推荐路径
+- [ ] README 保留 GitHub Releases 手动安装 fallback
+
+## Phase 2 - 新增 first-run bootstrap
+
+- [ ] 设计 `looper bootstrap`
+- [ ] `bootstrap` 支持 preflight 检查（平台、架构、`git`、`gh`）
+- [ ] `bootstrap` 支持初始化 `~/.looper/` 目录结构
+- [ ] `bootstrap` 在 config 缺失时支持生成最小 `~/.looper/config.json`
+- [ ] `bootstrap` 支持最小 project 注册或跳过逻辑
+- [ ] `bootstrap` 支持交互式选择 `agent.vendor`
+- [ ] `bootstrap` 支持配置 `notifications.osascript.enabled`
+- [ ] `bootstrap` 支持可选启用 `server.authMode=local-token`
+- [ ] `bootstrap` 自动执行 `looper daemon install`
+- [ ] `bootstrap` 自动执行 `looper daemon start`
+- [ ] `bootstrap` 自动做 health check 并输出安装摘要
+- [ ] `bootstrap` 支持 `--yes` 非交互模式
+- [ ] `bootstrap` 具备幂等行为
+- [ ] `bootstrap` 在依赖缺失时快速失败并输出人工安装指引
+- [ ] `bootstrap` 不预创建 daemon 专属 runtime 目录的未来可变布局
+- [ ] `bootstrap` 明确部分失败后的重入语义（已装未启 / 已配未装 / 已装启动失败）
+
+## Phase 3 - 正式定义 Release Contract
+
+- [ ] 冻结 `looper-<os>-<arch>` / `looperd-<os>-<arch>` 命名约定
+- [ ] 冻结 `<asset>.sha256` sidecar 命名约定
+- [ ] 冻结 managed daemon 安装路径 `~/.looper/bin/looperd`
+- [ ] 冻结 daemon lookup 顺序 `~/.looper/bin/looperd` → `$PATH`
+- [ ] 为每个 release 生成 `manifest.json`
+- [ ] 为每个 release 生成 `manifest.json.minisig`
+- [ ] 在 manifest 中声明 `manifestVersion`
+- [ ] 在 manifest 中声明 `version` 与 `tag`
+- [ ] 在 manifest 中声明 `channel`
+- [ ] 在 manifest 中声明 `apiVersion`
+- [ ] 在 manifest 中声明 `schemaVersion`
+- [ ] 在 manifest 中声明 `minCliForDaemon` / `minDaemonForCli`
+- [ ] 在 manifest 中声明完整 artifact URL / sha256 / size
+- [ ] 为 GitHub Release body 补齐固定的 Compatibility / Upgrade Notes 区块
+- [ ] 明确 manifest 是机器权威真相，Release body 是人类可读投影
+- [ ] release workflow 的 asset 校验步骤拒绝缺少 `manifest.json` / 签名文件的 release
+- [ ] 为 frozen asset naming / install path 增加 contract test
+
+## Phase 4 - 完成统一升级入口
+
+- [ ] 完成顶层 `looper upgrade`
+- [ ] 支持 `looper upgrade --check`
+- [ ] 支持 `looper upgrade --cli`
+- [ ] 支持 `looper upgrade --daemon`
+- [ ] 支持 `looper upgrade --to <version>`
+- [ ] 支持 `looper upgrade --channel <stable|beta>`
+- [ ] 支持 `looper upgrade --rollback`
+- [ ] 支持 `looper upgrade --yes`
+- [ ] 升级流程引入 upgrade lock，避免并发升级
+- [ ] 明确 upgrade 离线 / 超时 / manifest 缓存策略
+- [ ] 升级前先校验 manifest 签名
+- [ ] 升级前先计算 current/latest plan
+- [ ] current/latest 判断改为真正的 semver compare
+- [ ] major 升级要求显式确认
+- [ ] 明确 `--to <older-version>` 的 downgrade 语义与边界
+- [ ] 明确 `upgrade --check` 的退出码契约
+- [ ] 明确完整 flag × install-source 行为矩阵
+- [ ] 增加 upgrade lock stale-lock 检测与 `--force-unlock`
+- [ ] 增加 `~/.looper/state/upgrade.json` 状态文件
+
+## Phase 5 - CLI 自升级与 daemon 升级安全性
+
+- [ ] CLI 自升级支持 staging 下载
+- [ ] CLI 自升级支持原子替换
+- [ ] CLI 自升级保留上一版 `looper.prev`
+- [ ] CLI 路径不可写时给出明确人工替代步骤
+- [ ] Homebrew 安装来源默认拒绝 CLI 自升级并给出 `brew upgrade` 指引
+- [ ] `go install` 路径默认拒绝 CLI 自升级并给出对应指引
+- [ ] 明确 install-source 检测机制（build-time + path heuristic）
+- [ ] daemon 升级支持 staging 下载
+- [ ] daemon 升级支持 checksum + manifest 校验
+- [ ] daemon 升级支持原子替换
+- [ ] daemon 升级保留上一版 `looperd.prev`
+- [ ] 新增或补齐安全停止 daemon 的受支持能力
+- [ ] 用正式 `daemon stop` / 等价内部原语替换当前 “Phase 1 minimal process management” 提示
+- [ ] 明确 daemon 升级时有活跃 loops 的处理策略（拒绝 / drain / force-stop）
+- [ ] daemon 升级失败时自动回滚二进制
+- [ ] daemon 升级成功后执行健康检查
+- [ ] 升级状态写入专用 state 文件
+- [ ] 明确升级被中断（如 Ctrl+C）时的恢复语义
+
+## Phase 6 - DB 备份与回滚边界
+
+- [ ] 升级前判断目标版本是否触发 migration
+- [ ] 触发 migration 时自动创建 pre-upgrade DB backup
+- [ ] backup 文件命名包含版本与时间戳
+- [ ] `package.requireBackupBeforeMigrate` 默认值切换策略明确
+- [ ] `looper upgrade --rollback` 明确只承诺二进制回滚
+- [ ] schema 已升级且旧 binary 不兼容时，阻止直接 rollback 并给出恢复指引
+- [ ] daemon 启动时增加 schema-version downgrade 保护
+- [ ] downgrade / rollback 在替换二进制前执行 schema 兼容性预检
+
+## Phase 7 - 兼容与协议策略
+
+- [ ] 明确 CLI 与 daemon 继续共享同一版本号
+- [ ] 明确 CLI / daemon 从同一 git tag 发布
+- [ ] 源码默认版本切换为 dev version，由 build/release 注入正式版本
+- [ ] 明确同一 major 内的兼容原则
+- [ ] 明确 `minDaemonForCli` / `minCliForDaemon` 的执行语义
+- [ ] 明确恢复路径命令（`upgrade*` / `version` / `daemon install|start|restart|status|logs`）不受 daemon-version gating 阻断
+- [ ] `/api/v1` 的非破坏性演进规则写入用户可见文档
+- [ ] 破坏性接口变更必须通过 `/api/v2` 引入
+- [ ] 建立 N / N-1 兼容 smoke 验证
+- [ ] 明确 version/source 判定顺序（binary / API / manifest / release）
+- [ ] 补齐 prerelease channel 规则（draft 不算、prerelease 不进 stable）
+- [ ] 补齐 `looper version --json` 输出（product/api/schema/build/channel）
+- [ ] `version --json` 在同一 major 内保持稳定，仅允许新增字段
+
+## Phase 8 - Gatekeeper / 信任链 / 平台体验
+
+- [ ] 安装文档写清当前 unsigned binary 限制
+- [ ] 安装脚本对 quarantine 处理要求显式用户确认
+- [ ] `bootstrap` 对 quarantine 处理要求显式用户确认
+- [ ] 输出清晰的 Gatekeeper 人工放行指引
+- [ ] release workflow 预留 Apple codesign / notarization 扩展点
+- [ ] 明确 install 首跳信任模型与文档表述
+
+## Phase 9 - daemon 托管模式演进
+
+- [ ] 正式设计 `looper daemon install --launchd`
+- [ ] 生成 `LaunchAgents` plist
+- [ ] 用 `launchctl` 接管 start / stop / restart 语义
+- [ ] 明确 `foreground` 与 `launchd` 两条路径的文档边界
+- [ ] 将“开机自启/崩溃恢复”能力只归属到 `launchd` 模式
+
+## Phase 10 - 分发渠道扩展
+
+- [ ] 新建 Homebrew tap
+- [ ] formula 只分发 `looper`
+- [ ] formula 与 release manifest / asset 命名保持一致
+- [ ] 文档补齐 GitHub Releases / install script / Homebrew 三条路径
+
+## Phase 11 - Workflow 与验证
+
+- [ ] release workflow 改为 tag 驱动版本注入
+- [ ] release workflow 生成 manifest
+- [ ] release workflow 对 manifest 进行签名
+- [ ] signed manifest + 对应 workflow 支持完成前，不宣称 unified upgrade 已 GA
+- [ ] release workflow 校验完整 asset 集
+- [ ] release workflow 支持 stable / beta channel
+- [ ] prerelease tag 正确映射到 beta channel
+- [ ] 验证 `manifest.json.version`、二进制 `--version`、Git tag 三者一致
+- [ ] release workflow 增加 CLI + daemon 组合 smoke
+- [ ] 验证二进制 `--version` 与 Git tag / GitHub Release 一致
+- [ ] 验证干净 macOS 机器一键安装成功
+- [ ] 验证 `bootstrap` 幂等
+- [ ] 验证 `upgrade` 成功路径
+- [ ] 验证 `upgrade` 失败后的自动 rollback
+- [ ] 验证 migration 前 backup 正常生成
+- [ ] 验证旧版本/新版本兼容提示正确
+- [ ] 验证文档中的安装路径与实际 workflow 一致
+
+## Out of scope for this checklist
+
+- Linux / Windows 正式支持
+- GUI `.pkg` 安装器
+- 将 `looperd` 变成独立面向用户的主安装入口

--- a/specs/2026-04-22-install-upgrade-strategy/spec.md
+++ b/specs/2026-04-22-install-upgrade-strategy/spec.md
@@ -1,0 +1,1050 @@
+# Looper 安装与版本升级完整方案
+
+## 1. 背景
+
+当前仓库已经切到 Go-first 的 CLI + daemon 形态：
+
+- `looper` 作为用户入口 CLI
+- `looperd` 作为本地 daemon
+- GitHub Releases 发布 `looper-*` / `looperd-*` 二进制与 `.sha256`
+- `looper daemon install` 可以把 managed daemon 安装到 `~/.looper/bin/looperd`
+- `looper upgrade --check` 与 `looper upgrade --daemon` 已存在，但完整统一升级路径尚未完成
+
+现状虽然“可用”，但还不满足“把产品发给另一个用户，他可以低摩擦安装并持续升级”的要求。
+
+主要问题：
+
+1. CLI 安装仍偏手动，缺少一条真正推荐的一键路径。
+2. 首次使用需要用户自己拼装 config、agent env、project 注册流程。
+3. `looper upgrade` 还不是完整的 CLI + daemon 统一升级入口。
+4. release 对机器消费者的契约还不够完整，只有 asset + checksum，没有稳定 manifest / channel / rollback 语义。
+5. 当前 macOS 二进制未签名，Gatekeeper 体验不稳定。
+
+本 spec 的目标，是给 Looper 定义一套完整、可分期落地的安装与升级方案，并与当前 Go 版本的现实约束保持一致。
+
+---
+
+## 2. 目标
+
+目标：
+
+1. 为新 macOS 用户提供低摩擦安装路径。
+2. 明确“安装什么、谁负责安装 daemon、谁负责升级”的职责边界。
+3. 提供统一的 `looper upgrade` 体验，覆盖 CLI、daemon、检查、回滚与版本 pin。
+4. 定义 release contract，让 CLI / 安装脚本 / Homebrew 等机器消费者都可稳定依赖。
+5. 明确 CLI / daemon 的兼容与版本策略，避免静默错配。
+6. 将 rollback、DB 备份、失败恢复纳入正式设计，而不是靠人工排障。
+
+非目标：
+
+1. 本次不把 Linux / Windows 一起拉进当前支持矩阵。
+2. 本次不要求立刻提供 `.pkg` 图形安装器。
+3. 本次不要求立即完成 Apple notarization；但必须为其预留演进路径。
+4. 本次不改动现有 `~/.looper/` runtime layout 的核心目录约定。
+
+## 2.1 执行分期约定
+
+本文描述的是目标方案与演进路线；具体实施顺序与完成状态以同目录下 `checklist.md` 为准。
+
+即：
+
+> **spec 负责设计与约束，checklist 负责执行 truth。**
+
+本文中的 “Phase 1 / 2 / 3” 只是产品路线分组，不与 `checklist.md` 中更细的执行 phase 编号做一一对应。
+
+## 2.2 支持平台范围
+
+本 spec 当前仅覆盖：
+
+- macOS 13+（arm64 / x64）为正式支持范围
+- macOS 12 为 best-effort
+
+以下平台不在本 spec 的执行范围内：
+
+- macOS <= 11
+- Linux
+- Windows
+
+---
+
+## 3. 结论
+
+## 3.1 推荐安装模型
+
+Looper 的推荐安装模型调整为：
+
+> **统一由 `looper` CLI 承担用户入口、bootstrap、daemon 安装与升级编排职责。**
+
+推荐用户路径：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/install.sh | sh
+looper bootstrap
+```
+
+或：
+
+```bash
+brew install powerformer/tap/looper
+looper bootstrap
+```
+
+其中：
+
+- 分发渠道面向用户只分发 `looper`
+- `looperd` 不要求用户独立理解与手动管理
+- `looper bootstrap` 负责初始化 `~/.looper/`、生成默认配置、安装 daemon、启动并验证
+- `looper upgrade` 负责统一升级 CLI + daemon
+
+换言之：
+
+> **用户安装的是 Looper，不是分别安装 CLI 和 daemon。**
+
+## 3.2 推荐升级模型
+
+统一升级入口固定为：
+
+```bash
+looper upgrade
+```
+
+同时保留显式子路径：
+
+```bash
+looper upgrade --check
+looper upgrade --cli
+looper upgrade --daemon
+looper upgrade --to 0.3.0
+looper upgrade --rollback
+looper upgrade --channel beta
+```
+
+升级逻辑由 CLI 编排，daemon 不承担自更新职责。
+
+## 3.3 推荐分发渠道
+
+分发渠道按成熟度分层：
+
+### A. GitHub Releases（source of truth）
+
+必须继续保留，并作为所有其他渠道的底层来源。
+
+发布资产：
+
+- `looper-darwin-arm64`
+- `looper-darwin-arm64.sha256`
+- `looper-darwin-x64`
+- `looper-darwin-x64.sha256`
+- `looperd-darwin-arm64`
+- `looperd-darwin-arm64.sha256`
+- `looperd-darwin-x64`
+- `looperd-darwin-x64.sha256`
+
+### B. 安装脚本（默认推荐）
+
+新增 `scripts/install.sh` 作为默认推荐安装路径：
+
+- 检测 macOS 架构
+- 下载匹配的 `looper` binary
+- 校验 `sha256`
+- 安装到用户可写 PATH（优先已在 PATH 中的用户目录；若 `~/.local/bin` 不在 PATH，则需显式提示并经用户确认后追加 shell profile，或回退到 `/usr/local/bin`）
+- 安装完成后提示运行 `looper bootstrap`
+
+该脚本只安装 CLI，不直接安装 daemon。
+
+### C. Homebrew tap（Phase 2）
+
+新增 `powerformer/tap`：
+
+- formula 只安装 `looper`
+- post-install 不做 daemon 安装，只提示 `looper bootstrap`
+- 避免为 `looperd` 再维护第二套面向用户的显式安装路径
+
+### D. `go install`（开发者路径）
+
+保留为开发者/贡献者路径，但明确不是普通用户推荐方案。
+
+### E. uninstall
+
+需要提供显式卸载路径：
+
+- `scripts/uninstall.sh`
+- 或后续 `looper uninstall`
+
+至少要支持删除：
+
+- CLI binary
+- managed daemon binary
+- updater state
+
+并对是否删除 `~/.looper/config.json` / DB / logs / worktrees 给出显式确认。
+
+---
+
+## 4. Release Contract
+
+当前 release 资产命名与 managed daemon 路径已经形成兼容边界；本方案要求将其正式冻结，并在此基础上增加 manifest 契约。
+
+同时，本节明确：
+
+> **GitHub Release 不只是二进制下载容器，而是 Looper 产品版本的正式发布载体。**
+
+## 4.1 已冻结的兼容锚点
+
+以下约定继续保留：
+
+1. CLI release 资产命名保留 `looper-<os>-<arch>`。
+2. daemon release 资产命名保留 `looperd-<os>-<arch>`。
+3. checksum sidecar 保留 `<asset>.sha256`。
+4. managed daemon 安装路径保留 `~/.looper/bin/looperd`。
+5. daemon 查找顺序保留 `~/.looper/bin/looperd` → `$PATH`。
+
+## 4.1.1 GitHub Release 作为正式产品版本载体
+
+Looper 的正式产品版本，必须通过 GitHub tag + GitHub Release 对外表达。
+
+规则：
+
+1. 每个正式版本都必须对应一个 git tag。
+2. 每个对外发布版本都必须有对应的 GitHub Release。
+3. CLI 与 daemon 的对外发布版本以同一个 GitHub Release 为准。
+4. 用户可见的“当前版本 / 最新版本 / 可升级版本”判断，以 GitHub Release 元数据为主，而不是以源码中的硬编码字符串为主。
+
+这意味着：
+
+> **Git tag / GitHub Release 是版本 source of truth；二进制中的版本号由构建时注入。**
+
+## 4.1.2 Git tag 规则
+
+tag 采用标准 SemVer 形态：
+
+- `v0.3.0`
+- `v0.3.1`
+- `v0.4.0-rc.1`
+- `v1.0.0-beta.2`
+
+约束：
+
+1. tag 一律带前缀 `v`。
+2. release title 采用 `Looper vX.Y.Z`。
+3. prerelease tag 必须在 GitHub Release 中标记为 prerelease。
+4. draft release 不能被 `upgrade --check` 视为可升级目标。
+
+## 4.2 新增 manifest
+
+每个 release 必须新增：
+
+- `manifest.json`
+- `manifest.json.minisig`
+
+`manifest.json` 是 CLI updater、安装脚本、Homebrew formula 生成脚本的稳定机器输入。
+
+对机器消费者：
+
+> **manifest 是权威机器真相；GitHub Release body 是从同一输入派生的人类可读投影。**
+
+建议结构：
+
+```json
+{
+  "manifestVersion": 1,
+  "version": "0.3.0",
+  "tag": "v0.3.0",
+  "released": "2026-04-22T12:00:00Z",
+  "channel": "stable",
+  "apiVersion": "v1",
+  "schemaVersion": 12,
+  "minCliForDaemon": "0.2.0",
+  "minDaemonForCli": "0.2.0",
+  "artifacts": {
+    "looper-darwin-arm64": {
+      "url": "https://github.com/...",
+      "sha256": "...",
+      "size": 123
+    },
+    "looperd-darwin-arm64": {
+      "url": "https://github.com/...",
+      "sha256": "...",
+      "size": 456
+    }
+  }
+}
+```
+
+## 4.2.1 manifest 发现地址
+
+manifest 不能依赖“枚举所有 GitHub release 后自己猜最新版本”。
+
+必须提供稳定发现地址，例如：
+
+- `https://github.com/powerformer/looper/releases/latest/download/manifest.json`
+- `https://github.com/powerformer/looper/releases/latest/download/manifest.json.minisig`
+
+若后续引入 `stable` / `beta` channel，则需要为每个 channel 提供独立稳定地址，例如：
+
+- `.../channels/stable/manifest.json`
+- `.../channels/beta/manifest.json`
+
+在没有独立 channel endpoint 之前，CLI 只把 `stable` 作为默认受支持自动发现路径；`beta` 可通过显式 `--to` 或预发布 channel URL 实现。
+
+### 为什么需要 manifest
+
+因为仅靠 GitHub Releases asset 枚举不够：
+
+1. 无法表达 channel（stable / beta）。
+2. 无法表达兼容窗口（`minDaemonForCli` / `minCliForDaemon`）。
+3. 无法表达 API version 与升级策略。
+4. 无法表达 schema 兼容边界。
+5. 无法为未来签名校验提供稳定入口。
+
+## 4.2.2 GitHub Release body 约定
+
+GitHub Release body 不应只依赖自动生成 notes，还必须包含稳定的兼容信息块。
+
+至少应包含：
+
+1. Summary
+2. Compatibility
+   - product version
+   - API version
+   - schema version
+   - `minCliForDaemon`
+   - `minDaemonForCli`
+3. Upgrade notes
+   - 是否有 migration
+   - 是否有手动 restart / config 迁移要求
+4. Artifacts
+
+即使未来机器读取以 `manifest.json` 为主，人类阅读的 GitHub Release 页面也必须能直接看出“这版会不会 break、怎么升、需要注意什么”。
+
+权威关系要求：
+
+- 机器消费者以 `manifest.json` 为准
+- 人类阅读以 Release body 为准
+- 二者若不一致，属于 release workflow defect，不能视为允许存在的双真相
+
+## 4.2.3 Manifest forward compatibility
+
+CLI 必须拒绝解析 `manifestVersion` 高于自己所支持上限的 manifest。
+
+此时应：
+
+1. 给出结构化错误
+2. 明确提示用户先升级 CLI
+3. 仅在必要时回退到最小化 release asset 枚举，用于告诉用户“哪个 CLI 版本理解这个 manifest”
+
+时间戳格式统一采用 RFC3339 UTC。
+
+## 4.3 完整性与真实性校验
+
+下载链路必须区分两类校验：
+
+1. **完整性**：`sha256`
+2. **真实性**：`manifest.json.minisig`
+
+仅靠 `.sha256` 只能防损坏，不能防替换。
+
+因此：
+
+> **CLI 与安装脚本最终都必须以签名过的 manifest 为信任根。**
+
+在 Apple codesign / notarization 完成前，`minisign` 是当前成本最低且足够实用的真实性方案。
+
+补充说明：
+
+- 初次安装的第一跳信任仍然来自 HTTPS + GitHub release/脚本分发地址
+- manifest 签名主要保护后续 upgrade 与 machine-consumer 下载链路
+- 如后续评估认为 GitHub OIDC + `cosign` 更适合 workflow，则允许在实现前替换签名方案，但必须保持“有签名 manifest”这一能力目标不变
+
+---
+
+## 5. 首次安装与 bootstrap 体验
+
+## 5.1 新用户目标路径
+
+理想路径：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/install.sh | sh
+looper bootstrap
+```
+
+完成后用户应具备：
+
+- 已安装 `looper`
+- 已安装 managed `looperd`
+- 已创建最小 `~/.looper/config.json`
+- 已启动 daemon
+- 已通过 `looper status` 验证
+
+## 5.2 `looper bootstrap`
+
+新增命令：
+
+```bash
+looper bootstrap
+```
+
+职责：
+
+1. preflight 检查：
+   - 当前平台/架构是否支持
+   - `git` / `gh` 是否可用
+   - 如启用 `gh` 集成，可提示 `gh auth status`
+2. 初始化目录：
+   - `~/.looper/bin`
+   - `~/.looper/backups`
+   - `~/.looper/logs`
+3. 若配置不存在，则交互式生成最小 `config.json`
+4. 提示用户选择或填写：
+   - `agent.vendor`
+   - 是否启用 `notifications.osascript.enabled`
+   - 是否启用 `server.authMode=local-token`
+   - 默认 project（可跳过）
+5. 若未安装或版本不符合目标版本，则执行 `looper daemon install`
+6. 自动执行 `looper daemon start`
+7. 轮询 `/api/v1/status` 或等价 health check
+8. 输出 next steps（如 `looper project add /path/to/repo`）
+
+### 幂等性要求
+
+`bootstrap` 必须是幂等的：
+
+- 已有 config 时不覆盖，除非用户显式要求
+- 已安装 daemon 时不重复下载，除非版本不匹配或 `--force`
+- 已启动 daemon 时优先做状态确认
+
+### 部分失败后的重入语义
+
+`bootstrap` 必须显式处理以下部分完成状态：
+
+1. **无 config、无 daemon**
+   - 按完整初始化路径执行
+2. **有 config、无 daemon**
+   - 跳过 config 初始化，继续安装 daemon
+3. **有 config、有 daemon binary、daemon 未运行**
+   - 不重复下载，直接做 daemon 启动与 health check
+4. **有 config、有 daemon binary、daemon 已运行**
+   - 做状态确认并输出摘要，不重复执行破坏性步骤
+5. **daemon 安装成功但启动失败**
+   - 下次 `bootstrap` 必须识别为“已安装但未运行”，优先执行诊断/启动，而不是回到全量重装路径
+
+### 非交互模式
+
+必须支持：
+
+```bash
+looper bootstrap --yes --project-path /path/to/repo --agent-vendor opencode
+```
+
+用于：
+
+- CI smoke
+- 文档脚本化验证
+- 高级用户自动化安装
+
+### 依赖缺失时的原则
+
+对于 `git` / `gh` 等依赖：
+
+- `bootstrap` 负责检测与清晰报错
+- 不负责静默替用户安装系统工具
+- 文档中提供 Homebrew 等人工安装提示
+
+## 5.3 Gatekeeper 处理
+
+在未完成 Apple 签名/公证前：
+
+1. 文档中明确说明二进制可能被 Gatekeeper 拦截。
+2. `bootstrap` / 安装脚本可在获得用户明确确认后执行 `xattr -d com.apple.quarantine`。
+3. 如果用户拒绝，应输出清晰人工处理指引。
+
+即：
+
+> **可以帮助用户处理 quarantine，但不能静默越过用户同意。**
+
+---
+
+## 6. daemon 生命周期方案
+
+## 6.1 当前阶段（Phase 1 / 2）
+
+当前默认保留 `foreground` 模式作为受支持主路径：
+
+- `looper daemon install`
+- `looper daemon start`
+- `looper daemon restart`
+- `looper daemon status`
+- `looper daemon logs`
+
+CLI 是 daemon lifecycle 的唯一编排入口。
+
+## 6.2 `launchd` 演进
+
+`daemon.mode=launchd` 已在配置面存在，但尚未形成完整主路径。
+
+本方案要求在 Phase 2 把它补成正式能力：
+
+- `looper daemon install --launchd`
+- 写入 `~/Library/LaunchAgents/...plist`
+- 用 `launchctl bootstrap` / `kickstart` / `bootout` 编排
+- 让 daemon 获得开机自启、崩溃恢复、用户态托管能力
+
+原则：
+
+> 不在 `foreground` 路径上硬补“伪后台托管”；完整托管能力应明确落在 `launchd` 模式。
+
+---
+
+## 7. 升级方案
+
+## 7.1 命令面
+
+统一升级命令面定义为：
+
+```bash
+looper upgrade
+looper upgrade --check
+looper upgrade --cli
+looper upgrade --daemon
+looper upgrade --to <version>
+looper upgrade --channel <stable|beta>
+looper upgrade --rollback
+looper upgrade --yes
+```
+
+语义：
+
+- `upgrade`：升级 CLI + daemon 到当前 channel 最新版本
+- `--check`：只展示 current/latest 与兼容状态
+- `--cli`：只升级 CLI
+- `--daemon`：只升级 daemon
+- `--to`：升级/安装到指定版本
+- `--channel`：切换稳定/预发布通道
+- `--rollback`：回滚到上一版已保留二进制
+
+### 7.1.1 flag 与安装来源矩阵
+
+| 场景 | release 二进制安装 | Homebrew 安装 | `go install` / dev 安装 |
+|---|---|---|---|
+| `looper upgrade` | 升级 CLI + daemon | 升级 daemon，并提示用 `brew upgrade` 升级 CLI | 升级 daemon，CLI 自升级默认拒绝 |
+| `looper upgrade --cli` | 允许 | 拒绝，并提示 `brew upgrade` | 拒绝，并提示重新 `go install` / 重新构建 |
+| `looper upgrade --daemon` | 允许 | 允许 | 允许 |
+| `looper upgrade --to <version>` | 允许，但受 schema / compatibility 预检约束 | CLI 部分按 Homebrew 规则拒绝自升级 | CLI 部分按 dev 安装规则拒绝自升级 |
+| `looper upgrade --rollback` | 允许 | 仅对 daemon 回滚；CLI 按渠道自管 | 仅对 daemon 回滚；CLI 不做自回滚 |
+
+默认决策：
+
+> 在 v1 中，`--channel` 只作为一次性命令参数，不持久化到配置。
+
+### 7.1.2 退出码约定
+
+`looper upgrade --check` 需要明确退出码语义：
+
+- `0`：检查成功，且当前已是最新稳定版本
+- `1`：检查成功，且存在可升级版本
+- `>1`：检查失败（网络、签名、解析等错误）
+
+其他 upgrade 子命令默认沿用“成功 0 / 失败非 0”的常规 CLI 约定。
+
+## 7.2 推荐默认流程
+
+执行 `looper upgrade` 时：
+
+1. 拉取当前 channel 的 `manifest.json`
+2. 校验 manifest 签名
+3. 获取 current CLI / daemon 版本
+4. 计算升级 plan（含 version、schema、install-source、channel 预检）
+5. 获取 upgrade lock，避免并发升级
+6. 若 daemon 正在执行 in-flight loops，则默认拒绝升级 daemon，并提示用户稍后重试或显式选择强制策略
+7. 如涉及 major 升级，要求显式确认
+8. 下载目标 CLI / daemon 到 staging 目录
+9. 校验 `sha256`
+10. 执行 CLI 自升级
+11. 执行 daemon 升级
+12. 做健康检查
+13. 成功后写入 upgrade state；失败则自动 rollback
+
+这里的 latest/current 判断，应基于真正的 SemVer 比较，而不是字符串比较。
+
+### 7.2.1 Upgrade lock 与中断恢复
+
+upgrade lock 推荐落到：
+
+- `~/.looper/run/upgrade.lock`
+
+要求：
+
+1. lock 必须记录 PID 与启动时间等最小状态
+2. stale lock 必须可检测（进程不存在或启动时间不匹配）
+3. 需要提供受控的 `--force-unlock` 逃生口
+4. 升级过程中断时，状态写入 `~/.looper/state/upgrade.json`
+
+`upgrade.json` 至少应记录：
+
+- current version
+- previous version
+- target version
+- startedAt
+- install source
+- daemon upgrade stage
+
+下次执行 upgrade 时，CLI 必须先判断是继续、回滚还是安全放弃。
+
+## 7.3 CLI 自升级
+
+CLI 自升级由当前运行的 `looper` 进程完成。
+
+要求：
+
+1. 检测当前 CLI 路径是否可写。
+2. 使用临时文件 + 原子替换。
+3. 保留上一版到 `looper.prev`。
+4. 若不可写，则打印明确的人类可执行替代步骤，而不是静默失败。
+5. 若当前安装来源是 Homebrew 或 `go install` 路径，则默认拒绝自升级，并提示用户使用对应渠道升级。
+
+### 7.3.1 安装来源识别
+
+CLI 需要识别当前安装来源，推荐优先级：
+
+1. build-time 注入的 `installSource`
+2. 已知路径模式（如 Homebrew Cellar）
+3. dev / `go install` 特征
+4. 若仍无法确定，则标记为 `unknown`
+
+安全默认值：
+
+> 当安装来源无法可靠识别时，拒绝 CLI 自升级，并给出人工升级指引。
+
+## 7.4 daemon 升级
+
+daemon 升级要求：
+
+1. 升级目标固定为 managed daemon 路径 `~/.looper/bin/looperd`
+2. 使用 staging 下载
+3. checksum 与 manifest 校验通过后再切换
+4. 升级前必要时停止 daemon
+5. 原子替换并保留 `looperd.prev`
+6. 启动新 daemon 并轮询健康检查
+7. 如失败，自动回滚到 `looperd.prev`
+
+这里要求明确补齐 daemon 停止能力：
+
+> **要么新增 `looper daemon stop`，要么把“安全停止并替换 daemon”实现为受支持内部原语；不能把它留成隐式假设。**
+
+该能力是 unified upgrade 的前置能力，不依赖 `launchd` 正式化完成后才可落地。
+
+当前实现只提供 `upgrade --daemon` 的薄包装，不满足这里的 rollback / health-check / manifest-gated 要求；在这些要求全部落地前，不应把现有行为误认为“完整 daemon upgrade 方案已存在”。
+
+## 7.5 升级提示策略
+
+所有命令不应被更新检查阻塞。
+
+允许增加“轻提示”机制：
+
+- 最多每 24 小时检查一次最新版本
+- 若存在新版本，仅输出一行提示
+- 支持通过 config / env 关闭
+
+更新检查必须有超时与缓存策略：
+
+- 离线时快速失败
+- 不阻塞主命令执行
+- 可缓存上一次 manifest 摘要
+
+---
+
+## 8. 版本与兼容策略
+
+本节将版本概念拆成 4 层，避免“只有一个模糊 version 字段”的状态。
+
+## 8.0 版本分层模型
+
+Looper 的版本体系分为：
+
+1. **Product Version**
+   - 用户可见版本
+   - 通过 git tag / GitHub Release 表达
+   - CLI 与 daemon 共享
+
+2. **API Version**
+   - CLI 与 daemon 管理协议版本
+   - 体现在 `/api/v1/*`
+   - 只在协议破坏性变更时升级
+
+3. **Schema Version**
+   - SQLite schema 版本
+   - 由 daemon migration 系统维护
+   - 用于 upgrade / downgrade 安全边界
+
+4. **Build Metadata**
+   - git sha
+   - build timestamp
+   - dev build 标识
+   - 用于排障，不构成产品版本本身
+
+原则：
+
+> 产品版本、API 版本、Schema 版本必须明确区分，不能继续用单一字符串承担全部语义。
+
+## 8.1 版本号策略
+
+继续保持：
+
+1. CLI 与 daemon 共享同一版本号
+2. 同一 git tag 发布二者
+3. 构建出的 CLI / daemon `--version` 必须与 tag 对应版本一致
+
+当前阶段不建议将 CLI 与 daemon 版本解耦。
+
+同时要求：
+
+1. 源码中的默认版本必须是 dev version，而不是手工维护的正式 release version。
+2. 正式版本号由 release build 注入。
+3. PR / 本地未打 tag 构建可显示为 `0.0.0-dev` 或等价 dev semver。
+
+`minDaemonForCli` / `minCliForDaemon` 主要用于：
+
+- 只升级了一侧
+- rollback 后短暂错位
+- 指定版本安装/降级
+- Homebrew / 手动替换导致的版本偏差
+
+## 8.1.1 Product Version 的 source of truth
+
+Product Version 的唯一 source of truth 是：
+
+1. git tag
+2. GitHub Release
+
+不是：
+
+- 手工改源码常量后再让 release 去适配它
+
+推荐模型：
+
+1. 源码默认 `0.0.0-dev`
+2. release workflow 从 tag 解析出 `X.Y.Z`
+3. 通过 build flags 注入到 CLI 与 daemon
+4. `version --json` 输出最终注入值
+
+这样可以避免：
+
+- 忘记 bump 硬编码版本
+- tag 与二进制版本漂移
+- PR 专门为了改版本号而制造噪音提交
+
+### 8.1.1a 版本注入迁移步骤
+
+从“源码硬编码正式版本”切换到“tag 驱动版本注入”是一次明确迁移，不应被视为自然发生。
+
+迁移要求：
+
+1. 将源码默认版本切换为 `0.0.0-dev`
+2. 同一个 PR / 变更批次中，把 release workflow 改为从 `github.ref_name` 解析正式版本
+3. 同时更新版本比较逻辑，明确 dev build 的比较语义
+
+默认规则：
+
+- `0.0.0-dev` 本地/PR 构建默认视为开发构建
+- `upgrade --check` 对 dev build 可以提示“存在正式 release”，但不能把这种状态误报为普通 patch drift
+
+在这一步迁移完成前，tag-driven version injection 仍属于目标设计，而不是既有事实。
+
+## 8.1.2 SemVer 规则
+
+在当前 pre-1.0 阶段，采用：
+
+- `0.MINOR.PATCH`
+
+规则：
+
+1. `MINOR` 可包含 breaking changes
+2. `PATCH` 只用于 bugfix / 文档 / 非破坏性小改动
+3. 任何会影响 CLI surface、API、config、schema 的明显变更，都不应伪装成 patch
+
+在 1.0 以后，再切换到标准语义：
+
+- MAJOR：breaking
+- MINOR：backward-compatible feature
+- PATCH：bugfix
+
+## 8.1.3 Prerelease 规则
+
+允许的 prerelease 形态：
+
+- `-alpha.N`
+- `-beta.N`
+- `-rc.N`
+
+规则：
+
+1. prerelease 必须发布到 GitHub Release，并标记为 prerelease
+2. stable channel 默认不消费 prerelease
+3. 只有显式 `--channel beta` 或等价 prerelease channel 时，CLI 才会把它视为候选升级目标
+4. draft release 永远不是升级目标
+
+## 8.2 兼容原则
+
+本方案定义：
+
+1. 同一 major 内，CLI 与 daemon 应保持兼容。
+2. 同一 major 内允许短暂错位，但必须在 manifest 中声明最小兼容版本。
+3. 当 daemon 低于 `minDaemonForCli` 时，CLI 必须拒绝继续执行需要 daemon 的操作，并明确提示升级。
+4. 当 CLI 低于 `minCliForDaemon` 时，也必须给出结构化升级提示。
+5. `upgrade --check` 对 current/latest 的判断必须使用真正的 semver compare，而不是简单字符串 compare。
+
+例外：以下命令不应因 daemon 版本过旧而被阻断，因为它们本身就是恢复路径的一部分：
+
+- `looper upgrade*`
+- `looper version`
+- `looper daemon install|start|restart|status|logs`
+
+## 8.3 API 版本原则
+
+管理 API 的兼容边界继续以 `/api/v1/*` 为基础。
+
+规则：
+
+1. `v1` 内只允许非破坏性新增。
+2. 破坏性变更必须通过 `/api/v2/*` 引入。
+3. 新旧 API 的重叠期不能少于两个 minor release。
+
+即：
+
+> **不允许通过“看起来还是 v1，实际上悄悄 break”来推进升级。**
+
+另外，manifest 中声明的最小兼容版本只有在目标 release 正式提供该字段后才强制执行；旧 release 未声明时，CLI 采用保守兼容提示，而不是伪精确 hard-fail。
+
+## 8.4 Schema 版本原则
+
+Schema Version 是 daemon 与 SQLite 的兼容边界，不应再隐含在“某个版本升级可能有 migration”这种模糊表达里。
+
+规则：
+
+1. daemon 启动时必须知道自己支持到哪个 schema version
+2. 若磁盘上的 schema version 高于当前 daemon 所支持版本，则 daemon 必须拒绝启动
+3. 若磁盘上的 schema version 低于当前 daemon 所支持版本，则执行 forward migration
+4. rollback / downgrade 不自动承诺 schema 回退
+
+因此：
+
+> **Product Version 不等于 Schema Version；升级判断必须同时考虑二者。**
+
+因此，`upgrade --to <older-version>` 或 `--rollback` 在真正替换二进制前，必须先做 schema 兼容性预检；若目标版本不支持当前 schema，则操作必须在替换前就被拒绝。
+
+## 8.5 `version` 命令与状态接口
+
+为让人和机器都能看懂版本状态，最终应补齐：
+
+- `looper version --json`
+- `/api/v1/status` 中的服务版本字段
+
+至少输出：
+
+- product version
+- api version
+- schema version
+- git sha
+- build timestamp
+- channel
+
+版本来源判定顺序也需要冻结：
+
+1. daemon 正在运行时，以 `/api/v1/status` 中 daemon 自报版本为准
+2. daemon 未运行时，以 managed daemon binary 的 `--version` 为准
+3. 若 managed daemon 不存在，则回退到 `$PATH` daemon binary
+4. latest 版本一律以 GitHub Release / manifest 为准
+
+`version --json` 的输出在同一 major 内应保持稳定，仅允许新增字段，不允许静默删字段或改字段含义。
+
+---
+
+## 9. 数据安全、回滚与失败恢复
+
+## 9.1 二进制回滚
+
+每次成功升级后都要保留：
+
+- `looper.prev`
+- `looperd.prev`
+
+并支持：
+
+```bash
+looper upgrade --rollback
+```
+
+## 9.2 数据库备份
+
+daemon 升级可能伴随 migration。
+
+因此要求：
+
+1. 升级前判断目标版本是否包含未应用 migration
+2. 若包含 migration，则在升级前自动备份 DB 到 `~/.looper/backups/`
+3. 备份文件命名应包含版本与时间戳
+4. `package.requireBackupBeforeMigrate` 在后续 minor 中应默认切为 `true`
+
+建议切换策略：
+
+- 新增该能力的下一个 minor release 先支持但默认不变
+- 再下一个 minor release 将默认值切到 `true`
+- README / release notes 必须提前声明
+
+## 9.3 回滚边界
+
+回滚能力必须明确边界：
+
+1. 二进制回滚始终支持
+2. 跨 migration 的 DB 语义回滚不承诺自动完成
+3. 若 schema 已升级且旧 binary 无法兼容，则 `--rollback` 必须拒绝直接切换，并提示用户从 pre-upgrade backup 恢复
+
+同样地：
+
+- `looper upgrade --to <older-version>` 视为 downgrade
+- downgrade 适用与 rollback 相同的 migration 安全边界
+- 不能把 `--to` 作为绕过数据兼容检查的后门
+
+---
+
+## 10. Release Workflow 变更
+
+现有 `.github/workflows/release.yml` 已具备基础构建与发布能力；本 spec 要求在其上继续补齐：
+
+1. 生成 `manifest.json`
+2. 对 manifest 做签名并上传
+3. 校验完整 asset 集是否存在
+4. 增加 N / N-1 兼容 smoke
+5. 区分 stable / beta channel
+6. 后续补 Apple codesign / notarization
+7. 由 tag 驱动正式版本注入，而不是由源码常量反向校验 tag
+8. release body 补齐 Compatibility / Upgrade Notes 区块
+
+注意：signed manifest 是完整 `upgrade` GA 的前置条件。
+
+- 在 signed manifest 完成前，新的 `upgrade` 流程只能视为 internal preview
+- 对外 GA 不应建立在 unsigned manifest 或双真相 release body 之上
+
+## 10.0.1 版本注入原则
+
+release workflow 需要改成：
+
+1. 读取 `github.ref_name`（如 `v0.3.0`）
+2. 解析出产品版本 `0.3.0`
+3. 作为构建参数注入 CLI / daemon
+4. 再产出 release artifacts 与 `manifest.json`
+
+而不是：
+
+1. 先读二进制里的版本
+2. 再检查是否碰巧等于 tag
+
+前者是版本体系，后者只是发布前的一次一致性碰运气检查。
+
+## 10.1 Channel 设计
+
+建议 channel：
+
+- `stable`
+- `beta`
+
+规则：
+
+- 正式 tag 默认进入 `stable`
+- `-rc.*` / `-beta.*` 进入 `beta`
+- `looper upgrade --channel beta` 才会消费预发布资产
+
+`--channel` 需要明确语义：
+
+- 默认作为单次命令参数
+- 若后续需要持久化，则新增明确 config 字段，而不是隐式写入现有配置
+
+---
+
+## 11. 分期路线
+
+## Milestone A - 用户可安装、可自助初始化
+
+交付：
+
+- `scripts/install.sh`
+- `scripts/uninstall.sh`
+- `looper bootstrap`
+- 完整 README / install doc
+- release 补齐完整 CLI + daemon asset 集
+
+目标：
+
+> 干净 macOS 用户可以在几分钟内完成安装、初始化、启动、验证。
+
+## Milestone B - 用户可稳定升级与托管运行
+
+交付：
+
+- 完整 `looper upgrade`
+- rollback
+- pre-migration backup
+- `launchd` 模式正式化
+- Homebrew tap
+
+## Milestone C - 用户可无摩擦信任安装
+
+交付：
+
+- Apple codesign
+- notarization
+- 可选 `.pkg`
+- 更完整的 channel / release contract 文档化
+
+---
+
+## 12. 关键设计决策
+
+1. **CLI 是唯一用户入口。**
+   - 用户不应该单独理解 `looperd` 的安装学。
+
+2. **CLI 安装与 daemon 安装解耦，但体验上统一。**
+   - 渠道只安装 `looper`，`bootstrap` 再安装 `looperd`。
+
+3. **manifest + 签名是升级系统的信任根。**
+   - 不能长期只靠 GitHub Release assets 枚举。
+
+3a. **GitHub Release 是正式产品版本的发布面。**
+   - 用户、CLI、文档、升级检查都应围绕 GitHub Release 构建一致心智。
+
+4. **升级必须先设计 rollback。**
+   - 否则“自动升级”只是自动制造损坏。
+
+5. **API break 只能显式升级版本。**
+   - 不能把 `/api/v1` 当成可随意破坏的内部接口。
+
+5a. **版本必须分层。**
+   - Product / API / Schema / Build Metadata 各自承担各自语义。
+
+6. **不为了追求“自动后台运行”而污染 foreground 模式。**
+   - 真正托管能力明确走 `launchd`。
+7. **安装来源必须影响升级行为。**
+   - Homebrew / `go install` / 手动下载三条路径不能伪装成同一种可自升级安装。
+
+---
+
+## 13. 验收标准
+
+当以下条件满足时，本方案可视为基本落地：
+
+1. 新用户仅通过安装脚本或 Homebrew，即可拿到 `looper`。
+2. 新用户运行 `looper bootstrap` 后，可在不阅读源码的前提下完成 daemon 安装、启动与 `looper status` 验证。
+3. `looper upgrade` 可以统一升级 CLI + daemon。
+4. 升级失败时有自动 rollback，且不会静默破坏当前安装。
+5. release 总是包含完整、可预测、可验证的 asset 集与 manifest。
+6. README / docs 与实际支持路径一致，不再出现隐藏步骤。
+
+---
+
+## 14. Out of scope for this spec
+
+- 立即支持 Linux / Windows 安装矩阵
+- 将 `looperd` 暴露为独立面向用户的主要安装入口
+- 在本 spec 内直接重做配置模型
+- 在 Milestone A 就提供 GUI installer

--- a/tools/release-manifest/main.go
+++ b/tools/release-manifest/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/powerformer/looper/internal/release"
+)
+
+func main() {
+	var (
+		tag             = flag.String("tag", "", "git tag (for example: v0.3.0)")
+		version         = flag.String("version", "", "release version without v prefix; defaults from tag")
+		released        = flag.String("released", "", "RFC3339 UTC release timestamp")
+		channel         = flag.String("channel", "", "release channel (stable|beta), defaults from version")
+		apiVersion      = flag.String("api-version", "v1", "management API version")
+		schemaVersion   = flag.String("schema-version", release.CurrentSchemaVersion(), "storage schema version")
+		minCliForDaemon = flag.String("min-cli-for-daemon", "", "minimum CLI required by daemon")
+		minDaemonForCli = flag.String("min-daemon-for-cli", "", "minimum daemon required by CLI")
+		repo            = flag.String("repo", "powerformer/looper", "GitHub repo owner/name")
+		assetsDir       = flag.String("assets-dir", "", "release assets directory")
+		output          = flag.String("output", "", "output manifest path")
+		requiredAssets  = flag.String("required-assets", "", "comma-separated required artifact names")
+	)
+	flag.Parse()
+
+	if strings.TrimSpace(*tag) == "" || strings.TrimSpace(*released) == "" || strings.TrimSpace(*assetsDir) == "" || strings.TrimSpace(*output) == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "required flags: -tag, -released, -assets-dir, -output")
+		os.Exit(2)
+	}
+
+	releasedAt, err := time.Parse(time.RFC3339, strings.TrimSpace(*released))
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "parse -released: %v\n", err)
+		os.Exit(1)
+	}
+
+	required := splitCSV(*requiredAssets)
+	manifest, err := release.BuildManifest(release.BuildManifestInput{
+		Tag:               *tag,
+		Version:           *version,
+		Released:          releasedAt,
+		Channel:           *channel,
+		APIVersion:        *apiVersion,
+		SchemaVersion:     *schemaVersion,
+		MinCliForDaemon:   *minCliForDaemon,
+		MinDaemonForCli:   *minDaemonForCli,
+		Repo:              *repo,
+		AssetsDir:         *assetsDir,
+		RequiredArtifacts: required,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "build manifest: %v\n", err)
+		os.Exit(1)
+	}
+
+	encoded, err := release.EncodeManifest(manifest)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "encode manifest: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(strings.TrimSpace(*output), encoded, 0o644); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "write manifest: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func splitCSV(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- add first-run bootstrap and install/uninstall scripts for Looper CLI setup
- implement CLI/daemon upgrade flow with semver-aware version checks and self-upgrade safeguards
- add release manifest/version metadata support and document the install-upgrade strategy

Closes #70.