### PR TITLE
feat: make completed worker tasks discoverable

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1079,6 +1079,8 @@ type activeRunsListResponse struct {
 }
 
 type activeRunsQuery struct {
+	All       bool
+	Status    string
 	Type      string
 	ProjectID string
 	Repo      string
@@ -1094,6 +1096,7 @@ type activeRunView struct {
 	Status      string             `json:"status"`
 	CurrentStep *string            `json:"currentStep"`
 	StartedAt   *string            `json:"startedAt"`
+	EndedAt     *string            `json:"endedAt,omitempty"`
 	Target      activeRunTarget    `json:"target"`
 	Agent       *activeRunAgent    `json:"agent"`
 	Worktree    *activeRunWorktree `json:"worktree"`
@@ -1697,7 +1700,7 @@ func (h *Handler) buildActiveRunsResponse(r *http.Request) (activeRunsListRespon
 		return activeRunsListResponse{}, err
 	}
 
-	items, err := h.buildActiveRunViews(r.Context(), true)
+	items, err := h.buildActiveRunViews(r.Context(), true, query.All || query.Status != "")
 	if err != nil {
 		return activeRunsListResponse{}, err
 	}
@@ -1765,7 +1768,7 @@ func (h *Handler) buildActiveRunRouteResponse(r *http.Request, path string) (any
 }
 
 func (h *Handler) buildActiveRunDetailResponse(ctx context.Context, loopID string) (activeRunView, error) {
-	items, err := h.buildActiveRunViews(ctx, true)
+	items, err := h.buildActiveRunViews(ctx, true, false)
 	if err != nil {
 		return activeRunView{}, err
 	}
@@ -1777,7 +1780,7 @@ func (h *Handler) buildActiveRunDetailResponse(ctx context.Context, loopID strin
 	return activeRunView{}, apiError{code: pkgapi.ErrorCodeActiveRunNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Active run not found for loop: %s", loopID)}
 }
 
-func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWithoutRuns bool) ([]activeRunView, error) {
+func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWithoutRuns bool, includeInactiveLoops bool) ([]activeRunView, error) {
 	services := h.context.Runtime.Services()
 	if services.Repositories == nil || services.Repositories.Runs == nil || services.Repositories.Loops == nil || services.Repositories.Queue == nil || services.Repositories.AgentExecutions == nil || services.Repositories.Projects == nil {
 		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
@@ -1919,8 +1922,67 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 		})
 	}
 
+	includedLoopIDs := make(map[string]struct{}, len(runningViews)+len(runningLoopViews)+len(queuedViews))
+	for _, item := range runningViews {
+		includedLoopIDs[item.LoopID] = struct{}{}
+	}
+	for _, item := range runningLoopViews {
+		includedLoopIDs[item.LoopID] = struct{}{}
+	}
+	for _, item := range queuedViews {
+		includedLoopIDs[item.LoopID] = struct{}{}
+	}
+
+	inactiveLoopViews := make([]activeRunView, 0)
+	if includeInactiveLoops {
+		for _, loop := range loopsList {
+			if _, ok := includedLoopIDs[loop.ID]; ok {
+				continue
+			}
+			target, ok, err := h.tryBuildActiveRunTarget(ctx, loop)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+			var (
+				latestRun *storage.RunRecord
+				runID     *string
+				worktree  *activeRunWorktree
+			)
+			latestRun, err = services.Repositories.Runs.GetLatestByLoopID(ctx, loop.ID)
+			if err != nil {
+				return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+			}
+			startedAt := firstNonEmptyString(loop.LastRunAt, loop.NextRunAt, stringPtrOrNil(loop.UpdatedAt), stringPtrOrNil(loop.CreatedAt))
+			var endedAt *string
+			if latestRun != nil {
+				runID = &latestRun.ID
+				startedAt = stringPtrOrNil(latestRun.StartedAt)
+				endedAt = latestRun.EndedAt
+				worktree = buildWorktreeSummary(loop, *latestRun)
+			}
+			inactiveLoopViews = append(inactiveLoopViews, activeRunView{
+				Seq:         loop.Seq,
+				RunID:       runID,
+				LoopID:      loop.ID,
+				ProjectID:   loop.ProjectID,
+				Type:        loop.Type,
+				Status:      loop.Status,
+				CurrentStep: nil,
+				StartedAt:   startedAt,
+				EndedAt:     endedAt,
+				Target:      target,
+				Agent:       nil,
+				Worktree:    worktree,
+			})
+		}
+	}
+
 	items := append(runningViews, runningLoopViews...)
 	items = append(items, queuedViews...)
+	items = append(items, inactiveLoopViews...)
 	sort.Slice(items, func(i, j int) bool {
 		return compareActiveRunViews(items[i], items[j]) < 0
 	})
@@ -2006,6 +2068,8 @@ func (h *Handler) tryBuildActiveRunTarget(ctx context.Context, loop storage.Loop
 
 func readActiveRunsQuery(values url.Values) (activeRunsQuery, error) {
 	query := activeRunsQuery{
+		All:       strings.EqualFold(strings.TrimSpace(values.Get("all")), "true"),
+		Status:    strings.TrimSpace(values.Get("status")),
 		Type:      strings.TrimSpace(values.Get("type")),
 		ProjectID: strings.TrimSpace(values.Get("projectId")),
 		Repo:      strings.TrimSpace(values.Get("repo")),
@@ -2032,6 +2096,9 @@ func parsePositiveInt64(value, fieldName string) (int64, error) {
 }
 
 func matchesActiveRunQuery(item activeRunView, query activeRunsQuery) bool {
+	if query.Status != "" && item.Status != query.Status {
+		return false
+	}
 	if query.Type != "" && item.Type != query.Type {
 		return false
 	}
@@ -2074,10 +2141,10 @@ func compareActiveRunViews(left, right activeRunView) int {
 		return rightAgent - leftAgent
 	}
 
-	leftStarted := derefString(left.StartedAt)
-	rightStarted := derefString(right.StartedAt)
+	leftStarted := derefString(firstNonEmptyString(left.EndedAt, left.StartedAt))
+	rightStarted := derefString(firstNonEmptyString(right.EndedAt, right.StartedAt))
 	if leftStarted != rightStarted {
-		if leftStarted < rightStarted {
+		if leftStarted > rightStarted {
 			return -1
 		}
 		return 1

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -3704,6 +3704,176 @@ func TestActiveRunsIncludesPausedLoopWithRunningRun(t *testing.T) {
 	assertEqual(t, item["status"], "running")
 }
 
+func TestActiveRunsStatusAndTypeFiltersIncludeInactiveCompletedWorkerLoops(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	completedAt := fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString)
+
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID:        "project_1",
+		Name:      "Looper",
+		RepoPath:  "/tmp/repos/looper",
+		Archived:  false,
+		CreatedAt: nowISO,
+		UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	for _, loop := range []storage.LoopRecord{
+		{
+			ID:         "loop_worker_completed",
+			Seq:        12,
+			ProjectID:  "project_1",
+			Type:       "worker",
+			TargetType: "issue",
+			TargetID:   stringPtr("issue:acme/looper:42"),
+			Repo:       stringPtr("acme/looper"),
+			Status:     "completed",
+			LastRunAt:  stringPtr(completedAt),
+			CreatedAt:  nowISO,
+			UpdatedAt:  completedAt,
+		},
+		{
+			ID:         "loop_worker_running",
+			Seq:        13,
+			ProjectID:  "project_1",
+			Type:       "worker",
+			TargetType: "issue",
+			TargetID:   stringPtr("issue:acme/looper:43"),
+			Repo:       stringPtr("acme/looper"),
+			Status:     "running",
+			LastRunAt:  stringPtr(nowISO),
+			CreatedAt:  nowISO,
+			UpdatedAt:  nowISO,
+		},
+		{
+			ID:         "loop_reviewer_completed",
+			Seq:        14,
+			ProjectID:  "project_1",
+			Type:       "reviewer",
+			TargetType: "pull_request",
+			TargetID:   stringPtr("pr:acme/looper:44"),
+			Repo:       stringPtr("acme/looper"),
+			PRNumber:   int64Ptr(44),
+			Status:     "completed",
+			LastRunAt:  stringPtr(completedAt),
+			CreatedAt:  nowISO,
+			UpdatedAt:  completedAt,
+		},
+	} {
+		if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+
+	defaultReq := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	defaultRecorder := httptest.NewRecorder()
+	h.ServeHTTP(defaultRecorder, defaultReq)
+	if defaultRecorder.Code != http.StatusOK {
+		t.Fatalf("default status = %d, want 200", defaultRecorder.Code)
+	}
+	defaultBody := parseJSONMap(t, defaultRecorder.Body.Bytes())
+	defaultItems := defaultBody["data"].(map[string]any)["items"].([]any)
+	if len(defaultItems) != 1 {
+		t.Fatalf("len(default items) = %d, want 1", len(defaultItems))
+	}
+	defaultItem := defaultItems[0].(map[string]any)
+	assertEqual(t, defaultItem["loopId"], "loop_worker_running")
+
+	filteredReq := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active?status=completed&type=worker", nil)
+	filteredRecorder := httptest.NewRecorder()
+	h.ServeHTTP(filteredRecorder, filteredReq)
+	if filteredRecorder.Code != http.StatusOK {
+		t.Fatalf("filtered status = %d, want 200", filteredRecorder.Code)
+	}
+	filteredBody := parseJSONMap(t, filteredRecorder.Body.Bytes())
+	filteredItems := filteredBody["data"].(map[string]any)["items"].([]any)
+	if len(filteredItems) != 1 {
+		t.Fatalf("len(filtered items) = %d, want 1", len(filteredItems))
+	}
+	filteredItem := filteredItems[0].(map[string]any)
+	assertEqual(t, filteredItem["loopId"], "loop_worker_completed")
+	assertEqual(t, filteredItem["type"], "worker")
+	assertEqual(t, filteredItem["status"], "completed")
+	assertEqual(t, filteredItem["runId"], nil)
+	assertEqual(t, filteredItem["agent"], nil)
+}
+
+func TestActiveRunsAllIncludesInactiveCompletedLoopWithLatestRunFields(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	startedAt := fixture.now.Add(-2 * time.Minute).UTC().Format(javaScriptISOString)
+	completedAt := fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString)
+
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID:        "project_1",
+		Name:      "Looper",
+		RepoPath:  "/tmp/repos/looper",
+		Archived:  false,
+		CreatedAt: nowISO,
+		UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:           "loop_worker_completed",
+		Seq:          15,
+		ProjectID:    "project_1",
+		Type:         "worker",
+		TargetType:   "issue",
+		TargetID:     stringPtr("issue:acme/looper:15"),
+		Repo:         stringPtr("acme/looper"),
+		Status:       "completed",
+		LastRunAt:    stringPtr(completedAt),
+		MetadataJSON: stringPtr(`{"worktreePath":"/tmp/worktrees/loop-15","branch":"feature/loop-15"}`),
+		CreatedAt:    nowISO,
+		UpdatedAt:    completedAt,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	if err := fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:             "run_15",
+		LoopID:         "loop_worker_completed",
+		Status:         "completed",
+		StartedAt:      startedAt,
+		EndedAt:        stringPtr(completedAt),
+		CheckpointJSON: stringPtr(`{"worktree":{"path":"/tmp/worktrees/loop-15","branch":"feature/loop-15"}}`),
+		CreatedAt:      startedAt,
+		UpdatedAt:      completedAt,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active?all=true", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
+	}
+	item := items[0].(map[string]any)
+	assertEqual(t, item["loopId"], "loop_worker_completed")
+	assertEqual(t, item["runId"], "run_15")
+	assertEqual(t, item["type"], "worker")
+	assertEqual(t, item["status"], "completed")
+	assertEqual(t, item["startedAt"], startedAt)
+	assertEqual(t, item["endedAt"], completedAt)
+	worktree := item["worktree"].(map[string]any)
+	assertEqual(t, worktree["path"], "/tmp/worktrees/loop-15")
+	assertEqual(t, worktree["branch"], "feature/loop-15")
+	assertEqual(t, item["agent"], nil)
+}
+
 func TestActiveRunDetailIncludesPausedLoopWithRunningRun(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -319,11 +319,15 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				short: "Show running loops",
 				runE:  runtime.activeRuns,
 				localFlags: []flagSpec{
+					boolFlag("all", "Show recent loops in any status"),
+					stringFlag("status", "status", "Filter by loop or run status"),
 					stringFlag("type", "type", "Filter by loop type"),
 					stringFlag("project", "projectId", "Filter by project id"),
 				},
 				exampleLines: []string{
 					"$ looper ps",
+					"$ looper ps --status completed --type worker",
+					"$ looper ps --all",
 					"$ looper ps --type reviewer --project project_1",
 				},
 			}),

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -1058,6 +1058,85 @@ func TestPSWithoutJSONShowsRunningLoopWithoutRunRow(t *testing.T) {
 	}
 }
 
+func TestPSStatusAndTypeFiltersUseActiveRunsQueryAndShowInactiveCompletedLoop(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/runs/active"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("status"), "completed"; got != want {
+			t.Fatalf("status query = %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("type"), "worker"; got != want {
+			t.Fatalf("type query = %q, want %q", got, want)
+		}
+		if got := r.URL.Query().Get("all"); got != "" {
+			t.Fatalf("all query = %q, want empty", got)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_active_runs", map[string]any{"items": []map[string]any{{
+			"seq":    12,
+			"type":   "worker",
+			"status": "completed",
+			"target": map[string]any{"label": "Issue #42"},
+		}}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "ps", "--status", "completed", "--type", "worker", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([ps --status completed --type worker]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([ps --status completed --type worker]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"worker", "completed", "Issue #42"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([ps --status completed --type worker]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
+func TestPSAllUsesActiveRunsAllQueryAndShowsInactiveCompletedLoop(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/runs/active"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("all"), "true"; got != want {
+			t.Fatalf("all query = %q, want %q", got, want)
+		}
+		if got := r.URL.Query().Get("status"); got != "" {
+			t.Fatalf("status query = %q, want empty", got)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_active_runs", map[string]any{"items": []map[string]any{{
+			"seq":     15,
+			"runId":   "run_15",
+			"type":    "worker",
+			"status":  "completed",
+			"endedAt": "2026-04-11T12:01:00.000Z",
+			"target":  map[string]any{"label": "Issue #15"},
+		}}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "ps", "--all", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([ps --all]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([ps --all]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"worker", "completed", "Issue #15"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([ps --all]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
 func TestStopAllWithoutJSONUsesStopAllRoute(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -145,6 +145,7 @@ type activeRunOutput struct {
 	Status      string  `json:"status"`
 	CurrentStep *string `json:"currentStep"`
 	StartedAt   *string `json:"startedAt"`
+	EndedAt     *string `json:"endedAt"`
 	Target      struct {
 		Label string `json:"label"`
 	} `json:"target"`
@@ -329,7 +330,7 @@ func writeHumanActiveRuns(w io.Writer, payload json.RawMessage) error {
 
 	rows := make([]tableRow, 0, len(data.Items))
 	for _, item := range data.Items {
-		rows = append(rows, tableRow{"#": item.Seq, "type": item.Type, "target": item.Target.Label, "step": item.CurrentStep, "agent": agentVendor(item.Agent), "pid": agentPID(item.Agent), "status": item.Status, "age": formatRelativeAge(item.StartedAt)})
+		rows = append(rows, tableRow{"#": item.Seq, "type": item.Type, "target": item.Target.Label, "step": item.CurrentStep, "agent": agentVendor(item.Agent), "pid": agentPID(item.Agent), "status": item.Status, "age": formatRelativeAge(firstNonEmptyCLIString(item.EndedAt, item.StartedAt))})
 	}
 	printTable(w, []string{"#", "type", "target", "step", "agent", "pid", "status", "age"}, rows)
 	return nil
@@ -718,6 +719,16 @@ func formatRelativeAge(startedAt *string) string {
 		return fmt.Sprintf("%dd", days)
 	}
 	return fmt.Sprintf("%dd%dh", days, remainingHours)
+}
+
+func firstNonEmptyCLIString(values ...*string) *string {
+	for _, value := range values {
+		if value != nil && strings.TrimSpace(*value) != "" {
+			trimmed := strings.TrimSpace(*value)
+			return &trimmed
+		}
+	}
+	return nil
 }
 
 func parseOptionalPositiveInt(value string, flag string) (*int64, error) {

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -262,6 +262,10 @@ func (r *commandRuntime) jump(cmd *cobra.Command, args []string) error {
 func (r *commandRuntime) activeRuns(cmd *cobra.Command, args []string) error {
 	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
 		query := url.Values{}
+		if getBoolFlag(cmd, "all") {
+			query.Set("all", "true")
+		}
+		addQueryString(query, "status", getStringFlag(cmd, "status"))
 		addQueryString(query, "type", getStringFlag(cmd, "type"))
 		addQueryString(query, "projectId", getStringFlag(cmd, "project"))
 


### PR DESCRIPTION
## Summary
- Add `looper ps --status <status>` and `looper ps --all` so completed worker loops can be found from the existing process view.
- Extend the active-runs API to include inactive loop rows when requested, including latest run timing/worktree details when available.
- Add CLI and API coverage for completed worker lookup and all-status listing.

## Validation
- `gofmt -w internal/cliapp/app.go internal/cliapp/json_output.go internal/cliapp/human_output.go internal/api/handler.go internal/cliapp/app_test.go internal/api/handler_test.go`
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #26

<!-- looper:stamp v=1 -->
<sub>Generated by looper 0.0.0-dev · runner=worker · agent=gpt-5.5</sub>