### PR TITLE
feat: add config update commands

### DIFF
--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -143,11 +143,22 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 			newCommand(commandSpec{
 				use:             "config",
 				short:           "Config commands",
-				helpSubcommands: []helpSubcommand{{name: "show", description: "Show active config"}},
+				helpSubcommands: []helpSubcommand{{name: "get", description: "Get a config file value"}, {name: "set", description: "Set a config file value"}, {name: "unset", description: "Unset a config file value"}, {name: "validate", description: "Validate the config file"}, {name: "show", description: "Show active config"}, {name: "edit", description: "Edit the config file"}},
 				helpWhenNoArgs:  true,
-				exampleLines:    []string{"$ looper config show --json"},
+				exampleLines: []string{
+					"$ looper config get defaults.allowRiskyFixes",
+					"$ looper config set defaults.allowRiskyFixes true",
+					"$ looper config unset defaults.allowRiskyFixes",
+					"$ looper config validate",
+					"$ looper config show --source",
+				},
 				subcommands: []*cobra.Command{
-					newCommand(commandSpec{use: "show", short: "Show active config", runE: runtime.configShow}),
+					newCommand(commandSpec{use: "get <key>", short: "Get a config file value", args: cobra.ExactArgs(1), runE: runtime.configGet}),
+					newCommand(commandSpec{use: "set <key> <value>", short: "Set a config file value", args: cobra.ExactArgs(2), runE: runtime.configSet}),
+					newCommand(commandSpec{use: "unset <key>", short: "Unset a config file value", args: cobra.ExactArgs(1), runE: runtime.configUnset}),
+					newCommand(commandSpec{use: "validate", short: "Validate the config file", runE: runtime.configValidate}),
+					newCommand(commandSpec{use: "show", short: "Show active config", runE: runtime.configShow, localFlags: []flagSpec{boolFlag("source", "Show config file values with their source layer")}}),
+					newCommand(commandSpec{use: "edit", short: "Edit the config file", runE: runtime.configEdit}),
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -50,7 +50,7 @@ func TestCommandGroupHelpListsExpectedSubcommands(t *testing.T) {
 		subcommands []string
 	}{
 		{args: []string{"project", "--help"}, subcommands: []string{"list    List projects", "add     Add a project", "remove  Remove a project"}},
-		{args: []string{"config", "--help"}, subcommands: []string{"show  Show active config"}},
+		{args: []string{"config", "--help"}, subcommands: []string{"get       Get a config file value", "set       Set a config file value", "unset     Unset a config file value", "validate  Validate the config file", "show      Show active config", "edit      Edit the config file"}},
 		{args: []string{"daemon", "--help"}, subcommands: []string{"install  Install the managed daemon binary", "status   Show daemon status", "start    Start the daemon", "stop     Stop the daemon", "restart  Restart the daemon", "logs     Show daemon logs"}},
 		{args: []string{"loop", "--help"}, subcommands: []string{"list   List loops", "start  Start a loop", "pause  Pause a loop"}},
 		{args: []string{"pr", "--help"}, subcommands: []string{"list    List pull requests", "show    Show a pull request", "status  Show pull request status"}},
@@ -559,6 +559,112 @@ func TestConfigShowWithoutJSONPrintsJSON(t *testing.T) {
 		t.Fatalf("Run([config show]) stderr = %q, want empty string", stderr)
 	}
 	assertJSONContains(t, stdout, "server", map[string]any{"authMode": "none"})
+}
+
+func TestConfigSetGetUnsetAllowRiskyFixes(t *testing.T) {
+	configPath := writeEditableCLIConfig(t)
+
+	exitCode, stdout, stderr := runApp(t, "config", "set", "defaults.allowRiskyFixes", "true", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([config set ...]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "Set defaults.allowRiskyFixes") {
+		t.Fatalf("stdout = %q, want set confirmation", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	exitCode, stdout, stderr = runApp(t, "config", "get", "defaults.allowRiskyFixes", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([config get ...]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if strings.TrimSpace(stdout) != "true" {
+		t.Fatalf("stdout = %q, want true", stdout)
+	}
+
+	exitCode, stdout, stderr = runApp(t, "config", "unset", "defaults.allowRiskyFixes", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([config unset ...]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "Unset defaults.allowRiskyFixes") {
+		t.Fatalf("stdout = %q, want unset confirmation", stdout)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(raw), "allowRiskyFixes") {
+		t.Fatalf("config = %s, want allowRiskyFixes removed", raw)
+	}
+}
+
+func TestConfigSetRejectsInvalidKeyAndValue(t *testing.T) {
+	configPath := writeEditableCLIConfig(t)
+
+	exitCode, _, stderr := runApp(t, "config", "set", "defaults.missing", "true", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatalf("Run([config set invalid key]) exit code = %d, want non-zero", exitCode)
+	}
+	if !strings.Contains(stderr, "unsupported config key") {
+		t.Fatalf("stderr = %q, want unsupported key", stderr)
+	}
+
+	exitCode, _, stderr = runApp(t, "config", "set", "defaults.allowRiskyFixes", "maybe", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatalf("Run([config set invalid value]) exit code = %d, want non-zero", exitCode)
+	}
+	if !strings.Contains(stderr, "not a boolean") {
+		t.Fatalf("stderr = %q, want boolean error", stderr)
+	}
+}
+
+func TestConfigValidateAndShowSource(t *testing.T) {
+	configPath := writeEditableCLIConfig(t)
+
+	exitCode, stdout, stderr := runApp(t, "config", "validate", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([config validate]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "Config valid") {
+		t.Fatalf("stdout = %q, want validation confirmation", stdout)
+	}
+
+	exitCode, stdout, stderr = runApp(t, "config", "show", "--source", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([config show --source]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("unmarshal source output: %v", err)
+	}
+	fields, ok := decoded["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("fields = %#v, want object", decoded["fields"])
+	}
+	allowRisky, ok := fields["defaults.allowRiskyFixes"].(map[string]any)
+	if !ok {
+		t.Fatalf("defaults.allowRiskyFixes = %#v, want object", fields["defaults.allowRiskyFixes"])
+	}
+	if got, want := allowRisky["source"], "config-file"; got != want {
+		t.Fatalf("source = %#v, want %#v", got, want)
+	}
+	if got, want := allowRisky["value"], false; got != want {
+		t.Fatalf("value = %#v, want %#v", got, want)
+	}
+}
+
+func TestConfigSetWarnsWhenFlagOverridesWrittenValue(t *testing.T) {
+	configPath := writeEditableCLIConfig(t)
+
+	exitCode, _, stderr := runApp(t, "config", "set", "defaults.fixAllPullRequests", "false", "--fix-all-pull-requests", "true", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([config set with override]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "warning: --fix-all-pull-requests is set") {
+		t.Fatalf("stderr = %q, want override warning", stderr)
+	}
 }
 
 func TestProjectListWithoutJSONPrintsTable(t *testing.T) {
@@ -1613,6 +1719,28 @@ func writeCLIConfig(t *testing.T, baseURL string, localToken string) string {
 		t.Fatalf("write config: %v", err)
 	}
 
+	return configPath
+}
+
+func writeEditableCLIConfig(t *testing.T) string {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	configPayload := map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": false},
+		},
+		"defaults": map[string]any{
+			"allowRiskyFixes": false,
+		},
+	}
+	raw, err := json.Marshal(configPayload)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 	return configPath
 }
 

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -42,6 +42,17 @@ func runAppWithContext(t *testing.T, ctx context.Context, args ...string) (int, 
 	return exitCode, stdout.String(), stderr.String()
 }
 
+func runAppWithLookPath(t *testing.T, lookPath config.LookPathFunc, args ...string) (int, string, string) {
+	t.Helper()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, LookPath: lookPath})
+	exitCode := app.Run(context.Background(), args)
+
+	return exitCode, stdout.String(), stderr.String()
+}
+
 func TestCommandGroupHelpListsExpectedSubcommands(t *testing.T) {
 	t.Parallel()
 
@@ -665,6 +676,132 @@ func TestConfigValidateAndShowSource(t *testing.T) {
 	}
 	if got, want := allowRisky["value"], false; got != want {
 		t.Fatalf("value = %#v, want %#v", got, want)
+	}
+}
+
+func TestConfigValidateRejectsEnabledOsascriptNotificationsWithoutResolvedPath(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": true, "throttleWindowSeconds": 60},
+		},
+		"defaults": map[string]any{
+			"allowRiskyFixes": false,
+		},
+	})
+
+	exitCode, stdout, stderr := runAppWithLookPath(t, func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}, "config", "validate", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatalf("Run([config validate]) exit code = %d, want non-zero", exitCode)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "tools.osascriptPath") || !strings.Contains(stderr, "notifications.osascript.enabled is true") {
+		t.Fatalf("stderr = %q, want osascript validation error", stderr)
+	}
+}
+
+func TestConfigSetRejectsWriteWhenEnabledOsascriptNotificationsLackResolvedPath(t *testing.T) {
+	configPath := writeEditableCLIConfigWithPayload(t, invalidOsascriptNotificationConfigPayload(false))
+	t.Setenv("LOOPER_CONFIG", writeEditableCLIConfig(t))
+
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config before set: %v", err)
+	}
+
+	exitCode, stdout, stderr := runAppWithLookPath(t, func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}, "config", "set", "defaults.allowRiskyFixes", "true", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatalf("Run([config set ...]) exit code = %d, want non-zero", exitCode)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "tools.osascriptPath") || !strings.Contains(stderr, "notifications.osascript.enabled is true") {
+		t.Fatalf("stderr = %q, want osascript validation error", stderr)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after set: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("config changed after failed set\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+func TestConfigUnsetRejectsWriteWhenEnabledOsascriptNotificationsLackResolvedPath(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeEditableCLIConfigWithPayload(t, invalidOsascriptNotificationConfigPayload(true))
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config before unset: %v", err)
+	}
+
+	exitCode, stdout, stderr := runAppWithLookPath(t, func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}, "config", "unset", "defaults.allowRiskyFixes", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatalf("Run([config unset ...]) exit code = %d, want non-zero", exitCode)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "tools.osascriptPath") || !strings.Contains(stderr, "notifications.osascript.enabled is true") {
+		t.Fatalf("stderr = %q, want osascript validation error", stderr)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after unset: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("config changed after failed unset\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+func TestConfigEditRejectsEnabledOsascriptNotificationsWithoutResolvedPath(t *testing.T) {
+	configPath := writeEditableCLIConfig(t)
+	editorPath := filepath.Join(t.TempDir(), "editor.sh")
+	editorScript := `#!/bin/sh
+cat > "$1" <<'EOF'
+{"notifications":{"osascript":{"enabled":true,"throttleWindowSeconds":60}},"defaults":{"allowRiskyFixes":false}}
+EOF
+`
+	if err := os.WriteFile(editorPath, []byte(editorScript), 0o755); err != nil {
+		t.Fatalf("write editor script: %v", err)
+	}
+	t.Setenv("EDITOR", editorPath)
+
+	exitCode, stdout, stderr := runAppWithLookPath(t, func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}, "config", "edit", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatalf("Run([config edit]) exit code = %d, want non-zero", exitCode)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "tools.osascriptPath") || !strings.Contains(stderr, "notifications.osascript.enabled is true") {
+		t.Fatalf("stderr = %q, want osascript validation error", stderr)
+	}
+}
+
+func invalidOsascriptNotificationConfigPayload(allowRiskyFixes bool) map[string]any {
+	return map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": true, "throttleWindowSeconds": 60},
+		},
+		"defaults": map[string]any{
+			"allowRiskyFixes": allowRiskyFixes,
+		},
 	}
 }
 
@@ -1738,8 +1875,7 @@ func writeCLIConfig(t *testing.T, baseURL string, localToken string) string {
 func writeEditableCLIConfig(t *testing.T) string {
 	t.Helper()
 
-	configPath := filepath.Join(t.TempDir(), "config.json")
-	configPayload := map[string]any{
+	return writeEditableCLIConfigWithPayload(t, map[string]any{
 		"notifications": map[string]any{
 			"osascript": map[string]any{"enabled": false},
 		},
@@ -1747,7 +1883,13 @@ func writeEditableCLIConfig(t *testing.T) string {
 			"allowRiskyFixes":    false,
 			"fixAllPullRequests": false,
 		},
-	}
+	})
+}
+
+func writeEditableCLIConfigWithPayload(t *testing.T, configPayload map[string]any) string {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
 	raw, err := json.Marshal(configPayload)
 	if err != nil {
 		t.Fatalf("marshal config: %v", err)

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -600,6 +600,19 @@ func TestConfigSetGetUnsetAllowRiskyFixes(t *testing.T) {
 	}
 }
 
+func TestConfigGetReadsConfigFileLayer(t *testing.T) {
+	configPath := writeEditableCLIConfig(t)
+	t.Setenv("LOOPER_FIX_ALL_PULL_REQUESTS", "true")
+
+	exitCode, stdout, stderr := runApp(t, "config", "get", "defaults.fixAllPullRequests", "--fix-all-pull-requests", "true", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([config get ...]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if strings.TrimSpace(stdout) != "false" {
+		t.Fatalf("stdout = %q, want config file value false", stdout)
+	}
+}
+
 func TestConfigSetRejectsInvalidKeyAndValue(t *testing.T) {
 	configPath := writeEditableCLIConfig(t)
 
@@ -1731,7 +1744,8 @@ func writeEditableCLIConfig(t *testing.T) string {
 			"osascript": map[string]any{"enabled": false},
 		},
 		"defaults": map[string]any{
-			"allowRiskyFixes": false,
+			"allowRiskyFixes":    false,
+			"fixAllPullRequests": false,
 		},
 	}
 	raw, err := json.Marshal(configPayload)

--- a/internal/cliapp/config_commands.go
+++ b/internal/cliapp/config_commands.go
@@ -68,9 +68,6 @@ func (r *commandRuntime) configSet(cmd *cobra.Command, args []string) error {
 	if err := r.writeConfigFile(loaded.Metadata.ConfigPath, partial); err != nil {
 		return err
 	}
-	if err := validatePartialConfig(partial); err != nil {
-		return err
-	}
 	r.warnConfigOverrides(cmd, field)
 	if getBoolFlag(cmd, "json") {
 		return writeJSON(cmd.OutOrStdout(), map[string]any{"key": field.key, "configPath": loaded.Metadata.ConfigPath, "updated": true})
@@ -93,9 +90,6 @@ func (r *commandRuntime) configUnset(cmd *cobra.Command, args []string) error {
 	if err := r.writeConfigFile(loaded.Metadata.ConfigPath, partial); err != nil {
 		return err
 	}
-	if err := validatePartialConfig(partial); err != nil {
-		return err
-	}
 	r.warnConfigOverrides(cmd, field)
 	if getBoolFlag(cmd, "json") {
 		return writeJSON(cmd.OutOrStdout(), map[string]any{"key": field.key, "configPath": loaded.Metadata.ConfigPath, "updated": true})
@@ -105,11 +99,8 @@ func (r *commandRuntime) configUnset(cmd *cobra.Command, args []string) error {
 }
 
 func (r *commandRuntime) configValidate(cmd *cobra.Command, args []string) error {
-	loaded, err := r.loadRawConfigForEdit()
+	loaded, err := r.loadConfigForEdit()
 	if err != nil {
-		return err
-	}
-	if err := validatePartialConfig(loaded.Partial); err != nil {
 		return err
 	}
 	if getBoolFlag(cmd, "json") {
@@ -174,7 +165,7 @@ func (r *commandRuntime) configEdit(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := validatePartialConfig(loadedAfter.Partial); err != nil {
+	if err := r.validateConfigFile(loadedAfter.Metadata.ConfigPath); err != nil {
 		return err
 	}
 	if getBoolFlag(cmd, "json") {
@@ -185,7 +176,7 @@ func (r *commandRuntime) configEdit(cmd *cobra.Command, args []string) error {
 }
 
 func (r *commandRuntime) loadConfigForEdit() (config.LoadedFileConfig, error) {
-	return config.LoadFile(config.LoadFileOptions{Args: ExtractConfigArgs(r.argv), LookPath: r.app.deps.LookPath})
+	return config.LoadFile(config.LoadFileOptions{Args: ExtractConfigArgs(r.argv), LookPath: r.lookPath()})
 }
 
 func (r *commandRuntime) loadRawConfigForEdit() (config.LoadedFileConfig, error) {
@@ -244,14 +235,11 @@ func resolveConfigPathFromArgs(argv []string, cwd string) (string, error) {
 }
 
 func (r *commandRuntime) writeConfigFile(path string, partial config.PartialConfig) error {
-	if err := validatePartialConfig(partial); err != nil {
+	if err := r.validatePartialConfig(partial); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create config directory: %w", err)
-	}
-	if err := backupConfigFile(path); err != nil {
-		return err
 	}
 	raw, err := json.MarshalIndent(partial, "", "  ")
 	if err != nil {
@@ -271,13 +259,24 @@ func (r *commandRuntime) writeConfigFile(path string, partial config.PartialConf
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close temporary config: %w", err)
 	}
+	if err := r.validateConfigFile(tmpPath); err != nil {
+		return err
+	}
+	if err := backupConfigFile(path); err != nil {
+		return err
+	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("replace config: %w", err)
 	}
 	return nil
 }
 
-func validatePartialConfig(partial config.PartialConfig) error {
+func (r *commandRuntime) validateConfigFile(path string) error {
+	_, err := config.LoadFile(config.LoadFileOptions{Args: []string{"--config", path}, LookPath: r.lookPath()})
+	return err
+}
+
+func (r *commandRuntime) validatePartialConfig(partial config.PartialConfig) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("determine current working directory: %w", err)

--- a/internal/cliapp/config_commands.go
+++ b/internal/cliapp/config_commands.go
@@ -40,7 +40,7 @@ func (r *commandRuntime) configGet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	loaded, err := r.loadConfigForEdit()
+	loaded, err := r.loadRawConfigForEdit()
 	if err != nil {
 		return err
 	}

--- a/internal/cliapp/config_commands.go
+++ b/internal/cliapp/config_commands.go
@@ -25,7 +25,7 @@ type configField struct {
 }
 
 var configFieldRegistry = map[string]configField{
-	"defaults.baseBranch":         stringField("defaults.baseBranch", "LOOPER_BASE_BRANCH", "", func(c config.Config) any { return c.Defaults.BaseBranch }, func(p *config.PartialConfig) **string { return &ensurePartialDefaults(p).BaseBranch }),
+	"defaults.baseBranch":         stringField("defaults.baseBranch", "", "", func(c config.Config) any { return c.Defaults.BaseBranch }, func(p *config.PartialConfig) **string { return &ensurePartialDefaults(p).BaseBranch }),
 	"defaults.allowAutoCommit":    boolField("defaults.allowAutoCommit", "LOOPER_ALLOW_AUTO_COMMIT", "", func(c config.Config) any { return c.Defaults.AllowAutoCommit }, func(p *config.PartialConfig) **bool { return &ensurePartialDefaults(p).AllowAutoCommit }),
 	"defaults.allowAutoPush":      boolField("defaults.allowAutoPush", "LOOPER_ALLOW_AUTO_PUSH", "", func(c config.Config) any { return c.Defaults.AllowAutoPush }, func(p *config.PartialConfig) **bool { return &ensurePartialDefaults(p).AllowAutoPush }),
 	"defaults.allowAutoApprove":   boolField("defaults.allowAutoApprove", "LOOPER_ALLOW_AUTO_APPROVE", "", func(c config.Config) any { return c.Defaults.AllowAutoApprove }, func(p *config.PartialConfig) **bool { return &ensurePartialDefaults(p).AllowAutoApprove }),

--- a/internal/cliapp/config_commands.go
+++ b/internal/cliapp/config_commands.go
@@ -1,0 +1,430 @@
+package cliapp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/powerformer/looper/internal/config"
+	"github.com/spf13/cobra"
+)
+
+type configField struct {
+	key       string
+	valueType string
+	env       string
+	flag      string
+	get       func(config.Config) any
+	set       func(*config.PartialConfig, string) error
+	unset     func(*config.PartialConfig)
+}
+
+var configFieldRegistry = map[string]configField{
+	"defaults.baseBranch":         stringField("defaults.baseBranch", "LOOPER_BASE_BRANCH", "", func(c config.Config) any { return c.Defaults.BaseBranch }, func(p *config.PartialConfig) **string { return &ensurePartialDefaults(p).BaseBranch }),
+	"defaults.allowAutoCommit":    boolField("defaults.allowAutoCommit", "LOOPER_ALLOW_AUTO_COMMIT", "", func(c config.Config) any { return c.Defaults.AllowAutoCommit }, func(p *config.PartialConfig) **bool { return &ensurePartialDefaults(p).AllowAutoCommit }),
+	"defaults.allowAutoPush":      boolField("defaults.allowAutoPush", "LOOPER_ALLOW_AUTO_PUSH", "", func(c config.Config) any { return c.Defaults.AllowAutoPush }, func(p *config.PartialConfig) **bool { return &ensurePartialDefaults(p).AllowAutoPush }),
+	"defaults.allowAutoApprove":   boolField("defaults.allowAutoApprove", "LOOPER_ALLOW_AUTO_APPROVE", "", func(c config.Config) any { return c.Defaults.AllowAutoApprove }, func(p *config.PartialConfig) **bool { return &ensurePartialDefaults(p).AllowAutoApprove }),
+	"defaults.allowAutoMerge":     boolField("defaults.allowAutoMerge", "", "", func(c config.Config) any { return c.Defaults.AllowAutoMerge }, func(p *config.PartialConfig) **bool { return &ensurePartialDefaults(p).AllowAutoMerge }),
+	"defaults.allowRiskyFixes":    boolField("defaults.allowRiskyFixes", "", "", func(c config.Config) any { return c.Defaults.AllowRiskyFixes }, func(p *config.PartialConfig) **bool { return &ensurePartialDefaults(p).AllowRiskyFixes }),
+	"defaults.fixAllPullRequests": boolField("defaults.fixAllPullRequests", "LOOPER_FIX_ALL_PULL_REQUESTS", "fix-all-pull-requests", func(c config.Config) any { return c.Defaults.FixAllPullRequests }, func(p *config.PartialConfig) **bool { return &ensurePartialDefaults(p).FixAllPullRequests }),
+	"defaults.openPrStrategy":     openPRStrategyField(),
+}
+
+func (r *commandRuntime) configGet(cmd *cobra.Command, args []string) error {
+	field, err := lookupConfigField(args[0])
+	if err != nil {
+		return err
+	}
+	loaded, err := r.loadConfigForEdit()
+	if err != nil {
+		return err
+	}
+	value := field.get(loaded.Config)
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), map[string]any{"key": field.key, "value": value})
+	}
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), value)
+	return err
+}
+
+func (r *commandRuntime) configSet(cmd *cobra.Command, args []string) error {
+	field, err := lookupConfigField(args[0])
+	if err != nil {
+		return err
+	}
+	loaded, err := r.loadRawConfigForEdit()
+	if err != nil {
+		return err
+	}
+	partial := loaded.Partial
+	if err := field.set(&partial, args[1]); err != nil {
+		return err
+	}
+	if err := r.writeConfigFile(loaded.Metadata.ConfigPath, partial); err != nil {
+		return err
+	}
+	if err := validatePartialConfig(partial); err != nil {
+		return err
+	}
+	r.warnConfigOverrides(cmd, field)
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), map[string]any{"key": field.key, "configPath": loaded.Metadata.ConfigPath, "updated": true})
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Set %s in %s\n", field.key, loaded.Metadata.ConfigPath)
+	return err
+}
+
+func (r *commandRuntime) configUnset(cmd *cobra.Command, args []string) error {
+	field, err := lookupConfigField(args[0])
+	if err != nil {
+		return err
+	}
+	loaded, err := r.loadRawConfigForEdit()
+	if err != nil {
+		return err
+	}
+	partial := loaded.Partial
+	field.unset(&partial)
+	if err := r.writeConfigFile(loaded.Metadata.ConfigPath, partial); err != nil {
+		return err
+	}
+	if err := validatePartialConfig(partial); err != nil {
+		return err
+	}
+	r.warnConfigOverrides(cmd, field)
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), map[string]any{"key": field.key, "configPath": loaded.Metadata.ConfigPath, "updated": true})
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Unset %s in %s\n", field.key, loaded.Metadata.ConfigPath)
+	return err
+}
+
+func (r *commandRuntime) configValidate(cmd *cobra.Command, args []string) error {
+	loaded, err := r.loadRawConfigForEdit()
+	if err != nil {
+		return err
+	}
+	if err := validatePartialConfig(loaded.Partial); err != nil {
+		return err
+	}
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), map[string]any{"configPath": loaded.Metadata.ConfigPath, "valid": true})
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Config valid: %s\n", loaded.Metadata.ConfigPath)
+	return err
+}
+
+func (r *commandRuntime) configShowSource(cmd *cobra.Command) error {
+	loaded, err := r.loadConfigForEdit()
+	if err != nil {
+		return err
+	}
+	values := make(map[string]map[string]any, len(configFieldRegistry))
+	for key, field := range configFieldRegistry {
+		source := "default"
+		if configFieldSet(loaded.Partial, key) {
+			source = "config-file"
+		}
+		if field.env != "" {
+			if _, ok := os.LookupEnv(field.env); ok {
+				source = "env"
+			}
+		}
+		if field.flag != "" && commandFlagChanged(cmd, field.flag) {
+			source = "cli"
+		}
+		values[key] = map[string]any{"value": field.get(loaded.Config), "source": source}
+	}
+	return writeJSON(cmd.OutOrStdout(), map[string]any{"configPath": loaded.Metadata.ConfigPath, "fields": values})
+}
+
+func (r *commandRuntime) configEdit(cmd *cobra.Command, args []string) error {
+	loaded, err := r.loadRawConfigForEdit()
+	if err != nil {
+		return err
+	}
+	if !loaded.Metadata.ConfigFilePresent {
+		if err := r.writeConfigFile(loaded.Metadata.ConfigPath, loaded.Partial); err != nil {
+			return err
+		}
+	}
+	editor := os.Getenv("VISUAL")
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+	}
+	if editor == "" {
+		return fmt.Errorf("config edit requires VISUAL or EDITOR to be set")
+	}
+	if err := backupConfigFile(loaded.Metadata.ConfigPath); err != nil {
+		return err
+	}
+	editCmd := exec.CommandContext(cmd.Context(), "sh", "-c", editor+" \"$1\"", "looper-editor", loaded.Metadata.ConfigPath)
+	editCmd.Stdin = cmd.InOrStdin()
+	editCmd.Stdout = cmd.OutOrStdout()
+	editCmd.Stderr = cmd.ErrOrStderr()
+	if err := editCmd.Run(); err != nil {
+		return fmt.Errorf("run editor: %w", err)
+	}
+	loadedAfter, err := r.loadRawConfigForEdit()
+	if err != nil {
+		return err
+	}
+	if err := validatePartialConfig(loadedAfter.Partial); err != nil {
+		return err
+	}
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), map[string]any{"configPath": loaded.Metadata.ConfigPath, "valid": true})
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Config valid: %s\n", loaded.Metadata.ConfigPath)
+	return err
+}
+
+func (r *commandRuntime) loadConfigForEdit() (config.LoadedFileConfig, error) {
+	return config.LoadFile(config.LoadFileOptions{Args: ExtractConfigArgs(r.argv), LookPath: r.app.deps.LookPath})
+}
+
+func (r *commandRuntime) loadRawConfigForEdit() (config.LoadedFileConfig, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return config.LoadedFileConfig{}, fmt.Errorf("determine current working directory: %w", err)
+	}
+	configPath, err := resolveConfigPathFromArgs(r.argv, cwd)
+	if err != nil {
+		return config.LoadedFileConfig{}, err
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return config.LoadedFileConfig{}, fmt.Errorf("failed to read config file at %s: %w", configPath, err)
+		}
+		full, normErr := config.Normalize(cwd)
+		if normErr != nil {
+			return config.LoadedFileConfig{}, normErr
+		}
+		return config.LoadedFileConfig{Config: full, Partial: config.PartialConfig{}, Metadata: config.LoadFileMetadata{ConfigPath: configPath, ConfigFilePresent: false}}, nil
+	}
+	var partial config.PartialConfig
+	if err := json.Unmarshal(raw, &partial); err != nil {
+		return config.LoadedFileConfig{}, fmt.Errorf("failed to read config file at %s: %w", configPath, err)
+	}
+	full, err := config.Normalize(cwd, partial)
+	if err != nil {
+		return config.LoadedFileConfig{}, err
+	}
+	return config.LoadedFileConfig{Config: full, Partial: partial, Metadata: config.LoadFileMetadata{ConfigPath: configPath, ConfigFilePresent: true}}, nil
+}
+
+func resolveConfigPathFromArgs(argv []string, cwd string) (string, error) {
+	args := ExtractConfigArgs(argv)
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if arg == "--config" {
+			if index+1 >= len(args) {
+				return "", fmt.Errorf("missing value for --config")
+			}
+			return config.ResolveConfigPath(args[index+1], cwd), nil
+		}
+		if strings.HasPrefix(arg, "--config=") {
+			return config.ResolveConfigPath(strings.TrimPrefix(arg, "--config="), cwd), nil
+		}
+	}
+	if envPath, ok := os.LookupEnv("LOOPER_CONFIG"); ok {
+		return config.ResolveConfigPath(envPath, cwd), nil
+	}
+	defaultPath, err := config.DefaultConfigPath()
+	if err != nil {
+		return "", fmt.Errorf("determine default config path: %w", err)
+	}
+	return config.ResolveConfigPath(defaultPath, cwd), nil
+}
+
+func (r *commandRuntime) writeConfigFile(path string, partial config.PartialConfig) error {
+	if err := validatePartialConfig(partial); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+	if err := backupConfigFile(path); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(partial, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode config: %w", err)
+	}
+	raw = append(raw, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".config-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary config: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(raw); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temporary config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary config: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace config: %w", err)
+	}
+	return nil
+}
+
+func validatePartialConfig(partial config.PartialConfig) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("determine current working directory: %w", err)
+	}
+	full, err := config.Normalize(cwd, partial)
+	if err != nil {
+		return err
+	}
+	return config.Validate(full)
+}
+
+func backupConfigFile(path string) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read config for backup: %w", err)
+	}
+	backupPath := fmt.Sprintf("%s.%s.bak", path, time.Now().UTC().Format("20060102150405.000000000"))
+	if err := os.WriteFile(backupPath, raw, 0o600); err != nil {
+		return fmt.Errorf("write config backup: %w", err)
+	}
+	return nil
+}
+
+func (r *commandRuntime) warnConfigOverrides(cmd *cobra.Command, field configField) {
+	if field.env != "" {
+		if _, ok := os.LookupEnv(field.env); ok {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s is set, so %s from the config file may not take effect\n", field.env, field.key)
+		}
+	}
+	if field.flag != "" && commandFlagChanged(cmd, field.flag) {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: --%s is set, so %s from the config file may not take effect\n", field.flag, field.key)
+	}
+}
+
+func commandFlagChanged(cmd *cobra.Command, name string) bool {
+	flag := cmd.Flags().Lookup(name)
+	if flag != nil && flag.Changed {
+		return true
+	}
+	flag = cmd.InheritedFlags().Lookup(name)
+	return flag != nil && flag.Changed
+}
+
+func lookupConfigField(key string) (configField, error) {
+	field, ok := configFieldRegistry[key]
+	if !ok {
+		keys := make([]string, 0, len(configFieldRegistry))
+		for registered := range configFieldRegistry {
+			keys = append(keys, registered)
+		}
+		sort.Strings(keys)
+		return configField{}, fmt.Errorf("unsupported config key %q; supported keys: %s", key, strings.Join(keys, ", "))
+	}
+	return field, nil
+}
+
+func boolField(key, env, flag string, get func(config.Config) any, target func(*config.PartialConfig) **bool) configField {
+	return configField{key: key, valueType: "boolean", env: env, flag: flag, get: get, set: func(p *config.PartialConfig, raw string) error {
+		value, err := parseConfigBool(raw)
+		if err != nil {
+			return fmt.Errorf("invalid value for %s: %q is not a boolean (use true or false)", key, raw)
+		}
+		*target(p) = &value
+		return nil
+	}, unset: func(p *config.PartialConfig) {
+		if p.Defaults == nil {
+			return
+		}
+		*target(p) = nil
+	}}
+}
+
+func stringField(key, env, flag string, get func(config.Config) any, target func(*config.PartialConfig) **string) configField {
+	return configField{key: key, valueType: "string", env: env, flag: flag, get: get, set: func(p *config.PartialConfig, raw string) error {
+		if strings.TrimSpace(raw) == "" {
+			return fmt.Errorf("invalid value for %s: must be a non-empty string", key)
+		}
+		*target(p) = &raw
+		return nil
+	}, unset: func(p *config.PartialConfig) {
+		if p.Defaults == nil {
+			return
+		}
+		*target(p) = nil
+	}}
+}
+
+func openPRStrategyField() configField {
+	return configField{key: "defaults.openPrStrategy", valueType: "string", get: func(c config.Config) any { return c.Defaults.OpenPRStrategy }, set: func(p *config.PartialConfig, raw string) error {
+		switch config.OpenPRStrategy(raw) {
+		case config.OpenPRStrategyAllDone, config.OpenPRStrategyFirstCommit, config.OpenPRStrategyManual:
+			value := config.OpenPRStrategy(raw)
+			ensurePartialDefaults(p).OpenPRStrategy = &value
+			return nil
+		default:
+			return fmt.Errorf("invalid value for defaults.openPrStrategy: must be one of: %s, %s, %s", config.OpenPRStrategyAllDone, config.OpenPRStrategyFirstCommit, config.OpenPRStrategyManual)
+		}
+	}, unset: func(p *config.PartialConfig) {
+		if p.Defaults != nil {
+			p.Defaults.OpenPRStrategy = nil
+		}
+	}}
+}
+
+func parseConfigBool(raw string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "true", "1", "yes", "on":
+		return true, nil
+	case "false", "0", "no", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean")
+	}
+}
+
+func ensurePartialDefaults(partial *config.PartialConfig) *config.PartialDefaultsConfig {
+	if partial.Defaults == nil {
+		partial.Defaults = &config.PartialDefaultsConfig{}
+	}
+	return partial.Defaults
+}
+
+func configFieldSet(partial config.PartialConfig, key string) bool {
+	if partial.Defaults == nil {
+		return false
+	}
+	switch key {
+	case "defaults.baseBranch":
+		return partial.Defaults.BaseBranch != nil
+	case "defaults.allowAutoCommit":
+		return partial.Defaults.AllowAutoCommit != nil
+	case "defaults.allowAutoPush":
+		return partial.Defaults.AllowAutoPush != nil
+	case "defaults.allowAutoApprove":
+		return partial.Defaults.AllowAutoApprove != nil
+	case "defaults.allowAutoMerge":
+		return partial.Defaults.AllowAutoMerge != nil
+	case "defaults.allowRiskyFixes":
+		return partial.Defaults.AllowRiskyFixes != nil
+	case "defaults.fixAllPullRequests":
+		return partial.Defaults.FixAllPullRequests != nil
+	case "defaults.openPrStrategy":
+		return partial.Defaults.OpenPRStrategy != nil
+	default:
+		return false
+	}
+}

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -32,6 +32,9 @@ func (r *commandRuntime) status(cmd *cobra.Command, args []string) error {
 }
 
 func (r *commandRuntime) configShow(cmd *cobra.Command, args []string) error {
+	if getBoolFlag(cmd, "source") {
+		return r.configShowSource(cmd)
+	}
 	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
 		return r.getJSON(ctx, "/api/v1/config")
 	}, func(w io.Writer, payload json.RawMessage) error {


### PR DESCRIPTION
## Summary
- Add first-class `looper config get/set/unset/validate/edit` commands backed by an explicit allowlisted config-field registry.
- Persist config-file-layer updates with validation, backups, and atomic writes while warning about env/CLI overrides.
- Cover normal writes, invalid keys/values, validation/source output, and override warnings in CLI tests.

Closes #110