### PR TITLE
Fix project add when PR snapshots exceed diff limit

### DIFF
--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -149,12 +149,29 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		return result, canceledErr
 	}
 	if result.ExitCode != 0 {
-		return result, &CommandExecutionError{Message: fmt.Sprintf("Command exited with code %d", result.ExitCode), Result: result}
+		return result, &CommandExecutionError{Message: commandFailureMessage(result), Result: result}
 	}
 	if waitErr != nil {
 		return result, waitErr
 	}
 	return result, nil
+}
+
+func commandFailureMessage(result Result) string {
+	message := fmt.Sprintf("Command exited with code %d", result.ExitCode)
+	stderr := strings.TrimSpace(result.Stderr)
+	stdout := strings.TrimSpace(result.Stdout)
+	if stderr != "" {
+		message += ": " + stderr
+	}
+	if stdout != "" {
+		if stderr != "" {
+			message += "\nstdout: " + stdout
+		} else {
+			message += ": " + stdout
+		}
+	}
+	return message
 }
 
 func envSlice(env map[string]string) []string {

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -47,6 +47,24 @@ func TestRunReturnsCommandExecutionErrorOnNonZeroExit(t *testing.T) {
 	if commandErr.Result.Stderr != "bad" {
 		t.Fatalf("Stderr = %q, want bad", commandErr.Result.Stderr)
 	}
+	if !strings.Contains(commandErr.Error(), "bad") {
+		t.Fatalf("error = %q, want stderr detail", commandErr.Error())
+	}
+}
+
+func TestRunIncludesStdoutWhenNonZeroExitHasNoStderr(t *testing.T) {
+	t.Parallel()
+	_, err := Run(context.Background(), Options{
+		Command: "/bin/sh",
+		Args:    []string{"-c", `printf 'useful output'; exit 2`},
+	})
+	var commandErr *CommandExecutionError
+	if !errors.As(err, &commandErr) {
+		t.Fatalf("error = %v, want CommandExecutionError", err)
+	}
+	if !strings.Contains(commandErr.Error(), "Command exited with code 2: useful output") {
+		t.Fatalf("error = %q, want stdout detail", commandErr.Error())
+	}
 }
 
 func TestRunTimesOutAndPreservesCapturedOutput(t *testing.T) {

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -566,7 +567,15 @@ func (s *Service) discoverPullRequests(ctx context.Context, project storage.Proj
 			CapturedAt: currentISO(s.Now),
 		})
 		if err != nil {
-			return 0, err
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return 0, err
+			}
+			message := err.Error()
+			if s.Logger != nil {
+				s.Logger.Warn("failed to snapshot pull request for project", map[string]any{"projectId": project.ID, "repo": *repo, "pullRequestNumber": pullRequest.Number, "message": message})
+			}
+			*warnings = append(*warnings, fmt.Sprintf("Could not snapshot pull request #%d: %s", pullRequest.Number, message))
+			continue
 		}
 		if err := s.Repos.PullRequestSnapshots.Upsert(ctx, snapshot); err != nil {
 			return 0, err

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -570,6 +570,9 @@ func (s *Service) discoverPullRequests(ctx context.Context, project storage.Proj
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return 0, err
 			}
+			if ctxErr := ctx.Err(); errors.Is(ctxErr, context.Canceled) || errors.Is(ctxErr, context.DeadlineExceeded) {
+				return 0, ctxErr
+			}
 			message := err.Error()
 			if s.Logger != nil {
 				s.Logger.Warn("failed to snapshot pull request for project", map[string]any{"projectId": project.ID, "repo": *repo, "pullRequestNumber": pullRequest.Number, "message": message})

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/powerformer/looper/internal/config"
+	"github.com/powerformer/looper/internal/infra/shell"
 	"github.com/powerformer/looper/internal/storage"
 )
 
@@ -235,6 +236,33 @@ func TestServiceAddProjectPropagatesPullRequestSnapshotCancellation(t *testing.T
 		},
 		CapturePullRequestSnapshot: func(context.Context, CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
 			return storage.PullRequestSnapshotRecord{}, context.Canceled
+		},
+	}
+	repo := "powerformer/looper"
+
+	_, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("AddProject() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestServiceAddProjectPropagatesSnapshotCommandErrorCancellation(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	service := &Service{
+		DB:    coordinator.DB(),
+		Repos: repos,
+		Now:   func() time.Time { return now },
+		ListOpenPullRequests: func(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
+			return []PullRequestSummary{{Number: 73, State: "OPEN", IsDraft: false}}, nil
+		},
+		CapturePullRequestSnapshot: func(context.Context, CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
+			cancel()
+			return storage.PullRequestSnapshotRecord{}, &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{ExitCode: 1}}
 		},
 	}
 	repo := "powerformer/looper"

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -169,6 +169,82 @@ func TestServiceAddProjectReturnsDiscoveryWarnings(t *testing.T) {
 	}
 }
 
