### PR TITLE
fix: show run failures in logs output

### DIFF
--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -1489,6 +1489,82 @@ func TestLogsWithoutJSONPrintsAgentErrorMessage(t *testing.T) {
 	}
 }
 
+func TestLogsWithoutJSONPrintsRunFailureWhenNoAgentOutput(t *testing.T) {
+	t.Parallel()
+
+	failureMessage := "Command exited with code 1: GraphQL: Could not resolve to a PullRequest with the number of 345. (repository.pullRequest)"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/loops/loop_1/logs"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_logs", map[string]any{
+			"seq":        12,
+			"loopId":     "loop_1",
+			"loopType":   "reviewer",
+			"loopStatus": "failed",
+			"run": map[string]any{
+				"runId":        "run_1",
+				"currentStep":  "discover",
+				"status":       "failed",
+				"errorMessage": failureMessage,
+			},
+			"agent": nil,
+		}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "logs", "loop_1", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([logs loop_1]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([logs loop_1]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Loop #12 · reviewer · failed", "Run run_1 · step: discover", "Failure: " + failureMessage} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([logs loop_1]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+	if strings.Contains(stdout, "No agent output for the current step.") {
+		t.Fatalf("Run([logs loop_1]) stdout = %q, did not expect no-output message", stdout)
+	}
+}
+
+func TestLogsWithoutJSONPrintsRunSummaryWhenAgentOutputEmpty(t *testing.T) {
+	t.Parallel()
+
+	summary := "discover failed before agent output was captured"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(t, w, pkgapi.Success("req_logs", map[string]any{
+			"seq":        12,
+			"loopId":     "loop_1",
+			"loopType":   "reviewer",
+			"loopStatus": "failed",
+			"run":        map[string]any{"runId": "run_1", "currentStep": "discover", "status": "failed", "summary": summary},
+			"agent":      map[string]any{"vendor": "codex", "status": "failed", "stdout": "", "stderr": ""},
+		}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "logs", "loop_1", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([logs loop_1]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([logs loop_1]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Agent: codex", "Failure: " + summary} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([logs loop_1]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+	if strings.Contains(stdout, "No output captured.") {
+		t.Fatalf("Run([logs loop_1]) stdout = %q, did not expect no-output message", stdout)
+	}
+}
+
 func TestLogsWithoutJSONDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -1595,6 +1671,53 @@ func TestLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
 		t.Fatalf("Run([logs loop_1 --follow]) stderr = %q, want empty string", stderr)
 	}
 	for _, want := range []string{"Loop #12 · reviewer · running", "Run run_1 · step: review", "Agent: codex · pid 1234 · running", "codex line1", "codex line2"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([logs loop_1 --follow]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
+func TestLogsFollowPrintsFailureAfterEmptyOutputRunFails(t *testing.T) {
+	t.Parallel()
+
+	failureMessage := "Command exited with code 1: GraphQL: Could not resolve to a PullRequest with the number of 345. (repository.pullRequest)"
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/loops/loop_1/logs"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		requests++
+		if r.URL.Query().Get("follow") == "1" {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "event: snapshot\n")
+			_, _ = io.WriteString(w, "data: {\"seq\":12,\"loopType\":\"reviewer\",\"loopStatus\":\"running\",\"run\":{\"runId\":\"run_1\",\"status\":\"running\",\"currentStep\":\"discover\"},\"agent\":{\"executionId\":\"exec_1\",\"vendor\":\"codex\",\"pid\":1234,\"status\":\"running\",\"stdout\":\"\",\"stderr\":\"\"}}\n\n")
+			_, _ = io.WriteString(w, "event: end\n")
+			_, _ = io.WriteString(w, "data: {\"reason\":\"run_completed\"}\n\n")
+			return
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_logs", map[string]any{
+			"seq":        12,
+			"loopId":     "loop_1",
+			"loopType":   "reviewer",
+			"loopStatus": "failed",
+			"run":        map[string]any{"runId": "run_1", "currentStep": "discover", "status": "failed", "errorMessage": failureMessage},
+			"agent":      map[string]any{"executionId": "exec_1", "vendor": "codex", "pid": 1234, "status": "failed", "stdout": "", "stderr": ""},
+		}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "logs", "loop_1", "--follow", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([logs loop_1 --follow]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([logs loop_1 --follow]) stderr = %q, want empty string", stderr)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want follow stream plus final snapshot fetch", requests)
+	}
+	for _, want := range []string{"Waiting for log output...", "Loop #12 · reviewer · failed", "Failure: " + failureMessage} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("Run([logs loop_1 --follow]) stdout = %q, want to contain %q", stdout, want)
 		}

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -164,9 +164,11 @@ type loopLogsOutput struct {
 	LoopType   string `json:"loopType"`
 	LoopStatus string `json:"loopStatus"`
 	Run        *struct {
-		RunID       string  `json:"runId"`
-		Status      string  `json:"status"`
-		CurrentStep *string `json:"currentStep"`
+		RunID        string  `json:"runId"`
+		Status       string  `json:"status"`
+		CurrentStep  *string `json:"currentStep"`
+		Summary      *string `json:"summary"`
+		ErrorMessage *string `json:"errorMessage"`
 	} `json:"run"`
 	Agent *struct {
 		ExecutionID  string  `json:"executionId"`
@@ -361,6 +363,10 @@ func writeHumanLoopLogsSnapshot(w io.Writer, data loopLogsOutput, stderr bool, f
 		return err
 	}
 	if data.Agent == nil {
+		if failure := loopLogsRunFailureMessage(data); failure != "" {
+			_, err := fmt.Fprintf(w, "Failure: %s\n", failure)
+			return err
+		}
 		message := "No agent output for the current step."
 		if follow && loopLogsCanContinue(data) {
 			message = "Waiting for agent output..."
@@ -377,6 +383,10 @@ func writeHumanLoopLogsSnapshot(w io.Writer, data loopLogsOutput, stderr bool, f
 		return err
 	}
 	if content == "" {
+		if failure := loopLogsRunFailureMessage(data); failure != "" {
+			_, err := fmt.Fprintf(w, "Failure: %s\n", failure)
+			return err
+		}
 		message := "No output captured."
 		if follow && loopLogsCanContinue(data) {
 			message = "Waiting for log output..."
@@ -386,6 +396,32 @@ func writeHumanLoopLogsSnapshot(w io.Writer, data loopLogsOutput, stderr bool, f
 	}
 
 	return writeLoopLogContent(w, content)
+}
+
+func loopLogsRunFailureMessage(data loopLogsOutput) string {
+	if data.Run == nil {
+		return ""
+	}
+	if data.Run.ErrorMessage != nil {
+		if message := strings.TrimSpace(*data.Run.ErrorMessage); message != "" {
+			return message
+		}
+	}
+	if data.Run.Summary != nil {
+		if message := strings.TrimSpace(*data.Run.Summary); message != "" && loopLogsRunFailed(data.Run.Status) {
+			return message
+		}
+	}
+	return ""
+}
+
+func loopLogsRunFailed(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "failed", "parse_failed", "terminated", "stopped":
+		return true
+	default:
+		return false
+	}
 }
 
 func writeHumanLoopLogsHeader(w io.Writer, data loopLogsOutput) error {

--- a/internal/cliapp/logs_follow.go
+++ b/internal/cliapp/logs_follow.go
@@ -51,6 +51,7 @@ func (r *commandRuntime) followLoopLogs(cmd *cobra.Command, loopID string) error
 	reader := bufio.NewReader(response.Body)
 	lastExecutionID := ""
 	lastRunID := ""
+	sawLogContent := false
 	sawEnd := false
 
 	for {
@@ -73,6 +74,9 @@ func (r *commandRuntime) followLoopLogs(cmd *cobra.Command, loopID string) error
 			data, decodeErr := decodeLoopLogsOutput(json.RawMessage(payload))
 			if decodeErr != nil {
 				return decodeErr
+			}
+			if loopLogsSnapshotHasOutput(data, getBoolFlag(cmd, "stderr"), getBoolFlag(cmd, "full"), getStringFlag(cmd, "tail")) {
+				sawLogContent = true
 			}
 			if err := writeHumanLoopLogsSnapshot(cmd.OutOrStdout(), data, getBoolFlag(cmd, "stderr"), getBoolFlag(cmd, "full"), getStringFlag(cmd, "tail"), true); err != nil {
 				return err
@@ -113,11 +117,38 @@ func (r *commandRuntime) followLoopLogs(cmd *cobra.Command, loopID string) error
 			if _, err := io.WriteString(cmd.OutOrStdout(), chunk.Content); err != nil {
 				return err
 			}
+			if strings.TrimSpace(chunk.Content) != "" {
+				sawLogContent = true
+			}
 		case "end":
 			sawEnd = true
+			if !sawLogContent {
+				payload, err := r.getJSON(cmd.Context(), "/api/v1/loops/"+url.PathEscape(loopID)+"/logs")
+				if err != nil {
+					return err
+				}
+				data, err := decodeLoopLogsOutput(payload)
+				if err != nil {
+					return err
+				}
+				if loopLogsRunFailureMessage(data) != "" {
+					if _, err := fmt.Fprintln(cmd.OutOrStdout()); err != nil {
+						return err
+					}
+					return writeHumanLoopLogsSnapshot(cmd.OutOrStdout(), data, getBoolFlag(cmd, "stderr"), getBoolFlag(cmd, "full"), getStringFlag(cmd, "tail"), false)
+				}
+			}
 			return nil
 		}
 	}
+}
+
+func loopLogsSnapshotHasOutput(data loopLogsOutput, stderr bool, full bool, tail string) bool {
+	content, err := loopLogsInitialContent(data, stderr, full, tail)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(content) != "" || loopLogsRunFailureMessage(data) != ""
 }
 
 func readServerSentEvent(reader *bufio.Reader) (string, string, error) {


### PR DESCRIPTION
## Summary
- Display stored run error/summary details as `Failure:` when `looper logs` has no agent stdout/stderr to show.
- Refetch final logs for `looper logs --follow` when a run ends without output, so late failure details are surfaced.
- Add CLI coverage for empty-output run failures and summaries.

## Validation
- `go vet ./...`
- `go test ./internal/cliapp ./internal/api`
- `go test ./...`
- `go build ./...`

Closes #174

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.4.1 · runner=worker · agent=opencode</sub>