### PR TITLE
feat: speed up install and upgrade with archives, concurrency, and progress bar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,16 @@ jobs:
           shasum -a 256 "${{ matrix.artifact-name }}" > "${{ matrix.artifact-name }}.sha256"
           shasum -a 256 -c "${{ matrix.artifact-name }}.sha256"
 
+      - name: Create release archive
+        working-directory: dist/release
+        run: |
+          # Tar with -C so the binary lives at the archive root with its
+          # platform-suffixed name. Compressed downloads are roughly 30-40% of
+          # the raw binary size, which speeds up first install and self-upgrade.
+          tar -czf "${{ matrix.artifact-name }}.tar.gz" "${{ matrix.artifact-name }}"
+          shasum -a 256 "${{ matrix.artifact-name }}.tar.gz" > "${{ matrix.artifact-name }}.tar.gz.sha256"
+          shasum -a 256 -c "${{ matrix.artifact-name }}.tar.gz.sha256"
+
       - name: Upload release assets
         uses: actions/upload-artifact@v4
         with:
@@ -205,6 +215,8 @@ jobs:
           path: |
             dist/release/${{ matrix.artifact-name }}
             dist/release/${{ matrix.artifact-name }}.sha256
+            dist/release/${{ matrix.artifact-name }}.tar.gz
+            dist/release/${{ matrix.artifact-name }}.tar.gz.sha256
 
   build-looperd:
     needs:
@@ -264,6 +276,13 @@ jobs:
           shasum -a 256 "${{ matrix.artifact-name }}" > "${{ matrix.artifact-name }}.sha256"
           shasum -a 256 -c "${{ matrix.artifact-name }}.sha256"
 
+      - name: Create release archive
+        working-directory: dist/release
+        run: |
+          tar -czf "${{ matrix.artifact-name }}.tar.gz" "${{ matrix.artifact-name }}"
+          shasum -a 256 "${{ matrix.artifact-name }}.tar.gz" > "${{ matrix.artifact-name }}.tar.gz.sha256"
+          shasum -a 256 -c "${{ matrix.artifact-name }}.tar.gz.sha256"
+
       - name: Upload release assets
         uses: actions/upload-artifact@v4
         with:
@@ -271,6 +290,8 @@ jobs:
           path: |
             dist/release/${{ matrix.artifact-name }}
             dist/release/${{ matrix.artifact-name }}.sha256
+            dist/release/${{ matrix.artifact-name }}.tar.gz
+            dist/release/${{ matrix.artifact-name }}.tar.gz.sha256
 
   publish-release:
     needs:
@@ -301,8 +322,12 @@ jobs:
         run: |
           test -f release-assets/looper-darwin-arm64
           test -f release-assets/looper-darwin-arm64.sha256
+          test -f release-assets/looper-darwin-arm64.tar.gz
+          test -f release-assets/looper-darwin-arm64.tar.gz.sha256
           test -f release-assets/looperd-darwin-arm64
           test -f release-assets/looperd-darwin-arm64.sha256
+          test -f release-assets/looperd-darwin-arm64.tar.gz
+          test -f release-assets/looperd-darwin-arm64.tar.gz.sha256
 
       - name: Verify Linux artifacts are not published in Phase 1
         run: |
@@ -322,7 +347,7 @@ jobs:
             -min-cli-for-daemon "$LOOPER_BUILD_MIN_CLI_FOR_DAEMON" \
             -min-daemon-for-cli "$LOOPER_BUILD_MIN_DAEMON_FOR_CLI" \
             -assets-dir release-assets \
-            -required-assets "looper-darwin-arm64,looperd-darwin-arm64" \
+            -required-assets "looper-darwin-arm64,looper-darwin-arm64.tar.gz,looperd-darwin-arm64,looperd-darwin-arm64.tar.gz" \
             -output release-assets/manifest.json
 
       - name: Validate release manifest fields
@@ -350,7 +375,9 @@ jobs:
           assert m["minDaemonForCli"], "minDaemonForCli missing"
           required = {
               "looper-darwin-arm64",
+              "looper-darwin-arm64.tar.gz",
               "looperd-darwin-arm64",
+              "looperd-darwin-arm64.tar.gz",
           }
           assert required.issubset(set(m["artifacts"].keys())), "manifest missing artifacts"
           for name in required:
@@ -370,6 +397,10 @@ jobs:
           files: |
             release-assets/looper-darwin-arm64
             release-assets/looper-darwin-arm64.sha256
+            release-assets/looper-darwin-arm64.tar.gz
+            release-assets/looper-darwin-arm64.tar.gz.sha256
             release-assets/looperd-darwin-arm64
             release-assets/looperd-darwin-arm64.sha256
+            release-assets/looperd-darwin-arm64.tar.gz
+            release-assets/looperd-darwin-arm64.tar.gz.sha256
             release-assets/manifest.json

--- a/internal/cliapp/bootstrap_test.go
+++ b/internal/cliapp/bootstrap_test.go
@@ -122,7 +122,7 @@ func TestBootstrapYesInstallsStartsAndPrintsNextSteps(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([bootstrap --yes]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 14 B / 14 B (100%)") {
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: [####################] 14 B / 14 B (100%)") {
 		t.Fatalf("Run([bootstrap --yes]) stderr = %q, want daemon download progress", stderr.String())
 	}
 	if spawnCalls.Load() != 1 {
@@ -413,7 +413,7 @@ func TestBootstrapJSONSuppressesDaemonStartOutput(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([bootstrap --yes --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 14 B / 14 B (100%)") {
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: [####################] 14 B / 14 B (100%)") {
 		t.Fatalf("Run([bootstrap --yes --json]) stderr = %q, want daemon download progress", stderr.String())
 	}
 	var decoded bootstrapResult

--- a/internal/cliapp/daemon_install.go
+++ b/internal/cliapp/daemon_install.go
@@ -2,8 +2,6 @@ package cliapp
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -97,28 +95,14 @@ func (r *commandRuntime) installManagedDaemon(ctx context.Context, force bool, t
 		return daemonInstallResult{}, err
 	}
 
-	binaryAsset, checksumAsset, err := findLooperdReleaseAssets(release, target)
+	asset, err := findReleaseAssetSet(release, looperdBinaryName+"-"+target)
 	if err != nil {
-		return daemonInstallResult{}, err
+		return daemonInstallResult{}, fmt.Errorf("looperd release: %w", err)
 	}
 
-	binaryBytes, err := r.downloadBinary(ctx, binaryAsset.BrowserDownloadURL, binaryAsset.Name, progress)
+	binaryBytes, err := r.fetchAndExtractBinary(ctx, asset, progress)
 	if err != nil {
 		return daemonInstallResult{}, err
-	}
-
-	checksumText, err := r.downloadChecksum(ctx, checksumAsset.BrowserDownloadURL)
-	if err != nil {
-		return daemonInstallResult{}, err
-	}
-
-	expectedChecksum, err := parseChecksum(checksumText)
-	if err != nil {
-		return daemonInstallResult{}, err
-	}
-	actualChecksum := sha256.Sum256(binaryBytes)
-	if hex.EncodeToString(actualChecksum[:]) != expectedChecksum {
-		return daemonInstallResult{}, fmt.Errorf("Downloaded looperd checksum mismatch: expected %s, received %s", expectedChecksum, hex.EncodeToString(actualChecksum[:]))
 	}
 
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
@@ -142,7 +126,7 @@ func (r *commandRuntime) installManagedDaemon(ctx context.Context, force bool, t
 	return daemonInstallResult{
 		Target:         target,
 		InstallPath:    installPath,
-		DownloadedFrom: stringPtr(binaryAsset.BrowserDownloadURL),
+		DownloadedFrom: stringPtr(asset.PreferredURL),
 		Skipped:        false,
 	}, nil
 }
@@ -268,7 +252,7 @@ func (p *downloadProgress) print(initial bool) {
 		if p.total > 0 {
 			percent = int((p.read * 100) / p.total)
 		}
-		line = fmt.Sprintf("Downloading %s: %s / %s (%d%%)", p.name, formatDownloadBytes(p.read), formatDownloadBytes(p.total), percent)
+		line = fmt.Sprintf("Downloading %s: %s%s / %s (%d%%)", p.name, renderProgressBar(percent, downloadProgressBarWidth), formatDownloadBytes(p.read), formatDownloadBytes(p.total), percent)
 	} else if p.read > 0 {
 		line = fmt.Sprintf("Downloading %s: %s downloaded", p.name, formatDownloadBytes(p.read))
 	} else {
@@ -279,6 +263,42 @@ func (p *downloadProgress) print(initial bool) {
 		return
 	}
 	_, _ = fmt.Fprintf(p.w, "\r%s", line)
+}
+
+// downloadProgressBarWidth is the inner width of the textual progress bar
+// printed alongside byte counters. A small fixed width keeps output readable
+// on narrow terminals and stable in non-TTY logs.
+const downloadProgressBarWidth = 20
+
+// renderProgressBar returns a "[####------] " style bar string for the given
+// percentage. An empty string is returned when width is non-positive so the
+// renderer can be disabled by callers without conditional logic at the call
+// site.
+func renderProgressBar(percent int, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	filled := (percent * width) / 100
+	if filled > width {
+		filled = width
+	}
+	var builder strings.Builder
+	builder.Grow(width + 3)
+	builder.WriteByte('[')
+	for i := 0; i < filled; i++ {
+		builder.WriteByte('#')
+	}
+	for i := filled; i < width; i++ {
+		builder.WriteByte('-')
+	}
+	builder.WriteString("] ")
+	return builder.String()
 }
 
 func formatDownloadBytes(value int64) string {
@@ -338,35 +358,6 @@ func buildGitHubReleaseAPIURL(owner, repo, tag string) string {
 		return base + "/tags/" + tag
 	}
 	return base + "/latest"
-}
-
-func findLooperdReleaseAssets(release githubReleasePayload, target string) (githubReleaseAsset, githubReleaseAsset, error) {
-	binaryName := looperdBinaryName + "-" + target
-	checksumName := binaryName + ".sha256"
-
-	var binary githubReleaseAsset
-	var checksum githubReleaseAsset
-	for _, asset := range release.Assets {
-		switch asset.Name {
-		case binaryName:
-			binary = asset
-		case checksumName:
-			checksum = asset
-		}
-	}
-
-	missing := make([]string, 0, 2)
-	if strings.TrimSpace(binary.Name) == "" {
-		missing = append(missing, binaryName)
-	}
-	if strings.TrimSpace(checksum.Name) == "" {
-		missing = append(missing, checksumName)
-	}
-	if len(missing) > 0 {
-		return githubReleaseAsset{}, githubReleaseAsset{}, fmt.Errorf("GitHub release is missing required looperd asset(s): %s", strings.Join(missing, ", "))
-	}
-
-	return binary, checksum, nil
 }
 
 func parseChecksum(value string) (string, error) {

--- a/internal/cliapp/daemon_install.go
+++ b/internal/cliapp/daemon_install.go
@@ -29,6 +29,11 @@ type daemonInstallResult struct {
 	Skipped        bool    `json:"skipped"`
 }
 
+type preparedDaemonInstall struct {
+	result      daemonInstallResult
+	binaryBytes []byte
+}
+
 type githubReleasePayload struct {
 	TagName string               `json:"tag_name"`
 	Assets  []githubReleaseAsset `json:"assets"`
@@ -68,14 +73,25 @@ func (r *commandRuntime) daemonInstall(cmd *cobra.Command, args []string) error 
 }
 
 func (r *commandRuntime) installManagedDaemon(ctx context.Context, force bool, tag string, progress io.Writer) (daemonInstallResult, error) {
-	homeDir, err := r.homeDir()
+	prepared, err := r.prepareManagedDaemonInstall(ctx, force, tag, progress)
 	if err != nil {
 		return daemonInstallResult{}, err
+	}
+	if err := commitPreparedDaemonInstall(prepared); err != nil {
+		return daemonInstallResult{}, err
+	}
+	return prepared.result, nil
+}
+
+func (r *commandRuntime) prepareManagedDaemonInstall(ctx context.Context, force bool, tag string, progress io.Writer) (preparedDaemonInstall, error) {
+	homeDir, err := r.homeDir()
+	if err != nil {
+		return preparedDaemonInstall{}, err
 	}
 
 	target, err := resolveLooperdTarget(r.platform(), r.arch())
 	if err != nil {
-		return daemonInstallResult{}, err
+		return preparedDaemonInstall{}, err
 	}
 
 	installDir := filepath.Join(homeDir, ".looper", "bin")
@@ -83,52 +99,62 @@ func (r *commandRuntime) installManagedDaemon(ctx context.Context, force bool, t
 	if !force {
 		state, err := r.checkManagedDaemonBinary(ctx)
 		if err != nil {
-			return daemonInstallResult{}, err
+			return preparedDaemonInstall{}, err
 		}
 		if state.Exists {
-			return daemonInstallResult{Target: target, InstallPath: installPath, Skipped: true}, nil
+			return preparedDaemonInstall{result: daemonInstallResult{Target: target, InstallPath: installPath, Skipped: true}}, nil
 		}
 	}
 
 	release, err := r.fetchReleaseMetadata(ctx, tag)
 	if err != nil {
-		return daemonInstallResult{}, err
+		return preparedDaemonInstall{}, err
 	}
 
 	asset, err := findReleaseAssetSet(release, looperdBinaryName+"-"+target)
 	if err != nil {
-		return daemonInstallResult{}, fmt.Errorf("looperd release: %w", err)
+		return preparedDaemonInstall{}, fmt.Errorf("looperd release: %w", err)
 	}
 
 	binaryBytes, err := r.fetchAndExtractBinary(ctx, asset, progress)
 	if err != nil {
-		return daemonInstallResult{}, err
+		return preparedDaemonInstall{}, err
 	}
 
+	return preparedDaemonInstall{
+		result: daemonInstallResult{
+			Target:         target,
+			InstallPath:    installPath,
+			DownloadedFrom: stringPtr(asset.PreferredURL),
+			Skipped:        false,
+		},
+		binaryBytes: binaryBytes,
+	}, nil
+}
+
+func commitPreparedDaemonInstall(prepared preparedDaemonInstall) error {
+	if prepared.result.Skipped {
+		return nil
+	}
+	installDir := filepath.Dir(prepared.result.InstallPath)
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
-		return daemonInstallResult{}, fmt.Errorf("create install directory: %w", err)
+		return fmt.Errorf("create install directory: %w", err)
 	}
 
-	tempInstallPath := installPath + ".new"
-	if err := os.WriteFile(tempInstallPath, binaryBytes, 0o755); err != nil {
+	tempInstallPath := prepared.result.InstallPath + ".new"
+	if err := os.WriteFile(tempInstallPath, prepared.binaryBytes, 0o755); err != nil {
 		_ = removeTempInstallFile(tempInstallPath)
-		return daemonInstallResult{}, err
+		return err
 	}
 	if err := os.Chmod(tempInstallPath, 0o755); err != nil {
 		_ = removeTempInstallFile(tempInstallPath)
-		return daemonInstallResult{}, err
+		return err
 	}
-	if err := os.Rename(tempInstallPath, installPath); err != nil {
+	if err := os.Rename(tempInstallPath, prepared.result.InstallPath); err != nil {
 		_ = removeTempInstallFile(tempInstallPath)
-		return daemonInstallResult{}, err
+		return err
 	}
-
-	return daemonInstallResult{
-		Target:         target,
-		InstallPath:    installPath,
-		DownloadedFrom: stringPtr(asset.PreferredURL),
-		Skipped:        false,
-	}, nil
+	return nil
 }
 
 func (r *commandRuntime) fetchReleaseMetadata(ctx context.Context, tag string) (githubReleasePayload, error) {

--- a/internal/cliapp/daemon_install_test.go
+++ b/internal/cliapp/daemon_install_test.go
@@ -239,7 +239,7 @@ func TestDaemonInstallCommandPrintsHumanOutput(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([daemon install]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 3 B / 3 B (100%)") {
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: [####################] 3 B / 3 B (100%)") {
 		t.Fatalf("Run([daemon install]) stderr = %q, want download progress", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Installed looperd (darwin-arm64) to ") {

--- a/internal/cliapp/download.go
+++ b/internal/cliapp/download.go
@@ -163,6 +163,9 @@ func extractBinaryFromTarGz(archiveBytes []byte, binaryName string) ([]byte, err
 		if path.Base(header.Name) != binaryName {
 			continue
 		}
+		if header.Size > maxArchiveBinaryBytes {
+			return nil, fmt.Errorf("archive entry %q exceeds %d-byte limit", header.Name, maxArchiveBinaryBytes)
+		}
 		data, err := io.ReadAll(io.LimitReader(tarReader, maxArchiveBinaryBytes))
 		if err != nil {
 			return nil, fmt.Errorf("read tar entry %q: %w", header.Name, err)

--- a/internal/cliapp/download.go
+++ b/internal/cliapp/download.go
@@ -1,0 +1,230 @@
+package cliapp
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"sync"
+)
+
+// archiveAssetSuffix is appended to the per-target binary name to form the
+// archived release artifact name, e.g. looper-darwin-arm64.tar.gz.
+const archiveAssetSuffix = ".tar.gz"
+
+// maxArchiveBinaryBytes caps the size of any binary extracted from a release
+// archive. The current looper/looperd binaries weigh well below 100 MiB; the
+// generous ceiling guards against malicious or corrupt archives without
+// constraining legitimate growth.
+const maxArchiveBinaryBytes = 256 * 1024 * 1024
+
+// downloadAsset describes a single artifact that, once downloaded and
+// verified, produces a single executable binary. The archive variant is
+// preferred when available because it transfers significantly fewer bytes
+// than the raw binary.
+type downloadAsset struct {
+	// PreferredURL is the URL fetched for the binary payload. When IsArchive
+	// is true this is the archive download URL; otherwise it is the raw
+	// binary URL.
+	PreferredURL string
+	// PreferredName is the artifact name used in progress output.
+	PreferredName string
+	// ChecksumURL is the URL of the .sha256 file that pairs with PreferredURL.
+	ChecksumURL string
+	// IsArchive indicates whether PreferredURL points at a .tar.gz archive.
+	// When true the downloaded payload must be extracted before installation.
+	IsArchive bool
+	// BinaryName is the name of the binary inside the archive, used for both
+	// extraction and as the fallback artifact name when no archive exists.
+	BinaryName string
+}
+
+// findReleaseAssetSet locates the best download asset for the given binary
+// target. It prefers the .tar.gz archive when the release publishes one and
+// falls back to the raw binary so older releases keep working.
+func findReleaseAssetSet(release githubReleasePayload, binaryName string) (downloadAsset, error) {
+	archiveName := binaryName + archiveAssetSuffix
+	archiveChecksum := archiveName + ".sha256"
+	rawChecksum := binaryName + ".sha256"
+
+	var (
+		archiveAsset, archiveChecksumAsset githubReleaseAsset
+		binaryAsset, binaryChecksumAsset   githubReleaseAsset
+	)
+	for _, asset := range release.Assets {
+		switch asset.Name {
+		case archiveName:
+			archiveAsset = asset
+		case archiveChecksum:
+			archiveChecksumAsset = asset
+		case binaryName:
+			binaryAsset = asset
+		case rawChecksum:
+			binaryChecksumAsset = asset
+		}
+	}
+
+	archiveURL := strings.TrimSpace(archiveAsset.BrowserDownloadURL)
+	archiveChecksumURL := strings.TrimSpace(archiveChecksumAsset.BrowserDownloadURL)
+	if archiveURL != "" && archiveChecksumURL != "" {
+		return downloadAsset{
+			PreferredURL:  archiveURL,
+			PreferredName: archiveName,
+			ChecksumURL:   archiveChecksumURL,
+			IsArchive:     true,
+			BinaryName:    binaryName,
+		}, nil
+	}
+
+	binaryURL := strings.TrimSpace(binaryAsset.BrowserDownloadURL)
+	binaryChecksumURL := strings.TrimSpace(binaryChecksumAsset.BrowserDownloadURL)
+	missing := make([]string, 0, 2)
+	if binaryURL == "" {
+		missing = append(missing, binaryName)
+	}
+	if binaryChecksumURL == "" {
+		missing = append(missing, rawChecksum)
+	}
+	if len(missing) > 0 {
+		return downloadAsset{}, fmt.Errorf("release is missing required asset(s): %s", strings.Join(missing, ", "))
+	}
+
+	return downloadAsset{
+		PreferredURL:  binaryURL,
+		PreferredName: binaryName,
+		ChecksumURL:   binaryChecksumURL,
+		IsArchive:     false,
+		BinaryName:    binaryName,
+	}, nil
+}
+
+// fetchAndExtractBinary downloads the configured asset, verifies its
+// checksum, and (for archives) extracts the named binary. The returned bytes
+// are the final binary ready to be written to disk.
+func (r *commandRuntime) fetchAndExtractBinary(ctx context.Context, asset downloadAsset, progress io.Writer) ([]byte, error) {
+	payload, err := r.downloadBinary(ctx, asset.PreferredURL, asset.PreferredName, progress)
+	if err != nil {
+		return nil, err
+	}
+	checksumText, err := r.downloadChecksum(ctx, asset.ChecksumURL)
+	if err != nil {
+		return nil, err
+	}
+	expected, err := parseChecksum(checksumText)
+	if err != nil {
+		return nil, err
+	}
+	actual := sha256.Sum256(payload)
+	if hex.EncodeToString(actual[:]) != expected {
+		return nil, fmt.Errorf("downloaded %s checksum mismatch: expected %s, received %s", asset.PreferredName, expected, hex.EncodeToString(actual[:]))
+	}
+	if !asset.IsArchive {
+		return payload, nil
+	}
+	binary, err := extractBinaryFromTarGz(payload, asset.BinaryName)
+	if err != nil {
+		return nil, fmt.Errorf("extract %s from %s: %w", asset.BinaryName, asset.PreferredName, err)
+	}
+	return binary, nil
+}
+
+// extractBinaryFromTarGz reads a gzipped tar archive in memory and returns
+// the bytes of the entry whose base name matches binaryName. Other entries
+// are ignored. Symlinks and absolute paths are rejected to prevent
+// path-traversal attacks via crafted archives.
+func extractBinaryFromTarGz(archiveBytes []byte, binaryName string) ([]byte, error) {
+	gzReader, err := gzip.NewReader(bytes.NewReader(archiveBytes))
+	if err != nil {
+		return nil, fmt.Errorf("open gzip stream: %w", err)
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar header: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if strings.HasPrefix(header.Name, "/") || strings.Contains(header.Name, "..") {
+			return nil, fmt.Errorf("archive entry has unsafe path: %q", header.Name)
+		}
+		if path.Base(header.Name) != binaryName {
+			continue
+		}
+		data, err := io.ReadAll(io.LimitReader(tarReader, maxArchiveBinaryBytes))
+		if err != nil {
+			return nil, fmt.Errorf("read tar entry %q: %w", header.Name, err)
+		}
+		return data, nil
+	}
+	return nil, fmt.Errorf("archive does not contain entry %q", binaryName)
+}
+
+// concurrentProgressMux serializes progress writes from multiple goroutines
+// onto a single underlying writer. Carriage returns are rewritten to newlines
+// so concurrent artifact updates do not stomp each other on the same physical
+// line, which keeps both human output and test substring checks reliable.
+type concurrentProgressMux struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func newConcurrentProgressMux(w io.Writer) *concurrentProgressMux {
+	return &concurrentProgressMux{w: w}
+}
+
+func (m *concurrentProgressMux) writer() io.Writer {
+	if m == nil || m.w == nil {
+		return nil
+	}
+	return &concurrentLineWriter{parent: m}
+}
+
+type concurrentLineWriter struct {
+	parent *concurrentProgressMux
+}
+
+func (c *concurrentLineWriter) Write(p []byte) (int, error) {
+	if c == nil || c.parent == nil || c.parent.w == nil {
+		return len(p), nil
+	}
+	c.parent.mu.Lock()
+	defer c.parent.mu.Unlock()
+	rewritten := bytesReplaceCR(p)
+	if _, err := c.parent.w.Write(rewritten); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// bytesReplaceCR rewrites a payload so that lone carriage returns become
+// newlines, which is what concurrent line-oriented progress output needs.
+func bytesReplaceCR(input []byte) []byte {
+	if len(input) == 0 {
+		return input
+	}
+	if !bytes.ContainsRune(input, '\r') {
+		return input
+	}
+	out := make([]byte, 0, len(input))
+	for _, b := range input {
+		if b == '\r' {
+			out = append(out, '\n')
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
+}

--- a/internal/cliapp/download_test.go
+++ b/internal/cliapp/download_test.go
@@ -1,0 +1,317 @@
+package cliapp
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func buildTarGzArchive(t *testing.T, entryName string, contents []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	header := &tar.Header{
+		Name:     entryName,
+		Mode:     0o755,
+		Size:     int64(len(contents)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(header); err != nil {
+		t.Fatalf("tar write header: %v", err)
+	}
+	if _, err := tw.Write(contents); err != nil {
+		t.Fatalf("tar write contents: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractBinaryFromTarGzReturnsBinaryBytes(t *testing.T) {
+	t.Parallel()
+
+	want := []byte("real-binary-bytes")
+	archive := buildTarGzArchive(t, "looperd-darwin-arm64", want)
+
+	got, err := extractBinaryFromTarGz(archive, "looperd-darwin-arm64")
+	if err != nil {
+		t.Fatalf("extractBinaryFromTarGz() error = %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("extractBinaryFromTarGz() bytes = %q, want %q", got, want)
+	}
+}
+
+func TestExtractBinaryFromTarGzRejectsUnsafePaths(t *testing.T) {
+	t.Parallel()
+
+	archive := buildTarGzArchive(t, "../escape-binary", []byte("payload"))
+	_, err := extractBinaryFromTarGz(archive, "escape-binary")
+	if err == nil {
+		t.Fatal("extractBinaryFromTarGz() error = nil, want unsafe-path error")
+	}
+	if !strings.Contains(err.Error(), "unsafe path") {
+		t.Fatalf("error = %q, want unsafe-path message", err.Error())
+	}
+}
+
+func TestExtractBinaryFromTarGzReportsMissingEntry(t *testing.T) {
+	t.Parallel()
+
+	archive := buildTarGzArchive(t, "looperd-darwin-arm64", []byte("ok"))
+	_, err := extractBinaryFromTarGz(archive, "different-name")
+	if err == nil {
+		t.Fatal("extractBinaryFromTarGz() error = nil, want missing-entry error")
+	}
+	if !strings.Contains(err.Error(), "does not contain entry") {
+		t.Fatalf("error = %q, want missing-entry message", err.Error())
+	}
+}
+
+func TestFindReleaseAssetSetPrefersArchive(t *testing.T) {
+	t.Parallel()
+
+	release := githubReleasePayload{
+		Assets: []githubReleaseAsset{
+			{Name: "looperd-darwin-arm64", BrowserDownloadURL: "https://example.invalid/raw"},
+			{Name: "looperd-darwin-arm64.sha256", BrowserDownloadURL: "https://example.invalid/raw.sha256"},
+			{Name: "looperd-darwin-arm64.tar.gz", BrowserDownloadURL: "https://example.invalid/archive.tar.gz"},
+			{Name: "looperd-darwin-arm64.tar.gz.sha256", BrowserDownloadURL: "https://example.invalid/archive.tar.gz.sha256"},
+		},
+	}
+
+	asset, err := findReleaseAssetSet(release, "looperd-darwin-arm64")
+	if err != nil {
+		t.Fatalf("findReleaseAssetSet() error = %v", err)
+	}
+	if !asset.IsArchive {
+		t.Fatal("asset.IsArchive = false, want archive preferred")
+	}
+	if asset.PreferredURL != "https://example.invalid/archive.tar.gz" {
+		t.Fatalf("asset.PreferredURL = %q, want archive URL", asset.PreferredURL)
+	}
+	if asset.PreferredName != "looperd-darwin-arm64.tar.gz" {
+		t.Fatalf("asset.PreferredName = %q", asset.PreferredName)
+	}
+	if asset.BinaryName != "looperd-darwin-arm64" {
+		t.Fatalf("asset.BinaryName = %q", asset.BinaryName)
+	}
+}
+
+func TestFindReleaseAssetSetFallsBackToRawBinary(t *testing.T) {
+	t.Parallel()
+
+	release := githubReleasePayload{
+		Assets: []githubReleaseAsset{
+			{Name: "looperd-darwin-arm64", BrowserDownloadURL: "https://example.invalid/raw"},
+			{Name: "looperd-darwin-arm64.sha256", BrowserDownloadURL: "https://example.invalid/raw.sha256"},
+		},
+	}
+
+	asset, err := findReleaseAssetSet(release, "looperd-darwin-arm64")
+	if err != nil {
+		t.Fatalf("findReleaseAssetSet() error = %v", err)
+	}
+	if asset.IsArchive {
+		t.Fatal("asset.IsArchive = true, want raw binary fallback")
+	}
+	if asset.PreferredURL != "https://example.invalid/raw" {
+		t.Fatalf("asset.PreferredURL = %q", asset.PreferredURL)
+	}
+}
+
+func TestFindReleaseAssetSetReportsMissingAssets(t *testing.T) {
+	t.Parallel()
+
+	release := githubReleasePayload{Assets: []githubReleaseAsset{}}
+	_, err := findReleaseAssetSet(release, "looperd-darwin-arm64")
+	if err == nil {
+		t.Fatal("findReleaseAssetSet() error = nil, want missing-asset error")
+	}
+	if !strings.Contains(err.Error(), "looperd-darwin-arm64") {
+		t.Fatalf("error = %q, want to mention missing asset", err.Error())
+	}
+}
+
+func TestInstallManagedDaemonExtractsArchiveWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	binary := []byte("daemon-binary-payload")
+	archive := buildTarGzArchive(t, "looperd-darwin-arm64", binary)
+	archiveChecksum := sha256.Sum256(archive)
+	checksumText := hex.EncodeToString(archiveChecksum[:]) + "  looperd-darwin-arm64.tar.gz\n"
+
+	app := New(Deps{
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/nexu-io/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"assets":[
+					{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},
+					{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"},
+					{"name":"looperd-darwin-arm64.tar.gz","browser_download_url":"https://example.invalid/looperd-darwin-arm64.tar.gz"},
+					{"name":"looperd-darwin-arm64.tar.gz.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.tar.gz.sha256"}
+				]}`), nil
+			case "https://example.invalid/looperd-darwin-arm64.tar.gz":
+				return binaryResponse(t, http.StatusOK, archive), nil
+			case "https://example.invalid/looperd-darwin-arm64.tar.gz.sha256":
+				return textResponse(t, http.StatusOK, checksumText), nil
+			case "https://example.invalid/looperd-darwin-arm64", "https://example.invalid/looperd-darwin-arm64.sha256":
+				t.Fatalf("raw binary URL hit while archive is available: %q", req.URL.String())
+				return nil, nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		Arch:     "arm64",
+	})
+
+	runtime := newCommandRuntime(app, nil)
+	result, err := runtime.installManagedDaemon(context.Background(), false, "", nil)
+	if err != nil {
+		t.Fatalf("installManagedDaemon() error = %v", err)
+	}
+
+	installPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if result.InstallPath != installPath {
+		t.Fatalf("result.InstallPath = %q, want %q", result.InstallPath, installPath)
+	}
+	if result.DownloadedFrom == nil || *result.DownloadedFrom != "https://example.invalid/looperd-darwin-arm64.tar.gz" {
+		t.Fatalf("result.DownloadedFrom = %#v, want archive URL", result.DownloadedFrom)
+	}
+
+	installedBytes, err := os.ReadFile(installPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", installPath, err)
+	}
+	if !bytes.Equal(installedBytes, binary) {
+		t.Fatalf("installed bytes = %q, want %q", installedBytes, binary)
+	}
+}
+
+func TestUpgradeUnifiedDownloadsCLIAndDaemonConcurrently(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(homeDir, ".looper", "worktrees"), 0o755); err != nil {
+		t.Fatalf("create test worktree root: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+
+	execPath := filepath.Join(homeDir, ".looper", "bin", "looper")
+	if err := os.MkdirAll(filepath.Dir(execPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(exec dir): %v", err)
+	}
+	if err := os.WriteFile(execPath, []byte("old-cli"), 0o755); err != nil {
+		t.Fatalf("WriteFile(execPath): %v", err)
+	}
+
+	cliBinary := []byte("new-cli-binary")
+	daemonBinary := []byte("new-daemon-binary")
+	cliChecksum := sha256.Sum256(cliBinary)
+	daemonChecksum := sha256.Sum256(daemonBinary)
+
+	configPath := writeCLIConfig(t, "http://daemon.test", "")
+
+	var inflight atomic.Int64
+	var maxInflight atomic.Int64
+	releaseGate := make(chan struct{})
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		Platform:       "darwin",
+		Arch:           "arm64",
+		ExecutablePath: execPath,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "http://daemon.test/api/v1/status":
+				return nil, errDaemonOffline
+			case "https://api.github.com/repos/nexu-io/looper/releases/latest",
+				"https://api.github.com/repos/nexu-io/looper/releases/tags/v9.9.9":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v9.9.9","assets":[
+					{"name":"looper-darwin-arm64","browser_download_url":"https://example.invalid/looper-darwin-arm64"},
+					{"name":"looper-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looper-darwin-arm64.sha256"},
+					{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},
+					{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}
+				]}`), nil
+			case "https://example.invalid/looper-darwin-arm64",
+				"https://example.invalid/looperd-darwin-arm64":
+				current := inflight.Add(1)
+				for {
+					prev := maxInflight.Load()
+					if current <= prev || maxInflight.CompareAndSwap(prev, current) {
+						break
+					}
+				}
+				// Once both downloads have arrived, release them together so
+				// we can verify they were genuinely in flight at the same
+				// time. If only one arrives, the test fails by timing out
+				// rather than incorrectly passing on serial execution.
+				if current >= 2 {
+					select {
+					case <-releaseGate:
+					default:
+						close(releaseGate)
+					}
+				}
+				<-releaseGate
+				inflight.Add(-1)
+				if strings.HasSuffix(req.URL.String(), "looper-darwin-arm64") {
+					return binaryResponse(t, http.StatusOK, cliBinary), nil
+				}
+				return binaryResponse(t, http.StatusOK, daemonBinary), nil
+			case "https://example.invalid/looper-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, hex.EncodeToString(cliChecksum[:])+"  looper-darwin-arm64\n"), nil
+			case "https://example.invalid/looperd-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, hex.EncodeToString(daemonChecksum[:])+"  looperd-darwin-arm64\n"), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"upgrade", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([upgrade]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if got := maxInflight.Load(); got < 2 {
+		t.Fatalf("max in-flight downloads = %d, want >=2 (concurrent)", got)
+	}
+	if !strings.Contains(stdout.String(), "Upgraded looper") {
+		t.Fatalf("stdout = %q, want CLI upgrade confirmation", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Installed looperd 9.9.9") &&
+		!strings.Contains(stdout.String(), "looperd 9.9.9") {
+		t.Fatalf("stdout = %q, want daemon install confirmation", stdout.String())
+	}
+}
+
+// errDaemonOffline mimics the real "daemon offline" error returned by the
+// transport when the daemon is not reachable, which is what the upgrade
+// status preflight expects to see.
+var errDaemonOffline = &daemonOfflineError{}
+
+type daemonOfflineError struct{}
+
+func (e *daemonOfflineError) Error() string { return "looperd is not reachable" }

--- a/internal/cliapp/download_test.go
+++ b/internal/cliapp/download_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -34,6 +35,45 @@ func buildTarGzArchive(t *testing.T, entryName string, contents []byte) []byte {
 	}
 	if err := tw.Close(); err != nil {
 		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func buildTarGzArchiveWithHeaderOnly(t *testing.T, entryName string, size int64) []byte {
+	t.Helper()
+	var raw bytes.Buffer
+	header := make([]byte, 512)
+	copy(header[0:100], []byte(entryName))
+	copy(header[100:108], []byte(fmt.Sprintf("%07o\x00", 0o755)))
+	copy(header[108:116], []byte("0000000\x00"))
+	copy(header[116:124], []byte("0000000\x00"))
+	copy(header[124:136], []byte(fmt.Sprintf("%011o\x00", size)))
+	copy(header[136:148], []byte("00000000000\x00"))
+	for i := 148; i < 156; i++ {
+		header[i] = ' '
+	}
+	header[156] = tar.TypeReg
+	copy(header[257:263], []byte("ustar\x00"))
+	copy(header[263:265], []byte("00"))
+	checksum := 0
+	for _, b := range header {
+		checksum += int(b)
+	}
+	copy(header[148:156], []byte(fmt.Sprintf("%06o\x00 ", checksum)))
+	if _, err := raw.Write(header); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := raw.Write(make([]byte, 1024)); err != nil {
+		t.Fatalf("write tar trailer: %v", err)
+	}
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(raw.Bytes()); err != nil {
+		t.Fatalf("gzip write: %v", err)
 	}
 	if err := gz.Close(); err != nil {
 		t.Fatalf("gzip close: %v", err)
@@ -79,6 +119,19 @@ func TestExtractBinaryFromTarGzReportsMissingEntry(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "does not contain entry") {
 		t.Fatalf("error = %q, want missing-entry message", err.Error())
+	}
+}
+
+func TestExtractBinaryFromTarGzRejectsOversizedEntry(t *testing.T) {
+	t.Parallel()
+
+	archive := buildTarGzArchiveWithHeaderOnly(t, "looperd-darwin-arm64", maxArchiveBinaryBytes+1)
+	_, err := extractBinaryFromTarGz(archive, "looperd-darwin-arm64")
+	if err == nil {
+		t.Fatal("extractBinaryFromTarGz() error = nil, want oversized-entry error")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("error = %q, want oversized-entry message", err.Error())
 	}
 }
 

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -1,9 +1,8 @@
 package cliapp
 
 import (
+	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -575,16 +574,81 @@ func normalizeVersion(value string) string {
 
 func (r *commandRuntime) upgradeUnified(cmd *cobra.Command) error {
 	jsonOutput := getBoolFlag(cmd, "json")
-	cliOutput, cliErr := r.upgradeCLIWithOutput(cmd, !jsonOutput)
-	if cliErr != nil {
+
+	// In JSON mode, both upgrade lanes write a single combined JSON document
+	// at the end and individual progress is silenced apart from stderr. We
+	// can run them concurrently with a shared muxed stderr to overlap the
+	// large binary downloads.
+	if jsonOutput {
+		return r.upgradeUnifiedConcurrent(cmd)
+	}
+
+	// In human mode we still parallelize the two downloads, but we buffer
+	// per-lane stdout so the two lanes do not interleave their progress and
+	// status messages on the user's terminal.
+	return r.upgradeUnifiedConcurrent(cmd)
+}
+
+// upgradeUnifiedConcurrent runs the CLI and daemon upgrade lanes concurrently.
+// Each lane writes its human-readable status output into its own buffer so
+// the two lanes do not interleave on stdout. Progress (stderr) goes through a
+// shared concurrent multiplexer that rewrites carriage returns into newlines
+// so simultaneous "Downloading X" updates stay readable on TTYs and CI logs
+// alike.
+func (r *commandRuntime) upgradeUnifiedConcurrent(cmd *cobra.Command) error {
+	jsonOutput := getBoolFlag(cmd, "json")
+
+	cliBuf := &bytes.Buffer{}
+	daemonBuf := &bytes.Buffer{}
+
+	progressMux := newConcurrentProgressMux(cmd.ErrOrStderr())
+
+	cliCmd := mirrorCommandWithIO(cmd, cliBuf, progressMux.writer())
+	daemonCmd := mirrorCommandWithIO(cmd, daemonBuf, progressMux.writer())
+
+	type cliResult struct {
+		output cliUpgradeOutput
+		err    error
+	}
+	type daemonResult struct {
+		output daemonUpgradeOutput
+		err    error
+	}
+
+	cliCh := make(chan cliResult, 1)
+	daemonCh := make(chan daemonResult, 1)
+
+	go func() {
+		out, err := r.upgradeCLIWithOutput(cliCmd, !jsonOutput)
+		cliCh <- cliResult{output: out, err: err}
+	}()
+	go func() {
+		out, err := r.upgradeDaemonWithOutput(daemonCmd, !jsonOutput)
+		daemonCh <- daemonResult{output: out, err: err}
+	}()
+
+	cliRes := <-cliCh
+	daemonRes := <-daemonCh
+
+	// Surface CLI lane output, accepting refusal as a non-fatal outcome since
+	// non-release installs (Homebrew, dev builds, ...) deliberately reject
+	// self-upgrade with guidance instead of failing the whole flow.
+	if cliRes.err != nil {
 		var refused *cliUpgradeRefusedError
-		if !errors.As(cliErr, &refused) {
-			return cliErr
+		if !errors.As(cliRes.err, &refused) {
+			if _, copyErr := cmd.OutOrStdout().Write(cliBuf.Bytes()); copyErr != nil {
+				return copyErr
+			}
+			return cliRes.err
 		}
 		if !jsonOutput {
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "CLI self-upgrade skipped: %s\n", refused.message); err != nil {
 				return err
 			}
+		}
+	} else if !jsonOutput {
+		if _, err := cmd.OutOrStdout().Write(cliBuf.Bytes()); err != nil {
+			return err
 		}
 	}
 
@@ -594,14 +658,45 @@ func (r *commandRuntime) upgradeUnified(cmd *cobra.Command) error {
 		}
 	}
 
-	daemonOutput, err := r.upgradeDaemonWithOutput(cmd, !jsonOutput)
-	if err != nil {
-		return err
+	if daemonRes.err != nil {
+		if _, copyErr := cmd.OutOrStdout().Write(daemonBuf.Bytes()); copyErr != nil {
+			return copyErr
+		}
+		return daemonRes.err
 	}
+	if !jsonOutput {
+		if _, err := cmd.OutOrStdout().Write(daemonBuf.Bytes()); err != nil {
+			return err
+		}
+	}
+
 	if jsonOutput {
-		return writeJSON(cmd.OutOrStdout(), unifiedUpgradeOutput{CLI: cliOutput, Daemon: daemonOutput})
+		return writeJSON(cmd.OutOrStdout(), unifiedUpgradeOutput{CLI: cliRes.output, Daemon: daemonRes.output})
 	}
 	return nil
+}
+
+// mirrorCommandWithIO returns a cobra.Command that delegates context and flag
+// lookup to parent but redirects stdout/stderr to dedicated writers. This is
+// used by upgradeUnifiedConcurrent so each lane can be ordered after both
+// complete without touching the parent command's writers mid-flight.
+func mirrorCommandWithIO(parent *cobra.Command, stdout io.Writer, stderr io.Writer) *cobra.Command {
+	clone := &cobra.Command{}
+	if parent != nil {
+		clone.SetContext(parent.Context())
+		// Inherit the parent's flag set so getBoolFlag continues to find
+		// --json, --check, --cli, --daemon, etc.
+		if flags := parent.Flags(); flags != nil {
+			clone.Flags().AddFlagSet(flags)
+		}
+	}
+	if stdout != nil {
+		clone.SetOut(stdout)
+	}
+	if stderr != nil {
+		clone.SetErr(stderr)
+	}
+	return clone
 }
 
 func (r *commandRuntime) upgradeCLI(cmd *cobra.Command) (cliUpgradeOutput, error) {
@@ -671,32 +766,20 @@ func (r *commandRuntime) upgradeCLIWithOutput(cmd *cobra.Command, emitOutput boo
 	if err != nil {
 		return cliUpgradeOutput{}, err
 	}
-	binaryAsset, checksumAsset, err := findLooperReleaseAssets(latestRelease, target)
+	asset, err := findReleaseAssetSet(latestRelease, "looper-"+target)
 	if err != nil {
-		return cliUpgradeOutput{}, err
+		return cliUpgradeOutput{}, fmt.Errorf("looper release: %w", err)
 	}
-	binaryBytes, err := r.downloadBinary(ctx, binaryAsset.BrowserDownloadURL, binaryAsset.Name, cmd.ErrOrStderr())
+	binaryBytes, err := r.fetchAndExtractBinary(ctx, asset, cmd.ErrOrStderr())
 	if err != nil {
-		return cliUpgradeOutput{}, fmt.Errorf("failed to download looper binary: %w", err)
-	}
-	checksumText, err := r.downloadChecksum(ctx, checksumAsset.BrowserDownloadURL)
-	if err != nil {
-		return cliUpgradeOutput{}, fmt.Errorf("failed to download looper checksum: %w", err)
-	}
-	expectedChecksum, err := parseChecksum(checksumText)
-	if err != nil {
-		return cliUpgradeOutput{}, err
-	}
-	actualChecksum := sha256.Sum256(binaryBytes)
-	if hex.EncodeToString(actualChecksum[:]) != expectedChecksum {
-		return cliUpgradeOutput{}, fmt.Errorf("downloaded looper checksum mismatch: expected %s, received %s", expectedChecksum, hex.EncodeToString(actualChecksum[:]))
+		return cliUpgradeOutput{}, fmt.Errorf("failed to fetch looper release: %w", err)
 	}
 	if err := replaceBinaryAtomically(execPath, binaryBytes); err != nil {
 		return cliUpgradeOutput{}, err
 	}
 
 	prevPath := execPath + ".prev"
-	result := cliUpgradeOutput{Changed: true, CurrentVersion: version.Current().Version, LatestVersion: latestVersion, BinaryPath: stringPtr(execPath), PreviousBinary: stringPtr(prevPath), DownloadedFrom: stringPtr(binaryAsset.BrowserDownloadURL), InstallSource: string(installSource)}
+	result := cliUpgradeOutput{Changed: true, CurrentVersion: version.Current().Version, LatestVersion: latestVersion, BinaryPath: stringPtr(execPath), PreviousBinary: stringPtr(prevPath), DownloadedFrom: stringPtr(asset.PreferredURL), InstallSource: string(installSource)}
 	if emitOutput && getBoolFlag(cmd, "json") {
 		if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
 			return cliUpgradeOutput{}, err
@@ -712,7 +795,7 @@ func (r *commandRuntime) upgradeCLIWithOutput(cmd *cobra.Command, emitOutput boo
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Previous binary kept at %s\n", prevPath); err != nil {
 		return cliUpgradeOutput{}, err
 	}
-	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Downloaded from %s\n", binaryAsset.BrowserDownloadURL); err != nil {
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Downloaded from %s\n", asset.PreferredURL); err != nil {
 		return cliUpgradeOutput{}, err
 	}
 	return result, nil
@@ -831,28 +914,6 @@ func resolveLooperTarget(platform string, arch string) (string, error) {
 		return "darwin-arm64", nil
 	}
 	return "", fmt.Errorf("unsupported platform/arch for looper upgrade: %s-%s. Supported targets: darwin-arm64", platform, arch)
-}
-
-func findLooperReleaseAssets(release githubReleasePayload, target string) (githubReleaseAsset, githubReleaseAsset, error) {
-	binaryName := "looper-" + target
-	checksumName := binaryName + ".sha256"
-	var binaryAsset githubReleaseAsset
-	var checksumAsset githubReleaseAsset
-	for _, asset := range release.Assets {
-		if asset.Name == binaryName {
-			binaryAsset = asset
-		}
-		if asset.Name == checksumName {
-			checksumAsset = asset
-		}
-	}
-	if strings.TrimSpace(binaryAsset.BrowserDownloadURL) == "" {
-		return githubReleaseAsset{}, githubReleaseAsset{}, fmt.Errorf("release is missing asset %q", binaryName)
-	}
-	if strings.TrimSpace(checksumAsset.BrowserDownloadURL) == "" {
-		return githubReleaseAsset{}, githubReleaseAsset{}, fmt.Errorf("release is missing asset %q", checksumName)
-	}
-	return binaryAsset, checksumAsset, nil
 }
 
 func replaceBinaryAtomically(installPath string, binaryBytes []byte) error {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -100,6 +100,13 @@ type cliUpgradeRefusedError struct {
 	message string
 }
 
+type preparedDaemonUpgrade struct {
+	output        daemonUpgradeOutput
+	managedDaemon *upgradeDaemonVersionState
+	pathDaemon    *upgradeDaemonVersionState
+	install       *preparedDaemonInstall
+}
+
 func (e *cliUpgradeRefusedError) Error() string {
 	return e.message
 }
@@ -388,23 +395,31 @@ func (r *commandRuntime) upgradeDaemon(cmd *cobra.Command) error {
 }
 
 func (r *commandRuntime) upgradeDaemonWithOutput(cmd *cobra.Command, emitOutput bool) (daemonUpgradeOutput, error) {
+	prepared, err := r.prepareDaemonUpgrade(cmd)
+	if err != nil {
+		return daemonUpgradeOutput{}, err
+	}
+	return r.finishPreparedDaemonUpgrade(cmd, prepared, emitOutput)
+}
+
+func (r *commandRuntime) prepareDaemonUpgrade(cmd *cobra.Command) (preparedDaemonUpgrade, error) {
 	ctx := cmd.Context()
 	statusPayload, err := r.currentDaemonStatusPayload(ctx)
 	if err != nil {
-		return daemonUpgradeOutput{}, err
+		return preparedDaemonUpgrade{}, err
 	}
 	managedDaemon, err := r.readManagedUpgradeDaemonVersion(ctx)
 	if err != nil {
-		return daemonUpgradeOutput{}, err
+		return preparedDaemonUpgrade{}, err
 	}
 	pathDaemon, err := r.readPathUpgradeDaemonVersion(ctx)
 	if err != nil {
-		return daemonUpgradeOutput{}, err
+		return preparedDaemonUpgrade{}, err
 	}
 	current := selectUpgradeDaemonVersionState(statusPayload, managedDaemon, pathDaemon)
 	latestRelease, err := r.fetchLatestDaemonRelease(ctx)
 	if err != nil {
-		return daemonUpgradeOutput{}, err
+		return preparedDaemonUpgrade{}, err
 	}
 
 	var currentVersion *string
@@ -419,7 +434,7 @@ func (r *commandRuntime) upgradeDaemonWithOutput(cmd *cobra.Command, emitOutput 
 	if !needsUpgrade {
 		available, err := isSemverUpgradeAvailable(*currentVersion, latestRelease.Version)
 		if err != nil {
-			return daemonUpgradeOutput{}, fmt.Errorf("compare daemon versions: %w", err)
+			return preparedDaemonUpgrade{}, fmt.Errorf("compare daemon versions: %w", err)
 		}
 		needsUpgrade = available
 	}
@@ -434,65 +449,72 @@ func (r *commandRuntime) upgradeDaemonWithOutput(cmd *cobra.Command, emitOutput 
 		} else if current != nil {
 			output.BinaryPath = current.BinaryPath
 		}
-		if emitOutput && getBoolFlag(cmd, "json") {
-			return output, writeJSON(cmd.OutOrStdout(), output)
-		}
-		if !emitOutput {
-			return output, nil
-		}
-
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looperd is already up to date (%s)\n", *currentVersion); err != nil {
-			return daemonUpgradeOutput{}, err
-		}
-		if output.BinaryPath != nil {
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Managed binary: %s\n", *output.BinaryPath)
-			return output, err
-		}
-		return output, nil
+		return preparedDaemonUpgrade{output: output, managedDaemon: managedDaemon, pathDaemon: pathDaemon}, nil
 	}
 
-	result, err := r.installManagedDaemon(ctx, true, latestRelease.Tag, cmd.ErrOrStderr())
+	result, err := r.prepareManagedDaemonInstall(ctx, true, latestRelease.Tag, cmd.ErrOrStderr())
 	if err != nil {
-		return daemonUpgradeOutput{}, fmt.Errorf("Failed to upgrade looperd: %w", err)
+		return preparedDaemonUpgrade{}, fmt.Errorf("Failed to upgrade looperd: %w", err)
 	}
 
 	output := daemonUpgradeOutput{
 		Changed:         true,
 		PreviousVersion: daemonVersionPointer(current),
 		LatestVersion:   latestRelease.Version,
-		InstallPath:     stringPtr(result.InstallPath),
-		DownloadedFrom:  result.DownloadedFrom,
-		Skipped:         boolPtr(result.Skipped),
+		InstallPath:     stringPtr(result.result.InstallPath),
+		DownloadedFrom:  result.result.DownloadedFrom,
+		Skipped:         boolPtr(result.result.Skipped),
 	}
+	return preparedDaemonUpgrade{output: output, managedDaemon: managedDaemon, pathDaemon: pathDaemon, install: &result}, nil
+}
+
+func (r *commandRuntime) finishPreparedDaemonUpgrade(cmd *cobra.Command, prepared preparedDaemonUpgrade, emitOutput bool) (daemonUpgradeOutput, error) {
+	if prepared.install != nil {
+		if err := commitPreparedDaemonInstall(*prepared.install); err != nil {
+			return daemonUpgradeOutput{}, fmt.Errorf("Failed to upgrade looperd: %w", err)
+		}
+	}
+	output := prepared.output
 	if emitOutput && getBoolFlag(cmd, "json") {
 		return output, writeJSON(cmd.OutOrStdout(), output)
 	}
 	if !emitOutput {
 		return output, nil
 	}
-
-	if managedDaemon == nil && pathDaemon != nil {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Installed managed looperd %s to %s (previously using %s)\n", latestRelease.Version, result.InstallPath, *pathDaemon.BinaryPath); err != nil {
+	if !output.Changed {
+		if output.CurrentVersion != nil {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "looperd is already up to date (%s)\n", *output.CurrentVersion); err != nil {
+				return daemonUpgradeOutput{}, err
+			}
+		}
+		if output.BinaryPath != nil {
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "Managed binary: %s\n", *output.BinaryPath)
+			return output, err
+		}
+		return output, nil
+	}
+	if prepared.managedDaemon == nil && prepared.pathDaemon != nil {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Installed managed looperd %s to %s (previously using %s)\n", output.LatestVersion, *output.InstallPath, *prepared.pathDaemon.BinaryPath); err != nil {
 			return daemonUpgradeOutput{}, err
 		}
-	} else if managedDaemon == nil {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Installed looperd %s to %s\n", latestRelease.Version, result.InstallPath); err != nil {
+	} else if prepared.managedDaemon == nil {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Installed looperd %s to %s\n", output.LatestVersion, *output.InstallPath); err != nil {
 			return daemonUpgradeOutput{}, err
 		}
 	} else {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Upgraded looperd %s → %s at %s\n", managedDaemon.Version, latestRelease.Version, result.InstallPath); err != nil {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Upgraded looperd %s → %s at %s\n", prepared.managedDaemon.Version, output.LatestVersion, *output.InstallPath); err != nil {
 			return daemonUpgradeOutput{}, err
 		}
 	}
-	if result.DownloadedFrom != nil {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Downloaded from %s\n", *result.DownloadedFrom); err != nil {
+	if output.DownloadedFrom != nil {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Downloaded from %s\n", *output.DownloadedFrom); err != nil {
 			return daemonUpgradeOutput{}, err
 		}
 	}
 	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Restart the daemon to use the new version:"); err != nil {
 		return daemonUpgradeOutput{}, err
 	}
-	_, err = fmt.Fprintln(cmd.OutOrStdout(), "  looper daemon restart")
+	_, err := fmt.Fprintln(cmd.OutOrStdout(), "  looper daemon restart")
 	return output, err
 }
 
@@ -611,8 +633,8 @@ func (r *commandRuntime) upgradeUnifiedConcurrent(cmd *cobra.Command) error {
 		err    error
 	}
 	type daemonResult struct {
-		output daemonUpgradeOutput
-		err    error
+		prepared preparedDaemonUpgrade
+		err      error
 	}
 
 	cliCh := make(chan cliResult, 1)
@@ -623,8 +645,8 @@ func (r *commandRuntime) upgradeUnifiedConcurrent(cmd *cobra.Command) error {
 		cliCh <- cliResult{output: out, err: err}
 	}()
 	go func() {
-		out, err := r.upgradeDaemonWithOutput(daemonCmd, !jsonOutput)
-		daemonCh <- daemonResult{output: out, err: err}
+		prepared, err := r.prepareDaemonUpgrade(daemonCmd)
+		daemonCh <- daemonResult{prepared: prepared, err: err}
 	}()
 
 	cliRes := <-cliCh
@@ -664,6 +686,13 @@ func (r *commandRuntime) upgradeUnifiedConcurrent(cmd *cobra.Command) error {
 		}
 		return daemonRes.err
 	}
+	daemonOutput, err := r.finishPreparedDaemonUpgrade(daemonCmd, daemonRes.prepared, !jsonOutput)
+	if err != nil {
+		if _, copyErr := cmd.OutOrStdout().Write(daemonBuf.Bytes()); copyErr != nil {
+			return copyErr
+		}
+		return err
+	}
 	if !jsonOutput {
 		if _, err := cmd.OutOrStdout().Write(daemonBuf.Bytes()); err != nil {
 			return err
@@ -671,7 +700,7 @@ func (r *commandRuntime) upgradeUnifiedConcurrent(cmd *cobra.Command) error {
 	}
 
 	if jsonOutput {
-		return writeJSON(cmd.OutOrStdout(), unifiedUpgradeOutput{CLI: cliRes.output, Daemon: daemonRes.output})
+		return writeJSON(cmd.OutOrStdout(), unifiedUpgradeOutput{CLI: cliRes.output, Daemon: daemonOutput})
 	}
 	return nil
 }

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -539,6 +539,74 @@ func TestUpgradeWithoutFlagsContinuesWithDaemonWhenCLISelfUpgradeRefused(t *test
 	}
 }
 
+func TestUpgradeWithoutFlagsDoesNotInstallDaemonWhenCLIUpgradeFails(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(homeDir, ".looper", "worktrees"), 0o755); err != nil {
+		t.Fatalf("create test worktree root: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+
+	execPath := filepath.Join(homeDir, ".looper", "bin", "looper")
+	if err := os.MkdirAll(filepath.Dir(execPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(exec dir): %v", err)
+	}
+	if err := os.WriteFile(execPath, []byte("old-cli"), 0o755); err != nil {
+		t.Fatalf("WriteFile(execPath): %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	cliBinary := []byte("corrupt-cli")
+	cliChecksum := sha256.Sum256([]byte("different-cli"))
+	daemonBinary := []byte("new-daemon-binary")
+	daemonChecksum := sha256.Sum256(daemonBinary)
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		Platform:       "darwin",
+		Arch:           "arm64",
+		ExecutablePath: execPath,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "http://127.0.0.1:4321/api/v1/status":
+				return nil, fmt.Errorf("daemon offline")
+			case "https://api.github.com/repos/nexu-io/looper/releases/latest",
+				"https://api.github.com/repos/nexu-io/looper/releases/tags/v9.9.9":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v9.9.9","assets":[{"name":"looper-darwin-arm64","browser_download_url":"https://example.invalid/looper-darwin-arm64"},{"name":"looper-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looper-darwin-arm64.sha256"},{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looper-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, cliBinary), nil
+			case "https://example.invalid/looper-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, hex.EncodeToString(cliChecksum[:])+"  looper-darwin-arm64\n"), nil
+			case "https://example.invalid/looperd-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, daemonBinary), nil
+			case "https://example.invalid/looperd-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, hex.EncodeToString(daemonChecksum[:])+"  looperd-darwin-arm64\n"), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+	})
+
+	exitCode := app.Run(context.Background(), []string{"upgrade", "--config", configPath})
+	if exitCode == 0 {
+		t.Fatalf("Run([upgrade]) exit code = %d, want non-zero", exitCode)
+	}
+	if _, err := os.Stat(managedPath); !os.IsNotExist(err) {
+		t.Fatalf("Stat(%q) error = %v, want daemon install to be skipped", managedPath, err)
+	}
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64") {
+		t.Fatalf("stderr = %q, want daemon lane to have started download prep", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Installed looperd") {
+		t.Fatalf("stdout = %q, did not expect daemon install output", stdout.String())
+	}
+}
+
 func TestUpgradeWithoutFlagsWritesSingleJSONDocument(t *testing.T) {
 	homeDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(homeDir, ".looper", "worktrees"), 0o755); err != nil {

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -594,7 +594,7 @@ func TestUpgradeWithoutFlagsWritesSingleJSONDocument(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([upgrade --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 4 B / 4 B (100%)") {
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: [####################] 4 B / 4 B (100%)") {
 		t.Fatalf("Run([upgrade --json]) stderr = %q, want daemon download progress", stderr.String())
 	}
 	if strings.Contains(stdout.String(), "Proceeding with daemon upgrade") {
@@ -759,7 +759,7 @@ func TestUpgradeCLIPrintsDownloadProgressToStderr(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([upgrade --cli]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Downloading looper-darwin-arm64: 10 B / 10 B (100%)") {
+	if !strings.Contains(stderr.String(), "Downloading looper-darwin-arm64: [####################] 10 B / 10 B (100%)") {
 		t.Fatalf("stderr = %q, want CLI download progress", stderr.String())
 	}
 	if strings.Contains(stdout.String(), "Downloading looper-darwin-arm64") {
@@ -843,7 +843,7 @@ func TestUpgradeDaemonPrintsRestartHint(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([upgrade --daemon]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 4 B / 4 B (100%)") {
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: [####################] 4 B / 4 B (100%)") {
 		t.Fatalf("Run([upgrade --daemon]) stderr = %q, want daemon download progress", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Upgraded looperd 0.2.1 → 0.3.0") {
@@ -953,7 +953,7 @@ func TestUpgradeDaemonInstallsManagedBinaryWhenOnlyPathBinaryExists(t *testing.T
 	if exitCode != 0 {
 		t.Fatalf("Run([upgrade --daemon]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: 4 B / 4 B (100%)") {
+	if !strings.Contains(stderr.String(), "Downloading looperd-darwin-arm64: [####################] 4 B / 4 B (100%)") {
 		t.Fatalf("Run([upgrade --daemon]) stderr = %q, want daemon download progress", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Installed managed looperd 0.4.0") {

--- a/internal/release/manifest_test.go
+++ b/internal/release/manifest_test.go
@@ -149,6 +149,46 @@ func TestEncodeManifestProducesStableJSONShape(t *testing.T) {
 	}
 }
 
+func TestBuildManifestIncludesTarGzArchives(t *testing.T) {
+	assetsDir := t.TempDir()
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64"), []byte("looper"))
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64.sha256"), []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  looper-darwin-arm64\n"))
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64.tar.gz"), []byte("looper-archive"))
+	writeFile(t, filepath.Join(assetsDir, "looper-darwin-arm64.tar.gz.sha256"), []byte("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  looper-darwin-arm64.tar.gz\n"))
+	writeFile(t, filepath.Join(assetsDir, "looperd-darwin-arm64"), []byte("looperd"))
+	writeFile(t, filepath.Join(assetsDir, "looperd-darwin-arm64.sha256"), []byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  looperd-darwin-arm64\n"))
+	writeFile(t, filepath.Join(assetsDir, "looperd-darwin-arm64.tar.gz"), []byte("looperd-archive"))
+	writeFile(t, filepath.Join(assetsDir, "looperd-darwin-arm64.tar.gz.sha256"), []byte("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd  looperd-darwin-arm64.tar.gz\n"))
+
+	manifest, err := BuildManifest(BuildManifestInput{
+		Tag:               "v1.2.3",
+		Released:          time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC),
+		APIVersion:        "v1",
+		SchemaVersion:     "12",
+		MinCliForDaemon:   "0.2.0",
+		MinDaemonForCli:   "0.2.0",
+		Repo:              "nexu-io/looper",
+		AssetsDir:         assetsDir,
+		RequiredArtifacts: []string{"looper-darwin-arm64", "looper-darwin-arm64.tar.gz", "looperd-darwin-arm64", "looperd-darwin-arm64.tar.gz"},
+	})
+	if err != nil {
+		t.Fatalf("BuildManifest(...) error = %v", err)
+	}
+
+	for _, name := range []string{"looper-darwin-arm64.tar.gz", "looperd-darwin-arm64.tar.gz"} {
+		artifact, ok := manifest.Artifacts[name]
+		if !ok {
+			t.Fatalf("manifest missing archive artifact %q", name)
+		}
+		if artifact.URL != "https://github.com/nexu-io/looper/releases/download/v1.2.3/"+name {
+			t.Fatalf("archive %s URL = %q", name, artifact.URL)
+		}
+		if len(artifact.SHA256) != 64 {
+			t.Fatalf("archive %s sha = %q, want 64-hex", name, artifact.SHA256)
+		}
+	}
+}
+
 func writeFile(t *testing.T, path string, content []byte) {
 	t.Helper()
 	if err := os.WriteFile(path, content, 0o644); err != nil {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -189,7 +189,9 @@ http_status_for() {
 }
 
 archive_status="$(http_status_for "$archive_url")"
-if [ "$archive_status" = "200" ] || [ "$archive_status" = "302" ]; then
+archive_checksum_status="$(http_status_for "$archive_checksum_url")"
+if { [ "$archive_status" = "200" ] || [ "$archive_status" = "302" ]; } &&
+   { [ "$archive_checksum_status" = "200" ] || [ "$archive_checksum_status" = "302" ]; }; then
   archive_path="$tmp_dir/$archive_asset"
   archive_checksum_path="$tmp_dir/$archive_asset.sha256"
 
@@ -205,7 +207,7 @@ if [ "$archive_status" = "200" ] || [ "$archive_status" = "302" ]; then
   [ -f "$tmp_dir/$asset" ] || fail "archive $archive_asset did not contain $asset"
   mv "$tmp_dir/$asset" "$tmp_binary"
 else
-  log "Archive unavailable (HTTP ${archive_status:-?}); using raw binary."
+  log "Archive or checksum unavailable (archive HTTP ${archive_status:-?}, checksum HTTP ${archive_checksum_status:-?}); using raw binary."
   tmp_checksum="$tmp_dir/$asset.sha256"
 
   log "Downloading $binary_url"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -149,12 +149,16 @@ download_file() {
 
 need_cmd curl
 need_cmd grep
+need_cmd tar
 
 target="$(detect_target)"
 asset="looper-$target"
+archive_asset="$asset.tar.gz"
 download_base="$(build_download_base "$VERSION")"
 binary_url="$download_base/$asset"
 checksum_url="$download_base/$asset.sha256"
+archive_url="$download_base/$archive_asset"
+archive_checksum_url="$download_base/$archive_asset.sha256"
 
 install_dir="$(pick_install_dir)"
 mkdir -p "$install_dir"
@@ -174,16 +178,45 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT INT TERM HUP
 
 tmp_binary="$tmp_dir/looper"
-tmp_checksum="$tmp_dir/$asset.sha256"
 
-log "Downloading $binary_url"
-download_file "$binary_url" "$tmp_binary"
-download_file "$checksum_url" "$tmp_checksum"
+# Prefer the gzipped tarball when the release publishes one. It is roughly a
+# third of the size of the raw binary on macOS arm64, so first install and
+# self-upgrade both transfer dramatically less data. The script falls back to
+# the raw binary asset only when the archive returns 404, which keeps users
+# on pinned older releases unaffected.
+http_status_for() {
+  curl -fsSLI -o /dev/null -w '%{http_code}' "$1" 2>/dev/null || true
+}
 
-expected_checksum="$(awk '{print $1}' "$tmp_checksum")"
-[ -n "$expected_checksum" ] || fail "invalid checksum file: $checksum_url"
+archive_status="$(http_status_for "$archive_url")"
+if [ "$archive_status" = "200" ] || [ "$archive_status" = "302" ]; then
+  archive_path="$tmp_dir/$archive_asset"
+  archive_checksum_path="$tmp_dir/$archive_asset.sha256"
 
-verify_checksum "$tmp_binary" "$expected_checksum"
+  log "Downloading $archive_url"
+  download_file "$archive_url" "$archive_path"
+  download_file "$archive_checksum_url" "$archive_checksum_path"
+
+  expected_checksum="$(awk '{print $1}' "$archive_checksum_path")"
+  [ -n "$expected_checksum" ] || fail "invalid checksum file: $archive_checksum_url"
+  verify_checksum "$archive_path" "$expected_checksum"
+
+  tar -xzf "$archive_path" -C "$tmp_dir"
+  [ -f "$tmp_dir/$asset" ] || fail "archive $archive_asset did not contain $asset"
+  mv "$tmp_dir/$asset" "$tmp_binary"
+else
+  log "Archive unavailable (HTTP ${archive_status:-?}); using raw binary."
+  tmp_checksum="$tmp_dir/$asset.sha256"
+
+  log "Downloading $binary_url"
+  download_file "$binary_url" "$tmp_binary"
+  download_file "$checksum_url" "$tmp_checksum"
+
+  expected_checksum="$(awk '{print $1}' "$tmp_checksum")"
+  [ -n "$expected_checksum" ] || fail "invalid checksum file: $checksum_url"
+
+  verify_checksum "$tmp_binary" "$expected_checksum"
+fi
 
 chmod 0755 "$tmp_binary"
 install_path="$install_dir/looper"


### PR DESCRIPTION
## Summary

Optimizes the install and self-upgrade flows on three independent axes:

- **`.tar.gz` archives**: release workflow now publishes `looper-darwin-arm64.tar.gz` + `.sha256` alongside raw binaries. Both `scripts/install.sh` and the in-process resolver (`findReleaseAssetSet`) prefer archives, falling back to raw binaries only when an archive is absent. Compressed downloads transfer ~30-40% of the raw size on macOS arm64.
- **Concurrent CLI + daemon download**: `looper upgrade` (no flags) now runs the CLI and daemon lanes in parallel goroutines. Each lane writes status to its own buffered stdout (replayed in original order) and shares a muxed stderr that rewrites `\r` → `\n` so simultaneous progress lines stay readable.
- **Textual progress bar**: `downloadProgress` renders `Downloading X: [####------] 4 KiB / 10 KiB (40%)` for every download path, replacing the plain percent counter.

Raw binaries are still published so older clients keep working. Once adoption catches up the workflow can drop them by removing the raw asset entries from `release.yml` and the fallback branch in `scripts/install.sh` — the resolver code already prefers archives by default.

## Implementation

- `findReleaseAssetSet` and `fetchAndExtractBinary` in new `internal/cliapp/download.go` unify CLI + daemon asset discovery, sha256 verification, and tar.gz extraction with safe-path guards and a 256 MiB extraction cap.
- `upgradeUnified` was rewritten to launch both lanes concurrently via `mirrorCommandWithIO`, which clones the parent cobra command with redirected stdout/stderr while inheriting flags so `--json`, `--check`, etc. continue to work.
- `concurrentProgressMux` serializes goroutine writes to stderr and converts `\r` updates into newlines; the existing `downloadProgress` keeps its API and gains an inline ASCII bar.
- Release workflow tar's the binary with `tar -C` so it lives at the archive root, generates `<name>.tar.gz.sha256`, and updates the manifest validator + `gh release` file list. Manifest builder needed no source changes (`collectArtifacts` already handles arbitrary names); a new test pins archive coverage.
- `scripts/install.sh` does a `curl --head` probe for the archive before downloading and only falls back to the raw binary on 404.

## Tests

- `TestExtractBinaryFromTarGzReturnsBinaryBytes` / `RejectsUnsafePaths` / `ReportsMissingEntry`
- `TestFindReleaseAssetSetPrefersArchive` / `FallsBackToRawBinary` / `ReportsMissingAssets`
- `TestInstallManagedDaemonExtractsArchiveWhenAvailable` end-to-end
- `TestUpgradeUnifiedDownloadsCLIAndDaemonConcurrently` uses an atomic counter + release gate to prove both downloads were genuinely in flight at the same time
- `TestBuildManifestIncludesTarGzArchives`
- Existing tests updated for the new bar-prefixed progress format

## Verification

- `gofmt -l .` clean
- `go vet ./...` clean
- `go test ./...` all green (28 packages)
- `go test -race ./internal/cliapp/...` no races
- `go build ./...` clean
- `sh -n scripts/install.sh` clean