### PR TITLE
feat: auto-upgrade supported installs

### DIFF
--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -227,6 +227,7 @@
           },
           "package": {
             "distribution": "github-release",
+            "autoUpgradeEnabled": true,
             "autoMigrateOnStartup": true,
             "requireBackupBeforeMigrate": false
           },

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -427,6 +427,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 	})
 
 	addFlags(root.PersistentFlags(), globalFlags())
+	root.PersistentPreRunE = runtime.maybeRunAutoUpgrade
 	root.SetOut(a.stdout())
 	root.SetErr(a.stderr())
 	if a.deps.Stdin != nil {
@@ -577,6 +578,7 @@ func collectFlags(flagSet *pflag.FlagSet) []string {
 func globalFlags() []flagSpec {
 	return []flagSpec{
 		boolFlag("json", "Emit JSON output"),
+		boolFlag("no-auto-upgrade", "Disable automatic upgrade checks for this command"),
 		stringFlag("config", "path", "Config path"),
 		stringFlag("host", "host", "Server host"),
 		stringFlag("port", "port", "Server port"),
@@ -648,6 +650,7 @@ func (a *App) stderr() io.Writer {
 
 var configFlagNames = map[string]struct{}{
 	"config":                                {},
+	"no-auto-upgrade":                       {},
 	"host":                                  {},
 	"port":                                  {},
 	"db-path":                               {},
@@ -674,6 +677,7 @@ var configFlagNames = map[string]struct{}{
 }
 
 var configBoolFlagNames = map[string]struct{}{
+	"no-auto-upgrade":        {},
 	"no-custom-instructions": {},
 }
 

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -1033,7 +1033,18 @@ func TestConfigSetRejectsInvalidKeyAndValue(t *testing.T) {
 }
 
 func TestConfigValidateAndShowSource(t *testing.T) {
-	configPath := writeEditableCLIConfig(t)
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": false},
+		},
+		"defaults": map[string]any{
+			"allowRiskyFixes":    false,
+			"fixAllPullRequests": false,
+		},
+		"package": map[string]any{
+			"autoUpgradeEnabled": false,
+		},
+	})
 
 	exitCode, stdout, stderr := runApp(t, "config", "validate", "--config", configPath)
 	if exitCode != 0 {
@@ -1064,6 +1075,16 @@ func TestConfigValidateAndShowSource(t *testing.T) {
 	}
 	if got, want := allowRisky["value"], false; got != want {
 		t.Fatalf("value = %#v, want %#v", got, want)
+	}
+	autoUpgrade, ok := fields["package.autoUpgradeEnabled"].(map[string]any)
+	if !ok {
+		t.Fatalf("package.autoUpgradeEnabled = %#v, want object", fields["package.autoUpgradeEnabled"])
+	}
+	if got, want := autoUpgrade["source"], "config-file"; got != want {
+		t.Fatalf("package.autoUpgradeEnabled source = %#v, want %#v", got, want)
+	}
+	if got, want := autoUpgrade["value"], false; got != want {
+		t.Fatalf("package.autoUpgradeEnabled value = %#v, want %#v", got, want)
 	}
 
 	exitCode, stdout, stderr = runApp(t, "config", "show", "--source", "--no-custom-instructions=false", "--config", configPath)

--- a/internal/cliapp/config_commands.go
+++ b/internal/cliapp/config_commands.go
@@ -674,6 +674,8 @@ func configFieldSet(partial config.PartialConfig, key string) bool {
 		return partial.Defaults.OpenPRStrategy != nil
 	case "instructions.enabled":
 		return partial.Instructions != nil && partial.Instructions.Enabled != nil
+	case "package.autoUpgradeEnabled":
+		return partial.Package != nil && partial.Package.AutoUpgradeEnabled != nil
 	case "instructions.maxBytes":
 		return partial.Instructions != nil && partial.Instructions.MaxBytes != nil
 	case "reviewer.reviewEvents.clean":

--- a/internal/cliapp/config_commands.go
+++ b/internal/cliapp/config_commands.go
@@ -35,6 +35,7 @@ var configFieldRegistry = map[string]configField{
 	"defaults.fixAllPullRequests": boolField("defaults.fixAllPullRequests", "LOOPER_FIX_ALL_PULL_REQUESTS", "fix-all-pull-requests", func(c config.Config) any { return c.Defaults.FixAllPullRequests }, func(p *config.PartialConfig) **bool { return &ensurePartialDefaults(p).FixAllPullRequests }),
 	"defaults.openPrStrategy":     openPRStrategyField(),
 	"instructions.enabled":        boolField("instructions.enabled", "", "no-custom-instructions", func(c config.Config) any { return c.Instructions.Enabled }, func(p *config.PartialConfig) **bool { return &ensurePartialInstructions(p).Enabled }),
+	"package.autoUpgradeEnabled":  boolField("package.autoUpgradeEnabled", "LOOPER_AUTO_UPGRADE_ENABLED", "no-auto-upgrade", func(c config.Config) any { return c.Package.AutoUpgradeEnabled }, func(p *config.PartialConfig) **bool { return &ensurePartialPackage(p).AutoUpgradeEnabled }),
 	"instructions.maxBytes":       positiveIntField("instructions.maxBytes", "", "", func(c config.Config) any { return c.Instructions.MaxBytes }, func(p *config.PartialConfig) **int { return &ensurePartialInstructions(p).MaxBytes }),
 	"reviewer.reviewEvents.clean": reviewerReviewEventField("reviewer.reviewEvents.clean", "LOOPER_REVIEWER_REVIEW_EVENTS_CLEAN", "reviewer-clean-review-event", func(c config.Config) any { return c.Reviewer.ReviewEvents.Clean }, func(p *config.PartialConfig) **config.ReviewerReviewEvent {
 		return &ensurePartialReviewerReviewEvents(p).Clean
@@ -541,6 +542,13 @@ func ensurePartialInstructions(partial *config.PartialConfig) *config.PartialIns
 		partial.Instructions = &config.PartialInstructionsConfig{}
 	}
 	return partial.Instructions
+}
+
+func ensurePartialPackage(partial *config.PartialConfig) *config.PartialPackageConfig {
+	if partial.Package == nil {
+		partial.Package = &config.PartialPackageConfig{}
+	}
+	return partial.Package
 }
 
 func ensurePartialRoles(partial *config.PartialConfig) *config.PartialRoleConfigs {

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -105,10 +105,7 @@ func (r *commandRuntime) daemonStatus(cmd *cobra.Command, args []string) error {
 	var managedVersion *daemonVersionState
 	managedPath, managedPathErr := r.managedDaemonBinaryPath()
 	if managedPathErr == nil && (versionState == nil || (versionState.BinaryPath != nil && *versionState.BinaryPath == managedPath)) {
-		managedVersion, err = r.readManagedDaemonVersion(cmd.Context())
-		if err != nil {
-			return err
-		}
+		managedVersion, _ = r.readManagedDaemonVersion(cmd.Context())
 	}
 
 	output := daemonStatusOutput{

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -48,20 +48,24 @@ type daemonVersionState struct {
 }
 
 type daemonStatusOutput struct {
-	Mode                   config.DaemonMode          `json:"mode"`
-	ConfiguredMode         config.DaemonMode          `json:"configuredMode"`
-	RunningMode            *config.DaemonMode         `json:"runningMode,omitempty"`
-	RestartPolicy          config.DaemonRestartPolicy `json:"restartPolicy"`
-	RestartThrottleSeconds int                        `json:"restartThrottleSeconds"`
-	ConfigPath             string                     `json:"configPath"`
-	LogDir                 string                     `json:"logDir"`
-	APIReachable           bool                       `json:"apiReachable"`
-	DaemonVersion          *string                    `json:"daemonVersion"`
-	DaemonVersionSource    *string                    `json:"daemonVersionSource"`
-	DaemonBinaryPath       *string                    `json:"daemonBinaryPath"`
-	Lifecycle              daemonLifecycleStatus      `json:"lifecycle"`
-	Status                 json.RawMessage            `json:"status"`
-	Health                 json.RawMessage            `json:"health"`
+	Mode                        config.DaemonMode          `json:"mode"`
+	ConfiguredMode              config.DaemonMode          `json:"configuredMode"`
+	RunningMode                 *config.DaemonMode         `json:"runningMode,omitempty"`
+	RestartPolicy               config.DaemonRestartPolicy `json:"restartPolicy"`
+	RestartThrottleSeconds      int                        `json:"restartThrottleSeconds"`
+	ConfigPath                  string                     `json:"configPath"`
+	LogDir                      string                     `json:"logDir"`
+	APIReachable                bool                       `json:"apiReachable"`
+	DaemonVersion               *string                    `json:"daemonVersion"`
+	DaemonVersionSource         *string                    `json:"daemonVersionSource"`
+	DaemonBinaryPath            *string                    `json:"daemonBinaryPath"`
+	ManagedDaemonVersion        *string                    `json:"managedDaemonVersion,omitempty"`
+	ManagedDaemonBinaryPath     *string                    `json:"managedDaemonBinaryPath,omitempty"`
+	DaemonUpgradePendingRestart bool                       `json:"daemonUpgradePendingRestart"`
+	PendingDaemonVersion        *string                    `json:"pendingDaemonVersion,omitempty"`
+	Lifecycle                   daemonLifecycleStatus      `json:"lifecycle"`
+	Status                      json.RawMessage            `json:"status"`
+	Health                      json.RawMessage            `json:"health"`
 }
 
 type daemonLogsOutput struct {
@@ -98,6 +102,14 @@ func (r *commandRuntime) daemonStatus(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	var managedVersion *daemonVersionState
+	managedPath, managedPathErr := r.managedDaemonBinaryPath()
+	if managedPathErr == nil && (versionState == nil || (versionState.BinaryPath != nil && *versionState.BinaryPath == managedPath)) {
+		managedVersion, err = r.readManagedDaemonVersion(cmd.Context())
+		if err != nil {
+			return err
+		}
+	}
 
 	output := daemonStatusOutput{
 		Mode:                   loaded.Config.Daemon.Mode,
@@ -119,6 +131,14 @@ func (r *commandRuntime) daemonStatus(cmd *cobra.Command, args []string) error {
 		output.DaemonVersion = &versionState.Version
 		output.DaemonVersionSource = &versionState.Source
 		output.DaemonBinaryPath = versionState.BinaryPath
+	}
+	if managedVersion != nil {
+		output.ManagedDaemonVersion = &managedVersion.Version
+		output.ManagedDaemonBinaryPath = managedVersion.BinaryPath
+	}
+	if pending, pendingVersion := daemonUpgradePendingRestart(lifecycle, versionState, managedVersion); pending {
+		output.DaemonUpgradePendingRestart = true
+		output.PendingDaemonVersion = pendingVersion
 	}
 
 	if getBoolFlag(cmd, "json") {
@@ -1319,6 +1339,7 @@ func tailLines(content string, count int) []string {
 
 func writeHumanDaemonStatus(w io.Writer, payload daemonStatusOutput) error {
 	entries := [][2]any{{"configuredMode", payload.ConfiguredMode}, {"runningMode", payload.RunningMode}, {"restartPolicy", payload.RestartPolicy}, {"restartThrottleSeconds", payload.RestartThrottleSeconds}, {"configPath", payload.ConfigPath}, {"logDir", payload.LogDir}, {"apiReachable", payload.APIReachable}, {"daemonVersion", payload.DaemonVersion}, {"daemonVersionSource", payload.DaemonVersionSource}, {"daemonBinaryPath", payload.DaemonBinaryPath}}
+	entries = append(entries, [2]any{"managedDaemonVersion", payload.ManagedDaemonVersion}, [2]any{"managedDaemonBinaryPath", payload.ManagedDaemonBinaryPath}, [2]any{"daemonUpgradePendingRestart", payload.DaemonUpgradePendingRestart}, [2]any{"pendingDaemonVersion", payload.PendingDaemonVersion})
 	if payload.ConfiguredMode == config.DaemonModeForeground {
 		entries = append(entries, [2]any{"restartBehavior", "not supervised; detached mode does not restart after crashes or reboot"})
 	}
@@ -1360,4 +1381,17 @@ func writeHumanDaemonStatus(w io.Writer, payload daemonStatusOutput) error {
 		return err
 	}
 	return writeJSON(w, selected)
+}
+
+func daemonUpgradePendingRestart(lifecycle daemonLifecycleStatus, running *daemonVersionState, managed *daemonVersionState) (bool, *string) {
+	if lifecycle.Process != "running" || running == nil || managed == nil {
+		return false, nil
+	}
+	if running.BinaryPath == nil || managed.BinaryPath == nil || *running.BinaryPath != *managed.BinaryPath {
+		return false, nil
+	}
+	if running.Version == managed.Version {
+		return false, nil
+	}
+	return true, stringPtr(managed.Version)
 }

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -124,6 +124,69 @@ func TestDaemonStatusJSONUsesAPIVersionAndBinaryPath(t *testing.T) {
 	assertJSONContains(t, stdout.String(), "daemonBinaryPath", "/opt/looper/bin/looperd")
 }
 
+func TestDaemonStatusJSONIgnoresManagedProbeFailureWhenAPIAlreadyReportedVersion(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/status":
+			writeEnvelope(t, w, pkgapi.Success("req_status", map[string]any{
+				"service": map[string]any{
+					"version": "0.6.0",
+					"binary": map[string]any{
+						"path": managedPath,
+					},
+				},
+			}))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeDaemonCLIConfig(t, server.URL)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: homeDir,
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "permission denied"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon", "status", "--json", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon status --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([daemon status --json]) stderr = %q, want empty string", stderr.String())
+	}
+	assertJSONContains(t, stdout.String(), "apiReachable", true)
+	assertJSONContains(t, stdout.String(), "daemonVersion", "0.6.0")
+	assertJSONContains(t, stdout.String(), "daemonVersionSource", "api")
+	assertJSONContains(t, stdout.String(), "daemonBinaryPath", managedPath)
+
+	var decoded map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal stdout JSON: %v\nraw=%q", err, stdout.String())
+	}
+	if _, ok := decoded["managedDaemonVersion"]; ok {
+		t.Fatalf("stdout JSON unexpectedly included managedDaemonVersion: %#v", decoded)
+	}
+	if _, ok := decoded["managedDaemonBinaryPath"]; ok {
+		t.Fatalf("stdout JSON unexpectedly included managedDaemonBinaryPath: %#v", decoded)
+	}
+}
+
 func TestDaemonUpgradePendingRestart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -124,6 +124,63 @@ func TestDaemonStatusJSONUsesAPIVersionAndBinaryPath(t *testing.T) {
 	assertJSONContains(t, stdout.String(), "daemonBinaryPath", "/opt/looper/bin/looperd")
 }
 
+func TestDaemonUpgradePendingRestart(t *testing.T) {
+	t.Parallel()
+
+	managedPath := "/tmp/.looper/bin/looperd"
+	otherPath := "/usr/local/bin/looperd"
+	for _, tc := range []struct {
+		name        string
+		lifecycle   daemonLifecycleStatus
+		running     *daemonVersionState
+		managed     *daemonVersionState
+		wantPending bool
+		wantVersion string
+	}{
+		{
+			name:        "running with different managed version",
+			lifecycle:   daemonLifecycleStatus{Process: "running"},
+			running:     &daemonVersionState{Version: "0.2.0", BinaryPath: stringPtr(managedPath)},
+			managed:     &daemonVersionState{Version: "0.3.0", BinaryPath: stringPtr(managedPath)},
+			wantPending: true,
+			wantVersion: "0.3.0",
+		},
+		{
+			name:        "stopped process",
+			lifecycle:   daemonLifecycleStatus{Process: "stopped"},
+			running:     &daemonVersionState{Version: "0.2.0", BinaryPath: stringPtr(managedPath)},
+			managed:     &daemonVersionState{Version: "0.3.0", BinaryPath: stringPtr(managedPath)},
+			wantPending: false,
+		},
+		{
+			name:        "mismatched binary paths",
+			lifecycle:   daemonLifecycleStatus{Process: "running"},
+			running:     &daemonVersionState{Version: "0.2.0", BinaryPath: stringPtr(otherPath)},
+			managed:     &daemonVersionState{Version: "0.3.0", BinaryPath: stringPtr(managedPath)},
+			wantPending: false,
+		},
+		{
+			name:        "same version",
+			lifecycle:   daemonLifecycleStatus{Process: "running"},
+			running:     &daemonVersionState{Version: "0.3.0", BinaryPath: stringPtr(managedPath)},
+			managed:     &daemonVersionState{Version: "0.3.0", BinaryPath: stringPtr(managedPath)},
+			wantPending: false,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotPending, gotVersion := daemonUpgradePendingRestart(tc.lifecycle, tc.running, tc.managed)
+			if gotPending != tc.wantPending {
+				t.Fatalf("daemonUpgradePendingRestart() pending = %v, want %v", gotPending, tc.wantPending)
+			}
+			if got := derefString(gotVersion); got != tc.wantVersion {
+				t.Fatalf("daemonUpgradePendingRestart() version = %q, want %q", got, tc.wantVersion)
+			}
+		})
+	}
+}
+
 func TestDaemonStartWritesPIDFileAndPassesConfigArgs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/testdata/golden/daemon-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/daemon-help.stdout.golden
@@ -29,6 +29,7 @@ Global Flags:
   --json                      Emit JSON output
   --log-dir <path>            Daemon log directory
   --looper-path <path>        Looper CLI path
+  --no-auto-upgrade           Disable automatic upgrade checks for this command
   --no-custom-instructions    Disable custom instructions for debugging
   --osascript-path <path>     osascript binary path
   --planner-agent-timeout-seconds <seconds> Planner agent execution timeout

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -41,6 +41,7 @@ Flags:
   --json                      Emit JSON output
   --log-dir <path>            Daemon log directory
   --looper-path <path>        Looper CLI path
+  --no-auto-upgrade           Disable automatic upgrade checks for this command
   --no-custom-instructions    Disable custom instructions for debugging
   --osascript-path <path>     osascript binary path
   --planner-agent-timeout-seconds <seconds> Planner agent execution timeout

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -154,7 +154,7 @@ func shouldSkipAutoUpgrade(cmd *cobra.Command) bool {
 		return true
 	}
 	path := strings.TrimSpace(cmd.CommandPath())
-	return path == "looper upgrade"
+	return path == "looper" || path == "looper upgrade"
 }
 
 func newAutoUpgradeCommand(parent *cobra.Command) *cobra.Command {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 
@@ -152,6 +153,11 @@ func shouldSkipAutoUpgrade(cmd *cobra.Command) bool {
 	}
 	if cmd.Name() == "help" {
 		return true
+	}
+	if cmd.RunE != nil {
+		if reflect.ValueOf(cmd.RunE).Pointer() == reflect.ValueOf(helpCommand).Pointer() {
+			return true
+		}
 	}
 	path := strings.TrimSpace(cmd.CommandPath())
 	return path == "looper" || path == "looper upgrade"

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -11,10 +11,21 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/nexu-io/looper/internal/version"
 	"github.com/spf13/cobra"
 )
+
+const (
+	autoUpgradeStateSchemaVersion = 1
+	autoUpgradeCheckInterval      = 24 * time.Hour
+)
+
+type autoUpgradeState struct {
+	SchemaVersion int        `json:"schemaVersion"`
+	LastCheckedAt *time.Time `json:"lastCheckedAt,omitempty"`
+}
 
 type upgradeCheckSummary struct {
 	CLI    upgradeCLISummary    `json:"cli"`
@@ -91,6 +102,180 @@ type cliUpgradeRefusedError struct {
 
 func (e *cliUpgradeRefusedError) Error() string {
 	return e.message
+}
+
+func (r *commandRuntime) maybeRunAutoUpgrade(cmd *cobra.Command, args []string) error {
+	_ = args
+	if shouldSkipAutoUpgrade(cmd) {
+		return nil
+	}
+	execPath, err := r.executablePath()
+	if err != nil {
+		return nil
+	}
+	if detectCLIInstallSource(execPath) != cliInstallSourceRelease {
+		return nil
+	}
+
+	loaded, err := r.loadConfig()
+	if err != nil {
+		return nil
+	}
+	if !loaded.Config.Package.AutoUpgradeEnabled {
+		return nil
+	}
+
+	statePath, err := r.resolveAutoUpgradeStatePath()
+	if err != nil {
+		return nil
+	}
+	state, err := r.readAutoUpgradeState(statePath)
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade skipped: read state: %v\n", err)
+		return nil
+	}
+	if !shouldRunAutoUpgradeCheck(state, time.Now()) {
+		return nil
+	}
+
+	autoCmd := newAutoUpgradeCommand(cmd)
+	r.runAutoUpgrade(autoCmd)
+	if err := r.writeAutoUpgradeState(statePath, autoUpgradeState{LastCheckedAt: timePtr(time.Now())}); err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade state update failed: %v\n", err)
+	}
+	return nil
+}
+
+func shouldSkipAutoUpgrade(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return true
+	}
+	if cmd.Name() == "help" {
+		return true
+	}
+	path := strings.TrimSpace(cmd.CommandPath())
+	return path == "looper upgrade"
+}
+
+func newAutoUpgradeCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{}
+	if parent != nil {
+		cmd.SetContext(parent.Context())
+		cmd.SetOut(parent.ErrOrStderr())
+		cmd.SetErr(parent.ErrOrStderr())
+	}
+	return cmd
+}
+
+func (r *commandRuntime) runAutoUpgrade(cmd *cobra.Command) {
+	cliOutput, cliErr := r.upgradeCLIWithOutput(cmd, false)
+	if cliErr != nil {
+		var refused *cliUpgradeRefusedError
+		if errors.As(cliErr, &refused) {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: CLI skipped: %s\n", refused.message)
+		} else {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: CLI check failed: %v\n", cliErr)
+		}
+	} else if cliOutput.Changed {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: upgraded looper %s → %s\n", cliOutput.CurrentVersion, cliOutput.LatestVersion)
+	}
+
+	managedDaemon, err := r.readManagedUpgradeDaemonVersion(cmd.Context())
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: daemon check failed: %v\n", err)
+		return
+	}
+	if managedDaemon == nil {
+		return
+	}
+
+	statusPayload, statusErr := r.currentDaemonStatusPayload(cmd.Context())
+	if statusErr != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: daemon status check failed: %v\n", statusErr)
+		return
+	}
+	pathDaemon, pathErr := r.readPathUpgradeDaemonVersion(cmd.Context())
+	if pathErr != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: daemon path version check failed: %v\n", pathErr)
+		return
+	}
+	runningDaemon := selectUpgradeDaemonVersionState(statusPayload, managedDaemon, pathDaemon)
+
+	daemonOutput, daemonErr := r.upgradeDaemonWithOutput(cmd, false)
+	if daemonErr != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: daemon check failed: %v\n", daemonErr)
+		return
+	}
+	if !daemonOutput.Changed {
+		return
+	}
+
+	if daemonOutput.PreviousVersion != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: installed looperd %s → %s\n", *daemonOutput.PreviousVersion, daemonOutput.LatestVersion)
+	} else {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: installed looperd %s\n", daemonOutput.LatestVersion)
+	}
+	if len(statusPayload) > 0 && runningDaemon != nil && runningDaemon.Source == "installed-binary" && runningDaemon.Version != daemonOutput.LatestVersion {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: looperd %s is installed on disk, but the running daemon is still %s. Run `looper daemon restart`.\n", daemonOutput.LatestVersion, runningDaemon.Version)
+	}
+}
+
+func (r *commandRuntime) resolveAutoUpgradeStatePath() (string, error) {
+	homeDir, err := r.homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".looper", "auto-upgrade.state.json"), nil
+}
+
+func (r *commandRuntime) readAutoUpgradeState(path string) (*autoUpgradeState, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var state autoUpgradeState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("decode auto-upgrade state: %w", err)
+	}
+	if state.SchemaVersion != 0 && state.SchemaVersion != autoUpgradeStateSchemaVersion {
+		return nil, fmt.Errorf("unsupported auto-upgrade state schemaVersion %d", state.SchemaVersion)
+	}
+	return &state, nil
+}
+
+func (r *commandRuntime) writeAutoUpgradeState(path string, state autoUpgradeState) error {
+	state.SchemaVersion = autoUpgradeStateSchemaVersion
+	raw, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := fmt.Sprintf("%s.tmp.%d", path, time.Now().UnixNano())
+	if err := os.WriteFile(tmp, raw, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+func shouldRunAutoUpgradeCheck(state *autoUpgradeState, now time.Time) bool {
+	if state == nil || state.LastCheckedAt == nil {
+		return true
+	}
+	return now.Sub(*state.LastCheckedAt) >= autoUpgradeCheckInterval
+}
+
+func timePtr(value time.Time) *time.Time {
+	return &value
 }
 
 func (r *commandRuntime) upgrade(cmd *cobra.Command, args []string) error {

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -35,6 +35,202 @@ func TestResolveLooperTarget(t *testing.T) {
 	}
 }
 
+func TestShouldRunAutoUpgradeCheck(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-autoUpgradeCheckInterval + time.Minute)
+	old := now.Add(-autoUpgradeCheckInterval - time.Minute)
+
+	for _, tc := range []struct {
+		name  string
+		state *autoUpgradeState
+		want  bool
+	}{
+		{name: "nil state", state: nil, want: true},
+		{name: "missing timestamp", state: &autoUpgradeState{}, want: true},
+		{name: "recent timestamp", state: &autoUpgradeState{LastCheckedAt: &recent}, want: false},
+		{name: "expired timestamp", state: &autoUpgradeState{LastCheckedAt: &old}, want: true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldRunAutoUpgradeCheck(tc.state, now); got != tc.want {
+				t.Fatalf("shouldRunAutoUpgradeCheck() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRootPreRunSkipsAutoUpgradeForUnsupportedInstallSource(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		ExecutablePath: "/opt/homebrew/Cellar/looper/0.2.1/bin/looper",
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
+			return nil, nil
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"version"})
+	if exitCode != 0 {
+		t.Fatalf("Run([version]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([version]) stderr = %q, want empty string", stderr.String())
+	}
+	if got, want := stdout.String(), "0.0.0-dev\n"; got != want {
+		t.Fatalf("Run([version]) stdout = %q, want %q", got, want)
+	}
+}
+
+func TestVersionNoAutoUpgradeFlagDisablesAutoUpgrade(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
+			return nil, nil
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"version", "--no-auto-upgrade", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([version --no-auto-upgrade]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([version --no-auto-upgrade]) stderr = %q, want empty string", stderr.String())
+	}
+}
+
+func TestEnvDisablesAutoUpgrade(t *testing.T) {
+	homeDir := t.TempDir()
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	t.Setenv("LOOPER_AUTO_UPGRADE_ENABLED", "false")
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
+			return nil, nil
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"version", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([version --config]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([version --config]) stderr = %q, want empty string", stderr.String())
+	}
+}
+
+func TestAutoUpgradeCachesLatestReleaseCheck(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	statePath := filepath.Join(homeDir, ".looper", "auto-upgrade.state.json")
+	var latestCalls int
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/nexu-io/looper/releases/latest":
+				latestCalls++
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.0.0-dev","assets":[]}`), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	for i := 0; i < 2; i++ {
+		stdout.Reset()
+		stderr.Reset()
+		exitCode := app.Run(context.Background(), []string{"version", "--config", configPath})
+		if exitCode != 0 {
+			t.Fatalf("run %d Run([version --config]) exit code = %d, want 0; stderr=%q", i+1, exitCode, stderr.String())
+		}
+	}
+	if latestCalls != 1 {
+		t.Fatalf("latest release calls = %d, want 1", latestCalls)
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("Stat(auto-upgrade state) error = %v, want file to exist", err)
+	}
+}
+
+func TestCorruptAutoUpgradeStateSkipsNetworkAndPreservesFile(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	statePath := filepath.Join(homeDir, ".looper", "auto-upgrade.state.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(state dir) error = %v", err)
+	}
+	const corrupt = "{invalid json\n"
+	if err := os.WriteFile(statePath, []byte(corrupt), 0o644); err != nil {
+		t.Fatalf("WriteFile(statePath) error = %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
+			return nil, nil
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"version", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([version --config]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Auto-upgrade skipped: read state") {
+		t.Fatalf("stderr = %q, want corrupt state warning", stderr.String())
+	}
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile(statePath) error = %v", err)
+	}
+	if string(raw) != corrupt {
+		t.Fatalf("state file content = %q, want %q", string(raw), corrupt)
+	}
+}
+
 func TestUpgradeCheckPrintsSummary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -89,6 +89,35 @@ func TestRootPreRunSkipsAutoUpgradeForUnsupportedInstallSource(t *testing.T) {
 	}
 }
 
+func TestRootPreRunSkipsAutoUpgradeForBareRootHelp(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
+			return nil, nil
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), nil)
+	if exitCode != 0 {
+		t.Fatalf("Run([]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([]) stderr = %q, want empty string", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Usage:\n  looper") {
+		t.Fatalf("Run([]) stdout = %q, want root help output", stdout.String())
+	}
+}
+
 func TestVersionNoAutoUpgradeFlagDisablesAutoUpgrade(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -118,6 +118,35 @@ func TestRootPreRunSkipsAutoUpgradeForBareRootHelp(t *testing.T) {
 	}
 }
 
+func TestRootPreRunSkipsAutoUpgradeForHelpOnlySubcommand(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
+			return nil, nil
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"daemon"})
+	if exitCode != 0 {
+		t.Fatalf("Run([daemon]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run([daemon]) stderr = %q, want empty string", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Usage:\n  looper daemon") {
+		t.Fatalf("Run([daemon]) stdout = %q, want daemon help output", stdout.String())
+	}
+}
+
 func TestVersionNoAutoUpgradeFlagDisablesAutoUpgrade(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -119,6 +119,7 @@ func DefaultConfig(cwd string) (Config, error) {
 		},
 		Package: PackageConfig{
 			Distribution:               "github-release",
+			AutoUpgradeEnabled:         true,
 			AutoMigrateOnStartup:       true,
 			RequireBackupBeforeMigrate: false,
 		},

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -221,6 +221,21 @@ func parseCLIArgs(args []string) (parsedCLIArgs, error) {
 				}
 			}
 			ensureInstructionsConfig(&parsed.overrides).Enabled = boolPtr(!disable)
