### PR TITLE
fix: recover stale worker worktree paths

### DIFF
--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -2465,6 +2465,14 @@ func (g smokeGitGateway) CreateWorktree(ctx context.Context, input worker.Create
 	}, nil
 }
 
+func (g smokeGitGateway) RestoreWorktree(ctx context.Context, input worker.RestoreWorktreeInput) (*worker.RestoreWorktreeResult, error) {
+	record, err := g.gateway.RestoreWorktree(ctx, gitinfra.RestoreWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, Branch: input.Branch, WorktreeRoot: input.WorktreeRoot, CheckoutMode: gitinfra.CheckoutMode(input.CheckoutMode), ExpectedWorktreePath: input.ExpectedWorktreePath})
+	if err != nil || record == nil {
+		return nil, err
+	}
+	return &worker.RestoreWorktreeResult{WorktreePath: record.WorktreePath, Branch: record.Branch, BaseBranch: strings.TrimSpace(derefString(record.BaseBranch)), HeadSHA: strings.TrimSpace(derefString(record.HeadSHA)), WorktreeID: record.ID}, nil
+}
+
 func (g smokeGitGateway) PrepareWorktree(ctx context.Context, input worker.PrepareWorktreeInput) (worker.PrepareWorktreeResult, error) {
 	prepared, err := g.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{
 		WorktreePath:    input.WorktreePath,

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -572,6 +572,14 @@ func (a workerGitAdapter) CreateWorktree(ctx context.Context, input worker.Creat
 	return worker.CreateWorktreeResult{WorktreePath: worktree.WorktreePath, Branch: worktree.Branch, BaseBranch: derefString(worktree.BaseBranch), HeadSHA: derefString(worktree.HeadSHA), WorktreeID: worktree.ID}, nil
 }
 
+func (a workerGitAdapter) RestoreWorktree(ctx context.Context, input worker.RestoreWorktreeInput) (*worker.RestoreWorktreeResult, error) {
+	worktree, err := a.gateway.RestoreWorktree(ctx, gitinfra.RestoreWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, Branch: input.Branch, WorktreeRoot: input.WorktreeRoot, CheckoutMode: gitinfra.CheckoutMode(input.CheckoutMode), ExpectedWorktreePath: input.ExpectedWorktreePath})
+	if err != nil || worktree == nil {
+		return nil, err
+	}
+	return &worker.RestoreWorktreeResult{WorktreePath: worktree.WorktreePath, Branch: worktree.Branch, BaseBranch: derefString(worktree.BaseBranch), HeadSHA: derefString(worktree.HeadSHA), WorktreeID: worktree.ID}, nil
+}
+
 func (a workerGitAdapter) PrepareWorktree(ctx context.Context, input worker.PrepareWorktreeInput) (worker.PrepareWorktreeResult, error) {
 	result, err := a.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{WorktreePath: input.WorktreePath, Branch: input.Branch, ExpectedHeadSHA: input.ExpectedHeadSHA, Remote: input.Remote})
 	if err != nil {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -226,6 +226,23 @@ type CreateWorktreeResult struct {
 	WorktreeID   string
 }
 
+type RestoreWorktreeInput struct {
+	ProjectID            string
+	RepoPath             string
+	Branch               string
+	WorktreeRoot         string
+	CheckoutMode         string
+	ExpectedWorktreePath string
+}
+
+type RestoreWorktreeResult struct {
+	WorktreePath string
+	Branch       string
+	BaseBranch   string
+	HeadSHA      string
+	WorktreeID   string
+}
+
 type PrepareWorktreeInput struct {
 	WorktreePath    string
 	Branch          string
@@ -266,6 +283,7 @@ type CommitResult struct{ CommitSHA string }
 
 type GitGateway interface {
 	CreateWorktree(context.Context, CreateWorktreeInput) (CreateWorktreeResult, error)
+	RestoreWorktree(context.Context, RestoreWorktreeInput) (*RestoreWorktreeResult, error)
 	PrepareWorktree(context.Context, PrepareWorktreeInput) (PrepareWorktreeResult, error)
 	InspectHead(context.Context, InspectHeadInput) (InspectHeadResult, error)
 	Commit(context.Context, CommitInput) (CommitResult, error)
@@ -1114,6 +1132,78 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (w
 	return checkpoint, nil
 }
 
+func (r *Runner) ensureWorkerWorktreeUsable(ctx context.Context, input stepInput, checkpoint *workerCheckpoint, work workerInput, worktree checkpointWorktree) (checkpointWorktree, error) {
+	if strings.TrimSpace(worktree.Path) == "" {
+		return worktree, nil
+	}
+	info, err := os.Stat(worktree.Path)
+	if err == nil {
+		if !info.IsDir() {
+			return r.recoverWorkerWorktree(ctx, input, checkpoint, work, worktree, "path exists but is not a directory")
+		}
+		if _, gitErr := os.Stat(filepath.Join(worktree.Path, ".git")); gitErr != nil {
+			if errors.Is(gitErr, os.ErrNotExist) {
+				return r.recoverWorkerWorktree(ctx, input, checkpoint, work, worktree, "path is not a usable git worktree")
+			}
+			return worktree, &loopError{message: fmt.Sprintf("Unable to inspect worker worktree git metadata at %s for branch %s: %v", worktree.Path, firstNonEmpty(worktree.Branch, work.Branch, "unknown"), gitErr), kind: FailureRetryableTransient}
+		}
+		return worktree, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return worktree, &loopError{message: fmt.Sprintf("Unable to inspect worker worktree path %s for branch %s: %v", worktree.Path, firstNonEmpty(worktree.Branch, work.Branch, "unknown"), err), kind: FailureRetryableTransient}
+	}
+	return r.recoverWorkerWorktree(ctx, input, checkpoint, work, worktree, "path does not exist")
+}
+
+func (r *Runner) recoverWorkerWorktree(ctx context.Context, input stepInput, checkpoint *workerCheckpoint, work workerInput, worktree checkpointWorktree, reason string) (checkpointWorktree, error) {
+	if r.git == nil {
+		return worktree, staleWorkerWorktreeError(worktree, work, reason+" and git gateway is not configured")
+	}
+	branch := firstNonEmpty(worktree.Branch, work.Branch)
+	if branch == "" {
+		return worktree, staleWorkerWorktreeError(worktree, work, reason+" and target branch is not recorded")
+	}
+	worktreeRoot, rootErr := workerWorktreeRoot(input.Project)
+	if rootErr != nil {
+		return worktree, &loopError{message: rootErr.Error(), kind: FailureRetryableTransient}
+	}
+	restored, restoreErr := r.git.RestoreWorktree(ctx, RestoreWorktreeInput{ProjectID: input.Project.ID, RepoPath: input.Project.RepoPath, Branch: branch, WorktreeRoot: worktreeRoot, ExpectedWorktreePath: worktree.Path})
+	if restoreErr != nil {
+		return worktree, &loopError{message: fmt.Sprintf("Worker worktree path %s for branch %s is stale (%s) and re-resolving registered git worktrees failed: %v", worktree.Path, branch, reason, restoreErr), kind: FailureRetryableAfterResume}
+	}
+	if restored == nil || strings.TrimSpace(restored.WorktreePath) == "" {
+		return worktree, staleWorkerWorktreeError(worktree, work, reason+" and no active git worktree is registered for that branch")
+	}
+	recovered := worktree
+	recovered.Path = restored.WorktreePath
+	recovered.Branch = firstNonEmpty(restored.Branch, branch)
+	recovered.BaseBranch = firstNonEmpty(worktree.BaseBranch, restored.BaseBranch, work.BaseBranch)
+	recovered.HeadSHA = firstNonEmpty(worktree.HeadSHA, restored.HeadSHA)
+	recovered.ID = firstNonEmpty(restored.WorktreeID, worktree.ID)
+	checkpoint.Worktree = &recovered
+	checkpoint.ResumePolicy = "advance_from_checkpoint"
+	if input.Run.ID != "" {
+		if persistErr := r.persistCheckpoint(ctx, input.Run.ID, *checkpoint); persistErr != nil {
+			return worktree, &loopError{message: persistErr.Error(), kind: FailureRetryableAfterResume}
+		}
+	}
+	return recovered, nil
+}
+
+func workerWorktreeRoot(project storage.ProjectRecord) (string, error) {
+	projectMetadata := parseJSONObject(project.MetadataJSON)
+	worktreeRoot := stringFromAnyDefault(projectMetadata["worktreeRoot"])
+	if worktreeRoot != "" {
+		return worktreeRoot, nil
+	}
+	return config.DefaultProjectWorktreeRoot(project.ID, project.RepoPath)
+}
+
+func staleWorkerWorktreeError(worktree checkpointWorktree, work workerInput, detail string) error {
+	branch := firstNonEmpty(worktree.Branch, work.Branch, "unknown")
+	return &loopError{message: fmt.Sprintf("Worker worktree path %s for branch %s is stale (%s). Run `git -C <repo> worktree list` to find or recreate the branch worktree, then resume the worker run.", worktree.Path, branch, detail), kind: FailureManualIntervention}
+}
+
 func (r *Runner) runPlanStep(input stepInput) (workerCheckpoint, error) {
 	checkpoint := input.Checkpoint
 	if checkpoint.Plan != nil {
@@ -1156,6 +1246,10 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 		return checkpoint, err
 	}
 	worktree, err := requireWorktree(checkpoint)
+	if err != nil {
+		return checkpoint, err
+	}
+	worktree, err = r.ensureWorkerWorktreeUsable(ctx, input, &checkpoint, work, worktree)
 	if err != nil {
 		return checkpoint, err
 	}
@@ -1276,7 +1370,15 @@ func (r *Runner) reconcileWorkerGitState(ctx context.Context, checkpoint *worker
 
 func (r *Runner) runValidateStep(ctx context.Context, input stepInput) (workerCheckpoint, error) {
 	checkpoint := input.Checkpoint
+	work, err := requireWork(checkpoint)
+	if err != nil {
+		return checkpoint, err
+	}
 	worktree, err := requireWorktree(checkpoint)
+	if err != nil {
+		return checkpoint, err
+	}
+	worktree, err = r.ensureWorkerWorktreeUsable(ctx, input, &checkpoint, work, worktree)
 	if err != nil {
 		return checkpoint, err
 	}
@@ -1299,6 +1401,10 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		return checkpoint, &loopError{message: firstNonEmpty(checkpoint.Validation.Summary, "Validation failed"), kind: FailureManualIntervention}
 	}
 	worktree, err := requireWorktree(checkpoint)
+	if err != nil {
+		return checkpoint, err
+	}
+	worktree, err = r.ensureWorkerWorktreeUsable(ctx, input, &checkpoint, work, worktree)
 	if err != nil {
 		return checkpoint, err
 	}

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -481,6 +481,68 @@ func TestRunExecuteStepFailsResumedCompletedCheckpointWithoutParsedResult(t *tes
 	}
 }
 
+func TestRunExecuteStepRecoversStaleWorktreePathBeforeAgentStart(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	recoveredPath := t.TempDir()
+	stalePath := filepath.Join(t.TempDir(), "old-worktree")
+	branch := "looper/feature"
+	git := &fakeGitGateway{
+		restoreResult: &RestoreWorktreeResult{WorktreePath: recoveredPath, Branch: branch, BaseBranch: "main", HeadSHA: "def456", WorktreeID: "worktree_recovered"},
+		inspectResult: InspectHeadResult{HeadSHA: "def456"},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true})
+	run := storage.RunRecord{ID: "run_stale_worktree", LoopID: "loop_worker_1", Status: "running", CurrentStep: stringPtr(string(stepExecute)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+	checkpoint, err := runner.runExecuteStep(context.Background(), stepInput{
+		Project: *project,
+		Loop:    *loop,
+		Run:     run,
+		Checkpoint: workerCheckpoint{
+			Work:     &workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", ExecutionMode: "create-pr"},
+			Worktree: &checkpointWorktree{ID: "worktree_old", Path: stalePath, Branch: branch, BaseBranch: "main", HeadSHA: "abc123"},
+			Plan:     &checkpointPlan{Summary: "Implement worker loop", Items: []string{"Do it"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runExecuteStep() error = %v", err)
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != recoveredPath || checkpoint.Worktree.ID != "worktree_recovered" || checkpoint.Worktree.HeadSHA != "abc123" {
+		t.Fatalf("checkpoint.Worktree = %#v, want recovered worktree", checkpoint.Worktree)
+	}
+	if len(git.restoreCalls) != 1 || git.restoreCalls[0].Branch != branch || git.restoreCalls[0].ExpectedWorktreePath != stalePath {
+		t.Fatalf("restoreCalls = %#v, want branch recovery from stale path", git.restoreCalls)
+	}
+	if len(agent.starts) != 1 || agent.starts[0].WorkingDirectory != recoveredPath {
+		t.Fatalf("agent starts = %#v, want recovered working directory", agent.starts)
+	}
+	if len(git.inspectCalls) != 1 || git.inspectCalls[0].WorktreePath != recoveredPath {
+		t.Fatalf("inspectCalls = %#v, want recovered worktree path", git.inspectCalls)
+	}
+	persisted, err := fixture.repos.Runs.GetByID(context.Background(), run.ID)
+	if err != nil || persisted == nil {
+		t.Fatalf("Runs.GetByID() = (%#v, %v), want persisted run", persisted, err)
+	}
+	persistedCheckpoint, err := parseCheckpoint(persisted.CheckpointJSON)
+	if err != nil {
+		t.Fatalf("parseCheckpoint() error = %v", err)
+	}
+	if persistedCheckpoint.Worktree == nil || persistedCheckpoint.Worktree.Path != recoveredPath {
+		t.Fatalf("persisted checkpoint worktree = %#v, want recovered path", persistedCheckpoint.Worktree)
+	}
+}
+
 func TestCreateRunContextReplaysExecuteWhenResumeCheckpointParseStatusIsInvalid(t *testing.T) {
 	t.Parallel()
 
@@ -2406,6 +2468,7 @@ func (f *fakeGitHubGateway) AddPullRequestReviewers(_ context.Context, input Pul
 
 type fakeGitGateway struct {
 	createResult   CreateWorktreeResult
+	restoreResult  *RestoreWorktreeResult
 	prepareResult  PrepareWorktreeResult
 	inspectResult  InspectHeadResult
 	inspectResults []InspectHeadResult
@@ -2413,6 +2476,7 @@ type fakeGitGateway struct {
 	inspectIndex   int
 	commitResult   CommitResult
 	createCalls    []CreateWorktreeInput
+	restoreCalls   []RestoreWorktreeInput
 	pushCalls      []PushInput
 	prepareCalls   []PrepareWorktreeInput
 	inspectCalls   []InspectHeadInput
@@ -2424,6 +2488,14 @@ type fakeGitGateway struct {
 func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeInput) (CreateWorktreeResult, error) {
 	f.createCalls = append(f.createCalls, input)
 	return f.createResult, nil
+}
+
+func (f *fakeGitGateway) RestoreWorktree(_ context.Context, input RestoreWorktreeInput) (*RestoreWorktreeResult, error) {
+	f.restoreCalls = append(f.restoreCalls, input)
+	if f.restoreResult != nil {
+		return f.restoreResult, nil
+	}
+	return &RestoreWorktreeResult{WorktreePath: input.ExpectedWorktreePath, Branch: input.Branch}, nil
 }
 
 func (f *fakeGitGateway) PrepareWorktree(_ context.Context, input PrepareWorktreeInput) (PrepareWorktreeResult, error) {


### PR DESCRIPTION
## Summary
- Re-resolve worker checkpoint worktree paths when the persisted path is missing or not a usable Git worktree before execution, validation, or PR fallback operations.
- Persist the recovered worktree path back into the run checkpoint while preserving the original baseline SHA for reconciliation.
- Add worker coverage for stale persisted worktree recovery before agent startup.

## Validation
- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- `go build ./...`

Closes #206

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.5.4 · runner=worker · agent=opencode</sub>