### PR TITLE
fix: resume reviewer sessions after provider overload

### DIFF
--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -170,7 +170,7 @@ func isRecoverableNativeResumeSource(status string, resumeStatus *string) bool {
 		return false
 	}
 	switch status {
-	case "running", "cancelling", "killed", "timeout", "failed":
+	case "running", "cancelling", "killed", "timeout", "failed", "completed":
 		return true
 	default:
 		return false

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -41,20 +41,21 @@ type ExecutorOptions struct {
 }
 
 type RunInput struct {
-	ExecutionID      string
-	ProjectID        string
-	LoopID           string
-	RunID            string
-	Prompt           string
-	WorkingDirectory string
-	Timeout          time.Duration
-	HeartbeatTimeout time.Duration
-	GracefulShutdown time.Duration
-	MaxOutputBytes   int
-	Metadata         map[string]any
-	IdempotencyKey   string
-	Env              map[string]string
-	NativeSessionID  string
+	ExecutionID        string
+	ProjectID          string
+	LoopID             string
+	RunID              string
+	Prompt             string
+	NativeResumePrompt string
+	WorkingDirectory   string
+	Timeout            time.Duration
+	HeartbeatTimeout   time.Duration
+	GracefulShutdown   time.Duration
+	MaxOutputBytes     int
+	Metadata           map[string]any
+	IdempotencyKey     string
+	Env                map[string]string
+	NativeSessionID    string
 }
 
 type Result struct {
@@ -195,7 +196,11 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 	if err != nil {
 		return nil, err
 	}
-	command, args := ResolveSpawnWithNativeResume(e.config, input.Prompt, resume.SessionID, resume.Enabled)
+	spawnPrompt := input.Prompt
+	if resume.Enabled && strings.TrimSpace(input.NativeResumePrompt) != "" {
+		spawnPrompt = input.NativeResumePrompt
+	}
+	command, args := ResolveSpawnWithNativeResume(e.config, spawnPrompt, resume.SessionID, resume.Enabled)
 
 	cmd := exec.Command(command, args...)
 	cmd.Dir = input.WorkingDirectory
@@ -208,7 +213,7 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 		cmd.Env = append(cmd.Env, key+"="+value)
 	}
 	cmd.Env = append(cmd.Env,
-		"LOOPER_PROMPT="+input.Prompt,
+		"LOOPER_PROMPT="+spawnPrompt,
 		completionMarkerEnv+"="+CompletionMarkerPrefix,
 	)
 

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -139,6 +139,19 @@ func TestResolveSpawnWithNativeResumeDoesNotDuplicateEqualsFlags(t *testing.T) {
 	}
 }
 
+func TestRecoverableNativeResumeSourceAllowsCompletedPending(t *testing.T) {
+	t.Parallel()
+
+	pending := "pending"
+	if !isRecoverableNativeResumeSource("completed", &pending) {
+		t.Fatalf("isRecoverableNativeResumeSource(completed, pending) = false, want true")
+	}
+	notPending := "captured"
+	if isRecoverableNativeResumeSource("completed", &notPending) {
+		t.Fatalf("isRecoverableNativeResumeSource(completed, captured) = true, want false")
+	}
+}
+
 func TestExtractNativeSessionID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -310,7 +310,7 @@ func TestExecutorFallsBackAfterFailedNativeResumeAttempt(t *testing.T) {
 		},
 	})
 
-	failedExec, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_resume_failed", LoopID: "loop_1", WorkingDirectory: t.TempDir(), Prompt: "continue work", Timeout: 5 * time.Second, Env: map[string]string{"ARGS_PATH": argsPath}})
+	failedExec, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_resume_failed", LoopID: "loop_1", WorkingDirectory: t.TempDir(), Prompt: "full checkpoint prompt", NativeResumePrompt: "continue work", Timeout: 5 * time.Second, Env: map[string]string{"ARGS_PATH": argsPath}})
 	if err != nil {
 		t.Fatalf("Start(first) error = %v", err)
 	}
@@ -333,7 +333,7 @@ func TestExecutorFallsBackAfterFailedNativeResumeAttempt(t *testing.T) {
 		t.Fatalf("ReadFile(argsPath) error = %v", err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(argsBytes)), "\n")
-	if len(lines) != 2 || lines[0] != "exec resume codex-session-1 continue work" || lines[1] != "exec continue work" {
+	if len(lines) != 2 || lines[0] != "exec resume codex-session-1 continue work" || lines[1] != "exec full checkpoint prompt" {
 		t.Fatalf("spawned args = %#v, want native resume then immediate checkpoint restart", lines)
 	}
 }

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3411,7 +3411,7 @@ If the review or thread-resolution result was already posted, report the existin
 }
 
 func transientProviderMessageFromAgentResult(result AgentResult) string {
-	for _, candidate := range []string{result.Summary, result.Stderr, result.Stdout} {
+	for _, candidate := range []string{result.Summary, result.Stderr} {
 		candidate = strings.TrimSpace(candidate)
 		if isTransientModelProviderMessage(candidate) {
 			return candidate

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3394,7 +3394,42 @@ func (r *Runner) hasPendingNativeResume(ctx context.Context, loopID string) bool
 		r.logWarn("reviewer native resume pending lookup failed", map[string]any{"loopId": loopID, "error": err.Error()})
 		return false
 	}
-	return latest != nil && latest.NativeSessionID != nil && strings.TrimSpace(*latest.NativeSessionID) != "" && latest.NativeResumeStatus != nil && *latest.NativeResumeStatus == "pending"
+	return r.isResumableNativeSession(latest)
+}
+
+func (r *Runner) isResumableNativeSession(latest *storage.AgentExecutionRecord) bool {
+	if latest == nil || latest.NativeSessionID == nil || strings.TrimSpace(*latest.NativeSessionID) == "" {
+		return false
+	}
+	if !isRecoverableReviewerNativeResumeSource(latest.Status, latest.NativeResumeStatus) {
+		return false
+	}
+	currentVendor := config.AgentVendor(strings.TrimSpace(r.agentRuntime))
+	if currentVendor == "" {
+		return true
+	}
+	return nativeResumeSupportedForReviewer(currentVendor) && latest.Vendor == string(currentVendor)
+}
+
+func nativeResumeSupportedForReviewer(vendor config.AgentVendor) bool {
+	switch vendor {
+	case config.AgentVendorClaudeCode, config.AgentVendorCodex, config.AgentVendorOpenCode, config.AgentVendorCursorCLI:
+		return true
+	default:
+		return false
+	}
+}
+
+func isRecoverableReviewerNativeResumeSource(status string, resumeStatus *string) bool {
+	if resumeStatus == nil || *resumeStatus != "pending" {
+		return false
+	}
+	switch status {
+	case "running", "cancelling", "killed", "timeout", "failed", "completed":
+		return true
+	default:
+		return false
+	}
 }
 
 func nativeResumeContinuationPrompt(phase string, repo string, prNumber int64, headSHA string, idempotencyKey string) string {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1229,6 +1229,7 @@ func (r *Runner) executeStepWithTransientExternalRetry(ctx context.Context, step
 	checkpoint := input.Checkpoint
 	var err error
 	for attempt := int64(1); attempt <= maxAttempts; attempt++ {
+		input.Checkpoint = checkpoint
 		checkpoint, err = r.executeStepOnce(ctx, step, input)
 		if err == nil {
 			if attempt > 1 {
@@ -1240,6 +1241,9 @@ func (r *Runner) executeStepWithTransientExternalRetry(ctx context.Context, step
 			break
 		}
 		delay := retryDelay(r.retryBaseDelay, attempt, err)
+		if r.hasPendingNativeResume(ctx, input.Loop.ID) {
+			delay = 0
+		}
 		if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
 			r.logWarn("reviewer transient external retry budget exhausted", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "queueItemId": input.QueueItem.ID, "step": string(step), "attempt": attempt, "maxAttempts": maxAttempts, "retryDelay": delay.String(), "error": err.Error()})
 			break
@@ -1844,12 +1848,19 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 	if err != nil {
 		r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.failed", "thread_resolution", executionID, reviewerAgentWaitErrorPayload(err, r.now().Sub(agentStartedAt)))
 		r.logWarn("reviewer agent wait failed", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "repo": input.Repo, "prNumber": input.PRNumber, "phase": "thread_resolution", "executionId": executionID, "elapsedSeconds": durationSeconds(r.now().Sub(agentStartedAt)), "error": err.Error()})
+		r.markAgentExecutionNativeResumePendingForTransientProvider(ctx, executionID, err.Error())
 		return nil, err
 	}
 	r.appendReviewerAgentEvent(ctx, input, reviewerAgentTerminalEvent(result), "thread_resolution", executionID, reviewerAgentResultPayload(result, r.now().Sub(agentStartedAt)))
 	r.logInfo("reviewer agent completed", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "repo": input.Repo, "prNumber": input.PRNumber, "phase": "thread_resolution", "executionId": executionID, "status": result.Status, "timeoutType": result.TimeoutType, "elapsedSeconds": elapsedSeconds(result, r.now().Sub(agentStartedAt)), "parseStatus": result.ParseStatus})
 	if result.Status != "completed" {
-		return nil, &loopError{message: reviewerAgentFailureMessage("thread resolution", result, "thread resolution classifier failed"), kind: FailureRetryableTransient}
+		message := reviewerAgentFailureMessage("thread resolution", result, "thread resolution classifier failed")
+		r.markAgentExecutionNativeResumePendingForTransientProvider(ctx, executionID, message)
+		return nil, &loopError{message: message, kind: FailureRetryableTransient}
+	}
+	if message := transientProviderMessageFromAgentResult(result); message != "" {
+		r.markAgentExecutionNativeResumePendingForTransientProvider(ctx, executionID, message)
+		return nil, &loopError{message: message, kind: FailureRetryableTransient}
 	}
 	parsed, err := parseThreadResolutionOutput(result.Stdout)
 	if err != nil {
@@ -2109,6 +2120,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	if err != nil {
 		r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.failed", "review", executionID, reviewerAgentWaitErrorPayload(err, r.now().Sub(agentStartedAt)))
 		r.logWarn("reviewer agent wait failed", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "repo": input.Repo, "prNumber": input.PRNumber, "phase": "review", "executionId": executionID, "elapsedSeconds": durationSeconds(r.now().Sub(agentStartedAt)), "error": err.Error()})
+		r.markAgentExecutionNativeResumePendingForTransientProvider(ctx, executionID, err.Error())
 		return checkpoint, err
 	}
 	r.appendReviewerAgentEvent(ctx, input, reviewerAgentTerminalEvent(result), "review", executionID, reviewerAgentResultPayload(result, r.now().Sub(agentStartedAt)))
@@ -2134,6 +2146,9 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		} else if agent.IsAgentSetupFailureMessage(message) {
 			kind = FailureManualIntervention
 		}
+		if kind == FailureRetryableTransient {
+			r.markAgentExecutionNativeResumePendingForTransientProvider(ctx, executionID, message)
+		}
 		return checkpoint, &loopError{message: message, kind: kind}
 	}
 	if result.ParseStatus != "parsed" {
@@ -2149,6 +2164,10 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		}
 		if reason, ok := r.detectRediscoveryRequired(ctx, input, checkpoint); ok {
 			return markReviewerRunStale(checkpoint, reason), nil
+		}
+		if message := transientProviderMessageFromAgentResult(result); message != "" {
+			r.markAgentExecutionNativeResumePendingForTransientProvider(ctx, executionID, message)
+			return checkpoint, &loopError{message: message, kind: FailureRetryableTransient}
 		}
 		checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, MarkerVerificationMisses: 1}
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
@@ -3331,6 +3350,55 @@ func (r *Runner) isTransientExternalFailure(err error) bool {
 		return loopErr.kind == FailureRetryableTransient && isTransientModelProviderMessage(loopErr.message)
 	}
 	return false
+}
+
+func (r *Runner) markAgentExecutionNativeResumePendingForTransientProvider(ctx context.Context, executionID string, message string) bool {
+	if strings.TrimSpace(executionID) == "" || !isTransientModelProviderMessage(message) || r.repos == nil || r.repos.AgentExecutions == nil {
+		return false
+	}
+	record, err := r.repos.AgentExecutions.GetByID(ctx, executionID)
+	if err != nil {
+		r.logWarn("reviewer native resume source lookup failed", map[string]any{"executionId": executionID, "error": err.Error()})
+		return false
+	}
+	if record == nil || record.NativeSessionID == nil || strings.TrimSpace(*record.NativeSessionID) == "" {
+		return false
+	}
+	if record.NativeResumeStatus != nil && *record.NativeResumeStatus == "pending" {
+		return true
+	}
+	record.NativeResumeMode = stringPtr("native_resume")
+	record.NativeResumeStatus = stringPtr("pending")
+	record.NativeResumeError = stringPtr(strings.TrimSpace(message))
+	record.UpdatedAt = r.nowISO()
+	if err := r.repos.AgentExecutions.Upsert(ctx, *record); err != nil {
+		r.logWarn("reviewer native resume source mark failed", map[string]any{"executionId": executionID, "error": err.Error()})
+		return false
+	}
+	r.logInfo("reviewer native resume retry queued", map[string]any{"executionId": executionID, "loopId": derefString(record.LoopID), "runId": derefString(record.RunID)})
+	return true
+}
+
+func (r *Runner) hasPendingNativeResume(ctx context.Context, loopID string) bool {
+	if strings.TrimSpace(loopID) == "" || r.repos == nil || r.repos.AgentExecutions == nil {
+		return false
+	}
+	latest, err := r.repos.AgentExecutions.GetLatestByLoopID(ctx, loopID)
+	if err != nil {
+		r.logWarn("reviewer native resume pending lookup failed", map[string]any{"loopId": loopID, "error": err.Error()})
+		return false
+	}
+	return latest != nil && latest.NativeSessionID != nil && strings.TrimSpace(*latest.NativeSessionID) != "" && latest.NativeResumeStatus != nil && *latest.NativeResumeStatus == "pending"
+}
+
+func transientProviderMessageFromAgentResult(result AgentResult) string {
+	for _, candidate := range []string{result.Summary, result.Stderr, result.Stdout} {
+		candidate = strings.TrimSpace(candidate)
+		if isTransientModelProviderMessage(candidate) {
+			return candidate
+		}
+	}
+	return ""
 }
 
 func (r *Runner) nowISO() string {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1838,6 +1838,9 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 	slices.Sort(candidateIDs)
 	idempotencyKey := fmt.Sprintf("reviewer-thread-resolution:%s:%d:%s:%s", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, strings.Join(candidateIDs, ","))
 	prompt := buildThreadResolutionPrompt(input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, threads)
+	if r.hasPendingNativeResume(ctx, input.Loop.ID) {
+		prompt = nativeResumeContinuationPrompt("thread-resolution", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, idempotencyKey)
+	}
 	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: map[string]any{"loopType": "reviewer", "phase": "thread_resolution", "repo": input.Repo, "prNumber": input.PRNumber}, IdempotencyKey: idempotencyKey})
 	if err != nil {
 		return nil, err
@@ -2091,6 +2094,9 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	idempotencyKey := agentNativeReviewID(input.Loop.ID, checkpoint.Snapshot.HeadSHA)
 	policy := r.discoveryPolicyForProject(input.Project.ID)
 	prompt, instructionBlock := buildReviewPromptWithInstructions(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint, input.Run.ID, idempotencyKey, r.effectiveReviewEvents(input.Loop.MetadataJSON), isManualReviewerLoop(input.Loop), policy.RequireReviewRequest, r.scope, r.disclosure, r.agentRuntime, r.agentModel, r.looperCLIPath)
+	if r.hasPendingNativeResume(ctx, input.Loop.ID) {
+		prompt = nativeResumeContinuationPrompt("review", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, idempotencyKey)
+	}
 	metadata := map[string]any{"loopType": "reviewer", "repo": input.Repo, "prNumber": input.PRNumber}
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 		metadata[key] = value
@@ -3389,6 +3395,19 @@ func (r *Runner) hasPendingNativeResume(ctx context.Context, loopID string) bool
 		return false
 	}
 	return latest != nil && latest.NativeSessionID != nil && strings.TrimSpace(*latest.NativeSessionID) != "" && latest.NativeResumeStatus != nil && *latest.NativeResumeStatus == "pending"
+}
+
+func nativeResumeContinuationPrompt(phase string, repo string, prNumber int64, headSHA string, idempotencyKey string) string {
+	return fmt.Sprintf(`Continue the existing Looper reviewer %s task in this resumed native session.
+
+Do not restart from scratch or ask for more context. Reuse the prior session context and continue from the transient provider interruption.
+
+Before any GitHub side effect, re-check the current PR/head/idempotency guards from the existing instructions:
+- PR: %s#%d
+- expected head SHA: %s
+- idempotency key: %s
+
+If the review or thread-resolution result was already posted, report the existing completion marker instead of posting a duplicate.`, strings.TrimSpace(phase), repo, prNumber, headSHA, idempotencyKey)
 }
 
 func transientProviderMessageFromAgentResult(result AgentResult) string {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1861,15 +1861,15 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 		r.markAgentExecutionNativeResumePendingForTransientProvider(ctx, executionID, message)
 		return nil, &loopError{message: message, kind: FailureRetryableTransient}
 	}
+	parsed, err := parseThreadResolutionOutput(result.Stdout)
+	if err == nil {
+		return parsed.Decisions, nil
+	}
 	if message := transientProviderMessageFromAgentResult(result); message != "" {
 		r.markAgentExecutionNativeResumePendingForTransientProvider(ctx, executionID, message)
 		return nil, &loopError{message: message, kind: FailureRetryableTransient}
 	}
-	parsed, err := parseThreadResolutionOutput(result.Stdout)
-	if err != nil {
-		return nil, &loopError{message: err.Error(), kind: FailureNonRetryable}
-	}
-	return parsed.Decisions, nil
+	return nil, &loopError{message: err.Error(), kind: FailureNonRetryable}
 }
 
 func buildThreadResolutionPrompt(repo string, prNumber int64, headSHA string, threads []ReviewThread) string {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -305,16 +305,17 @@ type GitGateway interface {
 }
 
 type AgentRunInput struct {
-	ExecutionID      string
-	ProjectID        string
-	LoopID           string
-	RunID            string
-	Prompt           string
-	WorkingDirectory string
-	Timeout          time.Duration
-	HeartbeatTimeout time.Duration
-	Metadata         map[string]any
-	IdempotencyKey   string
+	ExecutionID        string
+	ProjectID          string
+	LoopID             string
+	RunID              string
+	Prompt             string
+	NativeResumePrompt string
+	WorkingDirectory   string
+	Timeout            time.Duration
+	HeartbeatTimeout   time.Duration
+	Metadata           map[string]any
+	IdempotencyKey     string
 }
 
 type AgentResult struct {
@@ -2094,14 +2095,15 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	idempotencyKey := agentNativeReviewID(input.Loop.ID, checkpoint.Snapshot.HeadSHA)
 	policy := r.discoveryPolicyForProject(input.Project.ID)
 	prompt, instructionBlock := buildReviewPromptWithInstructions(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint, input.Run.ID, idempotencyKey, r.effectiveReviewEvents(input.Loop.MetadataJSON), isManualReviewerLoop(input.Loop), policy.RequireReviewRequest, r.scope, r.disclosure, r.agentRuntime, r.agentModel, r.looperCLIPath)
+	nativeResumePrompt := ""
 	if r.hasPendingNativeResume(ctx, input.Loop.ID) {
-		prompt = nativeResumeContinuationPrompt("review", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, idempotencyKey)
+		nativeResumePrompt = nativeResumeContinuationPrompt("review", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, idempotencyKey)
 	}
 	metadata := map[string]any{"loopType": "reviewer", "repo": input.Repo, "prNumber": input.PRNumber}
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 		metadata[key] = value
 	}
-	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: metadata, IdempotencyKey: idempotencyKey})
+	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, NativeResumePrompt: nativeResumePrompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: metadata, IdempotencyKey: idempotencyKey})
 	if err != nil {
 		return checkpoint, err
 	}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1241,7 +1241,7 @@ func (r *Runner) executeStepWithTransientExternalRetry(ctx context.Context, step
 			break
 		}
 		delay := retryDelay(r.retryBaseDelay, attempt, err)
