### PR TITLE
fix: unblock daemon startup recovery

### DIFF
--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/powerformer/looper/internal/config"
 	"github.com/powerformer/looper/internal/version"
@@ -33,6 +34,11 @@ type Deps struct {
 	Sleep          sleepFunc
 	Getwd          getwdFunc
 	ExecutablePath string
+
+	// DaemonStartTimeout overrides how long daemon start/restart waits for the
+	// spawned looperd process to become API-ready. It is primarily intended for
+	// tests; production uses the CLI default.
+	DaemonStartTimeout time.Duration
 }
 
 type App struct {

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -18,7 +18,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const daemonCommandTimeout = 5 * time.Second
+const (
+	daemonCommandTimeout       = 5 * time.Second
+	daemonStartReadyTimeout    = 30 * time.Second
+	daemonStartReadyPollPeriod = 100 * time.Millisecond
+)
 
 type commandExecutionResult struct {
 	Stdout   string
@@ -206,7 +210,7 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to start looperd: process did not report a pid")
 	}
 
-	err = r.waitForDaemonReady(ctx, client, pid, startupLogPath, apiURL, 5*time.Second, 100*time.Millisecond)
+	err = r.waitForDaemonReady(ctx, client, pid, startupLogPath, apiURL, r.daemonStartReadyTimeout(), daemonStartReadyPollPeriod)
 	if err != nil {
 		if r.isProcessAlive(pid) {
 			_ = r.killProcess(pid, int(syscall.SIGTERM))
@@ -233,6 +237,13 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 	}
 	_, err = fmt.Fprintln(cmd.OutOrStdout(), "Phase 1 process management is minimal and does not provide full background supervision.")
 	return err
+}
+
+func (r *commandRuntime) daemonStartReadyTimeout() time.Duration {
+	if r.app != nil && r.app.deps.DaemonStartTimeout > 0 {
+		return r.app.deps.DaemonStartTimeout
+	}
+	return daemonStartReadyTimeout
 }
 
 func (r *commandRuntime) daemonSpawnCallerCWD(args []string, env []string) (string, error) {

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -896,9 +896,10 @@ func TestDaemonStartReadinessTimeoutTerminatesSpawnedProcessAndRemovesPIDFile(t 
 		signal int
 	}, 0, 8)
 	app := New(Deps{
-		Stdout:  stdout,
-		Stderr:  stderr,
-		HomeDir: homeDir,
+		Stdout:             stdout,
+		Stderr:             stderr,
+		HomeDir:            homeDir,
+		DaemonStartTimeout: 200 * time.Millisecond,
 		ReadFile: func(path string) ([]byte, error) {
 			return nil, os.ErrNotExist
 		},

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -955,7 +955,7 @@ func (r *Runtime) runDeferredReviewerRecovery(ctx context.Context, repositories 
 	if err != nil {
 		return 0, err
 	}
-	reviewerLoginByProjectID := make(map[string]*string)
+	reviewerLoginByProjectID := make(map[string]string)
 	requeued := int64(0)
 	for _, loop := range loops {
 		if err := ctx.Err(); err != nil {
@@ -978,19 +978,16 @@ func (r *Runtime) runDeferredReviewerRecovery(ctx context.Context, repositories 
 		if !reviewerRecoveryNeedsFreshLogin(loop, latestRun, policy) {
 			continue
 		}
-		if _, cached := reviewerLoginByProjectID[loop.ProjectID]; !cached {
+		cachedLogin, cached := reviewerLoginByProjectID[loop.ProjectID]
+		if !cached {
 			login, ok := r.currentReviewerLoginForRecovery(ctx, repositories, githubGateway, loop, latestRun, policy)
-			if ok {
-				reviewerLoginByProjectID[loop.ProjectID] = stringPtr(login)
-			} else {
-				reviewerLoginByProjectID[loop.ProjectID] = nil
+			if !ok {
+				continue
 			}
+			cachedLogin = login
+			reviewerLoginByProjectID[loop.ProjectID] = cachedLogin
 		}
-		cachedLogin := reviewerLoginByProjectID[loop.ProjectID]
-		if cachedLogin == nil {
-			continue
-		}
-		policy.currentLogin = *cachedLogin
+		policy.currentLogin = cachedLogin
 		if !shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, policy) {
 			continue
 		}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -101,8 +101,12 @@ type Runtime struct {
 	schedulerWake    chan struct{}
 	schedulerCancel  context.CancelFunc
 	schedulerTasks   *schedulerTaskTracker
+	recoveryCancel   context.CancelFunc
+	recoveryDone     chan struct{}
 	activeExecutions *ActiveExecutionRegistry
 }
+
+const reviewerRecoveryLoginTimeout = 3 * time.Second
 
 func New(options Options) *Runtime {
 	now := options.Now
@@ -188,6 +192,7 @@ func (r *Runtime) Stop(reason string) {
 			r.logger.Info("looperd runtime stopping", map[string]any{"reason": reason})
 		}
 
+		r.stopDeferredReviewerRecovery()
 		r.stopSchedulerLoop()
 
 		r.mu.Lock()
@@ -346,7 +351,7 @@ func (r *Runtime) start(ctx context.Context) error {
 	if err := r.syncConfiguredProjects(ctx, repositories, r.config, startedAt); err != nil {
 		return err
 	}
-	recoverySummary, err := r.runRecoveryPipeline(ctx, repositories, githubGateway, startedAt)
+	recoverySummary, err := r.runRecoveryPipeline(ctx, repositories, nil, startedAt)
 	if err != nil {
 		return err
 	}
@@ -386,6 +391,7 @@ func (r *Runtime) start(ctx context.Context) error {
 	if !schedulerDisabled {
 		r.startSchedulerLoop()
 	}
+	r.startDeferredReviewerRecovery(githubGateway)
 
 	started = true
 
@@ -489,6 +495,65 @@ func (r *Runtime) stopSchedulerLoop() {
 		r.schedulerTasks = nil
 	}
 	r.mu.Unlock()
+}
+
+func (r *Runtime) startDeferredReviewerRecovery(githubGateway *githubinfra.Gateway) {
+	if githubGateway == nil {
+		return
+	}
+	services := r.Services()
+	if services.Repositories == nil {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	r.mu.Lock()
+	r.recoveryCancel = cancel
+	r.recoveryDone = done
+	r.mu.Unlock()
+
+	go func(repositories *storage.Repositories) {
+		defer close(done)
+		requeued, err := r.runDeferredReviewerRecovery(ctx, repositories, githubGateway, r.now().UTC())
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			if r.logger != nil {
+				r.logger.Warn("looperd deferred reviewer recovery failed", map[string]any{"error": err.Error()})
+			}
+			return
+		}
+		if requeued > 0 && r.logger != nil {
+			r.logger.Info("looperd deferred reviewer recovery completed", map[string]any{"loopsRequeued": requeued})
+		}
+	}(services.Repositories)
+}
+
+func (r *Runtime) stopDeferredReviewerRecovery() {
+	r.mu.Lock()
+	cancel := r.recoveryCancel
+	done := r.recoveryDone
+	r.recoveryCancel = nil
+	r.recoveryDone = nil
+	r.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done == nil {
+		return
+	}
+	timer := time.NewTimer(r.shutdownTimeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		if r.logger != nil {
+			r.logger.Warn("looperd stop timed out waiting for deferred reviewer recovery", map[string]any{"timeoutMs": r.shutdownTimeout.Milliseconds()})
+		}
+	}
 }
 
 func (r *Runtime) TriggerSchedulerTick() {
@@ -716,10 +781,8 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 			stopOnReadyLabel:       r.config.Reviewer.Loop.StopOnReadyLabel,
 			maxConsecutiveFailures: int64(r.config.Reviewer.Loop.MaxConsecutiveFailures),
 		}
-		if canRefreshReviewerLoginForRecovery(loop, latestRun) {
-			if login, ok := r.currentReviewerLoginForRecovery(ctx, repositories, githubGateway, loop, latestRun, policy); ok {
-				policy.currentLogin = login
-			}
+		if reviewerRecoveryNeedsFreshLogin(loop, latestRun, policy) {
+			continue
 		}
 		if shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, policy) {
 			recoveredQueueItems, err := repositories.Queue.RequeueFailedByID(ctx, loop.ID, latestQueue.ID, nowISO)
@@ -881,6 +944,92 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 	summary.EventsWritten = eventsWritten
 
 	return summary, nil
+}
+
+func (r *Runtime) runDeferredReviewerRecovery(ctx context.Context, repositories *storage.Repositories, githubGateway *githubinfra.Gateway, now time.Time) (int64, error) {
+	if repositories == nil || githubGateway == nil {
+		return 0, nil
+	}
+	nowISO := formatJavaScriptISOString(now)
+	loops, err := repositories.Loops.List(ctx)
+	if err != nil {
+		return 0, err
+	}
+	reviewerLoginByProjectID := make(map[string]*string)
+	requeued := int64(0)
+	for _, loop := range loops {
+		if err := ctx.Err(); err != nil {
+			return requeued, err
+		}
+		latestRun, err := repositories.Runs.GetLatestByLoopID(ctx, loop.ID)
+		if err != nil {
+			return requeued, err
+		}
+		latestQueue, err := repositories.Queue.GetLatestByLoopID(ctx, loop.ID)
+		if err != nil {
+			return requeued, err
+		}
+		policy := runtimeReviewerRecoveryPolicy{
+			includeDrafts:          r.config.Roles.Reviewer.Triggers.IncludeDrafts,
+			stopOnApproved:         r.config.Reviewer.Loop.StopOnApproved,
+			stopOnReadyLabel:       r.config.Reviewer.Loop.StopOnReadyLabel,
+			maxConsecutiveFailures: int64(r.config.Reviewer.Loop.MaxConsecutiveFailures),
+		}
+		if !reviewerRecoveryNeedsFreshLogin(loop, latestRun, policy) {
+			continue
+		}
+		if _, cached := reviewerLoginByProjectID[loop.ProjectID]; !cached {
+			login, ok := r.currentReviewerLoginForRecovery(ctx, repositories, githubGateway, loop, latestRun, policy)
+			if ok {
+				reviewerLoginByProjectID[loop.ProjectID] = stringPtr(login)
+			} else {
+				reviewerLoginByProjectID[loop.ProjectID] = nil
+			}
+		}
+		cachedLogin := reviewerLoginByProjectID[loop.ProjectID]
+		if cachedLogin == nil {
+			continue
+		}
+		policy.currentLogin = *cachedLogin
+		if !shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, policy) {
+			continue
+		}
+		recoveredQueueItems, err := repositories.Queue.RequeueFailedByID(ctx, loop.ID, latestQueue.ID, nowISO)
+		if err != nil {
+			return requeued, err
+		}
+		if recoveredQueueItems == 0 {
+			active, activeErr := repositories.Queue.FindActiveByLoopID(ctx, loop.ID)
+			if activeErr != nil {
+				return requeued, activeErr
+			}
+			if active == nil {
+				return requeued, fmt.Errorf("reviewer deferred recovery did not requeue failed queue item %s for loop %s", latestQueue.ID, loop.ID)
+			}
+		}
+		requeuedLoop := autoRecoveredReviewerLoop(loop, nowISO)
+		if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
+			return requeued, err
+		}
+		requeued += 1
+		if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
+			ID:         newRuntimeEventID(),
+			EventType:  "looperd.recovery.reviewer_auto_recovered",
+			LoopID:     stringPtr(loop.ID),
+			EntityType: stringPtr("loop"),
+			EntityID:   stringPtr(loop.ID),
+			PayloadJSON: mustMarshalJSON(map[string]any{
+				"previousStatus":      loop.Status,
+				"nextRunAt":           nowISO,
+				"recoveredQueueItems": recoveredQueueItems,
+				"deferred":            true,
+			}),
+			CreatedAt: nowISO,
+		}); err != nil {
+			return requeued, err
+		}
+	}
+	return requeued, nil
 }
 
 func (r *Runtime) appendStartedEvent(ctx context.Context, startedAt time.Time) error {
@@ -1373,7 +1522,9 @@ func (r *Runtime) currentReviewerLoginForRecovery(ctx context.Context, repositor
 	if project == nil || strings.TrimSpace(project.RepoPath) == "" {
 		return "", false
 	}
-	login, err := githubGateway.GetCurrentUserLogin(ctx, project.RepoPath)
+	loginCtx, cancel := context.WithTimeout(ctx, reviewerRecoveryLoginTimeout)
+	defer cancel()
+	login, err := githubGateway.GetCurrentUserLogin(loginCtx, project.RepoPath)
 	if err != nil {
 		if r.logger != nil {
 			r.logger.Warn("failed to refresh reviewer login during recovery", map[string]any{"loopId": loop.ID, "projectId": loop.ProjectID, "error": err.Error()})
@@ -1389,6 +1540,14 @@ func (r *Runtime) currentReviewerLoginForRecovery(ctx context.Context, repositor
 
 func canRefreshReviewerLoginForRecovery(loop storage.LoopRecord, latestRun *storage.RunRecord) bool {
 	return loop.Type == string(domain.LoopTypeReviewer) && loop.Status == "failed" && latestRun != nil && latestRun.Status == "failed"
+}
+
+func reviewerRecoveryNeedsFreshLogin(loop storage.LoopRecord, latestRun *storage.RunRecord, policy runtimeReviewerRecoveryPolicy) bool {
+	if !canRefreshReviewerLoginForRecovery(loop, latestRun) || !policy.stopOnApproved || latestRun == nil {
+		return false
+	}
+	checkpoint := parseRuntimeReviewerCheckpoint(latestRun.CheckpointJSON)
+	return checkpoint.Detail != nil && len(checkpoint.Detail.Reviews) > 0
 }
 
 func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *storage.RunRecord, latestQueue *storage.QueueItemRecord, policy runtimeReviewerRecoveryPolicy) bool {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -991,6 +991,13 @@ func (r *Runtime) runDeferredReviewerRecovery(ctx context.Context, repositories 
 		if !shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, policy) {
 			continue
 		}
+		currentLoop, err := repositories.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return requeued, err
+		}
+		if currentLoop == nil || !shouldAutoRecoverFailedReviewerLoop(*currentLoop, latestRun, latestQueue, policy) {
+			continue
+		}
 		recoveredQueueItems, err := repositories.Queue.RequeueFailedByID(ctx, loop.ID, latestQueue.ID, nowISO)
 		if err != nil {
 			return requeued, err
@@ -1004,7 +1011,7 @@ func (r *Runtime) runDeferredReviewerRecovery(ctx context.Context, repositories 
 				return requeued, fmt.Errorf("reviewer deferred recovery did not requeue failed queue item %s for loop %s", latestQueue.ID, loop.ID)
 			}
 		}
-		requeuedLoop := autoRecoveredReviewerLoop(loop, nowISO)
+		requeuedLoop := autoRecoveredReviewerLoop(*currentLoop, nowISO)
 		if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
 			return requeued, err
 		}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -13,6 +14,8 @@ import (
 	"time"
 
 	"github.com/powerformer/looper/internal/config"
+	githubinfra "github.com/powerformer/looper/internal/infra/github"
+	"github.com/powerformer/looper/internal/infra/shell"
 	"github.com/powerformer/looper/internal/storage"
 )
 
@@ -1884,6 +1887,114 @@ func TestCanRefreshReviewerLoginForRecovery(t *testing.T) {
 	}
 }
 
+func TestRunRecoveryPipelineDefersReviewerLoginRefresh(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	coordinator := openMigratedCoordinator(t, cfg.Storage.DBPath, filepath.Join(workingDir, "backups"))
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+
+	projectOneRepoPath := filepath.Join(workingDir, "repo-one")
+	projectTwoRepoPath := filepath.Join(workingDir, "repo-two")
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper One", RepoPath: projectOneRepoPath, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(project_1) error = %v", err)
+	}
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_2", Name: "Looper Two", RepoPath: projectTwoRepoPath, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(project_2) error = %v", err)
+	}
+
+	seedFailedReviewerRecoveryLoop(t, repositories, "project_1", "loop_project1_a", 1, nowISO)
+	seedFailedReviewerRecoveryLoop(t, repositories, "project_1", "loop_project1_b", 2, nowISO)
+	seedFailedReviewerRecoveryLoop(t, repositories, "project_2", "loop_project2_a", 3, nowISO)
+
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
+		t.Fatal("startup recovery should not call gh api user")
+		return shell.Result{}, nil
+	}})
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+
+	summary, err := rt.runRecoveryPipeline(context.Background(), repositories, githubGateway, now)
+	if err != nil {
+		t.Fatalf("runRecoveryPipeline() error = %v", err)
+	}
+	if summary.LoopsRequeued != 0 {
+		t.Fatalf("LoopsRequeued = %d, want 0 for reviewer loops needing fresh login", summary.LoopsRequeued)
+	}
+	assertLoopStatus(t, repositories, "loop_project1_a", "failed")
+	assertLoopStatus(t, repositories, "loop_project1_b", "failed")
+	assertLoopStatus(t, repositories, "loop_project2_a", "failed")
+}
+
+func TestDeferredReviewerRecoveryRefreshesLoginAtMostOncePerProject(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	coordinator := openMigratedCoordinator(t, cfg.Storage.DBPath, filepath.Join(workingDir, "backups"))
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+
+	projectOneRepoPath := filepath.Join(workingDir, "repo-one")
+	projectTwoRepoPath := filepath.Join(workingDir, "repo-two")
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper One", RepoPath: projectOneRepoPath, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(project_1) error = %v", err)
+	}
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_2", Name: "Looper Two", RepoPath: projectTwoRepoPath, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(project_2) error = %v", err)
+	}
+
+	seedFailedReviewerRecoveryLoop(t, repositories, "project_1", "loop_project1_a", 1, nowISO)
+	seedFailedReviewerRecoveryLoop(t, repositories, "project_1", "loop_project1_b", 2, nowISO)
+	seedFailedReviewerRecoveryLoop(t, repositories, "project_2", "loop_project2_a", 3, nowISO)
+
+	var mu sync.Mutex
+	loginCallsByCWD := map[string]int{}
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
+		mu.Lock()
+		loginCallsByCWD[options.CWD]++
+		mu.Unlock()
+		return shell.Result{Stdout: "other\n"}, nil
+	}})
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+
+	requeued, err := rt.runDeferredReviewerRecovery(context.Background(), repositories, githubGateway, now)
+	if err != nil {
+		t.Fatalf("runDeferredReviewerRecovery() error = %v", err)
+	}
+	if requeued != 3 {
+		t.Fatalf("runDeferredReviewerRecovery() = %d, want 3", requeued)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := loginCallsByCWD[projectOneRepoPath]; got != 1 {
+		t.Fatalf("GetCurrentUserLogin() calls for %q = %d, want 1", projectOneRepoPath, got)
+	}
+	if got := loginCallsByCWD[projectTwoRepoPath]; got != 1 {
+		t.Fatalf("GetCurrentUserLogin() calls for %q = %d, want 1", projectTwoRepoPath, got)
+	}
+	if len(loginCallsByCWD) != 2 {
+		t.Fatalf("GetCurrentUserLogin() call map = %#v, want exactly two project repo paths", loginCallsByCWD)
+	}
+	assertLoopStatus(t, repositories, "loop_project1_a", "queued")
+	assertLoopStatus(t, repositories, "loop_project1_b", "queued")
+	assertLoopStatus(t, repositories, "loop_project2_a", "queued")
+}
+
 func TestShouldAutoRecoverFailedReviewerLoopUsesRefreshedCurrentLogin(t *testing.T) {
 	t.Parallel()
 	errorKind := "retryable_after_resume"
@@ -2090,6 +2201,34 @@ func seedLoopWithRun(t *testing.T, repos *storage.Repositories, projectID, loopI
 	}); err != nil {
 		t.Fatalf("Runs.Upsert(%s) error = %v", loopID, err)
 	}
+}
+
+func seedFailedReviewerRecoveryLoop(t *testing.T, repos *storage.Repositories, projectID, loopID string, seq int64, nowISO string) {
+	t.Helper()
+
+	repo := "acme/looper"
+	prNumber := int64(42 + seq)
+	targetID := "pr:acme/looper:" + mustFormatInt64(prNumber)
+	metadata := mustMarshalJSON(map[string]any{"loop": map[string]any{"enabled": true, "failureCount": 1, "consecutiveFailures": 1, "lastFailure": "PR head changed before publish"}})
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: seq, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert(%s) error = %v", loopID, err)
+	}
+	step := "publish"
+	errorMessage := "PR head changed before publish: expected old, got new"
+	checkpoint := `{"resumePolicy":"restart_from_discover","detail":{"state":"OPEN","reviewDecision":"APPROVED","headSha":"abc123","currentLogin":"octocat","reviews":[{"author":{"login":"octocat"},"state":"APPROVED","commit":{"oid":"abc123"}}],"labels":[]}}`
+	runID := "run_" + loopID
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: runID, LoopID: loopID, Status: "failed", CurrentStep: &step, CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert(%s) error = %v", runID, err)
+	}
+	queueKind := "retryable_after_resume"
+	queueID := "queue_" + loopID
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:" + projectID + ":" + loopID + ":acme/looper:" + mustFormatInt64(prNumber), Priority: storage.QueuePriorityReviewer, Status: "failed", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, FinishedAt: &nowISO, LastError: &errorMessage, LastErrorKind: &queueKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert(%s) error = %v", queueID, err)
+	}
+}
+
+func mustFormatInt64(value int64) string {
+	return strconv.FormatInt(value, 10)
 }
 
 func assertLoopStatus(t *testing.T, repos *storage.Repositories, loopID, want string) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2057,6 +2057,56 @@ func TestDeferredReviewerRecoveryDoesNotCacheFailedLoginRefresh(t *testing.T) {
 	}
 }
 
