### PR TITLE
ci: run checks on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened
@@ -14,7 +17,7 @@ concurrency:
 
 jobs:
   verify:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Run CI on pushes to the main branch in addition to pull request updates.
- Guard the draft PR condition so the verify job can also run for push events.

## Tests
- go test ./...