### PR TITLE
fix: prevent duplicate reviewer comments

### DIFF
--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -996,13 +996,13 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		return checkpoint, &loopError{message: message, kind: kind}
 	}
 	feedback := parseReviewFeedback(result)
-	if !feedback.Clean && len(feedback.Comments) == 0 {
+	if !feedback.Clean && len(feedback.Comments) == 0 && strings.TrimSpace(feedback.Body) == "" {
 		_ = r.tryRemoveReaction(ctx, input, "eyes")
 		kind := FailureRetryableTransient
 		if result.ParseStatus == "invalid_json" {
 			kind = FailureNonRetryable
 		}
-		return checkpoint, &loopError{message: "Reviewer agent produced no actionable review comments", kind: kind}
+		return checkpoint, &loopError{message: "Reviewer agent produced no actionable review feedback", kind: kind}
 	}
 	checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, Event: ternaryReviewEvent(feedback.Clean), Body: feedback.Body, Summary: result.Summary, Comments: feedback.Comments, Clean: feedback.Clean}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
@@ -1105,6 +1105,14 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		topLevel := topLevelComments(pending.Comments)
 		for pending.PublishState.TopLevelCommentsPosted < len(topLevel) {
 			comment := topLevel[pending.PublishState.TopLevelCommentsPosted]
+			if isDuplicateTopLevelReviewComment(comment, pending.Body) {
+				pending.PublishState.TopLevelCommentsPosted++
+				checkpoint.PendingReview = pending.clone()
+				if err := r.persistCheckpoint(ctx, input.Run.ID, stepPublish, checkpoint); err != nil {
+					return checkpoint, err
+				}
+				continue
+			}
 			if err := r.github.AddPullRequestComment(ctx, PullRequestCommentInput{Repo: repo, PRNumber: prNumber, Body: comment.Body, CWD: input.Project.RepoPath}); err != nil {
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 			}
@@ -1662,6 +1670,7 @@ func buildReviewPrompt(repo string, prNumber int64, checkpoint reviewerCheckpoin
 		"Use verdict=actionable whenever there is any actionable advice.",
 		"Prefer inline comments for specific code-level feedback when you can anchor them confidently to the diff using the changed file path and file line numbers shown in the PR diff.",
 		"Use top-level comments without path/line only for architectural, cross-cutting, or otherwise unanchorable feedback.",
+		"Do not repeat the overall body/summary as a comment; comments must add distinct actionable feedback.",
 		"For multiline inline comments, startLine/startSide must identify the first line and line/side the last line; omit startLine/startSide for single-line comments.",
 		"Write substantially more detail than a brief summary; every comment should explain the problem, why it matters, and the concrete change to make.",
 		"Do not approve. If the review is clean, return verdict=clean with comments=[].",
@@ -1678,7 +1687,7 @@ func parseReviewFeedback(result AgentResult) parsedReviewFeedback {
 	if fallback == "" {
 		return parsedReviewFeedback{}
 	}
-	return parsedReviewFeedback{Body: fallback, Comments: []reviewFeedbackComment{{Body: fallback}}, Clean: false}
+	return parsedReviewFeedback{Body: fallback, Comments: []reviewFeedbackComment{}, Clean: false}
 }
 
 func extractReviewOutput(stdout string) string {
@@ -1704,6 +1713,7 @@ func parseStructuredReviewOutput(output string) (parsedReviewFeedback, bool) {
 	if err := json.Unmarshal([]byte(output), &payload); err != nil {
 		return parsedReviewFeedback{}, false
 	}
+	body := strings.TrimSpace(payload.Body)
 	comments := make([]reviewFeedbackComment, 0, len(payload.Comments))
 	for _, comment := range payload.Comments {
 		normalized := normalizeReviewFeedbackComment(comment)
@@ -1712,10 +1722,11 @@ func parseStructuredReviewOutput(output string) (parsedReviewFeedback, bool) {
 		}
 	}
 	clean := strings.EqualFold(payload.Verdict, "clean") && len(comments) == 0
-	if !clean && len(comments) == 0 {
+	comments = dedupeReviewFeedbackComments(comments, body)
+	if !clean && len(comments) == 0 && body == "" {
 		return parsedReviewFeedback{}, false
 	}
-	return parsedReviewFeedback{Body: strings.TrimSpace(payload.Body), Comments: comments, Clean: clean}, true
+	return parsedReviewFeedback{Body: body, Comments: comments, Clean: clean}, true
 }
 
 func normalizeReviewFeedbackComment(comment reviewFeedbackComment) reviewFeedbackComment {
@@ -1745,7 +1756,37 @@ func normalizePendingReviewCheckpoint(pending pendingReviewCheckpoint) pendingRe
 	if pending.Comments == nil {
 		pending.Comments = []reviewFeedbackComment{}
 	}
+	if pending.PublishState.TopLevelCommentsPosted == 0 {
+		pending.Comments = dedupeReviewFeedbackComments(pending.Comments, pending.Body)
+	}
 	return pending
+}
+
+func dedupeReviewFeedbackComments(comments []reviewFeedbackComment, body string) []reviewFeedbackComment {
+	if len(comments) == 0 {
+		return []reviewFeedbackComment{}
+	}
+	result := make([]reviewFeedbackComment, 0, len(comments))
+	seenTopLevel := map[string]struct{}{}
+	for _, comment := range comments {
+		if comment.Body == "" {
+			continue
+		}
+		if isInlineReviewFeedbackComment(comment) {
+			result = append(result, comment)
+			continue
+		}
+		key := normalizedReviewFeedbackText(comment.Body)
+		if key == "" || key == normalizedReviewFeedbackText(body) {
+			continue
+		}
+		if _, ok := seenTopLevel[key]; ok {
+			continue
+		}
+		seenTopLevel[key] = struct{}{}
+		result = append(result, comment)
+	}
+	return result
 }
 
 func (r *Runner) cleanupReviewerWorktreeIfTerminal(ctx context.Context, project storage.ProjectRecord, checkpoint *reviewerCheckpoint) {
@@ -1826,7 +1867,7 @@ func summarizeLogs(stdout string) string {
 
 func hasInlineComments(comments []reviewFeedbackComment) bool {
 	for _, comment := range comments {
-		if comment.Path != "" && comment.Line > 0 && comment.Side != "" {
+		if isInlineReviewFeedbackComment(comment) {
 			return true
 		}
 	}
@@ -1836,7 +1877,7 @@ func hasInlineComments(comments []reviewFeedbackComment) bool {
 func inlineComments(comments []reviewFeedbackComment) []reviewFeedbackComment {
 	result := make([]reviewFeedbackComment, 0)
 	for _, comment := range comments {
-		if comment.Path != "" && comment.Line > 0 && comment.Side != "" {
+		if isInlineReviewFeedbackComment(comment) {
 			result = append(result, comment)
 		}
 	}
@@ -1851,6 +1892,22 @@ func topLevelComments(comments []reviewFeedbackComment) []reviewFeedbackComment 
 		}
 	}
 	return result
+}
+
+func isInlineReviewFeedbackComment(comment reviewFeedbackComment) bool {
+	return comment.Path != "" && comment.Line > 0 && comment.Side != ""
+}
+
+func isDuplicateTopLevelReviewComment(comment reviewFeedbackComment, body string) bool {
+	if isInlineReviewFeedbackComment(comment) {
+		return false
+	}
+	key := normalizedReviewFeedbackText(comment.Body)
+	return key != "" && key == normalizedReviewFeedbackText(body)
+}
+
+func normalizedReviewFeedbackText(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
 }
 
 func toGitHubReviewComments(comments []reviewFeedbackComment) []ReviewComment {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -494,7 +494,7 @@ func TestProcessClaimedItemRetriesPublishFromCheckpointWithoutRerunningReview(t 
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{submitFailuresRemaining: 1}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Please add tests"}]}`}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Add an integration test for the retry path"}]}`}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
@@ -570,7 +570,7 @@ func TestProcessClaimedItemSkipsPublishWhenReviewRequestRemovedBeforeRetry(t *te
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{submitFailuresRemaining: 1, reviewRequests: []string{"octocat"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Please add tests"}]}`}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Add an integration test for the retry path"}]}`}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
@@ -616,7 +616,7 @@ func TestProcessClaimedItemRecordsPublishedHeadWhenReviewRequestRemovedAfterSubm
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{prCommentFailuresRemaining: 1, reviewRequests: []string{"octocat"}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Please add tests"}]}`}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `{"verdict":"actionable","body":"Please add tests","comments":[{"body":"Add an integration test for the retry path"}]}`}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
@@ -1339,6 +1339,149 @@ func TestExtractReviewOutputStripsCompletionMarkerLine(t *testing.T) {
 	parsed, ok := parseStructuredReviewOutput(output)
 	if !ok || !parsed.Clean {
 		t.Fatalf("parsed = %#v, %v, want clean structured review", parsed, ok)
+	}
+}
+
+func TestParseStructuredReviewOutputAcceptsBodyOnlyActionableReview(t *testing.T) {
+	t.Parallel()
+
+	parsed, ok := parseStructuredReviewOutput(`{"verdict":"actionable","body":"Cross-cutting feedback","comments":[]}`)
+	if !ok {
+		t.Fatalf("parseStructuredReviewOutput() ok = false, want true")
+	}
+	if parsed.Clean || parsed.Body != "Cross-cutting feedback" || len(parsed.Comments) != 0 {
+		t.Fatalf("parsed = %#v, want actionable body-only feedback", parsed)
+	}
+}
+
+func TestParseStructuredReviewOutputDropsDuplicateTopLevelComments(t *testing.T) {
+	t.Parallel()
+
+	parsed, ok := parseStructuredReviewOutput(`{"verdict":"actionable","body":"Please add tests","comments":[{"body":" Please   add tests "},{"body":"Add an integration test"},{"body":"Add an integration test"},{"body":"Please add tests","path":"a.go","line":12,"side":"RIGHT"}]}`)
+	if !ok {
+		t.Fatalf("parseStructuredReviewOutput() ok = false, want true")
+	}
+	if len(parsed.Comments) != 2 {
+		t.Fatalf("comments = %#v, want distinct top-level plus inline duplicate preserved", parsed.Comments)
+	}
+	if parsed.Comments[0].Body != "Add an integration test" {
+		t.Fatalf("first comment = %#v, want distinct top-level comment", parsed.Comments[0])
+	}
+	if parsed.Comments[1].Path != "a.go" || parsed.Comments[1].Line != 12 || parsed.Comments[1].Side != "RIGHT" {
+		t.Fatalf("second comment = %#v, want inline comment preserved", parsed.Comments[1])
+	}
+}
+
+func TestParseStructuredReviewOutputDoesNotDedupeIntoCleanReview(t *testing.T) {
+	t.Parallel()
+
+	parsed, ok := parseStructuredReviewOutput(`{"verdict":"clean","body":"Please add tests","comments":[{"body":"Please add tests"}]}`)
+	if !ok {
+		t.Fatalf("parseStructuredReviewOutput() ok = false, want true")
+	}
+	if parsed.Clean {
+		t.Fatalf("parsed = %#v, want duplicate comment not to convert response into clean review", parsed)
+	}
+	if parsed.Body != "Please add tests" || len(parsed.Comments) != 0 {
+		t.Fatalf("parsed = %#v, want actionable body-only feedback after duplicate cleanup", parsed)
+	}
+}
+
+func TestRunPublishStepSkipsDuplicateTopLevelReviewBodyComment(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"octocat"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_duplicate_top_level", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     loop,
+		Run:      storage.RunRecord{ID: "run_duplicate_top_level"},
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadSHA: "abc123"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: (&pendingReviewCheckpoint{
+				HeadSHA: "abc123",
+				Event:   ReviewEventComment,
+				Body:    "Please add tests",
+				Summary: "Please add tests",
+				Comments: []reviewFeedbackComment{
+					{Body: "Please add tests"},
+				},
+			}).clone(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v", err)
+	}
+	if len(github.submitCalls) != 1 {
+		t.Fatalf("submitCalls = %d, want 1", len(github.submitCalls))
+	}
+	if len(github.prComments) != 0 {
+		t.Fatalf("prComments = %#v, want duplicate top-level comment skipped", github.prComments)
+	}
+	if checkpoint.PendingReview == nil || checkpoint.PendingReview.PublishState == nil || checkpoint.PendingReview.PublishState.TopLevelCommentsPosted != 0 {
+		t.Fatalf("checkpoint pending review = %#v, want duplicate removed before publish", checkpoint.PendingReview)
+	}
+}
+
+func TestRunPublishStepKeepsTopLevelCommentMatchingUnpublishedSummary(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"octocat"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_summary_top_level", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	_, err = runner.runPublishStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     loop,
+		Run:      storage.RunRecord{ID: "run_summary_top_level"},
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadSHA: "abc123"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: (&pendingReviewCheckpoint{
+				HeadSHA: "abc123",
+				Event:   ReviewEventComment,
+				Summary: "Please add tests",
+				Comments: []reviewFeedbackComment{
+					{Body: "Please add tests"},
+				},
+			}).clone(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v", err)
+	}
+	if len(github.submitCalls) != 0 {
+		t.Fatalf("submitCalls = %d, want no body-only review submission", len(github.submitCalls))
+	}
+	if len(github.prComments) != 1 || github.prComments[0].Body != "Please add tests" {
+		t.Fatalf("prComments = %#v, want top-level comment matching unpublished summary", github.prComments)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Allow actionable reviewer output to be body-only without manufacturing duplicate top-level comments.
- Deduplicate unanchored reviewer comments against the published review body while preserving distinct top-level fallback feedback.
- Add regression coverage for duplicate body comments, unpublished summaries, and clean verdict dedupe edge cases.

## Validation
- go test ./internal/reviewer
- go test ./...
- go vet ./...
- go build ./...