### PR TITLE
Fix reviewer auto-discovery gating

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -125,9 +125,9 @@ Use this when new commits are expected to keep landing on the PR.
 Reviewer mainly watches two kinds of PRs:
 
 - open PRs where the current GitHub user was requested as a reviewer
-- open PRs labeled `looper:spec-reviewing`
+- manually-started reviewer loops from this machine, including `looper review owner/repo#42 --loop`
 
-So for a spec PR, reviewer can find it even if no explicit review request was added, as long as the PR has `looper:spec-reviewing`.
+For spec PRs, `looper:spec-reviewing` marks the review phase, but it does not by itself authorize other users' Looper instances to run. Request review from the intended GitHub user to trigger that user's automatic reviewer.
 
 ### What happens after reviewer finishes
 
@@ -233,8 +233,9 @@ So:
 Reviewer automatically pays attention to:
 
 - PRs where the current GitHub user has a review request
+- manual reviewer loops created on this machine
 
-Also, any PR labeled `looper:spec-reviewing` can be discovered by reviewer.
+The `looper:spec-reviewing` label is a phase marker; automatic review still requires a review request unless the loop was explicitly started locally.
 
 ## 11. Common GitHub / PR commands
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1200,7 +1200,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 			}
 		}
 	}
-	if startStep != stepDiscover && !isManualReviewerLoop(loop) && needsReviewerEligibilityRediscovery(checkpoint) {
+	if startStep != stepDiscover && !isManualReviewerLoop(loop) && needsReviewerEligibilityRediscovery(checkpoint, startStep) {
 		startStep = stepDiscover
 		restartFromDiscover = true
 	}
@@ -1386,7 +1386,10 @@ func isManualReviewerLoop(loop storage.LoopRecord) bool {
 	return manual
 }
 
-func needsReviewerEligibilityRediscovery(checkpoint reviewerCheckpoint) bool {
+func needsReviewerEligibilityRediscovery(checkpoint reviewerCheckpoint, startStep ReviewerStep) bool {
+	if checkpoint.PendingReview != nil && (startStep == stepReview || startStep == stepPublish) {
+		return false
+	}
 	return checkpoint.Detail == nil || checkpoint.Detail.ReviewRequests == nil
 }
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1037,6 +1037,8 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 	if err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
+	phase := resolvePullRequestPhase(detail.Labels)
+	checkpointPhase := resolvePullRequestPhase(detailLabels(input.Checkpoint.Detail))
 	if !isManualReviewerLoop(input.Loop) {
 		currentLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
 		if err != nil {
@@ -1044,6 +1046,9 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		}
 		if !isCurrentUserRequested(detail.ReviewRequests, normalizeLogin(currentLogin)) {
 			if pending.PublishState.ReviewSubmitted {
+				if err := r.transitionSpecReviewLabels(ctx, input, detail, phase, checkpointPhase, reviewEvent); err != nil {
+					return checkpoint, err
+				}
 				if err := r.recordPublishedReviewProgress(ctx, input, pending, reviewEvent); err != nil {
 					return checkpoint, err
 				}
@@ -1052,8 +1057,6 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 			return checkpoint, nil
 		}
 	}
-	phase := resolvePullRequestPhase(detail.Labels)
-	checkpointPhase := resolvePullRequestPhase(detailLabels(input.Checkpoint.Detail))
 	if detail.HeadSHA != "" && detail.HeadSHA != pending.HeadSHA {
 		return checkpoint, &loopError{message: fmt.Sprintf("PR head changed before publish: expected %s, got %s", pending.HeadSHA, detail.HeadSHA), kind: FailureRetryableAfterResume}
 	}
@@ -1118,29 +1121,37 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		_ = r.tryRemoveReaction(ctx, input, "+1")
 	}
 	_ = r.tryRemoveReaction(ctx, input, "eyes")
-	postSubmitDetail := detail
-	if reviewEvent == ReviewEventApprove && (phase == "spec" || checkpointPhase == "spec") {
-		postSubmitDetail, err = r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: input.Project.RepoPath})
-		if err != nil {
-			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
-		}
-	}
-	if reviewEvent == ReviewEventApprove && (phase == "spec" || checkpointPhase == "spec") && isSpecReviewClean(postSubmitDetail) {
-		if specpr.HasLabel(postSubmitDetail.Labels, specpr.ReviewingLabel) {
-			if err := r.github.RemovePullRequestLabels(ctx, PullRequestLabelsInput{Repo: repo, PRNumber: prNumber, Labels: []string{specpr.ReviewingLabel}, CWD: input.Project.RepoPath}); err != nil {
-				return checkpoint, err
-			}
-		}
-		if !specpr.HasLabel(postSubmitDetail.Labels, specpr.ReadyLabel) {
-			if err := r.github.AddPullRequestLabels(ctx, PullRequestLabelsInput{Repo: repo, PRNumber: prNumber, Labels: []string{specpr.ReadyLabel}, CWD: input.Project.RepoPath}); err != nil {
-				return checkpoint, err
-			}
-		}
+	if err := r.transitionSpecReviewLabels(ctx, input, detail, phase, checkpointPhase, reviewEvent); err != nil {
+		return checkpoint, err
 	}
 	if err := r.recordPublishedReviewProgress(ctx, input, pending, reviewEvent); err != nil {
 		return checkpoint, err
 	}
 	return checkpoint, nil
+}
+
+func (r *Runner) transitionSpecReviewLabels(ctx context.Context, input stepInput, detail PullRequestDetail, phase string, checkpointPhase string, reviewEvent ReviewEvent) error {
+	if reviewEvent != ReviewEventApprove || (phase != "spec" && checkpointPhase != "spec") {
+		return nil
+	}
+	postSubmitDetail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
+	if err != nil {
+		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if !isSpecReviewClean(postSubmitDetail) {
+		return nil
+	}
+	if specpr.HasLabel(postSubmitDetail.Labels, specpr.ReviewingLabel) {
+		if err := r.github.RemovePullRequestLabels(ctx, PullRequestLabelsInput{Repo: input.Repo, PRNumber: input.PRNumber, Labels: []string{specpr.ReviewingLabel}, CWD: input.Project.RepoPath}); err != nil {
+			return err
+		}
+	}
+	if !specpr.HasLabel(postSubmitDetail.Labels, specpr.ReadyLabel) {
+		if err := r.github.AddPullRequestLabels(ctx, PullRequestLabelsInput{Repo: input.Repo, PRNumber: input.PRNumber, Labels: []string{specpr.ReadyLabel}, CWD: input.Project.RepoPath}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *Runner) recordPublishedReviewProgress(ctx context.Context, input stepInput, pending pendingReviewCheckpoint, reviewEvent ReviewEvent) error {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -533,7 +533,6 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[key] = struct{}{}
 		detail, viewErr := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: *loop.PRNumber, CWD: project.RepoPath})
 		if viewErr != nil {
 			result.Skipped++
@@ -547,6 +546,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			result.Skipped++
 			continue
 		}
+		seen[key] = struct{}{}
 		if err := enqueue(summaryFromDetail(detail), &loop); err != nil {
 			return DiscoveryResult{}, err
 		}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1037,6 +1037,16 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 	if err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
+	if !isManualReviewerLoop(input.Loop) {
+		currentLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+		if err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
+		if !isCurrentUserRequested(detail.ReviewRequests, normalizeLogin(currentLogin)) {
+			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", repo, prNumber)
+			return checkpoint, nil
+		}
+	}
 	phase := resolvePullRequestPhase(detail.Labels)
 	checkpointPhase := resolvePullRequestPhase(detailLabels(input.Checkpoint.Detail))
 	if detail.HeadSHA != "" && detail.HeadSHA != pending.HeadSHA {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -459,7 +459,10 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
-	currentLogin, _ := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+	currentLogin, err := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
 	currentLogin = normalizeLogin(currentLogin)
 	result := DiscoveryResult{}
 	seen := map[string]struct{}{}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1043,6 +1043,11 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		if !isCurrentUserRequested(detail.ReviewRequests, normalizeLogin(currentLogin)) {
+			if pending.PublishState.ReviewSubmitted {
+				if err := r.recordPublishedReviewProgress(ctx, input, pending, reviewEvent); err != nil {
+					return checkpoint, err
+				}
+			}
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", repo, prNumber)
 			return checkpoint, nil
 		}
@@ -1132,15 +1137,22 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 			}
 		}
 	}