+func TestServiceAddProjectWarnsWhenPullRequestSnapshotFails(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	service := &Service{
+		DB:    coordinator.DB(),
+		Repos: repos,
+		Now:   func() time.Time { return now },
+		ListOpenPullRequests: func(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
+			return []PullRequestSummary{{Number: 73, State: "OPEN", IsDraft: false}}, nil
+		},
+		CapturePullRequestSnapshot: func(context.Context, CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
+			return storage.PullRequestSnapshotRecord{}, errors.New("could not find pull request diff: HTTP 406: Sorry, the diff exceeded the maximum number of lines (20000)")
+		},
+	}
+	repo := "powerformer/looper"
+
+	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo})
+	if err != nil {
+		t.Fatalf("AddProject() error = %v", err)
+	}
+	if result.DiscoveredPullRequests != 0 {
+		t.Fatalf("AddProject().DiscoveredPullRequests = %d, want 0", result.DiscoveredPullRequests)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("len(AddProject().Warnings) = %d, want 1", len(result.Warnings))
+	}
+	wantWarning := "Could not snapshot pull request #73: could not find pull request diff: HTTP 406: Sorry, the diff exceeded the maximum number of lines (20000)"
+	if result.Warnings[0] != wantWarning {
+		t.Fatalf("Warnings[0] = %q, want %q", result.Warnings[0], wantWarning)
+	}
+	stored, getErr := repos.Projects.GetByID(ctx, "looper")
+	if getErr != nil {
+		t.Fatalf("Projects.GetByID() error = %v", getErr)
+	}
+	if stored == nil {
+		t.Fatal("Projects.GetByID() = nil, want stored project")
+	}
+	snapshot, getErr := repos.PullRequestSnapshots.GetLatest(ctx, repo, 73)
+	if getErr != nil {
+		t.Fatalf("PullRequestSnapshots.GetLatest() error = %v", getErr)
+	}
+	if snapshot != nil {
+		t.Fatalf("PullRequestSnapshots.GetLatest() = %#v, want nil", snapshot)
+	}
+}
+
+func TestServiceAddProjectPropagatesPullRequestSnapshotCancellation(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	service := &Service{
+		DB:    coordinator.DB(),
+		Repos: repos,
+		Now:   func() time.Time { return now },
+		ListOpenPullRequests: func(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
+			return []PullRequestSummary{{Number: 73, State: "OPEN", IsDraft: false}}, nil
+		},
+		CapturePullRequestSnapshot: func(context.Context, CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
+			return storage.PullRequestSnapshotRecord{}, context.Canceled
+		},
+	}
+	repo := "powerformer/looper"
+
+	_, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("AddProject() error = %v, want context.Canceled", err)
+	}
+}
+
 func TestServiceAddProjectReturnsConflictForExplicitExistingID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Downgrade non-cancellation PR snapshot capture failures during `project add` to warnings so added projects remain successful.
- Include captured stderr/stdout in non-zero shell command errors so GitHub CLI failures surface their underlying cause.
- Add regression coverage for oversized PR diff snapshot failures, cancellation propagation, and shell error details.

## Validation
- `gofmt -w internal/projects/service.go internal/projects/service_test.go internal/infra/shell/runner.go internal/infra/shell/runner_test.go`
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #73