### PR TITLE
feat: add looper agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ go test ./...
 
 Build artifacts go to `dist/` and are gitignored — don't edit generated files.
 
+## Agent skill
+
+Looper includes an installable agent skill for setup, status, config, daemon lifecycle, and troubleshooting guidance:
+
+```bash
+npx skills add ./skills/looper
+```
+
+See [`skills/looper/SKILL.md`](skills/looper/SKILL.md) for install and verification details.
+
 ## Runtime notes
 
 - `looperd` fails fast on invalid config; runtime paths must be writable

--- a/README.md
+++ b/README.md
@@ -71,10 +71,21 @@ Fast path (macOS, `darwin-arm64`):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/install.sh | sh
-looper bootstrap --yes --project-path /path/to/repo --agent-vendor opencode
+looper bootstrap
+looper project add /path/to/your/local/repo
 ```
 
-`bootstrap` writes your config, installs the managed daemon, registers the repo as a project, and starts `looperd`.
+`bootstrap` interactively writes your config, installs the managed daemon, and starts `looperd`. Use `--yes` only for scripts or other non-interactive installs.
+
+`/path/to/your/local/repo` means the local git checkout you want Looper to watch — the directory that contains that repo's `.git` folder, not a GitHub URL. For example:
+
+```bash
+looper project add ~/src/my-app
+# or, from inside the repo:
+looper project add .
+```
+
+Add each repo you want Looper to watch after bootstrap.
 
 Full install, upgrade, uninstall, and from-source instructions: **[docs/installation.md](docs/installation.md)**.
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ Looper includes an installable agent skill for setup, status, config, daemon lif
 npx skills add ./skills/looper
 ```
 
+Or install it directly from GitHub:
+
+```bash
+npx skills add https://github.com/powerformer/looper/tree/main/skills/looper
+```
+
 See [`skills/looper/SKILL.md`](skills/looper/SKILL.md) for install and verification details.
 
 ## Runtime notes

--- a/skills/looper/SKILL.md
+++ b/skills/looper/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: looper
+description: Use when configuring, starting, checking, or troubleshooting looper, looperd, ~/.looper config, or runtime paths; when setting up Looper for agents; or when diagnosing status, logs, osascript, git, gh, writable path, or daemon startup issues.
+---
+
+# Looper
+
+Use this skill when an agent needs to configure, start, check, operate, or troubleshoot Looper (`looper` CLI, `looperd` daemon, or files under `~/.looper`).
+
+## Quick start for agents
+
+1. Read the relevant reference before acting:
+   - `references/cli.md` for installation, uninstall, and installed CLI workflows.
+   - `references/config.md` before reading or changing `~/.looper/config.json`.
+   - `references/daemon.md` before starting, stopping, or debugging `looperd`.
+2. Prefer read-only checks first:
+
+   ```bash
+   looper status
+   looper daemon status
+   looper daemon status --json
+   ```
+
+3. For local environment diagnostics, run the bundled read-only helper:
+
+   ```bash
+   bash skills/looper/scripts/check.sh
+   ```
+
+## Quick reference
+
+| Situation | Use |
+| --- | --- |
+| Need install, uninstall, bootstrap, project registration, or CLI commands | `references/cli.md` |
+| Need to inspect or edit config | `references/config.md` |
+| Need daemon startup, status, logs, or restart help | `references/daemon.md` |
+| Need read-only local diagnostics | `scripts/check.sh` |
+
+## Install this skill
+
+From a checkout of this repository, users can add the skill with:
+
+```bash
+npx skills add ./skills/looper
+```
+
+Or directly from the repository path supported by the skill installer:
+
+```bash
+npx skills add https://github.com/powerformer/looper/tree/main/skills/looper
+```
+
+Verify installation by confirming `looper` appears in the skill installer's list output, then ask the agent to “check looper status” and ensure it invokes this skill.
+
+## Safety rules
+
+- Do not overwrite or rewrite `~/.looper/config.json` without explicit user confirmation.
+- Do not delete runtime artifacts (`~/.looper/looper.sqlite`, `backups/`, `logs/`, `worktrees/`) unless the user explicitly asks and understands the impact.
+- Starting or restarting `looperd` can launch background automation against configured GitHub repositories; confirm intent before doing so.
+- Prefer `looper daemon status`, `looper daemon logs`, and `scripts/check.sh` before making changes.
+- Never print secrets from config or environment. Redact tokens and API keys in summaries.
+
+## Common mistakes
+
+- Starting with `cat ~/.looper/config.json`: use targeted inspection and redact secrets instead.
+- Restarting immediately under pressure: check status/logs first and confirm because automation may run.
+- Disabling `notifications.osascript.enabled` silently: confirm the change or set an explicit `tools.osascriptPath`.
+- Rewriting the whole config for one fix: make targeted edits and preserve existing settings.
+- Treating missing `~/.looper/` as permission to create/delete data: explain the impact and ask first.
+
+## Core facts
+
+- Default config path: `~/.looper/config.json`.
+- Config precedence: defaults → config file → environment → CLI flags.
+- Default runtime artifacts live under `~/.looper/`.
+- `looperd` fails fast on config-validation errors and requires writable runtime paths.
+- Tool paths for `git`, `gh`, and `osascript` are auto-detected unless explicitly configured.
+- If `notifications.osascript.enabled` is true, `osascript` must resolve or startup fails.
+
+## Diagnostic helper
+
+`scripts/check.sh` is read-only and deterministic. It checks required tools (`git`, `gh`), `gh auth status`, optional `osascript`, `looper --version`, config presence, and `~/.looper` writability. It exits nonzero only for missing required tools, an unset `HOME`, or unwritable runtime paths.

--- a/skills/looper/SKILL.md
+++ b/skills/looper/SKILL.md
@@ -24,7 +24,7 @@ Use this skill when an agent needs to configure, start, check, operate, or troub
 3. For local environment diagnostics, run the bundled read-only helper:
 
    ```bash
-   bash skills/looper/scripts/check.sh
+   bash scripts/check.sh
    ```
 
 ## Quick reference

--- a/skills/looper/references/cli.md
+++ b/skills/looper/references/cli.md
@@ -1,0 +1,117 @@
+# Looper CLI reference for agents
+
+This skill is for end-user Looper operation. Prefer the installed `looper` CLI and managed `looperd` daemon; do not suggest developer-only commands to end users.
+
+## Install and uninstall
+
+Install Looper with the script shown in the project README:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/install.sh | sh
+```
+
+Uninstall Looper with:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/powerformer/looper/main/scripts/uninstall.sh | sh
+```
+
+The uninstall script removes the CLI binary, managed daemon binary, and updater state. It asks before deleting config, database, backups, logs, and worktrees.
+
+## Installed CLI checks
+
+Use read-only commands before changing state:
+
+```bash
+looper status
+looper daemon status
+looper daemon status --json
+looper daemon logs
+```
+
+## Common operations
+
+Initial setup normally uses:
+
+Before bootstrap:
+
+- Confirm the target repo path is absolute and points to a Git repository.
+- Confirm the intended `agent.vendor` (for example `opencode`).
+- Check `gh auth status` and ensure `git`/`gh` resolve in the environment that will run `looperd`.
+- If `git` or `gh` are missing, ask before installing them. On macOS with Homebrew, the usual repair is `brew install git gh`; otherwise use the user's OS/package manager.
+- Ask before using `--yes`; bootstrap may create config, install or reuse the managed daemon, register a project, and start the daemon.
+- If `~/.looper/config.json` already exists, inspect targeted fields first and avoid overwriting user configuration.
+
+```bash
+looper bootstrap --yes --project-path /path/to/repo --agent-vendor opencode
+```
+
+After bootstrap, validate with:
+
+```bash
+looper status
+looper daemon status
+looper daemon logs --startup
+```
+
+## Add an existing project/repo
+
+If Looper is already installed and the user has an existing local repository, register it explicitly instead of re-running first-time bootstrap:
+
+```bash
+looper project add /absolute/path/to/repo --id myproj --repo owner/repo
+```
+
+Preflight before adding:
+
+- Confirm `/absolute/path/to/repo` is the user's intended local Git repository.
+- Prefer an absolute path; avoid registering a guessed or relative path without confirmation.
+- Confirm the GitHub repository slug (`owner/repo`) or let the user provide it.
+- Check `gh auth status` and ensure the authenticated account can access the repository.
+- If `--id` is omitted, Looper generates or infers a project id; use `--id` when the user needs a stable, memorable project id.
+- Use `--name`, `--base-branch`, and `--worktree-root` only when the user wants non-default values.
+- Use `--snapshot-mode async`, `full`, or `off` only when the user asks to control initial PR snapshot behavior; default behavior is configured by `defaults.addSnapshotMode`.
+
+Validate after adding:
+
+```bash
+looper project list
+looper status
+```
+
+After a project is registered, Looper can often infer it from commands run inside that repo. If no project matches the current directory, or multiple projects match, pass `--project <id>` explicitly.
+
+Daemon lifecycle commands:
+
+```bash
+looper daemon install
+looper daemon start
+looper daemon status
+looper daemon logs
+looper daemon restart
+looper daemon stop
+```
+
+Loop inspection commands:
+
+```bash
+looper ps
+looper logs <id> --follow
+looper jump <id>
+looper stop <id>
+```
+
+Upgrade commands:
+
+```bash
+looper upgrade --check
+looper upgrade
+looper upgrade --cli
+looper upgrade --daemon
+```
+
+## Agent behavior
+
+- Prefer status/log commands first.
+- Use installed `looper` commands for end-user setup and troubleshooting.
+- Do not rewrite user config or delete runtime artifacts unless explicitly confirmed.

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -679,7 +679,7 @@ If `server.authMode=local-token`, export `LOOPER_TOKEN` before using the CLI.
 After config or path changes, validate in this order:
 
 ```bash
-bash skills/looper/scripts/check.sh
+bash scripts/check.sh
 looper daemon status
 looper daemon logs --startup
 ```

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -88,10 +88,10 @@ Use this as a map of supported sections, not as a template to paste wholesale:
       "enabled": true
     },
     "timeouts": {
-      "plannerSeconds": 1800,
-      "workerSeconds": 3600,
-      "reviewerSeconds": 1800,
-      "fixerSeconds": 1800
+      "plannerSeconds": 3600,
+      "workerSeconds": 10800,
+      "reviewerSeconds": 5400,
+      "fixerSeconds": 7200
     }
   },
   "logging": {
@@ -287,7 +287,7 @@ Use `looper daemon status`, `looper daemon status --json`, `looper daemon logs`,
 - `params`: free-form vendor-specific parameters.
 - `env`: environment variables passed to the agent process. Redact secrets.
 - `nativeResume.enabled`: local-machine native session resume after daemon restart, default `true`.
-- `timeouts`: role-specific agent execution timeout seconds. Defaults: planner `1800`, worker `3600`, reviewer `1800`, fixer `1800`.
+- `timeouts`: role-specific agent execution timeout seconds. Defaults: planner `3600`, worker `10800`, reviewer `5400`, fixer `7200`.
 
 `vendor` is required for agent-driven loops. Without it, the daemon can run but planner/reviewer/fixer/worker loops cannot be created or started.
 

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -1,0 +1,715 @@
+# Looper configuration reference for agents
+
+Use this reference before inspecting or changing `~/.looper/config.json`. Do not overwrite user config; make targeted edits only after confirmation and redact secrets in summaries.
+
+## Install layout and config loading
+
+Default config path:
+
+```text
+~/.looper/config.json
+```
+
+For the default macOS install flow:
+
+- `looper` is installed from a GitHub Release binary.
+- `looper daemon install` installs the managed daemon binary to `~/.looper/bin/looperd`.
+- Daemon lookup order is `~/.looper/bin/looperd`, then `$PATH`.
+- `looper daemon start` writes `~/.looper/looperd.pid` and lifecycle state to `~/.looper/looperd.state.json`.
+
+`looperd` loads configuration in this order:
+
+1. built-in defaults
+2. config file
+3. environment variables
+4. CLI flags
+
+Later layers override earlier ones. Objects are merged deeply, arrays are replaced as a whole, and omitted fields keep the previous-layer value.
+
+Custom config path:
+
+- `LOOPER_CONFIG=/absolute/or/relative/path/to/config.json`
+- `looperd --config /absolute/or/relative/path/to/config.json`
+
+Relative config paths resolve from the working directory used to start `looperd`.
+
+## Minimal config
+
+`agent.vendor` has no built-in default. Set it when planner, reviewer, fixer, or worker loops should run.
+
+```json
+{
+  "agent": {
+    "vendor": "opencode"
+  },
+  "projects": [
+    {
+      "id": "looper",
+      "name": "Looper",
+      "repoPath": "/absolute/path/to/repo"
+    }
+  ]
+}
+```
+
+## Full config shape
+
+Use this as a map of supported sections, not as a template to paste wholesale:
+
+```json
+{
+  "server": {
+    "host": "127.0.0.1",
+    "port": 17310,
+    "authMode": "local-token",
+    "localToken": "replace-me"
+  },
+  "storage": {
+    "mode": "sqlite",
+    "dbPath": "/Users/you/.looper/looper.sqlite",
+    "backupDir": "/Users/you/.looper/backups"
+  },
+  "scheduler": {
+    "pollIntervalSeconds": 30,
+    "maxConcurrentRuns": 3,
+    "retryMaxAttempts": 5,
+    "retryBaseDelayMs": 5000
+  },
+  "agent": {
+    "vendor": "opencode",
+    "model": "your-model-if-needed",
+    "params": {
+      "reasoning": "medium"
+    },
+    "env": {
+      "OPENAI_API_KEY": "replace-me"
+    },
+    "nativeResume": {
+      "enabled": true
+    },
+    "timeouts": {
+      "plannerSeconds": 1800,
+      "workerSeconds": 3600,
+      "reviewerSeconds": 1800,
+      "fixerSeconds": 1800
+    }
+  },
+  "logging": {
+    "level": "info",
+    "maxSizeMB": 10,
+    "maxFiles": 5
+  },
+  "notifications": {
+    "inApp": true,
+    "osascript": {
+      "enabled": true,
+      "soundForLevels": ["action_required", "failure"],
+      "throttleWindowSeconds": 60
+    }
+  },
+  "disclosure": {
+    "enabled": true,
+    "includeAgent": true,
+    "includeOS": false,
+    "channels": {
+      "gitCommit": true,
+      "pullRequest": true,
+      "issueComment": true,
+      "reviewComment": true,
+      "inlineCommentVisible": false
+    }
+  },
+  "tools": {
+    "gitPath": "/usr/bin/git",
+    "ghPath": "/opt/homebrew/bin/gh",
+    "osascriptPath": "/usr/bin/osascript"
+  },
+  "daemon": {
+    "mode": "foreground",
+    "restartPolicy": "on-failure",
+    "restartThrottleSeconds": 10,
+    "logDir": "/Users/you/.looper/logs",
+    "workingDirectory": "/absolute/path/to/where/you/start/looperd",
+    "environment": {
+      "EXAMPLE_FLAG": "1"
+    }
+  },
+  "package": {
+    "distribution": "github-release",
+    "autoMigrateOnStartup": true,
+    "requireBackupBeforeMigrate": false
+  },
+  "defaults": {
+    "baseBranch": "main",
+    "allowAutoCommit": true,
+    "allowAutoPush": true,
+    "allowAutoApprove": false,
+    "allowAutoMerge": false,
+    "allowRiskyFixes": false,
+    "openPrStrategy": "all_done",
+    "addSnapshotMode": "async"
+  },
+  "reviewer": {
+    "reviewEvents": {
+      "clean": "COMMENT",
+      "blocking": "COMMENT"
+    }
+  },
+  "roles": {
+    "planner": {
+      "autoDiscovery": true,
+      "triggers": {
+        "labels": ["looper:plan"],
+        "labelMode": "all",
+        "requireAssigneeCurrentUser": true
+      }
+    },
+    "reviewer": {
+      "autoDiscovery": true,
+      "triggers": {
+        "includeDrafts": false,
+        "requireReviewRequest": true,
+        "labels": [],
+        "labelMode": "all"
+      },
+      "specReview": {
+        "includeReviewingLabel": true,
+        "reviewingLabel": "looper:spec-reviewing"
+      }
+    },
+    "fixer": {
+      "autoDiscovery": true,
+      "triggers": {
+        "includeDrafts": false,
+        "authorFilter": "current_user",
+        "labels": [],
+        "labelMode": "all"
+      }
+    },
+    "worker": {
+      "autoDiscovery": true,
+      "triggers": {
+        "labels": ["looper:worker-ready"],
+        "labelMode": "all",
+        "requireAssigneeCurrentUser": true
+      }
+    }
+  },
+  "projects": [
+    {
+      "id": "looper",
+      "name": "Looper",
+      "repoPath": "/absolute/path/to/looper",
+      "baseBranch": "main",
+      "worktreeRoot": "/Users/you/.looper/worktrees/looper",
+      "roles": {
+        "worker": {
+          "triggers": {
+            "labels": ["team:alpha", "worker-ready"],
+            "labelMode": "any"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+## Runtime paths
+
+Default runtime artifacts live under `~/.looper/`:
+
+- `config.json`
+- `looper.sqlite`
+- `backups/`
+- `logs/`
+- `worktrees/`
+- `bin/looperd`
+- `looperd.pid`
+- `looperd.state.json`
+
+Default storage paths:
+
+- DB: `~/.looper/looper.sqlite`
+- backups: `~/.looper/backups`
+
+## Daemon supervision config
+
+Supervision applies only to `looperd` lifecycle. Looper does not supervise arbitrary user commands or agent subprocesses.
+
+`daemon.mode` values:
+
+- `foreground` (default): starts `looperd` as a detached background process. It writes pid/state files but is not actively supervised and will not automatically restart after crash, logout, or reboot.
+- `launchd`: on macOS, installs and bootstraps a user LaunchAgent. It can restart according to `daemon.restartPolicy` and start at login. Unsupported platforms return an actionable error.
+
+Restart options:
+
+- `daemon.restartPolicy`: `never`, `on-failure`, or `always` (default `on-failure`).
+- `daemon.restartThrottleSeconds`: positive integer throttle, default `10`.
+- `daemon.plistPath`: optional macOS LaunchAgent plist path. Default: `~/Library/LaunchAgents/com.powerformer.looper.looperd.plist`.
+
+Runtime diagnostics:
+
+- state: `~/.looper/looperd.state.json`
+- pid: `~/.looper/looperd.pid`
+- main log: `~/.looper/logs/looperd.log`
+- startup logs: `~/.looper/logs/startup/`
+- launchd logs: `~/.looper/logs/launchd/looperd.stdout.log`, `~/.looper/logs/launchd/looperd.stderr.log`
+
+Use `looper daemon status`, `looper daemon status --json`, `looper daemon logs`, and `looper daemon logs --startup` to inspect daemon state.
+
+## Field reference
+
+### `server`
+
+- `host`: bind host, default `127.0.0.1`.
+- `port`: bind port, default `17310`.
+- `authMode`: `none` or `local-token`.
+- `localToken`: required when `authMode` is `local-token`. If enabled, export `LOOPER_TOKEN` before using the CLI.
+
+### `storage`
+
+- `mode`: currently must be `sqlite`.
+- `dbPath`: SQLite database path.
+- `backupDir`: backup output directory.
+
+### `scheduler`
+
+- `pollIntervalSeconds`: queue poll interval, integer `>= 10`.
+- `maxConcurrentRuns`: positive integer.
+- `retryMaxAttempts`: positive integer.
+- `retryBaseDelayMs`: positive integer.
+
+### `agent`
+
+- `vendor`: one of `claude-code`, `codex`, `opencode`, `cursor-cli`.
+- `model`: optional model identifier.
+- `params`: free-form vendor-specific parameters.
+- `env`: environment variables passed to the agent process. Redact secrets.
+- `nativeResume.enabled`: local-machine native session resume after daemon restart, default `true`.
+- `timeouts`: role-specific agent execution timeout seconds. Defaults: planner `1800`, worker `3600`, reviewer `1800`, fixer `1800`.
+
+`vendor` is required for agent-driven loops. Without it, the daemon can run but planner/reviewer/fixer/worker loops cannot be created or started.
+
+Native resume is local-machine only. Session stores are not portable across hosts or users, and resume can fall back if the vendor CLI cannot reattach. Set `LOOPER_AGENT_NATIVE_RESUME_ENABLED=false` to disable it.
+
+### `logging`
+
+- `level`: `debug`, `info`, `warn`, or `error`.
+- `maxSizeMB`: positive integer log rotation size.
+- `maxFiles`: positive integer retained file count, including active `looperd.log`.
+
+### `notifications`
+
+- `inApp`: enables in-app notifications.
+- `osascript.enabled`: enables macOS notifications.
+- `osascript.soundForLevels`: subset of `action_required`, `failure`.
+- `osascript.throttleWindowSeconds`: positive integer.
+
+Defaults:
+
+- macOS: `notifications.osascript.enabled=true`.
+- non-macOS: `notifications.osascript.enabled=false`.
+
+If `notifications.osascript.enabled=true`, `tools.osascriptPath` must resolve.
+
+Disable osascript notifications only after confirmation:
+
+```json
+{
+  "notifications": {
+    "osascript": {
+      "enabled": false
+    }
+  }
+}
+```
+
+### `disclosure`
+
+`looperd` adds local attribution to generated GitHub text and commit messages. This is not telemetry.
+
+- `enabled`: disclosure stamps, default `true`.
+- `includeAgent`: include configured agent vendor/model, default `true`.
+- `includeOS`: include OS family only, default `false`.
+- `channels.gitCommit`: add `Generated-By:` trailer.
+- `channels.pullRequest`: add PR body footer.
+- `channels.issueComment`: add issue/PR comment footer.
+- `channels.reviewComment`: disclose generated review summaries and inline comments.
+- `channels.inlineCommentVisible`: visible footer for inline comments when `true`; hidden marker when `false`.
+
+Disclosure stamps use an allowlist: product, version, runner role, configured agent vendor/model, and optionally OS family. They do not include hostnames, usernames, local paths, IP/MAC addresses, kernel versions, env vars, tokens, endpoints, or machine identifiers.
+
+### `tools`
+
+- `gitPath`
+- `ghPath`
+- `osascriptPath`
+
+If omitted, `looperd` detects from `PATH`. Startup validation fails when required tools cannot resolve.
+
+Use targeted edits like these only after confirmation:
+
+```json
+{
+  "tools": {
+    "gitPath": "/opt/homebrew/bin/git",
+    "ghPath": "/opt/homebrew/bin/gh",
+    "osascriptPath": "/usr/bin/osascript"
+  }
+}
+```
+
+If a tool exists in an interactive shell but not for `looperd`, suspect a daemon environment `PATH` mismatch. Prefer explicit `tools.*Path` over shell-profile changes.
+
+### `daemon`
+
+- `mode`: `foreground` or `launchd`.
+- `restartPolicy`: `never`, `on-failure`, or `always`.
+- `restartThrottleSeconds`: positive supervisor restart throttle in seconds.
+- `plistPath`: optional macOS user LaunchAgent plist path for `launchd` mode.
+- `logDir`: daemon log directory.
+- `shutdownTimeoutMs`: graceful shutdown timeout in milliseconds.
+- `workingDirectory`: daemon working directory.
+- `environment`: reserved daemon environment map; part of config surface but not a primary user-facing runtime control.
+
+Defaults: `mode=foreground`, `restartPolicy=on-failure`, `restartThrottleSeconds=10`, `logDir=~/.looper/logs`, `shutdownTimeoutMs=1000`, `workingDirectory` is the current working directory when config loads.
+
+### `package`
+
+- `distribution`: install-channel metadata; current supported installs use `github-release`.
+- `autoMigrateOnStartup`: run DB migrations on startup.
+- `requireBackupBeforeMigrate`: require a backup before migrations.
+
+### `defaults`
+
+- `baseBranch`: default project branch, usually `main`.
+- `allowAutoCommit`: default `true`.
+- `allowAutoPush`: default `true`.
+- `allowAutoApprove`: default `false`.
+- `allowAutoMerge`: default `false`.
+- `allowRiskyFixes`: default `false`.
+- `fixAllPullRequests`: legacy fixer discovery switch, default `false`; prefer `roles.fixer.triggers.authorFilter`.
+- `openPrStrategy`: `all_done`, `first_commit`, or `manual`; default `all_done`.
+- `addSnapshotMode`: `async`, `full`, or `off`; default `async`. `looper project add --snapshot-mode` overrides per request.
+
+`defaults.allowAutoApprove=true` is a legacy alias for reviewer clean approvals. Explicit `reviewer.reviewEvents.clean` wins.
+
+### `reviewer`
+
+- `reviewEvents.clean`: `COMMENT` or `APPROVE`, default `COMMENT`.
+- `reviewEvents.blocking`: `COMMENT` or `REQUEST_CHANGES`, default `COMMENT`.
+- Deprecated reviewer budget options are ignored by the reviewer filter.
+
+Safe default comment-only behavior:
+
+```json
+{
+  "reviewer": {
+    "reviewEvents": {
+      "clean": "COMMENT",
+      "blocking": "COMMENT"
+    }
+  }
+}
+```
+
+Decision reviews require explicit opt-in:
+
+```json
+{
+  "reviewer": {
+    "reviewEvents": {
+      "clean": "APPROVE",
+      "blocking": "REQUEST_CHANGES"
+    }
+  }
+}
+```
+
+Reviewer behavior matrix:
+
+| Reviewer outcome | `reviewEvents.clean` | `reviewEvents.blocking` | GitHub event |
+| --- | --- | --- | --- |
+| `clean` | `COMMENT` | any | `COMMENT` |
+| `clean` | `APPROVE` | any | `APPROVE` |
+| `non_blocking` | any | any | `COMMENT` |
+| `blocking` | any | `COMMENT` | `COMMENT` |
+| `blocking` | any | `REQUEST_CHANGES` | `REQUEST_CHANGES` |
+| legacy `actionable` | any | any | `COMMENT` |
+
+One-off reviewer jobs can snapshot policy into loop metadata:
+
+```bash
+looper review owner/repo#123 \
+  --clean-review-event APPROVE \
+  --blocking-review-event REQUEST_CHANGES
+```
+
+### `roles`
+
+The `roles` section controls scheduler auto-discovery for planner, reviewer, fixer, and worker. It does not block manual commands, direct processing, retries, or already queued work.
+
+Default discovery:
+
+- planner: open issues labeled `looper:plan` assigned to current GitHub user.
+- worker: open issues labeled `looper:worker-ready` assigned to current GitHub user.
+- reviewer: open non-draft PRs where current user is requested for review, plus spec-review follow-up.
+- fixer: open non-draft PRs authored by current user that have actionable review items.
+
+Common fields:
+
+- `roles.<role>.autoDiscovery`: when `false`, scheduler skips new discovery for that role.
+- issue roles (`planner`, `worker`): `triggers.labels`, `triggers.labelMode` (`all` or `any`), `triggers.requireAssigneeCurrentUser`.
+- reviewer: `triggers.includeDrafts`, `triggers.requireReviewRequest`, `triggers.labels`, `triggers.labelMode`, `specReview.includeReviewingLabel`, `specReview.reviewingLabel`.
+- fixer: `triggers.includeDrafts`, `triggers.authorFilter` (`current_user` or `any`), `triggers.labels`, `triggers.labelMode`.
+
+Trigger fields are combined with logical AND. Empty label lists mean no label constraint.
+
+Examples:
+
+```json
+{
+  "roles": {
+    "planner": {
+      "triggers": {
+        "labels": ["team:alpha", "needs-plan"],
+        "labelMode": "any",
+        "requireAssigneeCurrentUser": false
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "roles": {
+    "reviewer": {
+      "autoDiscovery": false
+    },
+    "fixer": {
+      "triggers": {
+        "authorFilter": "any"
+      }
+    }
+  }
+}
+```
+
+`defaults.fixAllPullRequests=true` maps to `roles.fixer.triggers.authorFilter=any` only when that role field is not explicitly configured.
+
+### `projects`
+
+Each project registers a repo Looper can target.
+
+Prefer `looper project add /absolute/path/to/repo --id <id> --repo owner/repo` for adding an existing local repository. Edit `projects[]` manually only when the CLI flow is not suitable and after confirming the exact config change.
+
+- `id`: stable unique identifier.
+- `name`: display name.
+- `repoPath`: absolute repository path.
+- `baseBranch`: optional per-project override.
+- `worktreeRoot`: optional per-project worktree root.
+- `roles`: optional per-project role overrides for `planner`, `worker`, `reviewer`, and `fixer`.
+
+Project role overrides fall back to global role values when fields are absent. Unknown role keys are rejected during config loading.
+
+```json
+{
+  "projects": [
+    {
+      "id": "looper",
+      "name": "Looper",
+      "repoPath": "/Users/you/src/looper",
+      "baseBranch": "main",
+      "worktreeRoot": "/Users/you/.looper/worktrees/looper",
+      "roles": {
+        "reviewer": {
+          "triggers": {
+            "labels": ["needs-review"],
+            "requireReviewRequest": false
+          }
+        },
+        "worker": {
+          "autoDiscovery": false
+        }
+      }
+    }
+  ]
+}
+```
+
+## Environment variable overrides
+
+Supported environment overrides:
+
+- `LOOPER_CONFIG`
+- `LOOPER_HOST`
+- `LOOPER_PORT`
+- `LOOPER_DB_PATH`
+- `LOOPER_LOG_DIR`
+- `LOOPER_DAEMON_MODE`
+- `LOOPER_DAEMON_RESTART_POLICY`
+- `LOOPER_DAEMON_RESTART_THROTTLE_SECONDS`
+- `LOOPER_WORKING_DIRECTORY`
+- `LOOPER_GIT_PATH`
+- `LOOPER_GH_PATH`
+- `LOOPER_OSASCRIPT_PATH`
+- `LOOPER_OSASCRIPT_ENABLED`
+- `LOOPER_IN_APP_NOTIFICATIONS`
+- `LOOPER_AGENT_NATIVE_RESUME_ENABLED`
+- `LOOPER_AGENT_TIMEOUTS_PLANNER_SECONDS`
+- `LOOPER_AGENT_TIMEOUTS_WORKER_SECONDS`
+- `LOOPER_AGENT_TIMEOUTS_REVIEWER_SECONDS`
+- `LOOPER_AGENT_TIMEOUTS_FIXER_SECONDS`
+- `LOOPER_ALLOW_AUTO_COMMIT`
+- `LOOPER_ALLOW_AUTO_PUSH`
+- `LOOPER_ALLOW_AUTO_APPROVE`
+- `LOOPER_REVIEWER_REVIEW_EVENTS_CLEAN`
+- `LOOPER_REVIEWER_REVIEW_EVENTS_BLOCKING`
+- `LOOPER_FIX_ALL_PULL_REQUESTS`
+- `LOOPER_ROLES_PLANNER_AUTO_DISCOVERY`
+- `LOOPER_ROLES_PLANNER_TRIGGERS_LABELS`
+- `LOOPER_ROLES_PLANNER_TRIGGERS_LABEL_MODE`
+- `LOOPER_ROLES_PLANNER_TRIGGERS_REQUIRE_ASSIGNEE_CURRENT_USER`
+- `LOOPER_ROLES_WORKER_AUTO_DISCOVERY`
+- `LOOPER_ROLES_WORKER_TRIGGERS_LABELS`
+- `LOOPER_ROLES_WORKER_TRIGGERS_LABEL_MODE`
+- `LOOPER_ROLES_WORKER_TRIGGERS_REQUIRE_ASSIGNEE_CURRENT_USER`
+- `LOOPER_ROLES_REVIEWER_AUTO_DISCOVERY`
+- `LOOPER_ROLES_REVIEWER_TRIGGERS_INCLUDE_DRAFTS`
+- `LOOPER_ROLES_REVIEWER_TRIGGERS_REQUIRE_REVIEW_REQUEST`
+- `LOOPER_ROLES_REVIEWER_TRIGGERS_LABELS`
+- `LOOPER_ROLES_REVIEWER_TRIGGERS_LABEL_MODE`
+- `LOOPER_ROLES_REVIEWER_SPEC_REVIEW_INCLUDE_REVIEWING_LABEL`
+- `LOOPER_ROLES_REVIEWER_SPEC_REVIEW_REVIEWING_LABEL`
+- `LOOPER_ROLES_FIXER_AUTO_DISCOVERY`
+- `LOOPER_ROLES_FIXER_TRIGGERS_INCLUDE_DRAFTS`
+- `LOOPER_ROLES_FIXER_TRIGGERS_LABELS`
+- `LOOPER_ROLES_FIXER_TRIGGERS_LABEL_MODE`
+- `LOOPER_ROLES_FIXER_TRIGGERS_AUTHOR_FILTER`
+
+Boolean environment variables accept truthy `1`, `true`, `yes`, `on` and falsy `0`, `false`, `no`, `off`.
+
+Example:
+
+```bash
+LOOPER_CONFIG="$HOME/custom-looper/config.json" \
+LOOPER_PORT=4321 \
+LOOPER_ALLOW_AUTO_PUSH=false \
+looperd
+```
+
+Migration note: the default `looperd` port changed from `4310` to `17310`. Explicit config, `LOOPER_PORT`, and `--port` keep precedence.
+
+Precedence example: config sets port `4310`, `LOOPER_PORT=5000`, and `looperd --port 6000` means daemon uses `6000`.
+
+## CLI flag overrides
+
+Supported `looperd` flags:
+
+- `--config`
+- `--host`
+- `--port`
+- `--db-path`
+- `--log-dir`
+- `--daemon-mode`
+- `--daemon-restart-policy`
+- `--daemon-restart-throttle-seconds`
+- `--git-path`
+- `--gh-path`
+- `--osascript-path`
+- `--planner-agent-timeout-seconds`
+- `--worker-agent-timeout-seconds`
+- `--reviewer-agent-timeout-seconds`
+- `--fixer-agent-timeout-seconds`
+- `--allow-auto-commit`
+- `--allow-auto-push`
+- `--allow-auto-approve`
+- `--reviewer-clean-review-event`
+- `--reviewer-blocking-review-event`
+
+Example:
+
+```bash
+looperd \
+  --config "$HOME/custom-looper/config.json" \
+  --port 4321 \
+  --allow-auto-push=false
+```
+
+## Validation rules and startup failures
+
+`looperd` fails fast on invalid config. Common validation rules:
+
+- required strings must be non-empty
+- numeric fields must be positive integers where applicable
+- `server.port` must be between `1` and `65535`
+- `scheduler.pollIntervalSeconds` must be at least `10`
+- `authMode=local-token` requires `server.localToken`
+- `projects[].id` must be valid and unique
+- `storage.dbPath` parent directory must be writable
+- `daemon.logDir` must be writable
+- `daemon.workingDirectory` must be writable
+- default worktree root must be writable
+- required tool paths must resolve
+- `osascript` must resolve when osascript notifications are enabled
+
+Writable path recovery:
+
+1. Stop or avoid starting the daemon before changing runtime files.
+2. Check ownership and permissions of `~/.looper` and configured storage/log/backup/worktree paths.
+3. If paths contain important data (`looper.sqlite`, `backups/`, `worktrees/`), back up or move them before repairs.
+4. Prefer fixing ownership/permissions or relocating configured paths over deleting runtime state.
+5. If the user still wants deletion, explain it can remove config, DB state, backups, logs, worktrees, daemon binaries, pid, and lifecycle state.
+
+## Recommended first-time setup
+
+1. Install `git` and `gh`.
+2. Create `~/.looper/config.json` or run confirmed bootstrap flow.
+3. Add at least one project in `projects`.
+4. Set `agent.vendor`.
+5. Start the daemon with installed `looper` / managed `looperd`.
+6. Run `looper config show` to inspect effective config.
+
+If `server.authMode=local-token`, export `LOOPER_TOKEN` before using the CLI.
+
+## Troubleshooting
+
+After config or path changes, validate in this order:
+
+```bash
+bash skills/looper/scripts/check.sh
+looper daemon status
+looper daemon logs --startup
+```
+
+Restart only after confirming with the user because `looperd` may launch configured repository automation.
+
+### `tools.gitPath` or `tools.ghPath` could not be resolved
+
+Set explicit paths in config or ensure binaries are on `PATH` for the environment that starts `looperd`. Check `command -v git`, `command -v gh`, and `gh auth status`.
+
+### `tools.osascriptPath is required when osascript notifications are enabled`
+
+Either install/expose `osascript`, set `tools.osascriptPath`, or disable macOS notifications after confirmation.
+
+### A runtime path is not writable
+
+Make sure the daemon user can write to:
+
+- parent directory of `storage.dbPath`
+- `daemon.logDir`
+- `daemon.workingDirectory`
+- default worktree root under `~/.looper/worktrees`
+
+### `server.authMode=local-token` CLI failures
+
+If local-token auth is enabled, `server.localToken` must be configured and CLI calls need matching `LOOPER_TOKEN` in the environment.
+
+## Safety notes
+
+- Ask before creating, overwriting, or deleting `~/.looper/config.json`.
+- Never expose secrets from `agent.env`, tokens, or local environment variables.
+- Prefer targeted JSON edits over rewriting the whole config.
+- Confirm before changing configured projects, worktree roots, defaults that allow auto-push/auto-merge, reviewer approval behavior, or notification settings.

--- a/skills/looper/references/daemon.md
+++ b/skills/looper/references/daemon.md
@@ -1,0 +1,75 @@
+# Looper daemon reference for agents
+
+`looperd` is the background daemon that polls GitHub and runs configured Looper roles. Starting or restarting it can trigger repository automation, so confirm user intent before changing lifecycle state.
+
+## Read-only checks
+
+Start with:
+
+```bash
+looper daemon status
+looper daemon status --json
+looper status
+looper daemon logs
+looper daemon logs --startup
+```
+
+## Install and start
+
+Managed daemon install:
+
+```bash
+looper daemon install
+looper daemon start
+```
+
+By default, `looper daemon start` launches `looperd` detached. Detached mode writes `~/.looper/looperd.pid` and `~/.looper/looperd.state.json`, but it is not supervised across crashes, logout, or reboot.
+
+On macOS, supervised LaunchAgent mode is available:
+
+```bash
+looper daemon start --daemon-mode launchd
+looper daemon status
+looper daemon logs
+```
+
+Launchd mode creates or uses a user LaunchAgent plist and stores logs under `~/.looper/logs/`.
+
+## Troubleshooting startup failures
+
+Check these before changing config:
+
+1. `git` and `gh` are installed and resolvable.
+2. `gh` is authenticated for the target repositories.
+3. `~/.looper/` and configured storage/log/backup/worktree paths are writable.
+4. `~/.looper/config.json` is valid JSON and passes Looper validation.
+5. If notifications enable osascript, `osascript` resolves.
+6. The managed daemon binary exists at `~/.looper/bin/looperd` or `looperd` resolves on `PATH`.
+
+Useful checks:
+
+```bash
+command -v git
+command -v gh
+gh auth status
+command -v osascript
+test -w ~/.looper
+```
+
+If a tool resolves in your shell but not for `looperd`, set explicit `tools.gitPath`, `tools.ghPath`, or `tools.osascriptPath` in config after confirming with the user.
+
+If `git` or `gh` are missing, ask before installing them. On macOS with Homebrew, the usual repair is:
+
+```bash
+brew install git gh
+```
+
+On other systems, use the user's OS/package manager.
+
+Useful repair command after daemon binary issues:
+
+```bash
+looper daemon install --force
+```
+
+After any repair, re-run read-only checks and only run repair or restart commands after confirming with the user.

--- a/skills/looper/scripts/check.sh
+++ b/skills/looper/scripts/check.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -eu
+
+status=0
+
+say() {
+  printf '%s\n' "$1"
+}
+
+check_cmd() {
+  name="$1"
+  if command -v "$name" >/dev/null 2>&1; then
+    say "ok: $name -> $(command -v "$name")"
+  else
+    say "missing: $name"
+    status=1
+  fi
+}
+
+say "Looper environment check (read-only)"
+
+home="${HOME:-}"
+if [ -z "$home" ]; then
+  say "error: HOME is not set"
+  exit 1
+fi
+
+check_cmd git
+check_cmd gh
+
+if command -v gh >/dev/null 2>&1; then
+  if gh auth status >/dev/null 2>&1; then
+    say "ok: gh auth status works"
+  else
+    say "warn: gh found but auth status failed"
+  fi
+fi
+
+if command -v osascript >/dev/null 2>&1; then
+  say "ok: osascript -> $(command -v osascript)"
+else
+  say "warn: osascript not found (required only when notifications.osascript.enabled is true)"
+fi
+
+if command -v looper >/dev/null 2>&1; then
+  say "ok: looper -> $(command -v looper)"
+  if looper --version >/dev/null 2>&1; then
+    say "ok: looper --version works"
+  else
+    say "warn: looper found but --version failed"
+  fi
+else
+  say "warn: looper not found on PATH"
+fi
+
+config_path="${LOOPER_CONFIG:-$home/.looper/config.json}"
+if [ -f "$config_path" ]; then
+  say "ok: config exists at $config_path"
+else
+  say "warn: config not found at $config_path"
+fi
+
+runtime_dir="$home/.looper"
+if [ -d "$runtime_dir" ]; then
+  if [ -w "$runtime_dir" ]; then
+    say "ok: runtime directory writable at $runtime_dir"
+  else
+    say "error: runtime directory is not writable at $runtime_dir"
+    status=1
+  fi
+else
+  say "warn: runtime directory does not exist at $runtime_dir (not creating it)"
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary
- Add an installable Looper agent skill with frontmatter, install instructions, safety rules, and read-only diagnostics.
- Document end-user CLI, daemon lifecycle, project registration, config, troubleshooting, and runtime guidance under `skills/looper/references/`.
- Link the skill from the README so users can install it with `npx skills add`.

## Test Plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `skills/looper/scripts/check.sh`
- [x] skill docs validation checks for required coverage and no developer-only Go commands