### PR TITLE
fix: improve conflict notification tone

### DIFF
--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1428,7 +1428,7 @@ func buildConflictedPullRequestNotice(repo string, prNumber int64, author string
 	if base == "" {
 		base = "the base branch"
 	}
-	return fmt.Sprintf("%s I couldn't generate review comments for %s#%d because this pull request currently has merge conflicts.\n\nPlease resolve the conflicts with %s, push the updated branch, and then request or wait for the review to run again.\n\n%s", mention, repo, prNumber, base, marker)
+	return fmt.Sprintf("%s I'm holding off on generating review comments for %s#%d because this pull request has merge conflicts right now.\n\nPlease resolve the conflicts with %s and push the updated branch. Once that's done, request or wait for the review to run again and I'll take another look.\n\n%s", mention, repo, prNumber, base, marker)
 }
 
 func conflictNoticeMarker(dedupeKey string) string {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -911,7 +911,7 @@ func TestRunFilterStepSkipsConflictedPullRequest(t *testing.T) {
 		t.Fatalf("issue comment calls = %d, want 1", len(github.issueCommentCalls))
 	}
 	body := github.issueCommentCalls[0].Body
-	for _, want := range []string{"@octocat", "acme/looper#42", "merge conflicts", "resolve the conflicts with main"} {
+	for _, want := range []string{"@octocat", "I'm holding off on generating review comments", "acme/looper#42", "merge conflicts", "resolve the conflicts with main", "I'll take another look"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("issue comment body = %q, want to contain %q", body, want)
 		}


### PR DESCRIPTION
## Summary
- Rewords the conflicted PR review notification to sound warmer and less robotic.
- Keeps the guidance clear that merge conflicts block review generation and should be resolved before retrying.
- Updates the reviewer test expectations for the new message tone.

## Validation
- go test ./...
- go build ./...

Closes #214

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.5.6 · runner=worker · agent=opencode</sub>