### PR TITLE
Fix worker stop termination

### DIFF
--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -192,6 +192,18 @@ func stopLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 
 	result.ExecutionID = latestExecution.ID
 	result.Vendor = latestExecution.Vendor
+	if services.ActiveExecutions != nil {
+		killed, err := services.ActiveExecutions.Kill(result.LoopID, latestRun.ID, latestExecution.ID, reason)
+		if err != nil {
+			return nil, err
+		}
+		if killed {
+			if err := markExecutionCancelling(ctx, services, *latestExecution, reasonCopy, now); err != nil {
+				return nil, err
+			}
+			return result, nil
+		}
+	}
 	if latestExecution.PID == nil || *latestExecution.PID <= 0 {
 		return result, nil
 	}
@@ -208,22 +220,51 @@ func stopLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 	}
 	result.PID = *latestExecution.PID
 	if signal != nil {
-		if err := signal(pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+		if err := signalAgentProcessGroup(pid, signal, 5*time.Second); err != nil {
 			return nil, err
 		}
 	}
 
-	updated := *latestExecution
-	updated.Status = "cancelling"
-	updated.UpdatedAt = eventlog.FormatJavaScriptISOString(now().UTC())
-	if updated.ErrorMessage == nil {
-		updated.ErrorMessage = &reasonCopy
-	}
-	if err := services.Repositories.AgentExecutions.Upsert(ctx, updated); err != nil {
+	if err := markExecutionCancelling(ctx, services, *latestExecution, reasonCopy, now); err != nil {
 		return nil, err
 	}
 
 	return result, nil
+}
+
+func signalAgentProcessGroup(pid int, signalProcess signalProcessFunc, grace time.Duration) error {
+	if err := signalProcess(-pid, syscall.SIGTERM); err != nil {
+		if !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+		if err := signalProcess(pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+	}
+	if grace > 0 {
+		go func() {
+			timer := time.NewTimer(grace)
+			defer timer.Stop()
+			<-timer.C
+			if err := signalProcess(-pid, syscall.SIGKILL); errors.Is(err, syscall.ESRCH) {
+				_ = signalProcess(pid, syscall.SIGKILL)
+			}
+		}()
+	}
+	return nil
+}
+
+func markExecutionCancelling(ctx context.Context, services looperdruntime.Services, execution storage.AgentExecutionRecord, reason string, now func() time.Time) error {
+	if services.Repositories == nil || services.Repositories.AgentExecutions == nil {
+		return nil
+	}
+	updated := execution
+	updated.Status = "cancelling"
+	updated.UpdatedAt = eventlog.FormatJavaScriptISOString(now().UTC())
+	if updated.ErrorMessage == nil {
+		updated.ErrorMessage = &reason
+	}
+	return services.Repositories.AgentExecutions.Upsert(ctx, updated)
 }
 
 func hasVersionArg(args []string) bool {

--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -192,6 +192,9 @@ func stopLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 
 	result.ExecutionID = latestExecution.ID
 	result.Vendor = latestExecution.Vendor
+	if latestExecution.Status != "running" {
+		return result, nil
+	}
 	if services.ActiveExecutions != nil {
 		killed, err := services.ActiveExecutions.Kill(result.LoopID, latestRun.ID, latestExecution.ID, reason)
 		if err != nil {
@@ -265,7 +268,14 @@ func markExecutionCancelling(ctx context.Context, services looperdruntime.Servic
 	if services.Repositories == nil || services.Repositories.AgentExecutions == nil {
 		return nil
 	}
-	updated := execution
+	current, err := services.Repositories.AgentExecutions.GetByID(ctx, execution.ID)
+	if err != nil {
+		return err
+	}
+	if current == nil || current.Status != "running" {
+		return nil
+	}
+	updated := *current
 	updated.Status = "cancelling"
 	updated.UpdatedAt = eventlog.FormatJavaScriptISOString(now().UTC())
 	if updated.ErrorMessage == nil {

--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -233,15 +233,22 @@ func stopLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 }
 
 func signalAgentProcessGroup(pid int, signalProcess signalProcessFunc, grace time.Duration) error {
+	termSignaled := false
 	if err := signalProcess(-pid, syscall.SIGTERM); err != nil {
 		if !errors.Is(err, syscall.ESRCH) {
 			return err
 		}
-		if err := signalProcess(pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+		if err := signalProcess(pid, syscall.SIGTERM); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return nil
+			}
 			return err
 		}
+		termSignaled = true
+	} else {
+		termSignaled = true
 	}
-	if grace > 0 {
+	if grace > 0 && termSignaled {
 		go func() {
 			timer := time.NewTimer(grace)
 			defer timer.Stop()

--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -192,7 +192,7 @@ func stopLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 
 	result.ExecutionID = latestExecution.ID
 	result.Vendor = latestExecution.Vendor
-	if latestExecution.Status != "running" {
+	if !isStoppableExecutionStatus(latestExecution.Status) {
 		return result, nil
 	}
 	if services.ActiveExecutions != nil {
@@ -233,6 +233,10 @@ func stopLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 	}
 
 	return result, nil
+}
+
+func isStoppableExecutionStatus(status string) bool {
+	return status == "running" || status == "cancelling"
 }
 
 func signalAgentProcessGroup(pid int, signalProcess signalProcessFunc, grace time.Duration) error {

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -377,6 +377,134 @@ func TestStopLoopKillsActiveInMemoryExecution(t *testing.T) {
 	}
 }
 
+func TestStopLoopRetriesActiveInMemoryExecutionAlreadyCancelling(t *testing.T) {
+	ctx := context.Background()
+	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(ctx); err != nil {
+		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 12, 0, 0, 0, time.UTC)
+	nowISO := "2026-04-21T12:00:00.000Z"
+	project := storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Projects.Upsert(ctx, project); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 30, ProjectID: project.ID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_1", LoopID: loop.ID, Status: "running", StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	agentExecution := storage.AgentExecutionRecord{ID: "agentexec_1", ProjectID: &project.ID, LoopID: &loop.ID, RunID: &run.ID, Vendor: "codex", Status: "cancelling", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.AgentExecutions.Upsert(ctx, agentExecution); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	registry := looperdruntime.NewActiveExecutionRegistry()
+	active := &fakeActiveExecution{}
+	unregister := registry.Register(loop.ID, run.ID, agentExecution.ID, active)
+	defer unregister()
+	services := looperdruntime.Services{
+		Coordinator:      coordinator,
+		Repositories:     repos,
+		Loops:            &loops.Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }},
+		ActiveExecutions: registry,
+	}
+
+	signaled := false
+	gotResult, err := stopLoop(ctx, services, loop.ID, "Stopped by test", func() time.Time { return now }, func(int, syscall.Signal) error {
+		signaled = true
+		return nil
+	}, nil)
+	if err != nil {
+		t.Fatalf("stopLoop() error = %v", err)
+	}
+	result, ok := gotResult.(stopLoopResult)
+	if !ok {
+		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
+	}
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 {
+		t.Fatalf("stopLoop() result = %#v", result)
+	}
+	if !active.killed {
+		t.Fatal("active execution Kill was not invoked")
+	}
+	if active.reason != "Stopped by test" {
+		t.Fatalf("Kill reason = %q, want stop reason", active.reason)
+	}
+	if signaled {
+		t.Fatal("signal invoked, want active execution kill path")
+	}
+}
+
+func TestStopLoopSignalsExecutionAlreadyCancelling(t *testing.T) {
+	ctx := context.Background()
+	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(ctx); err != nil {
+		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 12, 0, 0, 0, time.UTC)
+	nowISO := "2026-04-21T12:00:00.000Z"
+	project := storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Projects.Upsert(ctx, project); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 30, ProjectID: project.ID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_1", LoopID: loop.ID, Status: "running", StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	pid := int64(4321)
+	agentExecution := storage.AgentExecutionRecord{ID: "agentexec_1", ProjectID: &project.ID, LoopID: &loop.ID, RunID: &run.ID, Vendor: "codex", Status: "cancelling", PID: &pid, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.AgentExecutions.Upsert(ctx, agentExecution); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	services := looperdruntime.Services{
+		Coordinator:  coordinator,
+		Repositories: repos,
+		Loops:        &loops.Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }},
+	}
+
+	var signalCalls []int
+	gotResult, err := stopLoop(ctx, services, loop.ID, "Stopped by test", func() time.Time { return now }, func(gotPID int, _ syscall.Signal) error {
+		signalCalls = append(signalCalls, gotPID)
+		return syscall.ESRCH
+	}, func(context.Context, storage.AgentExecutionRecord, int) (bool, bool, error) {
+		return true, true, nil
+	})
+	if err != nil {
+		t.Fatalf("stopLoop() error = %v", err)
+	}
+	result, ok := gotResult.(stopLoopResult)
+	if !ok {
+		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
+	}
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != pid {
+		t.Fatalf("stopLoop() result = %#v", result)
+	}
+	if len(signalCalls) != 2 || signalCalls[0] != -int(pid) || signalCalls[1] != int(pid) {
+		t.Fatalf("signal calls = %#v, want process group then process", signalCalls)
+	}
+}
+
 func TestStopLoopSkipsStaleActiveExecutionWhenLatestExecutionCompleted(t *testing.T) {
 	ctx := context.Background()
 	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -279,6 +279,32 @@ func TestStopLoopPausesLoopAndSignalsActiveExecution(t *testing.T) {
 	}
 }
 
+func TestSignalAgentProcessGroupDoesNotEscalateAfterESRCH(t *testing.T) {
+	pid := 4321
+	grace := 10 * time.Millisecond
+	killCalled := make(chan struct{}, 1)
+
+	err := signalAgentProcessGroup(pid, func(gotPID int, sig syscall.Signal) error {
+		if sig == syscall.SIGKILL {
+			killCalled <- struct{}{}
+			return nil
+		}
+		if sig != syscall.SIGTERM {
+			t.Fatalf("signal = %v, want SIGTERM", sig)
+		}
+		return syscall.ESRCH
+	}, grace)
+	if err != nil {
+		t.Fatalf("signalAgentProcessGroup() error = %v", err)
+	}
+
+	select {
+	case <-killCalled:
+		t.Fatal("SIGKILL escalation was armed after SIGTERM returned ESRCH")
+	case <-time.After(3 * grace):
+	}
+}
+
 func TestStopLoopKillsActiveInMemoryExecution(t *testing.T) {
 	ctx := context.Background()
 	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -229,6 +229,9 @@ func TestStopLoopPausesLoopAndSignalsActiveExecution(t *testing.T) {
 	gotSignalPID := 0
 	verified := false
 	gotResult, err := stopLoop(ctx, services, loop.ID, "Stopped by test", func() time.Time { return now }, func(pid int, sig syscall.Signal) error {
+		if sig == syscall.SIGKILL {
+			return nil
+		}
 		called = true
 		gotSignalPID = pid
 		if sig != syscall.SIGTERM {
@@ -253,8 +256,8 @@ func TestStopLoopPausesLoopAndSignalsActiveExecution(t *testing.T) {
 	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != pid {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
-	if !called || gotSignalPID != int(pid) {
-		t.Fatalf("signal invoked = %v pid=%d, want true pid=%d", called, gotSignalPID, pid)
+	if !called || gotSignalPID != -int(pid) {
+		t.Fatalf("signal invoked = %v pid=%d, want true pid=%d", called, gotSignalPID, -pid)
 	}
 	if !verified {
 		t.Fatal("execution verifier was not called")
@@ -266,6 +269,78 @@ func TestStopLoopPausesLoopAndSignalsActiveExecution(t *testing.T) {
 	}
 	if storedLoop == nil || storedLoop.Status != "paused" {
 		t.Fatalf("Loops.GetByID() = %#v, want paused loop", storedLoop)
+	}
+	storedExecution, err := repos.AgentExecutions.GetByID(ctx, agentExecution.ID)
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
+	}
+	if storedExecution == nil || storedExecution.Status != "cancelling" {
+		t.Fatalf("AgentExecutions.GetByID() = %#v, want cancelling execution", storedExecution)
+	}
+}
+
+func TestStopLoopKillsActiveInMemoryExecution(t *testing.T) {
+	ctx := context.Background()
+	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(ctx); err != nil {
+		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 12, 0, 0, 0, time.UTC)
+	nowISO := "2026-04-21T12:00:00.000Z"
+	project := storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Projects.Upsert(ctx, project); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 30, ProjectID: project.ID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_1", LoopID: loop.ID, Status: "running", StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	agentExecution := storage.AgentExecutionRecord{ID: "agentexec_1", ProjectID: &project.ID, LoopID: &loop.ID, RunID: &run.ID, Vendor: "codex", Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.AgentExecutions.Upsert(ctx, agentExecution); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	registry := looperdruntime.NewActiveExecutionRegistry()
+	active := &fakeActiveExecution{}
+	unregister := registry.Register(loop.ID, run.ID, agentExecution.ID, active)
+	defer unregister()
+	services := looperdruntime.Services{
+		Coordinator:      coordinator,
+		Repositories:     repos,
+		Loops:            &loops.Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }},
+		ActiveExecutions: registry,
+	}
+
+	signaled := false
+	gotResult, err := stopLoop(ctx, services, loop.ID, "Stopped by test", func() time.Time { return now }, func(int, syscall.Signal) error {
+		signaled = true
+		return nil
+	}, nil)
+	if err != nil {
+		t.Fatalf("stopLoop() error = %v", err)
+	}
+	result, ok := gotResult.(stopLoopResult)
+	if !ok {
+		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
+	}
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 {
+		t.Fatalf("stopLoop() result = %#v", result)
+	}
+	if signaled {
+		t.Fatal("signal invoked, want active execution kill path")
+	}
+	if active.reason != "Stopped by test" {
+		t.Fatalf("Kill reason = %q, want stop reason", active.reason)
 	}
 	storedExecution, err := repos.AgentExecutions.GetByID(ctx, agentExecution.ID)
 	if err != nil {
@@ -345,4 +420,13 @@ func TestStopLoopSkipsSignalWhenExecutionVerifierRejectsPID(t *testing.T) {
 	if storedExecution == nil || storedExecution.Status != "running" {
 		t.Fatalf("AgentExecutions.GetByID() = %#v, want running execution", storedExecution)
 	}
+}
+
+type fakeActiveExecution struct {
+	reason string
+}
+
+func (f *fakeActiveExecution) Kill(reason string) error {
+	f.reason = reason
+	return nil
 }

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -377,6 +377,151 @@ func TestStopLoopKillsActiveInMemoryExecution(t *testing.T) {
 	}
 }
 
+func TestStopLoopSkipsStaleActiveExecutionWhenLatestExecutionCompleted(t *testing.T) {
+	ctx := context.Background()
+	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(ctx); err != nil {
+		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 12, 0, 0, 0, time.UTC)
+	nowISO := "2026-04-21T12:00:00.000Z"
+	project := storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Projects.Upsert(ctx, project); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 30, ProjectID: project.ID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_1", LoopID: loop.ID, Status: "running", StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	pid := int64(4321)
+	agentExecution := storage.AgentExecutionRecord{ID: "agentexec_1", ProjectID: &project.ID, LoopID: &loop.ID, RunID: &run.ID, Vendor: "codex", Status: "completed", PID: &pid, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.AgentExecutions.Upsert(ctx, agentExecution); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	registry := looperdruntime.NewActiveExecutionRegistry()
+	active := &fakeActiveExecution{}
+	unregister := registry.Register(loop.ID, run.ID, agentExecution.ID, active)
+	defer unregister()
+	services := looperdruntime.Services{
+		Coordinator:      coordinator,
+		Repositories:     repos,
+		Loops:            &loops.Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }},
+		ActiveExecutions: registry,
+	}
+
+	signaled := false
+	gotResult, err := stopLoop(ctx, services, loop.ID, "Stopped by test", func() time.Time { return now }, func(int, syscall.Signal) error {
+		signaled = true
+		return nil
+	}, nil)
+	if err != nil {
+		t.Fatalf("stopLoop() error = %v", err)
+	}
+
+	result, ok := gotResult.(stopLoopResult)
+	if !ok {
+		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
+	}
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 {
+		t.Fatalf("stopLoop() result = %#v", result)
+	}
+	if active.killed {
+		t.Fatal("active execution Kill invoked, want stale registry entry skipped")
+	}
+	if signaled {
+		t.Fatal("signal invoked, want completed execution to be skipped")
+	}
+
+	storedExecution, err := repos.AgentExecutions.GetByID(ctx, agentExecution.ID)
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
+	}
+	if storedExecution == nil || storedExecution.Status != "completed" {
+		t.Fatalf("AgentExecutions.GetByID() = %#v, want completed execution", storedExecution)
+	}
+}
+
+func TestStopLoopDoesNotOverwriteCompletedExecutionAfterActiveKill(t *testing.T) {
+	ctx := context.Background()
+	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(ctx); err != nil {
+		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 12, 0, 0, 0, time.UTC)
+	nowISO := "2026-04-21T12:00:00.000Z"
+	project := storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Projects.Upsert(ctx, project); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 30, ProjectID: project.ID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_1", LoopID: loop.ID, Status: "running", StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	agentExecution := storage.AgentExecutionRecord{ID: "agentexec_1", ProjectID: &project.ID, LoopID: &loop.ID, RunID: &run.ID, Vendor: "codex", Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.AgentExecutions.Upsert(ctx, agentExecution); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	registry := looperdruntime.NewActiveExecutionRegistry()
+	active := &fakeActiveExecution{onKill: func() error {
+		completed := agentExecution
+		completed.Status = "completed"
+		return repos.AgentExecutions.Upsert(ctx, completed)
+	}}
+	unregister := registry.Register(loop.ID, run.ID, agentExecution.ID, active)
+	defer unregister()
+	services := looperdruntime.Services{
+		Coordinator:      coordinator,
+		Repositories:     repos,
+		Loops:            &loops.Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }},
+		ActiveExecutions: registry,
+	}
+
+	gotResult, err := stopLoop(ctx, services, loop.ID, "Stopped by test", func() time.Time { return now }, nil, nil)
+	if err != nil {
+		t.Fatalf("stopLoop() error = %v", err)
+	}
+	result, ok := gotResult.(stopLoopResult)
+	if !ok {
+		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
+	}
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" {
+		t.Fatalf("stopLoop() result = %#v", result)
+	}
+	if !active.killed {
+		t.Fatal("active execution Kill was not invoked")
+	}
+
+	storedExecution, err := repos.AgentExecutions.GetByID(ctx, agentExecution.ID)
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
+	}
+	if storedExecution == nil || storedExecution.Status != "completed" {
+		t.Fatalf("AgentExecutions.GetByID() = %#v, want completed execution", storedExecution)
+	}
+}
+
 func TestStopLoopSkipsSignalWhenExecutionVerifierRejectsPID(t *testing.T) {
 	ctx := context.Background()
 	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
@@ -449,10 +594,16 @@ func TestStopLoopSkipsSignalWhenExecutionVerifierRejectsPID(t *testing.T) {
 }
 
 type fakeActiveExecution struct {
+	killed bool
 	reason string
+	onKill func() error
 }
 
 func (f *fakeActiveExecution) Kill(reason string) error {
+	f.killed = true
 	f.reason = reason
+	if f.onKill != nil {
+		return f.onKill()
+	}
 	return nil
 }

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -300,6 +300,12 @@ func (x *execution) run(ctx context.Context) {
 			if timedOut || killed {
 				continue
 			}
+			select {
+			case waitErr = <-waitCh:
+				waiting = false
+				continue
+			default:
+			}
 			if x.timeSinceLastOutput() < x.heartbeatTimeout {
 				continue
 			}

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -113,6 +113,7 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 
 	cmd := exec.Command(command, args...)
 	cmd.Dir = input.WorkingDirectory
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Env = os.Environ()
 	for key, value := range e.config.Env {
 		cmd.Env = append(cmd.Env, key+"="+value)
@@ -209,6 +210,36 @@ func (x *execution) Kill(reason string) error {
 	return nil
 }
 
+func (x *execution) signalProcessGroup(signal syscall.Signal) error {
+	if x.process.Process == nil {
+		return os.ErrProcessDone
+	}
+	pid := x.process.Process.Pid
+	if pid <= 0 {
+		return x.process.Process.Signal(signal)
+	}
+	if err := syscall.Kill(-pid, signal); err != nil {
+		if err == syscall.ESRCH {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return nil
+}
+
+func (x *execution) killProcessGroup() error {
+	if x.process.Process == nil {
+		return os.ErrProcessDone
+	}
+	pid := x.process.Process.Pid
+	if pid > 0 {
+		if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil || err == syscall.ESRCH {
+			return nil
+		}
+	}
+	return x.process.Process.Kill()
+}
+
 func (x *execution) run(ctx context.Context) {
 	waitCh := make(chan error, 1)
 	go func() { waitCh <- x.process.Wait() }()
@@ -227,8 +258,8 @@ func (x *execution) run(ctx context.Context) {
 				if x.process.Process == nil {
 					return
 				}
-				if err := x.process.Process.Signal(syscall.SIGTERM); err != nil && err != os.ErrProcessDone {
-					_ = x.process.Process.Kill()
+				if err := x.signalProcessGroup(syscall.SIGTERM); err != nil && err != os.ErrProcessDone {
+					_ = x.killProcessGroup()
 					return
 				}
 				grace := x.gracefulShutdown
@@ -266,7 +297,7 @@ func (x *execution) run(ctx context.Context) {
 			x.setStatus("timeout")
 			terminateSignal()
 		case <-tickerChan(inactivityTimer):
-			if timedOut || killed || x.process.ProcessState != nil {
+			if timedOut || killed {
 				continue
 			}
 			if x.timeSinceLastOutput() < x.heartbeatTimeout {
@@ -292,10 +323,11 @@ func (x *execution) run(ctx context.Context) {
 			terminateSignal()
 		case <-graceKillTimer:
 			graceKillTimer = nil
-			if x.process.Process != nil {
-				_ = x.process.Process.Kill()
-			}
+			_ = x.killProcessGroup()
 		}
+	}
+	if killed || timedOut {
+		_ = x.killProcessGroup()
 	}
 
 	stdout := x.stdoutString()

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -252,16 +252,20 @@ func (x *execution) run(ctx context.Context) {
 		graceKillTimer  <-chan time.Time
 		timeoutTimer    <-chan time.Time
 		inactivityTimer *time.Ticker
+		termDelivered   bool
 		terminateOnce   sync.Once
 		terminateSignal = func() {
 			terminateOnce.Do(func() {
 				if x.process.Process == nil {
 					return
 				}
-				if err := x.signalProcessGroup(syscall.SIGTERM); err != nil && err != os.ErrProcessDone {
-					_ = x.killProcessGroup()
+				if err := x.signalProcessGroup(syscall.SIGTERM); err != nil {
+					if err != os.ErrProcessDone {
+						_ = x.killProcessGroup()
+					}
 					return
 				}
+				termDelivered = true
 				grace := x.gracefulShutdown
 				if grace <= 0 {
 					grace = 5 * time.Second
@@ -332,7 +336,7 @@ func (x *execution) run(ctx context.Context) {
 			_ = x.killProcessGroup()
 		}
 	}
-	if killed || timedOut {
+	if termDelivered && (killed || timedOut) {
 		_ = x.killProcessGroup()
 	}
 

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -2,8 +2,11 @@ package agent
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -343,6 +346,37 @@ func TestExecutorTimeoutMarksTimeout(t *testing.T) {
 	}
 }
 
+func TestExecutorKillTerminatesChildProcessGroup(t *testing.T) {
+	workDir := t.TempDir()
+	childPIDPath := filepath.Join(workDir, "child.pid")
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", `(trap '' TERM; while true; do sleep 1; done) & echo $! > "$CHILD_PID_FILE"; wait`}}}})
+
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_kill_group", WorkingDirectory: workDir, Prompt: "ignored", Timeout: 5 * time.Second, GracefulShutdown: 20 * time.Millisecond, Env: map[string]string{"CHILD_PID_FILE": childPIDPath}})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	childPID := waitForPIDFile(t, childPIDPath)
+	if err := execHandle.Kill("stopped by test"); err != nil {
+		t.Fatalf("Kill() error = %v", err)
+	}
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "killed" {
+		t.Fatalf("result.Status = %q, want killed", result.Status)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(childPID, 0); err == syscall.ESRCH {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("child process %d is still running after execution Kill", childPID)
+}
+
 func TestExecutorHeartbeatTimeoutMarksTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -437,4 +471,21 @@ func containsEvent(events []storage.EventLogRecord, eventType string) bool {
 
 func containsText(haystack, needle string) bool {
 	return strings.Contains(haystack, needle)
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+			if err == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for pid file %s", path)
+	return 0
 }

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -1576,6 +1576,10 @@ func (e smokeAgentExecution) Wait(ctx context.Context) (worker.AgentResult, erro
 	}, nil
 }
 
+func (e smokeAgentExecution) Kill(reason string) error {
+	return e.execution.Kill(reason)
+}
+
 func derefString(value *string) string {
 	if value == nil {
 		return ""

--- a/internal/runtime/active_executions.go
+++ b/internal/runtime/active_executions.go
@@ -1,0 +1,51 @@
+package runtime
+
+import "sync"
+
+type activeExecution interface {
+	Kill(string) error
+}
+
+type ActiveExecutionRegistry struct {
+	mu         sync.Mutex
+	executions map[string]activeExecution
+}
+
+func NewActiveExecutionRegistry() *ActiveExecutionRegistry {
+	return &ActiveExecutionRegistry{executions: make(map[string]activeExecution)}
+}
+
+func (r *ActiveExecutionRegistry) Register(loopID, runID, executionID string, execution activeExecution) func() {
+	if r == nil || execution == nil {
+		return func() {}
+	}
+	key := activeExecutionKey(loopID, runID, executionID)
+	r.mu.Lock()
+	r.executions[key] = execution
+	r.mu.Unlock()
+	return func() {
+		r.mu.Lock()
+		if r.executions[key] == execution {
+			delete(r.executions, key)
+		}
+		r.mu.Unlock()
+	}
+}
+
+func (r *ActiveExecutionRegistry) Kill(loopID, runID, executionID, reason string) (bool, error) {
+	if r == nil {
+		return false, nil
+	}
+	key := activeExecutionKey(loopID, runID, executionID)
+	r.mu.Lock()
+	execution := r.executions[key]
+	r.mu.Unlock()
+	if execution == nil {
+		return false, nil
+	}
+	return true, execution.Kill(reason)
+}
+
+func activeExecutionKey(loopID, runID, executionID string) string {
+	return loopID + "\x00" + runID + "\x00" + executionID
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -64,11 +64,12 @@ type Options struct {
 }
 
 type Services struct {
-	Coordinator  *storage.SQLiteCoordinator
-	Repositories *storage.Repositories
-	Projects     *projects.Service
-	Loops        *loops.Service
-	Runs         *runs.Service
+	Coordinator      *storage.SQLiteCoordinator
+	Repositories     *storage.Repositories
+	Projects         *projects.Service
+	Loops            *loops.Service
+	Runs             *runs.Service
+	ActiveExecutions *ActiveExecutionRegistry
 }
 
 type Runtime struct {
@@ -85,20 +86,21 @@ type Runtime struct {
 	signalProcess          SignalProcessFunc
 	shutdownTimeout        time.Duration
 
-	mu              sync.RWMutex
-	startedAt       *time.Time
-	recovery        RecoverySummary
-	stopped         bool
-	services        Services
-	startErr        error
-	startOnce       sync.Once
-	shutdownOnce    sync.Once
-	shutdownCh      chan struct{}
-	schedulerStop   chan struct{}
-	schedulerDone   chan struct{}
-	schedulerWake   chan struct{}
-	schedulerCancel context.CancelFunc
-	schedulerTasks  *schedulerTaskTracker
+	mu               sync.RWMutex
+	startedAt        *time.Time
+	recovery         RecoverySummary
+	stopped          bool
+	services         Services
+	startErr         error
+	startOnce        sync.Once
+	shutdownOnce     sync.Once
+	shutdownCh       chan struct{}
+	schedulerStop    chan struct{}
+	schedulerDone    chan struct{}
+	schedulerWake    chan struct{}
+	schedulerCancel  context.CancelFunc
+	schedulerTasks   *schedulerTaskTracker
+	activeExecutions *ActiveExecutionRegistry
 }
 
 func New(options Options) *Runtime {
@@ -151,6 +153,7 @@ func New(options Options) *Runtime {
 		shutdownTimeout:        shutdownTimeout,
 		recovery:               createEmptyRecoverySummary(),
 		shutdownCh:             make(chan struct{}),
+		activeExecutions:       NewActiveExecutionRegistry(),
 	}
 	if !customSchedulerTick {
 		rt.runSchedulerTick = rt.executeDefaultSchedulerTick
@@ -352,15 +355,16 @@ func (r *Runtime) start(ctx context.Context) error {
 	r.startedAt = &startedAt
 	r.recovery = recoverySummary
 	r.services = Services{
-		Coordinator:  coordinator,
-		Repositories: repositories,
-		Projects:     projectService,
-		Loops:        loopService,
-		Runs:         runService,
+		Coordinator:      coordinator,
+		Repositories:     repositories,
+		Projects:         projectService,
+		Loops:            loopService,
+		Runs:             runService,
+		ActiveExecutions: r.activeExecutions,
 	}
 	schedulerDisabled := false
 	if !r.customSchedulerTick {
-		r.defaultSchedulerTick = buildDefaultSchedulerTick(r.config, r.logger, coordinator, repositories, gitGateway, githubGateway, func() schedulerAsyncRunner {
+		r.defaultSchedulerTick = buildDefaultSchedulerTick(r.config, r.logger, coordinator, repositories, gitGateway, githubGateway, r.activeExecutions, func() schedulerAsyncRunner {
 			r.mu.RLock()
 			defer r.mu.RUnlock()
 			return r.schedulerTasks
@@ -559,12 +563,18 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				continue
 			}
 			if running {
-				if err := r.signalProcess(pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+				if err := r.signalAgentProcessGroup(pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
 					if r.logger != nil {
 						r.logger.Warn("failed to cleanup orphan agent execution", map[string]any{"executionId": execution.ID, "pid": pid, "error": err.Error()})
 					}
 					continue
 				}
+				go func(pid int) {
+					timer := time.NewTimer(5 * time.Second)
+					defer timer.Stop()
+					<-timer.C
+					_ = r.signalAgentProcessGroup(pid, syscall.SIGKILL)
+				}(pid)
 			}
 
 			cleaned := execution
@@ -1165,6 +1175,19 @@ func defaultReadProcessCommand(ctx context.Context, pid int) (string, error) {
 
 func defaultSignalProcess(pid int, signal syscall.Signal) error {
 	return syscall.Kill(pid, signal)
+}
+
+func (r *Runtime) signalAgentProcessGroup(pid int, signal syscall.Signal) error {
+	if r.signalProcess == nil {
+		return nil
+	}
+	if err := r.signalProcess(-pid, signal); err != nil {
+		if !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+		return r.signalProcess(pid, signal)
+	}
+	return nil
 }
 
 func createEmptyRecoverySummary() RecoverySummary {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -563,18 +563,24 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				continue
 			}
 			if running {
-				if err := r.signalAgentProcessGroup(pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
-					if r.logger != nil {
-						r.logger.Warn("failed to cleanup orphan agent execution", map[string]any{"executionId": execution.ID, "pid": pid, "error": err.Error()})
+				if err := r.signalAgentProcessGroup(pid, syscall.SIGTERM); err != nil {
+					if errors.Is(err, syscall.ESRCH) {
+						running = false
+					} else {
+						if r.logger != nil {
+							r.logger.Warn("failed to cleanup orphan agent execution", map[string]any{"executionId": execution.ID, "pid": pid, "error": err.Error()})
+						}
+						continue
 					}
-					continue
 				}
-				go func(pid int) {
-					timer := time.NewTimer(5 * time.Second)
-					defer timer.Stop()
-					<-timer.C
-					_ = r.signalAgentProcessGroup(pid, syscall.SIGKILL)
-				}(pid)
+				if running {
+					go func(pid int) {
+						timer := time.NewTimer(5 * time.Second)
+						defer timer.Stop()
+						<-timer.C
+						_ = r.signalAgentProcessGroup(pid, syscall.SIGKILL)
+					}(pid)
+				}
 			}
 
 			cleaned := execution

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -806,8 +806,11 @@ func TestRuntimeRecoveryCleansOrphanAgentExecutions(t *testing.T) {
 			return "codex exec fix failing tests", nil
 		},
 		SignalProcess: func(gotPID int, signal syscall.Signal) error {
-			if gotPID != int(pid) || signal != syscall.SIGTERM {
-				t.Fatalf("SignalProcess(%d, %v), want (%d, SIGTERM)", gotPID, signal, pid)
+			if signal == syscall.SIGKILL {
+				return nil
+			}
+			if gotPID != -int(pid) || signal != syscall.SIGTERM {
+				t.Fatalf("SignalProcess(%d, %v), want (%d, SIGTERM)", gotPID, signal, -pid)
 			}
 			return nil
 		},

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -504,14 +504,27 @@ func (a workerGitAdapter) Push(ctx context.Context, input worker.PushInput) erro
 	return a.gateway.Push(ctx, gitinfra.PushInput{WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ProtectedBranches: input.ProtectedBranches})
 }
 
-type workerAgentExecutorAdapter struct{ executor *agent.ConfiguredExecutor }
-type workerAgentExecutionAdapter struct{ execution agent.Execution }
+type workerAgentExecutorAdapter struct {
+	executor *agent.ConfiguredExecutor
+	registry *ActiveExecutionRegistry
+}
+type workerAgentExecutionAdapter struct {
+	execution agent.Execution
+}
 
 func (a workerAgentExecutorAdapter) Start(ctx context.Context, input worker.AgentRunInput) (worker.AgentExecution, error) {
 	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
 	if err != nil {
 		return nil, err
 	}
+	unregister := func() {}
+	if a.registry != nil {
+		unregister = a.registry.Register(input.LoopID, input.RunID, input.ExecutionID, execution)
+	}
+	go func() {
+		_, _ = execution.Wait(context.Background())
+		unregister()
+	}()
 	return workerAgentExecutionAdapter{execution: execution}, nil
 }
 
@@ -523,7 +536,11 @@ func (a workerAgentExecutionAdapter) Wait(ctx context.Context) (worker.AgentResu
 	return worker.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, ParseStatus: result.ParseStatus, ChangedFiles: result.ChangedFiles, Commits: result.Commits, Lifecycle: result.Lifecycle}, nil
 }
 
-func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, asyncRunner func() schedulerAsyncRunner, now func() time.Time) RunSchedulerTickFunc {
+func (a workerAgentExecutionAdapter) Kill(reason string) error {
+	return a.execution.Kill(reason)
+}
+
+func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, now func() time.Time) RunSchedulerTickFunc {
 	if now == nil {
 		now = time.Now
 	}
@@ -670,7 +687,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			return githubCLIAutoPROpeningAvailable(ctx, cfg, githubGateway, logger, repo, cwd)
 		},
 		Git:              workerGitAdapter{gateway: gitGateway},
-		AgentExecutor:    workerAgentExecutorAdapter{executor: agentExecutor},
+		AgentExecutor:    workerAgentExecutorAdapter{executor: agentExecutor, registry: activeExecutions},
 		Logger:           logger,
 		Now:              now,
 		AllowAutoCommit:  cfg.Defaults.AllowAutoCommit,

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -266,6 +266,7 @@ type AgentResult struct {
 
 type AgentExecution interface {
 	Wait(context.Context) (AgentResult, error)
+	Kill(string) error
 }
 
 type AgentExecutor interface {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -2170,6 +2170,8 @@ func (f fakeAgentExecution) Wait(ctx context.Context) (AgentResult, error) {
 	return f.result, nil
 }
 
+func (f fakeAgentExecution) Kill(string) error { return nil }
+
 type testLogger struct{}
 
 func (*testLogger) Debug(string, map[string]any) {}


### PR DESCRIPTION
## Summary
- Track active worker agent executions in memory so `looper stop` can invoke the live execution kill path instead of only signaling a stored PID.
- Start agent commands in their own process group and terminate the group with SIGTERM/SIGKILL escalation so child processes do not linger.
- Extend stop/recovery fallback signaling and tests to cover in-memory kills, process-group signaling, and child termination.

## Validation
- `go test ./cmd/looperd ./internal/agent ./internal/runtime ./internal/worker`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./internal/agent ./internal/runtime ./cmd/looperd`

Closes #95