-		if r.hasPendingNativeResume(ctx, input.Loop.ID) {
+		if r.shouldSkipTransientRetryDelayForNativeResume(ctx, input.Loop.ID, err) {
 			delay = 0
 		}
 		if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
@@ -3395,6 +3395,39 @@ func (r *Runner) hasPendingNativeResume(ctx context.Context, loopID string) bool
 		return false
 	}
 	return r.isResumableNativeSession(latest)
+}
+
+func (r *Runner) shouldSkipTransientRetryDelayForNativeResume(ctx context.Context, loopID string, err error) bool {
+	return isTransientModelProviderOverloadFailure(err) && r.hasPendingNativeResume(ctx, loopID)
+}
+
+func isTransientModelProviderOverloadFailure(err error) bool {
+	if err == nil || githubinfra.IsTransientError(err) {
+		return false
+	}
+	var loopErr *loopError
+	if errors.As(err, &loopErr) {
+		return loopErr.kind == FailureRetryableTransient && isTransientModelProviderOverloadMessage(loopErr.message)
+	}
+	return isTransientModelProviderOverloadMessage(err.Error())
+}
+
+func isTransientModelProviderOverloadMessage(message string) bool {
+	message = strings.ToLower(message)
+	for _, fragment := range []string{
+		"server_is_overloaded",
+		"service_unavailable_error",
+		"overloaded_error",
+		"server is overloaded",
+		"overloaded",
+		"http 529",
+		"status code: 529",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Runner) isResumableNativeSession(latest *storage.AgentExecutionRecord) bool {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4004,7 +4004,7 @@ func TestRunReviewStepUsesStableIdempotencyKeyAcrossRuns(t *testing.T) {
 	}
 }
 
-func TestRunReviewStepUsesShortPromptForPendingNativeResume(t *testing.T) {
+func TestRunReviewStepKeepsFullPromptForPendingNativeResumeFallback(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	ctx := context.Background()
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
@@ -4046,11 +4046,15 @@ func TestRunReviewStepUsesShortPromptForPendingNativeResume(t *testing.T) {
 		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
 	}
 	prompt := agent.starts[0].Prompt
-	if !strings.Contains(prompt, "Continue the existing Looper reviewer review task") || !strings.Contains(prompt, "idempotency key: reviewer:loop_native_resume_prompt:abc123") {
-		t.Fatalf("prompt = %q, want short native resume continuation prompt", prompt)
+	if strings.Contains(prompt, "Continue the existing Looper reviewer review task") {
+		t.Fatalf("prompt = %q, want full review prompt for checkpoint fallback safety", prompt)
 	}
-	if strings.Contains(prompt, "Review pull request") || strings.Contains(prompt, "Minimal PR seed") {
-		t.Fatalf("prompt = %q, want no full review prompt on native resume", prompt)
+	if !strings.Contains(prompt, "Review pull request") && !strings.Contains(prompt, "Minimal PR seed") {
+		t.Fatalf("prompt = %q, want full review prompt for checkpoint fallback safety", prompt)
+	}
+	nativeResumePrompt := agent.starts[0].NativeResumePrompt
+	if !strings.Contains(nativeResumePrompt, "Continue the existing Looper reviewer review task") || !strings.Contains(nativeResumePrompt, "idempotency key: reviewer:loop_native_resume_prompt:abc123") {
+		t.Fatalf("native resume prompt = %q, want short native resume continuation prompt", nativeResumePrompt)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4008,7 +4008,7 @@ func TestRunReviewStepUsesShortPromptForPendingNativeResume(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	ctx := context.Background()
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AgentRuntime: string(config.AgentVendorOpenCode)})
 	project, err := fixture.repos.Projects.GetByID(ctx, "project_1")
 	if err != nil || project == nil {
 		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
@@ -4051,6 +4051,56 @@ func TestRunReviewStepUsesShortPromptForPendingNativeResume(t *testing.T) {
 	}
 	if strings.Contains(prompt, "Review pull request") || strings.Contains(prompt, "Minimal PR seed") {
 		t.Fatalf("prompt = %q, want no full review prompt on native resume", prompt)
+	}
+}
+
+func TestRunReviewStepUsesFullPromptWhenPendingNativeResumeVendorDiffers(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AgentRuntime: string(config.AgentVendorOpenCode)})
+	project, err := fixture.repos.Projects.GetByID(ctx, "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_native_resume_vendor_mismatch", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_native_resume_vendor_mismatch", LoopID: loop.ID, Status: "running", StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: "agent_previous_codex_overload", ProjectID: stringPtr(project.ID), LoopID: stringPtr(loop.ID), RunID: stringPtr(run.ID), Vendor: string(config.AgentVendorCodex), Status: "completed", NativeSessionID: stringPtr("session-123"), NativeResumeStatus: stringPtr("pending"), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	_, err = runner.runReviewStep(ctx, stepInput{
+		Project:  *project,
+		Loop:     loop,
+		Run:      run,
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: fixture.nowISO()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runReviewStep() error = %v", err)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
+	}
+	prompt := agent.starts[0].Prompt
+	if strings.Contains(prompt, "Continue the existing Looper reviewer review task") {
+		t.Fatalf("prompt = %q, want full review prompt when native resume is not compatible", prompt)
+	}
+	if !strings.Contains(prompt, "Review pull request") && !strings.Contains(prompt, "Minimal PR seed") {
+		t.Fatalf("prompt = %q, want full review prompt when native resume is not compatible", prompt)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -5696,6 +5696,27 @@ func TestRunThreadResolutionStepCommentsAndResolvesObjectiveLooperThread(t *test
 	}
 }
 
+func TestTransientProviderMessageFromAgentResultIgnoresSuccessfulStdout(t *testing.T) {
+	t.Parallel()
+
+	result := AgentResult{Status: "completed", Summary: "classified threads", Stdout: `{"decisions":[{"threadId":"thread_1","decision":"needs_human","evidence":"the previous report mentioned service unavailable and overloaded capacity","confidence":"high"}]}`}
+
+	if message := transientProviderMessageFromAgentResult(result); message != "" {
+		t.Fatalf("transientProviderMessageFromAgentResult() = %q, want empty", message)
+	}
+}
+
+func TestTransientProviderMessageFromAgentResultUsesSummaryAndStderr(t *testing.T) {
+	t.Parallel()
+
+	if message := transientProviderMessageFromAgentResult(AgentResult{Status: "completed", Summary: "server_is_overloaded"}); message == "" {
+		t.Fatalf("transientProviderMessageFromAgentResult(summary overload) = empty, want message")
+	}
+	if message := transientProviderMessageFromAgentResult(AgentResult{Status: "completed", Stderr: "service unavailable"}); message == "" {
+		t.Fatalf("transientProviderMessageFromAgentResult(stderr overload) = empty, want message")
+	}
+}
+
 func TestRunThreadResolutionStepResolvesLooperThreadWhenCurrentUserRequestNotRequired(t *testing.T) {
 	t.Parallel()
 	policy := defaultThreadResolutionPolicy(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4004,6 +4004,56 @@ func TestRunReviewStepUsesStableIdempotencyKeyAcrossRuns(t *testing.T) {
 	}
 }
 
+func TestRunReviewStepUsesShortPromptForPendingNativeResume(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+	project, err := fixture.repos.Projects.GetByID(ctx, "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_native_resume_prompt", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_native_resume_prompt", LoopID: loop.ID, Status: "running", StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: "agent_previous_overload", ProjectID: stringPtr(project.ID), LoopID: stringPtr(loop.ID), RunID: stringPtr(run.ID), Vendor: string(config.AgentVendorOpenCode), Status: "completed", NativeSessionID: stringPtr("session-123"), NativeResumeStatus: stringPtr("pending"), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	_, err = runner.runReviewStep(ctx, stepInput{
+		Project:  *project,
+		Loop:     loop,
+		Run:      run,
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: fixture.nowISO()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runReviewStep() error = %v", err)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
+	}
+	prompt := agent.starts[0].Prompt
+	if !strings.Contains(prompt, "Continue the existing Looper reviewer review task") || !strings.Contains(prompt, "idempotency key: reviewer:loop_native_resume_prompt:abc123") {
+		t.Fatalf("prompt = %q, want short native resume continuation prompt", prompt)
+	}
+	if strings.Contains(prompt, "Review pull request") || strings.Contains(prompt, "Minimal PR seed") {
+		t.Fatalf("prompt = %q, want no full review prompt on native resume", prompt)
+	}
+}
+
 func TestRunReviewStepPersistsRepreparedWorktreeBeforeAgentStart(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4392,6 +4392,69 @@ func TestRetryDelayAddsBoundedJitter(t *testing.T) {
 	}
 }
 
+func TestMarkAgentExecutionNativeResumePendingForTransientProvider(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	ctx := context.Background()
+	nowISO := fixture.nowISO()
+	loopID := "loop_native_resume"
+	runID := "run_native_resume"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	if err := fixture.repos.Loops.Upsert(ctx, storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(ctx, storage.RunRecord{ID: runID, LoopID: loopID, Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: "agent_native_resume", ProjectID: stringPtr("project_1"), LoopID: stringPtr(loopID), RunID: stringPtr(runID), Vendor: string(config.AgentVendorOpenCode), Status: "completed", NativeSessionID: stringPtr("session-123"), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	if !runner.markAgentExecutionNativeResumePendingForTransientProvider(ctx, "agent_native_resume", `{"type":"error","error":{"code":"server_is_overloaded"}}`) {
+		t.Fatalf("markAgentExecutionNativeResumePendingForTransientProvider() = false, want true")
+	}
+	record, err := fixture.repos.AgentExecutions.GetByID(ctx, "agent_native_resume")
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
+	}
+	if record.NativeResumeMode == nil || *record.NativeResumeMode != "native_resume" || record.NativeResumeStatus == nil || *record.NativeResumeStatus != "pending" {
+		t.Fatalf("native resume fields = mode:%v status:%v, want native_resume/pending", record.NativeResumeMode, record.NativeResumeStatus)
+	}
+	if !runner.hasPendingNativeResume(ctx, loopID) {
+		t.Fatalf("hasPendingNativeResume() = false, want true")
+	}
+}
+
+func TestMarkAgentExecutionNativeResumePendingRequiresSessionAndProviderError(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	ctx := context.Background()
+	nowISO := fixture.nowISO()
+	loopID := "loop_no_session"
+	runID := "run_no_session"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	if err := fixture.repos.Loops.Upsert(ctx, storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(ctx, storage.RunRecord{ID: runID, LoopID: loopID, Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: "agent_no_session", ProjectID: stringPtr("project_1"), LoopID: stringPtr(loopID), RunID: stringPtr(runID), Vendor: string(config.AgentVendorOpenCode), Status: "failed", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+	if runner.markAgentExecutionNativeResumePendingForTransientProvider(ctx, "agent_no_session", "server_is_overloaded") {
+		t.Fatalf("mark without native session = true, want false")
+	}
+	if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: "agent_non_provider", ProjectID: stringPtr("project_1"), LoopID: stringPtr(loopID), RunID: stringPtr(runID), Vendor: string(config.AgentVendorOpenCode), Status: "failed", NativeSessionID: stringPtr("session-123"), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+	if runner.markAgentExecutionNativeResumePendingForTransientProvider(ctx, "agent_non_provider", "permission denied") {
+		t.Fatalf("mark non-provider failure = true, want false")
+	}
+}
+
 func TestProcessClaimedItemRetriesTransientModelOverloadInRun(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed"}, {Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}, waitErrs: []error{fmt.Errorf("service_unavailable_error: server_is_overloaded")}}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4526,6 +4526,36 @@ func TestMarkAgentExecutionNativeResumePendingForTransientProvider(t *testing.T)
 	}
 }
 
+func TestNativeResumeImmediateRetryRequiresCurrentProviderOverload(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	ctx := context.Background()
+	nowISO := fixture.nowISO()
+	loopID := "loop_native_resume_delay"
+	runID := "run_native_resume_delay"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	if err := fixture.repos.Loops.Upsert(ctx, storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(ctx, storage.RunRecord{ID: runID, LoopID: loopID, Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: "agent_native_resume_delay", ProjectID: stringPtr("project_1"), LoopID: stringPtr(loopID), RunID: stringPtr(runID), Vendor: string(config.AgentVendorOpenCode), Status: "completed", NativeSessionID: stringPtr("session-123"), NativeResumeStatus: stringPtr("pending"), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	if !runner.shouldSkipTransientRetryDelayForNativeResume(ctx, loopID, fmt.Errorf("service_unavailable_error: server_is_overloaded")) {
+		t.Fatalf("provider overload with pending native resume should skip retry delay")
+	}
+	if runner.shouldSkipTransientRetryDelayForNativeResume(ctx, loopID, &githubinfra.TransientError{Err: fmt.Errorf("GitHub GraphQL HTTP 504")}) {
+		t.Fatalf("GitHub transient failure should keep retry delay even with pending native resume")
+	}
+	if runner.shouldSkipTransientRetryDelayForNativeResume(ctx, loopID, &loopError{message: "GraphQL request failed with HTTP 504", kind: FailureRetryableTransient}) {
+		t.Fatalf("non-provider transient loop error should keep retry delay even with pending native resume")
+	}
+}
+
 func TestMarkAgentExecutionNativeResumePendingRequiresSessionAndProviderError(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -5746,6 +5746,28 @@ func TestRunThreadResolutionStepCommentsAndResolvesObjectiveLooperThread(t *test
 	}
 }
 
+func TestRunThreadResolutionStepIgnoresProviderWordsInSuccessfulSummaryJSON(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = true
+	policy.Mode = config.ReviewerThreadResolutionModeCommentOnly
+	jsonOutput := `{"decisions":[{"threadId":"thread_1","decision":"needs_human","evidence":"the previous report mentioned service unavailable and overloaded capacity","confidence":"high"}]}`
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewRequests: []string{"looper-bot"}, reviewThreads: []ReviewThread{{ID: "thread_1", Comments: []ReviewThreadComment{{ID: "comment_1", Author: "looper-bot", Body: "Please update this. <!-- looper:stamp v=1 -->", CommitOID: "old-head"}}}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", ParseStatus: "missing", Summary: jsonOutput, Stdout: jsonOutput}}}
+	runner := New(Options{GitHub: github, AgentExecutor: agent, ThreadResolution: policy, Now: func() time.Time { return time.Unix(0, 0).UTC() }})
+
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), threadResolutionStepInput())
+	if err != nil {
+		t.Fatalf("runThreadResolutionStep() error = %v", err)
+	}
+	if checkpoint.ThreadResolution == nil || checkpoint.ThreadResolution.Commented != 1 {
+		t.Fatalf("ThreadResolution = %#v, want one comment", checkpoint.ThreadResolution)
+	}
+	if len(github.addThreadReplyCalls) != 1 || !strings.Contains(github.addThreadReplyCalls[0].Body, "service unavailable") {
+		t.Fatalf("addThreadReplyCalls = %#v, want evidence comment", github.addThreadReplyCalls)
+	}
+}
+
 func TestTransientProviderMessageFromAgentResultIgnoresSuccessfulStdout(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -362,7 +362,7 @@ func (a reviewerGitAdapter) CleanupWorktree(ctx context.Context, input reviewer.
 }
 
 func (a reviewerAgentExecutorAdapter) Start(ctx context.Context, input reviewer.AgentRunInput) (reviewer.AgentExecution, error) {
-	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
+	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, NativeResumePrompt: input.NativeResumePrompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Mark reviewer agent executions with captured native sessions as resume-pending when provider overloads occur.
- Retry immediately when a pending native session is available to reduce session/cache expiry risk.
- Allow completed pending executions to be native resume sources and cover the behavior with tests.

## Tests
- go test ./internal/agent ./internal/reviewer
- go test ./...