### PR TITLE
fix: harden daemon start detection

### DIFF
--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -72,7 +72,7 @@ func TestBootstrapYesInstallsStartsAndPrintsNextSteps(t *testing.T) {
 				if !daemonStarted.Load() {
 					return nil, fmt.Errorf("daemon offline")
 				}
-				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true}}}`), nil
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true,"binary":{"name":"looperd"}}}}`), nil
 			default:
 				t.Fatalf("unexpected request URL %q", req.URL.String())
 				return nil, nil
@@ -208,7 +208,7 @@ func TestBootstrapJSONSuppressesDaemonStartOutput(t *testing.T) {
 				if !daemonStarted.Load() {
 					return nil, fmt.Errorf("daemon offline")
 				}
-				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true}}}`), nil
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true,"binary":{"name":"looperd"}}}}`), nil
 			default:
 				t.Fatalf("unexpected request URL %q", req.URL.String())
 				return nil, nil
@@ -471,7 +471,7 @@ func TestBootstrapIdempotentWhenConfigProjectAndDaemonAlreadyHealthy(t *testing.
 				return nil, nil
 			}
 			if req.URL.String() == "http://daemon.test/api/v1/status" {
-				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true}}}`), nil
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true,"binary":{"name":"looperd"}}}}`), nil
 			}
 			if req.URL.String() == "http://daemon.test/api/v1/healthz" {
 				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_health","data":{"healthy":true}}}`), nil
@@ -564,7 +564,7 @@ func TestBootstrapIdempotentSkipsGitHubWhenManagedDaemonInstalled(t *testing.T) 
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.String() {
 			case "http://daemon.test/api/v1/status":
-				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true}}}`), nil
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true,"binary":{"name":"looperd"}}}}`), nil
 			case "http://daemon.test/api/v1/healthz":
 				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_health","data":{"healthy":true}}}`), nil
 			default:
@@ -643,7 +643,7 @@ func TestBootstrapAddsProjectWithoutPersistingRuntimeOverrides(t *testing.T) {
 			case "https://api.github.com/repos/powerformer/looper/releases/latest":
 				return jsonResponse(t, http.StatusOK, `{"tag_name":"v1.2.3","assets":[]}`), nil
 			case "http://daemon.test/api/v1/status":
-				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true}}}`), nil
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true,"binary":{"name":"looperd"}}}}`), nil
 			case "http://daemon.test/api/v1/healthz":
 				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_health","data":{"healthy":true}}}`), nil
 			default:

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -108,10 +108,12 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 	_ = args
 
 	ctx := cmd.Context()
-	binary, err := r.resolveDaemonBinary(ctx)
+	loaded, err := r.loadConfig()
 	if err != nil {
 		return err
 	}
