### PR TITLE
Fix terminal agent setup failures

### DIFF
--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -298,12 +298,25 @@ func (x *execution) run(ctx context.Context) {
 	stdout := x.stdoutString()
 	stderr := x.stderrString()
 	status := x.finalStatus(timedOut, killed)
-	completion := parseCompletion(stdout, stderr)
-	if completion.Summary == "" {
-		completion.Summary = summarizeLogs(stdout, stderr)
-	}
 	if waitErr != nil && status == "failed" && strings.TrimSpace(stderr) == "" {
 		stderr = waitErr.Error()
+	}
+	errorMessage := ""
+	if status == "failed" || status == "timeout" || status == "killed" {
+		errorMessage = strings.TrimSpace(stderr)
+		if errorMessage == "" {
+			errorMessage = killReason
+		}
+	}
+	completion := parseCompletion(stdout, stderr)
+	if status != "completed" {
+		completion = completionParse{ParseStatus: "missing"}
+	}
+	if completion.Summary == "" {
+		completion.Summary = errorMessage
+		if completion.Summary == "" {
+			completion.Summary = summarizeLogs(stdout, stderr)
+		}
 	}
 	endedAtISO := eventlog.FormatJavaScriptISOString(x.executor.now().UTC())
 	result := Result{
@@ -320,13 +333,6 @@ func (x *execution) run(ctx context.Context) {
 		PID:              pidOrZero(x.process.Process),
 	}
 
-	errorMessage := ""
-	if status == "failed" || status == "timeout" || status == "killed" {
-		errorMessage = strings.TrimSpace(stderr)
-		if errorMessage == "" {
-			errorMessage = killReason
-		}
-	}
 	x.persistFinal(status, result, errorMessage, endedAtISO)
 	eventType := "agent.completed"
 	if status == "timeout" {
@@ -682,10 +688,46 @@ func parseCompletion(stdout, stderr string) completionParse {
 			if summary, ok := parsed["summary"].(string); ok {
 				result.Summary = summary
 			}
+			if isTemplateCompletion(result, parsed) {
+				continue
+			}
 			return result
 		}
 	}
 	return completionParse{ParseStatus: "missing"}
+}
+
+func isTemplateCompletion(result completionParse, parsed map[string]any) bool {
+	if strings.TrimSpace(result.Summary) != "<one-sentence summary>" {
+		return false
+	}
+	if len(parsed) != 1 {
+		return false
+	}
+	_, ok := parsed["summary"]
+	return ok
+}
+
+func IsAgentSetupFailureMessage(message string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(message))
+	if normalized == "" {
+		return false
+	}
+	patterns := []string{
+		"requires a newer version",
+		"please upgrade to the latest app or cli",
+		"unsupported model",
+		"unknown model",
+		"invalid model",
+		"model is not supported",
+		"unrecognized model",
+	}
+	for _, pattern := range patterns {
+		if strings.Contains(normalized, pattern) {
+			return true
+		}
+	}
+	return false
 }
 
 func asStringSlice(value any) []string {

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -713,17 +713,41 @@ func IsAgentSetupFailureMessage(message string) bool {
 	if normalized == "" {
 		return false
 	}
-	patterns := []string{
-		"requires a newer version",
-		"please upgrade to the latest app or cli",
+	for _, line := range strings.Split(normalized, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if isCodexVersionSetupFailure(line) || isAgentModelSetupFailure(line) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCodexVersionSetupFailure(line string) bool {
+	return strings.Contains(line, " model requires a newer version of codex") &&
+		strings.Contains(line, "please upgrade to the latest app or cli")
+}
+
+func isAgentModelSetupFailure(line string) bool {
+	modelFailurePhrases := []string{
 		"unsupported model",
 		"unknown model",
 		"invalid model",
 		"model is not supported",
 		"unrecognized model",
 	}
+	if !containsAny(line, modelFailurePhrases) {
+		return false
+	}
+	return containsAny(line, []string{"agent setup", "agent configuration", "configured model", "model configuration", "--model", "model:"}) &&
+		containsAny(line, []string{"codex", "claude", "opencode", "cursor"})
+}
+
+func containsAny(value string, patterns []string) bool {
 	for _, pattern := range patterns {
-		if strings.Contains(normalized, pattern) {
+		if strings.Contains(value, pattern) {
 			return true
 		}
 	}

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -170,6 +170,48 @@ func TestExecutorInvalidJSONCompletionPreservesSignalAndFallsBackToLogs(t *testi
 	}
 }
 
+func TestExecutorFailedCommandIgnoresEchoedTemplateCompletion(t *testing.T) {
+	t.Parallel()
+
+	realError := "The 'gpt-5.5' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", `printf '__LOOPER_RESULT__={"summary":"<one-sentence summary>"}\n'; printf "$REAL_ERROR\n" >&2; exit 1`}}}})
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_failed_template", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: time.Second, Env: map[string]string{"REAL_ERROR": realError}})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "failed" {
+		t.Fatalf("result.Status = %q, want failed", result.Status)
+	}
+	if result.ParseStatus != "missing" || result.CompletionSignal != "" {
+		t.Fatalf("result = %#v, want failed command to ignore echoed completion marker", result)
+	}
+	if !strings.Contains(result.Summary, realError) || strings.Contains(result.Summary, "<one-sentence summary>") {
+		t.Fatalf("result.Summary = %q, want real stderr without template placeholder", result.Summary)
+	}
+}
+
+func TestParseCompletionIgnoresTemplatePlaceholder(t *testing.T) {
+	t.Parallel()
+
+	parsed := parseCompletion(CompletionMarkerPrefix+`{"summary":"<one-sentence summary>"}`+"\nreal work\n", "")
+	if parsed.ParseStatus != "missing" || parsed.Summary != "" {
+		t.Fatalf("parseCompletion() = %#v, want template placeholder ignored", parsed)
+	}
+}
+
+func TestIsAgentSetupFailureMessageDetectsCodexModelCompatibility(t *testing.T) {
+	t.Parallel()
+
+	message := "The 'gpt-5.5' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."
+	if !IsAgentSetupFailureMessage(message) {
+		t.Fatalf("IsAgentSetupFailureMessage(%q) = false, want true", message)
+	}
+}
+
 func TestExecutorHeartbeatUpdatesWhileOutputArrives(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -212,6 +212,21 @@ func TestIsAgentSetupFailureMessageDetectsCodexModelCompatibility(t *testing.T) 
 	}
 }
 
