### PR TITLE
Validate worker issue targets

### DIFF
--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -71,14 +71,15 @@ type PullRequestDetail struct {
 }
 
 type IssueSummary struct {
-	Number    int64
-	Title     string
-	Body      string
-	URL       string
-	State     string
-	Author    string
-	Assignees []string
-	Labels    []string
+	Number        int64
+	Title         string
+	Body          string
+	URL           string
+	State         string
+	Author        string
+	Assignees     []string
+	Labels        []string
+	IsPullRequest bool
 }
 
 type IssueDetail = IssueSummary
@@ -304,7 +305,7 @@ func (g *Gateway) ListOpenIssues(ctx context.Context, input ListOpenIssuesInput)
 }
 
 func (g *Gateway) ViewIssue(ctx context.Context, input ViewIssueInput) (IssueDetail, error) {
-	result, err := g.runGh(ctx, input.CWD, "", "issue", "view", fmt.Sprintf("%d", input.IssueNumber), "--repo", input.Repo, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "author", "assignees", "labels"}, ","))
+	result, err := g.runGh(ctx, input.CWD, "", "api", fmt.Sprintf("repos/%s/issues/%d", input.Repo, input.IssueNumber))
 	if err != nil {
 		return IssueDetail{}, err
 	}
@@ -313,14 +314,15 @@ func (g *Gateway) ViewIssue(ctx context.Context, input ViewIssueInput) (IssueDet
 		return IssueDetail{}, err
 	}
 	return IssueDetail{
-		Number:    asInt64(row["number"]),
-		Title:     asString(row["title"]),
-		Body:      asString(row["body"]),
-		URL:       asString(row["url"]),
-		State:     asString(row["state"]),
-		Author:    extractAuthor(row["author"]),
-		Assignees: extractActorLogins(row["assignees"]),
-		Labels:    extractLabelNames(row["labels"]),
+		Number:        asInt64(row["number"]),
+		Title:         asString(row["title"]),
+		Body:          asString(row["body"]),
+		URL:           firstNonEmpty(asString(row["html_url"]), asString(row["url"])),
+		State:         asString(row["state"]),
+		Author:        extractAuthor(firstNonNil(row["user"], row["author"])),
+		Assignees:     extractActorLogins(row["assignees"]),
+		Labels:        extractLabelNames(row["labels"]),
+		IsPullRequest: row["pull_request"] != nil,
 	}, nil
 }
 
