### PR TITLE
Fix source CLI usage docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - Supported implementation is Go-first. Root commands are the source of truth:
   - `go run ./cmd/looperd`
-  - `go run ./cmd/looper -- <args>`
+  - `go run ./cmd/looper <args>`
   - `go build ./...`
   - `go vet ./...`
   - `go test ./...`

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Useful pointers:
 From the repo root:
 
 - `go run ./cmd/looperd`
-- `go run ./cmd/looper -- <args>`
+- `go run ./cmd/looper <args>`
 - `go build ./...`
 - `go vet ./...`
 - `go test ./...`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -136,5 +136,5 @@ go run ./cmd/looperd
 In another shell, run the CLI from source:
 
 ```bash
-go run ./cmd/looper -- status
+go run ./cmd/looper status
 ```


### PR DESCRIPTION
## Summary
- Remove the extra `--` from documented `go run ./cmd/looper` source invocations.
- Keep README, installation docs, and agent guidance consistent with the working CLI syntax.

## Testing
- `go run ./cmd/looper version`