### PR TITLE
feat: resume active issue work loops

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2524,6 +2524,7 @@ type workerCreateResponse struct {
 	SpecPath    *string `json:"specPath"`
 	BaseBranch  string  `json:"baseBranch"`
 	IssueNumber *int64  `json:"issueNumber,omitempty"`
+	Reused      bool    `json:"reused,omitempty"`
 }
 
 type plannerCreateResponse struct {
@@ -2755,6 +2756,10 @@ func (h *Handler) buildWorkersCreateResponse(r *http.Request) (workerCreateRespo
 	if baseBranch == nil {
 		return workerCreateResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "baseBranch is required"}
 	}
+	requestedIssueTarget := (*domain.LoopTarget)(nil)
+	if issueNumber != nil {
+		requestedIssueTarget = &domain.LoopTarget{TargetType: domain.LoopTargetTypeIssue, Repo: *repo, IssueNumber: *issueNumber}
+	}
 
 	effectivePRNumber := (*int64)(nil)
 	if prNumber != nil {
@@ -2829,20 +2834,34 @@ func (h *Handler) buildWorkersCreateResponse(r *http.Request) (workerCreateRespo
 		return workerCreateResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
 	metadataJSON := string(payloadJSONBytes)
+	reusedWorkerLoop := false
 
 	record, err := storage.WithTransactionValue(r.Context(), services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
 		repos := storage.NewRepositories(tx)
-		seq, seqErr := repos.Loops.AllocateSeq(r.Context())
-		if seqErr != nil {
-			return storage.LoopRecord{}, seqErr
-		}
 
 		existing, listErr := repos.Loops.List(r.Context())
 		if listErr != nil {
 			return storage.LoopRecord{}, listErr
 		}
+		if issueNumber != nil {
+			if existingLoop, existingTarget, ok, reuseErr := reusableWorkerLoopForIssueRequestCompat(existing, projectID, *requestedIssueTarget, target); reuseErr != nil {
+				return storage.LoopRecord{}, reuseErr
+			} else if ok {
+				reusedWorkerLoop = true
+				resumed, resumeErr := h.resumeReusableWorkerLoopCompat(r.Context(), repos, existingLoop, existingTarget, nowISO)
+				if resumeErr != nil {
+					return storage.LoopRecord{}, resumeErr
+				}
+				return resumed, nil
+			}
+		}
 		if uniqueErr := assertUniqueActiveLoopCompat(existing, "", projectID, domain.LoopTypeWorker, target, domain.LoopStatusQueued); uniqueErr != nil {
 			return storage.LoopRecord{}, uniqueErr
+		}
+
+		seq, seqErr := repos.Loops.AllocateSeq(r.Context())
+		if seqErr != nil {
+			return storage.LoopRecord{}, seqErr
 		}
 
 		record := storage.LoopRecord{
@@ -2910,7 +2929,13 @@ func (h *Handler) buildWorkersCreateResponse(r *http.Request) (workerCreateRespo
 		return workerCreateResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
 	if h.context.TriggerSchedulerTick != nil {
-		h.context.TriggerSchedulerTick()
+		if !reusedWorkerLoop || record.Status == string(domain.LoopStatusQueued) {
+			h.context.TriggerSchedulerTick()
+		}
+	}
+
+	if reusedWorkerLoop {
+		title, prompt, effectiveSpecPath, baseBranch, issueNumber = reusedWorkerResponseFields(record, title, prompt, effectiveSpecPath, baseBranch, issueNumber)
 	}
 
 	response := workerCreateResponse{
@@ -2918,11 +2943,135 @@ func (h *Handler) buildWorkersCreateResponse(r *http.Request) (workerCreateRespo
 		Title:        title,
 		Prompt:       prompt,
 		SpecPath:     effectiveSpecPath,
-		BaseBranch:   *baseBranch,
+		BaseBranch:   derefString(baseBranch),
 		IssueNumber:  issueNumber,
+		Reused:       reusedWorkerLoop,
 	}
 
 	return response, nil
+}
+
+func reusableWorkerLoopForIssueRequestCompat(existing []storage.LoopRecord, projectID string, issueTarget, effectiveTarget domain.LoopTarget) (storage.LoopRecord, domain.LoopTarget, bool, error) {
+	for _, loop := range existing {
+		if loop.ProjectID != projectID || loop.Type != string(domain.LoopTypeWorker) {
+			continue
+		}
+		status := domain.LoopStatus(loop.Status)
+		if !domain.IsConflictingActiveLoopStatus(status) {
+			continue
+		}
+		loopTarget, err := loopTargetFromRecordCompat(loop)
+		if err != nil {
+			return storage.LoopRecord{}, domain.LoopTarget{}, false, err
+		}
+		key := loopTargetKeyFromRecordCompat(loop)
+		if key != loopTargetKeyCompat(issueTarget) && key != loopTargetKeyCompat(effectiveTarget) {
+			continue
+		}
+		return loop, loopTarget, true, nil
+	}
+
+	return storage.LoopRecord{}, domain.LoopTarget{}, false, nil
+}
+
+func (h *Handler) resumeReusableWorkerLoopCompat(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, target domain.LoopTarget, nowISO string) (storage.LoopRecord, error) {
+	status := domain.LoopStatus(loop.Status)
+	shouldQueue := status == domain.LoopStatusIdle || status == domain.LoopStatusPaused || status == domain.LoopStatusQueued
+	if status == domain.LoopStatusIdle || status == domain.LoopStatusPaused {
+		if err := domain.AssertLoopStatusTransition(status, domain.LoopStatusQueued); err != nil {
+			return storage.LoopRecord{}, err
+		}
+		loop.Status = string(domain.LoopStatusQueued)
+		loop.NextRunAt = &nowISO
+		loop.UpdatedAt = nowISO
+		if err := repos.Loops.Upsert(ctx, loop); err != nil {
+			return storage.LoopRecord{}, err
+		}
+	}
+
+	if shouldQueue {
+		requeued, err := repos.Queue.RequeueLatestCancelledByLoop(ctx, loop.ID, nowISO)
+		if err != nil {
+			return storage.LoopRecord{}, err
+		}
+		if requeued == 0 {
+			activeQueue, findErr := repos.Queue.FindActiveByLoopID(ctx, loop.ID)
+			if findErr != nil {
+				return storage.LoopRecord{}, findErr
+			}
+			if activeQueue == nil {
+				latestQueue, latestErr := repos.Queue.GetLatestByLoopID(ctx, loop.ID)
+				if latestErr != nil {
+					return storage.LoopRecord{}, latestErr
+				}
+				if latestQueue != nil {
+					if latestQueue.DedupeKey != "" {
+						activeDedupe, dedupeErr := repos.Queue.FindActiveByDedupe(ctx, latestQueue.DedupeKey)
+						if dedupeErr != nil {
+							return storage.LoopRecord{}, dedupeErr
+						}
+						if activeDedupe != nil {
+							return loop, nil
+						}
+					}
+					replacement := *latestQueue
+					replacement.ID = generateRequestID()
+					replacement.Status = "queued"
+					replacement.AvailableAt = nowISO
+					replacement.Attempts = 0
+					replacement.ClaimedBy = nil
+					replacement.ClaimedAt = nil
+					replacement.StartedAt = nil
+					replacement.FinishedAt = nil
+					replacement.LastError = nil
+					replacement.LastErrorKind = nil
+					replacement.CreatedAt = nowISO
+					replacement.UpdatedAt = nowISO
+					if err := repos.Queue.Upsert(ctx, replacement); err != nil {
+						return storage.LoopRecord{}, err
+					}
+				} else {
+					queueRecord, ok, queueErr := buildQueuedLoopQueueRecordCompat(loop, target, nowISO, loop.MetadataJSON, int64(h.context.Config.Scheduler.RetryMaxAttempts))
+					if queueErr != nil {
+						return storage.LoopRecord{}, queueErr
+					}
+					if ok {
+						if upsertQueueErr := repos.Queue.Upsert(ctx, queueRecord); upsertQueueErr != nil {
+							return storage.LoopRecord{}, upsertQueueErr
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return loop, nil
+}
+
+func reusedWorkerResponseFields(loop storage.LoopRecord, fallbackTitle string, fallbackPrompt, fallbackSpecPath, fallbackBaseBranch *string, fallbackIssueNumber *int64) (string, *string, *string, *string, *int64) {
+	metadata := parseJSONObject(loop.MetadataJSON)
+	worker, _ := metadata["worker"].(map[string]any)
+	title := fallbackTitle
+	if value := readStringAny(worker["title"]); value != nil {
+		title = *value
+	}
+	prompt := fallbackPrompt
+	if value := readStringAny(worker["prompt"]); value != nil {
+		prompt = value
+	}
+	specPath := fallbackSpecPath
+	if value := readStringAny(worker["specPath"]); value != nil {
+		specPath = value
+	}
+	baseBranch := fallbackBaseBranch
+	if value := readStringAny(worker["baseBranch"]); value != nil {
+		baseBranch = value
+	}
+	issueNumber := fallbackIssueNumber
+	if value := int64MetadataPtr(worker, "issueNumber"); value != nil {
+		issueNumber = value
+	}
+	return title, prompt, specPath, baseBranch, issueNumber
 }
 
 func (h *Handler) buildPlannersCreateResponse(r *http.Request) (plannerCreateResponse, error) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2895,22 +2895,117 @@ func TestHandlerWorkersCreateAllowsConcurrentProjectWorkers(t *testing.T) {
 	}
 }
 
-func TestHandlerWorkersCreateRejectsDuplicateIssueWorkers(t *testing.T) {
+func TestHandlerWorkersCreateReusesDuplicateIssueWorkers(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		status     string
+		wantStatus string
+	}{
+		{name: "queued", status: "queued", wantStatus: "queued"},
+		{name: "running", status: "running", wantStatus: "running"},
+		{name: "paused", status: "paused", wantStatus: "queued"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newTestFixture(t)
+			seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)
+			nowISO := fixture.now.UTC().Format(javaScriptISOString)
+			metadataJSON := `{"worker":{"title":"Existing issue worker","repo":"acme/looper","baseBranch":"main","issueNumber":77}}`
+
+			if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+				ID:           "loop_existing_issue_worker",
+				Seq:          1,
+				ProjectID:    "project_1",
+				Type:         "worker",
+				TargetType:   "issue",
+				TargetID:     stringPtr("issue:acme/looper:77"),
+				Repo:         stringPtr("acme/looper"),
+				Status:       tt.status,
+				MetadataJSON: &metadataJSON,
+				CreatedAt:    nowISO,
+				UpdatedAt:    nowISO,
+			}); err != nil {
+				t.Fatalf("Loops.Upsert(loop_existing_issue_worker) error = %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/workers", bytes.NewReader([]byte(`{"projectId":"project_1","repo":"acme/looper","issueNumber":77,"baseBranch":"main"}`)))
+			req.Header.Set("x-request-id", "fixture-request-id")
+			req.Header.Set("content-type", "application/json")
+			recorder := httptest.NewRecorder()
+
+			NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
+
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+			}
+			body := parseJSONMap(t, recorder.Body.Bytes())
+			data := body["data"].(map[string]any)
+			assertEqual(t, data["id"], "loop_existing_issue_worker")
+			assertEqual(t, data["title"], "Existing issue worker")
+			assertEqual(t, data["status"], tt.wantStatus)
+			assertEqual(t, data["reused"], true)
+
+			loops, err := fixture.runtime.Services().Repositories.Loops.List(context.Background())
+			if err != nil {
+				t.Fatalf("Loops.List() error = %v", err)
+			}
+			matching := 0
+			for _, loop := range loops {
+				if loop.Type == "worker" && loop.TargetType == "issue" && derefString(loop.TargetID) == "issue:acme/looper:77" {
+					matching++
+				}
+			}
+			assertEqual(t, matching, 1)
+
+			if tt.wantStatus == "queued" {
+				queueItem, err := fixture.runtime.Services().Repositories.Queue.FindActiveByDedupe(context.Background(), "worker:project_1:acme/looper:77")
+				if err != nil {
+					t.Fatalf("Queue.FindActiveByDedupe() error = %v", err)
+				}
+				if queueItem == nil || queueItem.LoopID == nil || *queueItem.LoopID != "loop_existing_issue_worker" {
+					t.Fatalf("active queue item = %#v, want existing issue worker queued", queueItem)
+				}
+			}
+		})
+	}
+}
+
+func TestHandlerWorkersCreateReusesIssueWorkerBeforePlannerPRTarget(t *testing.T) {
 	fixture := newTestFixture(t)
 	seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	issueTargetID := "issue:acme/looper:77"
+	prNumber := int64(42)
+	plannerMetadata := `{"prNumber":42,"specPath":"specs/planner.md"}`
+	workerMetadata := `{"worker":{"title":"Existing issue worker","repo":"acme/looper","baseBranch":"main","issueNumber":77}}`
 
 	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
-		ID:         "loop_existing_issue_worker",
-		Seq:        1,
-		ProjectID:  "project_1",
-		Type:       "worker",
-		TargetType: "issue",
-		TargetID:   stringPtr("issue:acme/looper:77"),
-		Repo:       stringPtr("acme/looper"),
-		Status:     "queued",
-		CreatedAt:  nowISO,
-		UpdatedAt:  nowISO,
+		ID:           "loop_planner_pr_target",
+		Seq:          1,
+		ProjectID:    "project_1",
+		Type:         "planner",
+		TargetType:   "issue",
+		TargetID:     &issueTargetID,
+		Repo:         stringPtr("acme/looper"),
+		PRNumber:     &prNumber,
+		Status:       "running",
+		MetadataJSON: &plannerMetadata,
+		CreatedAt:    nowISO,
+		UpdatedAt:    nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_planner_pr_target) error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:           "loop_existing_issue_worker",
+		Seq:          2,
+		ProjectID:    "project_1",
+		Type:         "worker",
+		TargetType:   "issue",
+		TargetID:     &issueTargetID,
+		Repo:         stringPtr("acme/looper"),
+		Status:       "queued",
+		MetadataJSON: &workerMetadata,
+		CreatedAt:    nowISO,
+		UpdatedAt:    nowISO,
 	}); err != nil {
 		t.Fatalf("Loops.Upsert(loop_existing_issue_worker) error = %v", err)
 	}
@@ -2922,12 +3017,14 @@ func TestHandlerWorkersCreateRejectsDuplicateIssueWorkers(t *testing.T) {
 
 	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
 
-	if recorder.Code != http.StatusConflict {
-		t.Fatalf("status = %d, want 409", recorder.Code)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
 	}
 	body := parseJSONMap(t, recorder.Body.Bytes())
-	apiErr := body["error"].(map[string]any)
-	assertEqual(t, apiErr["code"], "LOOP_CONFLICT")
+	data := body["data"].(map[string]any)
+	assertEqual(t, data["id"], "loop_existing_issue_worker")
+	assertEqual(t, data["targetType"], "issue")
+	assertEqual(t, data["reused"], true)
 }
 
 func TestHandlerWorkersCreateTriggersSchedulerTickHook(t *testing.T) {

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -2057,6 +2057,39 @@ func TestWorkCreateIssueRequiresExplicitProjectWhenCurrentProjectIsAmbiguous(t *
 	}
 }
 
+func TestWorkCreateIssuePrintsReusedWorkerMessage(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workers":
+			if got, want := r.Method, http.MethodPost; got != want {
+				t.Fatalf("request method = %q, want %q", got, want)
+			}
+			writeEnvelope(t, w, pkgapi.Success("req_worker", map[string]any{"id": "loop_existing", "projectId": "project_1", "repo": "acme/looper", "status": "queued", "issueNumber": 54, "title": "Implement issue #54", "baseBranch": "main", "reused": true}))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr})
+
+	exitCode := app.Run(context.Background(), []string{"work", "--issue", "54", "--project", "project_1", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([work --issue 54]) exit code = %d, want 0", exitCode)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("Run([work --issue 54]) stderr = %q, want empty string", got)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Existing worker reused") {
+		t.Fatalf("Run([work --issue 54]) stdout = %q, want to contain %q", got, "Existing worker reused")
+	}
+}
+
 func TestPlanCreateIssueResolvesProjectFromCurrentProject(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -110,6 +110,7 @@ type pullRequestOutput struct {
 		LatestRunStatus *string `json:"latestRunStatus"`
 	} `json:"loopStatus"`
 	Stopped     bool    `json:"stopped"`
+	Reused      bool    `json:"reused"`
 	LoopID      string  `json:"loopId"`
 	RunID       *string `json:"runId"`
 	ExecutionID *string `json:"executionId"`
@@ -579,7 +580,11 @@ func writeHumanWorkerCreate(w io.Writer, payload json.RawMessage) error {
 	if data.Title != nil {
 		title = *data.Title
 	}
-	printSection(w, "Worker started", [][2]any{{"id", data.ID}, {"title", title}, {"status", data.Status}})
+	heading := "Worker started"
+	if data.Reused {
+		heading = "Existing worker reused"
+	}
+	printSection(w, heading, [][2]any{{"id", data.ID}, {"title", title}, {"status", data.Status}})
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Reuse existing active issue worker loops instead of returning loop conflicts from `looper work --issue`.
- Resume paused/idle reused issue loops into the queue while preserving queued/running lifecycle behavior.
- Add API and CLI coverage for reused worker responses and clear human output.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #193

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.5.2 · runner=worker · agent=opencode</sub>