### PR TITLE
fix: remove reviewer wall-clock default limit

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -349,12 +349,16 @@ Default values:
 
 - `reviewEvents.clean`: review event for clean reviewer outcomes. Allowed values: `COMMENT`, `APPROVE`. Default: `COMMENT`.
 - `reviewEvents.blocking`: review event for blocking reviewer outcomes. Allowed values: `COMMENT`, `REQUEST_CHANGES`. Default: `COMMENT`.
+- `loop.maxWallClockSeconds`: maximum wall-clock lifetime for a follow-up reviewer loop, measured from loop creation. Use `0` for no wall-clock limit. Default: `0`.
 
 Default reviewer behavior is safe and comment-only:
 
 ```json
 {
   "reviewer": {
+    "loop": {
+      "maxWallClockSeconds": 0
+    },
     "reviewEvents": {
       "clean": "COMMENT",
       "blocking": "COMMENT"

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -243,7 +243,7 @@
               "minPublishIntervalSeconds": 300,
               "maxIterationsPerPR": 20,
               "maxIterationsPerHead": 1,
-              "maxWallClockSeconds": 14400,
+              "maxWallClockSeconds": 0,
               "maxConsecutiveFailures": 3,
               "maxAgentExecutionsPerPR": 25,
               "stopOnApproved": true,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,9 @@ func TestRoleDefaultsMirrorCurrentDiscoveryPolicy(t *testing.T) {
 	if got := cfg.Roles.Worker; !got.AutoDiscovery || got.Triggers.LabelMode != LabelModeAll || !got.Triggers.RequireAssigneeCurrentUser || !reflectStringSlicesEqual(got.Triggers.Labels, []string{"looper:worker-ready"}) {
 		t.Fatalf("worker role defaults = %#v", got)
 	}
+	if got := cfg.Reviewer.Loop.MaxWallClockSeconds; got != 0 {
+		t.Fatalf("reviewer loop max wall clock default = %d, want 0", got)
+	}
 }
 
 func TestAgentTimeoutConfigOverrides(t *testing.T) {
@@ -859,7 +862,7 @@ func TestLoadFileReturnsConfigValidationErrorForUnsupportedConfig(t *testing.T) 
 		"logging": {"level": "verbose", "maxFiles": 0},
 		"daemon": {"mode": "invalid", "shutdownTimeoutMs": 0},
 		"defaults": {"openPrStrategy": "unsupported"},
-		"reviewer": {"loop": {"quietPeriodSeconds": -1, "minPublishIntervalSeconds": -1, "maxIterationsPerPR": 0}, "scope": "wide", "publishMode": "stream"},
+		"reviewer": {"loop": {"quietPeriodSeconds": -1, "minPublishIntervalSeconds": -1, "maxIterationsPerPR": 0, "maxWallClockSeconds": -1}, "scope": "wide", "publishMode": "stream"},
 		"notifications": {"osascript": {"soundForLevels": ["ring"]}},
 		"projects": [{"id": "../../tmp", "name": "bad", "repoPath": "/repos/bad"}]
 	}`
@@ -889,6 +892,7 @@ func TestLoadFileReturnsConfigValidationErrorForUnsupportedConfig(t *testing.T) 
 	assertValidationIssue(t, validationErr, "reviewer.loop.quietPeriodSeconds", "must be an integer >= 0")
 	assertValidationIssue(t, validationErr, "reviewer.loop.minPublishIntervalSeconds", "must be an integer >= 0")
 	assertValidationIssue(t, validationErr, "reviewer.loop.maxIterationsPerPR", "must be a positive integer")
+	assertValidationIssue(t, validationErr, "reviewer.loop.maxWallClockSeconds", "must be an integer >= 0")
 	assertValidationIssue(t, validationErr, "reviewer.scope", "must be one of: full_pr, changed_files, changed_ranges")
 	assertValidationIssue(t, validationErr, "reviewer.publishMode", "must be single_review")
 	assertValidationIssue(t, validationErr, "notifications.osascript.soundForLevels", "contains unsupported value: ring")

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -137,7 +137,7 @@ func DefaultConfig(cwd string) (Config, error) {
 				MinPublishIntervalSeconds: 300,
 				MaxIterationsPerPR:        20,
 				MaxIterationsPerHead:      1,
-				MaxWallClockSeconds:       14400,
+				MaxWallClockSeconds:       0,
 				MaxConsecutiveFailures:    3,
 				MaxAgentExecutionsPerPR:   25,
 				StopOnApproved:            true,

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -183,7 +183,7 @@
           "minPublishIntervalSeconds": 300,
           "maxIterationsPerPR": 20,
           "maxIterationsPerHead": 1,
-          "maxWallClockSeconds": 14400,
+          "maxWallClockSeconds": 0,
           "maxConsecutiveFailures": 3,
           "maxAgentExecutionsPerPR": 25,
           "stopOnApproved": true,

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -116,7 +116,7 @@
           "minPublishIntervalSeconds": 300,
           "maxIterationsPerPR": 20,
           "maxIterationsPerHead": 1,
-          "maxWallClockSeconds": 14400,
+          "maxWallClockSeconds": 0,
           "maxConsecutiveFailures": 3,
           "maxAgentExecutionsPerPR": 25,
           "stopOnApproved": true,

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -201,7 +201,7 @@
           "minPublishIntervalSeconds": 300,
           "maxIterationsPerPR": 20,
           "maxIterationsPerHead": 1,
-          "maxWallClockSeconds": 14400,
+          "maxWallClockSeconds": 0,
           "maxConsecutiveFailures": 3,
           "maxAgentExecutionsPerPR": 25,
           "stopOnApproved": true,

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -150,8 +150,8 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 	if config.Reviewer.Loop.MaxIterationsPerHead < 1 {
 		issues = append(issues, ValidationIssue{Path: "reviewer.loop.maxIterationsPerHead", Message: "must be a positive integer"})
 	}
-	if config.Reviewer.Loop.MaxWallClockSeconds < 1 {
-		issues = append(issues, ValidationIssue{Path: "reviewer.loop.maxWallClockSeconds", Message: "must be a positive integer"})
+	if config.Reviewer.Loop.MaxWallClockSeconds < 0 {
+		issues = append(issues, ValidationIssue{Path: "reviewer.loop.maxWallClockSeconds", Message: "must be an integer >= 0"})
 	}
 	if config.Reviewer.Loop.MaxConsecutiveFailures < 1 {
 		issues = append(issues, ValidationIssue{Path: "reviewer.loop.maxConsecutiveFailures", Message: "must be a positive integer"})

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -529,7 +529,7 @@ func New(options Options) *Runner {
 	}
 	loopConfig := options.LoopConfig
 	if loopConfig.MaxIterationsPerPR == 0 {
-		loopConfig = config.ReviewerLoopConfig{EnabledByDefault: false, QuietPeriodSeconds: 60, MinPublishIntervalSeconds: 300, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: true, StopOnReadyLabel: true, StopOnIdenticalOutput: true}
+		loopConfig = config.ReviewerLoopConfig{EnabledByDefault: false, QuietPeriodSeconds: 60, MinPublishIntervalSeconds: 300, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 0, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: true, StopOnReadyLabel: true, StopOnIdenticalOutput: true}
 	}
 	scope := options.Scope
 	if scope == "" {
@@ -3349,9 +3349,11 @@ func (r *Runner) loopBudgetTerminationReason(loop storage.LoopRecord, headSHA st
 			return "max_iterations_per_head"
 		}
 	}
-	if start, ok := loopMeta["startTime"].(string); ok && start != "" {
-		if parsed, err := time.Parse(time.RFC3339Nano, start); err == nil && r.now().Sub(parsed) >= time.Duration(r.loopConfig.MaxWallClockSeconds)*time.Second {
-			return "max_wall_clock"
+	if r.loopConfig.MaxWallClockSeconds > 0 {
+		if start, ok := loopMeta["startTime"].(string); ok && start != "" {
+			if parsed, err := time.Parse(time.RFC3339Nano, start); err == nil && r.now().Sub(parsed) >= time.Duration(r.loopConfig.MaxWallClockSeconds)*time.Second {
+				return "max_wall_clock"
+			}
 		}
 	}
 	return ""

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -782,6 +782,13 @@ func TestReviewerLoopBudgetTerminationReasons(t *testing.T) {
 	if got := runner.loopBudgetTerminationReason(loop, "abc123"); got != "max_iterations_per_pr" {
 		t.Fatalf("loopBudgetTerminationReason() = %q, want max_iterations_per_pr", got)
 	}
+
+	unlimitedRunner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 2, MaxWallClockSeconds: 0, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25}})
+	metadata = `{"loop":{"iterationCount":1,"agentExecutionCount":1,"consecutiveFailures":0,"iterationsByHead":{"old":1},"startTime":"2026-04-11T12:00:00.000Z"}}`
+	loop.MetadataJSON = &metadata
+	if got := unlimitedRunner.loopBudgetTerminationReason(loop, "abc123"); got != "" {
+		t.Fatalf("loopBudgetTerminationReason() = %q, want no termination when max wall clock is 0", got)
+	}
 }
 
 func TestRunFilterStepSkipsAlreadyReviewedHeadBeforeBudgetTermination(t *testing.T) {


### PR DESCRIPTION
## Summary
- Change reviewer loop `maxWallClockSeconds` default to `0` so follow-up review loops do not expire by wall-clock time by default.
- Treat `0` as unlimited in reviewer budget checks while still allowing positive configured limits.
- Update config validation, docs, parity fixtures, API contracts, and tests for the new default.

## Tests
- `go test ./...`