### PR TITLE
fix: log review submit request and response details

### DIFF
--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -1,6 +1,7 @@
 package cliapp
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,6 +29,16 @@ type reviewSubmitComment struct {
 	Side      string `json:"side"`
 	StartLine int64  `json:"start_line"`
 	StartSide string `json:"start_side"`
+}
+
+type reviewSubmitDiagnosticFields struct {
+	Repo     string
+	PRNumber int64
+	Event    string
+	CommitID string
+	Payload  reviewSubmitPayload
+	Error    string
+	Extra    map[string]any
 }
 
 func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
@@ -76,7 +87,10 @@ func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("determine current working directory: %w", err)
 	}
 
-	gh := githubinfra.New(githubinfra.Options{GHPath: *loaded.Config.Tools.GHPath, CWD: cwd, GHRun: shell.Run})
+	diagnosticWriter := func(event string, fields map[string]any) {
+		writeReviewSubmitDiagnosticEntry(cmd.ErrOrStderr(), event, fields)
+	}
+	gh := githubinfra.New(githubinfra.Options{GHPath: *loaded.Config.Tools.GHPath, CWD: cwd, GHRun: shell.Run, ReviewSubmitDiagnostic: diagnosticWriter})
 	metadata, err := gh.GetPullRequestHeadAndAuthor(cmd.Context(), githubinfra.ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: cwd})
 	if err != nil {
 		return fmt.Errorf("validate expected PR head commit: %w", err)
@@ -85,6 +99,7 @@ func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if err := validateReviewSubmitBody(payload.Body, payload.Comments, commitID, event, policy, metadata.Author); err != nil {
+		writeReviewSubmitDiagnostic(cmd.ErrOrStderr(), "github_review_submit_validation_failed", reviewSubmitDiagnosticFields{Repo: repo, PRNumber: prNumber, Event: event, CommitID: commitID, Payload: payload, Error: err.Error()})
 		return err
 	}
 	submissionEvent, err := r.effectiveReviewSubmitEvent(cmd, gh, repo, prNumber, event, metadata.Author, cwd)
@@ -305,4 +320,75 @@ func submitReviewWithoutAnchorValidation(cmd *cobra.Command, gh *githubinfra.Gat
 		return fmt.Errorf("submit PR review without anchor validation: %w", err)
 	}
 	return writeJSON(cmd.OutOrStdout(), map[string]any{"submitted": true})
+}
+
+func writeReviewSubmitDiagnostic(w io.Writer, event string, fields reviewSubmitDiagnosticFields) {
+	entry := map[string]any{
+		"repo":         fields.Repo,
+		"pr_number":    fields.PRNumber,
+		"event":        event,
+		"review_event": fields.Event,
+		"commit_id":    strings.TrimSpace(fields.CommitID),
+		"method":       "POST",
+		"endpoint":     fmt.Sprintf("repos/%s/pulls/%d/reviews", fields.Repo, fields.PRNumber),
+		"payload": map[string]any{
+			"body_marker": reviewSubmitPayloadBodyMarker(fields.Payload.Body),
+			"comments":    reviewSubmitPayloadComments(fields.Payload.Comments),
+		},
+	}
+	if strings.TrimSpace(fields.Error) != "" {
+		entry["error"] = strings.TrimSpace(fields.Error)
+	}
+	for key, value := range fields.Extra {
+		entry[key] = value
+	}
+	writeReviewSubmitDiagnosticEntry(w, event, entry)
+}
+
+func writeReviewSubmitDiagnosticEntry(w io.Writer, event string, fields map[string]any) {
+	if w == nil {
+		return
+	}
+	entry := map[string]any{"event": event}
+	for key, value := range fields {
+		entry[key] = value
+	}
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	_, _ = io.Copy(w, bytes.NewReader(append(encoded, '\n')))
+}
+
+func reviewSubmitPayloadBodyMarker(body string) map[string]any {
+	matches := reviewSubmitMarkerRE.FindAllStringSubmatch(body, -1)
+	if len(matches) == 0 {
+		return map[string]any{}
+	}
+	fields := parseReviewSubmitMarkerFields(matches[0][1])
+	return map[string]any{"id": fields["id"], "head": fields["head"], "outcome": fields["outcome"]}
+}
+
+func reviewSubmitPayloadComments(comments []reviewSubmitComment) []map[string]any {
+	summary := make([]map[string]any, 0, len(comments))
+	for idx, comment := range comments {
+		entry := map[string]any{"index": idx}
+		if comment.Path != "" {
+			entry["path"] = comment.Path
+		}
+		if comment.Line > 0 {
+			entry["line"] = comment.Line
+		}
+		if comment.Side != "" {
+			entry["side"] = strings.ToUpper(strings.TrimSpace(comment.Side))
+		}
+		if comment.StartLine > 0 {
+			entry["start_line"] = comment.StartLine
+		}
+		if comment.StartSide != "" {
+			entry["start_side"] = strings.ToUpper(strings.TrimSpace(comment.StartSide))
+		}
+		summary = append(summary, entry)
+	}
+	return summary
 }

--- a/internal/cliapp/review_submit_test.go
+++ b/internal/cliapp/review_submit_test.go
@@ -3,6 +3,7 @@ package cliapp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -286,6 +287,49 @@ func TestEffectiveReviewSubmitEventDoesNotFetchUserForComment(t *testing.T) {
 	}
 	if got != "COMMENT" {
 		t.Fatalf("effectiveReviewSubmitEvent() = %q, want COMMENT", got)
+	}
+}
+
+func TestWriteReviewSubmitDiagnosticWritesStructuredJSON(t *testing.T) {
+	t.Parallel()
+	stderr := &bytes.Buffer{}
+	payload := reviewSubmitPayload{
+		Body:     "Please revisit this.\n<!-- looper:review id=abc head=def outcome=blocking -->",
+		Comments: []reviewSubmitComment{{Body: "anchor", Path: "app.go", Line: 7, Side: "RIGHT", StartLine: 5, StartSide: "RIGHT"}},
+	}
+	writeReviewSubmitDiagnostic(stderr, "github_review_submit_validation_failed", reviewSubmitDiagnosticFields{
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Event:    "REQUEST_CHANGES",
+		CommitID: "def",
+		Payload:  payload,
+		Error:    "review marker outcome=clean does not match REQUEST_CHANGES event",
+	})
+	var entry map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &entry); err != nil {
+		t.Fatalf("decode stderr JSON: %v\n%s", err, stderr.String())
+	}
+	if entry["event"] != "github_review_submit_validation_failed" {
+		t.Fatalf("event = %#v, want validation_failed", entry["event"])
+	}
+	if entry["repo"] != "acme/looper" || entry["pr_number"] != float64(42) || entry["commit_id"] != "def" {
+		t.Fatalf("entry = %#v, want repo/pr/commit", entry)
+	}
+	payloadEntry, _ := entry["payload"].(map[string]any)
+	marker, _ := payloadEntry["body_marker"].(map[string]any)
+	if marker["id"] != "abc" || marker["head"] != "def" || marker["outcome"] != "blocking" {
+		t.Fatalf("body marker = %#v, want marker fields", marker)
+	}
+	comments, _ := payloadEntry["comments"].([]any)
+	if len(comments) != 1 {
+		t.Fatalf("comments = %#v, want one comment", comments)
+	}
+	comment, _ := comments[0].(map[string]any)
+	if comment["path"] != "app.go" || comment["line"] != float64(7) || comment["side"] != "RIGHT" || comment["start_line"] != float64(5) || comment["start_side"] != "RIGHT" {
+		t.Fatalf("comment = %#v, want anchor summary", comment)
+	}
+	if entry["error"] == "" {
+		t.Fatalf("entry = %#v, want error field", entry)
 	}
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -33,17 +33,19 @@ var prNumberURLPattern = regexp.MustCompile(`/pull/(\d+)(?:/|$)`)
 var ErrDiffTooLarge = errors.New("github pull request diff is too large")
 
 type Options struct {
-	GHPath string
-	CWD    string
-	Now    func() time.Time
-	GHRun  func(context.Context, shell.Options) (shell.Result, error)
+	GHPath                 string
+	CWD                    string
+	Now                    func() time.Time
+	GHRun                  func(context.Context, shell.Options) (shell.Result, error)
+	ReviewSubmitDiagnostic func(event string, fields map[string]any)
 }
 
 type Gateway struct {
-	ghPath string
-	cwd    string
-	now    func() time.Time
-	ghRun  func(context.Context, shell.Options) (shell.Result, error)
+	ghPath                 string
+	cwd                    string
+	now                    func() time.Time
+	ghRun                  func(context.Context, shell.Options) (shell.Result, error)
+	reviewSubmitDiagnostic func(event string, fields map[string]any)
 }
 
 type PullRequestSummary struct {
@@ -144,12 +146,13 @@ type SubmitReviewInput struct {
 }
 
 type ReviewComment struct {
-	Body      string
-	Path      string
-	Line      int64
-	Side      string
-	StartLine int64
-	StartSide string
+	Body            string
+	Path            string
+	Line            int64
+	Side            string
+	StartLine       int64
+	StartSide       string
+	DiagnosticIndex int
 }
 
 type VerifyReviewMarkerInput struct {
@@ -363,7 +366,7 @@ func New(options Options) *Gateway {
 	if ghRun == nil {
 		ghRun = shell.Run
 	}
-	return &Gateway{ghPath: ghPath, cwd: options.CWD, now: now, ghRun: ghRun}
+	return &Gateway{ghPath: ghPath, cwd: options.CWD, now: now, ghRun: ghRun, reviewSubmitDiagnostic: options.ReviewSubmitDiagnostic}
 }
 
 func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
@@ -749,28 +752,57 @@ func (g *Gateway) GetPullRequestDiff(ctx context.Context, input GetPullRequestDi
 }
 
 func (g *Gateway) SubmitReview(ctx context.Context, input SubmitReviewInput) error {
+	request := g.reviewSubmitRequest(input)
 	if marker, ok := findReviewIdempotencyMarker(input.Body, ""); ok && marker.Outcome == "clean" && len(input.Comments) > 0 {
-		return fmt.Errorf("clean review marker cannot be submitted with review comments")
+		err := fmt.Errorf("clean review marker cannot be submitted with review comments")
+		g.emitReviewSubmitDiagnostic("github_review_submit_validation_failed", map[string]any{"request": request, "error": err.Error()})
+		return err
 	}
 	var flags []reviewQualityFlag
-	input.Body, input.Comments, flags = normalizeReviewAnchors(input.Body, input.Comments, input.Anchors)
+	var processing reviewCommentProcessing
+	input.Body, input.Comments, flags, processing = normalizeReviewAnchors(input.Body, input.Comments, input.Anchors)
+	request = g.reviewSubmitRequest(input)
+	request["comment_processing"] = map[string]any{
+		"original_count":   processing.OriginalCount,
+		"submitted_count":  processing.SubmittedCount,
+		"normalized_count": processing.NormalizedCount,
+		"downgraded_count": processing.DowngradedCount,
+		"dropped_count":    processing.DroppedCount,
+		"comments":         processing.Comments,
+	}
 	gateApplies, err := reviewQualityGateApplies(input.Event, input.Body)
 	if err != nil {
+		g.emitReviewSubmitDiagnostic("github_review_submit_validation_failed", map[string]any{"request": request, "error": err.Error()})
 		return err
 	}
 	if gateApplies && len(flags) > 0 {
-		return fmt.Errorf("review quality gate failed: %s", formatReviewQualityFlags(flags))
+		err := fmt.Errorf("review quality gate failed: %s", formatReviewQualityFlags(flags))
+		g.emitReviewSubmitDiagnostic("github_review_submit_validation_failed", map[string]any{"request": request, "error": err.Error(), "quality_flags": reviewQualityFlagsSummary(flags)})
+		return err
 	}
 	comments := input.Comments[:0]
 	for _, comment := range input.Comments {
 		comment.Body = normalizeInlineReviewDisclosure(comment.Body, input.Disclosure)
 		if strings.TrimSpace(comment.Body) == "" {
+			processing.DroppedCount++
+			markReviewCommentDropped(processing.Comments, comment.DiagnosticIndex)
 			continue
 		}
 		comments = append(comments, comment)
 	}
 	input.Comments = comments
+	processing.SubmittedCount = len(input.Comments)
+	request = g.reviewSubmitRequest(input)
+	request["comment_processing"] = map[string]any{
+		"original_count":   processing.OriginalCount,
+		"submitted_count":  processing.SubmittedCount,
+		"normalized_count": processing.NormalizedCount,
+		"downgraded_count": processing.DowngradedCount,
+		"dropped_count":    processing.DroppedCount,
+		"comments":         processing.Comments,
+	}
 	if len(input.Comments) > 0 || strings.TrimSpace(input.CommitID) != "" {
+		endpoint := fmt.Sprintf("repos/%s/pulls/%d/reviews", input.Repo, input.PRNumber)
 		payload := map[string]any{
 			"event":     input.Event,
 			"body":      emptyToNil(input.Body),
@@ -803,7 +835,26 @@ func (g *Gateway) SubmitReview(ctx context.Context, input SubmitReviewInput) err
 		if err != nil {
 			return fmt.Errorf("marshal gh review payload: %w", err)
 		}
-		_, err = g.runGh(ctx, input.CWD, string(body), "api", fmt.Sprintf("repos/%s/pulls/%d/reviews", input.Repo, input.PRNumber), "--method", "POST", "--input", "-")
+		request["method"] = "POST"
+		request["endpoint"] = endpoint
+		g.emitReviewSubmitDiagnostic("github_review_submit_prepared", map[string]any{"request": request})
+		result, err := g.runGh(ctx, input.CWD, string(body), "api", endpoint, "--method", "POST", "--input", "-", "--include")
+		if err != nil {
+			fields := map[string]any{"request": request, "gh_stdout": reviewSubmitRawStdout(result.Stdout), "gh_stderr": result.Stderr, "gh_error": sanitizeReviewSubmitCommandError(err.Error())}
+			if response, ok := parseReviewSubmitHTTPResponse(result.Stdout); ok {
+				if response.StatusCode > 0 {
+					fields["http_status"] = response.StatusCode
+				}
+				if response.Body != "" {
+					fields["response_body"] = response.Body
+				}
+				if len(response.Headers) > 0 {
+					fields["response_headers"] = response.Headers
+				}
+			}
+			g.emitReviewSubmitDiagnostic("github_review_submit_failed", fields)
+			return err
+		}
 		return err
 	}
 	args := []string{"pr", "review", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo, "--" + strings.ToLower(strings.ReplaceAll(input.Event, "_", "-"))}
@@ -812,6 +863,115 @@ func (g *Gateway) SubmitReview(ctx context.Context, input SubmitReviewInput) err
 	}
 	_, err = g.runGh(ctx, input.CWD, "", args...)
 	return err
+}
+
+func (g *Gateway) emitReviewSubmitDiagnostic(event string, fields map[string]any) {
+	if g.reviewSubmitDiagnostic != nil {
+		g.reviewSubmitDiagnostic(event, fields)
+	}
+}
+
+func (g *Gateway) reviewSubmitRequest(input SubmitReviewInput) map[string]any {
+	endpoint := fmt.Sprintf("repos/%s/pulls/%d/reviews", input.Repo, input.PRNumber)
+	request := map[string]any{
+		"repo":      input.Repo,
+		"pr_number": input.PRNumber,
+		"event":     input.Event,
+		"commit_id": strings.TrimSpace(input.CommitID),
+		"method":    "POST",
+		"endpoint":  endpoint,
+		"payload": map[string]any{
+			"body_marker": reviewSubmitBodyMarkerSummary(input.Body),
+			"comments":    reviewSubmitCommentsSummary(input.Comments),
+		},
+	}
+	return request
+}
+
+func reviewSubmitBodyMarkerSummary(body string) map[string]any {
+	if marker, ok := findReviewIdempotencyMarker(body, ""); ok {
+		return map[string]any{"id": marker.ID, "head": marker.Head, "outcome": marker.Outcome}
+	}
+	return map[string]any{}
+}
+
+func reviewSubmitCommentsSummary(comments []ReviewComment) []map[string]any {
+	summary := make([]map[string]any, 0, len(comments))
+	for idx, comment := range comments {
+		entry := map[string]any{"index": reviewCommentDiagnosticIndex(comment, idx)}
+		for key, value := range reviewCommentAnchorMap(comment) {
+			entry[key] = value
+		}
+		summary = append(summary, entry)
+	}
+	return summary
+}
+
+func reviewCommentDiagnosticIndex(comment ReviewComment, fallback int) int {
+	if comment.DiagnosticIndex != 0 || fallback == 0 {
+		return comment.DiagnosticIndex
+	}
+	return fallback
+}
+
+func reviewQualityFlagsSummary(flags []reviewQualityFlag) []map[string]any {
+	summary := make([]map[string]any, 0, len(flags))
+	for _, flag := range flags {
+		summary = append(summary, map[string]any{"kind": flag.Kind, "detail": flag.Detail})
+	}
+	return summary
+}
+
+func reviewSubmitRawStdout(raw string) string {
+	if response, ok := parseReviewSubmitHTTPResponse(raw); ok && response.Body != "" {
+		return response.Body
+	}
+	return raw
+}
+
+func sanitizeReviewSubmitCommandError(message string) string {
+	message = strings.TrimSpace(message)
+	if head, _, ok := strings.Cut(message, "\nstdout:"); ok {
+		return strings.TrimSpace(head)
+	}
+	return message
+}
+
+type reviewSubmitHTTPResponse struct {
+	StatusCode int
+	Headers    map[string]any
+	Body       string
+}
+
+func parseReviewSubmitHTTPResponse(raw string) (reviewSubmitHTTPResponse, bool) {
+	raw = strings.ReplaceAll(raw, "\r\n", "\n")
+	parts := strings.SplitN(raw, "\n\n", 2)
+	if len(parts) != 2 {
+		return reviewSubmitHTTPResponse{}, false
+	}
+	headLines := strings.Split(parts[0], "\n")
+	if len(headLines) == 0 || !strings.HasPrefix(headLines[0], "HTTP/") {
+		return reviewSubmitHTTPResponse{}, false
+	}
+	response := reviewSubmitHTTPResponse{Headers: map[string]any{}, Body: strings.TrimSpace(parts[1])}
+	fields := strings.Fields(headLines[0])
+	if len(fields) >= 2 {
+		if status, err := strconv.Atoi(fields[1]); err == nil {
+			response.StatusCode = status
+		}
+	}
+	for _, line := range headLines[1:] {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		normalizedKey := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "-", "_"))
+		switch normalizedKey {
+		case "x_github_request_id", "x_ratelimit_limit", "x_ratelimit_remaining", "x_ratelimit_reset", "retry_after", "content_type":
+			response.Headers[normalizedKey] = strings.TrimSpace(value)
+		}
+	}
+	return response, true
 }
 
 func normalizeInlineReviewDisclosure(body string, disclosureCfg config.DisclosureConfig) string {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -19,7 +19,7 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case args == "api repos/acme/looper/pulls/42/reviews --method POST --input -":
+		case args == "api repos/acme/looper/pulls/42/reviews --method POST --input - --include":
 			runner.stdin = options.Stdin
 			return shell.Result{Stdout: "{}"}, nil
 		case strings.HasPrefix(args, "pr list"):
@@ -196,7 +196,7 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	log := strings.Join(runner.calls, "\n")
 	for _, needle := range []string{
 		"pr review 42 --repo acme/looper --comment --body app.go: Looks good",
-		"api repos/acme/looper/pulls/42/reviews --method POST --input -",
+		"api repos/acme/looper/pulls/42/reviews --method POST --input - --include",
 		"pr comment 42 --repo acme/looper --body High-level follow-up",
 		"api repos/acme/looper/issues/42/reactions --method POST -H Accept: application/vnd.github+json -f content=eyes",
 		"api --paginate --slurp repos/acme/looper/issues/42/reactions -H Accept: application/vnd.github+json",
@@ -345,7 +345,7 @@ func TestSubmitReviewUsesAPIForTopLevelReviewWithCommitID(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input -" {
+		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input - --include" {
 			t.Fatalf("unexpected gh args: %q", args)
 		}
 		runner.stdin = options.Stdin
@@ -365,7 +365,7 @@ func TestSubmitReviewNormalizesAnchorsBeforePublishing(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input -" {
+		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input - --include" {
 			t.Fatalf("unexpected gh args: %q", args)
 		}
 		runner.stdin = options.Stdin
@@ -389,7 +389,7 @@ func TestSubmitReviewStripsDisclosureFromInlineCommentsWhenReviewDisclosureDisab
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input -" {
+		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input - --include" {
 			t.Fatalf("unexpected gh args: %q", args)
 		}
 		runner.stdin = options.Stdin
@@ -411,7 +411,7 @@ func TestSubmitReviewDropsInlineCommentsEmptyAfterDisabledDisclosureStrip(t *tes
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input -" {
+		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input - --include" {
 			t.Fatalf("unexpected gh args: %q", args)
 		}
 		runner.stdin = options.Stdin
@@ -433,7 +433,7 @@ func TestSubmitReviewPreservesInlineDisclosureWhenReviewDisclosureEnabled(t *tes
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input -" {
+		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input - --include" {
 			t.Fatalf("unexpected gh args: %q", args)
 		}
 		runner.stdin = options.Stdin
@@ -456,7 +456,7 @@ func TestSubmitReviewNormalizesVisibleInlineDisclosureWhenInlineVisibleDisabled(
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input -" {
+		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input - --include" {
 			t.Fatalf("unexpected gh args: %q", args)
 		}
 		runner.stdin = options.Stdin
@@ -480,7 +480,7 @@ func TestSubmitReviewNormalizesLegacyVisibleInlineDisclosureWhenInlineVisibleDis
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input -" {
+		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input - --include" {
 			t.Fatalf("unexpected gh args: %q", args)
 		}
 		runner.stdin = options.Stdin
@@ -504,7 +504,7 @@ func TestSubmitReviewNormalizesLegacyVisibleInlineDisclosureWithoutMarkerWhenInl
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input -" {
+		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input - --include" {
 			t.Fatalf("unexpected gh args: %q", args)
 		}
 		runner.stdin = options.Stdin
@@ -1342,4 +1342,118 @@ func TestSubmitReviewRejectsCleanMarkerWithComments(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "clean review marker cannot be submitted with review comments") {
 		t.Fatalf("SubmitReview() error = %v, want clean-with-comments rejection", err)
 	}
+}
+
+func TestSubmitReviewLogsValidationFailureDiagnostics(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		t.Fatalf("unexpected gh call: %q", strings.Join(options.Args, " "))
+		return shell.Result{}, nil
+	}
+	var events []reviewSubmitDiagnosticEvent
+	gateway := New(Options{
+		GHPath: "gh",
+		CWD:    t.TempDir(),
+		GHRun:  runner.run,
+		ReviewSubmitDiagnostic: func(event string, fields map[string]any) {
+			events = append(events, reviewSubmitDiagnosticEvent{Name: event, Fields: fields})
+		},
+	})
+	err := gateway.SubmitReview(context.Background(), SubmitReviewInput{Repo: "acme/looper", PRNumber: 42, Event: "COMMENT", Body: "LGTM\n<!-- looper:review id=abc head=def outcome=clean -->", CommitID: "def", Comments: []ReviewComment{{Body: "But fix this", Path: "app.go", Line: 1, Side: "RIGHT"}}})
+	if err == nil || !strings.Contains(err.Error(), "clean review marker cannot be submitted with review comments") {
+		t.Fatalf("SubmitReview() error = %v, want clean-with-comments rejection", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("diagnostic events = %#v, want one validation failure event", events)
+	}
+	if events[0].Name != "github_review_submit_validation_failed" {
+		t.Fatalf("event name = %q, want github_review_submit_validation_failed", events[0].Name)
+	}
+	if got := events[0].Fields["error"]; got != "clean review marker cannot be submitted with review comments" {
+		t.Fatalf("error = %#v, want clean marker rejection", got)
+	}
+	request, _ := events[0].Fields["request"].(map[string]any)
+	if request["repo"] != "acme/looper" || request["pr_number"] != int64(42) || request["commit_id"] != "def" {
+		t.Fatalf("request summary = %#v, want repo/pr/commit", request)
+	}
+	payload, _ := request["payload"].(map[string]any)
+	marker, _ := payload["body_marker"].(map[string]any)
+	if marker["id"] != "abc" || marker["head"] != "def" || marker["outcome"] != "clean" {
+		t.Fatalf("body marker = %#v, want marker fields", marker)
+	}
+	comments, _ := payload["comments"].([]map[string]any)
+	if len(comments) != 1 || comments[0]["path"] != "app.go" || comments[0]["line"] != int64(1) || comments[0]["side"] != "RIGHT" {
+		t.Fatalf("payload comments = %#v, want inline anchor summary", comments)
+	}
+}
+
+func TestSubmitReviewLogsGhFailureDiagnostics(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		if args != "api repos/acme/looper/pulls/42/reviews --method POST --input - --include" {
+			t.Fatalf("unexpected gh args: %q", args)
+		}
+		result := shell.Result{
+			ExitCode: 1,
+			Stdout: strings.Join([]string{
+				"HTTP/2.0 422 Unprocessable Entity",
+				"X-GitHub-Request-Id: req-123",
+				"X-RateLimit-Remaining: 4999",
+				"",
+				`{"message":"Unprocessable Entity","errors":["An internal error occurred, please try again."]}`,
+			}, "\n"),
+			Stderr: "gh: Unprocessable Entity (HTTP 422)",
+		}
+		return result, &shell.CommandExecutionError{Message: "Command exited with code 1: gh: Unprocessable Entity (HTTP 422)", Result: result}
+	}
+	anchors := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -1 +1 @@\n+new\n")
+	var events []reviewSubmitDiagnosticEvent
+	gateway := New(Options{
+		GHPath: "gh",
+		CWD:    t.TempDir(),
+		GHRun:  runner.run,
+		ReviewSubmitDiagnostic: func(event string, fields map[string]any) {
+			events = append(events, reviewSubmitDiagnosticEvent{Name: event, Fields: fields})
+		},
+	})
+	err := gateway.SubmitReview(context.Background(), SubmitReviewInput{Repo: "acme/looper", PRNumber: 42, Event: "REQUEST_CHANGES", Body: "Please fix this.\n<!-- looper:review id=abc head=def outcome=blocking -->", CommitID: "def", Comments: []ReviewComment{{Body: "Fix this anchor", Path: "app.go", Line: 1, Side: "RIGHT"}}, Anchors: &anchors})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 422") {
+		t.Fatalf("SubmitReview() error = %v, want HTTP 422 failure", err)
+	}
+	if len(events) < 2 {
+		t.Fatalf("diagnostic events = %#v, want prepare and failure events", events)
+	}
+	failure := events[len(events)-1]
+	if failure.Name != "github_review_submit_failed" {
+		t.Fatalf("failure event name = %q, want github_review_submit_failed", failure.Name)
+	}
+	if failure.Fields["http_status"] != 422 {
+		t.Fatalf("http_status = %#v, want 422", failure.Fields["http_status"])
+	}
+	if failure.Fields["response_body"] != `{"message":"Unprocessable Entity","errors":["An internal error occurred, please try again."]}` {
+		t.Fatalf("response_body = %#v, want raw response body", failure.Fields["response_body"])
+	}
+	if failure.Fields["gh_stderr"] != "gh: Unprocessable Entity (HTTP 422)" {
+		t.Fatalf("gh_stderr = %#v, want gh stderr", failure.Fields["gh_stderr"])
+	}
+	headers, _ := failure.Fields["response_headers"].(map[string]any)
+	if headers["x_github_request_id"] != "req-123" || headers["x_ratelimit_remaining"] != "4999" {
+		t.Fatalf("response_headers = %#v, want selected headers", headers)
+	}
+	request, _ := failure.Fields["request"].(map[string]any)
+	if request["event"] != "REQUEST_CHANGES" {
+		t.Fatalf("request = %#v, want request event", request)
+	}
+	normalization, _ := request["comment_processing"].(map[string]any)
+	if normalization["original_count"] != 1 || normalization["submitted_count"] != 1 {
+		t.Fatalf("comment_processing = %#v, want counts", normalization)
+	}
+}
+
+type reviewSubmitDiagnosticEvent struct {
+	Name   string
+	Fields map[string]any
 }

--- a/internal/infra/github/review_anchor.go
+++ b/internal/infra/github/review_anchor.go
@@ -14,35 +14,65 @@ type reviewQualityFlag struct {
 	Detail string
 }
 
-func normalizeReviewAnchors(body string, comments []ReviewComment, anchors *diffanchor.Index) (string, []ReviewComment, []reviewQualityFlag) {
+type reviewCommentProcessing struct {
+	OriginalCount   int
+	SubmittedCount  int
+	NormalizedCount int
+	DowngradedCount int
+	DroppedCount    int
+	Comments        []map[string]any
+}
+
+func normalizeReviewAnchors(body string, comments []ReviewComment, anchors *diffanchor.Index) (string, []ReviewComment, []reviewQualityFlag, reviewCommentProcessing) {
 	flags := []reviewQualityFlag{}
+	processing := reviewCommentProcessing{OriginalCount: len(comments), Comments: make([]map[string]any, 0, len(comments))}
 	if anchors == nil {
 		if len(comments) == 0 && strings.TrimSpace(body) != "" {
 			if result := diffanchor.ValidateTopLevelLocation(body); result.QualityFlagged {
 				flags = append(flags, reviewQualityFlag{Kind: "top-level-location-missing", Detail: result.Reason})
 			}
 		}
-		return body, comments, flags
+		processing.SubmittedCount = len(comments)
+		for idx := range comments {
+			comments[idx].DiagnosticIndex = idx
+			processing.Comments = append(processing.Comments, reviewCommentProcessingEntry(idx, "kept", comments[idx], comments[idx], ""))
+		}
+		return body, comments, flags, processing
 	}
 	kept := make([]ReviewComment, 0, len(comments))
 	downgraded := []string{}
-	for _, comment := range comments {
+	for idx, comment := range comments {
+		original := comment
 		anchor := diffanchor.Anchor{Path: comment.Path, Line: comment.Line, Side: comment.Side, StartLine: comment.StartLine, StartSide: comment.StartSide}
 		result := anchors.Validate(anchor)
 		if result.Valid {
-			kept = append(kept, normalizeReviewCommentAnchor(comment))
+			comment.DiagnosticIndex = idx
+			normalized := normalizeReviewCommentAnchor(comment)
+			kept = append(kept, normalized)
+			action := "kept"
+			if reviewCommentAnchorChanged(original, normalized) {
+				processing.NormalizedCount++
+				action = "normalized"
+			}
+			processing.Comments = append(processing.Comments, reviewCommentProcessingEntry(idx, action, original, normalized, ""))
 			continue
 		}
 		if nearest, ok := nearestSafeReviewAnchor(*anchors, anchor); ok {
+			comment.DiagnosticIndex = idx
 			comment.Line = nearest.Line
 			comment.Side = nearest.Side
 			comment.StartLine = nearest.StartLine
 			comment.StartSide = nearest.StartSide
 			comment.Body = addOriginalReviewLocation(comment.Body, anchor)
-			kept = append(kept, normalizeReviewCommentAnchor(comment))
+			normalized := normalizeReviewCommentAnchor(comment)
+			kept = append(kept, normalized)
+			processing.NormalizedCount++
+			processing.Comments = append(processing.Comments, reviewCommentProcessingEntry(idx, "retargeted", original, normalized, result.Reason))
 			continue
 		}
 		downgraded = append(downgraded, diffanchor.FallbackBody(comment.Body, anchor, result.Reason))
+		processing.DowngradedCount++
+		processing.Comments = append(processing.Comments, reviewCommentProcessingEntry(idx, "downgraded", original, ReviewComment{}, result.Reason))
 		if result.QualityFlagged {
 			flags = append(flags, reviewQualityFlag{Kind: "top-level-location-missing", Detail: result.Reason})
 		}
@@ -60,7 +90,55 @@ func normalizeReviewAnchors(body string, comments []ReviewComment, anchors *diff
 			flags = append(flags, reviewQualityFlag{Kind: "top-level-location-missing", Detail: result.Reason})
 		}
 	}
-	return body, kept, flags
+	processing.SubmittedCount = len(kept)
+	return body, kept, flags, processing
+}
+
+func reviewCommentProcessingEntry(index int, action string, original ReviewComment, final ReviewComment, reason string) map[string]any {
+	entry := map[string]any{"index": index, "action": action}
+	if originalAnchor := reviewCommentAnchorMap(original); len(originalAnchor) > 0 {
+		entry["original_anchor"] = originalAnchor
+	}
+	if finalAnchor := reviewCommentAnchorMap(final); len(finalAnchor) > 0 {
+		entry["final_anchor"] = finalAnchor
+	}
+	if strings.TrimSpace(reason) != "" {
+		entry["reason"] = strings.TrimSpace(reason)
+	}
+	return entry
+}
+
+func reviewCommentAnchorChanged(before ReviewComment, after ReviewComment) bool {
+	return before.Path != after.Path || before.Line != after.Line || normalizeReviewCommentSide(before.Side) != after.Side || before.StartLine != after.StartLine || normalizeReviewCommentSide(before.StartSide) != after.StartSide
+}
+
+func reviewCommentAnchorMap(comment ReviewComment) map[string]any {
+	anchor := map[string]any{}
+	if strings.TrimSpace(comment.Path) != "" {
+		anchor["path"] = comment.Path
+	}
+	if comment.Line > 0 {
+		anchor["line"] = comment.Line
+	}
+	if side := normalizeReviewCommentSide(comment.Side); side != "" {
+		anchor["side"] = side
+	}
+	if comment.StartLine > 0 {
+		anchor["start_line"] = comment.StartLine
+	}
+	if startSide := normalizeReviewCommentSide(comment.StartSide); startSide != "" {
+		anchor["start_side"] = startSide
+	}
+	return anchor
+}
+
+func markReviewCommentDropped(entries []map[string]any, index int) {
+	for _, entry := range entries {
+		if entryIndex, ok := entry["index"].(int); ok && entryIndex == index {
+			entry["action"] = "dropped"
+			return
+		}
+	}
 }
 
 func nearestSafeReviewAnchor(idx diffanchor.Index, anchor diffanchor.Anchor) (diffanchor.Anchor, bool) {

--- a/internal/infra/github/review_anchor_test.go
+++ b/internal/infra/github/review_anchor_test.go
@@ -10,7 +10,7 @@ import (
 func TestNormalizeReviewAnchorsPreservesValidAndDowngradesInvalid(t *testing.T) {
 	t.Parallel()
 	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -1,2 +1,2 @@\n-old\n+new\n keep\n")
-	body, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+	body, comments, flags, _ := normalizeReviewAnchors("Needs changes", []ReviewComment{
 		{Body: "Valid inline", Path: "app.go", Line: 1, Side: "RIGHT"},
 		{Body: "Invalid inline", Path: "app.go", Line: 99, Side: "RIGHT"},
 	}, &idx)
@@ -32,7 +32,7 @@ func TestNormalizeReviewAnchorsPreservesValidAndDowngradesInvalid(t *testing.T) 
 func TestNormalizeReviewAnchorsMovesNearbyOutOfRangeAnchorToNearestHunk(t *testing.T) {
 	t.Parallel()
 	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -10,2 +10,2 @@\n old\n+new\n")
-	body, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+	body, comments, flags, _ := normalizeReviewAnchors("Needs changes", []ReviewComment{
 		{Body: "Nearby issue", Path: "app.go", Line: 13, Side: "RIGHT"},
 	}, &idx)
 
@@ -56,7 +56,7 @@ func TestNormalizeReviewAnchorsMovesNearbyOutOfRangeAnchorToNearestHunk(t *testi
 func TestNormalizeReviewAnchorsFallsBackForFarOutOfRangeAnchor(t *testing.T) {
 	t.Parallel()
 	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -10,2 +10,2 @@\n old\n+new\n")
-	body, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+	body, comments, flags, _ := normalizeReviewAnchors("Needs changes", []ReviewComment{
 		{Body: "Far issue", Path: "app.go", Line: 99, Side: "RIGHT"},
 	}, &idx)
 
@@ -77,7 +77,7 @@ func TestNormalizeReviewAnchorsFallsBackForFarOutOfRangeAnchor(t *testing.T) {
 func TestNormalizeReviewAnchorsDoesNotMoveWrongSideContextAnchor(t *testing.T) {
 	t.Parallel()
 	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -10,3 +10,3 @@\n context\n-old\n+new\n tail\n")
-	body, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+	body, comments, flags, _ := normalizeReviewAnchors("Needs changes", []ReviewComment{
 		{Body: "Context issue", Path: "app.go", Line: 10, Side: "LEFT"},
 	}, &idx)
 
@@ -95,7 +95,7 @@ func TestNormalizeReviewAnchorsDoesNotMoveWrongSideContextAnchor(t *testing.T) {
 func TestNormalizeReviewAnchorsDoesNotMoveAmbiguousNearestAnchor(t *testing.T) {
 	t.Parallel()
 	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -10,1 +10,1 @@\n-a\n+b\n@@ -14,1 +14,1 @@\n-c\n+d\n")
-	body, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+	body, comments, flags, _ := normalizeReviewAnchors("Needs changes", []ReviewComment{
 		{Body: "Between hunks", Path: "app.go", Line: 12, Side: "RIGHT"},
 	}, &idx)
 
@@ -113,7 +113,7 @@ func TestNormalizeReviewAnchorsDoesNotMoveAmbiguousNearestAnchor(t *testing.T) {
 func TestNormalizeReviewAnchorsCanonicalizesValidSides(t *testing.T) {
 	t.Parallel()
 	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -1,2 +1,2 @@\n-old\n+new\n keep\n")
-	_, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+	_, comments, flags, _ := normalizeReviewAnchors("Needs changes", []ReviewComment{
 		{Body: "Valid inline", Path: "app.go", StartLine: 1, StartSide: "right", Line: 2, Side: "right"},
 	}, &idx)
 
@@ -131,7 +131,7 @@ func TestNormalizeReviewAnchorsCanonicalizesValidSides(t *testing.T) {
 func TestNormalizeReviewAnchorsPreservesValidPathSpaces(t *testing.T) {
 	t.Parallel()
 	idx := diffanchor.Parse("diff --git a/ leading.go b/ leading.go\n@@ -1,2 +1,2 @@\n-old\n+new\n keep\n")
-	_, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+	_, comments, flags, _ := normalizeReviewAnchors("Needs changes", []ReviewComment{
 		{Body: "Valid inline", Path: " leading.go", Line: 1, Side: "RIGHT"},
 	}, &idx)
 
@@ -148,7 +148,7 @@ func TestNormalizeReviewAnchorsPreservesValidPathSpaces(t *testing.T) {
 
 func TestNormalizeReviewAnchorsFlagsUnlocatedTopLevelComment(t *testing.T) {
 	t.Parallel()
-	_, _, flags := normalizeReviewAnchors("This is vague and needs work.", nil, nil)
+	_, _, flags, _ := normalizeReviewAnchors("This is vague and needs work.", nil, nil)
 	if len(flags) != 1 || flags[0].Kind != "top-level-location-missing" {
 		t.Fatalf("flags = %#v, want top-level-location-missing", flags)
 	}
@@ -156,7 +156,7 @@ func TestNormalizeReviewAnchorsFlagsUnlocatedTopLevelComment(t *testing.T) {
 
 func TestNormalizeReviewAnchorsDoesNotFlagEmptyTopLevelBody(t *testing.T) {
 	t.Parallel()
-	_, _, flags := normalizeReviewAnchors("", nil, nil)
+	_, _, flags, _ := normalizeReviewAnchors("", nil, nil)
 	if len(flags) != 0 {
 		t.Fatalf("flags = %#v, want none for empty top-level body", flags)
 	}
@@ -220,7 +220,7 @@ func TestReviewQualityGateRejectsExtraMalformedMarker(t *testing.T) {
 func TestNormalizeReviewAnchorsClearsSingleLineStartRange(t *testing.T) {
 	t.Parallel()
 	idx := diffanchor.Parse("diff --git a/app.go b/app.go\n@@ -1,2 +1,2 @@\n-old\n+new\n keep\n")
-	_, comments, flags := normalizeReviewAnchors("Needs changes", []ReviewComment{
+	_, comments, flags, _ := normalizeReviewAnchors("Needs changes", []ReviewComment{
 		{Body: "Valid inline", Path: "app.go", StartLine: 1, StartSide: "RIGHT", Line: 1, Side: "RIGHT"},
 	}, &idx)
 	if len(flags) != 0 {


### PR DESCRIPTION
## Summary
- add structured diagnostics for `looper review submit` validation failures and delegated `gh api` review submissions, including repo/PR/event metadata, sanitized payload markers, inline anchor summaries, and comment normalization outcomes
- capture debuggable GitHub failure details from the review submit path, including sanitized `gh` stdout/stderr, HTTP status, response body, and selected response headers such as the GitHub request id
- extend gateway and CLI tests to cover the new review-submit diagnostics and comment processing summaries

## Verification
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #237
<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.6.2 · runner=worker · agent=opencode</sub>