@@ -955,6 +957,24 @@ func extractLabelNames(value any) []string {
 		}
 	}
 	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstNonNil(values ...any) any {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
 }
 
 func parsePRNumberFromURL(value string) int64 {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -21,8 +21,8 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 			return shell.Result{Stdout: `[{"number":42,"title":"Review me","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","author":{"login":"octocat"},"reviewRequests":[{"__typename":"User","login":"OctoCat"},{"__typename":"Team","slug":"platform"}]}]`}, nil
 		case strings.HasPrefix(args, "issue list"):
 			return shell.Result{Stdout: `[{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","author":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}]`}, nil
-		case strings.HasPrefix(args, "issue view"):
-			return shell.Result{Stdout: `{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","author":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}`}, nil
+		case args == "api repos/acme/looper/issues/8":
+			return shell.Result{Stdout: `{"number":8,"title":"Fix gateway","body":"Issue body","html_url":"https://example.test/issues/8","state":"open","user":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}`}, nil
 		case args == "api repos/acme/looper/issues/8/comments --method POST -f body=Looper started":
 			return shell.Result{Stdout: `{"id":91,"html_url":"https://example.test/issues/8#issuecomment-91"}`}, nil
 		case args == "api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished":
@@ -144,6 +144,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if issueDetail.Number != 8 {
 		t.Fatalf("issueDetail.Number = %d, want 8", issueDetail.Number)
 	}
+	if issueDetail.State != "open" || issueDetail.IsPullRequest {
+		t.Fatalf("issueDetail = %#v, want open issue not pull request", issueDetail)
+	}
 	if comment.ID != 91 || comment.URL != "https://example.test/issues/8#issuecomment-91" {
 		t.Fatalf("comment = %#v, want parsed issue comment metadata", comment)
 	}
@@ -178,7 +181,7 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 		"api repos/acme/looper/issues/42/reactions/7 --method DELETE -H Accept: application/vnd.github+json",
 		"pr list --repo acme/looper --state open --limit 30 --label phase-1",
 		"issue list --repo acme/looper --state open --limit 30 --assignee reviewer --label phase-1",
-		"issue view 8 --repo acme/looper",
+		"api repos/acme/looper/issues/8",
 		"api repos/acme/looper/issues/8/comments --method POST -f body=Looper started",
 		"api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished",
 		"label create phase-1 --repo acme/looper --color 5319e7 --description Managed by looper --force",

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -395,7 +395,7 @@ func (a workerGitHubAdapter) ViewIssue(ctx context.Context, input worker.ViewIss
 	if err != nil {
 		return worker.IssueDetail{}, err
 	}
-	return worker.IssueDetail{Number: issue.Number, Title: issue.Title, Body: issue.Body, URL: issue.URL}, nil
+	return worker.IssueDetail{Number: issue.Number, Title: issue.Title, Body: issue.Body, URL: issue.URL, State: issue.State, IsPullRequest: issue.IsPullRequest}, nil
 }
 
 func (a workerGitHubAdapter) CreateIssueComment(ctx context.Context, input worker.IssueCommentInput) (worker.IssueCommentResult, error) {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -82,10 +82,12 @@ type PullRequestDetail struct {
 }
 
 type IssueDetail struct {
-	Number int64
-	Title  string
-	Body   string
-	URL    string
+	Number        int64
+	Title         string
+	Body          string
+	URL           string
+	State         string
+	IsPullRequest bool
 }
 
 type IssueCommentInput struct {
@@ -1091,12 +1093,18 @@ func (r *Runner) resolveWorkerInput(ctx context.Context, project storage.Project
 	if work.ExecutionMode == "create-pr" && work.Prompt == "" && work.SpecPath == "" && work.IssueNumber == 0 {
 		return workerInput{}, &loopError{message: "worker.prompt or worker.specPath is required", kind: FailureNonRetryable}
 	}
-	if work.ExecutionMode == "create-pr" && work.IssueNumber > 0 && work.Prompt == "" && work.SpecPath == "" && r.github != nil {
-		issue, err := r.github.ViewIssue(ctx, ViewIssueInput{Repo: issueLookupRepo(work), IssueNumber: work.IssueNumber, CWD: project.RepoPath})
+	if work.ExecutionMode == "create-pr" && work.IssueNumber > 0 && r.github != nil {
+		lookupRepo := issueLookupRepo(work)
+		issue, err := r.github.ViewIssue(ctx, ViewIssueInput{Repo: lookupRepo, IssueNumber: work.IssueNumber, CWD: project.RepoPath})
 		if err != nil {
 			return workerInput{}, err
 		}
-		work = hydrateWorkerInputFromIssue(work, issue)
+		if err := validateWorkerIssueTarget(lookupRepo, work.IssueNumber, issue); err != nil {
+			return workerInput{}, err
+		}
+		if work.Prompt == "" && work.SpecPath == "" {
+			work = hydrateWorkerInputFromIssue(work, issue)
+		}
 	}
 	if loop.TargetType == "pull_request" {
 		repo := firstNonEmpty(derefString(loop.Repo), work.Repo)
@@ -1912,6 +1920,17 @@ func hydrateWorkerInputFromIssue(work workerInput, issue IssueDetail) workerInpu
 	work.Prompt = buildIssuePrompt(work.IssueRepo, issue)
 	work.IssueURL = firstNonEmpty(issue.URL, work.IssueURL)
 	return work
+}
+
+func validateWorkerIssueTarget(repo string, issueNumber int64, issue IssueDetail) error {
+	reference := formatIssueReference(repo, issueNumber)
+	if issue.IsPullRequest {
+		return &loopError{message: fmt.Sprintf("%s is a pull request, not an issue; worker issue targets must reference an open GitHub issue", reference), kind: FailureNonRetryable}
+	}
+	if issue.State != "" && !strings.EqualFold(issue.State, "OPEN") {
+		return &loopError{message: fmt.Sprintf("%s is %s; worker issue targets must reference an open GitHub issue", reference, strings.ToLower(issue.State)), kind: FailureNonRetryable}
+	}
+	return nil
 }
 
 func buildIssuePrompt(repo string, issue IssueDetail) string {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -535,6 +535,78 @@ func TestResolveWorkerInputUsesIssueURLRepoForIssueHydrationLookup(t *testing.T)
 	}
 }
 
+func TestResolveWorkerInputRejectsClosedIssueTargetEvenWithSpecPath(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{issueDetail: IssueDetail{Number: 27, Title: "Closed issue", State: "CLOSED"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	queueItem, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	payload := `{"title":"Implement worker loop","repo":"acme/looper","issueNumber":27,"specPath":"specs/planner.md","baseBranch":"main"}`
+	loopMetadata := `{"worker":{"title":"Implement worker loop","repo":"acme/looper","issueNumber":27,"specPath":"specs/planner.md","baseBranch":"main"}}`
+	loop.MetadataJSON = &loopMetadata
+	queueItem.PayloadJSON = &payload
+
+	_, err = runner.resolveWorkerInput(context.Background(), *project, *loop, *queueItem, workerCheckpoint{})
+	if err == nil {
+		t.Fatal("resolveWorkerInput() error = nil, want closed issue validation error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureNonRetryable {
+		t.Fatalf("error = %T %[1]v, want non-retryable loopError", err)
+	}
+	if !strings.Contains(err.Error(), "acme/looper#27 is closed") || !strings.Contains(err.Error(), "open GitHub issue") {
+		t.Fatalf("error = %q, want clear closed issue message", err.Error())
+	}
+}
+
+func TestResolveWorkerInputRejectsPullRequestIssueTarget(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{issueDetail: IssueDetail{Number: 27, Title: "PR", State: "OPEN", IsPullRequest: true}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	queueItem, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	payload := `{"title":"Implement worker loop","repo":"acme/looper","issueNumber":27,"baseBranch":"main"}`
+	loopMetadata := `{"worker":{"title":"Implement worker loop","repo":"acme/looper","issueNumber":27,"baseBranch":"main"}}`
+	loop.MetadataJSON = &loopMetadata
+	queueItem.PayloadJSON = &payload
+
+	_, err = runner.resolveWorkerInput(context.Background(), *project, *loop, *queueItem, workerCheckpoint{})
+	if err == nil {
+		t.Fatal("resolveWorkerInput() error = nil, want PR validation error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureNonRetryable {
+		t.Fatalf("error = %T %[1]v, want non-retryable loopError", err)
+	}
+	if !strings.Contains(err.Error(), "acme/looper#27 is a pull request") || !strings.Contains(err.Error(), "open GitHub issue") {
+		t.Fatalf("error = %q, want clear pull request message", err.Error())
+	}
+}
+
 func TestProcessClaimedItemUsesIssueLockForIssueTargetedWorker(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)


### PR DESCRIPTION
## Summary
- Validate `looper work --issue` targets before resolving worker input so closed issues and pull request numbers are rejected.
- Fetch issue details through the GitHub Issues REST endpoint to detect PR-backed issue numbers.
- Add regression coverage for closed issue and PR-number rejection.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #79