### PR TITLE
feat: recover stuck reviewer guardrail loops

### DIFF
--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -389,6 +389,8 @@ type DiscoveryResult struct {
 	Skipped        int
 }
 
+const maxReviewerAutoRecoveryAttempts = 3
+
 type ProcessResult struct {
 	LoopID      string
 	RunID       string
@@ -595,6 +597,15 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		loopResult, loopErr := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, existing)
 		if loopErr != nil {
 			return loopErr
+		}
+		if terminalReviewerLoopReason(loopResult.record) == "failed" {
+			recovered, recoverErr := r.recoverFailedReviewerLoop(ctx, loopResult.record, pr)
+			if recoverErr != nil {
+				return recoverErr
+			}
+			if recovered != nil {
+				loopResult.record = *recovered
+			}
 		}
 		if terminalReviewerLoopReason(loopResult.record) != "" {
 			result.Skipped++
@@ -2207,6 +2218,129 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 	}
 	r.appendEvent(ctx, eventInput{eventType: "loop.created", projectID: project.ID, loopID: loop.ID, entityType: "loop", entityID: loop.ID, payload: map[string]any{"type": "reviewer", "repo": repo, "prNumber": prNumber}})
 	return loopUpsertResult{record: loop, created: true}, nil
+}
+
+func (r *Runner) recoverFailedReviewerLoop(ctx context.Context, loop storage.LoopRecord, pr PullRequestSummary) (*storage.LoopRecord, error) {
+	eligible, queueID, reason, err := r.failedReviewerLoopRecoveryEligibility(ctx, loop, pr)
+	if err != nil {
+		return nil, err
+	}
+	if !eligible {
+		r.logInfo("reviewer auto-recovery skipped", map[string]any{"loopId": loop.ID, "reason": reason})
+		r.appendEvent(ctx, eventInput{eventType: "reviewer.auto_recovery.skipped", projectID: loop.ProjectID, loopID: loop.ID, entityType: "loop", entityID: loop.ID, payload: map[string]any{"reason": reason}})
+		return nil, nil
+	}
+	nowISO := r.nowISO()
+	requeued, err := r.repos.Queue.RequeueFailedByID(ctx, loop.ID, queueID, nowISO)
+	if err != nil {
+		return nil, err
+	}
+	if requeued == 0 {
+		active, activeErr := r.repos.Queue.FindActiveByLoopID(ctx, loop.ID)
+		if activeErr != nil {
+			return nil, activeErr
+		}
+		if active == nil {
+			return nil, fmt.Errorf("reviewer auto-recovery did not requeue failed queue item %s for loop %s", queueID, loop.ID)
+		}
+	}
+	updated, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+		updated.Status = "queued"
+		updated.NextRunAt = stringPtr(nowISO)
+		meta := parseJSONObject(updated.MetadataJSON)
+		loopMeta := reviewerLoopMetadata(meta)
+		loopMeta["status"] = "active"
+		loopMeta["lastStatus"] = "auto_recovered"
+		loopMeta["autoRecoveryAttempts"] = intFromAny(loopMeta["autoRecoveryAttempts"]) + 1
+		loopMeta["lastAutoRecoveryReason"] = reason
+		delete(loopMeta, "terminationReason")
+		meta["loop"] = loopMeta
+		if encoded, marshalErr := json.Marshal(meta); marshalErr == nil {
+			text := string(encoded)
+			updated.MetadataJSON = &text
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	r.logInfo("reviewer auto-recovered failed loop", map[string]any{"loopId": loop.ID, "reason": reason})
+	r.appendEvent(ctx, eventInput{eventType: "reviewer.auto_recovery.requeued", projectID: loop.ProjectID, loopID: loop.ID, entityType: "loop", entityID: loop.ID, payload: map[string]any{"reason": reason, "attempt": intFromAny(reviewerLoopMetadata(parseJSONObject(updated.MetadataJSON))["autoRecoveryAttempts"])}})
+	return &updated, nil
+}
+
+func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop storage.LoopRecord, pr PullRequestSummary) (bool, string, string, error) {
+	if loop.Type != "reviewer" || loop.Status != "failed" || isManualReviewerLoop(loop) {
+		return false, "", "not_failed_reviewer_loop", nil
+	}
+	if normalizePRState(pr.State) != "open" {
+		return false, "", "pr_not_open", nil
+	}
+	if !r.discoveryPolicy.IncludeDrafts && pr.IsDraft {
+		return false, "", "draft_pr", nil
+	}
+	if strings.EqualFold(strings.TrimSpace(pr.ReviewDecision), "APPROVED") {
+		return false, "", "approved", nil
+	}
+	if specpr.HasLabel(pr.Labels, specpr.ReadyLabel) {
+		return false, "", "ready_label", nil
+	}
+	meta := parseJSONObject(loop.MetadataJSON)
+	loopMeta := reviewerLoopMetadata(meta)
+	if reason, _ := stringFromAny(loopMeta["terminationReason"]); reason != "" {
+		return false, "", reason, nil
+	}
+	if intFromAny(loopMeta["consecutiveFailures"]) >= r.loopConfig.MaxConsecutiveFailures {
+		return false, "", "max_consecutive_failures", nil
+	}
+	if intFromAny(loopMeta["autoRecoveryAttempts"]) >= maxReviewerAutoRecoveryAttempts {
+		return false, "", "auto_recovery_attempt_cap", nil
+	}
+	latestRun, err := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return false, "", "", err
+	}
+	latestQueue, err := r.repos.Queue.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return false, "", "", err
+	}
+	if latestQueue == nil || latestQueue.Status != "failed" {
+		return false, "", "latest_queue_not_failed", nil
+	}
+	if latestRun == nil || latestRun.Status != "failed" {
+		return false, "", "latest_run_not_failed", nil
+	}
+	checkpoint := reviewerCheckpoint{}
+	checkpoint = parseCheckpoint(latestRun.CheckpointJSON)
+	queueKind := ""
+	if latestQueue.LastErrorKind != nil {
+		queueKind = *latestQueue.LastErrorKind
+	}
+	if queueKind == string(FailureManualIntervention) || checkpoint.ResumePolicy == "manual_intervention" {
+		return false, "", "manual_intervention", nil
+	}
+	if queueKind == string(FailureRetryableAfterResume) && (checkpoint.ResumePolicy == "restart_from_discover" || checkpoint.ResumePolicy == "rerun_review") {
+		return true, latestQueue.ID, "retryable_after_resume_" + checkpoint.ResumePolicy, nil
+	}
+	latestMessage := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage))
+	if latestMessage == "" {
+		latestMessage = derefString(latestQueue.LastError)
+	}
+	if isKnownReviewerRediscoveryGuardrail(latestMessage) && isReviewerRediscoveryRunStep(latestRun) {
+		return true, latestQueue.ID, "historical_guardrail", nil
+	}
+	return false, "", "not_whitelisted", nil
+}
+
+func isKnownReviewerRediscoveryGuardrail(message string) bool {
+	return strings.Contains(message, "PR head changed before publish") || strings.Contains(message, "review request removed before publish")
+}
+
+func isReviewerRediscoveryRunStep(run *storage.RunRecord) bool {
+	if run == nil || run.CurrentStep == nil {
+		return false
+	}
+	step := strings.TrimSpace(*run.CurrentStep)
+	return step == string(stepPublish) || step == string(stepReview) || step == string(stepThreadResolution)
 }
 
 func (r *Runner) markLoopQueuedForReview(ctx context.Context, loop storage.LoopRecord, availableAt string) error {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2278,10 +2278,10 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if !r.discoveryPolicy.IncludeDrafts && pr.IsDraft {
 		return false, "", "draft_pr", nil
 	}
-	if strings.EqualFold(strings.TrimSpace(pr.ReviewDecision), "APPROVED") {
+	if r.loopConfig.StopOnApproved && strings.EqualFold(strings.TrimSpace(pr.ReviewDecision), "APPROVED") {
 		return false, "", "approved", nil
 	}
-	if specpr.HasLabel(pr.Labels, specpr.ReadyLabel) {
+	if r.loopConfig.StopOnReadyLabel && specpr.HasLabel(pr.Labels, specpr.ReadyLabel) {
 		return false, "", "ready_label", nil
 	}
 	meta := parseJSONObject(loop.MetadataJSON)

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2285,6 +2285,9 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 		return false, "", "ready_label", nil
 	}
 	meta := parseJSONObject(loop.MetadataJSON)
+	if !r.loopEnabled(meta) {
+		return false, "", "loop_disabled", nil
+	}
 	loopMeta := reviewerLoopMetadata(meta)
 	if reason, _ := stringFromAny(loopMeta["terminationReason"]); reason != "" {
 		return false, "", reason, nil

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -48,6 +48,71 @@ func TestDiscoverPullRequestsCreatesLoopAndQueue(t *testing.T) {
 	}
 }
 
+func TestDiscoverPullRequestsRecoversRetryableAfterResumeRestartFromDiscover(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	loopID, queueID := seedFailedReviewerRecoveryLoop(t, fixture, failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish: expected old, got new"})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25}})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 || result.QueueItems[0].ID != queueID {
+		t.Fatalf("QueueItems = %#v, want recovered existing queue item %s", result.QueueItems, queueID)
+	}
+	loop, _ := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	queue, _ := fixture.repos.Queue.GetByID(context.Background(), queueID)
+	if loop == nil || loop.Status != "queued" || queue == nil || queue.Status != "queued" || queue.LastError != nil || queue.LastErrorKind != nil {
+		t.Fatalf("loop=%#v queue=%#v, want queued loop and cleared failed queue metadata", loop, queue)
+	}
+
+	again, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("second DiscoverPullRequests() error = %v", err)
+	}
+	queues, _ := fixture.repos.Queue.List(context.Background())
+	if len(again.QueueItems) != 1 || len(queues) != 1 {
+		t.Fatalf("second result=%#v queues=%#v, want idempotent single active queue", again, queues)
+	}
+}
+
+func TestReviewerFailedLoopRecoveryEligibilityWhitelist(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		seed failedReviewerRecoverySeed
+		pr   PullRequestSummary
+		want bool
+	}{
+		{name: "retryable rerun review", seed: failedReviewerRecoverySeed{ResumePolicy: "rerun_review", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "marker missing"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
+		{name: "historical guardrail non retryable", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureNonRetryable), ErrorMessage: "review request removed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
+		{name: "manual intervention", seed: failedReviewerRecoverySeed{ResumePolicy: "manual_intervention", QueueErrorKind: string(FailureManualIntervention), ErrorMessage: "operator needed"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
+		{name: "closed pr", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "CLOSED"}, want: false},
+		{name: "approved pr", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN", ReviewDecision: "APPROVED"}, want: false},
+		{name: "ready label", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN", Labels: []string{specpr.ReadyLabel}}, want: false},
+		{name: "max failure budget", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", ConsecutiveFailures: 3}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
+		{name: "attempt cap", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", AutoRecoveryAttempts: maxReviewerAutoRecoveryAttempts}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			loopID, _ := seedFailedReviewerRecoveryLoop(t, fixture, tt.seed)
+			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25}})
+			loop, _ := fixture.repos.Loops.GetByID(context.Background(), loopID)
+			eligible, _, _, err := runner.failedReviewerLoopRecoveryEligibility(context.Background(), *loop, tt.pr)
+			if err != nil {
+				t.Fatalf("failedReviewerLoopRecoveryEligibility() error = %v", err)
+			}
+			if eligible != tt.want {
+				t.Fatalf("eligible = %v, want %v", eligible, tt.want)
+			}
+		})
+	}
+}
+
 func TestReviewDisclosureInstructionPreservesVisibleInlineGuidance(t *testing.T) {
 	t.Parallel()
 	disclosureCfg := config.DefaultDisclosureConfig()
@@ -3870,6 +3935,41 @@ func (f *runnerFixture) advance(delta time.Duration) { f.current = f.current.Add
 
 func (f *runnerFixture) nowISO() string {
 	return fmt.Sprintf("%s.000Z", f.current.UTC().Format("2006-01-02T15:04:05"))
+}
+
+type failedReviewerRecoverySeed struct {
+	ResumePolicy         string
+	QueueErrorKind       string
+	ErrorMessage         string
+	ConsecutiveFailures  int
+	AutoRecoveryAttempts int
+}
+
+func seedFailedReviewerRecoveryLoop(t *testing.T, fixture *runnerFixture, seed failedReviewerRecoverySeed) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	loopID := "loop_recover_reviewer"
+	queueID := "queue_recover_reviewer"
+	consecutive := seed.ConsecutiveFailures
+	if consecutive == 0 {
+		consecutive = 1
+	}
+	metadata := mustMarshalJSON(map[string]any{"loop": map[string]any{"enabled": true, "failureCount": consecutive, "consecutiveFailures": consecutive, "lastFailure": seed.ErrorMessage, "autoRecoveryAttempts": seed.AutoRecoveryAttempts}})
+	if err := fixture.repos.Loops.Upsert(ctx, storage.LoopRecord{ID: loopID, Seq: 165, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpoint := mustMarshalJSON(reviewerCheckpoint{ResumePolicy: seed.ResumePolicy, Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", ReviewRequests: []string{"octocat"}}})
+	if err := fixture.repos.Runs.Upsert(ctx, storage.RunRecord{ID: "run_recover_reviewer", LoopID: loopID, Status: "failed", CurrentStep: stringPtr(string(stepPublish)), CheckpointJSON: &checkpoint, Summary: &seed.ErrorMessage, ErrorMessage: &seed.ErrorMessage, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Queue.Upsert(ctx, storage.QueueItemRecord{ID: queueID, ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: buildReviewerDedupeKey("project_1", loopID, repo, prNumber), Priority: storage.QueuePriorityReviewer, Status: "failed", AvailableAt: nowISO, Attempts: 3, MaxAttempts: 3, FinishedAt: &nowISO, LastError: &seed.ErrorMessage, LastErrorKind: &seed.QueueErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	return loopID, queueID
 }
 
 type fakeGitHubGateway struct {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -91,6 +91,8 @@ func TestReviewerFailedLoopRecoveryEligibilityWhitelist(t *testing.T) {
 		{name: "closed pr", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "CLOSED"}, want: false},
 		{name: "approved pr", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN", ReviewDecision: "APPROVED"}, want: false},
 		{name: "ready label", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN", Labels: []string{specpr.ReadyLabel}}, want: false},
+		{name: "follow updates disabled", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", FollowUpdates: boolPtr(false)}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
+		{name: "loop disabled", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", LoopEnabled: boolPtr(false)}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 		{name: "max failure budget", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", ConsecutiveFailures: 3}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 		{name: "attempt cap", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", AutoRecoveryAttempts: maxReviewerAutoRecoveryAttempts}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 	}
@@ -3937,12 +3939,16 @@ func (f *runnerFixture) nowISO() string {
 	return fmt.Sprintf("%s.000Z", f.current.UTC().Format("2006-01-02T15:04:05"))
 }
 
+func boolPtr(value bool) *bool { return &value }
+
 type failedReviewerRecoverySeed struct {
 	ResumePolicy         string
 	QueueErrorKind       string
 	ErrorMessage         string
 	ConsecutiveFailures  int
 	AutoRecoveryAttempts int
+	FollowUpdates        *bool
+	LoopEnabled          *bool
 }
 
 func seedFailedReviewerRecoveryLoop(t *testing.T, fixture *runnerFixture, seed failedReviewerRecoverySeed) (string, string) {
@@ -3958,7 +3964,15 @@ func seedFailedReviewerRecoveryLoop(t *testing.T, fixture *runnerFixture, seed f
 	if consecutive == 0 {
 		consecutive = 1
 	}
-	metadata := mustMarshalJSON(map[string]any{"loop": map[string]any{"enabled": true, "failureCount": consecutive, "consecutiveFailures": consecutive, "lastFailure": seed.ErrorMessage, "autoRecoveryAttempts": seed.AutoRecoveryAttempts}})
+	loopEnabled := true
+	if seed.LoopEnabled != nil {
+		loopEnabled = *seed.LoopEnabled
+	}
+	metadataMap := map[string]any{"loop": map[string]any{"enabled": loopEnabled, "failureCount": consecutive, "consecutiveFailures": consecutive, "lastFailure": seed.ErrorMessage, "autoRecoveryAttempts": seed.AutoRecoveryAttempts}}
+	if seed.FollowUpdates != nil {
+		metadataMap["followUpdates"] = *seed.FollowUpdates
+	}
+	metadata := mustMarshalJSON(metadataMap)
 	if err := fixture.repos.Loops.Upsert(ctx, storage.LoopRecord{ID: loopID, Seq: 165, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -102,7 +102,7 @@ func TestReviewerFailedLoopRecoveryEligibilityWhitelist(t *testing.T) {
 			t.Parallel()
 			fixture := newRunnerFixture(t)
 			loopID, _ := seedFailedReviewerRecoveryLoop(t, fixture, tt.seed)
-			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25}})
+			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: true, StopOnReadyLabel: true}})
 			loop, _ := fixture.repos.Loops.GetByID(context.Background(), loopID)
 			eligible, _, _, err := runner.failedReviewerLoopRecoveryEligibility(context.Background(), *loop, tt.pr)
 			if err != nil {
@@ -110,6 +110,35 @@ func TestReviewerFailedLoopRecoveryEligibilityWhitelist(t *testing.T) {
 			}
 			if eligible != tt.want {
 				t.Fatalf("eligible = %v, want %v", eligible, tt.want)
+			}
+		})
+	}
+}
+
+func TestReviewerFailedLoopRecoveryEligibilityHonorsStopOnConfig(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		loopConfig config.ReviewerLoopConfig
+		pr         PullRequestSummary
+	}{
+		{name: "approved allowed", loopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: false, StopOnReadyLabel: true}, pr: PullRequestSummary{Number: 42, State: "OPEN", ReviewDecision: "APPROVED"}},
+		{name: "ready label allowed", loopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: true, StopOnReadyLabel: false}, pr: PullRequestSummary{Number: 42, State: "OPEN", Labels: []string{specpr.ReadyLabel}}},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			loopID, _ := seedFailedReviewerRecoveryLoop(t, fixture, failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish: expected old, got new"})
+			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: tt.loopConfig})
+			loop, _ := fixture.repos.Loops.GetByID(context.Background(), loopID)
+			eligible, _, _, err := runner.failedReviewerLoopRecoveryEligibility(context.Background(), *loop, tt.pr)
+			if err != nil {
+				t.Fatalf("failedReviewerLoopRecoveryEligibility() error = %v", err)
+			}
+			if !eligible {
+				t.Fatalf("eligible = false, want true")
 			}
 		})
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1262,6 +1262,7 @@ type runtimeReviewerCheckpoint struct {
 	ResumePolicy string `json:"resumePolicy,omitempty"`
 	Detail       *struct {
 		State          string   `json:"state,omitempty"`
+		IsDraft        bool     `json:"isDraft,omitempty"`
 		ReviewDecision string   `json:"reviewDecision,omitempty"`
 		Labels         []string `json:"labels,omitempty"`
 	} `json:"detail,omitempty"`
@@ -1301,6 +1302,9 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 		return false
 	}
 	if strings.ToLower(strings.TrimSpace(checkpoint.Detail.State)) != "open" {
+		return false
+	}
+	if checkpoint.Detail.IsDraft {
 		return false
 	}
 	if strings.EqualFold(strings.TrimSpace(checkpoint.Detail.ReviewDecision), "APPROVED") || specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1275,6 +1275,9 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 	if manual, _ := meta["manual"].(bool); manual {
 		return false
 	}
+	if !runtimeReviewerLoopEnabled(meta) {
+		return false
+	}
 	loopMeta := runtimeReviewerLoopMetadata(meta)
 	if reason, _ := runtimeStringFromAny(loopMeta["terminationReason"]); reason != "" {
 		return false
@@ -1353,6 +1356,18 @@ func runtimeReviewerLoopMetadata(meta map[string]any) map[string]any {
 		loopMeta = map[string]any{}
 	}
 	return loopMeta
+}
+
+func runtimeReviewerLoopEnabled(meta map[string]any) bool {
+	if enabled, ok := meta["followUpdates"].(bool); ok {
+		return enabled
+	}
+	if loopMeta, ok := meta["loop"].(map[string]any); ok {
+		if enabled, ok := loopMeta["enabled"].(bool); ok {
+			return enabled
+		}
+	}
+	return false
 }
 
 func runtimeIntFromAny(value any) int {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -689,7 +689,12 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 		if err != nil {
 			return RecoverySummary{}, err
 		}
-		if shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, int64(r.config.Reviewer.Loop.MaxConsecutiveFailures)) {
+		if shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, runtimeReviewerRecoveryPolicy{
+			includeDrafts:          r.config.Roles.Reviewer.Triggers.IncludeDrafts,
+			stopOnApproved:         r.config.Reviewer.Loop.StopOnApproved,
+			stopOnReadyLabel:       r.config.Reviewer.Loop.StopOnReadyLabel,
+			maxConsecutiveFailures: int64(r.config.Reviewer.Loop.MaxConsecutiveFailures),
+		}) {
 			recoveredQueueItems, err := repositories.Queue.RequeueFailedByID(ctx, loop.ID, latestQueue.ID, nowISO)
 			if err != nil {
 				return RecoverySummary{}, err
@@ -1268,7 +1273,14 @@ type runtimeReviewerCheckpoint struct {
 	} `json:"detail,omitempty"`
 }
 
-func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *storage.RunRecord, latestQueue *storage.QueueItemRecord, maxConsecutiveFailures int64) bool {
+type runtimeReviewerRecoveryPolicy struct {
+	includeDrafts          bool
+	stopOnApproved         bool
+	stopOnReadyLabel       bool
+	maxConsecutiveFailures int64
+}
+
+func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *storage.RunRecord, latestQueue *storage.QueueItemRecord, policy runtimeReviewerRecoveryPolicy) bool {
 	if loop.Type != string(domain.LoopTypeReviewer) || loop.Status != "failed" || latestRun == nil || latestRun.Status != "failed" || latestQueue == nil || latestQueue.Status != "failed" {
 		return false
 	}
@@ -1283,7 +1295,7 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 	if reason, _ := runtimeStringFromAny(loopMeta["terminationReason"]); reason != "" {
 		return false
 	}
-	if maxConsecutiveFailures > 0 && int64(runtimeIntFromAny(loopMeta["consecutiveFailures"])) >= maxConsecutiveFailures {
+	if policy.maxConsecutiveFailures > 0 && int64(runtimeIntFromAny(loopMeta["consecutiveFailures"])) >= policy.maxConsecutiveFailures {
 		return false
 	}
 	if runtimeIntFromAny(loopMeta["autoRecoveryAttempts"]) >= maxReviewerAutoRecoveryAttempts {
@@ -1304,10 +1316,13 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 	if strings.ToLower(strings.TrimSpace(checkpoint.Detail.State)) != "open" {
 		return false
 	}
-	if checkpoint.Detail.IsDraft {
+	if !policy.includeDrafts && checkpoint.Detail.IsDraft {
 		return false
 	}
-	if strings.EqualFold(strings.TrimSpace(checkpoint.Detail.ReviewDecision), "APPROVED") || specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {
+	if policy.stopOnApproved && strings.EqualFold(strings.TrimSpace(checkpoint.Detail.ReviewDecision), "APPROVED") {
+		return false
+	}
+	if policy.stopOnReadyLabel && specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {
 		return false
 	}
 	failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage), queueMessage)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -19,6 +19,7 @@ import (
 	"github.com/powerformer/looper/internal/domain"
 	gitinfra "github.com/powerformer/looper/internal/infra/git"
 	githubinfra "github.com/powerformer/looper/internal/infra/github"
+	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/loops"
 	"github.com/powerformer/looper/internal/projects"
 	"github.com/powerformer/looper/internal/runs"
@@ -684,6 +685,49 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 			eventsWritten += 1
 		}
 
+		latestQueue, err := repositories.Queue.GetLatestByLoopID(ctx, loop.ID)
+		if err != nil {
+			return RecoverySummary{}, err
+		}
+		if shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, int64(r.config.Reviewer.Loop.MaxConsecutiveFailures)) {
+			recoveredQueueItems, err := repositories.Queue.RequeueFailedByID(ctx, loop.ID, latestQueue.ID, nowISO)
+			if err != nil {
+				return RecoverySummary{}, err
+			}
+			if recoveredQueueItems == 0 {
+				active, activeErr := repositories.Queue.FindActiveByLoopID(ctx, loop.ID)
+				if activeErr != nil {
+					return RecoverySummary{}, activeErr
+				}
+				if active == nil {
+					return RecoverySummary{}, fmt.Errorf("reviewer recovery did not requeue failed queue item %s for loop %s", latestQueue.ID, loop.ID)
+				}
+			}
+			requeuedLoop := autoRecoveredReviewerLoop(loop, nowISO)
+			if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
+				return RecoverySummary{}, err
+			}
+			requeuedLoopIDs[loop.ID] = struct{}{}
+			summary.LoopsRequeued += 1
+			if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
+				ID:         newRuntimeEventID(),
+				EventType:  "looperd.recovery.reviewer_auto_recovered",
+				LoopID:     stringPtr(loop.ID),
+				EntityType: stringPtr("loop"),
+				EntityID:   stringPtr(loop.ID),
+				PayloadJSON: mustMarshalJSON(map[string]any{
+					"previousStatus":      loop.Status,
+					"nextRunAt":           nowISO,
+					"recoveredQueueItems": recoveredQueueItems,
+				}),
+				CreatedAt: nowISO,
+			}); err != nil {
+				return RecoverySummary{}, err
+			}
+			eventsWritten += 1
+			continue
+		}
+
 		if shouldRequeueLoop(loop, latestRun) {
 			requeuedLoop := loop
 			requeuedLoop.Status = "queued"
@@ -1210,6 +1254,148 @@ func createEmptyRecoverySummary() RecoverySummary {
 		LoopsRequeued:         0,
 		EventsWritten:         0,
 	}
+}
+
+const maxReviewerAutoRecoveryAttempts = 3
+
+type runtimeReviewerCheckpoint struct {
+	ResumePolicy string `json:"resumePolicy,omitempty"`
+	Detail       *struct {
+		State          string   `json:"state,omitempty"`
+		ReviewDecision string   `json:"reviewDecision,omitempty"`
+		Labels         []string `json:"labels,omitempty"`
+	} `json:"detail,omitempty"`
+}
+
+func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *storage.RunRecord, latestQueue *storage.QueueItemRecord, maxConsecutiveFailures int64) bool {
+	if loop.Type != string(domain.LoopTypeReviewer) || loop.Status != "failed" || latestRun == nil || latestRun.Status != "failed" || latestQueue == nil || latestQueue.Status != "failed" {
+		return false
+	}
+	meta := parseRuntimeJSONObject(loop.MetadataJSON)
+	if manual, _ := meta["manual"].(bool); manual {
+		return false
+	}
+	loopMeta := runtimeReviewerLoopMetadata(meta)
+	if reason, _ := runtimeStringFromAny(loopMeta["terminationReason"]); reason != "" {
+		return false
+	}
+	if maxConsecutiveFailures > 0 && int64(runtimeIntFromAny(loopMeta["consecutiveFailures"])) >= maxConsecutiveFailures {
+		return false
+	}
+	if runtimeIntFromAny(loopMeta["autoRecoveryAttempts"]) >= maxReviewerAutoRecoveryAttempts {
+		return false
+	}
+	checkpoint := parseRuntimeReviewerCheckpoint(latestRun.CheckpointJSON)
+	if checkpoint.ResumePolicy == "manual_intervention" {
+		return false
+	}
+	queueKind := derefString(latestQueue.LastErrorKind)
+	queueMessage := derefString(latestQueue.LastError)
+	if queueKind == "manual_intervention" {
+		return false
+	}
+	if checkpoint.Detail == nil {
+		return false
+	}
+	if strings.ToLower(strings.TrimSpace(checkpoint.Detail.State)) != "open" {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(checkpoint.Detail.ReviewDecision), "APPROVED") || specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {
+		return false
+	}
+	failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage), queueMessage)
+	return (queueKind == "retryable_after_resume" && (checkpoint.ResumePolicy == "restart_from_discover" || checkpoint.ResumePolicy == "rerun_review")) || (isKnownReviewerRediscoveryGuardrail(failureSummary) && isRuntimeReviewerRediscoveryRunStep(latestRun))
+}
+
+func autoRecoveredReviewerLoop(loop storage.LoopRecord, nowISO string) storage.LoopRecord {
+	updated := loop
+	updated.Status = "queued"
+	updated.NextRunAt = stringPtr(nowISO)
+	updated.UpdatedAt = nowISO
+	meta := parseRuntimeJSONObject(updated.MetadataJSON)
+	loopMeta := runtimeReviewerLoopMetadata(meta)
+	loopMeta["status"] = "active"
+	loopMeta["lastStatus"] = "auto_recovered"
+	loopMeta["autoRecoveryAttempts"] = runtimeIntFromAny(loopMeta["autoRecoveryAttempts"]) + 1
+	delete(loopMeta, "terminationReason")
+	meta["loop"] = loopMeta
+	encoded, err := json.Marshal(meta)
+	if err == nil {
+		text := string(encoded)
+		updated.MetadataJSON = &text
+	}
+	return updated
+}
+
+func parseRuntimeReviewerCheckpoint(value *string) runtimeReviewerCheckpoint {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return runtimeReviewerCheckpoint{}
+	}
+	var checkpoint runtimeReviewerCheckpoint
+	_ = json.Unmarshal([]byte(*value), &checkpoint)
+	return checkpoint
+}
+
+func parseRuntimeJSONObject(value *string) map[string]any {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return map[string]any{}
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(*value), &decoded); err != nil || decoded == nil {
+		return map[string]any{}
+	}
+	return decoded
+}
+
+func runtimeReviewerLoopMetadata(meta map[string]any) map[string]any {
+	loopMeta, _ := meta["loop"].(map[string]any)
+	if loopMeta == nil {
+		loopMeta = map[string]any{}
+	}
+	return loopMeta
+}
+
+func runtimeIntFromAny(value any) int {
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	default:
+		return 0
+	}
+}
+
+func runtimeStringFromAny(value any) (string, bool) {
+	text, ok := value.(string)
+	return text, ok
+}
+
+func isKnownReviewerRediscoveryGuardrail(message string) bool {
+	return strings.Contains(message, "PR head changed before publish") || strings.Contains(message, "review request removed before publish")
+}
+
+func isRuntimeReviewerRediscoveryRunStep(run *storage.RunRecord) bool {
+	if run == nil || run.CurrentStep == nil {
+		return false
+	}
+	switch strings.TrimSpace(*run.CurrentStep) {
+	case "publish", "review", "thread_resolution":
+		return true
+	default:
+		return false
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func shouldRequeueLoop(loop storage.LoopRecord, latestRun *storage.RunRecord) bool {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1428,6 +1428,7 @@ func TestShouldAutoRecoverFailedReviewerLoopRefusesUnsafeStates(t *testing.T) {
 	baseLoop := storage.LoopRecord{ID: "loop_recover", Type: "reviewer", Status: "failed", MetadataJSON: stringPtr(`{"loop":{"consecutiveFailures":1}}`)}
 	baseRun := storage.RunRecord{ID: "run_recover", LoopID: "loop_recover", Status: "failed", CurrentStep: &step, CheckpointJSON: checkpoint(`"detail":{"state":"OPEN","reviewDecision":"","labels":[]}`), Summary: &errorMessage, ErrorMessage: &errorMessage}
 	baseQueue := storage.QueueItemRecord{ID: "queue_recover", LoopID: stringPtr("loop_recover"), Status: "failed", LastError: &errorMessage, LastErrorKind: &errorKind}
+	defaultPolicy := runtimeReviewerRecoveryPolicy{stopOnApproved: true, stopOnReadyLabel: true, maxConsecutiveFailures: 3}
 
 	tests := []struct {
 		name  string
@@ -1506,8 +1507,40 @@ func TestShouldAutoRecoverFailedReviewerLoopRefusesUnsafeStates(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if shouldAutoRecoverFailedReviewerLoop(tt.loop, &tt.run, &tt.queue, 3) {
+			if shouldAutoRecoverFailedReviewerLoop(tt.loop, &tt.run, &tt.queue, defaultPolicy) {
 				t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = true, want false")
+			}
+		})
+	}
+}
+
+func TestShouldAutoRecoverFailedReviewerLoopHonorsRecoveryPolicy(t *testing.T) {
+	t.Parallel()
+	errorKind := "retryable_after_resume"
+	errorMessage := "PR head changed before publish: expected old, got new"
+	step := "publish"
+	checkpoint := func(detail string) *string {
+		value := `{"resumePolicy":"restart_from_discover",` + detail + `}`
+		return &value
+	}
+	loop := storage.LoopRecord{ID: "loop_recover", Type: "reviewer", Status: "failed", MetadataJSON: stringPtr(`{"loop":{"enabled":true,"consecutiveFailures":1}}`)}
+	queue := storage.QueueItemRecord{ID: "queue_recover", LoopID: stringPtr("loop_recover"), Status: "failed", LastError: &errorMessage, LastErrorKind: &errorKind}
+	policy := runtimeReviewerRecoveryPolicy{includeDrafts: true, stopOnApproved: false, stopOnReadyLabel: false, maxConsecutiveFailures: 3}
+
+	tests := []struct {
+		name string
+		run  storage.RunRecord
+	}{
+		{name: "draft checkpoint", run: storage.RunRecord{ID: "run_recover_draft", LoopID: "loop_recover", Status: "failed", CurrentStep: &step, CheckpointJSON: checkpoint(`"detail":{"state":"OPEN","isDraft":true,"reviewDecision":"","labels":[]}`), Summary: &errorMessage, ErrorMessage: &errorMessage}},
+		{name: "approved checkpoint", run: storage.RunRecord{ID: "run_recover_approved", LoopID: "loop_recover", Status: "failed", CurrentStep: &step, CheckpointJSON: checkpoint(`"detail":{"state":"OPEN","reviewDecision":"APPROVED","labels":[]}`), Summary: &errorMessage, ErrorMessage: &errorMessage}},
+		{name: "ready label checkpoint", run: storage.RunRecord{ID: "run_recover_ready", LoopID: "loop_recover", Status: "failed", CurrentStep: &step, CheckpointJSON: checkpoint(`"detail":{"state":"OPEN","reviewDecision":"","labels":["looper:spec-ready"]}`), Summary: &errorMessage, ErrorMessage: &errorMessage}},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if !shouldAutoRecoverFailedReviewerLoop(loop, &tt.run, &queue, policy) {
+				t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = false, want true")
 			}
 		})
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1446,6 +1446,11 @@ func TestShouldAutoRecoverFailedReviewerLoopRefusesUnsafeStates(t *testing.T) {
 			r.CheckpointJSON = checkpoint(`"detail":{"state":"CLOSED","reviewDecision":"","labels":[]}`)
 			return r
 		}(), queue: baseQueue},
+		{name: "draft checkpoint", loop: baseLoop, run: func() storage.RunRecord {
+			r := baseRun
+			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","isDraft":true,"reviewDecision":"","labels":[]}`)
+			return r
+		}(), queue: baseQueue},
 		{name: "approved checkpoint", loop: baseLoop, run: func() storage.RunRecord {
 			r := baseRun
 			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","reviewDecision":"APPROVED","labels":[]}`)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1353,6 +1353,151 @@ func TestDefaultSyncConfiguredProjectsPreservesRepoMetadataWhenRepoPathIsUnchang
 	}
 }
 
+func TestRunRecoveryPipelineAutoRecoversFailedReviewerGuardrailLoop(t *testing.T) {
+	t.Parallel()
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), cfg.Storage.DBPath, storage.SQLiteCoordinatorOptions{})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	defer coordinator.Close()
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 0, 0, 0, time.UTC)
+	nowISO := "2026-04-17T12:00:00.000Z"
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	loopID := "loop_runtime_reviewer_recover"
+	queueID := "queue_runtime_reviewer_recover"
+	metadata := mustMarshalJSON(map[string]any{"loop": map[string]any{"enabled": true, "failureCount": 1, "consecutiveFailures": 1, "lastFailure": "PR head changed before publish"}})
+	if err := repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 165, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpoint := `{"resumePolicy":"restart_from_discover","detail":{"state":"OPEN","reviewDecision":"","labels":[]}}`
+	errorMessage := "PR head changed before publish: expected old, got new"
+	if err := repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_runtime_reviewer_recover", LoopID: loopID, Status: "failed", CurrentStep: stringPtr("publish"), CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	queueKind := "retryable_after_resume"
+	if err := repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:project_1:loop_runtime_reviewer_recover:acme/looper:42", Priority: storage.QueuePriorityReviewer, Status: "failed", AvailableAt: nowISO, Attempts: 3, MaxAttempts: 3, FinishedAt: &nowISO, LastError: &errorMessage, LastErrorKind: &queueKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+	summary, err := rt.runRecoveryPipeline(context.Background(), repositories, now)
+	if err != nil {
+		t.Fatalf("runRecoveryPipeline() error = %v", err)
+	}
+	if summary.LoopsRequeued != 1 {
+		t.Fatalf("LoopsRequeued = %d, want 1", summary.LoopsRequeued)
+	}
+	loop, _ := repositories.Loops.GetByID(context.Background(), loopID)
+	queue, _ := repositories.Queue.GetByID(context.Background(), queueID)
+	if loop == nil || loop.Status != "queued" || queue == nil || queue.Status != "queued" {
+		t.Fatalf("loop=%#v queue=%#v, want recovered queued loop and queue", loop, queue)
+	}
+	summary, err = rt.runRecoveryPipeline(context.Background(), repositories, now)
+	if err != nil {
+		t.Fatalf("second runRecoveryPipeline() error = %v", err)
+	}
+	queues, _ := repositories.Queue.List(context.Background())
+	if summary.LoopsRequeued != 0 || len(queues) != 1 {
+		t.Fatalf("second summary=%#v queues=%#v, want idempotent no duplicate", summary, queues)
+	}
+}
+
+func TestShouldAutoRecoverFailedReviewerLoopRefusesUnsafeStates(t *testing.T) {
+	t.Parallel()
+	errorKind := "retryable_after_resume"
+	errorMessage := "PR head changed before publish: expected old, got new"
+	step := "publish"
+	checkpoint := func(detail string) *string {
+		value := `{"resumePolicy":"restart_from_discover",` + detail + `}`
+		return &value
+	}
+	baseLoop := storage.LoopRecord{ID: "loop_recover", Type: "reviewer", Status: "failed", MetadataJSON: stringPtr(`{"loop":{"consecutiveFailures":1}}`)}
+	baseRun := storage.RunRecord{ID: "run_recover", LoopID: "loop_recover", Status: "failed", CurrentStep: &step, CheckpointJSON: checkpoint(`"detail":{"state":"OPEN","reviewDecision":"","labels":[]}`), Summary: &errorMessage, ErrorMessage: &errorMessage}
+	baseQueue := storage.QueueItemRecord{ID: "queue_recover", LoopID: stringPtr("loop_recover"), Status: "failed", LastError: &errorMessage, LastErrorKind: &errorKind}
+
+	tests := []struct {
+		name  string
+		loop  storage.LoopRecord
+		run   storage.RunRecord
+		queue storage.QueueItemRecord
+	}{
+		{name: "manual intervention kind", loop: baseLoop, run: baseRun, queue: func() storage.QueueItemRecord {
+			q := baseQueue
+			kind := "manual_intervention"
+			q.LastErrorKind = &kind
+			return q
+		}()},
+		{name: "closed checkpoint", loop: baseLoop, run: func() storage.RunRecord {
+			r := baseRun
+			r.CheckpointJSON = checkpoint(`"detail":{"state":"CLOSED","reviewDecision":"","labels":[]}`)
+			return r
+		}(), queue: baseQueue},
+		{name: "approved checkpoint", loop: baseLoop, run: func() storage.RunRecord {
+			r := baseRun
+			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","reviewDecision":"APPROVED","labels":[]}`)
+			return r
+		}(), queue: baseQueue},
+		{name: "ready label checkpoint", loop: baseLoop, run: func() storage.RunRecord {
+			r := baseRun
+			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","reviewDecision":"","labels":["looper:spec-ready"]}`)
+			return r
+		}(), queue: baseQueue},
+		{name: "missing checkpoint detail", loop: baseLoop, run: func() storage.RunRecord {
+			r := baseRun
+			r.CheckpointJSON = stringPtr(`{"resumePolicy":"restart_from_discover"}`)
+			return r
+		}(), queue: baseQueue},
+		{name: "max failure budget", loop: func() storage.LoopRecord {
+			l := baseLoop
+			l.MetadataJSON = stringPtr(`{"loop":{"consecutiveFailures":3}}`)
+			return l
+		}(), run: baseRun, queue: baseQueue},
+		{name: "attempt cap", loop: func() storage.LoopRecord {
+			l := baseLoop
+			l.MetadataJSON = stringPtr(`{"loop":{"consecutiveFailures":1,"autoRecoveryAttempts":3}}`)
+			return l
+		}(), run: baseRun, queue: baseQueue},
+		{name: "latest queue not failed", loop: baseLoop, run: baseRun, queue: func() storage.QueueItemRecord { q := baseQueue; q.Status = "completed"; return q }()},
+		{name: "unrelated run step", loop: baseLoop, run: func() storage.RunRecord {
+			r := baseRun
+			s := "setup"
+			r.CurrentStep = &s
+			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","reviewDecision":"","labels":[]}`)
+			r.Summary = &errorMessage
+			r.ErrorMessage = &errorMessage
+			return r
+		}(), queue: func() storage.QueueItemRecord {
+			q := baseQueue
+			kind := "non_retryable"
+			q.LastErrorKind = &kind
+			return q
+		}()},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if shouldAutoRecoverFailedReviewerLoop(tt.loop, &tt.run, &tt.queue, 3) {
+				t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = true, want false")
+			}
+		})
+	}
+}
+
 func TestDefaultSyncConfiguredProjectsPreservesUnknownMetadataFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1451,6 +1451,16 @@ func TestShouldAutoRecoverFailedReviewerLoopRefusesUnsafeStates(t *testing.T) {
 			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","reviewDecision":"APPROVED","labels":[]}`)
 			return r
 		}(), queue: baseQueue},
