### PR TITLE
feat: schedule project PR snapshots asynchronously

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,7 @@ Example minimal `~/.looper/config.json`:
     "allowAutoMerge": false,
     "allowRiskyFixes": false,
     "openPrStrategy": "all_done",
-    "addSnapshotMode": "async"
+    "addSnapshotMode": "full"
   },
   "projects": [
     {
@@ -250,7 +250,7 @@ Default values:
 - `allowAutoMerge`: `false`
 - `allowRiskyFixes`: `false`
 - `openPrStrategy`: `all_done`
-- `addSnapshotMode`: `async`
+- `addSnapshotMode`: `full`
 
 ### `projects`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,7 +126,8 @@ Example minimal `~/.looper/config.json`:
     "allowAutoApprove": false,
     "allowAutoMerge": false,
     "allowRiskyFixes": false,
-    "openPrStrategy": "all_done"
+    "openPrStrategy": "all_done",
+    "addSnapshotMode": "async"
   },
   "projects": [
     {
@@ -238,6 +239,7 @@ Defaults:
 - `allowAutoMerge`
 - `allowRiskyFixes`
 - `openPrStrategy`: `all_done`, `first_commit`, or `manual`
+- `addSnapshotMode`: project-add PR snapshot behavior: `async`, `full`, or `off`; `looper project add --snapshot-mode` overrides this per request
 
 Default values:
 
@@ -248,6 +250,7 @@ Default values:
 - `allowAutoMerge`: `false`
 - `allowRiskyFixes`: `false`
 - `openPrStrategy`: `all_done`
+- `addSnapshotMode`: `async`
 
 ### `projects`
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1048,6 +1048,8 @@ type createProjectResponse struct {
 	projectResponse
 	DiscoveredPullRequests int      `json:"discoveredPullRequests"`
 	DiscoveredWorktrees    int      `json:"discoveredWorktrees"`
+	PendingSnapshots       int      `json:"pendingSnapshots"`
+	CapturedSnapshots      int      `json:"capturedSnapshots"`
 	Warnings               []string `json:"warnings"`
 }
 
@@ -3787,6 +3789,7 @@ type createProjectRequest struct {
 	BaseBranch   *string `json:"baseBranch"`
 	WorktreeRoot *string `json:"worktreeRoot"`
 	Repo         *string `json:"repo"`
+	SnapshotMode *string `json:"snapshotMode"`
 }
 
 func (h *Handler) buildCreateProjectResponse(r *http.Request, service projectService) (createProjectResponse, error) {
@@ -3818,6 +3821,13 @@ func (h *Handler) buildCreateProjectResponse(r *http.Request, service projectSer
 	if baseBranch == "" {
 		baseBranch = h.context.Config.Defaults.BaseBranch
 	}
+	snapshotMode := projects.SnapshotMode(strings.TrimSpace(derefString(body.SnapshotMode)))
+	if snapshotMode == "" {
+		snapshotMode = projects.SnapshotMode(h.context.Config.Defaults.AddSnapshotMode)
+	}
+	if snapshotMode != "" && snapshotMode != projects.SnapshotModeAsync && snapshotMode != projects.SnapshotModeFull && snapshotMode != projects.SnapshotModeOff {
+		return createProjectResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "snapshotMode must be one of: async, full, off"}
+	}
 
 	result, err := service.AddProject(r.Context(), projects.AddInput{
 		ID:           projectID,
@@ -3827,6 +3837,7 @@ func (h *Handler) buildCreateProjectResponse(r *http.Request, service projectSer
 		IDSource:     idSource,
 		WorktreeRoot: normalizeOptionalString(body.WorktreeRoot),
 		Repo:         normalizeOptionalString(body.Repo),
+		SnapshotMode: snapshotMode,
 	})
 	if err != nil {
 		var collision projects.ProjectIDCollisionError
@@ -3845,6 +3856,8 @@ func (h *Handler) buildCreateProjectResponse(r *http.Request, service projectSer
 		projectResponse:        serializeProject(result.Project, h.context.Config.Defaults.BaseBranch),
 		DiscoveredPullRequests: result.DiscoveredPullRequests,
 		DiscoveredWorktrees:    result.DiscoveredWorktrees,
+		PendingSnapshots:       result.PendingSnapshots,
+		CapturedSnapshots:      result.CapturedSnapshots,
 		Warnings:               append([]string{}, result.Warnings...),
 	}, nil
 }

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -128,6 +128,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					stringFlag("base-branch", "branch", "Base branch"),
 					stringFlag("worktree-root", "path", "Worktree root"),
 					stringFlag("repo", "repo", "Repository slug"),
+					stringFlag("snapshot-mode", "mode", "Snapshot mode for project add: async, full, or off"),
 				},
 				exampleLines: []string{
 					"$ looper project list",

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -64,6 +64,8 @@ type projectOutput struct {
 	UpdatedAt              string   `json:"updatedAt"`
 	DiscoveredPullRequests int      `json:"discoveredPullRequests"`
 	DiscoveredWorktrees    int      `json:"discoveredWorktrees"`
+	PendingSnapshots       int      `json:"pendingSnapshots"`
+	CapturedSnapshots      int      `json:"capturedSnapshots"`
 	Warnings               []string `json:"warnings"`
 }
 
@@ -202,7 +204,7 @@ func writeHumanProjectAdd(w io.Writer, payload json.RawMessage) error {
 		return fmt.Errorf("decode project response: %w", err)
 	}
 
-	printSection(w, "Project added", [][2]any{{"id", data.ID}, {"name", data.Name}, {"repoPath", data.RepoPath}, {"baseBranch", data.BaseBranch}, {"repo", data.Repo}, {"discoveredPullRequests", data.DiscoveredPullRequests}, {"discoveredWorktrees", data.DiscoveredWorktrees}})
+	printSection(w, "Project added", [][2]any{{"id", data.ID}, {"name", data.Name}, {"repoPath", data.RepoPath}, {"baseBranch", data.BaseBranch}, {"repo", data.Repo}, {"discoveredPullRequests", data.DiscoveredPullRequests}, {"discoveredWorktrees", data.DiscoveredWorktrees}, {"scheduledSnapshots", data.PendingSnapshots}, {"capturedSnapshots", data.CapturedSnapshots}})
 	if len(data.Warnings) > 0 {
 		fmt.Fprintln(w)
 		entries := make([][2]any, 0, len(data.Warnings))

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -69,6 +69,7 @@ func (r *commandRuntime) projectAdd(cmd *cobra.Command, args []string) error {
 		setString(body, "baseBranch", getStringFlag(cmd, "base-branch"))
 		setString(body, "worktreeRoot", getStringFlag(cmd, "worktree-root"))
 		setString(body, "repo", getStringFlag(cmd, "repo"))
+		setString(body, "snapshotMode", getStringFlag(cmd, "snapshot-mode"))
 
 		return r.postJSON(ctx, "/api/v1/projects", body)
 	}, writeHumanProjectAdd)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -666,6 +666,10 @@ func TestDefaultConfigMatchesDaemonDefaults(t *testing.T) {
 		t.Fatalf("DefaultConfig().Defaults.OpenPRStrategy = %q, want %q", config.Defaults.OpenPRStrategy, OpenPRStrategyAllDone)
 	}
 
+	if config.Defaults.AddSnapshotMode != AddSnapshotModeFull {
+		t.Fatalf("DefaultConfig().Defaults.AddSnapshotMode = %q, want %q", config.Defaults.AddSnapshotMode, AddSnapshotModeFull)
+	}
+
 	if len(config.Agent.Params) != 0 || len(config.Agent.Env) != 0 {
 		t.Fatalf("DefaultConfig().Agent maps = %#v / %#v, want empty maps", config.Agent.Params, config.Agent.Env)
 	}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -110,7 +110,7 @@ func DefaultConfig(cwd string) (Config, error) {
 			AllowRiskyFixes:    false,
 			FixAllPullRequests: false,
 			OpenPRStrategy:     OpenPRStrategyAllDone,
-			AddSnapshotMode:    AddSnapshotModeAsync,
+			AddSnapshotMode:    AddSnapshotModeFull,
 		},
 		Projects: []ProjectRefConfig{},
 	}, nil

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -110,6 +110,7 @@ func DefaultConfig(cwd string) (Config, error) {
 			AllowRiskyFixes:    false,
 			FixAllPullRequests: false,
 			OpenPRStrategy:     OpenPRStrategyAllDone,
+			AddSnapshotMode:    AddSnapshotModeAsync,
 		},
 		Projects: []ProjectRefConfig{},
 	}, nil

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -256,6 +256,10 @@ func mergeDefaultsConfig(config *DefaultsConfig, partial PartialDefaultsConfig) 
 	if partial.OpenPRStrategy != nil {
 		config.OpenPRStrategy = *partial.OpenPRStrategy
 	}
+
+	if partial.AddSnapshotMode != nil {
+		config.AddSnapshotMode = *partial.AddSnapshotMode
+	}
 }
 
 func mergeAnyMap(base map[string]any, override map[string]any) map[string]any {

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -141,7 +141,7 @@
         "allowRiskyFixes": false,
         "fixAllPullRequests": false,
         "openPrStrategy": "all_done",
-        "addSnapshotMode": "async"
+        "addSnapshotMode": "full"
       },
       "projects": [
         {

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -140,7 +140,8 @@
         "allowAutoMerge": false,
         "allowRiskyFixes": false,
         "fixAllPullRequests": false,
-        "openPrStrategy": "all_done"
+        "openPrStrategy": "all_done",
+        "addSnapshotMode": "async"
       },
       "projects": [
         {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -76,7 +76,8 @@
         "allowAutoMerge": false,
         "allowRiskyFixes": false,
         "fixAllPullRequests": false,
-        "openPrStrategy": "all_done"
+        "openPrStrategy": "all_done",
+        "addSnapshotMode": "async"
       },
       "projects": []
     },

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -77,7 +77,7 @@
         "allowRiskyFixes": false,
         "fixAllPullRequests": false,
         "openPrStrategy": "all_done",
-        "addSnapshotMode": "async"
+        "addSnapshotMode": "full"
       },
       "projects": []
     },

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -72,7 +72,8 @@
           "allowAutoApprove": true,
           "allowAutoMerge": true,
           "allowRiskyFixes": true,
-          "openPrStrategy": "first_commit"
+          "openPrStrategy": "first_commit",
+          "addSnapshotMode": "async"
         },
         "projects": [
           {
@@ -156,7 +157,8 @@
         "allowAutoMerge": true,
         "allowRiskyFixes": true,
         "fixAllPullRequests": false,
-        "openPrStrategy": "first_commit"
+        "openPrStrategy": "first_commit",
+        "addSnapshotMode": "async"
       },
       "projects": [
         {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -40,6 +40,14 @@ const (
 	OpenPRStrategyManual      OpenPRStrategy = "manual"
 )
 
+type AddSnapshotMode string
+
+const (
+	AddSnapshotModeAsync AddSnapshotMode = "async"
+	AddSnapshotModeFull  AddSnapshotMode = "full"
+	AddSnapshotModeOff   AddSnapshotMode = "off"
+)
+
 type NotificationSoundLevel string
 
 const (
@@ -122,14 +130,15 @@ type PackageConfig struct {
 }
 
 type DefaultsConfig struct {
-	BaseBranch         string         `json:"baseBranch"`
-	AllowAutoCommit    bool           `json:"allowAutoCommit"`
-	AllowAutoPush      bool           `json:"allowAutoPush"`
-	AllowAutoApprove   bool           `json:"allowAutoApprove"`
-	AllowAutoMerge     bool           `json:"allowAutoMerge"`
-	AllowRiskyFixes    bool           `json:"allowRiskyFixes"`
-	FixAllPullRequests bool           `json:"fixAllPullRequests"`
-	OpenPRStrategy     OpenPRStrategy `json:"openPrStrategy"`
+	BaseBranch         string          `json:"baseBranch"`
+	AllowAutoCommit    bool            `json:"allowAutoCommit"`
+	AllowAutoPush      bool            `json:"allowAutoPush"`
+	AllowAutoApprove   bool            `json:"allowAutoApprove"`
+	AllowAutoMerge     bool            `json:"allowAutoMerge"`
+	AllowRiskyFixes    bool            `json:"allowRiskyFixes"`
+	FixAllPullRequests bool            `json:"fixAllPullRequests"`
+	OpenPRStrategy     OpenPRStrategy  `json:"openPrStrategy"`
+	AddSnapshotMode    AddSnapshotMode `json:"addSnapshotMode"`
 }
 
 type ProjectRefConfig struct {
@@ -221,14 +230,15 @@ type PartialPackageConfig struct {
 }
 
 type PartialDefaultsConfig struct {
-	BaseBranch         *string         `json:"baseBranch,omitempty"`
-	AllowAutoCommit    *bool           `json:"allowAutoCommit,omitempty"`
-	AllowAutoPush      *bool           `json:"allowAutoPush,omitempty"`
-	AllowAutoApprove   *bool           `json:"allowAutoApprove,omitempty"`
-	AllowAutoMerge     *bool           `json:"allowAutoMerge,omitempty"`
-	AllowRiskyFixes    *bool           `json:"allowRiskyFixes,omitempty"`
-	FixAllPullRequests *bool           `json:"fixAllPullRequests,omitempty"`
-	OpenPRStrategy     *OpenPRStrategy `json:"openPrStrategy,omitempty"`
+	BaseBranch         *string          `json:"baseBranch,omitempty"`
+	AllowAutoCommit    *bool            `json:"allowAutoCommit,omitempty"`
+	AllowAutoPush      *bool            `json:"allowAutoPush,omitempty"`
+	AllowAutoApprove   *bool            `json:"allowAutoApprove,omitempty"`
+	AllowAutoMerge     *bool            `json:"allowAutoMerge,omitempty"`
+	AllowRiskyFixes    *bool            `json:"allowRiskyFixes,omitempty"`
+	FixAllPullRequests *bool            `json:"fixAllPullRequests,omitempty"`
+	OpenPRStrategy     *OpenPRStrategy  `json:"openPrStrategy,omitempty"`
+	AddSnapshotMode    *AddSnapshotMode `json:"addSnapshotMode,omitempty"`
 }
 
 type PartialConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -131,6 +131,10 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 		issues = append(issues, ValidationIssue{Path: "defaults.openPrStrategy", Message: fmt.Sprintf("must be one of: %s, %s, %s", OpenPRStrategyAllDone, OpenPRStrategyFirstCommit, OpenPRStrategyManual)})
 	}
 
+	if !isValidAddSnapshotMode(config.Defaults.AddSnapshotMode) {
+		issues = append(issues, ValidationIssue{Path: "defaults.addSnapshotMode", Message: fmt.Sprintf("must be one of: %s, %s, %s", AddSnapshotModeAsync, AddSnapshotModeFull, AddSnapshotModeOff)})
+	}
+
 	projectIDs := make(map[string]struct{}, len(config.Projects))
 	for index, project := range config.Projects {
 		prefix := fmt.Sprintf("projects[%d]", index)
@@ -306,6 +310,15 @@ func isValidNotificationSoundLevel(level NotificationSoundLevel) bool {
 func isValidOpenPRStrategy(strategy OpenPRStrategy) bool {
 	switch strategy {
 	case OpenPRStrategyAllDone, OpenPRStrategyFirstCommit, OpenPRStrategyManual:
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidAddSnapshotMode(mode AddSnapshotMode) bool {
+	switch mode {
+	case AddSnapshotModeAsync, AddSnapshotModeFull, AddSnapshotModeOff:
 		return true
 	default:
 		return false

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -19,7 +19,15 @@ import (
 
 const javaScriptISOStringLayout = "2006-01-02T15:04:05.000Z"
 
+const (
+	defaultGhCommandTimeout = 60 * time.Second
+	prListGhCommandTimeout  = 15 * time.Second
+	prDiffGhCommandTimeout  = 180 * time.Second
+)
+
 var prNumberURLPattern = regexp.MustCompile(`/pull/(\d+)(?:/|$)`)
+
+var ErrDiffTooLarge = errors.New("github pull request diff is too large")
 
 type Options struct {
 	GHPath string
@@ -173,11 +181,12 @@ type UpdatePullRequestTitleInput struct {
 }
 
 type ListOpenPullRequestsInput struct {
-	Repo   string
-	CWD    string
-	Limit  int
-	Label  string
-	Author string
+	Repo    string
+	CWD     string
+	Limit   int
+	Label   string
+	Author  string
+	Timeout time.Duration
 }
 
 type ListOpenIssuesInput struct {
@@ -254,7 +263,11 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 	}
 	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "author", "reviewRequests"}, ","))
 
-	result, err := g.runGh(ctx, input.CWD, "", args...)
+	timeout := input.Timeout
+	if timeout <= 0 {
+		timeout = defaultGhCommandTimeout
+	}
+	result, err := g.runGhWithTimeout(ctx, input.CWD, "", timeout, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -437,8 +450,11 @@ func (g *Gateway) ResolveReviewThread(ctx context.Context, input ResolveReviewTh
 }
 
 func (g *Gateway) GetPullRequestDiff(ctx context.Context, input GetPullRequestDiffInput) (string, error) {
-	result, err := g.runGh(ctx, input.CWD, "", "pr", "diff", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo)
+	result, err := g.runGhWithTimeout(ctx, input.CWD, "", prDiffGhCommandTimeout, "pr", "diff", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo)
 	if err != nil {
+		if isDiffTooLargeError(err) {
+			return "", ErrDiffTooLarge
+		}
 		return "", err
 	}
 	return result.Stdout, nil
@@ -620,13 +636,20 @@ func (g *Gateway) CapturePullRequestSnapshot(ctx context.Context, input CaptureP
 	}
 	diff, err := g.GetPullRequestDiff(ctx, GetPullRequestDiffInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 	if err != nil {
-		return storage.PullRequestSnapshotRecord{}, err
+		if !errors.Is(err, ErrDiffTooLarge) {
+			return storage.PullRequestSnapshotRecord{}, err
+		}
 	}
 	capturedAt := strings.TrimSpace(input.CapturedAt)
 	if capturedAt == "" {
 		capturedAt = g.now().UTC().Format(javaScriptISOStringLayout)
 	}
-	payload, err := json.Marshal(map[string]any{"detail": detail, "diff": diff})
+	payloadMap := map[string]any{"detail": detail, "diff": diff}
+	if errors.Is(err, ErrDiffTooLarge) {
+		payloadMap["diffTruncated"] = true
+		payloadMap["diffTruncationReason"] = "github_too_large"
+	}
+	payload, err := json.Marshal(payloadMap)
 	if err != nil {
 		return storage.PullRequestSnapshotRecord{}, fmt.Errorf("marshal pull request snapshot payload: %w", err)
 	}
@@ -748,7 +771,19 @@ func (g *Gateway) ensureLabelsExist(ctx context.Context, repo string, labels []s
 }
 
 func (g *Gateway) runGh(ctx context.Context, cwd, stdin string, args ...string) (shell.Result, error) {
-	return g.ghRun(ctx, shell.Options{Command: g.ghPath, Args: args, CWD: valueOr(strings.TrimSpace(cwd), g.cwd), Stdin: stdin})
+	return g.runGhWithTimeout(ctx, cwd, stdin, defaultGhCommandTimeout, args...)
+}
+
+func (g *Gateway) runGhWithTimeout(ctx context.Context, cwd, stdin string, timeout time.Duration, args ...string) (shell.Result, error) {
+	return g.ghRun(ctx, shell.Options{Command: g.ghPath, Args: args, CWD: valueOr(strings.TrimSpace(cwd), g.cwd), Stdin: stdin, Timeout: timeout})
+}
+
+func isDiffTooLargeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "http 406") || strings.Contains(message, "too_large") || strings.Contains(message, "diff exceeded maximum number of lines")
 }
 
 func defaultLimit(limit int) int {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -2,8 +2,10 @@ package github
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/powerformer/looper/internal/infra/shell"
 )
@@ -329,6 +331,65 @@ func TestGatewayIgnoresMissingLabelDeleteErrors(t *testing.T) {
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
 	if err := gateway.RemovePullRequestLabels(context.Background(), PullRequestLabelsInput{Repo: "acme/looper", PRNumber: 42, Labels: []string{"looper:spec-ready"}}); err != nil {
 		t.Fatalf("RemovePullRequestLabels() error = %v, want nil", err)
+	}
+}
+
+func TestGatewayCapturePullRequestSnapshotTruncatesTooLargeDiff(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch {
+		case strings.HasPrefix(args, "pr view"):
+			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","state":"OPEN","headRefOid":"abc123"}`}, nil
+		case strings.Contains(args, "reviewThreads"):
+			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}`}, nil
+		case strings.HasPrefix(args, "pr diff"):
+			result := shell.Result{ExitCode: 1, Stderr: "HTTP 406: diff exceeded maximum number of lines too_large"}
+			return result, &shell.CommandExecutionError{Message: result.Stderr, Result: result}
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+	gateway := New(Options{GHPath: "gh", GHRun: runner.run})
+
+	snapshot, err := gateway.CapturePullRequestSnapshot(context.Background(), CapturePullRequestSnapshotInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("CapturePullRequestSnapshot() error = %v", err)
+	}
+	if snapshot.PayloadJSON == nil || !strings.Contains(*snapshot.PayloadJSON, `"diffTruncated":true`) || !strings.Contains(*snapshot.PayloadJSON, `"diffTruncationReason":"github_too_large"`) {
+		t.Fatalf("PayloadJSON = %v, want truncated marker", snapshot.PayloadJSON)
+	}
+}
+
+func TestGatewayDiffGenericFailureStillFails(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		result := shell.Result{ExitCode: 1, Stderr: "network failed"}
+		return result, &shell.CommandExecutionError{Message: result.Stderr, Result: result}
+	}
+	gateway := New(Options{GHPath: "gh", GHRun: runner.run})
+	_, err := gateway.GetPullRequestDiff(context.Background(), GetPullRequestDiffInput{Repo: "acme/looper", PRNumber: 42})
+	if err == nil || errors.Is(err, ErrDiffTooLarge) {
+		t.Fatalf("GetPullRequestDiff() error = %v, want generic failure", err)
+	}
+}
+
+func TestGatewayRunGhPassesTimeouts(t *testing.T) {
+	t.Parallel()
+	var timeouts []time.Duration
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		timeouts = append(timeouts, options.Timeout)
+		return shell.Result{Stdout: "[]"}, nil
+	}
+	gateway := New(Options{GHPath: "gh", GHRun: runner.run})
+	_, _ = gateway.ListOpenPullRequests(context.Background(), ListOpenPullRequestsInput{Repo: "acme/looper", Timeout: prListGhCommandTimeout})
+	_, _ = gateway.GetPullRequestDiff(context.Background(), GetPullRequestDiffInput{Repo: "acme/looper", PRNumber: 42})
+	if len(timeouts) != 2 || timeouts[0] != prListGhCommandTimeout || timeouts[1] != prDiffGhCommandTimeout {
+		t.Fatalf("timeouts = %#v, want list/diff timeouts", timeouts)
 	}
 }
 

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -33,6 +33,15 @@ type ListOpenPullRequestsFunc func(context.Context, ListOpenPullRequestsInput) (
 
 type CapturePullRequestSnapshotFunc func(context.Context, CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error)
 
+type SnapshotMode string
+
+const (
+	SnapshotModeAsync SnapshotMode = "async"
+	SnapshotModeFull  SnapshotMode = "full"
+	SnapshotModeOff   SnapshotMode = "off"
+	queueTypeSnapshot              = "snapshot"
+)
+
 type WorktreeListEntry struct {
 	Path    string
 	Branch  string
@@ -41,9 +50,10 @@ type WorktreeListEntry struct {
 }
 
 type ListOpenPullRequestsInput struct {
-	Repo  string
-	CWD   string
-	Limit int
+	Repo    string
+	CWD     string
+	Limit   int
+	Timeout time.Duration
 }
 
 type PullRequestSummary struct {
@@ -79,6 +89,7 @@ type AddInput struct {
 	IDSource     string
 	WorktreeRoot *string
 	Repo         *string
+	SnapshotMode SnapshotMode
 }
 
 type AddResult struct {
@@ -86,6 +97,8 @@ type AddResult struct {
 	Repo                   *string
 	DiscoveredPullRequests int
 	DiscoveredWorktrees    int
+	PendingSnapshots       int
+	CapturedSnapshots      int
 	Warnings               []string
 }
 
@@ -216,7 +229,7 @@ func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, er
 	if err != nil {
 		return AddResult{}, err
 	}
-	discoveredPullRequests, err := s.discoverPullRequests(ctx, record, repo, &warnings)
+	discoveredPullRequests, pendingSnapshots, capturedSnapshots, err := s.discoverPullRequests(ctx, record, repo, snapshotModeOrDefault(input.SnapshotMode), &warnings)
 	if err != nil {
 		return AddResult{}, err
 	}
@@ -226,6 +239,8 @@ func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, er
 		Repo:                   repo,
 		DiscoveredPullRequests: discoveredPullRequests,
 		DiscoveredWorktrees:    discoveredWorktrees,
+		PendingSnapshots:       pendingSnapshots,
+		CapturedSnapshots:      capturedSnapshots,
 		Warnings:               warnings,
 	}, nil
 }
@@ -601,24 +616,42 @@ func (s *Service) discoverWorktrees(ctx context.Context, project storage.Project
 	return discovered, nil
 }
 
-func (s *Service) discoverPullRequests(ctx context.Context, project storage.ProjectRecord, repo *string, warnings *[]string) (int, error) {
-	if repo == nil || strings.TrimSpace(*repo) == "" || s.ListOpenPullRequests == nil || s.CapturePullRequestSnapshot == nil || s.Repos == nil || s.Repos.PullRequestSnapshots == nil {
-		return 0, nil
+func (s *Service) discoverPullRequests(ctx context.Context, project storage.ProjectRecord, repo *string, mode SnapshotMode, warnings *[]string) (int, int, int, error) {
+	if mode == SnapshotModeOff || repo == nil || strings.TrimSpace(*repo) == "" || s.ListOpenPullRequests == nil {
+		return 0, 0, 0, nil
 	}
 
-	pullRequests, err := s.ListOpenPullRequests(ctx, ListOpenPullRequestsInput{Repo: *repo, CWD: project.RepoPath})
+	listCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	pullRequests, err := s.ListOpenPullRequests(listCtx, ListOpenPullRequestsInput{Repo: *repo, CWD: project.RepoPath, Limit: 1000, Timeout: 15 * time.Second})
 	if err != nil {
 		message := err.Error()
 		if s.Logger != nil {
 			s.Logger.Warn("failed to discover pull requests for project", map[string]any{"projectId": project.ID, "repo": *repo, "message": message})
 		}
 		*warnings = append(*warnings, fmt.Sprintf("Could not discover pull requests: %s", message))
-		return 0, nil
+		return 0, 0, 0, nil
 	}
 
 	discovered := 0
+	pending := 0
+	captured := 0
 	for _, pullRequest := range pullRequests {
 		if pullRequest.IsDraft || normalizePRState(pullRequest.State) != "open" {
+			continue
+		}
+		discovered++
+		if mode == SnapshotModeAsync {
+			queued, err := s.enqueuePullRequestSnapshot(ctx, project, *repo, pullRequest.Number)
+			if err != nil {
+				return 0, 0, 0, err
+			}
+			if queued {
+				pending++
+			}
+			continue
+		}
+		if s.CapturePullRequestSnapshot == nil || s.Repos == nil || s.Repos.PullRequestSnapshots == nil {
 			continue
 		}
 
@@ -631,10 +664,10 @@ func (s *Service) discoverPullRequests(ctx context.Context, project storage.Proj
 		})
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return 0, err
+				return 0, 0, 0, err
 			}
 			if ctxErr := ctx.Err(); errors.Is(ctxErr, context.Canceled) || errors.Is(ctxErr, context.DeadlineExceeded) {
-				return 0, ctxErr
+				return 0, 0, 0, ctxErr
 			}
 			message := err.Error()
 			if s.Logger != nil {
@@ -644,12 +677,58 @@ func (s *Service) discoverPullRequests(ctx context.Context, project storage.Proj
 			continue
 		}
 		if err := s.Repos.PullRequestSnapshots.Upsert(ctx, snapshot); err != nil {
-			return 0, err
+			return 0, 0, 0, err
 		}
-		discovered++
+		captured++
 	}
 
-	return discovered, nil
+	return discovered, pending, captured, nil
+}
+
+func (s *Service) enqueuePullRequestSnapshot(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64) (bool, error) {
+	if s.Repos == nil || s.Repos.Queue == nil {
+		return false, nil
+	}
+	dedupeKey := fmt.Sprintf("snapshot:%s:%s:%d", project.ID, repo, prNumber)
+	existing, err := s.Repos.Queue.FindActiveByDedupe(ctx, dedupeKey)
+	if err != nil {
+		return false, err
+	}
+	if existing != nil {
+		return true, nil
+	}
+	nowISO := currentISO(s.Now)
+	payload, err := json.Marshal(map[string]any{"cwd": project.RepoPath})
+	if err != nil {
+		return false, err
+	}
+	record := storage.QueueItemRecord{
+		ID:          fmt.Sprintf("snapshot_%s_%d_%d", project.ID, prNumber, currentTime(s.Now).UnixNano()),
+		ProjectID:   &project.ID,
+		Type:        queueTypeSnapshot,
+		TargetType:  "pull_request_snapshot",
+		TargetID:    fmt.Sprintf("%s#%d", repo, prNumber),
+		Repo:        &repo,
+		PRNumber:    &prNumber,
+		DedupeKey:   dedupeKey,
+		Priority:    1,
+		Status:      "queued",
+		AvailableAt: nowISO,
+		MaxAttempts: 3,
+		PayloadJSON: stringPointer(string(payload)),
+		CreatedAt:   nowISO,
+		UpdatedAt:   nowISO,
+	}
+	return true, s.Repos.Queue.Upsert(ctx, record)
+}
+
+func snapshotModeOrDefault(mode SnapshotMode) SnapshotMode {
+	switch mode {
+	case SnapshotModeFull, SnapshotModeOff:
+		return mode
+	default:
+		return SnapshotModeAsync
+	}
 }
 
 func normalizePRState(state string) string {

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -79,6 +79,7 @@ type Service struct {
 	ListWorktrees              ListWorktreesFunc
 	ListOpenPullRequests       ListOpenPullRequestsFunc
 	CapturePullRequestSnapshot CapturePullRequestSnapshotFunc
+	AsyncSnapshotQueueEnabled  func() bool
 }
 
 type AddInput struct {
@@ -620,6 +621,10 @@ func (s *Service) discoverPullRequests(ctx context.Context, project storage.Proj
 	if mode == SnapshotModeOff || repo == nil || strings.TrimSpace(*repo) == "" || s.ListOpenPullRequests == nil {
 		return 0, 0, 0, nil
 	}
+	if mode == SnapshotModeAsync && !s.asyncSnapshotQueueEnabled() {
+		mode = SnapshotModeFull
+		*warnings = append(*warnings, "Async snapshot mode requires the scheduler; capturing snapshots synchronously instead.")
+	}
 
 	listCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
@@ -683,6 +688,13 @@ func (s *Service) discoverPullRequests(ctx context.Context, project storage.Proj
 	}
 
 	return discovered, pending, captured, nil
+}
+
+func (s *Service) asyncSnapshotQueueEnabled() bool {
+	if s.AsyncSnapshotQueueEnabled == nil {
+		return true
+	}
+	return s.AsyncSnapshotQueueEnabled()
 }
 
 func (s *Service) enqueuePullRequestSnapshot(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64) (bool, error) {

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -723,7 +723,7 @@ func (s *Service) enqueuePullRequestSnapshot(ctx context.Context, project storag
 		Repo:        &repo,
 		PRNumber:    &prNumber,
 		DedupeKey:   dedupeKey,
-		Priority:    1,
+		Priority:    storage.QueuePrioritySnapshot,
 		Status:      "queued",
 		AvailableAt: nowISO,
 		MaxAttempts: 3,

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -166,6 +166,54 @@ func TestServiceAddProjectDefaultAsyncEnqueuesSnapshotsWithoutCapturing(t *testi
 	}
 }
 
+func TestServiceAddProjectAsyncFallsBackToFullWhenQueueDisabled(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	repo := "powerformer/looper"
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	service := &Service{
+		DB:    coordinator.DB(),
+		Repos: repos,
+		Now:   func() time.Time { return now },
+		ListOpenPullRequests: func(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
+			return []PullRequestSummary{{Number: 1, State: "OPEN", IsDraft: false}}, nil
+		},
+		CapturePullRequestSnapshot: func(context.Context, CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
+			capturedAt := now.UTC().Format(time.RFC3339Nano)
+			return storage.PullRequestSnapshotRecord{ID: "snapshot_1", ProjectID: "looper", Repo: repo, PRNumber: 1, HeadSHA: "abc123", Title: stringPointer("PR 1"), CapturedAt: capturedAt, CreatedAt: capturedAt}, nil
+		},
+		AsyncSnapshotQueueEnabled: func() bool { return false },
+	}
+
+	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo, SnapshotMode: SnapshotModeAsync})
+	if err != nil {
+		t.Fatalf("AddProject() error = %v", err)
+	}
+	if result.DiscoveredPullRequests != 1 || result.PendingSnapshots != 0 || result.CapturedSnapshots != 1 {
+		t.Fatalf("AddProject() counts = discovered %d pending %d captured %d, want 1/0/1", result.DiscoveredPullRequests, result.PendingSnapshots, result.CapturedSnapshots)
+	}
+	if len(result.Warnings) != 1 || result.Warnings[0] != "Async snapshot mode requires the scheduler; capturing snapshots synchronously instead." {
+		t.Fatalf("AddProject().Warnings = %#v, want async fallback warning", result.Warnings)
+	}
+	items, err := repos.Queue.List(ctx)
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("queue items = %#v, want none", items)
+	}
+	snapshot, err := repos.PullRequestSnapshots.GetLatest(ctx, repo, 1)
+	if err != nil {
+		t.Fatalf("PullRequestSnapshots.GetLatest() error = %v", err)
+	}
+	if snapshot == nil {
+		t.Fatal("snapshot = nil, want captured snapshot")
+	}
+}
+
 func TestServiceAddProjectSnapshotModeOffSkipsPullRequestDiscovery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -164,6 +164,9 @@ func TestServiceAddProjectDefaultAsyncEnqueuesSnapshotsWithoutCapturing(t *testi
 	if len(items) != 1 || items[0].Type != "snapshot" || items[0].PRNumber == nil || *items[0].PRNumber != 1 {
 		t.Fatalf("queue items = %#v, want one snapshot for PR 1", items)
 	}
+	if items[0].Priority != storage.QueuePrioritySnapshot {
+		t.Fatalf("snapshot priority = %d, want %d", items[0].Priority, storage.QueuePrioritySnapshot)
+	}
 }
 
 func TestServiceAddProjectAsyncFallsBackToFullWhenQueueDisabled(t *testing.T) {

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -93,7 +93,7 @@ func TestServiceAddProjectDiscoversPullRequestsAndWorktrees(t *testing.T) {
 		},
 	}
 
-	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main"})
+	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", SnapshotMode: SnapshotModeFull})
 	if err != nil {
 		t.Fatalf("AddProject() error = %v", err)
 	}
@@ -126,6 +126,68 @@ func TestServiceAddProjectDiscoversPullRequestsAndWorktrees(t *testing.T) {
 	}
 }
 
+func TestServiceAddProjectDefaultAsyncEnqueuesSnapshotsWithoutCapturing(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	captured := false
+	repo := "powerformer/looper"
+	service := &Service{
+		DB:    coordinator.DB(),
+		Repos: repos,
+		Now:   func() time.Time { return time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC) },
+		ListOpenPullRequests: func(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
+			return []PullRequestSummary{{Number: 1, State: "OPEN", IsDraft: false}, {Number: 2, State: "OPEN", IsDraft: true}}, nil
+		},
+		CapturePullRequestSnapshot: func(context.Context, CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
+			captured = true
+			return storage.PullRequestSnapshotRecord{}, nil
+		},
+	}
+
+	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo})
+	if err != nil {
+		t.Fatalf("AddProject() error = %v", err)
+	}
+	if captured {
+		t.Fatal("CapturePullRequestSnapshot called in default async mode")
+	}
+	if result.DiscoveredPullRequests != 1 || result.PendingSnapshots != 1 || result.CapturedSnapshots != 0 {
+		t.Fatalf("AddProject() counts = discovered %d pending %d captured %d, want 1/1/0", result.DiscoveredPullRequests, result.PendingSnapshots, result.CapturedSnapshots)
+	}
+	items, err := repos.Queue.List(ctx)
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(items) != 1 || items[0].Type != "snapshot" || items[0].PRNumber == nil || *items[0].PRNumber != 1 {
+		t.Fatalf("queue items = %#v, want one snapshot for PR 1", items)
+	}
+}
+
+func TestServiceAddProjectSnapshotModeOffSkipsPullRequestDiscovery(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	listed := false
+	repo := "powerformer/looper"
+	service := &Service{DB: coordinator.DB(), Repos: repos, Now: time.Now, ListOpenPullRequests: func(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
+		listed = true
+		return nil, nil
+	}}
+
+	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo, SnapshotMode: SnapshotModeOff})
+	if err != nil {
+		t.Fatalf("AddProject() error = %v", err)
+	}
+	if listed || result.DiscoveredPullRequests != 0 || result.PendingSnapshots != 0 {
+		t.Fatalf("off mode listed=%v counts=%#v, want no discovery", listed, result)
+	}
+}
+
 func TestServiceAddProjectReturnsDiscoveryWarnings(t *testing.T) {
 	t.Parallel()
 
@@ -149,7 +211,7 @@ func TestServiceAddProjectReturnsDiscoveryWarnings(t *testing.T) {
 	}
 	repo := "powerformer/looper"
 
-	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo})
+	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo, SnapshotMode: SnapshotModeFull})
 	if err != nil {
 		t.Fatalf("AddProject() error = %v", err)
 	}
@@ -190,12 +252,12 @@ func TestServiceAddProjectWarnsWhenPullRequestSnapshotFails(t *testing.T) {
 	}
 	repo := "powerformer/looper"
 
-	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo})
+	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo, SnapshotMode: SnapshotModeFull})
 	if err != nil {
 		t.Fatalf("AddProject() error = %v", err)
 	}
-	if result.DiscoveredPullRequests != 0 {
-		t.Fatalf("AddProject().DiscoveredPullRequests = %d, want 0", result.DiscoveredPullRequests)
+	if result.DiscoveredPullRequests != 1 {
+		t.Fatalf("AddProject().DiscoveredPullRequests = %d, want 1", result.DiscoveredPullRequests)
 	}
 	if len(result.Warnings) != 1 {
 		t.Fatalf("len(AddProject().Warnings) = %d, want 1", len(result.Warnings))
@@ -240,7 +302,7 @@ func TestServiceAddProjectPropagatesPullRequestSnapshotCancellation(t *testing.T
 	}
 	repo := "powerformer/looper"
 
-	_, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo})
+	_, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo, SnapshotMode: SnapshotModeFull})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("AddProject() error = %v, want context.Canceled", err)
 	}
@@ -267,7 +329,7 @@ func TestServiceAddProjectPropagatesSnapshotCommandErrorCancellation(t *testing.
 	}
 	repo := "powerformer/looper"
 
-	_, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo})
+	_, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo, SnapshotMode: SnapshotModeFull})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("AddProject() error = %v, want context.Canceled", err)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -335,6 +335,9 @@ func (r *Runtime) start(ctx context.Context) error {
 		CapturePullRequestSnapshot: func(ctx context.Context, input projects.CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
 			return githubGateway.CapturePullRequestSnapshot(ctx, githubinfra.CapturePullRequestSnapshotInput{ProjectID: input.ProjectID, Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, CapturedAt: input.CapturedAt})
 		},
+		AsyncSnapshotQueueEnabled: func() bool {
+			return r.customSchedulerTick || r.config.Agent.Vendor != nil
+		},
 	}
 	loopService := &loops.Service{DB: coordinator.DB(), Repos: repositories, Now: r.now}
 	runService := &runs.Service{DB: coordinator.DB(), Repos: repositories, Loops: loopService, Now: r.now}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -322,7 +322,7 @@ func (r *Runtime) start(ctx context.Context) error {
 			return items, nil
 		},
 		ListOpenPullRequests: func(ctx context.Context, input projects.ListOpenPullRequestsInput) ([]projects.PullRequestSummary, error) {
-			pullRequests, err := githubGateway.ListOpenPullRequests(ctx, githubinfra.ListOpenPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: input.Limit})
+			pullRequests, err := githubGateway.ListOpenPullRequests(ctx, githubinfra.ListOpenPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: input.Limit, Timeout: input.Timeout})
 			if err != nil {
 				return nil, err
 			}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1021,6 +1021,10 @@ func failSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord, in
 		now = time.Now
 	}
 	nowISO := formatJavaScriptISOString(now().UTC())
+	nextAttempts := item.Attempts + 1
+	if kind == "retryable_transient" && nextAttempts < item.MaxAttempts {
+		return input.Repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: item.ID, AvailableAt: nowISO, Attempts: nextAttempts, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
+	}
 	return input.Repos.Queue.Fail(ctx, storage.QueueFailInput{ID: item.ID, FinishedAt: nowISO, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -46,6 +46,10 @@ type workerScheduler interface {
 	ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) (*worker.ProcessResult, error)
 }
 
+type snapshotScheduler interface {
+	CapturePullRequestSnapshot(context.Context, githubinfra.CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error)
+}
+
 type schedulerAsyncRunner interface {
 	Go(func())
 }
@@ -60,6 +64,7 @@ type defaultSchedulerTickInput struct {
 	Reviewer          reviewerScheduler
 	Fixer             fixerScheduler
 	Worker            workerScheduler
+	Snapshotter       snapshotScheduler
 }
 
 type schedulerTaskTracker struct{ wg sync.WaitGroup }
@@ -724,6 +729,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			Reviewer:          reviewerRunner,
 			Fixer:             fixerRunner,
 			Worker:            workerRunner,
+			Snapshotter:       githubGateway,
 		})
 	}
 }
@@ -939,9 +945,59 @@ func schedulerQueueProcessor(item storage.QueueItemRecord, input defaultSchedule
 			_, err := input.Worker.ProcessClaimedQueueItem(ctx, item)
 			return wrapSchedulerQueueError(item.Type, err)
 		}, nil
+	case "snapshot":
+		if input.Snapshotter == nil || input.Repos == nil || input.Repos.Queue == nil || input.Repos.PullRequestSnapshots == nil {
+			return nil, fmt.Errorf("snapshot runner is not configured")
+		}
+		return func(ctx context.Context) error {
+			return processSnapshotQueueItem(ctx, item, input)
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported queue item type %q", item.Type)
 	}
+}
+
+func processSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord, input defaultSchedulerTickInput) error {
+	if item.ProjectID == nil || strings.TrimSpace(*item.ProjectID) == "" || item.Repo == nil || strings.TrimSpace(*item.Repo) == "" || item.PRNumber == nil {
+		return failSnapshotQueueItem(ctx, item, input, "invalid snapshot queue item", "non_retryable")
+	}
+	project, err := input.Repos.Projects.GetByID(ctx, *item.ProjectID)
+	if err != nil {
+		return err
+	}
+	if project == nil {
+		return failSnapshotQueueItem(ctx, item, input, "project not found", "non_retryable")
+	}
+	cwd := project.RepoPath
+	if item.PayloadJSON != nil && strings.TrimSpace(*item.PayloadJSON) != "" {
+		payload := map[string]any{}
+		if err := json.Unmarshal([]byte(*item.PayloadJSON), &payload); err == nil {
+			if payloadCWD, _ := payload["cwd"].(string); strings.TrimSpace(payloadCWD) != "" {
+				cwd = strings.TrimSpace(payloadCWD)
+			}
+		}
+	}
+	now := input.Now
+	if now == nil {
+		now = time.Now
+	}
+	snapshot, err := input.Snapshotter.CapturePullRequestSnapshot(ctx, githubinfra.CapturePullRequestSnapshotInput{ProjectID: project.ID, Repo: *item.Repo, PRNumber: *item.PRNumber, CWD: cwd, CapturedAt: formatJavaScriptISOString(now().UTC())})
+	if err != nil {
+		return failSnapshotQueueItem(ctx, item, input, err.Error(), "retryable_transient")
+	}
+	if err := input.Repos.PullRequestSnapshots.Upsert(ctx, snapshot); err != nil {
+		return err
+	}
+	return input.Repos.Queue.Complete(ctx, item.ID, formatJavaScriptISOString(now().UTC()))
+}
+
+func failSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord, input defaultSchedulerTickInput, message, kind string) error {
+	now := input.Now
+	if now == nil {
+		now = time.Now
+	}
+	nowISO := formatJavaScriptISOString(now().UTC())
+	return input.Repos.Queue.Fail(ctx, storage.QueueFailInput{ID: item.ID, FinishedAt: nowISO, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
 }
 
 func repoFromProjectMetadata(metadataJSON *string) string {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -987,7 +987,7 @@ func processSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord,
 	}
 	project, err := input.Repos.Projects.GetByID(ctx, *item.ProjectID)
 	if err != nil {
-		return err
+		return failSnapshotQueueItem(ctx, item, input, err.Error(), "retryable_transient")
 	}
 	if project == nil {
 		return failSnapshotQueueItem(ctx, item, input, "project not found", "non_retryable")

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1010,7 +1010,7 @@ func processSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord,
 		return failSnapshotQueueItem(ctx, item, input, err.Error(), "retryable_transient")
 	}
 	if err := input.Repos.PullRequestSnapshots.Upsert(ctx, snapshot); err != nil {
-		return err
+		return failSnapshotQueueItem(ctx, item, input, err.Error(), "retryable_transient")
 	}
 	return input.Repos.Queue.Complete(ctx, item.ID, formatJavaScriptISOString(now().UTC()))
 }

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1012,7 +1012,10 @@ func processSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord,
 	if err := input.Repos.PullRequestSnapshots.Upsert(ctx, snapshot); err != nil {
 		return failSnapshotQueueItem(ctx, item, input, err.Error(), "retryable_transient")
 	}
-	return input.Repos.Queue.Complete(ctx, item.ID, formatJavaScriptISOString(now().UTC()))
+	if err := input.Repos.Queue.Complete(ctx, item.ID, formatJavaScriptISOString(now().UTC())); err != nil {
+		return failSnapshotQueueItem(ctx, item, input, err.Error(), "retryable_transient")
+	}
+	return nil
 }
 
 func failSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord, input defaultSchedulerTickInput, message, kind string) error {

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -323,6 +323,50 @@ func TestProcessSnapshotQueueItemRetriesTransientPersistenceFailure(t *testing.T
 	}
 }
 
+func TestProcessSnapshotQueueItemRetriesTransientProjectLookupFailure(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "snapshot-project-lookup-retry.sqlite"), backupDir)
+	setupRepos := storage.NewRepositories(coordinator.DB())
+	repos := storage.NewRepositories(&failingProjectLookupQuerier{db: coordinator.DB()})
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	projectID := "looper"
+	repo := "powerformer/looper"
+	prNumber := int64(109)
+	if err := setupRepos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	queueItem := storage.QueueItemRecord{ID: "queue_snapshot_project_lookup_1", ProjectID: &projectID, Type: "snapshot", TargetType: "pull_request", TargetID: "powerformer/looper#109", Repo: &repo, PRNumber: &prNumber, DedupeKey: "snapshot:powerformer/looper:109", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := setupRepos.Queue.Upsert(context.Background(), queueItem); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	err := processSnapshotQueueItem(context.Background(), queueItem, defaultSchedulerTickInput{
+		Repos:       repos,
+		Now:         func() time.Time { return now },
+		Snapshotter: stubSnapshotScheduler{},
+	})
+	if err != nil {
+		t.Fatalf("processSnapshotQueueItem() error = %v", err)
+	}
+	updated, err := repos.Queue.GetByID(context.Background(), queueItem.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if updated == nil {
+		t.Fatal("Queue.GetByID() = nil, want retried queue item")
+	}
+	if updated.Status != "queued" || updated.Attempts != 1 || updated.FinishedAt != nil {
+		t.Fatalf("queue item = %#v, want queued retry with one attempt and no finished_at", updated)
+	}
+	if updated.LastError == nil || !strings.Contains(*updated.LastError, "get project by id") || updated.LastErrorKind == nil || *updated.LastErrorKind != "retryable_transient" {
+		t.Fatalf("queue item error = (%v, %v), want retryable project lookup failure", updated.LastError, updated.LastErrorKind)
+	}
+}
+
 func TestSchedulerAvailableSlotsAccountsForRunningQueueItems(t *testing.T) {
 	t.Parallel()
 
@@ -709,6 +753,25 @@ func (q *failingSnapshotUpsertQuerier) QueryContext(ctx context.Context, query s
 }
 
 func (q *failingSnapshotUpsertQuerier) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return q.db.QueryRowContext(ctx, query, args...)
+}
+
+type failingProjectLookupQuerier struct {
+	db *sql.DB
+}
+
+func (q *failingProjectLookupQuerier) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return q.db.ExecContext(ctx, query, args...)
+}
+
+func (q *failingProjectLookupQuerier) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return q.db.QueryContext(ctx, query, args...)
+}
+
+func (q *failingProjectLookupQuerier) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	if strings.Contains(query, "FROM projects WHERE id") {
+		return q.db.QueryRowContext(ctx, `SELECT * FROM missing_projects_table`)
+	}
 	return q.db.QueryRowContext(ctx, query, args...)
 }
 

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -276,6 +277,49 @@ func TestProcessSnapshotQueueItemRetriesTransientCaptureFailure(t *testing.T) {
 	}
 	if updated.LastError == nil || *updated.LastError != "gh timeout" || updated.LastErrorKind == nil || *updated.LastErrorKind != "retryable_transient" {
 		t.Fatalf("queue item error = (%v, %v), want retryable gh timeout", updated.LastError, updated.LastErrorKind)
+	}
+}
+
+func TestProcessSnapshotQueueItemRetriesTransientPersistenceFailure(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "snapshot-upsert-retry.sqlite"), backupDir)
+	repos := storage.NewRepositories(&failingSnapshotUpsertQuerier{db: coordinator.DB(), err: errors.New("database is locked")})
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	projectID := "looper"
+	repo := "powerformer/looper"
+	prNumber := int64(109)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	queueItem := storage.QueueItemRecord{ID: "queue_snapshot_upsert_1", ProjectID: &projectID, Type: "snapshot", TargetType: "pull_request", TargetID: "powerformer/looper#109", Repo: &repo, PRNumber: &prNumber, DedupeKey: "snapshot:powerformer/looper:109", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Queue.Upsert(context.Background(), queueItem); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	err := processSnapshotQueueItem(context.Background(), queueItem, defaultSchedulerTickInput{
+		Repos:       repos,
+		Now:         func() time.Time { return now },
+		Snapshotter: stubSnapshotScheduler{},
+	})
+	if err != nil {
+		t.Fatalf("processSnapshotQueueItem() error = %v", err)
+	}
+	updated, err := repos.Queue.GetByID(context.Background(), queueItem.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if updated == nil {
+		t.Fatal("Queue.GetByID() = nil, want retried queue item")
+	}
+	if updated.Status != "queued" || updated.Attempts != 1 || updated.FinishedAt != nil {
+		t.Fatalf("queue item = %#v, want queued retry with one attempt and no finished_at", updated)
+	}
+	if updated.LastError == nil || !strings.Contains(*updated.LastError, "database is locked") || updated.LastErrorKind == nil || *updated.LastErrorKind != "retryable_transient" {
+		t.Fatalf("queue item error = (%v, %v), want retryable database is locked", updated.LastError, updated.LastErrorKind)
 	}
 }
 
@@ -646,6 +690,26 @@ type stubSnapshotScheduler struct {
 
 func (s stubSnapshotScheduler) CapturePullRequestSnapshot(context.Context, githubinfra.CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
 	return storage.PullRequestSnapshotRecord{}, s.err
+}
+
+type failingSnapshotUpsertQuerier struct {
+	db  *sql.DB
+	err error
+}
+
+func (q *failingSnapshotUpsertQuerier) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	if strings.Contains(query, "INSERT INTO pull_request_snapshots") {
+		return nil, q.err
+	}
+	return q.db.ExecContext(ctx, query, args...)
+}
+
+func (q *failingSnapshotUpsertQuerier) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return q.db.QueryContext(ctx, query, args...)
+}
+
+func (q *failingSnapshotUpsertQuerier) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return q.db.QueryRowContext(ctx, query, args...)
 }
 
 func waitForSchedulerCondition(t *testing.T, condition func() bool) {

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -367,6 +367,48 @@ func TestProcessSnapshotQueueItemRetriesTransientProjectLookupFailure(t *testing
 	}
 }
 
+func TestProcessSnapshotQueueItemRetriesTransientCompletionFailure(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "snapshot-complete-retry.sqlite"), backupDir)
+	setupRepos := storage.NewRepositories(coordinator.DB())
+	repos := storage.NewRepositories(&failingQueueCompleteQuerier{db: coordinator.DB(), err: errors.New("database is locked")})
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	projectID := "looper"
+	repo := "powerformer/looper"
+	prNumber := int64(109)
+	if err := setupRepos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	queueItem := storage.QueueItemRecord{ID: "queue_snapshot_complete_1", ProjectID: &projectID, Type: "snapshot", TargetType: "pull_request", TargetID: "powerformer/looper#109", Repo: &repo, PRNumber: &prNumber, DedupeKey: "snapshot:powerformer/looper:109", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := setupRepos.Queue.Upsert(context.Background(), queueItem); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	err := processSnapshotQueueItem(context.Background(), queueItem, defaultSchedulerTickInput{
+		Repos:       repos,
+		Now:         func() time.Time { return now },
+		Snapshotter: stubSnapshotScheduler{},
+	})
+	if err != nil {
+		t.Fatalf("processSnapshotQueueItem() error = %v", err)
+	}
+	updated, err := repos.Queue.GetByID(context.Background(), queueItem.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if updated == nil {
+		t.Fatal("Queue.GetByID() = nil, want retried queue item")
+	}
+	if updated.Status != "queued" || updated.Attempts != 1 || updated.FinishedAt != nil {
+		t.Fatalf("queue item = %#v, want queued retry with one attempt and no finished_at", updated)
+	}
+	assertQueueRetryError(t, updated, "database is locked")
+}
+
 func TestSchedulerAvailableSlotsAccountsForRunningQueueItems(t *testing.T) {
 	t.Parallel()
 
@@ -732,8 +774,8 @@ type stubSnapshotScheduler struct {
 	err error
 }
 
-func (s stubSnapshotScheduler) CapturePullRequestSnapshot(context.Context, githubinfra.CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
-	return storage.PullRequestSnapshotRecord{}, s.err
+func (s stubSnapshotScheduler) CapturePullRequestSnapshot(_ context.Context, input githubinfra.CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
+	return storage.PullRequestSnapshotRecord{ID: "snapshot_1", ProjectID: input.ProjectID, Repo: input.Repo, PRNumber: input.PRNumber, HeadSHA: "head", CapturedAt: input.CapturedAt, CreatedAt: input.CapturedAt}, s.err
 }
 
 type failingSnapshotUpsertQuerier struct {
@@ -773,6 +815,41 @@ func (q *failingProjectLookupQuerier) QueryRowContext(ctx context.Context, query
 		return q.db.QueryRowContext(ctx, `SELECT * FROM missing_projects_table`)
 	}
 	return q.db.QueryRowContext(ctx, query, args...)
+}
+
+type failingQueueCompleteQuerier struct {
+	db  *sql.DB
+	err error
+}
+
+func (q *failingQueueCompleteQuerier) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	if strings.Contains(query, "SET status = 'completed'") {
+		return nil, q.err
+	}
+	return q.db.ExecContext(ctx, query, args...)
+}
+
+func (q *failingQueueCompleteQuerier) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return q.db.QueryContext(ctx, query, args...)
+}
+
+func (q *failingQueueCompleteQuerier) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return q.db.QueryRowContext(ctx, query, args...)
+}
+
+func assertQueueRetryError(t *testing.T, item *storage.QueueItemRecord, message string) {
+	t.Helper()
+	lastError := "<nil>"
+	if item.LastError != nil {
+		lastError = *item.LastError
+	}
+	lastErrorKind := "<nil>"
+	if item.LastErrorKind != nil {
+		lastErrorKind = *item.LastErrorKind
+	}
+	if item.LastError == nil || !strings.Contains(*item.LastError, message) || item.LastErrorKind == nil || *item.LastErrorKind != "retryable_transient" {
+		t.Fatalf("queue item error = (%s, %s), want retryable %s", lastError, lastErrorKind, message)
+	}
 }
 
 func waitForSchedulerCondition(t *testing.T, condition func() bool) {

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -236,6 +236,49 @@ func TestRunScheduledQueueItemsErrorsWhenRunnerMissing(t *testing.T) {
 	}
 }
 
+func TestProcessSnapshotQueueItemRetriesTransientCaptureFailure(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "snapshot-retry.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	projectID := "looper"
+	repo := "powerformer/looper"
+	prNumber := int64(109)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	queueItem := storage.QueueItemRecord{ID: "queue_snapshot_1", ProjectID: &projectID, Type: "snapshot", TargetType: "pull_request", TargetID: "powerformer/looper#109", Repo: &repo, PRNumber: &prNumber, DedupeKey: "snapshot:powerformer/looper:109", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Queue.Upsert(context.Background(), queueItem); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	err := processSnapshotQueueItem(context.Background(), queueItem, defaultSchedulerTickInput{
+		Repos:       repos,
+		Now:         func() time.Time { return now },
+		Snapshotter: stubSnapshotScheduler{err: errors.New("gh timeout")},
+	})
+	if err != nil {
+		t.Fatalf("processSnapshotQueueItem() error = %v", err)
+	}
+	updated, err := repos.Queue.GetByID(context.Background(), queueItem.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if updated == nil {
+		t.Fatal("Queue.GetByID() = nil, want retried queue item")
+	}
+	if updated.Status != "queued" || updated.Attempts != 1 || updated.FinishedAt != nil {
+		t.Fatalf("queue item = %#v, want queued retry with one attempt and no finished_at", updated)
+	}
+	if updated.LastError == nil || *updated.LastError != "gh timeout" || updated.LastErrorKind == nil || *updated.LastErrorKind != "retryable_transient" {
+		t.Fatalf("queue item error = (%v, %v), want retryable gh timeout", updated.LastError, updated.LastErrorKind)
+	}
+}
+
 func TestSchedulerAvailableSlotsAccountsForRunningQueueItems(t *testing.T) {
 	t.Parallel()
 
@@ -595,6 +638,14 @@ func (s *blockingWorkerScheduler) ProcessNext(_ context.Context, _ string) (*wor
 
 func (s *blockingWorkerScheduler) ProcessClaimedQueueItem(ctx context.Context, _ storage.QueueItemRecord) (*worker.ProcessResult, error) {
 	return s.ProcessNext(ctx, "")
+}
+
+type stubSnapshotScheduler struct {
+	err error
+}
+
+func (s stubSnapshotScheduler) CapturePullRequestSnapshot(context.Context, githubinfra.CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
+	return storage.PullRequestSnapshotRecord{}, s.err
 }
 
 func waitForSchedulerCondition(t *testing.T, condition func() bool) {

--- a/internal/storage/queue_priorities.go
+++ b/internal/storage/queue_priorities.go
@@ -5,4 +5,5 @@ const (
 	QueuePriorityReviewer int64 = 2
 	QueuePriorityFixer    int64 = 2
 	QueuePriorityWorker   int64 = 3
+	QueuePrioritySnapshot int64 = 4
 )

--- a/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
+++ b/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
@@ -198,7 +198,8 @@
             "allowAutoMerge": false,
             "allowRiskyFixes": false,
             "fixAllPullRequests": false,
-            "openPrStrategy": "all_done"
+            "openPrStrategy": "all_done",
+            "addSnapshotMode": "async"
           },
           "projects": []
         },
@@ -594,6 +595,8 @@
           "updatedAt": "2026-04-11T12:00:00.000Z",
           "discoveredPullRequests": 1,
           "discoveredWorktrees": 2,
+          "pendingSnapshots": 0,
+          "capturedSnapshots": 1,
           "warnings": []
         },
         "requestId": "fixture-request-id"

--- a/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
+++ b/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
@@ -199,7 +199,7 @@
             "allowRiskyFixes": false,
             "fixAllPullRequests": false,
             "openPrStrategy": "all_done",
-            "addSnapshotMode": "async"
+            "addSnapshotMode": "full"
           },
           "projects": []
         },


### PR DESCRIPTION
## Summary
- Make `project add` default to async PR snapshot scheduling with `full` and `off` snapshot modes exposed through config, API, and CLI.
- Add snapshot queue processing, bounded GitHub command timeouts, and non-fatal handling for GitHub diff-too-large responses.
- Update human/API outputs, docs, compatibility fixtures, and tests for async scheduling and truncated snapshots.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #100