### PR TITLE
fix: handle reviewer drift as skipped

### DIFF
--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/powerformer/looper/internal/config"
 	"github.com/powerformer/looper/internal/disclosure"
 	"github.com/powerformer/looper/internal/eventlog"
+	gitinfra "github.com/powerformer/looper/internal/infra/git"
 	githubinfra "github.com/powerformer/looper/internal/infra/github"
 	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/storage"
@@ -1564,6 +1565,10 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 	}
 	prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{WorktreePath: created.WorktreePath, Branch: branch, Ref: prRef, ExpectedHeadSHA: checkpoint.Snapshot.HeadSHA})
 	if err != nil {
+		var remoteHeadChanged *gitinfra.RemoteHeadChangedError
+		if errors.As(err, &remoteHeadChanged) {
+			return markReviewerRunStale(checkpoint, remoteHeadChanged.Error()), nil
+		}
 		return checkpoint, err
 	}
 	if !prepared.Clean {
@@ -3219,6 +3224,10 @@ func (r *Runner) classifyFailure(err error) *loopError {
 	if errors.As(err, &typed) {
 		return typed
 	}
+	var remoteHeadChanged *gitinfra.RemoteHeadChangedError
+	if errors.As(err, &remoteHeadChanged) {
+		return &loopError{message: remoteHeadChanged.Error(), kind: FailureRetryableAfterResume}
+	}
 	var transient transientFailure
 	if errors.As(err, &transient) && transient.Temporary() {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
@@ -3384,15 +3393,39 @@ func rediscoverySignalFromAgentResult(result AgentResult, allowReviewRequestSign
 	for _, candidate := range []string{result.Summary, result.Stdout, result.Stderr} {
 		for _, line := range strings.Split(candidate, "\n") {
 			line = strings.TrimSpace(line)
+			searchable := stripMarkdownCodeSpans(line)
 			switch {
-			case line == "PR head changed before publish" || strings.HasPrefix(line, "PR head changed before publish:"):
-				return line, true
-			case allowReviewRequestSignal && line == "review request removed before publish":
-				return line, true
+			case strings.Contains(searchable, "PR head changed before publish"):
+				return extractRediscoverySignal(searchable, "PR head changed before publish"), true
+			case allowReviewRequestSignal && strings.Contains(searchable, "review request removed before publish"):
+				return extractRediscoverySignal(searchable, "review request removed before publish"), true
 			}
 		}
 	}
 	return "", false
+}
+
+func stripMarkdownCodeSpans(line string) string {
+	for {
+		start := strings.Index(line, "`")
+		if start < 0 {
+			return line
+		}
+		end := strings.Index(line[start+1:], "`")
+		if end < 0 {
+			return line
+		}
+		end += start + 1
+		line = line[:start] + line[end+1:]
+	}
+}
+
+func extractRediscoverySignal(line, signal string) string {
+	index := strings.Index(line, signal)
+	if index < 0 {
+		return strings.TrimSpace(line)
+	}
+	return strings.TrimSpace(line[index:])
 }
 
 func stepsFrom(start ReviewerStep) []ReviewerStep {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2043,6 +2043,9 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		if err := r.persistCheckpoint(ctx, input.Run.ID, stepReview, checkpoint); err != nil {
 			return checkpoint, err
 		}
+		if checkpoint.SkipReason != "" {
+			return checkpoint, nil
+		}
 	}
 	worktree, err := requireWorktree(checkpoint)
 	if err != nil {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4009,6 +4009,61 @@ func TestRunReviewStepPersistsRepreparedWorktreeBeforeAgentStart(t *testing.T) {
 	}
 }
 
+func TestRunReviewStepStopsAfterStaleReprepareDuringReview(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{prepareErr: &gitinfra.RemoteHeadChangedError{Branch: "refs/pull/42/head", ExpectedHeadSHA: "abc123", ActualHeadSHA: "def456"}, worktreePath: filepath.Join(t.TempDir(), "reviewer-worktree")}
+	agent := &fakeAgentExecutor{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	prNumber := int64(42)
+	loopTarget := "pr:42"
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	initialCheckpoint := reviewerCheckpoint{
+		Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+		Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+		Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "deleted-worktree"), Branch: "feature/review-me", PreparedAt: fixture.nowISO()},
+	}
+	checkpointJSON := mustMarshalJSON(initialCheckpoint)
+	run := storage.RunRecord{ID: "run_1", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepReview)), CheckpointJSON: &checkpointJSON, StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	checkpoint, err := runner.runReviewStep(context.Background(), stepInput{
+		Project:    *project,
+		Loop:       loop,
+		Run:        run,
+		Repo:       "acme/looper",
+		PRNumber:   prNumber,
+		Checkpoint: initialCheckpoint,
+	})
+	if err != nil {
+		t.Fatalf("runReviewStep() error = %v", err)
+	}
+	if checkpoint.SkipKind != "stale" || !contains(checkpoint.SkipReason, "Remote head changed for refs/pull/42/head") {
+		t.Fatalf("checkpoint = %#v, want stale remote-head skip", checkpoint)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("len(agent.starts) = %d, want 0", len(agent.starts))
+	}
+	persistedRun, err := fixture.repos.Runs.GetByID(context.Background(), run.ID)
+	if err != nil || persistedRun == nil {
+		t.Fatalf("Runs.GetByID() = (%#v, %v), want run", persistedRun, err)
+	}
+	persistedCheckpoint := parseCheckpoint(persistedRun.CheckpointJSON)
+	if persistedCheckpoint.SkipKind != "stale" || !contains(persistedCheckpoint.SkipReason, "Remote head changed for refs/pull/42/head") {
+		t.Fatalf("persisted checkpoint = %#v, want stale remote-head skip", persistedCheckpoint)
+	}
+}
+
 func TestProcessClaimedItemRetryAfterReviewFailureRepreparesWorktree(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/powerformer/looper/internal/config"
 	"github.com/powerformer/looper/internal/eventlog"
+	gitinfra "github.com/powerformer/looper/internal/infra/git"
 	githubinfra "github.com/powerformer/looper/internal/infra/github"
 	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/storage"
@@ -5152,6 +5153,67 @@ func TestProcessClaimedItemMarksStaleOnUnparsedHeadChangeGuardrail(t *testing.T)
 	}
 }
 
+func TestProcessClaimedItemMarksStaleOnEmbeddedUnparsedGuardrail(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewMarkerMissing: true}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Stderr: "fatal: publish aborted: review request removed before publish; not posting review"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" || !contains(result.Summary, "review request removed before publish") {
+		t.Fatalf("result = %#v, want stale review-request skip", result)
+	}
+	latestRun, err := fixture.repos.Runs.GetLatestByLoopID(context.Background(), result.LoopID)
+	if err != nil || latestRun == nil {
+		t.Fatalf("GetLatestByLoopID() = (%#v, %v), want run", latestRun, err)
+	}
+	checkpoint := parseCheckpoint(latestRun.CheckpointJSON)
+	if checkpoint.SkipKind != "stale" {
+		t.Fatalf("SkipKind = %q, want stale", checkpoint.SkipKind)
+	}
+}
+
+func TestProcessClaimedItemMarksStaleWhenRemoteHeadChangesDuringWorktree(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{prepareErr: &gitinfra.RemoteHeadChangedError{Branch: "refs/pull/42/head", ExpectedHeadSHA: "abc123", ActualHeadSHA: "def456"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" || !contains(result.Summary, "Remote head changed for refs/pull/42/head") {
+		t.Fatalf("result = %#v, want stale remote-head skip", result)
+	}
+	latestRun, err := fixture.repos.Runs.GetLatestByLoopID(context.Background(), result.LoopID)
+	if err != nil || latestRun == nil {
+		t.Fatalf("GetLatestByLoopID() = (%#v, %v), want run", latestRun, err)
+	}
+	checkpoint := parseCheckpoint(latestRun.CheckpointJSON)
+	if checkpoint.SkipKind != "stale" {
+		t.Fatalf("SkipKind = %q, want stale", checkpoint.SkipKind)
+	}
+}
+
 func TestRunReviewStepIgnoresPromptEchoedRediscoveryGuardrail(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -5766,6 +5828,7 @@ type fakeGitGateway struct {
 	prepareCalls []PrepareWorktreeInput
 	cleanupCalls []CleanupWorktreeInput
 	prepareClean *bool
+	prepareErr   error
 }
 
 func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeInput) (CreateWorktreeResult, error) {
@@ -5783,6 +5846,9 @@ func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeI
 
 func (f *fakeGitGateway) PrepareWorktree(_ context.Context, input PrepareWorktreeInput) (PrepareWorktreeResult, error) {
 	f.prepareCalls = append(f.prepareCalls, input)
+	if f.prepareErr != nil {
+		return PrepareWorktreeResult{}, f.prepareErr
+	}
 	clean := true
 	if f.prepareClean != nil {
 		clean = *f.prepareClean


### PR DESCRIPTION
## Summary
- Mark remote PR head changes during reviewer worktree preparation as stale skips instead of hard failures.
- Classify typed remote-head drift as retryable-after-resume for any remaining error paths.
- Detect PR-head and review-request drift signals when they are embedded in agent summary/stdout/stderr, while ignoring prompt text echoed in code spans.

## Validation
- `go test ./internal/reviewer`
- `GOCACHE=/tmp/looper-go-build-cache go vet ./...`
- `GOCACHE=/tmp/looper-go-build-cache go build ./...`
- `GOCACHE=/tmp/looper-go-build-cache go test ./internal/agent`

Full `GOCACHE=/tmp/looper-go-build-cache go test ./...` was also attempted, but this sandbox blocks some required local listener and home-directory worktree operations (`httptest` bind denied; `~/.looper/worktrees` not writable).

Closes #222

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.6.0 · runner=worker · agent=codex</sub>