+		{name: "follow updates disabled", loop: func() storage.LoopRecord {
+			l := baseLoop
+			l.MetadataJSON = stringPtr(`{"followUpdates":false,"loop":{"enabled":true,"consecutiveFailures":1}}`)
+			return l
+		}(), run: baseRun, queue: baseQueue},
+		{name: "loop disabled", loop: func() storage.LoopRecord {
+			l := baseLoop
+			l.MetadataJSON = stringPtr(`{"loop":{"enabled":false,"consecutiveFailures":1}}`)
+			return l
+		}(), run: baseRun, queue: baseQueue},
 		{name: "ready label checkpoint", loop: baseLoop, run: func() storage.RunRecord {
 			r := baseRun
 			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","reviewDecision":"","labels":["looper:spec-ready"]}`)

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -881,10 +882,11 @@ func githubCLIAutoPROpeningAvailable(ctx context.Context, cfg config.Config, git
 	if githubGateway == nil {
 		return false
 	}
-	authenticated, err := githubGateway.IsAuthenticated(ctx, cwd, githubAuthHostname(repo))
+	hostname := githubAuthHostname(repo)
+	authenticated, err := githubGateway.IsAuthenticated(ctx, cwd, hostname)
 	if err != nil {
 		if logger != nil {
-			logger.Warn("github cli auth check failed; disabling automatic PR opening", map[string]any{"error": err.Error(), "repo": repo, "hostname": githubAuthHostname(repo)})
+			logger.Warn("github cli auth check failed; disabling automatic PR opening", map[string]any{"error": err.Error(), "repo": repo, "hostname": hostname})
 		}
 		return false
 	}
@@ -896,6 +898,15 @@ func githubAuthHostname(repo string) string {
 	repo = strings.TrimSpace(repo)
 	if repo == "" {
 		return defaultHost
+	}
+	if parsed, err := url.Parse(repo); err == nil && parsed.Hostname() != "" {
+		return parsed.Hostname()
+	}
+	if at := strings.Index(repo, "@"); at >= 0 {
+		repo = repo[at+1:]
+	}
+	if colon := strings.Index(repo, ":"); colon > 0 {
+		return strings.TrimSpace(repo[:colon])
 	}
 	parts := strings.Split(repo, "/")
 	if len(parts) == 3 && strings.TrimSpace(parts[0]) != "" {

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -1138,6 +1138,70 @@ func (r *QueueRepository) RequeueLatestCancelledByLoop(ctx context.Context, loop
 	return affected, nil
 }
 
+func (r *QueueRepository) RequeueLatestFailedByLoop(ctx context.Context, loopID, queuedAt string) (int64, error) {
+	queueID, err := r.findLatestQueueIDByLoopStatus(ctx, loopID, "failed")
+	if err != nil {
+		return 0, err
+	}
+	if queueID == "" {
+		return 0, nil
+	}
+
+	return r.RequeueFailedByID(ctx, loopID, queueID, queuedAt)
+}
+
+func (r *QueueRepository) RequeueFailedByID(ctx context.Context, loopID, queueID, queuedAt string) (int64, error) {
+	if loopID == "" || queueID == "" {
+		return 0, nil
+	}
+
+	result, err := r.q.ExecContext(ctx, `
+		UPDATE queue_items
+		SET status = 'queued',
+			available_at = ?,
+			attempts = 0,
+			claimed_by = NULL,
+			claimed_at = NULL,
+			started_at = NULL,
+			finished_at = NULL,
+			last_error = NULL,
+			last_error_kind = NULL,
+			updated_at = ?
+		WHERE id = ? AND loop_id = ? AND status = 'failed'
+			AND NOT EXISTS (
+				SELECT 1 FROM queue_items
+				WHERE loop_id = ? AND status IN ('queued', 'running') AND id != ?
+			)
+	`, queuedAt, queuedAt, queueID, loopID, loopID, queueID)
+	if err != nil {
+		return 0, fmt.Errorf("requeue failed queue item by id: %w", err)
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read requeue failed queue item rows affected: %w", err)
+	}
+
+	return affected, nil
+}
+
+func (r *QueueRepository) findLatestQueueIDByLoopStatus(ctx context.Context, loopID, status string) (string, error) {
+	row := r.q.QueryRowContext(ctx, `
+		SELECT id
+		FROM queue_items
+		WHERE loop_id = ? AND status = ?
+		ORDER BY updated_at DESC, created_at DESC, id DESC LIMIT 1
+	`, loopID, status)
+	var queueID string
+	if err := row.Scan(&queueID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("get latest %s queue item by loop: %w", status, err)
+	}
+	return queueID, nil
+}
+
 func (r *QueueRepository) findLatestCancelledQueueIDByLoop(ctx context.Context, loopID string, onlyUnstarted bool) (string, error) {
 	query := `
 		SELECT id

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -624,6 +624,57 @@ func TestQueueRoundTripBasics(t *testing.T) {
 	}
 }
 
+func TestQueueRequeueFailedByIDRequiresMatchingLoopAndNoActiveQueue(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	ctx := context.Background()
+	repos := NewRepositories(coordinator.DB())
+
+	now := "2026-04-11T12:00:00.000Z"
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: "project_requeue", Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	for seq, loopID := range []string{"loop_a", "loop_b"} {
+		if err := repos.Loops.Upsert(ctx, LoopRecord{ID: loopID, Seq: int64(seq + 1), ProjectID: "project_requeue", Type: "reviewer", TargetType: "pull_request", Status: "failed", CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loopID, err)
+		}
+	}
+	loopA := "loop_a"
+	loopB := "loop_b"
+	lastError := "PR head changed before publish"
+	if err := repos.Queue.Upsert(ctx, QueueItemRecord{ID: "failed_a", LoopID: &loopA, Type: "reviewer", TargetType: "pull_request", TargetID: "pr:a", DedupeKey: "reviewer:a", Priority: QueuePriorityReviewer, Status: "failed", AvailableAt: now, Attempts: 3, MaxAttempts: 3, LastError: &lastError, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(failed_a) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(ctx, QueueItemRecord{ID: "active_b", LoopID: &loopB, Type: "reviewer", TargetType: "pull_request", TargetID: "pr:b", DedupeKey: "reviewer:b", Priority: QueuePriorityReviewer, Status: "queued", AvailableAt: now, Attempts: 0, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(active_b) error = %v", err)
+	}
+
+	affected, err := repos.Queue.RequeueFailedByID(ctx, loopB, "failed_a", now)
+	if err != nil {
+		t.Fatalf("RequeueFailedByID(wrong loop) error = %v", err)
+	}
+	if affected != 0 {
+		t.Fatalf("RequeueFailedByID(wrong loop) affected = %d, want 0", affected)
+	}
+	item, _ := repos.Queue.GetByID(ctx, "failed_a")
+	if item == nil || item.Status != "failed" {
+		t.Fatalf("failed_a status = %#v, want still failed", item)
+	}
+
+	affected, err = repos.Queue.RequeueFailedByID(ctx, loopA, "failed_a", now)
+	if err != nil {
+		t.Fatalf("RequeueFailedByID(correct loop) error = %v", err)
+	}
+	if affected != 1 {
+		t.Fatalf("RequeueFailedByID(correct loop) affected = %d, want 1", affected)
+	}
+	item, _ = repos.Queue.GetByID(ctx, "failed_a")
+	if item == nil || item.Status != "queued" || item.LastError != nil || item.Attempts != 0 {
+		t.Fatalf("failed_a = %#v, want requeued with cleared failure metadata", item)
+	}
+}
+
 func TestQueueClaimOrderingAndBlockers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Recover failed reviewer loops during discovery and startup only when the latest failed run/queue item matches whitelisted retryable guardrail states.
- Requeue the exact failed queue item without duplicating active reviewer work and cap automatic recovery attempts.
- Add reviewer, runtime, and queue repository tests for eligible recovery, unsafe states, idempotency, and queue guards.

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #165

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.0.0-dev · runner=worker · agent=opencode</sub>