+func TestIsAgentSetupFailureMessageIgnoresIncidentalModelText(t *testing.T) {
+	t.Parallel()
+
+	messages := []string{
+		"custom tool failed: invalid model response from downstream service",
+		"retryable operation returned unknown model while parsing payload",
+		"unsupported model value in project data; try again later",
+	}
+	for _, message := range messages {
+		if IsAgentSetupFailureMessage(message) {
+			t.Fatalf("IsAgentSetupFailureMessage(%q) = true, want false", message)
+		}
+	}
+}
+
 func TestExecutorHeartbeatUpdatesWhileOutputArrives(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1018,6 +1018,7 @@ type loopLogsAgentPayload struct {
 	LastHeartbeatAt *string `json:"lastHeartbeatAt"`
 	Summary         *string `json:"summary"`
 	ParseStatus     *string `json:"parseStatus"`
+	ErrorMessage    *string `json:"errorMessage"`
 	Stdout          string  `json:"stdout"`
 	Stderr          string  `json:"stderr"`
 }
@@ -3212,6 +3213,7 @@ func (h *Handler) buildLoopLogsResponse(ctx context.Context, loop storage.LoopRe
 				LastHeartbeatAt: latestAgent.LastHeartbeatAt,
 				Summary:         latestAgent.Summary,
 				ParseStatus:     latestAgent.ParseStatus,
+				ErrorMessage:    latestAgent.ErrorMessage,
 				Stdout:          stdout,
 				Stderr:          stderr,
 			}

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -560,6 +560,30 @@ func TestLogsWithoutJSONPrintsHeaderAndTail(t *testing.T) {
 	}
 }
 
+func TestLogsWithoutJSONPrintsAgentErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	errorMessage := "The 'gpt-5.5' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(t, w, pkgapi.Success("req_logs", map[string]any{"seq": 12, "loopId": "loop_1", "loopType": "fixer", "loopStatus": "failed", "run": map[string]any{"runId": "run_1", "currentStep": "repair", "status": "failed"}, "agent": map[string]any{"vendor": "codex", "status": "failed", "errorMessage": errorMessage, "stdout": "", "stderr": errorMessage}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "logs", "loop_1", "--tail", "2", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([logs loop_1 --tail 2]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([logs loop_1 --tail 2]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Agent: codex", "Error: " + errorMessage, errorMessage} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([logs loop_1 --tail 2]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
 func TestLogsWithoutJSONDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -140,12 +140,13 @@ type loopLogsOutput struct {
 		CurrentStep *string `json:"currentStep"`
 	} `json:"run"`
 	Agent *struct {
-		ExecutionID string `json:"executionId"`
-		Vendor      string `json:"vendor"`
-		PID         *int64 `json:"pid"`
-		Status      string `json:"status"`
-		Stdout      string `json:"stdout"`
-		Stderr      string `json:"stderr"`
+		ExecutionID  string  `json:"executionId"`
+		Vendor       string  `json:"vendor"`
+		PID          *int64  `json:"pid"`
+		Status       string  `json:"status"`
+		ErrorMessage *string `json:"errorMessage"`
+		Stdout       string  `json:"stdout"`
+		Stderr       string  `json:"stderr"`
 	} `json:"agent"`
 }
 
@@ -364,7 +365,15 @@ func writeHumanLoopLogsRunAgent(w io.Writer, data loopLogsOutput) error {
 	if data.Agent == nil {
 		return nil
 	}
-	_, err := fmt.Fprintf(w, "Agent: %s · pid %s · %s\n\n", data.Agent.Vendor, formatScalar(data.Agent.PID), data.Agent.Status)
+	if _, err := fmt.Fprintf(w, "Agent: %s · pid %s · %s\n", data.Agent.Vendor, formatScalar(data.Agent.PID), data.Agent.Status); err != nil {
+		return err
+	}
+	if data.Agent.ErrorMessage != nil && strings.TrimSpace(*data.Agent.ErrorMessage) != "" {
+		if _, err := fmt.Fprintf(w, "Error: %s\n", strings.TrimSpace(*data.Agent.ErrorMessage)); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(w)
 	return err
 }
 

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -216,6 +216,7 @@ type AgentResult struct {
 	Status      string
 	Summary     string
 	Stdout      string
+	Stderr      string
 	ParseStatus string
 }
 
@@ -968,7 +969,12 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		return checkpoint, err
 	}
 	if !strings.EqualFold(result.Status, "completed") {
-		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, "Fixer agent "+result.Status), kind: FailureRetryableTransient}
+		message := firstNonEmpty(result.Summary, result.Stderr, "Fixer agent "+result.Status)
+		kind := FailureRetryableTransient
+		if agent.IsAgentSetupFailureMessage(message) {
+			kind = FailureManualIntervention
+		}
+		return checkpoint, &loopError{message: message, kind: kind}
 	}
 	if err := validateCompletedRepairCheckpoint(&checkpointRepair{Summary: result.Summary, ParseStatus: result.ParseStatus}); err != nil {
 		return checkpoint, err

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -275,6 +275,45 @@ func TestProcessClaimedItemFailsWhenRepairCompletionResultMissing(t *testing.T) 
 	}
 }
 
+func TestProcessClaimedItemTreatsAgentSetupFailureAsManualIntervention(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+		},
+	}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"}, prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true}}
+	errorMessage := "The 'gpt-5.5' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed", Stderr: errorMessage}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureManualIntervention || !contains(result.Summary, "requires a newer version") {
+		t.Fatalf("result = %#v, want manual_intervention with real agent error", result)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != string(FailureManualIntervention) || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want terminal manual_intervention failure", queue)
+	}
+}
+
 func TestRunRepairStepFailsResumedCompletedCheckpointWithoutParsedResult(t *testing.T) {
 	t.Parallel()
 

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -161,6 +161,7 @@ type AgentResult struct {
 	Status  string
 	Summary string
 	Stdout  string
+	Stderr  string
 	Commits []string
 }
 
@@ -752,7 +753,12 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 		return checkpoint, err
 	}
 	if !strings.EqualFold(result.Status, "completed") {
-		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, "Planner agent "+result.Status), kind: FailureRetryableTransient}
+		message := firstNonEmpty(result.Summary, result.Stderr, "Planner agent "+result.Status)
+		kind := FailureRetryableTransient
+		if agent.IsAgentSetupFailureMessage(message) {
+			kind = FailureManualIntervention
+		}
+		return checkpoint, &loopError{message: message, kind: kind}
 	}
 	checkpoint.WriteSpec = &checkpointWriteSpec{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Commits: append([]string(nil), result.Commits...)}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -236,6 +236,7 @@ type AgentResult struct {
 	Status      string
 	Summary     string
 	Stdout      string
+	Stderr      string
 	ParseStatus string
 }
 
