### PR TITLE
fix: persist historical logs

### DIFF
--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -18,8 +20,9 @@ import (
 )
 
 const (
-	defaultMaxOutputBytes = 256 * 1024
-	completionMarkerEnv   = "LOOPER_COMPLETION_MARKER"
+	defaultMaxOutputBytes    = 256 * 1024
+	maxPersistedLogReadBytes = 16 * 1024 * 1024
+	completionMarkerEnv      = "LOOPER_COMPLETION_MARKER"
 )
 
 type ExecutorConfig struct {
@@ -32,6 +35,7 @@ type ExecutorConfig struct {
 type ExecutorOptions struct {
 	Config ExecutorConfig
 	Repos  *storage.Repositories
+	LogDir string
 	Now    func() time.Time
 }
 
@@ -84,6 +88,7 @@ type Execution interface {
 type ConfiguredExecutor struct {
 	config ExecutorConfig
 	repos  *storage.Repositories
+	logDir string
 	now    func() time.Time
 }
 
@@ -92,7 +97,7 @@ func New(options ExecutorOptions) *ConfiguredExecutor {
 	if now == nil {
 		now = time.Now
 	}
-	return &ConfiguredExecutor{config: options.Config, repos: options.Repos, now: now}
+	return &ConfiguredExecutor{config: options.Config, repos: options.Repos, logDir: options.LogDir, now: now}
 }
 
 func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Execution, error) {
@@ -149,6 +154,8 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 		killCh:             make(chan string, 1),
 		doneCh:             make(chan execOutcome, 1),
 	}
+	x.stdoutLogPath, x.stderrLogPath = e.executionLogPaths(input, executionID)
+	x.initializePersistedLogs()
 	cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stdout", chunk) }}
 	cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stderr", chunk) }}
 	if err := cmd.Start(); err != nil {
@@ -186,6 +193,8 @@ type execution struct {
 	status         string
 	stdout         []byte
 	stderr         []byte
+	stdoutLogPath  string
+	stderrLogPath  string
 	heartbeatCount int64
 
 	killCh chan string
@@ -342,9 +351,16 @@ func (x *execution) run(ctx context.Context) {
 
 	stdout := x.stdoutString()
 	stderr := x.stderrString()
+	if persisted, ok := readPersistedExecutionLog(x.stdoutLogPath); ok {
+		stdout = persisted
+	}
+	if persisted, ok := readPersistedExecutionLog(x.stderrLogPath); ok {
+		stderr = persisted
+	}
 	status := x.finalStatus(timedOut, killed)
 	if waitErr != nil && status == "failed" && strings.TrimSpace(stderr) == "" {
 		stderr = waitErr.Error()
+		x.appendPersistedLog(x.stderrLogPath, []byte(stderr))
 	}
 	errorMessage := ""
 	if status == "failed" || status == "timeout" || status == "killed" {
@@ -404,8 +420,10 @@ func (x *execution) onOutput(stream string, chunk []byte) {
 	x.lastHeartbeatAtISO = nowISO
 	x.lastOutputAt = now
 	if stream == "stdout" {
+		x.appendPersistedLog(x.stdoutLogPath, chunk)
 		x.stdout = appendTailBounded(x.stdout, chunk, x.maxOutputBytes)
 	} else {
+		x.appendPersistedLog(x.stderrLogPath, chunk)
 		x.stderr = appendTailBounded(x.stderr, chunk, x.maxOutputBytes)
 	}
 	heartbeatCount := x.heartbeatCount
@@ -413,7 +431,7 @@ func (x *execution) onOutput(stream string, chunk []byte) {
 	stderr := string(x.stderr)
 	x.mu.Unlock()
 
-	outputJSON := mustJSON(map[string]string{"stdout": stdout, "stderr": stderr})
+	outputJSON := x.outputJSON(stdout, stderr)
 	x.persistStatus(x.currentStatus(), &heartbeatCount, &nowISO, &outputJSON)
 	x.bumpRunHeartbeat(nowISO)
 }
@@ -474,7 +492,14 @@ func (x *execution) persistFinal(status string, result Result, errorMessage, end
 	}
 	commandJSON := mustJSON(map[string]any{"command": x.command, "args": x.args})
 	metadata := mustJSON(map[string]any{"idempotencyKey": emptyToNil(x.input.IdempotencyKey), "metadata": x.input.Metadata})
-	outputJSON := mustJSON(map[string]any{"stdout": result.Stdout, "stderr": result.Stderr, "gitPrLifecycle": result.Lifecycle})
+	embeddedStdout := x.stdoutString()
+	embeddedStderr := x.stderrString()
+	if embeddedStderr == "" && result.Stderr != "" {
+		embeddedStderr = result.Stderr
+	}
+	output := x.outputPayload(embeddedStdout, embeddedStderr)
+	output["gitPrLifecycle"] = result.Lifecycle
+	outputJSON := mustJSON(output)
 	pid := int64(pidOrZero(x.process.Process))
 	parseStatus := result.ParseStatus
 	completionSignal := emptyToNil(result.CompletionSignal)
@@ -696,6 +721,112 @@ func stringArgs(value any) []string {
 		}
 	}
 	return result
+}
+
+func (e *ConfiguredExecutor) executionLogPaths(input RunInput, executionID string) (string, string) {
+	if strings.TrimSpace(e.logDir) == "" {
+		return "", ""
+	}
+	runID := safeLogPathSegment(firstNonEmpty(input.RunID, "runless"))
+	loopID := safeLogPathSegment(firstNonEmpty(input.LoopID, "loopless"))
+	execID := safeLogPathSegment(firstNonEmpty(executionID, "execution"))
+	dir := filepath.Join(e.logDir, "loops", loopID, runID)
+	return filepath.Join(dir, execID+".stdout.log"), filepath.Join(dir, execID+".stderr.log")
+}
+
+func safeLogPathSegment(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || trimmed == "." || trimmed == ".." {
+		return "unknown"
+	}
+	var builder strings.Builder
+	for _, r := range trimmed {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			builder.WriteRune(r)
+		default:
+			builder.WriteRune('_')
+		}
+	}
+	segment := builder.String()
+	if segment == "." || segment == ".." {
+		return "unknown"
+	}
+	return segment
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (x *execution) appendPersistedLog(path string, chunk []byte) {
+	if path == "" || len(chunk) == 0 {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	_, _ = file.Write(chunk)
+}
+
+func (x *execution) initializePersistedLogs() {
+	for _, path := range []string{x.stdoutLogPath, x.stderrLogPath} {
+		if path == "" {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			continue
+		}
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+		if err != nil {
+			continue
+		}
+		_ = file.Close()
+	}
+}
+
+func readPersistedExecutionLog(path string) (string, bool) {
+	if path == "" {
+		return "", false
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer file.Close()
+	raw, err := io.ReadAll(io.LimitReader(file, maxPersistedLogReadBytes+1))
+	if err != nil {
+		return "", false
+	}
+	if len(raw) > maxPersistedLogReadBytes {
+		raw = raw[:maxPersistedLogReadBytes]
+	}
+	return string(raw), true
+}
+
+func (x *execution) outputJSON(stdout, stderr string) string {
+	return mustJSON(x.outputPayload(stdout, stderr))
+}
+
+func (x *execution) outputPayload(stdout, stderr string) map[string]any {
+	payload := map[string]any{"stdout": stdout, "stderr": stderr}
+	if x.stdoutLogPath != "" {
+		payload["stdoutLogPath"] = x.stdoutLogPath
+	}
+	if x.stderrLogPath != "" {
+		payload["stderrLogPath"] = x.stderrLogPath
+	}
+	return payload
 }
 
 func appendTailBounded(existing []byte, chunk []byte, maxBytes int) []byte {

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -804,12 +804,18 @@ func readPersistedExecutionLog(path string) (string, bool) {
 		return "", false
 	}
 	defer file.Close()
-	raw, err := io.ReadAll(io.LimitReader(file, maxPersistedLogReadBytes+1))
+	info, err := file.Stat()
 	if err != nil {
 		return "", false
 	}
-	if len(raw) > maxPersistedLogReadBytes {
-		raw = raw[:maxPersistedLogReadBytes]
+	if info.Size() > maxPersistedLogReadBytes {
+		if _, err := file.Seek(info.Size()-maxPersistedLogReadBytes, io.SeekStart); err != nil {
+			return "", false
+		}
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, maxPersistedLogReadBytes))
+	if err != nil {
+		return "", false
 	}
 	return string(raw), true
 }

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -189,13 +189,14 @@ type execution struct {
 	lastHeartbeatAtISO string
 	lastOutputAt       time.Time
 
-	mu             sync.Mutex
-	status         string
-	stdout         []byte
-	stderr         []byte
-	stdoutLogPath  string
-	stderrLogPath  string
-	heartbeatCount int64
+	mu                      sync.Mutex
+	status                  string
+	stdout                  []byte
+	stderr                  []byte
+	stdoutLogPath           string
+	stderrLogPath           string
+	persistedLogWriteFailed bool
+	heartbeatCount          int64
 
 	killCh chan string
 	doneCh chan execOutcome
@@ -349,18 +350,13 @@ func (x *execution) run(ctx context.Context) {
 		_ = x.killProcessGroup()
 	}
 
-	stdout := x.stdoutString()
-	stderr := x.stderrString()
-	if persisted, ok := readPersistedExecutionLog(x.stdoutLogPath); ok {
-		stdout = persisted
-	}
-	if persisted, ok := readPersistedExecutionLog(x.stderrLogPath); ok {
-		stderr = persisted
-	}
+	stdout, stderr := x.resolveOutputLogs()
 	status := x.finalStatus(timedOut, killed)
 	if waitErr != nil && status == "failed" && strings.TrimSpace(stderr) == "" {
 		stderr = waitErr.Error()
-		x.appendPersistedLog(x.stderrLogPath, []byte(stderr))
+		if x.appendPersistedLog(x.stderrLogPath, []byte(stderr)) {
+			x.markPersistedLogWriteFailed()
+		}
 	}
 	errorMessage := ""
 	if status == "failed" || status == "timeout" || status == "killed" {
@@ -420,10 +416,14 @@ func (x *execution) onOutput(stream string, chunk []byte) {
 	x.lastHeartbeatAtISO = nowISO
 	x.lastOutputAt = now
 	if stream == "stdout" {
-		x.appendPersistedLog(x.stdoutLogPath, chunk)
+		if x.appendPersistedLog(x.stdoutLogPath, chunk) {
+			x.persistedLogWriteFailed = true
+		}
 		x.stdout = appendTailBounded(x.stdout, chunk, x.maxOutputBytes)
 	} else {
-		x.appendPersistedLog(x.stderrLogPath, chunk)
+		if x.appendPersistedLog(x.stderrLogPath, chunk) {
+			x.persistedLogWriteFailed = true
+		}
 		x.stderr = appendTailBounded(x.stderr, chunk, x.maxOutputBytes)
 	}
 	heartbeatCount := x.heartbeatCount
@@ -576,6 +576,33 @@ func (x *execution) heartbeatCountValue() int64 {
 	x.mu.Lock()
 	defer x.mu.Unlock()
 	return x.heartbeatCount
+}
+
+func (x *execution) resolveOutputLogs() (string, string) {
+	stdout := x.stdoutString()
+	stderr := x.stderrString()
+	if x.hasPersistedLogWriteFailure() {
+		return stdout, stderr
+	}
+	if persisted, ok := readPersistedExecutionLog(x.stdoutLogPath); ok {
+		stdout = persisted
+	}
+	if persisted, ok := readPersistedExecutionLog(x.stderrLogPath); ok {
+		stderr = persisted
+	}
+	return stdout, stderr
+}
+
+func (x *execution) hasPersistedLogWriteFailure() bool {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	return x.persistedLogWriteFailed
+}
+
+func (x *execution) markPersistedLogWriteFailed() {
+	x.mu.Lock()
+	x.persistedLogWriteFailed = true
+	x.mu.Unlock()
 }
 
 func (x *execution) timeSinceLastOutput() time.Duration {
@@ -764,19 +791,23 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func (x *execution) appendPersistedLog(path string, chunk []byte) {
+func (x *execution) appendPersistedLog(path string, chunk []byte) bool {
 	if path == "" || len(chunk) == 0 {
-		return
+		return false
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return
+		return true
 	}
 	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return
+		return true
 	}
-	defer file.Close()
-	_, _ = file.Write(chunk)
+	n, err := file.Write(chunk)
+	writeFailed := err != nil || n != len(chunk)
+	if err := file.Close(); err != nil {
+		writeFailed = true
+	}
+	return writeFailed
 }
 
 func (x *execution) initializePersistedLogs() {

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -255,6 +255,49 @@ func TestReadPersistedExecutionLogReadsTailToPreserveCompletionMarker(t *testing
 	}
 }
 
+func TestExecutionResolveOutputLogsSkipsPersistedReplacementAfterWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "stdout.log")
+	fullPersisted := strings.Repeat("persisted-", 4)
+	if err := os.WriteFile(logPath, []byte(fullPersisted), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	x := &execution{
+		stdout:                  []byte("tail-only"),
+		stdoutLogPath:           logPath,
+		persistedLogWriteFailed: true,
+	}
+
+	stdout, stderr := x.resolveOutputLogs()
+	if stdout != "tail-only" {
+		t.Fatalf("stdout = %q, want in-memory tail when persisted write failed", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty stderr", stderr)
+	}
+}
+
+func TestAppendPersistedLogMarksWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	dirPath := filepath.Join(t.TempDir(), "logs")
+	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	x := &execution{}
+	if !x.appendPersistedLog(dirPath, []byte("chunk")) {
+		t.Fatal("appendPersistedLog() = false, want true for unwritable path")
+	}
+	x.markPersistedLogWriteFailed()
+
+	if !x.hasPersistedLogWriteFailure() {
+		t.Fatal("hasPersistedLogWriteFailure() = false, want true")
+	}
+}
+
 func TestIsAgentSetupFailureMessageDetectsCodexModelCompatibility(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -227,6 +227,34 @@ func TestParseCompletionIgnoresTemplatePlaceholder(t *testing.T) {
 	}
 }
 
+func TestReadPersistedExecutionLogReadsTailToPreserveCompletionMarker(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "stdout.log")
+	completionLine := CompletionMarkerPrefix + `{"summary":"done from tail"}` + "\n"
+	headSize := maxPersistedLogReadBytes - len(completionLine) + 1023
+	fullLog := strings.Repeat("x", headSize) + "\n" + completionLine
+	if err := os.WriteFile(logPath, []byte(fullLog), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	persisted, ok := readPersistedExecutionLog(logPath)
+	if !ok {
+		t.Fatal("readPersistedExecutionLog() = ok false, want true")
+	}
+	if len(persisted) != maxPersistedLogReadBytes {
+		t.Fatalf("len(persisted) = %d, want %d", len(persisted), maxPersistedLogReadBytes)
+	}
+	if !strings.HasSuffix(persisted, completionLine) {
+		t.Fatalf("persisted log missing completion tail suffix")
+	}
+
+	parsed := parseCompletion(persisted, "")
+	if parsed.ParseStatus != "parsed" || parsed.Summary != "done from tail" || parsed.CompletionSignal != CompletionMarkerPrefix {
+		t.Fatalf("parseCompletion() = %#v, want parsed tail completion marker", parsed)
+	}
+}
+
 func TestIsAgentSetupFailureMessageDetectsCodexModelCompatibility(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -322,6 +323,78 @@ func TestExecutorBoundsCapturedOutputToTail(t *testing.T) {
 	}
 	if result.Stderr != "5678" {
 		t.Fatalf("stderr = %q, want 5678", result.Stderr)
+	}
+}
+
+func TestExecutorPersistsHistoricalLogsBeyondMaxOutputBytes(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	logDir := t.TempDir()
+	fullStdout := strings.Repeat("out-", 16)
+	fullStderr := strings.Repeat("err-", 16)
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", `printf "$FULL_STDOUT"; printf "$FULL_STDERR" >&2`}}},
+		Repos:  repos,
+		LogDir: logDir,
+	})
+
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_persisted_logs", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: time.Second, MaxOutputBytes: 8, Env: map[string]string{"FULL_STDOUT": fullStdout, "FULL_STDERR": fullStderr}})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Stdout != fullStdout {
+		t.Fatalf("result.Stdout = %q, want full persisted stdout %q", result.Stdout, fullStdout)
+	}
+	if result.Stderr != fullStderr {
+		t.Fatalf("result.Stderr = %q, want full persisted stderr %q", result.Stderr, fullStderr)
+	}
+
+	record, err := repos.AgentExecutions.GetByID(context.Background(), "agent_persisted_logs")
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
+	}
+	if record == nil || record.OutputJSON == nil {
+		t.Fatalf("agent execution record = %#v, want output_json", record)
+	}
+
+	var output struct {
+		Stdout        string `json:"stdout"`
+		Stderr        string `json:"stderr"`
+		StdoutLogPath string `json:"stdoutLogPath"`
+		StderrLogPath string `json:"stderrLogPath"`
+	}
+	if err := json.Unmarshal([]byte(*record.OutputJSON), &output); err != nil {
+		t.Fatalf("json.Unmarshal(output_json) error = %v", err)
+	}
+	if output.Stdout != fullStdout[len(fullStdout)-8:] {
+		t.Fatalf("output stdout = %q, want truncated tail %q", output.Stdout, fullStdout[len(fullStdout)-8:])
+	}
+	if output.Stderr != fullStderr[len(fullStderr)-8:] {
+		t.Fatalf("output stderr = %q, want truncated tail %q", output.Stderr, fullStderr[len(fullStderr)-8:])
+	}
+	if output.StdoutLogPath == "" || output.StderrLogPath == "" {
+		t.Fatalf("output log paths = %#v, want stdout/stderr log paths", output)
+	}
+	stdoutLog, err := os.ReadFile(output.StdoutLogPath)
+	if err != nil {
+		t.Fatalf("ReadFile(stdout log) error = %v", err)
+	}
+	stderrLog, err := os.ReadFile(output.StderrLogPath)
+	if err != nil {
+		t.Fatalf("ReadFile(stderr log) error = %v", err)
+	}
+	if string(stdoutLog) != fullStdout {
+		t.Fatalf("stdout log = %q, want %q", string(stdoutLog), fullStdout)
+	}
+	if string(stderrLog) != fullStderr {
+		t.Fatalf("stderr log = %q, want %q", string(stderrLog), fullStderr)
 	}
 }
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3363,7 +3363,7 @@ func (h *Handler) buildLoopLogsResponse(ctx context.Context, loop storage.LoopRe
 			return loopLogsResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: agentErr.Error()}
 		}
 		if latestAgent != nil {
-			stdout, stderr := parseAgentOutput(latestAgent.OutputJSON)
+			stdout, stderr := parseAgentOutput(h.context.Config.Daemon.LogDir, latestAgent.OutputJSON)
 			agentPayload = &loopLogsAgentPayload{
 				ExecutionID:     latestAgent.ID,
 				Vendor:          latestAgent.Vendor,
@@ -3772,18 +3772,68 @@ func mapLoopCreateError(err error) error {
 	}
 }
 
-func parseAgentOutput(outputJSON *string) (string, string) {
+const maxPersistedAgentLogReadBytes = 16 * 1024 * 1024
+
+func parseAgentOutput(logDir string, outputJSON *string) (string, string) {
 	if outputJSON == nil || strings.TrimSpace(*outputJSON) == "" {
 		return "", ""
 	}
 	var payload struct {
-		Stdout string `json:"stdout"`
-		Stderr string `json:"stderr"`
+		Stdout        string `json:"stdout"`
+		Stderr        string `json:"stderr"`
+		StdoutLogPath string `json:"stdoutLogPath"`
+		StderrLogPath string `json:"stderrLogPath"`
 	}
 	if err := json.Unmarshal([]byte(*outputJSON), &payload); err != nil {
 		return "", ""
 	}
+	if content, ok := readAgentOutputLog(logDir, payload.StdoutLogPath); ok {
+		payload.Stdout = content
+	}
+	if content, ok := readAgentOutputLog(logDir, payload.StderrLogPath); ok {
+		payload.Stderr = content
+	}
 	return payload.Stdout, payload.Stderr
+}
+
+func readAgentOutputLog(logDir string, path string) (string, bool) {
+	if strings.TrimSpace(path) == "" {
+		return "", false
+	}
+	if !isPathWithinDirectory(path, logDir) {
+		return "", false
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer file.Close()
+	raw, err := io.ReadAll(io.LimitReader(file, maxPersistedAgentLogReadBytes+1))
+	if err != nil {
+		return "", false
+	}
+	if len(raw) > maxPersistedAgentLogReadBytes {
+		raw = raw[:maxPersistedAgentLogReadBytes]
+	}
+	return string(raw), true
+}
+
+func isPathWithinDirectory(path string, directory string) bool {
+	if strings.TrimSpace(directory) == "" {
+		return false
+	}
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	absDir, err := filepath.Abs(filepath.Clean(directory))
+	if err != nil {
+		return false
+	}
+	if absPath == absDir {
+		return false
+	}
+	return strings.HasPrefix(absPath, absDir+string(os.PathSeparator))
 }
 
 func parseJSONObject(raw *string) map[string]any {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3808,12 +3808,18 @@ func readAgentOutputLog(logDir string, path string) (string, bool) {
 		return "", false
 	}
 	defer file.Close()
-	raw, err := io.ReadAll(io.LimitReader(file, maxPersistedAgentLogReadBytes+1))
+	info, err := file.Stat()
 	if err != nil {
 		return "", false
 	}
-	if len(raw) > maxPersistedAgentLogReadBytes {
-		raw = raw[:maxPersistedAgentLogReadBytes]
+	if info.Size() > maxPersistedAgentLogReadBytes {
+		if _, err := file.Seek(info.Size()-maxPersistedAgentLogReadBytes, io.SeekStart); err != nil {
+			return "", false
+		}
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, maxPersistedAgentLogReadBytes))
+	if err != nil {
+		return "", false
 	}
 	return string(raw), true
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -3022,6 +3022,57 @@ func TestHandlerLoopLogsFollowStreamsSnapshotAndChunk(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopLogsReturnsPersistedHistoricalAgentOutput(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedRunRouteData(t, fixture.runtime)
+
+	stdoutPath := filepath.Join(fixture.config.Daemon.LogDir, "loops", "loop_1", "run_1", "agent_exec_persisted.stdout.log")
+	stderrPath := filepath.Join(fixture.config.Daemon.LogDir, "loops", "loop_1", "run_1", "agent_exec_persisted.stderr.log")
+	fullStdout := strings.Repeat("stdout-line\n", 4)
+	fullStderr := strings.Repeat("stderr-line\n", 4)
+	if err := os.MkdirAll(filepath.Dir(stdoutPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(log dir) error = %v", err)
+	}
+	if err := os.WriteFile(stdoutPath, []byte(fullStdout), 0o644); err != nil {
+		t.Fatalf("WriteFile(stdoutPath) error = %v", err)
+	}
+	if err := os.WriteFile(stderrPath, []byte(fullStderr), 0o644); err != nil {
+		t.Fatalf("WriteFile(stderrPath) error = %v", err)
+	}
+
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	if err := fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
+		ID:              "agent_exec_persisted",
+		ProjectID:       stringPtr("project_1"),
+		LoopID:          stringPtr("loop_1"),
+		RunID:           stringPtr("run_1"),
+		Vendor:          "openai",
+		Status:          "completed",
+		PID:             int64Ptr(1234),
+		HeartbeatCount:  1,
+		LastHeartbeatAt: stringPtr(nowISO),
+		StartedAt:       nowISO,
+		OutputJSON:      stringPtr(`{"stdout":"tail-out","stderr":"tail-err","stdoutLogPath":"` + stdoutPath + `","stderrLogPath":"` + stderrPath + `"}`),
+		CreatedAt:       nowISO,
+		UpdatedAt:       nowISO,
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(agent_exec_persisted) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/loops/loop_1/logs", nil)
+	recorder := httptest.NewRecorder()
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	agent := data["agent"].(map[string]any)
+	assertEqual(t, agent["stdout"], fullStdout)
+	assertEqual(t, agent["stderr"], fullStderr)
+}
+
 func TestHandlerLoopLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
 	fixture := newTestFixture(t)
 	seedRunRouteData(t, fixture.runtime)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -285,6 +285,30 @@ func TestHandlerPullRequestStatusReturnsInternalErrorWhenLoopLookupFails(t *test
 	assertEqual(t, errMap["message"], "list loops: database is locked")
 }
 
+func TestReadAgentOutputLogReadsTailToPreserveCompletionMarker(t *testing.T) {
+	t.Parallel()
+
+	logDir := t.TempDir()
+	logPath := filepath.Join(logDir, "stdout.log")
+	completionLine := "__LOOPER_RESULT__={\"summary\":\"done from tail\"}\n"
+	headSize := maxPersistedAgentLogReadBytes - len(completionLine) + 1023
+	fullLog := strings.Repeat("x", headSize) + "\n" + completionLine
+	if err := os.WriteFile(logPath, []byte(fullLog), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	persisted, ok := readAgentOutputLog(logDir, logPath)
+	if !ok {
+		t.Fatal("readAgentOutputLog() = ok false, want true")
+	}
+	if len(persisted) != maxPersistedAgentLogReadBytes {
+		t.Fatalf("len(persisted) = %d, want %d", len(persisted), maxPersistedAgentLogReadBytes)
+	}
+	if !strings.HasSuffix(persisted, completionLine) {
+		t.Fatal("persisted log missing completion tail suffix")
+	}
+}
+
 func TestHandlerPullRequestStatusReturnsInternalErrorWhenRunLookupFails(t *testing.T) {
 	fixture := newTestFixture(t)
 	seedEventAndPullRequestRouteData(t, fixture.runtime)

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -169,6 +169,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				helpWhenNoArgs:  true,
 				persistentFlags: []flagSpec{
 					stringFlag("lines", "count", "Line count"),
+					boolFlag("full", "Show all retained daemon log lines, including rotated log files"),
 					boolFlag("force", "Overwrite existing installed daemon binary"),
 				},
 				exampleLines: []string{
@@ -178,6 +179,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					"$ looper daemon restart",
 					"$ looper daemon status",
 					"$ looper daemon logs --lines 50",
+					"$ looper daemon logs --full",
 				},
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "install", short: "Install the managed daemon binary", runE: runtime.daemonInstall}),

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -55,8 +55,10 @@ type daemonStatusOutput struct {
 }
 
 type daemonLogsOutput struct {
-	LogPath string   `json:"logPath"`
-	Lines   []string `json:"lines"`
+	LogPath  string   `json:"logPath"`
+	LogPaths []string `json:"logPaths"`
+	Full     bool     `json:"full"`
+	Lines    []string `json:"lines"`
 }
 
 func (r *commandRuntime) daemonStatus(cmd *cobra.Command, args []string) error {
@@ -452,9 +454,13 @@ func (r *commandRuntime) daemonLogs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	full := getBoolFlag(cmd, "full")
 	lineCountValue := strings.TrimSpace(getStringFlag(cmd, "lines"))
 	lineCount := int64(50)
 	if lineCountValue != "" {
+		if full {
+			return fmt.Errorf("--full cannot be combined with --lines")
+		}
 		lineCount, err = parsePositiveInt(lineCountValue, "--lines")
 		if err != nil {
 			return err
@@ -462,18 +468,21 @@ func (r *commandRuntime) daemonLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	logPath := filepath.Join(loaded.Config.Daemon.LogDir, "looperd.log")
-	raw, err := r.readFile(logPath)
+	content, logPaths, err := r.readRetainedDaemonLogs(logPath, loaded.Config.Logging.MaxFiles)
 	if err != nil {
 		return err
 	}
 
-	lines := tailLines(strings.TrimRight(string(raw), "\n"), int(lineCount))
-	output := daemonLogsOutput{LogPath: logPath, Lines: lines}
+	lines := splitLogLines(content)
+	if !full {
+		lines = tailLines(strings.Join(lines, "\n"), int(lineCount))
+	}
+	output := daemonLogsOutput{LogPath: logPath, LogPaths: logPaths, Full: full, Lines: lines}
 	if getBoolFlag(cmd, "json") {
 		return writeJSON(cmd.OutOrStdout(), output)
 	}
 
-	if _, err := fmt.Fprintln(cmd.OutOrStdout(), logPath); err != nil {
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s (retained files: %d; default tail: %d lines; use --full to show all retained logs)\n", logPath, len(logPaths), lineCount); err != nil {
 		return err
 	}
 	for _, line := range lines {
@@ -482,6 +491,55 @@ func (r *commandRuntime) daemonLogs(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
+}
+
+func (r *commandRuntime) readRetainedDaemonLogs(logPath string, maxFiles int) (string, []string, error) {
+	paths := retainedDaemonLogPaths(logPath, maxFiles)
+	var builder strings.Builder
+	readPaths := make([]string, 0, len(paths))
+	for _, path := range paths {
+		raw, err := r.readFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return "", nil, err
+		}
+		if len(raw) == 0 {
+			readPaths = append(readPaths, path)
+			continue
+		}
+		if builder.Len() > 0 && !strings.HasSuffix(builder.String(), "\n") {
+			builder.WriteString("\n")
+		}
+		builder.WriteString(strings.TrimRight(string(raw), "\n"))
+		builder.WriteString("\n")
+		readPaths = append(readPaths, path)
+	}
+	if len(readPaths) == 0 {
+		return "", nil, os.ErrNotExist
+	}
+	return strings.TrimRight(builder.String(), "\n"), readPaths, nil
+}
+
+func retainedDaemonLogPaths(logPath string, maxFiles int) []string {
+	if maxFiles < 1 {
+		maxFiles = 1
+	}
+	paths := make([]string, 0, maxFiles)
+	for index := maxFiles - 1; index >= 1; index-- {
+		paths = append(paths, fmt.Sprintf("%s.%d", logPath, index))
+	}
+	paths = append(paths, logPath)
+	return paths
+}
+
+func splitLogLines(content string) []string {
+	content = strings.TrimRight(content, "\n")
+	if content == "" {
+		return []string{}
+	}
+	return strings.Split(content, "\n")
 }
 
 func (r *commandRuntime) loadConfig() (config.LoadedFileConfig, error) {

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -1275,6 +1275,67 @@ func TestDaemonLogsJSONReturnsTail(t *testing.T) {
 	assertJSONContains(t, stdout.String(), "lines", []any{"two", "three"})
 }
 
+func TestDaemonLogsFullJSONIncludesRetainedHistoryBeforeActiveLog(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeDaemonCLIConfig(t, "http://127.0.0.1:1")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		ReadFile: func(path string) ([]byte, error) {
+			switch {
+			case strings.HasSuffix(path, filepath.Join("logs", "looperd.log.4")):
+				return []byte("oldest"), nil
+			case strings.HasSuffix(path, filepath.Join("logs", "looperd.log.3")):
+				return []byte("older"), nil
+			case strings.HasSuffix(path, filepath.Join("logs", "looperd.log.2")):
+				return []byte("old"), nil
+			case strings.HasSuffix(path, filepath.Join("logs", "looperd.log.1")):
+				return []byte("recent-rotated"), nil
+			case strings.HasSuffix(path, filepath.Join("logs", "looperd.log")):
+				return []byte("current-1\ncurrent-2\n"), nil
+			default:
+				return nil, os.ErrNotExist
+			}
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "logs", "--full", "--json", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon logs --full --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([daemon logs --full --json]) stderr = %q, want empty string", stderr.String())
+	}
+	assertJSONContains(t, stdout.String(), "full", true)
+	assertJSONContains(t, stdout.String(), "lines", []any{"oldest", "older", "old", "recent-rotated", "current-1", "current-2"})
+}
+
+func TestDaemonLogsRejectsFullWithLines(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeDaemonCLIConfig(t, "http://127.0.0.1:1")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "logs", "--full", "--lines", "2", "--config", configPath})
+	if exitCode != 1 {
+		t.Fatalf("Run([daemon logs --full --lines 2]) exit code = %d, want 1", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run([daemon logs --full --lines 2]) stdout = %q, want empty string", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "--full cannot be combined with --lines") {
+		t.Fatalf("stderr = %q, want full/lines conflict", stderr.String())
+	}
+}
+
 func writeDaemonCLIConfig(t *testing.T, baseURL string) string {
 	t.Helper()
 

--- a/internal/cliapp/testdata/golden/daemon-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/daemon-help.stdout.golden
@@ -11,6 +11,7 @@ Subcommands:
 
 Flags:
   --force                     Overwrite existing installed daemon binary
+  --full                      Show all retained daemon log lines, including rotated log files
   --lines <count>             Line count
 
 Global Flags:
@@ -33,3 +34,4 @@ $ looper daemon stop
 $ looper daemon restart
 $ looper daemon status
 $ looper daemon logs --lines 50
+$ looper daemon logs --full

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -687,8 +687,9 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			Params: cfg.Agent.Params,
 			Env:    cfg.Agent.Env,
 		},
-		Repos: repos,
-		Now:   now,
+		Repos:  repos,
+		LogDir: cfg.Daemon.LogDir,
+		Now:    now,
 	})
 	retryBaseDelay := time.Duration(cfg.Scheduler.RetryBaseDelayMS) * time.Millisecond
 	stamper := disclosure.FromConfig(cfg)


### PR DESCRIPTION
## Summary
- Persist agent stdout/stderr chunks to durable log files under the configured daemon log directory and have loop logs read those accumulated files when available.
- Extend daemon logs to read retained rotated log files with explicit `--full` behavior.
- Add tests covering persisted agent output, API loop log reads from persisted files, and retained daemon log history.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #133

<!-- looper:stamp v=1 -->
<sub>Generated by looper 0.0.0-dev · runner=worker · agent=gpt-5.5</sub>