### PR TITLE
feat: show release download progress

### DIFF
--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -573,7 +573,7 @@ func (r *commandRuntime) ensureBootstrapDaemon(ctx context.Context, force bool) 
 		return "already-installed", false, nil
 	}
 	reinstall := force || installed != nil
-	result, err := r.installManagedDaemon(ctx, reinstall, "")
+	result, err := r.installManagedDaemon(ctx, reinstall, "", r.app.stderr())
 	if err != nil {
 		return "", false, fmt.Errorf("install managed daemon: %w", err)
 	}

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -121,8 +121,8 @@ func TestBootstrapYesInstallsStartsAndPrintsNextSteps(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([bootstrap --yes]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("Run([bootstrap --yes]) stderr = %q, want empty string", stderr.String())
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 14 B / 14 B (100%)") {
+		t.Fatalf("Run([bootstrap --yes]) stderr = %q, want daemon download progress", stderr.String())
 	}
 	if spawnCalls.Load() != 1 {
 		t.Fatalf("spawnDetached calls = %d, want 1", spawnCalls.Load())
@@ -256,8 +256,8 @@ func TestBootstrapJSONSuppressesDaemonStartOutput(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([bootstrap --yes --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("Run([bootstrap --yes --json]) stderr = %q, want empty string", stderr.String())
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 14 B / 14 B (100%)") {
+		t.Fatalf("Run([bootstrap --yes --json]) stderr = %q, want daemon download progress", stderr.String())
 	}
 	var decoded bootstrapResult
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {

--- a/internal/cliapp/daemon_install.go
+++ b/internal/cliapp/daemon_install.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -43,7 +44,7 @@ type githubReleaseAsset struct {
 func (r *commandRuntime) daemonInstall(cmd *cobra.Command, args []string) error {
 	_ = args
 
-	result, err := r.installManagedDaemon(cmd.Context(), getBoolFlag(cmd, "force"), "")
+	result, err := r.installManagedDaemon(cmd.Context(), getBoolFlag(cmd, "force"), "", cmd.ErrOrStderr())
 	if err != nil {
 		return fmt.Errorf("Failed to install looperd: %w", err)
 	}
@@ -68,7 +69,7 @@ func (r *commandRuntime) daemonInstall(cmd *cobra.Command, args []string) error 
 	return nil
 }
 
-func (r *commandRuntime) installManagedDaemon(ctx context.Context, force bool, tag string) (daemonInstallResult, error) {
+func (r *commandRuntime) installManagedDaemon(ctx context.Context, force bool, tag string, progress io.Writer) (daemonInstallResult, error) {
 	homeDir, err := r.homeDir()
 	if err != nil {
 		return daemonInstallResult{}, err
@@ -99,7 +100,7 @@ func (r *commandRuntime) installManagedDaemon(ctx context.Context, force bool, t
 		return daemonInstallResult{}, err
 	}
 
-	binaryBytes, err := r.downloadBinary(ctx, binaryAsset.BrowserDownloadURL)
+	binaryBytes, err := r.downloadBinary(ctx, binaryAsset.BrowserDownloadURL, binaryAsset.Name, progress)
 	if err != nil {
 		return daemonInstallResult{}, err
 	}
@@ -174,23 +175,15 @@ func (r *commandRuntime) fetchReleaseMetadata(ctx context.Context, tag string) (
 	return payload, nil
 }
 
-func (r *commandRuntime) downloadBinary(ctx context.Context, url string) ([]byte, error) {
-	data, _, err := r.download(ctx, url, "application/octet-stream")
-	if err != nil {
-		return nil, fmt.Errorf("Failed to download looperd binary from %s (%v)", url, err)
-	}
-	return data, nil
-}
-
 func (r *commandRuntime) downloadChecksum(ctx context.Context, url string) (string, error) {
-	data, _, err := r.download(ctx, url, "text/plain")
+	data, _, err := r.download(ctx, url, "text/plain", "", nil)
 	if err != nil {
 		return "", fmt.Errorf("Failed to download looperd checksum from %s (%v)", url, err)
 	}
 	return string(data), nil
 }
 
-func (r *commandRuntime) download(ctx context.Context, url string, accept string) ([]byte, *http.Response, error) {
+func (r *commandRuntime) download(ctx context.Context, url string, accept string, progressName string, progress io.Writer) ([]byte, *http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
@@ -208,11 +201,97 @@ func (r *commandRuntime) download(ctx context.Context, url string, accept string
 		return nil, resp, fmt.Errorf("status %s", resp.Status)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	reader := resp.Body
+	if progress != nil && strings.TrimSpace(progressName) != "" {
+		tracker := newDownloadProgress(progress, progressName, resp.ContentLength)
+		defer tracker.finish()
+		reader = struct {
+			io.Reader
+			io.Closer
+		}{Reader: io.TeeReader(resp.Body, tracker), Closer: resp.Body}
+	}
+
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, nil, err
 	}
 	return data, resp, nil
+}
+
+func (r *commandRuntime) downloadBinary(ctx context.Context, url string, name string, progress io.Writer) ([]byte, error) {
+	data, _, err := r.download(ctx, url, "application/octet-stream", name, progress)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to download release binary from %s (%v)", url, err)
+	}
+	return data, nil
+}
+
+type downloadProgress struct {
+	w        io.Writer
+	name     string
+	total    int64
+	read     int64
+	last     time.Time
+	finished bool
+}
+
+func newDownloadProgress(w io.Writer, name string, total int64) *downloadProgress {
+	p := &downloadProgress{w: w, name: name, total: total}
+	p.print(true)
+	return p
+}
+
+func (p *downloadProgress) Write(data []byte) (int, error) {
+	p.read += int64(len(data))
+	if time.Since(p.last) >= 200*time.Millisecond {
+		p.print(false)
+	}
+	return len(data), nil
+}
+
+func (p *downloadProgress) finish() {
+	if p.finished {
+		return
+	}
+	p.finished = true
+	p.print(false)
+	_, _ = fmt.Fprintln(p.w)
+}
+
+func (p *downloadProgress) print(initial bool) {
+	p.last = time.Now()
+	var line string
+	if p.total > 0 {
+		percent := 0
+		if p.total > 0 {
+			percent = int((p.read * 100) / p.total)
+		}
+		line = fmt.Sprintf("Downloading %s: %s / %s (%d%%)", p.name, formatDownloadBytes(p.read), formatDownloadBytes(p.total), percent)
+	} else if p.read > 0 {
+		line = fmt.Sprintf("Downloading %s: %s downloaded", p.name, formatDownloadBytes(p.read))
+	} else {
+		line = fmt.Sprintf("Downloading %s...", p.name)
+	}
+	if initial {
+		_, _ = fmt.Fprint(p.w, line)
+		return
+	}
+	_, _ = fmt.Fprintf(p.w, "\r%s", line)
+}
+
+func formatDownloadBytes(value int64) string {
+	const unit = 1024
+	if value < unit {
+		return fmt.Sprintf("%d B", value)
+	}
+	divisor := int64(unit)
+	unitIndex := 0
+	for n := value / unit; n >= unit && unitIndex < 3; n /= unit {
+		divisor *= unit
+		unitIndex++
+	}
+	number := strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.1f", float64(value)/float64(divisor)), "0"), ".")
+	return fmt.Sprintf("%s %ciB", number, "KMGT"[unitIndex])
 }
 
 func (r *commandRuntime) httpClient() *http.Client {

--- a/internal/cliapp/daemon_install_test.go
+++ b/internal/cliapp/daemon_install_test.go
@@ -65,7 +65,7 @@ func TestInstallManagedDaemonInstallsBinary(t *testing.T) {
 	})
 
 	runtime := newCommandRuntime(app, nil)
-	result, err := runtime.installManagedDaemon(context.Background(), false, "")
+	result, err := runtime.installManagedDaemon(context.Background(), false, "", nil)
 	if err != nil {
 		t.Fatalf("installManagedDaemon() error = %v", err)
 	}
@@ -119,7 +119,7 @@ func TestInstallManagedDaemonSkipsExistingBinary(t *testing.T) {
 	})
 
 	runtime := newCommandRuntime(app, nil)
-	result, err := runtime.installManagedDaemon(context.Background(), false, "")
+	result, err := runtime.installManagedDaemon(context.Background(), false, "", nil)
 	if err != nil {
 		t.Fatalf("installManagedDaemon() error = %v", err)
 	}
@@ -168,14 +168,46 @@ func TestDaemonInstallCommandPrintsHumanOutput(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([daemon install]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("Run([daemon install]) stderr = %q, want empty string", stderr.String())
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 3 B / 3 B (100%)") {
+		t.Fatalf("Run([daemon install]) stderr = %q, want download progress", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Installed looperd (darwin-arm64) to ") {
 		t.Fatalf("Run([daemon install]) stdout = %q, want install confirmation", stdout.String())
 	}
 	if !strings.Contains(stdout.String(), "Downloaded from https://example.invalid/looperd-darwin-arm64") {
 		t.Fatalf("Run([daemon install]) stdout = %q, want download URL", stdout.String())
+	}
+}
+
+func TestDownloadBinaryProgressFallsBackWhenLengthUnknown(t *testing.T) {
+	t.Parallel()
+
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != "https://example.invalid/looperd-darwin-arm64" {
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+			}
+			return &http.Response{
+				StatusCode:    http.StatusOK,
+				Status:        http.StatusText(http.StatusOK),
+				Header:        http.Header{"Content-Type": []string{"application/octet-stream"}},
+				Body:          io.NopCloser(strings.NewReader("abcd")),
+				ContentLength: -1,
+			}, nil
+		}),
+	})
+	runtime := newCommandRuntime(app, nil)
+
+	data, err := runtime.downloadBinary(context.Background(), "https://example.invalid/looperd-darwin-arm64", "looperd-darwin-arm64", stderr)
+	if err != nil {
+		t.Fatalf("downloadBinary() error = %v", err)
+	}
+	if string(data) != "abcd" {
+		t.Fatalf("downloadBinary() data = %q, want abcd", string(data))
+	}
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 4 B downloaded") {
+		t.Fatalf("progress = %q, want unknown-size fallback", stderr.String())
 	}
 }
 
@@ -212,9 +244,10 @@ func textResponse(t *testing.T, status int, body string) *http.Response {
 func binaryResponse(t *testing.T, status int, body []byte) *http.Response {
 	t.Helper()
 	return &http.Response{
-		StatusCode: status,
-		Status:     http.StatusText(status),
-		Header:     http.Header{"Content-Type": []string{"application/octet-stream"}},
-		Body:       io.NopCloser(bytes.NewReader(body)),
+		StatusCode:    status,
+		Status:        http.StatusText(status),
+		Header:        http.Header{"Content-Type": []string{"application/octet-stream"}},
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
 	}
 }

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -261,7 +261,7 @@ func (r *commandRuntime) upgradeDaemonWithOutput(cmd *cobra.Command, emitOutput 
 		return output, nil
 	}
 
-	result, err := r.installManagedDaemon(ctx, true, latestRelease.Tag)
+	result, err := r.installManagedDaemon(ctx, true, latestRelease.Tag, cmd.ErrOrStderr())
 	if err != nil {
 		return daemonUpgradeOutput{}, fmt.Errorf("Failed to upgrade looperd: %w", err)
 	}
@@ -484,7 +484,7 @@ func (r *commandRuntime) upgradeCLIWithOutput(cmd *cobra.Command, emitOutput boo
 	if err != nil {
 		return cliUpgradeOutput{}, err
 	}
-	binaryBytes, err := r.downloadBinary(ctx, binaryAsset.BrowserDownloadURL)
+	binaryBytes, err := r.downloadBinary(ctx, binaryAsset.BrowserDownloadURL, binaryAsset.Name, cmd.ErrOrStderr())
 	if err != nil {
 		return cliUpgradeOutput{}, fmt.Errorf("failed to download looper binary: %w", err)
 	}

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -340,8 +340,8 @@ func TestUpgradeWithoutFlagsWritesSingleJSONDocument(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([upgrade --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("Run([upgrade --json]) stderr = %q, want empty string", stderr.String())
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 4 B / 4 B (100%)") {
+		t.Fatalf("Run([upgrade --json]) stderr = %q, want daemon download progress", stderr.String())
 	}
 	if strings.Contains(stdout.String(), "Proceeding with daemon upgrade") {
 		t.Fatalf("stdout = %q, want JSON without human progress text", stdout.String())
@@ -463,6 +463,56 @@ func TestUpgradeCLIPreflightsInstallPathBeforeDownload(t *testing.T) {
 	}
 }
 
+func TestUpgradeCLIPrintsDownloadProgressToStderr(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	execPath := filepath.Join(root, ".looper", "bin", "looper")
+	if err := os.MkdirAll(filepath.Dir(execPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(exec dir) error = %v", err)
+	}
+	if err := os.WriteFile(execPath, []byte("old looper"), 0o755); err != nil {
+		t.Fatalf("WriteFile(execPath) error = %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	binary := []byte("new looper")
+	checksum := sha256.Sum256(binary)
+	checksumText := hex.EncodeToString(checksum[:]) + "  looper-darwin-arm64\n"
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		Platform:       "darwin",
+		Arch:           "arm64",
+		ExecutablePath: execPath,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v999.0.0","assets":[{"name":"looper-darwin-arm64","browser_download_url":"https://example.invalid/looper-darwin-arm64"},{"name":"looper-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looper-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looper-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, binary), nil
+			case "https://example.invalid/looper-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, checksumText), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"upgrade", "--cli"})
+	if exitCode != 0 {
+		t.Fatalf("Run([upgrade --cli]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Downloading looper-darwin-arm64: 10 B / 10 B (100%)") {
+		t.Fatalf("stderr = %q, want CLI download progress", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Downloading looper-darwin-arm64") {
+		t.Fatalf("stdout = %q, did not expect download progress", stdout.String())
+	}
+}
+
 func TestDetectCLIInstallSourceTreatsInstallerSelectedUserBinAsRelease(t *testing.T) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil || homeDir == "" {
@@ -539,8 +589,8 @@ func TestUpgradeDaemonPrintsRestartHint(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([upgrade --daemon]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("Run([upgrade --daemon]) stderr = %q, want empty string", stderr.String())
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 4 B / 4 B (100%)") {
+		t.Fatalf("Run([upgrade --daemon]) stderr = %q, want daemon download progress", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Upgraded looperd 0.2.1 → 0.3.0") {
 		t.Fatalf("stdout = %q, want upgrade confirmation", stdout.String())
@@ -649,8 +699,8 @@ func TestUpgradeDaemonInstallsManagedBinaryWhenOnlyPathBinaryExists(t *testing.T
 	if exitCode != 0 {
 		t.Fatalf("Run([upgrade --daemon]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("Run([upgrade --daemon]) stderr = %q, want empty string", stderr.String())
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 4 B / 4 B (100%)") {
+		t.Fatalf("Run([upgrade --daemon]) stderr = %q, want daemon download progress", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Installed managed looperd 0.4.0") {
 		t.Fatalf("stdout = %q, want managed install message", stdout.String())


### PR DESCRIPTION
## Summary
- Add shared release binary download progress reporting for CLI self-upgrades, managed daemon installs/upgrades, and bootstrap installs.
- Write byte counts to stderr so stdout remains safe for human summaries and JSON output.
- Cover known Content-Length progress, unknown-size fallback output, and CLI/daemon/bootstrap flows in tests.

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #41

<!-- looper:stamp v=1 -->
<sub>Generated by looper 0.0.0-dev · runner=worker · agent=openai/gpt-5.5</sub>