### PR TITLE
reviewer: posted reviews can still fail when completion marker parsing or marker verification misses them

### DIFF
--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -1056,6 +1056,9 @@ func (m reviewIdempotencyMarker) matches(marker string) bool {
 	if id := fields["id"]; id != "" && id != m.ID {
 		return false
 	}
+	if idPrefix := fields["id_prefix"]; idPrefix != "" && !strings.HasPrefix(m.ID, idPrefix) {
+		return false
+	}
 	if head := fields["head"]; head != "" && head != m.Head {
 		return false
 	}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -792,6 +792,30 @@ func TestGatewayFindReviewMarkerExtractsOutcomeFromMatchedMarker(t *testing.T) {
 	}
 }
 
+func TestGatewayFindReviewMarkerMatchesExpectedHeadWithLegacyID(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		if strings.Join(options.Args, " ") == "api --paginate --slurp repos/acme/looper/pulls/42/reviews" {
+			return shell.Result{Stdout: `[
+				{"state":"COMMENTED","body":"<!-- looper:review id=reviewer:old-loop:abc123 head=abc123 outcome=actionable -->"},
+				{"state":"COMMENTED","body":"<!-- looper:review id=reviewer:old-loop:def456 head=def456 outcome=actionable -->"}
+			]`}, nil
+		}
+		t.Fatalf("unexpected gh args: %q", strings.Join(options.Args, " "))
+		return shell.Result{}, nil
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	marker, err := gateway.FindReviewMarker(context.Background(), VerifyReviewMarkerInput{Repo: "acme/looper", PRNumber: 42, Marker: "looper:review head=abc123", AllowedReviewEvents: []string{"COMMENT"}})
+	if err != nil {
+		t.Fatalf("FindReviewMarker() error = %v", err)
+	}
+	if !marker.Found || marker.Outcome != "actionable" || marker.Event != "COMMENT" {
+		t.Fatalf("FindReviewMarker() = %#v, want marker matching expected head despite legacy id", marker)
+	}
+}
+
 func TestGatewayFindReviewMarkerRequiresWellFormedMarker(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -792,14 +792,15 @@ func TestGatewayFindReviewMarkerExtractsOutcomeFromMatchedMarker(t *testing.T) {
 	}
 }
 
-func TestGatewayFindReviewMarkerMatchesExpectedHeadWithLegacyID(t *testing.T) {
+func TestGatewayFindReviewMarkerMatchesExpectedHeadWithLoopIDPrefix(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		if strings.Join(options.Args, " ") == "api --paginate --slurp repos/acme/looper/pulls/42/reviews" {
 			return shell.Result{Stdout: `[
-				{"state":"COMMENTED","body":"<!-- looper:review id=reviewer:old-loop:abc123 head=abc123 outcome=actionable -->"},
-				{"state":"COMMENTED","body":"<!-- looper:review id=reviewer:old-loop:def456 head=def456 outcome=actionable -->"}
+				{"state":"COMMENTED","body":"<!-- looper:review id=reviewer:other-loop:abc123 head=abc123 outcome=blocking -->"},
+				{"state":"COMMENTED","body":"<!-- looper:review id=reviewer:loop-1:legacy-run head=abc123 outcome=actionable -->"},
+				{"state":"COMMENTED","body":"<!-- looper:review id=reviewer:loop-1:def456 head=def456 outcome=clean -->"}
 			]`}, nil
 		}
 		t.Fatalf("unexpected gh args: %q", strings.Join(options.Args, " "))
@@ -807,12 +808,12 @@ func TestGatewayFindReviewMarkerMatchesExpectedHeadWithLegacyID(t *testing.T) {
 	}
 
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
-	marker, err := gateway.FindReviewMarker(context.Background(), VerifyReviewMarkerInput{Repo: "acme/looper", PRNumber: 42, Marker: "looper:review head=abc123", AllowedReviewEvents: []string{"COMMENT"}})
+	marker, err := gateway.FindReviewMarker(context.Background(), VerifyReviewMarkerInput{Repo: "acme/looper", PRNumber: 42, Marker: "looper:review id_prefix=reviewer:loop-1: head=abc123", AllowedReviewEvents: []string{"COMMENT"}})
 	if err != nil {
 		t.Fatalf("FindReviewMarker() error = %v", err)
 	}
 	if !marker.Found || marker.Outcome != "actionable" || marker.Event != "COMMENT" {
-		t.Fatalf("FindReviewMarker() = %#v, want marker matching expected head despite legacy id", marker)
+		t.Fatalf("FindReviewMarker() = %#v, want marker matching expected head and loop id prefix", marker)
 	}
 }
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2140,7 +2140,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		if reason, ok := r.detectRediscoveryRequired(ctx, input, checkpoint); ok {
 			return markReviewerRunStale(checkpoint, reason), nil
 		}
-		return checkpoint, &loopError{message: "Reviewer agent did not report a valid completion marker after publishing review", kind: FailureNonRetryable}
+		return checkpoint, &loopError{message: "Reviewer agent did not report a valid completion marker after publishing review", kind: FailureRetryableAfterResume}
 	}
 	if cleanReviewNoopSummary(result.Summary) {
 		policy := r.effectiveReviewEvents(input.Loop.MetadataJSON)
@@ -2341,7 +2341,18 @@ func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepIn
 		return ReviewMarkerResult{}, err
 	}
 	marker := agentNativeReviewMarker(input.Loop.ID, headSHA, idempotencyKey)
-	return r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: marker, AllowedReviewEvents: r.allowedReviewEventsForPolicy(r.effectiveReviewEvents(input.Loop.MetadataJSON)), AuthorLogin: currentLogin, AllowCleanComment: sameReviewAuthorLogin(currentLogin, prAuthorLogin), CWD: input.Project.RepoPath})
+	allowedEvents := r.allowedReviewEventsForPolicy(r.effectiveReviewEvents(input.Loop.MetadataJSON))
+	allowCleanComment := sameReviewAuthorLogin(currentLogin, prAuthorLogin)
+	found, err := r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: marker, AllowedReviewEvents: allowedEvents, AuthorLogin: currentLogin, AllowCleanComment: allowCleanComment, CWD: input.Project.RepoPath})
+	if err != nil || found.Found {
+		return found, err
+	}
+	headMarker := agentNativeHeadReviewMarker(headSHA)
+	found, err = r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: headMarker, AllowedReviewEvents: allowedEvents, AuthorLogin: currentLogin, AllowCleanComment: allowCleanComment, CWD: input.Project.RepoPath})
+	if err != nil || found.Found {
+		return found, err
+	}
+	return r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: headMarker, AllowedReviewEvents: allowedEvents, AllowCleanComment: allowCleanComment, CWD: input.Project.RepoPath})
 }
 
 func sameReviewAuthorLogin(a string, b string) bool {
@@ -4255,6 +4266,10 @@ func agentNativeReviewMarker(loopID string, headSHA string, idempotencyKey strin
 		idempotencyKey = fmt.Sprintf("reviewer:%s:%s", loopID, headSHA)
 	}
 	return fmt.Sprintf("looper:review id=%s head=%s", idempotencyKey, headSHA)
+}
+
+func agentNativeHeadReviewMarker(headSHA string) string {
+	return fmt.Sprintf("looper:review head=%s", headSHA)
 }
 
 func (r *Runner) cleanupReviewerWorktreeIfTerminal(ctx context.Context, project storage.ProjectRecord, checkpoint *reviewerCheckpoint) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2352,7 +2352,7 @@ func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepIn
 	if err != nil || found.Found {
 		return found, err
 	}
-	return r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: headMarker, AllowedReviewEvents: allowedEvents, AllowCleanComment: allowCleanComment, CWD: input.Project.RepoPath})
+	return found, nil
 }
 
 func sameReviewAuthorLogin(a string, b string) bool {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2140,6 +2140,8 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		if reason, ok := r.detectRediscoveryRequired(ctx, input, checkpoint); ok {
 			return markReviewerRunStale(checkpoint, reason), nil
 		}
+		checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, MarkerVerificationMisses: 1}
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		return checkpoint, &loopError{message: "Reviewer agent did not report a valid completion marker after publishing review", kind: FailureRetryableAfterResume}
 	}
 	if cleanReviewNoopSummary(result.Summary) {
@@ -2347,8 +2349,8 @@ func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepIn
 	if err != nil || found.Found {
 		return found, err
 	}
-	headMarker := agentNativeHeadReviewMarker(headSHA)
-	found, err = r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: headMarker, AllowedReviewEvents: allowedEvents, AuthorLogin: currentLogin, AllowCleanComment: allowCleanComment, CWD: input.Project.RepoPath})
+	loopMarker := agentNativeLoopReviewMarker(input.Loop.ID, headSHA)
+	found, err = r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: loopMarker, AllowedReviewEvents: allowedEvents, AuthorLogin: currentLogin, AllowCleanComment: allowCleanComment, CWD: input.Project.RepoPath})
 	if err != nil || found.Found {
 		return found, err
 	}
@@ -4268,8 +4270,8 @@ func agentNativeReviewMarker(loopID string, headSHA string, idempotencyKey strin
 	return fmt.Sprintf("looper:review id=%s head=%s", idempotencyKey, headSHA)
 }
 
-func agentNativeHeadReviewMarker(headSHA string) string {
-	return fmt.Sprintf("looper:review head=%s", headSHA)
+func agentNativeLoopReviewMarker(loopID string, headSHA string) string {
+	return fmt.Sprintf("looper:review id_prefix=reviewer:%s: head=%s", loopID, headSHA)
 }
 
 func (r *Runner) cleanupReviewerWorktreeIfTerminal(ctx context.Context, project storage.ProjectRecord, checkpoint *reviewerCheckpoint) {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -3256,6 +3256,14 @@ func TestProcessClaimedItemFailsWhenAgentMissingCompletionMarker(t *testing.T) {
 	if result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume || !contains(result.Summary, "valid completion marker") {
 		t.Fatalf("result = %#v, want retryable completion marker failure", result)
 	}
+	latestRun, err := fixture.repos.Runs.GetLatestByLoopID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("GetLatestByLoopID() error = %v", err)
+	}
+	checkpoint := parseCheckpoint(latestRun.CheckpointJSON)
+	if checkpoint.ResumePolicy != "advance_from_checkpoint" || checkpoint.PendingReview == nil || checkpoint.PendingReview.MarkerVerificationMisses != 1 {
+		t.Fatalf("checkpoint = %#v, want pending marker verification before retry", checkpoint)
+	}
 }
 
 func TestProcessClaimedItemRecoversMissingCompletionMarkerWhenReviewMarkerExists(t *testing.T) {
@@ -3319,6 +3327,10 @@ func TestProcessClaimedItemRecoversMissingCompletionMarkerWithLegacyReviewMarker
 		if input.AuthorLogin == "" {
 			t.Fatalf("review marker input %d has empty author login; tolerant lookup must stay author-scoped", i)
 		}
+	}
+	wantIDPrefix := fmt.Sprintf("id_prefix=reviewer:%s:", result.LoopID)
+	if !contains(github.reviewMarkerInputs[1].Marker, wantIDPrefix) {
+		t.Fatalf("tolerant marker = %q, want loop-scoped id prefix", github.reviewMarkerInputs[1].Marker)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -3253,8 +3253,8 @@ func TestProcessClaimedItemFailsWhenAgentMissingCompletionMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "failed" || result.FailureKind != FailureNonRetryable || !contains(result.Summary, "valid completion marker") {
-		t.Fatalf("result = %#v, want non-retryable completion marker failure", result)
+	if result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume || !contains(result.Summary, "valid completion marker") {
+		t.Fatalf("result = %#v, want retryable completion marker failure", result)
 	}
 }
 
@@ -3288,6 +3288,32 @@ func TestProcessClaimedItemRecoversMissingCompletionMarkerWhenReviewMarkerExists
 	}
 	if github.reviewMarkerCalls != 2 {
 		t.Fatalf("review marker calls = %d, want parse recovery lookup plus publish verification", github.reviewMarkerCalls)
+	}
+}
+
+func TestProcessClaimedItemRecoversMissingCompletionMarkerWithLegacyReviewMarkerID(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"octocat"}, reviewMarkerExactMissing: true, reviewMarkerBody: "posted review <!-- looper:review id=reviewer:legacy-loop:abc123 head=abc123 outcome=actionable -->"}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "posted maybe", Stdout: "posted maybe"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success after legacy marker recovery", result)
+	}
+	if github.reviewMarkerCalls < 3 {
+		t.Fatalf("review marker calls = %d, want exact miss followed by tolerant lookup", github.reviewMarkerCalls)
 	}
 }
 