+		case matchesFlag(arg, "--no-auto-upgrade"):
+			disable := true
+			if _, value, ok := strings.Cut(arg, "="); ok {
+				parsedValue, err := parseBoolean(value)
+				if err != nil {
+					return parsedCLIArgs{}, fmt.Errorf("invalid value for --no-auto-upgrade: %q is not a boolean", value)
+				}
+				disable = *parsedValue
+			} else if index+1 < len(args) && !strings.HasPrefix(args[index+1], "--") {
+				if parsedValue, err := parseBoolean(args[index+1]); err == nil {
+					disable = *parsedValue
+					index++
+				}
+			}
+			ensurePackageConfig(&parsed.overrides).AutoUpgradeEnabled = boolPtr(!disable)
 		case matchesFlag(arg, "--host"):
 			value, nextIndex, err := takeValue(index, "--host")
 			if err != nil {
@@ -602,6 +617,13 @@ func buildEnvOverrides(lookupEnv EnvLookupFunc) (PartialConfig, error) {
 		}
 		ensureOsascriptNotificationConfig(&overrides).Enabled = parsed
 	}
+	if value, ok := lookupEnv("LOOPER_AUTO_UPGRADE_ENABLED"); ok {
+		parsed, err := parseBoolean(value)
+		if err != nil {
+			return PartialConfig{}, fmt.Errorf("invalid value for LOOPER_AUTO_UPGRADE_ENABLED: %q is not a boolean", value)
+		}
+		ensurePackageConfig(&overrides).AutoUpgradeEnabled = parsed
+	}
 	if err := applyAgentTimeoutEnvOverrides(&overrides, lookupEnv); err != nil {
 		return PartialConfig{}, err
 	}
