### PR TITLE
docs: require semantic PR titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 
 - Build output lives in `dist/`; do not edit generated files.
 - CI (`.github/workflows/ci.yml`) runs on PR updates: `gofmt -l .` → `go vet ./...` → `go test ./...` → `go build ./...`.
+- Commit messages and PR titles must use semantic prefixes, for example `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, or `ci:`.
 
 ## Review guidelines
 


### PR DESCRIPTION
## Summary
- Document that commit messages and PR titles must use semantic prefixes.

## Verification
- Not run; documentation-only change.