@@ -3360,8 +3386,8 @@ func TestProcessClaimedItemRetriesWhenAgentReviewMarkerMissing(t *testing.T) {
 	if len(agent.starts) != 1 {
 		t.Fatalf("len(agent.starts) after retry = %d, want marker recheck without review rerun", len(agent.starts))
 	}
-	if github.reviewMarkerCalls != 2 {
-		t.Fatalf("review marker calls = %d, want initial lookup plus retry", github.reviewMarkerCalls)
+	if github.reviewMarkerCalls != 4 {
+		t.Fatalf("review marker calls = %d, want exact and tolerant initial lookups plus retry", github.reviewMarkerCalls)
 	}
 	updatedLoop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil || updatedLoop == nil || updatedLoop.MetadataJSON == nil {
@@ -5666,6 +5692,7 @@ type fakeGitHubGateway struct {
 	currentLoginErr                 error
 	currentLoginCalls               int
 	reviewMarkerMissing             bool
+	reviewMarkerExactMissing        bool
 	reviewMarkerErr                 error
 	reviewMarkerEvent               ReviewEvent
 	reviewMarkerOutcome             string
@@ -5813,6 +5840,9 @@ func (g *fakeGitHubGateway) FindReviewMarker(_ context.Context, input VerifyRevi
 	g.reviewMarkerCalls++
 	if g.reviewMarkerErr != nil {
 		return ReviewMarkerResult{}, g.reviewMarkerErr
+	}
+	if g.reviewMarkerExactMissing && strings.Contains(input.Marker, " id=") {
+		return ReviewMarkerResult{}, nil
 	}
 	if g.reviewMarkerEvent != "" && !reviewEventIn(input.AllowedReviewEvents, g.reviewMarkerEvent) {
 		return ReviewMarkerResult{}, nil

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -3315,6 +3315,11 @@ func TestProcessClaimedItemRecoversMissingCompletionMarkerWithLegacyReviewMarker
 	if github.reviewMarkerCalls < 3 {
 		t.Fatalf("review marker calls = %d, want exact miss followed by tolerant lookup", github.reviewMarkerCalls)
 	}
+	for i, input := range github.reviewMarkerInputs {
+		if input.AuthorLogin == "" {
+			t.Fatalf("review marker input %d has empty author login; tolerant lookup must stay author-scoped", i)
+		}
+	}
 }
 
 func TestProcessClaimedItemRecoversFailedAgentRunWhenReviewMarkerExists(t *testing.T) {
@@ -3386,7 +3391,7 @@ func TestProcessClaimedItemRetriesWhenAgentReviewMarkerMissing(t *testing.T) {
 	if len(agent.starts) != 1 {
 		t.Fatalf("len(agent.starts) after retry = %d, want marker recheck without review rerun", len(agent.starts))
 	}
-	if github.reviewMarkerCalls != 4 {
+	if github.reviewMarkerCalls != 3 {
 		t.Fatalf("review marker calls = %d, want exact and tolerant initial lookups plus retry", github.reviewMarkerCalls)
 	}
 	updatedLoop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
@@ -5700,6 +5705,7 @@ type fakeGitHubGateway struct {
 	reviewMarkerBodyExplicit        bool
 	reviewMarkerInlineCommentBodies []string
 	reviewMarkerCalls               int
+	reviewMarkerInputs              []VerifyReviewMarkerInput
 	viewDraft                       bool
 	viewState                       string
 	viewStateAfterFirstView         string
@@ -5838,6 +5844,7 @@ func (g *fakeGitHubGateway) CapturePullRequestSnapshot(_ context.Context, input 
 
 func (g *fakeGitHubGateway) FindReviewMarker(_ context.Context, input VerifyReviewMarkerInput) (ReviewMarkerResult, error) {
 	g.reviewMarkerCalls++
+	g.reviewMarkerInputs = append(g.reviewMarkerInputs, input)
 	if g.reviewMarkerErr != nil {
 		return ReviewMarkerResult{}, g.reviewMarkerErr
 	}


### PR DESCRIPTION
## Summary
- Implement: Implement GitHub issue powerformer/looper#225: reviewer: posted reviews can still fail when completion marker parsing or marker verification misses them

Issue body:
## Summary

Some reviewer runs successfully post a GitHub review with a Looper marker, but the run is still marked failed because the agent did not emit a parsed `__LOOPER_RESULT__` marker or because publish-time marker verification does not find the already-posted review.

This creates false failed reviewer loops and can trigger duplicate follow-up attempts.

## Evidence

### Posted review but run failed as missing completion marker

Loop 133 (`powerformer/looper#125`) shows the agent posted a GitHub review successfully:

```text
{"id":4202572321,...,"state":"COMMENTED","commit_id":"fdd4dd124989cae611642ba392bfe462694f01b6"}
```

The review body includes a Looper marker:

```html
<!-- looper:review id=reviewer:333e9f1e-75cb-466d-9224-13432ab972fe:fdd4dd124989cae611642ba392bfe462694f01b6 head=fdd4dd124989cae611642ba392bfe462694f01b6 outcome=actionable -->
```

But the loop ended as:

```text
last_error_kind = non_retryable
last_error = Reviewer agent did not report a valid completion marker after publishing review
```

### Publish step failed despite existing reviews

Loops 325 and 333 failed in `step=publish` with:

```text
Reviewer agent completed but no matching GitHub review marker was found; retrying marker verification before rerunning review
```

Then their queue items were cancelled with `loop_terminated`, even though the relevant PR already had reviews/approvals in the review list.

## Root cause

The runner has two separate success signals:

1. Agent stdout marker (`__LOOPER_RESULT__`) parsed by the executor.
2. GitHub review marker verification (`<!-- looper:review ... -->`).

When (1) is missing, the runner tries to recover by verifying (2), but that verification can miss valid posted reviews due to marker shape, idempotency key mismatch, event type, author, or timing. The fallback then treats the run as failed even though the external side effect already happened.

Relevant code:

- `internal/agent/executor.go:499-502` — failed/missing parse marker handling
- `internal/reviewer/runner.go:2083-2118` — missing parse marker recovery and final `FailureNonRetryable`
- `internal/reviewer/runner.go:2144+` — publish step verification of pending review markers

## Expected behavior

If a Looper-marked GitHub review exists for the expected head, the reviewer run should converge to success or skipped/idempotent completion even when the agent fails to emit `__LOOPER_RESULT__`.

It should not leave a failed loop after an external review was already posted.

## Proposed fix

- Make marker verification tolerant of legacy/current marker id shapes where safe.
- Search recent reviews/comments by expected head and marker prefix before failing missing completion marker cases.
- Treat found existing marker as `PendingReview` and advance to publish/idempotent completion.
- If verification is inconclusive, prefer `retryable_after_resume` over `non_retryable` so the runner can re-check GitHub state before rerunning the full review.
- Add tests where the agent posts a valid marked review but omits `__LOOPER_RESULT__`.

Issue URL: https://github.com/powerformer/looper/issues/225

## Agent Summary
Implemented reviewer marker recovery, committed and pushed the branch, but PR creation is still missing because the connector create call was cancelled and gh API calls cannot reach api.github.com.

Issue: powerformer/looper#225

Issue URL: https://github.com/powerformer/looper/issues/225

Prompt: Implement GitHub issue powerformer/looper#225: reviewer: posted reviews can still fail when completion marker parsing or marker verification misses them

Issue body:
## Summary

Some reviewer runs successfully post a GitHub review with a Looper marker, but the run is still marked failed because the agent did not emit a parsed `__LOOPER_RESULT__` marker or because publish-time marker verification does not find the already-posted review.

This creates false failed reviewer loops and can trigger duplicate follow-up attempts.

## Evidence

### Posted review but run failed as missing completion marker

Loop 133 (`powerformer/looper#125`) shows the agent posted a GitHub review successfully:

```text
{"id":4202572321,...,"state":"COMMENTED","commit_id":"fdd4dd124989cae611642ba392bfe462694f01b6"}
```

The review body includes a Looper marker:

```html
<!-- looper:review id=reviewer:333e9f1e-75cb-466d-9224-13432ab972fe:fdd4dd124989cae611642ba392bfe462694f01b6 head=fdd4dd124989cae611642ba392bfe462694f01b6 outcome=actionable -->
```

But the loop ended as:

```text
last_error_kind = non_retryable
last_error = Reviewer agent did not report a valid completion marker after publishing review
```

### Publish step failed despite existing reviews

Loops 325 and 333 failed in `step=publish` with:

```text
Reviewer agent completed but no matching GitHub review marker was found; retrying marker verification before rerunning review
```

Then their queue items were cancelled with `loop_terminated`, even though the relevant PR already had reviews/approvals in the review list.

## Root cause

The runner has two separate success signals:

1. Agent stdout marker (`__LOOPER_RESULT__`) parsed by the executor.
2. GitHub review marker verification (`<!-- looper:review ... -->`).

When (1) is missing, the runner tries to recover by verifying (2), but that verification can miss valid posted reviews due to marker shape, idempotency key mismatch, event type, author, or timing. The fallback then treats the run as failed even though the external side effect already happened.

Relevant code:

- `internal/agent/executor.go:499-502` — failed/missing parse marker handling
- `internal/reviewer/runner.go:2083-2118` — missing parse marker recovery and final `FailureNonRetryable`
- `internal/reviewer/runner.go:2144+` — publish step verification of pending review markers

## Expected behavior

If a Looper-marked GitHub review exists for the expected head, the reviewer run should converge to success or skipped/idempotent completion even when the agent fails to emit `__LOOPER_RESULT__`.

It should not leave a failed loop after an external review was already posted.

## Proposed fix

- Make marker verification tolerant of legacy/current marker id shapes where safe.
- Search recent reviews/comments by expected head and marker prefix before failing missing completion marker cases.
- Treat found existing marker as `PendingReview` and advance to publish/idempotent completion.
- If verification is inconclusive, prefer `retryable_after_resume` over `non_retryable` so the runner can re-check GitHub state before rerunning the full review.
- Add tests where the agent posts a valid marked review but omits `__LOOPER_RESULT__`.

Issue URL: https://github.com/powerformer/looper/issues/225

Closes #225

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.6.0 · runner=worker · agent=codex</sub>