### PR TITLE
Support removing projects from the CLI

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1200,7 +1200,7 @@ func (h *Handler) buildProjectRouteResponse(r *http.Request, path string) (any, 
 		}
 	}
 
-	identifier, err := decodeProjectIdentifier(path)
+	identifier, err := decodeProjectIdentifier(normalizePath(r.URL.EscapedPath()))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -271,6 +271,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if strings.HasPrefix(path, apiBasePath+"/projects/") {
+		payload, err := h.buildProjectRouteResponse(r, path)
+		if err != nil {
+			var typed apiError
+			if !asAPIError(err, &typed) {
+				typed = internalServerError(err)
+			}
+			h.writeError(w, requestID, typed)
+			return
+		}
+
+		h.writeSuccess(w, requestID, payload)
+		return
+	}
+
 	if strings.HasPrefix(path, apiBasePath+"/events/") {
 		payload, err := h.buildEntityEventsRouteResponse(r, path)
 		if err != nil {
@@ -1127,6 +1142,7 @@ type stopLoopResponse struct {
 type projectService interface {
 	List(context.Context) ([]storage.ProjectRecord, error)
 	AddProject(context.Context, projects.AddInput) (projects.AddResult, error)
+	RemoveProject(context.Context, string) (storage.ProjectRecord, error)
 }
 
 func (h *Handler) buildProjectsRouteResponse(r *http.Request) (any, error) {
@@ -1166,6 +1182,50 @@ func (h *Handler) buildProjectsRouteResponse(r *http.Request) (any, error) {
 			message: fmt.Sprintf("Unsupported method for %s", apiBasePath+"/projects"),
 		}
 	}
+}
+
+func (h *Handler) buildProjectRouteResponse(r *http.Request, path string) (any, error) {
+	service := h.context.ProjectsService
+	if service == nil {
+		runtimeProjects := h.context.Runtime.Services().Projects
+		if runtimeProjects != nil {
+			service = runtimeProjects
+		}
+	}
+	if service == nil {
+		return nil, apiError{
+			code:    pkgapi.ErrorCodeProjectsUnavailable,
+			status:  http.StatusInternalServerError,
+			message: "Project management is not available in this runtime",
+		}
+	}
+
+	identifier, err := decodeProjectIdentifier(path)
+	if err != nil {
+		return nil, err
+	}
+	if r.Method != http.MethodDelete {
+		return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
+	}
+
+	removed, err := service.RemoveProject(r.Context(), identifier)
+	if err != nil {
+		var notFound projects.ProjectNotFoundError
+		var ambiguous projects.AmbiguousProjectIdentifierError
+		var validation projects.ProjectValidationError
+		switch {
+		case errors.As(err, &notFound):
+			return nil, apiError{code: pkgapi.ErrorCodeProjectNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Project not found: %s", notFound.Identifier)}
+		case errors.As(err, &ambiguous):
+			return nil, apiError{code: pkgapi.ErrorCodeProjectAmbiguous, status: http.StatusConflict, message: err.Error()}
+		case errors.As(err, &validation):
+			return nil, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: err.Error()}
+		default:
+			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+	}
+
+	return serializeProject(removed, h.context.Config.Defaults.BaseBranch), nil
 }
 
 func (h *Handler) buildLoopsRouteResponse(r *http.Request) (any, error) {
@@ -1616,6 +1676,18 @@ func decodePathSegment(parts []string, index int) (string, error) {
 		return "", fmt.Errorf("missing path segment")
 	}
 	return decoded, nil
+}
+
+func decodeProjectIdentifier(path string) (string, error) {
+	parts := strings.Split(strings.TrimPrefix(path, apiBasePath+"/projects/"), "/")
+	if len(parts) != 1 {
+		return "", apiError{code: pkgapi.ErrorCodeRouteNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Unknown route: %s", path)}
+	}
+	identifier, err := decodePathSegment(parts, 0)
+	if err != nil {
+		return "", apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "project identifier is required"}
+	}
+	return identifier, nil
 }
 
 func (h *Handler) buildActiveRunsResponse(r *http.Request) (activeRunsListResponse, error) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -664,6 +664,50 @@ func TestHandlerProjectsCreateRouteReturnsDiscoveryDetails(t *testing.T) {
 	}
 }
 
+func TestHandlerProjectsRemoveRouteDeletesProject(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/projects/project_1", nil)
+	req.Header.Set("x-request-id", "fixture-request-id")
+	recorder := httptest.NewRecorder()
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	assertEqual(t, data["id"], "project_1")
+	assertEqual(t, data["name"], "Looper")
+	project, err := fixture.runtime.Services().Repositories.Projects.GetByID(context.Background(), "project_1")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	if project != nil {
+		t.Fatalf("project after delete = %#v, want nil", project)
+	}
+}
+
+func TestHandlerProjectsRemoveRouteReturnsNotFound(t *testing.T) {
+	fixture := newTestFixture(t)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/projects/missing", nil)
+	req.Header.Set("x-request-id", "fixture-request-id")
+	recorder := httptest.NewRecorder()
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	errorMap := body["error"].(map[string]any)
+	assertEqual(t, errorMap["code"], "PROJECT_NOT_FOUND")
+	assertEqual(t, errorMap["message"], "Project not found: missing")
+}
+
 func TestHandlerProjectsRouteErrorsMatchArtifactCases(t *testing.T) {
 	fixture := newTestFixture(t)
 
@@ -4267,8 +4311,9 @@ func seedConflictProject(t *testing.T, service *projects.Service) {
 }
 
 type fakeProjectService struct {
-	list       func(context.Context) ([]storage.ProjectRecord, error)
-	addProject func(context.Context, projects.AddInput) (projects.AddResult, error)
+	list          func(context.Context) ([]storage.ProjectRecord, error)
+	addProject    func(context.Context, projects.AddInput) (projects.AddResult, error)
+	removeProject func(context.Context, string) (storage.ProjectRecord, error)
 }
 
 func (f fakeProjectService) List(ctx context.Context) ([]storage.ProjectRecord, error) {
@@ -4283,6 +4328,13 @@ func (f fakeProjectService) AddProject(ctx context.Context, input projects.AddIn
 		return f.addProject(ctx, input)
 	}
 	return projects.AddResult{}, nil
+}
+
+func (f fakeProjectService) RemoveProject(ctx context.Context, identifier string) (storage.ProjectRecord, error) {
+	if f.removeProject != nil {
+		return f.removeProject(ctx, identifier)
+	}
+	return storage.ProjectRecord{}, nil
 }
 
 type errorArtifactCase struct {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -692,6 +692,34 @@ func TestHandlerProjectsRemoveRouteDeletesProject(t *testing.T) {
 	}
 }
 
+func TestHandlerProjectsRemoveRouteDeletesProjectWithEscapedSlashInName(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper/Core", RepoPath: "/tmp/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/projects/Looper%2FCore", nil)
+	req.Header.Set("x-request-id", "fixture-request-id")
+	recorder := httptest.NewRecorder()
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	assertEqual(t, data["id"], "project_1")
+	assertEqual(t, data["name"], "Looper/Core")
+	project, err := fixture.runtime.Services().Repositories.Projects.GetByID(context.Background(), "project_1")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	if project != nil {
+		t.Fatalf("project after delete = %#v, want nil", project)
+	}
+}
+
 func TestHandlerProjectsRemoveRouteReturnsNotFound(t *testing.T) {
 	fixture := newTestFixture(t)
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/projects/missing", nil)

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -119,7 +119,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 			newCommand(commandSpec{
 				use:             "project",
 				short:           "Project commands",
-				helpSubcommands: []helpSubcommand{{name: "list", description: "List projects"}, {name: "add", description: "Add a project"}},
+				helpSubcommands: []helpSubcommand{{name: "list", description: "List projects"}, {name: "add", description: "Add a project"}, {name: "remove", description: "Remove a project"}},
 				helpWhenNoArgs:  true,
 				persistentFlags: []flagSpec{
 					stringFlag("repo-path", "path", "Repository path"),
@@ -132,10 +132,12 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				exampleLines: []string{
 					"$ looper project list",
 					"$ looper project add /path/to/repo",
+					"$ looper project remove project_1 --force",
 				},
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "list", short: "List projects", runE: runtime.projectList}),
 					newCommand(commandSpec{use: "add", short: "Add a project", args: cobra.MaximumNArgs(1), runE: runtime.projectAdd}),
+					newCommand(commandSpec{use: "remove", short: "Remove a project", args: cobra.MaximumNArgs(1), runE: runtime.projectRemove, localFlags: []flagSpec{boolFlag("force", "Remove without prompting for confirmation")}}),
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -48,7 +49,7 @@ func TestCommandGroupHelpListsExpectedSubcommands(t *testing.T) {
 		args        []string
 		subcommands []string
 	}{
-		{args: []string{"project", "--help"}, subcommands: []string{"list  List projects", "add   Add a project"}},
+		{args: []string{"project", "--help"}, subcommands: []string{"list    List projects", "add     Add a project", "remove  Remove a project"}},
 		{args: []string{"config", "--help"}, subcommands: []string{"show  Show active config"}},
 		{args: []string{"daemon", "--help"}, subcommands: []string{"install  Install the managed daemon binary", "status   Show daemon status", "start    Start the daemon", "stop     Stop the daemon", "restart  Restart the daemon", "logs     Show daemon logs"}},
 		{args: []string{"loop", "--help"}, subcommands: []string{"list   List loops", "start  Start a loop", "pause  Pause a loop"}},
@@ -387,6 +388,94 @@ func TestProjectAddJSONPostsExpectedBody(t *testing.T) {
 		t.Fatalf("Run([project add ... --json]) stderr = %q, want empty string", stderr)
 	}
 	assertJSONContains(t, stdout, "id", "project_1")
+}
+
+func TestProjectRemoveForceDeletesResolvedProject(t *testing.T) {
+	t.Parallel()
+
+	var seenList atomic.Bool
+	var seenDelete atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects":
+			seenList.Store(true)
+			writeEnvelope(t, w, pkgapi.Success("req_projects", map[string]any{"items": []map[string]any{{"id": "project_1", "name": "Looper", "repoPath": "/tmp/repo", "baseBranch": "main", "updatedAt": "2026-04-20T10:00:00.000Z"}}}))
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/projects/project_1":
+			seenDelete.Store(true)
+			writeEnvelope(t, w, pkgapi.Success("req_project_remove", map[string]any{"id": "project_1", "name": "Looper", "repoPath": "/tmp/repo", "baseBranch": "main", "updatedAt": "2026-04-20T10:00:00.000Z"}))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "project", "remove", "Looper", "--force", "--json", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([project remove ... --force --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([project remove ... --force --json]) stderr = %q, want empty string", stderr)
+	}
+	if !seenList.Load() || !seenDelete.Load() {
+		t.Fatalf("requests seen list=%v delete=%v, want both", seenList.Load(), seenDelete.Load())
+	}
+	assertJSONContains(t, stdout, "id", "project_1")
+}
+
+func TestProjectRemovePromptsForConfirmation(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects":
+			writeEnvelope(t, w, pkgapi.Success("req_projects", map[string]any{"items": []map[string]any{{"id": "project_1", "name": "Looper", "repoPath": "/tmp/repo", "baseBranch": "main", "updatedAt": "2026-04-20T10:00:00.000Z"}}}))
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/projects/project_1":
+			writeEnvelope(t, w, pkgapi.Success("req_project_remove", map[string]any{"id": "project_1", "name": "Looper", "repoPath": "/tmp/repo", "baseBranch": "main", "updatedAt": "2026-04-20T10:00:00.000Z"}))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdin: strings.NewReader("project_1\n"), Stdout: stdout, Stderr: stderr})
+	exitCode := app.Run(context.Background(), []string{"project", "remove", "project_1", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([project remove ...]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Type \"project_1\" to confirm") {
+		t.Fatalf("stderr = %q, want confirmation prompt", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Project removed") {
+		t.Fatalf("stdout = %q, want removal summary", stdout.String())
+	}
+}
+
+func TestProjectRemoveMissingProjectReturnsClearError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Method, http.MethodGet; got != want {
+			t.Fatalf("request method = %q, want %q", got, want)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_projects", map[string]any{"items": []map[string]any{{"id": "project_1", "name": "Looper", "repoPath": "/tmp/repo"}}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "project", "remove", "missing", "--force", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatalf("Run([project remove missing --force]) exit code = %d, want non-zero", exitCode)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "project not found: missing") {
+		t.Fatalf("stderr = %q, want not found error", stderr)
+	}
 }
 
 func TestStatusWithoutJSONPrintsHumanReadableSections(t *testing.T) {

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -478,6 +478,32 @@ func TestProjectRemoveMissingProjectReturnsClearError(t *testing.T) {
 	}
 }
 
+func TestProjectRemoveResolveIDDoesNotFallBackToName(t *testing.T) {
+	t.Parallel()
+
+	projects := []projectOutput{{ID: "project_1", Name: "missing"}}
+	_, err := resolveProjectByIdentifier(projects, projectRemoveIdentifierValue{value: "missing", source: projectIdentifierSourceID})
+	if err == nil {
+		t.Fatal("resolveProjectByIdentifier(--id missing) error = nil, want project not found")
+	}
+	if !strings.Contains(err.Error(), "project not found: missing") {
+		t.Fatalf("resolveProjectByIdentifier(--id missing) error = %q, want not found", err.Error())
+	}
+}
+
+func TestProjectRemoveResolveNameDoesNotMatchIDFirst(t *testing.T) {
+	t.Parallel()
+
+	projects := []projectOutput{{ID: "Looper", Name: "Other"}, {ID: "project_1", Name: "Looper"}}
+	project, err := resolveProjectByIdentifier(projects, projectRemoveIdentifierValue{value: "Looper", source: projectIdentifierSourceName})
+	if err != nil {
+		t.Fatalf("resolveProjectByIdentifier(--name Looper) error = %v, want nil", err)
+	}
+	if got, want := project.ID, "project_1"; got != want {
+		t.Fatalf("resolveProjectByIdentifier(--name Looper) ID = %q, want %q", got, want)
+	}
+}
+
 func TestStatusWithoutJSONPrintsHumanReadableSections(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/daemon_client.go
+++ b/internal/cliapp/daemon_client.go
@@ -80,6 +80,10 @@ func (c *DaemonAPIClient) Post(ctx context.Context, path string, body any, out a
 	return c.request(ctx, http.MethodPost, path, body, out)
 }
 
+func (c *DaemonAPIClient) Delete(ctx context.Context, path string, out any) error {
+	return c.request(ctx, http.MethodDelete, path, nil, out)
+}
+
 func (c *DaemonAPIClient) request(ctx context.Context, method, path string, body any, out any) error {
 	request, err := c.buildRequest(ctx, method, path, body)
 	if err != nil {

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -214,6 +214,16 @@ func writeHumanProjectAdd(w io.Writer, payload json.RawMessage) error {
 	return nil
 }
 
+func writeHumanProjectRemove(w io.Writer, payload json.RawMessage) error {
+	var data projectOutput
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return fmt.Errorf("decode project response: %w", err)
+	}
+
+	printSection(w, "Project removed", [][2]any{{"id", data.ID}, {"name", data.Name}, {"repoPath", data.RepoPath}})
+	return nil
+}
+
 func writeHumanLoopList(w io.Writer, payload json.RawMessage) error {
 	var data loopsListOutput
 	if err := json.Unmarshal(payload, &data); err != nil {

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -1,6 +1,7 @@
 package cliapp
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -71,6 +72,32 @@ func (r *commandRuntime) projectAdd(cmd *cobra.Command, args []string) error {
 
 		return r.postJSON(ctx, "/api/v1/projects", body)
 	}, writeHumanProjectAdd)
+}
+
+func (r *commandRuntime) projectRemove(cmd *cobra.Command, args []string) error {
+	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
+		identifier, err := projectRemoveIdentifier(cmd, args)
+		if err != nil {
+			return nil, err
+		}
+
+		projects, err := r.listProjects(ctx)
+		if err != nil {
+			return nil, err
+		}
+		project, err := resolveProjectByIdentifier(projects, identifier)
+		if err != nil {
+			return nil, err
+		}
+
+		if !getBoolFlag(cmd, "force") {
+			if err := confirmProjectRemoval(cmd, project); err != nil {
+				return nil, err
+			}
+		}
+
+		return r.deleteJSON(ctx, "/api/v1/projects/"+url.PathEscape(project.ID))
+	}, writeHumanProjectRemove)
 }
 
 func (r *commandRuntime) loopList(cmd *cobra.Command, args []string) error {
@@ -400,6 +427,20 @@ func (r *commandRuntime) postJSON(ctx context.Context, path string, body any) (j
 	return payload, nil
 }
 
+func (r *commandRuntime) deleteJSON(ctx context.Context, path string) (json.RawMessage, error) {
+	client, err := r.apiClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var payload json.RawMessage
+	if err := client.Delete(ctx, path, &payload); err != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}
+
 func (r *commandRuntime) resolveLoopStartProjectID(ctx context.Context, repo string, explicitProjectID string) (string, error) {
 	projects, err := r.listProjects(ctx)
 	if err != nil {
@@ -636,6 +677,77 @@ func setString(target map[string]any, key, value string) {
 	if trimmed := strings.TrimSpace(value); trimmed != "" {
 		target[key] = trimmed
 	}
+}
+
+func projectRemoveIdentifier(cmd *cobra.Command, args []string) (string, error) {
+	identifier := ""
+	if len(args) > 0 {
+		identifier = strings.TrimSpace(args[0])
+	}
+	id := strings.TrimSpace(getStringFlag(cmd, "id"))
+	name := strings.TrimSpace(getStringFlag(cmd, "name"))
+	provided := 0
+	for _, value := range []string{identifier, id, name} {
+		if value != "" {
+			provided++
+		}
+	}
+	if provided == 0 {
+		return "", fmt.Errorf("Usage: looper project remove <id-or-name> [--force]")
+	}
+	if provided > 1 {
+		return "", fmt.Errorf("provide only one project identifier using an argument, --id, or --name")
+	}
+	if id != "" {
+		return id, nil
+	}
+	if name != "" {
+		return name, nil
+	}
+	return identifier, nil
+}
+
+func resolveProjectByIdentifier(projects []projectOutput, identifier string) (projectOutput, error) {
+	trimmed := strings.TrimSpace(identifier)
+	if trimmed == "" {
+		return projectOutput{}, fmt.Errorf("project identifier is required")
+	}
+
+	for _, project := range projects {
+		if project.ID == trimmed {
+			return project, nil
+		}
+	}
+
+	var matched *projectOutput
+	for index := range projects {
+		if strings.EqualFold(strings.TrimSpace(projects[index].Name), trimmed) {
+			if matched != nil {
+				return projectOutput{}, fmt.Errorf("project identifier matches multiple projects: %s", trimmed)
+			}
+			matched = &projects[index]
+		}
+	}
+	if matched != nil {
+		return *matched, nil
+	}
+
+	return projectOutput{}, fmt.Errorf("project not found: %s", trimmed)
+}
+
+func confirmProjectRemoval(cmd *cobra.Command, project projectOutput) error {
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Remove project %s (%s) and associated runtime records? Type %q to confirm: ", project.ID, project.Name, project.ID)
+	scanner := bufio.NewScanner(cmd.InOrStdin())
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("read confirmation: %w", err)
+		}
+		return fmt.Errorf("project removal cancelled")
+	}
+	if strings.TrimSpace(scanner.Text()) != project.ID {
+		return fmt.Errorf("project removal cancelled")
+	}
+	return nil
 }
 
 func addQueryString(query url.Values, key, value string) {

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -679,7 +679,20 @@ func setString(target map[string]any, key, value string) {
 	}
 }
 
-func projectRemoveIdentifier(cmd *cobra.Command, args []string) (string, error) {
+type projectIdentifierSource string
+
+const (
+	projectIdentifierSourceAny  projectIdentifierSource = "any"
+	projectIdentifierSourceID   projectIdentifierSource = "id"
+	projectIdentifierSourceName projectIdentifierSource = "name"
+)
+
+type projectRemoveIdentifierValue struct {
+	value  string
+	source projectIdentifierSource
+}
+
+func projectRemoveIdentifier(cmd *cobra.Command, args []string) (projectRemoveIdentifierValue, error) {
 	identifier := ""
 	if len(args) > 0 {
 		identifier = strings.TrimSpace(args[0])
@@ -693,39 +706,46 @@ func projectRemoveIdentifier(cmd *cobra.Command, args []string) (string, error) 
 		}
 	}
 	if provided == 0 {
-		return "", fmt.Errorf("Usage: looper project remove <id-or-name> [--force]")
+		return projectRemoveIdentifierValue{}, fmt.Errorf("Usage: looper project remove <id-or-name> [--force]")
 	}
 	if provided > 1 {
-		return "", fmt.Errorf("provide only one project identifier using an argument, --id, or --name")
+		return projectRemoveIdentifierValue{}, fmt.Errorf("provide only one project identifier using an argument, --id, or --name")
 	}
 	if id != "" {
-		return id, nil
+		return projectRemoveIdentifierValue{value: id, source: projectIdentifierSourceID}, nil
 	}
 	if name != "" {
-		return name, nil
+		return projectRemoveIdentifierValue{value: name, source: projectIdentifierSourceName}, nil
 	}
-	return identifier, nil
+	return projectRemoveIdentifierValue{value: identifier, source: projectIdentifierSourceAny}, nil
 }
 
-func resolveProjectByIdentifier(projects []projectOutput, identifier string) (projectOutput, error) {
-	trimmed := strings.TrimSpace(identifier)
+func resolveProjectByIdentifier(projects []projectOutput, identifier projectRemoveIdentifierValue) (projectOutput, error) {
+	trimmed := strings.TrimSpace(identifier.value)
 	if trimmed == "" {
 		return projectOutput{}, fmt.Errorf("project identifier is required")
 	}
 
-	for _, project := range projects {
-		if project.ID == trimmed {
-			return project, nil
+	if identifier.source == projectIdentifierSourceAny || identifier.source == projectIdentifierSourceID {
+		for _, project := range projects {
+			if project.ID == trimmed {
+				return project, nil
+			}
 		}
+	}
+	if identifier.source == projectIdentifierSourceID {
+		return projectOutput{}, fmt.Errorf("project not found: %s", trimmed)
 	}
 
 	var matched *projectOutput
-	for index := range projects {
-		if strings.EqualFold(strings.TrimSpace(projects[index].Name), trimmed) {
-			if matched != nil {
-				return projectOutput{}, fmt.Errorf("project identifier matches multiple projects: %s", trimmed)
+	if identifier.source == projectIdentifierSourceAny || identifier.source == projectIdentifierSourceName {
+		for index := range projects {
+			if strings.EqualFold(strings.TrimSpace(projects[index].Name), trimmed) {
+				if matched != nil {
+					return projectOutput{}, fmt.Errorf("project identifier matches multiple projects: %s", trimmed)
+				}
+				matched = &projects[index]
 			}
-			matched = &projects[index]
 		}
 	}
 	if matched != nil {

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -95,6 +95,22 @@ func (e ProjectIDCollisionError) Error() string {
 	return fmt.Sprintf("Derived project id collides with an existing explicit project: %s", e.ProjectID)
 }
 
+type ProjectNotFoundError struct{ Identifier string }
+
+func (e ProjectNotFoundError) Error() string {
+	return fmt.Sprintf("project not found: %s", e.Identifier)
+}
+
+type AmbiguousProjectIdentifierError struct{ Identifier string }
+
+func (e AmbiguousProjectIdentifierError) Error() string {
+	return fmt.Sprintf("project identifier matches multiple projects: %s", e.Identifier)
+}
+
+type ProjectValidationError struct{ Message string }
+
+func (e ProjectValidationError) Error() string { return e.Message }
+
 func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, error) {
 	if s.Repos == nil || s.Repos.Projects == nil {
 		return AddResult{}, fmt.Errorf("projects repository is not configured")
@@ -226,6 +242,53 @@ func (s *Service) List(ctx context.Context) ([]storage.ProjectRecord, error) {
 		return nil, fmt.Errorf("projects repository is not configured")
 	}
 	return s.Repos.Projects.List(ctx)
+}
+
+func (s *Service) RemoveProject(ctx context.Context, identifier string) (storage.ProjectRecord, error) {
+	if s.Repos == nil || s.Repos.Projects == nil {
+		return storage.ProjectRecord{}, fmt.Errorf("projects repository is not configured")
+	}
+
+	trimmed := strings.TrimSpace(identifier)
+	if trimmed == "" {
+		return storage.ProjectRecord{}, ProjectValidationError{Message: "project identifier is required"}
+	}
+
+	project, err := s.Repos.Projects.GetByID(ctx, trimmed)
+	if err != nil {
+		return storage.ProjectRecord{}, err
+	}
+	if project == nil {
+		items, err := s.Repos.Projects.List(ctx)
+		if err != nil {
+			return storage.ProjectRecord{}, err
+		}
+
+		for index := range items {
+			if strings.EqualFold(strings.TrimSpace(items[index].Name), trimmed) {
+				if project != nil {
+					return storage.ProjectRecord{}, AmbiguousProjectIdentifierError{Identifier: trimmed}
+				}
+				project = &items[index]
+			}
+		}
+	}
+	if project == nil {
+		return storage.ProjectRecord{}, ProjectNotFoundError{Identifier: trimmed}
+	}
+	if source, _ := parseMetadata(project.MetadataJSON)["source"].(string); source == "config" {
+		return storage.ProjectRecord{}, ProjectValidationError{Message: fmt.Sprintf("project %s is managed by config and cannot be removed from the CLI", project.ID)}
+	}
+
+	deleted, err := s.Repos.Projects.Delete(ctx, project.ID)
+	if err != nil {
+		return storage.ProjectRecord{}, err
+	}
+	if !deleted {
+		return storage.ProjectRecord{}, ProjectNotFoundError{Identifier: trimmed}
+	}
+
+	return *project, nil
 }
 
 func (s *Service) SyncConfigured(ctx context.Context, cfg config.Config, now time.Time) error {

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -393,6 +393,20 @@ func (r *ProjectsRepository) List(ctx context.Context) ([]ProjectRecord, error) 
 	return scanProjects(rows)
 }
 
+func (r *ProjectsRepository) Delete(ctx context.Context, id string) (bool, error) {
+	result, err := r.q.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, id)
+	if err != nil {
+		return false, fmt.Errorf("delete project: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("delete project rows affected: %w", err)
+	}
+
+	return rowsAffected > 0, nil
+}
+
 type LoopsRepository struct{ q sqliteQuerier }
 
 func (r *LoopsRepository) Upsert(ctx context.Context, record LoopRecord) error {


### PR DESCRIPTION
## Summary
- Add `looper project remove` with id/name resolution, confirmation prompts, and a `--force` option for non-interactive removal.
- Add DELETE project API/storage support with clear not-found and ambiguous-name errors.
- Cover the new command, help text, and API removal behavior in tests.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #89