### PR TITLE
feat: self-assign issues claimed by worker or planner

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -92,11 +92,14 @@ So the most common GitHub-side trigger is:
 
 Planner will:
 
+- add the current GitHub user as an issue assignee when the issue is claimed, preserving any existing assignees
 - create a worktree
 - write the spec file
 - push a spec PR
 - add the `looper:spec-reviewing` label to that PR
 - request reviewers when appropriate
+
+If planner cannot assign the issue in GitHub, it reports a retryable failure rather than continuing with ambiguous ownership.
 
 ## 6. Reviewer: review a spec PR or a normal PR
 
@@ -185,6 +188,8 @@ If that issue already has a related planner loop, worker will try to reuse plann
 - an existing open PR
 
 That means issue → planner → worker can flow through without manually copying the spec path.
+
+When worker claims an issue, it adds the current GitHub user as an assignee and preserves any existing assignees. If GitHub assignment fails, the claim reports a retryable failure instead of silently continuing with ambiguous ownership.
 
 ### Start directly from a spec
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -101,6 +101,13 @@ type IssueCommentInput struct {
 	CWD         string
 }
 
+type IssueAssigneesInput struct {
+	Repo        string
+	IssueNumber int64
+	Assignees   []string
+	CWD         string
+}
+
 type IssueCommentResult struct {
 	ID  int64
 	URL string
@@ -433,6 +440,30 @@ func (g *Gateway) CreateIssueComment(ctx context.Context, input IssueCommentInpu
 func (g *Gateway) UpdateIssueComment(ctx context.Context, input UpdateIssueCommentInput) error {
 	_, err := g.runGh(ctx, input.CWD, "", "api", fmt.Sprintf("repos/%s/issues/comments/%d", input.Repo, input.CommentID), "--method", "PATCH", "-f", "body="+input.Body)
 	return err
+}
+
+func (g *Gateway) AddIssueAssignees(ctx context.Context, input IssueAssigneesInput) error {
+	assignees := compactIssueAssignees(input.Assignees)
+	if len(assignees) == 0 {
+		return nil
+	}
+	args := []string{"api", fmt.Sprintf("repos/%s/issues/%d/assignees", input.Repo, input.IssueNumber), "--method", "POST"}
+	for _, assignee := range assignees {
+		args = append(args, "-f", "assignees[]="+assignee)
+	}
+	_, err := g.runGh(ctx, input.CWD, "", args...)
+	return err
+}
+
+func compactIssueAssignees(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
 }
 
 func (g *Gateway) ViewPullRequest(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -30,6 +30,8 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 			return shell.Result{Stdout: `{"id":91,"html_url":"https://example.test/issues/8#issuecomment-91"}`}, nil
 		case args == "api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished":
 			return shell.Result{Stdout: "{}"}, nil
+		case args == "api repos/acme/looper/issues/8/assignees --method POST -f assignees[]=reviewer":
+			return shell.Result{Stdout: "{}"}, nil
 		case strings.HasPrefix(args, "pr view"):
 			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"state":"UNRESOLVED"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
 		case strings.HasPrefix(args, "pr diff"):
@@ -89,6 +91,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	}
 	if err := gateway.UpdateIssueComment(context.Background(), UpdateIssueCommentInput{Repo: "acme/looper", CommentID: 91, Body: "Looper finished"}); err != nil {
 		t.Fatalf("UpdateIssueComment() error = %v", err)
+	}
+	if err := gateway.AddIssueAssignees(context.Background(), IssueAssigneesInput{Repo: "acme/looper", IssueNumber: 8, Assignees: []string{"reviewer"}}); err != nil {
+		t.Fatalf("AddIssueAssignees() error = %v", err)
 	}
 	snapshot, err := gateway.CapturePullRequestSnapshot(context.Background(), CapturePullRequestSnapshotInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
 	if err != nil {
@@ -193,6 +198,7 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 		"api repos/acme/looper/issues/8",
 		"api repos/acme/looper/issues/8/comments --method POST -f body=Looper started",
 		"api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished",
+		"api repos/acme/looper/issues/8/assignees --method POST -f assignees[]=reviewer",
 		"label create phase-1 --repo acme/looper --color 5319e7 --description Managed by looper --force",
 		"label create ready --repo acme/looper --color 5319e7 --description Managed by looper --force",
 		"api repos/acme/looper/issues/42/labels --method POST -f labels[]=phase-1 -f labels[]=ready",

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -138,10 +138,18 @@ type PullRequestReviewersInput struct {
 	CWD       string
 }
 
+type IssueAssigneesInput struct {
+	Repo        string
+	IssueNumber int64
+	Assignees   []string
+	CWD         string
+}
+
 type GitHubGateway interface {
 	ListOpenIssues(context.Context, ListOpenIssuesInput) ([]IssueSummary, error)
 	ViewIssue(context.Context, ViewIssueInput) (IssueDetail, error)
 	GetCurrentUserLogin(context.Context, string) (string, error)
+	AddIssueAssignees(context.Context, IssueAssigneesInput) error
 	ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error)
 	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
 	CreatePullRequest(context.Context, CreatePullRequestInput) (CreatePullRequestResult, error)
@@ -718,13 +726,7 @@ func (r *Runner) runDiscoverIssueStep(ctx context.Context, input stepInput) (pla
 	if err != nil {
 		return input.Checkpoint, err
 	}
-	currentLogin := firstNonEmpty(stringFromAnyDefault(payload["currentUserLogin"]), input.CheckpointIssueLogin())
-	if currentLogin == "" {
-		login, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
-		if err == nil {
-			currentLogin = normalizeLogin(login)
-		}
-	}
+	currentLogin := firstNonEmpty(normalizeLogin(stringFromAnyDefault(payload["currentUserLogin"])), input.CheckpointIssueLogin())
 	lockKey := firstNonEmpty(derefString(input.QueueItem.LockKey), buildIssueLockKey(repo, issueNumber))
 	nowISO := r.nowISO()
 	reason := "planner-run"
@@ -735,20 +737,42 @@ func (r *Runner) runDiscoverIssueStep(ctx context.Context, input stepInput) (pla
 	if !acquired {
 		return input.Checkpoint, &loopError{message: fmt.Sprintf("Issue lock is already held for %s", lockKey), kind: FailureRetryableTransient}
 	}
+	releaseOnError := true
+	defer func() {
+		if releaseOnError {
+			_ = r.repos.Locks.Release(context.Background(), lockKey)
+		}
+	}()
+	manual := isManualPlannerQueue(payload)
+	if !manual && !specpr.HasLabel(detail.Labels, discoveryLabel) {
+		checkpoint := input.Checkpoint
+		checkpoint.Issue = &checkpointIssue{Repo: repo, IssueNumber: issueNumber, Title: detail.Title, Body: detail.Body, URL: detail.URL, Assignees: cloneStrings(detail.Assignees), Labels: cloneStrings(detail.Labels), CurrentUserLogin: currentLogin, SpecPath: buildSpecPath(r.now(), issueNumber, detail.Title), RequestedReviewers: resolveRequestedReviewers(input.Project, input.Loop, detail.Assignees, currentLogin)}
+		checkpoint.ClaimedLockKey = lockKey
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		checkpoint.SkipReason = fmt.Sprintf("Issue %s#%d no longer has %s", repo, issueNumber, discoveryLabel)
+		releaseOnError = false
+		return checkpoint, nil
+	}
+	login, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+	if err != nil {
+		return input.Checkpoint, &loopError{message: fmt.Sprintf("Unable to resolve GitHub login for planner issue self-assignment on %s#%d: %v", repo, issueNumber, err), kind: FailureRetryableAfterResume}
+	}
+	currentLogin = normalizeLogin(login)
+	if currentLogin == "" {
+		return input.Checkpoint, &loopError{message: fmt.Sprintf("Unable to resolve GitHub login for planner issue self-assignment on %s#%d", repo, issueNumber), kind: FailureRetryableAfterResume}
+	}
+	if currentLogin != "" && !includesLogin(detail.Assignees, currentLogin) {
+		if err := r.github.AddIssueAssignees(ctx, IssueAssigneesInput{Repo: repo, IssueNumber: issueNumber, Assignees: []string{currentLogin}, CWD: input.Project.RepoPath}); err != nil {
+			return input.Checkpoint, &loopError{message: fmt.Sprintf("Unable to assign issue %s#%d to %s: %v", repo, issueNumber, currentLogin, err), kind: FailureRetryableAfterResume}
+		}
+		detail.Assignees = appendUniqueStrings(detail.Assignees, currentLogin)
+	}
 	checkpoint := input.Checkpoint
 	checkpoint.Issue = &checkpointIssue{Repo: repo, IssueNumber: issueNumber, Title: detail.Title, Body: detail.Body, URL: detail.URL, Assignees: cloneStrings(detail.Assignees), Labels: cloneStrings(detail.Labels), CurrentUserLogin: currentLogin, SpecPath: buildSpecPath(r.now(), issueNumber, detail.Title), RequestedReviewers: resolveRequestedReviewers(input.Project, input.Loop, detail.Assignees, currentLogin)}
 	checkpoint.ClaimedLockKey = lockKey
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
-	manual := isManualPlannerQueue(payload)
-	if !manual && currentLogin != "" && !includesLogin(detail.Assignees, currentLogin) {
-		checkpoint.SkipReason = fmt.Sprintf("Issue %s#%d is no longer assigned to %s", repo, issueNumber, currentLogin)
-		return checkpoint, nil
-	}
-	if !manual && !specpr.HasLabel(detail.Labels, discoveryLabel) {
-		checkpoint.SkipReason = fmt.Sprintf("Issue %s#%d no longer has %s", repo, issueNumber, discoveryLabel)
-		return checkpoint, nil
-	}
 	checkpoint.SkipReason = ""
+	releaseOnError = false
 	return checkpoint, nil
 }
 

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -257,6 +257,57 @@ func TestProcessClaimedItemSuccessfulPlannerPublish(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemSelfAssignsIssue(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{issues: []IssueSummary{{Number: 42, Title: "Plan this", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}}, issueDetail: IssueDetail{Number: 42, Title: "Plan this", Body: "details", URL: "https://example/issues/42", Assignees: []string{"teammate"}, Labels: []string{"looper:plan"}}, createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{ID: "worktree_1", WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "wrote spec"}}}, Logger: fixture.logger, Now: fixture.now, AllowAutoPush: boolPtr(true)})
+
+	_, _ = runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "planner-worker-1", "planner")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	if _, err := runner.ProcessClaimedItem(context.Background(), *claim); err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if len(github.addAssigneeCalls) != 1 {
+		t.Fatalf("addAssigneeCalls = %#v, want one self-assignment", github.addAssigneeCalls)
+	}
+	call := github.addAssigneeCalls[0]
+	if call.Repo != "acme/looper" || call.IssueNumber != 42 || len(call.Assignees) != 1 || call.Assignees[0] != "octocat" {
+		t.Fatalf("add assignee call = %#v, want octocat on acme/looper#42", call)
+	}
+}
+
+func TestProcessClaimedItemSurfacesIssueSelfAssignmentFailure(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{issues: []IssueSummary{{Number: 42, Title: "Plan this", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}}, issueDetail: IssueDetail{Number: 42, Title: "Plan this", Body: "details", URL: "https://example/issues/42", Assignees: []string{"teammate"}, Labels: []string{"looper:plan"}}, addAssigneeErr: fmt.Errorf("permission denied")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	_, _ = runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "planner-worker-1", "planner")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume || !strings.Contains(result.Summary, "Unable to assign issue acme/looper#42 to octocat") {
+		t.Fatalf("result = %#v, want clear retryable assignment failure", result)
+	}
+	acquired, err := fixture.repos.Locks.Acquire(context.Background(), storage.LockRecord{Key: "issue:acme/looper:42", Owner: "retry", ExpiresAt: fixture.now().Add(time.Minute).UTC().Format("2006-01-02T15:04:05.000Z"), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()})
+	if err != nil {
+		t.Fatalf("Locks.Acquire() error = %v", err)
+	}
+	if !acquired {
+		t.Fatal("Locks.Acquire() = false, want assignment failure to release issue lock")
+	}
+}
+
 func TestProcessClaimedItemAdoptsOpenBranchPRWhenLifecycleLacksPRNumber(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -712,6 +763,8 @@ type fakeGitHubGateway struct {
 	createPRCalls    []CreatePullRequestInput
 	addLabelCalls    []PullRequestLabelsInput
 	addReviewerCalls []PullRequestReviewersInput
+	addAssigneeCalls []IssueAssigneesInput
+	addAssigneeErr   error
 }
 
 func (f *fakeGitHubGateway) ListOpenIssues(context.Context, ListOpenIssuesInput) ([]IssueSummary, error) {
@@ -731,6 +784,11 @@ func (f *fakeGitHubGateway) ViewIssue(_ context.Context, input ViewIssueInput) (
 
 func (*fakeGitHubGateway) GetCurrentUserLogin(context.Context, string) (string, error) {
 	return "octocat", nil
+}
+
+func (f *fakeGitHubGateway) AddIssueAssignees(_ context.Context, input IssueAssigneesInput) error {
+	f.addAssigneeCalls = append(f.addAssigneeCalls, input)
+	return f.addAssigneeErr
 }
 
 func (f *fakeGitHubGateway) ListOpenPullRequests(_ context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -138,6 +138,10 @@ func (a plannerGitHubAdapter) GetCurrentUserLogin(ctx context.Context, cwd strin
 	return a.gateway.GetCurrentUserLogin(ctx, cwd)
 }
 
+func (a plannerGitHubAdapter) AddIssueAssignees(ctx context.Context, input planner.IssueAssigneesInput) error {
+	return a.gateway.AddIssueAssignees(ctx, githubinfra.IssueAssigneesInput{Repo: input.Repo, IssueNumber: input.IssueNumber, Assignees: input.Assignees, CWD: input.CWD})
+}
+
 func (a plannerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input planner.ListOpenPullRequestsInput) ([]planner.PullRequestSummary, error) {
 	pullRequests, err := a.gateway.ListOpenPullRequests(ctx, githubinfra.ListOpenPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: input.Limit})
 	if err != nil {
@@ -468,6 +472,10 @@ func (a workerGitHubAdapter) ListOpenIssues(ctx context.Context, input worker.Li
 
 func (a workerGitHubAdapter) GetCurrentUserLogin(ctx context.Context, cwd string) (string, error) {
 	return a.gateway.GetCurrentUserLogin(ctx, cwd)
+}
+
+func (a workerGitHubAdapter) AddIssueAssignees(ctx context.Context, input worker.IssueAssigneesInput) error {
+	return a.gateway.AddIssueAssignees(ctx, githubinfra.IssueAssigneesInput{Repo: input.Repo, IssueNumber: input.IssueNumber, Assignees: input.Assignees, CWD: input.CWD})
 }
 
 func (a workerGitHubAdapter) ViewPullRequest(ctx context.Context, input worker.ViewPullRequestInput) (worker.PullRequestDetail, error) {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -108,6 +108,13 @@ type IssueCommentInput struct {
 	CWD         string
 }
 
+type IssueAssigneesInput struct {
+	Repo        string
+	IssueNumber int64
+	Assignees   []string
+	CWD         string
+}
+
 type IssueCommentResult struct {
 	ID  int64
 	URL string
@@ -188,6 +195,7 @@ type GitHubGateway interface {
 	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
 	ViewIssue(context.Context, ViewIssueInput) (IssueDetail, error)
 	GetCurrentUserLogin(context.Context, string) (string, error)
+	AddIssueAssignees(context.Context, IssueAssigneesInput) error
 	CreateIssueComment(context.Context, IssueCommentInput) (IssueCommentResult, error)
 	UpdateIssueComment(context.Context, UpdateIssueCommentInput) error
 	CreatePullRequest(context.Context, CreatePullRequestInput) (CreatePullRequestResult, error)
@@ -929,6 +937,12 @@ func (r *Runner) runPrepareWorkStep(ctx context.Context, input stepInput) (worke
 	if !acquired {
 		return checkpoint, &loopError{message: fmt.Sprintf("Worker lock is already held for %s", lockKey), kind: FailureRetryableTransient}
 	}
+	if work.IssueNumber > 0 && r.github != nil {
+		if err := r.selfAssignIssue(ctx, work, input.Project.RepoPath); err != nil {
+			_ = r.repos.Locks.Release(context.Background(), lockKey)
+			return checkpoint, err
+		}
+	}
 	if input.Loop.TargetType == "pull_request" && work.Repo != "" && work.PRNumber > 0 && r.github != nil {
 		_ = r.github.RemovePullRequestLabels(ctx, PullRequestLabelsInput{Repo: work.Repo, PRNumber: work.PRNumber, Labels: []string{specpr.ReadyLabel}, CWD: input.Project.RepoPath})
 	}
@@ -938,6 +952,28 @@ func (r *Runner) runPrepareWorkStep(ctx context.Context, input stepInput) (worke
 	checkpoint.SkipReason = ""
 	r.syncIssueClaim(ctx, input, &checkpoint, issueClaimStatusRunning, "")
 	return checkpoint, nil
+}
+
+func (r *Runner) selfAssignIssue(ctx context.Context, work workerInput, cwd string) error {
+	if r.github == nil || work.IssueNumber <= 0 {
+		return nil
+	}
+	repo := issueLookupRepo(work)
+	if repo == "" {
+		return nil
+	}
+	login, err := r.github.GetCurrentUserLogin(ctx, cwd)
+	if err != nil {
+		return &loopError{message: fmt.Sprintf("Unable to resolve GitHub login for worker issue self-assignment on %s#%d: %v", repo, work.IssueNumber, err), kind: FailureRetryableAfterResume}
+	}
+	login = normalizeLogin(login)
+	if login == "" {
+		return &loopError{message: fmt.Sprintf("Unable to resolve GitHub login for worker issue self-assignment on %s#%d", repo, work.IssueNumber), kind: FailureRetryableAfterResume}
+	}
+	if err := r.github.AddIssueAssignees(ctx, IssueAssigneesInput{Repo: repo, IssueNumber: work.IssueNumber, Assignees: []string{login}, CWD: cwd}); err != nil {
+		return &loopError{message: fmt.Sprintf("Unable to assign issue %s#%d to %s: %v", repo, work.IssueNumber, login, err), kind: FailureRetryableAfterResume}
+	}
+	return nil
 }
 
 func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (workerCheckpoint, error) {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1172,6 +1172,54 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemSelfAssignsIssue(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "worker-login", issueDetail: IssueDetail{Number: 27, Title: "Implement worker loop", State: "open"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	if _, err := runner.ProcessClaimedQueueItem(context.Background(), *claim); err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if len(github.addAssigneeCalls) != 1 {
+		t.Fatalf("addAssigneeCalls = %#v, want one self-assignment", github.addAssigneeCalls)
+	}
+	call := github.addAssigneeCalls[0]
+	if call.Repo != "acme/looper" || call.IssueNumber != 27 || len(call.Assignees) != 1 || call.Assignees[0] != "worker-login" {
+		t.Fatalf("add assignee call = %#v, want worker-login on acme/looper#27", call)
+	}
+}
+
+func TestProcessClaimedItemSurfacesIssueSelfAssignmentFailure(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "worker-login", issueDetail: IssueDetail{Number: 27, Title: "Implement worker loop", State: "open"}, addAssigneeErr: fmt.Errorf("permission denied")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume || !strings.Contains(result.Summary, "Unable to assign issue acme/looper#27 to worker-login") {
+		t.Fatalf("result = %#v, want clear retryable assignment failure", result)
+	}
+	acquired, err := fixture.repos.Locks.Acquire(context.Background(), storage.LockRecord{Key: "issue:acme/looper:27", Owner: "retry", ExpiresAt: fixture.now().Add(time.Minute).UTC().Format("2006-01-02T15:04:05.000Z"), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()})
+	if err != nil {
+		t.Fatalf("Locks.Acquire() error = %v", err)
+	}
+	if !acquired {
+		t.Fatal("Locks.Acquire() = false, want assignment failure to release issue lock")
+	}
+}
+
 func TestProcessClaimedItemPreservesPausedLoopOnRetryableFailureAfterPause(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -2076,6 +2124,8 @@ type fakeGitHubGateway struct {
 	updatePRTitleIndex      int
 	removeLabels            []PullRequestLabelsInput
 	reviewerCalls           []PullRequestReviewersInput
+	addAssigneeCalls        []IssueAssigneesInput
+	addAssigneeErr          error
 	createPRIndex           int
 }
 
@@ -2084,6 +2134,11 @@ func (f *fakeGitHubGateway) GetCurrentUserLogin(context.Context, string) (string
 		return "octocat", nil
 	}
 	return f.currentLogin, nil
+}
+
+func (f *fakeGitHubGateway) AddIssueAssignees(_ context.Context, input IssueAssigneesInput) error {
+	f.addAssigneeCalls = append(f.addAssigneeCalls, input)
+	return f.addAssigneeErr
 }
 
 func (f *fakeGitHubGateway) ListOpenIssues(_ context.Context, input ListOpenIssuesInput) ([]IssueSummary, error) {


### PR DESCRIPTION
## Summary
- Add GitHub issue assignment support to the gateway and runtime adapters.
- Self-assign planner and worker issue claims to the current GitHub user while preserving existing assignees.
- Surface assignment/login failures as retryable claim failures and release issue locks for safe retry.

## Validation
- go test ./internal/infra/github ./internal/planner ./internal/worker ./internal/runtime
- go vet ./...
- go build ./...

Closes #139

<!-- looper:stamp v=1 -->
<sub>Generated by looper 0.0.0-dev · runner=worker · agent=openai/gpt-5.5</sub>