### PR TITLE
[codex] fix: require fixer commits before resolving comments

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1348,15 +1348,15 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		fixItems = collectFixItems(detail)
 		checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, detail)
 	}
-	if shouldBlockResolveWithoutFix(checkpoint, fixItems) {
-		return checkpoint, &loopError{message: "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved", kind: FailureManualIntervention}
-	}
 	if checkpoint.ReconcileCommits != nil && checkpoint.ReconcileCommits.FinalHeadSHA != "" {
 		if err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: checkpoint.ReconcileCommits.FinalHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
 			return fmt.Sprintf("PR head changed before resolving comments: expected %s, got %s", checkpoint.ReconcileCommits.FinalHeadSHA, firstNonEmpty(actual, "unknown"))
 		}}); err != nil {
 			return checkpoint, err
 		}
+	}
+	if shouldBlockResolveWithoutFix(checkpoint, fixItems) {
+		return checkpoint, &loopError{message: "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved", kind: FailureManualIntervention}
 	}
 	if checkpoint.ResolvedComments == nil {
 		checkpoint.ResolvedComments = &checkpointResolvedComments{Items: []checkpointResolvedComment{}}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1339,6 +1339,18 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	if checkpoint.Push == nil {
 		return checkpoint, &loopError{message: "resolve-comments requires push step to complete", kind: FailureRetryableAfterResume}
 	}
+	fixItems := checkpoint.FixItems
+	if checkpoint.Push != nil && !checkpoint.Push.Pushed {
+		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
+		if err != nil {
+			return checkpoint, err
+		}
+		fixItems = collectFixItems(detail)
+		checkpoint.Detail = &checkpointDetail{State: detail.State, IsDraft: detail.IsDraft, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: cloneObjectSlice(detail.Comments), Checks: cloneObjectSlice(detail.Checks), HasConflicts: detail.HasConflicts}
+	}
+	if shouldBlockResolveWithoutFix(checkpoint, fixItems) {
+		return checkpoint, &loopError{message: "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved", kind: FailureManualIntervention}
+	}
 	if checkpoint.ReconcileCommits != nil && checkpoint.ReconcileCommits.FinalHeadSHA != "" {
 		if err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: checkpoint.ReconcileCommits.FinalHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
 			return fmt.Sprintf("PR head changed before resolving comments: expected %s, got %s", checkpoint.ReconcileCommits.FinalHeadSHA, firstNonEmpty(actual, "unknown"))
@@ -1350,7 +1362,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		checkpoint.ResolvedComments = &checkpointResolvedComments{Items: []checkpointResolvedComment{}}
 	}
 	failedCount := 0
-	for _, item := range checkpoint.FixItems {
+	for _, item := range fixItems {
 		if item.Type != "comment" {
 			continue
 		}
@@ -2211,6 +2223,30 @@ func shouldRestartFromDiscover(status string, failedStep FixerStep, failureSumma
 
 func shouldRebuildWorktree(checkpoint fixerCheckpoint) bool {
 	return checkpoint.Worktree != nil && checkpoint.Worktree.Path != "" && checkpoint.Worktree.PreparedAt == ""
+}
+
+func shouldBlockResolveWithoutFix(checkpoint fixerCheckpoint, fixItems []FixItem) bool {
+	if checkpoint.Push == nil || checkpoint.Push.Pushed {
+		return false
+	}
+	if checkpoint.ReconcileCommits == nil {
+		return false
+	}
+	if len(checkpoint.ReconcileCommits.NewCommitSHAs) > 0 {
+		return false
+	}
+	if checkpoint.ReconcileCommits.FinalHeadSHA != "" && checkpoint.ReconcileCommits.BaseHeadSHA != "" && checkpoint.ReconcileCommits.FinalHeadSHA != checkpoint.ReconcileCommits.BaseHeadSHA {
+		return false
+	}
+	if checkpoint.Lifecycle != nil && checkpoint.Lifecycle.Pushed {
+		return false
+	}
+	for _, item := range fixItems {
+		if item.Type == "comment" {
+			return true
+		}
+	}
+	return false
 }
 
 func rewindCheckpointForPrepareRetry(checkpoint fixerCheckpoint) fixerCheckpoint {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1346,7 +1346,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			return checkpoint, err
 		}
 		fixItems = collectFixItems(detail)
-		checkpoint.Detail = &checkpointDetail{State: detail.State, IsDraft: detail.IsDraft, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: cloneObjectSlice(detail.Comments), Checks: cloneObjectSlice(detail.Checks), HasConflicts: detail.HasConflicts}
+		checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, detail)
 	}
 	if shouldBlockResolveWithoutFix(checkpoint, fixItems) {
 		return checkpoint, &loopError{message: "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved", kind: FailureManualIntervention}
@@ -2238,9 +2238,6 @@ func shouldBlockResolveWithoutFix(checkpoint fixerCheckpoint, fixItems []FixItem
 	if checkpoint.ReconcileCommits.FinalHeadSHA != "" && checkpoint.ReconcileCommits.BaseHeadSHA != "" && checkpoint.ReconcileCommits.FinalHeadSHA != checkpoint.ReconcileCommits.BaseHeadSHA {
 		return false
 	}
-	if checkpoint.Lifecycle != nil && checkpoint.Lifecycle.Pushed {
-		return false
-	}
 	for _, item := range fixItems {
 		if item.Type == "comment" {
 			return true
@@ -2360,6 +2357,14 @@ func detailLabels(detail *checkpointDetail) []string {
 		return nil
 	}
 	return detail.Labels
+}
+
+func mergeCheckpointDetailPreservingLabels(existing *checkpointDetail, live PullRequestDetail) *checkpointDetail {
+	merged := &checkpointDetail{State: live.State, IsDraft: live.IsDraft, Labels: cloneStrings(live.Labels), HeadSHA: live.HeadSHA, HeadRefName: live.HeadRefName, BaseRefName: live.BaseRefName, BaseSHA: live.BaseSHA, ReviewDecision: live.ReviewDecision, Comments: cloneObjectSlice(live.Comments), Checks: cloneObjectSlice(live.Checks), HasConflicts: live.HasConflicts}
+	if existing != nil {
+		merged.Labels = cloneStrings(existing.Labels)
+	}
+	return merged
 }
 
 func detailHeadSHA(detail *checkpointDetail) string {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -433,6 +433,109 @@ func TestProcessClaimedItemCompletesSuccessfulFlow(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:  CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+		inspectResults: []InspectHeadResult{
+			{HeadSHA: "base-head"},
+			{HeadSHA: "base-head"},
+			{HeadSHA: "base-head"},
+		},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "blocked before editing because gh could not validate PR metadata", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureManualIntervention || !contains(result.Summary, "produced no new commits") {
+		t.Fatalf("result = %#v, want manual intervention failure for no-op repair", result)
+	}
+	if len(git.commitCalls) != 0 || len(git.pushCalls) != 0 || len(github.resolveCalls) != 0 {
+		t.Fatalf("commit calls=%d push calls=%d resolve calls=%d, want 0/0/0 after no-op repair", len(git.commitCalls), len(git.pushCalls), len(github.resolveCalls))
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	if run == nil || run.Status != "failed" || run.CurrentStep == nil || *run.CurrentStep != string(stepResolveComments) {
+		t.Fatalf("run = %#v, want failed run at resolve-comments step", run)
+	}
+	checkpoint := parseCheckpoint(run.CheckpointJSON)
+	if checkpoint.Push == nil || checkpoint.Push.Pushed || checkpoint.Push.SkippedReason == "" {
+		t.Fatalf("checkpoint.Push = %#v, want recorded no-op push", checkpoint.Push)
+	}
+	if checkpoint.ResolvedComments != nil {
+		t.Fatalf("checkpoint.ResolvedComments = %#v, want unresolved comments left untouched", checkpoint.ResolvedComments)
+	}
+}
+
+func TestProcessClaimedItemAllowsNoCommitWhenCommentsAlreadyResolved(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	unresolved := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
+	resolved := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix", "isResolved": true, "state": "RESOLVED"}
+	github := &fakeGitHubGateway{
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "base-head"}},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{unresolved}},
+			{Number: 42, State: "OPEN", HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{unresolved}},
+			{Number: 42, State: "OPEN", HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{resolved}},
+			{Number: 42, State: "OPEN", HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{resolved}},
+			{Number: 42, State: "OPEN", HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{resolved}},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:  CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+		inspectResults: []InspectHeadResult{
+			{HeadSHA: "base-head"},
+			{HeadSHA: "base-head"},
+			{HeadSHA: "base-head"},
+		},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "no edit needed because comment was already resolved", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success after live comments are already resolved", result)
+	}
+	if len(git.commitCalls) != 0 || len(git.pushCalls) != 0 || len(github.resolveCalls) != 0 {
+		t.Fatalf("commit calls=%d push calls=%d resolve calls=%d, want 0/0/0 after already-resolved live comments", len(git.commitCalls), len(git.pushCalls), len(github.resolveCalls))
+	}
+}
+
 func TestRunPrepareWorktreeStepPreservesExistingLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -438,10 +438,10 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{
-		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "base-head"}},
 		viewResponses: []PullRequestDetail{
-			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
-			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
 		},
 	}
 	git := &fakeGitGateway{
@@ -584,6 +584,77 @@ func TestRunResolveCommentsStepBlocksWithoutVerifiedPushEvidence(t *testing.T) {
 	}
 	if !contains(loopErr.Error(), "produced no new commits") {
 		t.Fatalf("error = %q, want no-new-commits message", loopErr.Error())
+	}
+}
+
+func TestRunResolveCommentsStepChecksHeadDriftBeforeNoFixBlock(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{
+		{
+			Number:      42,
+			State:       "OPEN",
+			HeadSHA:     "base-head",
+			HeadRefName: "feature/fix-42",
+			BaseRefName: "main",
+			BaseSHA:     "base-1",
+			Comments: []map[string]any{{
+				"id":       "c1",
+				"threadId": "t1",
+				"body":     "please fix",
+			}},
+		},
+		{
+			Number:      42,
+			State:       "OPEN",
+			HeadSHA:     "new-head",
+			HeadRefName: "feature/fix-42",
+			BaseRefName: "main",
+			BaseSHA:     "base-1",
+			Comments: []map[string]any{{
+				"id":       "c1",
+				"threadId": "t1",
+				"body":     "please fix",
+			}},
+		},
+	}}
+	runner := New(Options{GitHub: github, Sleep: func(time.Duration) {}})
+	checkpoint := fixerCheckpoint{
+		FixItems:   []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}},
+		Validation: &ValidationResult{Passed: true, Summary: "ok"},
+		Push:       &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		ReconcileCommits: &checkpointReconcileCommits{
+			BaseHeadSHA:      "base-head",
+			FinalHeadSHA:     "base-head",
+			NewCommitSHAs:    nil,
+			WorkingTreeClean: true,
+		},
+	}
+
+	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err == nil {
+		t.Fatal("runResolveCommentsStep() error = nil, want stale-head retry")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureRetryableAfterResume {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableAfterResume)
+	}
+	if !contains(loopErr.Error(), "PR head changed before resolving comments") {
+		t.Fatalf("error = %q, want stale-head message", loopErr.Error())
+	}
+	if github.viewIndex < 2 {
+		t.Fatalf("github.viewIndex = %d, want live refresh plus head check before no-fix block", github.viewIndex)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want none on stale head", len(github.resolveCalls))
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/powerformer/looper/internal/config"
+	"github.com/powerformer/looper/internal/infra/specpr"
 	"github.com/powerformer/looper/internal/lifecycle"
 	"github.com/powerformer/looper/internal/storage"
 )
@@ -533,6 +534,115 @@ func TestProcessClaimedItemAllowsNoCommitWhenCommentsAlreadyResolved(t *testing.
 	}
 	if len(git.commitCalls) != 0 || len(git.pushCalls) != 0 || len(github.resolveCalls) != 0 {
 		t.Fatalf("commit calls=%d push calls=%d resolve calls=%d, want 0/0/0 after already-resolved live comments", len(git.commitCalls), len(git.pushCalls), len(github.resolveCalls))
+	}
+}
+
+func TestRunResolveCommentsStepBlocksWithoutVerifiedPushEvidence(t *testing.T) {
+	t.Parallel()
+
+	runner := New(Options{GitHub: &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "base-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}}})
+	checkpoint := fixerCheckpoint{
+		FixItems:   []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}},
+		Validation: &ValidationResult{Passed: true, Summary: "ok"},
+		Push:       &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Lifecycle:  &lifecycle.State{Pushed: true},
+		ReconcileCommits: &checkpointReconcileCommits{
+			BaseHeadSHA:      "base-head",
+			FinalHeadSHA:     "base-head",
+			NewCommitSHAs:    nil,
+			WorkingTreeClean: true,
+		},
+	}
+
+	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err == nil {
+		t.Fatal("runResolveCommentsStep() error = nil, want manual intervention")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureManualIntervention {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureManualIntervention)
+	}
+	if !contains(loopErr.Error(), "produced no new commits") {
+		t.Fatalf("error = %q, want no-new-commits message", loopErr.Error())
+	}
+}
+
+func TestRunResolveCommentsStepPreservesCheckpointLabelSnapshotOnLiveRefresh(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "base-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Labels:      nil,
+		Comments: []map[string]any{{
+			"id":         "c1",
+			"threadId":   "t1",
+			"body":       "please fix",
+			"isResolved": true,
+			"state":      "RESOLVED",
+		}},
+	}}}
+	runner := New(Options{GitHub: github, Now: time.Now})
+	originalLabels := []string{specpr.ReviewingLabel}
+	checkpoint := fixerCheckpoint{
+		Detail: &checkpointDetail{
+			Labels:      append([]string(nil), originalLabels...),
+			HeadSHA:     "base-head",
+			HeadRefName: "feature/fix-42",
+			BaseRefName: "main",
+			Comments: []map[string]any{{
+				"id":       "c1",
+				"threadId": "t1",
+				"body":     "please fix",
+			}},
+		},
+		FixItems:         []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}},
+		Validation:       &ValidationResult{Passed: true, Summary: "ok"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if updated.Detail == nil {
+		t.Fatal("updated.Detail = nil, want merged detail")
+	}
+	if !specpr.HasLabel(updated.Detail.Labels, specpr.ReviewingLabel) {
+		t.Fatalf("updated.Detail.Labels = %#v, want preserved %q label", updated.Detail.Labels, specpr.ReviewingLabel)
+	}
+	if len(updated.Detail.Labels) != 1 {
+		t.Fatalf("updated.Detail.Labels = %#v, want preserved snapshot only", updated.Detail.Labels)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Prevent fixer runs from resolving review threads when the repair produced no new commits and the push step was a no-op.
- Add regression coverage for a Codex fixer that returns a parsed completion after failing pre-edit GitHub validation.

## Root Cause
Codex fixer runs can stop before editing when `gh` cannot reach GitHub from the agent sandbox. The runner still treated the parsed completion as successful, recorded `push.skipped` with `no_new_commits`, and proceeded to resolve review comments.

## Validation
- `go test ./internal/fixer`
- `go test ./...`