### PR TITLE
feat: discover worker-ready issues

### DIFF
--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -46,6 +46,10 @@ type workerScheduler interface {
 	ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) (*worker.ProcessResult, error)
 }
 
+type workerIssueDiscoveryScheduler interface {
+	DiscoverIssues(context.Context, worker.DiscoveryInput) (worker.DiscoveryResult, error)
+}
+
 type schedulerAsyncRunner interface {
 	Go(func())
 }
@@ -426,6 +430,22 @@ func (a workerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input wor
 	return result, nil
 }
 
+func (a workerGitHubAdapter) ListOpenIssues(ctx context.Context, input worker.ListOpenIssuesInput) ([]worker.IssueSummary, error) {
+	issues, err := a.gateway.ListOpenIssues(ctx, githubinfra.ListOpenIssuesInput{Repo: input.Repo, CWD: input.CWD, Limit: input.Limit, Assignee: input.Assignee, Label: input.Label})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]worker.IssueSummary, 0, len(issues))
+	for _, issue := range issues {
+		result = append(result, worker.IssueSummary{Number: issue.Number, Title: issue.Title, Body: issue.Body, URL: issue.URL, Assignees: issue.Assignees, Labels: issue.Labels})
+	}
+	return result, nil
+}
+
+func (a workerGitHubAdapter) GetCurrentUserLogin(ctx context.Context, cwd string) (string, error) {
+	return a.gateway.GetCurrentUserLogin(ctx, cwd)
+}
+
 func (a workerGitHubAdapter) ViewPullRequest(ctx context.Context, input worker.ViewPullRequestInput) (worker.PullRequestDetail, error) {
 	detail, err := a.gateway.ViewPullRequest(ctx, githubinfra.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 	if err != nil {
@@ -801,6 +821,10 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		if input.Fixer != nil {
 			_, err := input.Fixer.DiscoverPullRequests(ctx, fixer.DiscoveryInput{ProjectID: project.ID, Repo: repo})
 			appendErr(wrapSchedulerError("fixer discovery", project.ID, repo, err))
+		}
+		if discoverer, ok := input.Worker.(workerIssueDiscoveryScheduler); ok {
+			_, err := discoverer.DiscoverIssues(ctx, worker.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+			appendErr(wrapSchedulerError("worker issue discovery", project.ID, repo, err))
 		}
 	}
 

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -89,6 +89,9 @@ func TestRunDefaultSchedulerTickDiscoversStoredProjectsAndProcessesQueue(t *test
 	if len(fixerRunner.discoverCalls) != 1 || fixerRunner.discoverCalls[0].Repo != "powerformer/looper" {
 		t.Fatalf("fixer discover calls = %#v, want stored project repo", fixerRunner.discoverCalls)
 	}
+	if len(workerRunner.discoverCalls) != 1 || workerRunner.discoverCalls[0].Repo != "powerformer/looper" {
+		t.Fatalf("worker discover calls = %#v, want stored project repo", workerRunner.discoverCalls)
+	}
 	waitForSchedulerCondition(t, func() bool {
 		return workerRunner.processItemCount() == 1
 	})
@@ -512,9 +515,18 @@ func (s *stubFixerScheduler) processItemCount() int {
 
 type stubWorkerScheduler struct {
 	mu             sync.Mutex
+	discoverCalls  []worker.DiscoveryInput
+	discoverErr    error
 	processClaims  []string
 	processedItems []string
 	processErr     error
+}
+
+func (s *stubWorkerScheduler) DiscoverIssues(_ context.Context, input worker.DiscoveryInput) (worker.DiscoveryResult, error) {
+	s.mu.Lock()
+	s.discoverCalls = append(s.discoverCalls, input)
+	s.mu.Unlock()
+	return worker.DiscoveryResult{}, s.discoverErr
 }
 
 func (s *stubWorkerScheduler) ProcessNext(_ context.Context, claimedBy string) (*worker.ProcessResult, error) {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1619,7 +1619,7 @@ func (r *Runner) ensureLoopForDiscoveredIssue(ctx context.Context, project stora
 	targetID := buildIssueTargetID(repo, issue.Number)
 	baseBranch := firstNonEmpty(derefString(project.BaseBranch), "main")
 	work := workerInput{Title: firstNonEmpty(issue.Title, buildDefaultIssueWorkerTitle(repo, issue.Number)), Repo: repo, BaseBranch: baseBranch, ExecutionMode: "create-pr", IssueNumber: issue.Number, IssueURL: issue.URL}
-	workerMeta := map[string]any{"worker": work}
+	workerMeta := map[string]any{"worker": mergeWorkerMetadata(parseJSONObject(nil), work)}
 	loops, err := r.repos.Loops.List(ctx)
 	if err != nil {
 		return loopUpsertResult{}, err
@@ -1633,7 +1633,7 @@ func (r *Runner) ensureLoopForDiscoveredIssue(ctx context.Context, project stora
 				updated.Status = "queued"
 				updated.NextRunAt = &nowISO
 			}
-			metadataJSON, err := mergeLoopMetadataJSON(existing.MetadataJSON, workerMeta)
+			metadataJSON, err := mergeLoopMetadataJSON(existing.MetadataJSON, map[string]any{"worker": mergeWorkerMetadata(parseJSONObject(existing.MetadataJSON), work)})
 			if err == nil {
 				updated.MetadataJSON = &metadataJSON
 			}
@@ -2446,6 +2446,20 @@ func parseJSONObject(raw *string) map[string]any {
 		return map[string]any{}
 	}
 	return decoded
+}
+
+func mergeWorkerMetadata(metadata map[string]any, work workerInput) map[string]any {
+	workerMeta := map[string]any{}
+	if existing, ok := metadata["worker"].(map[string]any); ok {
+		for key, value := range existing {
+			workerMeta[key] = value
+		}
+	}
+	workJSON := parseJSONObject(stringPtr(mustMarshalJSON(work)))
+	for key, value := range workJSON {
+		workerMeta[key] = value
+	}
+	return workerMeta
 }
 
 func mustMarshalJSON(value any) string {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -47,6 +47,7 @@ const (
 	workerBranchSlugMaxWords  = 5
 	workerBranchHashLength    = 16
 	workerPRDedupeLookupLimit = 1000
+	issueDiscoveryLabel       = "looper:worker-ready"
 )
 
 var workerStepSequence = []WorkerStep{
@@ -68,6 +69,15 @@ type PullRequestSummary struct {
 	State       string
 	HeadRefName string
 	BaseRefName string
+}
+
+type IssueSummary struct {
+	Number    int64
+	Title     string
+	Body      string
+	URL       string
+	Assignees []string
+	Labels    []string
 }
 
 type PullRequestDetail struct {
@@ -164,10 +174,20 @@ type ListOpenPullRequestsInput struct {
 	Label string
 }
 
+type ListOpenIssuesInput struct {
+	Repo     string
+	CWD      string
+	Limit    int
+	Assignee string
+	Label    string
+}
+
 type GitHubGateway interface {
 	ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error)
+	ListOpenIssues(context.Context, ListOpenIssuesInput) ([]IssueSummary, error)
 	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
 	ViewIssue(context.Context, ViewIssueInput) (IssueDetail, error)
+	GetCurrentUserLogin(context.Context, string) (string, error)
 	CreateIssueComment(context.Context, IssueCommentInput) (IssueCommentResult, error)
 	UpdateIssueComment(context.Context, UpdateIssueCommentInput) error
 	CreatePullRequest(context.Context, CreatePullRequestInput) (CreatePullRequestResult, error)
@@ -368,6 +388,18 @@ type ProcessResult struct {
 	PullRequestNumber int64
 }
 
+type DiscoveryInput struct {
+	ProjectID string
+	Repo      string
+	Limit     int
+}
+
+type DiscoveryResult struct {
+	CreatedLoopIDs []string
+	QueueItems     []storage.QueueItemRecord
+	Skipped        int
+}
+
 type workerInput struct {
 	Title    string `json:"title,omitempty"`
 	Prompt   string `json:"prompt,omitempty"`
@@ -457,6 +489,11 @@ type loopError struct {
 	kind    QueueFailureKind
 }
 
+type loopUpsertResult struct {
+	record  storage.LoopRecord
+	created bool
+}
+
 func validateCompletedExecutionCheckpoint(execution *checkpointExecution) error {
 	if execution == nil || execution.Status != "completed" {
 		return nil
@@ -523,6 +560,58 @@ func New(options Options) *Runner {
 		onAgentExecutionStarted: options.OnAgentExecutionStarted,
 		onRunCompleted:          options.OnRunCompleted,
 	}
+}
+
+func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	if r.repos == nil || r.repos.Projects == nil || r.repos.Loops == nil || r.repos.Queue == nil || r.github == nil {
+		return DiscoveryResult{}, fmt.Errorf("worker discovery is not configured")
+	}
+	project, err := r.repos.Projects.GetByID(ctx, input.ProjectID)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if project == nil {
+		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
+	}
+	if project.Archived {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	login, err := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	login = normalizeLogin(login)
+	if login == "" {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	issues, err := r.github.ListOpenIssues(ctx, ListOpenIssuesInput{Repo: input.Repo, CWD: project.RepoPath, Limit: input.Limit, Assignee: login, Label: issueDiscoveryLabel})
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	result := DiscoveryResult{}
+	for _, issue := range issues {
+		if !shouldClaimWorkerIssue(issue, login) {
+			result.Skipped++
+			continue
+		}
+		loopResult, err := r.ensureLoopForDiscoveredIssue(ctx, *project, input.Repo, issue)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		if loopResult.created {
+			result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
+		}
+		if loopResult.record.Status == "paused" || loopResult.record.Status == "completed" {
+			result.Skipped++
+			continue
+		}
+		queueItem, err := r.enqueueDiscoveredIssue(ctx, *project, loopResult.record, input.Repo, issue)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		result.QueueItems = append(result.QueueItems, queueItem)
+	}
+	return result, nil
 }
 
 func (r *Runner) ProcessNext(ctx context.Context, claimedBy string) (*ProcessResult, error) {
@@ -1525,6 +1614,71 @@ func (r *Runner) persistPullRequestReference(ctx context.Context, loop storage.L
 	})
 }
 
+func (r *Runner) ensureLoopForDiscoveredIssue(ctx context.Context, project storage.ProjectRecord, repo string, issue IssueSummary) (loopUpsertResult, error) {
+	nowISO := r.nowISO()
+	targetID := buildIssueTargetID(repo, issue.Number)
+	baseBranch := firstNonEmpty(derefString(project.BaseBranch), "main")
+	work := workerInput{Title: firstNonEmpty(issue.Title, buildDefaultIssueWorkerTitle(repo, issue.Number)), Repo: repo, BaseBranch: baseBranch, ExecutionMode: "create-pr", IssueNumber: issue.Number, IssueURL: issue.URL}
+	workerMeta := map[string]any{"worker": work}
+	loops, err := r.repos.Loops.List(ctx)
+	if err != nil {
+		return loopUpsertResult{}, err
+	}
+	for _, existing := range loops {
+		if existing.Type == "worker" && existing.ProjectID == project.ID && existing.TargetType == "issue" && derefString(existing.TargetID) == targetID {
+			pausedOrCompleted := existing.Status == "paused" || existing.Status == "completed"
+			updated := existing
+			updated.Repo = &repo
+			if !pausedOrCompleted && updated.Status != "running" {
+				updated.Status = "queued"
+				updated.NextRunAt = &nowISO
+			}
+			metadataJSON, err := mergeLoopMetadataJSON(existing.MetadataJSON, workerMeta)
+			if err == nil {
+				updated.MetadataJSON = &metadataJSON
+			}
+			updated.UpdatedAt = nowISO
+			if err := r.repos.Loops.Upsert(ctx, updated); err != nil {
+				return loopUpsertResult{}, err
+			}
+			return loopUpsertResult{record: updated}, nil
+		}
+	}
+	seq, err := r.repos.Loops.AllocateSeq(ctx)
+	if err != nil {
+		return loopUpsertResult{}, err
+	}
+	metadataJSON := mustMarshalJSON(workerMeta)
+	loop := storage.LoopRecord{ID: eventlog.NewEventID("loop"), Seq: seq, ProjectID: project.ID, Type: "worker", TargetType: "issue", TargetID: &targetID, Repo: &repo, Status: "queued", MetadataJSON: &metadataJSON, NextRunAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := r.repos.Loops.Upsert(ctx, loop); err != nil {
+		return loopUpsertResult{}, err
+	}
+	return loopUpsertResult{record: loop, created: true}, nil
+}
+
+func (r *Runner) enqueueDiscoveredIssue(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord, repo string, issue IssueSummary) (storage.QueueItemRecord, error) {
+	dedupeKey := buildWorkerIssueDedupeKey(project.ID, repo, issue.Number)
+	existing, err := r.repos.Queue.FindActiveByDedupe(ctx, dedupeKey)
+	if err != nil {
+		return storage.QueueItemRecord{}, err
+	}
+	if existing != nil {
+		return *existing, nil
+	}
+	nowISO := r.nowISO()
+	baseBranch := firstNonEmpty(derefString(project.BaseBranch), "main")
+	payload := mustMarshalJSON(workerInput{Title: firstNonEmpty(issue.Title, buildDefaultIssueWorkerTitle(repo, issue.Number)), Repo: repo, BaseBranch: baseBranch, ExecutionMode: "create-pr", IssueNumber: issue.Number, IssueURL: issue.URL})
+	targetID := buildIssueTargetID(repo, issue.Number)
+	lockKey := targetID
+	projectID := project.ID
+	loopID := loop.ID
+	queueItem := storage.QueueItemRecord{ID: eventlog.NewEventID("queue"), ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "issue", TargetID: targetID, Repo: &repo, DedupeKey: dedupeKey, Priority: storage.QueuePriorityWorker, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: r.retryMaxAttempts, LockKey: &lockKey, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := r.repos.Queue.Upsert(ctx, queueItem); err != nil {
+		return storage.QueueItemRecord{}, err
+	}
+	return queueItem, nil
+}
+
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {
 	nextAttempts := queueItem.Attempts + 1
 	nowISO := r.nowISO()
@@ -2236,6 +2390,39 @@ func buildWorkerLoopHash(loopID string) string {
 
 func buildDefaultIssueWorkerTitle(repo string, issueNumber int64) string {
 	return fmt.Sprintf("Implement %s#%d", repo, issueNumber)
+}
+
+func buildIssueTargetID(repo string, issueNumber int64) string {
+	return fmt.Sprintf("issue:%s:%d", repo, issueNumber)
+}
+
+func buildWorkerIssueDedupeKey(projectID, repo string, issueNumber int64) string {
+	return fmt.Sprintf("worker:%s:%s:%d", projectID, repo, issueNumber)
+}
+
+func normalizeLogin(login string) string { return strings.ToLower(strings.TrimSpace(login)) }
+
+func includesLogin(values []string, target string) bool {
+	target = normalizeLogin(target)
+	for _, value := range values {
+		if normalizeLogin(value) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLabel(labels []string, target string) bool {
+	for _, label := range labels {
+		if strings.EqualFold(strings.TrimSpace(label), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldClaimWorkerIssue(issue IssueSummary, login string) bool {
+	return includesLogin(issue.Assignees, login) && hasLabel(issue.Labels, issueDiscoveryLabel)
 }
 
 func mergeLoopMetadataJSON(current *string, updates map[string]any) (string, error) {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -96,6 +96,51 @@ func TestDiscoverIssuesDedupesWorkerReadyIssue(t *testing.T) {
 	}
 }
 
+func TestDiscoverIssuesPreservesExistingWorkerMetadataOnRediscovery(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil {
+		t.Fatal("loop = nil, want worker loop")
+	}
+	loopMetadata := `{"worker":{"title":"Old title","repo":"acme/looper","issueNumber":27,"issueUrl":"https://github.com/acme/looper/issues/27","baseBranch":"develop","prompt":"Keep this prompt","specPath":"specs/worker.md","reviewers":["alice","bob"]}}`
+	loop.MetadataJSON = &loopMetadata
+	if err := fixture.repos.Loops.Upsert(context.Background(), *loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	github := &fakeGitHubGateway{currentLogin: "octocat", issues: []IssueSummary{{Number: 27, Title: "Updated worker-ready title", URL: "https://github.com/acme/looper/issues/27", Assignees: []string{"octocat"}, Labels: []string{"looper:worker-ready"}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	loop, err = fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() after rediscovery error = %v", err)
+	}
+	if loop == nil || loop.MetadataJSON == nil {
+		t.Fatalf("loop = %#v, want loop with metadata", loop)
+	}
+	for _, want := range []string{
+		`"title":"Updated worker-ready title"`,
+		`"repo":"acme/looper"`,
+		`"issueNumber":27`,
+		`"issueUrl":"https://github.com/acme/looper/issues/27"`,
+		`"baseBranch":"main"`,
+		`"prompt":"Keep this prompt"`,
+		`"specPath":"specs/worker.md"`,
+		`"reviewers":["alice","bob"]`,
+	} {
+		if !strings.Contains(*loop.MetadataJSON, want) {
+			t.Fatalf("MetadataJSON = %s, want substring %s", *loop.MetadataJSON, want)
+		}
+	}
+}
+
 func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -41,6 +41,61 @@ func TestProcessNextIgnoresOtherQueueTypes(t *testing.T) {
 	}
 }
 
+func TestDiscoverIssuesEnqueuesWorkerReadyAssignedIssue(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "octocat", issues: []IssueSummary{
+		{Number: 46, Title: "Implement worker-ready", URL: "https://github.com/acme/looper/issues/46", Assignees: []string{"octocat"}, Labels: []string{"looper:worker-ready"}},
+		{Number: 47, Title: "No label", Assignees: []string{"octocat"}},
+		{Number: 48, Title: "Wrong assignee", Assignees: []string{"someone"}, Labels: []string{"looper:worker-ready"}},
+	}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 || len(result.CreatedLoopIDs) != 1 || result.Skipped != 2 {
+		t.Fatalf("result = %#v, want one worker queue item, one loop, two skipped", result)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), result.QueueItems[0].ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Type != "worker" || queue.TargetType != "issue" || queue.TargetID != "issue:acme/looper:46" || queue.DedupeKey != "worker:project_1:acme/looper:46" {
+		t.Fatalf("queue = %#v, want worker issue queue for issue 46", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.CreatedLoopIDs[0])
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Type != "worker" || loop.TargetType != "issue" || loop.TargetID == nil || *loop.TargetID != "issue:acme/looper:46" {
+		t.Fatalf("loop = %#v, want worker issue loop for issue 46", loop)
+	}
+}
+
+func TestDiscoverIssuesDedupesWorkerReadyIssue(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "octocat", issues: []IssueSummary{{Number: 46, Title: "Implement worker-ready", Assignees: []string{"octocat"}, Labels: []string{"looper:worker-ready"}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	first, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("first DiscoverIssues() error = %v", err)
+	}
+	second, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("second DiscoverIssues() error = %v", err)
+	}
+	if len(first.QueueItems) != 1 || len(second.QueueItems) != 1 || first.QueueItems[0].ID != second.QueueItems[0].ID {
+		t.Fatalf("first=%#v second=%#v, want reused active queue item", first.QueueItems, second.QueueItems)
+	}
+	if len(second.CreatedLoopIDs) != 0 {
+		t.Fatalf("second.CreatedLoopIDs = %#v, want no duplicate loop", second.CreatedLoopIDs)
+	}
+}
+
 func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -1953,6 +2008,9 @@ func (f *runnerFixture) nowISO() string {
 func (f *runnerFixture) advance(delta time.Duration) { f.current = f.current.Add(delta) }
 
 type fakeGitHubGateway struct {
+	currentLogin            string
+	issues                  []IssueSummary
+	listIssueCalls          []ListOpenIssuesInput
 	openPRs                 []PullRequestSummary
 	openPRResponses         [][]PullRequestSummary
 	openPRIndex             int
@@ -1974,6 +2032,18 @@ type fakeGitHubGateway struct {
 	removeLabels            []PullRequestLabelsInput
 	reviewerCalls           []PullRequestReviewersInput
 	createPRIndex           int
+}
+
+func (f *fakeGitHubGateway) GetCurrentUserLogin(context.Context, string) (string, error) {
+	if f.currentLogin == "" {
+		return "octocat", nil
+	}
+	return f.currentLogin, nil
+}
+
+func (f *fakeGitHubGateway) ListOpenIssues(_ context.Context, input ListOpenIssuesInput) ([]IssueSummary, error) {
+	f.listIssueCalls = append(f.listIssueCalls, input)
+	return append([]IssueSummary(nil), f.issues...), nil
 }
 
 func (f *fakeGitHubGateway) ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {


### PR DESCRIPTION
## Summary
- Add worker issue discovery for `looper:worker-ready` labels assigned to the current GitHub user.
- Create/reuse worker loops and issue-scoped queue items with existing active dedupe behavior.
- Wire worker issue discovery into the default scheduler tick and cover assigned, ignored, and duplicate discovery cases.

## Validation
- `go test ./...`
- `go build ./...`

Closes #46