### PR TITLE
Fix worker dirty worktree reconciliation

### DIFF
--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -981,30 +981,67 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 	if err := r.persistCheckpoint(ctx, input.Run.ID, checkpoint); err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
-	if r.git != nil {
-		inspect, err := r.git.InspectHead(ctx, InspectHeadInput{WorktreePath: worktree.Path, BaseRef: firstNonEmpty(worktree.HeadSHA, worktree.BaseBranch)})
-		if err != nil {
-			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
-		}
-		if inspect.HasUncommittedChanges {
-			committed, err := r.git.Commit(ctx, CommitInput{WorktreePath: worktree.Path, Message: buildWorkerFallbackCommitMessage(work)})
-			if err != nil {
-				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
-			}
-			if committed.CommitSHA != "" {
-				checkpoint.Lifecycle.CommitSHAs = appendUniqueStrings(checkpoint.Lifecycle.CommitSHAs, committed.CommitSHA)
-			}
-			checkpoint.Lifecycle.Actions.Commit = lifecycle.ActionSourceFallback
-		} else if len(inspect.NewCommitSHAs) > 0 {
-			checkpoint.Lifecycle.CommitSHAs = appendUniqueStrings(checkpoint.Lifecycle.CommitSHAs, inspect.NewCommitSHAs...)
-			if checkpoint.Lifecycle.Actions.Commit == lifecycle.ActionSourceNone {
-				checkpoint.Lifecycle.Actions.Commit = lifecycle.ActionSourceAgent
-			}
-		}
+	if err := r.reconcileWorkerGitState(ctx, &checkpoint, work, worktree); err != nil {
+		return checkpoint, err
 	}
 	checkpoint.Execution.GitReconciled = true
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
+}
+
+func (r *Runner) reconcileWorkerGitState(ctx context.Context, checkpoint *workerCheckpoint, work workerInput, worktree checkpointWorktree) error {
+	checkpoint.ensureLifecycle("worker", worktree.Branch, worktree.BaseBranch, work.ExecutionMode == "create-pr")
+	if r.git == nil {
+		return nil
+	}
+	baseRef := firstNonEmpty(worktree.HeadSHA, worktree.BaseBranch)
+	inspect, err := r.git.InspectHead(ctx, InspectHeadInput{WorktreePath: worktree.Path, BaseRef: baseRef})
+	if err != nil {
+		checkpoint.Lifecycle.LastError = err.Error()
+		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if !inspect.HasUncommittedChanges {
+		checkpoint.Lifecycle.CommitSHAs = appendUniqueStrings(checkpoint.Lifecycle.CommitSHAs, inspect.NewCommitSHAs...)
+		if len(inspect.NewCommitSHAs) > 0 && checkpoint.Lifecycle.Actions.Commit == lifecycle.ActionSourceNone {
+			checkpoint.Lifecycle.Actions.Commit = lifecycle.ActionSourceAgent
+		}
+		checkpoint.Lifecycle.ReconciledAt = r.nowISO()
+		checkpoint.Lifecycle.ReconciledBy = "worker"
+		checkpoint.Lifecycle.LastError = ""
+		checkpoint.Lifecycle.Normalize()
+		return nil
+	}
+	if !r.allowAutoCommit {
+		message := fmt.Sprintf("Worker worktree has uncommitted changes before PR push for branch %s", firstNonEmpty(work.Branch, worktree.Branch))
+		checkpoint.Lifecycle.LastError = message
+		return &loopError{message: message, kind: FailureManualIntervention}
+	}
+	committed, err := r.git.Commit(ctx, CommitInput{WorktreePath: worktree.Path, Message: buildWorkerFallbackCommitMessage(work)})
+	if err != nil {
+		checkpoint.Lifecycle.LastError = err.Error()
+		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	finalInspect, err := r.git.InspectHead(ctx, InspectHeadInput{WorktreePath: worktree.Path, BaseRef: baseRef})
+	if err != nil {
+		checkpoint.Lifecycle.LastError = err.Error()
+		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if finalInspect.HasUncommittedChanges {
+		message := fmt.Sprintf("Worker fallback commit left uncommitted changes in branch %s", firstNonEmpty(work.Branch, worktree.Branch))
+		checkpoint.Lifecycle.LastError = message
+		return &loopError{message: message, kind: FailureManualIntervention}
+	}
+	checkpoint.Lifecycle.CommitSHAs = appendUniqueStrings(checkpoint.Lifecycle.CommitSHAs, inspect.NewCommitSHAs...)
+	checkpoint.Lifecycle.CommitSHAs = appendUniqueStrings(checkpoint.Lifecycle.CommitSHAs, finalInspect.NewCommitSHAs...)
+	if committed.CommitSHA != "" {
+		checkpoint.Lifecycle.CommitSHAs = appendUniqueStrings(checkpoint.Lifecycle.CommitSHAs, committed.CommitSHA)
+	}
+	checkpoint.Lifecycle.Actions.Commit = lifecycle.ActionSourceFallback
+	checkpoint.Lifecycle.ReconciledAt = r.nowISO()
+	checkpoint.Lifecycle.ReconciledBy = "worker"
+	checkpoint.Lifecycle.LastError = ""
+	checkpoint.Lifecycle.Normalize()
+	return nil
 }
 
 func (r *Runner) runValidateStep(ctx context.Context, input stepInput) (workerCheckpoint, error) {
@@ -1028,19 +1065,39 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 	if err != nil {
 		return checkpoint, err
 	}
-	if work.ExecutionMode == "create-pr" && (checkpoint.PullRequest != nil || input.Loop.PRNumber != nil) {
-		if checkpoint.PullRequest == nil {
-			checkpoint.PullRequest = &checkpointPullPR{Number: derefInt64(input.Loop.PRNumber), URL: stringFromAnyDefault(parseJSONObject(input.Loop.MetadataJSON)["prUrl"])}
-		}
-		r.syncIssueClaim(ctx, input, &checkpoint, issueClaimStatusPRLinked, "")
-		return checkpoint, nil
-	}
 	if checkpoint.Validation != nil && !checkpoint.Validation.Passed {
 		return checkpoint, &loopError{message: firstNonEmpty(checkpoint.Validation.Summary, "Validation failed"), kind: FailureManualIntervention}
 	}
 	worktree, err := requireWorktree(checkpoint)
 	if err != nil {
 		return checkpoint, err
+	}
+	if err := r.reconcileWorkerGitState(ctx, &checkpoint, work, worktree); err != nil {
+		return checkpoint, err
+	}
+	if err := r.persistCheckpoint(ctx, input.Run.ID, checkpoint); err != nil {
+		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if work.ExecutionMode == "create-pr" && (checkpoint.PullRequest != nil || input.Loop.PRNumber != nil) {
+		if checkpoint.PullRequest == nil {
+			checkpoint.PullRequest = &checkpointPullPR{Number: derefInt64(input.Loop.PRNumber), URL: stringFromAnyDefault(parseJSONObject(input.Loop.MetadataJSON)["prUrl"])}
+		}
+		pushedByFallback := false
+		if !checkpoint.Lifecycle.Pushed {
+			if !r.allowAutoPush {
+				checkpoint.SkipReason = fmt.Sprintf("Auto push disabled; manual PR opening required for worker %s", input.Loop.ID)
+				checkpoint.ResumePolicy = "manual_intervention"
+				return checkpoint, nil
+			}
+			if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
+				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+			}
+			pushedByFallback = true
+		}
+		checkpoint.markLifecyclePushAndPR(worktree.Branch, work.BaseBranch, checkpoint.PullRequest.Number, checkpoint.PullRequest.URL, pushedByFallback, input.Loop.PRNumber != nil)
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		r.syncIssueClaim(ctx, input, &checkpoint, issueClaimStatusPRLinked, "")
+		return checkpoint, nil
 	}
 	if work.ExecutionMode == "push-existing" {
 		if !r.allowAutoPush {
@@ -1868,7 +1925,7 @@ func (c *workerCheckpoint) markLifecyclePushAndPR(branch, baseBranch string, prN
 	if adopted {
 		c.Lifecycle.PRAdopted = true
 	}
-	if prNumber > 0 || prURL != "" {
+	if (prNumber > 0 || prURL != "") && c.Lifecycle.Actions.PR == lifecycle.ActionSourceNone {
 		c.Lifecycle.Actions.PR = lifecycle.ActionSourceFallback
 	}
 	c.Lifecycle.Normalize()

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1036,6 +1036,8 @@ func (r *Runner) reconcileWorkerGitState(ctx context.Context, checkpoint *worker
 	if committed.CommitSHA != "" {
 		checkpoint.Lifecycle.CommitSHAs = appendUniqueStrings(checkpoint.Lifecycle.CommitSHAs, committed.CommitSHA)
 	}
+	checkpoint.Lifecycle.Pushed = false
+	checkpoint.Lifecycle.Actions.Push = lifecycle.ActionSourceNone
 	checkpoint.Lifecycle.Actions.Commit = lifecycle.ActionSourceFallback
 	checkpoint.Lifecycle.ReconciledAt = r.nowISO()
 	checkpoint.Lifecycle.ReconciledBy = "worker"

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/powerformer/looper/internal/config"
+	"github.com/powerformer/looper/internal/lifecycle"
 	"github.com/powerformer/looper/internal/storage"
 )
 
@@ -1571,6 +1572,64 @@ func TestProcessClaimedItemExecuteResumeDoesNotRerunAgentAfterTransientInspectFa
 	}
 }
 
+func TestProcessClaimedItemPushExistingReconcilesDirtyWorktreeBeforePush(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	loopMeta := `{"worker":{"repo":"acme/looper","baseBranch":"main","specPath":"docs/spec.md"},"prUrl":"https://example/pr/42"}`
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_pr", Seq: 2, ProjectID: "project_1", Type: "worker", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "queued", MetadataJSON: &loopMeta, NextRunAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	loopID := "loop_worker_pr"
+	payload := `{"repo":"acme/looper","baseBranch":"main","specPath":"docs/spec.md"}`
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_pr", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "pull_request", TargetID: loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "worker:acme/looper:42", Priority: 1, Status: "queued", AvailableAt: nowISO, MaxAttempts: 3, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	git := &fakeGitGateway{
+		createResult:  CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/pr-42", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"},
+		prepareResult: PrepareWorktreeResult{HeadSHA: "abc123", Clean: true},
+		inspectResults: []InspectHeadResult{
+			{HeadSHA: "abc123"},
+			{HeadSHA: "abc123", HasUncommittedChanges: true, ChangedFiles: []string{"internal/worker/runner.go", "internal/lifecycle/lifecycle.go"}},
+			{HeadSHA: "fallback123", NewCommitSHAs: []string{"fallback123"}},
+		},
+		commitResult: CommitResult{CommitSHA: "fallback123"},
+	}
+	github := &fakeGitHubGateway{prDetail: PullRequestDetail{Number: 42, Title: "Existing PR", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123", URL: "https://example/pr/42"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	claim, _ = fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-2", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" || result.PullRequestNumber != 42 {
+		t.Fatalf("result = %#v, want success with existing PR", result)
+	}
+	if len(git.commitCalls) != 1 {
+		t.Fatalf("len(git.commitCalls) = %d, want fallback commit before push", len(git.commitCalls))
+	}
+	if len(git.pushCalls) != 1 {
+		t.Fatalf("len(git.pushCalls) = %d, want push after fallback commit", len(git.pushCalls))
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
+	if err != nil || run == nil {
+		t.Fatalf("Runs.GetByID() = (%#v, %v), want run", run, err)
+	}
+	checkpoint, err := parseCheckpoint(run.CheckpointJSON)
+	if err != nil {
+		t.Fatalf("parseCheckpoint() error = %v", err)
+	}
+	if checkpoint.Lifecycle == nil || checkpoint.Lifecycle.Actions.Commit != lifecycle.ActionSourceFallback || !checkpoint.Lifecycle.Pushed || checkpoint.Lifecycle.Actions.Push != lifecycle.ActionSourceFallback {
+		t.Fatalf("lifecycle = %#v, want fallback commit and push recorded", checkpoint.Lifecycle)
+	}
+}
+
 type runnerFixture struct {
 	coordinator *storage.SQLiteCoordinator
 	repos       *storage.Repositories
@@ -1714,19 +1773,20 @@ func (f *fakeGitHubGateway) AddPullRequestReviewers(_ context.Context, input Pul
 }
 
 type fakeGitGateway struct {
-	createResult  CreateWorktreeResult
-	prepareResult PrepareWorktreeResult
-	inspectResult InspectHeadResult
-	inspectErrors []error
-	inspectIndex  int
-	commitResult  CommitResult
-	createCalls   []CreateWorktreeInput
-	pushCalls     []PushInput
-	prepareCalls  []PrepareWorktreeInput
-	inspectCalls  []InspectHeadInput
-	commitCalls   []CommitInput
-	pushErrors    []error
-	pushIndex     int
+	createResult   CreateWorktreeResult
+	prepareResult  PrepareWorktreeResult
+	inspectResult  InspectHeadResult
+	inspectResults []InspectHeadResult
+	inspectErrors  []error
+	inspectIndex   int
+	commitResult   CommitResult
+	createCalls    []CreateWorktreeInput
+	pushCalls      []PushInput
+	prepareCalls   []PrepareWorktreeInput
+	inspectCalls   []InspectHeadInput
+	commitCalls    []CommitInput
+	pushErrors     []error
+	pushIndex      int
 }
 
 func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeInput) (CreateWorktreeResult, error) {
@@ -1748,6 +1808,11 @@ func (f *fakeGitGateway) InspectHead(_ context.Context, input InspectHeadInput) 
 		err := f.inspectErrors[f.inspectIndex]
 		f.inspectIndex++
 		return InspectHeadResult{}, err
+	}
+	if f.inspectIndex < len(f.inspectResults) {
+		result := f.inspectResults[f.inspectIndex]
+		f.inspectIndex++
+		return result, nil
 	}
 	f.inspectIndex++
 	return f.inspectResult, nil

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1630,6 +1630,76 @@ func TestProcessClaimedItemPushExistingReconcilesDirtyWorktreeBeforePush(t *test
 	}
 }
 
+func TestRunOpenPRStepPushesWhenFallbackCommitCreatedAndLifecycleAlreadyPushed(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+
+	prNumber := int64(555)
+	now := fixture.nowISO()
+	loopID := "loop_worker_pr_fallback"
+	loopTarget := "pr:acme/looper:555"
+	loopMeta := `{"worker":{"repo":"acme/looper","baseBranch":"main","baseSha":"abc123"},"prUrl":"https://example.com/pulls/555"}`
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 2, ProjectID: "project_1", Type: "worker", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "queued", MetadataJSON: &loopMeta, NextRunAt: &now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	checkpoint := workerCheckpoint{
+		Work:       &workerInput{Title: "Existing PR fallback regression", ExecutionMode: "create-pr", Repo: "acme/looper", BaseBranch: "main", PRNumber: prNumber, Branch: "feature/pr-555", IssueNumber: 0},
+		Worktree:   &checkpointWorktree{Path: filepath.Join(t.TempDir(), "wt"), Branch: "feature/pr-555", BaseBranch: "main", HeadSHA: "abc123", ID: "worktree_555"},
+		Validation: &ValidationResult{Passed: true, Summary: "ok"},
+		Lifecycle: &lifecycle.State{
+			Policy:        lifecycle.PolicyAgentManagedWithFallback,
+			PolicyVersion: lifecycle.PolicyVersion,
+			Branch:        "feature/pr-555",
+			BaseBranch:    "main",
+			Pushed:        true,
+			Actions:       lifecycle.Actions{Push: lifecycle.ActionSourceAgent},
+		},
+	}
+	runID := "run_openpr_regression"
+	checkpointJSON := mustMarshalJSON(checkpoint)
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: runID, LoopID: loopID, Status: "failed", CurrentStep: stringPtr(string(stepOpenPR)), LastCompletedStep: stringPtr(string(stepOpenPR)), CheckpointJSON: &checkpointJSON, StartedAt: now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	git := &fakeGitGateway{
+		inspectResults: []InspectHeadResult{
+			{HeadSHA: "abc123", HasUncommittedChanges: true, ChangedFiles: []string{"internal/worker/runner.go", "internal/lifecycle/lifecycle.go"}},
+			{HeadSHA: "fallback123", NewCommitSHAs: []string{"fallback123"}},
+		},
+		commitResult: CommitResult{CommitSHA: "fallback123"},
+	}
+
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), runID)
+	if err != nil || run == nil {
+		t.Fatalf("Runs.GetByID() = (%#v, %v), want run", run, err)
+	}
+
+	checkpointAfter, err := runner.runOpenPRStep(context.Background(), stepInput{Project: *project, Loop: *loop, Run: *run, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runOpenPRStep() error = %v", err)
+	}
+	if len(git.commitCalls) != 1 {
+		t.Fatalf("len(git.commitCalls) = %d, want 1", len(git.commitCalls))
+	}
+	if len(git.pushCalls) != 1 {
+		t.Fatalf("len(git.pushCalls) = %d, want 1", len(git.pushCalls))
+	}
+	if checkpointAfter.Lifecycle == nil || !checkpointAfter.Lifecycle.Pushed || checkpointAfter.Lifecycle.Actions.Commit != lifecycle.ActionSourceFallback || checkpointAfter.Lifecycle.Actions.Push != lifecycle.ActionSourceFallback {
+		t.Fatalf("updated lifecycle = %#v, want fallback actions and pushed", checkpointAfter.Lifecycle)
+	}
+}
+
 type runnerFixture struct {
 	coordinator *storage.SQLiteCoordinator
 	repos       *storage.Repositories


### PR DESCRIPTION
## Summary
- Reconcile worker git state again immediately before PR/push handling, including push-existing mode.
- Create a fallback commit for remaining dirty worktree changes when allowed, otherwise stop for manual intervention.
- Persist lifecycle reconciliation metadata and cover the push-existing dirty-worktree path with a regression test.

## Validation
- go test ./internal/worker
- go test ./...
- go vet ./...
- go build ./...

Closes #85