### PR TITLE
docs: add v0.2.7 changelog

### DIFF
--- a/docs/changelogs/v0.2.7.md
+++ b/docs/changelogs/v0.2.7.md
@@ -63,11 +63,11 @@ looper stop all
 
 It stops active loops, running runs, agent executions, and queued work items, then reports itemized results and summary counts.
 
-### Async PR snapshot scheduling for projects
+### Configurable async PR snapshot scheduling for projects
 
 `project add` can now schedule PR snapshots asynchronously when configured with `--snapshot-mode async` (or `addSnapshotMode: "async"`), so adding a project is less likely to block on large GitHub diffs or slow snapshot generation.
 
-Snapshot behavior is also configurable, including support for full snapshots or disabling snapshots.
+Snapshot behavior is configurable through `defaults.addSnapshotMode` or `looper project add --snapshot-mode`, with support for `async`, `full`, and `off`. The default remains `full`.
 
 ### Clear disclosure for Looper-generated content
 

--- a/docs/changelogs/v0.2.7.md
+++ b/docs/changelogs/v0.2.7.md
@@ -65,7 +65,7 @@ It stops active loops, running runs, agent executions, and queued work items, th
 
 ### Async PR snapshot scheduling for projects
 
-`project add` now schedules PR snapshots asynchronously by default, so adding a project is less likely to block on large GitHub diffs or slow snapshot generation.
+`project add` can now schedule PR snapshots asynchronously when configured with `--snapshot-mode async` (or `addSnapshotMode: "async"`), so adding a project is less likely to block on large GitHub diffs or slow snapshot generation.
 
 Snapshot behavior is also configurable, including support for full snapshots or disabling snapshots.
 

--- a/docs/changelogs/v0.2.7.md
+++ b/docs/changelogs/v0.2.7.md
@@ -1,0 +1,96 @@
+# Looper v0.2.7
+
+This release focuses on making Looper easier to operate from GitHub Issues, while improving setup, configuration, task control, and upgrade visibility.
+
+## Highlights
+
+### GitHub Issue automation with `looper:worker-ready`
+
+Looper can now discover GitHub Issues that are labeled with `looper:worker-ready` and assigned to the current GitHub user.
+
+This enables a simple Issue-driven worker workflow:
+
+1. Add the `looper:worker-ready` label to an Issue
+2. Assign the Issue to the user running Looper
+3. Let the Looper daemon discover it during its scheduler tick
+4. Looper creates or reuses a worker loop and queues issue-scoped work automatically
+
+Looper also reuses existing active work where possible, helping avoid duplicate processing for the same Issue.
+
+### Initialize standard Looper labels with `looper labels init`
+
+A new command is available for setting up Looper labels in a GitHub repository:
+
+```bash
+looper labels init
+```
+
+By default, Looper detects the current GitHub repository. You can also target a specific repository:
+
+```bash
+looper labels init --repo owner/repo
+```
+
+To preview changes without modifying labels:
+
+```bash
+looper labels init --dry-run
+```
+
+The command is idempotent: it creates missing standard labels, updates labels that need changes, and skips labels that are already configured correctly.
+
+### Manage configuration from the CLI
+
+Looper now includes first-class config commands:
+
+```bash
+looper config get
+looper config set
+looper config unset
+looper config validate
+looper config edit
+```
+
+Config updates are validated before being persisted, written safely with backups and atomic writes, and include warnings when values are overridden by environment variables or CLI flags.
+
+### Stop all active work at once
+
+A new command lets you stop all currently active Looper work:
+
+```bash
+looper stop all
+```
+
+It stops active loops, running runs, agent executions, and queued work items, then reports itemized results and summary counts.
+
+### Async PR snapshot scheduling for projects
+
+`project add` now schedules PR snapshots asynchronously by default, so adding a project is less likely to block on large GitHub diffs or slow snapshot generation.
+
+Snapshot behavior is also configurable, including support for full snapshots or disabling snapshots.
+
+### Clear disclosure for Looper-generated content
+
+Looper-generated commits, PR bodies, comments, review summaries, and inline review markers now include disclosure metadata by default. This makes it easier to identify content produced by Looper.
+
+### Release downloads now show progress
+
+Release binary downloads now report progress for CLI self-upgrades, managed daemon installs/upgrades, and bootstrap installs. Progress is written to stderr so stdout remains safe for summaries and JSON output.
+
+### More reliable daemon startup detection
+
+Daemon startup detection is now more robust:
+
+- Uses the daemon API status fingerprint as the source of truth
+- Handles missing or stale PID files more reliably
+- Captures startup output in restricted startup logs
+- Includes bounded log tails in startup failures and timeouts
+- Replaces fixed startup sleeps with a readiness loop
+
+## Documentation and project updates
+
+- Refreshed README product positioning
+- Added MIT License
+- Added project badges
+
+**Full Changelog**: https://github.com/powerformer/looper/compare/v0.2.6...v0.2.7


### PR DESCRIPTION
## Summary
- Add a detailed English changelog for Looper v0.2.7 under `docs/changelogs/`
- Highlight user-facing changes such as `looper:worker-ready`, `looper labels init`, config commands, stop-all, async snapshots, generated-content disclosure, download progress, and daemon startup reliability

## Testing
- Not run; documentation-only change