### PR TITLE
fix: optimize reviewer handling for unanchorable inline comments

### DIFF
--- a/internal/diffanchor/diffanchor.go
+++ b/internal/diffanchor/diffanchor.go
@@ -268,8 +268,8 @@ func genericTopLevelLocationName(name string) bool {
 	}
 }
 
-func DowngradeBody(body string, anchor Anchor, reason string) string {
-	location := fallbackLocation(anchor)
+func FallbackBody(body string, anchor Anchor, reason string) string {
+	location := FallbackLocation(anchor)
 	if location == "" {
 		location = "Location: unavailable; follow-up quality gate required."
 	}
@@ -277,8 +277,18 @@ func DowngradeBody(body string, anchor Anchor, reason string) string {
 	if trimmed := strings.TrimSpace(body); trimmed != "" {
 		parts = append(parts, trimmed)
 	}
-	parts = append(parts, "Downgraded from inline review comment: "+reason)
+	if reason = strings.TrimSpace(reason); reason != "" {
+		parts = append(parts, "Inline comment could not be anchored: "+reason)
+	}
 	return strings.Join(parts, "\n\n")
+}
+
+func DowngradeBody(body string, anchor Anchor, reason string) string {
+	return FallbackBody(body, anchor, reason)
+}
+
+func FallbackLocation(anchor Anchor) string {
+	return fallbackLocation(anchor)
 }
 
 func fallbackLocation(anchor Anchor) string {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -304,7 +304,7 @@ func TestSubmitReviewNormalizesAnchorsBeforePublishing(t *testing.T) {
 	if !strings.Contains(runner.stdin, `"path":"app.go"`) {
 		t.Fatalf("review payload did not publish valid path:\n%s", runner.stdin)
 	}
-	if strings.Contains(runner.stdin, `"path":"missing.go"`) || !strings.Contains(runner.stdin, "Invalid") || !strings.Contains(runner.stdin, "Downgraded from inline review comment") {
+	if strings.Contains(runner.stdin, `"path":"missing.go"`) || !strings.Contains(runner.stdin, "Invalid") || !strings.Contains(runner.stdin, "Inline comment could not be anchored") {
 		t.Fatalf("review payload did not downgrade invalid anchor into body:\n%s", runner.stdin)
 	}
 }

--- a/internal/infra/github/review_anchor.go
+++ b/internal/infra/github/review_anchor.go
@@ -7,6 +7,8 @@ import (
 	"github.com/powerformer/looper/internal/diffanchor"
 )
 
+const nearestReviewAnchorMaxDistance int64 = 3
+
 type reviewQualityFlag struct {
 	Kind   string
 	Detail string
@@ -25,12 +27,22 @@ func normalizeReviewAnchors(body string, comments []ReviewComment, anchors *diff
 	kept := make([]ReviewComment, 0, len(comments))
 	downgraded := []string{}
 	for _, comment := range comments {
-		result := anchors.Validate(diffanchor.Anchor{Path: comment.Path, Line: comment.Line, Side: comment.Side, StartLine: comment.StartLine, StartSide: comment.StartSide})
+		anchor := diffanchor.Anchor{Path: comment.Path, Line: comment.Line, Side: comment.Side, StartLine: comment.StartLine, StartSide: comment.StartSide}
+		result := anchors.Validate(anchor)
 		if result.Valid {
 			kept = append(kept, normalizeReviewCommentAnchor(comment))
 			continue
 		}
-		downgraded = append(downgraded, diffanchor.DowngradeBody(comment.Body, diffanchor.Anchor{Path: comment.Path, Line: comment.Line, Side: comment.Side, StartLine: comment.StartLine, StartSide: comment.StartSide}, result.Reason))
+		if nearest, ok := nearestSafeReviewAnchor(*anchors, anchor); ok {
+			comment.Line = nearest.Line
+			comment.Side = nearest.Side
+			comment.StartLine = nearest.StartLine
+			comment.StartSide = nearest.StartSide
+			comment.Body = addOriginalReviewLocation(comment.Body, anchor)
+			kept = append(kept, normalizeReviewCommentAnchor(comment))
+			continue
+		}
+		downgraded = append(downgraded, diffanchor.FallbackBody(comment.Body, anchor, result.Reason))
 		if result.QualityFlagged {
 			flags = append(flags, reviewQualityFlag{Kind: "top-level-location-missing", Detail: result.Reason})
 		}
@@ -49,6 +61,82 @@ func normalizeReviewAnchors(body string, comments []ReviewComment, anchors *diff
 		}
 	}
 	return body, kept, flags
+}
+
+func nearestSafeReviewAnchor(idx diffanchor.Index, anchor diffanchor.Anchor) (diffanchor.Anchor, bool) {
+	if anchor.Path == "" || anchor.Line <= 0 || normalizeReviewCommentSide(anchor.Side) == "" || anchor.StartLine > 0 && anchor.StartLine != anchor.Line {
+		return diffanchor.Anchor{}, false
+	}
+	if lineFallsWithinAnyRange(idx, anchor.Path, anchor.Line) {
+		return diffanchor.Anchor{}, false
+	}
+	side := normalizeReviewCommentSide(anchor.Side)
+	var nearest diffanchor.Range
+	var nearestDistance int64
+	ambiguous := false
+	for _, candidate := range idx.Ranges {
+		if candidate.Path != anchor.Path || candidate.Side != side {
+			continue
+		}
+		line := clampInt64(anchor.Line, candidate.Start, candidate.End)
+		distance := absInt64(anchor.Line - line)
+		if distance == 0 || distance > nearestReviewAnchorMaxDistance {
+			continue
+		}
+		if nearestDistance == 0 || distance < nearestDistance {
+			nearest = candidate
+			nearestDistance = distance
+			ambiguous = false
+			continue
+		}
+		if distance == nearestDistance {
+			ambiguous = true
+		}
+	}
+	if nearestDistance == 0 || ambiguous {
+		return diffanchor.Anchor{}, false
+	}
+	line := clampInt64(anchor.Line, nearest.Start, nearest.End)
+	return diffanchor.Anchor{Path: anchor.Path, Line: line, Side: side}, true
+}
+
+func lineFallsWithinAnyRange(idx diffanchor.Index, path string, line int64) bool {
+	for _, r := range idx.Ranges {
+		if r.Path == path && r.Start <= line && r.End >= line {
+			return true
+		}
+	}
+	return false
+}
+
+func absInt64(value int64) int64 {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+func clampInt64(value, min, max int64) int64 {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+func addOriginalReviewLocation(body string, anchor diffanchor.Anchor) string {
+	location := diffanchor.FallbackLocation(anchor)
+	if location == "" {
+		return body
+	}
+	location = strings.TrimPrefix(location, "Location: ")
+	prefix := "Original requested location: " + location
+	if trimmed := strings.TrimSpace(body); trimmed != "" {
+		return prefix + "\n\n" + trimmed
+	}
+	return prefix
 }
 
 func formatReviewQualityFlags(flags []reviewQualityFlag) string {

--- a/internal/infra/github/review_anchor_test.go
+++ b/internal/infra/github/review_anchor_test.go
@@ -18,7 +18,7 @@ func TestNormalizeReviewAnchorsPreservesValidAndDowngradesInvalid(t *testing.T) 
 	if len(comments) != 1 || comments[0].Body != "Valid inline" || comments[0].Line != 1 || comments[0].Side != "RIGHT" {
 		t.Fatalf("valid anchor was not preserved exactly: %#v", comments)
 	}
-	if !strings.Contains(body, "Invalid inline") || !strings.Contains(body, "Location: app.go RIGHT line 99") || !strings.Contains(body, "Downgraded from inline review comment") {
+	if !strings.Contains(body, "Invalid inline") || !strings.Contains(body, "Location: app.go RIGHT line 99") || !strings.Contains(body, "Inline comment could not be anchored") {
 		t.Fatalf("invalid anchor was not downgraded with fallback location:\n%s", body)
 	}
 	if strings.Index(body, "Location: app.go RIGHT line 99") > strings.Index(body, "Invalid inline") {
@@ -26,6 +26,87 @@ func TestNormalizeReviewAnchorsPreservesValidAndDowngradesInvalid(t *testing.T) 
 	}
 	if len(flags) != 0 {
 		t.Fatalf("unexpected quality flags: %#v", flags)
+	}
+}
+
+func TestNormalizeReviewAnchorsMovesNearbyOutOfRangeAnchorToNearestHunk(t *testing.T) {
+	t.Parallel()
+	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -10,2 +10,2 @@\n old\n+new\n")
+	body, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+		{Body: "Nearby issue", Path: "app.go", Line: 13, Side: "RIGHT"},
+	}, &idx)
+
+	if len(flags) != 0 {
+		t.Fatalf("unexpected quality flags: %#v", flags)
+	}
+	if body != "Needs changes" {
+		t.Fatalf("body = %q, want unchanged top-level body", body)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("comments = %#v, want one nearest-anchored comment", comments)
+	}
+	if comments[0].Path != "app.go" || comments[0].Line != 11 || comments[0].Side != "RIGHT" {
+		t.Fatalf("comment anchor = %#v, want app.go RIGHT line 11", comments[0])
+	}
+	if !strings.Contains(comments[0].Body, "Original requested location: app.go RIGHT line 13") || !strings.Contains(comments[0].Body, "Nearby issue") {
+		t.Fatalf("comment body did not preserve original location:\n%s", comments[0].Body)
+	}
+}
+
+func TestNormalizeReviewAnchorsFallsBackForFarOutOfRangeAnchor(t *testing.T) {
+	t.Parallel()
+	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -10,2 +10,2 @@\n old\n+new\n")
+	body, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+		{Body: "Far issue", Path: "app.go", Line: 99, Side: "RIGHT"},
+	}, &idx)
+
+	if len(comments) != 0 {
+		t.Fatalf("comments = %#v, want unanchorable comment converted to body", comments)
+	}
+	if len(flags) != 0 {
+		t.Fatalf("unexpected quality flags: %#v", flags)
+	}
+	if !strings.Contains(body, "Location: app.go RIGHT line 99") || !strings.Contains(body, "Far issue") || !strings.Contains(body, "Inline comment could not be anchored") {
+		t.Fatalf("body did not preserve far out-of-range feedback with context:\n%s", body)
+	}
+	if strings.Contains(body, "Downgraded from inline review comment") {
+		t.Fatalf("body contains noisy downgrade wording:\n%s", body)
+	}
+}
+
+func TestNormalizeReviewAnchorsDoesNotMoveWrongSideContextAnchor(t *testing.T) {
+	t.Parallel()
+	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -10,3 +10,3 @@\n context\n-old\n+new\n tail\n")
+	body, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+		{Body: "Context issue", Path: "app.go", Line: 10, Side: "LEFT"},
+	}, &idx)
+
+	if len(comments) != 0 {
+		t.Fatalf("comments = %#v, want wrong-side context anchor converted to body", comments)
+	}
+	if len(flags) != 0 {
+		t.Fatalf("unexpected quality flags: %#v", flags)
+	}
+	if !strings.Contains(body, "Location: app.go LEFT line 10") || !strings.Contains(body, "Context issue") {
+		t.Fatalf("body did not preserve wrong-side context feedback with context:\n%s", body)
+	}
+}
+
+func TestNormalizeReviewAnchorsDoesNotMoveAmbiguousNearestAnchor(t *testing.T) {
+	t.Parallel()
+	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -10,1 +10,1 @@\n-a\n+b\n@@ -14,1 +14,1 @@\n-c\n+d\n")
+	body, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+		{Body: "Between hunks", Path: "app.go", Line: 12, Side: "RIGHT"},
+	}, &idx)
+
+	if len(comments) != 0 {
+		t.Fatalf("comments = %#v, want ambiguous nearest anchor converted to body", comments)
+	}
+	if len(flags) != 0 {
+		t.Fatalf("unexpected quality flags: %#v", flags)
+	}
+	if !strings.Contains(body, "Location: app.go RIGHT line 12") || !strings.Contains(body, "Between hunks") {
+		t.Fatalf("body did not preserve ambiguous nearest feedback with context:\n%s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Re-check reviewer inline anchors against parsed PR diff ranges before submission and keep only valid inline comments.
- Move only unambiguous, nearby out-of-range anchors to the nearest safe hunk while preserving the originally requested location in the comment body.
- Convert far, ambiguous, or wrong-side anchors into contextual top-level feedback without visible GitHub downgrade noise.

## Validation
- go test -count=1 ./internal/diffanchor ./internal/infra/github
- env -u LOOPER_CONFIG -u LOOPER_LOOPER_PATH PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" go test ./...
- go vet ./...
- go build ./...

Closes #149

<!-- looper:stamp v=1 -->
<sub>Generated by looper 0.3.0 · runner=worker · agent=openai/gpt-5.5</sub>