+func TestDeferredReviewerRecoverySkipsLoopChangedAfterListing(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	coordinator := openMigratedCoordinator(t, cfg.Storage.DBPath, filepath.Join(workingDir, "backups"))
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+
+	projectRepoPath := filepath.Join(workingDir, "repo-one")
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper One", RepoPath: projectRepoPath, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(project_1) error = %v", err)
+	}
+
+	loopID := "loop_project1_a"
+	seedFailedReviewerRecoveryLoop(t, repositories, "project_1", loopID, 1, nowISO)
+
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
+		loop, err := repositories.Loops.GetByID(ctx, loopID)
+		if err != nil {
+			return shell.Result{}, err
+		}
+		if loop == nil {
+			return shell.Result{}, errors.New("missing loop")
+		}
+		loop.Status = "paused"
+		loop.UpdatedAt = nowISO
+		if err := repositories.Loops.Upsert(ctx, *loop); err != nil {
+			return shell.Result{}, err
+		}
+		return shell.Result{Stdout: "other\n"}, nil
+	}})
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+
+	requeued, err := rt.runDeferredReviewerRecovery(context.Background(), repositories, githubGateway, now)
+	if err != nil {
+		t.Fatalf("runDeferredReviewerRecovery() error = %v", err)
+	}
+	if requeued != 0 {
+		t.Fatalf("runDeferredReviewerRecovery() = %d, want 0", requeued)
+	}
+	assertLoopStatus(t, repositories, loopID, "paused")
+}
+
 func TestShouldAutoRecoverFailedReviewerLoopUsesRefreshedCurrentLogin(t *testing.T) {
 	t.Parallel()
 	errorKind := "retryable_after_resume"

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1995,6 +1995,68 @@ func TestDeferredReviewerRecoveryRefreshesLoginAtMostOncePerProject(t *testing.T
 	assertLoopStatus(t, repositories, "loop_project2_a", "queued")
 }
 
+func TestDeferredReviewerRecoveryDoesNotCacheFailedLoginRefresh(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	coordinator := openMigratedCoordinator(t, cfg.Storage.DBPath, filepath.Join(workingDir, "backups"))
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+
+	projectRepoPath := filepath.Join(workingDir, "repo-one")
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper One", RepoPath: projectRepoPath, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(project_1) error = %v", err)
+	}
+
+	seedFailedReviewerRecoveryLoop(t, repositories, "project_1", "loop_project1_a", 1, nowISO)
+	seedFailedReviewerRecoveryLoop(t, repositories, "project_1", "loop_project1_b", 2, nowISO)
+
+	loginCalls := 0
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
+		loginCalls++
+		if loginCalls == 1 {
+			return shell.Result{}, errors.New("transient gh timeout")
+		}
+		return shell.Result{Stdout: "other\n"}, nil
+	}})
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+
+	requeued, err := rt.runDeferredReviewerRecovery(context.Background(), repositories, githubGateway, now)
+	if err != nil {
+		t.Fatalf("runDeferredReviewerRecovery() error = %v", err)
+	}
+	if requeued != 1 {
+		t.Fatalf("runDeferredReviewerRecovery() = %d, want 1", requeued)
+	}
+	if loginCalls != 2 {
+		t.Fatalf("GetCurrentUserLogin() calls = %d, want retry after failed refresh", loginCalls)
+	}
+	projectLoops, err := repositories.Loops.List(context.Background())
+	if err != nil {
+		t.Fatalf("Loops.List() error = %v", err)
+	}
+	queued := 0
+	failed := 0
+	for _, loop := range projectLoops {
+		switch loop.Status {
+		case "queued":
+			queued++
+		case "failed":
+			failed++
+		}
+	}
+	if queued != 1 || failed != 1 {
+		t.Fatalf("loop statuses queued=%d failed=%d, want queued=1 failed=1", queued, failed)
+	}
+}
+
 func TestShouldAutoRecoverFailedReviewerLoopUsesRefreshedCurrentLogin(t *testing.T) {
 	t.Parallel()
 	errorKind := "retryable_after_resume"


### PR DESCRIPTION
## Summary
- Move GitHub identity refresh out of the synchronous daemon startup recovery path so API readiness is not blocked by `gh api user`.
- Run reviewer identity-based recovery asynchronously after startup with per-project login caching and a short timeout.
- Extend daemon start readiness timeout and test coverage for deferred recovery behavior.

## Tests
- go test ./...