@@ -957,6 +979,14 @@ func ensureDaemonConfig(partial *PartialConfig) *PartialDaemonConfig {
 	}
 
 	return partial.Daemon
+}
+
+func ensurePackageConfig(partial *PartialConfig) *PartialPackageConfig {
+	if partial.Package == nil {
+		partial.Package = &PartialPackageConfig{}
+	}
+
+	return partial.Package
 }
 
 func ensureDefaultsConfig(partial *PartialConfig) *PartialDefaultsConfig {

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -354,6 +354,10 @@ func mergePackageConfig(config *PackageConfig, partial PartialPackageConfig) {
 		config.Distribution = *partial.Distribution
 	}
 
+	if partial.AutoUpgradeEnabled != nil {
+		config.AutoUpgradeEnabled = *partial.AutoUpgradeEnabled
+	}
+
 	if partial.AutoMigrateOnStartup != nil {
 		config.AutoMigrateOnStartup = *partial.AutoMigrateOnStartup
 	}

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -167,6 +167,7 @@
       },
       "package": {
         "distribution": "github-release",
+        "autoUpgradeEnabled": true,
         "autoMigrateOnStartup": true,
         "requireBackupBeforeMigrate": false
       },

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -100,6 +100,7 @@
       },
       "package": {
         "distribution": "github-release",
+        "autoUpgradeEnabled": true,
         "autoMigrateOnStartup": true,
         "requireBackupBeforeMigrate": false
       },

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -67,6 +67,7 @@
         },
         "package": {
           "distribution": "github-release",
+          "autoUpgradeEnabled": true,
           "autoMigrateOnStartup": false,
           "requireBackupBeforeMigrate": true
         },
