### PR TITLE
perf: reduce reviewer timeout waste

### DIFF
--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2247,6 +2247,9 @@ func reviewerAgentTerminalEvent(result AgentResult) string {
 	if result.Status == "timeout" {
 		return "reviewer.agent.timed_out"
 	}
+	if result.Status != "completed" {
+		return "reviewer.agent.failed"
+	}
 	return "reviewer.agent.completed"
 }
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1599,12 +1599,12 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 	slices.Sort(candidateIDs)
 	idempotencyKey := fmt.Sprintf("reviewer-thread-resolution:%s:%d:%s:%s", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, strings.Join(candidateIDs, ","))
 	prompt := buildThreadResolutionPrompt(input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, threads)
-	r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.started", "thread_resolution", executionID, map[string]any{"promptBytes": len(prompt), "threadCount": len(threads), "timeoutSeconds": durationSeconds(r.agentTimeout), "idleTimeoutSeconds": durationSeconds(r.agentIdleTimeout)})
-	agentStartedAt := r.now()
 	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: map[string]any{"loopType": "reviewer", "phase": "thread_resolution", "repo": input.Repo, "prNumber": input.PRNumber}, IdempotencyKey: idempotencyKey})
 	if err != nil {
 		return nil, err
 	}
+	r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.started", "thread_resolution", executionID, map[string]any{"promptBytes": len(prompt), "threadCount": len(threads), "timeoutSeconds": durationSeconds(r.agentTimeout), "idleTimeoutSeconds": durationSeconds(r.agentIdleTimeout)})
+	agentStartedAt := r.now()
 	result, err := execution.Wait(ctx)
 	if err != nil {
 		return nil, err
@@ -1771,12 +1771,12 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 		metadata[key] = value
 	}
-	r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.started", "review", executionID, map[string]any{"promptBytes": len(prompt), "timeoutSeconds": durationSeconds(r.agentTimeout), "idleTimeoutSeconds": durationSeconds(r.agentIdleTimeout), "scope": string(r.scope), "headSha": checkpoint.Snapshot.HeadSHA})
-	agentStartedAt := r.now()
 	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: metadata, IdempotencyKey: idempotencyKey})
 	if err != nil {
 		return checkpoint, err
 	}
