### PR TITLE
Infer project for planner issue runs

### DIFF
--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -1007,6 +1007,62 @@ func TestWorkCreateIssueRequiresExplicitProjectWhenCurrentProjectIsAmbiguous(t *
 	}
 }
 
+func TestPlanCreateIssueResolvesProjectFromCurrentProject(t *testing.T) {
+	t.Parallel()
+
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", repoPath, err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			writeEnvelope(t, w, pkgapi.Success("req_projects", map[string]any{"items": []map[string]any{{"id": "project_1", "name": "Looper", "repoPath": repoPath, "repo": "acme/looper", "updatedAt": "2026-04-20T10:00:00.000Z"}}}))
+		case "/api/v1/planners":
+			if got, want := r.Method, http.MethodPost; got != want {
+				t.Fatalf("request method = %q, want %q", got, want)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got, want := body["projectId"], "project_1"; got != want {
+				t.Fatalf("body.projectId = %#v, want %#v", got, want)
+			}
+			if got, want := body["issueNumber"], float64(54); got != want {
+				t.Fatalf("body.issueNumber = %#v, want %#v", got, want)
+			}
+			writeEnvelope(t, w, pkgapi.Success("req_planner", map[string]any{"id": "planner_1", "projectId": "project_1", "issueNumber": 54, "status": "queued"}))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		Getwd: func() (string, error) {
+			return repoPath, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"plan", "--issue", "54", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([plan --issue 54]) exit code = %d, want 0", exitCode)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("Run([plan --issue 54]) stderr = %q, want empty string", got)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Planner started") {
+		t.Fatalf("Run([plan --issue 54]) stdout = %q, want to contain %q", got, "Planner started")
+	}
+}
+
 func TestResolveProjectForCWDPrefersMostSpecificRepoPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -336,8 +336,24 @@ func (r *commandRuntime) planCreate(cmd *cobra.Command, args []string) error {
 			return nil, err
 		}
 
+		resolvedProjectID := strings.TrimSpace(getStringFlag(cmd, "project"))
 		body := map[string]any{"issueNumber": issueNumber}
-		setString(body, "projectId", getStringFlag(cmd, "project"))
+
+		if resolvedProjectID == "" {
+			projects, err := r.listProjects(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			project, err := r.resolveExplicitOrCurrentProject(projects, resolvedProjectID)
+			if err != nil {
+				return nil, err
+			}
+
+			resolvedProjectID = project.ID
+		}
+
+		setString(body, "projectId", resolvedProjectID)
 
 		return r.postJSON(ctx, "/api/v1/planners", body)
 	}, writeHumanPlannerCreate)


### PR DESCRIPTION
## Summary
- Resolve `looper plan --issue` project IDs from the current working directory when `--project` is omitted.
- Add CLI coverage for planner issue runs using cwd-based project inference.

## Tests
- `go test ./internal/cliapp`
- `go test ./...`