### PR TITLE
feat: make bootstrap install looperd

### DIFF
--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -129,11 +129,41 @@ func (r *commandRuntime) runBootstrap(ctx context.Context, cmd *cobra.Command, o
 	}
 	client := r.apiClientFromLoaded(loaded)
 
-	apiReachable, err := r.bootstrapAPIReachable(ctx, client)
+	var apiReachable bool
+	if installed {
+		apiReachable, err = r.bootstrapAPIReachableForInstalled(ctx, client)
+	} else {
+		apiReachable, err = r.bootstrapAPIReachable(ctx, client)
+	}
 	if err != nil {
 		return bootstrapResult{}, err
 	}
-	if !apiReachable {
+	if apiReachable && installed {
+		expectedDaemon, err := r.readManagedDaemonVersion(ctx)
+		if err != nil {
+			return bootstrapResult{}, err
+		}
+		expectedVersion := ""
+		if expectedDaemon != nil {
+			expectedVersion = expectedDaemon.Version
+		}
+		matches, err := r.bootstrapReachableDaemonMatches(ctx, client, expectedVersion, managedDaemonPath)
+		if err != nil {
+			return bootstrapResult{}, err
+		}
+		if !matches {
+			if err := r.bootstrapCanRestartReachableDaemon(ctx, client, loaded); err != nil {
+				return bootstrapResult{}, err
+			}
+			if err := r.daemonRestartForBootstrap(cmd); err != nil {
+				return bootstrapResult{}, err
+			}
+			apiReachable, err = r.waitForBootstrapMatchingDaemon(ctx, client, expectedVersion, managedDaemonPath)
+			if err != nil {
+				return bootstrapResult{}, err
+			}
+		}
+	} else if !apiReachable {
 		if err := r.daemonStartForBootstrap(cmd); err != nil {
 			return bootstrapResult{}, err
 		}
@@ -296,6 +326,17 @@ func (r *commandRuntime) daemonStartForBootstrap(cmd *cobra.Command) error {
 	cmd.SetOut(io.Discard)
 	defer cmd.SetOut(originalOut)
 	return r.daemonStart(cmd, nil)
+}
+
+func (r *commandRuntime) daemonRestartForBootstrap(cmd *cobra.Command) error {
+	if !getBoolFlag(cmd, "json") {
+		return r.daemonRestart(cmd, nil)
+	}
+
+	originalOut := cmd.OutOrStdout()
+	cmd.SetOut(io.Discard)
+	defer cmd.SetOut(originalOut)
+	return r.daemonRestart(cmd, nil)
 }
 
 func (r *commandRuntime) bootstrapConfiguredToolPaths(configPath string) (config.ToolPathsConfig, error) {
@@ -636,6 +677,106 @@ func (r *commandRuntime) bootstrapAPIReachable(ctx context.Context, client *Daem
 		return false, healthErr
 	}
 	return false, nil
+}
+
+func (r *commandRuntime) bootstrapAPIReachableForInstalled(ctx context.Context, client *DaemonAPIClient) (bool, error) {
+	_, err := r.getJSONWithClient(ctx, client, "/api/v1/status")
+	if err == nil {
+		return true, nil
+	}
+	if isBootstrapProbeContextError(err) {
+		return false, err
+	}
+	if !isBootstrapProbeReachabilityError(err) {
+		return true, nil
+	}
+
+	_, healthErr := r.getJSONWithClient(ctx, client, "/api/v1/healthz")
+	if healthErr == nil {
+		return true, nil
+	}
+	if isBootstrapProbeContextError(healthErr) {
+		return false, healthErr
+	}
+	if !isBootstrapProbeReachabilityError(healthErr) {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (r *commandRuntime) bootstrapReachableDaemonMatches(ctx context.Context, client *DaemonAPIClient, expectedVersion string, managedDaemonPath string) (bool, error) {
+	payload, err := r.getJSONWithClient(ctx, client, "/api/v1/status")
+	if err != nil {
+		if isBootstrapProbeContextError(err) {
+			return false, err
+		}
+		return false, nil
+	}
+	return bootstrapDaemonPayloadMatchesManaged(payload, expectedVersion, managedDaemonPath), nil
+}
+
+func bootstrapDaemonPayloadMatchesManaged(payload json.RawMessage, expectedVersion string, managedDaemonPath string) bool {
+	binary := extractDaemonServiceBinary(payload)
+	if !bootstrapDaemonVersionMatchesExpected(binary.Version, expectedVersion) {
+		return false
+	}
+	if strings.TrimSpace(binary.Path) == "" {
+		return false
+	}
+	return filepath.Clean(binary.Path) == filepath.Clean(managedDaemonPath)
+}
+
+func bootstrapDaemonVersionMatchesExpected(daemonVersion string, expectedVersion string) bool {
+	if strings.TrimSpace(expectedVersion) == "" {
+		return bootstrapDaemonVersionMatches(daemonVersion)
+	}
+	return strings.TrimPrefix(strings.TrimSpace(daemonVersion), "v") == strings.TrimPrefix(strings.TrimSpace(expectedVersion), "v")
+}
+
+func (r *commandRuntime) bootstrapCanRestartReachableDaemon(ctx context.Context, client *DaemonAPIClient, loaded config.LoadedFileConfig) error {
+	localClient := r.localAPIClientFromLoaded(loaded)
+	if normalizeBootstrapBaseURL(client.baseURL) != normalizeBootstrapBaseURL(localClient.baseURL) {
+		return fmt.Errorf("installed managed looperd, but the configured API endpoint is not the local daemon endpoint; stop the stale looperd process manually and rerun `looper bootstrap`")
+	}
+
+	pidFilePath, err := r.resolveDaemonPIDFilePath()
+	if err != nil {
+		return err
+	}
+	existingPID, ok := r.readPIDFile(pidFilePath)
+	if !ok {
+		return fmt.Errorf("installed managed looperd, but a stale looperd API is already reachable and no daemon pid file was found; stop the stale looperd process manually and rerun `looper bootstrap`")
+	}
+	if !r.isProcessAlive(existingPID) {
+		return fmt.Errorf("installed managed looperd, but a stale looperd API is already reachable and the daemon pid file points to a stopped process; stop the stale looperd process manually and rerun `looper bootstrap`")
+	}
+	isLooperd, err := r.isLooperdProcess(ctx, existingPID)
+	if err != nil {
+		return err
+	}
+	if !isLooperd {
+		return fmt.Errorf("installed managed looperd, but a stale looperd API is already reachable and the daemon pid file does not point to looperd; stop the stale looperd process manually and rerun `looper bootstrap`")
+	}
+	return nil
+}
+
+func normalizeBootstrapBaseURL(baseURL string) string {
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+func (r *commandRuntime) waitForBootstrapMatchingDaemon(ctx context.Context, client *DaemonAPIClient, expectedVersion string, managedDaemonPath string) (bool, error) {
+	deadline := time.Now().Add(bootstrapHealthCheckTimeout)
+	for time.Now().Before(deadline) {
+		matches, err := r.bootstrapReachableDaemonMatches(ctx, client, expectedVersion, managedDaemonPath)
+		if err != nil {
+			return false, err
+		}
+		if matches {
+			return true, nil
+		}
+		r.sleep(250 * time.Millisecond)
+	}
+	return false, fmt.Errorf("looperd is reachable but does not report the managed daemon version/path; stop the stale looperd process manually and rerun `looper bootstrap`")
 }
 
 func isBootstrapProbeContextError(err error) bool {

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -723,7 +725,20 @@ func bootstrapDaemonPayloadMatchesManaged(payload json.RawMessage, expectedVersi
 	if strings.TrimSpace(binary.Path) == "" {
 		return false
 	}
-	return filepath.Clean(binary.Path) == filepath.Clean(managedDaemonPath)
+	return bootstrapDaemonPathMatchesManaged(binary.Path, managedDaemonPath)
+}
+
+func bootstrapDaemonPathMatchesManaged(binaryPath string, managedDaemonPath string) bool {
+	return canonicalBootstrapPath(binaryPath) == canonicalBootstrapPath(managedDaemonPath)
+}
+
+func canonicalBootstrapPath(path string) string {
+	cleanPath := filepath.Clean(path)
+	resolvedPath, err := filepath.EvalSymlinks(cleanPath)
+	if err != nil {
+		return cleanPath
+	}
+	return filepath.Clean(resolvedPath)
 }
 
 func bootstrapDaemonVersionMatchesExpected(daemonVersion string, expectedVersion string) bool {
@@ -761,7 +776,32 @@ func (r *commandRuntime) bootstrapCanRestartReachableDaemon(ctx context.Context,
 }
 
 func normalizeBootstrapBaseURL(baseURL string) string {
-	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return trimmed
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if isBootstrapLoopbackHost(host) {
+		host = "localhost"
+	}
+	if port := parsed.Port(); port != "" {
+		host = net.JoinHostPort(host, port)
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = host
+	parsed.User = nil
+	return strings.TrimRight(parsed.String(), "/")
+}
+
+func isBootstrapLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	parsedIP := net.ParseIP(host)
+	return parsedIP != nil && parsedIP.IsLoopback()
 }
 
 func (r *commandRuntime) waitForBootstrapMatchingDaemon(ctx context.Context, client *DaemonAPIClient, expectedVersion string, managedDaemonPath string) (bool, error) {

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/powerformer/looper/internal/config"
+	"github.com/powerformer/looper/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -569,11 +570,12 @@ func (r *commandRuntime) ensureBootstrapDaemon(ctx context.Context, force bool) 
 	if err != nil {
 		return "", false, err
 	}
-	if !force && installed != nil {
+	matchingTag := bootstrapDaemonReleaseTag()
+	if !force && installed != nil && bootstrapDaemonVersionMatches(installed.Version) {
 		return "already-installed", false, nil
 	}
 	reinstall := force || installed != nil
-	result, err := r.installManagedDaemon(ctx, reinstall, "", r.app.stderr())
+	result, err := r.installManagedDaemon(ctx, reinstall, matchingTag, r.app.stderr())
 	if err != nil {
 		return "", false, fmt.Errorf("install managed daemon: %w", err)
 	}
@@ -584,6 +586,25 @@ func (r *commandRuntime) ensureBootstrapDaemon(ctx context.Context, force bool) 
 		return "reinstalled", true, nil
 	}
 	return "installed", true, nil
+}
+
+func bootstrapDaemonVersionMatches(daemonVersion string) bool {
+	cliVersion := strings.TrimSpace(version.Current().Version)
+	if cliVersion == "" || cliVersion == "0.0.0-dev" || strings.Contains(cliVersion, "dev") {
+		return strings.TrimSpace(daemonVersion) != ""
+	}
+	return strings.TrimPrefix(strings.TrimSpace(daemonVersion), "v") == strings.TrimPrefix(cliVersion, "v")
+}
+
+func bootstrapDaemonReleaseTag() string {
+	cliVersion := strings.TrimSpace(version.Current().Version)
+	if cliVersion == "" || cliVersion == "0.0.0-dev" || strings.Contains(cliVersion, "dev") {
+		return ""
+	}
+	if strings.HasPrefix(cliVersion, "v") {
+		return cliVersion
+	}
+	return "v" + cliVersion
 }
 
 func (r *commandRuntime) bootstrapAPIReachable(ctx context.Context, client *DaemonAPIClient) (bool, error) {

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -566,11 +566,21 @@ func bootstrapLocalToken() string {
 }
 
 func (r *commandRuntime) ensureBootstrapDaemon(ctx context.Context, force bool) (string, bool, error) {
+	matchingTag := bootstrapDaemonReleaseTag()
+	if force {
+		result, err := r.installManagedDaemon(ctx, true, matchingTag, r.app.stderr())
+		if err != nil {
+			return "", false, fmt.Errorf("install managed daemon: %w", err)
+		}
+		if result.Skipped {
+			return "already-installed", false, nil
+		}
+		return "reinstalled", true, nil
+	}
 	installed, err := r.readManagedDaemonVersion(ctx)
 	if err != nil {
 		return "", false, err
 	}
-	matchingTag := bootstrapDaemonReleaseTag()
 	if !force && installed != nil && bootstrapDaemonVersionMatches(installed.Version) {
 		return "already-installed", false, nil
 	}

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -690,7 +690,7 @@ func (r *commandRuntime) bootstrapAPIReachableForInstalled(ctx context.Context, 
 		return false, err
 	}
 	if !isBootstrapProbeReachabilityError(err) {
-		return true, nil
+		return false, err
 	}
 
 	_, healthErr := r.getJSONWithClient(ctx, client, "/api/v1/healthz")

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -829,6 +829,98 @@ func TestBootstrapRestartsReachableStaleDaemonAfterReinstall(t *testing.T) {
 	assertJSONContains(t, stdout.String(), "daemonRunning", true)
 }
 
+func TestBootstrapInstalledStatusAPIErrorFailsWithoutSpawnOrRestart(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "bootstrap-status-error.json")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	binary := []byte("looperd-binary")
+	checksum := sha256.Sum256(binary)
+	checksumText := hex.EncodeToString(checksum[:]) + "  looperd-darwin-arm64\n"
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	var spawnCalls atomic.Int32
+	var killCalls atomic.Int32
+
+	app := New(Deps{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		LookPath: func(file string) (string, error) {
+			switch file {
+			case "git", "gh", "osascript":
+				return "/usr/bin/" + file, nil
+			default:
+				return "", fmt.Errorf("not found")
+			}
+		},
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v1.2.3","assets":[{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looperd-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, binary), nil
+			case "https://example.invalid/looperd-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, checksumText), nil
+			case "http://127.0.0.1:17310/api/v1/status":
+				return jsonResponse(t, http.StatusUnauthorized, `{"ok":false,"error":{"message":"missing token"}}`), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "/usr/bin/gh" && strings.Join(args, " ") == "auth status" {
+				return commandExecutionResult{ExitCode: 0}, nil
+			}
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				if _, err := os.Stat(managedPath); err != nil {
+					return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+				}
+				return commandExecutionResult{ExitCode: 0, Stdout: "1.2.3\n"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			_ = command
+			_ = args
+			_ = cwd
+			_ = env
+			spawnCalls.Add(1)
+			return 0, fmt.Errorf("spawn should not be called")
+		},
+		KillProcess: func(pid int, signal int) error {
+			killCalls.Add(1)
+			return fmt.Errorf("unexpected kill(%d, %d)", pid, signal)
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"bootstrap", "--yes", "--force", "--config", configPath})
+	if exitCode == 0 {
+		t.Fatalf("Run([bootstrap --yes --force]) exit code = 0, want error")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run([bootstrap --yes --force]) stdout = %q, want empty string", stdout.String())
+	}
+	if spawnCalls.Load() != 0 {
+		t.Fatalf("spawnDetached calls = %d, want 0", spawnCalls.Load())
+	}
+	if killCalls.Load() != 0 {
+		t.Fatalf("KillProcess calls = %d, want 0", killCalls.Load())
+	}
+	for _, want := range []string{"looper:", "missing token"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want to contain %q", stderr.String(), want)
+		}
+	}
+}
+
 func TestNormalizeBootstrapBaseURLTreatsLoopbackHostsAsLocal(t *testing.T) {
 	got := normalizeBootstrapBaseURL("http://localhost:17310/")
 	want := normalizeBootstrapBaseURL("http://127.0.0.1:17310")

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -249,6 +249,75 @@ func TestBootstrapReportsInvalidManagedDaemon(t *testing.T) {
 	}
 }
 
+func TestEnsureBootstrapDaemonForceReinstallsBrokenManagedBinary(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if err := os.MkdirAll(filepath.Dir(managedPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(managedPath, []byte("corrupt"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	binary := []byte("replacement-looperd")
+	checksum := sha256.Sum256(binary)
+	checksumText := hex.EncodeToString(checksum[:]) + "  looperd-darwin-arm64\n"
+	stderr := &bytes.Buffer{}
+
+	app := New(Deps{
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v1.2.3","assets":[{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looperd-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, binary), nil
+			case "https://example.invalid/looperd-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, checksumText), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "exec format error"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	runtime := newCommandRuntime(app, nil)
+	state, installed, err := runtime.ensureBootstrapDaemon(context.Background(), true)
+	if err != nil {
+		t.Fatalf("ensureBootstrapDaemon(force=true) error = %v", err)
+	}
+	if state != "reinstalled" {
+		t.Fatalf("ensureBootstrapDaemon(force=true) state = %q, want %q", state, "reinstalled")
+	}
+	if !installed {
+		t.Fatal("ensureBootstrapDaemon(force=true) installed = false, want true")
+	}
+
+	got, err := os.ReadFile(managedPath)
+	if err != nil {
+		t.Fatalf("ReadFile(managedPath) error = %v", err)
+	}
+	if !bytes.Equal(got, binary) {
+		t.Fatalf("managed daemon bytes = %q, want %q", got, binary)
+	}
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64") {
+		t.Fatalf("stderr = %q, want download progress", stderr.String())
+	}
+}
+
 func TestBootstrapJSONSuppressesDaemonStartOutput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -685,6 +686,147 @@ func TestBootstrapIdempotentWhenConfigProjectAndDaemonAlreadyHealthy(t *testing.
 	if string(afterRaw) != before {
 		t.Fatalf("config changed unexpectedly\nbefore=%s\nafter=%s", before, string(afterRaw))
 	}
+}
+
+func TestBootstrapRestartsReachableStaleDaemonAfterReinstall(t *testing.T) {
+	homeDir := t.TempDir()
+	cwd := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "bootstrap-stale-daemon.json")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	pidFilePath := filepath.Join(homeDir, ".looper", "looperd.pid")
+	if err := os.MkdirAll(filepath.Dir(managedPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(managed dir) error = %v", err)
+	}
+	if err := os.WriteFile(managedPath, []byte("old-looperd"), 0o755); err != nil {
+		t.Fatalf("WriteFile(managedPath) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(pidFilePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(pid dir) error = %v", err)
+	}
+	if err := os.WriteFile(pidFilePath, []byte("100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pidFilePath) error = %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"server":{"host":"127.0.0.1","port":17310,"authMode":"none"}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(configPath) error = %v", err)
+	}
+
+	binary := []byte("new-looperd")
+	checksum := sha256.Sum256(binary)
+	checksumText := hex.EncodeToString(checksum[:]) + "  looperd-darwin-arm64\n"
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	runningPID := 100
+	runningVersion := "0.1.0"
+	installedVersion := "0.1.0"
+	var spawnCalls atomic.Int32
+	var termCalls atomic.Int32
+
+	app := New(Deps{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		Getwd: func() (string, error) {
+			return cwd, nil
+		},
+		LookPath: func(file string) (string, error) {
+			switch file {
+			case "git", "gh", "osascript":
+				return "/usr/bin/" + file, nil
+			default:
+				return "", fmt.Errorf("not found")
+			}
+		},
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/powerformer/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v1.2.3","assets":[{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looperd-darwin-arm64":
+				installedVersion = "1.2.3"
+				return binaryResponse(t, http.StatusOK, binary), nil
+			case "https://example.invalid/looperd-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, checksumText), nil
+			case "http://daemon.test/api/v1/status", "http://127.0.0.1:17310/api/v1/status":
+				if runningPID == 0 {
+					return nil, fmt.Errorf("daemon offline")
+				}
+				binaryPath := managedPath
+				if runningVersion == "0.1.0" {
+					binaryPath = filepath.Join(homeDir, ".looper", "bin", "stale-looperd")
+				}
+				return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"requestId":"req_status","data":{"service":{"healthy":true,"version":%q,"binary":{"name":"looperd","path":%q}}}}`, runningVersion, binaryPath)), nil
+			case "http://daemon.test/api/v1/healthz", "http://127.0.0.1:17310/api/v1/healthz":
+				if runningPID == 0 {
+					return nil, fmt.Errorf("daemon offline")
+				}
+				return jsonResponse(t, http.StatusOK, `{"ok":true,"requestId":"req_health","data":{"healthy":true}}`), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "/usr/bin/gh" && strings.Join(args, " ") == "auth status" {
+				return commandExecutionResult{ExitCode: 0}, nil
+			}
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 0, Stdout: installedVersion + "\n"}, nil
+			}
+			if command == "ps" && len(args) == 4 && args[0] == "-p" && args[2] == "-o" && args[3] == "command=" {
+				if runningPID == 0 || args[1] != fmt.Sprintf("%d", runningPID) {
+					return commandExecutionResult{ExitCode: 1}, nil
+				}
+				return commandExecutionResult{ExitCode: 0, Stdout: managedPath + "\n"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			_ = args
+			_ = cwd
+			_ = env
+			if command != managedPath {
+				return 0, fmt.Errorf("unexpected command %q", command)
+			}
+			spawnCalls.Add(1)
+			runningPID = 4321
+			runningVersion = "1.2.3"
+			return runningPID, nil
+		},
+		KillProcess: func(pid int, signal int) error {
+			if signal == 0 {
+				if pid == runningPID && runningPID != 0 {
+					return nil
+				}
+				return os.ErrProcessDone
+			}
+			if pid == 100 && signal == int(syscall.SIGTERM) {
+				termCalls.Add(1)
+				runningPID = 0
+				return nil
+			}
+			return fmt.Errorf("unexpected kill(%d, %d)", pid, signal)
+		},
+		Sleep: func(duration time.Duration) {
+			_ = duration
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"bootstrap", "--yes", "--force", "--json", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([bootstrap --yes --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if termCalls.Load() != 1 {
+		t.Fatalf("SIGTERM calls = %d, want 1", termCalls.Load())
+	}
+	if spawnCalls.Load() != 1 {
+		t.Fatalf("spawnDetached calls = %d, want 1", spawnCalls.Load())
+	}
+	assertJSONContains(t, stdout.String(), "daemonInstallState", "reinstalled")
+	assertJSONContains(t, stdout.String(), "daemonInstalled", true)
+	assertJSONContains(t, stdout.String(), "daemonRunning", true)
 }
 
 func TestBootstrapIdempotentSkipsGitHubWhenManagedDaemonInstalled(t *testing.T) {

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -162,6 +162,93 @@ func TestBootstrapYesInstallsStartsAndPrintsNextSteps(t *testing.T) {
 	}
 }
 
+func TestBootstrapReportsNonExecutableManagedDaemon(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if err := os.MkdirAll(filepath.Dir(managedPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(managedPath, []byte("looperd"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		LookPath: func(file string) (string, error) {
+			return "/usr/bin/" + file, nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "/usr/bin/gh" && strings.Join(args, " ") == "auth status" {
+				return commandExecutionResult{ExitCode: 0}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"bootstrap", "--yes", "--config", filepath.Join(t.TempDir(), "config.json")})
+	if exitCode == 0 {
+		t.Fatalf("Run([bootstrap]) exit code = 0, want error")
+	}
+	for _, want := range []string{"not executable", "chmod +x " + managedPath, "looper daemon install --force"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want to contain %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestBootstrapReportsInvalidManagedDaemon(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if err := os.MkdirAll(filepath.Dir(managedPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(managedPath, []byte("corrupt"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stderr:   stderr,
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		LookPath: func(file string) (string, error) {
+			return "/usr/bin/" + file, nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == "/usr/bin/gh" && strings.Join(args, " ") == "auth status" {
+				return commandExecutionResult{ExitCode: 0}, nil
+			}
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "exec format error"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"bootstrap", "--yes", "--config", filepath.Join(t.TempDir(), "config.json")})
+	if exitCode == 0 {
+		t.Fatalf("Run([bootstrap]) exit code = 0, want error")
+	}
+	for _, want := range []string{"version check failed", "exec format error", "looper daemon install --force"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want to contain %q", stderr.String(), want)
+		}
+	}
+}
+
 func TestBootstrapJSONSuppressesDaemonStartOutput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -829,6 +829,49 @@ func TestBootstrapRestartsReachableStaleDaemonAfterReinstall(t *testing.T) {
 	assertJSONContains(t, stdout.String(), "daemonRunning", true)
 }
 
+func TestNormalizeBootstrapBaseURLTreatsLoopbackHostsAsLocal(t *testing.T) {
+	got := normalizeBootstrapBaseURL("http://localhost:17310/")
+	want := normalizeBootstrapBaseURL("http://127.0.0.1:17310")
+	if got != want {
+		t.Fatalf("normalized localhost URL = %q, normalized 127.0.0.1 URL = %q, want equal", got, want)
+	}
+
+	got = normalizeBootstrapBaseURL("http://[::1]:17310")
+	if got != want {
+		t.Fatalf("normalized ::1 URL = %q, normalized 127.0.0.1 URL = %q, want equal", got, want)
+	}
+
+	remote := normalizeBootstrapBaseURL("http://daemon.test:17310")
+	if remote == want {
+		t.Fatalf("normalized remote URL = %q, normalized local URL = %q, want different", remote, want)
+	}
+}
+
+func TestBootstrapDaemonPayloadMatchesManagedResolvesSymlinkedHome(t *testing.T) {
+	realHome := t.TempDir()
+	linkedParent := filepath.Join(t.TempDir(), "linked-home")
+	if err := os.Symlink(realHome, linkedParent); err != nil {
+		t.Skipf("Symlink() unsupported: %v", err)
+	}
+
+	managedPath := filepath.Join(linkedParent, ".looper", "bin", "looperd")
+	if err := os.MkdirAll(filepath.Dir(managedPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(managed dir) error = %v", err)
+	}
+	if err := os.WriteFile(managedPath, []byte("looperd"), 0o755); err != nil {
+		t.Fatalf("WriteFile(managedPath) error = %v", err)
+	}
+	canonicalPath, err := filepath.EvalSymlinks(managedPath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(managedPath) error = %v", err)
+	}
+
+	payload := json.RawMessage(fmt.Sprintf(`{"service":{"healthy":true,"version":"1.2.3","binary":{"name":"looperd","path":%q}}}`, canonicalPath))
+	if !bootstrapDaemonPayloadMatchesManaged(payload, "1.2.3", managedPath) {
+		t.Fatalf("bootstrapDaemonPayloadMatchesManaged() = false, want true for canonical status path and symlinked managed path")
+	}
+}
+
 func TestBootstrapIdempotentSkipsGitHubWhenManagedDaemonInstalled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/daemon_install.go
+++ b/internal/cliapp/daemon_install.go
@@ -83,10 +83,12 @@ func (r *commandRuntime) installManagedDaemon(ctx context.Context, force bool, t
 	installDir := filepath.Join(homeDir, ".looper", "bin")
 	installPath := filepath.Join(installDir, looperdBinaryName)
 	if !force {
-		if _, err := os.Stat(installPath); err == nil {
+		state, err := r.checkManagedDaemonBinary(ctx)
+		if err != nil {
+			return daemonInstallResult{}, err
+		}
+		if state.Exists {
 			return daemonInstallResult{Target: target, InstallPath: installPath, Skipped: true}, nil
-		} else if !os.IsNotExist(err) {
-			return daemonInstallResult{}, fmt.Errorf("check existing install: %w", err)
 		}
 	}
 

--- a/internal/cliapp/daemon_install_test.go
+++ b/internal/cliapp/daemon_install_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestResolveLooperdTarget(t *testing.T) {
@@ -116,6 +117,14 @@ func TestInstallManagedDaemonSkipsExistingBinary(t *testing.T) {
 		HomeDir:  homeDir,
 		Platform: "darwin",
 		Arch:     "arm64",
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == installPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 0, Stdout: "1.2.3\n"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
 	})
 
 	runtime := newCommandRuntime(app, nil)
@@ -131,6 +140,68 @@ func TestInstallManagedDaemonSkipsExistingBinary(t *testing.T) {
 	}
 	if result.Target != "darwin-arm64" {
 		t.Fatalf("result.Target = %q, want %q", result.Target, "darwin-arm64")
+	}
+}
+
+func TestInstallManagedDaemonReportsNonExecutableExistingBinary(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	installPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if err := os.MkdirAll(filepath.Dir(installPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(installPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	app := New(Deps{HomeDir: homeDir, Platform: "darwin", Arch: "arm64"})
+	runtime := newCommandRuntime(app, nil)
+	_, err := runtime.installManagedDaemon(context.Background(), false, "", nil)
+	if err == nil {
+		t.Fatalf("installManagedDaemon() error = nil, want permission error")
+	}
+	for _, want := range []string{"not executable", "chmod +x " + installPath, "looper daemon install --force"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want to contain %q", err.Error(), want)
+		}
+	}
+}
+
+func TestInstallManagedDaemonReportsInvalidExistingBinary(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	installPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if err := os.MkdirAll(filepath.Dir(installPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(installPath, []byte("corrupt"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	app := New(Deps{
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == installPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "exec format error"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+	runtime := newCommandRuntime(app, nil)
+	_, err := runtime.installManagedDaemon(context.Background(), false, "", nil)
+	if err == nil {
+		t.Fatalf("installManagedDaemon() error = nil, want invalid binary error")
+	}
+	for _, want := range []string{"version check failed", "exec format error", "looper daemon install --force"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want to contain %q", err.Error(), want)
+		}
 	}
 }
 

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -736,33 +736,75 @@ type resolvedDaemonBinary struct {
 	Source string
 }
 
+type daemonBinaryUsability struct {
+	Path    string
+	Version string
+	Exists  bool
+}
+
 func (r *commandRuntime) resolveDaemonBinary(ctx context.Context) (*resolvedDaemonBinary, error) {
-	managedPath, err := r.managedDaemonBinaryPath()
+	managed, err := r.checkManagedDaemonBinary(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	candidates := []resolvedDaemonBinary{{Path: managedPath, Source: "installed"}, {Path: looperdBinaryName, Source: "path"}}
-	for _, candidate := range candidates {
-		version, err := r.runVersionCommand(ctx, candidate.Path)
-		if err != nil {
-			return nil, err
-		}
-		if version != "" {
-			resolved := candidate
-			return &resolved, nil
-		}
+	if managed.Exists {
+		return &resolvedDaemonBinary{Path: managed.Path, Source: "installed"}, nil
 	}
+
+	version, err := r.runVersionCommandStrict(ctx, looperdBinaryName)
+	if version != "" {
+		return &resolvedDaemonBinary{Path: looperdBinaryName, Source: "path"}, nil
+	}
+	_ = err
 
 	return nil, fmt.Errorf("Cannot find looperd binary. Lookup order: ~/.looper/bin/looperd, then $PATH.")
 }
 
-func (r *commandRuntime) readManagedDaemonVersion(ctx context.Context) (*daemonVersionState, error) {
+func (r *commandRuntime) checkManagedDaemonBinary(ctx context.Context) (daemonBinaryUsability, error) {
 	binaryPath, err := r.managedDaemonBinaryPath()
+	if err != nil {
+		return daemonBinaryUsability{}, err
+	}
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			version, versionErr := r.runVersionCommandStrict(ctx, binaryPath)
+			if versionErr == nil && strings.TrimSpace(version) != "" {
+				return daemonBinaryUsability{Path: binaryPath, Version: version, Exists: true}, nil
+			}
+			return daemonBinaryUsability{Path: binaryPath}, nil
+		}
+		return daemonBinaryUsability{}, fmt.Errorf("check looperd at %s: %w", binaryPath, err)
+	}
+	if info.IsDir() {
+		return daemonBinaryUsability{}, fmt.Errorf("found looperd at %s, but it is a directory\n\nFix: remove or rename %s\nThen reinstall: looper daemon install --force", binaryPath, binaryPath)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return daemonBinaryUsability{}, fmt.Errorf("found looperd at %s, but it is not executable\n\nFix: chmod +x %s\nOr reinstall: looper daemon install --force", binaryPath, binaryPath)
+	}
+	version, err := r.runVersionCommandStrict(ctx, binaryPath)
+	if err != nil {
+		return daemonBinaryUsability{}, unusableManagedDaemonError(binaryPath, fmt.Sprintf("version check failed: %v", err))
+	}
+	if strings.TrimSpace(version) == "" {
+		return daemonBinaryUsability{}, unusableManagedDaemonError(binaryPath, "it did not report a version")
+	}
+	return daemonBinaryUsability{Path: binaryPath, Version: version, Exists: true}, nil
+}
+
+func unusableManagedDaemonError(path string, reason string) error {
+	return fmt.Errorf("found looperd at %s, but %s\n\nFix: looper daemon install --force", path, reason)
+}
+
+func (r *commandRuntime) readManagedDaemonVersion(ctx context.Context) (*daemonVersionState, error) {
+	state, err := r.checkManagedDaemonBinary(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return r.readDaemonVersion(ctx, binaryPath)
+	if !state.Exists {
+		return nil, nil
+	}
+	return &daemonVersionState{Version: state.Version, Source: "binary", BinaryPath: stringPtr(state.Path)}, nil
 }
 
 func (r *commandRuntime) readPathDaemonVersion(ctx context.Context) (*daemonVersionState, error) {
@@ -781,12 +823,24 @@ func (r *commandRuntime) readDaemonVersion(ctx context.Context, command string) 
 }
 
 func (r *commandRuntime) runVersionCommand(ctx context.Context, command string) (string, error) {
-	result, err := r.runCommand(ctx, command, []string{"--version"}, daemonCommandTimeout)
+	version, err := r.runVersionCommandStrict(ctx, command)
 	if err != nil {
 		return "", nil
 	}
+	return version, nil
+}
+
+func (r *commandRuntime) runVersionCommandStrict(ctx context.Context, command string) (string, error) {
+	result, err := r.runCommand(ctx, command, []string{"--version"}, daemonCommandTimeout)
+	if err != nil {
+		return "", err
+	}
 	if result.ExitCode != 0 {
-		return "", nil
+		message := strings.TrimSpace(result.Stderr)
+		if message == "" {
+			message = fmt.Sprintf("exit code %d", result.ExitCode)
+		}
+		return "", errors.New(message)
 	}
 	return strings.TrimSpace(result.Stdout), nil
 }

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -235,6 +235,38 @@ func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 	}
 }
 
+func TestDaemonStartReportsNonExecutableManagedDaemon(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if err := os.MkdirAll(filepath.Dir(managedPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(managedPath, []byte("looperd"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stderr:  stderr,
+		HomeDir: homeDir,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, os.ErrNotExist
+		})},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", writeDaemonCLIConfig(t, "http://daemon.test")})
+	if exitCode == 0 {
+		t.Fatalf("Run([daemon start]) exit code = 0, want error")
+	}
+	for _, want := range []string{"not executable", "chmod +x " + managedPath, "looper daemon install --force"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want to contain %q", stderr.String(), want)
+		}
+	}
+}
+
 func TestDaemonStartNormalizesForwardedRelativeConfigPathArgs(t *testing.T) {
 	homeDir := t.TempDir()
 	callerDir := t.TempDir()

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -177,6 +177,9 @@ if [ "$install_dir" = "$HOME/.local/bin" ] && ! in_path_dir "$install_dir"; then
 fi
 
 log ""
+log "This installer only installs the looper CLI."
+log "looper bootstrap will install/start the matching looperd daemon."
+log ""
 log "Next steps:"
 log "  looper bootstrap"
 log "  looper status"


### PR DESCRIPTION
## Summary
- Make `looper bootstrap` install the matching managed `looperd` release when missing or mismatched.
- Centralize managed daemon binary validation for bootstrap, daemon install, daemon start, and status fallback.
- Report non-executable or invalid managed daemon binaries with actionable remediation, and clarify install script next steps.

## Validation
- `go test ./internal/cliapp`
- `go vet ./...`
- `go build ./...`
- `go test ./...` (fails in `internal/config` parity fixtures because this environment detects an existing `looper` on PATH; unrelated to these changes)

Closes #141

<!-- looper:stamp v=1 -->
<sub>Generated by looper 0.0.0-dev · runner=worker · agent=openai/gpt-5.5</sub>