### PR TITLE
fix: replace looperd default port

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ Example minimal `~/.looper/config.json`:
 {
   "server": {
     "host": "127.0.0.1",
-    "port": 4310,
+    "port": 17310,
     "authMode": "local-token",
     "localToken": "replace-me"
   },
@@ -158,7 +158,7 @@ Example minimal `~/.looper/config.json`:
 ### `server`
 
 - `host`: bind host, default `127.0.0.1`
-- `port`: bind port, default `4310`
+- `port`: bind port, default `17310`
 - `authMode`: `none` or `local-token`
 - `localToken`: required when `authMode` is `local-token`
 
@@ -338,6 +338,8 @@ LOOPER_PORT=4321 \
 LOOPER_ALLOW_AUTO_PUSH=false \
 looperd
 ```
+
+Migration note: the default looperd port changed from `4310` to `17310` to reduce conflicts with other local services. Existing config files, `LOOPER_PORT`, and `--port` values continue to take precedence, so users with an explicit port setting keep their current port.
 
 Example precedence:
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -761,7 +761,7 @@ func TestManagedDaemonInstallUpgradeLifecycleEndToEnd(t *testing.T) {
 				return binaryResponse(t, http.StatusOK, newBinary), nil
 			case "https://example.invalid/looperd-darwin-arm64-v0.3.0.sha256":
 				return textResponse(t, http.StatusOK, hex.EncodeToString(newChecksum[:])+"  looperd-darwin-arm64\n"), nil
-			case "http://daemon.test/api/v1/status", "http://127.0.0.1:4310/api/v1/status":
+			case "http://daemon.test/api/v1/status", "http://127.0.0.1:17310/api/v1/status":
 				mu.Lock()
 				defer mu.Unlock()
 				if runningPID == 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -610,8 +610,8 @@ func TestDefaultConfigMatchesDaemonDefaults(t *testing.T) {
 		t.Fatalf("DefaultConfig().Server.Host = %q, want %q", config.Server.Host, "127.0.0.1")
 	}
 
-	if config.Server.Port != 4310 {
-		t.Fatalf("DefaultConfig().Server.Port = %d, want %d", config.Server.Port, 4310)
+	if config.Server.Port != DefaultServerPort {
+		t.Fatalf("DefaultConfig().Server.Port = %d, want %d", config.Server.Port, DefaultServerPort)
 	}
 
 	if config.Server.AuthMode != AuthModeNone {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 )
 
+const DefaultServerPort = 17310
+
 func DefaultLooperHome() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -54,7 +56,7 @@ func DefaultConfig(cwd string) (Config, error) {
 	return Config{
 		Server: ServerConfig{
 			Host:     "127.0.0.1",
-			Port:     4310,
+			Port:     DefaultServerPort,
 			AuthMode: AuthModeNone,
 		},
 		Storage: StorageConfig{

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -21,7 +21,7 @@
     "config": {
       "server": {
         "host": "127.0.0.9",
-        "port": 4310,
+        "port": 17310,
         "authMode": "none"
       },
       "storage": {

--- a/specs/2026-04-17-go-port-plan/artifacts/config-surface.md
+++ b/specs/2026-04-17-go-port-plan/artifacts/config-surface.md
@@ -43,7 +43,7 @@ Source: `apps/looperd/src/config/load.ts:24-68`, `apps/looperd/src/config/load.t
 
 - `looper` reads `--config`/`LOOPER_CONFIG`/`~/.looper/config.json` to find connection settings
 - `server.host` precedence: CLI flag → `LOOPER_HOST` → config file → `127.0.0.1`
-- `server.port` precedence: CLI flag → `LOOPER_PORT` → config file → `4310`
+- `server.port` precedence: CLI flag → `LOOPER_PORT` → config file → `17310`
 - API token precedence: `LOOPER_TOKEN` only; the CLI does not read `server.localToken` from file, it injects `localToken: options.env.LOOPER_TOKEN`
 - API base URL uses `server.baseUrl` from config file when present, otherwise `http://<host>:<port>`
 
@@ -54,7 +54,7 @@ Source: `apps/cli/src/index.ts:282-294`, `apps/cli/src/index.ts:2473-2516`
 | Field | Type / allowed values | Default / behavior | Validation / notes |
 | --- | --- | --- | --- |
 | `server.host` | string | `127.0.0.1` | required non-empty string |
-| `server.port` | integer | `4310` | `1..65535` |
+| `server.port` | integer | `17310` | `1..65535` |
 | `server.baseUrl` | optional string | none | CLI-only consumption when reading config |
 | `server.authMode` | `none` \| `local-token` | `none` | `local-token` requires `server.localToken` |
 | `server.localToken` | optional string | none | required when `authMode=local-token` |

--- a/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
+++ b/specs/2026-04-17-go-port-plan/artifacts/daemon-http.responses.compat.json
@@ -141,7 +141,7 @@
         "data": {
           "server": {
             "host": "127.0.0.1",
-            "port": 4310,
+            "port": 17310,
             "authMode": "none",
             "localTokenConfigured": false
           },


### PR DESCRIPTION
## Summary
- Change the default looperd bind port from 4310 to 17310 to reduce local service conflicts.
- Update default-config expectations, parity fixtures, compatibility artifacts, and docs to reflect the new default.
- Add a migration note clarifying explicit config, env, and CLI port overrides continue to take precedence.

## Validation
- gofmt
- go test ./...
- go vet ./...
- go build ./...

Closes #131

<!-- looper:stamp v=1 -->
<sub>Generated by looper 0.0.0-dev · runner=worker · agent=openai/gpt-5.5</sub>