### PR TITLE
feat: add recent run stats command

### DIFF
--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -410,15 +410,17 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 			newCommand(commandSpec{
 				use:             "run",
 				short:           "Run commands",
-				helpSubcommands: []helpSubcommand{{name: "list", description: "List runs"}},
+				helpSubcommands: []helpSubcommand{{name: "list", description: "List runs"}, {name: "stats", description: "Show recent run stats"}},
 				helpWhenNoArgs:  true,
 				persistentFlags: []flagSpec{stringFlag("loop", "loopId", "Filter by loop id")},
 				exampleLines: []string{
 					"$ looper run list",
+					"$ looper run stats --since 24h",
 					"$ looper run list --loop loop_1",
 				},
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "list", short: "List runs", runE: runtime.runList}),
+					newCommand(commandSpec{use: "stats", short: "Show recent run stats", args: cobra.NoArgs, runE: runtime.runStats, localFlags: []flagSpec{stringFlag("since", "duration", "Time window to aggregate (default 24h; supports h and d, for example 1h, 24h, 7d)"), stringFlag("role", "role", "Filter by role: planner, reviewer, worker, or fixer")}}),
 				},
 			}),
 		},

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -66,7 +66,7 @@ func TestCommandGroupHelpListsExpectedSubcommands(t *testing.T) {
 		{args: []string{"labels", "--help"}, subcommands: []string{"init  Initialize standard Looper GitHub labels"}},
 		{args: []string{"loop", "--help"}, subcommands: []string{"list   List loops", "start  Start a loop", "pause  Pause a loop"}},
 		{args: []string{"pr", "--help"}, subcommands: []string{"list    List pull requests", "show    Show a pull request", "status  Show pull request status"}},
-		{args: []string{"run", "--help"}, subcommands: []string{"list  List runs"}},
+		{args: []string{"run", "--help"}, subcommands: []string{"list   List runs", "stats  Show recent run stats"}},
 	}
 
 	for _, testCase := range tests {

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -207,7 +207,7 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 	}
 	for _, item := range queues {
 		updatedAt, ok := parseRunStatsTime(item.UpdatedAt)
-		if !ok || updatedAt.Before(sinceAt) || item.Attempts <= 0 {
+		if !ok || updatedAt.Before(sinceAt) || !queueItemHasRecentRetry(item) {
 			continue
 		}
 		role := item.Type
@@ -228,7 +228,7 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 			continue
 		}
 		stats := output.Roles[role]
-		stats.Retried += item.Attempts
+		stats.Retried++
 		output.Roles[role] = stats
 	}
 	for _, stats := range output.Roles {
@@ -371,9 +371,15 @@ func addEventToStats(stats *runRoleStats, event storage.EventLogRecord) {
 		stats.Requeued++
 	case runStatsEventIsRetry(eventType):
 		stats.Retried++
-	case strings.Contains(eventType, "interrupted"):
-		stats.Interrupted++
 	}
+}
+
+func queueItemHasRecentRetry(item storage.QueueItemRecord) bool {
+	if item.Attempts <= 0 || item.Status != "queued" || item.LastErrorKind == nil {
+		return false
+	}
+	errorKind := strings.ToLower(strings.TrimSpace(*item.LastErrorKind))
+	return strings.Contains(errorKind, "retryable")
 }
 
 func runStatsEventIsRetry(eventType string) bool {

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -197,6 +197,33 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 		addEventToStats(&stats, event)
 		output.Roles[role] = stats
 	}
+	queues, err := repos.Queue.List(ctx)
+	if err != nil {
+		return output, err
+	}
+	for _, item := range queues {
+		updatedAt, ok := parseRunStatsTime(item.UpdatedAt)
+		if !ok || updatedAt.Before(sinceAt) || item.Attempts <= 0 {
+			continue
+		}
+		role := item.Type
+		if item.LoopID != nil {
+			if loopFilter != "" && *item.LoopID != loopFilter {
+				continue
+			}
+			if mappedRole := loopRoles[*item.LoopID]; mappedRole != "" {
+				role = mappedRole
+			}
+		} else if loopFilter != "" {
+			continue
+		}
+		if !includeRunStatsRole(role, roleFilter) {
+			continue
+		}
+		stats := output.Roles[role]
+		stats.Retried += item.Attempts
+		output.Roles[role] = stats
+	}
 	for _, stats := range output.Roles {
 		addRoleStats(&output.Total, stats)
 	}

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -369,7 +369,9 @@ func queueItemHasRecentRetry(item storage.QueueItemRecord) bool {
 	if item.Attempts <= 0 || item.LastErrorKind == nil {
 		return false
 	}
-	if item.Status != "queued" && item.Status != "running" {
+	switch item.Status {
+	case "queued", "running", "completed", "failed":
+	default:
 		return false
 	}
 	errorKind := strings.ToLower(strings.TrimSpace(*item.LastErrorKind))

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -221,7 +221,7 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 			continue
 		}
 		stats := output.Roles[role]
-		stats.Retried++
+		stats.Retried += item.Attempts
 		output.Roles[role] = stats
 	}
 	for _, stats := range output.Roles {
@@ -366,7 +366,10 @@ func addEventToStats(stats *runRoleStats, event storage.EventLogRecord) {
 }
 
 func queueItemHasRecentRetry(item storage.QueueItemRecord) bool {
-	if item.Attempts <= 0 || item.Status != "queued" || item.LastErrorKind == nil {
+	if item.Attempts <= 0 || item.LastErrorKind == nil {
+		return false
+	}
+	if item.Status != "queued" && item.Status != "running" {
 		return false
 	}
 	errorKind := strings.ToLower(strings.TrimSpace(*item.LastErrorKind))

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -184,7 +184,6 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 	if err != nil {
 		return output, err
 	}
-	loopRetryEvents := map[string]struct{}{}
 	for _, event := range events {
 		createdAt, ok := parseRunStatsTime(event.CreatedAt)
 		if !ok || createdAt.Before(sinceAt) || event.LoopID == nil {
@@ -197,9 +196,6 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 		stats := output.Roles[role]
 		addEventToStats(&stats, event)
 		output.Roles[role] = stats
-		if runStatsEventIsRetry(event.EventType) {
-			loopRetryEvents[*event.LoopID] = struct{}{}
-		}
 	}
 	queues, err := repos.Queue.List(ctx)
 	if err != nil {
@@ -213,9 +209,6 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 		role := item.Type
 		if item.LoopID != nil {
 			if loopFilter != "" && *item.LoopID != loopFilter {
-				continue
-			}
-			if _, countedFromEvents := loopRetryEvents[*item.LoopID]; countedFromEvents {
 				continue
 			}
 			if mappedRole := loopRoles[*item.LoopID]; mappedRole != "" {
@@ -369,8 +362,6 @@ func addEventToStats(stats *runRoleStats, event storage.EventLogRecord) {
 	switch {
 	case strings.Contains(eventType, "requeued"):
 		stats.Requeued++
-	case runStatsEventIsRetry(eventType):
-		stats.Retried++
 	}
 }
 
@@ -380,10 +371,6 @@ func queueItemHasRecentRetry(item storage.QueueItemRecord) bool {
 	}
 	errorKind := strings.ToLower(strings.TrimSpace(*item.LastErrorKind))
 	return strings.Contains(errorKind, "retryable")
-}
-
-func runStatsEventIsRetry(eventType string) bool {
-	return strings.Contains(strings.ToLower(eventType), "retry")
 }
 
 func addRoleStats(total *runRoleStats, stats runRoleStats) {

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -370,7 +370,7 @@ func queueItemHasRecentRetry(item storage.QueueItemRecord) bool {
 		return false
 	}
 	switch item.Status {
-	case "queued", "running", "completed", "failed", "cancelled":
+	case "queued", "running", "completed", "failed", "cancelled", "manual_intervention":
 	default:
 		return false
 	}

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -1,0 +1,445 @@
+package cliapp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/powerformer/looper/internal/eventlog"
+	"github.com/powerformer/looper/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+const defaultRunStatsSince = "24h"
+
+var runStatsRoleOrder = []string{"planner", "reviewer", "worker", "fixer"}
+
+type runStatsOutput struct {
+	Since      string                     `json:"since"`
+	SinceAtISO string                     `json:"sinceAtIso"`
+	UntilISO   string                     `json:"untilIso"`
+	Roles      map[string]runRoleStats    `json:"roles"`
+	Total      runRoleStats               `json:"total"`
+	Scope      runStatsScopeDocumentation `json:"scope"`
+}
+
+type runStatsScopeDocumentation struct {
+	Runs            string `json:"runs"`
+	AgentExecutions string `json:"agentExecutions"`
+	ReviewOutcomes  string `json:"reviewOutcomes"`
+}
+
+type runRoleStats struct {
+	Success         int64               `json:"success"`
+	Failure         int64               `json:"failure"`
+	Skipped         int64               `json:"skipped"`
+	Interrupted     int64               `json:"interrupted"`
+	Requeued        int64               `json:"requeued"`
+	Retried         int64               `json:"retried"`
+	Running         int64               `json:"running"`
+	Cancelled       int64               `json:"cancelled"`
+	ParseFailed     int64               `json:"parseFailed"`
+	Outcomes        reviewOutcomeStats  `json:"outcomes"`
+	AgentExecutions agentExecutionStats `json:"agentExecutions"`
+}
+
+type reviewOutcomeStats struct {
+	Approved         int64 `json:"approved"`
+	Commented        int64 `json:"commented"`
+	RequestedChanges int64 `json:"requested_changes"`
+}
+
+type agentExecutionStats struct {
+	Success     int64            `json:"success"`
+	Failure     int64            `json:"failure"`
+	Interrupted int64            `json:"interrupted"`
+	Running     int64            `json:"running"`
+	Status      map[string]int64 `json:"status"`
+}
+
+func (r *commandRuntime) runStats(cmd *cobra.Command, args []string) error {
+	_ = args
+	sinceText := strings.TrimSpace(getStringFlag(cmd, "since"))
+	if sinceText == "" {
+		sinceText = defaultRunStatsSince
+	}
+	duration, err := parseRunStatsDuration(sinceText)
+	if err != nil {
+		return err
+	}
+	role := strings.ToLower(strings.TrimSpace(getStringFlag(cmd, "role")))
+	if role != "" && !isKnownRunStatsRole(role) {
+		return fmt.Errorf("unsupported --role %q; expected planner, reviewer, worker, or fixer", role)
+	}
+	loopFilter := strings.TrimSpace(getStringFlag(cmd, "loop"))
+
+	return r.withQueueRepositories(cmd.Context(), func(repos *storage.Repositories) error {
+		now := time.Now().UTC()
+		sinceAt := now.Add(-duration)
+		output, err := buildRunStatsOutput(cmd.Context(), repos, sinceText, sinceAt, now, role, loopFilter)
+		if err != nil {
+			return err
+		}
+		if getBoolFlag(cmd, "json") {
+			return writeJSON(cmd.OutOrStdout(), output)
+		}
+		return writeHumanRunStats(cmd.OutOrStdout(), output, role)
+	})
+}
+
+func parseRunStatsDuration(value string) (time.Duration, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		trimmed = defaultRunStatsSince
+	}
+	if strings.HasSuffix(trimmed, "d") || strings.HasSuffix(trimmed, "D") {
+		daysText := strings.TrimSpace(trimmed[:len(trimmed)-1])
+		days, err := time.ParseDuration(daysText + "h")
+		if err != nil {
+			return 0, fmt.Errorf("invalid --since duration %q", value)
+		}
+		duration := days * 24
+		if duration <= 0 {
+			return 0, fmt.Errorf("--since must be positive")
+		}
+		return duration, nil
+	}
+	duration, err := time.ParseDuration(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --since duration %q", value)
+	}
+	if duration <= 0 {
+		return 0, fmt.Errorf("--since must be positive")
+	}
+	return duration, nil
+}
+
+func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, sinceText string, sinceAt time.Time, until time.Time, roleFilter string, loopFilter string) (runStatsOutput, error) {
+	output := runStatsOutput{
+		Since:      sinceText,
+		SinceAtISO: eventlog.FormatJavaScriptISOString(sinceAt),
+		UntilISO:   eventlog.FormatJavaScriptISOString(until),
+		Roles:      initialRunStatsRoles(roleFilter),
+		Scope: runStatsScopeDocumentation{
+			Runs:            "Persisted run records joined to loop roles are included.",
+			AgentExecutions: "Persisted agent execution records linked to matching loops are included in each role's agentExecutions breakdown.",
+			ReviewOutcomes:  "Reviewer outcomes are inferred from persisted pr.review.posted events when available.",
+		},
+	}
+	sinceISO := eventlog.FormatJavaScriptISOString(sinceAt)
+
+	loops, err := repos.Loops.List(ctx)
+	if err != nil {
+		return output, err
+	}
+	loopRoles := make(map[string]string, len(loops))
+	for _, loop := range loops {
+		if loopFilter != "" && loop.ID != loopFilter {
+			continue
+		}
+		loopRoles[loop.ID] = loop.Type
+	}
+
+	runs, err := repos.Runs.ListSince(ctx, sinceISO)
+	if err != nil {
+		return output, err
+	}
+	for _, run := range runs {
+		startedAt, ok := parseRunStatsTime(run.StartedAt)
+		if !ok || startedAt.Before(sinceAt) {
+			continue
+		}
+		role := loopRoles[run.LoopID]
+		if !includeRunStatsRole(role, roleFilter) {
+			continue
+		}
+		stats := output.Roles[role]
+		addRunToStats(&stats, run)
+		output.Roles[role] = stats
+	}
+
+	agents, err := repos.AgentExecutions.ListSince(ctx, sinceISO)
+	if err != nil {
+		return output, err
+	}
+	for _, agent := range agents {
+		startedAt, ok := parseRunStatsTime(agent.StartedAt)
+		if !ok || startedAt.Before(sinceAt) || agent.LoopID == nil {
+			continue
+		}
+		role := loopRoles[*agent.LoopID]
+		if !includeRunStatsRole(role, roleFilter) {
+			continue
+		}
+		stats := output.Roles[role]
+		addAgentExecutionToStats(&stats.AgentExecutions, agent)
+		output.Roles[role] = stats
+	}
+
+	events, err := repos.Events.ListSince(ctx, sinceISO)
+	if err != nil {
+		return output, err
+	}
+	for _, event := range events {
+		createdAt, ok := parseRunStatsTime(event.CreatedAt)
+		if !ok || createdAt.Before(sinceAt) || event.LoopID == nil {
+			continue
+		}
+		role := loopRoles[*event.LoopID]
+		if !includeRunStatsRole(role, roleFilter) {
+			continue
+		}
+		stats := output.Roles[role]
+		addEventToStats(&stats, event)
+		output.Roles[role] = stats
+	}
+	queues, err := repos.Queue.List(ctx)
+	if err != nil {
+		return output, err
+	}
+	for _, item := range queues {
+		updatedAt, ok := parseRunStatsTime(item.UpdatedAt)
+		if !ok || updatedAt.Before(sinceAt) || item.Attempts <= 0 {
+			continue
+		}
+		role := item.Type
+		if item.LoopID != nil {
+			if loopFilter != "" && *item.LoopID != loopFilter {
+				continue
+			}
+			if mappedRole := loopRoles[*item.LoopID]; mappedRole != "" {
+				role = mappedRole
+			}
+		} else if loopFilter != "" {
+			continue
+		}
+		if !includeRunStatsRole(role, roleFilter) {
+			continue
+		}
+		stats := output.Roles[role]
+		stats.Retried += item.Attempts
+		output.Roles[role] = stats
+	}
+
+	for _, stats := range output.Roles {
+		addRoleStats(&output.Total, stats)
+	}
+	return output, nil
+}
+
+func initialRunStatsRoles(roleFilter string) map[string]runRoleStats {
+	roles := map[string]runRoleStats{}
+	for _, role := range runStatsRoleOrder {
+		if roleFilter == "" || role == roleFilter {
+			roles[role] = newRunRoleStats()
+		}
+	}
+	return roles
+}
+
+func newRunRoleStats() runRoleStats {
+	return runRoleStats{AgentExecutions: agentExecutionStats{Status: map[string]int64{}}}
+}
+
+func isKnownRunStatsRole(role string) bool {
+	for _, known := range runStatsRoleOrder {
+		if role == known {
+			return true
+		}
+	}
+	return false
+}
+
+func includeRunStatsRole(role string, filter string) bool {
+	if !isKnownRunStatsRole(role) {
+		return false
+	}
+	return filter == "" || role == filter
+}
+
+func parseRunStatsTime(value string) (time.Time, bool) {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed.UTC(), true
+}
+
+func addRunToStats(stats *runRoleStats, run storage.RunRecord) {
+	if runWasSkipped(run) {
+		stats.Skipped++
+	} else {
+		switch run.Status {
+		case "success", "completed":
+			stats.Success++
+		case "failed":
+			stats.Failure++
+		case "interrupted":
+			stats.Interrupted++
+		case "running", "queued":
+			stats.Running++
+		case "cancelled", "canceled":
+			stats.Cancelled++
+		case "parse_failed":
+			stats.ParseFailed++
+		}
+	}
+}
+
+func runWasSkipped(run storage.RunRecord) bool {
+	if run.CheckpointJSON == nil {
+		return false
+	}
+	var checkpoint struct {
+		SkipReason string `json:"skipReason"`
+		SkipKind   string `json:"skipKind"`
+	}
+	if err := json.Unmarshal([]byte(*run.CheckpointJSON), &checkpoint); err != nil {
+		return false
+	}
+	return strings.TrimSpace(checkpoint.SkipReason) != "" || strings.TrimSpace(checkpoint.SkipKind) != ""
+}
+
+func normalizeReviewEvent(event string) string {
+	switch strings.ToUpper(strings.TrimSpace(event)) {
+	case "APPROVE", "APPROVED":
+		return "approved"
+	case "COMMENT", "COMMENTED":
+		return "commented"
+	case "REQUEST_CHANGES", "CHANGES_REQUESTED", "REQUESTED_CHANGES":
+		return "requested_changes"
+	default:
+		return ""
+	}
+}
+
+func addReviewOutcome(stats *reviewOutcomeStats, outcome string) {
+	switch outcome {
+	case "approved":
+		stats.Approved++
+	case "commented":
+		stats.Commented++
+	case "requested_changes":
+		stats.RequestedChanges++
+	}
+}
+
+func addAgentExecutionToStats(stats *agentExecutionStats, agent storage.AgentExecutionRecord) {
+	status := strings.ToLower(strings.TrimSpace(agent.Status))
+	if status == "" {
+		status = "unknown"
+	}
+	if stats.Status == nil {
+		stats.Status = map[string]int64{}
+	}
+	stats.Status[status]++
+	switch status {
+	case "completed", "success", "succeeded":
+		stats.Success++
+	case "failed", "error", "parse_failed", "timeout", "timed_out":
+		stats.Failure++
+	case "interrupted", "cancelled", "canceled", "killed":
+		stats.Interrupted++
+	case "running", "starting", "cancelling", "queued":
+		stats.Running++
+	}
+}
+
+func addEventToStats(stats *runRoleStats, event storage.EventLogRecord) {
+	eventType := strings.ToLower(event.EventType)
+	if eventType == "pr.review.posted" {
+		var payload struct {
+			Event string `json:"event"`
+		}
+		if err := json.Unmarshal([]byte(event.PayloadJSON), &payload); err == nil {
+			addReviewOutcome(&stats.Outcomes, normalizeReviewEvent(payload.Event))
+		}
+		return
+	}
+	switch {
+	case strings.Contains(eventType, "requeued"):
+		stats.Requeued++
+	case strings.Contains(eventType, "retry"):
+		stats.Retried++
+	case strings.Contains(eventType, "interrupted"):
+		stats.Interrupted++
+	}
+}
+
+func addRoleStats(total *runRoleStats, stats runRoleStats) {
+	total.Success += stats.Success
+	total.Failure += stats.Failure
+	total.Skipped += stats.Skipped
+	total.Interrupted += stats.Interrupted
+	total.Requeued += stats.Requeued
+	total.Retried += stats.Retried
+	total.Running += stats.Running
+	total.Cancelled += stats.Cancelled
+	total.ParseFailed += stats.ParseFailed
+	total.Outcomes.Approved += stats.Outcomes.Approved
+	total.Outcomes.Commented += stats.Outcomes.Commented
+	total.Outcomes.RequestedChanges += stats.Outcomes.RequestedChanges
+	total.AgentExecutions.Success += stats.AgentExecutions.Success
+	total.AgentExecutions.Failure += stats.AgentExecutions.Failure
+	total.AgentExecutions.Interrupted += stats.AgentExecutions.Interrupted
+	total.AgentExecutions.Running += stats.AgentExecutions.Running
+	if total.AgentExecutions.Status == nil {
+		total.AgentExecutions.Status = map[string]int64{}
+	}
+	for status, count := range stats.AgentExecutions.Status {
+		total.AgentExecutions.Status[status] += count
+	}
+}
+
+func writeHumanRunStats(w io.Writer, output runStatsOutput, roleFilter string) error {
+	if runRoleStatsEmpty(output.Total) {
+		_, err := fmt.Fprintf(w, "No matching recent actions found since %s (%s).\n", output.Since, output.SinceAtISO)
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Recent run stats since %s (%s):\n", output.Since, output.SinceAtISO); err != nil {
+		return err
+	}
+	for _, role := range orderedRunStatsRoles(output.Roles, roleFilter) {
+		stats := output.Roles[role]
+		if _, err := fmt.Fprintf(w, "\n%s\n", role); err != nil {
+			return err
+		}
+		rows := [][2]any{{"success", stats.Success}, {"failure", stats.Failure}, {"skipped", stats.Skipped}, {"interrupted", stats.Interrupted}, {"requeued", stats.Requeued}, {"retried", stats.Retried}, {"running", stats.Running}, {"cancelled", stats.Cancelled}, {"parseFailed", stats.ParseFailed}, {"outcomes.approved", stats.Outcomes.Approved}, {"outcomes.commented", stats.Outcomes.Commented}, {"outcomes.requested_changes", stats.Outcomes.RequestedChanges}, {"agentExecutions.success", stats.AgentExecutions.Success}, {"agentExecutions.failure", stats.AgentExecutions.Failure}, {"agentExecutions.interrupted", stats.AgentExecutions.Interrupted}, {"agentExecutions.running", stats.AgentExecutions.Running}}
+		for _, row := range rows {
+			if _, err := fmt.Fprintf(w, "  %-32s %v\n", row[0], row[1]); err != nil {
+				return err
+			}
+		}
+		if len(stats.AgentExecutions.Status) > 0 {
+			statuses := make([]string, 0, len(stats.AgentExecutions.Status))
+			for status := range stats.AgentExecutions.Status {
+				statuses = append(statuses, status)
+			}
+			sort.Strings(statuses)
+			for _, status := range statuses {
+				if _, err := fmt.Fprintf(w, "  %-32s %v\n", "agentExecutions.status."+status, stats.AgentExecutions.Status[status]); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func orderedRunStatsRoles(roles map[string]runRoleStats, roleFilter string) []string {
+	ordered := make([]string, 0, len(roles))
+	for _, role := range runStatsRoleOrder {
+		if _, ok := roles[role]; ok && (roleFilter == "" || role == roleFilter) {
+			ordered = append(ordered, role)
+		}
+	}
+	return ordered
+}
+
+func runRoleStatsEmpty(stats runRoleStats) bool {
+	return stats.Success == 0 && stats.Failure == 0 && stats.Skipped == 0 && stats.Interrupted == 0 && stats.Requeued == 0 && stats.Retried == 0 && stats.Running == 0 && stats.Cancelled == 0 && stats.ParseFailed == 0 && stats.Outcomes.Approved == 0 && stats.Outcomes.Commented == 0 && stats.Outcomes.RequestedChanges == 0 && stats.AgentExecutions.Success == 0 && stats.AgentExecutions.Failure == 0 && stats.AgentExecutions.Interrupted == 0 && stats.AgentExecutions.Running == 0 && len(stats.AgentExecutions.Status) == 0
+}

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -184,6 +184,7 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 	if err != nil {
 		return output, err
 	}
+	loopRetryEvents := map[string]struct{}{}
 	for _, event := range events {
 		createdAt, ok := parseRunStatsTime(event.CreatedAt)
 		if !ok || createdAt.Before(sinceAt) || event.LoopID == nil {
@@ -196,19 +197,25 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 		stats := output.Roles[role]
 		addEventToStats(&stats, event)
 		output.Roles[role] = stats
+		if runStatsEventIsRetry(event.EventType) {
+			loopRetryEvents[*event.LoopID] = struct{}{}
+		}
 	}
 	queues, err := repos.Queue.List(ctx)
 	if err != nil {
 		return output, err
 	}
 	for _, item := range queues {
-		updatedAt, ok := parseRunStatsTime(item.UpdatedAt)
-		if !ok || updatedAt.Before(sinceAt) || item.Attempts <= 0 {
+		createdAt, ok := parseRunStatsTime(item.CreatedAt)
+		if !ok || createdAt.Before(sinceAt) || item.Attempts <= 0 {
 			continue
 		}
 		role := item.Type
 		if item.LoopID != nil {
 			if loopFilter != "" && *item.LoopID != loopFilter {
+				continue
+			}
+			if _, countedFromEvents := loopRetryEvents[*item.LoopID]; countedFromEvents {
 				continue
 			}
 			if mappedRole := loopRoles[*item.LoopID]; mappedRole != "" {
@@ -362,11 +369,15 @@ func addEventToStats(stats *runRoleStats, event storage.EventLogRecord) {
 	switch {
 	case strings.Contains(eventType, "requeued"):
 		stats.Requeued++
-	case strings.Contains(eventType, "retry"):
+	case runStatsEventIsRetry(eventType):
 		stats.Retried++
 	case strings.Contains(eventType, "interrupted"):
 		stats.Interrupted++
 	}
+}
+
+func runStatsEventIsRetry(eventType string) bool {
+	return strings.Contains(strings.ToLower(eventType), "retry")
 }
 
 func addRoleStats(total *runRoleStats, stats runRoleStats) {

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -197,34 +197,6 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 		addEventToStats(&stats, event)
 		output.Roles[role] = stats
 	}
-	queues, err := repos.Queue.List(ctx)
-	if err != nil {
-		return output, err
-	}
-	for _, item := range queues {
-		updatedAt, ok := parseRunStatsTime(item.UpdatedAt)
-		if !ok || updatedAt.Before(sinceAt) || item.Attempts <= 0 {
-			continue
-		}
-		role := item.Type
-		if item.LoopID != nil {
-			if loopFilter != "" && *item.LoopID != loopFilter {
-				continue
-			}
-			if mappedRole := loopRoles[*item.LoopID]; mappedRole != "" {
-				role = mappedRole
-			}
-		} else if loopFilter != "" {
-			continue
-		}
-		if !includeRunStatsRole(role, roleFilter) {
-			continue
-		}
-		stats := output.Roles[role]
-		stats.Retried += item.Attempts
-		output.Roles[role] = stats
-	}
-
 	for _, stats := range output.Roles {
 		addRoleStats(&output.Total, stats)
 	}

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -206,8 +206,8 @@ func buildRunStatsOutput(ctx context.Context, repos *storage.Repositories, since
 		return output, err
 	}
 	for _, item := range queues {
-		createdAt, ok := parseRunStatsTime(item.CreatedAt)
-		if !ok || createdAt.Before(sinceAt) || item.Attempts <= 0 {
+		updatedAt, ok := parseRunStatsTime(item.UpdatedAt)
+		if !ok || updatedAt.Before(sinceAt) || item.Attempts <= 0 {
 			continue
 		}
 		role := item.Type

--- a/internal/cliapp/run_stats_commands.go
+++ b/internal/cliapp/run_stats_commands.go
@@ -366,16 +366,15 @@ func addEventToStats(stats *runRoleStats, event storage.EventLogRecord) {
 }
 
 func queueItemHasRecentRetry(item storage.QueueItemRecord) bool {
-	if item.Attempts <= 0 || item.LastErrorKind == nil {
+	if item.Attempts <= 0 {
 		return false
 	}
 	switch item.Status {
-	case "queued", "running", "completed", "failed":
+	case "queued", "running", "completed", "failed", "cancelled":
 	default:
 		return false
 	}
-	errorKind := strings.ToLower(strings.TrimSpace(*item.LastErrorKind))
-	return strings.Contains(errorKind, "retryable")
+	return true
 }
 
 func addRoleStats(total *runRoleStats, stats runRoleStats) {

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -58,8 +58,8 @@ func TestRunStatsCommandOutputsJSONAndHuman(t *testing.T) {
 				t.Fatalf("fixer stats = %#v, want run and agent breakdowns", fixer)
 			}
 			worker := decoded.Roles["worker"]
-			if worker.Retried != 6 {
-				t.Fatalf("worker retried = %d, want queued and running queue attempts counted", worker.Retried)
+			if worker.Retried != 11 {
+				t.Fatalf("worker retried = %d, want queued, running, and terminal queue attempts counted", worker.Retried)
 			}
 		}},
 		{name: "human", args: []string{"run", "stats", "--since", "1000d", "--role", "reviewer"}, assert: func(t *testing.T, output string) {
@@ -195,6 +195,12 @@ func writeRunStatsCommandFixture(t *testing.T) string {
 	}
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_claimed_after_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_claimed_after_retry", Priority: 1, Status: "running", AvailableAt: now, Attempts: 4, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(worker claimed after retry) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_completed_after_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_completed_after_retry", Priority: 1, Status: "completed", AvailableAt: now, Attempts: 3, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(worker completed after retry) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_failed_after_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_failed_after_retry", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 2, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(worker failed after retry) error = %v", err)
 	}
 	return configPath
 }

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -58,7 +58,7 @@ func TestRunStatsCommandOutputsJSONAndHuman(t *testing.T) {
 				t.Fatalf("fixer stats = %#v, want run and agent breakdowns", fixer)
 			}
 			worker := decoded.Roles["worker"]
-			if worker.Retried != 11 {
+			if worker.Retried != 13 {
 				t.Fatalf("worker retried = %d, want queued, running, and terminal queue attempts counted", worker.Retried)
 			}
 		}},
@@ -201,6 +201,13 @@ func writeRunStatsCommandFixture(t *testing.T) string {
 	}
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_failed_after_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_failed_after_retry", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 2, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(worker failed after retry) error = %v", err)
+	}
+	nonRetryableKind := "non_retryable"
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_non_retryable_after_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_non_retryable_after_retry", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 1, MaxAttempts: 5, LastErrorKind: &nonRetryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(worker non-retryable after retry) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_cancelled_after_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_cancelled_after_retry", Priority: 1, Status: "cancelled", AvailableAt: now, Attempts: 1, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(worker cancelled after retry) error = %v", err)
 	}
 	return configPath
 }

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -54,8 +54,12 @@ func TestRunStatsCommandOutputsJSONAndHuman(t *testing.T) {
 				t.Fatalf("reviewer outcomes = %#v, want approved=1 requested_changes=1", reviewer.Outcomes)
 			}
 			fixer := decoded.Roles["fixer"]
-			if fixer.Success != 1 || fixer.Failure != 1 || fixer.Retried != 4 || fixer.AgentExecutions.Success != 1 || fixer.AgentExecutions.Failure != 1 || fixer.AgentExecutions.Status["completed"] != 1 {
+			if fixer.Success != 1 || fixer.Failure != 1 || fixer.Retried != 1 || fixer.AgentExecutions.Success != 1 || fixer.AgentExecutions.Failure != 1 || fixer.AgentExecutions.Status["completed"] != 1 {
 				t.Fatalf("fixer stats = %#v, want run and agent breakdowns", fixer)
+			}
+			worker := decoded.Roles["worker"]
+			if worker.Retried != 2 {
+				t.Fatalf("worker retried = %d, want queue-only retries counted", worker.Retried)
 			}
 		}},
 		{name: "human", args: []string{"run", "stats", "--since", "1000d", "--role", "reviewer"}, assert: func(t *testing.T, output string) {
@@ -140,6 +144,7 @@ func writeRunStatsCommandFixture(t *testing.T) string {
 	loops := []storage.LoopRecord{
 		{ID: "loop_reviewer", Seq: 1, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", Status: "completed", CreatedAt: now, UpdatedAt: now},
 		{ID: "loop_fixer", Seq: 2, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", Status: "completed", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_worker", Seq: 3, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "completed", CreatedAt: now, UpdatedAt: now},
 	}
 	for _, loop := range loops {
 		if err := repos.Loops.Upsert(context.Background(), loop); err != nil {
@@ -183,6 +188,9 @@ func writeRunStatsCommandFixture(t *testing.T) string {
 	}
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_retry", LoopID: stringPtr("loop_fixer"), Type: "fixer", TargetType: "pull_request", TargetID: "239", DedupeKey: "queue_fixer_retry", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 3, MaxAttempts: 5, CreatedAt: old, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(retry) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_retry", Priority: 1, Status: "queued", AvailableAt: now, Attempts: 2, MaxAttempts: 5, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(worker retry) error = %v", err)
 	}
 	return configPath
 }

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -181,6 +181,9 @@ func writeRunStatsCommandFixture(t *testing.T) string {
 	if err := repos.Events.Append(context.Background(), storage.EventLogRecord{ID: "event_retry", EventType: "fixer.push.retryable", LoopID: stringPtr("loop_fixer"), PayloadJSON: `{}`, CreatedAt: now}); err != nil {
 		t.Fatalf("Events.Append(retry) error = %v", err)
 	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_retry", LoopID: stringPtr("loop_fixer"), Type: "fixer", TargetType: "pull_request", TargetID: "239", DedupeKey: "queue_fixer_retry", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 3, MaxAttempts: 5, CreatedAt: old, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(retry) error = %v", err)
+	}
 	return configPath
 }
 

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -58,7 +58,7 @@ func TestRunStatsCommandOutputsJSONAndHuman(t *testing.T) {
 				t.Fatalf("fixer stats = %#v, want run and agent breakdowns", fixer)
 			}
 			worker := decoded.Roles["worker"]
-			if worker.Retried != 13 {
+			if worker.Retried != 14 {
 				t.Fatalf("worker retried = %d, want queued, running, and terminal queue attempts counted", worker.Retried)
 			}
 		}},
@@ -208,6 +208,9 @@ func writeRunStatsCommandFixture(t *testing.T) string {
 	}
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_cancelled_after_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_cancelled_after_retry", Priority: 1, Status: "cancelled", AvailableAt: now, Attempts: 1, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(worker cancelled after retry) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_manual_intervention_after_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_manual_intervention_after_retry", Priority: 1, Status: "manual_intervention", AvailableAt: now, Attempts: 1, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(worker manual intervention after retry) error = %v", err)
 	}
 	return configPath
 }

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -189,7 +189,7 @@ func writeRunStatsCommandFixture(t *testing.T) string {
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_retry", LoopID: stringPtr("loop_fixer"), Type: "fixer", TargetType: "pull_request", TargetID: "239", DedupeKey: "queue_fixer_retry", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 3, MaxAttempts: 5, CreatedAt: old, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(retry) error = %v", err)
 	}
-	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_retry", Priority: 1, Status: "queued", AvailableAt: now, Attempts: 2, MaxAttempts: 5, CreatedAt: now, UpdatedAt: now}); err != nil {
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_retry", Priority: 1, Status: "queued", AvailableAt: now, Attempts: 2, MaxAttempts: 5, CreatedAt: old, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(worker retry) error = %v", err)
 	}
 	return configPath

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -54,7 +54,7 @@ func TestRunStatsCommandOutputsJSONAndHuman(t *testing.T) {
 				t.Fatalf("reviewer outcomes = %#v, want approved=1 requested_changes=1", reviewer.Outcomes)
 			}
 			fixer := decoded.Roles["fixer"]
-			if fixer.Success != 1 || fixer.Failure != 1 || fixer.Retried != 1 || fixer.AgentExecutions.Success != 1 || fixer.AgentExecutions.Failure != 1 || fixer.AgentExecutions.Status["completed"] != 1 {
+			if fixer.Success != 1 || fixer.Failure != 1 || fixer.Retried != 4 || fixer.AgentExecutions.Success != 1 || fixer.AgentExecutions.Failure != 1 || fixer.AgentExecutions.Status["completed"] != 1 {
 				t.Fatalf("fixer stats = %#v, want run and agent breakdowns", fixer)
 			}
 		}},

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -58,7 +58,7 @@ func TestRunStatsCommandOutputsJSONAndHuman(t *testing.T) {
 				t.Fatalf("fixer stats = %#v, want run and agent breakdowns", fixer)
 			}
 			worker := decoded.Roles["worker"]
-			if worker.Retried != 2 {
+			if worker.Retried != 1 {
 				t.Fatalf("worker retried = %d, want queue-only retries counted", worker.Retried)
 			}
 		}},
@@ -189,8 +189,12 @@ func writeRunStatsCommandFixture(t *testing.T) string {
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_retry", LoopID: stringPtr("loop_fixer"), Type: "fixer", TargetType: "pull_request", TargetID: "239", DedupeKey: "queue_fixer_retry", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 3, MaxAttempts: 5, CreatedAt: old, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(retry) error = %v", err)
 	}
-	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_retry", Priority: 1, Status: "queued", AvailableAt: now, Attempts: 2, MaxAttempts: 5, CreatedAt: old, UpdatedAt: now}); err != nil {
+	retryableKind := "retryable_transient"
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_retry", Priority: 1, Status: "queued", AvailableAt: now, Attempts: 2, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(worker retry) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_claimed_after_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_claimed_after_retry", Priority: 1, Status: "running", AvailableAt: now, Attempts: 4, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(worker claimed after retry) error = %v", err)
 	}
 	return configPath
 }

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -58,8 +58,8 @@ func TestRunStatsCommandOutputsJSONAndHuman(t *testing.T) {
 				t.Fatalf("fixer stats = %#v, want run and agent breakdowns", fixer)
 			}
 			worker := decoded.Roles["worker"]
-			if worker.Retried != 1 {
-				t.Fatalf("worker retried = %d, want queue-only retries counted", worker.Retried)
+			if worker.Retried != 6 {
+				t.Fatalf("worker retried = %d, want queued and running queue attempts counted", worker.Retried)
 			}
 		}},
 		{name: "human", args: []string{"run", "stats", "--since", "1000d", "--role", "reviewer"}, assert: func(t *testing.T, output string) {

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -1,0 +1,225 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/powerformer/looper/internal/storage"
+)
+
+func TestRunStatsCommandOutputsJSONAndHuman(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		args   []string
+		assert func(*testing.T, string)
+	}{
+		{name: "json", args: []string{"run", "stats", "--since", "1000d", "--json"}, assert: func(t *testing.T, output string) {
+			var decoded struct {
+				Since string `json:"since"`
+				Roles map[string]struct {
+					Success     int64 `json:"success"`
+					Failure     int64 `json:"failure"`
+					Skipped     int64 `json:"skipped"`
+					Interrupted int64 `json:"interrupted"`
+					Requeued    int64 `json:"requeued"`
+					Retried     int64 `json:"retried"`
+					Outcomes    struct {
+						Approved         int64 `json:"approved"`
+						Commented        int64 `json:"commented"`
+						RequestedChanges int64 `json:"requested_changes"`
+					} `json:"outcomes"`
+					AgentExecutions struct {
+						Success int64            `json:"success"`
+						Failure int64            `json:"failure"`
+						Status  map[string]int64 `json:"status"`
+					} `json:"agentExecutions"`
+				} `json:"roles"`
+			}
+			if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v\noutput=%q", err, output)
+			}
+			reviewer := decoded.Roles["reviewer"]
+			if decoded.Since != "1000d" || reviewer.Success != 1 || reviewer.Failure != 1 || reviewer.Skipped != 1 || reviewer.Interrupted != 1 || reviewer.Requeued != 1 {
+				t.Fatalf("reviewer stats = %#v since=%q, want success/failure/skipped/interrupted/requeued", reviewer, decoded.Since)
+			}
+			if reviewer.Outcomes.Approved != 1 || reviewer.Outcomes.RequestedChanges != 1 {
+				t.Fatalf("reviewer outcomes = %#v, want approved=1 requested_changes=1", reviewer.Outcomes)
+			}
+			fixer := decoded.Roles["fixer"]
+			if fixer.Success != 1 || fixer.Failure != 1 || fixer.Retried != 1 || fixer.AgentExecutions.Success != 1 || fixer.AgentExecutions.Failure != 1 || fixer.AgentExecutions.Status["completed"] != 1 {
+				t.Fatalf("fixer stats = %#v, want run and agent breakdowns", fixer)
+			}
+		}},
+		{name: "human", args: []string{"run", "stats", "--since", "1000d", "--role", "reviewer"}, assert: func(t *testing.T, output string) {
+			for _, needle := range []string{"Recent run stats", "reviewer", "success", "skipped", "outcomes.approved"} {
+				if !strings.Contains(output, needle) {
+					t.Fatalf("run stats output missing %q\n%s", needle, output)
+				}
+			}
+			if strings.Contains(output, "\nfixer\n") {
+				t.Fatalf("run stats reviewer output included fixer section\n%s", output)
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := writeRunStatsCommandFixture(t)
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			app := New(Deps{Stdout: stdout, Stderr: stderr})
+			args := append(append([]string{}, tc.args...), "--config", configPath)
+			if exitCode := app.Run(context.Background(), args); exitCode != 0 {
+				t.Fatalf("Run(%v) exit code = %d, want 0; stderr=%q", args, exitCode, stderr.String())
+			}
+			tc.assert(t, stdout.String())
+		})
+	}
+}
+
+func TestRunStatsCommandEmptyStateAndDurationValidation(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeEmptyRunStatsCommandFixture(t)
+	exitCode, stdout, stderr := runApp(t, "run", "stats", "--since", "1h", "--config", configPath)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("Run([run stats empty]) = (%d, %q), want (0, empty)", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "No matching recent actions found") {
+		t.Fatalf("empty run stats output = %q, want empty state", stdout)
+	}
+
+	exitCode, _, stderr = runApp(t, "run", "stats", "--since", "bogus", "--config", configPath)
+	if exitCode == 0 || !strings.Contains(stderr, "invalid --since duration") {
+		t.Fatalf("Run([run stats --since bogus]) = (%d, %q), want duration error", exitCode, stderr)
+	}
+
+	exitCode, _, stderr = runApp(t, "run", "stats", "unexpected", "--config", configPath)
+	if exitCode == 0 || !strings.Contains(stderr, "unknown command") && !strings.Contains(stderr, "accepts 0 arg") {
+		t.Fatalf("Run([run stats unexpected]) = (%d, %q), want no-args error", exitCode, stderr)
+	}
+}
+
+func TestRunStatsCommandFiltersLoop(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeRunStatsCommandFixture(t)
+	exitCode, stdout, stderr := runApp(t, "run", "stats", "--since", "1000d", "--loop", "loop_reviewer", "--json", "--config", configPath)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("Run([run stats --loop]) = (%d, %q), want (0, empty)", exitCode, stderr)
+	}
+	var decoded struct {
+		Roles map[string]struct {
+			Success int64 `json:"success"`
+		} `json:"roles"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded.Roles["reviewer"].Success != 1 || decoded.Roles["fixer"].Success != 0 {
+		t.Fatalf("loop-filtered roles = %#v, want reviewer only counts", decoded.Roles)
+	}
+}
+
+func writeRunStatsCommandFixture(t *testing.T) string {
+	t.Helper()
+	configPath, repos := writeEmptyRunStatsCommandFixtureWithRepos(t)
+	now := "2026-04-11T12:00:00.000Z"
+	old := "2020-04-11T12:00:00.000Z"
+	projectID := "project_run_stats_cli"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	loops := []storage.LoopRecord{
+		{ID: "loop_reviewer", Seq: 1, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", Status: "completed", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_fixer", Seq: 2, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", Status: "completed", CreatedAt: now, UpdatedAt: now},
+	}
+	for _, loop := range loops {
+		if err := repos.Loops.Upsert(context.Background(), loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+
+	skippedCheckpoint := `{"skipReason":"draft pull request","skipKind":"draft"}`
+	runs := []storage.RunRecord{
+		{ID: "run_reviewer_success", LoopID: "loop_reviewer", Status: "success", StartedAt: now, CreatedAt: now, UpdatedAt: now},
+		{ID: "run_reviewer_failed", LoopID: "loop_reviewer", Status: "failed", StartedAt: now, CreatedAt: now, UpdatedAt: now},
+		{ID: "run_reviewer_skipped", LoopID: "loop_reviewer", Status: "success", CheckpointJSON: &skippedCheckpoint, StartedAt: now, CreatedAt: now, UpdatedAt: now},
+		{ID: "run_reviewer_interrupted", LoopID: "loop_reviewer", Status: "interrupted", StartedAt: now, CreatedAt: now, UpdatedAt: now},
+		{ID: "run_fixer_success", LoopID: "loop_fixer", Status: "success", StartedAt: now, CreatedAt: now, UpdatedAt: now},
+		{ID: "run_fixer_failed", LoopID: "loop_fixer", Status: "failed", StartedAt: now, CreatedAt: now, UpdatedAt: now},
+		{ID: "run_old", LoopID: "loop_fixer", Status: "success", StartedAt: old, CreatedAt: old, UpdatedAt: old},
+	}
+	for _, run := range runs {
+		if err := repos.Runs.Upsert(context.Background(), run); err != nil {
+			t.Fatalf("Runs.Upsert(%s) error = %v", run.ID, err)
+		}
+	}
+
+	if err := repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_fixer_completed", LoopID: stringPtr("loop_fixer"), RunID: stringPtr("run_fixer_success"), Vendor: "opencode", Status: "completed", StartedAt: now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(completed) error = %v", err)
+	}
+	if err := repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_fixer_failed", LoopID: stringPtr("loop_fixer"), RunID: stringPtr("run_fixer_failed"), Vendor: "opencode", Status: "failed", StartedAt: now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(failed) error = %v", err)
+	}
+	if err := repos.Events.Append(context.Background(), storage.EventLogRecord{ID: "event_requeued", EventType: "looperd.recovery.loop_requeued", LoopID: stringPtr("loop_reviewer"), PayloadJSON: `{}`, CreatedAt: now}); err != nil {
+		t.Fatalf("Events.Append(requeued) error = %v", err)
+	}
+	if err := repos.Events.Append(context.Background(), storage.EventLogRecord{ID: "event_review_approved", EventType: "pr.review.posted", LoopID: stringPtr("loop_reviewer"), RunID: stringPtr("run_reviewer_success"), PayloadJSON: `{"event":"APPROVE"}`, CreatedAt: now}); err != nil {
+		t.Fatalf("Events.Append(review approved) error = %v", err)
+	}
+	if err := repos.Events.Append(context.Background(), storage.EventLogRecord{ID: "event_review_requested_changes", EventType: "pr.review.posted", LoopID: stringPtr("loop_reviewer"), RunID: stringPtr("run_reviewer_failed"), PayloadJSON: `{"event":"REQUEST_CHANGES"}`, CreatedAt: now}); err != nil {
+		t.Fatalf("Events.Append(review requested changes) error = %v", err)
+	}
+	if err := repos.Events.Append(context.Background(), storage.EventLogRecord{ID: "event_retry", EventType: "fixer.push.retryable", LoopID: stringPtr("loop_fixer"), PayloadJSON: `{}`, CreatedAt: now}); err != nil {
+		t.Fatalf("Events.Append(retry) error = %v", err)
+	}
+	return configPath
+}
+
+func writeEmptyRunStatsCommandFixture(t *testing.T) string {
+	t.Helper()
+	configPath, _ := writeEmptyRunStatsCommandFixtureWithRepos(t)
+	return configPath
+}
+
+func writeEmptyRunStatsCommandFixtureWithRepos(t *testing.T) (string, *storage.Repositories) {
+	t.Helper()
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "looper.sqlite")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), dbPath, storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: filepath.Join(root, "backups")})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	configPath := filepath.Join(root, "config.json")
+	raw, err := json.Marshal(map[string]any{"storage": map[string]any{"dbPath": dbPath}})
+	if err != nil {
+		t.Fatalf("json.Marshal(config) error = %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+	return configPath, storage.NewRepositories(coordinator.DB())
+}
+
+func TestParseRunStatsDurationSupportsDays(t *testing.T) {
+	t.Parallel()
+	duration, err := parseRunStatsDuration("7d")
+	if err != nil {
+		t.Fatalf("parseRunStatsDuration(7d) error = %v", err)
+	}
+	if duration != 7*24*time.Hour {
+		t.Fatalf("parseRunStatsDuration(7d) = %v, want 168h", duration)
+	}
+}

--- a/internal/cliapp/run_stats_commands_test.go
+++ b/internal/cliapp/run_stats_commands_test.go
@@ -183,13 +183,13 @@ func writeRunStatsCommandFixture(t *testing.T) string {
 	if err := repos.Events.Append(context.Background(), storage.EventLogRecord{ID: "event_review_requested_changes", EventType: "pr.review.posted", LoopID: stringPtr("loop_reviewer"), RunID: stringPtr("run_reviewer_failed"), PayloadJSON: `{"event":"REQUEST_CHANGES"}`, CreatedAt: now}); err != nil {
 		t.Fatalf("Events.Append(review requested changes) error = %v", err)
 	}
-	if err := repos.Events.Append(context.Background(), storage.EventLogRecord{ID: "event_retry", EventType: "fixer.push.retryable", LoopID: stringPtr("loop_fixer"), PayloadJSON: `{}`, CreatedAt: now}); err != nil {
+	if err := repos.Events.Append(context.Background(), storage.EventLogRecord{ID: "event_retryable_failure", EventType: "fixer.push.retryable", LoopID: stringPtr("loop_fixer"), PayloadJSON: `{}`, CreatedAt: now}); err != nil {
 		t.Fatalf("Events.Append(retry) error = %v", err)
 	}
-	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_retry", LoopID: stringPtr("loop_fixer"), Type: "fixer", TargetType: "pull_request", TargetID: "239", DedupeKey: "queue_fixer_retry", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 3, MaxAttempts: 5, CreatedAt: old, UpdatedAt: now}); err != nil {
+	retryableKind := "retryable_transient"
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_retry", LoopID: stringPtr("loop_fixer"), Type: "fixer", TargetType: "pull_request", TargetID: "239", DedupeKey: "queue_fixer_retry", Priority: 1, Status: "queued", AvailableAt: now, Attempts: 1, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(retry) error = %v", err)
 	}
-	retryableKind := "retryable_transient"
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_retry", LoopID: stringPtr("loop_worker"), Type: "worker", TargetType: "project", TargetID: "project_run_stats_cli", DedupeKey: "queue_worker_retry", Priority: 1, Status: "queued", AvailableAt: now, Attempts: 2, MaxAttempts: 5, LastErrorKind: &retryableKind, CreatedAt: old, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(worker retry) error = %v", err)
 	}

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -353,6 +353,16 @@ func (r *EventsRepository) List(ctx context.Context, limit int64) ([]EventLogRec
 	return scanEventLogs(rows)
 }
 
+func (r *EventsRepository) ListSince(ctx context.Context, sinceISO string) ([]EventLogRecord, error) {
+	rows, err := r.q.QueryContext(ctx, `SELECT * FROM event_logs WHERE created_at >= ? ORDER BY created_at DESC`, sinceISO)
+	if err != nil {
+		return nil, fmt.Errorf("list event logs since: %w", err)
+	}
+	defer rows.Close()
+
+	return scanEventLogs(rows)
+}
+
 func (r *EventsRepository) ListByEntity(ctx context.Context, entityType, entityID string) ([]EventLogRecord, error) {
 	rows, err := r.q.QueryContext(ctx, `SELECT * FROM event_logs WHERE entity_type = ? AND entity_id = ? ORDER BY created_at ASC`, entityType, entityID)
 	if err != nil {
@@ -594,6 +604,16 @@ func (r *RunsRepository) List(ctx context.Context) ([]RunRecord, error) {
 	return scanRuns(rows)
 }
 
+func (r *RunsRepository) ListSince(ctx context.Context, sinceISO string) ([]RunRecord, error) {
+	rows, err := r.q.QueryContext(ctx, `SELECT * FROM runs WHERE started_at >= ? ORDER BY started_at DESC, id DESC`, sinceISO)
+	if err != nil {
+		return nil, fmt.Errorf("list runs since: %w", err)
+	}
+	defer rows.Close()
+
+	return scanRuns(rows)
+}
+
 func (r *RunsRepository) ListByStatus(ctx context.Context, status string) ([]RunRecord, error) {
 	rows, err := r.q.QueryContext(ctx, `SELECT * FROM runs WHERE status = ? ORDER BY started_at DESC, id DESC`, status)
 	if err != nil {
@@ -693,6 +713,26 @@ func (r *AgentExecutionsRepository) ListActive(ctx context.Context) ([]AgentExec
 	rows, err := r.q.QueryContext(ctx, `SELECT `+agentExecutionColumns+` FROM agent_executions WHERE status IN ('running', 'cancelling') ORDER BY started_at DESC, id DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("list active agent executions: %w", err)
+	}
+	defer rows.Close()
+
+	return scanAgentExecutions(rows)
+}
+
+func (r *AgentExecutionsRepository) List(ctx context.Context) ([]AgentExecutionRecord, error) {
+	rows, err := r.q.QueryContext(ctx, `SELECT `+agentExecutionColumns+` FROM agent_executions ORDER BY started_at DESC, id DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("list agent executions: %w", err)
+	}
+	defer rows.Close()
+
+	return scanAgentExecutions(rows)
+}
+
+func (r *AgentExecutionsRepository) ListSince(ctx context.Context, sinceISO string) ([]AgentExecutionRecord, error) {
+	rows, err := r.q.QueryContext(ctx, `SELECT `+agentExecutionColumns+` FROM agent_executions WHERE started_at >= ? ORDER BY started_at DESC, id DESC`, sinceISO)
+	if err != nil {
+		return nil, fmt.Errorf("list agent executions since: %w", err)
 	}
 	defer rows.Close()
 


### PR DESCRIPTION
## Summary
- Adds `looper run stats` with `--since`, `--role`, `--loop`, and `--json` support for recent persisted run/action summaries.
- Aggregates run status counts, reviewer skipped/interrupted/requeued outcomes, reviewer review events from structured event records, fixer/worker retry counts, and agent execution breakdowns.
- Adds stable JSON output with zero-valued role structures plus human-readable empty-state messaging.

## Validation
- `go test ./internal/cliapp ./internal/storage`
- `go vet ./...`
- `go build ./...`
- `go test ./...`

Closes #236

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.6.1 · runner=worker · agent=opencode</sub>