+	if err := r.recordPublishedReviewProgress(ctx, input, pending, reviewEvent); err != nil {
+		return checkpoint, err
+	}
+	return checkpoint, nil
+}
+
+func (r *Runner) recordPublishedReviewProgress(ctx context.Context, input stepInput, pending pendingReviewCheckpoint, reviewEvent ReviewEvent) error {
 	metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastPublishedHeadSha": pending.HeadSHA, "lastReviewEvent": string(reviewEvent), "lastReviewSummary": pending.Summary, "lastPublishedAt": r.nowISO()})
 	if err != nil {
-		return checkpoint, err
+		return err
 	}
 	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) { updated.MetadataJSON = stringPtr(metadataJSON) }); err != nil {
-		return checkpoint, err
+		return err
 	}
-	r.appendEvent(ctx, eventInput{eventType: "pr.review.posted", projectID: input.Project.ID, loopID: input.Loop.ID, runID: input.Run.ID, entityType: "pull_request", entityID: fmt.Sprintf("%s#%d", repo, prNumber), payload: map[string]any{"repo": repo, "prNumber": prNumber, "event": string(reviewEvent), "headSha": pending.HeadSHA}})
-	return checkpoint, nil
+	r.appendEvent(ctx, eventInput{eventType: "pr.review.posted", projectID: input.Project.ID, loopID: input.Loop.ID, runID: input.Run.ID, entityType: "pull_request", entityID: fmt.Sprintf("%s#%d", input.Repo, input.PRNumber), payload: map[string]any{"repo": input.Repo, "prNumber": input.PRNumber, "event": string(reviewEvent), "headSha": pending.HeadSHA}})
+	return nil
 }
 
 type eventInput struct {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -334,6 +334,7 @@ type checkpointDetail struct {
 	HeadRefName    string   `json:"headRefName,omitempty"`
 	BaseRefName    string   `json:"baseRefName,omitempty"`
 	Author         string   `json:"author,omitempty"`
+	ReviewRequests []string `json:"reviewRequests,omitempty"`
 }
 
 type checkpointWorktree struct {
@@ -500,7 +501,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		return enqueue(pr, nil)
 	}
 	for _, pr := range openPRs {
-		if pr.IsDraft || normalizePRState(pr.State) != "open" || currentLogin == "" || !isCurrentUserRequested(pr.ReviewRequests, currentLogin) {
+		if pr.IsDraft || normalizePRState(pr.State) != "open" || !isCurrentUserRequested(pr.ReviewRequests, currentLogin) {
 			result.Skipped++
 			continue
 		}
@@ -509,7 +510,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		}
 	}
 	for _, pr := range specPRs {
-		if pr.IsDraft || normalizePRState(pr.State) != "open" {
+		if pr.IsDraft || normalizePRState(pr.State) != "open" || !isCurrentUserRequested(pr.ReviewRequests, currentLogin) {
 			result.Skipped++
 			continue
 		}
@@ -536,6 +537,10 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			continue
 		}
 		if detail.IsDraft || normalizePRState(detail.State) != "open" {
+			result.Skipped++
+			continue
+		}
+		if !isManualReviewerLoop(loop) && !isCurrentUserRequested(detail.ReviewRequests, currentLogin) {
 			result.Skipped++
 			continue
 		}
@@ -783,7 +788,7 @@ func (r *Runner) executeStep(ctx context.Context, step ReviewerStep, input stepI
 	case stepDiscover:
 		return r.runDiscoverStep(ctx, input)
 	case stepFilter:
-		return r.runFilterStep(input)
+		return r.runFilterStep(ctx, input)
 	case stepClaim:
 		return r.runClaimStep(ctx, input)
 	case stepSnapshot:
@@ -805,12 +810,12 @@ func (r *Runner) runDiscoverStep(ctx context.Context, input stepInput) (reviewer
 		return input.Checkpoint, err
 	}
 	checkpoint := input.Checkpoint
-	checkpoint.Detail = &checkpointDetail{Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, Author: detail.Author}
+	checkpoint.Detail = &checkpointDetail{Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, Author: detail.Author, ReviewRequests: cloneStrings(detail.ReviewRequests)}
 	checkpoint.ResumePolicy = "replay_step"
 	return checkpoint, nil
 }
 
-func (r *Runner) runFilterStep(input stepInput) (reviewerCheckpoint, error) {
+func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCheckpoint, error) {
 	checkpoint := input.Checkpoint
 	if checkpoint.Detail == nil {
 		return checkpoint, &loopError{message: "Missing PR detail checkpoint for filter step", kind: FailureRetryableTransient}
@@ -822,6 +827,13 @@ func (r *Runner) runFilterStep(input stepInput) (reviewerCheckpoint, error) {
 	if normalizePRState(checkpoint.Detail.State) != "open" {
 		checkpoint.SkipReason = fmt.Sprintf("Skipped non-open pull request %s#%d", input.Repo, input.PRNumber)
 		return checkpoint, nil
+	}
+	if !isManualReviewerLoop(input.Loop) {
+		currentLogin, _ := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+		if !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, normalizeLogin(currentLogin)) {
+			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", input.Repo, input.PRNumber)
+			return checkpoint, nil
+		}
 	}
 	meta := parseJSONObject(input.Loop.MetadataJSON)
 	if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && checkpoint.Detail.HeadSHA != "" && last == checkpoint.Detail.HeadSHA {
@@ -1336,6 +1348,12 @@ func (r *Runner) listFollowUpLoops(ctx context.Context, projectID, repo string) 
 	return result, nil
 }
 
+func isManualReviewerLoop(loop storage.LoopRecord) bool {
+	meta := parseJSONObject(loop.MetadataJSON)
+	manual, _ := meta["manual"].(bool)
+	return manual
+}
+
 type enqueueInput struct {
 	ProjectID string
 	LoopID    string
@@ -1541,6 +1559,10 @@ func normalizeLogin(login string) string {
 }
 
 func isCurrentUserRequested(requested []string, currentLogin string) bool {
+	currentLogin = normalizeLogin(currentLogin)
+	if currentLogin == "" {
+		return false
+	}
 	for _, login := range requested {
 		if normalizeLogin(login) == currentLogin {
 			return true

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -829,7 +829,10 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		return checkpoint, nil
 	}
 	if !isManualReviewerLoop(input.Loop) {
-		currentLogin, _ := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+		currentLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+		if err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+		}
 		if !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, normalizeLogin(currentLogin)) {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", input.Repo, input.PRNumber)
 			return checkpoint, nil
@@ -1172,6 +1175,10 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 			}
 		}
 	}
+	if startStep != stepDiscover && !isManualReviewerLoop(loop) && needsReviewerEligibilityRediscovery(checkpoint) {
+		startStep = stepDiscover
+		restartFromDiscover = true
+	}
 	resumed := latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && startStep != stepDiscover
 	initialCheckpoint := reviewerCheckpoint{ResumePolicy: "replay_step"}
 	if resumed {
@@ -1352,6 +1359,10 @@ func isManualReviewerLoop(loop storage.LoopRecord) bool {
 	meta := parseJSONObject(loop.MetadataJSON)
 	manual, _ := meta["manual"].(bool)
 	return manual
+}
+
+func needsReviewerEligibilityRediscovery(checkpoint reviewerCheckpoint) bool {
+	return checkpoint.Detail == nil || checkpoint.Detail.ReviewRequests == nil
 }
 
 type enqueueInput struct {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -203,6 +203,37 @@ func TestDiscoverPullRequestsAllowsManualFollowUpWithoutReviewRequest(t *testing
 	}
 }
 
+func TestDiscoverPullRequestsAllowsManualFollowUpAfterSkippedAutomaticLoopForSamePR(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"alice"}, currentLogin: "bob"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	automaticMetadata := `{"followUpdates":true}`
+	manualMetadata := `{"followUpdates":true,"manual":true}`
+	for _, loop := range []storage.LoopRecord{
+		{ID: "loop_auto_follow", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &automaticMetadata, CreatedAt: nowISO, UpdatedAt: nowISO},
+		{ID: "loop_manual_follow_after_auto", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &manualMetadata, CreatedAt: nowISO, UpdatedAt: nowISO},
+	} {
+		if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("len(QueueItems) = %d, want 1", len(result.QueueItems))
+	}
+	if result.QueueItems[0].LoopID == nil || *result.QueueItems[0].LoopID != "loop_manual_follow_after_auto" {
+		t.Fatalf("queue loopID = %#v, want manual follow-up loop", result.QueueItems[0].LoopID)
+	}
+}
+
 func TestProcessClaimedItemSkipsQueuedAutomaticLoopWhenCurrentUserIsNotRequested(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -380,6 +380,64 @@ func TestProcessClaimedItemRestartsAutomaticResumeFromDiscoverForFreshReviewRequ
 	}
 }
 
+func TestProcessClaimedItemPreservesLegacyPublishCheckpointOnAutomaticResume(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"octocat"}}
+	agent := &fakeAgentExecutor{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_legacy_publish_resume", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	legacyCheckpoint := reviewerCheckpoint{
+		Detail: &checkpointDetail{Title: "Review me", State: "OPEN", HeadSHA: "abc123"},
+		PendingReview: &pendingReviewCheckpoint{
+			HeadSHA: "abc123",
+			Event:   ReviewEventComment,
+			Body:    "Actionable review",
+			Summary: "Actionable review",
+			Comments: []reviewFeedbackComment{
+				{Body: "Follow-up comment"},
+			},
+			PublishState: &publishState{ReviewSubmitted: true},
+		},
+		ResumePolicy: "advance_from_checkpoint",
+	}
+	legacyRun := storage.RunRecord{ID: "run_legacy_publish", LoopID: loop.ID, Status: "failed", CurrentStep: stringPtr(string(stepPublish)), LastCompletedStep: stringPtr(string(stepReview)), CheckpointJSON: stringPtr(mustMarshalJSON(legacyCheckpoint)), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), legacyRun); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	queue, err := runner.enqueue(context.Background(), enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success after publish resume", result)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("agent starts=%d, want no duplicate review", len(agent.starts))
+	}
+	if len(github.submitCalls) != 0 {
+		t.Fatalf("submit calls=%d, want no duplicate review submission", len(github.submitCalls))
+	}
+	if len(github.prComments) != 1 {
+		t.Fatalf("pr comments=%d, want remaining top-level comment", len(github.prComments))
+	}
+}
+
 func TestEnqueueScopesReviewerDedupeKeyToLoop(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -45,6 +45,21 @@ func TestDiscoverPullRequestsCreatesLoopAndQueue(t *testing.T) {
 	}
 }
 
+func TestDiscoverPullRequestsReturnsCurrentUserLookupError(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLoginErr: fmt.Errorf("gh auth failed")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err == nil || !strings.Contains(err.Error(), "gh auth failed") {
+		t.Fatalf("DiscoverPullRequests() error = %v, want gh auth failed", err)
+	}
+	if len(result.QueueItems) != 0 || len(result.CreatedLoopIDs) != 0 {
+		t.Fatalf("result = %#v, want no discovery results on auth error", result)
+	}
+}
+
 func TestDiscoverPullRequestsPreservesPausedLoop(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -104,6 +104,21 @@ func TestDiscoverPullRequestsSkipsSpecLabelWhenCurrentUserIsNotRequested(t *test
 	}
 }
 
+func TestDiscoverPullRequestsAllowsSpecLabelWhenCurrentUserIsRequested(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{labels: []string{specpr.ReviewingLabel}, reviewRequests: []string{"bob"}, currentLogin: "bob"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("len(QueueItems) = %d, want 1", len(result.QueueItems))
+	}
+}
+
 func TestDiscoverPullRequestsSkipsAutomaticFollowUpWhenCurrentUserIsNotRequested(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -124,6 +139,29 @@ func TestDiscoverPullRequestsSkipsAutomaticFollowUpWhenCurrentUserIsNotRequested
 	}
 	if len(result.QueueItems) != 0 {
 		t.Fatalf("len(QueueItems) = %d, want 0", len(result.QueueItems))
+	}
+}
+
+func TestDiscoverPullRequestsAllowsAutomaticFollowUpWhenCurrentUserIsRequested(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"bob"}, currentLogin: "bob"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"followUpdates":true}`
+	loop := storage.LoopRecord{ID: "loop_follow_requested", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("len(QueueItems) = %d, want 1", len(result.QueueItems))
 	}
 }
 
@@ -182,6 +220,117 @@ func TestProcessClaimedItemSkipsQueuedAutomaticLoopWhenCurrentUserIsNotRequested
 	}
 	if len(agent.starts) != 0 || len(git.createCalls) != 0 || len(github.submitCalls) != 0 {
 		t.Fatalf("agent starts=%d git creates=%d submit calls=%d, want no review work", len(agent.starts), len(git.createCalls), len(github.submitCalls))
+	}
+}
+
+func TestProcessClaimedItemRetriesWhenCurrentUserLookupFails(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLoginErr: fmt.Errorf("gh auth failed")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_lookup_error", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue, err := runner.enqueue(context.Background(), enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient {
+		t.Fatalf("result = %#v, want retryable transient failure", result)
+	}
+	queueAfter, err := fixture.repos.Queue.GetByID(context.Background(), queue.ID)
+	if err != nil || queueAfter == nil {
+		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queueAfter, err)
+	}
+	if queueAfter.Status != "queued" {
+		t.Fatalf("queue status = %s, want queued retry", queueAfter.Status)
+	}
+}
+
+func TestProcessClaimedItemAllowsManualQueuedLoopWithoutReviewRequest(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"alice"}, currentLogin: "bob"}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Manual review", Stdout: `{"verdict":"actionable","body":"Manual review","comments":[{"body":"Manual review"}]}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"manual":true}`
+	loop := storage.LoopRecord{ID: "loop_manual_api", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue, err := runner.enqueue(context.Background(), enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success", result)
+	}
+	if len(agent.starts) != 1 || len(github.submitCalls) != 1 {
+		t.Fatalf("agent starts=%d submit calls=%d, want review to run", len(agent.starts), len(github.submitCalls))
+	}
+}
+
+func TestProcessClaimedItemRestartsAutomaticResumeFromDiscoverForFreshReviewRequests(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"octocat"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Resumed review", Stdout: `{"verdict":"actionable","body":"Resumed review","comments":[{"body":"Resumed review"}]}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_legacy_resume", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	legacyCheckpoint := reviewerCheckpoint{Detail: &checkpointDetail{Title: "Review me", State: "OPEN", HeadSHA: "abc123"}, ResumePolicy: "advance_from_checkpoint"}
+	legacyRun := storage.RunRecord{ID: "run_legacy", LoopID: loop.ID, Status: "failed", CurrentStep: stringPtr(string(stepClaim)), LastCompletedStep: stringPtr(string(stepFilter)), CheckpointJSON: stringPtr(mustMarshalJSON(legacyCheckpoint)), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), legacyRun); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	queue, err := runner.enqueue(context.Background(), enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success after fresh discover", result)
+	}
+	if github.viewCalls == 0 || len(agent.starts) != 1 {
+		t.Fatalf("viewCalls=%d agent starts=%d, want fresh discover and review", github.viewCalls, len(agent.starts))
 	}
 }
 
@@ -984,6 +1133,7 @@ type fakeGitHubGateway struct {
 	labels                  []string
 	reviewRequests          []string
 	currentLogin            string
+	currentLoginErr         error
 }
 
 func (g *fakeGitHubGateway) ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
@@ -992,6 +1142,9 @@ func (g *fakeGitHubGateway) ListOpenPullRequests(context.Context, ListOpenPullRe
 }
 
 func (g *fakeGitHubGateway) GetCurrentUserLogin(context.Context, string) (string, error) {
+	if g.currentLoginErr != nil {
+		return "", g.currentLoginErr
+	}
 	if strings.TrimSpace(g.currentLogin) != "" {
 		return g.currentLogin, nil
 	}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -523,6 +523,56 @@ func TestProcessClaimedItemSkipsPublishWhenReviewRequestRemovedBeforeRetry(t *te
 	}
 }
 
+func TestProcessClaimedItemRecordsPublishedHeadWhenReviewRequestRemovedAfterSubmit(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{prCommentFailuresRemaining: 1, reviewRequests: []string{"octocat"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Please add tests"}]}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	firstClaim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || firstClaim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", firstClaim, err)
+	}
+	firstResult, err := runner.ProcessClaimedItem(context.Background(), *firstClaim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(first) error = %v", err)
+	}
+	if firstResult.Status != "failed" || firstResult.FailureKind != FailureRetryableAfterResume {
+		t.Fatalf("first result = %#v, want retryable_after_resume failure", firstResult)
+	}
+	if len(agent.starts) != 1 || len(github.submitCalls) != 1 || len(github.prComments) != 1 {
+		t.Fatalf("agent starts=%d submit calls=%d comments=%d, want submitted review then failed top-level comment", len(agent.starts), len(github.submitCalls), len(github.prComments))
+	}
+
+	github.reviewRequests = []string{}
+	fixture.advance(5 * time.Second)
+	retryClaim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || retryClaim == nil {
+		t.Fatalf("retry ClaimNext() = (%#v, %v), want claimed queue item", retryClaim, err)
+	}
+	retryResult, err := runner.ProcessClaimedItem(context.Background(), *retryClaim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(retry) error = %v", err)
+	}
+	if retryResult.Status != "skipped" || !contains(retryResult.Summary, "current user is not requested for review") {
+		t.Fatalf("retry result = %#v, want skipped missing review request", retryResult)
+	}
+	if len(agent.starts) != 1 || len(github.submitCalls) != 1 || len(github.prComments) != 1 {
+		t.Fatalf("agent starts=%d submit calls=%d comments=%d after retry, want no duplicate publish", len(agent.starts), len(github.submitCalls), len(github.prComments))
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), retryResult.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.MetadataJSON == nil || !contains(*loop.MetadataJSON, `"lastPublishedHeadSha":"abc123"`) {
+		t.Fatalf("loop after skipped retry = %#v, want lastPublishedHeadSha recorded", loop)
+	}
+}
+
 func TestProcessClaimedItemResumeReacquiresPullRequestLock(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -1182,19 +1232,20 @@ func (f *runnerFixture) nowISO() string {
 }
 
 type fakeGitHubGateway struct {
-	submitFailuresRemaining int
-	changeHeadOnSecondView  bool
-	viewCalls               int
-	submitCalls             []SubmitReviewInput
-	addedLabels             []PullRequestLabelsInput
-	removedLabels           []PullRequestLabelsInput
-	prComments              []PullRequestCommentInput
-	addedReactions          []PullRequestReactionInput
-	removedReactions        []PullRequestReactionInput
-	labels                  []string
-	reviewRequests          []string
-	currentLogin            string
-	currentLoginErr         error
+	submitFailuresRemaining    int
+	prCommentFailuresRemaining int
+	changeHeadOnSecondView     bool
+	viewCalls                  int
+	submitCalls                []SubmitReviewInput
+	addedLabels                []PullRequestLabelsInput
+	removedLabels              []PullRequestLabelsInput
+	prComments                 []PullRequestCommentInput
+	addedReactions             []PullRequestReactionInput
+	removedReactions           []PullRequestReactionInput
+	labels                     []string
+	reviewRequests             []string
+	currentLogin               string
+	currentLoginErr            error
 }
 
 func (g *fakeGitHubGateway) ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
@@ -1247,6 +1298,10 @@ func (g *fakeGitHubGateway) SubmitReview(_ context.Context, input SubmitReviewIn
 
 func (g *fakeGitHubGateway) AddPullRequestComment(_ context.Context, input PullRequestCommentInput) error {
 	g.prComments = append(g.prComments, input)
+	if g.prCommentFailuresRemaining > 0 {
+		g.prCommentFailuresRemaining--
+		return fmt.Errorf("temporary GitHub comment failure")
+	}
 	return nil
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -477,6 +477,52 @@ func TestProcessClaimedItemRetriesPublishFromCheckpointWithoutRerunningReview(t 
 	}
 }
 
+func TestProcessClaimedItemSkipsPublishWhenReviewRequestRemovedBeforeRetry(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{submitFailuresRemaining: 1, reviewRequests: []string{"octocat"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Please add tests"}]}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	firstClaim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || firstClaim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", firstClaim, err)
+	}
+	firstResult, err := runner.ProcessClaimedItem(context.Background(), *firstClaim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(first) error = %v", err)
+	}
+	if firstResult.Status != "failed" || firstResult.FailureKind != FailureRetryableAfterResume {
+		t.Fatalf("first result = %#v, want retryable_after_resume failure", firstResult)
+	}
+	if len(agent.starts) != 1 || len(github.submitCalls) != 1 {
+		t.Fatalf("agent starts=%d submit calls=%d, want initial review and publish attempt", len(agent.starts), len(github.submitCalls))
+	}
+
+	github.reviewRequests = []string{}
+	fixture.advance(5 * time.Second)
+	retryClaim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || retryClaim == nil {
+		t.Fatalf("retry ClaimNext() = (%#v, %v), want claimed queue item", retryClaim, err)
+	}
+	retryResult, err := runner.ProcessClaimedItem(context.Background(), *retryClaim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(retry) error = %v", err)
+	}
+	if retryResult.Status != "skipped" || !contains(retryResult.Summary, "current user is not requested for review") {
+		t.Fatalf("retry result = %#v, want skipped missing review request", retryResult)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) after retry = %d, want no rerun", len(agent.starts))
+	}
+	if len(github.submitCalls) != 1 {
+		t.Fatalf("len(github.submitCalls) after retry = %d, want no second publish", len(github.submitCalls))
+	}
+}
+
 func TestProcessClaimedItemResumeReacquiresPullRequestLock(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/storage"
 )
 
@@ -78,6 +79,109 @@ func TestDiscoverPullRequestsPreservesPausedLoop(t *testing.T) {
 	}
 	if len(items) != 0 {
 		t.Fatalf("len(Queue.List()) = %d, want 0", len(items))
+	}
+}
+
+func TestDiscoverPullRequestsSkipsSpecLabelWhenCurrentUserIsNotRequested(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{labels: []string{specpr.ReviewingLabel}, reviewRequests: []string{"alice"}, currentLogin: "bob"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.CreatedLoopIDs) != 0 || len(result.QueueItems) != 0 {
+		t.Fatalf("result = %#v, want no created loops or queue items", result)
+	}
+	items, err := fixture.repos.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("len(Queue.List()) = %d, want 0", len(items))
+	}
+}
+
+func TestDiscoverPullRequestsSkipsAutomaticFollowUpWhenCurrentUserIsNotRequested(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"alice"}, currentLogin: "bob"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"followUpdates":true}`
+	loop := storage.LoopRecord{ID: "loop_follow", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("len(QueueItems) = %d, want 0", len(result.QueueItems))
+	}
+}
+
+func TestDiscoverPullRequestsAllowsManualFollowUpWithoutReviewRequest(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"alice"}, currentLogin: "bob"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"followUpdates":true,"manual":true}`
+	loop := storage.LoopRecord{ID: "loop_manual_follow", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("len(QueueItems) = %d, want 1", len(result.QueueItems))
+	}
+}
+
+func TestProcessClaimedItemSkipsQueuedAutomaticLoopWhenCurrentUserIsNotRequested(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"alice"}, currentLogin: "bob"}
+	agent := &fakeAgentExecutor{}
+	git := &fakeGitGateway{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_api", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue, err := runner.enqueue(context.Background(), enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" || !strings.Contains(result.Summary, "not requested for review") {
+		t.Fatalf("result = %#v, want skipped not requested", result)
+	}
+	if len(agent.starts) != 0 || len(git.createCalls) != 0 || len(github.submitCalls) != 0 {
+		t.Fatalf("agent starts=%d git creates=%d submit calls=%d, want no review work", len(agent.starts), len(git.createCalls), len(github.submitCalls))
 	}
 }
 
@@ -878,13 +982,19 @@ type fakeGitHubGateway struct {
 	addedReactions          []PullRequestReactionInput
 	removedReactions        []PullRequestReactionInput
 	labels                  []string
+	reviewRequests          []string
+	currentLogin            string
 }
 
 func (g *fakeGitHubGateway) ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
-	return []PullRequestSummary{{Number: 42, Title: "Review me", State: "OPEN", Labels: append([]string(nil), g.labels...), HeadSHA: "abc123", ReviewRequests: []string{"octocat"}}, {Number: 99, Title: "Draft", State: "OPEN", IsDraft: true, HeadSHA: "draft123", ReviewRequests: []string{"octocat"}}}, nil
+	reviewRequests := g.effectiveReviewRequests()
+	return []PullRequestSummary{{Number: 42, Title: "Review me", State: "OPEN", Labels: append([]string(nil), g.labels...), HeadSHA: "abc123", ReviewRequests: reviewRequests}, {Number: 99, Title: "Draft", State: "OPEN", IsDraft: true, HeadSHA: "draft123", ReviewRequests: reviewRequests}}, nil
 }
 
 func (g *fakeGitHubGateway) GetCurrentUserLogin(context.Context, string) (string, error) {
+	if strings.TrimSpace(g.currentLogin) != "" {
+		return g.currentLogin, nil
+	}
 	return "octocat", nil
 }
 
@@ -894,7 +1004,14 @@ func (g *fakeGitHubGateway) ViewPullRequest(context.Context, ViewPullRequestInpu
 	if g.changeHeadOnSecondView && g.viewCalls >= 2 {
 		headSHA = "new-head"
 	}
-	return PullRequestDetail{Number: 42, Title: "Review me", Body: "PR body", State: "OPEN", Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, BaseSHA: "base123", HeadRefName: "feature/review-me", BaseRefName: "main", Author: "octocat", ReviewRequests: []string{"octocat"}, ChecksSummary: "SUCCESS", Diff: "diff --git a/a.ts b/a.ts"}, nil
+	return PullRequestDetail{Number: 42, Title: "Review me", Body: "PR body", State: "OPEN", Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, BaseSHA: "base123", HeadRefName: "feature/review-me", BaseRefName: "main", Author: "octocat", ReviewRequests: g.effectiveReviewRequests(), ChecksSummary: "SUCCESS", Diff: "diff --git a/a.ts b/a.ts"}, nil
+}
+
+func (g *fakeGitHubGateway) effectiveReviewRequests() []string {
+	if g.reviewRequests != nil {
+		return append([]string(nil), g.reviewRequests...)
+	}
+	return []string{"octocat"}
 }
 
 func (g *fakeGitHubGateway) CapturePullRequestSnapshot(_ context.Context, input CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -662,6 +662,64 @@ func TestProcessClaimedItemRecordsPublishedHeadWhenReviewRequestRemovedAfterSubm
 	}
 }
 
+func TestRunPublishStepTransitionsSpecLabelsWhenReviewRequestRemovedAfterSubmit(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{labels: []string{specpr.ReviewingLabel}, reviewRequests: []string{}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_spec_publish", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     loop,
+		Run:      storage.RunRecord{ID: "run_spec_publish"},
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{Labels: []string{specpr.ReviewingLabel}},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: (&pendingReviewCheckpoint{
+				HeadSHA: "abc123",
+				Event:   ReviewEventApprove,
+				Summary: "Looks good",
+				Clean:   true,
+				PublishState: &publishState{
+					ReviewSubmitted: true,
+				},
+			}).clone(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v", err)
+	}
+	if checkpoint.SkipReason == "" || !contains(checkpoint.SkipReason, "current user is not requested for review") {
+		t.Fatalf("SkipReason = %q, want missing review request skip", checkpoint.SkipReason)
+	}
+	if specpr.HasLabel(github.labels, specpr.ReviewingLabel) || !specpr.HasLabel(github.labels, specpr.ReadyLabel) {
+		t.Fatalf("labels after skipped publish = %#v, want reviewing removed and ready added", github.labels)
+	}
+	if len(github.removedLabels) != 1 || len(github.addedLabels) != 1 {
+		t.Fatalf("removedLabels=%#v addedLabels=%#v, want one transition", github.removedLabels, github.addedLabels)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if updated == nil || updated.MetadataJSON == nil || !contains(*updated.MetadataJSON, `"lastPublishedHeadSha":"abc123"`) {
+		t.Fatalf("loop after skipped publish = %#v, want lastPublishedHeadSha recorded", updated)
+	}
+}
+
 func TestProcessClaimedItemResumeReacquiresPullRequestLock(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)


### PR DESCRIPTION
## Summary
- Require the current GitHub user to be requested before automatic reviewer discovery can enqueue normal, spec-label, or non-manual follow-up PRs.
- Preserve explicit local manual reviewer loops as an opt-in exception and re-check eligibility during processing.
- Update reviewer docs and add regression tests for spec labels, follow-ups, queued loops, auth failures, and legacy resume handling.

## Tests
- go test ./internal/reviewer
- go test ./...