@@ -969,7 +970,12 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	}
 	if result.Status != "completed" {
 		_ = r.tryRemoveReaction(ctx, input, "eyes")
-		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Reviewer agent %s", result.Status)), kind: FailureRetryableTransient}
+		message := firstNonEmpty(result.Summary, result.Stderr, fmt.Sprintf("Reviewer agent %s", result.Status))
+		kind := FailureRetryableTransient
+		if agent.IsAgentSetupFailureMessage(message) {
+			kind = FailureManualIntervention
+		}
+		return checkpoint, &loopError{message: message, kind: kind}
 	}
 	feedback := parseReviewFeedback(result)
 	if !feedback.Clean && len(feedback.Comments) == 0 {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -171,7 +171,7 @@ func (a plannerAgentExecutionAdapter) Wait(ctx context.Context) (planner.AgentRe
 	if err != nil {
 		return planner.AgentResult{}, err
 	}
-	return planner.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Commits: result.Commits}, nil
+	return planner.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, Commits: result.Commits}, nil
 }
 
 type reviewerGitHubAdapter struct{ gateway *githubinfra.Gateway }
@@ -270,7 +270,7 @@ func (a reviewerAgentExecutionAdapter) Wait(ctx context.Context) (reviewer.Agent
 	if err != nil {
 		return reviewer.AgentResult{}, err
 	}
-	return reviewer.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, ParseStatus: result.ParseStatus}, nil
+	return reviewer.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, ParseStatus: result.ParseStatus}, nil
 }
 
 type fixerGitHubAdapter struct{ gateway *githubinfra.Gateway }
@@ -365,7 +365,7 @@ func (a fixerAgentExecutionAdapter) Wait(ctx context.Context) (fixer.AgentResult
 	if err != nil {
 		return fixer.AgentResult{}, err
 	}
-	return fixer.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, ParseStatus: result.ParseStatus}, nil
+	return fixer.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, ParseStatus: result.ParseStatus}, nil
 }
 
 type workerGitHubAdapter struct{ gateway *githubinfra.Gateway }
@@ -464,7 +464,7 @@ func (a workerAgentExecutionAdapter) Wait(ctx context.Context) (worker.AgentResu
 	if err != nil {
 		return worker.AgentResult{}, err
 	}
-	return worker.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, ParseStatus: result.ParseStatus, ChangedFiles: result.ChangedFiles, Commits: result.Commits}, nil
+	return worker.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, ParseStatus: result.ParseStatus, ChangedFiles: result.ChangedFiles, Commits: result.Commits}, nil
 }
 
 func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, asyncRunner func() schedulerAsyncRunner, now func() time.Time) RunSchedulerTickFunc {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -225,6 +225,7 @@ type AgentResult struct {
 	Status       string
 	Summary      string
 	Stdout       string
+	Stderr       string
 	ParseStatus  string
 	ChangedFiles []string
 	Commits      []string
@@ -924,7 +925,12 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 		return checkpoint, err
 	}
 	if result.Status != "completed" {
-		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, fmt.Sprintf("Worker agent %s", result.Status)), kind: FailureRetryableTransient}
+		message := firstNonEmpty(result.Summary, result.Stderr, fmt.Sprintf("Worker agent %s", result.Status))
+		kind := FailureRetryableTransient
+		if agent.IsAgentSetupFailureMessage(message) {
+			kind = FailureManualIntervention
+		}
+		return checkpoint, &loopError{message: message, kind: kind}
 	}
 	if err := validateCompletedExecutionCheckpoint(&checkpointExecution{Status: result.Status, Summary: result.Summary, ParseStatus: result.ParseStatus}); err != nil {
 		return checkpoint, err


### PR DESCRIPTION
## Summary
- Treat deterministic agent CLI/model setup failures as manual-intervention failures instead of retryable transient failures.
- Ignore echoed/template completion markers on failed agent processes so placeholder summaries do not hide real stderr.
- Surface persisted agent error messages through `looper logs` responses and human output.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #74