### PR TITLE
feat: default project add snapshots to async

### DIFF
--- a/docs/changelogs/v0.3.0.md
+++ b/docs/changelogs/v0.3.0.md
@@ -1,0 +1,6 @@
+# Looper v0.3.0
+
+## Behavior changes
+
+- `looper project add` now defaults to asynchronous PR snapshot scheduling. Project registration returns after open PRs are discovered and snapshot work is queued in the background, which avoids blocking initial setup on large diffs or slow GitHub responses.
+- To restore the previous synchronous snapshot capture behavior, run `looper project add --snapshot-mode full` or set `defaults.addSnapshotMode` to `full` in `~/.looper/config.json`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ Example minimal `~/.looper/config.json`:
     "allowAutoMerge": false,
     "allowRiskyFixes": false,
     "openPrStrategy": "all_done",
-    "addSnapshotMode": "full"
+    "addSnapshotMode": "async"
   },
   "projects": [
     {
@@ -266,7 +266,7 @@ Defaults:
 - `allowAutoMerge`
 - `allowRiskyFixes`
 - `openPrStrategy`: `all_done`, `first_commit`, or `manual`
-- `addSnapshotMode`: project-add PR snapshot behavior: `async`, `full`, or `off`; `looper project add --snapshot-mode` overrides this per request
+- `addSnapshotMode`: project-add PR snapshot behavior: `async`, `full`, or `off`; `looper project add --snapshot-mode` overrides this per request. The default is `async`, which queues PR snapshots for background capture so project registration can complete quickly. Use `full` to restore the previous synchronous capture behavior.
 
 Default values:
 
@@ -277,7 +277,23 @@ Default values:
 - `allowAutoMerge`: `false`
 - `allowRiskyFixes`: `false`
 - `openPrStrategy`: `all_done`
-- `addSnapshotMode`: `full`
+- `addSnapshotMode`: `async`
+
+To restore the previous synchronous `project add` behavior for one command:
+
+```bash
+looper project add --snapshot-mode full /absolute/path/to/repo
+```
+
+To restore it by default for all project additions:
+
+```json
+{
+  "defaults": {
+    "addSnapshotMode": "full"
+  }
+}
+```
 
 ### `projects`
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -226,7 +226,7 @@ func writeHumanProjectAdd(w io.Writer, payload json.RawMessage) error {
 		return fmt.Errorf("decode project response: %w", err)
 	}
 
-	printSection(w, "Project added", [][2]any{{"id", data.ID}, {"name", data.Name}, {"repoPath", data.RepoPath}, {"baseBranch", data.BaseBranch}, {"repo", data.Repo}, {"discoveredPullRequests", data.DiscoveredPullRequests}, {"discoveredWorktrees", data.DiscoveredWorktrees}, {"scheduledSnapshots", data.PendingSnapshots}, {"capturedSnapshots", data.CapturedSnapshots}})
+	printSection(w, "Project added", [][2]any{{"id", data.ID}, {"name", data.Name}, {"repoPath", data.RepoPath}, {"baseBranch", data.BaseBranch}, {"repo", data.Repo}, {"discoveredPullRequests", data.DiscoveredPullRequests}, {"discoveredWorktrees", data.DiscoveredWorktrees}, {"queuedSnapshots", data.PendingSnapshots}, {"capturedSnapshots", data.CapturedSnapshots}})
 	if len(data.Warnings) > 0 {
 		fmt.Fprintln(w)
 		entries := make([][2]any, 0, len(data.Warnings))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -666,8 +666,8 @@ func TestDefaultConfigMatchesDaemonDefaults(t *testing.T) {
 		t.Fatalf("DefaultConfig().Defaults.OpenPRStrategy = %q, want %q", config.Defaults.OpenPRStrategy, OpenPRStrategyAllDone)
 	}
 
-	if config.Defaults.AddSnapshotMode != AddSnapshotModeFull {
-		t.Fatalf("DefaultConfig().Defaults.AddSnapshotMode = %q, want %q", config.Defaults.AddSnapshotMode, AddSnapshotModeFull)
+	if config.Defaults.AddSnapshotMode != AddSnapshotModeAsync {
+		t.Fatalf("DefaultConfig().Defaults.AddSnapshotMode = %q, want %q", config.Defaults.AddSnapshotMode, AddSnapshotModeAsync)
 	}
 
 	if len(config.Agent.Params) != 0 || len(config.Agent.Env) != 0 {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -111,7 +111,7 @@ func DefaultConfig(cwd string) (Config, error) {
 			AllowRiskyFixes:    false,
 			FixAllPullRequests: false,
 			OpenPRStrategy:     OpenPRStrategyAllDone,
-			AddSnapshotMode:    AddSnapshotModeFull,
+			AddSnapshotMode:    AddSnapshotModeAsync,
 		},
 		Projects: []ProjectRefConfig{},
 	}, nil

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -153,7 +153,7 @@
         "allowRiskyFixes": false,
         "fixAllPullRequests": false,
         "openPrStrategy": "all_done",
-        "addSnapshotMode": "full"
+        "addSnapshotMode": "async"
       },
       "projects": [
         {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -89,7 +89,7 @@
         "allowRiskyFixes": false,
         "fixAllPullRequests": false,
         "openPrStrategy": "all_done",
-        "addSnapshotMode": "full"
+        "addSnapshotMode": "async"
       },
       "projects": []
     },

--- a/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
+++ b/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
@@ -199,7 +199,7 @@
             "allowRiskyFixes": false,
             "fixAllPullRequests": false,
             "openPrStrategy": "all_done",
-            "addSnapshotMode": "full"
+            "addSnapshotMode": "async"
           },
           "projects": []
         },


### PR DESCRIPTION
## Summary
- Change the default project-add PR snapshot mode from synchronous `full` capture to asynchronous `async` scheduling.
- Update config defaults, parity fixtures, human output wording, configuration docs, and v0.3.0 release notes.
- Document how to restore the old synchronous behavior with `--snapshot-mode full` or `defaults.addSnapshotMode: \"full\"`.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #119

<!-- looper:stamp v=1 -->
<sub>Generated by looper 0.0.0-dev · runner=worker · agent=openai/gpt-5.5</sub>