+	r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.started", "review", executionID, map[string]any{"promptBytes": len(prompt), "timeoutSeconds": durationSeconds(r.agentTimeout), "idleTimeoutSeconds": durationSeconds(r.agentIdleTimeout), "scope": string(r.scope), "headSha": checkpoint.Snapshot.HeadSHA})
+	agentStartedAt := r.now()
 	if err := r.recordAgentExecutionStarted(ctx, input.Loop.ID); err != nil {
 		r.logWarn("reviewer agent execution start metadata update failed", map[string]any{"loopId": input.Loop.ID, "runId": input.Run.ID, "error": err.Error()})
 	}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -74,7 +74,7 @@ const (
 )
 
 const (
-	defaultAgentTimeout = 30 * time.Minute
+	defaultAgentTimeout = 90 * time.Minute
 	defaultClaimTTL     = 5 * time.Minute
 	defaultRetryDelay   = 5 * time.Second
 	defaultRetryMax     = 3
@@ -1009,13 +1009,15 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	r.appendEvent(ctx, eventInput{eventType: "run.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep)}})
 	r.logInfo("reviewer run started", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep), "resumed": resumedRun.Resumed})
 	for _, step := range stepsFrom(resumedRun.StartStep) {
+		stepStartedAt := r.now()
 		run, err = r.persistStepStarted(ctx, run, step, checkpoint)
 		if err != nil {
 			return ProcessResult{}, err
 		}
-		r.appendEvent(ctx, eventInput{eventType: "loop.step.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"step": string(step)}})
+		r.appendEvent(ctx, eventInput{eventType: "loop.step.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"step": string(step), "startedAt": eventlog.FormatJavaScriptISOString(stepStartedAt.UTC())}})
 		checkpoint, err = r.executeStep(ctx, step, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem, Repo: *queueItem.Repo, PRNumber: *queueItem.PRNumber, Checkpoint: checkpoint})
 		if err != nil {
+			stepElapsedSeconds := durationSeconds(r.now().Sub(stepStartedAt))
 			failure := r.classifyFailure(err)
 			latest := r.getLatestCheckpoint(ctx, run, checkpoint)
 			if checkpoint.ResumePolicy == "rerun_review" || hasPendingReviewMarkerMiss(checkpoint) {
@@ -1041,9 +1043,9 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
 				return ProcessResult{}, err
 			}
-			r.appendEvent(ctx, eventInput{eventType: "loop.step.failed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"message": failure.message, "failureKind": string(failure.kind), "currentStep": derefString(run.CurrentStep)}})
+			r.appendEvent(ctx, eventInput{eventType: "loop.step.failed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"message": failure.message, "failureKind": string(failure.kind), "currentStep": derefString(run.CurrentStep), "elapsedSeconds": stepElapsedSeconds}})
 			r.appendEvent(ctx, eventInput{eventType: "run.failed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"summary": failure.message, "failureKind": string(failure.kind)}})
-			r.logError("reviewer run failed", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": derefString(run.CurrentStep), "failureKind": string(failure.kind), "summary": failure.message})
+			r.logError("reviewer run failed", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": derefString(run.CurrentStep), "elapsedSeconds": stepElapsedSeconds, "failureKind": string(failure.kind), "summary": failure.message})
 			failedQueue, queueErr := r.failQueueItem(ctx, queueItem, failure.kind, failure.message)
 			if queueErr != nil {
 				return ProcessResult{}, queueErr
@@ -1095,7 +1097,9 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		if err != nil {
 			return ProcessResult{}, err
 		}
-		r.appendEvent(ctx, eventInput{eventType: "loop.step.completed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"step": string(step)}})
+		stepElapsedSeconds := durationSeconds(r.now().Sub(stepStartedAt))
+		r.appendEvent(ctx, eventInput{eventType: "loop.step.completed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"step": string(step), "elapsedSeconds": stepElapsedSeconds}})
+		r.logInfo("reviewer step completed", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "step": string(step), "elapsedSeconds": stepElapsedSeconds})
 		if checkpoint.SkipReason != "" {
 			break
 		}
@@ -1594,7 +1598,10 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 	}
 	slices.Sort(candidateIDs)
 	idempotencyKey := fmt.Sprintf("reviewer-thread-resolution:%s:%d:%s:%s", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, strings.Join(candidateIDs, ","))
-	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: buildThreadResolutionPrompt(input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, threads), WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: map[string]any{"loopType": "reviewer", "phase": "thread_resolution", "repo": input.Repo, "prNumber": input.PRNumber}, IdempotencyKey: idempotencyKey})
+	prompt := buildThreadResolutionPrompt(input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, threads)
+	r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.started", "thread_resolution", executionID, map[string]any{"promptBytes": len(prompt), "threadCount": len(threads), "timeoutSeconds": durationSeconds(r.agentTimeout), "idleTimeoutSeconds": durationSeconds(r.agentIdleTimeout)})
+	agentStartedAt := r.now()
+	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: map[string]any{"loopType": "reviewer", "phase": "thread_resolution", "repo": input.Repo, "prNumber": input.PRNumber}, IdempotencyKey: idempotencyKey})
 	if err != nil {
 		return nil, err
 	}
@@ -1602,8 +1609,10 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 	if err != nil {
 		return nil, err
 	}
+	r.appendReviewerAgentEvent(ctx, input, reviewerAgentTerminalEvent(result), "thread_resolution", executionID, reviewerAgentResultPayload(result, r.now().Sub(agentStartedAt)))
+	r.logInfo("reviewer agent completed", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "repo": input.Repo, "prNumber": input.PRNumber, "phase": "thread_resolution", "executionId": executionID, "status": result.Status, "timeoutType": result.TimeoutType, "elapsedSeconds": elapsedSeconds(result, r.now().Sub(agentStartedAt)), "parseStatus": result.ParseStatus})
 	if result.Status != "completed" {
-		return nil, &loopError{message: firstNonEmpty(result.Summary, result.Stderr, "thread resolution classifier failed"), kind: FailureRetryableTransient}
+		return nil, &loopError{message: reviewerAgentFailureMessage("thread resolution", result, "thread resolution classifier failed"), kind: FailureRetryableTransient}
 	}
 	parsed, err := parseThreadResolutionOutput(result.Stdout)
 	if err != nil {
@@ -1762,6 +1771,8 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 		metadata[key] = value
 	}
+	r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.started", "review", executionID, map[string]any{"promptBytes": len(prompt), "timeoutSeconds": durationSeconds(r.agentTimeout), "idleTimeoutSeconds": durationSeconds(r.agentIdleTimeout), "scope": string(r.scope), "headSha": checkpoint.Snapshot.HeadSHA})
+	agentStartedAt := r.now()
 	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: metadata, IdempotencyKey: idempotencyKey})
 	if err != nil {
 		return checkpoint, err
@@ -1778,6 +1789,8 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	if err != nil {
 		return checkpoint, err
 	}
+	r.appendReviewerAgentEvent(ctx, input, reviewerAgentTerminalEvent(result), "review", executionID, reviewerAgentResultPayload(result, r.now().Sub(agentStartedAt)))
+	r.logInfo("reviewer agent completed", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "repo": input.Repo, "prNumber": input.PRNumber, "phase": "review", "executionId": executionID, "status": result.Status, "timeoutType": result.TimeoutType, "elapsedSeconds": elapsedSeconds(result, r.now().Sub(agentStartedAt)), "parseStatus": result.ParseStatus})
 	if result.Status != "completed" {
 		if reason, ok := r.detectHeadChangeRequired(ctx, input, checkpoint); ok {
 			checkpoint.ResumePolicy = "restart_from_discover"
@@ -1794,7 +1807,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 			checkpoint.ResumePolicy = "restart_from_discover"
 			return checkpoint, &loopError{message: reason, kind: FailureRetryableAfterResume}
 		}
-		message := firstNonEmpty(result.Summary, result.Stderr, fmt.Sprintf("Reviewer agent %s", result.Status))
+		message := reviewerAgentFailureMessage("review", result, fmt.Sprintf("Reviewer agent %s", result.Status))
 		kind := FailureRetryableTransient
 		if agent.IsAgentSetupFailureMessage(message) {
 			kind = FailureManualIntervention
@@ -1982,6 +1995,88 @@ func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepIn
 	}
 	marker := agentNativeReviewMarker(input.Loop.ID, headSHA, idempotencyKey)
 	return r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: marker, AllowedReviewEvents: r.allowedReviewEventsForPolicy(r.effectiveReviewEvents(input.Loop.MetadataJSON)), AuthorLogin: currentLogin, CWD: input.Project.RepoPath})
+}
+
+func (r *Runner) appendReviewerAgentEvent(ctx context.Context, input stepInput, eventType, phase, executionID string, payload map[string]any) {
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	payload["repo"] = input.Repo
+	payload["prNumber"] = input.PRNumber
+	payload["phase"] = phase
+	payload["executionId"] = executionID
+	r.appendEvent(ctx, eventInput{eventType: eventType, projectID: input.Project.ID, loopID: input.Loop.ID, runID: input.Run.ID, entityType: "pull_request", entityID: fmt.Sprintf("%s#%d", input.Repo, input.PRNumber), payload: payload})
+}
+
+func reviewerAgentTerminalEvent(result AgentResult) string {
+	if result.Status == "timeout" {
+		return "reviewer.agent.timed_out"
+	}
+	return "reviewer.agent.completed"
+}
+
+func reviewerAgentResultPayload(result AgentResult, observedElapsed time.Duration) map[string]any {
+	return map[string]any{
+		"status":                       result.Status,
+		"timeoutType":                  result.TimeoutType,
+		"configuredIdleTimeoutSeconds": result.ConfiguredIdleTimeoutSeconds,
+		"configuredMaxRuntimeSeconds":  result.ConfiguredMaxRuntimeSeconds,
+		"elapsedRuntimeSeconds":        elapsedSeconds(result, observedElapsed),
+		"lastProgressAt":               result.LastProgressAt,
+		"parseStatus":                  result.ParseStatus,
+		"summary":                      firstNonEmpty(result.Summary, summarizeAgentStderr(result.Stderr)),
+	}
+}
+
+func reviewerAgentFailureMessage(phase string, result AgentResult, fallback string) string {
+	base := firstNonEmpty(result.Summary, result.Stderr, fallback)
+	if result.Status != "timeout" {
+		return base
+	}
+	timeoutType := result.TimeoutType
+	if timeoutType == "" {
+		timeoutType = "unknown"
+	}
+	parts := []string{fmt.Sprintf("Reviewer %s agent timed out (%s)", phase, timeoutType)}
+	if result.ElapsedRuntimeSeconds > 0 {
+		parts = append(parts, fmt.Sprintf("after %ds", result.ElapsedRuntimeSeconds))
+	}
+	if result.ConfiguredMaxRuntimeSeconds > 0 || result.ConfiguredIdleTimeoutSeconds > 0 {
+		parts = append(parts, fmt.Sprintf("configured max runtime %ds, idle timeout %ds", result.ConfiguredMaxRuntimeSeconds, result.ConfiguredIdleTimeoutSeconds))
+	}
+	if result.LastProgressAt != "" {
+		parts = append(parts, "last progress at "+result.LastProgressAt)
+	}
+	if base != "" {
+		parts = append(parts, "summary: "+base)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func summarizeAgentStderr(stderr string) string {
+	stderr = strings.TrimSpace(stderr)
+	if len(stderr) <= 240 {
+		return stderr
+	}
+	return strings.TrimSpace(stderr[:240]) + "…"
+}
+
+func elapsedSeconds(result AgentResult, observedElapsed time.Duration) int64 {
+	if result.ElapsedRuntimeSeconds > 0 {
+		return result.ElapsedRuntimeSeconds
+	}
+	return durationSeconds(observedElapsed)
+}
+
+func durationSeconds(duration time.Duration) int64 {
+	if duration <= 0 {
+		return 0
+	}
+	seconds := int64(duration / time.Second)
+	if seconds == 0 {
+		return 1
+	}
+	return seconds
 }
 
 func (r *Runner) applyVerifiedReviewSideEffects(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, detail PullRequestDetail, marker ReviewMarkerResult) error {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1788,6 +1788,8 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 	agentStartedAt := r.now()
 	result, err := execution.Wait(ctx)
 	if err != nil {
+		r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.failed", "thread_resolution", executionID, reviewerAgentWaitErrorPayload(err, r.now().Sub(agentStartedAt)))
+		r.logWarn("reviewer agent wait failed", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "repo": input.Repo, "prNumber": input.PRNumber, "phase": "thread_resolution", "executionId": executionID, "elapsedSeconds": durationSeconds(r.now().Sub(agentStartedAt)), "error": err.Error()})
 		return nil, err
 	}
 	r.appendReviewerAgentEvent(ctx, input, reviewerAgentTerminalEvent(result), "thread_resolution", executionID, reviewerAgentResultPayload(result, r.now().Sub(agentStartedAt)))
@@ -1968,6 +1970,8 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	}
 	result, err := execution.Wait(ctx)
 	if err != nil {
+		r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.failed", "review", executionID, reviewerAgentWaitErrorPayload(err, r.now().Sub(agentStartedAt)))
+		r.logWarn("reviewer agent wait failed", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "repo": input.Repo, "prNumber": input.PRNumber, "phase": "review", "executionId": executionID, "elapsedSeconds": durationSeconds(r.now().Sub(agentStartedAt)), "error": err.Error()})
 		return checkpoint, err
 	}
 	r.appendReviewerAgentEvent(ctx, input, reviewerAgentTerminalEvent(result), "review", executionID, reviewerAgentResultPayload(result, r.now().Sub(agentStartedAt)))
@@ -2256,6 +2260,18 @@ func reviewerAgentResultPayload(result AgentResult, observedElapsed time.Duratio
 		"lastProgressAt":               result.LastProgressAt,
 		"parseStatus":                  result.ParseStatus,
 		"summary":                      firstNonEmpty(result.Summary, summarizeAgentStderr(result.Stderr)),
+	}
+}
+
+func reviewerAgentWaitErrorPayload(err error, observedElapsed time.Duration) map[string]any {
+	summary := ""
+	if err != nil {
+		summary = err.Error()
+	}
+	return map[string]any{
+		"status":                "wait_error",
+		"elapsedRuntimeSeconds": durationSeconds(observedElapsed),
+		"summary":               summary,
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4282,6 +4282,43 @@ func TestProcessClaimedItemClassifiesReviewerTimeoutWithDiagnostics(t *testing.T
 	}
 }
 
+func TestProcessClaimedItemEmitsFailedTerminalEventForReviewerAgentFailure(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewMarkerMissing: true}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed", Summary: "agent failed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claim, err)
+	}
+	if _, err := runner.ProcessClaimedItem(context.Background(), *claim); err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	events, err := fixture.repos.Events.ListByEntity(context.Background(), "pull_request", "acme/looper#42")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	foundFailedEvent := false
+	for _, event := range events {
+		switch event.EventType {
+		case "reviewer.agent.failed":
+			if strings.Contains(event.PayloadJSON, `"status":"failed"`) {
+				foundFailedEvent = true
+			}
+		case "reviewer.agent.completed":
+			t.Fatalf("events = %#v, want reviewer.agent.failed instead of reviewer.agent.completed", events)
+		}
+	}
+	if !foundFailedEvent {
+		t.Fatalf("events = %#v, want reviewer.agent.failed terminal event", events)
+	}
+}
+
 func TestProcessClaimedItemDoesNotEmitStartedWhenReviewerAgentStartFails(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4020,6 +4020,37 @@ func TestProcessClaimedItemClassifiesReviewerTimeoutWithDiagnostics(t *testing.T
 	}
 }
 
+func TestProcessClaimedItemDoesNotEmitStartedWhenReviewerAgentStartFails(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	agent := &fakeAgentExecutor{startErr: fmt.Errorf("executor setup failed")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" {
+		t.Fatalf("result = %#v, want failed start result", result)
+	}
+	events, err := fixture.repos.Events.ListByEntity(context.Background(), "pull_request", "acme/looper#42")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	for _, event := range events {
+		if event.EventType == "reviewer.agent.started" {
+			t.Fatalf("events = %#v, want no reviewer.agent.started on start failure", events)
+		}
+	}
+}
+
 func TestNewDefaultsReviewerTimeoutToNinetyMinutes(t *testing.T) {
 	t.Parallel()
 	runner := New(Options{})
@@ -5039,14 +5070,18 @@ func (f *fakeGitGateway) CleanupWorktree(_ context.Context, input CleanupWorktre
 }
 
 type fakeAgentExecutor struct {
-	results []AgentResult
-	starts  []AgentRunInput
-	waitErr error
-	wait    func(context.Context) error
+	results  []AgentResult
+	starts   []AgentRunInput
+	startErr error
+	waitErr  error
+	wait     func(context.Context) error
 }
 
 func (f *fakeAgentExecutor) Start(_ context.Context, input AgentRunInput) (AgentExecution, error) {
 	f.starts = append(f.starts, input)
+	if f.startErr != nil {
+		return nil, f.startErr
+	}
 	if len(f.results) == 0 {
 		return nil, fmt.Errorf("no queued agent result")
 	}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4313,6 +4313,47 @@ func TestProcessClaimedItemDoesNotEmitStartedWhenReviewerAgentStartFails(t *test
 	}
 }
 
+func TestProcessClaimedItemEmitsTerminalEventWhenReviewerAgentWaitFails(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed"}}, waitErr: fmt.Errorf("execution transport failed")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" {
+		t.Fatalf("result = %#v, want failed wait result", result)
+	}
+	events, err := fixture.repos.Events.ListByEntity(context.Background(), "pull_request", "acme/looper#42")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	foundStarted := false
+	foundFailed := false
+	for _, event := range events {
+		switch event.EventType {
+		case "reviewer.agent.started":
+			foundStarted = true
+		case "reviewer.agent.failed":
+			if strings.Contains(event.PayloadJSON, `"status":"wait_error"`) && strings.Contains(event.PayloadJSON, "execution transport failed") {
+				foundFailed = true
+			}
+		}
+	}
+	if !foundStarted || !foundFailed {
+		t.Fatalf("events = %#v, want started and terminal wait-error events", events)
+	}
+}
+
 func TestNewDefaultsReviewerTimeoutToNinetyMinutes(t *testing.T) {
 	t.Parallel()
 	runner := New(Options{})

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -3979,6 +3979,55 @@ func TestProcessClaimedItemPreservesPausedLoopOnRetryableFailureAfterPause(t *te
 	}
 }
 
+func TestProcessClaimedItemClassifiesReviewerTimeoutWithDiagnostics(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewMarkerMissing: true}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "timeout", Summary: "processed 900 files before timeout", TimeoutType: "max_runtime", ConfiguredMaxRuntimeSeconds: 5400, ConfiguredIdleTimeoutSeconds: 600, ElapsedRuntimeSeconds: 5400, LastProgressAt: "2026-04-11T12:45:00.000Z"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient {
+		t.Fatalf("result = %#v, want retryable timeout failure", result)
+	}
+	for _, want := range []string{"timed out (max_runtime)", "configured max runtime 5400s", "idle timeout 600s", "last progress at 2026-04-11T12:45:00.000Z", "processed 900 files"} {
+		if !strings.Contains(result.Summary, want) {
+			t.Fatalf("result.Summary = %q, want %q", result.Summary, want)
+		}
+	}
+	events, err := fixture.repos.Events.ListByEntity(context.Background(), "pull_request", "acme/looper#42")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	foundTimeoutEvent := false
+	for _, event := range events {
+		if event.EventType == "reviewer.agent.timed_out" && strings.Contains(event.PayloadJSON, `"timeoutType":"max_runtime"`) && strings.Contains(event.PayloadJSON, `"elapsedRuntimeSeconds":5400`) {
+			foundTimeoutEvent = true
+		}
+	}
+	if !foundTimeoutEvent {
+		t.Fatalf("events = %#v, want reviewer.agent.timed_out diagnostics", events)
+	}
+}
+
+func TestNewDefaultsReviewerTimeoutToNinetyMinutes(t *testing.T) {
+	t.Parallel()
+	runner := New(Options{})
+	if runner.agentTimeout != 90*time.Minute {
+		t.Fatalf("agentTimeout = %s, want 90m", runner.agentTimeout)
+	}
+}
+
 func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Align the reviewer fallback agent runtime with the 90-minute configured default to reduce large-PR max-runtime timeouts.
- Add reviewer step and agent phase timing events/logs, including prompt size and timeout policy metadata.
- Classify reviewer agent timeouts with explicit timeout type, configured limits, elapsed runtime, last progress, and summary context.

## Validation
- go test ./internal/reviewer
- go test ./...
- go build ./...
- go vet ./...

Closes #201

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.5.4 · runner=worker · agent=opencode</sub>