### PR TITLE
fix: resolve reviewer threads after review request removal

### DIFF
--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1706,7 +1706,7 @@ func markThreadResolutionRediscoveryOnRefreshError(checkpoint reviewerCheckpoint
 
 func (r *Runner) hasThreadResolutionFollowUpCandidate(ctx context.Context, cwd, repo string, prNumber int64, headSHA, currentLogin string) bool {
 	policy := r.threadResolution
-	if !policy.Enabled || r.github == nil || strings.TrimSpace(headSHA) == "" || strings.TrimSpace(currentLogin) == "" {
+	if !policy.Enabled || policy.RequireCurrentReviewRequest || r.github == nil || strings.TrimSpace(headSHA) == "" || strings.TrimSpace(currentLogin) == "" {
 		return false
 	}
 	limit := policy.MaxThreadsPerRun

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -437,16 +437,17 @@ type ProcessResult struct {
 }
 
 type reviewerCheckpoint struct {
-	ResumePolicy      string                      `json:"resumePolicy,omitempty"`
-	Detail            *checkpointDetail           `json:"detail,omitempty"`
-	ClaimedLockKey    string                      `json:"claimedLockKey,omitempty"`
-	Snapshot          *checkpointSnapshot         `json:"snapshot,omitempty"`
-	Worktree          *checkpointWorktree         `json:"worktree,omitempty"`
-	ThreadResolution  *threadResolutionCheckpoint `json:"threadResolution,omitempty"`
-	PendingReview     *pendingReviewCheckpoint    `json:"pendingReview,omitempty"`
-	SkipReason        string                      `json:"skipReason,omitempty"`
-	SkipKind          string                      `json:"skipKind,omitempty"`
-	SkipReviewerLogin string                      `json:"skipReviewerLogin,omitempty"`
+	ResumePolicy                 string                      `json:"resumePolicy,omitempty"`
+	Detail                       *checkpointDetail           `json:"detail,omitempty"`
+	ClaimedLockKey               string                      `json:"claimedLockKey,omitempty"`
+	Snapshot                     *checkpointSnapshot         `json:"snapshot,omitempty"`
+	Worktree                     *checkpointWorktree         `json:"worktree,omitempty"`
+	ThreadResolution             *threadResolutionCheckpoint `json:"threadResolution,omitempty"`
+	ThreadResolutionFollowUpOnly bool                        `json:"threadResolutionFollowUpOnly,omitempty"`
+	PendingReview                *pendingReviewCheckpoint    `json:"pendingReview,omitempty"`
+	SkipReason                   string                      `json:"skipReason,omitempty"`
+	SkipKind                     string                      `json:"skipKind,omitempty"`
+	SkipReviewerLogin            string                      `json:"skipReviewerLogin,omitempty"`
 }
 
 type checkpointDetail struct {
@@ -1241,9 +1242,13 @@ func (r *Runner) runDiscoverStep(ctx context.Context, input stepInput) (reviewer
 		return input.Checkpoint, err
 	}
 	checkpoint := input.Checkpoint
-	checkpoint.Detail = &checkpointDetail{Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, Author: detail.Author, ReviewRequests: cloneStrings(detail.ReviewRequests), HasConflicts: detail.HasConflicts, Comments: cloneObjectSlice(detail.Comments), IssueComments: cloneObjectSlice(detail.IssueComments), Reviews: cloneObjectSlice(detail.Reviews)}
+	checkpoint.Detail = checkpointDetailFromDetail(detail)
 	checkpoint.ResumePolicy = "replay_step"
 	return checkpoint, nil
+}
+
+func checkpointDetailFromDetail(detail PullRequestDetail) *checkpointDetail {
+	return &checkpointDetail{Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, Author: detail.Author, ReviewRequests: cloneStrings(detail.ReviewRequests), HasConflicts: detail.HasConflicts, Comments: cloneObjectSlice(detail.Comments), IssueComments: cloneObjectSlice(detail.IssueComments), Reviews: cloneObjectSlice(detail.Reviews)}
 }
 
 func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCheckpoint, error) {
@@ -1331,7 +1336,11 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 			currentLogin = normalizeLogin(lookupLogin)
 			checkpoint.Detail.CurrentLogin = currentLogin
 		}
-		if !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, currentLogin) && !r.hasThreadResolutionFollowUpCandidate(ctx, input.Project.RepoPath, input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA, currentLogin) {
+		if !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, currentLogin) {
+			if r.hasThreadResolutionFollowUpCandidate(ctx, input.Project.RepoPath, input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA, currentLogin) {
+				checkpoint.ThreadResolutionFollowUpOnly = true
+				return checkpoint, nil
+			}
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", input.Repo, input.PRNumber)
 			checkpoint.SkipKind = "not_requested"
 			return checkpoint, nil
@@ -2015,6 +2024,9 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	if checkpoint.PendingReview != nil {
 		return checkpoint, nil
 	}
+	if skipped, next, err := r.skipThreadResolutionFollowUpReview(ctx, input, checkpoint); skipped || err != nil {
+		return next, err
+	}
 	if checkpoint.Snapshot == nil {
 		return checkpoint, &loopError{message: "Missing PR snapshot checkpoint for review step", kind: FailureRetryableTransient}
 	}
@@ -2210,6 +2222,10 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 	if reason := reviewerPublishDriftReason(input, checkpoint, detail); reason != "" {
 		return markReviewerRunStale(checkpoint, reason), nil
 	}
+	checkpoint.Detail = checkpointDetailFromDetail(detail)
+	if skipped, next, err := r.skipThreadResolutionFollowUpReview(ctx, input, checkpoint); skipped || err != nil {
+		return next, err
+	}
 	markerResult := ReviewMarkerResult{}
 	if pending.Event == reviewEventAgentNative {
 		found, err := r.verifyAgentNativeReviewMarker(ctx, input, pending.HeadSHA, pending.IdempotencyKey, cleanReviewAuthorLogin(checkpoint, detail))
@@ -2223,12 +2239,12 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		return checkpoint, &loopError{message: "Legacy pending review checkpoint cannot be verified; rerunning review before marking publish success", kind: FailureRetryableAfterResume}
 	}
 	policy := r.discoveryPolicyForProject(input.Project.ID)
-	if !isManualReviewerLoop(input.Loop) && policy.RequireReviewRequest {
+	if !isManualReviewerLoop(input.Loop) && policy.RequireReviewRequest && !markerResult.Found {
 		currentLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
 		if err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
-		if !isCurrentUserRequested(detail.ReviewRequests, normalizeLogin(currentLogin)) && !markerResult.Found {
+		if !isCurrentUserRequested(detail.ReviewRequests, normalizeLogin(currentLogin)) {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", repo, prNumber)
 			return checkpoint, nil
 		}
@@ -2266,6 +2282,32 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		return checkpoint, err
 	}
 	return checkpoint, nil
+}
+
+func (r *Runner) skipThreadResolutionFollowUpReview(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint) (bool, reviewerCheckpoint, error) {
+	if !checkpoint.ThreadResolutionFollowUpOnly {
+		return false, checkpoint, nil
+	}
+	policy := r.discoveryPolicyForProject(input.Project.ID)
+	if isManualReviewerLoop(input.Loop) || !policy.RequireReviewRequest || checkpoint.Detail == nil {
+		return false, checkpoint, nil
+	}
+	currentLogin := strings.TrimSpace(checkpoint.Detail.CurrentLogin)
+	if currentLogin == "" {
+		lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+		if err != nil {
+			return false, checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
+		currentLogin = normalizeLogin(lookupLogin)
+		checkpoint.Detail.CurrentLogin = currentLogin
+	}
+	if isCurrentUserRequested(checkpoint.Detail.ReviewRequests, currentLogin) {
+		return false, checkpoint, nil
+	}
+	checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", input.Repo, input.PRNumber)
+	checkpoint.SkipKind = "not_requested"
+	checkpoint.PendingReview = nil
+	return true, checkpoint, nil
 }
 
 func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepInput, headSHA string, idempotencyKey string, prAuthorLogin string) (ReviewMarkerResult, error) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1742,7 +1742,7 @@ func (r *Runner) threadResolutionCandidate(thread ReviewThread, headSHA, current
 		return false
 	}
 	if policy.RequireNewHeadSinceThread && headSHA != "" {
-		threadSHA := originalThreadFeedbackCommitOID(thread)
+		threadSHA := latestThreadFeedbackCommitOID(thread)
 		if threadSHA == "" || threadSHA == headSHA {
 			return false
 		}
@@ -1929,18 +1929,6 @@ func isLooperAuthoredThread(thread ReviewThread) bool {
 func latestThreadFeedbackCommitOID(thread ReviewThread) string {
 	for i := len(thread.Comments) - 1; i >= 0; i-- {
 		comment := thread.Comments[i]
-		if strings.Contains(comment.Body, "looper:thread-resolution") {
-			continue
-		}
-		if oid := firstNonEmpty(comment.CommitOID, comment.OriginalCommitOID); oid != "" {
-			return oid
-		}
-	}
-	return ""
-}
-
-func originalThreadFeedbackCommitOID(thread ReviewThread) string {
-	for _, comment := range thread.Comments {
 		if strings.Contains(comment.Body, "looper:thread-resolution") {
 			continue
 		}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1761,6 +1761,9 @@ func (r *Runner) refreshThreadResolutionCandidate(ctx context.Context, input ste
 	if normalizePRState(detail.State) != "open" || detail.HeadSHA != headSHA {
 		return nil, PullRequestDetail{}, &loopError{message: "PR changed during thread reconciliation", kind: FailureRetryableAfterResume}
 	}
+	if policy.RequireCurrentReviewRequest && !isCurrentUserRequested(detail.ReviewRequests, currentLogin) {
+		return nil, detail, nil
+	}
 	latest, err := r.github.ListReviewThreads(ctx, ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath, Limit: limit})
 	if err != nil {
 		return nil, detail, &loopError{message: err.Error(), kind: FailureRetryableTransient}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -756,7 +756,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			result.Skipped++
 			continue
 		}
-		if !isManualReviewerLoop(loop) && policy.RequireReviewRequest && !isCurrentUserRequested(detail.ReviewRequests, currentLogin) {
+		if !isManualReviewerLoop(loop) && policy.RequireReviewRequest && !isCurrentUserRequested(detail.ReviewRequests, currentLogin) && !r.hasThreadResolutionFollowUpCandidate(ctx, project.RepoPath, input.Repo, *loop.PRNumber, detail.HeadSHA, currentLogin) {
 			result.Skipped++
 			continue
 		}
@@ -1320,7 +1320,7 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 			currentLogin = normalizeLogin(lookupLogin)
 			checkpoint.Detail.CurrentLogin = currentLogin
 		}
-		if !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, currentLogin) {
+		if !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, currentLogin) && !r.hasThreadResolutionFollowUpCandidate(ctx, input.Project.RepoPath, input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA, currentLogin) {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", input.Repo, input.PRNumber)
 			checkpoint.SkipKind = "not_requested"
 			return checkpoint, nil
@@ -1586,10 +1586,6 @@ func (r *Runner) runThreadResolutionStep(ctx context.Context, input stepInput) (
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
 	currentLogin = normalizeLogin(currentLogin)
-	if policy.RequireCurrentReviewRequest && !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, currentLogin) {
-		r.appendThreadResolutionEvent(ctx, input, checkpoint.Snapshot.HeadSHA, "skipped", "current_user_not_requested", "", "skipped", "current_user_not_requested")
-		return checkpoint, nil
-	}
 	limit := policy.MaxThreadsPerRun
 	if limit <= 0 {
 		limit = 10
@@ -1630,7 +1626,7 @@ func (r *Runner) runThreadResolutionStep(ctx context.Context, input stepInput) (
 			decision = threadResolutionAgentDecision{ThreadID: thread.ID, Decision: "needs_human", Evidence: "no classifier decision returned", Confidence: "low"}
 		}
 		result.Processed++
-		auditedForHead := hasThreadResolutionAuditForHead(thread, checkpoint.Snapshot.HeadSHA)
+		auditedForHead := hasSufficientThreadResolutionAuditForDecision(policy, thread, checkpoint.Snapshot.HeadSHA, decision)
 		commented := false
 		resolved := false
 		skippedReason := ""
@@ -1697,6 +1693,32 @@ func markThreadResolutionRediscoveryOnRefreshError(checkpoint reviewerCheckpoint
 	return checkpoint
 }
 
+func (r *Runner) hasThreadResolutionFollowUpCandidate(ctx context.Context, cwd, repo string, prNumber int64, headSHA, currentLogin string) bool {
+	policy := r.threadResolution
+	if !policy.Enabled || r.github == nil || strings.TrimSpace(headSHA) == "" || strings.TrimSpace(currentLogin) == "" {
+		return false
+	}
+	limit := policy.MaxThreadsPerRun
+	if limit <= 0 {
+		limit = 10
+	}
+	fetchLimit := limit * 5
+	if fetchLimit < 100 {
+		fetchLimit = 100
+	}
+	threads, err := r.github.ListReviewThreads(ctx, ListReviewThreadsInput{Repo: repo, PRNumber: prNumber, CWD: cwd, Limit: fetchLimit})
+	if err != nil {
+		r.logWarn("reviewer thread resolution follow-up candidate lookup failed", map[string]any{"repo": repo, "prNumber": prNumber, "error": err.Error()})
+		return false
+	}
+	for _, thread := range threads {
+		if r.threadResolutionCandidate(thread, headSHA, currentLogin, policy) {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *Runner) threadResolutionCandidate(thread ReviewThread, headSHA, currentLogin string, policy config.ReviewerThreadResolutionConfig) bool {
 	if thread.IsResolved || thread.ID == "" || len(thread.Comments) == 0 {
 		return false
@@ -1709,7 +1731,7 @@ func (r *Runner) threadResolutionCandidate(thread ReviewThread, headSHA, current
 		return false
 	}
 	if policy.RequireNewHeadSinceThread && headSHA != "" {
-		threadSHA := latestThreadFeedbackCommitOID(thread)
+		threadSHA := originalThreadFeedbackCommitOID(thread)
 		if threadSHA == "" || threadSHA == headSHA {
 			return false
 		}
@@ -1727,9 +1749,6 @@ func (r *Runner) refreshThreadResolutionCandidate(ctx context.Context, input ste
 	}
 	if normalizePRState(detail.State) != "open" || detail.HeadSHA != headSHA {
 		return nil, PullRequestDetail{}, &loopError{message: "PR changed during thread reconciliation", kind: FailureRetryableAfterResume}
-	}
-	if policy.RequireCurrentReviewRequest && !isCurrentUserRequested(detail.ReviewRequests, currentLogin) {
-		return nil, detail, nil
 	}
 	latest, err := r.github.ListReviewThreads(ctx, ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath, Limit: limit})
 	if err != nil {
@@ -1871,6 +1890,13 @@ func hasThreadResolutionAuditForHead(thread ReviewThread, headSHA string) bool {
 	return false
 }
 
+func hasSufficientThreadResolutionAuditForDecision(policy config.ReviewerThreadResolutionConfig, thread ReviewThread, headSHA string, decision threadResolutionAgentDecision) bool {
+	if policy.Mode == config.ReviewerThreadResolutionModeResolveObjective && isObjectiveThreadResolutionDecision(decision) {
+		return hasObjectiveThreadResolutionAuditForHead(thread, thread.ID, headSHA)
+	}
+	return hasThreadResolutionAuditForHead(thread, headSHA)
+}
+
 func hasObjectiveThreadResolutionAuditForHead(thread ReviewThread, threadID, headSHA string) bool {
 	for _, comment := range thread.Comments {
 		body := comment.Body
@@ -1892,6 +1918,18 @@ func isLooperAuthoredThread(thread ReviewThread) bool {
 func latestThreadFeedbackCommitOID(thread ReviewThread) string {
 	for i := len(thread.Comments) - 1; i >= 0; i-- {
 		comment := thread.Comments[i]
+		if strings.Contains(comment.Body, "looper:thread-resolution") {
+			continue
+		}
+		if oid := firstNonEmpty(comment.CommitOID, comment.OriginalCommitOID); oid != "" {
+			return oid
+		}
+	}
+	return ""
+}
+
+func originalThreadFeedbackCommitOID(thread ReviewThread) string {
+	for _, comment := range thread.Comments {
 		if strings.Contains(comment.Body, "looper:thread-resolution") {
 			continue
 		}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -480,6 +480,7 @@ func TestDiscoverPullRequestsAllowsThreadResolutionFollowUpWhenCurrentUserIsNotR
 	policy := defaultThreadResolutionPolicy(t)
 	policy.Enabled = true
 	policy.Mode = config.ReviewerThreadResolutionModeResolveObjective
+	policy.RequireCurrentReviewRequest = false
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy})
 	nowISO := fixture.nowISO()
 	repo := "acme/looper"
@@ -496,6 +497,33 @@ func TestDiscoverPullRequestsAllowsThreadResolutionFollowUpWhenCurrentUserIsNotR
 	}
 	if len(result.QueueItems) != 1 {
 		t.Fatalf("len(QueueItems) = %d, want 1", len(result.QueueItems))
+	}
+}
+
+func TestDiscoverPullRequestsRequiresCurrentReviewRequestBeforeThreadResolutionFollowUp(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"alice"}, currentLogin: "bob", reviewThreads: []ReviewThread{{ID: "thread_1", Comments: []ReviewThreadComment{{ID: "comment_1", Author: "bob", Body: "Please update this. <!-- looper:stamp v=1 -->", CommitOID: "old-head"}}}}}
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = true
+	policy.Mode = config.ReviewerThreadResolutionModeResolveObjective
+	policy.RequireCurrentReviewRequest = true
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"followUpdates":true}`
+	loop := storage.LoopRecord{ID: "loop_follow_thread_resolution_requires_request", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("len(QueueItems) = %d, want 0", len(result.QueueItems))
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -5209,7 +5209,7 @@ func TestRunThreadResolutionStepResolvesLooperThreadWhenCurrentUserNotRequested(
 	}
 }
 
-func TestRunThreadResolutionStepUsesOriginalThreadCommitForNewHeadCheck(t *testing.T) {
+func TestRunThreadResolutionStepRequiresNewHeadAfterLatestThreadFeedback(t *testing.T) {
 	t.Parallel()
 	policy := defaultThreadResolutionPolicy(t)
 	policy.Enabled = true
@@ -5225,8 +5225,11 @@ func TestRunThreadResolutionStepUsesOriginalThreadCommitForNewHeadCheck(t *testi
 	if err != nil {
 		t.Fatalf("runThreadResolutionStep() error = %v", err)
 	}
-	if checkpoint.ThreadResolution == nil || checkpoint.ThreadResolution.Reported != 1 || checkpoint.ThreadResolution.Resolved != 1 {
-		t.Fatalf("ThreadResolution = %#v, want thread eligible and resolved", checkpoint.ThreadResolution)
+	if checkpoint.ThreadResolution == nil || checkpoint.ThreadResolution.Reported != 0 || checkpoint.ThreadResolution.Processed != 0 {
+		t.Fatalf("ThreadResolution = %#v, want no eligible candidates", checkpoint.ThreadResolution)
+	}
+	if len(agent.starts) != 0 || len(github.addThreadReplyCalls) != 0 || len(github.resolveThreadCalls) != 0 {
+		t.Fatalf("side effects: agent=%d replies=%d resolves=%d, want none", len(agent.starts), len(github.addThreadReplyCalls), len(github.resolveThreadCalls))
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -5049,6 +5049,78 @@ func TestRunReviewStepIgnoresUnparsedReviewRequestGuardrailForManualLoop(t *test
 	}
 }
 
+func TestRunReviewStepSkipsWhenFollowUpLostReviewRequest(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"alice"}, currentLogin: "bob"}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "should not run", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	checkpoint, err := runner.runReviewStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     storage.LoopRecord{ID: "loop_followup_request_gone", ProjectID: project.ID, Type: "reviewer"},
+		Run:      storage.RunRecord{ID: "run_followup_request_gone", LoopID: "loop_followup_request_gone"},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:                       &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", ReviewRequests: []string{"alice"}, CurrentLogin: "bob"},
+			Snapshot:                     &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree:                     &checkpointWorktree{Path: t.TempDir(), Branch: "pr-42-head", PreparedAt: fixture.nowISO()},
+			ThreadResolutionFollowUpOnly: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("runReviewStep() error = %v", err)
+	}
+	if checkpoint.SkipKind != "not_requested" {
+		t.Fatalf("SkipKind = %q, want not_requested", checkpoint.SkipKind)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("len(agent.starts) = %d, want 0", len(agent.starts))
+	}
+}
+
+func TestRunPublishStepSkipsPendingReviewWhenFollowUpLostReviewRequest(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"alice"}, currentLogin: "bob", reviewMarkerEvent: ReviewEventComment, reviewMarkerOutcome: "non_blocking"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     storage.LoopRecord{ID: "loop_publish_request_gone", ProjectID: project.ID, Type: "reviewer"},
+		Run:      storage.RunRecord{ID: "run_publish_request_gone", LoopID: "loop_publish_request_gone"},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:                       &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", ReviewRequests: []string{"bob"}, CurrentLogin: "bob"},
+			Snapshot:                     &checkpointSnapshot{HeadSHA: "abc123"},
+			ThreadResolutionFollowUpOnly: true,
+			PendingReview:                &pendingReviewCheckpoint{HeadSHA: "abc123", IdempotencyKey: "reviewer:loop_publish_request_gone:abc123", Event: reviewEventAgentNative, Summary: "posted review"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v", err)
+	}
+	if checkpoint.SkipKind != "not_requested" {
+		t.Fatalf("SkipKind = %q, want not_requested", checkpoint.SkipKind)
+	}
+	if checkpoint.PendingReview != nil {
+		t.Fatalf("PendingReview = %#v, want nil", checkpoint.PendingReview)
+	}
+	if github.reviewMarkerCalls != 0 {
+		t.Fatalf("reviewMarkerCalls = %d, want 0", github.reviewMarkerCalls)
+	}
+}
+
 func TestProcessClaimedItemMarksStaleOnUnparsedHeadChangeGuardrail(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -473,6 +473,32 @@ func TestDiscoverPullRequestsSkipsAutomaticFollowUpWhenCurrentUserIsNotRequested
 	}
 }
 
+func TestDiscoverPullRequestsAllowsThreadResolutionFollowUpWhenCurrentUserIsNotRequested(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"alice"}, currentLogin: "bob", reviewThreads: []ReviewThread{{ID: "thread_1", Comments: []ReviewThreadComment{{ID: "comment_1", Author: "bob", Body: "Please update this. <!-- looper:stamp v=1 -->", CommitOID: "old-head"}}}}}
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = true
+	policy.Mode = config.ReviewerThreadResolutionModeResolveObjective
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"followUpdates":true}`
+	loop := storage.LoopRecord{ID: "loop_follow_thread_resolution", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("len(QueueItems) = %d, want 1", len(result.QueueItems))
+	}
+}
+
 func TestDiscoverPullRequestsAllowsAutomaticFollowUpWhenCurrentUserIsRequested(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -5072,6 +5098,74 @@ func TestRunThreadResolutionStepCommentsAndResolvesObjectiveLooperThread(t *test
 	}
 	if len(agent.starts) != 1 || !strings.Contains(agent.starts[0].IdempotencyKey, "thread_1") {
 		t.Fatalf("agent starts = %#v, want thread id in idempotency key", agent.starts)
+	}
+}
+
+func TestRunThreadResolutionStepResolvesLooperThreadWhenCurrentUserNotRequested(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = true
+	policy.Mode = config.ReviewerThreadResolutionModeResolveObjective
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewRequests: []string{"alice"}, reviewThreads: []ReviewThread{{ID: "thread_1", Comments: []ReviewThreadComment{{ID: "comment_1", Author: "looper-bot", Body: "Please update this. <!-- looper:stamp v=1 -->", CommitOID: "old-head"}}}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Stdout: `{"decisions":[{"threadId":"thread_1","decision":"objectively_fixed","evidence":"the nil check is now present","confidence":"high"}]}`}}}
+	runner := New(Options{GitHub: github, AgentExecutor: agent, ThreadResolution: policy, Now: func() time.Time { return time.Unix(0, 0).UTC() }})
+	input := threadResolutionStepInput()
+	input.Checkpoint.Detail.ReviewRequests = []string{"alice"}
+
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("runThreadResolutionStep() error = %v", err)
+	}
+	if checkpoint.ThreadResolution == nil || checkpoint.ThreadResolution.Commented != 1 || checkpoint.ThreadResolution.Resolved != 1 {
+		t.Fatalf("ThreadResolution = %#v, want one comment and one resolution", checkpoint.ThreadResolution)
+	}
+	if len(github.resolveThreadCalls) != 1 || github.resolveThreadCalls[0].ThreadID != "thread_1" {
+		t.Fatalf("resolveThreadCalls = %#v, want thread_1 resolved", github.resolveThreadCalls)
+	}
+}
+
+func TestRunThreadResolutionStepUsesOriginalThreadCommitForNewHeadCheck(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = true
+	policy.Mode = config.ReviewerThreadResolutionModeResolveObjective
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewRequests: []string{"looper-bot"}, reviewThreads: []ReviewThread{{ID: "thread_1", Comments: []ReviewThreadComment{
+		{ID: "comment_1", Author: "looper-bot", Body: "Please update this. <!-- looper:stamp v=1 -->", CommitOID: "old-head"},
+		{ID: "comment_2", Author: "octocat", Body: "Fixed in the latest push.", CommitOID: "abc123"},
+	}}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Stdout: `{"decisions":[{"threadId":"thread_1","decision":"objectively_fixed","evidence":"the nil check is now present","confidence":"high"}]}`}}}
+	runner := New(Options{GitHub: github, AgentExecutor: agent, ThreadResolution: policy, Now: func() time.Time { return time.Unix(0, 0).UTC() }})
+
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), threadResolutionStepInput())
+	if err != nil {
+		t.Fatalf("runThreadResolutionStep() error = %v", err)
+	}
+	if checkpoint.ThreadResolution == nil || checkpoint.ThreadResolution.Reported != 1 || checkpoint.ThreadResolution.Resolved != 1 {
+		t.Fatalf("ThreadResolution = %#v, want thread eligible and resolved", checkpoint.ThreadResolution)
+	}
+}
+
+func TestRunThreadResolutionStepSupersedesNonObjectiveAuditForObjectiveDecision(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = true
+	policy.Mode = config.ReviewerThreadResolutionModeResolveObjective
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewRequests: []string{"looper-bot"}, reviewThreads: []ReviewThread{{ID: "thread_1", Comments: []ReviewThreadComment{
+		{ID: "comment_1", Author: "looper-bot", Body: "Please update this. <!-- looper:stamp v=1 -->", CommitOID: "old-head"},
+		{ID: "comment_2", Author: "looper-bot", Body: "Looper checked this thread. <!-- looper:thread-resolution thread=thread_1 head=abc123 decision=needs_human -->", CommitOID: "abc123"},
+	}}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Stdout: `{"decisions":[{"threadId":"thread_1","decision":"objectively_fixed","evidence":"the nil check is now present","confidence":"high"}]}`}}}
+	runner := New(Options{GitHub: github, AgentExecutor: agent, ThreadResolution: policy, Now: func() time.Time { return time.Unix(0, 0).UTC() }})
+
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), threadResolutionStepInput())
+	if err != nil {
+		t.Fatalf("runThreadResolutionStep() error = %v", err)
+	}
+	if checkpoint.ThreadResolution == nil || checkpoint.ThreadResolution.Commented != 1 || checkpoint.ThreadResolution.Resolved != 1 {
+		t.Fatalf("ThreadResolution = %#v, want superseding objective comment and resolution", checkpoint.ThreadResolution)
+	}
+	if len(github.addThreadReplyCalls) != 1 || !strings.Contains(github.addThreadReplyCalls[0].Body, "decision=objectively_fixed") {
+		t.Fatalf("addThreadReplyCalls = %#v, want objective audit reply", github.addThreadReplyCalls)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -5186,11 +5186,12 @@ func TestRunThreadResolutionStepCommentsAndResolvesObjectiveLooperThread(t *test
 	}
 }
 
-func TestRunThreadResolutionStepResolvesLooperThreadWhenCurrentUserNotRequested(t *testing.T) {
+func TestRunThreadResolutionStepResolvesLooperThreadWhenCurrentUserRequestNotRequired(t *testing.T) {
 	t.Parallel()
 	policy := defaultThreadResolutionPolicy(t)
 	policy.Enabled = true
 	policy.Mode = config.ReviewerThreadResolutionModeResolveObjective
+	policy.RequireCurrentReviewRequest = false
 	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewRequests: []string{"alice"}, reviewThreads: []ReviewThread{{ID: "thread_1", Comments: []ReviewThreadComment{{ID: "comment_1", Author: "looper-bot", Body: "Please update this. <!-- looper:stamp v=1 -->", CommitOID: "old-head"}}}}}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Stdout: `{"decisions":[{"threadId":"thread_1","decision":"objectively_fixed","evidence":"the nil check is now present","confidence":"high"}]}`}}}
 	runner := New(Options{GitHub: github, AgentExecutor: agent, ThreadResolution: policy, Now: func() time.Time { return time.Unix(0, 0).UTC() }})
@@ -5206,6 +5207,30 @@ func TestRunThreadResolutionStepResolvesLooperThreadWhenCurrentUserNotRequested(
 	}
 	if len(github.resolveThreadCalls) != 1 || github.resolveThreadCalls[0].ThreadID != "thread_1" {
 		t.Fatalf("resolveThreadCalls = %#v, want thread_1 resolved", github.resolveThreadCalls)
+	}
+}
+
+func TestRunThreadResolutionStepRechecksCurrentReviewRequestBeforeThreadAction(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = true
+	policy.Mode = config.ReviewerThreadResolutionModeResolveObjective
+	policy.RequireCurrentReviewRequest = true
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewRequests: []string{"alice"}, reviewThreads: []ReviewThread{{ID: "thread_1", Comments: []ReviewThreadComment{{ID: "comment_1", Author: "looper-bot", Body: "Please update this. <!-- looper:stamp v=1 -->", CommitOID: "old-head"}}}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Stdout: `{"decisions":[{"threadId":"thread_1","decision":"objectively_fixed","evidence":"the nil check is now present","confidence":"high"}]}`}}}
+	runner := New(Options{GitHub: github, AgentExecutor: agent, ThreadResolution: policy, Now: func() time.Time { return time.Unix(0, 0).UTC() }})
+	input := threadResolutionStepInput()
+	input.Checkpoint.Detail.ReviewRequests = []string{"looper-bot"}
+
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("runThreadResolutionStep() error = %v", err)
+	}
+	if checkpoint.ThreadResolution == nil || checkpoint.ThreadResolution.Reported != 1 || checkpoint.ThreadResolution.Processed != 1 || checkpoint.ThreadResolution.Commented != 0 || checkpoint.ThreadResolution.Resolved != 0 {
+		t.Fatalf("ThreadResolution = %#v, want candidate processed but no thread action", checkpoint.ThreadResolution)
+	}
+	if len(github.addThreadReplyCalls) != 0 || len(github.resolveThreadCalls) != 0 {
+		t.Fatalf("side effects: replies=%d resolves=%d, want none", len(github.addThreadReplyCalls), len(github.resolveThreadCalls))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Allow reviewer follow-up runs to proceed for eligible Looper-authored unresolved threads even after GitHub removes the review request.
- Fix thread-resolution eligibility around author replies on the current head and prior non-objective audit comments.
- Add regression coverage for discovery, resolution, and audit superseding cases.

## Tests
- go test ./...