### PR TITLE
feat: support initializing Looper labels

### DIFF
--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -94,7 +94,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 	root := newCommand(commandSpec{
 		use:             "looper",
 		short:           "Looper command-line interface",
-		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
+		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "labels", description: "GitHub label commands"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
 		helpWhenNoArgs:  true,
 		subcommands: []*cobra.Command{
 			newCommand(commandSpec{use: "status", short: "Show service status", runE: runtime.status}),
@@ -189,6 +189,27 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					"$ looper upgrade --check",
 					"$ looper upgrade --cli",
 					"$ looper upgrade --daemon",
+				},
+			}),
+			newCommand(commandSpec{
+				use:             "labels",
+				short:           "GitHub label commands",
+				helpSubcommands: []helpSubcommand{{name: "init", description: "Initialize standard Looper GitHub labels"}},
+				helpWhenNoArgs:  true,
+				exampleLines: []string{
+					"$ looper labels init",
+					"$ looper labels init --repo acme/looper --dry-run",
+				},
+				subcommands: []*cobra.Command{
+					newCommand(commandSpec{
+						use:   "init",
+						short: "Initialize standard Looper GitHub labels",
+						runE:  runtime.labelsInit,
+						localFlags: []flagSpec{
+							stringFlag("repo", "owner/name", "GitHub repository slug"),
+							boolFlag("dry-run", "Preview label changes without applying them"),
+						},
+					}),
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -52,6 +52,7 @@ func TestCommandGroupHelpListsExpectedSubcommands(t *testing.T) {
 		{args: []string{"project", "--help"}, subcommands: []string{"list    List projects", "add     Add a project", "remove  Remove a project"}},
 		{args: []string{"config", "--help"}, subcommands: []string{"show  Show active config"}},
 		{args: []string{"daemon", "--help"}, subcommands: []string{"install  Install the managed daemon binary", "status   Show daemon status", "start    Start the daemon", "stop     Stop the daemon", "restart  Restart the daemon", "logs     Show daemon logs"}},
+		{args: []string{"labels", "--help"}, subcommands: []string{"init  Initialize standard Looper GitHub labels"}},
 		{args: []string{"loop", "--help"}, subcommands: []string{"list   List loops", "start  Start a loop", "pause  Pause a loop"}},
 		{args: []string{"pr", "--help"}, subcommands: []string{"list    List pull requests", "show    Show a pull request", "status  Show pull request status"}},
 		{args: []string{"run", "--help"}, subcommands: []string{"list  List runs"}},
@@ -79,6 +80,89 @@ func TestCommandGroupHelpListsExpectedSubcommands(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestLabelsInitDryRunPrintsPlannedChanges(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeDaemonCLIConfig(t, "http://127.0.0.1:1")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	var calls []string
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		Getwd: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			calls = append(calls, command+" "+strings.Join(args, " "))
+			switch strings.Join(args, " ") {
+			case "auth status":
+				return commandExecutionResult{}, nil
+			case "label list --repo acme/looper --limit 1000 --json name,color,description":
+				return commandExecutionResult{Stdout: `[{"name":"looper:plan","color":"5319e7","description":"Picked up automatically by planner"}]`}, nil
+			default:
+				t.Fatalf("unexpected command: %s %s", command, strings.Join(args, " "))
+				return commandExecutionResult{}, nil
+			}
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"labels", "init", "--repo", "acme/looper", "--dry-run", "--gh-path", "/fake/gh", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run(labels init --dry-run) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run(labels init --dry-run) stderr = %q, want empty string", stderr.String())
+	}
+	for _, want := range []string{"Previewing Looper labels for acme/looper", "skipped looper:plan", "created looper:spec-reviewing", "created looper:spec-ready", "Summary: created=3 updated=0 skipped=1 failed=0"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want to contain %q", stdout.String(), want)
+		}
+	}
+	for _, call := range calls {
+		if strings.Contains(call, "label create") || strings.Contains(call, "label edit") {
+			t.Fatalf("dry run executed mutation command: %s", call)
+		}
+	}
+}
+
+func TestLabelsInitRequiresAuthenticatedGH(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeDaemonCLIConfig(t, "http://127.0.0.1:1")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		Getwd: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = command
+			_ = timeout
+			if strings.Join(args, " ") != "auth status" {
+				t.Fatalf("unexpected command args: %s", strings.Join(args, " "))
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not logged in"}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"labels", "init", "--repo", "acme/looper", "--gh-path", "/fake/gh", "--config", configPath})
+	if exitCode == 0 {
+		t.Fatalf("Run(labels init unauthenticated) exit code = %d, want non-zero", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run(labels init unauthenticated) stdout = %q, want empty string", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "gh is not authenticated; run `gh auth login` and retry") {
+		t.Fatalf("stderr = %q, want actionable auth error", stderr.String())
 	}
 }
 

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -101,7 +101,7 @@ func TestLabelsInitDryRunPrintsPlannedChanges(t *testing.T) {
 			_ = timeout
 			calls = append(calls, command+" "+strings.Join(args, " "))
 			switch strings.Join(args, " ") {
-			case "auth status":
+			case "auth status --hostname github.com":
 				return commandExecutionResult{}, nil
 			case "label list --repo acme/looper --limit 1000 --json name,color,description":
 				return commandExecutionResult{Stdout: `[{"name":"looper:plan","color":"5319e7","description":"Picked up automatically by planner"}]`}, nil
@@ -147,7 +147,7 @@ func TestLabelsInitRequiresAuthenticatedGH(t *testing.T) {
 			_ = ctx
 			_ = command
 			_ = timeout
-			if strings.Join(args, " ") != "auth status" {
+			if strings.Join(args, " ") != "auth status --hostname github.com" {
 				t.Fatalf("unexpected command args: %s", strings.Join(args, " "))
 			}
 			return commandExecutionResult{ExitCode: 1, Stderr: "not logged in"}, nil
@@ -183,7 +183,7 @@ func TestLabelsInitFailsAndPrintsGHStderrWhenMutationFails(t *testing.T) {
 			_ = command
 			_ = timeout
 			switch strings.Join(args, " ") {
-			case "auth status":
+			case "auth status --hostname github.com":
 				return commandExecutionResult{}, nil
 			case "label list --repo acme/looper --limit 1000 --json name,color,description":
 				return commandExecutionResult{Stdout: `[{"name":"looper:plan","color":"5319e7","description":"Picked up automatically by planner"}]`}, nil
@@ -212,6 +212,29 @@ func TestLabelsInitFailsAndPrintsGHStderrWhenMutationFails(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "initialize labels for acme/looper: 1 label mutation(s) failed") {
 		t.Fatalf("stderr = %q, want command failure", stderr.String())
+	}
+}
+
+func TestLabelsAuthHostname(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		repo string
+		want string
+	}{
+		{name: "empty", repo: "", want: "github.com"},
+		{name: "owner name", repo: "acme/looper", want: "github.com"},
+		{name: "host owner name", repo: "github.example.com/acme/looper", want: "github.example.com"},
+		{name: "trim host", repo: " github.example.com/acme/looper ", want: "github.example.com"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := labelsAuthHostname(tc.repo); got != tc.want {
+				t.Fatalf("labelsAuthHostname(%q) = %q, want %q", tc.repo, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -166,6 +166,55 @@ func TestLabelsInitRequiresAuthenticatedGH(t *testing.T) {
 	}
 }
 
+func TestLabelsInitFailsAndPrintsGHStderrWhenMutationFails(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeDaemonCLIConfig(t, "http://127.0.0.1:1")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		Getwd: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = command
+			_ = timeout
+			switch strings.Join(args, " ") {
+			case "auth status":
+				return commandExecutionResult{}, nil
+			case "label list --repo acme/looper --limit 1000 --json name,color,description":
+				return commandExecutionResult{Stdout: `[{"name":"looper:plan","color":"5319e7","description":"Picked up automatically by planner"}]`}, nil
+			case "label create looper:spec-reviewing --repo acme/looper --color 1d76db --description Spec PR is under review":
+				return commandExecutionResult{ExitCode: 1, Stderr: "GraphQL: Resource not accessible by integration"}, nil
+			case "label create looper:spec-ready --repo acme/looper --color 0e8a16 --description Spec PR is ready for implementation":
+				return commandExecutionResult{Stdout: "{}"}, nil
+			case "label create looper:needs-human --repo acme/looper --color d93f0b --description Looper requires manual intervention":
+				return commandExecutionResult{Stdout: "{}"}, nil
+			default:
+				t.Fatalf("unexpected command args: %s", strings.Join(args, " "))
+				return commandExecutionResult{}, nil
+			}
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"labels", "init", "--repo", "acme/looper", "--gh-path", "/fake/gh", "--config", configPath})
+	if exitCode == 0 {
+		t.Fatalf("Run(labels init) exit code = 0, want non-zero")
+	}
+	if !strings.Contains(stdout.String(), "failed looper:spec-reviewing: gh exited with code 1: GraphQL: Resource not accessible by integration") {
+		t.Fatalf("stdout = %q, want failed label with gh stderr", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Summary: created=2 updated=0 skipped=1 failed=1") {
+		t.Fatalf("stdout = %q, want failed summary", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "initialize labels for acme/looper: 1 label mutation(s) failed") {
+		t.Fatalf("stderr = %q, want command failure", stderr.String())
+	}
+}
+
 func TestRootHelpIncludesGlobalFlagsWithFrozenSyntax(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/labels.go
+++ b/internal/cliapp/labels.go
@@ -29,20 +29,19 @@ func (r *commandRuntime) labelsInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("determine current working directory: %w", err)
 	}
 
-	gh := githubinfra.New(githubinfra.Options{GHPath: *loaded.Config.Tools.GHPath, CWD: cwd, GHRun: r.runGHCommand})
-	if authenticated, err := gh.IsAuthenticated(cmd.Context(), cwd, ""); err != nil {
-		return fmt.Errorf("check gh authentication: %w", err)
-	} else if !authenticated {
-		return fmt.Errorf("gh is not authenticated; run `gh auth login` and retry")
-	}
-
 	repo := strings.TrimSpace(getStringFlag(cmd, "repo"))
+	gh := githubinfra.New(githubinfra.Options{GHPath: *loaded.Config.Tools.GHPath, CWD: cwd, GHRun: r.runGHCommand})
 	if repo == "" {
 		detected, err := gh.DetectCurrentRepository(cmd.Context(), cwd)
 		if err != nil {
 			return fmt.Errorf("detect GitHub repository from current directory: run from a GitHub-backed repository or pass --repo owner/name: %w", err)
 		}
 		repo = detected
+	}
+	if authenticated, err := gh.IsAuthenticated(cmd.Context(), cwd, labelsAuthHostname(repo)); err != nil {
+		return fmt.Errorf("check gh authentication: %w", err)
+	} else if !authenticated {
+		return fmt.Errorf("gh is not authenticated; run `gh auth login` and retry")
 	}
 
 	result, err := gh.InitializeLabels(cmd.Context(), githubinfra.InitializeLabelsInput{Repo: repo, CWD: cwd, DryRun: getBoolFlag(cmd, "dry-run")})
@@ -60,6 +59,19 @@ func (r *commandRuntime) labelsInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("initialize labels for %s: %w", repo, err)
 	}
 	return nil
+}
+
+func labelsAuthHostname(repo string) string {
+	const defaultHost = "github.com"
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return defaultHost
+	}
+	parts := strings.Split(repo, "/")
+	if len(parts) == 3 && strings.TrimSpace(parts[0]) != "" {
+		return strings.TrimSpace(parts[0])
+	}
+	return defaultHost
 }
 
 func (r *commandRuntime) runGHCommand(ctx context.Context, options shell.Options) (shell.Result, error) {

--- a/internal/cliapp/labels.go
+++ b/internal/cliapp/labels.go
@@ -1,0 +1,91 @@
+package cliapp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	githubinfra "github.com/powerformer/looper/internal/infra/github"
+	"github.com/powerformer/looper/internal/infra/shell"
+	"github.com/spf13/cobra"
+)
+
+const labelsInitCommandTimeout = 30 * time.Second
+
+func (r *commandRuntime) labelsInit(cmd *cobra.Command, args []string) error {
+	_ = args
+	loaded, err := r.loadConfig()
+	if err != nil {
+		return err
+	}
+	if loaded.Config.Tools.GHPath == nil || strings.TrimSpace(*loaded.Config.Tools.GHPath) == "" {
+		return fmt.Errorf("GitHub CLI (gh) not found; install gh or set --gh-path <path>")
+	}
+
+	cwd, err := r.getwd()
+	if err != nil {
+		return fmt.Errorf("determine current working directory: %w", err)
+	}
+
+	gh := githubinfra.New(githubinfra.Options{GHPath: *loaded.Config.Tools.GHPath, CWD: cwd, GHRun: r.runGHCommand})
+	if authenticated, err := gh.IsAuthenticated(cmd.Context(), cwd, ""); err != nil {
+		return fmt.Errorf("check gh authentication: %w", err)
+	} else if !authenticated {
+		return fmt.Errorf("gh is not authenticated; run `gh auth login` and retry")
+	}
+
+	repo := strings.TrimSpace(getStringFlag(cmd, "repo"))
+	if repo == "" {
+		detected, err := gh.DetectCurrentRepository(cmd.Context(), cwd)
+		if err != nil {
+			return fmt.Errorf("detect GitHub repository from current directory: run from a GitHub-backed repository or pass --repo owner/name: %w", err)
+		}
+		repo = detected
+	}
+
+	result, err := gh.InitializeLabels(cmd.Context(), githubinfra.InitializeLabelsInput{Repo: repo, CWD: cwd, DryRun: getBoolFlag(cmd, "dry-run")})
+	if err != nil {
+		return fmt.Errorf("initialize labels for %s: %w", repo, err)
+	}
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), result)
+	}
+	return writeHumanLabelsInit(cmd.OutOrStdout(), result)
+}
+
+func (r *commandRuntime) runGHCommand(ctx context.Context, options shell.Options) (shell.Result, error) {
+	result, err := r.runCommand(ctx, options.Command, options.Args, labelsInitCommandTimeout)
+	shellResult := shell.Result{Stdout: result.Stdout, Stderr: result.Stderr, ExitCode: result.ExitCode}
+	if err != nil {
+		return shellResult, err
+	}
+	if result.ExitCode != 0 {
+		return shellResult, &shell.CommandExecutionError{Message: fmt.Sprintf("gh exited with code %d", result.ExitCode), Result: shellResult}
+	}
+	return shellResult, nil
+}
+
+func writeHumanLabelsInit(w io.Writer, result githubinfra.LabelInitResult) error {
+	if result.DryRun {
+		if _, err := fmt.Fprintf(w, "Previewing Looper labels for %s\n", result.Repo); err != nil {
+			return err
+		}
+	} else if _, err := fmt.Fprintf(w, "Initialized Looper labels for %s\n", result.Repo); err != nil {
+		return err
+	}
+
+	for _, label := range result.Labels {
+		line := fmt.Sprintf("%s %s", label.Status, label.Name)
+		if label.Error != "" {
+			line += ": " + label.Error
+		}
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+
+	_, err := fmt.Fprintf(w, "Summary: created=%d updated=%d skipped=%d failed=%d\n", result.Summary.Created, result.Summary.Updated, result.Summary.Skipped, result.Summary.Failed)
+	return err
+}

--- a/internal/cliapp/labels.go
+++ b/internal/cliapp/labels.go
@@ -46,13 +46,20 @@ func (r *commandRuntime) labelsInit(cmd *cobra.Command, args []string) error {
 	}
 
 	result, err := gh.InitializeLabels(cmd.Context(), githubinfra.InitializeLabelsInput{Repo: repo, CWD: cwd, DryRun: getBoolFlag(cmd, "dry-run")})
-	if err != nil {
+	if err != nil && result.Repo == "" {
 		return fmt.Errorf("initialize labels for %s: %w", repo, err)
 	}
 	if getBoolFlag(cmd, "json") {
-		return writeJSON(cmd.OutOrStdout(), result)
+		if writeErr := writeJSON(cmd.OutOrStdout(), result); writeErr != nil {
+			return writeErr
+		}
+	} else if writeErr := writeHumanLabelsInit(cmd.OutOrStdout(), result); writeErr != nil {
+		return writeErr
 	}
-	return writeHumanLabelsInit(cmd.OutOrStdout(), result)
+	if err != nil {
+		return fmt.Errorf("initialize labels for %s: %w", repo, err)
+	}
+	return nil
 }
 
 func (r *commandRuntime) runGHCommand(ctx context.Context, options shell.Options) (shell.Result, error) {
@@ -62,7 +69,11 @@ func (r *commandRuntime) runGHCommand(ctx context.Context, options shell.Options
 		return shellResult, err
 	}
 	if result.ExitCode != 0 {
-		return shellResult, &shell.CommandExecutionError{Message: fmt.Sprintf("gh exited with code %d", result.ExitCode), Result: shellResult}
+		message := fmt.Sprintf("gh exited with code %d", result.ExitCode)
+		if stderr := strings.TrimSpace(result.Stderr); stderr != "" {
+			message += ": " + stderr
+		}
+		return shellResult, &shell.CommandExecutionError{Message: message, Result: shellResult}
 	}
 	return shellResult, nil
 }

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -12,6 +12,7 @@ Subcommands:
   config     Config commands
   daemon     Daemon commands
   upgrade    Check or upgrade Looper installations
+  labels     GitHub label commands
   loop       Loop commands
   work       Create a worker run
   plan       Create a planner run

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -220,6 +220,40 @@ type CapturePullRequestSnapshotInput struct {
 	CapturedAt string
 }
 
+type InitializeLabelsInput struct {
+	Repo   string
+	CWD    string
+	DryRun bool
+}
+
+type LabelDefinition struct {
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+}
+
+type LabelInitResult struct {
+	Repo    string           `json:"repo"`
+	DryRun  bool             `json:"dryRun"`
+	Labels  []LabelInitItem  `json:"labels"`
+	Summary LabelInitSummary `json:"summary"`
+}
+
+type LabelInitItem struct {
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+	Error       string `json:"error,omitempty"`
+}
+
+type LabelInitSummary struct {
+	Created int `json:"created"`
+	Updated int `json:"updated"`
+	Skipped int `json:"skipped"`
+	Failed  int `json:"failed"`
+}
+
 type ReviewThreadNotFoundError struct {
 	ThreadID string
 }
@@ -613,6 +647,60 @@ func (g *Gateway) GetCurrentUserLogin(ctx context.Context, cwd string) (string, 
 	return strings.TrimSpace(result.Stdout), nil
 }
 
+func (g *Gateway) DetectCurrentRepository(ctx context.Context, cwd string) (string, error) {
+	result, err := g.runGh(ctx, cwd, "", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
+	if err != nil {
+		return "", err
+	}
+	repo := strings.TrimSpace(result.Stdout)
+	if _, _, err := parseRepo(repo); err != nil {
+		return "", err
+	}
+	return repo, nil
+}
+
+func (g *Gateway) InitializeLabels(ctx context.Context, input InitializeLabelsInput) (LabelInitResult, error) {
+	repo := strings.TrimSpace(input.Repo)
+	if _, _, err := parseRepo(repo); err != nil {
+		return LabelInitResult{}, err
+	}
+
+	existing, err := g.listRepositoryLabels(ctx, repo, input.CWD)
+	if err != nil {
+		return LabelInitResult{}, err
+	}
+
+	result := LabelInitResult{Repo: repo, DryRun: input.DryRun, Labels: make([]LabelInitItem, 0, len(StandardLooperLabels()))}
+	for _, definition := range StandardLooperLabels() {
+		item := LabelInitItem{Name: definition.Name, Color: definition.Color, Description: definition.Description}
+		current, ok := existing[strings.ToLower(definition.Name)]
+		switch {
+		case !ok:
+			item.Status = "created"
+			if !input.DryRun {
+				_, err = g.runGh(ctx, input.CWD, "", "label", "create", definition.Name, "--repo", repo, "--color", definition.Color, "--description", definition.Description)
+			}
+		case normalizeLabelColor(current.Color) == normalizeLabelColor(definition.Color) && strings.TrimSpace(current.Description) == definition.Description:
+			item.Status = "skipped"
+		default:
+			item.Status = "updated"
+			if !input.DryRun {
+				_, err = g.runGh(ctx, input.CWD, "", "label", "edit", current.Name, "--repo", repo, "--color", definition.Color, "--description", definition.Description)
+			}
+		}
+
+		if err != nil {
+			item.Status = "failed"
+			item.Error = err.Error()
+			err = nil
+		}
+		result.Labels = append(result.Labels, item)
+		incrementLabelSummary(&result.Summary, item.Status)
+	}
+
+	return result, nil
+}
+
 func (g *Gateway) CapturePullRequestSnapshot(ctx context.Context, input CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
 	detail, err := g.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 	if err != nil {
@@ -747,6 +835,26 @@ func (g *Gateway) ensureLabelsExist(ctx context.Context, repo string, labels []s
 	return nil
 }
 
+func (g *Gateway) listRepositoryLabels(ctx context.Context, repo string, cwd string) (map[string]LabelDefinition, error) {
+	result, err := g.runGh(ctx, cwd, "", "label", "list", "--repo", repo, "--limit", "1000", "--json", "name,color,description")
+	if err != nil {
+		return nil, err
+	}
+	rows, err := decodeJSONArray(result.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]LabelDefinition, len(rows))
+	for _, row := range rows {
+		name := strings.TrimSpace(asString(row["name"]))
+		if name == "" {
+			continue
+		}
+		out[strings.ToLower(name)] = LabelDefinition{Name: name, Color: normalizeLabelColor(asString(row["color"])), Description: strings.TrimSpace(asString(row["description"]))}
+	}
+	return out, nil
+}
+
 func (g *Gateway) runGh(ctx context.Context, cwd, stdin string, args ...string) (shell.Result, error) {
 	return g.ghRun(ctx, shell.Options{Command: g.ghPath, Args: args, CWD: valueOr(strings.TrimSpace(cwd), g.cwd), Stdin: stdin})
 }
@@ -873,6 +981,32 @@ func resolveLabelDescription(label string) string {
 		return "Looper requires manual intervention"
 	default:
 		return "Managed by looper"
+	}
+}
+
+func StandardLooperLabels() []LabelDefinition {
+	return []LabelDefinition{
+		{Name: "looper:plan", Color: resolveLabelColor("looper:plan"), Description: resolveLabelDescription("looper:plan")},
+		{Name: specpr.ReviewingLabel, Color: resolveLabelColor(specpr.ReviewingLabel), Description: resolveLabelDescription(specpr.ReviewingLabel)},
+		{Name: specpr.ReadyLabel, Color: resolveLabelColor(specpr.ReadyLabel), Description: resolveLabelDescription(specpr.ReadyLabel)},
+		{Name: specpr.NeedsHumanLabel, Color: resolveLabelColor(specpr.NeedsHumanLabel), Description: resolveLabelDescription(specpr.NeedsHumanLabel)},
+	}
+}
+
+func normalizeLabelColor(value string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(value)), "#")
+}
+
+func incrementLabelSummary(summary *LabelInitSummary, status string) {
+	switch status {
+	case "created":
+		summary.Created++
+	case "updated":
+		summary.Updated++
+	case "skipped":
+		summary.Skipped++
+	case "failed":
+		summary.Failed++
 	}
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -648,12 +648,16 @@ func (g *Gateway) GetCurrentUserLogin(ctx context.Context, cwd string) (string, 
 }
 
 func (g *Gateway) DetectCurrentRepository(ctx context.Context, cwd string) (string, error) {
-	result, err := g.runGh(ctx, cwd, "", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
+	result, err := g.runGh(ctx, cwd, "", "repo", "view", "--json", "nameWithOwner,url")
 	if err != nil {
 		return "", err
 	}
-	repo := strings.TrimSpace(result.Stdout)
-	if _, _, err := parseRepo(repo); err != nil {
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return "", err
+	}
+	repo := hostQualifiedRepo(asString(row["nameWithOwner"]), asString(row["url"]))
+	if err := validateGitHubRepoSlug(repo); err != nil {
 		return "", err
 	}
 	return repo, nil
@@ -661,7 +665,7 @@ func (g *Gateway) DetectCurrentRepository(ctx context.Context, cwd string) (stri
 
 func (g *Gateway) InitializeLabels(ctx context.Context, input InitializeLabelsInput) (LabelInitResult, error) {
 	repo := strings.TrimSpace(input.Repo)
-	if _, _, err := parseRepo(repo); err != nil {
+	if err := validateGitHubRepoSlug(repo); err != nil {
 		return LabelInitResult{}, err
 	}
 
@@ -875,6 +879,26 @@ func parseRepo(repo string) (string, string, error) {
 		return "", "", fmt.Errorf("invalid GitHub repo: %s", repo)
 	}
 	return parts[0], parts[1], nil
+}
+
+func validateGitHubRepoSlug(repo string) error {
+	parts := strings.Split(strings.TrimSpace(repo), "/")
+	if (len(parts) != 2 && len(parts) != 3) || strings.TrimSpace(parts[len(parts)-2]) == "" || strings.TrimSpace(parts[len(parts)-1]) == "" {
+		return fmt.Errorf("invalid GitHub repo: %s", repo)
+	}
+	if len(parts) == 3 && strings.TrimSpace(parts[0]) == "" {
+		return fmt.Errorf("invalid GitHub repo: %s", repo)
+	}
+	return nil
+}
+
+func hostQualifiedRepo(nameWithOwner string, repoURL string) string {
+	repo := strings.TrimSpace(nameWithOwner)
+	parsed, err := url.Parse(strings.TrimSpace(repoURL))
+	if err != nil || parsed.Hostname() == "" || parsed.Hostname() == "github.com" {
+		return repo
+	}
+	return parsed.Hostname() + "/" + repo
 }
 
 func summarizeChecks(checks []map[string]any) string {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -698,6 +698,9 @@ func (g *Gateway) InitializeLabels(ctx context.Context, input InitializeLabelsIn
 		incrementLabelSummary(&result.Summary, item.Status)
 	}
 
+	if result.Summary.Failed > 0 {
+		return result, fmt.Errorf("%d label mutation(s) failed", result.Summary.Failed)
+	}
 	return result, nil
 }
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -332,6 +332,90 @@ func TestGatewayIgnoresMissingLabelDeleteErrors(t *testing.T) {
 	}
 }
 
+func TestGatewayInitializesLooperLabelsIdempotently(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch args {
+		case "label list --repo acme/looper --limit 1000 --json name,color,description":
+			return shell.Result{Stdout: `[{"name":"looper:plan","color":"5319e7","description":"Picked up automatically by planner"},{"name":"looper:spec-reviewing","color":"000000","description":"Old description"}]`}, nil
+		case "label edit looper:spec-reviewing --repo acme/looper --color 1d76db --description Spec PR is under review":
+			return shell.Result{Stdout: "{}"}, nil
+		case "label create looper:spec-ready --repo acme/looper --color 0e8a16 --description Spec PR is ready for implementation":
+			return shell.Result{Stdout: "{}"}, nil
+		case "label create looper:needs-human --repo acme/looper --color d93f0b --description Looper requires manual intervention":
+			return shell.Result{Stdout: "{}"}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	result, err := gateway.InitializeLabels(context.Background(), InitializeLabelsInput{Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("InitializeLabels() error = %v", err)
+	}
+	if result.Summary.Created != 2 || result.Summary.Updated != 1 || result.Summary.Skipped != 1 || result.Summary.Failed != 0 {
+		t.Fatalf("InitializeLabels() summary = %#v, want created=2 updated=1 skipped=1 failed=0", result.Summary)
+	}
+
+	log := strings.Join(runner.calls, "\n")
+	for _, needle := range []string{
+		"label list --repo acme/looper --limit 1000 --json name,color,description",
+		"label edit looper:spec-reviewing --repo acme/looper --color 1d76db --description Spec PR is under review",
+		"label create looper:spec-ready --repo acme/looper --color 0e8a16 --description Spec PR is ready for implementation",
+		"label create looper:needs-human --repo acme/looper --color d93f0b --description Looper requires manual intervention",
+	} {
+		if !strings.Contains(log, needle) {
+			t.Fatalf("gh log missing %q\n%s", needle, log)
+		}
+	}
+}
+
+func TestGatewayDryRunInitializesLooperLabelsWithoutMutating(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		if args == "label list --repo acme/looper --limit 1000 --json name,color,description" {
+			return shell.Result{Stdout: `[]`}, nil
+		}
+		t.Fatalf("unexpected gh args: %q", args)
+		return shell.Result{}, nil
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	result, err := gateway.InitializeLabels(context.Background(), InitializeLabelsInput{Repo: "acme/looper", DryRun: true})
+	if err != nil {
+		t.Fatalf("InitializeLabels(dry run) error = %v", err)
+	}
+	if result.Summary.Created != 4 || len(runner.calls) != 1 {
+		t.Fatalf("dry run result = %#v, calls = %#v; want four planned creates and only label list", result.Summary, runner.calls)
+	}
+}
+
+func TestGatewayDetectsCurrentRepository(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		if args := strings.Join(options.Args, " "); args != "repo view --json nameWithOwner --jq .nameWithOwner" {
+			t.Fatalf("gh args = %q, want repo view", args)
+		}
+		return shell.Result{Stdout: "acme/looper\n"}, nil
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	repo, err := gateway.DetectCurrentRepository(context.Background(), "")
+	if err != nil {
+		t.Fatalf("DetectCurrentRepository() error = %v", err)
+	}
+	if repo != "acme/looper" {
+		t.Fatalf("DetectCurrentRepository() = %q, want acme/looper", repo)
+	}
+}
+
 type fakeGHRunner struct {
 	t       *testing.T
 	calls   []string

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -396,6 +396,40 @@ func TestGatewayDryRunInitializesLooperLabelsWithoutMutating(t *testing.T) {
 	}
 }
 
+func TestGatewayInitializeLabelsReturnsErrorWhenMutationFails(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch args {
+		case "label list --repo acme/looper --limit 1000 --json name,color,description":
+			return shell.Result{Stdout: `[{"name":"looper:plan","color":"5319e7","description":"Picked up automatically by planner"}]`}, nil
+		case "label create looper:spec-reviewing --repo acme/looper --color 1d76db --description Spec PR is under review":
+			result := shell.Result{ExitCode: 1, Stderr: "permission denied"}
+			return result, &shell.CommandExecutionError{Message: "gh exited with code 1: permission denied", Result: result}
+		case "label create looper:spec-ready --repo acme/looper --color 0e8a16 --description Spec PR is ready for implementation":
+			return shell.Result{Stdout: "{}"}, nil
+		case "label create looper:needs-human --repo acme/looper --color d93f0b --description Looper requires manual intervention":
+			return shell.Result{Stdout: "{}"}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	result, err := gateway.InitializeLabels(context.Background(), InitializeLabelsInput{Repo: "acme/looper"})
+	if err == nil {
+		t.Fatalf("InitializeLabels() error = nil, want failure")
+	}
+	if result.Summary.Failed != 1 || result.Summary.Created != 2 || result.Summary.Skipped != 1 {
+		t.Fatalf("InitializeLabels() summary = %#v, want created=2 skipped=1 failed=1", result.Summary)
+	}
+	if got := result.Labels[1].Error; !strings.Contains(got, "permission denied") {
+		t.Fatalf("failed label error = %q, want stderr details", got)
+	}
+}
+
 func TestGatewayDetectsCurrentRepository(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -374,6 +374,38 @@ func TestGatewayInitializesLooperLabelsIdempotently(t *testing.T) {
 	}
 }
 
+func TestGatewayInitializesLooperLabelsForHostQualifiedRepo(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch args {
+		case "label list --repo github.example.com/acme/looper --limit 1000 --json name,color,description":
+			return shell.Result{Stdout: `[]`}, nil
+		case "label create looper:plan --repo github.example.com/acme/looper --color 5319e7 --description Picked up automatically by planner":
+			return shell.Result{Stdout: "{}"}, nil
+		case "label create looper:spec-reviewing --repo github.example.com/acme/looper --color 1d76db --description Spec PR is under review":
+			return shell.Result{Stdout: "{}"}, nil
+		case "label create looper:spec-ready --repo github.example.com/acme/looper --color 0e8a16 --description Spec PR is ready for implementation":
+			return shell.Result{Stdout: "{}"}, nil
+		case "label create looper:needs-human --repo github.example.com/acme/looper --color d93f0b --description Looper requires manual intervention":
+			return shell.Result{Stdout: "{}"}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	result, err := gateway.InitializeLabels(context.Background(), InitializeLabelsInput{Repo: "github.example.com/acme/looper"})
+	if err != nil {
+		t.Fatalf("InitializeLabels() error = %v", err)
+	}
+	if result.Repo != "github.example.com/acme/looper" || result.Summary.Created != 4 {
+		t.Fatalf("InitializeLabels() result = %#v, want host-qualified repo and created=4", result)
+	}
+}
+
 func TestGatewayDryRunInitializesLooperLabelsWithoutMutating(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}
@@ -434,10 +466,10 @@ func TestGatewayDetectsCurrentRepository(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
-		if args := strings.Join(options.Args, " "); args != "repo view --json nameWithOwner --jq .nameWithOwner" {
+		if args := strings.Join(options.Args, " "); args != "repo view --json nameWithOwner,url" {
 			t.Fatalf("gh args = %q, want repo view", args)
 		}
-		return shell.Result{Stdout: "acme/looper\n"}, nil
+		return shell.Result{Stdout: `{"nameWithOwner":"acme/looper","url":"https://github.com/acme/looper"}`}, nil
 	}
 
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
@@ -447,6 +479,26 @@ func TestGatewayDetectsCurrentRepository(t *testing.T) {
 	}
 	if repo != "acme/looper" {
 		t.Fatalf("DetectCurrentRepository() = %q, want acme/looper", repo)
+	}
+}
+
+func TestGatewayDetectsCurrentEnterpriseRepository(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		if args := strings.Join(options.Args, " "); args != "repo view --json nameWithOwner,url" {
+			t.Fatalf("gh args = %q, want repo view", args)
+		}
+		return shell.Result{Stdout: `{"nameWithOwner":"acme/looper","url":"https://github.example.com/acme/looper"}`}, nil
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	repo, err := gateway.DetectCurrentRepository(context.Background(), "")
+	if err != nil {
+		t.Fatalf("DetectCurrentRepository() error = %v", err)
+	}
+	if repo != "github.example.com/acme/looper" {
+		t.Fatalf("DetectCurrentRepository() = %q, want github.example.com/acme/looper", repo)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `looper labels init` with `--repo` and `--dry-run` support.
- Detect the current GitHub repository when `--repo` is omitted and validate `gh` availability/authentication with actionable errors.
- Create, update, skip, and report standard Looper labels idempotently.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #103