### PR TITLE
Support manual releases and remove Darwin x64 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,15 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to release, for example v1.2.3"
+        required: true
+        type: string
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
 permissions:
   contents: write
@@ -20,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
+      release-tag: ${{ steps.release-version.outputs.tag }}
       release-version: ${{ steps.release-version.outputs.value }}
       release-channel: ${{ steps.release-version.outputs.channel }}
       release-prerelease: ${{ steps.release-version.outputs.prerelease }}
@@ -28,6 +35,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -51,7 +60,7 @@ jobs:
       - name: Read release version and channel from tag
         id: release-version
         run: |
-          tag_name="${{ github.ref_name }}"
+          tag_name="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "Tag must match vMAJOR.MINOR.PATCH[-PRERELEASE]: ${tag_name}" >&2
             exit 1
@@ -64,6 +73,7 @@ jobs:
             prerelease="true"
           fi
           released="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "tag=${tag_name}" >> "$GITHUB_OUTPUT"
           echo "value=${release_version}" >> "$GITHUB_OUTPUT"
           echo "channel=${channel}" >> "$GITHUB_OUTPUT"
           echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
@@ -71,12 +81,12 @@ jobs:
 
       - name: Build
         env:
-          LOOPER_BUILD_GIT_SHA: ${{ github.sha }}
           LOOPER_BUILD_VERSION: ${{ steps.release-version.outputs.value }}
-          LOOPER_BUILD_VERSION_SOURCE: git-tag:${{ github.ref_name }}
+          LOOPER_BUILD_VERSION_SOURCE: git-tag:${{ steps.release-version.outputs.tag }}
           LOOPER_BUILD_CHANNEL: ${{ steps.release-version.outputs.channel }}
           LOOPER_BUILD_API_VERSION: v1
         run: |
+          export LOOPER_BUILD_GIT_SHA="$(git rev-parse HEAD)"
           export LOOPER_BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           go build -ldflags "$(go run ./tools/go-build-flags)" ./...
 
@@ -88,8 +98,8 @@ jobs:
       - name: Create draft GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Looper ${{ github.ref_name }}
+          tag_name: ${{ needs.prepare-go-release.outputs.release-tag }}
+          name: Looper ${{ needs.prepare-go-release.outputs.release-tag }}
           draft: true
           prerelease: ${{ needs.prepare-go-release.outputs.release-prerelease }}
           generate_release_notes: true
@@ -112,6 +122,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-go-release.outputs.release-tag }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -122,12 +134,12 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          LOOPER_BUILD_GIT_SHA: ${{ github.sha }}
           LOOPER_BUILD_VERSION: ${{ needs.prepare-go-release.outputs.release-version }}
-          LOOPER_BUILD_VERSION_SOURCE: git-tag:${{ github.ref_name }}
+          LOOPER_BUILD_VERSION_SOURCE: git-tag:${{ needs.prepare-go-release.outputs.release-tag }}
           LOOPER_BUILD_CHANNEL: ${{ needs.prepare-go-release.outputs.release-channel }}
           LOOPER_BUILD_API_VERSION: v1
         run: |
+          export LOOPER_BUILD_GIT_SHA="$(git rev-parse HEAD)"
           export LOOPER_BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           mkdir -p dist/release
           go build -trimpath -ldflags "$(go run ./tools/go-build-flags)" -o "dist/release/${{ matrix.artifact-name }}" ./cmd/looper
@@ -179,6 +191,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-go-release.outputs.release-tag }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -189,12 +203,12 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          LOOPER_BUILD_GIT_SHA: ${{ github.sha }}
           LOOPER_BUILD_VERSION: ${{ needs.prepare-go-release.outputs.release-version }}
-          LOOPER_BUILD_VERSION_SOURCE: git-tag:${{ github.ref_name }}
+          LOOPER_BUILD_VERSION_SOURCE: git-tag:${{ needs.prepare-go-release.outputs.release-tag }}
           LOOPER_BUILD_CHANNEL: ${{ needs.prepare-go-release.outputs.release-channel }}
           LOOPER_BUILD_API_VERSION: v1
         run: |
+          export LOOPER_BUILD_GIT_SHA="$(git rev-parse HEAD)"
           export LOOPER_BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           mkdir -p dist/release
           go build -trimpath -ldflags "$(go run ./tools/go-build-flags)" -o "dist/release/${{ matrix.artifact-name }}" ./cmd/looperd
@@ -234,6 +248,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-go-release.outputs.release-tag }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -264,7 +280,7 @@ jobs:
       - name: Generate release manifest
         run: |
           go run ./tools/release-manifest \
-            -tag "${{ github.ref_name }}" \
+            -tag "${{ needs.prepare-go-release.outputs.release-tag }}" \
             -version "${{ needs.prepare-go-release.outputs.release-version }}" \
             -released "${{ needs.prepare-go-release.outputs.release-timestamp }}" \
             -channel "${{ needs.prepare-go-release.outputs.release-channel }}" \
@@ -277,7 +293,7 @@ jobs:
 
       - name: Validate release manifest fields
         env:
-          EXPECTED_TAG: ${{ github.ref_name }}
+          EXPECTED_TAG: ${{ needs.prepare-go-release.outputs.release-tag }}
           EXPECTED_VERSION: ${{ needs.prepare-go-release.outputs.release-version }}
           EXPECTED_CHANNEL: ${{ needs.prepare-go-release.outputs.release-channel }}
         run: |
@@ -313,8 +329,8 @@ jobs:
       - name: Publish GitHub release with assets
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Looper ${{ github.ref_name }}
+          tag_name: ${{ needs.prepare-go-release.outputs.release-tag }}
+          name: Looper ${{ needs.prepare-go-release.outputs.release-tag }}
           draft: false
           prerelease: ${{ needs.prepare-go-release.outputs.release-prerelease }}
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,17 @@ jobs:
       release-channel: ${{ steps.release-version.outputs.channel }}
       release-prerelease: ${{ steps.release-version.outputs.prerelease }}
       release-timestamp: ${{ steps.release-version.outputs.released }}
+      release-commit: ${{ steps.release-commit.outputs.sha }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.sha }}
+
+      - name: Pin release commit
+        id: release-commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -123,7 +128,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare-go-release.outputs.release-tag }}
+          ref: ${{ needs.prepare-go-release.outputs.release-commit }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -192,7 +197,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare-go-release.outputs.release-tag }}
+          ref: ${{ needs.prepare-go-release.outputs.release-commit }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -249,7 +254,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare-go-release.outputs.release-tag }}
+          ref: ${{ needs.prepare-go-release.outputs.release-commit }}
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This document contains the detailed install, upgrade, uninstall, and source-buil
 
 For the default supported install path:
 
-- macOS (`darwin-arm64` or `darwin-x64`)
+- macOS (`darwin-arm64`)
 - `git`
 - `gh`
 
@@ -38,7 +38,7 @@ looper bootstrap --yes --project-path /path/to/repo --agent-vendor opencode
 2. Rename it to `looper` if needed.
 3. Place it on your `PATH`, for example `/usr/local/bin/looper` or `~/.local/bin/looper`.
 
-GitHub Releases publish standalone Go binaries for both `looper` and `looperd` on `darwin-arm64` and `darwin-x64`.
+GitHub Releases publish standalone Go binaries for both `looper` and `looperd` on `darwin-arm64`.
 
 Linux is not currently supported for the managed daemon flow.
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -702,7 +702,7 @@ func (h *Handler) buildStatusResponse(ctx context.Context) (statusResponse, erro
 				InstallDir:       installDir,
 				CurrentTarget:    currentTarget,
 				ArtifactName:     artifactName,
-				SupportedTargets: []string{"darwin-arm64", "darwin-x64"},
+				SupportedTargets: []string{"darwin-arm64"},
 			},
 		},
 		Storage: statusStorage{
@@ -864,15 +864,7 @@ func homeDirOrEmpty() string {
 }
 
 func currentLooperdTarget() string {
-	arch := runtime.GOARCH
-	switch arch {
-	case "amd64":
-		arch = "x64"
-	case "arm64":
-		arch = "arm64"
-	}
-
-	return fmt.Sprintf("%s-%s", runtime.GOOS, arch)
+	return fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 }
 
 func normalizeRecoverySummary(summary looperdruntime.RecoverySummary) map[string]any {
@@ -3966,7 +3958,6 @@ func deriveProjectIDFromRepoPath(repoPath string) string {
 func looperdArtifactName(target string) *string {
 	supported := map[string]struct{}{
 		"darwin-arm64": {},
-		"darwin-x64":   {},
 	}
 
 	if _, ok := supported[target]; !ok {

--- a/internal/cliapp/daemon_install.go
+++ b/internal/cliapp/daemon_install.go
@@ -247,11 +247,8 @@ func resolveLooperdTarget(platform string, arch string) (string, error) {
 	if platform == "darwin" && arch == "arm64" {
 		return "darwin-arm64", nil
 	}
-	if platform == "darwin" && (arch == "amd64" || arch == "x64") {
-		return "darwin-x64", nil
-	}
 
-	return "", fmt.Errorf("Unsupported platform/arch for looperd install: %s-%s. Supported targets: darwin-arm64, darwin-x64", platform, arch)
+	return "", fmt.Errorf("Unsupported platform/arch for looperd install: %s-%s. Supported targets: darwin-arm64", platform, arch)
 }
 
 func buildGitHubReleaseAPIURL(owner, repo, tag string) string {

--- a/internal/cliapp/daemon_install_test.go
+++ b/internal/cliapp/daemon_install_test.go
@@ -24,17 +24,16 @@ func TestResolveLooperdTarget(t *testing.T) {
 		t.Fatalf("resolveLooperdTarget(darwin, arm64) = %q, want %q", target, "darwin-arm64")
 	}
 
-	target, err = resolveLooperdTarget("darwin", "amd64")
-	if err != nil {
-		t.Fatalf("resolveLooperdTarget(darwin, amd64) error = %v", err)
-	}
-	if target != "darwin-x64" {
-		t.Fatalf("resolveLooperdTarget(darwin, amd64) = %q, want %q", target, "darwin-x64")
+	_, err = resolveLooperdTarget("linux", "amd64")
+	if err == nil || err.Error() != "Unsupported platform/arch for looperd install: linux-amd64. Supported targets: darwin-arm64" {
+		t.Fatalf("resolveLooperdTarget(linux, amd64) error = %v", err)
 	}
 
-	_, err = resolveLooperdTarget("linux", "amd64")
-	if err == nil || err.Error() != "Unsupported platform/arch for looperd install: linux-amd64. Supported targets: darwin-arm64, darwin-x64" {
-		t.Fatalf("resolveLooperdTarget(linux, amd64) error = %v", err)
+	for _, arch := range []string{"amd64", "x64"} {
+		_, err = resolveLooperdTarget("darwin", arch)
+		if err == nil {
+			t.Fatalf("resolveLooperdTarget(darwin, %s) error = nil, want unsupported", arch)
+		}
 	}
 }
 
@@ -116,7 +115,7 @@ func TestInstallManagedDaemonSkipsExistingBinary(t *testing.T) {
 		}),
 		HomeDir:  homeDir,
 		Platform: "darwin",
-		Arch:     "amd64",
+		Arch:     "arm64",
 	})
 
 	runtime := newCommandRuntime(app, nil)
@@ -130,8 +129,8 @@ func TestInstallManagedDaemonSkipsExistingBinary(t *testing.T) {
 	if result.DownloadedFrom != nil {
 		t.Fatalf("result.DownloadedFrom = %#v, want nil", result.DownloadedFrom)
 	}
-	if result.Target != "darwin-x64" {
-		t.Fatalf("result.Target = %q, want %q", result.Target, "darwin-x64")
+	if result.Target != "darwin-arm64" {
+		t.Fatalf("result.Target = %q, want %q", result.Target, "darwin-arm64")
 	}
 }
 

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -639,10 +639,7 @@ func resolveLooperTarget(platform string, arch string) (string, error) {
 	if platform == "darwin" && arch == "arm64" {
 		return "darwin-arm64", nil
 	}
-	if platform == "darwin" && (arch == "amd64" || arch == "x64") {
-		return "darwin-x64", nil
-	}
-	return "", fmt.Errorf("unsupported platform/arch for looper upgrade: %s-%s. Supported targets: darwin-arm64, darwin-x64", platform, arch)
+	return "", fmt.Errorf("unsupported platform/arch for looper upgrade: %s-%s. Supported targets: darwin-arm64", platform, arch)
 }
 
 func findLooperReleaseAssets(release githubReleasePayload, target string) (githubReleaseAsset, githubReleaseAsset, error) {

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -16,6 +16,25 @@ import (
 	"time"
 )
 
+func TestResolveLooperTarget(t *testing.T) {
+	t.Parallel()
+
+	target, err := resolveLooperTarget("darwin", "arm64")
+	if err != nil {
+		t.Fatalf("resolveLooperTarget(darwin, arm64) error = %v", err)
+	}
+	if target != "darwin-arm64" {
+		t.Fatalf("resolveLooperTarget(darwin, arm64) = %q, want %q", target, "darwin-arm64")
+	}
+
+	for _, arch := range []string{"amd64", "x64"} {
+		_, err = resolveLooperTarget("darwin", arch)
+		if err == nil {
+			t.Fatalf("resolveLooperTarget(darwin, %s) error = nil, want unsupported", arch)
+		}
+	}
+}
+
 func TestUpgradeCheckPrintsSummary(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,8 +27,7 @@ detect_target() {
 
   case "$arch" in
     arm64|aarch64) printf 'darwin-arm64\n' ;;
-    x86_64|amd64) printf 'darwin-x64\n' ;;
-    *) fail "unsupported architecture: $arch (supported: arm64, x86_64)" ;;
+    *) fail "unsupported architecture: $arch (supported: arm64)" ;;
   esac
 }
 

--- a/specs/2026-04-15-cli-daemon-distribution/checklist.md
+++ b/specs/2026-04-15-cli-daemon-distribution/checklist.md
@@ -28,10 +28,9 @@
 - [x] 在 `apps/looperd/package.json` 增加 `compile` 脚本
 - [x] 增加按平台 target 的 compile 脚本
 - [x] 第一批支持 `darwin-arm64`
-- [x] 第一批支持 `darwin-x64`
 - [x] 明确 Linux 不进入当前范围
 - [x] 验证 compile 产物至少可执行 `--version`（完整运行依赖 Phase 3）
-- [x] 验证 compiled binary 体积是否在可接受范围，并记录预期大小（当前实测：darwin-arm64 ≈ 58.9 MiB，darwin-x64 ≈ 64.1 MiB；Phase 1 先以单产物 < 70 MiB 为可接受范围）
+- [x] 验证 compiled binary 体积是否在可接受范围，并记录预期大小（当前实测：darwin-arm64 ≈ 58.9 MiB；Phase 1 先以单产物 < 70 MiB 为可接受范围）
 
 ## Phase 3 - SQLite migrations 内嵌化
 
@@ -60,9 +59,8 @@
 > release workflow 是 compile 可用性的权威验证点；本地 compile 失败不能单独作为否定该分发模型的依据。
 
 - [x] 增加 tag 驱动的 release workflow
-- [x] matrix 构建 macOS 双架构 `looperd` binary
+- [x] matrix 构建 macOS `looperd` binary
 - [x] 第一批 workflow 至少覆盖 `darwin-arm64`
-- [x] 第一批 workflow 至少覆盖 `darwin-x64`
 - [x] macOS targets 使用 macOS runners 构建
 - [x] 明确当前 workflow 不发布 Linux artifacts
 - [x] 上传 GitHub Release artifacts
@@ -150,7 +148,7 @@
 - `bun test apps/looperd/src/storage/sqlite/migrate.test.ts apps/cli/src/index.test.ts` 通过，补齐 Phase 11 缺失单测
 - `bun run typecheck` 与 `bun run build` 通过
 - 本地 tarball 全局安装 smoke：`npm install -g --prefix <tmp> apps/cli/powerformer-looper-0.2.1.tgz` 后 `looper --help` 正常
-- 手动安装 compiled `looperd-darwin-x64` 到 `~/.looper/bin/looperd` 后，`looper daemon start`、`looper daemon status --json`、`looper status --json` 均正常
+- 手动安装 compiled `looperd-darwin-arm64` 到 `~/.looper/bin/looperd` 后，`looper daemon start`、`looper daemon status --json`、`looper status --json` 均正常
 - GitHub Release download 逻辑由 `apps/cli/src/daemon-release.test.ts` 与 `apps/cli/src/daemon-install.test.ts` 覆盖；仓库当前尚无公开 release 可做真实 smoke
 
 ## Out of scope for this spec

--- a/specs/2026-04-15-cli-daemon-distribution/spec.md
+++ b/specs/2026-04-15-cli-daemon-distribution/spec.md
@@ -74,7 +74,6 @@
 2. 如果继续走 npm 包，用户仍需在机器上安装 Bun 才能运行 daemon。
 3. 如果想在 npm 包中直接塞 compiled daemon，就会变成 per-platform 包管理问题：
    - `darwin-arm64`
-   - `darwin-x64`
 4. 这会显著增加 npm publish 与安装逻辑复杂度。
 
 所以：
@@ -237,12 +236,10 @@ bun build --compile src/index.ts --outfile looperd
 需要按 macOS 架构分别构建：
 
 - `darwin-arm64`
-- `darwin-x64`
 
 当前一期仅覆盖：
 
 - `darwin-arm64`
-- `darwin-x64`
 
 Linux 不进入当前实施范围。
 
@@ -695,7 +692,6 @@ release workflow 至少需要承担下面职责：
    - 例如 `v0.2.0`
 2. **matrix 构建 `looperd`**
    - 至少支持 `darwin-arm64`
-   - 至少支持 `darwin-x64`
 3. **上传 release artifacts**
    - 产物名必须稳定、可预测
 4. **生成并上传 checksum**
@@ -711,9 +707,7 @@ release workflow 至少需要承担下面职责：
 建议明确稳定命名规则，例如：
 
 - `looperd-darwin-arm64`
-- `looperd-darwin-x64`
 - `looperd-darwin-arm64.sha256`
-- `looperd-darwin-x64.sha256`
 
 如后续需要带版本号，也应保证规则稳定，例如：
 
@@ -734,7 +728,7 @@ Phase 1 可以直接依赖：
 
 当前 release workflow 已显式验证：
 
-1. Release assets 名称固定为 `looperd-darwin-{arm64,x64}` 与对应 `.sha256`
+1. Release assets 名称固定为 `looperd-darwin-arm64` 与对应 `.sha256`
 2. Phase 1 不发布 Linux artifacts
 3. tag / checksum / `--version` 均在 workflow 内校验
 
@@ -916,11 +910,10 @@ looper daemon status
 当前实测（本仓库 `apps/looperd/scripts/compile.ts` 默认产物）：
 
 - `looperd-darwin-arm64`：约 **58.9 MiB**
-- `looperd-darwin-x64`：约 **64.1 MiB**
 
 因此当前 phase 可接受的预期范围可先定为：
 
-- **darwin-arm64 / darwin-x64 单个 artifact 预期约 59–64 MiB**
+- **darwin-arm64 artifact 预期约 59 MiB**
 - **只要单个 release binary 未明显超过 70 MiB，就仍视为可接受**
 
 这会影响：

--- a/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
+++ b/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
@@ -71,7 +71,7 @@
               "installDir": "<home>/.looper/bin",
               "currentTarget": "<current-target>",
               "artifactName": "<artifact-name>",
-              "supportedTargets": ["darwin-arm64", "darwin-x64"]
+              "supportedTargets": ["darwin-arm64"]
             }
           },
           "storage": {

--- a/specs/2026-04-17-go-port-plan/artifacts/drop-in-artifact-install-path-compatibility.md
+++ b/specs/2026-04-17-go-port-plan/artifacts/drop-in-artifact-install-path-compatibility.md
@@ -8,9 +8,7 @@ This artifact closes the Ralph task to preserve drop-in artifact naming, install
 
 - GitHub release assets keep the predictable binary names consumed by existing install/upgrade flows:
   - `looper-darwin-arm64`
-  - `looper-darwin-x64`
   - `looperd-darwin-arm64`
-  - `looperd-darwin-x64`
 - Checksum sidecars keep the existing `<asset>.sha256` naming.
 - The managed daemon install target remains `~/.looper/bin/looperd`.
 - CLI daemon lookup order remains `~/.looper/bin/looperd`, then `$PATH`.

--- a/specs/2026-04-22-install-upgrade-strategy/checklist.md
+++ b/specs/2026-04-22-install-upgrade-strategy/checklist.md
@@ -5,7 +5,7 @@
 - [ ] 明确 Looper 的用户安装入口是 `looper`，不是分别安装 CLI / daemon
 - [ ] 明确 release 渠道只面向用户直接分发 `looper`
 - [ ] 明确 `looperd` 继续由 CLI 负责安装与升级编排
-- [ ] 明确当前主支持矩阵仍是 macOS `darwin-arm64` / `darwin-x64`
+- [ ] 明确当前主支持矩阵仍是 macOS `darwin-arm64`
 - [ ] 明确 `go install` 仅为开发者路径，不作为普通用户推荐安装方式
 - [ ] 明确 `foreground` 仍是当前受支持默认 daemon 模式
 - [ ] 明确 `launchd` 作为下一阶段正式托管模式演进方向

--- a/specs/2026-04-22-install-upgrade-strategy/spec.md
+++ b/specs/2026-04-22-install-upgrade-strategy/spec.md
@@ -56,7 +56,7 @@
 
 本 spec 当前仅覆盖：
 
-- macOS 13+（arm64 / x64）为正式支持范围
+- macOS 13+（arm64）为正式支持范围
 - macOS 12 为 best-effort
 
 以下平台不在本 spec 的执行范围内：
@@ -133,12 +133,8 @@ looper upgrade --channel beta
 
 - `looper-darwin-arm64`
 - `looper-darwin-arm64.sha256`
-- `looper-darwin-x64`
-- `looper-darwin-x64.sha256`
 - `looperd-darwin-arm64`
 - `looperd-darwin-arm64.sha256`
-- `looperd-darwin-x64`
-- `looperd-darwin-x64.sha256`
 
 ### B. 安装脚本（默认推荐）
 


### PR DESCRIPTION
## Summary
- Add a manual release workflow trigger that accepts an existing tag and consistently builds/publishes from that tag.
- Remove remaining Darwin x64 support references from runtime status, install/upgrade target resolution, installer script, docs, and specs.
- Add regression coverage that Darwin amd64/x64 targets are rejected for managed install and CLI upgrade flows.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "YAML OK"'`
- `go test ./...`
- `git grep -n -e 'darwin-x64' -e 'darwin_amd64' -e 'darwin-amd64' -e 'looper-darwin-x64' -e 'looperd-darwin-x64' -e 'macOS Intel' -- . ':!node_modules' ':!.opencode'`