### PR TITLE
fix: scope reviewer approved-stop

### DIFF
--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -61,6 +61,7 @@ type PullRequestSummary struct {
 	HasConflicts   bool
 	Author         string
 	ReviewRequests []string
+	Reviews        []map[string]any
 }
 
 type PullRequestDetail struct {
@@ -372,7 +373,7 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 	if strings.TrimSpace(input.Author) != "" {
 		args = append(args, "--author", strings.TrimSpace(input.Author))
 	}
-	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "mergeStateStatus"}, ","))
+	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "mergeStateStatus"}, ","))
 
 	timeout := input.Timeout
 	if timeout <= 0 {
@@ -403,6 +404,7 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 			HasConflicts:   asString(row["mergeStateStatus"]) == "DIRTY",
 			Author:         extractAuthor(row["author"]),
 			ReviewRequests: extractReviewRequestLogins(row["reviewRequests"]),
+			Reviews:        toObjectSlice(row["reviews"]),
 		})
 	}
 	return out, nil

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1224,7 +1224,7 @@ func TestListOpenPullRequestsPassesAllLabelsToGH(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "pr list --repo acme/looper --state open --limit 30 --label bug --label priority --json number,title,url,state,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,baseRefOid,author,reviewRequests,mergeStateStatus" {
+		if args != "pr list --repo acme/looper --state open --limit 30 --label bug --label priority --json number,title,url,state,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,baseRefOid,author,reviewRequests,reviews,mergeStateStatus" {
 			t.Fatalf("gh args = %q, want repeated label filters", args)
 		}
 		return shell.Result{Stdout: `[]`}, nil

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1164,7 +1164,28 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		return checkpoint, nil
 	}
 	currentLogin := ""
-	if !isManualReviewerLoop(input.Loop) && len(checkpoint.Detail.Reviews) > 0 && (r.loopConfig.StopOnApproved || r.discoveryPolicy.RequireReviewRequest) {
+	if !isManualReviewerLoop(input.Loop) && r.loopConfig.StopOnApproved && len(checkpoint.Detail.Reviews) == 0 && strings.EqualFold(strings.TrimSpace(checkpoint.Detail.ReviewDecision), "APPROVED") {
+		checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for approved pull request %s#%d", input.Repo, input.PRNumber)
+		checkpoint.SkipKind = "approved"
+		if err := r.terminateLoop(ctx, input.Loop, "approved"); err != nil {
+			return checkpoint, err
+		}
+		return checkpoint, nil
+	}
+	if !isManualReviewerLoop(input.Loop) && r.loopConfig.StopOnReadyLabel && specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {
+		checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for ready pull request %s#%d", input.Repo, input.PRNumber)
+		checkpoint.SkipKind = "ready_label"
+		if err := r.terminateLoop(ctx, input.Loop, "ready_label"); err != nil {
+			return checkpoint, err
+		}
+		return checkpoint, nil
+	}
+	if checkpoint.Detail.HasConflicts {
+		checkpoint.SkipReason = fmt.Sprintf("Skipped conflicted pull request %s#%d", input.Repo, input.PRNumber)
+		checkpoint.SkipKind = "conflicted"
+		return checkpoint, nil
+	}
+	if !isManualReviewerLoop(input.Loop) && len(checkpoint.Detail.Reviews) > 0 && r.loopConfig.StopOnApproved {
 		if currentLogin == "" {
 			lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
 			if err != nil {
@@ -1181,19 +1202,6 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 			}
 			return checkpoint, nil
 		}
-	}
-	if !isManualReviewerLoop(input.Loop) && r.loopConfig.StopOnReadyLabel && specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {
-		checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for ready pull request %s#%d", input.Repo, input.PRNumber)
-		checkpoint.SkipKind = "ready_label"
-		if err := r.terminateLoop(ctx, input.Loop, "ready_label"); err != nil {
-			return checkpoint, err
-		}
-		return checkpoint, nil
-	}
-	if checkpoint.Detail.HasConflicts {
-		checkpoint.SkipReason = fmt.Sprintf("Skipped conflicted pull request %s#%d", input.Repo, input.PRNumber)
-		checkpoint.SkipKind = "conflicted"
-		return checkpoint, nil
 	}
 	if !isManualReviewerLoop(input.Loop) && len(checkpoint.Detail.Reviews) > 0 {
 		if currentLogin == "" {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2435,15 +2435,6 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if !r.discoveryPolicy.IncludeDrafts && pr.IsDraft {
 		return false, "", "draft_pr", nil
 	}
-	if r.loopConfig.StopOnApproved && len(pr.Reviews) > 0 {
-		currentLogin, err := r.currentLoginForLoop(ctx, loop)
-		if err != nil {
-			return false, "", "", err
-		}
-		if hasApprovedReviewByAuthorForHead(pr.Reviews, currentLogin, pr.HeadSHA) {
-			return false, "", "approved", nil
-		}
-	}
 	if r.loopConfig.StopOnReadyLabel && specpr.HasLabel(pr.Labels, specpr.ReadyLabel) {
 		return false, "", "ready_label", nil
 	}
@@ -2460,6 +2451,15 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	}
 	if intFromAny(loopMeta["autoRecoveryAttempts"]) >= maxReviewerAutoRecoveryAttempts {
 		return false, "", "auto_recovery_attempt_cap", nil
+	}
+	if r.loopConfig.StopOnApproved && len(pr.Reviews) > 0 {
+		currentLogin, err := r.currentLoginForLoop(ctx, loop)
+		if err != nil {
+			return false, "", "", err
+		}
+		if hasApprovedReviewByAuthorForHead(pr.Reviews, currentLogin, pr.HeadSHA) {
+			return false, "", "approved", nil
+		}
 	}
 	latestRun, err := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID)
 	if err != nil {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -92,6 +92,7 @@ type PullRequestSummary struct {
 	HasConflicts   bool
 	Author         string
 	ReviewRequests []string
+	Reviews        []map[string]any
 }
 
 type PullRequestDetail struct {
@@ -431,6 +432,7 @@ type checkpointDetail struct {
 	Author         string           `json:"author,omitempty"`
 	ReviewRequests []string         `json:"reviewRequests,omitempty"`
 	HasConflicts   bool             `json:"hasConflicts,omitempty"`
+	CurrentLogin   string           `json:"currentLogin,omitempty"`
 	Reviews        []map[string]any `json:"reviews,omitempty"`
 }
 
@@ -1161,13 +1163,24 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		}
 		return checkpoint, nil
 	}
-	if !isManualReviewerLoop(input.Loop) && r.loopConfig.StopOnApproved && strings.EqualFold(strings.TrimSpace(checkpoint.Detail.ReviewDecision), "APPROVED") {
-		checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for approved pull request %s#%d", input.Repo, input.PRNumber)
-		checkpoint.SkipKind = "approved"
-		if err := r.terminateLoop(ctx, input.Loop, "approved"); err != nil {
-			return checkpoint, err
+	currentLogin := normalizeLogin(checkpoint.Detail.CurrentLogin)
+	if !isManualReviewerLoop(input.Loop) && len(checkpoint.Detail.Reviews) > 0 && (r.loopConfig.StopOnApproved || r.discoveryPolicy.RequireReviewRequest) {
+		if currentLogin == "" {
+			lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+			if err != nil {
+				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+			}
+			currentLogin = normalizeLogin(lookupLogin)
+			checkpoint.Detail.CurrentLogin = currentLogin
 		}
-		return checkpoint, nil
+		if r.loopConfig.StopOnApproved && hasApprovedReviewByAuthorForHead(checkpoint.Detail.Reviews, currentLogin, checkpoint.Detail.HeadSHA) {
+			checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for approved pull request %s#%d", input.Repo, input.PRNumber)
+			checkpoint.SkipKind = "approved"
+			if err := r.terminateLoop(ctx, input.Loop, "approved"); err != nil {
+				return checkpoint, err
+			}
+			return checkpoint, nil
+		}
 	}
 	if !isManualReviewerLoop(input.Loop) && r.loopConfig.StopOnReadyLabel && specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {
 		checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for ready pull request %s#%d", input.Repo, input.PRNumber)
@@ -1183,14 +1196,18 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		return checkpoint, nil
 	}
 	if !isManualReviewerLoop(input.Loop) && len(checkpoint.Detail.Reviews) > 0 {
-		currentLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
-		if err != nil {
-			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+		if currentLogin == "" {
+			lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+			if err != nil {
+				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+			}
+			currentLogin = normalizeLogin(lookupLogin)
+			checkpoint.Detail.CurrentLogin = currentLogin
 		}
 		if hasReviewByAuthorForHead(checkpoint.Detail.Reviews, currentLogin, checkpoint.Detail.HeadSHA) {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user already reviewed head %s", input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA)
 			checkpoint.SkipKind = "already_reviewed_by_current_user"
-			checkpoint.SkipReviewerLogin = normalizeLogin(currentLogin)
+			checkpoint.SkipReviewerLogin = currentLogin
 			return checkpoint, nil
 		}
 	}
@@ -2406,8 +2423,14 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if !r.discoveryPolicy.IncludeDrafts && pr.IsDraft {
 		return false, "", "draft_pr", nil
 	}
-	if r.loopConfig.StopOnApproved && strings.EqualFold(strings.TrimSpace(pr.ReviewDecision), "APPROVED") {
-		return false, "", "approved", nil
+	if r.loopConfig.StopOnApproved && len(pr.Reviews) > 0 {
+		currentLogin, err := r.currentLoginForLoop(ctx, loop)
+		if err != nil {
+			return false, "", "", err
+		}
+		if hasApprovedReviewByAuthorForHead(pr.Reviews, currentLogin, pr.HeadSHA) {
+			return false, "", "approved", nil
+		}
 	}
 	if r.loopConfig.StopOnReadyLabel && specpr.HasLabel(pr.Labels, specpr.ReadyLabel) {
 		return false, "", "ready_label", nil
@@ -2729,9 +2752,19 @@ func (r *Runner) detectHeadChangeRequired(ctx context.Context, input stepInput, 
 }
 
 func hasReviewByAuthorForHead(reviews []map[string]any, login string, headSHA string) bool {
+	return hasReviewByAuthorForHeadMatchingState(reviews, login, headSHA, isSubmittedReviewState)
+}
+
+func hasApprovedReviewByAuthorForHead(reviews []map[string]any, login string, headSHA string) bool {
+	return hasReviewByAuthorForHeadMatchingState(reviews, login, headSHA, func(state string) bool {
+		return strings.EqualFold(strings.TrimSpace(state), "APPROVED")
+	})
+}
+
+func hasReviewByAuthorForHeadMatchingState(reviews []map[string]any, login string, headSHA string, stateMatches func(string) bool) bool {
 	login = normalizeLogin(login)
 	headSHA = strings.TrimSpace(headSHA)
-	if login == "" || headSHA == "" {
+	if login == "" || headSHA == "" || stateMatches == nil {
 		return false
 	}
 	for _, review := range reviews {
@@ -2743,7 +2776,7 @@ func hasReviewByAuthorForHead(reviews []map[string]any, login string, headSHA st
 			continue
 		}
 		state, _ := stringFromAny(review["state"])
-		if !isSubmittedReviewState(state) {
+		if !stateMatches(state) {
 			continue
 		}
 		commit, ok := review["commit"].(map[string]any)
@@ -2755,6 +2788,22 @@ func hasReviewByAuthorForHead(reviews []map[string]any, login string, headSHA st
 		}
 	}
 	return false
+}
+
+func (r *Runner) currentLoginForLoop(ctx context.Context, loop storage.LoopRecord) (string, error) {
+	project, err := r.repos.Projects.GetByID(ctx, loop.ProjectID)
+	if err != nil {
+		return "", err
+	}
+	cwd := ""
+	if project != nil {
+		cwd = project.RepoPath
+	}
+	login, err := r.github.GetCurrentUserLogin(ctx, cwd)
+	if err != nil {
+		return "", err
+	}
+	return normalizeLogin(login), nil
 }
 
 func isSubmittedReviewState(state string) bool {
@@ -3308,7 +3357,7 @@ func containsAnyString(values []any, target string) bool {
 }
 
 func summaryFromDetail(detail PullRequestDetail) PullRequestSummary {
-	return PullRequestSummary{Number: detail.Number, Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HasConflicts: detail.HasConflicts, Author: detail.Author, ReviewRequests: cloneStrings(detail.ReviewRequests)}
+	return PullRequestSummary{Number: detail.Number, Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HasConflicts: detail.HasConflicts, Author: detail.Author, ReviewRequests: cloneStrings(detail.ReviewRequests), Reviews: cloneObjectSlice(detail.Reviews)}
 }
 
 func normalizePRState(value string) string {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2452,15 +2452,6 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if intFromAny(loopMeta["autoRecoveryAttempts"]) >= maxReviewerAutoRecoveryAttempts {
 		return false, "", "auto_recovery_attempt_cap", nil
 	}
-	if r.loopConfig.StopOnApproved && len(pr.Reviews) > 0 {
-		currentLogin, err := r.currentLoginForLoop(ctx, loop)
-		if err != nil {
-			return false, "", "", err
-		}
-		if hasApprovedReviewByAuthorForHead(pr.Reviews, currentLogin, pr.HeadSHA) {
-			return false, "", "approved", nil
-		}
-	}
 	latestRun, err := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID)
 	if err != nil {
 		return false, "", "", err
@@ -2484,7 +2475,24 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if queueKind == string(FailureManualIntervention) || checkpoint.ResumePolicy == "manual_intervention" {
 		return false, "", "manual_intervention", nil
 	}
+	approvedByCurrentUser := func() (bool, error) {
+		if !r.loopConfig.StopOnApproved || len(pr.Reviews) == 0 {
+			return false, nil
+		}
+		currentLogin, err := r.currentLoginForLoop(ctx, loop)
+		if err != nil {
+			return false, err
+		}
+		return hasApprovedReviewByAuthorForHead(pr.Reviews, currentLogin, pr.HeadSHA), nil
+	}
 	if queueKind == string(FailureRetryableAfterResume) && (checkpoint.ResumePolicy == "restart_from_discover" || checkpoint.ResumePolicy == "rerun_review") {
+		approved, err := approvedByCurrentUser()
+		if err != nil {
+			return false, "", "", err
+		}
+		if approved {
+			return false, "", "approved", nil
+		}
 		return true, latestQueue.ID, "retryable_after_resume_" + checkpoint.ResumePolicy, nil
 	}
 	latestMessage := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage))
@@ -2492,6 +2500,13 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 		latestMessage = derefString(latestQueue.LastError)
 	}
 	if isKnownReviewerRediscoveryGuardrail(latestMessage) && isReviewerRediscoveryRunStep(latestRun) {
+		approved, err := approvedByCurrentUser()
+		if err != nil {
+			return false, "", "", err
+		}
+		if approved {
+			return false, "", "approved", nil
+		}
 		return true, latestQueue.ID, "historical_guardrail", nil
 	}
 	return false, "", "not_whitelisted", nil

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1163,7 +1163,7 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		}
 		return checkpoint, nil
 	}
-	currentLogin := normalizeLogin(checkpoint.Detail.CurrentLogin)
+	currentLogin := ""
 	if !isManualReviewerLoop(input.Loop) && len(checkpoint.Detail.Reviews) > 0 && (r.loopConfig.StopOnApproved || r.discoveryPolicy.RequireReviewRequest) {
 		if currentLogin == "" {
 			lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
@@ -1228,11 +1228,15 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		}
 	}
 	if !isManualReviewerLoop(input.Loop) && r.discoveryPolicy.RequireReviewRequest {
-		currentLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
-		if err != nil {
-			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+		if currentLogin == "" {
+			lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+			if err != nil {
+				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+			}
+			currentLogin = normalizeLogin(lookupLogin)
+			checkpoint.Detail.CurrentLogin = currentLogin
 		}
-		if !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, normalizeLogin(currentLogin)) {
+		if !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, currentLogin) {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", input.Repo, input.PRNumber)
 			checkpoint.SkipKind = "not_requested"
 			return checkpoint, nil

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -721,7 +721,28 @@ func TestRunFilterStepSkipsConflictedPullRequest(t *testing.T) {
 	}
 }
 
-func TestRunFilterStepTerminatesApprovedBeforeConflictSkip(t *testing.T) {
+func TestRunFilterStepSkipsConflictedPullRequestBeforeLoginLookup(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLoginErr: fmt.Errorf("gh auth failed")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	reviews := []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}
+
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", HasConflicts: true, ReviewDecision: "APPROVED", Reviews: reviews}}})
+	if err != nil {
+		t.Fatalf("runFilterStep() error = %v", err)
+	}
+	if checkpoint.SkipKind != "conflicted" {
+		t.Fatalf("SkipKind = %q, want conflicted", checkpoint.SkipKind)
+	}
+	if github.currentLoginCalls != 0 {
+		t.Fatalf("GetCurrentUserLogin calls = %d, want 0", github.currentLoginCalls)
+	}
+}
+
+func TestRunFilterStepTerminatesLegacyApprovedWithoutReviewsBeforeConflictSkip(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
@@ -732,9 +753,7 @@ func TestRunFilterStepTerminatesApprovedBeforeConflictSkip(t *testing.T) {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 
-	reviews := []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}
-
-	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", HasConflicts: true, ReviewDecision: "APPROVED", Reviews: reviews}}})
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", HasConflicts: true, ReviewDecision: "APPROVED"}}})
 	if err != nil {
 		t.Fatalf("runFilterStep() error = %v", err)
 	}
@@ -803,6 +822,31 @@ func TestRunFilterStepTerminatesReadyBeforeConflictSkip(t *testing.T) {
 	}
 	if updated.Status != "terminated" {
 		t.Fatalf("loop status = %q, want terminated", updated.Status)
+	}
+}
+
+func TestRunFilterStepTerminatesReadyBeforeLoginLookup(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLoginErr: fmt.Errorf("gh auth failed")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_ready_login_error", ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	reviews := []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}
+
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", Labels: []string{specpr.ReadyLabel}, Reviews: reviews}}})
+	if err != nil {
+		t.Fatalf("runFilterStep() error = %v", err)
+	}
+	if checkpoint.SkipKind != "ready_label" {
+		t.Fatalf("SkipKind = %q, want ready_label", checkpoint.SkipKind)
+	}
+	if github.currentLoginCalls != 0 {
+		t.Fatalf("GetCurrentUserLogin calls = %d, want 0", github.currentLoginCalls)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -824,6 +824,30 @@ func TestRunFilterStepSkipsPullRequestAlreadyReviewedByCurrentUserForHead(t *tes
 	}
 }
 
+func TestRunFilterStepRefreshesCurrentLoginBeforeAlreadyReviewedCheck(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "new-user"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	reviews := []map[string]any{{"author": map[string]any{"login": "old-user"}, "state": "COMMENTED", "commit": map[string]any{"oid": "abc123"}}}
+
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", CurrentLogin: "old-user", ReviewRequests: []string{"new-user"}, Reviews: reviews}}})
+	if err != nil {
+		t.Fatalf("runFilterStep() error = %v", err)
+	}
+	if checkpoint.SkipReason != "" {
+		t.Fatalf("SkipReason = %q, want no skip for stale checkpoint login", checkpoint.SkipReason)
+	}
+	if checkpoint.Detail.CurrentLogin != "new-user" {
+		t.Fatalf("CurrentLogin = %q, want refreshed login", checkpoint.Detail.CurrentLogin)
+	}
+	if github.currentLoginCalls != 1 {
+		t.Fatalf("GetCurrentUserLogin calls = %d, want 1", github.currentLoginCalls)
+	}
+}
+
 func TestRunFilterStepTerminatesApprovedBeforeAlreadyReviewedSkip(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -850,6 +874,38 @@ func TestRunFilterStepTerminatesApprovedBeforeAlreadyReviewedSkip(t *testing.T) 
 	}
 	if updated.Status != "terminated" {
 		t.Fatalf("loop status = %q, want terminated", updated.Status)
+	}
+}
+
+func TestRunFilterStepRefreshesCurrentLoginBeforeApprovedCheck(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "new-user"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_stale_approved", ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	reviews := []map[string]any{{"author": map[string]any{"login": "old-user"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}
+
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", CurrentLogin: "old-user", ReviewRequests: []string{"new-user"}, Reviews: reviews}}})
+	if err != nil {
+		t.Fatalf("runFilterStep() error = %v", err)
+	}
+	if checkpoint.SkipReason != "" {
+		t.Fatalf("SkipReason = %q, want no termination for stale checkpoint login", checkpoint.SkipReason)
+	}
+	if checkpoint.Detail.CurrentLogin != "new-user" {
+		t.Fatalf("CurrentLogin = %q, want refreshed login", checkpoint.Detail.CurrentLogin)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", updated, err)
+	}
+	if updated.Status == "terminated" {
+		t.Fatalf("loop status = %q, want not terminated", updated.Status)
 	}
 }
 
@@ -4484,6 +4540,7 @@ type fakeGitHubGateway struct {
 	reviewRequests                  []string
 	currentLogin                    string
 	currentLoginErr                 error
+	currentLoginCalls               int
 	reviewMarkerMissing             bool
 	reviewMarkerErr                 error
 	reviewMarkerEvent               ReviewEvent
@@ -4524,6 +4581,7 @@ func (g *fakeGitHubGateway) ListOpenPullRequests(_ context.Context, input ListOp
 }
 
 func (g *fakeGitHubGateway) GetCurrentUserLogin(context.Context, string) (string, error) {
+	g.currentLoginCalls++
 	if g.currentLoginErr != nil {
 		return "", g.currentLoginErr
 	}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -145,6 +145,43 @@ func TestReviewerFailedLoopRecoveryEligibilityHonorsStopOnConfig(t *testing.T) {
 	}
 }
 
+func TestReviewerFailedLoopRecoveryEligibilitySkipsCurrentLoginForLocalBlockers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		seed       failedReviewerRecoverySeed
+		wantReason string
+	}{
+		{name: "loop disabled", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", LoopEnabled: boolPtr(false)}, wantReason: "loop_disabled"},
+		{name: "max consecutive failures", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", ConsecutiveFailures: 3}, wantReason: "max_consecutive_failures"},
+		{name: "attempt cap", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", AutoRecoveryAttempts: maxReviewerAutoRecoveryAttempts}, wantReason: "auto_recovery_attempt_cap"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			github := &fakeGitHubGateway{currentLoginErr: fmt.Errorf("gh auth failed")}
+			loopID, _ := seedFailedReviewerRecoveryLoop(t, fixture, tt.seed)
+			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: true, StopOnReadyLabel: true}})
+			loop, _ := fixture.repos.Loops.GetByID(context.Background(), loopID)
+			eligible, _, reason, err := runner.failedReviewerLoopRecoveryEligibility(context.Background(), *loop, PullRequestSummary{Number: 42, State: "OPEN", HeadSHA: "abc123", Reviews: []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}})
+			if err != nil {
+				t.Fatalf("failedReviewerLoopRecoveryEligibility() error = %v", err)
+			}
+			if eligible {
+				t.Fatalf("eligible = true, want false")
+			}
+			if reason != tt.wantReason {
+				t.Fatalf("reason = %q, want %q", reason, tt.wantReason)
+			}
+			if github.currentLoginCalls != 0 {
+				t.Fatalf("currentLoginCalls = %d, want 0", github.currentLoginCalls)
+			}
+		})
+	}
+}
+
 func TestSummaryFromDetailPreservesReviewsForApprovalRecovery(t *testing.T) {
 	t.Parallel()
 	reviews := []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -89,7 +89,8 @@ func TestReviewerFailedLoopRecoveryEligibilityWhitelist(t *testing.T) {
 		{name: "historical guardrail non retryable", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureNonRetryable), ErrorMessage: "review request removed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
 		{name: "manual intervention", seed: failedReviewerRecoverySeed{ResumePolicy: "manual_intervention", QueueErrorKind: string(FailureManualIntervention), ErrorMessage: "operator needed"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 		{name: "closed pr", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "CLOSED"}, want: false},
-		{name: "approved pr", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN", ReviewDecision: "APPROVED"}, want: false},
+		{name: "approved by current user on head", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN", ReviewDecision: "APPROVED", HeadSHA: "abc123", Reviews: []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}}, want: false},
+		{name: "approved by another user", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN", ReviewDecision: "APPROVED", HeadSHA: "abc123", Reviews: []map[string]any{{"author": map[string]any{"login": "other"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}}, want: true},
 		{name: "ready label", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN", Labels: []string{specpr.ReadyLabel}}, want: false},
 		{name: "follow updates disabled", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", FollowUpdates: boolPtr(false)}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 		{name: "loop disabled", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", LoopEnabled: boolPtr(false)}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
@@ -141,6 +142,17 @@ func TestReviewerFailedLoopRecoveryEligibilityHonorsStopOnConfig(t *testing.T) {
 				t.Fatalf("eligible = false, want true")
 			}
 		})
+	}
+}
+
+func TestSummaryFromDetailPreservesReviewsForApprovalRecovery(t *testing.T) {
+	t.Parallel()
+	reviews := []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}
+
+	summary := summaryFromDetail(PullRequestDetail{Number: 42, State: "OPEN", HeadSHA: "abc123", Reviews: reviews})
+
+	if !hasApprovedReviewByAuthorForHead(summary.Reviews, "octocat", "abc123") {
+		t.Fatalf("summary reviews = %#v, want current-user approved review preserved", summary.Reviews)
 	}
 }
 
@@ -720,7 +732,9 @@ func TestRunFilterStepTerminatesApprovedBeforeConflictSkip(t *testing.T) {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 
-	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", HasConflicts: true, ReviewDecision: "APPROVED"}}})
+	reviews := []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}
+
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", HasConflicts: true, ReviewDecision: "APPROVED", Reviews: reviews}}})
 	if err != nil {
 		t.Fatalf("runFilterStep() error = %v", err)
 	}
@@ -733,6 +747,35 @@ func TestRunFilterStepTerminatesApprovedBeforeConflictSkip(t *testing.T) {
 	}
 	if updated.Status != "terminated" {
 		t.Fatalf("loop status = %q, want terminated", updated.Status)
+	}
+}
+
+func TestRunFilterStepDoesNotTerminateWhenOnlyAnotherReviewerApproved(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "octocat"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_other_approved", ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	reviews := []map[string]any{{"author": map[string]any{"login": "other"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}
+
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", ReviewDecision: "APPROVED", ReviewRequests: []string{"octocat"}, Reviews: reviews}}})
+	if err != nil {
+		t.Fatalf("runFilterStep() error = %v", err)
+	}
+	if checkpoint.SkipKind == "approved" {
+		t.Fatalf("SkipKind = %q, want no approved termination", checkpoint.SkipKind)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", updated, err)
+	}
+	if updated.Status == "terminated" {
+		t.Fatalf("loop status = %q, want not terminated", updated.Status)
 	}
 }
 
@@ -1235,7 +1278,7 @@ func TestDiscoverPullRequestsDoesNotRequeueApprovedReadyOrDraftNonActionablePRs(
 		github *fakeGitHubGateway
 		want   string
 	}{
-		{name: "approved", github: &fakeGitHubGateway{reviewDecision: "APPROVED", reviewRequests: []string{"octocat"}}, want: "approved"},
+		{name: "approved", github: &fakeGitHubGateway{reviewDecision: "APPROVED", reviewRequests: []string{"octocat"}, reviews: []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}}, want: "approved"},
 		{name: "ready", github: &fakeGitHubGateway{labels: []string{specpr.ReadyLabel}, reviewRequests: []string{"octocat"}}, want: "ready"},
 		{name: "draft", github: &fakeGitHubGateway{listOpenByLabel: map[string][]PullRequestSummary{"": {{Number: 42, Title: "Draft", State: "OPEN", IsDraft: true, HeadSHA: "draft123", ReviewRequests: []string{"octocat"}}}}}, want: "draft"},
 	} {
@@ -4477,7 +4520,7 @@ func (g *fakeGitHubGateway) ListOpenPullRequests(_ context.Context, input ListOp
 	if headSHA == "" {
 		headSHA = "abc123"
 	}
-	return []PullRequestSummary{{Number: 42, Title: "Review me", State: "OPEN", ReviewDecision: g.reviewDecision, Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, BaseSHA: "base123", HasConflicts: g.hasConflicts, ReviewRequests: reviewRequests}, {Number: 99, Title: "Draft", State: "OPEN", IsDraft: true, HeadSHA: "draft123", BaseSHA: "base123", ReviewRequests: reviewRequests}}, nil
+	return []PullRequestSummary{{Number: 42, Title: "Review me", State: "OPEN", ReviewDecision: g.reviewDecision, Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, BaseSHA: "base123", HasConflicts: g.hasConflicts, ReviewRequests: reviewRequests, Reviews: cloneCommentMaps(g.reviews)}, {Number: 99, Title: "Draft", State: "OPEN", IsDraft: true, HeadSHA: "draft123", BaseSHA: "base123", ReviewRequests: reviewRequests}}, nil
 }
 
 func (g *fakeGitHubGateway) GetCurrentUserLogin(context.Context, string) (string, error) {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -182,6 +182,78 @@ func TestReviewerFailedLoopRecoveryEligibilitySkipsCurrentLoginForLocalBlockers(
 	}
 }
 
+func TestReviewerFailedLoopRecoveryEligibilitySkipsCurrentLoginForDeterministicBlockers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		seed       failedReviewerRecoverySeed
+		mutate     func(t *testing.T, fixture *runnerFixture, loopID string)
+		wantReason string
+	}{
+		{
+			name:       "latest queue not failed",
+			seed:       failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"},
+			wantReason: "latest_queue_not_failed",
+			mutate: func(t *testing.T, fixture *runnerFixture, loopID string) {
+				t.Helper()
+				queue, err := fixture.repos.Queue.GetLatestByLoopID(context.Background(), loopID)
+				if err != nil || queue == nil {
+					t.Fatalf("Queue.GetLatestByLoopID() = (%#v, %v), want queue", queue, err)
+				}
+				queue.Status = "queued"
+				if err := fixture.repos.Queue.Upsert(context.Background(), *queue); err != nil {
+					t.Fatalf("Queue.Upsert() error = %v", err)
+				}
+			},
+		},
+		{
+			name:       "latest run not failed",
+			seed:       failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"},
+			wantReason: "latest_run_not_failed",
+			mutate: func(t *testing.T, fixture *runnerFixture, loopID string) {
+				t.Helper()
+				run, err := fixture.repos.Runs.GetLatestByLoopID(context.Background(), loopID)
+				if err != nil || run == nil {
+					t.Fatalf("Runs.GetLatestByLoopID() = (%#v, %v), want run", run, err)
+				}
+				run.Status = "completed"
+				if err := fixture.repos.Runs.Upsert(context.Background(), *run); err != nil {
+					t.Fatalf("Runs.Upsert() error = %v", err)
+				}
+			},
+		},
+		{name: "manual intervention", seed: failedReviewerRecoverySeed{ResumePolicy: "manual_intervention", QueueErrorKind: string(FailureManualIntervention), ErrorMessage: "operator needed"}, wantReason: "manual_intervention"},
+		{name: "not whitelisted", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureNonRetryable), ErrorMessage: "marker missing"}, wantReason: "not_whitelisted"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			github := &fakeGitHubGateway{currentLoginErr: fmt.Errorf("gh auth failed")}
+			loopID, _ := seedFailedReviewerRecoveryLoop(t, fixture, tt.seed)
+			if tt.mutate != nil {
+				tt.mutate(t, fixture, loopID)
+			}
+			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: true, StopOnReadyLabel: true}})
+			loop, _ := fixture.repos.Loops.GetByID(context.Background(), loopID)
+			eligible, _, reason, err := runner.failedReviewerLoopRecoveryEligibility(context.Background(), *loop, PullRequestSummary{Number: 42, State: "OPEN", HeadSHA: "abc123", Reviews: []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}})
+			if err != nil {
+				t.Fatalf("failedReviewerLoopRecoveryEligibility() error = %v", err)
+			}
+			if eligible {
+				t.Fatalf("eligible = true, want false")
+			}
+			if reason != tt.wantReason {
+				t.Fatalf("reason = %q, want %q", reason, tt.wantReason)
+			}
+			if github.currentLoginCalls != 0 {
+				t.Fatalf("currentLoginCalls = %d, want 0", github.currentLoginCalls)
+			}
+		})
+	}
+}
+
 func TestSummaryFromDetailPreservesReviewsForApprovalRecovery(t *testing.T) {
 	t.Parallel()
 	reviews := []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1266,10 +1266,12 @@ const maxReviewerAutoRecoveryAttempts = 3
 type runtimeReviewerCheckpoint struct {
 	ResumePolicy string `json:"resumePolicy,omitempty"`
 	Detail       *struct {
-		State          string   `json:"state,omitempty"`
-		IsDraft        bool     `json:"isDraft,omitempty"`
-		ReviewDecision string   `json:"reviewDecision,omitempty"`
-		Labels         []string `json:"labels,omitempty"`
+		State        string           `json:"state,omitempty"`
+		IsDraft      bool             `json:"isDraft,omitempty"`
+		Labels       []string         `json:"labels,omitempty"`
+		HeadSHA      string           `json:"headSha,omitempty"`
+		CurrentLogin string           `json:"currentLogin,omitempty"`
+		Reviews      []map[string]any `json:"reviews,omitempty"`
 	} `json:"detail,omitempty"`
 }
 
@@ -1319,7 +1321,7 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 	if !policy.includeDrafts && checkpoint.Detail.IsDraft {
 		return false
 	}
-	if policy.stopOnApproved && strings.EqualFold(strings.TrimSpace(checkpoint.Detail.ReviewDecision), "APPROVED") {
+	if policy.stopOnApproved && runtimeHasApprovedReviewByAuthorForHead(checkpoint.Detail.Reviews, checkpoint.Detail.CurrentLogin, checkpoint.Detail.HeadSHA) {
 		return false
 	}
 	if policy.stopOnReadyLabel && specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {
@@ -1405,6 +1407,36 @@ func runtimeIntFromAny(value any) int {
 func runtimeStringFromAny(value any) (string, bool) {
 	text, ok := value.(string)
 	return text, ok
+}
+
+func runtimeHasApprovedReviewByAuthorForHead(reviews []map[string]any, login string, headSHA string) bool {
+	login = strings.ToLower(strings.TrimSpace(login))
+	headSHA = strings.TrimSpace(headSHA)
+	if login == "" || headSHA == "" {
+		return false
+	}
+	for _, review := range reviews {
+		author, ok := review["author"].(map[string]any)
+		if !ok {
+			continue
+		}
+		authorLogin, ok := runtimeStringFromAny(author["login"])
+		if !ok || strings.ToLower(strings.TrimSpace(authorLogin)) != login {
+			continue
+		}
+		state, _ := runtimeStringFromAny(review["state"])
+		if !strings.EqualFold(strings.TrimSpace(state), "APPROVED") {
+			continue
+		}
+		commit, ok := review["commit"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if oid, ok := runtimeStringFromAny(commit["oid"]); ok && strings.TrimSpace(oid) == headSHA {
+			return true
+		}
+	}
+	return false
 }
 
 func isKnownReviewerRediscoveryGuardrail(message string) bool {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -346,7 +346,7 @@ func (r *Runtime) start(ctx context.Context) error {
 	if err := r.syncConfiguredProjects(ctx, repositories, r.config, startedAt); err != nil {
 		return err
 	}
-	recoverySummary, err := r.runRecoveryPipeline(ctx, repositories, startedAt)
+	recoverySummary, err := r.runRecoveryPipeline(ctx, repositories, githubGateway, startedAt)
 	if err != nil {
 		return err
 	}
@@ -537,7 +537,7 @@ func (r *Runtime) executeDefaultSchedulerTick(ctx context.Context, services Serv
 	return tick(ctx, services)
 }
 
-func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage.Repositories, now time.Time) (RecoverySummary, error) {
+func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage.Repositories, githubGateway *githubinfra.Gateway, now time.Time) (RecoverySummary, error) {
 	nowISO := formatJavaScriptISOString(now)
 	eventsWritten := int64(0)
 	summary := createEmptyRecoverySummary()
@@ -689,12 +689,16 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 		if err != nil {
 			return RecoverySummary{}, err
 		}
-		if shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, runtimeReviewerRecoveryPolicy{
+		policy := runtimeReviewerRecoveryPolicy{
 			includeDrafts:          r.config.Roles.Reviewer.Triggers.IncludeDrafts,
 			stopOnApproved:         r.config.Reviewer.Loop.StopOnApproved,
 			stopOnReadyLabel:       r.config.Reviewer.Loop.StopOnReadyLabel,
 			maxConsecutiveFailures: int64(r.config.Reviewer.Loop.MaxConsecutiveFailures),
-		}) {
+		}
+		if login, ok := r.currentReviewerLoginForRecovery(ctx, repositories, githubGateway, loop, latestRun, policy); ok {
+			policy.currentLogin = login
+		}
+		if shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, policy) {
 			recoveredQueueItems, err := repositories.Queue.RequeueFailedByID(ctx, loop.ID, latestQueue.ID, nowISO)
 			if err != nil {
 				return RecoverySummary{}, err
@@ -1281,6 +1285,39 @@ type runtimeReviewerRecoveryPolicy struct {
 	stopOnApproved         bool
 	stopOnReadyLabel       bool
 	maxConsecutiveFailures int64
+	currentLogin           string
+}
+
+func (r *Runtime) currentReviewerLoginForRecovery(ctx context.Context, repositories *storage.Repositories, githubGateway *githubinfra.Gateway, loop storage.LoopRecord, latestRun *storage.RunRecord, policy runtimeReviewerRecoveryPolicy) (string, bool) {
+	if githubGateway == nil || !policy.stopOnApproved || latestRun == nil || strings.TrimSpace(loop.ProjectID) == "" {
+		return "", false
+	}
+	checkpoint := parseRuntimeReviewerCheckpoint(latestRun.CheckpointJSON)
+	if checkpoint.Detail == nil || len(checkpoint.Detail.Reviews) == 0 {
+		return "", false
+	}
+	project, err := repositories.Projects.GetByID(ctx, loop.ProjectID)
+	if err != nil {
+		if r.logger != nil {
+			r.logger.Warn("failed to load project for reviewer recovery login refresh", map[string]any{"loopId": loop.ID, "projectId": loop.ProjectID, "error": err.Error()})
+		}
+		return "", false
+	}
+	if project == nil || strings.TrimSpace(project.RepoPath) == "" {
+		return "", false
+	}
+	login, err := githubGateway.GetCurrentUserLogin(ctx, project.RepoPath)
+	if err != nil {
+		if r.logger != nil {
+			r.logger.Warn("failed to refresh reviewer login during recovery", map[string]any{"loopId": loop.ID, "projectId": loop.ProjectID, "error": err.Error()})
+		}
+		return "", false
+	}
+	login = strings.ToLower(strings.TrimSpace(login))
+	if login == "" {
+		return "", false
+	}
+	return login, true
 }
 
 func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *storage.RunRecord, latestQueue *storage.QueueItemRecord, policy runtimeReviewerRecoveryPolicy) bool {
@@ -1322,7 +1359,11 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 	if !policy.includeDrafts && checkpoint.Detail.IsDraft {
 		return false
 	}
-	if policy.stopOnApproved && runtimeReviewerCheckpointApprovedForRecovery(checkpoint.Detail.Reviews, checkpoint.Detail.CurrentLogin, checkpoint.Detail.HeadSHA, checkpoint.Detail.ReviewDecision) {
+	currentLogin := checkpoint.Detail.CurrentLogin
+	if strings.TrimSpace(policy.currentLogin) != "" {
+		currentLogin = policy.currentLogin
+	}
+	if policy.stopOnApproved && runtimeReviewerCheckpointApprovedForRecovery(checkpoint.Detail.Reviews, currentLogin, checkpoint.Detail.HeadSHA, checkpoint.Detail.ReviewDecision) {
 		return false
 	}
 	if policy.stopOnReadyLabel && specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -695,8 +695,10 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 			stopOnReadyLabel:       r.config.Reviewer.Loop.StopOnReadyLabel,
 			maxConsecutiveFailures: int64(r.config.Reviewer.Loop.MaxConsecutiveFailures),
 		}
-		if login, ok := r.currentReviewerLoginForRecovery(ctx, repositories, githubGateway, loop, latestRun, policy); ok {
-			policy.currentLogin = login
+		if canRefreshReviewerLoginForRecovery(loop, latestRun) {
+			if login, ok := r.currentReviewerLoginForRecovery(ctx, repositories, githubGateway, loop, latestRun, policy); ok {
+				policy.currentLogin = login
+			}
 		}
 		if shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, policy) {
 			recoveredQueueItems, err := repositories.Queue.RequeueFailedByID(ctx, loop.ID, latestQueue.ID, nowISO)
@@ -1318,6 +1320,10 @@ func (r *Runtime) currentReviewerLoginForRecovery(ctx context.Context, repositor
 		return "", false
 	}
 	return login, true
+}
+
+func canRefreshReviewerLoginForRecovery(loop storage.LoopRecord, latestRun *storage.RunRecord) bool {
+	return loop.Type == string(domain.LoopTypeReviewer) && loop.Status == "failed" && latestRun != nil && latestRun.Status == "failed"
 }
 
 func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *storage.RunRecord, latestQueue *storage.QueueItemRecord, policy runtimeReviewerRecoveryPolicy) bool {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1266,12 +1266,13 @@ const maxReviewerAutoRecoveryAttempts = 3
 type runtimeReviewerCheckpoint struct {
 	ResumePolicy string `json:"resumePolicy,omitempty"`
 	Detail       *struct {
-		State        string           `json:"state,omitempty"`
-		IsDraft      bool             `json:"isDraft,omitempty"`
-		Labels       []string         `json:"labels,omitempty"`
-		HeadSHA      string           `json:"headSha,omitempty"`
-		CurrentLogin string           `json:"currentLogin,omitempty"`
-		Reviews      []map[string]any `json:"reviews,omitempty"`
+		State          string           `json:"state,omitempty"`
+		IsDraft        bool             `json:"isDraft,omitempty"`
+		ReviewDecision string           `json:"reviewDecision,omitempty"`
+		Labels         []string         `json:"labels,omitempty"`
+		HeadSHA        string           `json:"headSha,omitempty"`
+		CurrentLogin   string           `json:"currentLogin,omitempty"`
+		Reviews        []map[string]any `json:"reviews,omitempty"`
 	} `json:"detail,omitempty"`
 }
 
@@ -1321,7 +1322,7 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 	if !policy.includeDrafts && checkpoint.Detail.IsDraft {
 		return false
 	}
-	if policy.stopOnApproved && runtimeHasApprovedReviewByAuthorForHead(checkpoint.Detail.Reviews, checkpoint.Detail.CurrentLogin, checkpoint.Detail.HeadSHA) {
+	if policy.stopOnApproved && runtimeReviewerCheckpointApprovedForRecovery(checkpoint.Detail.Reviews, checkpoint.Detail.CurrentLogin, checkpoint.Detail.HeadSHA, checkpoint.Detail.ReviewDecision) {
 		return false
 	}
 	if policy.stopOnReadyLabel && specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {
@@ -1437,6 +1438,16 @@ func runtimeHasApprovedReviewByAuthorForHead(reviews []map[string]any, login str
 		}
 	}
 	return false
+}
+
+func runtimeReviewerCheckpointApprovedForRecovery(reviews []map[string]any, login string, headSHA string, reviewDecision string) bool {
+	if runtimeHasApprovedReviewByAuthorForHead(reviews, login, headSHA) {
+		return true
+	}
+	if strings.TrimSpace(login) != "" && strings.TrimSpace(headSHA) != "" && len(reviews) > 0 {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(reviewDecision), "APPROVED")
 }
 
 func isKnownReviewerRediscoveryGuardrail(message string) bool {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1452,9 +1452,9 @@ func TestShouldAutoRecoverFailedReviewerLoopRefusesUnsafeStates(t *testing.T) {
 			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","isDraft":true,"reviewDecision":"","labels":[]}`)
 			return r
 		}(), queue: baseQueue},
-		{name: "approved checkpoint", loop: baseLoop, run: func() storage.RunRecord {
+		{name: "approved by current user on checkpoint head", loop: baseLoop, run: func() storage.RunRecord {
 			r := baseRun
-			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","reviewDecision":"APPROVED","labels":[]}`)
+			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","headSha":"abc123","currentLogin":"octocat","reviews":[{"author":{"login":"octocat"},"state":"APPROVED","commit":{"oid":"abc123"}}],"labels":[]}`)
 			return r
 		}(), queue: baseQueue},
 		{name: "follow updates disabled", loop: func() storage.LoopRecord {
@@ -1511,6 +1511,22 @@ func TestShouldAutoRecoverFailedReviewerLoopRefusesUnsafeStates(t *testing.T) {
 				t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = true, want false")
 			}
 		})
+	}
+}
+
+func TestShouldAutoRecoverFailedReviewerLoopIgnoresApprovalByAnotherUser(t *testing.T) {
+	t.Parallel()
+	errorKind := "retryable_after_resume"
+	errorMessage := "PR head changed before publish: expected old, got new"
+	step := "publish"
+	checkpoint := `{"resumePolicy":"restart_from_discover","detail":{"state":"OPEN","headSha":"abc123","currentLogin":"octocat","reviews":[{"author":{"login":"other"},"state":"APPROVED","commit":{"oid":"abc123"}}],"labels":[]}}`
+	loop := storage.LoopRecord{ID: "loop_recover", Type: "reviewer", Status: "failed", MetadataJSON: stringPtr(`{"loop":{"enabled":true,"consecutiveFailures":1}}`)}
+	run := storage.RunRecord{ID: "run_recover", LoopID: "loop_recover", Status: "failed", CurrentStep: &step, CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage}
+	queue := storage.QueueItemRecord{ID: "queue_recover", LoopID: stringPtr("loop_recover"), Status: "failed", LastError: &errorMessage, LastErrorKind: &errorKind}
+	policy := runtimeReviewerRecoveryPolicy{stopOnApproved: true, stopOnReadyLabel: true, maxConsecutiveFailures: 3}
+
+	if !shouldAutoRecoverFailedReviewerLoop(loop, &run, &queue, policy) {
+		t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = false, want true")
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1457,6 +1457,16 @@ func TestShouldAutoRecoverFailedReviewerLoopRefusesUnsafeStates(t *testing.T) {
 			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","headSha":"abc123","currentLogin":"octocat","reviews":[{"author":{"login":"octocat"},"state":"APPROVED","commit":{"oid":"abc123"}}],"labels":[]}`)
 			return r
 		}(), queue: baseQueue},
+		{name: "legacy approved review decision checkpoint", loop: baseLoop, run: func() storage.RunRecord {
+			r := baseRun
+			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","reviewDecision":"APPROVED","labels":[]}`)
+			return r
+		}(), queue: baseQueue},
+		{name: "approved decision before current login checkpoint", loop: baseLoop, run: func() storage.RunRecord {
+			r := baseRun
+			r.CheckpointJSON = checkpoint(`"detail":{"state":"OPEN","headSha":"abc123","reviewDecision":"APPROVED","reviews":[{"author":{"login":"octocat"},"state":"APPROVED","commit":{"oid":"abc123"}}],"labels":[]}`)
+			return r
+		}(), queue: baseQueue},
 		{name: "follow updates disabled", loop: func() storage.LoopRecord {
 			l := baseLoop
 			l.MetadataJSON = stringPtr(`{"followUpdates":false,"loop":{"enabled":true,"consecutiveFailures":1}}`)
@@ -1519,7 +1529,7 @@ func TestShouldAutoRecoverFailedReviewerLoopIgnoresApprovalByAnotherUser(t *test
 	errorKind := "retryable_after_resume"
 	errorMessage := "PR head changed before publish: expected old, got new"
 	step := "publish"
-	checkpoint := `{"resumePolicy":"restart_from_discover","detail":{"state":"OPEN","headSha":"abc123","currentLogin":"octocat","reviews":[{"author":{"login":"other"},"state":"APPROVED","commit":{"oid":"abc123"}}],"labels":[]}}`
+	checkpoint := `{"resumePolicy":"restart_from_discover","detail":{"state":"OPEN","reviewDecision":"APPROVED","headSha":"abc123","currentLogin":"octocat","reviews":[{"author":{"login":"other"},"state":"APPROVED","commit":{"oid":"abc123"}}],"labels":[]}}`
 	loop := storage.LoopRecord{ID: "loop_recover", Type: "reviewer", Status: "failed", MetadataJSON: stringPtr(`{"loop":{"enabled":true,"consecutiveFailures":1}}`)}
 	run := storage.RunRecord{ID: "run_recover", LoopID: "loop_recover", Status: "failed", CurrentStep: &step, CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage}
 	queue := storage.QueueItemRecord{ID: "queue_recover", LoopID: stringPtr("loop_recover"), Status: "failed", LastError: &errorMessage, LastErrorKind: &errorKind}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1540,6 +1540,33 @@ func TestShouldAutoRecoverFailedReviewerLoopIgnoresApprovalByAnotherUser(t *test
 	}
 }
 
+func TestCanRefreshReviewerLoginForRecovery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		loop      storage.LoopRecord
+		latestRun *storage.RunRecord
+		want      bool
+	}{
+		{name: "reviewer failed loop and run", loop: storage.LoopRecord{Type: "reviewer", Status: "failed"}, latestRun: &storage.RunRecord{Status: "failed"}, want: true},
+		{name: "non-reviewer loop", loop: storage.LoopRecord{Type: "worker", Status: "failed"}, latestRun: &storage.RunRecord{Status: "failed"}, want: false},
+		{name: "non-failed loop status", loop: storage.LoopRecord{Type: "reviewer", Status: "running"}, latestRun: &storage.RunRecord{Status: "failed"}, want: false},
+		{name: "nil latest run", loop: storage.LoopRecord{Type: "reviewer", Status: "failed"}, latestRun: nil, want: false},
+		{name: "non-failed latest run", loop: storage.LoopRecord{Type: "reviewer", Status: "failed"}, latestRun: &storage.RunRecord{Status: "completed"}, want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := canRefreshReviewerLoginForRecovery(tt.loop, tt.latestRun); got != tt.want {
+				t.Fatalf("canRefreshReviewerLoginForRecovery() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestShouldAutoRecoverFailedReviewerLoopUsesRefreshedCurrentLogin(t *testing.T) {
 	t.Parallel()
 	errorKind := "retryable_after_resume"

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1394,7 +1394,7 @@ func TestRunRecoveryPipelineAutoRecoversFailedReviewerGuardrailLoop(t *testing.T
 		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
 	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
-	summary, err := rt.runRecoveryPipeline(context.Background(), repositories, now)
+	summary, err := rt.runRecoveryPipeline(context.Background(), repositories, nil, now)
 	if err != nil {
 		t.Fatalf("runRecoveryPipeline() error = %v", err)
 	}
@@ -1406,7 +1406,7 @@ func TestRunRecoveryPipelineAutoRecoversFailedReviewerGuardrailLoop(t *testing.T
 	if loop == nil || loop.Status != "queued" || queue == nil || queue.Status != "queued" {
 		t.Fatalf("loop=%#v queue=%#v, want recovered queued loop and queue", loop, queue)
 	}
-	summary, err = rt.runRecoveryPipeline(context.Background(), repositories, now)
+	summary, err = rt.runRecoveryPipeline(context.Background(), repositories, nil, now)
 	if err != nil {
 		t.Fatalf("second runRecoveryPipeline() error = %v", err)
 	}
@@ -1534,6 +1534,22 @@ func TestShouldAutoRecoverFailedReviewerLoopIgnoresApprovalByAnotherUser(t *test
 	run := storage.RunRecord{ID: "run_recover", LoopID: "loop_recover", Status: "failed", CurrentStep: &step, CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage}
 	queue := storage.QueueItemRecord{ID: "queue_recover", LoopID: stringPtr("loop_recover"), Status: "failed", LastError: &errorMessage, LastErrorKind: &errorKind}
 	policy := runtimeReviewerRecoveryPolicy{stopOnApproved: true, stopOnReadyLabel: true, maxConsecutiveFailures: 3}
+
+	if !shouldAutoRecoverFailedReviewerLoop(loop, &run, &queue, policy) {
+		t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = false, want true")
+	}
+}
+
+func TestShouldAutoRecoverFailedReviewerLoopUsesRefreshedCurrentLogin(t *testing.T) {
+	t.Parallel()
+	errorKind := "retryable_after_resume"
+	errorMessage := "PR head changed before publish: expected old, got new"
+	step := "publish"
+	checkpoint := `{"resumePolicy":"restart_from_discover","detail":{"state":"OPEN","reviewDecision":"APPROVED","headSha":"abc123","currentLogin":"octocat","reviews":[{"author":{"login":"octocat"},"state":"APPROVED","commit":{"oid":"abc123"}}],"labels":[]}}`
+	loop := storage.LoopRecord{ID: "loop_recover", Type: "reviewer", Status: "failed", MetadataJSON: stringPtr(`{"loop":{"enabled":true,"consecutiveFailures":1}}`)}
+	run := storage.RunRecord{ID: "run_recover", LoopID: "loop_recover", Status: "failed", CurrentStep: &step, CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage}
+	queue := storage.QueueItemRecord{ID: "queue_recover", LoopID: stringPtr("loop_recover"), Status: "failed", LastError: &errorMessage, LastErrorKind: &errorKind}
+	policy := runtimeReviewerRecoveryPolicy{stopOnApproved: true, stopOnReadyLabel: true, maxConsecutiveFailures: 3, currentLogin: "other"}
 
 	if !shouldAutoRecoverFailedReviewerLoop(loop, &run, &queue, policy) {
 		t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = false, want true")

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -249,7 +249,7 @@ func (a reviewerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input r
 	}
 	result := make([]reviewer.PullRequestSummary, 0, len(pullRequests))
 	for _, pr := range pullRequests {
-		result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: pr.ReviewDecision, Labels: pr.Labels, HeadSHA: pr.HeadSHA, BaseSHA: pr.BaseSHA, HasConflicts: pr.HasConflicts, Author: pr.Author, ReviewRequests: pr.ReviewRequests})
+		result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: pr.ReviewDecision, Labels: pr.Labels, HeadSHA: pr.HeadSHA, BaseSHA: pr.BaseSHA, HasConflicts: pr.HasConflicts, Author: pr.Author, ReviewRequests: pr.ReviewRequests, Reviews: pr.Reviews})
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Summary
- Scope reviewer StopOnApproved checks to approvals by the current Looper user on the current PR head SHA.
- Carry review data through PR listing/recovery paths and runtime checkpoints so recovery gates use the same scoped approval semantics.
- Add tests for approvals by another reviewer versus the current user across filter and recovery flows.

Closes #178

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.4.1 · runner=worker · agent=opencode</sub>