### PR TITLE
fix: stop repeated reviewer filter re-enqueue churn

### DIFF
--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -57,6 +57,8 @@ type PullRequestSummary struct {
 	HeadRefName    string
 	BaseRefName    string
 	HeadSHA        string
+	BaseSHA        string
+	HasConflicts   bool
 	Author         string
 	ReviewRequests []string
 }
@@ -365,7 +367,7 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 	if strings.TrimSpace(input.Author) != "" {
 		args = append(args, "--author", strings.TrimSpace(input.Author))
 	}
-	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "author", "reviewRequests"}, ","))
+	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "mergeStateStatus"}, ","))
 
 	timeout := input.Timeout
 	if timeout <= 0 {
@@ -392,6 +394,8 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 			HeadRefName:    asString(row["headRefName"]),
 			BaseRefName:    asString(row["baseRefName"]),
 			HeadSHA:        asString(row["headRefOid"]),
+			BaseSHA:        asString(row["baseRefOid"]),
+			HasConflicts:   asString(row["mergeStateStatus"]) == "DIRTY",
 			Author:         extractAuthor(row["author"]),
 			ReviewRequests: extractReviewRequestLogins(row["reviewRequests"]),
 		})

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -23,7 +23,7 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 			runner.stdin = options.Stdin
 			return shell.Result{Stdout: "{}"}, nil
 		case strings.HasPrefix(args, "pr list"):
-			return shell.Result{Stdout: `[{"number":42,"title":"Review me","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","author":{"login":"octocat"},"reviewRequests":[{"__typename":"User","login":"OctoCat"},{"__typename":"Team","slug":"platform"}]}]`}, nil
+			return shell.Result{Stdout: `[{"number":42,"title":"Review me","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"reviewRequests":[{"__typename":"User","login":"OctoCat"},{"__typename":"Team","slug":"platform"}]}]`}, nil
 		case strings.HasPrefix(args, "issue list"):
 			return shell.Result{Stdout: `[{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","author":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}]`}, nil
 		case args == "api repos/acme/looper/issues/8":
@@ -149,6 +149,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	}
 	if got := prs[0].ReviewRequests; len(got) != 1 || got[0] != "OctoCat" {
 		t.Fatalf("prs[0].ReviewRequests = %#v, want [OctoCat]", got)
+	}
+	if prs[0].BaseSHA != "def456" || !prs[0].HasConflicts {
+		t.Fatalf("prs[0] = %#v, want base sha and conflict state", prs[0])
 	}
 	if got := issues[0].Assignees; len(got) != 1 || got[0] != "reviewer" {
 		t.Fatalf("issues[0].Assignees = %#v, want [reviewer]", got)
@@ -1171,7 +1174,7 @@ func TestListOpenPullRequestsPassesAllLabelsToGH(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "pr list --repo acme/looper --state open --limit 30 --label bug --label priority --json number,title,url,state,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,author,reviewRequests" {
+		if args != "pr list --repo acme/looper --state open --limit 30 --label bug --label priority --json number,title,url,state,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,baseRefOid,author,reviewRequests,mergeStateStatus" {
 			t.Fatalf("gh args = %q, want repeated label filters", args)
 		}
 		return shell.Result{Stdout: `[]`}, nil

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -85,6 +85,8 @@ type PullRequestSummary struct {
 	ReviewDecision string
 	Labels         []string
 	HeadSHA        string
+	BaseSHA        string
+	HasConflicts   bool
 	Author         string
 	ReviewRequests []string
 }
@@ -407,6 +409,7 @@ type reviewerCheckpoint struct {
 	ThreadResolution *threadResolutionCheckpoint `json:"threadResolution,omitempty"`
 	PendingReview    *pendingReviewCheckpoint    `json:"pendingReview,omitempty"`
 	SkipReason       string                      `json:"skipReason,omitempty"`
+	SkipKind         string                      `json:"skipKind,omitempty"`
 }
 
 type checkpointDetail struct {
@@ -606,6 +609,10 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		meta := parseJSONObject(loopResult.record.MetadataJSON)
 		_, hasPublishedHead := stringFromAny(meta["lastPublishedHeadSha"])
 		if !r.loopEnabled(meta) && (!loopResult.created || hasPublishedHead) {
+			result.Skipped++
+			return nil
+		}
+		if reviewerDiscoverySuppressedByLastSkip(meta, pr) {
 			result.Skipped++
 			return nil
 		}
@@ -1117,10 +1124,12 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 	}
 	if !r.discoveryPolicy.IncludeDrafts && checkpoint.Detail.IsDraft {
 		checkpoint.SkipReason = fmt.Sprintf("Skipped draft pull request %s#%d", input.Repo, input.PRNumber)
+		checkpoint.SkipKind = "draft"
 		return checkpoint, nil
 	}
 	if normalizePRState(checkpoint.Detail.State) != "open" {
 		checkpoint.SkipReason = fmt.Sprintf("Skipped non-open pull request %s#%d", input.Repo, input.PRNumber)
+		checkpoint.SkipKind = "non_open"
 		if err := r.terminateLoop(ctx, input.Loop, "pr_closed_or_merged"); err != nil {
 			return checkpoint, err
 		}
@@ -1128,6 +1137,7 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 	}
 	if !isManualReviewerLoop(input.Loop) && r.loopConfig.StopOnApproved && strings.EqualFold(strings.TrimSpace(checkpoint.Detail.ReviewDecision), "APPROVED") {
 		checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for approved pull request %s#%d", input.Repo, input.PRNumber)
+		checkpoint.SkipKind = "approved"
 		if err := r.terminateLoop(ctx, input.Loop, "approved"); err != nil {
 			return checkpoint, err
 		}
@@ -1135,6 +1145,7 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 	}
 	if !isManualReviewerLoop(input.Loop) && r.loopConfig.StopOnReadyLabel && specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {
 		checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for ready pull request %s#%d", input.Repo, input.PRNumber)
+		checkpoint.SkipKind = "ready_label"
 		if err := r.terminateLoop(ctx, input.Loop, "ready_label"); err != nil {
 			return checkpoint, err
 		}
@@ -1142,6 +1153,7 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 	}
 	if checkpoint.Detail.HasConflicts {
 		checkpoint.SkipReason = fmt.Sprintf("Skipped conflicted pull request %s#%d", input.Repo, input.PRNumber)
+		checkpoint.SkipKind = "conflicted"
 		return checkpoint, nil
 	}
 	if !isManualReviewerLoop(input.Loop) && len(checkpoint.Detail.Reviews) > 0 {
@@ -1151,17 +1163,20 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		}
 		if hasReviewByAuthorForHead(checkpoint.Detail.Reviews, currentLogin, checkpoint.Detail.HeadSHA) {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user already reviewed head %s", input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA)
+			checkpoint.SkipKind = "already_reviewed_by_current_user"
 			return checkpoint, nil
 		}
 	}
 	meta := parseJSONObject(input.Loop.MetadataJSON)
 	if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && checkpoint.Detail.HeadSHA != "" && last == checkpoint.Detail.HeadSHA {
 		checkpoint.SkipReason = fmt.Sprintf("Skipped already-reviewed head %s for %s#%d", checkpoint.Detail.HeadSHA, input.Repo, input.PRNumber)
+		checkpoint.SkipKind = "already_published_head"
 		return checkpoint, nil
 	}
 	if r.loopEnabled(meta) {
 		if reason := r.loopBudgetTerminationReason(input.Loop, checkpoint.Detail.HeadSHA); reason != "" {
 			checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for %s#%d: %s", input.Repo, input.PRNumber, reason)
+			checkpoint.SkipKind = reason
 			if err := r.terminateLoop(ctx, input.Loop, reason); err != nil {
 				return checkpoint, err
 			}
@@ -1175,6 +1190,7 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		}
 		if !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, normalizeLogin(currentLogin)) {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", input.Repo, input.PRNumber)
+			checkpoint.SkipKind = "not_requested"
 			return checkpoint, nil
 		}
 	}
@@ -2576,6 +2592,43 @@ func mergeLoopMetadataJSON(current *string, updates map[string]any) (string, err
 	return string(encoded), nil
 }
 
+func reviewerDiscoverySuppressedByLastSkip(meta map[string]any, pr PullRequestSummary) bool {
+	raw, _ := meta["lastFilterSkip"].(map[string]any)
+	if raw == nil {
+		return false
+	}
+	kind, _ := stringFromAny(raw["kind"])
+	if !isDiscoverySuppressingSkipKind(kind) {
+		return false
+	}
+	headSHA, _ := stringFromAny(raw["headSha"])
+	if headSHA == "" || pr.HeadSHA == "" || headSHA != pr.HeadSHA {
+		return false
+	}
+	if kind == "conflicted" && !pr.HasConflicts {
+		return false
+	}
+	if label, ok := stringFromAny(raw["requiredLabel"]); ok && label != "" && !specpr.HasLabel(pr.Labels, label) {
+		return false
+	}
+	if decision, ok := stringFromAny(raw["reviewDecision"]); ok && decision != "" && !strings.EqualFold(strings.TrimSpace(pr.ReviewDecision), decision) {
+		return false
+	}
+	if draft, ok := raw["isDraft"].(bool); ok && draft != pr.IsDraft {
+		return false
+	}
+	return true
+}
+
+func isDiscoverySuppressingSkipKind(kind string) bool {
+	switch kind {
+	case "conflicted", "already_reviewed_by_current_user", "already_published_head", "draft", "approved", "ready_label":
+		return true
+	default:
+		return false
+	}
+}
+
 func (r *Runner) loopEnabled(meta map[string]any) bool {
 	if enabled, ok := meta["followUpdates"].(bool); ok {
 		return enabled
@@ -2815,9 +2868,44 @@ func (r *Runner) recordLoopSuccessMetadata(current *string, checkpoint reviewerC
 	if loopMeta["terminationReason"] == nil {
 		loopMeta["status"] = "waiting"
 	}
+	if checkpoint.SkipReason != "" {
+		delete(meta, "lastFilterSkip")
+		if skip := filterSkipMetadata(checkpoint, r.nowISO()); skip != nil {
+			meta["lastFilterSkip"] = skip
+		}
+	} else {
+		delete(meta, "lastFilterSkip")
+	}
 	meta["loop"] = loopMeta
 	encoded, err := json.Marshal(meta)
 	return string(encoded), err
+}
+
+func filterSkipMetadata(checkpoint reviewerCheckpoint, recordedAt string) map[string]any {
+	if checkpoint.Detail == nil || !isDiscoverySuppressingSkipKind(checkpoint.SkipKind) {
+		return nil
+	}
+	metadata := map[string]any{
+		"kind":       checkpoint.SkipKind,
+		"reason":     checkpoint.SkipReason,
+		"recordedAt": recordedAt,
+	}
+	if checkpoint.Detail.HeadSHA != "" {
+		metadata["headSha"] = checkpoint.Detail.HeadSHA
+	}
+	if checkpoint.Detail.IsDraft {
+		metadata["isDraft"] = true
+	}
+	if checkpoint.Detail.ReviewDecision != "" {
+		metadata["reviewDecision"] = strings.TrimSpace(checkpoint.Detail.ReviewDecision)
+	}
+	if checkpoint.Detail.HasConflicts {
+		metadata["hasConflicts"] = true
+	}
+	if checkpoint.SkipKind == "ready_label" {
+		metadata["requiredLabel"] = specpr.ReadyLabel
+	}
+	return metadata
 }
 
 func loopSuccessOutputFingerprint(checkpoint reviewerCheckpoint, summary string) string {
@@ -2940,7 +3028,7 @@ func containsAnyString(values []any, target string) bool {
 }
 
 func summaryFromDetail(detail PullRequestDetail) PullRequestSummary {
-	return PullRequestSummary{Number: detail.Number, Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, Author: detail.Author, ReviewRequests: cloneStrings(detail.ReviewRequests)}
+	return PullRequestSummary{Number: detail.Number, Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HasConflicts: detail.HasConflicts, Author: detail.Author, ReviewRequests: cloneStrings(detail.ReviewRequests)}
 }
 
 func normalizePRState(value string) string {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2624,17 +2624,23 @@ func reviewerDiscoverySuppressedByLastSkip(meta map[string]any, pr PullRequestSu
 			return false
 		}
 	}
-	if kind == "conflicted" && !pr.HasConflicts {
-		return false
-	}
-	if label, ok := stringFromAny(raw["requiredLabel"]); ok && label != "" && !specpr.HasLabel(pr.Labels, label) {
-		return false
-	}
-	if decision, ok := stringFromAny(raw["reviewDecision"]); ok && decision != "" && !strings.EqualFold(strings.TrimSpace(pr.ReviewDecision), decision) {
-		return false
-	}
-	if draft, ok := raw["isDraft"].(bool); ok && draft != pr.IsDraft {
-		return false
+	switch kind {
+	case "conflicted":
+		if !pr.HasConflicts {
+			return false
+		}
+	case "ready_label":
+		if label, ok := stringFromAny(raw["requiredLabel"]); ok && label != "" && !specpr.HasLabel(pr.Labels, label) {
+			return false
+		}
+	case "approved":
+		if decision, ok := stringFromAny(raw["reviewDecision"]); ok && decision != "" && !strings.EqualFold(strings.TrimSpace(pr.ReviewDecision), decision) {
+			return false
+		}
+	case "draft":
+		if draft, ok := raw["isDraft"].(bool); ok && draft != pr.IsDraft {
+			return false
+		}
 	}
 	return true
 }
@@ -2925,13 +2931,13 @@ func filterSkipMetadata(checkpoint reviewerCheckpoint, recordedAt string) map[st
 	if checkpoint.Detail.HeadSHA != "" {
 		metadata["headSha"] = checkpoint.Detail.HeadSHA
 	}
-	if checkpoint.Detail.IsDraft {
+	if checkpoint.SkipKind == "draft" && checkpoint.Detail.IsDraft {
 		metadata["isDraft"] = true
 	}
-	if checkpoint.Detail.ReviewDecision != "" {
+	if checkpoint.SkipKind == "approved" && checkpoint.Detail.ReviewDecision != "" {
 		metadata["reviewDecision"] = strings.TrimSpace(checkpoint.Detail.ReviewDecision)
 	}
-	if checkpoint.Detail.HasConflicts {
+	if checkpoint.SkipKind == "conflicted" && checkpoint.Detail.HasConflicts {
 		metadata["hasConflicts"] = true
 	}
 	if checkpoint.SkipKind == "ready_label" {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -401,15 +401,16 @@ type ProcessResult struct {
 }
 
 type reviewerCheckpoint struct {
-	ResumePolicy     string                      `json:"resumePolicy,omitempty"`
-	Detail           *checkpointDetail           `json:"detail,omitempty"`
-	ClaimedLockKey   string                      `json:"claimedLockKey,omitempty"`
-	Snapshot         *checkpointSnapshot         `json:"snapshot,omitempty"`
-	Worktree         *checkpointWorktree         `json:"worktree,omitempty"`
-	ThreadResolution *threadResolutionCheckpoint `json:"threadResolution,omitempty"`
-	PendingReview    *pendingReviewCheckpoint    `json:"pendingReview,omitempty"`
-	SkipReason       string                      `json:"skipReason,omitempty"`
-	SkipKind         string                      `json:"skipKind,omitempty"`
+	ResumePolicy      string                      `json:"resumePolicy,omitempty"`
+	Detail            *checkpointDetail           `json:"detail,omitempty"`
+	ClaimedLockKey    string                      `json:"claimedLockKey,omitempty"`
+	Snapshot          *checkpointSnapshot         `json:"snapshot,omitempty"`
+	Worktree          *checkpointWorktree         `json:"worktree,omitempty"`
+	ThreadResolution  *threadResolutionCheckpoint `json:"threadResolution,omitempty"`
+	PendingReview     *pendingReviewCheckpoint    `json:"pendingReview,omitempty"`
+	SkipReason        string                      `json:"skipReason,omitempty"`
+	SkipKind          string                      `json:"skipKind,omitempty"`
+	SkipReviewerLogin string                      `json:"skipReviewerLogin,omitempty"`
 }
 
 type checkpointDetail struct {
@@ -612,7 +613,18 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			result.Skipped++
 			return nil
 		}
-		if reviewerDiscoverySuppressedByLastSkip(meta, pr) {
+		if reviewerDiscoverySuppressedByLastSkip(meta, pr, currentLogin) {
+			result.Skipped++
+			return nil
+		}
+		if reviewerLastSkipNeedsCurrentLogin(meta, pr) && currentLogin == "" {
+			lookupLogin, lookupErr := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+			if lookupErr != nil {
+				lookupLogin = ""
+			}
+			currentLogin = normalizeLogin(lookupLogin)
+		}
+		if reviewerDiscoverySuppressedByLastSkip(meta, pr, currentLogin) {
 			result.Skipped++
 			return nil
 		}
@@ -1164,6 +1176,7 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		if hasReviewByAuthorForHead(checkpoint.Detail.Reviews, currentLogin, checkpoint.Detail.HeadSHA) {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user already reviewed head %s", input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA)
 			checkpoint.SkipKind = "already_reviewed_by_current_user"
+			checkpoint.SkipReviewerLogin = normalizeLogin(currentLogin)
 			return checkpoint, nil
 		}
 	}
@@ -2592,7 +2605,7 @@ func mergeLoopMetadataJSON(current *string, updates map[string]any) (string, err
 	return string(encoded), nil
 }
 
-func reviewerDiscoverySuppressedByLastSkip(meta map[string]any, pr PullRequestSummary) bool {
+func reviewerDiscoverySuppressedByLastSkip(meta map[string]any, pr PullRequestSummary, currentLogin string) bool {
 	raw, _ := meta["lastFilterSkip"].(map[string]any)
 	if raw == nil {
 		return false
@@ -2604,6 +2617,12 @@ func reviewerDiscoverySuppressedByLastSkip(meta map[string]any, pr PullRequestSu
 	headSHA, _ := stringFromAny(raw["headSha"])
 	if headSHA == "" || pr.HeadSHA == "" || headSHA != pr.HeadSHA {
 		return false
+	}
+	if kind == "already_reviewed_by_current_user" {
+		reviewerLogin, _ := stringFromAny(raw["reviewerLogin"])
+		if normalizeLogin(reviewerLogin) == "" || normalizeLogin(currentLogin) == "" || normalizeLogin(reviewerLogin) != normalizeLogin(currentLogin) {
+			return false
+		}
 	}
 	if kind == "conflicted" && !pr.HasConflicts {
 		return false
@@ -2618,6 +2637,19 @@ func reviewerDiscoverySuppressedByLastSkip(meta map[string]any, pr PullRequestSu
 		return false
 	}
 	return true
+}
+
+func reviewerLastSkipNeedsCurrentLogin(meta map[string]any, pr PullRequestSummary) bool {
+	raw, _ := meta["lastFilterSkip"].(map[string]any)
+	if raw == nil {
+		return false
+	}
+	kind, _ := stringFromAny(raw["kind"])
+	if kind != "already_reviewed_by_current_user" {
+		return false
+	}
+	headSHA, _ := stringFromAny(raw["headSha"])
+	return headSHA != "" && pr.HeadSHA != "" && headSHA == pr.HeadSHA
 }
 
 func isDiscoverySuppressingSkipKind(kind string) bool {
@@ -2904,6 +2936,9 @@ func filterSkipMetadata(checkpoint reviewerCheckpoint, recordedAt string) map[st
 	}
 	if checkpoint.SkipKind == "ready_label" {
 		metadata["requiredLabel"] = specpr.ReadyLabel
+	}
+	if checkpoint.SkipKind == "already_reviewed_by_current_user" && checkpoint.SkipReviewerLogin != "" {
+		metadata["reviewerLogin"] = normalizeLogin(checkpoint.SkipReviewerLogin)
 	}
 	return metadata
 }

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1005,6 +1005,163 @@ func TestProcessClaimedItemSkipsQueuedAutomaticLoopWhenCurrentUserIsNotRequested
 	}
 }
 
+func TestDiscoverPullRequestsSuppressesRepeatedConflictSkipUntilHeadChanges(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{hasConflicts: true, reviewRequests: []string{"octocat"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: testReviewerLoopConfig()})
+	repo := "acme/looper"
+
+	first, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil || len(first.QueueItems) != 1 {
+		t.Fatalf("first DiscoverPullRequests() = (%#v, %v), want one queue item", first, err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed queue item", claimed, err)
+	}
+	processed, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil || processed.Status != "skipped" || !strings.Contains(processed.Summary, "conflicted") {
+		t.Fatalf("ProcessClaimedItem() = (%#v, %v), want conflicted skip", processed, err)
+	}
+
+	second, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("second DiscoverPullRequests() error = %v", err)
+	}
+	if len(second.QueueItems) != 0 {
+		t.Fatalf("second QueueItems = %#v, want no re-enqueue for unchanged conflicted head", second.QueueItems)
+	}
+	items, err := fixture.repos.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(Queue.List()) = %d, want original completed item only", len(items))
+	}
+
+	github.listHeadSHA = "new-head"
+	github.viewHeadSHA = "new-head"
+	third, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("third DiscoverPullRequests() error = %v", err)
+	}
+	if len(third.QueueItems) != 1 {
+		t.Fatalf("third QueueItems = %#v, want re-enqueue for new head", third.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsRequeuesConflictedSkipWhenConflictClears(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{hasConflicts: true, reviewRequests: []string{"octocat"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: testReviewerLoopConfig()})
+	repo := "acme/looper"
+
+	first, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil || len(first.QueueItems) != 1 {
+		t.Fatalf("first DiscoverPullRequests() = (%#v, %v), want one queue item", first, err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed queue item", claimed, err)
+	}
+	processed, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil || processed.Status != "skipped" || !strings.Contains(processed.Summary, "conflicted") {
+		t.Fatalf("ProcessClaimedItem() = (%#v, %v), want conflicted skip", processed, err)
+	}
+
+	github.hasConflicts = false
+	second, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("second DiscoverPullRequests() error = %v", err)
+	}
+	if len(second.QueueItems) != 1 {
+		t.Fatalf("second QueueItems = %#v, want re-enqueue when conflict clears for same head", second.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsSuppressesRepeatedAlreadyReviewedSkip(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	reviews := []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "COMMENTED", "commit": map[string]any{"oid": "abc123"}}}
+	github := &fakeGitHubGateway{currentLogin: "octocat", reviews: reviews, reviewRequests: []string{"octocat"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: testReviewerLoopConfig()})
+	repo := "acme/looper"
+
+	first, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil || len(first.QueueItems) != 1 {
+		t.Fatalf("first DiscoverPullRequests() = (%#v, %v), want one queue item", first, err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed queue item", claimed, err)
+	}
+	processed, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+	if err != nil || processed.Status != "skipped" || !strings.Contains(processed.Summary, "already reviewed head abc123") {
+		t.Fatalf("ProcessClaimedItem() = (%#v, %v), want already-reviewed skip", processed, err)
+	}
+
+	second, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("second DiscoverPullRequests() error = %v", err)
+	}
+	if len(second.QueueItems) != 0 {
+		t.Fatalf("second QueueItems = %#v, want no re-enqueue for unchanged already-reviewed head", second.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsDoesNotRequeueApprovedReadyOrDraftNonActionablePRs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		github *fakeGitHubGateway
+		want   string
+	}{
+		{name: "approved", github: &fakeGitHubGateway{reviewDecision: "APPROVED", reviewRequests: []string{"octocat"}}, want: "approved"},
+		{name: "ready", github: &fakeGitHubGateway{labels: []string{specpr.ReadyLabel}, reviewRequests: []string{"octocat"}}, want: "ready"},
+		{name: "draft", github: &fakeGitHubGateway{listOpenByLabel: map[string][]PullRequestSummary{"": {{Number: 42, Title: "Draft", State: "OPEN", IsDraft: true, HeadSHA: "draft123", ReviewRequests: []string{"octocat"}}}}}, want: "draft"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: tc.github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: testReviewerLoopConfig()})
+			repo := "acme/looper"
+
+			first, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+			if err != nil {
+				t.Fatalf("first DiscoverPullRequests() error = %v", err)
+			}
+			if tc.want == "draft" {
+				if len(first.QueueItems) != 0 {
+					t.Fatalf("draft QueueItems = %#v, want no queue items", first.QueueItems)
+				}
+			} else {
+				if len(first.QueueItems) != 1 {
+					t.Fatalf("first QueueItems = %#v, want one queue item", first.QueueItems)
+				}
+				claimed, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+				if err != nil || claimed == nil {
+					t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed queue item", claimed, err)
+				}
+				processed, err := runner.ProcessClaimedItem(context.Background(), *claimed)
+				if err != nil || processed.Status != "skipped" || !strings.Contains(processed.Summary, tc.want) {
+					t.Fatalf("ProcessClaimedItem() = (%#v, %v), want %s skip", processed, err, tc.want)
+				}
+			}
+
+			second, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+			if err != nil {
+				t.Fatalf("second DiscoverPullRequests() error = %v", err)
+			}
+			if len(second.QueueItems) != 0 {
+				t.Fatalf("second QueueItems = %#v, want no repeated non-actionable requeue", second.QueueItems)
+			}
+		})
+	}
+}
+
 func TestProcessClaimedItemSkipsTerminalLoopWithoutStartingRun(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -3866,6 +4023,10 @@ func newRunnerFixture(t *testing.T) *runnerFixture {
 	return fixture
 }
 
+func testReviewerLoopConfig() config.ReviewerLoopConfig {
+	return config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 60, MinPublishIntervalSeconds: 300, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: true, StopOnReadyLabel: true, StopOnIdenticalOutput: true}
+}
+
 func (f *runnerFixture) advance(delta time.Duration) { f.current = f.current.Add(delta) }
 
 func (f *runnerFixture) nowISO() string {
@@ -3924,7 +4085,7 @@ func (g *fakeGitHubGateway) ListOpenPullRequests(_ context.Context, input ListOp
 	if headSHA == "" {
 		headSHA = "abc123"
 	}
-	return []PullRequestSummary{{Number: 42, Title: "Review me", State: "OPEN", ReviewDecision: g.reviewDecision, Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, ReviewRequests: reviewRequests}, {Number: 99, Title: "Draft", State: "OPEN", IsDraft: true, HeadSHA: "draft123", ReviewRequests: reviewRequests}}, nil
+	return []PullRequestSummary{{Number: 42, Title: "Review me", State: "OPEN", ReviewDecision: g.reviewDecision, Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, BaseSHA: "base123", HasConflicts: g.hasConflicts, ReviewRequests: reviewRequests}, {Number: 99, Title: "Draft", State: "OPEN", IsDraft: true, HeadSHA: "draft123", BaseSHA: "base123", ReviewRequests: reviewRequests}}, nil
 }
 
 func (g *fakeGitHubGateway) GetCurrentUserLogin(context.Context, string) (string, error) {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1008,7 +1008,7 @@ func TestProcessClaimedItemSkipsQueuedAutomaticLoopWhenCurrentUserIsNotRequested
 func TestDiscoverPullRequestsSuppressesRepeatedConflictSkipUntilHeadChanges(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	github := &fakeGitHubGateway{hasConflicts: true, reviewRequests: []string{"octocat"}}
+	github := &fakeGitHubGateway{hasConflicts: true, reviewDecision: "REVIEW_REQUIRED", reviewRequests: []string{"octocat"}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: testReviewerLoopConfig()})
 	repo := "acme/looper"
 
@@ -1025,12 +1025,13 @@ func TestDiscoverPullRequestsSuppressesRepeatedConflictSkipUntilHeadChanges(t *t
 		t.Fatalf("ProcessClaimedItem() = (%#v, %v), want conflicted skip", processed, err)
 	}
 
+	github.reviewDecision = "APPROVED"
 	second, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
 	if err != nil {
 		t.Fatalf("second DiscoverPullRequests() error = %v", err)
 	}
 	if len(second.QueueItems) != 0 {
-		t.Fatalf("second QueueItems = %#v, want no re-enqueue for unchanged conflicted head", second.QueueItems)
+		t.Fatalf("second QueueItems = %#v, want no re-enqueue while conflict remains after review decision changes", second.QueueItems)
 	}
 	items, err := fixture.repos.Queue.List(context.Background())
 	if err != nil {
@@ -1085,7 +1086,7 @@ func TestDiscoverPullRequestsSuppressesRepeatedAlreadyReviewedSkip(t *testing.T)
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	reviews := []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "COMMENTED", "commit": map[string]any{"oid": "abc123"}}}
-	github := &fakeGitHubGateway{currentLogin: "octocat", reviews: reviews, reviewRequests: []string{"octocat"}}
+	github := &fakeGitHubGateway{currentLogin: "octocat", reviewDecision: "REVIEW_REQUIRED", reviews: reviews, reviewRequests: []string{"octocat"}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: testReviewerLoopConfig()})
 	repo := "acme/looper"
 
@@ -1110,12 +1111,13 @@ func TestDiscoverPullRequestsSuppressesRepeatedAlreadyReviewedSkip(t *testing.T)
 		t.Fatalf("lastFilterSkip.reviewerLogin = %q, want octocat", got)
 	}
 
+	github.reviewDecision = "APPROVED"
 	second, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
 	if err != nil {
 		t.Fatalf("second DiscoverPullRequests() error = %v", err)
 	}
 	if len(second.QueueItems) != 0 {
-		t.Fatalf("second QueueItems = %#v, want no re-enqueue for unchanged already-reviewed head", second.QueueItems)
+		t.Fatalf("second QueueItems = %#v, want no re-enqueue for unchanged already-reviewed head after review decision changes", second.QueueItems)
 	}
 
 	github.currentLogin = "looper-bot"

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1101,6 +1101,14 @@ func TestDiscoverPullRequestsSuppressesRepeatedAlreadyReviewedSkip(t *testing.T)
 	if err != nil || processed.Status != "skipped" || !strings.Contains(processed.Summary, "already reviewed head abc123") {
 		t.Fatalf("ProcessClaimedItem() = (%#v, %v), want already-reviewed skip", processed, err)
 	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), first.CreatedLoopIDs[0])
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+	lastSkip, _ := parseJSONObject(loop.MetadataJSON)["lastFilterSkip"].(map[string]any)
+	if got, _ := stringFromAny(lastSkip["reviewerLogin"]); got != "octocat" {
+		t.Fatalf("lastFilterSkip.reviewerLogin = %q, want octocat", got)
+	}
 
 	second, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
 	if err != nil {
@@ -1108,6 +1116,16 @@ func TestDiscoverPullRequestsSuppressesRepeatedAlreadyReviewedSkip(t *testing.T)
 	}
 	if len(second.QueueItems) != 0 {
 		t.Fatalf("second QueueItems = %#v, want no re-enqueue for unchanged already-reviewed head", second.QueueItems)
+	}
+
+	github.currentLogin = "looper-bot"
+	github.reviewRequests = []string{"looper-bot"}
+	third, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("third DiscoverPullRequests() error = %v", err)
+	}
+	if len(third.QueueItems) != 1 {
+		t.Fatalf("third QueueItems = %#v, want re-enqueue when reviewer login changes", third.QueueItems)
 	}
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -248,7 +248,7 @@ func (a reviewerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input r
 	}
 	result := make([]reviewer.PullRequestSummary, 0, len(pullRequests))
 	for _, pr := range pullRequests {
-		result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: pr.ReviewDecision, Labels: pr.Labels, HeadSHA: pr.HeadSHA, Author: pr.Author, ReviewRequests: pr.ReviewRequests})
+		result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: pr.ReviewDecision, Labels: pr.Labels, HeadSHA: pr.HeadSHA, BaseSHA: pr.BaseSHA, HasConflicts: pr.HasConflicts, Author: pr.Author, ReviewRequests: pr.ReviewRequests})
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Summary
- Persist filter skip metadata for non-actionable reviewer loops so discovery suppresses unchanged conflict, already-reviewed, approved, ready, and draft cases.
- Carry PR list merge/conflict state into reviewer discovery so conflicted PRs can be rediscovered when conflicts clear or the head changes.
- Add repeated discovery tests for conflict, already-reviewed, approved/ready, draft, conflict-clear, and new-head rediscovery behavior.

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #166

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.0.0-dev · runner=worker · agent=opencode</sub>