### PR TITLE
Bypass planner discovery checks for manual issues

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2360,6 +2360,12 @@ func (h *Handler) buildCreateLoopResponse(r *http.Request) (loopResponse, error)
 	if err != nil {
 		return loopResponse{}, err
 	}
+	if domain.LoopType(loopType) == domain.LoopTypePlanner {
+		metadataJSON, err = manualPlannerMetadataJSON(metadataJSON, target.IssueNumber)
+		if err != nil {
+			return loopResponse{}, err
+		}
+	}
 
 	now := h.now().UTC()
 	record, err := storage.WithTransactionValue(r.Context(), services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
@@ -2731,7 +2737,11 @@ func (h *Handler) buildPlannersCreateResponse(r *http.Request) (plannerCreateRes
 
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
 	targetID := fmt.Sprintf("issue:%s:%d", *repo, *issueNumber)
-	metadataJSON := fmt.Sprintf(`{"issueNumber":%d}`, *issueNumber)
+	metadataJSONPtr, err := manualPlannerMetadataJSON(nil, *issueNumber)
+	if err != nil {
+		return plannerCreateResponse{}, err
+	}
+	metadataJSON := derefString(metadataJSONPtr)
 
 	record, err := storage.WithTransactionValue(r.Context(), services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
 		repos := storage.NewRepositories(tx)
@@ -2769,7 +2779,7 @@ func (h *Handler) buildPlannersCreateResponse(r *http.Request) (plannerCreateRes
 			return storage.LoopRecord{}, upsertErr
 		}
 
-		queueRecord, ok, queueErr := buildQueuedLoopQueueRecordCompat(record, target, nowISO, nil, int64(h.context.Config.Scheduler.RetryMaxAttempts))
+		queueRecord, ok, queueErr := buildQueuedLoopQueueRecordCompat(record, target, nowISO, &metadataJSON, int64(h.context.Config.Scheduler.RetryMaxAttempts))
 		if queueErr != nil {
 			return storage.LoopRecord{}, queueErr
 		}
@@ -3317,6 +3327,23 @@ func normalizeMetadataJSON(raw json.RawMessage) (*string, error) {
 	return &text, nil
 }
 
+func manualPlannerMetadataJSON(existing *string, issueNumber int64) (*string, error) {
+	metadata := map[string]any{}
+	if existing != nil && strings.TrimSpace(*existing) != "" {
+		if err := json.Unmarshal([]byte(*existing), &metadata); err != nil {
+			return nil, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "metadata must be a JSON object"}
+		}
+	}
+	metadata["issueNumber"] = issueNumber
+	metadata["manual"] = true
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	text := string(encoded)
+	return &text, nil
+}
+
 func buildQueuedLoopQueueRecordCompat(record storage.LoopRecord, target domain.LoopTarget, nowISO string, metadataJSON *string, maxAttempts int64) (storage.QueueItemRecord, bool, error) {
 	queueType := domain.LoopType(record.Type)
 	if queueType != domain.LoopTypeReviewer && queueType != domain.LoopTypeFixer && queueType != domain.LoopTypeWorker && queueType != domain.LoopTypePlanner {
@@ -3350,7 +3377,21 @@ func buildQueuedLoopQueueRecordCompat(record storage.LoopRecord, target domain.L
 			return storage.QueueItemRecord{}, false, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("%s loop requires repo and issueNumber", record.Type)}
 		}
 		lockKey := fmt.Sprintf("issue:%s:%d", repo, issueNumber)
-		payloadJSON := fmt.Sprintf(`{"issueNumber":%d}`, issueNumber)
+		manual := false
+		if metadata := parseJSONObject(metadataJSON); metadata["manual"] == true {
+			if boolValue, ok := metadata["manual"].(bool); ok {
+				manual = boolValue
+			}
+		}
+		payload := map[string]any{"issueNumber": issueNumber}
+		if manual {
+			payload["manual"] = true
+		}
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			return storage.QueueItemRecord{}, false, err
+		}
+		payloadJSON := string(payloadBytes)
 		queueRecord.TargetType = string(domain.LoopTargetTypeIssue)
 		queueRecord.TargetID = lockKey
 		queueRecord.Repo = &repo

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2055,6 +2055,9 @@ func TestHandlerCreateLoopPlannerEnqueuesSchedulableLoop(t *testing.T) {
 	data := resp["data"].(map[string]any)
 	loopID := data["id"].(string)
 	assertEqual(t, data["status"], "running")
+	metadata := parseJSONMap(t, []byte(data["metadataJson"].(string)))
+	assertEqual(t, metadata["manual"], true)
+	assertEqual(t, metadata["issueNumber"], float64(123))
 
 	queueItems, err := fixture.runtime.Services().Repositories.Queue.List(context.Background())
 	if err != nil {
@@ -2075,6 +2078,9 @@ func TestHandlerCreateLoopPlannerEnqueuesSchedulableLoop(t *testing.T) {
 	assertEqual(t, queue.TargetType, "issue")
 	assertEqual(t, queue.TargetID, "issue:acme/looper:123")
 	assertEqual(t, queue.DedupeKey, "planner:project_1:"+loopID+":acme/looper:123")
+	payload := parseJSONMap(t, []byte(*queue.PayloadJSON))
+	assertEqual(t, payload["manual"], true)
+	assertEqual(t, payload["issueNumber"], float64(123))
 	assertEqual(t, triggered, 1)
 }
 

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -674,11 +674,12 @@ func (r *Runner) runDiscoverIssueStep(ctx context.Context, input stepInput) (pla
 	checkpoint.Issue = &checkpointIssue{Repo: repo, IssueNumber: issueNumber, Title: detail.Title, Body: detail.Body, URL: detail.URL, Assignees: cloneStrings(detail.Assignees), Labels: cloneStrings(detail.Labels), CurrentUserLogin: currentLogin, SpecPath: buildSpecPath(r.now(), issueNumber, detail.Title), RequestedReviewers: resolveRequestedReviewers(input.Project, input.Loop, detail.Assignees, currentLogin)}
 	checkpoint.ClaimedLockKey = lockKey
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
-	if currentLogin != "" && !includesLogin(detail.Assignees, currentLogin) {
+	manual := isManualPlannerQueue(payload, input.Loop.MetadataJSON)
+	if !manual && currentLogin != "" && !includesLogin(detail.Assignees, currentLogin) {
 		checkpoint.SkipReason = fmt.Sprintf("Issue %s#%d is no longer assigned to %s", repo, issueNumber, currentLogin)
 		return checkpoint, nil
 	}
-	if !specpr.HasLabel(detail.Labels, discoveryLabel) {
+	if !manual && !specpr.HasLabel(detail.Labels, discoveryLabel) {
 		checkpoint.SkipReason = fmt.Sprintf("Issue %s#%d no longer has %s", repo, issueNumber, discoveryLabel)
 		return checkpoint, nil
 	}
@@ -1269,6 +1270,16 @@ func includesLogin(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func isManualPlannerQueue(payload map[string]any, loopMetadataJSON *string) bool {
+	manual, ok := payload["manual"].(bool)
+	if ok && manual {
+		return true
+	}
+	metadata := parseJSONObject(loopMetadataJSON)
+	manual, ok = metadata["manual"].(bool)
+	return ok && manual
 }
 
 func shouldClaimIssue(issue IssueSummary, login string) bool {

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -674,7 +674,7 @@ func (r *Runner) runDiscoverIssueStep(ctx context.Context, input stepInput) (pla
 	checkpoint.Issue = &checkpointIssue{Repo: repo, IssueNumber: issueNumber, Title: detail.Title, Body: detail.Body, URL: detail.URL, Assignees: cloneStrings(detail.Assignees), Labels: cloneStrings(detail.Labels), CurrentUserLogin: currentLogin, SpecPath: buildSpecPath(r.now(), issueNumber, detail.Title), RequestedReviewers: resolveRequestedReviewers(input.Project, input.Loop, detail.Assignees, currentLogin)}
 	checkpoint.ClaimedLockKey = lockKey
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
-	manual := isManualPlannerQueue(payload, input.Loop.MetadataJSON)
+	manual := isManualPlannerQueue(payload)
 	if !manual && currentLogin != "" && !includesLogin(detail.Assignees, currentLogin) {
 		checkpoint.SkipReason = fmt.Sprintf("Issue %s#%d is no longer assigned to %s", repo, issueNumber, currentLogin)
 		return checkpoint, nil
@@ -1272,13 +1272,8 @@ func includesLogin(values []string, target string) bool {
 	return false
 }
 
-func isManualPlannerQueue(payload map[string]any, loopMetadataJSON *string) bool {
+func isManualPlannerQueue(payload map[string]any) bool {
 	manual, ok := payload["manual"].(bool)
-	if ok && manual {
-		return true
-	}
-	metadata := parseJSONObject(loopMetadataJSON)
-	manual, ok = metadata["manual"].(bool)
 	return ok && manual
 }
 

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -86,6 +86,85 @@ func TestDiscoverIssuesEnqueuesAcrossProjectsForSameIssue(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemManualPlannerBypassesDiscoveryChecks(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	issue := IssueSummary{Number: 42, Title: "Plan this"}
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue)
+	if err != nil {
+		t.Fatalf("ensureLoopForIssue() error = %v", err)
+	}
+	queueItem, err := (&Runner{repos: fixture.repos, now: fixture.now, retryMaxAttempts: 3}).enqueue(context.Background(), enqueueInput{ProjectID: "project_1", LoopID: loopResult.record.ID, Repo: "acme/looper", IssueNumber: issue.Number, Payload: map[string]any{"issueNumber": issue.Number, "manual": true}})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	github := &fakeGitHubGateway{issueDetail: IssueDetail{Number: 42, Title: "Plan this", Assignees: []string{"someone"}, Labels: []string{"not-looper:plan"}, Body: "details", URL: "https://example/issues/42"}}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{ID: "worktree_1", WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "wrote spec"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoPush: boolPtr(true)})
+	github.createPRResult = CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}
+
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "planner-worker-1", "planner")
+	if err != nil || claimed == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claimed, err)
+	}
+	if claimed.ID != queueItem.ID {
+		t.Fatalf("claimed.ID = %q, want %q", claimed.ID, queueItem.ID)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success", result)
+	}
+	if result.PullRequestNumber != 101 {
+		t.Fatalf("result.PullRequestNumber = %d, want 101", result.PullRequestNumber)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("agent starts = %d, want 1", len(agent.starts))
+	}
+}
+
+func TestProcessClaimedItemPlannerSkipsWhenNotManualAndIneligible(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	issue := IssueSummary{Number: 42, Title: "Plan this"}
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue)
+	if err != nil {
+		t.Fatalf("ensureLoopForIssue() error = %v", err)
+	}
+	queueItem, err := (&Runner{repos: fixture.repos, now: fixture.now, retryMaxAttempts: 3}).enqueue(context.Background(), enqueueInput{ProjectID: "project_1", LoopID: loopResult.record.ID, Repo: "acme/looper", IssueNumber: issue.Number, Payload: map[string]any{"issueNumber": issue.Number}})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	github := &fakeGitHubGateway{issueDetail: IssueDetail{Number: 42, Title: "Plan this", Assignees: []string{"someone"}, Labels: []string{"not-looper:plan"}, Body: "details", URL: "https://example/issues/42"}}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{ID: "worktree_1", WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "wrote spec"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoPush: boolPtr(true)})
+
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "planner-worker-1", "planner")
+	if err != nil || claimed == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claimed, err)
+	}
+	if claimed.ID != queueItem.ID {
+		t.Fatalf("claimed.ID = %q, want %q", claimed.ID, queueItem.ID)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped", result)
+	}
+	if result.FailureKind != "" {
+		t.Fatalf("result.FailureKind = %q, want empty", result.FailureKind)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("len(agent.starts) = %d, want 0", len(agent.starts))
+	}
+}
+
 func TestProcessClaimedItemSuccessfulPlannerPublish(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -165,6 +165,46 @@ func TestProcessClaimedItemPlannerSkipsWhenNotManualAndIneligible(t *testing.T) 
 	}
 }
 
+func TestProcessClaimedItemDiscoveryQueueIgnoresManualLoopMetadata(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	issue := IssueSummary{Number: 42, Title: "Plan this"}
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue)
+	if err != nil {
+		t.Fatalf("ensureLoopForIssue() error = %v", err)
+	}
+	loop := loopResult.record
+	loop.MetadataJSON = stringPtr(`{"manual":true,"issueNumber":42}`)
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queueItem, err := (&Runner{repos: fixture.repos, now: fixture.now, retryMaxAttempts: 3}).enqueue(context.Background(), enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: "acme/looper", IssueNumber: issue.Number, Payload: map[string]any{"issueNumber": issue.Number}})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	github := &fakeGitHubGateway{issueDetail: IssueDetail{Number: 42, Title: "Plan this", Assignees: []string{"someone"}, Labels: []string{"not-looper:plan"}, Body: "details", URL: "https://example/issues/42"}}
+	agent := &fakeAgentExecutor{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoPush: boolPtr(true)})
+
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "planner-worker-1", "planner")
+	if err != nil || claimed == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claimed, err)
+	}
+	if claimed.ID != queueItem.ID {
+		t.Fatalf("claimed.ID = %q, want %q", claimed.ID, queueItem.ID)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped", result)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("len(agent.starts) = %d, want 0", len(agent.starts))
+	}
+}
+
 func TestProcessClaimedItemSuccessfulPlannerPublish(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -916,7 +916,11 @@ func buildRecoveryQueueItem(loop storage.LoopRecord, nowISO string, maxAttempts 
 			return storage.QueueItemRecord{}, false, err
 		}
 		lockKey := fmt.Sprintf("issue:%s:%d", repo, issueNumber)
-		payloadJSON := fmt.Sprintf(`{"issueNumber":%d}`, issueNumber)
+		payload := map[string]any{"issueNumber": issueNumber}
+		if recoveryLoopHasManualPlannerMetadata(loop.MetadataJSON) {
+			payload["manual"] = true
+		}
+		payloadJSON := mustMarshalJSON(payload)
 		queueRecord.TargetType = string(domain.LoopTargetTypeIssue)
 		queueRecord.TargetID = lockKey
 		queueRecord.Repo = &repo
@@ -993,6 +997,18 @@ func buildRecoveryQueueItem(loop storage.LoopRecord, nowISO string, maxAttempts 
 	}
 
 	return queueRecord, true, nil
+}
+
+func recoveryLoopHasManualPlannerMetadata(metadataJSON *string) bool {
+	if metadataJSON == nil || strings.TrimSpace(*metadataJSON) == "" {
+		return false
+	}
+	metadata := map[string]any{}
+	if err := json.Unmarshal([]byte(*metadataJSON), &metadata); err != nil {
+		return false
+	}
+	manual, ok := metadata["manual"].(bool)
+	return ok && manual
 }
 
 func buildRecoveryWorkerPayloadJSON(metadataJSON *string) *string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -917,9 +917,6 @@ func buildRecoveryQueueItem(loop storage.LoopRecord, nowISO string, maxAttempts 
 		}
 		lockKey := fmt.Sprintf("issue:%s:%d", repo, issueNumber)
 		payload := map[string]any{"issueNumber": issueNumber}
