### PR TITLE
fix: retry transient reviewer provider failures

### DIFF
--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -78,9 +78,12 @@ const (
 	defaultClaimTTL     = 5 * time.Minute
 	defaultRetryDelay   = 5 * time.Second
 	defaultRetryMax     = 3
+	maxRetryDelay       = 60 * time.Second
 
 	defaultHeadChangePollInterval = 15 * time.Second
 )
+
+var retryAfterPattern = regexp.MustCompile(`(?i)retry-after\s*[:=]\s*(\d+)`)
 
 type PullRequestSummary struct {
 	Number         int64
@@ -1210,6 +1213,11 @@ func (r *Runner) executeStepOnce(ctx context.Context, step ReviewerStep, input s
 }
 
 func (r *Runner) executeStepWithTransientExternalRetry(ctx context.Context, step ReviewerStep, input stepInput) (reviewerCheckpoint, error) {
+	if _, ok := ctx.Deadline(); !ok && r.agentTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.agentTimeout)
+		defer cancel()
+	}
 	maxAttempts := r.retryMaxAttempts
 	if maxAttempts <= 0 {
 		maxAttempts = defaultRetryMax
@@ -1227,8 +1235,12 @@ func (r *Runner) executeStepWithTransientExternalRetry(ctx context.Context, step
 		if attempt >= maxAttempts || !r.isTransientExternalFailure(err) {
 			break
 		}
-		delay := backoffDelay(r.retryBaseDelay, attempt)
-		r.logWarn("reviewer transient external failure retrying", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "queueItemId": input.QueueItem.ID, "step": string(step), "attempt": attempt, "nextAttempt": attempt + 1, "maxAttempts": maxAttempts, "retryDelay": delay.String(), "error": err.Error()})
+		delay := retryDelay(r.retryBaseDelay, attempt, err)
+		if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
+			r.logWarn("reviewer transient external retry budget exhausted", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "queueItemId": input.QueueItem.ID, "step": string(step), "attempt": attempt, "maxAttempts": maxAttempts, "retryDelay": delay.String(), "error": err.Error()})
+			break
+		}
+		r.logInfo("reviewer transient external failure retrying", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "queueItemId": input.QueueItem.ID, "step": string(step), "attempt": attempt, "nextAttempt": attempt + 1, "maxAttempts": maxAttempts, "retryDelay": delay.String(), "error": err.Error()})
 		if sleepErr := sleepWithContext(ctx, delay); sleepErr != nil {
 			return checkpoint, errors.Join(err, sleepErr)
 		}
@@ -4296,7 +4308,35 @@ func backoffDelay(base time.Duration, attempts int64) time.Duration {
 	for i := int64(1); i < attempts; i++ {
 		delay *= 2
 	}
+	if delay > maxRetryDelay {
+		return maxRetryDelay
+	}
 	return delay
+}
+
+func retryDelay(base time.Duration, attempts int64, err error) time.Duration {
+	if delay, ok := retryAfterDelay(err); ok {
+		if delay > maxRetryDelay {
+			return maxRetryDelay
+		}
+		return delay
+	}
+	return backoffDelay(base, attempts)
+}
+
+func retryAfterDelay(err error) (time.Duration, bool) {
+	if err == nil {
+		return 0, false
+	}
+	matches := retryAfterPattern.FindStringSubmatch(err.Error())
+	if len(matches) != 2 {
+		return 0, false
+	}
+	seconds, parseErr := time.ParseDuration(matches[1] + "s")
+	if parseErr != nil || seconds < 0 {
+		return 0, false
+	}
+	return seconds, true
 }
 
 func reviewerStepSupportsTransientExternalRetry(step ReviewerStep) bool {
@@ -4320,9 +4360,38 @@ func isTransientModelProviderMessage(message string) bool {
 	for _, fragment := range []string{
 		"server_is_overloaded",
 		"service_unavailable_error",
+		"overloaded_error",
 		"server is overloaded",
 		"service unavailable",
 		"overloaded",
+		"unexpected eof",
+		"tls handshake timeout",
+		"connection reset by peer",
+		"connection refused",
+		"connection timed out",
+		"i/o timeout",
+		"temporary failure in name resolution",
+		"network is unreachable",
+		"http 408",
+		"http 429",
+		"http 500",
+		"http 502",
+		"http 503",
+		"http 504",
+		"http 529",
+		"status code: 408",
+		"status code: 429",
+		"status code: 500",
+		"status code: 502",
+		"status code: 503",
+		"status code: 504",
+		"status code: 529",
+		"408 request timeout",
+		"429 too many requests",
+		"500 internal server error",
+		"502 bad gateway",
+		"503 service unavailable",
+		"504 gateway timeout",
 	} {
 		if strings.Contains(message, fragment) {
 			return true

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2,12 +2,14 @@ package reviewer
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -77,8 +79,9 @@ const (
 	defaultAgentTimeout = 90 * time.Minute
 	defaultClaimTTL     = 5 * time.Minute
 	defaultRetryDelay   = 5 * time.Second
-	defaultRetryMax     = 3
+	defaultRetryMax     = 5
 	maxRetryDelay       = 60 * time.Second
+	retryJitterDivisor  = 4
 
 	defaultHeadChangePollInterval = 15 * time.Second
 )
@@ -4321,7 +4324,26 @@ func retryDelay(base time.Duration, attempts int64, err error) time.Duration {
 		}
 		return delay
 	}
-	return backoffDelay(base, attempts)
+	return jitterDelay(backoffDelay(base, attempts))
+}
+
+func jitterDelay(delay time.Duration) time.Duration {
+	if delay <= 0 || delay >= maxRetryDelay {
+		return delay
+	}
+	maxJitter := delay / retryJitterDivisor
+	if maxJitter <= 0 {
+		return delay
+	}
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(maxJitter)+1))
+	if err != nil {
+		return delay
+	}
+	delay += time.Duration(n.Int64())
+	if delay > maxRetryDelay {
+		return maxRetryDelay
+	}
+	return delay
 }
 
 func retryAfterDelay(err error) (time.Duration, bool) {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4156,6 +4156,18 @@ func TestRetryDelayHonorsRetryAfterAndCapsBackoff(t *testing.T) {
 	}
 }
 