@@ -185,6 +186,7 @@
       },
       "package": {
         "distribution": "github-release",
+        "autoUpgradeEnabled": true,
         "autoMigrateOnStartup": false,
         "requireBackupBeforeMigrate": true
       },

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -239,6 +239,7 @@ type DaemonConfig struct {
 
 type PackageConfig struct {
 	Distribution               string `json:"distribution"`
+	AutoUpgradeEnabled         bool   `json:"autoUpgradeEnabled"`
 	AutoMigrateOnStartup       bool   `json:"autoMigrateOnStartup"`
 	RequireBackupBeforeMigrate bool   `json:"requireBackupBeforeMigrate"`
 }
@@ -488,6 +489,7 @@ type PartialDaemonConfig struct {
 
 type PartialPackageConfig struct {
 	Distribution               *string `json:"distribution,omitempty"`
+	AutoUpgradeEnabled         *bool   `json:"autoUpgradeEnabled,omitempty"`
 	AutoMigrateOnStartup       *bool   `json:"autoMigrateOnStartup,omitempty"`
 	RequireBackupBeforeMigrate *bool   `json:"requireBackupBeforeMigrate,omitempty"`
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -134,6 +134,10 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 		issues = append(issues, ValidationIssue{Path: "daemon.workingDirectory", Message: "must be a non-empty path"})
 	}
 
+	if strings.TrimSpace(config.Package.Distribution) == "" {
+		issues = append(issues, ValidationIssue{Path: "package.distribution", Message: "must be a non-empty string"})
+	}
+
 	if config.Defaults.BaseBranch == "" {
 		issues = append(issues, ValidationIssue{Path: "defaults.baseBranch", Message: "must be a non-empty string"})
 	}


### PR DESCRIPTION
## Summary
- Enable default-on, cached auto-upgrade checks for supported release-binary installs with config/env/CLI opt-outs.
- Add best-effort CLI and managed daemon upgrade handling while keeping failures non-fatal.
- Surface daemon pending-restart status when the managed daemon binary has been upgraded on disk.

## Validation
- go test ./internal/config ./internal/api ./internal/cliapp
- go build ./...
- go vet ./...
- go test ./...
- git diff --check

Closes #244