### PR TITLE
perf: reduce queued wait time in scheduler

### DIFF
--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -94,7 +94,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 	root := newCommand(commandSpec{
 		use:             "looper",
 		short:           "Looper command-line interface",
-		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "prompt", description: "Prompt inspection commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "labels", description: "GitHub label commands"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
+		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "prompt", description: "Prompt inspection commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "labels", description: "GitHub label commands"}, {name: "queue", description: "Queue inspection and maintenance commands"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
 		helpWhenNoArgs:  true,
 		subcommands: []*cobra.Command{
 			newCommand(commandSpec{use: "status", short: "Show service status", runE: runtime.status}),
@@ -234,6 +234,22 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 							boolFlag("dry-run", "Preview label changes without applying them"),
 						},
 					}),
+				},
+			}),
+			newCommand(commandSpec{
+				use:             "queue",
+				short:           "Queue inspection and maintenance commands",
+				helpSubcommands: []helpSubcommand{{name: "stats", description: "Show queue eligibility stats"}, {name: "list", description: "List queue items"}, {name: "cleanup", description: "Clean stale queue items"}},
+				helpWhenNoArgs:  true,
+				exampleLines: []string{
+					"$ looper queue stats",
+					"$ looper queue list --eligible",
+					"$ looper queue cleanup --stale",
+				},
+				subcommands: []*cobra.Command{
+					newCommand(commandSpec{use: "stats", short: "Show queue eligibility stats", runE: runtime.queueStats}),
+					newCommand(commandSpec{use: "list", short: "List queue items", runE: runtime.queueList, localFlags: []flagSpec{boolFlag("eligible", "Only list currently eligible queued items")}}),
+					newCommand(commandSpec{use: "cleanup", short: "Clean stale queue items", runE: runtime.queueCleanup, localFlags: []flagSpec{boolFlag("stale", "Cancel queued items blocked by terminal loops")}}),
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/queue_commands.go
+++ b/internal/cliapp/queue_commands.go
@@ -1,0 +1,199 @@
+package cliapp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/powerformer/looper/internal/eventlog"
+	"github.com/powerformer/looper/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+type queueStatsOutput struct {
+	NowISO                           string `json:"nowIso"`
+	TotalQueued                      int64  `json:"totalQueued"`
+	EligibleQueued                   int64  `json:"eligibleQueued"`
+	BlockedByTerminalOrPausedLoop    int64  `json:"blockedByTerminalOrPausedLoop"`
+	BlockedByLockKey                 int64  `json:"blockedByLockKey"`
+	BlockedByReviewerFixerDependency int64  `json:"blockedByReviewerFixerDependency"`
+	ScheduledForFuture               int64  `json:"scheduledForFuture"`
+	StaleQueued                      int64  `json:"staleQueued"`
+}
+
+type queueListOutput struct {
+	NowISO string                   `json:"nowIso"`
+	Items  []queueItemCommandOutput `json:"items"`
+}
+
+type queueItemCommandOutput struct {
+	ID            string  `json:"id"`
+	ProjectID     *string `json:"projectId,omitempty"`
+	LoopID        *string `json:"loopId,omitempty"`
+	Type          string  `json:"type"`
+	TargetType    string  `json:"targetType"`
+	TargetID      string  `json:"targetId"`
+	Repo          *string `json:"repo,omitempty"`
+	PRNumber      *int64  `json:"prNumber,omitempty"`
+	Priority      int64   `json:"priority"`
+	Status        string  `json:"status"`
+	AvailableAt   string  `json:"availableAt"`
+	Attempts      int64   `json:"attempts"`
+	MaxAttempts   int64   `json:"maxAttempts"`
+	LockKey       *string `json:"lockKey,omitempty"`
+	LastError     *string `json:"lastError,omitempty"`
+	LastErrorKind *string `json:"lastErrorKind,omitempty"`
+	CreatedAt     string  `json:"createdAt"`
+	UpdatedAt     string  `json:"updatedAt"`
+}
+
+type queueCleanupOutput struct {
+	Stale   bool  `json:"stale"`
+	Cleaned int64 `json:"cleaned"`
+}
+
+func (r *commandRuntime) queueStats(cmd *cobra.Command, args []string) error {
+	_ = args
+	return r.withQueueRepositories(cmd.Context(), func(repos *storage.Repositories) error {
+		nowISO := eventlog.FormatJavaScriptISOString(time.Now().UTC())
+		stats, err := repos.Queue.Stats(cmd.Context(), nowISO)
+		if err != nil {
+			return err
+		}
+		output := queueStatsOutput{
+			NowISO:                           nowISO,
+			TotalQueued:                      stats.TotalQueued,
+			EligibleQueued:                   stats.EligibleQueued,
+			BlockedByTerminalOrPausedLoop:    stats.BlockedByTerminalOrPausedLoop,
+			BlockedByLockKey:                 stats.BlockedByLockKey,
+			BlockedByReviewerFixerDependency: stats.BlockedByReviewerFixerDependency,
+			ScheduledForFuture:               stats.ScheduledForFuture,
+			StaleQueued:                      stats.StaleQueued,
+		}
+		if getBoolFlag(cmd, "json") {
+			return writeJSON(cmd.OutOrStdout(), output)
+		}
+		return writeHumanQueueStats(cmd.OutOrStdout(), output)
+	})
+}
+
+func (r *commandRuntime) queueList(cmd *cobra.Command, args []string) error {
+	_ = args
+	return r.withQueueRepositories(cmd.Context(), func(repos *storage.Repositories) error {
+		nowISO := eventlog.FormatJavaScriptISOString(time.Now().UTC())
+		var (
+			items []storage.QueueItemRecord
+			err   error
+		)
+		if getBoolFlag(cmd, "eligible") {
+			items, err = repos.Queue.ListScheduled(cmd.Context(), nowISO, 1000)
+		} else {
+			items, err = repos.Queue.ListQueued(cmd.Context(), 1000)
+		}
+		if err != nil {
+			return err
+		}
+		output := queueListOutput{NowISO: nowISO, Items: queueItemOutputs(items)}
+		if getBoolFlag(cmd, "json") {
+			return writeJSON(cmd.OutOrStdout(), output)
+		}
+		return writeHumanQueueList(cmd.OutOrStdout(), output)
+	})
+}
+
+func (r *commandRuntime) queueCleanup(cmd *cobra.Command, args []string) error {
+	_ = args
+	if !getBoolFlag(cmd, "stale") {
+		return fmt.Errorf("queue cleanup currently requires --stale")
+	}
+	return r.withQueueRepositories(cmd.Context(), func(repos *storage.Repositories) error {
+		nowISO := eventlog.FormatJavaScriptISOString(time.Now().UTC())
+		cleaned, err := repos.Queue.CleanupStaleQueued(cmd.Context(), nowISO, "stale queue item attached to terminal loop")
+		if err != nil {
+			return err
+		}
+		output := queueCleanupOutput{Stale: true, Cleaned: cleaned}
+		if getBoolFlag(cmd, "json") {
+			return writeJSON(cmd.OutOrStdout(), output)
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "Cleaned %d stale queued item(s).\n", cleaned)
+		return err
+	})
+}
+
+func (r *commandRuntime) withQueueRepositories(ctx context.Context, fn func(*storage.Repositories) error) error {
+	loaded, err := r.loadConfig()
+	if err != nil {
+		return err
+	}
+	db, err := storage.OpenSQLiteDB(ctx, loaded.Config.Storage.DBPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return fn(storage.NewRepositories(db))
+}
+
+func queueItemOutputs(items []storage.QueueItemRecord) []queueItemCommandOutput {
+	outputs := make([]queueItemCommandOutput, 0, len(items))
+	for _, item := range items {
+		outputs = append(outputs, queueItemCommandOutput{
+			ID:            item.ID,
+			ProjectID:     item.ProjectID,
+			LoopID:        item.LoopID,
+			Type:          item.Type,
+			TargetType:    item.TargetType,
+			TargetID:      item.TargetID,
+			Repo:          item.Repo,
+			PRNumber:      item.PRNumber,
+			Priority:      item.Priority,
+			Status:        item.Status,
+			AvailableAt:   item.AvailableAt,
+			Attempts:      item.Attempts,
+			MaxAttempts:   item.MaxAttempts,
+			LockKey:       item.LockKey,
+			LastError:     item.LastError,
+			LastErrorKind: item.LastErrorKind,
+			CreatedAt:     item.CreatedAt,
+			UpdatedAt:     item.UpdatedAt,
+		})
+	}
+	return outputs
+}
+
+func writeHumanQueueStats(w io.Writer, output queueStatsOutput) error {
+	rows := [][2]any{
+		{"totalQueued", output.TotalQueued},
+		{"eligibleQueued", output.EligibleQueued},
+		{"blockedByTerminalOrPausedLoop", output.BlockedByTerminalOrPausedLoop},
+		{"blockedByLockKey", output.BlockedByLockKey},
+		{"blockedByReviewerFixerDependency", output.BlockedByReviewerFixerDependency},
+		{"scheduledForFuture", output.ScheduledForFuture},
+		{"staleQueued", output.StaleQueued},
+	}
+	for _, row := range rows {
+		if _, err := fmt.Fprintf(w, "%-36s %v\n", row[0], row[1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeHumanQueueList(w io.Writer, output queueListOutput) error {
+	if len(output.Items) == 0 {
+		_, err := fmt.Fprintln(w, "No eligible queued items.")
+		return err
+	}
+	for _, item := range output.Items {
+		target := strings.TrimSpace(item.TargetID)
+		if item.Repo != nil && item.PRNumber != nil {
+			target = fmt.Sprintf("%s#%d", *item.Repo, *item.PRNumber)
+		}
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", item.ID, item.Type, item.Status, item.AvailableAt, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cliapp/queue_commands_test.go
+++ b/internal/cliapp/queue_commands_test.go
@@ -1,0 +1,173 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/powerformer/looper/internal/storage"
+)
+
+func TestQueueStatsCommandOutputsJSONAndHuman(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		args   []string
+		assert func(*testing.T, string)
+	}{
+		{name: "json", args: []string{"queue", "stats", "--json"}, assert: func(t *testing.T, output string) {
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v\noutput=%q", err, output)
+			}
+			if decoded["eligibleQueued"] != float64(1) || decoded["staleQueued"] != float64(1) {
+				t.Fatalf("queue stats json = %#v, want eligibleQueued=1 staleQueued=1", decoded)
+			}
+		}},
+		{name: "human", args: []string{"queue", "stats"}, assert: func(t *testing.T, output string) {
+			for _, needle := range []string{"totalQueued", "eligibleQueued", "staleQueued"} {
+				if !strings.Contains(output, needle) {
+					t.Fatalf("queue stats output missing %q\n%s", needle, output)
+				}
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath, _ := writeQueueCommandFixture(t)
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			app := New(Deps{Stdout: stdout, Stderr: stderr})
+			args := append(append([]string{}, tc.args...), "--config", configPath)
+			if exitCode := app.Run(context.Background(), args); exitCode != 0 {
+				t.Fatalf("Run(%v) exit code = %d, want 0; stderr=%q", args, exitCode, stderr.String())
+			}
+			tc.assert(t, stdout.String())
+		})
+	}
+}
+
+func TestQueueCleanupCommandOutputsJSONAndHuman(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		args   []string
+		assert func(*testing.T, string)
+	}{
+		{name: "json", args: []string{"queue", "cleanup", "--stale", "--json"}, assert: func(t *testing.T, output string) {
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v\noutput=%q", err, output)
+			}
+			if decoded["cleaned"] != float64(1) || decoded["stale"] != true {
+				t.Fatalf("queue cleanup json = %#v, want cleaned=1 stale=true", decoded)
+			}
+		}},
+		{name: "human", args: []string{"queue", "cleanup", "--stale"}, assert: func(t *testing.T, output string) {
+			if !strings.Contains(output, "Cleaned 1 stale queued item(s).") {
+				t.Fatalf("queue cleanup output = %q, want cleanup summary", output)
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath, repos := writeQueueCommandFixture(t)
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			app := New(Deps{Stdout: stdout, Stderr: stderr})
+			args := append(append([]string{}, tc.args...), "--config", configPath)
+			if exitCode := app.Run(context.Background(), args); exitCode != 0 {
+				t.Fatalf("Run(%v) exit code = %d, want 0; stderr=%q", args, exitCode, stderr.String())
+			}
+			tc.assert(t, stdout.String())
+			item, err := repos.Queue.GetByID(context.Background(), "qi_stale")
+			if err != nil {
+				t.Fatalf("Queue.GetByID() error = %v", err)
+			}
+			if item == nil || item.Status != "cancelled" {
+				t.Fatalf("Queue.GetByID(qi_stale) = %#v, want cancelled", item)
+			}
+		})
+	}
+}
+
+func TestQueueListCommandListsQueuedItemsAndFiltersEligible(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		args        []string
+		wantContain []string
+		wantOmit    []string
+	}{
+		{name: "default lists queued", args: []string{"queue", "list"}, wantContain: []string{"qi_eligible", "qi_stale"}},
+		{name: "eligible filters blocked", args: []string{"queue", "list", "--eligible"}, wantContain: []string{"qi_eligible"}, wantOmit: []string{"qi_stale"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath, _ := writeQueueCommandFixture(t)
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			app := New(Deps{Stdout: stdout, Stderr: stderr})
+			args := append(append([]string{}, tc.args...), "--config", configPath)
+			if exitCode := app.Run(context.Background(), args); exitCode != 0 {
+				t.Fatalf("Run(%v) exit code = %d, want 0; stderr=%q", args, exitCode, stderr.String())
+			}
+			output := stdout.String()
+			for _, needle := range tc.wantContain {
+				if !strings.Contains(output, needle) {
+					t.Fatalf("queue list output missing %q\n%s", needle, output)
+				}
+			}
+			for _, needle := range tc.wantOmit {
+				if strings.Contains(output, needle) {
+					t.Fatalf("queue list output includes %q\n%s", needle, output)
+				}
+			}
+		})
+	}
+}
+
+func writeQueueCommandFixture(t *testing.T) (string, *storage.Repositories) {
+	t.Helper()
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "looper.sqlite")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), dbPath, storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: filepath.Join(root, "backups")})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	projectID := "project_queue_cli"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_eligible", Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_eligible) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_stale", Seq: 2, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "terminated", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_stale) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "qi_eligible", ProjectID: &projectID, LoopID: stringPtr("loop_eligible"), Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "eligible", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(qi_eligible) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "qi_stale", ProjectID: &projectID, LoopID: stringPtr("loop_stale"), Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "stale", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(qi_stale) error = %v", err)
+	}
+	configPath := filepath.Join(root, "config.json")
+	raw, err := json.Marshal(map[string]any{"storage": map[string]any{"dbPath": dbPath}})
+	if err != nil {
+		t.Fatalf("json.Marshal(config) error = %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+	return configPath, repos
+}

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -14,6 +14,7 @@ Subcommands:
   daemon     Daemon commands
   upgrade    Check or upgrade Looper installations
   labels     GitHub label commands
+  queue      Queue inspection and maintenance commands
   loop       Loop commands
   work       Create a worker run
   plan       Create a planner run

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/powerformer/looper/internal/bootstrap"
 	"github.com/powerformer/looper/internal/config"
 	"github.com/powerformer/looper/internal/eventlog"
+	githubinfra "github.com/powerformer/looper/internal/infra/github"
 	"github.com/powerformer/looper/internal/infra/shell"
 	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/lifecycle"
@@ -1623,6 +1624,9 @@ func (r *Runner) classifyFailure(err error) *loopError {
 	message := err.Error()
 	if strings.Contains(strings.ToLower(message), "remote head changed") {
 		return &loopError{message: message, kind: FailureRetryableAfterResume}
+	}
+	if githubinfra.IsTransientError(err) {
+		return &loopError{message: message, kind: FailureRetryableTransient}
 	}
 	return &loopError{message: message, kind: FailureNonRetryable}
 }

--- a/internal/infra/github/errors.go
+++ b/internal/infra/github/errors.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/powerformer/looper/internal/infra/shell"
+)
+
+type TransientError struct {
+	Err error
+}
+
+func (e *TransientError) Error() string {
+	return fmt.Sprintf("transient GitHub error: %v", e.Err)
+}
+
+func (e *TransientError) Unwrap() error {
+	return e.Err
+}
+
+// IsTransientError reports whether a GitHub CLI/API failure is likely caused by
+// network or service flakiness and should be retried instead of treated as a
+// terminal loop failure.
+func IsTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var transientErr *TransientError
+	if errors.As(err, &transientErr) {
+		return true
+	}
+	var commandErr *shell.CommandExecutionError
+	if errors.As(err, &commandErr) {
+		message := strings.Join([]string{commandErr.Message, commandErr.Result.Stdout, commandErr.Result.Stderr}, "\n")
+		return looksLikeGitHubFailure(message) && isTransientGitHubMessage(message)
+	}
+	message := err.Error()
+	if !looksLikeGitHubFailure(message) {
+		return false
+	}
+	return isTransientGitHubMessage(message)
+}
+
+func looksLikeGitHubFailure(message string) bool {
+	message = strings.ToLower(message)
+	for _, fragment := range []string{
+		"github",
+		"api.github.com",
+		"graphql",
+		"gh api",
+		"gh pr",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func isTransientGitHubMessage(message string) bool {
+	message = strings.ToLower(message)
+	for _, fragment := range []string{
+		"tls handshake timeout",
+		"unexpected eof",
+		"connection reset by peer",
+		"connection refused",
+		"connection timed out",
+		"i/o timeout",
+		"temporary failure in name resolution",
+		"no such host",
+		"network is unreachable",
+		"stream error",
+		"http2: server sent goaway",
+		"502 bad gateway",
+		"503 service unavailable",
+		"504 gateway timeout",
+		"graphql: something went wrong",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -1534,7 +1534,11 @@ func (g *Gateway) runGh(ctx context.Context, cwd, stdin string, args ...string) 
 }
 
 func (g *Gateway) runGhWithTimeout(ctx context.Context, cwd, stdin string, timeout time.Duration, args ...string) (shell.Result, error) {
-	return g.ghRun(ctx, shell.Options{Command: g.ghPath, Args: args, CWD: valueOr(strings.TrimSpace(cwd), g.cwd), Stdin: stdin, Timeout: timeout})
+	result, err := g.ghRun(ctx, shell.Options{Command: g.ghPath, Args: args, CWD: valueOr(strings.TrimSpace(cwd), g.cwd), Stdin: stdin, Timeout: timeout})
+	if err != nil && isTransientGitHubMessage(strings.Join([]string{err.Error(), result.Stdout, result.Stderr}, "\n")) {
+		return result, &TransientError{Err: err}
+	}
+	return result, err
 }
 
 func isDiffTooLargeError(err error) bool {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -240,6 +240,35 @@ func TestGetPullRequestHeadSHA(t *testing.T) {
 	}
 }
 
+func TestIsTransientErrorTreatsShellCommandNetworkFailuresAsRetryable(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "gateway-wrapped tls handshake timeout", err: &TransientError{Err: &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "net/http: TLS handshake timeout"}}}},
+		{name: "unexpected eof", err: &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "Post https://api.github.com/graphql: unexpected EOF"}}},
+		{name: "graphql transient", err: &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stdout: `{"errors":[{"message":"GraphQL: Something went wrong while executing your query."}]}`}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if !IsTransientError(tc.err) {
+				t.Fatalf("IsTransientError(%v) = false, want true", tc.err)
+			}
+		})
+	}
+}
+
+func TestIsTransientErrorIgnoresNonGitHubShellFailures(t *testing.T) {
+	t.Parallel()
+
+	err := &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "unexpected EOF while reading local file"}}
+	if IsTransientError(err) {
+		t.Fatal("IsTransientError(non-GitHub shell EOF) = true, want false")
+	}
+}
+
 func TestSubmitReviewRejectsQualityFlagsBeforePublishing(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/powerformer/looper/internal/bootstrap"
 	"github.com/powerformer/looper/internal/config"
 	"github.com/powerformer/looper/internal/eventlog"
+	githubinfra "github.com/powerformer/looper/internal/infra/github"
 	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/lifecycle"
 	"github.com/powerformer/looper/internal/storage"
@@ -1407,6 +1408,9 @@ func (r *Runner) classifyFailure(err error) *loopError {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	}
+	if githubinfra.IsTransientError(err) {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
 	return &loopError{message: err.Error(), kind: FailureNonRetryable}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/powerformer/looper/internal/diffanchor"
 	"github.com/powerformer/looper/internal/disclosure"
 	"github.com/powerformer/looper/internal/eventlog"
+	githubinfra "github.com/powerformer/looper/internal/infra/github"
 	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/storage"
 	"github.com/powerformer/looper/internal/version"
@@ -2385,6 +2386,9 @@ func (r *Runner) classifyFailure(err error) *loopError {
 	}
 	var transient transientFailure
 	if errors.As(err, &transient) && transient.Temporary() {
+		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	}
+	if githubinfra.IsTransientError(err) {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
 	return &loopError{message: err.Error(), kind: FailureNonRetryable}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -921,9 +921,19 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		}
 	}
 
+	availableSlots, err := schedulerAvailableSlots(ctx, input.Repos, input.MaxConcurrentRuns)
+	if err != nil {
+		appendErr(err)
+		availableSlots = 0
+	}
+	if availableSlots > 0 && input.Repos.Queue != nil {
+		appendErr(claimAndRunScheduledQueueItems(ctx, availableSlots, input))
+	}
+
 	projectsList, err := input.Repos.Projects.List(ctx)
 	if err != nil {
-		return err
+		appendErr(err)
+		return errors.Join(errs...)
 	}
 	for _, project := range projectsList {
 		if err := ctx.Err(); err != nil {
@@ -963,18 +973,6 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		} else if input.Worker != nil && input.Logger != nil && !discoveryEnabled(input.WorkerDiscoveryEnabled) {
 			input.Logger.Debug("worker auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
 		}
-	}
-
-	if err := ctx.Err(); err != nil {
-		return errors.Join(append(errs, err)...)
-	}
-	availableSlots, err := schedulerAvailableSlots(ctx, input.Repos, input.MaxConcurrentRuns)
-	if err != nil {
-		appendErr(err)
-		availableSlots = 0
-	}
-	if availableSlots > 0 && input.Repos.Queue != nil {
-		appendErr(claimAndRunScheduledQueueItems(ctx, availableSlots, input))
 	}
 
 	if len(errs) == 0 {

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -101,6 +101,46 @@ func TestRunDefaultSchedulerTickDiscoversStoredProjectsAndProcessesQueue(t *test
 	}
 }
 
+func TestRunDefaultSchedulerTickClaimsQueuedWorkBeforeDiscovery(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "scheduler-claim-first.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	baseBranch := "main"
+	projectMetadata := `{"repo":"powerformer/looper"}`
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "looper", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), BaseBranch: &baseBranch, MetadataJSON: &projectMetadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	projectID := "looper"
+	loopTarget := "project:looper"
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_claim_first", Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &loopTarget, Repo: stringPtr("powerformer/looper"), Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	loopID := "loop_worker_claim_first"
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_claim_first", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: loopTarget, Repo: stringPtr("powerformer/looper"), DedupeKey: "worker:loop_worker_claim_first", Priority: 1, Status: "queued", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	plannerRunner := &queueStatusCheckingPlannerScheduler{t: t, repos: repos, queueItemID: "queue_worker_claim_first"}
+
+	if err := runDefaultSchedulerTick(context.Background(), defaultSchedulerTickInput{
+		Repos:             repos,
+		Now:               func() time.Time { return now },
+		MaxConcurrentRuns: 1,
+		Planner:           plannerRunner,
+		Worker:            &stubWorkerScheduler{},
+	}); err != nil {
+		t.Fatalf("runDefaultSchedulerTick() error = %v", err)
+	}
+	if !plannerRunner.checkedClaimedStatus {
+		t.Fatal("planner discovery did not verify claimed queue item status")
+	}
+}
+
 func TestRunScheduledQueueItemsDispatchesEachSupportedType(t *testing.T) {
 	t.Parallel()
 
@@ -567,6 +607,41 @@ type stubPlannerScheduler struct {
 	processedItems []string
 	discoverErr    error
 	processErr     error
+}
+
+type queueStatusCheckingPlannerScheduler struct {
+	t                    *testing.T
+	repos                *storage.Repositories
+	queueItemID          string
+	checkedClaimedStatus bool
+}
+
+func (s *queueStatusCheckingPlannerScheduler) DiscoverIssues(ctx context.Context, _ planner.DiscoveryInput) (planner.DiscoveryResult, error) {
+	s.t.Helper()
+	item, err := s.repos.Queue.GetByID(ctx, s.queueItemID)
+	if err != nil {
+		s.t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if item == nil {
+		s.t.Fatal("Queue.GetByID() = nil, want claimed queue item")
+	}
+	if item.Status != "running" {
+		s.t.Fatalf("queue item status during discovery = %q, want running", item.Status)
+	}
+	if item.ClaimedBy == nil || *item.ClaimedBy != "scheduler" {
+		s.t.Fatalf("queue item claimed_by during discovery = %v, want scheduler", item.ClaimedBy)
+	}
+	s.checkedClaimedStatus = true
+	return planner.DiscoveryResult{}, nil
+}
+
+func (s *queueStatusCheckingPlannerScheduler) ProcessNext(context.Context, string) (*planner.ProcessResult, error) {
+	return nil, nil
+}
+
+func (s *queueStatusCheckingPlannerScheduler) ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) (*planner.ProcessResult, error) {
+	return nil, nil
+
 }
 
 func (s *stubPlannerScheduler) DiscoverIssues(_ context.Context, input planner.DiscoveryInput) (planner.DiscoveryResult, error) {

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -183,6 +183,16 @@ type QueueItemRecord struct {
 	UpdatedAt     string
 }
 
+type QueueStats struct {
+	TotalQueued                      int64
+	EligibleQueued                   int64
+	BlockedByTerminalOrPausedLoop    int64
+	BlockedByLockKey                 int64
+	BlockedByReviewerFixerDependency int64
+	ScheduledForFuture               int64
+	StaleQueued                      int64
+}
+
 type QueueMarkRetryInput struct {
 	ID           string
 	AvailableAt  string
@@ -884,6 +894,26 @@ func (r *QueueRepository) List(ctx context.Context) ([]QueueItemRecord, error) {
 	return scanQueueItems(rows)
 }
 
+func (r *QueueRepository) ListQueued(ctx context.Context, limit int64) ([]QueueItemRecord, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	rows, err := r.q.QueryContext(ctx, `
+		SELECT *
+		FROM queue_items
+		WHERE status = 'queued'
+		ORDER BY priority ASC, available_at ASC, created_at ASC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list queued queue items: %w", err)
+	}
+	defer rows.Close()
+
+	return scanQueueItems(rows)
+}
+
 func (r *QueueRepository) CountByStatus(ctx context.Context, status string) (int64, error) {
 	row := r.q.QueryRowContext(ctx, `SELECT COUNT(*) FROM queue_items WHERE status = ?`, status)
 	var count int64
@@ -941,6 +971,91 @@ func (r *QueueRepository) ListScheduled(ctx context.Context, nowISO string, limi
 	defer rows.Close()
 
 	return scanQueueItems(rows)
+}
+
+func (r *QueueRepository) Stats(ctx context.Context, nowISO string) (QueueStats, error) {
+	stats := QueueStats{}
+	queries := []struct {
+		name string
+		dest *int64
+		sql  string
+		now  bool
+	}{
+		{name: "total queued", dest: &stats.TotalQueued, sql: `SELECT COUNT(*) FROM queue_items WHERE status = 'queued'`},
+		{name: "eligible queued", dest: &stats.EligibleQueued, sql: `SELECT COUNT(*) FROM (` + scheduledQueueBaseQuery + `)`, now: true},
+		{name: "blocked by terminal or paused loop", dest: &stats.BlockedByTerminalOrPausedLoop, sql: `
+			SELECT COUNT(*)
+			FROM queue_items qi
+			JOIN loops l ON l.id = qi.loop_id
+			WHERE qi.status = 'queued'
+				AND l.status IN ('paused', 'completed', 'failed', 'interrupted', 'terminated', 'stopped')
+		`},
+		{name: "blocked by lock key", dest: &stats.BlockedByLockKey, now: true, sql: `
+			SELECT COUNT(*)
+			FROM queue_items qi
+			WHERE qi.status = 'queued'
+				AND qi.available_at <= ?
+				AND qi.lock_key IS NOT NULL
+				AND EXISTS (
+					SELECT 1
+					FROM queue_items lock_blocker
+					WHERE lock_blocker.lock_key = qi.lock_key
+						AND lock_blocker.status = 'running'
+						AND lock_blocker.id != qi.id
+				)
+		`},
+		{name: "blocked by reviewer/fixer dependency", dest: &stats.BlockedByReviewerFixerDependency, now: true, sql: `
+			SELECT COUNT(*)
+			FROM queue_items qi
+			WHERE qi.status = 'queued'
+				AND qi.available_at <= ?
+				AND qi.type = 'fixer'
+				AND qi.repo IS NOT NULL
+				AND qi.pr_number IS NOT NULL
+				AND EXISTS (
+					SELECT 1
+					FROM queue_items blocker
+					WHERE blocker.type = 'reviewer'
+						AND blocker.repo = qi.repo
+						AND blocker.pr_number = qi.pr_number
+						AND blocker.status IN ('queued', 'running')
+						AND blocker.id != qi.id
+				)
+		`},
+		{name: "scheduled for future", dest: &stats.ScheduledForFuture, sql: `SELECT COUNT(*) FROM queue_items WHERE status = 'queued' AND available_at > ?`, now: true},
+		{name: "stale queued", dest: &stats.StaleQueued, sql: staleQueuedCountQuery},
+	}
+
+	for _, query := range queries {
+		args := []any{}
+		if query.now {
+			args = append(args, nowISO)
+		}
+		if err := r.q.QueryRowContext(ctx, query.sql, args...).Scan(query.dest); err != nil {
+			return QueueStats{}, fmt.Errorf("count queue items %s: %w", query.name, err)
+		}
+	}
+	return stats, nil
+}
+
+func (r *QueueRepository) CleanupStaleQueued(ctx context.Context, finishedAt string, reason string) (int64, error) {
+	result, err := r.q.ExecContext(ctx, `
+		UPDATE queue_items
+		SET status = 'cancelled',
+			finished_at = ?,
+			last_error = ?,
+			last_error_kind = 'non_retryable',
+			updated_at = ?
+		WHERE id IN (`+staleQueuedIDsQuery+`)
+	`, finishedAt, reason, finishedAt)
+	if err != nil {
+		return 0, fmt.Errorf("cleanup stale queued items: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read cleanup stale queued items rows affected: %w", err)
+	}
+	return affected, nil
 }
 
 func (r *QueueRepository) ClaimNext(ctx context.Context, nowISO, claimedBy string) (*QueueItemRecord, error) {
@@ -1305,6 +1420,16 @@ const scheduledQueueOrderBy = `
 `
 
 const scheduledQueueQuery = scheduledQueueBaseQuery + scheduledQueueOrderBy
+
+const staleQueuedIDsQuery = `
+	SELECT qi.id
+	FROM queue_items qi
+	JOIN loops l ON l.id = qi.loop_id
+	WHERE qi.status = 'queued'
+		AND l.status IN ('completed', 'failed', 'interrupted', 'terminated', 'stopped')
+`
+
+const staleQueuedCountQuery = `SELECT COUNT(*) FROM (` + staleQueuedIDsQuery + `)`
 
 func scanProjects(rows *sql.Rows) ([]ProjectRecord, error) {
 	records := make([]ProjectRecord, 0)

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -911,6 +911,76 @@ func TestQueueClaimNextOfTypeSkipsTerminatedAndStoppedLoops(t *testing.T) {
 	}
 }
 
+func TestQueueStatsAndCleanupStaleQueued(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	projectID := "project_queue_stats"
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	for i, loop := range []LoopRecord{
+		{ID: "loop_eligible", Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_future", Seq: 2, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_terminal", Seq: 3, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "completed", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_lock_wait", Seq: 4, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_lock_running", Seq: 5, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_reviewer", Seq: 6, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", Status: "running", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_fixer", Seq: 7, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", Status: "running", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_stale", Seq: 8, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "terminated", CreatedAt: now, UpdatedAt: now},
+	} {
+		loop.Seq = int64(i + 1)
+		if err := repos.Loops.Upsert(ctx, loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+	lockKey := "repo:acme/looper"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	for _, item := range []QueueItemRecord{
+		{ID: "qi_eligible", ProjectID: &projectID, LoopID: strPtr("loop_eligible"), Type: "worker", TargetType: "project", TargetID: "project_queue_stats", DedupeKey: "eligible", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "qi_future", ProjectID: &projectID, LoopID: strPtr("loop_future"), Type: "worker", TargetType: "project", TargetID: "project_queue_stats", DedupeKey: "future", Priority: 1, Status: "queued", AvailableAt: "2026-04-11T12:10:00.000Z", MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "qi_terminal", ProjectID: &projectID, LoopID: strPtr("loop_terminal"), Type: "worker", TargetType: "project", TargetID: "project_queue_stats", DedupeKey: "terminal", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "qi_lock_running", ProjectID: &projectID, LoopID: strPtr("loop_lock_running"), Type: "worker", TargetType: "project", TargetID: "project_queue_stats", DedupeKey: "lock-running", Priority: 1, Status: "running", AvailableAt: now, LockKey: &lockKey, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "qi_lock_wait", ProjectID: &projectID, LoopID: strPtr("loop_lock_wait"), Type: "worker", TargetType: "project", TargetID: "project_queue_stats", DedupeKey: "lock-wait", Priority: 1, Status: "queued", AvailableAt: now, LockKey: &lockKey, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "qi_reviewer", ProjectID: &projectID, LoopID: strPtr("loop_reviewer"), Type: "reviewer", TargetType: "pull_request", TargetID: "acme/looper#42", Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "qi_fixer", ProjectID: &projectID, LoopID: strPtr("loop_fixer"), Type: "fixer", TargetType: "pull_request", TargetID: "acme/looper#42", Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "qi_stale", ProjectID: &projectID, LoopID: strPtr("loop_stale"), Type: "worker", TargetType: "project", TargetID: "project_queue_stats", DedupeKey: "stale", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := repos.Queue.Upsert(ctx, item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+
+	stats, err := repos.Queue.Stats(ctx, now)
+	if err != nil {
+		t.Fatalf("Queue.Stats() error = %v", err)
+	}
+	if stats.TotalQueued != 7 || stats.EligibleQueued != 2 || stats.BlockedByTerminalOrPausedLoop != 2 || stats.BlockedByLockKey != 1 || stats.BlockedByReviewerFixerDependency != 1 || stats.ScheduledForFuture != 1 || stats.StaleQueued != 2 {
+		t.Fatalf("Queue.Stats() = %#v, want total=7 eligible=2 terminal=2 lock=1 dependency=1 future=1 stale=2", stats)
+	}
+
+	cleaned, err := repos.Queue.CleanupStaleQueued(ctx, now, "stale queue item attached to terminal loop")
+	if err != nil {
+		t.Fatalf("Queue.CleanupStaleQueued() error = %v", err)
+	}
+	if cleaned != 2 {
+		t.Fatalf("Queue.CleanupStaleQueued() = %d, want 2", cleaned)
+	}
+	for _, id := range []string{"qi_terminal", "qi_stale"} {
+		item, err := repos.Queue.GetByID(ctx, id)
+		if err != nil {
+			t.Fatalf("Queue.GetByID(%s) error = %v", id, err)
+		}
+		if item == nil || item.Status != "cancelled" || item.LastErrorKind == nil || *item.LastErrorKind != "non_retryable" {
+			t.Fatalf("Queue.GetByID(%s) after cleanup = %#v, want cancelled non_retryable", id, item)
+		}
+	}
+}
+
 func strPtr(value string) *string {
 	return &value
 }

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/powerformer/looper/internal/bootstrap"
 	"github.com/powerformer/looper/internal/config"
 	"github.com/powerformer/looper/internal/eventlog"
+	githubinfra "github.com/powerformer/looper/internal/infra/github"
 	"github.com/powerformer/looper/internal/infra/shell"
 	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/lifecycle"
@@ -2045,6 +2046,9 @@ func (r *Runner) classifyFailure(err error) *loopError {
 		return typed
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	}
+	if githubinfra.IsTransientError(err) {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
 	return &loopError{message: err.Error(), kind: FailureNonRetryable}


### PR DESCRIPTION
## Summary
- Claim eligible queued work before project discovery so queued items are not delayed by slow GitHub discovery.
- Classify transient GitHub CLI/API network failures as retryable across planner, worker, reviewer, and fixer runs.
- Add queue stats, list, and stale cleanup CLI commands for eligibility debugging and safe maintenance.

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #167

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.0.0-dev · runner=worker · agent=opencode</sub>