+func TestRetryDelayAddsBoundedJitter(t *testing.T) {
+	base := time.Second
+	wantMin := 2 * base
+	wantMax := wantMin + wantMin/retryJitterDivisor
+	for i := 0; i < 20; i++ {
+		got := retryDelay(base, 2, fmt.Errorf("anthropic overloaded"))
+		if got < wantMin || got > wantMax {
+			t.Fatalf("retryDelay(jittered) = %v, want between %v and %v", got, wantMin, wantMax)
+		}
+	}
+}
+
 func TestProcessClaimedItemRetriesTransientModelOverloadInRun(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed"}, {Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}, waitErrs: []error{fmt.Errorf("service_unavailable_error: server_is_overloaded")}}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4128,6 +4128,34 @@ func TestIsTransientExternalFailureDetectsWrappedGitHubStatus(t *testing.T) {
 	}
 }
 
+func TestIsTransientExternalFailureDetectsModelProviderHTTPAndNetworkFailures(t *testing.T) {
+	runner := New(Options{})
+	for _, message := range []string{
+		`Error: {"type":"error","error":{"type":"service_unavailable_error","code":"server_is_overloaded"}}`,
+		"anthropic overloaded_error: retry later",
+		"POST https://api.anthropic.com/v1/messages: unexpected EOF",
+		"net/http: TLS handshake timeout",
+		"anthropic request failed with HTTP 529",
+		"anthropic request failed with status code: 429",
+	} {
+		if !runner.isTransientExternalFailure(fmt.Errorf("%s", message)) {
+			t.Fatalf("isTransientExternalFailure(%q) = false, want true", message)
+		}
+	}
+}
+
+func TestRetryDelayHonorsRetryAfterAndCapsBackoff(t *testing.T) {
+	if got := retryDelay(time.Second, 1, fmt.Errorf("anthropic overloaded; retry-after: 7")); got != 7*time.Second {
+		t.Fatalf("retryDelay(retry-after) = %v, want 7s", got)
+	}
+	if got := retryDelay(time.Minute, 3, fmt.Errorf("anthropic overloaded; retry-after: 120")); got != maxRetryDelay {
+		t.Fatalf("retryDelay(capped retry-after) = %v, want %v", got, maxRetryDelay)
+	}
+	if got := retryDelay(time.Minute, 3, fmt.Errorf("anthropic overloaded")); got != maxRetryDelay {
+		t.Fatalf("retryDelay(capped exponential) = %v, want %v", got, maxRetryDelay)
+	}
+}
+
 func TestProcessClaimedItemRetriesTransientModelOverloadInRun(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed"}, {Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}, waitErrs: []error{fmt.Errorf("service_unavailable_error: server_is_overloaded")}}


### PR DESCRIPTION
## Summary
- Retry reviewer transient external failures from overloaded Anthropic/model providers, retryable HTTP statuses, and network resets before failing a run.
- Bound retry delays with a 60s cap, honor `Retry-After` values when present, add jitter to exponential backoff, and stop retrying when the reviewer agent timeout budget would be exceeded.
- Increase the reviewer retry budget to 5 attempts and add reviewer tests for overload payloads, provider/network/status classification, retry-delay behavior, and full run recovery.

## Validation
- `go test ./internal/reviewer`
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #220

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.6.0 · runner=worker · agent=opencode</sub>