### PR TITLE
feat: support stopping all running tasks

### DIFF
--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -495,15 +495,40 @@ func refreshStopAllCandidate(ctx context.Context, repos *storage.Repositories, l
 	} else if queueItem != nil {
 		candidate.ActiveQueue = true
 	}
+	runsList, err := repos.Runs.List(ctx)
+	if err != nil {
+		return stopAllCandidate{}, err
+	}
+	runByID := make(map[string]storage.RunRecord, len(runsList))
+	for _, run := range runsList {
+		runByID[run.ID] = run
+	}
 	if run, err := repos.Runs.GetLatestByLoopID(ctx, loopID); err != nil {
 		return stopAllCandidate{}, err
 	} else if run != nil {
 		candidate.Run = run
-		if execution, err := repos.AgentExecutions.GetLatestByRunID(ctx, run.ID); err != nil {
-			return stopAllCandidate{}, err
-		} else if execution != nil {
-			candidate.Execution = execution
+	}
+	executions, err := repos.AgentExecutions.ListActive(ctx)
+	if err != nil {
+		return stopAllCandidate{}, err
+	}
+	for _, execution := range executions {
+		executionLoopID := ""
+		if execution.LoopID != nil {
+			executionLoopID = *execution.LoopID
 		}
+		if executionLoopID == "" && execution.RunID != nil {
+			if run, ok := runByID[*execution.RunID]; ok {
+				executionLoopID = run.LoopID
+			}
+		}
+		if executionLoopID != loopID {
+			continue
+		}
+		candidate.Executions = append(candidate.Executions, execution)
+	}
+	if len(candidate.Executions) > 0 {
+		candidate.Execution = &candidate.Executions[0]
 	}
 	return candidate, nil
 }

--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -320,12 +320,15 @@ func stopAllLoops(ctx context.Context, services looperdruntime.Services, reason 
 
 		_, err := stopLoop(ctx, services, candidate.Loop.ID, reason, now, signal, executionMatchesProcess)
 		if err != nil {
+			stopErr := err
 			if candidate.Execution != nil && candidate.Execution.Status == "running" {
-				err = stopCandidateExecution(ctx, services, candidate, reason, now, signal, executionMatchesProcess)
+				if fallbackErr := stopCandidateExecution(ctx, services, candidate, reason, now, signal, executionMatchesProcess); fallbackErr != nil {
+					err = errors.Join(stopErr, fallbackErr)
+				} else {
+					err = stopErr
+				}
 			}
-			if err == nil {
-				item.Result = string(stopAllResultStopped)
-			} else if refreshed, refreshErr := refreshStopAllCandidate(ctx, services.Repositories, candidate.Loop.ID); refreshErr == nil {
+			if refreshed, refreshErr := refreshStopAllCandidate(ctx, services.Repositories, candidate.Loop.ID); refreshErr == nil {
 				refreshedResult := classifyStopAllResult(refreshed)
 				if refreshedResult == stopAllResultAlreadyFinished || refreshedResult == stopAllResultAlreadyStopping {
 					item.Result = string(refreshedResult)

--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"slices"
+	"sort"
 	"sync"
 	"syscall"
 	"time"
@@ -114,6 +115,9 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 		Runtime: rt,
 		StopLoop: func(ctx context.Context, loopID, reason string) (any, error) {
 			return stopLoop(ctx, rt.Services(), loopID, reason, time.Now, syscall.Kill, rt.ExecutionMatchesProcess)
+		},
+		StopAll: func(ctx context.Context, reason string) (any, error) {
+			return stopAllLoops(ctx, rt.Services(), reason, time.Now, syscall.Kill, rt.ExecutionMatchesProcess)
 		},
 		TriggerSchedulerTick: func() {
 			rt.TriggerSchedulerTick()
@@ -233,6 +237,328 @@ func stopLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 	}
 
 	return result, nil
+}
+
+type stopAllResult string
+
+const (
+	stopAllResultStopped         stopAllResult = "stopped"
+	stopAllResultAlreadyFinished stopAllResult = "alreadyFinished"
+	stopAllResultAlreadyStopping stopAllResult = "alreadyStopping"
+	stopAllResultFailed          stopAllResult = "failed"
+)
+
+type stopAllSummary struct {
+	Total           int `json:"total"`
+	Stopped         int `json:"stopped"`
+	AlreadyFinished int `json:"alreadyFinished"`
+	AlreadyStopping int `json:"alreadyStopping"`
+	Failed          int `json:"failed"`
+}
+
+type stopAllItem struct {
+	LoopID                  string `json:"loopId,omitempty"`
+	Seq                     int64  `json:"seq,omitempty"`
+	Type                    string `json:"type,omitempty"`
+	RunID                   string `json:"runId,omitempty"`
+	ExecutionID             string `json:"executionId,omitempty"`
+	PreviousLoopStatus      string `json:"previousLoopStatus,omitempty"`
+	PreviousRunStatus       string `json:"previousRunStatus,omitempty"`
+	PreviousExecutionStatus string `json:"previousExecutionStatus,omitempty"`
+	Result                  string `json:"result"`
+	Error                   string `json:"error,omitempty"`
+}
+
+type stopAllResponse struct {
+	Summary stopAllSummary `json:"summary"`
+	Items   []stopAllItem  `json:"items"`
+}
+
+type stopAllCandidate struct {
+	Loop        storage.LoopRecord
+	Run         *storage.RunRecord
+	Execution   *storage.AgentExecutionRecord
+	Executions  []storage.AgentExecutionRecord
+	ActiveQueue bool
+}
+
+func stopAllLoops(ctx context.Context, services looperdruntime.Services, reason string, now func() time.Time, signal signalProcessFunc, executionMatchesProcess executionMatchesProcessFunc) (stopAllResponse, error) {
+	if services.Loops == nil {
+		return stopAllResponse{}, fmt.Errorf("loops service is not configured")
+	}
+	if services.Repositories == nil || services.Repositories.Loops == nil || services.Repositories.Runs == nil || services.Repositories.Queue == nil || services.Repositories.AgentExecutions == nil {
+		return stopAllResponse{}, fmt.Errorf("storage is not configured")
+	}
+
+	candidates, err := collectStopAllCandidates(ctx, services.Repositories)
+	if err != nil {
+		return stopAllResponse{}, err
+	}
+
+	response := stopAllResponse{Items: make([]stopAllItem, 0, len(candidates))}
+	for _, candidate := range candidates {
+		item := stopAllItem{
+			LoopID:             candidate.Loop.ID,
+			Seq:                candidate.Loop.Seq,
+			Type:               candidate.Loop.Type,
+			PreviousLoopStatus: candidate.Loop.Status,
+		}
+		if candidate.Run != nil {
+			item.RunID = candidate.Run.ID
+			item.PreviousRunStatus = candidate.Run.Status
+		}
+		if candidate.Execution != nil {
+			item.ExecutionID = candidate.Execution.ID
+			item.PreviousExecutionStatus = candidate.Execution.Status
+		}
+
+		item.Result = string(classifyStopAllResult(candidate))
+		if item.Result == string(stopAllResultAlreadyFinished) || item.Result == string(stopAllResultAlreadyStopping) {
+			response.Items = append(response.Items, item)
+			continue
+		}
+
+		_, err := stopLoop(ctx, services, candidate.Loop.ID, reason, now, signal, executionMatchesProcess)
+		if err != nil {
+			if candidate.Execution != nil && candidate.Execution.Status == "running" {
+				err = stopCandidateExecution(ctx, services, candidate, reason, now, signal, executionMatchesProcess)
+			}
+			if err == nil {
+				item.Result = string(stopAllResultStopped)
+			} else if refreshed, refreshErr := refreshStopAllCandidate(ctx, services.Repositories, candidate.Loop.ID); refreshErr == nil {
+				refreshedResult := classifyStopAllResult(refreshed)
+				if refreshedResult == stopAllResultAlreadyFinished || refreshedResult == stopAllResultAlreadyStopping {
+					item.Result = string(refreshedResult)
+				} else {
+					item.Result = string(stopAllResultFailed)
+					item.Error = err.Error()
+				}
+			} else {
+				item.Result = string(stopAllResultFailed)
+				item.Error = err.Error()
+			}
+		} else {
+			for _, execution := range candidate.Executions {
+				if execution.Status != "running" {
+					continue
+				}
+				execCandidate := candidate
+				execCandidate.Execution = &execution
+				if execErr := stopCandidateExecution(ctx, services, execCandidate, reason, now, signal, executionMatchesProcess); execErr != nil && item.Error == "" {
+					item.Result = string(stopAllResultFailed)
+					item.Error = execErr.Error()
+				}
+			}
+		}
+		if item.Result == string(stopAllResultFailed) {
+			// Keep the per-item failure while still processing remaining candidates.
+		} else if refreshed, refreshErr := refreshStopAllCandidate(ctx, services.Repositories, candidate.Loop.ID); refreshErr != nil {
+			item.Result = string(stopAllResultFailed)
+			item.Error = refreshErr.Error()
+		} else if classifyStopAllResult(refreshed) == stopAllResultAlreadyFinished {
+			item.Result = string(stopAllResultAlreadyFinished)
+		}
+		response.Items = append(response.Items, item)
+	}
+
+	for _, item := range response.Items {
+		response.Summary.Total++
+		switch stopAllResult(item.Result) {
+		case stopAllResultStopped:
+			response.Summary.Stopped++
+		case stopAllResultAlreadyFinished:
+			response.Summary.AlreadyFinished++
+		case stopAllResultAlreadyStopping:
+			response.Summary.AlreadyStopping++
+		case stopAllResultFailed:
+			response.Summary.Failed++
+		}
+	}
+
+	return response, nil
+}
+
+func collectStopAllCandidates(ctx context.Context, repos *storage.Repositories) ([]stopAllCandidate, error) {
+	loopsList, err := repos.Loops.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	runsList, err := repos.Runs.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	executions, err := repos.AgentExecutions.ListActive(ctx)
+	if err != nil {
+		return nil, err
+	}
+	queueItems, err := repos.Queue.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	loopsByID := make(map[string]storage.LoopRecord, len(loopsList))
+	for _, loop := range loopsList {
+		loopsByID[loop.ID] = loop
+	}
+	bestRunByLoopID := make(map[string]storage.RunRecord)
+	runByID := make(map[string]storage.RunRecord, len(runsList))
+	for _, run := range runsList {
+		runByID[run.ID] = run
+		current, ok := bestRunByLoopID[run.LoopID]
+		if !ok || (current.Status != "running" && run.Status == "running") {
+			bestRunByLoopID[run.LoopID] = run
+		}
+	}
+	activeExecutionsByLoopID := make(map[string][]storage.AgentExecutionRecord)
+	for _, execution := range executions {
+		loopID := ""
+		if execution.LoopID != nil {
+			loopID = *execution.LoopID
+		}
+		if loopID == "" && execution.RunID != nil {
+			if run, ok := runByID[*execution.RunID]; ok {
+				loopID = run.LoopID
+			}
+		}
+		if loopID == "" {
+			continue
+		}
+		activeExecutionsByLoopID[loopID] = append(activeExecutionsByLoopID[loopID], execution)
+	}
+
+	activeLoopIDs := make(map[string]struct{})
+	for _, run := range runsList {
+		if run.Status == "running" {
+			activeLoopIDs[run.LoopID] = struct{}{}
+		}
+	}
+	for _, loop := range loopsList {
+		if loop.Status == "queued" || loop.Status == "running" {
+			activeLoopIDs[loop.ID] = struct{}{}
+		}
+	}
+	for _, item := range queueItems {
+		if item.LoopID != nil && (item.Status == "queued" || item.Status == "running") {
+			activeLoopIDs[*item.LoopID] = struct{}{}
+		}
+	}
+	for loopID := range activeExecutionsByLoopID {
+		activeLoopIDs[loopID] = struct{}{}
+	}
+	activeQueueByLoopID := make(map[string]bool)
+	for _, item := range queueItems {
+		if item.LoopID != nil && (item.Status == "queued" || item.Status == "running") {
+			activeQueueByLoopID[*item.LoopID] = true
+		}
+	}
+
+	candidates := make([]stopAllCandidate, 0, len(activeLoopIDs))
+	for loopID := range activeLoopIDs {
+		loop, ok := loopsByID[loopID]
+		if !ok {
+			continue
+		}
+		candidate := stopAllCandidate{Loop: loop}
+		if run, ok := bestRunByLoopID[loopID]; ok {
+			candidate.Run = &run
+		}
+		if executions, ok := activeExecutionsByLoopID[loopID]; ok && len(executions) > 0 {
+			candidate.Executions = executions
+			candidate.Execution = &executions[0]
+		}
+		candidate.ActiveQueue = activeQueueByLoopID[loopID]
+		candidates = append(candidates, candidate)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Loop.Seq != candidates[j].Loop.Seq {
+			return candidates[i].Loop.Seq < candidates[j].Loop.Seq
+		}
+		return candidates[i].Loop.ID < candidates[j].Loop.ID
+	})
+	return candidates, nil
+}
+
+func refreshStopAllCandidate(ctx context.Context, repos *storage.Repositories, loopID string) (stopAllCandidate, error) {
+	loop, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return stopAllCandidate{}, err
+	}
+	if loop == nil {
+		return stopAllCandidate{}, nil
+	}
+	candidate := stopAllCandidate{Loop: *loop}
+	if queueItem, err := repos.Queue.FindActiveByLoopID(ctx, loopID); err != nil {
+		return stopAllCandidate{}, err
+	} else if queueItem != nil {
+		candidate.ActiveQueue = true
+	}
+	if run, err := repos.Runs.GetLatestByLoopID(ctx, loopID); err != nil {
+		return stopAllCandidate{}, err
+	} else if run != nil {
+		candidate.Run = run
+		if execution, err := repos.AgentExecutions.GetLatestByRunID(ctx, run.ID); err != nil {
+			return stopAllCandidate{}, err
+		} else if execution != nil {
+			candidate.Execution = execution
+		}
+	}
+	return candidate, nil
+}
+
+func classifyStopAllResult(candidate stopAllCandidate) stopAllResult {
+	if candidate.Execution != nil && candidate.Execution.Status == "cancelling" {
+		if candidate.Loop.Status != "queued" && candidate.Loop.Status != "running" && !candidate.ActiveQueue {
+			return stopAllResultAlreadyStopping
+		}
+	}
+	if candidate.Execution != nil && candidate.Execution.Status == "running" {
+		return stopAllResultStopped
+	}
+	if candidate.Run != nil && candidate.Run.Status != "" && candidate.Run.Status != "running" && candidate.Loop.Status != "queued" && candidate.Loop.Status != "running" && !candidate.ActiveQueue {
+		return stopAllResultAlreadyFinished
+	}
+	return stopAllResultStopped
+}
+
+func stopCandidateExecution(ctx context.Context, services looperdruntime.Services, candidate stopAllCandidate, reason string, now func() time.Time, signal signalProcessFunc, executionMatchesProcess executionMatchesProcessFunc) error {
+	if candidate.Execution == nil {
+		return nil
+	}
+	runID := ""
+	if candidate.Execution.RunID != nil {
+		runID = *candidate.Execution.RunID
+	}
+	if runID == "" && candidate.Run != nil {
+		runID = candidate.Run.ID
+	}
+	if services.ActiveExecutions != nil && runID != "" {
+		killed, err := services.ActiveExecutions.Kill(candidate.Loop.ID, runID, candidate.Execution.ID, reason)
+		if err != nil {
+			return err
+		}
+		if killed {
+			return markExecutionCancelling(ctx, services, *candidate.Execution, reason, now)
+		}
+	}
+	if candidate.Execution.PID == nil || *candidate.Execution.PID <= 0 {
+		return nil
+	}
+	pid := int(*candidate.Execution.PID)
+	if executionMatchesProcess != nil {
+		matches, running, err := executionMatchesProcess(ctx, *candidate.Execution, pid)
+		if err != nil {
+			return err
+		}
+		if !running || !matches {
+			return nil
+		}
+	}
+	if signal != nil {
+		if err := signalAgentProcessGroup(pid, signal, 5*time.Second); err != nil {
+			return err
+		}
+	}
+	return markExecutionCancelling(ctx, services, *candidate.Execution, reason, now)
 }
 
 func isStoppableExecutionStatus(status string) bool {

--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -509,13 +509,31 @@ func refreshStopAllCandidate(ctx context.Context, repos *storage.Repositories, l
 }
 
 func classifyStopAllResult(candidate stopAllCandidate) stopAllResult {
-	if candidate.Execution != nil && candidate.Execution.Status == "cancelling" {
+	hasRunningExecution := false
+	hasCancellingExecution := false
+	for _, execution := range candidate.Executions {
+		switch execution.Status {
+		case "running":
+			hasRunningExecution = true
+		case "cancelling":
+			hasCancellingExecution = true
+		}
+	}
+	if candidate.Execution != nil {
+		switch candidate.Execution.Status {
+		case "running":
+			hasRunningExecution = true
+		case "cancelling":
+			hasCancellingExecution = true
+		}
+	}
+	if hasRunningExecution {
+		return stopAllResultStopped
+	}
+	if hasCancellingExecution {
 		if candidate.Loop.Status != "queued" && candidate.Loop.Status != "running" && !candidate.ActiveQueue {
 			return stopAllResultAlreadyStopping
 		}
-	}
-	if candidate.Execution != nil && candidate.Execution.Status == "running" {
-		return stopAllResultStopped
 	}
 	if candidate.Run != nil && candidate.Run.Status != "" && candidate.Run.Status != "running" && candidate.Loop.Status != "queued" && candidate.Loop.Status != "running" && !candidate.ActiveQueue {
 		return stopAllResultAlreadyFinished

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"syscall"
 	"testing"
 	"time"
@@ -721,6 +723,65 @@ func TestStopLoopSkipsSignalWhenExecutionVerifierRejectsPID(t *testing.T) {
 	}
 }
 
+func TestStopAllLoopsHandlesMixedTypesPartialFailureAndRepeatedCalls(t *testing.T) {
+	ctx := context.Background()
+	services, repos, now := newStopAllTestServices(t)
+
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_planner", seq: 1, loopType: "planner", loopStatus: "running", runID: "run_planner", runStatus: "running", executionID: "exec_planner", executionStatus: "running", pid: 4101})
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_reviewer", seq: 2, loopType: "reviewer", loopStatus: "running", runID: "run_reviewer", runStatus: "running", executionID: "exec_reviewer", executionStatus: "running", pid: 4102})
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_worker", seq: 3, loopType: "worker", loopStatus: "running", runID: "run_worker", runStatus: "running", executionID: "exec_worker", executionStatus: "running", pid: 4103})
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_fixer", seq: 4, loopType: "fixer", loopStatus: "running", runID: "run_fixer", runStatus: "running", executionID: "exec_fixer", executionStatus: "cancelling", pid: 4104})
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_future", seq: 5, loopType: "auditor", loopStatus: "running", runID: "run_future", runStatus: "running", executionID: "exec_future", executionStatus: "running", pid: 4105})
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_queued", seq: 6, loopType: "worker", loopStatus: "queued", queueStatus: "running"})
+
+	var signalPIDs []int
+	response, err := stopAllLoops(ctx, services, "Stopped by test", func() time.Time { return now }, func(pid int, sig syscall.Signal) error {
+		if sig != syscall.SIGTERM {
+			return nil
+		}
+		signalPIDs = append(signalPIDs, pid)
+		if pid == -4102 || pid == 4102 {
+			return fmt.Errorf("signal failed")
+		}
+		return syscall.ESRCH
+	}, func(_ context.Context, execution storage.AgentExecutionRecord, pid int) (bool, bool, error) {
+		return true, true, nil
+	})
+	if err != nil {
+		t.Fatalf("stopAllLoops() error = %v", err)
+	}
+
+	if got, want := response.Summary, (stopAllSummary{Total: 6, Stopped: 5, Failed: 1}); got != want {
+		t.Fatalf("stopAllLoops() summary = %#v, want %#v", got, want)
+	}
+	if got := stopAllItemTypes(response.Items); !slices.Equal(got, []string{"planner", "reviewer", "worker", "fixer", "auditor", "worker"}) {
+		t.Fatalf("item types = %#v, want mixed known and future types", got)
+	}
+	assertStopAllItemResult(t, response.Items, "loop_reviewer", string(stopAllResultFailed))
+	assertStopAllItemResult(t, response.Items, "loop_fixer", string(stopAllResultStopped))
+	assertStopAllItemResult(t, response.Items, "loop_future", string(stopAllResultStopped))
+	assertStopAllItemResult(t, response.Items, "loop_queued", string(stopAllResultStopped))
+	if !slices.Contains(signalPIDs, -4101) || !slices.Contains(signalPIDs, -4103) || !slices.Contains(signalPIDs, -4105) {
+		t.Fatalf("signal pids = %#v, want other loops processed after failure", signalPIDs)
+	}
+
+	repeated, err := stopAllLoops(ctx, services, "Stopped by test again", func() time.Time { return now.Add(time.Minute) }, func(pid int, sig syscall.Signal) error {
+		if sig != syscall.SIGTERM {
+			return nil
+		}
+		return syscall.ESRCH
+	}, func(_ context.Context, execution storage.AgentExecutionRecord, pid int) (bool, bool, error) {
+		return true, true, nil
+	})
+	if err != nil {
+		t.Fatalf("second stopAllLoops() error = %v", err)
+	}
+	if repeated.Summary.AlreadyStopping < 4 {
+		t.Fatalf("second stopAllLoops() summary = %#v, want repeated call to report alreadyStopping", repeated.Summary)
+	}
+	assertStopAllItemResult(t, repeated.Items, "loop_future", string(stopAllResultAlreadyStopping))
+}
+
 type fakeActiveExecution struct {
 	killed bool
 	reason string
@@ -735,3 +796,90 @@ func (f *fakeActiveExecution) Kill(reason string) error {
 	}
 	return nil
 }
+
+type stopAllLoopFixture struct {
+	loopID          string
+	seq             int64
+	loopType        string
+	loopStatus      string
+	runID           string
+	runStatus       string
+	executionID     string
+	executionStatus string
+	pid             int64
+	queueStatus     string
+}
+
+func newStopAllTestServices(t *testing.T) (looperdruntime.Services, *storage.Repositories, time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(ctx); err != nil {
+		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 12, 0, 0, 0, time.UTC)
+	nowISO := now.Format("2006-01-02T15:04:05.000Z")
+	project := storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Projects.Upsert(ctx, project); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	services := looperdruntime.Services{Coordinator: coordinator, Repositories: repos, Loops: &loops.Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }}}
+	return services, repos, now
+}
+
+func insertStopAllTestLoop(t *testing.T, ctx context.Context, repos *storage.Repositories, now time.Time, fixture stopAllLoopFixture) {
+	t.Helper()
+	nowISO := now.Format("2006-01-02T15:04:05.000Z")
+	if err := repos.Loops.Upsert(ctx, storage.LoopRecord{ID: fixture.loopID, Seq: fixture.seq, ProjectID: "project_1", Type: fixture.loopType, TargetType: "project", Status: fixture.loopStatus, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert(%s) error = %v", fixture.loopID, err)
+	}
+	if fixture.runID != "" {
+		if err := repos.Runs.Upsert(ctx, storage.RunRecord{ID: fixture.runID, LoopID: fixture.loopID, Status: fixture.runStatus, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+			t.Fatalf("Runs.Upsert(%s) error = %v", fixture.runID, err)
+		}
+	}
+	if fixture.executionID != "" {
+		pid := fixture.pid
+		exec := storage.AgentExecutionRecord{ID: fixture.executionID, ProjectID: stringPtr("project_1"), LoopID: &fixture.loopID, RunID: &fixture.runID, Vendor: "codex", Status: fixture.executionStatus, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+		if pid > 0 {
+			exec.PID = &pid
+		}
+		if err := repos.AgentExecutions.Upsert(ctx, exec); err != nil {
+			t.Fatalf("AgentExecutions.Upsert(%s) error = %v", fixture.executionID, err)
+		}
+	}
+	if fixture.queueStatus != "" {
+		if err := repos.Queue.Upsert(ctx, storage.QueueItemRecord{ID: "queue_" + fixture.loopID, ProjectID: stringPtr("project_1"), LoopID: &fixture.loopID, Type: fixture.loopType, TargetType: "project", TargetID: "project_1", DedupeKey: "dedupe:" + fixture.loopID, Priority: 1, Status: fixture.queueStatus, AvailableAt: nowISO, Attempts: 0, MaxAttempts: 1, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", fixture.loopID, err)
+		}
+	}
+}
+
+func assertStopAllItemResult(t *testing.T, items []stopAllItem, loopID, want string) {
+	t.Helper()
+	for _, item := range items {
+		if item.LoopID == loopID {
+			if item.Result != want {
+				t.Fatalf("item %s result = %q, want %q", loopID, item.Result, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("loop %s not found in stop-all items: %#v", loopID, items)
+}
+
+func stopAllItemTypes(items []stopAllItem) []string {
+	types := make([]string, 0, len(items))
+	for _, item := range items {
+		types = append(types, item.Type)
+	}
+	return types
+}
+
+func stringPtr(value string) *string { return &value }

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -801,6 +801,35 @@ func TestClassifyStopAllResultChecksAllActiveExecutionsBeforeAlreadyStopping(t *
 	}
 }
 
+func TestRefreshStopAllCandidateKeepsOtherActiveExecutionsForClassification(t *testing.T) {
+	services, repos, now := newStopAllTestServices(t)
+	ctx := context.Background()
+
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_mixed", seq: 1, loopType: "worker", loopStatus: "paused", runID: "run_newest", runStatus: "finished", executionID: "exec_newest", executionStatus: "cancelling"})
+	otherRunID := "run_other"
+	olderISO := now.Add(-time.Minute).Format("2006-01-02T15:04:05.000Z")
+	if err := repos.Runs.Upsert(ctx, storage.RunRecord{ID: otherRunID, LoopID: "loop_mixed", Status: "running", StartedAt: olderISO, LastHeartbeatAt: &olderISO, CreatedAt: olderISO, UpdatedAt: olderISO}); err != nil {
+		t.Fatalf("Runs.Upsert(%s) error = %v", otherRunID, err)
+	}
+	if err := repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: "exec_other", ProjectID: stringPtr("project_1"), RunID: &otherRunID, Vendor: "codex", Status: "running", StartedAt: olderISO, CreatedAt: olderISO, UpdatedAt: olderISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(exec_other) error = %v", err)
+	}
+
+	refreshed, err := refreshStopAllCandidate(ctx, services.Repositories, "loop_mixed")
+	if err != nil {
+		t.Fatalf("refreshStopAllCandidate() error = %v", err)
+	}
+	if len(refreshed.Executions) != 2 {
+		t.Fatalf("len(refreshed.Executions) = %d, want 2", len(refreshed.Executions))
+	}
+	if refreshed.Execution == nil || refreshed.Execution.ID != "exec_newest" {
+		t.Fatalf("refreshed.Execution = %#v, want newest cancelling execution", refreshed.Execution)
+	}
+	if got := classifyStopAllResult(refreshed); got != stopAllResultStopped {
+		t.Fatalf("classifyStopAllResult(refresh) = %q, want %q while another execution is still running", got, stopAllResultStopped)
+	}
+}
+
 type fakeActiveExecution struct {
 	killed bool
 	reason string

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -782,6 +782,25 @@ func TestStopAllLoopsHandlesMixedTypesPartialFailureAndRepeatedCalls(t *testing.
 	assertStopAllItemResult(t, repeated.Items, "loop_future", string(stopAllResultAlreadyStopping))
 }
 
+func TestClassifyStopAllResultChecksAllActiveExecutionsBeforeAlreadyStopping(t *testing.T) {
+	runID := "run_mixed"
+	cancelling := storage.AgentExecutionRecord{ID: "exec_cancelling", RunID: &runID, Status: "cancelling"}
+	running := storage.AgentExecutionRecord{ID: "exec_running", RunID: &runID, Status: "running"}
+	candidate := stopAllCandidate{
+		Loop:      storage.LoopRecord{ID: "loop_mixed", Status: "paused"},
+		Run:       &storage.RunRecord{ID: runID, Status: "running"},
+		Execution: &cancelling,
+		Executions: []storage.AgentExecutionRecord{
+			cancelling,
+			running,
+		},
+	}
+
+	if got := classifyStopAllResult(candidate); got != stopAllResultStopped {
+		t.Fatalf("classifyStopAllResult() = %q, want %q while any active execution is still running", got, stopAllResultStopped)
+	}
+}
+
 type fakeActiveExecution struct {
 	killed bool
 	reason string

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -52,6 +52,7 @@ type Context struct {
 	Now                  func() time.Time
 	RecoverySummary      func() any
 	StopLoop             func(context.Context, string, string) (any, error)
+	StopAll              func(context.Context, string) (any, error)
 	TriggerSchedulerTick func()
 }
 
@@ -1719,14 +1720,26 @@ func (h *Handler) buildActiveRunRouteResponse(r *http.Request, path string) (any
 		return nil, apiError{code: pkgapi.ErrorCodeRouteNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Unknown route: %s", path)}
 	}
 
-	loop, err := h.resolveLoop(r.Context(), selector)
-	if err != nil {
-		return nil, err
+	if selector == "stop-all" {
+		if len(parts) != 1 {
+			return nil, apiError{code: pkgapi.ErrorCodeRouteNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Unknown route: %s", path)}
+		}
+		if r.Method != http.MethodPost {
+			return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
+		}
+		if h.context.StopAll == nil {
+			return nil, apiError{code: pkgapi.ErrorCodeRuntimeControlUnavailable, status: http.StatusNotImplemented, message: "Runtime control is not available in this process"}
+		}
+		return h.context.StopAll(r.Context(), "Stopped by user via selector all")
 	}
 
 	if len(parts) == 1 || strings.TrimSpace(parts[1]) == "" {
 		if r.Method != http.MethodGet {
 			return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
+		}
+		loop, err := h.resolveLoop(r.Context(), selector)
+		if err != nil {
+			return nil, err
 		}
 		return h.buildActiveRunDetailResponse(r.Context(), loop.ID)
 	}
@@ -1738,6 +1751,10 @@ func (h *Handler) buildActiveRunRouteResponse(r *http.Request, path string) (any
 		}
 		if h.context.StopLoop == nil {
 			return nil, apiError{code: pkgapi.ErrorCodeRuntimeControlUnavailable, status: http.StatusNotImplemented, message: "Runtime control is not available in this process"}
+		}
+		loop, err := h.resolveLoop(r.Context(), selector)
+		if err != nil {
+			return nil, err
 		}
 		return h.context.StopLoop(r.Context(), loop.ID, fmt.Sprintf("Stopped by user via selector %s", selector))
 	default:

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2895,6 +2895,38 @@ func TestHandlerRunRoutesMatchFrozenSuccessArtifacts(t *testing.T) {
 	}
 }
 
+func TestHandlerActiveRunsStopAllUsesContextStopAll(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedRunRouteData(t, fixture.runtime)
+
+	called := 0
+	var gotReason string
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/active/stop-all", nil)
+	recorder := httptest.NewRecorder()
+
+	NewHandler(Context{
+		Config:  fixture.config,
+		Runtime: fixture.runtime,
+		StopAll: func(_ context.Context, reason string) (any, error) {
+			called++
+			gotReason = reason
+			return map[string]any{"summary": map[string]any{"total": 0, "stopped": 0, "alreadyFinished": 0, "alreadyStopping": 0, "failed": 0}, "items": []map[string]any{}}, nil
+		},
+		StopLoop: func(context.Context, string, string) (any, error) {
+			t.Fatal("StopLoop should not be called for stop-all route")
+			return nil, nil
+		},
+	}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	assertEqual(t, called, 1)
+	assertEqual(t, gotReason, "Stopped by user via selector all")
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	assertEqual(t, body["ok"], true)
+}
+
 func TestHandlerLoopLogsFollowStreamsSnapshotAndChunk(t *testing.T) {
 	fixture := newTestFixture(t)
 	seedRunRouteData(t, fixture.runtime)

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -326,7 +326,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					"$ looper logs 12 --follow",
 				},
 			}),
-			newCommand(commandSpec{use: "stop <id>", short: "Stop an active loop", args: cobra.ExactArgs(1), runE: runtime.stopLoop, exampleLines: []string{"$ looper stop 12"}}),
+			newCommand(commandSpec{use: "stop <id|all>", short: "Stop an active loop or all active loops", args: cobra.ExactArgs(1), runE: runtime.stopLoop, exampleLines: []string{"$ looper stop 12", "$ looper stop all"}}),
 			newCommand(commandSpec{
 				use:             "run",
 				short:           "Run commands",

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -646,6 +646,77 @@ func TestPSWithoutJSONShowsRunningLoopWithoutRunRow(t *testing.T) {
 	}
 }
 
+func TestStopAllWithoutJSONUsesStopAllRoute(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Method, http.MethodPost; got != want {
+			t.Fatalf("method = %q, want %q", got, want)
+		}
+		if got, want := r.URL.Path, "/api/v1/runs/active/stop-all"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_stop_all", map[string]any{"summary": map[string]any{"total": 1, "stopped": 1, "alreadyFinished": 0, "alreadyStopping": 0, "failed": 0}, "items": []map[string]any{{"seq": 12, "type": "worker", "loopId": "loop_12", "runId": "run_12", "executionId": "exec_12", "result": "stopped"}}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "stop", "all", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([stop all]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([stop all]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Stopped running tasks", "loop_12", "worker", "stopped"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([stop all]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
+func TestStopAllWithoutJSONPrintsNoRunningWorkMessage(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(t, w, pkgapi.Success("req_stop_all_empty", map[string]any{"summary": map[string]any{"total": 0, "stopped": 0, "alreadyFinished": 0, "alreadyStopping": 0, "failed": 0}, "items": []map[string]any{}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "stop", "all", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([stop all]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([stop all]) stderr = %q, want empty string", stderr)
+	}
+	if got, want := stdout, "No running tasks to stop.\n"; got != want {
+		t.Fatalf("Run([stop all]) stdout = %q, want %q", got, want)
+	}
+}
+
+func TestStopAllWithoutJSONReturnsNonZeroForPartialFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(t, w, pkgapi.Success("req_stop_all_partial", map[string]any{"summary": map[string]any{"total": 2, "stopped": 1, "alreadyFinished": 0, "alreadyStopping": 0, "failed": 1}, "items": []map[string]any{{"seq": 1, "type": "planner", "loopId": "loop_1", "runId": "run_1", "executionId": "exec_1", "result": "stopped"}, {"seq": 2, "type": "reviewer", "loopId": "loop_2", "runId": "run_2", "executionId": "exec_2", "result": "failed", "error": "signal failed"}}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "stop", "all", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatal("Run([stop all]) exit code = 0, want non-zero")
+	}
+	if !strings.Contains(stdout, "Stopped running tasks") || !strings.Contains(stdout, "signal failed") {
+		t.Fatalf("Run([stop all]) stdout = %q, want summary and failure row", stdout)
+	}
+	if !strings.Contains(stderr, "failed to stop 1 running task(s)") {
+		t.Fatalf("Run([stop all]) stderr = %q, want partial failure message", stderr)
+	}
+}
+
 func TestLogsWithoutJSONPrintsHeaderAndTail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -115,6 +115,28 @@ type activeRunsOutput struct {
 	Items []activeRunOutput `json:"items"`
 }
 
+type stopAllOutput struct {
+	Summary struct {
+		Total           int `json:"total"`
+		Stopped         int `json:"stopped"`
+		AlreadyFinished int `json:"alreadyFinished"`
+		AlreadyStopping int `json:"alreadyStopping"`
+		Failed          int `json:"failed"`
+	} `json:"summary"`
+	Items []struct {
+		LoopID                  string `json:"loopId"`
+		Seq                     int64  `json:"seq"`
+		Type                    string `json:"type"`
+		RunID                   string `json:"runId"`
+		ExecutionID             string `json:"executionId"`
+		PreviousLoopStatus      string `json:"previousLoopStatus"`
+		PreviousRunStatus       string `json:"previousRunStatus"`
+		PreviousExecutionStatus string `json:"previousExecutionStatus"`
+		Result                  string `json:"result"`
+		Error                   string `json:"error"`
+	} `json:"items"`
+}
+
 type activeRunOutput struct {
 	Seq         int64   `json:"seq"`
 	Type        string  `json:"type"`
@@ -460,6 +482,33 @@ func writeHumanStopLoop(w io.Writer, payload json.RawMessage) error {
 	printSection(w, "Loop stopped", [][2]any{{"loopId", data.LoopID}, {"runId", data.RunID}, {"executionId", data.ExecutionID}, {"vendor", data.Vendor}, {"pid", data.PID}, {"stopped", data.Stopped}})
 	if !data.Stopped {
 		return fmt.Errorf("Loop %s could not be stopped", data.LoopID)
+	}
+	return nil
+}
+
+func writeHumanStopAll(w io.Writer, payload json.RawMessage) error {
+	var data stopAllOutput
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return fmt.Errorf("decode stop-all response: %w", err)
+	}
+	if data.Summary.Total == 0 {
+		_, err := fmt.Fprintln(w, "No running tasks to stop.")
+		return err
+	}
+	printSection(w, "Stopped running tasks", [][2]any{
+		{"total", data.Summary.Total},
+		{"stopped", data.Summary.Stopped},
+		{"alreadyFinished", data.Summary.AlreadyFinished},
+		{"alreadyStopping", data.Summary.AlreadyStopping},
+		{"failed", data.Summary.Failed},
+	})
+	rows := make([]tableRow, 0, len(data.Items))
+	for _, item := range data.Items {
+		rows = append(rows, tableRow{"seq": item.Seq, "type": item.Type, "loopId": item.LoopID, "runId": item.RunID, "executionId": item.ExecutionID, "result": item.Result, "error": item.Error})
+	}
+	printTable(w, []string{"seq", "type", "loopId", "runId", "executionId", "result", "error"}, rows)
+	if data.Summary.Failed > 0 {
+		return fmt.Errorf("failed to stop %d running task(s)", data.Summary.Failed)
 	}
 	return nil
 }

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -284,10 +284,41 @@ func (r *commandRuntime) loopLogs(cmd *cobra.Command, args []string) error {
 }
 
 func (r *commandRuntime) stopLoop(cmd *cobra.Command, args []string) error {
+	selector := strings.TrimSpace(args[0])
+	if selector == "all" {
+		payload, err := r.postJSON(cmd.Context(), "/api/v1/runs/active/stop-all", nil)
+		if err != nil {
+			return err
+		}
+		if getBoolFlag(cmd, "json") {
+			if err := writeJSON(cmd.OutOrStdout(), payload); err != nil {
+				return err
+			}
+		} else if err := writeHumanStopAll(cmd.OutOrStdout(), payload); err != nil {
+			return err
+		}
+		if failed, err := stopAllFailedCount(payload); err != nil {
+			return err
+		} else if failed > 0 {
+			return fmt.Errorf("failed to stop %d running task(s)", failed)
+		}
+		return nil
+	}
 	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
-		selector := strings.TrimSpace(args[0])
 		return r.postJSON(ctx, "/api/v1/runs/active/"+url.PathEscape(selector)+"/stop", nil)
 	}, writeHumanStopLoop)
+}
+
+func stopAllFailedCount(payload json.RawMessage) (int, error) {
+	var data struct {
+		Summary struct {
+			Failed int `json:"failed"`
+		} `json:"summary"`
+	}
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return 0, fmt.Errorf("decode stop-all response: %w", err)
+	}
+	return data.Summary.Failed, nil
 }
 
 func (r *commandRuntime) runList(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- Add `looper stop all` and route it to a dedicated `POST /api/v1/runs/active/stop-all` aggregate endpoint.
- Stop active loops, running runs, active agent executions, and queued queue items discovered from runtime/storage state without hard-coded loop type filtering.
- Return itemized stop-all results with summary counts and fail the CLI when any item fails.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #99