### PR TITLE
feat: support supervised looperd lifecycle management

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,7 @@ For the default supported macOS install flow:
 - `looper` is installed from a GitHub Release Go binary
 - `looper daemon install` installs the managed daemon binary to `~/.looper/bin/looperd`
 - `looper daemon start` writes its pid file to `~/.looper/looperd.pid`
+- `looper daemon start` writes lifecycle diagnostics to `~/.looper/looperd.state.json`
 
 The daemon lookup order used by the CLI is `~/.looper/bin/looperd`, then `$PATH`.
 
@@ -120,6 +121,8 @@ Example minimal `~/.looper/config.json`:
   },
   "daemon": {
     "mode": "foreground",
+    "restartPolicy": "on-failure",
+    "restartThrottleSeconds": 10,
     "logDir": "/Users/you/.looper/logs",
     "workingDirectory": "/absolute/path/to/where/you/start/looperd",
     "environment": {
@@ -207,6 +210,33 @@ Example minimal `~/.looper/config.json`:
 }
 ```
 
+## Daemon supervision
+
+Supervision applies only to the `looperd` daemon lifecycle. Looper does not supervise arbitrary user commands or agent subprocesses.
+
+`daemon.mode` controls how `looper daemon start` manages `looperd`:
+
+- `foreground` (default): starts `looperd` as a detached background process. This mode writes `~/.looper/looperd.pid` and `~/.looper/looperd.state.json`, but it is not actively supervised and will not automatically restart after a crash, logout, or reboot.
+- `launchd`: on macOS, installs and bootstraps a user LaunchAgent for `looperd`. This mode can restart according to `daemon.restartPolicy` and can start again at login through launchd. On non-macOS platforms it returns an actionable unsupported-platform error.
+
+Restart options:
+
+- `daemon.restartPolicy`: `never`, `on-failure`, or `always` (default `on-failure`). For launchd, `on-failure` maps to `KeepAlive` with unsuccessful-exit semantics, and `always` maps to `KeepAlive=true`.
+- `daemon.restartThrottleSeconds`: positive integer throttle passed to the supervisor to avoid tight crash loops (default `10`).
+- `daemon.plistPath`: optional macOS LaunchAgent plist path. If omitted, Looper uses `~/Library/LaunchAgents/com.powerformer.looper.looperd.plist`.
+
+Runtime diagnostics are discoverable from `looper daemon status` and `looper daemon status --json`:
+
+- state file: `~/.looper/looperd.state.json`
+- compatibility pid file: `~/.looper/looperd.pid`
+- main daemon log: `~/.looper/logs/looperd.log`
+- startup logs: `~/.looper/logs/startup/`
+- launchd stdout/stderr logs: `~/.looper/logs/launchd/looperd.stdout.log` and `~/.looper/logs/launchd/looperd.stderr.log`
+
+`looper daemon status` reports mode, PID, start time, supervisor source, restart policy, stale/exited process detection, last exit reason when known or inferred, and log paths. Some abnormal exits, such as SIGKILL, OOM, or reboot, cannot be recorded by the exiting process; the next status command infers them from stale state/PID records.
+
+Use `looper daemon logs` for the main retained daemon log and `looper daemon logs --startup` for recent startup logs.
+
 ## Field reference
 
 ### `server`
@@ -291,16 +321,21 @@ If these are omitted, `looperd` tries to detect them from `PATH`. Startup valida
 ### `daemon`
 
 - `mode`: `foreground` or `launchd`
+- `restartPolicy`: `never`, `on-failure`, or `always`; applies to supervised modes such as `launchd`
+- `restartThrottleSeconds`: positive supervisor restart throttle in seconds
+- `plistPath`: optional macOS user LaunchAgent plist path for `launchd` mode
 - `logDir`: daemon log directory
 - `shutdownTimeoutMs`: graceful shutdown timeout in milliseconds
 - `workingDirectory`: working directory used by the daemon
 - `environment`: reserved daemon environment map; currently part of the config surface, but not a primary user-facing runtime control in the documented flow
 
-Current packaged install and CLI management flows use `foreground` as the primary documented path. `launchd` remains part of the configuration surface, but it is not the primary documented install flow.
+`foreground` starts a detached process only and does not survive crashes or reboot. `launchd` is the supported supervised mode on macOS; unsupported platforms return an actionable error instead of silently falling back.
 
 Defaults:
 
 - `mode`: `foreground`
+- `restartPolicy`: `on-failure`
+- `restartThrottleSeconds`: `10`
 - `logDir`: `~/.looper/logs`
 - `shutdownTimeoutMs`: `1000`
 - `workingDirectory`: current working directory when config is loaded
@@ -507,6 +542,8 @@ Supported environment overrides:
 - `LOOPER_DB_PATH`
 - `LOOPER_LOG_DIR`
 - `LOOPER_DAEMON_MODE`
+- `LOOPER_DAEMON_RESTART_POLICY`
+- `LOOPER_DAEMON_RESTART_THROTTLE_SECONDS`
 - `LOOPER_WORKING_DIRECTORY`
 - `LOOPER_GIT_PATH`
 - `LOOPER_GH_PATH`
@@ -574,6 +611,8 @@ Supported `looperd` flags:
 - `--db-path`
 - `--log-dir`
 - `--daemon-mode`
+- `--daemon-restart-policy`
+- `--daemon-restart-throttle-seconds`
 - `--git-path`
 - `--gh-path`
 - `--osascript-path`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,7 +67,40 @@ Manual fallback:
 
 Daemon lookup order is fixed to `~/.looper/bin/looperd`, then `$PATH`.
 
-`looper daemon start` writes a pid file and launches the daemon, but it does not provide full background supervision.
+By default, `looper daemon start` launches `looperd` detached and prints `started detached, not supervised`. Detached mode writes `~/.looper/looperd.pid` and `~/.looper/looperd.state.json`, but it does not restart after crashes, logout, or reboot.
+
+### Supervised daemon mode on macOS
+
+For actively supervised `looperd` lifecycle management on macOS, use the user LaunchAgent mode:
+
+```bash
+looper daemon start --daemon-mode launchd
+looper daemon status
+looper daemon status --json
+looper daemon logs
+```
+
+Launchd mode:
+
+- creates a user LaunchAgent plist at `~/Library/LaunchAgents/com.powerformer.looper.looperd.plist` unless `daemon.plistPath` is set
+- stores launchd stdout/stderr logs under `~/.looper/logs/launchd/`
+- stores startup logs under `~/.looper/logs/startup/`
+- stores lifecycle state in `~/.looper/looperd.state.json`
+- maps `daemon.restartPolicy` to launchd `KeepAlive` behavior
+- uses `daemon.restartThrottleSeconds` as the launchd `ThrottleInterval`
+- may recover after login/system restart when launchd loads the user agent
+
+Supported restart policies are `never`, `on-failure`, and `always`; the default is `on-failure` with a 10 second throttle. Linux/systemd supervision is not implemented yet; on unsupported platforms, `--daemon-mode launchd` returns an actionable error instead of silently falling back.
+
+Troubleshooting commands:
+
+```bash
+looper daemon status
+looper daemon status --json
+looper daemon logs --startup
+```
+
+Status output distinguishes detached mode from launchd-supervised mode and includes PID, start time, supervisor, restart policy, stale/exited state, last error/reason, and log locations.
 
 ## Verify the install
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -630,11 +630,13 @@ type configServerResponse struct {
 }
 
 type configDaemonResponse struct {
-	Mode             config.DaemonMode `json:"mode"`
-	PlistPath        *string           `json:"plistPath,omitempty"`
-	LogDir           string            `json:"logDir"`
-	WorkingDirectory string            `json:"workingDirectory"`
-	Environment      map[string]string `json:"environment"`
+	Mode                   config.DaemonMode          `json:"mode"`
+	RestartPolicy          config.DaemonRestartPolicy `json:"restartPolicy"`
+	RestartThrottleSeconds int                        `json:"restartThrottleSeconds"`
+	PlistPath              *string                    `json:"plistPath,omitempty"`
+	LogDir                 string                     `json:"logDir"`
+	WorkingDirectory       string                     `json:"workingDirectory"`
+	Environment            map[string]string          `json:"environment"`
 }
 
 func (h *Handler) buildConfigResponse() configResponse {
@@ -655,11 +657,13 @@ func (h *Handler) buildConfigResponse() configResponse {
 		Notifications: cfg.Notifications,
 		Tools:         cfg.Tools,
 		Daemon: configDaemonResponse{
-			Mode:             cfg.Daemon.Mode,
-			PlistPath:        cfg.Daemon.PlistPath,
-			LogDir:           cfg.Daemon.LogDir,
-			WorkingDirectory: cfg.Daemon.WorkingDirectory,
-			Environment:      cfg.Daemon.Environment,
+			Mode:                   cfg.Daemon.Mode,
+			RestartPolicy:          cfg.Daemon.RestartPolicy,
+			RestartThrottleSeconds: cfg.Daemon.RestartThrottleSeconds,
+			PlistPath:              cfg.Daemon.PlistPath,
+			LogDir:                 cfg.Daemon.LogDir,
+			WorkingDirectory:       cfg.Daemon.WorkingDirectory,
+			Environment:            cfg.Daemon.Environment,
 		},
 		Package:  cfg.Package,
 		Defaults: cfg.Defaults,

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -202,6 +202,8 @@
           },
           "daemon": {
             "mode": "foreground",
+            "restartPolicy": "on-failure",
+            "restartThrottleSeconds": 10,
             "logDir": "<tmp-root>/logs",
             "workingDirectory": "<tmp-root>",
             "environment": {}

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -186,6 +186,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				persistentFlags: []flagSpec{
 					stringFlag("lines", "count", "Line count"),
 					boolFlag("full", "Show all retained daemon log lines, including rotated log files"),
+					boolFlag("startup", "Show daemon startup logs instead of main logs"),
 					boolFlag("force", "Overwrite existing installed daemon binary"),
 				},
 				exampleLines: []string{
@@ -580,6 +581,8 @@ func globalFlags() []flagSpec {
 		stringFlag("db-path", "path", "Database path"),
 		stringFlag("log-dir", "path", "Daemon log directory"),
 		stringFlag("daemon-mode", "mode", "Daemon mode"),
+		stringFlag("daemon-restart-policy", "policy", "Daemon supervisor restart policy: never, on-failure, or always"),
+		stringFlag("daemon-restart-throttle-seconds", "seconds", "Daemon supervisor restart throttle"),
 		stringFlag("git-path", "path", "Git binary path"),
 		stringFlag("gh-path", "path", "GitHub CLI path"),
 		stringFlag("looper-path", "path", "Looper CLI path"),
@@ -643,6 +646,8 @@ var configFlagNames = map[string]struct{}{
 	"db-path":                               {},
 	"log-dir":                               {},
 	"daemon-mode":                           {},
+	"daemon-restart-policy":                 {},
+	"daemon-restart-throttle-seconds":       {},
 	"git-path":                              {},
 	"gh-path":                               {},
 	"looper-path":                           {},

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -509,7 +509,7 @@ func (r *commandRuntime) stopDaemonProcess(ctx context.Context, out io.Writer, s
 		if err != nil {
 			return false, err
 		}
-		return r.stopLaunchdDaemon(ctx, out, loaded, startIfMissing)
+		return r.stopLaunchdDaemon(ctx, out, loaded, state, startIfMissing)
 	}
 
 	pidFilePath, err := r.resolveDaemonPIDFilePath()
@@ -521,7 +521,7 @@ func (r *commandRuntime) stopDaemonProcess(ctx context.Context, out io.Writer, s
 	if !ok {
 		loaded, loadErr := r.loadConfig()
 		if loadErr == nil && loaded.Config.Daemon.Mode == config.DaemonModeLaunchd {
-			return r.stopLaunchdDaemon(ctx, out, loaded, startIfMissing)
+			return r.stopLaunchdDaemon(ctx, out, loaded, nil, startIfMissing)
 		}
 		if startIfMissing {
 			if _, err := fmt.Fprintln(out, "No daemon pid file found; starting daemon."); err != nil {

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -47,15 +48,20 @@ type daemonVersionState struct {
 }
 
 type daemonStatusOutput struct {
-	Mode                config.DaemonMode `json:"mode"`
-	ConfigPath          string            `json:"configPath"`
-	LogDir              string            `json:"logDir"`
-	APIReachable        bool              `json:"apiReachable"`
-	DaemonVersion       *string           `json:"daemonVersion"`
-	DaemonVersionSource *string           `json:"daemonVersionSource"`
-	DaemonBinaryPath    *string           `json:"daemonBinaryPath"`
-	Status              json.RawMessage   `json:"status"`
-	Health              json.RawMessage   `json:"health"`
+	Mode                   config.DaemonMode          `json:"mode"`
+	ConfiguredMode         config.DaemonMode          `json:"configuredMode"`
+	RunningMode            *config.DaemonMode         `json:"runningMode,omitempty"`
+	RestartPolicy          config.DaemonRestartPolicy `json:"restartPolicy"`
+	RestartThrottleSeconds int                        `json:"restartThrottleSeconds"`
+	ConfigPath             string                     `json:"configPath"`
+	LogDir                 string                     `json:"logDir"`
+	APIReachable           bool                       `json:"apiReachable"`
+	DaemonVersion          *string                    `json:"daemonVersion"`
+	DaemonVersionSource    *string                    `json:"daemonVersionSource"`
+	DaemonBinaryPath       *string                    `json:"daemonBinaryPath"`
+	Lifecycle              daemonLifecycleStatus      `json:"lifecycle"`
+	Status                 json.RawMessage            `json:"status"`
+	Health                 json.RawMessage            `json:"health"`
 }
 
 type daemonLogsOutput struct {
@@ -88,14 +94,26 @@ func (r *commandRuntime) daemonStatus(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	lifecycle, err := r.daemonLifecycleStatus(cmd.Context(), loaded)
+	if err != nil {
+		return err
+	}
 
 	output := daemonStatusOutput{
-		Mode:         loaded.Config.Daemon.Mode,
-		ConfigPath:   loaded.Metadata.ConfigPath,
-		LogDir:       loaded.Config.Daemon.LogDir,
-		APIReachable: apiReachable,
-		Status:       statusPayload,
-		Health:       healthPayload,
+		Mode:                   loaded.Config.Daemon.Mode,
+		ConfiguredMode:         loaded.Config.Daemon.Mode,
+		RestartPolicy:          loaded.Config.Daemon.RestartPolicy,
+		RestartThrottleSeconds: loaded.Config.Daemon.RestartThrottleSeconds,
+		ConfigPath:             loaded.Metadata.ConfigPath,
+		LogDir:                 loaded.Config.Daemon.LogDir,
+		APIReachable:           apiReachable,
+		Lifecycle:              lifecycle,
+		Status:                 statusPayload,
+		Health:                 healthPayload,
+	}
+	if lifecycle.State != nil && lifecycle.Process == "running" {
+		runningMode := lifecycle.State.Mode
+		output.RunningMode = &runningMode
 	}
 	if versionState != nil {
 		output.DaemonVersion = &versionState.Version
@@ -120,6 +138,70 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 	}
 	client := r.localAPIClientFromLoaded(loaded)
 	apiURL := client.baseURL
+	if !r.skipAPIStartProbe {
+		lifecycle, err := r.daemonLifecycleStatus(ctx, loaded)
+		if err != nil {
+			return err
+		}
+		if lifecycle.Process == "running" {
+			if lifecycle.State != nil && lifecycle.State.Mode != loaded.Config.Daemon.Mode {
+				return fmt.Errorf("looperd is already running in %s mode; refusing to start %s mode. Stop the existing daemon first with `looper daemon stop`", lifecycle.State.Mode, loaded.Config.Daemon.Mode)
+			}
+			if lifecycle.State != nil {
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looperd already appears to be running in %s mode (pid %d)\n", lifecycle.State.Mode, lifecycle.State.PID); err != nil {
+					return err
+				}
+				return nil
+			}
+			if _, err := fmt.Fprintln(cmd.OutOrStdout(), "looperd already appears to be running from an existing pid file"); err != nil {
+				return err
+			}
+			return nil
+		}
+		if lifecycle.Process == "not-looperd" {
+			pid := 0
+			if lifecycle.State != nil {
+				pid = lifecycle.State.PID
+			} else if filePID, ok := r.readPIDFile(lifecycle.PIDPath); ok {
+				pid = filePID
+			}
+			return fmt.Errorf("daemon lifecycle state or pid file points to alive non-looperd process %d; refusing to start %s mode", pid, loaded.Config.Daemon.Mode)
+		}
+	}
+
+	if loaded.Config.Daemon.Mode == config.DaemonModeLaunchd {
+		if !r.skipAPIStartProbe {
+			probe, err := r.probeDaemonStatus(ctx, client)
+			if err != nil {
+				return err
+			}
+			if probe.isLooperd {
+				return fmt.Errorf("looperd already appears to be serving %s but is not recorded as launchd-supervised; stop the existing daemon before starting launchd supervision", apiURL)
+			}
+		}
+		binary, err := r.resolveDaemonBinary(ctx)
+		if err != nil {
+			return err
+		}
+		env := os.Environ()
+		extractedArgs := ExtractConfigArgs(r.argv)
+		callerCWD, err := r.daemonSpawnCallerCWD(extractedArgs, env)
+		if err != nil {
+			return err
+		}
+		forwardedArgs := normalizeForwardedConfigPathArgs(extractedArgs, callerCWD)
+		cwd := loaded.Config.Daemon.WorkingDirectory
+		if strings.TrimSpace(callerCWD) == "" && strings.TrimSpace(cwd) != "" && !filepath.IsAbs(cwd) {
+			callerCWD, err = r.getwd()
+			if err != nil {
+				return fmt.Errorf("resolve current working directory for launchd WorkingDirectory: %w", err)
+			}
+		}
+		if strings.TrimSpace(callerCWD) != "" && strings.TrimSpace(cwd) != "" && !filepath.IsAbs(cwd) {
+			cwd = filepath.Join(callerCWD, cwd)
+		}
+		return r.startLaunchdDaemon(ctx, cmd.OutOrStdout(), loaded, binary, forwardedArgs, cwd, daemonSpawnEnv(env, loaded.Metadata.ConfigPath, callerCWD), client, apiURL)
+	}
 
 	pidFilePath, err := r.resolveDaemonPIDFilePath()
 	if err != nil {
@@ -216,6 +298,11 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 			_ = r.killProcess(pid, int(syscall.SIGTERM))
 		}
 		r.removePIDFile(pidFilePath)
+		if statePath, stateErr := r.resolveDaemonStatePath(); stateErr == nil {
+			now := time.Now().UTC()
+			state := daemonLifecycleState{SchemaVersion: daemonStateSchemaVersion, Mode: config.DaemonModeForeground, PID: pid, StartedAt: &now, BinaryPath: binary.Path, Logs: daemonLogState(loaded), LastExit: &daemonLifecycleExitState{At: now, Reason: "detached looperd exited or failed readiness during startup", LogPath: startupLogPath}, LastError: err.Error()}
+			_ = r.writeDaemonLifecycleState(statePath, state)
+		}
 		return err
 	}
 
@@ -225,17 +312,29 @@ func (r *commandRuntime) daemonStart(cmd *cobra.Command, args []string) error {
 	if err := r.writeFile(pidFilePath, []byte(fmt.Sprintf("%d\n", pid)), 0o644); err != nil {
 		return fmt.Errorf("write daemon pid file: %w", err)
 	}
+	statePath, err := r.resolveDaemonStatePath()
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	state := daemonLifecycleState{SchemaVersion: daemonStateSchemaVersion, Mode: config.DaemonModeForeground, PID: pid, StartedAt: &now, BinaryPath: binary.Path, Logs: daemonLogState(loaded)}
+	if err := r.writeDaemonLifecycleState(statePath, state); err != nil {
+		return fmt.Errorf("write daemon lifecycle state: %w", err)
+	}
 
-	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Started looperd (%s) with pid %d\n", binary.Path, pid); err != nil {
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Started looperd detached, not supervised (%s) with pid %d\n", binary.Path, pid); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "PID file: %s\n", pidFilePath); err != nil {
 		return err
 	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "State file: %s\n", statePath); err != nil {
+		return err
+	}
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Startup log: %s\n", startupLogPath); err != nil {
 		return err
 	}
-	_, err = fmt.Fprintln(cmd.OutOrStdout(), "Phase 1 process management is minimal and does not provide full background supervision.")
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), "Detached mode does not restart after crashes or system reboot. Use --daemon-mode launchd on macOS for supervised lifecycle management.")
 	return err
 }
 
@@ -397,6 +496,22 @@ func (r *commandRuntime) daemonStop(cmd *cobra.Command, args []string) error {
 }
 
 func (r *commandRuntime) stopDaemonProcess(ctx context.Context, out io.Writer, startIfMissing bool) (bool, error) {
+	statePath, err := r.resolveDaemonStatePath()
+	if err != nil {
+		return false, err
+	}
+	state, err := r.readDaemonLifecycleState(statePath)
+	if err != nil {
+		return false, err
+	}
+	if state != nil && state.Mode == config.DaemonModeLaunchd {
+		loaded, err := r.loadConfig()
+		if err != nil {
+			return false, err
+		}
+		return r.stopLaunchdDaemon(ctx, out, loaded, startIfMissing)
+	}
+
 	pidFilePath, err := r.resolveDaemonPIDFilePath()
 	if err != nil {
 		return false, err
@@ -404,6 +519,10 @@ func (r *commandRuntime) stopDaemonProcess(ctx context.Context, out io.Writer, s
 
 	existingPID, ok := r.readPIDFile(pidFilePath)
 	if !ok {
+		loaded, loadErr := r.loadConfig()
+		if loadErr == nil && loaded.Config.Daemon.Mode == config.DaemonModeLaunchd {
+			return r.stopLaunchdDaemon(ctx, out, loaded, startIfMissing)
+		}
 		if startIfMissing {
 			if _, err := fmt.Fprintln(out, "No daemon pid file found; starting daemon."); err != nil {
 				return false, err
@@ -453,6 +572,12 @@ func (r *commandRuntime) stopDaemonProcess(ctx context.Context, out io.Writer, s
 		return false, err
 	}
 	r.removePIDFile(pidFilePath)
+	if state != nil {
+		now := time.Now().UTC()
+		state.LastExit = &daemonLifecycleExitState{At: now, Reason: "stopped by looper daemon stop", LogPath: state.Logs.Main}
+		state.PID = 0
+		_ = r.writeDaemonLifecycleState(statePath, *state)
+	}
 	if _, err := fmt.Fprintf(out, "Stopped looperd pid %d\n", existingPID); err != nil {
 		return false, err
 	}
@@ -481,7 +606,14 @@ func (r *commandRuntime) daemonLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	logPath := filepath.Join(loaded.Config.Daemon.LogDir, "looperd.log")
-	content, logPaths, err := r.readRetainedDaemonLogs(logPath, loaded.Config.Logging.MaxFiles)
+	var content string
+	var logPaths []string
+	if getBoolFlag(cmd, "startup") {
+		logPath = filepath.Join(loaded.Config.Daemon.LogDir, "startup")
+		content, logPaths, err = r.readStartupDaemonLogs(logPath)
+	} else {
+		content, logPaths, err = r.readRetainedDaemonLogs(logPath, loaded.Config.Logging.MaxFiles)
+	}
 	if err != nil {
 		return err
 	}
@@ -504,6 +636,41 @@ func (r *commandRuntime) daemonLogs(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
+}
+
+func (r *commandRuntime) readStartupDaemonLogs(startupDir string) (string, []string, error) {
+	paths, err := filepath.Glob(filepath.Join(startupDir, "looperd-*.log"))
+	if err != nil {
+		return "", nil, err
+	}
+	if len(paths) == 0 {
+		return "", nil, os.ErrNotExist
+	}
+	sort.Strings(paths)
+	if len(paths) > 10 {
+		paths = paths[len(paths)-10:]
+	}
+	var builder strings.Builder
+	readPaths := make([]string, 0, len(paths))
+	for _, path := range paths {
+		raw, err := r.readFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return "", nil, err
+		}
+		if builder.Len() > 0 && !strings.HasSuffix(builder.String(), "\n") {
+			builder.WriteString("\n")
+		}
+		builder.WriteString(strings.TrimRight(string(raw), "\n"))
+		builder.WriteString("\n")
+		readPaths = append(readPaths, path)
+	}
+	if len(readPaths) == 0 {
+		return "", nil, os.ErrNotExist
+	}
+	return strings.TrimRight(builder.String(), "\n"), readPaths, nil
 }
 
 func (r *commandRuntime) readRetainedDaemonLogs(logPath string, maxFiles int) (string, []string, error) {
@@ -687,7 +854,22 @@ func (r *commandRuntime) createStartupLogPath(loaded config.LoadedFileConfig) (s
 	if err := r.mkdirAll(startupLogDir, 0o700); err != nil {
 		return "", fmt.Errorf("create daemon startup log directory: %w", err)
 	}
+	r.pruneStartupLogs(startupLogDir, loaded.Config.Logging.MaxFiles*2)
 	return filepath.Join(startupLogDir, fmt.Sprintf("looperd-%s.log", time.Now().UTC().Format("20060102T150405.000000000Z"))), nil
+}
+
+func (r *commandRuntime) pruneStartupLogs(startupLogDir string, keep int) {
+	if keep < 1 {
+		keep = 10
+	}
+	paths, err := filepath.Glob(filepath.Join(startupLogDir, "looperd-*.log"))
+	if err != nil || len(paths) <= keep {
+		return
+	}
+	sort.Strings(paths)
+	for _, path := range paths[:len(paths)-keep] {
+		_ = r.removeFile(path)
+	}
 }
 
 func (r *commandRuntime) waitForDaemonReady(ctx context.Context, client *DaemonAPIClient, pid int, startupLogPath string, apiURL string, timeout time.Duration, interval time.Duration) error {
@@ -1136,8 +1318,31 @@ func tailLines(content string, count int) []string {
 }
 
 func writeHumanDaemonStatus(w io.Writer, payload daemonStatusOutput) error {
-	entries := [][2]any{{"mode", payload.Mode}, {"configPath", payload.ConfigPath}, {"logDir", payload.LogDir}, {"apiReachable", payload.APIReachable}, {"daemonVersion", payload.DaemonVersion}, {"daemonVersionSource", payload.DaemonVersionSource}, {"daemonBinaryPath", payload.DaemonBinaryPath}}
+	entries := [][2]any{{"configuredMode", payload.ConfiguredMode}, {"runningMode", payload.RunningMode}, {"restartPolicy", payload.RestartPolicy}, {"restartThrottleSeconds", payload.RestartThrottleSeconds}, {"configPath", payload.ConfigPath}, {"logDir", payload.LogDir}, {"apiReachable", payload.APIReachable}, {"daemonVersion", payload.DaemonVersion}, {"daemonVersionSource", payload.DaemonVersionSource}, {"daemonBinaryPath", payload.DaemonBinaryPath}}
+	if payload.ConfiguredMode == config.DaemonModeForeground {
+		entries = append(entries, [2]any{"restartBehavior", "not supervised; detached mode does not restart after crashes or reboot"})
+	}
 	printSection(w, "Daemon", entries)
+	if payload.Lifecycle.StatePath != "" {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		lifecycleEntries := [][2]any{{"process", payload.Lifecycle.Process}, {"statePath", payload.Lifecycle.StatePath}, {"pidPath", payload.Lifecycle.PIDPath}, {"staleState", payload.Lifecycle.StaleState}}
+		if state := payload.Lifecycle.State; state != nil {
+			lifecycleEntries = append(lifecycleEntries, [2]any{"pid", state.PID}, [2]any{"startedAt", state.StartedAt}, [2]any{"binaryPath", state.BinaryPath})
+			if state.Supervisor != nil {
+				lifecycleEntries = append(lifecycleEntries, [2]any{"supervisor", state.Supervisor.Source}, [2]any{"supervisorLabel", state.Supervisor.Label}, [2]any{"plistPath", state.Supervisor.PlistPath})
+			}
+			lifecycleEntries = append(lifecycleEntries, [2]any{"logMain", state.Logs.Main}, [2]any{"logStartupDir", state.Logs.StartupDir}, [2]any{"logStdout", state.Logs.Stdout}, [2]any{"logStderr", state.Logs.Stderr})
+			if state.LastExit != nil {
+				lifecycleEntries = append(lifecycleEntries, [2]any{"lastExitAt", state.LastExit.At}, [2]any{"lastExitReason", state.LastExit.Reason}, [2]any{"lastExitLog", state.LastExit.LogPath})
+			}
+			if state.LastError != "" {
+				lifecycleEntries = append(lifecycleEntries, [2]any{"lastError", state.LastError})
+			}
+		}
+		printSection(w, "Lifecycle", lifecycleEntries)
+	}
 
 	if !payload.APIReachable {
 		return nil

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/powerformer/looper/internal/config"
 	pkgapi "github.com/powerformer/looper/pkg/api"
 )
 
@@ -93,11 +94,13 @@ func TestDaemonStatusJSONUsesAPIVersionAndBinaryPath(t *testing.T) {
 	defer server.Close()
 
 	configPath := writeDaemonCLIConfig(t, server.URL)
+	homeDir := t.TempDir()
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	app := New(Deps{
-		Stdout: stdout,
-		Stderr: stderr,
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: homeDir,
 		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
 			_ = ctx
 			_ = command
@@ -136,8 +139,7 @@ func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 		args    []string
 		cwd     string
 	}{}
-	var wrotePath string
-	var wroteBody string
+	writes := map[string]string{}
 	var mkdirPath string
 	killCalls := make([]struct {
 		pid    int
@@ -193,8 +195,7 @@ func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 		},
 		WriteFile: func(path string, data []byte, perm os.FileMode) error {
 			_ = perm
-			wrotePath = path
-			wroteBody = string(data)
+			writes[path] = string(data)
 			return nil
 		},
 		Sleep: func(duration time.Duration) {
@@ -221,17 +222,120 @@ func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 	if got, want := mkdirPath, filepath.Join(homeDir, ".looper"); got != want {
 		t.Fatalf("mkdirPath = %q, want %q", got, want)
 	}
-	if got, want := wrotePath, filepath.Join(homeDir, ".looper", "looperd.pid"); got != want {
-		t.Fatalf("wrotePath = %q, want %q", got, want)
+	pidPath := filepath.Join(homeDir, ".looper", "looperd.pid")
+	if writes[pidPath] != "4321\n" {
+		t.Fatalf("pid write = %q, want %q", writes[pidPath], "4321\n")
 	}
-	if wroteBody != "4321\n" {
-		t.Fatalf("wroteBody = %q, want %q", wroteBody, "4321\n")
+	statePath := filepath.Join(homeDir, ".looper", "looperd.state.json")
+	if !strings.Contains(writes[statePath], `"mode": "foreground"`) || !strings.Contains(writes[statePath], `"pid": 4321`) {
+		t.Fatalf("state write = %q, want foreground state with pid", writes[statePath])
 	}
 	if len(killCalls) != 2 || killCalls[0].pid != 4321 || killCalls[0].signal != 0 || killCalls[1].pid != 4321 || killCalls[1].signal != 0 {
 		t.Fatalf("killCalls = %#v, want readiness liveness probes for pid 4321", killCalls)
 	}
 	if !strings.Contains(stdout.String(), "Started looperd") {
 		t.Fatalf("stdout = %q, want start confirmation", stdout.String())
+	}
+}
+
+func TestDaemonLifecycleStateReadWriteAndStaleDetection(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	statePath := filepath.Join(homeDir, ".looper", "looperd.state.json")
+	startedAt := time.Date(2026, 5, 2, 10, 15, 30, 0, time.UTC)
+	app := New(Deps{
+		HomeDir: homeDir,
+		KillProcess: func(pid int, signal int) error {
+			_ = signal
+			if pid == 9999 {
+				return os.ErrProcessDone
+			}
+			return nil
+		},
+	})
+	runtime := newCommandRuntime(app, nil)
+	state := daemonLifecycleState{Mode: "foreground", PID: 9999, StartedAt: &startedAt, BinaryPath: "/tmp/looperd", Logs: daemonLifecycleLogState{Main: "/tmp/looperd.log"}}
+	if err := runtime.writeDaemonLifecycleState(statePath, state); err != nil {
+		t.Fatalf("writeDaemonLifecycleState() error = %v", err)
+	}
+	readState, err := runtime.readDaemonLifecycleState(statePath)
+	if err != nil {
+		t.Fatalf("readDaemonLifecycleState() error = %v", err)
+	}
+	if readState.SchemaVersion != daemonStateSchemaVersion || readState.PID != 9999 || readState.BinaryPath != "/tmp/looperd" {
+		t.Fatalf("read state = %#v, want persisted schema/pid/binary", readState)
+	}
+
+	loaded := writeDaemonCLIConfig(t, "http://daemon.test")
+	status, err := runtime.daemonLifecycleStatus(context.Background(), mustLoadConfig(t, loaded))
+	if err != nil {
+		t.Fatalf("daemonLifecycleStatus() error = %v", err)
+	}
+	if status.Process != "exited" || !status.StaleState || status.State.LastExit == nil || !strings.Contains(status.State.LastExit.Reason, "no longer running") {
+		t.Fatalf("status = %#v, want inferred stale exit", status)
+	}
+}
+
+func TestGenerateLaunchdPlistRestartPolicyMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		policy     string
+		want       string
+		wantAbsent string
+	}{
+		{name: "never", policy: "never", wantAbsent: "<key>KeepAlive</key>"},
+		{name: "on failure", policy: "on-failure", want: "<key>SuccessfulExit</key>\n\t\t<false/>"},
+		{name: "always", policy: "always", want: "<key>KeepAlive</key>\n\t<true/>"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			plist, err := generateLaunchdPlist(launchdPlistConfig{Label: launchdLooperdLabel, ProgramArguments: []string{"/bin/looperd", "--config", "/tmp/config.json"}, WorkingDirectory: "/tmp", Environment: map[string]string{"LOOPER_CONFIG": "/tmp/config.json"}, RunAtLoad: true, RestartPolicy: config.DaemonRestartPolicy(tt.policy), RestartThrottleSeconds: 10, StandardOutPath: "/tmp/stdout.log", StandardErrorPath: "/tmp/stderr.log"})
+			if err != nil {
+				t.Fatalf("generateLaunchdPlist() error = %v", err)
+			}
+			got := string(plist)
+			for _, want := range []string{"<key>Label</key>", launchdLooperdLabel, "<key>ProgramArguments</key>", "<key>RunAtLoad</key>", "<key>ThrottleInterval</key>", "<integer>10</integer>", "<key>StandardOutPath</key>", "<key>StandardErrorPath</key>"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("plist missing %q:\n%s", want, got)
+				}
+			}
+			if tt.want != "" && !strings.Contains(got, tt.want) {
+				t.Fatalf("plist missing policy mapping %q:\n%s", tt.want, got)
+			}
+			if tt.wantAbsent != "" && strings.Contains(got, tt.wantAbsent) {
+				t.Fatalf("plist contains %q unexpectedly:\n%s", tt.wantAbsent, got)
+			}
+		})
+	}
+}
+
+func TestDaemonStartLaunchdUnsupportedPlatform(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeDaemonCLIConfig(t, "http://daemon.test")
+	homeDir := t.TempDir()
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HomeDir: homeDir, Platform: "linux", HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, os.ErrNotExist })}, RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+		_ = ctx
+		_ = timeout
+		if command == managedPath && strings.Join(args, " ") == "--version" {
+			return commandExecutionResult{Stdout: "0.6.0\n", ExitCode: 0}, nil
+		}
+		return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+	}})
+	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--daemon-mode", "launchd", "--config", configPath})
+	if exitCode == 0 {
+		t.Fatalf("Run([daemon start --daemon-mode launchd]) exit code = 0, want error")
+	}
+	if !strings.Contains(stderr.String(), "only supported on macOS") {
+		t.Fatalf("stderr = %q, want unsupported platform guidance", stderr.String())
 	}
 }
 
@@ -607,7 +711,7 @@ func TestDaemonStartStalePIDFileUsesReachableLooperdAPI(t *testing.T) {
 	}
 }
 
-func TestDaemonStartAliveNonLooperdPIDFileUsesReachableLooperdAPI(t *testing.T) {
+func TestDaemonStartAliveNonLooperdPIDFileFailsEvenWithReachableLooperdAPI(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -620,7 +724,6 @@ func TestDaemonStartAliveNonLooperdPIDFileUsesReachableLooperdAPI(t *testing.T) 
 	configPath := writeDaemonCLIConfigForBindEndpoint(t, server.URL, nil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	removed := false
 	app := New(Deps{
 		Stdout:  stdout,
 		Stderr:  stderr,
@@ -645,12 +748,7 @@ func TestDaemonStartAliveNonLooperdPIDFileUsesReachableLooperdAPI(t *testing.T) 
 			}
 			return nil
 		},
-		RemoveFile: func(path string) error {
-			if path == pidFilePath {
-				removed = true
-			}
-			return nil
-		},
+		RemoveFile: func(path string) error { return nil },
 		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
 			t.Fatal("SpawnDetached() called, want existing API reused")
 			return 0, nil
@@ -658,17 +756,11 @@ func TestDaemonStartAliveNonLooperdPIDFileUsesReachableLooperdAPI(t *testing.T) 
 	})
 
 	exitCode := app.Run(context.Background(), []string{"daemon", "start", "--config", configPath})
-	if exitCode != 0 {
-		t.Fatalf("Run([daemon start]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	if exitCode == 0 {
+		t.Fatal("Run([daemon start]) exit code = 0, want non-zero")
 	}
-	if !removed {
-		t.Fatal("stale pid file pointing at alive non-looperd process was not removed")
-	}
-	if !strings.Contains(stdout.String(), "pid file points to non-looperd pid 9876") || !strings.Contains(stdout.String(), server.URL) {
-		t.Fatalf("stdout = %q, want already running message with URL and non-looperd pid", stdout.String())
-	}
-	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty", stderr.String())
+	if !strings.Contains(stderr.String(), "alive non-looperd process 9876") {
+		t.Fatalf("stderr = %q, want non-looperd pid refusal", stderr.String())
 	}
 }
 
@@ -925,7 +1017,12 @@ func TestDaemonStartReadinessTimeoutTerminatesSpawnedProcessAndRemovesPIDFile(t 
 			return nil
 		},
 		WriteFile: func(path string, data []byte, perm os.FileMode) error {
-			t.Fatalf("WriteFile(%q) called, want readiness failure before pid file write", path)
+			if !strings.HasSuffix(path, "looperd.state.json") {
+				t.Fatalf("WriteFile(%q) called, want only lifecycle failure state write", path)
+			}
+			if !strings.Contains(string(data), "detached looperd exited or failed readiness during startup") {
+				t.Fatalf("state write = %s, want startup failure diagnostics", string(data))
+			}
 			return nil
 		},
 		Sleep: func(duration time.Duration) {},
@@ -1408,6 +1505,15 @@ func writeDaemonCLIConfig(t *testing.T, baseURL string) string {
 		t.Fatalf("WriteFile(config) error = %v", err)
 	}
 	return configPath
+}
+
+func mustLoadConfig(t *testing.T, path string) config.LoadedFileConfig {
+	t.Helper()
+	loaded, err := config.LoadFile(config.LoadFileOptions{Args: []string{"--config", path}})
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	return loaded
 }
 
 func writeDaemonCLIConfigForBindEndpoint(t *testing.T, bindURL string, baseURL *string) string {

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -314,6 +314,125 @@ func TestGenerateLaunchdPlistRestartPolicyMapping(t *testing.T) {
 	}
 }
 
+func TestResolveLaunchdPlistPathNormalizesRelativeConfigPath(t *testing.T) {
+	t.Parallel()
+
+	callerDir := t.TempDir()
+	plistPath := filepath.Join("agents", "looperd.plist")
+	loaded := config.LoadedFileConfig{}
+	loaded.Config.Daemon.PlistPath = &plistPath
+	runtime := newCommandRuntime(New(Deps{Getwd: func() (string, error) { return callerDir, nil }}), nil)
+
+	resolved, err := runtime.resolveLaunchdPlistPath(loaded)
+	if err != nil {
+		t.Fatalf("resolveLaunchdPlistPath() error = %v", err)
+	}
+	if got, want := resolved, filepath.Join(callerDir, "agents", "looperd.plist"); got != want {
+		t.Fatalf("resolveLaunchdPlistPath() = %q, want %q", got, want)
+	}
+}
+
+func TestStopLaunchdDaemonUsesPersistedStatePlistPath(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	currentPlistPath := filepath.Join(homeDir, "current.plist")
+	persistedPlistPath := filepath.Join(homeDir, "persisted.plist")
+	loaded := config.LoadedFileConfig{}
+	loaded.Config.Daemon.PlistPath = &currentPlistPath
+	state := &daemonLifecycleState{Mode: config.DaemonModeLaunchd, PID: 4321, Logs: daemonLifecycleLogState{Main: filepath.Join(homeDir, "looperd.log")}, Supervisor: &daemonSupervisorState{Source: "launchd", Label: launchdLooperdLabel, PlistPath: persistedPlistPath}}
+	var bootoutArgs []string
+	var removed []string
+	runtime := newCommandRuntime(New(Deps{
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		LookPath: func(file string) (string, error) {
+			if file == "launchctl" {
+				return "/bin/launchctl", nil
+			}
+			return "", os.ErrNotExist
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = command
+			_ = timeout
+			bootoutArgs = append([]string{}, args...)
+			return commandExecutionResult{ExitCode: 0}, nil
+		},
+		RemoveFile: func(path string) error {
+			removed = append(removed, path)
+			return nil
+		},
+	}), nil)
+
+	stopped, err := runtime.stopLaunchdDaemon(context.Background(), &bytes.Buffer{}, loaded, state, false)
+	if err != nil {
+		t.Fatalf("stopLaunchdDaemon() error = %v", err)
+	}
+	if !stopped {
+		t.Fatal("stopLaunchdDaemon() stopped = false, want true")
+	}
+	if len(bootoutArgs) != 3 || bootoutArgs[0] != "bootout" || bootoutArgs[2] != persistedPlistPath {
+		t.Fatalf("launchctl args = %#v, want bootout of persisted plist %q", bootoutArgs, persistedPlistPath)
+	}
+	if len(removed) == 0 || removed[len(removed)-1] != persistedPlistPath {
+		t.Fatalf("removed files = %#v, want persisted plist removed", removed)
+	}
+}
+
+func TestRefreshLaunchdLifecycleStateClearsStalePIDWhenServiceAbsent(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	statePath := filepath.Join(homeDir, ".looper", "looperd.state.json")
+	pidPath := filepath.Join(homeDir, ".looper", "looperd.pid")
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte("4321\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid) error = %v", err)
+	}
+	runtime := newCommandRuntime(New(Deps{
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		LookPath: func(file string) (string, error) {
+			if file == "launchctl" {
+				return "/bin/launchctl", nil
+			}
+			return "", os.ErrNotExist
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = command
+			_ = args
+			_ = timeout
+			return commandExecutionResult{Stdout: "{ service = inactive; }\n", ExitCode: 0}, nil
+		},
+	}), nil)
+	state := daemonLifecycleState{Mode: config.DaemonModeLaunchd, PID: 4321, Logs: daemonLifecycleLogState{Main: filepath.Join(homeDir, "looperd.log")}, Supervisor: &daemonSupervisorState{Source: "launchd", Label: launchdLooperdLabel}}
+	if err := runtime.writeDaemonLifecycleState(statePath, state); err != nil {
+		t.Fatalf("writeDaemonLifecycleState() error = %v", err)
+	}
+
+	updated, err := runtime.refreshLaunchdLifecycleState(context.Background(), loadedLaunchdTestConfig(homeDir), statePath, &state)
+	if err != nil {
+		t.Fatalf("refreshLaunchdLifecycleState() error = %v", err)
+	}
+	if updated == nil || updated.PID != 0 || updated.LastExit == nil || !strings.Contains(updated.LastExit.Reason, "clearing stale pid 4321") {
+		t.Fatalf("updated state = %#v, want stale pid cleared with last exit reason", updated)
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Fatalf("pid file stat error = %v, want not exist", err)
+	}
+	persisted, err := runtime.readDaemonLifecycleState(statePath)
+	if err != nil {
+		t.Fatalf("readDaemonLifecycleState() error = %v", err)
+	}
+	if persisted.PID != 0 {
+		t.Fatalf("persisted PID = %d, want 0", persisted.PID)
+	}
+}
+
 func TestDaemonStartLaunchdUnsupportedPlatform(t *testing.T) {
 	t.Parallel()
 
@@ -1585,6 +1704,12 @@ func writeLooperdStatusEnvelope(t *testing.T, w http.ResponseWriter) {
 			},
 		},
 	}))
+}
+
+func loadedLaunchdTestConfig(root string) config.LoadedFileConfig {
+	loaded := config.LoadedFileConfig{}
+	loaded.Config.Daemon.LogDir = filepath.Join(root, "logs")
+	return loaded
 }
 
 func daemonVersionCommand(managedPath string) runCommandFunc {

--- a/internal/cliapp/daemon_supervision.go
+++ b/internal/cliapp/daemon_supervision.go
@@ -87,13 +87,35 @@ func (r *commandRuntime) resolveDaemonStatePath() (string, error) {
 
 func (r *commandRuntime) resolveLaunchdPlistPath(loaded config.LoadedFileConfig) (string, error) {
 	if loaded.Config.Daemon.PlistPath != nil && strings.TrimSpace(*loaded.Config.Daemon.PlistPath) != "" {
-		return *loaded.Config.Daemon.PlistPath, nil
+		return r.resolveStablePath(*loaded.Config.Daemon.PlistPath)
 	}
 	homeDir, err := r.homeDir()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(homeDir, "Library", "LaunchAgents", launchdLooperdLabel+".plist"), nil
+}
+
+func (r *commandRuntime) resolveStablePath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", nil
+	}
+	if filepath.IsAbs(trimmed) {
+		return filepath.Clean(trimmed), nil
+	}
+	cwd, err := r.getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(filepath.Join(cwd, trimmed)), nil
+}
+
+func (r *commandRuntime) resolveLaunchdPlistPathForState(loaded config.LoadedFileConfig, state *daemonLifecycleState) (string, error) {
+	if state != nil && state.Supervisor != nil && strings.TrimSpace(state.Supervisor.PlistPath) != "" {
+		return r.resolveStablePath(state.Supervisor.PlistPath)
+	}
+	return r.resolveLaunchdPlistPath(loaded)
 }
 
 func daemonLogState(loaded config.LoadedFileConfig) daemonLifecycleLogState {
@@ -222,7 +244,28 @@ func (r *commandRuntime) refreshLaunchdLifecycleState(ctx context.Context, loade
 	}
 	domain := fmt.Sprintf("gui/%d", os.Getuid())
 	pid := r.launchdPID(ctx, launchctlPath, domain, label)
-	if pid <= 0 || pid == state.PID {
+	if pid <= 0 {
+		if state.PID == 0 {
+			return state, nil
+		}
+		updated := *state
+		updated.PID = 0
+		now := time.Now().UTC()
+		updated.LastExit = &daemonLifecycleExitState{At: now, Reason: fmt.Sprintf("launchd service %s is not reporting a pid; clearing stale pid %d", label, state.PID), LogPath: state.Logs.Main}
+		updated.LastError = updated.LastExit.Reason
+		if updated.Logs.Main == "" {
+			updated.Logs = daemonLogState(loaded)
+		}
+		if err := r.writeDaemonLifecycleState(statePath, updated); err != nil {
+			return state, err
+		}
+		pidPath, err := r.resolveDaemonPIDFilePath()
+		if err == nil {
+			r.removePIDFile(pidPath)
+		}
+		return &updated, nil
+	}
+	if pid == state.PID {
 		return state, nil
 	}
 	updated := *state
@@ -312,7 +355,7 @@ func (r *commandRuntime) startLaunchdDaemon(ctx context.Context, out io.Writer, 
 	return err
 }
 
-func (r *commandRuntime) stopLaunchdDaemon(ctx context.Context, out io.Writer, loaded config.LoadedFileConfig, startIfMissing bool) (bool, error) {
+func (r *commandRuntime) stopLaunchdDaemon(ctx context.Context, out io.Writer, loaded config.LoadedFileConfig, state *daemonLifecycleState, startIfMissing bool) (bool, error) {
 	if r.platform() != "darwin" {
 		return false, fmt.Errorf("daemon.mode=launchd is only supported on macOS; cannot stop launchd supervision on this platform")
 	}
@@ -320,7 +363,7 @@ func (r *commandRuntime) stopLaunchdDaemon(ctx context.Context, out io.Writer, l
 	if err != nil || strings.TrimSpace(launchctlPath) == "" {
 		return false, fmt.Errorf("daemon.mode=launchd requires launchctl to stop supervised looperd")
 	}
-	plistPath, err := r.resolveLaunchdPlistPath(loaded)
+	plistPath, err := r.resolveLaunchdPlistPathForState(loaded, state)
 	if err != nil {
 		return false, err
 	}
@@ -333,7 +376,9 @@ func (r *commandRuntime) stopLaunchdDaemon(ctx context.Context, out io.Writer, l
 		return false, fmt.Errorf("launchctl bootout failed: %s", strings.TrimSpace(result.Stderr))
 	}
 	statePath, _ := r.resolveDaemonStatePath()
-	state, _ := r.readDaemonLifecycleState(statePath)
+	if state == nil {
+		state, _ = r.readDaemonLifecycleState(statePath)
+	}
 	if state != nil {
 		now := time.Now().UTC()
 		state.LastExit = &daemonLifecycleExitState{At: now, Reason: "stopped by looper daemon stop", LogPath: state.Logs.Main}

--- a/internal/cliapp/daemon_supervision.go
+++ b/internal/cliapp/daemon_supervision.go
@@ -1,0 +1,480 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/powerformer/looper/internal/config"
+)
+
+const (
+	daemonStateSchemaVersion = 1
+	launchdLooperdLabel      = "com.powerformer.looper.looperd"
+)
+
+type daemonLifecycleState struct {
+	SchemaVersion int                       `json:"schemaVersion"`
+	Mode          config.DaemonMode         `json:"mode"`
+	PID           int                       `json:"pid,omitempty"`
+	StartedAt     *time.Time                `json:"startedAt,omitempty"`
+	BinaryPath    string                    `json:"binaryPath,omitempty"`
+	Supervisor    *daemonSupervisorState    `json:"supervisor,omitempty"`
+	Logs          daemonLifecycleLogState   `json:"logs"`
+	LastExit      *daemonLifecycleExitState `json:"lastExit,omitempty"`
+	LastError     string                    `json:"lastError,omitempty"`
+}
+
+type daemonSupervisorState struct {
+	Source                 string                     `json:"source"`
+	Label                  string                     `json:"label,omitempty"`
+	PlistPath              string                     `json:"plistPath,omitempty"`
+	RestartPolicy          config.DaemonRestartPolicy `json:"restartPolicy"`
+	RestartThrottleSeconds int                        `json:"restartThrottleSeconds"`
+}
+
+type daemonLifecycleLogState struct {
+	Main       string `json:"main"`
+	StartupDir string `json:"startupDir"`
+	Stdout     string `json:"stdout,omitempty"`
+	Stderr     string `json:"stderr,omitempty"`
+}
+
+type daemonLifecycleExitState struct {
+	At       time.Time `json:"at"`
+	ExitCode *int      `json:"exitCode,omitempty"`
+	Signal   *string   `json:"signal,omitempty"`
+	Reason   string    `json:"reason"`
+	LogPath  string    `json:"logPath,omitempty"`
+}
+
+type daemonLifecycleStatus struct {
+	State      *daemonLifecycleState `json:"state,omitempty"`
+	StatePath  string                `json:"statePath"`
+	PIDPath    string                `json:"pidPath"`
+	Process    string                `json:"process"`
+	StaleState bool                  `json:"staleState"`
+}
+
+type launchdPlistConfig struct {
+	Label                  string
+	ProgramArguments       []string
+	WorkingDirectory       string
+	Environment            map[string]string
+	RunAtLoad              bool
+	RestartPolicy          config.DaemonRestartPolicy
+	RestartThrottleSeconds int
+	StandardOutPath        string
+	StandardErrorPath      string
+}
+
+func (r *commandRuntime) resolveDaemonStatePath() (string, error) {
+	homeDir, err := r.homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".looper", "looperd.state.json"), nil
+}
+
+func (r *commandRuntime) resolveLaunchdPlistPath(loaded config.LoadedFileConfig) (string, error) {
+	if loaded.Config.Daemon.PlistPath != nil && strings.TrimSpace(*loaded.Config.Daemon.PlistPath) != "" {
+		return *loaded.Config.Daemon.PlistPath, nil
+	}
+	homeDir, err := r.homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, "Library", "LaunchAgents", launchdLooperdLabel+".plist"), nil
+}
+
+func daemonLogState(loaded config.LoadedFileConfig) daemonLifecycleLogState {
+	logDir := loaded.Config.Daemon.LogDir
+	return daemonLifecycleLogState{
+		Main:       filepath.Join(logDir, "looperd.log"),
+		StartupDir: filepath.Join(logDir, "startup"),
+		Stdout:     filepath.Join(logDir, "launchd", "looperd.stdout.log"),
+		Stderr:     filepath.Join(logDir, "launchd", "looperd.stderr.log"),
+	}
+}
+
+func (r *commandRuntime) readDaemonLifecycleState(path string) (*daemonLifecycleState, error) {
+	raw, err := r.readFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var state daemonLifecycleState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("read daemon lifecycle state: %w", err)
+	}
+	if state.SchemaVersion != daemonStateSchemaVersion {
+		return nil, fmt.Errorf("unsupported daemon lifecycle state schemaVersion %d at %s", state.SchemaVersion, path)
+	}
+	return &state, nil
+}
+
+func (r *commandRuntime) writeDaemonLifecycleState(path string, state daemonLifecycleState) error {
+	state.SchemaVersion = daemonStateSchemaVersion
+	raw, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	if err := r.mkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if r.app.deps.WriteFile != nil {
+		return r.writeFile(path, raw, 0o644)
+	}
+	tmp := fmt.Sprintf("%s.tmp.%d", path, time.Now().UnixNano())
+	if err := os.WriteFile(tmp, raw, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+func (r *commandRuntime) daemonLifecycleStatus(ctx context.Context, loaded config.LoadedFileConfig) (daemonLifecycleStatus, error) {
+	statePath, err := r.resolveDaemonStatePath()
+	if err != nil {
+		return daemonLifecycleStatus{}, err
+	}
+	pidPath, err := r.resolveDaemonPIDFilePath()
+	if err != nil {
+		return daemonLifecycleStatus{}, err
+	}
+	state, err := r.readDaemonLifecycleState(statePath)
+	if err != nil {
+		return daemonLifecycleStatus{}, err
+	}
+	status := daemonLifecycleStatus{State: state, StatePath: statePath, PIDPath: pidPath, Process: "unknown"}
+	if state != nil && state.Mode == config.DaemonModeLaunchd {
+		if refreshed, err := r.refreshLaunchdLifecycleState(ctx, loaded, statePath, state); err != nil {
+			state.LastError = err.Error()
+		} else if refreshed != nil {
+			state = refreshed
+			status.State = refreshed
+		}
+	}
+	pid := 0
+	if state != nil {
+		pid = state.PID
+	}
+	if pid == 0 {
+		if filePID, ok := r.readPIDFile(pidPath); ok {
+			pid = filePID
+		}
+	}
+	if pid == 0 {
+		status.Process = "not-running"
+		return status, nil
+	}
+	if r.isProcessAlive(pid) {
+		isLooperd, err := r.isLooperdProcess(ctx, pid)
+		if err != nil {
+			return daemonLifecycleStatus{}, err
+		}
+		if !isLooperd {
+			status.Process = "not-looperd"
+			status.StaleState = true
+			return status, nil
+		}
+		status.Process = "running"
+		return status, nil
+	}
+	status.Process = "exited"
+	status.StaleState = true
+	if state != nil && state.LastExit == nil {
+		now := time.Now().UTC()
+		state.LastExit = &daemonLifecycleExitState{At: now, Reason: fmt.Sprintf("process %d is no longer running; exit code unavailable (possibly SIGKILL, OOM, reboot, or supervisor stop)", pid), LogPath: state.Logs.Main}
+		state.LastError = state.LastExit.Reason
+		_ = r.writeDaemonLifecycleState(statePath, *state)
+	}
+	_ = loaded
+	return status, nil
+}
+
+func (r *commandRuntime) refreshLaunchdLifecycleState(ctx context.Context, loaded config.LoadedFileConfig, statePath string, state *daemonLifecycleState) (*daemonLifecycleState, error) {
+	if state == nil || r.platform() != "darwin" {
+		return state, nil
+	}
+	launchctlPath, err := r.lookPath()("launchctl")
+	if err != nil || strings.TrimSpace(launchctlPath) == "" {
+		return state, fmt.Errorf("launchd lifecycle state exists, but launchctl is unavailable; install/repair macOS launchd tools to inspect supervised looperd")
+	}
+	label := launchdLooperdLabel
+	if state.Supervisor != nil && strings.TrimSpace(state.Supervisor.Label) != "" {
+		label = state.Supervisor.Label
+	}
+	domain := fmt.Sprintf("gui/%d", os.Getuid())
+	pid := r.launchdPID(ctx, launchctlPath, domain, label)
+	if pid <= 0 || pid == state.PID {
+		return state, nil
+	}
+	updated := *state
+	updated.PID = pid
+	updated.LastError = ""
+	if updated.Logs.Main == "" {
+		updated.Logs = daemonLogState(loaded)
+	}
+	if err := r.writeDaemonLifecycleState(statePath, updated); err != nil {
+		return state, err
+	}
+	pidPath, err := r.resolveDaemonPIDFilePath()
+	if err == nil {
+		_ = r.mkdirAll(filepath.Dir(pidPath), 0o755)
+		_ = r.writeFile(pidPath, []byte(fmt.Sprintf("%d\n", pid)), 0o644)
+	}
+	return &updated, nil
+}
+
+func (r *commandRuntime) startLaunchdDaemon(ctx context.Context, out io.Writer, loaded config.LoadedFileConfig, binary *resolvedDaemonBinary, args []string, cwd string, env []string, client *DaemonAPIClient, apiURL string) error {
+	if r.platform() != "darwin" {
+		return fmt.Errorf("daemon.mode=launchd is only supported on macOS. Use daemon.mode=foreground for detached-only mode on this platform, or configure a platform supervisor when support is added")
+	}
+	launchctlPath, err := r.lookPath()("launchctl")
+	if err != nil || strings.TrimSpace(launchctlPath) == "" {
+		return fmt.Errorf("daemon.mode=launchd requires launchctl. Install/repair macOS launchd tools, or set daemon.mode=foreground for detached-only start")
+	}
+	plistPath, err := r.resolveLaunchdPlistPath(loaded)
+	if err != nil {
+		return err
+	}
+	logs := daemonLogState(loaded)
+	if err := r.mkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		return fmt.Errorf("create LaunchAgents directory: %w", err)
+	}
+	if err := r.mkdirAll(filepath.Dir(logs.Stdout), 0o755); err != nil {
+		return fmt.Errorf("create launchd log directory: %w", err)
+	}
+	programArgs := append([]string{binary.Path}, args...)
+	launchEnv := launchdEnvironment(env)
+	for key, value := range loaded.Config.Daemon.Environment {
+		launchEnv[key] = value
+	}
+	plist, err := generateLaunchdPlist(launchdPlistConfig{Label: launchdLooperdLabel, ProgramArguments: programArgs, WorkingDirectory: cwd, Environment: launchEnv, RunAtLoad: true, RestartPolicy: loaded.Config.Daemon.RestartPolicy, RestartThrottleSeconds: loaded.Config.Daemon.RestartThrottleSeconds, StandardOutPath: logs.Stdout, StandardErrorPath: logs.Stderr})
+	if err != nil {
+		return err
+	}
+	if err := r.writeFile(plistPath, plist, 0o644); err != nil {
+		return fmt.Errorf("write launchd plist: %w", err)
+	}
+	domain := fmt.Sprintf("gui/%d", os.Getuid())
+	_, _ = r.runCommand(ctx, launchctlPath, []string{"bootout", domain, plistPath}, daemonCommandTimeout)
+	result, err := r.runCommand(ctx, launchctlPath, []string{"bootstrap", domain, plistPath}, daemonCommandTimeout)
+	if err != nil {
+		return fmt.Errorf("launchctl bootstrap failed: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("launchctl bootstrap failed: %s", strings.TrimSpace(result.Stderr))
+	}
+	if err := r.waitForDaemonReadyByAPI(ctx, client, apiURL, r.daemonStartReadyTimeout(), daemonStartReadyPollPeriod); err != nil {
+		_, _ = r.runCommand(ctx, launchctlPath, []string{"bootout", domain, plistPath}, daemonCommandTimeout)
+		_ = r.removeFile(plistPath)
+		statePath, stateErr := r.resolveDaemonStatePath()
+		if stateErr == nil {
+			now := time.Now().UTC()
+			state := daemonLifecycleState{SchemaVersion: daemonStateSchemaVersion, Mode: config.DaemonModeLaunchd, StartedAt: &now, BinaryPath: binary.Path, Logs: logs, LastError: fmt.Sprintf("launchd daemon did not become ready at %s: %v", apiURL, err), Supervisor: &daemonSupervisorState{Source: "launchd", Label: launchdLooperdLabel, PlistPath: plistPath, RestartPolicy: loaded.Config.Daemon.RestartPolicy, RestartThrottleSeconds: loaded.Config.Daemon.RestartThrottleSeconds}}
+			_ = r.writeDaemonLifecycleState(statePath, state)
+		}
+		return fmt.Errorf("launchd daemon did not become ready at %s: %w; stdout log: %s; stderr log: %s", apiURL, err, logs.Stdout, logs.Stderr)
+	}
+	pid := r.launchdPID(ctx, launchctlPath, domain, launchdLooperdLabel)
+	now := time.Now().UTC()
+	statePath, err := r.resolveDaemonStatePath()
+	if err != nil {
+		return err
+	}
+	state := daemonLifecycleState{SchemaVersion: daemonStateSchemaVersion, Mode: config.DaemonModeLaunchd, PID: pid, StartedAt: &now, BinaryPath: binary.Path, Logs: logs, Supervisor: &daemonSupervisorState{Source: "launchd", Label: launchdLooperdLabel, PlistPath: plistPath, RestartPolicy: loaded.Config.Daemon.RestartPolicy, RestartThrottleSeconds: loaded.Config.Daemon.RestartThrottleSeconds}}
+	if err := r.writeDaemonLifecycleState(statePath, state); err != nil {
+		return fmt.Errorf("write daemon lifecycle state: %w", err)
+	}
+	if pid > 0 {
+		pidPath, _ := r.resolveDaemonPIDFilePath()
+		_ = r.mkdirAll(filepath.Dir(pidPath), 0o755)
+		_ = r.writeFile(pidPath, []byte(fmt.Sprintf("%d\n", pid)), 0o644)
+	}
+	_, err = fmt.Fprintf(out, "Started looperd under launchd supervision (%s)\nSupervisor: launchd label %s\nRestart policy: %s (throttle %ds)\nLaunchAgent: %s\nLogs: %s, %s\nState: %s\n", binary.Path, launchdLooperdLabel, loaded.Config.Daemon.RestartPolicy, loaded.Config.Daemon.RestartThrottleSeconds, plistPath, logs.Stdout, logs.Stderr, statePath)
+	return err
+}
+
+func (r *commandRuntime) stopLaunchdDaemon(ctx context.Context, out io.Writer, loaded config.LoadedFileConfig, startIfMissing bool) (bool, error) {
+	if r.platform() != "darwin" {
+		return false, fmt.Errorf("daemon.mode=launchd is only supported on macOS; cannot stop launchd supervision on this platform")
+	}
+	launchctlPath, err := r.lookPath()("launchctl")
+	if err != nil || strings.TrimSpace(launchctlPath) == "" {
+		return false, fmt.Errorf("daemon.mode=launchd requires launchctl to stop supervised looperd")
+	}
+	plistPath, err := r.resolveLaunchdPlistPath(loaded)
+	if err != nil {
+		return false, err
+	}
+	domain := fmt.Sprintf("gui/%d", os.Getuid())
+	result, err := r.runCommand(ctx, launchctlPath, []string{"bootout", domain, plistPath}, daemonCommandTimeout)
+	if err != nil {
+		return false, err
+	}
+	if result.ExitCode != 0 && !isLaunchdNotLoadedError(result.Stderr) {
+		return false, fmt.Errorf("launchctl bootout failed: %s", strings.TrimSpace(result.Stderr))
+	}
+	statePath, _ := r.resolveDaemonStatePath()
+	state, _ := r.readDaemonLifecycleState(statePath)
+	if state != nil {
+		now := time.Now().UTC()
+		state.LastExit = &daemonLifecycleExitState{At: now, Reason: "stopped by looper daemon stop", LogPath: state.Logs.Main}
+		state.PID = 0
+		_ = r.writeDaemonLifecycleState(statePath, *state)
+	}
+	pidPath, _ := r.resolveDaemonPIDFilePath()
+	r.removePIDFile(pidPath)
+	_ = r.removeFile(plistPath)
+	if startIfMissing {
+		_, err = fmt.Fprintln(out, "Stopped launchd-supervised looperd; starting daemon.")
+	} else {
+		_, err = fmt.Fprintf(out, "Stopped launchd-supervised looperd (%s)\n", launchdLooperdLabel)
+	}
+	return true, err
+}
+
+func isLaunchdNotLoadedError(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	return strings.Contains(lower, "service is not loaded") || strings.Contains(lower, "could not find") || strings.Contains(lower, "no such process") || strings.Contains(lower, "does not exist") || strings.Contains(lower, "not found")
+}
+
+func (r *commandRuntime) waitForDaemonReadyByAPI(ctx context.Context, client *DaemonAPIClient, apiURL string, timeout time.Duration, interval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastProbeErr error
+	for time.Now().Before(deadline) {
+		payload, err := r.getJSONWithClient(ctx, client, "/api/v1/status")
+		if err != nil {
+			lastProbeErr = err
+		} else if isLooperdStatusPayload(payload) {
+			return nil
+		} else {
+			lastProbeErr = fmt.Errorf("/api/v1/status at %s did not identify looperd", apiURL)
+		}
+		r.sleep(interval)
+	}
+	message := fmt.Sprintf("Timed out waiting for launchd-supervised looperd to become ready at %s", apiURL)
+	if lastProbeErr != nil {
+		message += fmt.Sprintf("; last readiness error: %v", lastProbeErr)
+	}
+	return fmt.Errorf(message)
+}
+
+func (r *commandRuntime) launchdPID(ctx context.Context, launchctlPath string, domain string, label string) int {
+	result, err := r.runCommand(ctx, launchctlPath, []string{"print", domain + "/" + label}, daemonCommandTimeout)
+	if err != nil || result.ExitCode != 0 {
+		return 0
+	}
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "pid =") {
+			pid, _ := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "pid =")))
+			return pid
+		}
+	}
+	return 0
+}
+
+func generateLaunchdPlist(cfg launchdPlistConfig) ([]byte, error) {
+	if strings.TrimSpace(cfg.Label) == "" {
+		return nil, fmt.Errorf("launchd label is required")
+	}
+	if len(cfg.ProgramArguments) == 0 || strings.TrimSpace(cfg.ProgramArguments[0]) == "" {
+		return nil, fmt.Errorf("launchd ProgramArguments are required")
+	}
+	if cfg.RestartThrottleSeconds < 1 {
+		return nil, fmt.Errorf("launchd ThrottleInterval must be positive")
+	}
+	var b bytes.Buffer
+	b.WriteString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+	b.WriteString("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n")
+	b.WriteString("<plist version=\"1.0\">\n<dict>\n")
+	writePlistString(&b, "Label", cfg.Label)
+	b.WriteString("\t<key>ProgramArguments</key>\n\t<array>\n")
+	for _, arg := range cfg.ProgramArguments {
+		b.WriteString("\t\t<string>" + html.EscapeString(arg) + "</string>\n")
+	}
+	b.WriteString("\t</array>\n")
+	writePlistString(&b, "WorkingDirectory", cfg.WorkingDirectory)
+	if len(cfg.Environment) > 0 {
+		b.WriteString("\t<key>EnvironmentVariables</key>\n\t<dict>\n")
+		keys := make([]string, 0, len(cfg.Environment))
+		for key := range cfg.Environment {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			writePlistString(&b, key, cfg.Environment[key])
+		}
+		b.WriteString("\t</dict>\n")
+	}
+	writePlistBool(&b, "RunAtLoad", cfg.RunAtLoad)
+	switch cfg.RestartPolicy {
+	case config.DaemonRestartNever:
+	case config.DaemonRestartOnFailure:
+		b.WriteString("\t<key>KeepAlive</key>\n\t<dict>\n\t\t<key>SuccessfulExit</key>\n\t\t<false/>\n\t</dict>\n")
+	case config.DaemonRestartAlways:
+		writePlistBool(&b, "KeepAlive", true)
+	default:
+		return nil, fmt.Errorf("unsupported restart policy %q", cfg.RestartPolicy)
+	}
+	b.WriteString(fmt.Sprintf("\t<key>ThrottleInterval</key>\n\t<integer>%d</integer>\n", cfg.RestartThrottleSeconds))
+	writePlistString(&b, "StandardOutPath", cfg.StandardOutPath)
+	writePlistString(&b, "StandardErrorPath", cfg.StandardErrorPath)
+	b.WriteString("</dict>\n</plist>\n")
+	return b.Bytes(), nil
+}
+
+func writePlistString(b *bytes.Buffer, key string, value string) {
+	b.WriteString("\t<key>" + html.EscapeString(key) + "</key>\n\t<string>" + html.EscapeString(value) + "</string>\n")
+}
+
+func writePlistBool(b *bytes.Buffer, key string, value bool) {
+	b.WriteString("\t<key>" + html.EscapeString(key) + "</key>\n")
+	if value {
+		b.WriteString("\t<true/>\n")
+	} else {
+		b.WriteString("\t<false/>\n")
+	}
+}
+
+func launchdEnvironment(env []string) map[string]string {
+	allowed := map[string]struct{}{
+		"HOME":          {},
+		"PATH":          {},
+		"SHELL":         {},
+		"TMPDIR":        {},
+		"LOOPER_CONFIG": {},
+	}
+	for name := range daemonSpawnPathEnvNames {
+		allowed[name] = struct{}{}
+	}
+	result := make(map[string]string, len(allowed))
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok || name == "" {
+			continue
+		}
+		if _, keep := allowed[name]; keep || strings.HasPrefix(name, "LOOPER_") {
+			result[name] = value
+		}
+	}
+	return result
+}

--- a/internal/cliapp/testdata/golden/daemon-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/daemon-help.stdout.golden
@@ -13,10 +13,13 @@ Flags:
   --force                     Overwrite existing installed daemon binary
   --full                      Show all retained daemon log lines, including rotated log files
   --lines <count>             Line count
+  --startup                   Show daemon startup logs instead of main logs
 
 Global Flags:
   --config <path>             Config path
   --daemon-mode <mode>        Daemon mode
+  --daemon-restart-policy <policy> Daemon supervisor restart policy: never, on-failure, or always
+  --daemon-restart-throttle-seconds <seconds> Daemon supervisor restart throttle
   --db-path <path>            Database path
   --fix-all-pull-requests <bool> Allow fixer to inspect and fix PRs created by any author
   --gh-path <path>            GitHub CLI path

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -30,6 +30,8 @@ Subcommands:
 Flags:
   --config <path>             Config path
   --daemon-mode <mode>        Daemon mode
+  --daemon-restart-policy <policy> Daemon supervisor restart policy: never, on-failure, or always
+  --daemon-restart-throttle-seconds <seconds> Daemon supervisor restart throttle
   --db-path <path>            Database path
   --fix-all-pull-requests <bool> Allow fixer to inspect and fix PRs created by any author
   --gh-path <path>            GitHub CLI path

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -872,6 +872,68 @@ func TestValidateAllowsLegacyProjectIDsForUpgradeCompatibility(t *testing.T) {
 	}
 }
 
+func TestValidateDaemonSupervisionConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mutate    func(*Config)
+		wantPath  string
+		wantError string
+	}{
+		{
+			name: "valid launchd restart policy",
+			mutate: func(cfg *Config) {
+				cfg.Daemon.Mode = DaemonModeLaunchd
+				cfg.Daemon.RestartPolicy = DaemonRestartAlways
+				cfg.Daemon.RestartThrottleSeconds = 30
+			},
+		},
+		{
+			name: "invalid restart policy",
+			mutate: func(cfg *Config) {
+				cfg.Daemon.RestartPolicy = DaemonRestartPolicy("sometimes")
+			},
+			wantPath:  "daemon.restartPolicy",
+			wantError: "must be one of: never, on-failure, always",
+		},
+		{
+			name: "invalid throttle",
+			mutate: func(cfg *Config) {
+				cfg.Daemon.RestartThrottleSeconds = 0
+			},
+			wantPath:  "daemon.restartThrottleSeconds",
+			wantError: "must be a positive integer",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg, err := DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig() error = %v", err)
+			}
+			tt.mutate(&cfg)
+			err = Validate(cfg)
+			if tt.wantPath == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Validate() error = nil, want validation error")
+			}
+			var validationErr *ConfigValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("Validate() error = %T, want *ConfigValidationError", err)
+			}
+			assertValidationIssue(t, validationErr, tt.wantPath, tt.wantError)
+		})
+	}
+}
+
 func TestValidateRejectsDuplicateAndIncompleteProjects(t *testing.T) {
 	config, err := DefaultConfig(t.TempDir())
 	if err != nil {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -93,11 +93,13 @@ func DefaultConfig(cwd string) (Config, error) {
 		Disclosure: DefaultDisclosureConfig(),
 		Tools:      ToolPathsConfig{},
 		Daemon: DaemonConfig{
-			Mode:              DaemonModeForeground,
-			LogDir:            logDir,
-			ShutdownTimeoutMS: 1000,
-			WorkingDirectory:  cwd,
-			Environment:       map[string]string{},
+			Mode:                   DaemonModeForeground,
+			RestartPolicy:          DaemonRestartOnFailure,
+			RestartThrottleSeconds: 10,
+			LogDir:                 logDir,
+			ShutdownTimeoutMS:      1000,
+			WorkingDirectory:       cwd,
+			Environment:            map[string]string{},
 		},
 		Package: PackageConfig{
 			Distribution:               "github-release",

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -239,6 +239,25 @@ func parseCLIArgs(args []string) (parsedCLIArgs, error) {
 			daemonMode := DaemonMode(value)
 			ensureDaemonConfig(&parsed.overrides).Mode = &daemonMode
 			index = nextIndex
+		case matchesFlag(arg, "--daemon-restart-policy"):
+			value, nextIndex, err := takeValue(index, "--daemon-restart-policy")
+			if err != nil {
+				return parsedCLIArgs{}, err
+			}
+			policy := DaemonRestartPolicy(value)
+			ensureDaemonConfig(&parsed.overrides).RestartPolicy = &policy
+			index = nextIndex
+		case matchesFlag(arg, "--daemon-restart-throttle-seconds"):
+			value, nextIndex, err := takeValue(index, "--daemon-restart-throttle-seconds")
+			if err != nil {
+				return parsedCLIArgs{}, err
+			}
+			parsedValue, err := parseInteger(value)
+			if err != nil {
+				return parsedCLIArgs{}, fmt.Errorf("invalid value for --daemon-restart-throttle-seconds: %q is not an integer", value)
+			}
+			ensureDaemonConfig(&parsed.overrides).RestartThrottleSeconds = parsedValue
+			index = nextIndex
 		case matchesFlag(arg, "--git-path"):
 			value, nextIndex, err := takeValue(index, "--git-path")
 			if err != nil {
@@ -477,6 +496,17 @@ func buildEnvOverrides(lookupEnv EnvLookupFunc) (PartialConfig, error) {
 	if value, ok := lookupEnv("LOOPER_DAEMON_MODE"); ok {
 		daemonMode := DaemonMode(value)
 		ensureDaemonConfig(&overrides).Mode = &daemonMode
+	}
+	if value, ok := lookupEnv("LOOPER_DAEMON_RESTART_POLICY"); ok {
+		policy := DaemonRestartPolicy(value)
+		ensureDaemonConfig(&overrides).RestartPolicy = &policy
+	}
+	if value, ok := lookupEnv("LOOPER_DAEMON_RESTART_THROTTLE_SECONDS"); ok {
+		parsed, err := parseInteger(value)
+		if err != nil {
+			return PartialConfig{}, fmt.Errorf("invalid value for LOOPER_DAEMON_RESTART_THROTTLE_SECONDS: %q is not an integer", value)
+		}
+		ensureDaemonConfig(&overrides).RestartThrottleSeconds = parsed
 	}
 	if value, ok := lookupEnv("LOOPER_WORKING_DIRECTORY"); ok {
 		ensureDaemonConfig(&overrides).WorkingDirectory = stringPtr(value)

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -265,6 +265,14 @@ func mergeDaemonConfig(config *DaemonConfig, partial PartialDaemonConfig) {
 		config.Mode = *partial.Mode
 	}
 
+	if partial.RestartPolicy != nil {
+		config.RestartPolicy = *partial.RestartPolicy
+	}
+
+	if partial.RestartThrottleSeconds != nil {
+		config.RestartThrottleSeconds = *partial.RestartThrottleSeconds
+	}
+
 	if partial.PlistPath != nil {
 		config.PlistPath = stringPtr(*partial.PlistPath)
 	}

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -137,6 +137,8 @@
       },
       "daemon": {
         "mode": "foreground",
+        "restartPolicy": "on-failure",
+        "restartThrottleSeconds": 10,
         "logDir": "__TMP__/env-logs",
         "workingDirectory": "__TMP__/workspace",
         "environment": {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -75,6 +75,8 @@
       },
       "daemon": {
         "mode": "foreground",
+        "restartPolicy": "on-failure",
+        "restartThrottleSeconds": 10,
         "logDir": "__TMP__/runtime-logs",
         "workingDirectory": "__TMP__/runtime",
         "environment": {}

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -155,6 +155,8 @@
       },
       "daemon": {
         "mode": "launchd",
+        "restartPolicy": "on-failure",
+        "restartThrottleSeconds": 10,
         "logDir": "__TMP__/launchd-logs",
         "workingDirectory": "__TMP__/launchd-workdir",
         "environment": {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -32,6 +32,14 @@ const (
 	DaemonModeLaunchd    DaemonMode = "launchd"
 )
 
+type DaemonRestartPolicy string
+
+const (
+	DaemonRestartNever     DaemonRestartPolicy = "never"
+	DaemonRestartOnFailure DaemonRestartPolicy = "on-failure"
+	DaemonRestartAlways    DaemonRestartPolicy = "always"
+)
+
 type OpenPRStrategy string
 
 const (
@@ -197,12 +205,14 @@ const (
 )
 
 type DaemonConfig struct {
-	Mode              DaemonMode        `json:"mode"`
-	PlistPath         *string           `json:"plistPath,omitempty"`
-	LogDir            string            `json:"logDir"`
-	ShutdownTimeoutMS int               `json:"shutdownTimeoutMs"`
-	WorkingDirectory  string            `json:"workingDirectory"`
-	Environment       map[string]string `json:"environment"`
+	Mode                   DaemonMode          `json:"mode"`
+	RestartPolicy          DaemonRestartPolicy `json:"restartPolicy"`
+	RestartThrottleSeconds int                 `json:"restartThrottleSeconds"`
+	PlistPath              *string             `json:"plistPath,omitempty"`
+	LogDir                 string              `json:"logDir"`
+	ShutdownTimeoutMS      int                 `json:"shutdownTimeoutMs"`
+	WorkingDirectory       string              `json:"workingDirectory"`
+	Environment            map[string]string   `json:"environment"`
 }
 
 type PackageConfig struct {
@@ -421,12 +431,14 @@ type PartialToolPathsConfig struct {
 }
 
 type PartialDaemonConfig struct {
-	Mode              *DaemonMode       `json:"mode,omitempty"`
-	PlistPath         *string           `json:"plistPath,omitempty"`
-	LogDir            *string           `json:"logDir,omitempty"`
-	ShutdownTimeoutMS *int              `json:"shutdownTimeoutMs,omitempty"`
-	WorkingDirectory  *string           `json:"workingDirectory,omitempty"`
-	Environment       map[string]string `json:"environment,omitempty"`
+	Mode                   *DaemonMode          `json:"mode,omitempty"`
+	RestartPolicy          *DaemonRestartPolicy `json:"restartPolicy,omitempty"`
+	RestartThrottleSeconds *int                 `json:"restartThrottleSeconds,omitempty"`
+	PlistPath              *string              `json:"plistPath,omitempty"`
+	LogDir                 *string              `json:"logDir,omitempty"`
+	ShutdownTimeoutMS      *int                 `json:"shutdownTimeoutMs,omitempty"`
+	WorkingDirectory       *string              `json:"workingDirectory,omitempty"`
+	Environment            map[string]string    `json:"environment,omitempty"`
 }
 
 type PartialPackageConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -112,6 +112,14 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 		issues = append(issues, ValidationIssue{Path: "daemon.mode", Message: fmt.Sprintf("must be one of: %s, %s", DaemonModeForeground, DaemonModeLaunchd)})
 	}
 
+	if !isValidDaemonRestartPolicy(config.Daemon.RestartPolicy) {
+		issues = append(issues, ValidationIssue{Path: "daemon.restartPolicy", Message: fmt.Sprintf("must be one of: %s, %s, %s", DaemonRestartNever, DaemonRestartOnFailure, DaemonRestartAlways)})
+	}
+
+	if config.Daemon.RestartThrottleSeconds < 1 {
+		issues = append(issues, ValidationIssue{Path: "daemon.restartThrottleSeconds", Message: "must be a positive integer"})
+	}
+
 	if config.Daemon.LogDir == "" {
 		issues = append(issues, ValidationIssue{Path: "daemon.logDir", Message: "must be a non-empty path"})
 	}
@@ -507,6 +515,15 @@ func isValidAuthMode(mode AuthMode) bool {
 func isValidDaemonMode(mode DaemonMode) bool {
 	switch mode {
 	case DaemonModeForeground, DaemonModeLaunchd:
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidDaemonRestartPolicy(policy DaemonRestartPolicy) bool {
+	switch policy {
+	case DaemonRestartNever, DaemonRestartOnFailure, DaemonRestartAlways:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
- Add daemon lifecycle state persistence and status diagnostics that distinguish detached foreground mode from supervised launchd mode.
- Implement macOS user LaunchAgent generation/bootstrap/bootout with restart policy mapping, throttle settings, log paths, and unsupported-platform errors.
- Document supervision boundaries, config/env/CLI options, log locations, and troubleshooting; extend tests for config validation, state persistence, stale PID detection, launchd plist mapping, and CLI output.

## Validation
- `env -u LOOPER_CONFIG HOME=/var/folders/qc/b9xm79rd3h1d7k619h0lm3240000gn/T/opencode/looper-test-home go test ./...`
- `env -u LOOPER_CONFIG HOME=/var/folders/qc/b9xm79rd3h1d7k619h0lm3240000gn/T/opencode/looper-test-home go vet ./...`
- `go build ./...`

Closes #161

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.5.6 · runner=worker · agent=opencode</sub>