+	client := r.apiClientFromLoaded(loaded)
+	apiURL := client.baseURL
 
 	pidFilePath, err := r.resolveDaemonPIDFilePath()
 	if err != nil {
@@ -125,17 +127,31 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			if isLooperd {
-				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looperd already appears to be running (pid %d)\n", existingPID); err != nil {
+				probe, err := r.probeDaemonStatus(ctx, client)
+				if err != nil {
+					return err
+				}
+				if !probe.isLooperd {
+					return fmt.Errorf("Daemon pid %d appears to be looperd, but %s did not confirm a running looperd", existingPID, apiURL)
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looperd already appears to be running at %s (pid %d)\n", apiURL, existingPID); err != nil {
 					return err
 				}
 				_, err = fmt.Fprintln(cmd.OutOrStdout(), "Phase 1 process management is minimal: use `looper daemon restart` or stop the process manually if needed.")
 				return err
 			}
 
-			r.removePIDFile(pidFilePath)
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Daemon pid %d does not appear to be looperd; treating pid file as stale.\n", existingPID); err != nil {
+			probe, err := r.probeDaemonStatus(ctx, client)
+			if err != nil {
 				return err
 			}
+			if probe.isLooperd {
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looperd already appears to be running at %s (pid file points to non-looperd pid %d)\n", apiURL, existingPID); err != nil {
+					return err
+				}
+				return nil
+			}
+			return fmt.Errorf("Daemon pid file points to alive non-looperd process %d; refusing to overwrite it", existingPID)
 		} else {
 			r.removePIDFile(pidFilePath)
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Removed stale daemon pid file for pid %d\n", existingPID); err != nil {
@@ -144,11 +160,34 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if !r.skipAPIStartProbe {
+		probe, err := r.probeDaemonStatus(ctx, client)
+		if err != nil {
+			return err
+		}
+		if probe.isLooperd {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looperd already appears to be running at %s (pid file missing)\n", apiURL); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
+	binary, err := r.resolveDaemonBinary(ctx)
+	if err != nil {
+		return err
+	}
+
 	cwd, err := r.getwd()
 	if err != nil {
 		return fmt.Errorf("determine current working directory: %w", err)
 	}
+	startupLogPath, err := r.createStartupLogPath(loaded)
+	if err != nil {
+		return err
+	}
 
+	r.startupOutputPath = startupLogPath
 	pid, err := r.spawnDetached(binary.Path, ExtractConfigArgs(r.argv), cwd, os.Environ())
 	if err != nil {
 		return fmt.Errorf("Failed to start looperd: %w", err)
@@ -157,19 +196,10 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to start looperd: process did not report a pid")
 	}
 
-	r.sleep(100 * time.Millisecond)
-	if !r.isProcessAlive(pid) {
-		r.removePIDFile(pidFilePath)
-		return fmt.Errorf("Failed to start looperd: process %d exited during startup", pid)
-	}
-
-	isLooperd, err := r.isLooperdProcess(ctx, pid)
+	err = r.waitForDaemonReady(ctx, client, pid, startupLogPath, apiURL, 5*time.Second, 100*time.Millisecond)
 	if err != nil {
-		return err
-	}
-	if !isLooperd {
 		r.removePIDFile(pidFilePath)
-		return fmt.Errorf("Failed to start looperd: process %d exited during startup", pid)
+		return err
 	}
 
 	if err := r.mkdirAll(filepath.Dir(pidFilePath), 0o755); err != nil {
@@ -185,6 +215,9 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "PID file: %s\n", pidFilePath); err != nil {
 		return err
 	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Startup log: %s\n", startupLogPath); err != nil {
+		return err
+	}
 	_, err = fmt.Fprintln(cmd.OutOrStdout(), "Phase 1 process management is minimal and does not provide full background supervision.")
 	return err
 }
@@ -192,10 +225,12 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 func (r *commandRuntime) daemonRestart(cmd *cobra.Command, args []string) error {
 	_ = args
 
-	if _, err := r.stopDaemonProcess(cmd.Context(), cmd.OutOrStdout(), true); err != nil {
+	stopped, err := r.stopDaemonProcess(cmd.Context(), cmd.OutOrStdout(), true)
+	if err != nil {
 		return err
 	}
 
+	r.skipAPIStartProbe = stopped
 	return r.daemonStart(cmd, nil)
 }
 
@@ -367,6 +402,7 @@ func (r *commandRuntime) detectDaemonVersionState(ctx context.Context, statusPay
 }
 
 type daemonServiceBinary struct {
+	Name    string
 	Version string
 	Path    string
 }
@@ -380,6 +416,7 @@ func extractDaemonServiceBinary(payload json.RawMessage) daemonServiceBinary {
 		Service struct {
 			Version string `json:"version"`
 			Binary  struct {
+				Name string `json:"name"`
 				Path string `json:"path"`
 			} `json:"binary"`
 		} `json:"service"`
@@ -389,9 +426,96 @@ func extractDaemonServiceBinary(payload json.RawMessage) daemonServiceBinary {
 	}
 
 	return daemonServiceBinary{
+		Name:    strings.TrimSpace(decoded.Service.Binary.Name),
 		Version: strings.TrimSpace(decoded.Service.Version),
 		Path:    strings.TrimSpace(decoded.Service.Binary.Path),
 	}
+}
+
+type daemonStatusProbe struct {
+	reachable bool
+	isLooperd bool
+	payload   json.RawMessage
+}
+
+func (r *commandRuntime) probeDaemonStatus(ctx context.Context, client *DaemonAPIClient) (daemonStatusProbe, error) {
+	payload, err := r.getJSONWithClient(ctx, client, "/api/v1/status")
+	if err != nil {
+		var apiErr *DaemonAPIError
+		if errors.As(err, &apiErr) && apiErr.Status > 0 {
+			return daemonStatusProbe{reachable: true}, fmt.Errorf("configured API endpoint %s responded but did not return looperd status: %w", client.baseURL, err)
+		}
+		return daemonStatusProbe{}, nil
+	}
+
+	if !isLooperdStatusPayload(payload) {
+		return daemonStatusProbe{reachable: true, payload: payload}, fmt.Errorf("configured API endpoint %s is occupied by another service: /api/v1/status did not identify looperd", client.baseURL)
+	}
+	return daemonStatusProbe{reachable: true, isLooperd: true, payload: payload}, nil
+}
+
+func isLooperdStatusPayload(payload json.RawMessage) bool {
+	binary := extractDaemonServiceBinary(payload)
+	if binary.Name == looperdBinaryName {
+		return true
+	}
+	return binary.Version != "" && filepath.Base(binary.Path) == looperdBinaryName
+}
+
+func (r *commandRuntime) createStartupLogPath(loaded config.LoadedFileConfig) (string, error) {
+	startupLogDir := filepath.Join(loaded.Config.Daemon.LogDir, "startup")
+	if err := r.mkdirAll(startupLogDir, 0o700); err != nil {
+		return "", fmt.Errorf("create daemon startup log directory: %w", err)
+	}
+	return filepath.Join(startupLogDir, fmt.Sprintf("looperd-%s.log", time.Now().UTC().Format("20060102T150405.000000000Z"))), nil
+}
+
+func (r *commandRuntime) waitForDaemonReady(ctx context.Context, client *DaemonAPIClient, pid int, startupLogPath string, apiURL string, timeout time.Duration, interval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastProbeErr error
+	for time.Now().Before(deadline) {
+		if !r.isProcessAlive(pid) {
+			return r.daemonStartupFailureError(fmt.Sprintf("Failed to start looperd: process %d exited during startup", pid), startupLogPath, lastProbeErr)
+		}
+		payload, err := r.getJSONWithClient(ctx, client, "/api/v1/status")
+		if err != nil {
+			lastProbeErr = err
+		} else if isLooperdStatusPayload(payload) {
+			if !r.isProcessAlive(pid) {
+				return r.daemonStartupFailureError(fmt.Sprintf("Failed to start looperd: process %d exited during startup", pid), startupLogPath, lastProbeErr)
+			}
+			return nil
+		} else {
+			lastProbeErr = fmt.Errorf("/api/v1/status at %s did not identify looperd", apiURL)
+		}
+		r.sleep(interval)
+	}
+
+	message := fmt.Sprintf("Timed out waiting for looperd pid %d to become ready at %s", pid, apiURL)
+	return r.daemonStartupFailureError(message, startupLogPath, lastProbeErr)
+}
+
+func (r *commandRuntime) daemonStartupFailureError(message string, startupLogPath string, cause error) error {
+	var builder strings.Builder
+	builder.WriteString(message)
+	builder.WriteString(fmt.Sprintf("; startup log: %s", startupLogPath))
+	if cause != nil {
+		builder.WriteString(fmt.Sprintf("; last readiness error: %v", cause))
+	}
+	if tail := r.readStartupLogTail(startupLogPath, 20); tail != "" {
+		builder.WriteString("; startup log tail:\n")
+		builder.WriteString(tail)
+	}
+	return errors.New(builder.String())
+}
+
+func (r *commandRuntime) readStartupLogTail(path string, lineCount int) string {
+	raw, err := r.readFile(path)
+	if err != nil {
+		return ""
+	}
+	lines := tailLines(strings.TrimRight(string(raw), "\n"), lineCount)
+	return strings.Join(lines, "\n")
 }
 
 func extractDaemonVersion(payload json.RawMessage) string {
@@ -646,12 +770,18 @@ func (r *commandRuntime) spawnDetached(command string, args []string, cwd string
 	}
 	defer devNull.Close()
 
+	startupLog, err := os.OpenFile(r.startupOutputPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return 0, err
+	}
+	defer startupLog.Close()
+
 	cmd := exec.Command(command, args...)
 	cmd.Dir = cwd
 	cmd.Env = env
 	cmd.Stdin = devNull
-	cmd.Stdout = devNull
-	cmd.Stderr = devNull
+	cmd.Stdout = startupLog
+	cmd.Stderr = startupLog
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := cmd.Start(); err != nil {
 		return 0, err

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -198,6 +198,9 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 
 	err = r.waitForDaemonReady(ctx, client, pid, startupLogPath, apiURL, 5*time.Second, 100*time.Millisecond)
 	if err != nil {
+		if r.isProcessAlive(pid) {
+			_ = r.killProcess(pid, int(syscall.SIGTERM))
+		}
 		r.removePIDFile(pidFilePath)
 		return err
 	}

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -112,7 +112,7 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	client := r.apiClientFromLoaded(loaded)
+	client := r.localAPIClientFromLoaded(loaded)
 	apiURL := client.baseURL
 
 	pidFilePath, err := r.resolveDaemonPIDFilePath()
@@ -375,6 +375,15 @@ func (r *commandRuntime) apiClientFromLoaded(loaded config.LoadedFileConfig) *Da
 		baseURL = fmt.Sprintf("http://%s:%d", loaded.Config.Server.Host, loaded.Config.Server.Port)
 	}
 
+	return r.newAPIClientForLoaded(loaded, baseURL)
+}
+
+func (r *commandRuntime) localAPIClientFromLoaded(loaded config.LoadedFileConfig) *DaemonAPIClient {
+	baseURL := fmt.Sprintf("http://%s:%d", loaded.Config.Server.Host, loaded.Config.Server.Port)
+	return r.newAPIClientForLoaded(loaded, baseURL)
+}
+
+func (r *commandRuntime) newAPIClientForLoaded(loaded config.LoadedFileConfig, baseURL string) *DaemonAPIClient {
 	token := ""
 	if loaded.Config.Server.AuthMode == config.AuthModeLocalToken && loaded.Config.Server.LocalToken != nil {
 		token = strings.TrimSpace(*loaded.Config.Server.LocalToken)

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -146,6 +146,7 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			if probe.isLooperd {
+				r.removePIDFile(pidFilePath)
 				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looperd already appears to be running at %s (pid file points to non-looperd pid %d)\n", apiURL, existingPID); err != nil {
 					return err
 				}

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -244,7 +247,7 @@ func TestDaemonStartMissingPIDFileUsesReachableLooperdAPI(t *testing.T) {
 	}))
 	defer server.Close()
 
-	configPath := writeDaemonCLIConfig(t, server.URL)
+	configPath := writeDaemonCLIConfigForBindEndpoint(t, server.URL, nil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	app := New(Deps{
@@ -282,7 +285,7 @@ func TestDaemonStartStalePIDFileUsesReachableLooperdAPI(t *testing.T) {
 
 	homeDir := t.TempDir()
 	pidFilePath := filepath.Join(homeDir, ".looper", "looperd.pid")
-	configPath := writeDaemonCLIConfig(t, server.URL)
+	configPath := writeDaemonCLIConfigForBindEndpoint(t, server.URL, nil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	removed := false
@@ -337,7 +340,7 @@ func TestDaemonStartNonLooperdAPIServiceFailsBeforeSpawn(t *testing.T) {
 	}))
 	defer server.Close()
 
-	configPath := writeDaemonCLIConfig(t, server.URL)
+	configPath := writeDaemonCLIConfigForBindEndpoint(t, server.URL, nil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	app := New(Deps{
@@ -368,7 +371,7 @@ func TestDaemonStartNonLooperdAPIServiceFailsBeforeSpawn(t *testing.T) {
 func TestDaemonStartExitedProcessIncludesStartupLogTail(t *testing.T) {
 	t.Parallel()
 
-	configPath := writeDaemonCLIConfig(t, "http://127.0.0.1:1")
+	configPath := writeDaemonCLIConfigForBindEndpoint(t, "http://127.0.0.1:1", nil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	app := New(Deps{
@@ -425,7 +428,7 @@ func TestDaemonStartReadinessLoopWaitsForStatus(t *testing.T) {
 	}))
 	defer server.Close()
 
-	configPath := writeDaemonCLIConfig(t, server.URL)
+	configPath := writeDaemonCLIConfigForBindEndpoint(t, server.URL, nil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	clientRequests := 0
@@ -472,12 +475,77 @@ func TestDaemonStartReadinessLoopWaitsForStatus(t *testing.T) {
 	}
 }
 
+func TestDaemonStartIgnoresRemoteBaseURLForLocalReadiness(t *testing.T) {
+	t.Parallel()
+
+	remoteRequests := 0
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteRequests++
+		writeLooperdStatusEnvelope(t, w)
+	}))
+	defer remoteServer.Close()
+
+	localRequests := 0
+	localServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		localRequests++
+		writeLooperdStatusEnvelope(t, w)
+	}))
+	defer localServer.Close()
+
+	homeDir := t.TempDir()
+	configPath := writeDaemonCLIConfigForBindEndpoint(t, localServer.URL, &remoteServer.URL)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	spawned := false
+	clientRequests := 0
+	app := New(Deps{
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: homeDir,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			clientRequests++
+			if clientRequests == 1 {
+				return nil, os.ErrNotExist
+			}
+			return http.DefaultTransport.RoundTrip(req)
+		})},
+		ReadFile:   func(path string) ([]byte, error) { return nil, os.ErrNotExist },
+		RunCommand: daemonVersionCommand(filepath.Join(homeDir, ".looper", "bin", "looperd")),
+		Getwd:      func() (string, error) { return "/tmp/workspace", nil },
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			spawned = true
+			return 4321, nil
+		},
+		KillProcess: func(pid int, signal int) error { return nil },
+		MkdirAll:    func(path string, perm os.FileMode) error { return nil },
+		WriteFile:   func(path string, data []byte, perm os.FileMode) error { return nil },
+		Sleep:       func(duration time.Duration) {},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon start]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !spawned {
+		t.Fatal("SpawnDetached() was not called; remote baseUrl appears to have short-circuited startup")
+	}
+	if remoteRequests != 0 {
+		t.Fatalf("remote baseUrl requests = %d, want 0", remoteRequests)
+	}
+	if localRequests == 0 {
+		t.Fatalf("local bind endpoint requests = %d, want readiness poll", localRequests)
+	}
+	if !strings.Contains(stdout.String(), "Started looperd") || !strings.Contains(stdout.String(), "pid 4321") {
+		t.Fatalf("stdout = %q, want start confirmation", stdout.String())
+	}
+}
+
 func TestDaemonStartReadinessTimeoutTerminatesSpawnedProcessAndRemovesPIDFile(t *testing.T) {
 	t.Parallel()
 
 	homeDir := t.TempDir()
 	pidFilePath := filepath.Join(homeDir, ".looper", "looperd.pid")
-	configPath := writeDaemonCLIConfig(t, "http://127.0.0.1:1")
+	configPath := writeDaemonCLIConfigForBindEndpoint(t, "http://127.0.0.1:1", nil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	removeCalls := make([]string, 0, 1)
@@ -932,6 +1000,65 @@ func writeDaemonCLIConfig(t *testing.T, baseURL string) string {
 	if err != nil {
 		t.Fatalf("Marshal(config) error = %v", err)
 	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+	return configPath
+}
+
+func writeDaemonCLIConfigForBindEndpoint(t *testing.T, bindURL string, baseURL *string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(bindURL)
+	if err != nil {
+		t.Fatalf("Parse(bindURL) error = %v", err)
+	}
+	host, portText, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q) error = %v", parsed.Host, err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("Atoi(%q) error = %v", portText, err)
+	}
+
+	root := t.TempDir()
+	logDir := filepath.Join(root, "logs")
+	workingDir := filepath.Join(root, "working")
+	storageDir := filepath.Join(root, "storage")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(logDir) error = %v", err)
+	}
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workingDir) error = %v", err)
+	}
+	if err := os.MkdirAll(storageDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(storageDir) error = %v", err)
+	}
+
+	serverConfig := map[string]any{
+		"host":     host,
+		"port":     port,
+		"authMode": "none",
+	}
+	if baseURL != nil {
+		serverConfig["baseUrl"] = *baseURL
+	}
+	payload := map[string]any{
+		"server": serverConfig,
+		"daemon": map[string]any{
+			"logDir":           logDir,
+			"workingDirectory": workingDir,
+		},
+		"storage": map[string]any{
+			"dbPath": filepath.Join(storageDir, "looper.sqlite"),
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal(config) error = %v", err)
+	}
+	configPath := filepath.Join(root, "config.json")
 	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
 		t.Fatalf("WriteFile(config) error = %v", err)
 	}

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -330,6 +330,71 @@ func TestDaemonStartStalePIDFileUsesReachableLooperdAPI(t *testing.T) {
 	}
 }
 
+func TestDaemonStartAliveNonLooperdPIDFileUsesReachableLooperdAPI(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeLooperdStatusEnvelope(t, w)
+	}))
+	defer server.Close()
+
+	homeDir := t.TempDir()
+	pidFilePath := filepath.Join(homeDir, ".looper", "looperd.pid")
+	configPath := writeDaemonCLIConfigForBindEndpoint(t, server.URL, nil)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	removed := false
+	app := New(Deps{
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: homeDir,
+		ReadFile: func(path string) ([]byte, error) {
+			if path == pidFilePath {
+				return []byte("9876\n"), nil
+			}
+			return nil, os.ErrNotExist
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "ps" && len(args) >= 2 && args[1] == "9876" {
+				return commandExecutionResult{Stdout: "/usr/bin/sleep\n", ExitCode: 0}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+		KillProcess: func(pid int, signal int) error {
+			if pid != 9876 || signal != 0 {
+				t.Fatalf("KillProcess(%d, %d), want liveness probe for pid 9876", pid, signal)
+			}
+			return nil
+		},
+		RemoveFile: func(path string) error {
+			if path == pidFilePath {
+				removed = true
+			}
+			return nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			t.Fatal("SpawnDetached() called, want existing API reused")
+			return 0, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon start]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !removed {
+		t.Fatal("stale pid file pointing at alive non-looperd process was not removed")
+	}
+	if !strings.Contains(stdout.String(), "pid file points to non-looperd pid 9876") || !strings.Contains(stdout.String(), server.URL) {
+		t.Fatalf("stdout = %q, want already running message with URL and non-looperd pid", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestDaemonStartNonLooperdAPIServiceFailsBeforeSpawn(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -468,6 +469,81 @@ func TestDaemonStartReadinessLoopWaitsForStatus(t *testing.T) {
 	}
 	if requests < 3 {
 		t.Fatalf("status requests = %d, want readiness loop to retry until ready", requests)
+	}
+}
+
+func TestDaemonStartReadinessTimeoutTerminatesSpawnedProcessAndRemovesPIDFile(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	pidFilePath := filepath.Join(homeDir, ".looper", "looperd.pid")
+	configPath := writeDaemonCLIConfig(t, "http://127.0.0.1:1")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	removeCalls := make([]string, 0, 1)
+	killCalls := make([]struct {
+		pid    int
+		signal int
+	}, 0, 8)
+	app := New(Deps{
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: homeDir,
+		ReadFile: func(path string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		},
+		RunCommand: daemonVersionCommand(filepath.Join(homeDir, ".looper", "bin", "looperd")),
+		Getwd: func() (string, error) {
+			return "/tmp/workspace", nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			return 4321, nil
+		},
+		KillProcess: func(pid int, signal int) error {
+			killCalls = append(killCalls, struct {
+				pid    int
+				signal int
+			}{pid: pid, signal: signal})
+			return nil
+		},
+		MkdirAll: func(path string, perm os.FileMode) error {
+			return nil
+		},
+		RemoveFile: func(path string) error {
+			removeCalls = append(removeCalls, path)
+			return nil
+		},
+		WriteFile: func(path string, data []byte, perm os.FileMode) error {
+			t.Fatalf("WriteFile(%q) called, want readiness failure before pid file write", path)
+			return nil
+		},
+		Sleep: func(duration time.Duration) {},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath})
+	if exitCode == 0 {
+		t.Fatal("Run([daemon start]) exit code = 0, want non-zero")
+	}
+	if got := len(removeCalls); got != 1 || removeCalls[0] != pidFilePath {
+		t.Fatalf("removeCalls = %#v, want [%q]", removeCalls, pidFilePath)
+	}
+	if got := len(killCalls); got < 3 {
+		t.Fatalf("killCalls = %#v, want readiness liveness probes plus SIGTERM cleanup", killCalls)
+	}
+	lastKill := killCalls[len(killCalls)-1]
+	if lastKill.pid != 4321 || lastKill.signal != int(syscall.SIGTERM) {
+		t.Fatalf("last kill call = %#v, want pid 4321 SIGTERM", lastKill)
+	}
+	for i, call := range killCalls[:len(killCalls)-1] {
+		if call.pid != 4321 || call.signal != 0 {
+			t.Fatalf("killCalls[%d] = %#v, want pid 4321 signal 0 readiness probe", i, call)
+		}
+	}
+	if !strings.Contains(stderr.String(), "Timed out waiting for looperd pid 4321 to become ready") {
+		t.Fatalf("stderr = %q, want readiness timeout", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "last readiness error") {
+		t.Fatalf("stderr = %q, want last readiness error details", stderr.String())
 	}
 }
 

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -122,7 +122,8 @@ func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 
 	homeDir := t.TempDir()
 	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
-	configPath := filepath.Join(t.TempDir(), "config.json")
+	configPath := writeDaemonCLIConfig(t, "http://daemon.test")
+	statusRequests := 0
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	spawned := struct {
@@ -142,6 +143,13 @@ func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 		Stdout:  stdout,
 		Stderr:  stderr,
 		HomeDir: homeDir,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			statusRequests++
+			if statusRequests == 1 {
+				return nil, os.ErrNotExist
+			}
+			return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"binary":{"name":"looperd"}}}}`), nil
+		})},
 		Getwd: func() (string, error) {
 			return "/tmp/workspace", nil
 		},
@@ -189,7 +197,7 @@ func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 		},
 	})
 
-	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath, "--port", "9999", "--db-path", "/tmp/looper.sqlite"})
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath, "--db-path", "/tmp/looper.sqlite"})
 	if exitCode != 0 {
 		t.Fatalf("Run([daemon start]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
@@ -199,8 +207,8 @@ func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 	if spawned.command != managedPath {
 		t.Fatalf("spawned.command = %q, want %q", spawned.command, managedPath)
 	}
-	if got, want := strings.Join(spawned.args, "\n"), strings.Join([]string{"--config", configPath, "--port", "9999", "--db-path", "/tmp/looper.sqlite"}, "\n"); got != want {
-		t.Fatalf("spawned.args = %#v, want %#v", spawned.args, []string{"--config", configPath, "--port", "9999", "--db-path", "/tmp/looper.sqlite"})
+	if got, want := strings.Join(spawned.args, "\n"), strings.Join([]string{"--config", configPath, "--db-path", "/tmp/looper.sqlite"}, "\n"); got != want {
+		t.Fatalf("spawned.args = %#v, want %#v", spawned.args, []string{"--config", configPath, "--db-path", "/tmp/looper.sqlite"})
 	}
 	if spawned.cwd != "/tmp/workspace" {
 		t.Fatalf("spawned.cwd = %q, want %q", spawned.cwd, "/tmp/workspace")
@@ -214,11 +222,252 @@ func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 	if wroteBody != "4321\n" {
 		t.Fatalf("wroteBody = %q, want %q", wroteBody, "4321\n")
 	}
-	if len(killCalls) != 1 || killCalls[0].pid != 4321 || killCalls[0].signal != 0 {
-		t.Fatalf("killCalls = %#v, want only signal 0 probe for pid 4321", killCalls)
+	if len(killCalls) != 2 || killCalls[0].pid != 4321 || killCalls[0].signal != 0 || killCalls[1].pid != 4321 || killCalls[1].signal != 0 {
+		t.Fatalf("killCalls = %#v, want readiness liveness probes for pid 4321", killCalls)
 	}
 	if !strings.Contains(stdout.String(), "Started looperd") {
 		t.Fatalf("stdout = %q, want start confirmation", stdout.String())
+	}
+}
+
+func TestDaemonStartMissingPIDFileUsesReachableLooperdAPI(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/api/v1/status" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		writeLooperdStatusEnvelope(t, w)
+	}))
+	defer server.Close()
+
+	configPath := writeDaemonCLIConfig(t, server.URL)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		ReadFile: func(path string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		},
+		RunCommand: daemonVersionCommand(t.TempDir()),
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			t.Fatal("SpawnDetached() called, want existing API reused")
+			return 0, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon start]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "pid file missing") || !strings.Contains(stdout.String(), server.URL) {
+		t.Fatalf("stdout = %q, want already running message with URL and missing pid", stdout.String())
+	}
+	if requests == 0 {
+		t.Fatal("status endpoint was not probed")
+	}
+}
+
+func TestDaemonStartStalePIDFileUsesReachableLooperdAPI(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeLooperdStatusEnvelope(t, w)
+	}))
+	defer server.Close()
+
+	homeDir := t.TempDir()
+	pidFilePath := filepath.Join(homeDir, ".looper", "looperd.pid")
+	configPath := writeDaemonCLIConfig(t, server.URL)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	removed := false
+	app := New(Deps{
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: homeDir,
+		ReadFile: func(path string) ([]byte, error) {
+			if path == pidFilePath {
+				return []byte("9876\n"), nil
+			}
+			return nil, os.ErrNotExist
+		},
+		RunCommand: daemonVersionCommand(filepath.Join(homeDir, ".looper", "bin", "looperd")),
+		KillProcess: func(pid int, signal int) error {
+			if pid == 9876 && signal == 0 {
+				return os.ErrProcessDone
+			}
+			return nil
+		},
+		RemoveFile: func(path string) error {
+			if path == pidFilePath {
+				removed = true
+			}
+			return nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			t.Fatal("SpawnDetached() called, want existing API reused")
+			return 0, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon start]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !removed {
+		t.Fatal("stale pid file was not removed")
+	}
+	if !strings.Contains(stdout.String(), "Removed stale daemon pid file") || !strings.Contains(stdout.String(), "pid file missing") {
+		t.Fatalf("stdout = %q, want stale removal and API success messages", stdout.String())
+	}
+}
+
+func TestDaemonStartNonLooperdAPIServiceFailsBeforeSpawn(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(t, w, pkgapi.Success("req_status", map[string]any{
+			"service": map[string]any{"binary": map[string]any{"name": "not-looperd"}},
+		}))
+	}))
+	defer server.Close()
+
+	configPath := writeDaemonCLIConfig(t, server.URL)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		ReadFile: func(path string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		},
+		RunCommand: daemonVersionCommand(t.TempDir()),
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			t.Fatal("SpawnDetached() called, want port occupation failure")
+			return 0, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath})
+	if exitCode == 0 {
+		t.Fatal("Run([daemon start]) exit code = 0, want non-zero")
+	}
+	if !strings.Contains(stderr.String(), "occupied by another service") {
+		t.Fatalf("stderr = %q, want occupied-by-another-service diagnostic", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestDaemonStartExitedProcessIncludesStartupLogTail(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeDaemonCLIConfig(t, "http://127.0.0.1:1")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		ReadFile: func(path string) ([]byte, error) {
+			if strings.Contains(path, filepath.Join("startup", "looperd-")) {
+				return []byte("line one\nconfig validation failed: missing storage.dbPath\n"), nil
+			}
+			return nil, os.ErrNotExist
+		},
+		RunCommand: daemonVersionCommand(t.TempDir()),
+		Getwd: func() (string, error) {
+			return "/tmp/workspace", nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			return 4321, nil
+		},
+		KillProcess: func(pid int, signal int) error {
+			if pid == 4321 && signal == 0 {
+				return os.ErrProcessDone
+			}
+			return nil
+		},
+		MkdirAll: func(path string, perm os.FileMode) error {
+			return nil
+		},
+		RemoveFile: func(path string) error {
+			return nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath})
+	if exitCode == 0 {
+		t.Fatal("Run([daemon start]) exit code = 0, want non-zero")
+	}
+	if !strings.Contains(stderr.String(), "startup log:") || !strings.Contains(stderr.String(), "config validation failed") {
+		t.Fatalf("stderr = %q, want startup log path and tail", stderr.String())
+	}
+}
+
+func TestDaemonStartReadinessLoopWaitsForStatus(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			writeEnvelope(t, w, map[string]any{"ok": false, "requestId": "req_not_ready", "error": map[string]any{"message": "not ready"}})
+			return
+		}
+		writeLooperdStatusEnvelope(t, w)
+	}))
+	defer server.Close()
+
+	configPath := writeDaemonCLIConfig(t, server.URL)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	clientRequests := 0
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			clientRequests++
+			if clientRequests == 1 {
+				return nil, os.ErrNotExist
+			}
+			return http.DefaultTransport.RoundTrip(req)
+		})},
+		ReadFile: func(path string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{Stdout: "0.7.0\n", ExitCode: 0}, nil
+			}
+			if command == "ps" && len(args) >= 2 && args[1] == "4321" {
+				return commandExecutionResult{Stdout: filepath.Join(t.TempDir(), "looperd") + "\n", ExitCode: 0}, nil
+			}
+			return commandExecutionResult{ExitCode: 1}, nil
+		},
+		Getwd: func() (string, error) { return "/tmp/workspace", nil },
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			return 4321, nil
+		},
+		KillProcess: func(pid int, signal int) error { return nil },
+		MkdirAll:    func(path string, perm os.FileMode) error { return nil },
+		WriteFile:   func(path string, data []byte, perm os.FileMode) error { return nil },
+		Sleep:       func(duration time.Duration) {},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon start]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if requests < 3 {
+		t.Fatalf("status requests = %d, want readiness loop to retry until ready", requests)
 	}
 }
 
@@ -608,4 +857,28 @@ func writeDaemonCLIConfig(t *testing.T, baseURL string) string {
 		t.Fatalf("WriteFile(config) error = %v", err)
 	}
 	return configPath
+}
+
+func writeLooperdStatusEnvelope(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	writeEnvelope(t, w, pkgapi.Success("req_status", map[string]any{
+		"service": map[string]any{
+			"version": "0.7.0",
+			"binary": map[string]any{
+				"name": "looperd",
+			},
+		},
+	}))
+}
+
+func daemonVersionCommand(managedPath string) runCommandFunc {
+	return func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+		_ = ctx
+		_ = timeout
+		_ = managedPath
+		if strings.Join(args, " ") == "--version" {
+			return commandExecutionResult{Stdout: "0.7.0\n", ExitCode: 0}, nil
+		}
+		return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+	}
 }

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -493,6 +493,9 @@ func TestDaemonRestartStopsExistingPIDAndStartsReplacement(t *testing.T) {
 		Stdout:  stdout,
 		Stderr:  stderr,
 		HomeDir: homeDir,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_status","data":{"service":{"binary":{"name":"looperd"}}}}`), nil
+		})},
 		Getwd: func() (string, error) {
 			return "/tmp/workspace", nil
 		},

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -17,8 +17,10 @@ import (
 )
 
 type commandRuntime struct {
-	app  *App
-	argv []string
+	app               *App
+	argv              []string
+	startupOutputPath string
+	skipAPIStartProbe bool
 }
 
 func newCommandRuntime(app *App, argv []string) *commandRuntime {

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -717,7 +717,7 @@ func TestManagedDaemonInstallUpgradeLifecycleEndToEnd(t *testing.T) {
 				if runningPID == 0 {
 					return nil, fmt.Errorf("daemon offline")
 				}
-				return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"requestId":"req_status","data":{"service":{"version":%q}}}`, runningVersion)), nil
+				return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"requestId":"req_status","data":{"service":{"version":%q,"binary":{"name":"looperd"}}}}`, runningVersion)), nil
 			default:
 				t.Fatalf("unexpected request URL %q", req.URL.String())
 				return nil, nil

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -711,7 +711,7 @@ func TestManagedDaemonInstallUpgradeLifecycleEndToEnd(t *testing.T) {
 				return binaryResponse(t, http.StatusOK, newBinary), nil
 			case "https://example.invalid/looperd-darwin-arm64-v0.3.0.sha256":
 				return textResponse(t, http.StatusOK, hex.EncodeToString(newChecksum[:])+"  looperd-darwin-arm64\n"), nil
-			case "http://daemon.test/api/v1/status":
+			case "http://daemon.test/api/v1/status", "http://127.0.0.1:4310/api/v1/status":
 				mu.Lock()
 				defer mu.Unlock()
 				if runningPID == 0 {


### PR DESCRIPTION
## Summary
- Treat the daemon API status fingerprint as the source of truth before spawning, including missing/stale PID file cases.
- Capture detached startup output in restrictive startup logs and include bounded log tails in startup failures/timeouts.
- Replace the fixed startup sleep with a readiness loop that waits for looperd status and reports actionable diagnostics.

## Validation
- go vet ./...
- go test ./...
- go build ./...

Closes #107