### PR TITLE
chore: fix duplicated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check for existing GitHub release
+        id: existing-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare-go-release.outputs.release-tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create draft GitHub release
+        if: steps.existing-release.outputs.exists != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.prepare-go-release.outputs.release-tag }}
@@ -338,7 +352,6 @@ jobs:
           name: Looper ${{ needs.prepare-go-release.outputs.release-tag }}
           draft: false
           prerelease: ${{ needs.prepare-go-release.outputs.release-prerelease }}
-          generate_release_notes: true
           files: |
             release-assets/looper-darwin-arm64
             release-assets/looper-darwin-arm64.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,11 +107,26 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-go-release.outputs.release-tag }}
         run: |
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          response_file="$(mktemp)"
+          status="$(curl --silent --show-error --output "$response_file" --write-out "%{http_code}" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GH_REPO}/releases/tags/${RELEASE_TAG}")"
+
+          case "$status" in
+            200)
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Failed to check release ${RELEASE_TAG}; GitHub API returned HTTP ${status}." >&2
+              cat "$response_file" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Create draft GitHub release
         if: steps.existing-release.outputs.exists != 'true'


### PR DESCRIPTION
## Summary
- Skip draft release creation when the release already exists so reruns do not regenerate notes into an edited draft body.
- Stop regenerating release notes in the publish/assets step to avoid appending duplicate generated notes.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "YAML OK"'`