### PR TITLE
feat: add progress-aware agent timeouts

### DIFF
--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -312,8 +312,10 @@ func (x *execution) run(ctx context.Context) {
 			waiting = false
 		case <-timeoutTimer:
 			timeoutTimer = nil
-			timedOut = true
-			timeoutType = "max_runtime"
+			if !timedOut {
+				timedOut = true
+				timeoutType = "max_runtime"
+			}
 			if killReason == "" {
 				killReason = fmt.Sprintf("agent max runtime timed out after %s", x.timeout)
 			}

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -56,18 +56,23 @@ type RunInput struct {
 }
 
 type Result struct {
-	Status           string
-	Summary          string
-	Stdout           string
-	Stderr           string
-	ParseStatus      string
-	CompletionSignal string
-	Artifacts        []string
-	ChangedFiles     []string
-	Commits          []string
-	Lifecycle        *lifecycle.State
-	HeartbeatCount   int64
-	PID              int
+	Status                       string
+	Summary                      string
+	Stdout                       string
+	Stderr                       string
+	ParseStatus                  string
+	CompletionSignal             string
+	Artifacts                    []string
+	ChangedFiles                 []string
+	Commits                      []string
+	Lifecycle                    *lifecycle.State
+	HeartbeatCount               int64
+	TimeoutType                  string
+	ConfiguredIdleTimeoutSeconds int64
+	ConfiguredMaxRuntimeSeconds  int64
+	ElapsedRuntimeSeconds        int64
+	LastProgressAt               string
+	PID                          int
 }
 
 type completionParse struct {
@@ -140,6 +145,7 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 		executor:           e,
 		input:              input,
 		executionID:        executionID,
+		startedAt:          startedAt,
 		command:            command,
 		args:               args,
 		startedAtISO:       startedAtISO,
@@ -178,6 +184,7 @@ type execution struct {
 	executor           *ConfiguredExecutor
 	input              RunInput
 	executionID        string
+	startedAt          time.Time
 	command            string
 	args               []string
 	startedAtISO       string
@@ -257,6 +264,7 @@ func (x *execution) run(ctx context.Context) {
 	var (
 		waitErr         error
 		timedOut        bool
+		timeoutType     string
 		killed          bool
 		killReason      string
 		graceKillTimer  <-chan time.Time
@@ -305,8 +313,9 @@ func (x *execution) run(ctx context.Context) {
 		case <-timeoutTimer:
 			timeoutTimer = nil
 			timedOut = true
+			timeoutType = "max_runtime"
 			if killReason == "" {
-				killReason = "agent timed out"
+				killReason = fmt.Sprintf("agent max runtime timed out after %s", x.timeout)
 			}
 			x.setStatus("timeout")
 			terminateSignal()
@@ -324,8 +333,9 @@ func (x *execution) run(ctx context.Context) {
 				continue
 			}
 			timedOut = true
+			timeoutType = "idle"
 			if killReason == "" {
-				killReason = fmt.Sprintf("agent heartbeat timed out after %s", x.heartbeatTimeout)
+				killReason = fmt.Sprintf("agent idle timed out after %s without observable progress", x.heartbeatTimeout)
 			}
 			x.setStatus("timeout")
 			terminateSignal()
@@ -376,33 +386,51 @@ func (x *execution) run(ctx context.Context) {
 		}
 	}
 	endedAtISO := eventlog.FormatJavaScriptISOString(x.executor.now().UTC())
+	lastProgressAt := x.lastProgressAtISO()
 	result := Result{
-		Status:           status,
-		Summary:          completion.Summary,
-		Stdout:           stdout,
-		Stderr:           stderr,
-		ParseStatus:      completion.ParseStatus,
-		CompletionSignal: completion.CompletionSignal,
-		Artifacts:        append([]string(nil), completion.Artifacts...),
-		ChangedFiles:     append([]string(nil), completion.ChangedFiles...),
-		Commits:          append([]string(nil), completion.Commits...),
-		Lifecycle:        completion.Lifecycle,
-		HeartbeatCount:   x.heartbeatCountValue(),
-		PID:              pidOrZero(x.process.Process),
+		Status:                       status,
+		Summary:                      completion.Summary,
+		Stdout:                       stdout,
+		Stderr:                       stderr,
+		ParseStatus:                  completion.ParseStatus,
+		CompletionSignal:             completion.CompletionSignal,
+		Artifacts:                    append([]string(nil), completion.Artifacts...),
+		ChangedFiles:                 append([]string(nil), completion.ChangedFiles...),
+		Commits:                      append([]string(nil), completion.Commits...),
+		Lifecycle:                    completion.Lifecycle,
+		HeartbeatCount:               x.heartbeatCountValue(),
+		TimeoutType:                  timeoutType,
+		ConfiguredIdleTimeoutSeconds: durationSeconds(x.heartbeatTimeout),
+		ConfiguredMaxRuntimeSeconds:  durationSeconds(x.timeout),
+		ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
+		LastProgressAt:               lastProgressAt,
+		PID:                          pidOrZero(x.process.Process),
 	}
 
 	x.persistFinal(status, result, errorMessage, endedAtISO)
 	eventType := "agent.completed"
 	if status == "timeout" {
-		eventType = "agent.timed_out"
+		switch timeoutType {
+		case "idle":
+			eventType = "agent.idle_timeout"
+		case "max_runtime":
+			eventType = "agent.max_runtime_timeout"
+		default:
+			eventType = "agent.timed_out"
+		}
 	} else if status == "killed" {
 		eventType = "agent.killed"
 	}
 	x.executor.appendLifecycleEvent(eventType, x.input, x.executionID, map[string]any{
-		"status":         status,
-		"parseStatus":    result.ParseStatus,
-		"heartbeatCount": result.HeartbeatCount,
-		"summary":        result.Summary,
+		"status":                       status,
+		"timeoutType":                  timeoutType,
+		"configuredIdleTimeoutSeconds": result.ConfiguredIdleTimeoutSeconds,
+		"configuredMaxRuntimeSeconds":  result.ConfiguredMaxRuntimeSeconds,
+		"elapsedRuntimeSeconds":        result.ElapsedRuntimeSeconds,
+		"lastProgressAt":               result.LastProgressAt,
+		"parseStatus":                  result.ParseStatus,
+		"heartbeatCount":               result.HeartbeatCount,
+		"summary":                      result.Summary,
 	}, endedAtISO)
 
 	x.doneCh <- execOutcome{result: result, err: nil}
@@ -455,7 +483,7 @@ func (x *execution) persistStatus(status string, heartbeatCount *int64, heartbea
 	if x.executor.repos == nil || x.executor.repos.AgentExecutions == nil {
 		return
 	}
-	metadata := mustJSON(map[string]any{"idempotencyKey": emptyToNil(x.input.IdempotencyKey), "metadata": x.input.Metadata})
+	metadata := mustJSON(x.executionMetadata(""))
 	commandJSON := mustJSON(map[string]any{"command": x.command, "args": x.args})
 	pid := int64(pidOrZero(x.process.Process))
 	record := storage.AgentExecutionRecord{
@@ -491,7 +519,7 @@ func (x *execution) persistFinal(status string, result Result, errorMessage, end
 		return
 	}
 	commandJSON := mustJSON(map[string]any{"command": x.command, "args": x.args})
-	metadata := mustJSON(map[string]any{"idempotencyKey": emptyToNil(x.input.IdempotencyKey), "metadata": x.input.Metadata})
+	metadata := mustJSON(x.executionMetadata(result.TimeoutType))
 	embeddedStdout := x.stdoutString()
 	embeddedStderr := x.stderrString()
 	if embeddedStderr == "" && result.Stderr != "" {
@@ -576,6 +604,44 @@ func (x *execution) heartbeatCountValue() int64 {
 	x.mu.Lock()
 	defer x.mu.Unlock()
 	return x.heartbeatCount
+}
+
+func (x *execution) lastProgressAtISO() string {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	return x.lastHeartbeatAtISO
+}
+
+func (x *execution) executionMetadata(timeoutType string) map[string]any {
+	metadata := map[string]any{
+		"idempotencyKey": emptyToNil(x.input.IdempotencyKey),
+		"metadata":       x.input.Metadata,
+		"timeoutPolicy": map[string]any{
+			"idleTimeoutSeconds": durationSeconds(x.heartbeatTimeout),
+			"maxRuntimeSeconds":  durationSeconds(x.timeout),
+		},
+	}
+	if timeoutType != "" {
+		metadata["timeout"] = map[string]any{
+			"type":                         timeoutType,
+			"configuredIdleTimeoutSeconds": durationSeconds(x.heartbeatTimeout),
+			"configuredMaxRuntimeSeconds":  durationSeconds(x.timeout),
+			"elapsedRuntimeSeconds":        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
+			"lastProgressAt":               x.lastProgressAtISO(),
+		}
+	}
+	return metadata
+}
+
+func durationSeconds(duration time.Duration) int64 {
+	if duration <= 0 {
+		return 0
+	}
+	seconds := int64(duration / time.Second)
+	if seconds == 0 {
+		return 1
+	}
+	return seconds
 }
 
 func (x *execution) resolveOutputLogs() (string, string) {

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -524,7 +524,9 @@ func TestExecutorKillTerminatesChildProcessGroup(t *testing.T) {
 func TestExecutorHeartbeatTimeoutMarksTimeout(t *testing.T) {
 	t.Parallel()
 
-	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", "printf 'beat\n'; sleep 1"}}}})
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", "printf 'beat\n'; sleep 1"}}}, Repos: repos})
 
 	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_heartbeat_timeout", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: time.Second, HeartbeatTimeout: 50 * time.Millisecond, GracefulShutdown: 10 * time.Millisecond})
 	if err != nil {
@@ -537,6 +539,47 @@ func TestExecutorHeartbeatTimeoutMarksTimeout(t *testing.T) {
 	}
 	if result.Status != "timeout" {
 		t.Fatalf("result.Status = %q, want timeout", result.Status)
+	}
+	if result.TimeoutType != "idle" || result.ConfiguredIdleTimeoutSeconds != 1 || result.ConfiguredMaxRuntimeSeconds != 1 || result.LastProgressAt == "" {
+		t.Fatalf("timeout diagnostics = %#v, want idle metadata", result)
+	}
+	events, err := repos.Events.ListByEntity(context.Background(), "agent_execution", "agent_heartbeat_timeout")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	if !containsEvent(events, "agent.idle_timeout") {
+		t.Fatalf("agent events = %#v, want idle timeout event", events)
+	}
+}
+
+func TestExecutorMaxRuntimeTimeoutIgnoresProgressResets(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", "while true; do printf 'beat\n'; sleep 0.02; done"}}}, Repos: repos})
+
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_max_runtime_timeout", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: 80 * time.Millisecond, HeartbeatTimeout: time.Second, GracefulShutdown: 10 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "timeout" || result.TimeoutType != "max_runtime" {
+		t.Fatalf("result = %#v, want max runtime timeout", result)
+	}
+	if result.HeartbeatCount < 2 {
+		t.Fatalf("HeartbeatCount = %d, want progress before max runtime timeout", result.HeartbeatCount)
+	}
+	events, err := repos.Events.ListByEntity(context.Background(), "agent_execution", "agent_max_runtime_timeout")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	if !containsEvent(events, "agent.max_runtime_timeout") {
+		t.Fatalf("agent events = %#v, want max runtime timeout event", events)
 	}
 }
 

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -552,6 +552,28 @@ func TestExecutorHeartbeatTimeoutMarksTimeout(t *testing.T) {
 	}
 }
 
+func TestExecutorHeartbeatTimeoutPreservesOriginalTimeoutTypeDuringGracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", `printf 'beat\n'; trap '' TERM; while true; do sleep 0.05; done`}}}})
+
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_heartbeat_timeout_grace", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: 120 * time.Millisecond, HeartbeatTimeout: 50 * time.Millisecond, GracefulShutdown: 200 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "timeout" {
+		t.Fatalf("result.Status = %q, want timeout", result.Status)
+	}
+	if result.TimeoutType != "idle" {
+		t.Fatalf("result.TimeoutType = %q, want idle preserved after max runtime fires", result.TimeoutType)
+	}
+}
+
 func TestExecutorMaxRuntimeTimeoutIgnoresProgressResets(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -178,10 +178,18 @@
             "env": {},
             "params": {},
             "timeouts": {
-              "fixerSeconds": 1800,
+              "fixerIdleTimeoutSeconds": 600,
+              "fixerMaxRuntimeSeconds": 3600,
+              "fixerSeconds": 3600,
+              "plannerIdleTimeoutSeconds": 600,
+              "plannerMaxRuntimeSeconds": 1800,
               "plannerSeconds": 1800,
-              "reviewerSeconds": 1800,
-              "workerSeconds": 3600
+              "reviewerIdleTimeoutSeconds": 600,
+              "reviewerMaxRuntimeSeconds": 3600,
+              "reviewerSeconds": 3600,
+              "workerIdleTimeoutSeconds": 900,
+              "workerMaxRuntimeSeconds": 5400,
+              "workerSeconds": 5400
             },
             "vendor": "opencode"
           },

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,7 +59,7 @@ func TestRoleDefaultsMirrorCurrentDiscoveryPolicy(t *testing.T) {
 		t.Fatalf("Normalize() error = %v", err)
 	}
 
-	if got := cfg.Agent.Timeouts; got.PlannerSeconds != 1800 || got.WorkerSeconds != 3600 || got.ReviewerSeconds != 1800 || got.FixerSeconds != 1800 {
+	if got := cfg.Agent.Timeouts; got.PlannerSeconds != 1800 || got.WorkerSeconds != 5400 || got.ReviewerSeconds != 3600 || got.FixerSeconds != 3600 || got.PlannerIdleTimeoutSeconds != 600 || got.WorkerIdleTimeoutSeconds != 900 || got.ReviewerIdleTimeoutSeconds != 600 || got.FixerIdleTimeoutSeconds != 600 {
 		t.Fatalf("agent timeout defaults = %#v", got)
 	}
 
@@ -101,7 +101,7 @@ func TestAgentTimeoutConfigOverrides(t *testing.T) {
 	}
 
 	got := loaded.Config.Agent.Timeouts
-	if got.PlannerSeconds != 1200 || got.WorkerSeconds != 4200 || got.ReviewerSeconds != 2100 || got.FixerSeconds != 1800 {
+	if got.PlannerSeconds != 1200 || got.PlannerMaxRuntimeSeconds != 1200 || got.WorkerSeconds != 4200 || got.WorkerMaxRuntimeSeconds != 4200 || got.ReviewerSeconds != 2100 || got.ReviewerMaxRuntimeSeconds != 2100 || got.FixerSeconds != 1800 || got.FixerMaxRuntimeSeconds != 1800 {
 		t.Fatalf("agent timeouts = %#v", got)
 	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -75,9 +75,18 @@ func DefaultConfig(cwd string) (Config, error) {
 			Env:    map[string]string{},
 			Timeouts: AgentTimeoutConfig{
 				PlannerSeconds:  30 * 60,
-				WorkerSeconds:   60 * 60,
-				ReviewerSeconds: 30 * 60,
-				FixerSeconds:    30 * 60,
+				WorkerSeconds:   90 * 60,
+				ReviewerSeconds: 60 * 60,
+				FixerSeconds:    60 * 60,
+
+				PlannerIdleTimeoutSeconds:  10 * 60,
+				PlannerMaxRuntimeSeconds:   30 * 60,
+				WorkerIdleTimeoutSeconds:   15 * 60,
+				WorkerMaxRuntimeSeconds:    90 * 60,
+				ReviewerIdleTimeoutSeconds: 10 * 60,
+				ReviewerMaxRuntimeSeconds:  60 * 60,
+				FixerIdleTimeoutSeconds:    10 * 60,
+				FixerMaxRuntimeSeconds:     60 * 60,
 			},
 		},
 		Logging: LoggingConfig{

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -676,6 +676,30 @@ func applyAgentTimeoutEnvOverrides(overrides *PartialConfig, lookupEnv EnvLookup
 	if err := integerEnv("LOOPER_AGENT_TIMEOUTS_FIXER_SECONDS", func(v *int) { ensureAgentTimeoutConfig(overrides).FixerSeconds = v }); err != nil {
 		return err
 	}
+	if err := integerEnv("LOOPER_AGENT_TIMEOUTS_PLANNER_IDLE_TIMEOUT_SECONDS", func(v *int) { ensureAgentTimeoutConfig(overrides).PlannerIdleTimeoutSeconds = v }); err != nil {
+		return err
+	}
+	if err := integerEnv("LOOPER_AGENT_TIMEOUTS_PLANNER_MAX_RUNTIME_SECONDS", func(v *int) { ensureAgentTimeoutConfig(overrides).PlannerMaxRuntimeSeconds = v }); err != nil {
+		return err
+	}
+	if err := integerEnv("LOOPER_AGENT_TIMEOUTS_WORKER_IDLE_TIMEOUT_SECONDS", func(v *int) { ensureAgentTimeoutConfig(overrides).WorkerIdleTimeoutSeconds = v }); err != nil {
+		return err
+	}
+	if err := integerEnv("LOOPER_AGENT_TIMEOUTS_WORKER_MAX_RUNTIME_SECONDS", func(v *int) { ensureAgentTimeoutConfig(overrides).WorkerMaxRuntimeSeconds = v }); err != nil {
+		return err
+	}
+	if err := integerEnv("LOOPER_AGENT_TIMEOUTS_REVIEWER_IDLE_TIMEOUT_SECONDS", func(v *int) { ensureAgentTimeoutConfig(overrides).ReviewerIdleTimeoutSeconds = v }); err != nil {
+		return err
+	}
+	if err := integerEnv("LOOPER_AGENT_TIMEOUTS_REVIEWER_MAX_RUNTIME_SECONDS", func(v *int) { ensureAgentTimeoutConfig(overrides).ReviewerMaxRuntimeSeconds = v }); err != nil {
+		return err
+	}
+	if err := integerEnv("LOOPER_AGENT_TIMEOUTS_FIXER_IDLE_TIMEOUT_SECONDS", func(v *int) { ensureAgentTimeoutConfig(overrides).FixerIdleTimeoutSeconds = v }); err != nil {
+		return err
+	}
+	if err := integerEnv("LOOPER_AGENT_TIMEOUTS_FIXER_MAX_RUNTIME_SECONDS", func(v *int) { ensureAgentTimeoutConfig(overrides).FixerMaxRuntimeSeconds = v }); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -175,15 +175,47 @@ func mergeAgentConfig(config *AgentConfig, partial PartialAgentConfig) {
 func mergeAgentTimeoutConfig(config *AgentTimeoutConfig, partial PartialAgentTimeoutConfig) {
 	if partial.PlannerSeconds != nil {
 		config.PlannerSeconds = *partial.PlannerSeconds
+		config.PlannerMaxRuntimeSeconds = *partial.PlannerSeconds
 	}
 	if partial.WorkerSeconds != nil {
 		config.WorkerSeconds = *partial.WorkerSeconds
+		config.WorkerMaxRuntimeSeconds = *partial.WorkerSeconds
 	}
 	if partial.ReviewerSeconds != nil {
 		config.ReviewerSeconds = *partial.ReviewerSeconds
+		config.ReviewerMaxRuntimeSeconds = *partial.ReviewerSeconds
 	}
 	if partial.FixerSeconds != nil {
 		config.FixerSeconds = *partial.FixerSeconds
+		config.FixerMaxRuntimeSeconds = *partial.FixerSeconds
+	}
+	if partial.PlannerIdleTimeoutSeconds != nil {
+		config.PlannerIdleTimeoutSeconds = *partial.PlannerIdleTimeoutSeconds
+	}
+	if partial.PlannerMaxRuntimeSeconds != nil {
+		config.PlannerMaxRuntimeSeconds = *partial.PlannerMaxRuntimeSeconds
+		config.PlannerSeconds = *partial.PlannerMaxRuntimeSeconds
+	}
+	if partial.WorkerIdleTimeoutSeconds != nil {
+		config.WorkerIdleTimeoutSeconds = *partial.WorkerIdleTimeoutSeconds
+	}
+	if partial.WorkerMaxRuntimeSeconds != nil {
+		config.WorkerMaxRuntimeSeconds = *partial.WorkerMaxRuntimeSeconds
+		config.WorkerSeconds = *partial.WorkerMaxRuntimeSeconds
+	}
+	if partial.ReviewerIdleTimeoutSeconds != nil {
+		config.ReviewerIdleTimeoutSeconds = *partial.ReviewerIdleTimeoutSeconds
+	}
+	if partial.ReviewerMaxRuntimeSeconds != nil {
+		config.ReviewerMaxRuntimeSeconds = *partial.ReviewerMaxRuntimeSeconds
+		config.ReviewerSeconds = *partial.ReviewerMaxRuntimeSeconds
+	}
+	if partial.FixerIdleTimeoutSeconds != nil {
+		config.FixerIdleTimeoutSeconds = *partial.FixerIdleTimeoutSeconds
+	}
+	if partial.FixerMaxRuntimeSeconds != nil {
+		config.FixerMaxRuntimeSeconds = *partial.FixerMaxRuntimeSeconds
+		config.FixerSeconds = *partial.FixerMaxRuntimeSeconds
 	}
 }
 

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -106,8 +106,16 @@
         "timeouts": {
           "plannerSeconds": 1800,
           "workerSeconds": 2400,
-          "reviewerSeconds": 1800,
-          "fixerSeconds": 1800
+          "reviewerSeconds": 3600,
+          "fixerSeconds": 3600,
+          "plannerIdleTimeoutSeconds": 600,
+          "plannerMaxRuntimeSeconds": 1800,
+          "workerIdleTimeoutSeconds": 900,
+          "workerMaxRuntimeSeconds": 2400,
+          "reviewerIdleTimeoutSeconds": 600,
+          "reviewerMaxRuntimeSeconds": 3600,
+          "fixerIdleTimeoutSeconds": 600,
+          "fixerMaxRuntimeSeconds": 3600
         }
       },
       "logging": {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -40,9 +40,17 @@
         "env": {},
         "timeouts": {
           "plannerSeconds": 1800,
-          "workerSeconds": 3600,
-          "reviewerSeconds": 1800,
-          "fixerSeconds": 1800
+          "workerSeconds": 5400,
+          "reviewerSeconds": 3600,
+          "fixerSeconds": 3600,
+          "plannerIdleTimeoutSeconds": 600,
+          "plannerMaxRuntimeSeconds": 1800,
+          "workerIdleTimeoutSeconds": 900,
+          "workerMaxRuntimeSeconds": 5400,
+          "reviewerIdleTimeoutSeconds": 600,
+          "reviewerMaxRuntimeSeconds": 3600,
+          "fixerIdleTimeoutSeconds": 600,
+          "fixerMaxRuntimeSeconds": 3600
         }
       },
       "logging": {

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -124,9 +124,17 @@
         },
         "timeouts": {
           "plannerSeconds": 1800,
-          "workerSeconds": 3600,
+          "workerSeconds": 5400,
           "reviewerSeconds": 2700,
-          "fixerSeconds": 1800
+          "fixerSeconds": 3600,
+          "plannerIdleTimeoutSeconds": 600,
+          "plannerMaxRuntimeSeconds": 1800,
+          "workerIdleTimeoutSeconds": 900,
+          "workerMaxRuntimeSeconds": 5400,
+          "reviewerIdleTimeoutSeconds": 600,
+          "reviewerMaxRuntimeSeconds": 2700,
+          "fixerIdleTimeoutSeconds": 600,
+          "fixerMaxRuntimeSeconds": 3600
         }
       },
       "logging": {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -146,6 +146,15 @@ type AgentTimeoutConfig struct {
 	WorkerSeconds   int `json:"workerSeconds"`
 	ReviewerSeconds int `json:"reviewerSeconds"`
 	FixerSeconds    int `json:"fixerSeconds"`
+
+	PlannerIdleTimeoutSeconds  int `json:"plannerIdleTimeoutSeconds"`
+	PlannerMaxRuntimeSeconds   int `json:"plannerMaxRuntimeSeconds"`
+	WorkerIdleTimeoutSeconds   int `json:"workerIdleTimeoutSeconds"`
+	WorkerMaxRuntimeSeconds    int `json:"workerMaxRuntimeSeconds"`
+	ReviewerIdleTimeoutSeconds int `json:"reviewerIdleTimeoutSeconds"`
+	ReviewerMaxRuntimeSeconds  int `json:"reviewerMaxRuntimeSeconds"`
+	FixerIdleTimeoutSeconds    int `json:"fixerIdleTimeoutSeconds"`
+	FixerMaxRuntimeSeconds     int `json:"fixerMaxRuntimeSeconds"`
 }
 
 type NotificationConfig struct {
@@ -395,6 +404,15 @@ type PartialAgentTimeoutConfig struct {
 	WorkerSeconds   *int `json:"workerSeconds,omitempty"`
 	ReviewerSeconds *int `json:"reviewerSeconds,omitempty"`
 	FixerSeconds    *int `json:"fixerSeconds,omitempty"`
+
+	PlannerIdleTimeoutSeconds  *int `json:"plannerIdleTimeoutSeconds,omitempty"`
+	PlannerMaxRuntimeSeconds   *int `json:"plannerMaxRuntimeSeconds,omitempty"`
+	WorkerIdleTimeoutSeconds   *int `json:"workerIdleTimeoutSeconds,omitempty"`
+	WorkerMaxRuntimeSeconds    *int `json:"workerMaxRuntimeSeconds,omitempty"`
+	ReviewerIdleTimeoutSeconds *int `json:"reviewerIdleTimeoutSeconds,omitempty"`
+	ReviewerMaxRuntimeSeconds  *int `json:"reviewerMaxRuntimeSeconds,omitempty"`
+	FixerIdleTimeoutSeconds    *int `json:"fixerIdleTimeoutSeconds,omitempty"`
+	FixerMaxRuntimeSeconds     *int `json:"fixerMaxRuntimeSeconds,omitempty"`
 }
 
 type PartialNotificationConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -275,6 +275,14 @@ func validateAgentTimeouts(timeouts AgentTimeoutConfig, path string, issues *[]V
 	validateAgentTimeoutSeconds(timeouts.WorkerSeconds, path+".workerSeconds", issues)
 	validateAgentTimeoutSeconds(timeouts.ReviewerSeconds, path+".reviewerSeconds", issues)
 	validateAgentTimeoutSeconds(timeouts.FixerSeconds, path+".fixerSeconds", issues)
+	validateAgentTimeoutSeconds(timeouts.PlannerIdleTimeoutSeconds, path+".plannerIdleTimeoutSeconds", issues)
+	validateAgentTimeoutSeconds(timeouts.PlannerMaxRuntimeSeconds, path+".plannerMaxRuntimeSeconds", issues)
+	validateAgentTimeoutSeconds(timeouts.WorkerIdleTimeoutSeconds, path+".workerIdleTimeoutSeconds", issues)
+	validateAgentTimeoutSeconds(timeouts.WorkerMaxRuntimeSeconds, path+".workerMaxRuntimeSeconds", issues)
+	validateAgentTimeoutSeconds(timeouts.ReviewerIdleTimeoutSeconds, path+".reviewerIdleTimeoutSeconds", issues)
+	validateAgentTimeoutSeconds(timeouts.ReviewerMaxRuntimeSeconds, path+".reviewerMaxRuntimeSeconds", issues)
+	validateAgentTimeoutSeconds(timeouts.FixerIdleTimeoutSeconds, path+".fixerIdleTimeoutSeconds", issues)
+	validateAgentTimeoutSeconds(timeouts.FixerMaxRuntimeSeconds, path+".fixerMaxRuntimeSeconds", issues)
 }
 
 func validateAgentTimeoutSeconds(seconds int, path string, issues *[]ValidationIssue) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1169,6 +1169,9 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	if !strings.EqualFold(result.Status, "completed") {
 		checkpoint.Repair = checkpointRepairFromAgentResult(executionID, detailHeadSHA(checkpoint.Detail), result, r.nowISO())
 		checkpoint.ResumePolicy = "retry_from_timeout_context"
+		if err := r.persistCheckpoint(ctx, input.Run.ID, stepRepair, checkpoint); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
 		message := firstNonEmpty(result.Summary, result.Stderr, "Fixer agent "+result.Status)
 		kind := FailureRetryableTransient
 		if agent.IsAgentSetupFailureMessage(message) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -219,17 +219,23 @@ type AgentRunInput struct {
 	Prompt           string
 	WorkingDirectory string
 	Timeout          time.Duration
+	HeartbeatTimeout time.Duration
 	Metadata         map[string]any
 	IdempotencyKey   string
 }
 
 type AgentResult struct {
-	Status      string
-	Summary     string
-	Stdout      string
-	Stderr      string
-	ParseStatus string
-	Lifecycle   *lifecycle.State
+	Status                       string
+	Summary                      string
+	Stdout                       string
+	Stderr                       string
+	ParseStatus                  string
+	Lifecycle                    *lifecycle.State
+	TimeoutType                  string
+	ConfiguredIdleTimeoutSeconds int64
+	ConfiguredMaxRuntimeSeconds  int64
+	ElapsedRuntimeSeconds        int64
+	LastProgressAt               string
 }
 
 type AgentExecution interface {
@@ -274,6 +280,7 @@ type Options struct {
 	Logger                  bootstrap.Logger
 	Now                     func() time.Time
 	AgentTimeout            time.Duration
+	AgentIdleTimeout        time.Duration
 	ClaimTTL                time.Duration
 	ValidationCommands      []string
 	ValidationRunner        ValidationRunner
@@ -309,6 +316,7 @@ type Runner struct {
 	logger                  bootstrap.Logger
 	now                     func() time.Time
 	agentTimeout            time.Duration
+	agentIdleTimeout        time.Duration
 	claimTTL                time.Duration
 	validationCommands      []string
 	validationRunner        ValidationRunner
@@ -391,12 +399,18 @@ type checkpointWorktree struct {
 }
 
 type checkpointRepair struct {
-	AgentExecutionID string           `json:"agentExecutionId,omitempty"`
-	Summary          string           `json:"summary,omitempty"`
-	HeadSHA          string           `json:"headSha,omitempty"`
-	ParseStatus      string           `json:"parseStatus,omitempty"`
-	Lifecycle        *lifecycle.State `json:"gitPrLifecycle,omitempty"`
-	CompletedAt      string           `json:"completedAt,omitempty"`
+	AgentExecutionID             string           `json:"agentExecutionId,omitempty"`
+	Summary                      string           `json:"summary,omitempty"`
+	HeadSHA                      string           `json:"headSha,omitempty"`
+	ParseStatus                  string           `json:"parseStatus,omitempty"`
+	Lifecycle                    *lifecycle.State `json:"gitPrLifecycle,omitempty"`
+	CompletedAt                  string           `json:"completedAt,omitempty"`
+	Status                       string           `json:"status,omitempty"`
+	TimeoutType                  string           `json:"timeoutType,omitempty"`
+	ConfiguredIdleTimeoutSeconds int64            `json:"configuredIdleTimeoutSeconds,omitempty"`
+	ConfiguredMaxRuntimeSeconds  int64            `json:"configuredMaxRuntimeSeconds,omitempty"`
+	ElapsedRuntimeSeconds        int64            `json:"elapsedRuntimeSeconds,omitempty"`
+	LastProgressAt               string           `json:"lastProgressAt,omitempty"`
 }
 
 type checkpointReconcileCommits struct {
@@ -456,6 +470,8 @@ type loopError struct {
 	kind    QueueFailureKind
 }
 
+func (e *loopError) Error() string { return e.message }
+
 func validateCompletedRepairCheckpoint(repair *checkpointRepair) error {
 	if repair == nil {
 		return nil
@@ -469,7 +485,9 @@ func validateCompletedRepairCheckpoint(repair *checkpointRepair) error {
 	}
 }
 
-func (e *loopError) Error() string { return e.message }
+func checkpointRepairFromAgentResult(executionID, headSHA string, result AgentResult, nowISO string) *checkpointRepair {
+	return &checkpointRepair{AgentExecutionID: executionID, Status: result.Status, Summary: result.Summary, HeadSHA: headSHA, ParseStatus: result.ParseStatus, Lifecycle: result.Lifecycle, CompletedAt: nowISO, TimeoutType: result.TimeoutType, ConfiguredIdleTimeoutSeconds: result.ConfiguredIdleTimeoutSeconds, ConfiguredMaxRuntimeSeconds: result.ConfiguredMaxRuntimeSeconds, ElapsedRuntimeSeconds: result.ElapsedRuntimeSeconds, LastProgressAt: result.LastProgressAt}
+}
 
 func New(options Options) *Runner {
 	now := options.Now
@@ -479,6 +497,10 @@ func New(options Options) *Runner {
 	agentTimeout := options.AgentTimeout
 	if agentTimeout <= 0 {
 		agentTimeout = defaultAgentTimeout
+	}
+	agentIdleTimeout := options.AgentIdleTimeout
+	if agentIdleTimeout <= 0 {
+		agentIdleTimeout = 10 * time.Minute
 	}
 	claimTTL := options.ClaimTTL
 	if claimTTL <= 0 {
@@ -516,6 +538,7 @@ func New(options Options) *Runner {
 		logger:                  options.Logger,
 		now:                     now,
 		agentTimeout:            agentTimeout,
+		agentIdleTimeout:        agentIdleTimeout,
 		claimTTL:                claimTTL,
 		validationCommands:      append([]string(nil), options.ValidationCommands...),
 		validationRunner:        options.ValidationRunner,
@@ -1130,7 +1153,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 		metadata[key] = value
 	}
-	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, Metadata: metadata, IdempotencyKey: fmt.Sprintf("fixer:%s:%s:%s", input.Loop.ID, firstNonEmpty(checkpoint.FixItemsHash, "unknown"), firstNonEmpty(detailHeadSHA(checkpoint.Detail), "unknown"))})
+	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: metadata, IdempotencyKey: fmt.Sprintf("fixer:%s:%s:%s", input.Loop.ID, firstNonEmpty(checkpoint.FixItemsHash, "unknown"), firstNonEmpty(detailHeadSHA(checkpoint.Detail), "unknown"))})
 	if err != nil {
 		return checkpoint, err
 	}
@@ -1144,6 +1167,8 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		return checkpoint, err
 	}
 	if !strings.EqualFold(result.Status, "completed") {
+		checkpoint.Repair = checkpointRepairFromAgentResult(executionID, detailHeadSHA(checkpoint.Detail), result, r.nowISO())
+		checkpoint.ResumePolicy = "retry_from_timeout_context"
 		message := firstNonEmpty(result.Summary, result.Stderr, "Fixer agent "+result.Status)
 		kind := FailureRetryableTransient
 		if agent.IsAgentSetupFailureMessage(message) {
@@ -1154,7 +1179,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	if err := validateCompletedRepairCheckpoint(&checkpointRepair{Summary: result.Summary, ParseStatus: result.ParseStatus}); err != nil {
 		return checkpoint, err
 	}
-	checkpoint.Repair = &checkpointRepair{AgentExecutionID: executionID, Summary: result.Summary, HeadSHA: detailHeadSHA(checkpoint.Detail), ParseStatus: result.ParseStatus, Lifecycle: result.Lifecycle, CompletedAt: r.nowISO()}
+	checkpoint.Repair = checkpointRepairFromAgentResult(executionID, detailHeadSHA(checkpoint.Detail), result, r.nowISO())
 	checkpoint.ensureLifecycle("fixer", worktree.Branch, detailBaseRefName(checkpoint.Detail), false)
 	if result.Lifecycle != nil {
 		checkpoint.Lifecycle.MergeAgent(result.Lifecycle, r.nowISO())

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -549,6 +549,50 @@ func TestProcessClaimedItemFailsWhenRepairCompletionResultMissing(t *testing.T) 
 	}
 }
 
+func TestProcessClaimedItemPersistsCheckpointWhenRepairReturnsNonCompleted(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:  CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed", Summary: "upstream server_error"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient || !contains(result.Summary, "server_error") {
+		t.Fatalf("result = %#v, want retryable failed result with upstream error", result)
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	checkpoint := parseCheckpoint(run.CheckpointJSON)
+	if checkpoint.ResumePolicy != "retry_from_timeout_context" {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want retry_from_timeout_context", checkpoint.ResumePolicy)
+	}
+	if checkpoint.Repair == nil || checkpoint.Repair.Status != "failed" || checkpoint.Repair.Summary != "upstream server_error" {
+		t.Fatalf("checkpoint.Repair = %#v, want persisted repair checkpoint", checkpoint.Repair)
+	}
+}
+
 func TestProcessClaimedItemTreatsAgentSetupFailureAsManualIntervention(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -926,6 +926,9 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 		if !strings.EqualFold(result.Status, "completed") {
 			checkpoint.WriteSpec = checkpointWriteSpecFromAgentResult(result)
 			checkpoint.ResumePolicy = "retry_from_timeout_context"
+			if err := r.persistCheckpoint(ctx, input.Run.ID, stepWriteSpec, checkpoint); err != nil {
+				return checkpoint, wrapRetryableAfterResume(err)
+			}
 			message := firstNonEmpty(result.Summary, result.Stderr, "Planner agent "+result.Status)
 			kind := FailureRetryableTransient
 			if agent.IsAgentSetupFailureMessage(message) {

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -217,17 +217,23 @@ type AgentRunInput struct {
 	Prompt           string
 	WorkingDirectory string
 	Timeout          time.Duration
+	HeartbeatTimeout time.Duration
 	Metadata         map[string]any
 	IdempotencyKey   string
 }
 
 type AgentResult struct {
-	Status    string
-	Summary   string
-	Stdout    string
-	Stderr    string
-	Commits   []string
-	Lifecycle *lifecycle.State
+	Status                       string
+	Summary                      string
+	Stdout                       string
+	Stderr                       string
+	Commits                      []string
+	Lifecycle                    *lifecycle.State
+	TimeoutType                  string
+	ConfiguredIdleTimeoutSeconds int64
+	ConfiguredMaxRuntimeSeconds  int64
+	ElapsedRuntimeSeconds        int64
+	LastProgressAt               string
 }
 
 type AgentExecution interface {
@@ -259,6 +265,7 @@ type Options struct {
 	Logger                  bootstrap.Logger
 	Now                     func() time.Time
 	AgentTimeout            time.Duration
+	AgentIdleTimeout        time.Duration
 	ClaimTTL                time.Duration
 	AllowAutoPush           *bool
 	Disclosure              *config.DisclosureConfig
@@ -287,6 +294,7 @@ type Runner struct {
 	logger                  bootstrap.Logger
 	now                     func() time.Time
 	agentTimeout            time.Duration
+	agentIdleTimeout        time.Duration
 	claimTTL                time.Duration
 	allowAutoPush           bool
 	disclosure              config.DisclosureConfig
@@ -356,12 +364,17 @@ type checkpointWorktree struct {
 }
 
 type checkpointWriteSpec struct {
-	Status        string           `json:"status,omitempty"`
-	Summary       string           `json:"summary,omitempty"`
-	Stdout        string           `json:"stdout,omitempty"`
-	Commits       []string         `json:"commits,omitempty"`
-	Lifecycle     *lifecycle.State `json:"gitPrLifecycle,omitempty"`
-	GitReconciled bool             `json:"gitReconciled,omitempty"`
+	Status                       string           `json:"status,omitempty"`
+	Summary                      string           `json:"summary,omitempty"`
+	Stdout                       string           `json:"stdout,omitempty"`
+	Commits                      []string         `json:"commits,omitempty"`
+	Lifecycle                    *lifecycle.State `json:"gitPrLifecycle,omitempty"`
+	GitReconciled                bool             `json:"gitReconciled,omitempty"`
+	TimeoutType                  string           `json:"timeoutType,omitempty"`
+	ConfiguredIdleTimeoutSeconds int64            `json:"configuredIdleTimeoutSeconds,omitempty"`
+	ConfiguredMaxRuntimeSeconds  int64            `json:"configuredMaxRuntimeSeconds,omitempty"`
+	ElapsedRuntimeSeconds        int64            `json:"elapsedRuntimeSeconds,omitempty"`
+	LastProgressAt               string           `json:"lastProgressAt,omitempty"`
 }
 
 type checkpointPullRequest struct {
@@ -380,6 +393,10 @@ type checkpointPublishState struct {
 type checkpointNotify struct {
 	SentAt  string `json:"sentAt,omitempty"`
 	Message string `json:"message,omitempty"`
+}
+
+func checkpointWriteSpecFromAgentResult(result AgentResult) *checkpointWriteSpec {
+	return &checkpointWriteSpec{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Commits: append([]string(nil), result.Commits...), Lifecycle: result.Lifecycle, TimeoutType: result.TimeoutType, ConfiguredIdleTimeoutSeconds: result.ConfiguredIdleTimeoutSeconds, ConfiguredMaxRuntimeSeconds: result.ConfiguredMaxRuntimeSeconds, ElapsedRuntimeSeconds: result.ElapsedRuntimeSeconds, LastProgressAt: result.LastProgressAt}
 }
 
 type resumedRunContext struct {
@@ -415,6 +432,10 @@ func New(options Options) *Runner {
 	if agentTimeout <= 0 {
 		agentTimeout = defaultAgentTimeout
 	}
+	agentIdleTimeout := options.AgentIdleTimeout
+	if agentIdleTimeout <= 0 {
+		agentIdleTimeout = 10 * time.Minute
+	}
 	claimTTL := options.ClaimTTL
 	if claimTTL <= 0 {
 		claimTTL = defaultClaimTTL
@@ -439,7 +460,7 @@ func New(options Options) *Runner {
 	if policy.LabelMode == "" {
 		policy = DiscoveryPolicy{AutoDiscovery: true, Labels: []string{discoveryLabel}, LabelMode: config.LabelModeAll, RequireAssigneeCurrentUser: true}
 	}
-	return &Runner{db: options.DB, repos: options.Repos, github: options.GitHub, git: options.Git, agentExecutor: options.AgentExecutor, logger: options.Logger, now: now, agentTimeout: agentTimeout, claimTTL: claimTTL, allowAutoPush: allowAutoPush, disclosure: disclosureCfg, agentRuntime: strings.TrimSpace(options.AgentRuntime), customInstructions: customInstructionConfig(options.CustomInstructions), projectRoleConfig: options.CustomInstructions, agentModel: derefString(options.AgentModel), retryBaseDelay: retryBaseDelay, retryMaxAttempts: retryMax, onAgentExecutionStarted: options.OnAgentExecutionStarted, discoveryPolicy: policy}
+	return &Runner{db: options.DB, repos: options.Repos, github: options.GitHub, git: options.Git, agentExecutor: options.AgentExecutor, logger: options.Logger, now: now, agentTimeout: agentTimeout, agentIdleTimeout: agentIdleTimeout, claimTTL: claimTTL, allowAutoPush: allowAutoPush, disclosure: disclosureCfg, agentRuntime: strings.TrimSpace(options.AgentRuntime), customInstructions: customInstructionConfig(options.CustomInstructions), projectRoleConfig: options.CustomInstructions, agentModel: derefString(options.AgentModel), retryBaseDelay: retryBaseDelay, retryMaxAttempts: retryMax, onAgentExecutionStarted: options.OnAgentExecutionStarted, discoveryPolicy: policy}
 }
 
 func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
@@ -889,7 +910,7 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 		for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 			metadata[key] = value
 		}
-		execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, Metadata: metadata, IdempotencyKey: fmt.Sprintf("planner:%s", input.Loop.ID)})
+		execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: metadata, IdempotencyKey: fmt.Sprintf("planner:%s", input.Loop.ID)})
 		if err != nil {
 			return checkpoint, err
 		}
@@ -903,6 +924,8 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 			return checkpoint, err
 		}
 		if !strings.EqualFold(result.Status, "completed") {
+			checkpoint.WriteSpec = checkpointWriteSpecFromAgentResult(result)
+			checkpoint.ResumePolicy = "retry_from_timeout_context"
 			message := firstNonEmpty(result.Summary, result.Stderr, "Planner agent "+result.Status)
 			kind := FailureRetryableTransient
 			if agent.IsAgentSetupFailureMessage(message) {
@@ -910,7 +933,7 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 			}
 			return checkpoint, &loopError{message: message, kind: kind}
 		}
-		checkpoint.WriteSpec = &checkpointWriteSpec{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Commits: append([]string(nil), result.Commits...), Lifecycle: result.Lifecycle}
+		checkpoint.WriteSpec = checkpointWriteSpecFromAgentResult(result)
 		checkpoint.ensureLifecycle("planner", worktree.Branch, worktree.BaseBranch, true)
 		if result.Lifecycle != nil {
 			checkpoint.Lifecycle.MergeAgent(result.Lifecycle, r.nowISO())

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -655,6 +655,13 @@ func TestWriteSpecFailureMarksRunQueueLoop(t *testing.T) {
 	if run == nil || run.Status != "failed" || run.CurrentStep == nil || *run.CurrentStep != string(stepWriteSpec) {
 		t.Fatalf("run = %#v, want failed run on write-spec", run)
 	}
+	checkpoint := parseCheckpoint(run.CheckpointJSON)
+	if checkpoint.ResumePolicy != "retry_from_timeout_context" {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want retry_from_timeout_context", checkpoint.ResumePolicy)
+	}
+	if checkpoint.WriteSpec == nil || checkpoint.WriteSpec.Status != "failed" || checkpoint.WriteSpec.Summary != "agent failed" {
+		t.Fatalf("checkpoint.WriteSpec = %#v, want failed persisted write-spec checkpoint", checkpoint.WriteSpec)
+	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -287,16 +287,22 @@ type AgentRunInput struct {
 	Prompt           string
 	WorkingDirectory string
 	Timeout          time.Duration
+	HeartbeatTimeout time.Duration
 	Metadata         map[string]any
 	IdempotencyKey   string
 }
 
 type AgentResult struct {
-	Status      string
-	Summary     string
-	Stdout      string
-	Stderr      string
-	ParseStatus string
+	Status                       string
+	Summary                      string
+	Stdout                       string
+	Stderr                       string
+	ParseStatus                  string
+	TimeoutType                  string
+	ConfiguredIdleTimeoutSeconds int64
+	ConfiguredMaxRuntimeSeconds  int64
+	ElapsedRuntimeSeconds        int64
+	LastProgressAt               string
 }
 
 type AgentExecution interface {
@@ -328,6 +334,7 @@ type Options struct {
 	Logger                  bootstrap.Logger
 	Now                     func() time.Time
 	AgentTimeout            time.Duration
+	AgentIdleTimeout        time.Duration
 	ClaimTTL                time.Duration
 	AllowAutoApprove        bool
 	ReviewEvents            config.ReviewerReviewEventsConfig
@@ -365,6 +372,7 @@ type Runner struct {
 	logger                  bootstrap.Logger
 	now                     func() time.Time
 	agentTimeout            time.Duration
+	agentIdleTimeout        time.Duration
 	claimTTL                time.Duration
 	allowAutoApprove        bool
 	reviewEvents            config.ReviewerReviewEventsConfig
@@ -499,6 +507,10 @@ func New(options Options) *Runner {
 	if agentTimeout <= 0 {
 		agentTimeout = defaultAgentTimeout
 	}
+	agentIdleTimeout := options.AgentIdleTimeout
+	if agentIdleTimeout <= 0 {
+		agentIdleTimeout = 10 * time.Minute
+	}
 	claimTTL := options.ClaimTTL
 	if claimTTL <= 0 {
 		claimTTL = defaultClaimTTL
@@ -550,6 +562,7 @@ func New(options Options) *Runner {
 		logger:                  options.Logger,
 		now:                     now,
 		agentTimeout:            agentTimeout,
+		agentIdleTimeout:        agentIdleTimeout,
 		claimTTL:                claimTTL,
 		allowAutoApprove:        options.AllowAutoApprove,
 		reviewEvents:            reviewEvents,
@@ -1581,7 +1594,7 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 	}
 	slices.Sort(candidateIDs)
 	idempotencyKey := fmt.Sprintf("reviewer-thread-resolution:%s:%d:%s:%s", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, strings.Join(candidateIDs, ","))
-	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: buildThreadResolutionPrompt(input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, threads), WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, Metadata: map[string]any{"loopType": "reviewer", "phase": "thread_resolution", "repo": input.Repo, "prNumber": input.PRNumber}, IdempotencyKey: idempotencyKey})
+	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: buildThreadResolutionPrompt(input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, threads), WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: map[string]any{"loopType": "reviewer", "phase": "thread_resolution", "repo": input.Repo, "prNumber": input.PRNumber}, IdempotencyKey: idempotencyKey})
 	if err != nil {
 		return nil, err
 	}
@@ -1749,7 +1762,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 		metadata[key] = value
 	}
-	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, Metadata: metadata, IdempotencyKey: idempotencyKey})
+	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: metadata, IdempotencyKey: idempotencyKey})
 	if err != nil {
 		return checkpoint, err
 	}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -222,7 +222,7 @@ type plannerAgentExecutorAdapter struct{ executor *agent.ConfiguredExecutor }
 type plannerAgentExecutionAdapter struct{ execution agent.Execution }
 
 func (a plannerAgentExecutorAdapter) Start(ctx context.Context, input planner.AgentRunInput) (planner.AgentExecution, error) {
-	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
+	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func (a plannerAgentExecutionAdapter) Wait(ctx context.Context) (planner.AgentRe
 	if err != nil {
 		return planner.AgentResult{}, err
 	}
-	return planner.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, Commits: result.Commits, Lifecycle: result.Lifecycle}, nil
+	return planner.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, Commits: result.Commits, Lifecycle: result.Lifecycle, TimeoutType: result.TimeoutType, ConfiguredIdleTimeoutSeconds: result.ConfiguredIdleTimeoutSeconds, ConfiguredMaxRuntimeSeconds: result.ConfiguredMaxRuntimeSeconds, ElapsedRuntimeSeconds: result.ElapsedRuntimeSeconds, LastProgressAt: result.LastProgressAt}, nil
 }
 
 type reviewerGitHubAdapter struct {
@@ -349,7 +349,7 @@ func (a reviewerGitAdapter) CleanupWorktree(ctx context.Context, input reviewer.
 }
 
 func (a reviewerAgentExecutorAdapter) Start(ctx context.Context, input reviewer.AgentRunInput) (reviewer.AgentExecution, error) {
-	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
+	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +361,7 @@ func (a reviewerAgentExecutionAdapter) Wait(ctx context.Context) (reviewer.Agent
 	if err != nil {
 		return reviewer.AgentResult{}, err
 	}
-	return reviewer.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, ParseStatus: result.ParseStatus}, nil
+	return reviewer.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, ParseStatus: result.ParseStatus, TimeoutType: result.TimeoutType, ConfiguredIdleTimeoutSeconds: result.ConfiguredIdleTimeoutSeconds, ConfiguredMaxRuntimeSeconds: result.ConfiguredMaxRuntimeSeconds, ElapsedRuntimeSeconds: result.ElapsedRuntimeSeconds, LastProgressAt: result.LastProgressAt}, nil
 }
 
 type fixerGitHubAdapter struct{ gateway *githubinfra.Gateway }
@@ -456,7 +456,7 @@ type fixerAgentExecutorAdapter struct{ executor *agent.ConfiguredExecutor }
 type fixerAgentExecutionAdapter struct{ execution agent.Execution }
 
 func (a fixerAgentExecutorAdapter) Start(ctx context.Context, input fixer.AgentRunInput) (fixer.AgentExecution, error) {
-	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
+	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +468,7 @@ func (a fixerAgentExecutionAdapter) Wait(ctx context.Context) (fixer.AgentResult
 	if err != nil {
 		return fixer.AgentResult{}, err
 	}
-	return fixer.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, ParseStatus: result.ParseStatus, Lifecycle: result.Lifecycle}, nil
+	return fixer.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, ParseStatus: result.ParseStatus, Lifecycle: result.Lifecycle, TimeoutType: result.TimeoutType, ConfiguredIdleTimeoutSeconds: result.ConfiguredIdleTimeoutSeconds, ConfiguredMaxRuntimeSeconds: result.ConfiguredMaxRuntimeSeconds, ElapsedRuntimeSeconds: result.ElapsedRuntimeSeconds, LastProgressAt: result.LastProgressAt}, nil
 }
 
 type workerGitHubAdapter struct {
@@ -610,7 +610,7 @@ type workerAgentExecutionAdapter struct {
 }
 
 func (a workerAgentExecutorAdapter) Start(ctx context.Context, input worker.AgentRunInput) (worker.AgentExecution, error) {
-	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
+	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
 	if err != nil {
 		return nil, err
 	}
@@ -630,7 +630,7 @@ func (a workerAgentExecutionAdapter) Wait(ctx context.Context) (worker.AgentResu
 	if err != nil {
 		return worker.AgentResult{}, err
 	}
-	return worker.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, ParseStatus: result.ParseStatus, ChangedFiles: result.ChangedFiles, Commits: result.Commits, Lifecycle: result.Lifecycle}, nil
+	return worker.AgentResult{Status: result.Status, Summary: result.Summary, Stdout: result.Stdout, Stderr: result.Stderr, ParseStatus: result.ParseStatus, ChangedFiles: result.ChangedFiles, Commits: result.Commits, Lifecycle: result.Lifecycle, TimeoutType: result.TimeoutType, ConfiguredIdleTimeoutSeconds: result.ConfiguredIdleTimeoutSeconds, ConfiguredMaxRuntimeSeconds: result.ConfiguredMaxRuntimeSeconds, ElapsedRuntimeSeconds: result.ElapsedRuntimeSeconds, LastProgressAt: result.LastProgressAt}, nil
 }
 
 func (a workerAgentExecutionAdapter) Kill(reason string) error {
@@ -748,7 +748,8 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 		AgentRuntime:       agentRuntime,
 		CustomInstructions: &cfg,
 		AgentModel:         cfg.Agent.Model,
-		AgentTimeout:       time.Duration(cfg.Agent.Timeouts.PlannerSeconds) * time.Second,
+		AgentTimeout:       time.Duration(cfg.Agent.Timeouts.PlannerMaxRuntimeSeconds) * time.Second,
+		AgentIdleTimeout:   time.Duration(cfg.Agent.Timeouts.PlannerIdleTimeoutSeconds) * time.Second,
 		DiscoveryPolicy: planner.DiscoveryPolicy{
 			AutoDiscovery:              cfg.Roles.Planner.AutoDiscovery,
 			Labels:                     append([]string(nil), cfg.Roles.Planner.Triggers.Labels...),
@@ -789,7 +790,8 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 		CustomInstructions:      &cfg,
 		LooperCLIPath:           derefString(cfg.Tools.LooperPath),
 		AgentModel:              cfg.Agent.Model,
-		AgentTimeout:            time.Duration(cfg.Agent.Timeouts.ReviewerSeconds) * time.Second,
+		AgentTimeout:            time.Duration(cfg.Agent.Timeouts.ReviewerMaxRuntimeSeconds) * time.Second,
+		AgentIdleTimeout:        time.Duration(cfg.Agent.Timeouts.ReviewerIdleTimeoutSeconds) * time.Second,
 		RetryBaseDelay:          retryBaseDelay,
 		RetryMaxAttempts:        int64(cfg.Scheduler.RetryMaxAttempts),
 		OnAgentExecutionStarted: func(ctx context.Context, input reviewer.AgentExecutionStartedInput) error {
@@ -819,7 +821,8 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 		AgentRuntime:       agentRuntime,
 		CustomInstructions: &cfg,
 		AgentModel:         cfg.Agent.Model,
-		AgentTimeout:       time.Duration(cfg.Agent.Timeouts.FixerSeconds) * time.Second,
+		AgentTimeout:       time.Duration(cfg.Agent.Timeouts.FixerMaxRuntimeSeconds) * time.Second,
+		AgentIdleTimeout:   time.Duration(cfg.Agent.Timeouts.FixerIdleTimeoutSeconds) * time.Second,
 		RetryBaseDelay:     retryBaseDelay,
 		RetryMaxAttempts:   int64(cfg.Scheduler.RetryMaxAttempts),
 		OnAgentExecutionStarted: func(ctx context.Context, input fixer.AgentExecutionStartedInput) error {
@@ -850,7 +853,8 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 		AgentRuntime:       agentRuntime,
 		CustomInstructions: &cfg,
 		AgentModel:         cfg.Agent.Model,
-		AgentTimeout:       time.Duration(cfg.Agent.Timeouts.WorkerSeconds) * time.Second,
+		AgentTimeout:       time.Duration(cfg.Agent.Timeouts.WorkerMaxRuntimeSeconds) * time.Second,
+		AgentIdleTimeout:   time.Duration(cfg.Agent.Timeouts.WorkerIdleTimeoutSeconds) * time.Second,
 		RetryBaseDelay:     retryBaseDelay,
 		RetryMaxAttempts:   int64(cfg.Scheduler.RetryMaxAttempts),
 		OnRunCompleted: func(ctx context.Context, input worker.RunCompletedInput) error {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1183,6 +1183,9 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 		if result.Status != "completed" {
 			checkpoint.Execution = checkpointExecutionFromAgentResult(result)
 			checkpoint.ResumePolicy = "retry_from_timeout_context"
+			if err := r.persistCheckpoint(ctx, input.Run.ID, checkpoint); err != nil {
+				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+			}
 			message := firstNonEmpty(result.Summary, result.Stderr, fmt.Sprintf("Worker agent %s", result.Status))
 			kind := FailureRetryableTransient
 			if agent.IsAgentSetupFailureMessage(message) {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -280,19 +280,25 @@ type AgentRunInput struct {
 	Prompt           string
 	WorkingDirectory string
 	Timeout          time.Duration
+	HeartbeatTimeout time.Duration
 	Metadata         map[string]any
 	IdempotencyKey   string
 }
 
 type AgentResult struct {
-	Status       string
-	Summary      string
-	Stdout       string
-	Stderr       string
-	ParseStatus  string
-	ChangedFiles []string
-	Commits      []string
-	Lifecycle    *lifecycle.State
+	Status                       string
+	Summary                      string
+	Stdout                       string
+	Stderr                       string
+	ParseStatus                  string
+	ChangedFiles                 []string
+	Commits                      []string
+	Lifecycle                    *lifecycle.State
+	TimeoutType                  string
+	ConfiguredIdleTimeoutSeconds int64
+	ConfiguredMaxRuntimeSeconds  int64
+	ElapsedRuntimeSeconds        int64
+	LastProgressAt               string
 }
 
 type AgentExecution interface {
@@ -354,6 +360,7 @@ type Options struct {
 	Logger                          bootstrap.Logger
 	Now                             func() time.Time
 	AgentTimeout                    time.Duration
+	AgentIdleTimeout                time.Duration
 	ClaimTTL                        time.Duration
 	ValidationCommands              []string
 	ValidationRunner                ValidationRunner
@@ -387,6 +394,7 @@ type Runner struct {
 	logger                  bootstrap.Logger
 	now                     func() time.Time
 	agentTimeout            time.Duration
+	agentIdleTimeout        time.Duration
 	claimTTL                time.Duration
 	validationCommands      []string
 	validationRunner        ValidationRunner
@@ -484,14 +492,19 @@ type checkpointPlan struct {
 }
 
 type checkpointExecution struct {
-	Status        string           `json:"status,omitempty"`
-	Summary       string           `json:"summary,omitempty"`
-	ParseStatus   string           `json:"parseStatus,omitempty"`
-	ChangedFiles  []string         `json:"changedFiles,omitempty"`
-	Commits       []string         `json:"commits,omitempty"`
-	Lifecycle     *lifecycle.State `json:"gitPrLifecycle,omitempty"`
-	Stdout        string           `json:"stdout,omitempty"`
-	GitReconciled bool             `json:"gitReconciled,omitempty"`
+	Status                       string           `json:"status,omitempty"`
+	Summary                      string           `json:"summary,omitempty"`
+	ParseStatus                  string           `json:"parseStatus,omitempty"`
+	ChangedFiles                 []string         `json:"changedFiles,omitempty"`
+	Commits                      []string         `json:"commits,omitempty"`
+	Lifecycle                    *lifecycle.State `json:"gitPrLifecycle,omitempty"`
+	Stdout                       string           `json:"stdout,omitempty"`
+	GitReconciled                bool             `json:"gitReconciled,omitempty"`
+	TimeoutType                  string           `json:"timeoutType,omitempty"`
+	ConfiguredIdleTimeoutSeconds int64            `json:"configuredIdleTimeoutSeconds,omitempty"`
+	ConfiguredMaxRuntimeSeconds  int64            `json:"configuredMaxRuntimeSeconds,omitempty"`
+	ElapsedRuntimeSeconds        int64            `json:"elapsedRuntimeSeconds,omitempty"`
+	LastProgressAt               string           `json:"lastProgressAt,omitempty"`
 }
 
 type checkpointPullPR struct {
@@ -537,6 +550,15 @@ func validateCompletedExecutionCheckpoint(execution *checkpointExecution) error 
 	}
 }
 
+func checkpointExecutionFromAgentResult(result AgentResult) *checkpointExecution {
+	return &checkpointExecution{
+		Status: result.Status, Summary: result.Summary, ParseStatus: result.ParseStatus,
+		ChangedFiles: append([]string(nil), result.ChangedFiles...), Commits: append([]string(nil), result.Commits...), Lifecycle: result.Lifecycle, Stdout: result.Stdout,
+		TimeoutType: result.TimeoutType, ConfiguredIdleTimeoutSeconds: result.ConfiguredIdleTimeoutSeconds, ConfiguredMaxRuntimeSeconds: result.ConfiguredMaxRuntimeSeconds,
+		ElapsedRuntimeSeconds: result.ElapsedRuntimeSeconds, LastProgressAt: result.LastProgressAt,
+	}
+}
+
 func (e *loopError) Error() string { return e.message }
 
 func New(options Options) *Runner {
@@ -547,6 +569,10 @@ func New(options Options) *Runner {
 	agentTimeout := options.AgentTimeout
 	if agentTimeout <= 0 {
 		agentTimeout = defaultAgentTimeout
+	}
+	agentIdleTimeout := options.AgentIdleTimeout
+	if agentIdleTimeout <= 0 {
+		agentIdleTimeout = 15 * time.Minute
 	}
 	claimTTL := options.ClaimTTL
 	if claimTTL <= 0 {
@@ -585,6 +611,7 @@ func New(options Options) *Runner {
 		logger:                  options.Logger,
 		now:                     now,
 		agentTimeout:            agentTimeout,
+		agentIdleTimeout:        agentIdleTimeout,
 		claimTTL:                claimTTL,
 		validationCommands:      append([]string(nil), options.ValidationCommands...),
 		validationRunner:        options.ValidationRunner,
@@ -1142,7 +1169,7 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 		for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 			metadata[key] = value
 		}
-		execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, Metadata: metadata, IdempotencyKey: fmt.Sprintf("worker:%s", input.Loop.ID)})
+		execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: metadata, IdempotencyKey: fmt.Sprintf("worker:%s", input.Loop.ID)})
 		if err != nil {
 			return checkpoint, err
 		}
@@ -1154,6 +1181,8 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 			return checkpoint, err
 		}
 		if result.Status != "completed" {
+			checkpoint.Execution = checkpointExecutionFromAgentResult(result)
+			checkpoint.ResumePolicy = "retry_from_timeout_context"
 			message := firstNonEmpty(result.Summary, result.Stderr, fmt.Sprintf("Worker agent %s", result.Status))
 			kind := FailureRetryableTransient
 			if agent.IsAgentSetupFailureMessage(message) {
@@ -1164,7 +1193,7 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 		if err := validateCompletedExecutionCheckpoint(&checkpointExecution{Status: result.Status, Summary: result.Summary, ParseStatus: result.ParseStatus}); err != nil {
 			return checkpoint, err
 		}
-		checkpoint.Execution = &checkpointExecution{Status: result.Status, Summary: result.Summary, ParseStatus: result.ParseStatus, ChangedFiles: append([]string(nil), result.ChangedFiles...), Commits: append([]string(nil), result.Commits...), Lifecycle: result.Lifecycle, Stdout: result.Stdout}
+		checkpoint.Execution = checkpointExecutionFromAgentResult(result)
 		checkpoint.ensureLifecycle("worker", worktree.Branch, worktree.BaseBranch, work.ExecutionMode == "create-pr")
 		if result.Lifecycle != nil {
 			checkpoint.Lifecycle.MergeAgent(result.Lifecycle, r.nowISO())

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -415,6 +415,41 @@ func TestProcessClaimedItemFailsWhenAgentCompletionResultMissing(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemPersistsCheckpointWhenAgentReturnsNonCompleted(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed", Summary: "upstream server_error", Stdout: "server_error"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient || !strings.Contains(result.Summary, "server_error") {
+		t.Fatalf("result = %#v, want retryable failed result with upstream error", result)
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	checkpoint, err := parseCheckpoint(run.CheckpointJSON)
+	if err != nil {
+		t.Fatalf("parseCheckpoint() error = %v", err)
+	}
+	if checkpoint.ResumePolicy != "retry_from_timeout_context" {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want retry_from_timeout_context", checkpoint.ResumePolicy)
+	}
+	if checkpoint.Execution == nil || checkpoint.Execution.Status != "failed" || checkpoint.Execution.Summary != "upstream server_error" {
+		t.Fatalf("checkpoint.Execution = %#v, want persisted execution checkpoint", checkpoint.Execution)
+	}
+}
+
 func TestRunExecuteStepFailsResumedCompletedCheckpointWithoutParsedResult(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add per-role idle timeout and max runtime timeout configuration for planner, worker, reviewer, and fixer agents.
- Classify timeout outcomes as idle vs max-runtime with diagnostic event/metadata fields.
- Preserve timeout context in role checkpoints and cover idle/max-runtime behavior with tests.

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #190