### PR TITLE
Rename spec PRs after worker takeover

### DIFF
--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -162,6 +163,13 @@ type CreatePullRequestInput struct {
 type CreatePullRequestResult struct {
 	Number int64
 	URL    string
+}
+
+type UpdatePullRequestTitleInput struct {
+	Repo     string
+	PRNumber int64
+	Title    string
+	CWD      string
 }
 
 type ListOpenPullRequestsInput struct {
@@ -558,6 +566,11 @@ func (g *Gateway) CreatePullRequest(ctx context.Context, input CreatePullRequest
 		return CreatePullRequestResult{}, &shell.CommandExecutionError{Message: "gh pr create returned an empty URL", Result: result}
 	}
 	return CreatePullRequestResult{Number: parsePRNumberFromURL(prURL), URL: prURL}, nil
+}
+
+func (g *Gateway) UpdatePullRequestTitle(ctx context.Context, input UpdatePullRequestTitleInput) error {
+	_, err := g.runGh(ctx, input.CWD, "", "pr", "edit", strconv.FormatInt(input.PRNumber, 10), "--repo", input.Repo, "--title", input.Title)
+	return err
 }
 
 func (g *Gateway) IsAuthenticated(ctx context.Context, cwd, hostname string) (bool, error) {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -59,6 +59,8 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 			return shell.Result{Stdout: "{}"}, nil
 		case args == "pr create --repo acme/looper --head feature --base main --title Add support --body Body":
 			return shell.Result{Stdout: "https://example.test/pull/88\n"}, nil
+		case args == "pr edit 42 --repo acme/looper --title Implement support":
+			return shell.Result{Stdout: ""}, nil
 		default:
 			t.Fatalf("unexpected gh args: %q", args)
 			return shell.Result{}, nil
@@ -119,6 +121,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	created, err := gateway.CreatePullRequest(context.Background(), CreatePullRequestInput{Repo: "acme/looper", HeadBranch: "feature", BaseBranch: "main", Title: "Add support", Body: "Body"})
 	if err != nil {
 		t.Fatalf("CreatePullRequest() error = %v", err)
+	}
+	if err := gateway.UpdatePullRequestTitle(context.Background(), UpdatePullRequestTitleInput{Repo: "acme/looper", PRNumber: 42, Title: "Implement support"}); err != nil {
+		t.Fatalf("UpdatePullRequestTitle() error = %v", err)
 	}
 	detail, err := gateway.ViewPullRequest(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42})
 	if err != nil {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -454,6 +454,10 @@ func (a workerGitHubAdapter) CreatePullRequest(ctx context.Context, input worker
 	return worker.CreatePullRequestResult{Number: pr.Number, URL: pr.URL}, nil
 }
 
+func (a workerGitHubAdapter) UpdatePullRequestTitle(ctx context.Context, input worker.UpdatePullRequestTitleInput) error {
+	return a.gateway.UpdatePullRequestTitle(ctx, githubinfra.UpdatePullRequestTitleInput{Repo: input.Repo, PRNumber: input.PRNumber, Title: input.Title, CWD: input.CWD})
+}
+
 func (a workerGitHubAdapter) RemovePullRequestLabels(ctx context.Context, input worker.PullRequestLabelsInput) error {
 	return a.gateway.RemovePullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: input.Repo, PRNumber: input.PRNumber, Labels: input.Labels, CWD: input.CWD})
 }

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1897,14 +1897,17 @@ func buildWorkerFallbackCommitMessage(work workerInput) string {
 }
 
 func (r *Runner) renamePlannerSpecPullRequestAfterTakeover(ctx context.Context, work workerInput, cwd string) error {
-	if r.github == nil || work.ExecutionMode != "push-existing" || work.PRNumber <= 0 || !isPlannerSpecPullRequestTitle(work.PRTitle) {
+	if r.github == nil || work.ExecutionMode != "push-existing" || work.PRNumber <= 0 {
 		return nil
 	}
 	current, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: work.Repo, PRNumber: work.PRNumber, CWD: cwd})
 	if err != nil {
 		return err
 	}