-		if recoveryLoopHasManualPlannerMetadata(loop.MetadataJSON) {
-			payload["manual"] = true
-		}
 		payloadJSON := mustMarshalJSON(payload)
 		queueRecord.TargetType = string(domain.LoopTargetTypeIssue)
 		queueRecord.TargetID = lockKey
@@ -997,18 +994,6 @@ func buildRecoveryQueueItem(loop storage.LoopRecord, nowISO string, maxAttempts 
 	}
 
 	return queueRecord, true, nil
-}
-
-func recoveryLoopHasManualPlannerMetadata(metadataJSON *string) bool {
-	if metadataJSON == nil || strings.TrimSpace(*metadataJSON) == "" {
-		return false
-	}
-	metadata := map[string]any{}
-	if err := json.Unmarshal([]byte(*metadataJSON), &metadata); err != nil {
-		return false
-	}
-	manual, ok := metadata["manual"].(bool)
-	return ok && manual
 }
 
 func buildRecoveryWorkerPayloadJSON(metadataJSON *string) *string {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -355,7 +355,7 @@ func TestBuildRecoveryQueueItemRecordUsesIssueLockForWorkerTargets(t *testing.T)
 	}
 }
 
-func TestBuildRecoveryQueueItemPreservesManualPlannerPayload(t *testing.T) {
+func TestBuildRecoveryQueueItemDoesNotRestoreManualPlannerPayloadFromLoopMetadata(t *testing.T) {
 	t.Parallel()
 
 	loop := storage.LoopRecord{
@@ -377,14 +377,17 @@ func TestBuildRecoveryQueueItemPreservesManualPlannerPayload(t *testing.T) {
 		t.Fatal("buildRecoveryQueueItem() ok = false, want true")
 	}
 	if record.PayloadJSON == nil {
-		t.Fatal("record.PayloadJSON = nil, want manual planner payload")
+		t.Fatal("record.PayloadJSON = nil, want planner issue payload")
 	}
 	payload := map[string]any{}
 	if err := json.Unmarshal([]byte(*record.PayloadJSON), &payload); err != nil {
 		t.Fatalf("json.Unmarshal(payload) error = %v", err)
 	}
-	if payload["manual"] != true || payload["issueNumber"] != float64(82) {
-		t.Fatalf("payload = %#v, want manual planner issue payload", payload)
+	if _, ok := payload["manual"]; ok {
+		t.Fatalf("payload = %#v, want recovery payload without manual bypass", payload)
+	}
+	if payload["issueNumber"] != float64(82) {
+		t.Fatalf("payload = %#v, want planner issue payload", payload)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -355,6 +355,39 @@ func TestBuildRecoveryQueueItemRecordUsesIssueLockForWorkerTargets(t *testing.T)
 	}
 }
 
+func TestBuildRecoveryQueueItemPreservesManualPlannerPayload(t *testing.T) {
+	t.Parallel()
+
+	loop := storage.LoopRecord{
+		ID:           "loop_planner_manual",
+		ProjectID:    "project_1",
+		Type:         "planner",
+		TargetType:   "issue",
+		TargetID:     stringPtr("issue:acme/looper:82"),
+		Repo:         stringPtr("acme/looper"),
+		Status:       "queued",
+		MetadataJSON: stringPtr(`{"issueNumber":82,"manual":true}`),
+	}
+
+	record, ok, err := buildRecoveryQueueItem(loop, "2026-04-17T12:34:56.000Z", 3)
+	if err != nil {
+		t.Fatalf("buildRecoveryQueueItem() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("buildRecoveryQueueItem() ok = false, want true")
+	}
+	if record.PayloadJSON == nil {
+		t.Fatal("record.PayloadJSON = nil, want manual planner payload")
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal([]byte(*record.PayloadJSON), &payload); err != nil {
+		t.Fatalf("json.Unmarshal(payload) error = %v", err)
+	}
+	if payload["manual"] != true || payload["issueNumber"] != float64(82) {
+		t.Fatalf("payload = %#v, want manual planner issue payload", payload)
+	}
+}
+
 func TestRuntimeStartConfiguresDefaultSchedulerTickAtStartup(t *testing.T) {
 	t.Parallel()
 

--- a/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
+++ b/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
@@ -542,7 +542,7 @@
           "prNumber": null,
           "status": "running",
           "configJson": null,
-          "metadataJson": "{\"issueNumber\":77}",
+          "metadataJson": "{\"issueNumber\":77,\"manual\":true}",
           "lastRunAt": null,
           "nextRunAt": "<generated-timestamp>",
           "createdAt": "<generated-timestamp>",


### PR DESCRIPTION
## Summary
- Mark manually-created planner loops and queue items with manual intent metadata.
- Skip assignment and `looper:plan` label eligibility checks only for manual planner queue processing.
- Preserve manual planner metadata during recovery and add regression coverage for manual bypass vs discovery skips.

## Validation
- gofmt
- go test ./...
- go vet ./...
- go build ./...

Closes #82