### PR TITLE
fix: mark reviewer head drift as interrupted

### DIFF
--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -523,8 +523,9 @@ type resumedRunContext struct {
 }
 
 type loopError struct {
-	message string
-	kind    QueueFailureKind
+	message     string
+	kind        QueueFailureKind
+	interrupted bool
 }
 
 func (e *loopError) Error() string { return e.message }
@@ -1076,12 +1077,24 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 				}
 			}
 			latest.ResumePolicy = resumePolicy
-			if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
+			runStatus := "failed"
+			stepEventType := "loop.step.failed"
+			runEventType := "run.failed"
+			if failure.interrupted {
+				runStatus = "interrupted"
+				stepEventType = "loop.step.interrupted"
+				runEventType = "run.interrupted"
+			}
+			if _, err := r.completeRun(ctx, run, runStatus, failure.message, failure.message, latest); err != nil {
 				return ProcessResult{}, err
 			}
-			r.appendEvent(ctx, eventInput{eventType: "loop.step.failed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"message": failure.message, "failureKind": string(failure.kind), "currentStep": derefString(run.CurrentStep), "elapsedSeconds": stepElapsedSeconds}})
-			r.appendEvent(ctx, eventInput{eventType: "run.failed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"summary": failure.message, "failureKind": string(failure.kind)}})
-			r.logError("reviewer run failed", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": derefString(run.CurrentStep), "elapsedSeconds": stepElapsedSeconds, "failureKind": string(failure.kind), "summary": failure.message})
+			r.appendEvent(ctx, eventInput{eventType: stepEventType, projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"message": failure.message, "failureKind": string(failure.kind), "currentStep": derefString(run.CurrentStep), "elapsedSeconds": stepElapsedSeconds}})
+			r.appendEvent(ctx, eventInput{eventType: runEventType, projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"summary": failure.message, "failureKind": string(failure.kind)}})
+			if failure.interrupted {
+				r.logInfo("reviewer run interrupted", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": derefString(run.CurrentStep), "elapsedSeconds": stepElapsedSeconds, "failureKind": string(failure.kind), "summary": failure.message})
+			} else {
+				r.logError("reviewer run failed", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": derefString(run.CurrentStep), "elapsedSeconds": stepElapsedSeconds, "failureKind": string(failure.kind), "summary": failure.message})
+			}
 			failedQueue, queueErr := r.failQueueItem(ctx, queueItem, failure.kind, failure.message)
 			if queueErr != nil {
 				return ProcessResult{}, queueErr
@@ -1089,11 +1102,13 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			terminalFailure := false
 			_, loopErr := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
 				updated.LastRunAt = stringPtr(r.nowISO())
-				metadataJSON, metaErr := r.recordLoopFailureMetadata(updated.MetadataJSON, failure.message)
-				if metaErr == nil {
-					updated.MetadataJSON = &metadataJSON
+				if !failure.interrupted {
+					metadataJSON, metaErr := r.recordLoopFailureMetadata(updated.MetadataJSON, failure.message)
+					if metaErr == nil {
+						updated.MetadataJSON = &metadataJSON
+					}
 				}
-				if terminalReviewerLoopReason(*updated) == "failed" {
+				if !failure.interrupted && terminalReviewerLoopReason(*updated) == "failed" {
 					terminalFailure = true
 					updated.Status = "failed"
 					updated.NextRunAt = nil
@@ -1123,7 +1138,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			if failedQueue == nil || failedQueue.Status != "queued" {
 				r.cleanupReviewerWorktreeIfTerminal(context.Background(), *project, &latest)
 			}
-			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
+			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: runStatus, Summary: failure.message, FailureKind: failure.kind}, nil
 		}
 		if step == stepClaim {
 			claimedLockKey = checkpoint.ClaimedLockKey
@@ -2104,7 +2119,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	if headChangeReason != "" {
 		checkpoint.PendingReview = nil
 		checkpoint.ResumePolicy = "restart_from_discover"
-		return checkpoint, &loopError{message: headChangeReason, kind: FailureRetryableAfterResume}
+		return checkpoint, &loopError{message: headChangeReason, kind: FailureRetryableAfterResume, interrupted: true}
 	}
 	if err != nil {
 		r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.failed", "review", executionID, reviewerAgentWaitErrorPayload(err, r.now().Sub(agentStartedAt)))
@@ -3362,7 +3377,7 @@ func shouldRestartFromDiscover(status string, failedStep ReviewerStep, failureSu
 	if failedStep != stepPublish && failedStep != stepReview && failedStep != stepThreadResolution {
 		return false
 	}
-	return strings.Contains(failureSummary, "PR head changed before publish") || strings.Contains(failureSummary, "review request removed before publish") || strings.Contains(failureSummary, "PR changed during thread reconciliation")
+	return strings.Contains(failureSummary, "PR head changed before publish") || strings.Contains(failureSummary, "PR head changed while reviewer was running") || strings.Contains(failureSummary, "review request removed before publish") || strings.Contains(failureSummary, "PR changed during thread reconciliation")
 }
 
 func (r *Runner) detectRediscoveryRequired(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint) (string, bool) {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2503,17 +2503,20 @@ func TestProcessClaimedItemInterruptsRunningReviewerWhenHeadChanges(t *testing.T
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume || !contains(result.Summary, "PR head changed while reviewer was running") {
-		t.Fatalf("result = %#v, want retryable interruption for head change", result)
+	if result.Status != "interrupted" || result.FailureKind != FailureRetryableAfterResume || !contains(result.Summary, "PR head changed while reviewer was running") {
+		t.Fatalf("result = %#v, want interrupted retryable head change", result)
 	}
 	if len(agent.killedReasons) != 1 || !contains(agent.killedReasons[0], "new-head") {
 		t.Fatalf("killedReasons = %#v, want one head-change kill", agent.killedReasons)
 	}
-	failedRun, err := fixture.repos.Runs.GetByID(ctx, result.RunID)
-	if err != nil || failedRun == nil {
-		t.Fatalf("Runs.GetByID() = (%#v, %v), want failed run", failedRun, err)
+	interruptedRun, err := fixture.repos.Runs.GetByID(ctx, result.RunID)
+	if err != nil || interruptedRun == nil {
+		t.Fatalf("Runs.GetByID() = (%#v, %v), want interrupted run", interruptedRun, err)
 	}
-	checkpoint := parseCheckpoint(failedRun.CheckpointJSON)
+	if interruptedRun.Status != "interrupted" {
+		t.Fatalf("run.Status = %q, want interrupted", interruptedRun.Status)
+	}
+	checkpoint := parseCheckpoint(interruptedRun.CheckpointJSON)
 	if checkpoint.ResumePolicy != "restart_from_discover" || checkpoint.PendingReview != nil {
 		t.Fatalf("checkpoint = %#v, want restart_from_discover without stale pending review", checkpoint)
 	}


### PR DESCRIPTION
## Summary
- Mark reviewer PR head-change monitor terminations as `interrupted` instead of `failed`.
- Preserve retry/requeue behavior with `restart_from_discover` so the reviewer restarts on the latest head.
- Update reviewer test coverage to expect interrupted runs for stale in-flight reviews.

## Validation
- `go test ./internal/reviewer`
- `go test ./...` (first run hit a transient `internal/agent` timeout; targeted rerun and full rerun passed)

Closes #234

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.6.1 · runner=worker · agent=opencode</sub>