-	if !isPlannerSpecPullRequestTitle(current.Title) || strings.TrimSpace(current.Title) != strings.TrimSpace(work.PRTitle) {
+	if !isPlannerSpecPullRequestTitle(current.Title) {
+		return nil
+	}
+	if work.PRTitle != "" && strings.TrimSpace(current.Title) != strings.TrimSpace(work.PRTitle) {
 		return nil
 	}
 	work.PRTitle = current.Title

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -124,6 +124,13 @@ type CreatePullRequestResult struct {
 	URL    string
 }
 
+type UpdatePullRequestTitleInput struct {
+	Repo     string
+	PRNumber int64
+	Title    string
+	CWD      string
+}
+
 type PullRequestLabelsInput struct {
 	Repo     string
 	PRNumber int64
@@ -164,6 +171,7 @@ type GitHubGateway interface {
 	CreateIssueComment(context.Context, IssueCommentInput) (IssueCommentResult, error)
 	UpdateIssueComment(context.Context, UpdateIssueCommentInput) error
 	CreatePullRequest(context.Context, CreatePullRequestInput) (CreatePullRequestResult, error)
+	UpdatePullRequestTitle(context.Context, UpdatePullRequestTitleInput) error
 	RemovePullRequestLabels(context.Context, PullRequestLabelsInput) error
 	AddPullRequestReviewers(context.Context, PullRequestReviewersInput) error
 }
@@ -371,6 +379,7 @@ type workerInput struct {
 	IssueNumber   int64    `json:"issueNumber,omitempty"`
 	IssueURL      string   `json:"issueUrl,omitempty"`
 	PRNumber      int64    `json:"prNumber,omitempty"`
+	PRTitle       string   `json:"prTitle,omitempty"`
 	Branch        string   `json:"branch,omitempty"`
 	HeadSHA       string   `json:"headSha,omitempty"`
 	Reviewers     []string `json:"reviewers,omitempty"`
@@ -1051,6 +1060,9 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: firstNonEmpty(work.Branch, worktree.Branch), ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
+		if err := r.renamePlannerSpecPullRequestAfterTakeover(ctx, work, input.Project.RepoPath); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
 		if len(work.Reviewers) > 0 && work.PRNumber > 0 && r.github != nil {
 			_ = r.github.AddPullRequestReviewers(ctx, PullRequestReviewersInput{Repo: work.Repo, PRNumber: work.PRNumber, Reviewers: append([]string(nil), work.Reviewers...), CWD: input.Project.RepoPath})
 		}
@@ -1185,7 +1197,7 @@ func (r *Runner) resolveWorkerInput(ctx context.Context, project storage.Project
 		if err != nil {
 			return workerInput{}, err
 		}
-		work.Title = firstNonEmpty(detail.Title, work.Title)
+		work.PRTitle = detail.Title
 		work.Repo = repo
 		work.PRNumber = prNumber
 		work.BaseBranch = firstNonEmpty(detail.BaseRefName, work.BaseBranch)
@@ -1886,6 +1898,47 @@ func buildWorkerFallbackCommitMessage(work workerInput) string {
 	return fmt.Sprintf("worker: %s", title)
 }
 
+func (r *Runner) renamePlannerSpecPullRequestAfterTakeover(ctx context.Context, work workerInput, cwd string) error {
+	if r.github == nil || work.ExecutionMode != "push-existing" || work.PRNumber <= 0 || !isPlannerSpecPullRequestTitle(work.PRTitle) {
+		return nil
+	}
+	current, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: work.Repo, PRNumber: work.PRNumber, CWD: cwd})
+	if err != nil {
+		return err
+	}
+	if !isPlannerSpecPullRequestTitle(current.Title) {
+		return nil
+	}
+	work.PRTitle = current.Title
+	title := implementationPullRequestTitle(work)
+	if title == "" || title == strings.TrimSpace(current.Title) {
+		return nil
+	}
+	return r.github.UpdatePullRequestTitle(ctx, UpdatePullRequestTitleInput{Repo: work.Repo, PRNumber: work.PRNumber, Title: title, CWD: cwd})
+}
+
+func isPlannerSpecPullRequestTitle(title string) bool {
+	title = strings.TrimSpace(title)
+	return strings.HasPrefix(strings.ToLower(title), "spec:")
+}
+
+func implementationPullRequestTitle(work workerInput) string {
+	title := strings.TrimSpace(work.Title)
+	if title != "" && !isPlannerSpecPullRequestTitle(title) && title != "Worker run" {
+		return title
+	}
+	prTitle := strings.TrimSpace(work.PRTitle)
+	if len(prTitle) >= len("Spec:") && strings.EqualFold(prTitle[:len("Spec:")], "Spec:") {
+		if stripped := strings.TrimSpace(prTitle[len("Spec:"):]); stripped != "" {
+			return stripped
+		}
+	}
+	if stripped := strings.TrimSpace(strings.TrimPrefix(prTitle, "Spec:")); stripped != "" {
+		return stripped
+	}
+	return title
+}
+
 func buildWorkerPrompt(repoRootPath string, work workerInput, plan *checkpointPlan, allowAgentPRCreation bool) (string, error) {
 	parts := []string{}
 	if work.ExecutionMode == "push-existing" {
@@ -1939,6 +1992,9 @@ func buildAgentPullRequestInstruction(work workerInput) string {
 	}
 	if work.IssueNumber > 0 {
 		parts = append(parts, fmt.Sprintf("Include `Closes %s` in the PR body.", formatIssueClosingReference(work.Repo, work.IssueRepo, work.IssueNumber)))
+	}
+	if work.ExecutionMode == "push-existing" {
+		parts = append(parts, "If the existing PR title still has the planner/spec-generated `Spec: ...` format after implementation is pushed, rename it to an implementation-oriented title; preserve human-edited titles.")
 	}
 	return strings.Join(parts, "\n")
 }

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1060,9 +1060,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: firstNonEmpty(work.Branch, worktree.Branch), ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
-		if err := r.renamePlannerSpecPullRequestAfterTakeover(ctx, work, input.Project.RepoPath); err != nil {
-			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
-		}
+		_ = r.renamePlannerSpecPullRequestAfterTakeover(ctx, work, input.Project.RepoPath)
 		if len(work.Reviewers) > 0 && work.PRNumber > 0 && r.github != nil {
 			_ = r.github.AddPullRequestReviewers(ctx, PullRequestReviewersInput{Repo: work.Repo, PRNumber: work.PRNumber, Reviewers: append([]string(nil), work.Reviewers...), CWD: input.Project.RepoPath})
 		}
@@ -1906,7 +1904,7 @@ func (r *Runner) renamePlannerSpecPullRequestAfterTakeover(ctx context.Context, 
 	if err != nil {
 		return err
 	}
-	if !isPlannerSpecPullRequestTitle(current.Title) {
+	if !isPlannerSpecPullRequestTitle(current.Title) || strings.TrimSpace(current.Title) != strings.TrimSpace(work.PRTitle) {
 		return nil
 	}
 	work.PRTitle = current.Title

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1482,9 +1482,10 @@ func TestProcessClaimedItemPreservesPRTitleEditedDuringTakeover(t *testing.T) {
 		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/pr-42", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	humanEditedTitle := "Spec: Revised login flow"
 	github := &fakeGitHubGateway{prDetailResponses: []PullRequestDetail{
 		{Number: 42, Title: "Spec: Add login flow", Body: "## Summary\n\nSpec: specs/login/spec.md", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123"},
-		{Number: 42, Title: "Human edit while worker runs", Body: "## Summary\n\nSpec: specs/login/spec.md", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123"},
+		{Number: 42, Title: humanEditedTitle, Body: "## Summary\n\nSpec: specs/login/spec.md", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123"},
 	}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
 
@@ -1502,6 +1503,43 @@ func TestProcessClaimedItemPreservesPRTitleEditedDuringTakeover(t *testing.T) {
 	}
 	if len(github.updatePRTitleCalls) != 0 {
 		t.Fatalf("len(github.updatePRTitleCalls) = %d, want 0", len(github.updatePRTitleCalls))
+	}
+}
+
+func TestProcessClaimedItemIgnoresUpdatePRTitleErrorsDuringPushExistingTakeover(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	loopMeta := `{"worker":{"title":"Implement login flow","repo":"acme/looper","baseBranch":"main"}}`
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_pr", Seq: 2, ProjectID: "project_1", Type: "worker", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "queued", MetadataJSON: &loopMeta, NextRunAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	loopID := "loop_worker_pr"
+	payload := `{"title":"Implement login flow","repo":"acme/looper","baseBranch":"main"}`
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_pr", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "pull_request", TargetID: loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "worker:acme/looper:42", Priority: 1, Status: "queued", AvailableAt: nowISO, MaxAttempts: 3, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/pr-42", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{prDetail: PullRequestDetail{Number: 42, Title: "Spec: Add login flow", Body: "## Summary\n\nSpec: specs/login/spec.md", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123"}, updatePRTitleErrors: []error{errors.New("title update blocked")}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	claim, _ = fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-2", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" || result.PullRequestNumber != 42 {
+		t.Fatalf("result = %#v, want success with PR 42", result)
+	}
+	if len(github.updatePRTitleCalls) != 1 {
+		t.Fatalf("len(github.updatePRTitleCalls) = %d, want 1", len(github.updatePRTitleCalls))
+	}
+	if got := github.updatePRTitleCalls[0].Title; got != "Implement login flow" {
+		t.Fatalf("updated title = %q, want worker title", got)
 	}
 }
 
@@ -1782,6 +1820,8 @@ type fakeGitHubGateway struct {
 	createPRErrors          []error
 	createPRCalls           []CreatePullRequestInput
 	updatePRTitleCalls      []UpdatePullRequestTitleInput
+	updatePRTitleErrors     []error
+	updatePRTitleIndex      int
 	removeLabels            []PullRequestLabelsInput
 	reviewerCalls           []PullRequestReviewersInput
 	createPRIndex           int
@@ -1859,6 +1899,11 @@ func (f *fakeGitHubGateway) CreatePullRequest(_ context.Context, input CreatePul
 
 func (f *fakeGitHubGateway) UpdatePullRequestTitle(_ context.Context, input UpdatePullRequestTitleInput) error {
 	f.updatePRTitleCalls = append(f.updatePRTitleCalls, input)
+	if f.updatePRTitleIndex < len(f.updatePRTitleErrors) {
+		err := f.updatePRTitleErrors[f.updatePRTitleIndex]
+		f.updatePRTitleIndex++
+		return err
+	}
 	return nil
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1394,6 +1394,151 @@ func TestProcessClaimedItemPullRequestLoopRequiresSpecPath(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemRenamesPlannerSpecPRAfterPushExistingTakeover(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	loopMeta := `{"worker":{"title":"Implement login flow","repo":"acme/looper","baseBranch":"main"}}`
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_pr", Seq: 2, ProjectID: "project_1", Type: "worker", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "queued", MetadataJSON: &loopMeta, NextRunAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	loopID := "loop_worker_pr"
+	payload := `{"title":"Implement login flow","repo":"acme/looper","baseBranch":"main"}`
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_pr", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "pull_request", TargetID: loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "worker:acme/looper:42", Priority: 1, Status: "queued", AvailableAt: nowISO, MaxAttempts: 3, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/pr-42", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{prDetail: PullRequestDetail{Number: 42, Title: "Spec: Add login flow", Body: "## Summary\n\nSpec: specs/login/spec.md", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	claim, _ = fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-2", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" || result.PullRequestNumber != 42 {
+		t.Fatalf("result = %#v, want success with PR 42", result)
+	}
+	if len(github.updatePRTitleCalls) != 1 {
+		t.Fatalf("len(github.updatePRTitleCalls) = %d, want 1", len(github.updatePRTitleCalls))
+	}
+	if got := github.updatePRTitleCalls[0].Title; got != "Implement login flow" {
+		t.Fatalf("updated title = %q, want worker title", got)
+	}
+}
+
+func TestProcessClaimedItemPreservesHumanEditedPRAfterPushExistingTakeover(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	loopMeta := `{"worker":{"title":"Implement login flow","repo":"acme/looper","baseBranch":"main"}}`
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_pr", Seq: 2, ProjectID: "project_1", Type: "worker", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "queued", MetadataJSON: &loopMeta, NextRunAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	loopID := "loop_worker_pr"
+	payload := `{"title":"Implement login flow","repo":"acme/looper","baseBranch":"main"}`
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_pr", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "pull_request", TargetID: loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "worker:acme/looper:42", Priority: 1, Status: "queued", AvailableAt: nowISO, MaxAttempts: 3, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/pr-42", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{prDetail: PullRequestDetail{Number: 42, Title: "Human-written implementation title", Body: "## Summary\n\nSpec: specs/login/spec.md", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	claim, _ = fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-2", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" || result.PullRequestNumber != 42 {
+		t.Fatalf("result = %#v, want success with PR 42", result)
+	}
+	if len(github.updatePRTitleCalls) != 0 {
+		t.Fatalf("len(github.updatePRTitleCalls) = %d, want 0", len(github.updatePRTitleCalls))
+	}
+}
+
+func TestProcessClaimedItemPreservesPRTitleEditedDuringTakeover(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	loopMeta := `{"worker":{"title":"Implement login flow","repo":"acme/looper","baseBranch":"main"}}`
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_pr", Seq: 2, ProjectID: "project_1", Type: "worker", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "queued", MetadataJSON: &loopMeta, NextRunAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	loopID := "loop_worker_pr"
+	payload := `{"title":"Implement login flow","repo":"acme/looper","baseBranch":"main"}`
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_pr", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "pull_request", TargetID: loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "worker:acme/looper:42", Priority: 1, Status: "queued", AvailableAt: nowISO, MaxAttempts: 3, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/pr-42", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{prDetailResponses: []PullRequestDetail{
+		{Number: 42, Title: "Spec: Add login flow", Body: "## Summary\n\nSpec: specs/login/spec.md", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123"},
+		{Number: 42, Title: "Human edit while worker runs", Body: "## Summary\n\nSpec: specs/login/spec.md", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123"},
+	}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	claim, _ = fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-2", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" || result.PullRequestNumber != 42 {
+		t.Fatalf("result = %#v, want success with PR 42", result)
+	}
+	if len(github.viewPRCalls) != 2 {
+		t.Fatalf("len(github.viewPRCalls) = %d, want re-fetch before rename", len(github.viewPRCalls))
+	}
+	if len(github.updatePRTitleCalls) != 0 {
+		t.Fatalf("len(github.updatePRTitleCalls) = %d, want 0", len(github.updatePRTitleCalls))
+	}
+}
+
+func TestProcessClaimedItemDoesNotRenamePlannerSpecPRWhenPushFails(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	loopMeta := `{"worker":{"title":"Implement login flow","repo":"acme/looper","baseBranch":"main"}}`
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_pr", Seq: 2, ProjectID: "project_1", Type: "worker", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "queued", MetadataJSON: &loopMeta, NextRunAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	loopID := "loop_worker_pr"
+	payload := `{"title":"Implement login flow","repo":"acme/looper","baseBranch":"main"}`
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_pr", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "pull_request", TargetID: loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "worker:acme/looper:42", Priority: 1, Status: "queued", AvailableAt: nowISO, MaxAttempts: 3, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/pr-42", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}, pushErrors: []error{errors.New("push failed")}}
+	github := &fakeGitHubGateway{prDetail: PullRequestDetail{Number: 42, Title: "Spec: Add login flow", Body: "## Summary\n\nSpec: specs/login/spec.md", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	claim, _ = fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-2", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume {
+		t.Fatalf("result = %#v, want retryable failure", result)
+	}
+	if len(github.updatePRTitleCalls) != 0 {
+		t.Fatalf("len(github.updatePRTitleCalls) = %d, want 0", len(github.updatePRTitleCalls))
+	}
+}
+
 func TestProcessClaimedItemFindsExistingPRAfterPush(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -1625,7 +1770,10 @@ type fakeGitHubGateway struct {
 	openPRResponses         [][]PullRequestSummary
 	openPRIndex             int
 	prDetail                PullRequestDetail
+	prDetailResponses       []PullRequestDetail
+	viewPRIndex             int
 	issueDetail             IssueDetail
+	viewPRCalls             []ViewPullRequestInput
 	viewIssueCalls          []ViewIssueInput
 	createIssueCommentCalls []IssueCommentInput
 	updateIssueCommentCalls []UpdateIssueCommentInput
@@ -1633,6 +1781,7 @@ type fakeGitHubGateway struct {
 	createPRResult          CreatePullRequestResult
 	createPRErrors          []error
 	createPRCalls           []CreatePullRequestInput
+	updatePRTitleCalls      []UpdatePullRequestTitleInput
 	removeLabels            []PullRequestLabelsInput
 	reviewerCalls           []PullRequestReviewersInput
 	createPRIndex           int
@@ -1648,7 +1797,12 @@ func (f *fakeGitHubGateway) ListOpenPullRequests(context.Context, ListOpenPullRe
 }
 
 func (f *fakeGitHubGateway) ViewPullRequest(_ context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
+	f.viewPRCalls = append(f.viewPRCalls, input)
 	detail := f.prDetail
+	if f.viewPRIndex < len(f.prDetailResponses) {
+		detail = f.prDetailResponses[f.viewPRIndex]
+	}
+	f.viewPRIndex++
 	if detail.Number == 0 {
 		detail.Number = input.PRNumber
 	}
@@ -1701,6 +1855,11 @@ func (f *fakeGitHubGateway) CreatePullRequest(_ context.Context, input CreatePul
 	}
 	f.createPRIndex++
 	return f.createPRResult, nil
+}
+
+func (f *fakeGitHubGateway) UpdatePullRequestTitle(_ context.Context, input UpdatePullRequestTitleInput) error {
+	f.updatePRTitleCalls = append(f.updatePRTitleCalls, input)
+	return nil
 }
 
 func (f *fakeGitHubGateway) RemovePullRequestLabels(_ context.Context, input PullRequestLabelsInput) error {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1431,6 +1431,26 @@ func TestProcessClaimedItemRenamesPlannerSpecPRAfterPushExistingTakeover(t *test
 	}
 }
 
+func TestRenamePlannerSpecPullRequestAfterTakeoverBackfillsMissingCheckpointTitle(t *testing.T) {
+	t.Parallel()
+	github := &fakeGitHubGateway{prDetail: PullRequestDetail{Number: 42, Title: "Spec: Add login flow", BaseRefName: "main", HeadRefName: "feature/pr-42", HeadSHA: "abc123"}}
+	runner := New(Options{GitHub: github})
+	work := workerInput{Title: "Implement login flow", Repo: "acme/looper", BaseBranch: "main", ExecutionMode: "push-existing", PRNumber: 42}
+
+	if err := runner.renamePlannerSpecPullRequestAfterTakeover(context.Background(), work, ""); err != nil {
+		t.Fatalf("renamePlannerSpecPullRequestAfterTakeover() error = %v", err)
+	}
+	if len(github.viewPRCalls) != 1 {
+		t.Fatalf("len(github.viewPRCalls) = %d, want 1", len(github.viewPRCalls))
+	}
+	if len(github.updatePRTitleCalls) != 1 {
+		t.Fatalf("len(github.updatePRTitleCalls) = %d, want 1", len(github.updatePRTitleCalls))
+	}
+	if got := github.updatePRTitleCalls[0].Title; got != "Implement login flow" {
+		t.Fatalf("updated title = %q, want worker title", got)
+	}
+}
+
 func TestProcessClaimedItemPreservesHumanEditedPRAfterPushExistingTakeover(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)


### PR DESCRIPTION
## Summary
- Rename planner-created `Spec: ...` PR titles after worker push-existing takeover succeeds.
- Preserve human-edited PR titles by re-checking the current title before editing.
- Add worker and GitHub gateway tests for title updates, human edits, and push failures.

## Validation
- `go vet ./...`
- `go test ./...`
- `go build ./...`

Closes #86