### PR TITLE
fix: retry transient reviewer external failures

### DIFF
--- a/internal/infra/github/errors.go
+++ b/internal/infra/github/errors.go
@@ -34,10 +34,10 @@ func IsTransientError(err error) bool {
 	var commandErr *shell.CommandExecutionError
 	if errors.As(err, &commandErr) {
 		message := strings.Join([]string{commandErr.Message, commandErr.Result.Stdout, commandErr.Result.Stderr}, "\n")
-		return looksLikeGitHubFailure(message) && isTransientGitHubMessage(message)
+		return (looksLikeGitHubFailure(message) && isTransientGitHubMessage(message)) || isExplicitTransientGitHubStatus(message)
 	}
 	message := err.Error()
-	if !looksLikeGitHubFailure(message) {
+	if !looksLikeGitHubFailure(message) && !isExplicitTransientGitHubStatus(message) {
 		return false
 	}
 	return isTransientGitHubMessage(message)
@@ -73,10 +73,35 @@ func isTransientGitHubMessage(message string) bool {
 		"network is unreachable",
 		"stream error",
 		"http2: server sent goaway",
+		"http 502",
+		"502 bad gateway",
+		"http 503",
+		"503 service unavailable",
+		"http 504",
+		"504 gateway timeout",
+		"secondary rate limit",
+		"rate limit exceeded",
+		"api rate limit exceeded",
+		"graphql: something went wrong",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func isExplicitTransientGitHubStatus(message string) bool {
+	message = strings.ToLower(message)
+	for _, fragment := range []string{
+		"http 502",
+		"http 503",
+		"http 504",
 		"502 bad gateway",
 		"503 service unavailable",
 		"504 gateway timeout",
-		"graphql: something went wrong",
+		"secondary rate limit",
+		"api rate limit exceeded",
 	} {
 		if strings.Contains(message, fragment) {
 			return true

--- a/internal/infra/github/errors.go
+++ b/internal/infra/github/errors.go
@@ -101,6 +101,7 @@ func isExplicitTransientGitHubStatus(message string) bool {
 		"503 service unavailable",
 		"504 gateway timeout",
 		"secondary rate limit",
+		"rate limit exceeded",
 		"api rate limit exceeded",
 	} {
 		if strings.Contains(message, fragment) {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -274,6 +274,7 @@ func TestIsTransientErrorTreatsShellCommandNetworkFailuresAsRetryable(t *testing
 		{name: "gateway-wrapped tls handshake timeout", err: &TransientError{Err: &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "net/http: TLS handshake timeout"}}}},
 		{name: "unexpected eof", err: &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "Post https://api.github.com/graphql: unexpected EOF"}}},
 		{name: "graphql transient", err: &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stdout: `{"errors":[{"message":"GraphQL: Something went wrong while executing your query."}]}`}}},
+		{name: "bare http 504", err: fmt.Errorf("HTTP 504")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -275,6 +275,7 @@ func TestIsTransientErrorTreatsShellCommandNetworkFailuresAsRetryable(t *testing
 		{name: "unexpected eof", err: &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "Post https://api.github.com/graphql: unexpected EOF"}}},
 		{name: "graphql transient", err: &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stdout: `{"errors":[{"message":"GraphQL: Something went wrong while executing your query."}]}`}}},
 		{name: "bare http 504", err: fmt.Errorf("HTTP 504")},
+		{name: "generic rate limit", err: fmt.Errorf("rate limit exceeded")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1147,6 +1147,13 @@ type stepInput struct {
 }
 
 func (r *Runner) executeStep(ctx context.Context, step ReviewerStep, input stepInput) (reviewerCheckpoint, error) {
+	if reviewerStepSupportsTransientExternalRetry(step) {
+		return r.executeStepWithTransientExternalRetry(ctx, step, input)
+	}
+	return r.executeStepOnce(ctx, step, input)
+}
+
+func (r *Runner) executeStepOnce(ctx context.Context, step ReviewerStep, input stepInput) (reviewerCheckpoint, error) {
 	switch step {
 	case stepDiscover:
 		return r.runDiscoverStep(ctx, input)
@@ -1167,6 +1174,33 @@ func (r *Runner) executeStep(ctx context.Context, step ReviewerStep, input stepI
 	default:
 		return input.Checkpoint, fmt.Errorf("unsupported reviewer step: %s", step)
 	}
+}
+
+func (r *Runner) executeStepWithTransientExternalRetry(ctx context.Context, step ReviewerStep, input stepInput) (reviewerCheckpoint, error) {
+	maxAttempts := r.retryMaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = defaultRetryMax
+	}
+	checkpoint := input.Checkpoint
+	var err error
+	for attempt := int64(1); attempt <= maxAttempts; attempt++ {
+		checkpoint, err = r.executeStepOnce(ctx, step, input)
+		if err == nil {
+			if attempt > 1 {
+				r.logInfo("reviewer transient external retry succeeded", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "queueItemId": input.QueueItem.ID, "step": string(step), "attempt": attempt, "maxAttempts": maxAttempts})
+			}
+			return checkpoint, nil
+		}
+		if attempt >= maxAttempts || !r.isTransientExternalFailure(err) {
+			break
+		}
+		delay := backoffDelay(r.retryBaseDelay, attempt)
+		r.logWarn("reviewer transient external failure retrying", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "queueItemId": input.QueueItem.ID, "step": string(step), "attempt": attempt, "nextAttempt": attempt + 1, "maxAttempts": maxAttempts, "retryDelay": delay.String(), "error": err.Error()})
+		if sleepErr := sleepWithContext(ctx, delay); sleepErr != nil {
+			return checkpoint, errors.Join(err, sleepErr)
+		}
+	}
+	return checkpoint, err
 }
 
 func (r *Runner) runDiscoverStep(ctx context.Context, input stepInput) (reviewerCheckpoint, error) {
@@ -2744,7 +2778,24 @@ func (r *Runner) classifyFailure(err error) *loopError {
 	if githubinfra.IsTransientError(err) {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
+	if isTransientModelProviderError(err) {
+		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	}
 	return &loopError{message: err.Error(), kind: FailureNonRetryable}
+}
+
+func (r *Runner) isTransientExternalFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if githubinfra.IsTransientError(err) || isTransientModelProviderError(err) {
+		return true
+	}
+	var loopErr *loopError
+	if errors.As(err, &loopErr) {
+		return loopErr.kind == FailureRetryableTransient && isTransientModelProviderMessage(loopErr.message)
+	}
+	return false
 }
 
 func (r *Runner) nowISO() string {
@@ -3793,6 +3844,52 @@ func backoffDelay(base time.Duration, attempts int64) time.Duration {
 		delay *= 2
 	}
 	return delay
+}
+
+func reviewerStepSupportsTransientExternalRetry(step ReviewerStep) bool {
+	switch step {
+	case stepSnapshot, stepThreadResolution, stepReview:
+		return true
+	default:
+		return false
+	}
+}
+
+func isTransientModelProviderError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return isTransientModelProviderMessage(err.Error())
+}
+
+func isTransientModelProviderMessage(message string) bool {
+	message = strings.ToLower(message)
+	for _, fragment := range []string{
+		"server_is_overloaded",
+		"service_unavailable_error",
+		"server is overloaded",
+		"service unavailable",
+		"overloaded",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func isRetryableFailure(kind QueueFailureKind) bool {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/powerformer/looper/internal/config"
 	"github.com/powerformer/looper/internal/eventlog"
+	githubinfra "github.com/powerformer/looper/internal/infra/github"
 	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/storage"
 )
@@ -3713,6 +3714,110 @@ func TestProcessClaimedItemRetryAfterReviewFailureRepreparesWorktree(t *testing.
 	}
 }
 
+func TestProcessClaimedItemRetriesTransientSnapshotFailureInRun(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{captureSnapshotErrs: []error{&githubinfra.TransientError{Err: fmt.Errorf("GitHub GraphQL HTTP 504")}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
+	logger := &testLogger{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{worktreePath: filepath.Join(t.TempDir(), "reviewer-worktree")}, AgentExecutor: agent, Logger: logger, Now: fixture.now, RetryBaseDelay: time.Nanosecond})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claim", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("ProcessClaimedItem() = %#v, want success after snapshot retry", result)
+	}
+	if github.captureSnapshotCalls != 2 {
+		t.Fatalf("captureSnapshotCalls = %d, want 2", github.captureSnapshotCalls)
+	}
+	if !logger.hasMessage("reviewer transient external failure retrying") || !logger.hasMessage("reviewer transient external retry succeeded") {
+		t.Fatalf("logger messages = %#v, want retry attempt and success logs", logger.messages)
+	}
+}
+
+func TestExecuteStepDoesNotRetryNonTransientSnapshotFailure(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{captureSnapshotErrs: []error{fmt.Errorf("GraphQL: Resource not accessible by integration")}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now, RetryBaseDelay: time.Nanosecond})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+
+	_, err = runner.executeStep(context.Background(), stepSnapshot, stepInput{Project: *project, Loop: storage.LoopRecord{ID: "loop_1"}, Run: storage.RunRecord{ID: "run_1"}, QueueItem: storage.QueueItemRecord{ID: "queue_1"}, Repo: "acme/looper", PRNumber: 42})
+	if err == nil || !strings.Contains(err.Error(), "Resource not accessible") {
+		t.Fatalf("executeStep(snapshot) error = %v, want non-transient failure", err)
+	}
+	if github.captureSnapshotCalls != 1 {
+		t.Fatalf("captureSnapshotCalls = %d, want 1", github.captureSnapshotCalls)
+	}
+}
+
+func TestExecuteStepPreservesFinalTransientFailureAfterRetryExhaustion(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{captureSnapshotErrs: []error{
+		&githubinfra.TransientError{Err: fmt.Errorf("GitHub GraphQL HTTP 504 first")},
+		&githubinfra.TransientError{Err: fmt.Errorf("GitHub GraphQL HTTP 504 final")},
+	}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now, RetryBaseDelay: time.Nanosecond, RetryMaxAttempts: 2})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+
+	_, err = runner.executeStep(context.Background(), stepSnapshot, stepInput{Project: *project, Loop: storage.LoopRecord{ID: "loop_1"}, Run: storage.RunRecord{ID: "run_1"}, QueueItem: storage.QueueItemRecord{ID: "queue_1"}, Repo: "acme/looper", PRNumber: 42})
+	if err == nil || !strings.Contains(err.Error(), "final") || strings.Contains(err.Error(), "first") {
+		t.Fatalf("executeStep(snapshot) error = %v, want final transient failure only", err)
+	}
+	if github.captureSnapshotCalls != 2 {
+		t.Fatalf("captureSnapshotCalls = %d, want 2", github.captureSnapshotCalls)
+	}
+}
+
+func TestIsTransientExternalFailureDetectsWrappedGitHubStatus(t *testing.T) {
+	runner := New(Options{})
+	err := &loopError{message: "GraphQL request failed with HTTP 504", kind: FailureRetryableTransient}
+	if !runner.isTransientExternalFailure(err) {
+		t.Fatal("isTransientExternalFailure(wrapped HTTP 504) = false, want true")
+	}
+}
+
+func TestProcessClaimedItemRetriesTransientModelOverloadInRun(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed"}, {Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}, waitErrs: []error{fmt.Errorf("service_unavailable_error: server_is_overloaded")}}
+	logger := &testLogger{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{worktreePath: filepath.Join(t.TempDir(), "reviewer-worktree")}, AgentExecutor: agent, Logger: logger, Now: fixture.now, RetryBaseDelay: time.Nanosecond})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claim", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("ProcessClaimedItem() = %#v, want success after model retry", result)
+	}
+	if len(agent.starts) != 2 {
+		t.Fatalf("len(agent.starts) = %d, want 2", len(agent.starts))
+	}
+	if !logger.hasMessage("reviewer transient external failure retrying") || !logger.hasMessage("reviewer transient external retry succeeded") {
+		t.Fatalf("logger messages = %#v, want retry attempt and success logs", logger.messages)
+	}
+}
+
 func TestProcessClaimedItemPersistsFailedLoopWhenMaxConsecutiveFailuresReached(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -4784,6 +4889,8 @@ type fakeGitHubGateway struct {
 	removeLabelErr                  error
 	reviewThreads                   []ReviewThread
 	viewHeadSHA                     string
+	captureSnapshotErrs             []error
+	captureSnapshotCalls            int
 	addThreadReplyCalls             []AddReviewThreadReplyInput
 	resolveThreadCalls              []ResolveReviewThreadInput
 	addReactionCalls                []PullRequestReactionInput
@@ -4867,6 +4974,14 @@ func (g *fakeGitHubGateway) effectiveReviewRequests() []string {
 }
 
 func (g *fakeGitHubGateway) CapturePullRequestSnapshot(_ context.Context, input CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
+	g.captureSnapshotCalls++
+	if len(g.captureSnapshotErrs) > 0 {
+		err := g.captureSnapshotErrs[0]
+		g.captureSnapshotErrs = g.captureSnapshotErrs[1:]
+		if err != nil {
+			return storage.PullRequestSnapshotRecord{}, err
+		}
+	}
 	headSHA := "abc123"
 	if g.changeHeadOnSecondView && g.viewCalls >= 2 {
 		headSHA = "new-head"
@@ -4990,10 +5105,11 @@ func (f *fakeGitGateway) CleanupWorktree(_ context.Context, input CleanupWorktre
 }
 
 type fakeAgentExecutor struct {
-	results []AgentResult
-	starts  []AgentRunInput
-	waitErr error
-	wait    func(context.Context) error
+	results  []AgentResult
+	starts   []AgentRunInput
+	waitErr  error
+	waitErrs []error
+	wait     func(context.Context) error
 }
 
 func (f *fakeAgentExecutor) Start(_ context.Context, input AgentRunInput) (AgentExecution, error) {
@@ -5003,7 +5119,12 @@ func (f *fakeAgentExecutor) Start(_ context.Context, input AgentRunInput) (Agent
 	}
 	result := f.results[0]
 	f.results = f.results[1:]
-	return fakeAgentExecution{result: result, waitErr: f.waitErr, wait: f.wait}, nil
+	waitErr := f.waitErr
+	if len(f.waitErrs) > 0 {
+		waitErr = f.waitErrs[0]
+		f.waitErrs = f.waitErrs[1:]
+	}
+	return fakeAgentExecution{result: result, waitErr: waitErr, wait: f.wait}, nil
 }
 
 type fakeAgentExecution struct {
@@ -5027,11 +5148,26 @@ func (f fakeAgentExecution) Wait(ctx context.Context) (AgentResult, error) {
 	return f.result, nil
 }
 
-type testLogger struct{}
+type testLogger struct {
+	messages []string
+}
 
-func (*testLogger) Debug(string, map[string]any) {}
-func (*testLogger) Info(string, map[string]any)  {}
-func (*testLogger) Warn(string, map[string]any)  {}
-func (*testLogger) Error(string, map[string]any) {}
+func (l *testLogger) Debug(message string, _ map[string]any) {
+	l.messages = append(l.messages, message)
+}
+func (l *testLogger) Info(message string, _ map[string]any) { l.messages = append(l.messages, message) }
+func (l *testLogger) Warn(message string, _ map[string]any) { l.messages = append(l.messages, message) }
+func (l *testLogger) Error(message string, _ map[string]any) {
+	l.messages = append(l.messages, message)
+}
+
+func (l *testLogger) hasMessage(want string) bool {
+	for _, message := range l.messages {
+		if message == want {
+			return true
+		}
+	}
+	return false
+}
 
 func contains(haystack, needle string) bool { return strings.Contains(haystack, needle) }


### PR DESCRIPTION
## Summary
- Retry transient reviewer snapshot/review external failures in-run with bounded exponential backoff before queue failure handling.
- Expand GitHub transient detection for HTTP 502/503/504 and rate-limit responses, and classify model overload errors as retryable.
- Add coverage for retry success, non-retryable failures, retry exhaustion, wrapped GitHub status errors, and logging visibility.

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #199

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.5.4 · runner=worker · agent=opencode</sub>