### PR TITLE
feat: auto-reply to review comment authors before resolving threads

### DIFF
--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -219,7 +219,7 @@ func DefaultDisclosureConfig() DisclosureConfig {
 			PullRequest:          true,
 			IssueComment:         true,
 			ReviewComment:        true,
-			InlineCommentVisible: false,
+			InlineCommentVisible: true,
 		},
 	}
 }

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -146,7 +146,7 @@
           "pullRequest": true,
           "issueComment": true,
           "reviewComment": true,
-          "inlineCommentVisible": false
+          "inlineCommentVisible": true
         }
       },
       "tools": {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -81,7 +81,7 @@
           "pullRequest": true,
           "issueComment": true,
           "reviewComment": true,
-          "inlineCommentVisible": false
+          "inlineCommentVisible": true
         }
       },
       "tools": {

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -165,7 +165,7 @@
           "pullRequest": true,
           "issueComment": true,
           "reviewComment": true,
-          "inlineCommentVisible": false
+          "inlineCommentVisible": true
         }
       },
       "tools": {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1660,17 +1660,13 @@ func buildFixerReplyBody(item FixItem, commitSHA, explanation string) string {
 }
 
 func summarizeFixItem(item FixItem) string {
-	summary := strings.TrimSpace(item.Summary)
+	summary := sanitizeReplyExplanation(item.Summary)
 	if summary == "" {
 		return ""
 	}
-	summary = strings.ReplaceAll(summary, "<!-- looper:stamp v=1 -->", "")
-	summary = strings.TrimSpace(summary)
-	if summary == "" {
-		return ""
-	}
-	if len(summary) > 240 {
-		summary = strings.TrimSpace(summary[:240]) + "…"
+	if len([]rune(summary)) > 240 {
+		runes := []rune(summary)
+		summary = strings.TrimSpace(string(runes[:240])) + "…"
 	}
 	lines := strings.Split(summary, "\n")
 	for index, line := range lines {
@@ -1739,7 +1735,11 @@ func (r *Runner) publishRoundSummaryComment(ctx context.Context, input stepInput
 		checkpoint.SummaryComment.UpdatedAt = r.nowISO()
 		return
 	}
-	if existingID, existingURL := findExistingFixerSummaryCommentID(checkpoint.Detail, headSHA); existingID != 0 {
+	trustedLogin := ""
+	if login, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath); err == nil {
+		trustedLogin = login
+	}
+	if existingID, existingURL := findExistingFixerSummaryCommentID(checkpoint.Detail, headSHA, trustedLogin); existingID != 0 {
 		if err := r.github.UpdateIssueComment(ctx, UpdateIssueCommentInput{Repo: input.Repo, CommentID: existingID, Body: body, CWD: input.Project.RepoPath}); err != nil {
 			checkpoint.SummaryComment = &checkpointSummaryComment{CommentID: existingID, URL: existingURL, HeadSHA: headSHA, FixItemsHash: checkpoint.FixItemsHash, State: "update_failed", Error: err.Error(), UpdatedAt: r.nowISO()}
 			return
@@ -1930,7 +1930,7 @@ func summaryStatusIcon(status string) string {
 // findExistingFixerSummaryCommentID scans the PR's issue comments for a prior
 // summary keyed by the same head SHA. Used for edit-on-retry when our local
 // checkpoint was wiped (resume across daemon restarts, scheduler re-claim).
-func findExistingFixerSummaryCommentID(detail *checkpointDetail, headSHA string) (int64, string) {
+func findExistingFixerSummaryCommentID(detail *checkpointDetail, headSHA, trustedLogin string) (int64, string) {
 	if detail == nil || headSHA == "" {
 		return 0, ""
 	}
@@ -1941,6 +1941,9 @@ func findExistingFixerSummaryCommentID(detail *checkpointDetail, headSHA string)
 	for _, comment := range detail.IssueComments {
 		body, _ := stringFromAny(comment["body"])
 		if !strings.Contains(body, marker) {
+			continue
+		}
+		if !isTrustedFixerSummaryComment(comment, trustedLogin, body) {
 			continue
 		}
 		idVal := comment["id"]
@@ -1960,6 +1963,22 @@ func findExistingFixerSummaryCommentID(detail *checkpointDetail, headSHA string)
 		return id, url
 	}
 	return 0, ""
+}
+
+func isTrustedFixerSummaryComment(comment map[string]any, trustedLogin, body string) bool {
+	if strings.Contains(body, "looper:stamp") {
+		return true
+	}
+	if sameGitHubLogin(issueCommentAuthorLogin(comment), trustedLogin) {
+		return true
+	}
+	return false
+}
+
+func issueCommentAuthorLogin(comment map[string]any) string {
+	author, _ := comment["author"].(map[string]any)
+	login, _ := stringFromAny(author["login"])
+	return login
 }
 
 func (r *Runner) runRecheckStep(ctx context.Context, input stepInput) (fixerCheckpoint, error) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -521,15 +521,16 @@ func checkpointRepairFromAgentResult(executionID, headSHA string, result AgentRe
 // limits prompt-injection blast radius if a malicious reviewer plants payload.
 const maxReplyExplanationLength = 500
 
-// parseReplyExplanationsFromStdout extracts the optional review_thread_replies
-// array from the final __LOOPER_RESULT__ JSON line. Failure to parse is not an
-// error: the runner falls back to the generic reply body. Entries are filtered
-// against the current fixItems snapshot (keyed by fixItemId, with a defensive
-// threadId cross-check), deduplicated keeping the first valid occurrence, and
-// truncated. Disclosure markers, @mentions, and HTML tags are stripped so the
-// adapter remains the only path that stamps and templates the reply.
-func parseReplyExplanationsFromStdout(stdout string, fixItems []FixItem) []replyExplanationEntry {
-	if strings.TrimSpace(stdout) == "" {
+// parseReplyExplanations extracts the optional review_thread_replies array from
+// the final __LOOPER_RESULT__ JSON line. Failure to parse is not an error: the
+// runner falls back to the generic reply body. Entries are filtered against the
+// current fixItems snapshot (keyed by fixItemId, with a defensive threadId
+// cross-check), deduplicated keeping the first valid occurrence, and truncated.
+// Disclosure markers, @mentions, and HTML tags are stripped so the adapter
+// remains the only path that stamps and templates the reply.
+func parseReplyExplanations(stdout, stderr string, fixItems []FixItem) []replyExplanationEntry {
+	combined := stdout + "\n" + stderr
+	if strings.TrimSpace(combined) == "" {
 		return nil
 	}
 	itemsByID := make(map[string]FixItem, len(fixItems))
@@ -545,7 +546,7 @@ func parseReplyExplanationsFromStdout(stdout string, fixItems []FixItem) []reply
 	if len(itemsByID) == 0 {
 		return nil
 	}
-	payload := extractCompletionMarkerPayload(stdout)
+	payload := extractCompletionMarkerPayload(combined)
 	if payload == "" {
 		return nil
 	}
@@ -632,7 +633,7 @@ func sanitizeReplyExplanation(raw string) string {
 }
 
 var (
-	leadingMentionPattern = regexp.MustCompile(`(?m)^(?:@[A-Za-z0-9][A-Za-z0-9-]{0,38}\s+)+`)
+	leadingMentionPattern = regexp.MustCompile(`(?m)^(?:@[A-Za-z0-9][A-Za-z0-9-]{0,38}(?:[,:;]+)?\s*)+`)
 	htmlTagPattern        = regexp.MustCompile(`</?[A-Za-z][^>]*>`)
 )
 
@@ -1330,7 +1331,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		return checkpoint, err
 	}
 	checkpoint.Repair = checkpointRepairFromAgentResult(executionID, detailHeadSHA(checkpoint.Detail), result, r.nowISO())
-	checkpoint.Repair.ReplyExplanations = parseReplyExplanationsFromStdout(result.Stdout, checkpoint.FixItems)
+	checkpoint.Repair.ReplyExplanations = parseReplyExplanations(result.Stdout, result.Stderr, checkpoint.FixItems)
 	checkpoint.Repair.FixItemsHash = checkpoint.FixItemsHash
 	checkpoint.ensureLifecycle("fixer", worktree.Branch, detailBaseRefName(checkpoint.Detail), false)
 	if result.Lifecycle != nil {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -100,6 +100,7 @@ type PullRequestDetail struct {
 	BaseSHA        string
 	ReviewDecision string
 	Comments       []map[string]any
+	IssueComments  []map[string]any
 	Checks         []map[string]any
 	HasConflicts   bool
 	Author         string
@@ -133,6 +134,25 @@ type AddReviewThreadReplyInput struct {
 	CWD      string
 }
 
+type IssueCommentInput struct {
+	Repo        string
+	IssueNumber int64
+	Body        string
+	CWD         string
+}
+
+type IssueCommentResult struct {
+	ID  int64
+	URL string
+}
+
+type UpdateIssueCommentInput struct {
+	Repo      string
+	CommentID int64
+	Body      string
+	CWD       string
+}
+
 type PullRequestLabelsInput struct {
 	Repo     string
 	PRNumber int64
@@ -147,6 +167,8 @@ type GitHubGateway interface {
 	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
 	ResolveReviewThread(context.Context, ResolveReviewThreadInput) error
 	AddReviewThreadReply(context.Context, AddReviewThreadReplyInput) error
+	CreateIssueComment(context.Context, IssueCommentInput) (IssueCommentResult, error)
+	UpdateIssueComment(context.Context, UpdateIssueCommentInput) error
 	AddPullRequestLabels(context.Context, PullRequestLabelsInput) error
 	RemovePullRequestLabels(context.Context, PullRequestLabelsInput) error
 }
@@ -383,6 +405,7 @@ type fixerCheckpoint struct {
 	Validation       *ValidationResult           `json:"validation,omitempty"`
 	Push             *checkpointPush             `json:"push,omitempty"`
 	ResolvedComments *checkpointResolvedComments `json:"resolvedComments,omitempty"`
+	SummaryComment   *checkpointSummaryComment   `json:"summaryComment,omitempty"`
 	Recheck          *checkpointRecheck          `json:"recheck,omitempty"`
 	SkipReason       string                      `json:"skipReason,omitempty"`
 }
@@ -397,6 +420,7 @@ type checkpointDetail struct {
 	BaseSHA        string           `json:"baseSha,omitempty"`
 	ReviewDecision string           `json:"reviewDecision,omitempty"`
 	Comments       []map[string]any `json:"comments,omitempty"`
+	IssueComments  []map[string]any `json:"issueComments,omitempty"`
 	Checks         []map[string]any `json:"checks,omitempty"`
 	HasConflicts   bool             `json:"hasConflicts,omitempty"`
 }
@@ -469,6 +493,16 @@ type checkpointResolvedComment struct {
 	UpdatedAt  string `json:"updatedAt,omitempty"`
 	ReplyState string `json:"replyState,omitempty"`
 	ReplyError string `json:"replyError,omitempty"`
+}
+
+type checkpointSummaryComment struct {
+	CommentID    int64  `json:"commentId,omitempty"`
+	URL          string `json:"url,omitempty"`
+	HeadSHA      string `json:"headSha,omitempty"`
+	FixItemsHash string `json:"fixItemsHash,omitempty"`
+	State        string `json:"state,omitempty"`
+	Error        string `json:"error,omitempty"`
+	UpdatedAt    string `json:"updatedAt,omitempty"`
 }
 
 type checkpointRecheck struct {
@@ -1156,7 +1190,7 @@ func (r *Runner) runDiscoverPRStep(ctx context.Context, input stepInput) (fixerC
 		return input.Checkpoint, err
 	}
 	checkpoint := input.Checkpoint
-	checkpoint.Detail = &checkpointDetail{State: detail.State, IsDraft: detail.IsDraft, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: cloneObjectSlice(detail.Comments), Checks: cloneObjectSlice(detail.Checks), HasConflicts: detail.HasConflicts}
+	checkpoint.Detail = &checkpointDetail{State: detail.State, IsDraft: detail.IsDraft, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: cloneObjectSlice(detail.Comments), IssueComments: cloneObjectSlice(detail.IssueComments), Checks: cloneObjectSlice(detail.Checks), HasConflicts: detail.HasConflicts}
 	checkpoint.ResumePolicy = "replay_step"
 	return checkpoint, nil
 }
@@ -1543,6 +1577,9 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "resolved", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 	}
 	r.appendEvent(ctx, eventInput{eventType: "fixer.comments.resolved", projectID: input.Project.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"items": checkpoint.ResolvedComments.Items}})
+	if failedCount == 0 {
+		r.publishRoundSummaryComment(ctx, input, &checkpoint, fixItems, commitSHA, explanationByID)
+	}
 	if failedCount > 0 {
 		return checkpoint, &loopError{message: fmt.Sprintf("Failed to resolve %d review thread(s)", failedCount), kind: FailureRetryableAfterResume}
 	}
@@ -1648,6 +1685,281 @@ func shortCommitSHA(value string) string {
 		return value
 	}
 	return value[:7]
+}
+
+const fixerSummaryMarkerPrefix = "<!-- looper:fixer-round head="
+
+// fixerRoundSummaryMarker returns a hidden marker keyed by head SHA. The marker
+// lets future fixer runs find and edit the existing summary instead of posting
+// a duplicate when the same round retries (resume after transient failure,
+// scheduler re-claim, etc.).
+func fixerRoundSummaryMarker(headSHA string) string {
+	if headSHA == "" {
+		return ""
+	}
+	return fixerSummaryMarkerPrefix + headSHA + " -->"
+}
+
+// publishRoundSummaryComment posts (or edits) a single PR conversation comment
+// summarizing this fixer round: the commit, every fix item with its outcome,
+// agent explanations when present, and links to each thread. The summary is
+// best-effort and never blocks the resolve step.
+func (r *Runner) publishRoundSummaryComment(ctx context.Context, input stepInput, checkpoint *fixerCheckpoint, fixItems []FixItem, commitSHA string, explanationByID map[string]string) {
+	headSHA := commitSHA
+	if headSHA == "" && checkpoint.ReconcileCommits != nil {
+		headSHA = checkpoint.ReconcileCommits.FinalHeadSHA
+	}
+	if headSHA == "" {
+		headSHA = detailHeadSHA(checkpoint.Detail)
+	}
+	if headSHA == "" {
+		return
+	}
+	if checkpoint.Push == nil || !checkpoint.Push.Pushed {
+		return
+	}
+	if !roundProducedNewCommits(checkpoint) {
+		return
+	}
+	commentItems := summaryCommentItems(fixItems, checkpoint, explanationByID)
+	if len(commentItems) == 0 {
+		return
+	}
+	body := buildFixerSummaryCommentBody(input.Repo, input.PRNumber, headSHA, commitSHA, commentItems)
+	if checkpoint.SummaryComment != nil && checkpoint.SummaryComment.HeadSHA == headSHA && checkpoint.SummaryComment.CommentID != 0 {
+		if err := r.github.UpdateIssueComment(ctx, UpdateIssueCommentInput{Repo: input.Repo, CommentID: checkpoint.SummaryComment.CommentID, Body: body, CWD: input.Project.RepoPath}); err != nil {
+			checkpoint.SummaryComment.State = "update_failed"
+			checkpoint.SummaryComment.Error = err.Error()
+			checkpoint.SummaryComment.UpdatedAt = r.nowISO()
+			return
+		}
+		checkpoint.SummaryComment.State = "updated"
+		checkpoint.SummaryComment.Error = ""
+		checkpoint.SummaryComment.FixItemsHash = checkpoint.FixItemsHash
+		checkpoint.SummaryComment.UpdatedAt = r.nowISO()
+		return
+	}
+	if existingID, existingURL := findExistingFixerSummaryCommentID(checkpoint.Detail, headSHA); existingID != 0 {
+		if err := r.github.UpdateIssueComment(ctx, UpdateIssueCommentInput{Repo: input.Repo, CommentID: existingID, Body: body, CWD: input.Project.RepoPath}); err != nil {
+			checkpoint.SummaryComment = &checkpointSummaryComment{CommentID: existingID, URL: existingURL, HeadSHA: headSHA, FixItemsHash: checkpoint.FixItemsHash, State: "update_failed", Error: err.Error(), UpdatedAt: r.nowISO()}
+			return
+		}
+		checkpoint.SummaryComment = &checkpointSummaryComment{CommentID: existingID, URL: existingURL, HeadSHA: headSHA, FixItemsHash: checkpoint.FixItemsHash, State: "updated", UpdatedAt: r.nowISO()}
+		return
+	}
+	created, err := r.github.CreateIssueComment(ctx, IssueCommentInput{Repo: input.Repo, IssueNumber: input.PRNumber, Body: body, CWD: input.Project.RepoPath})
+	if err != nil {
+		checkpoint.SummaryComment = &checkpointSummaryComment{HeadSHA: headSHA, FixItemsHash: checkpoint.FixItemsHash, State: "create_failed", Error: err.Error(), UpdatedAt: r.nowISO()}
+		return
+	}
+	checkpoint.SummaryComment = &checkpointSummaryComment{CommentID: created.ID, URL: created.URL, HeadSHA: headSHA, FixItemsHash: checkpoint.FixItemsHash, State: "created", UpdatedAt: r.nowISO()}
+	r.appendEvent(ctx, eventInput{eventType: "fixer.summary.posted", projectID: input.Project.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"commentId": created.ID, "url": created.URL, "headSha": headSHA, "items": len(commentItems)}})
+}
+
+// roundProducedNewCommits returns true when the current fixer round actually
+// pushed at least one new commit. The summary is suppressed for no-op runs so
+// PR conversations aren't spammed with empty heartbeats.
+func roundProducedNewCommits(checkpoint *fixerCheckpoint) bool {
+	if checkpoint == nil || checkpoint.ReconcileCommits == nil {
+		return false
+	}
+	rc := checkpoint.ReconcileCommits
+	if len(rc.NewCommitSHAs) > 0 {
+		return true
+	}
+	if rc.FinalHeadSHA != "" && rc.BaseHeadSHA != "" && rc.FinalHeadSHA != rc.BaseHeadSHA {
+		return true
+	}
+	return false
+}
+
+// fixerSummaryItem is the per-fix-item view rendered into the summary body.
+// Resolved (or already-resolved) comments display as ✅; failed/conflict/check
+// items keep their outcome visible so reviewers can see what's still open.
+type fixerSummaryItem struct {
+	FixItem     FixItem
+	Status      string
+	Explanation string
+	ThreadURL   string
+	ReplyState  string
+}
+
+func summaryCommentItems(fixItems []FixItem, checkpoint *fixerCheckpoint, explanationByID map[string]string) []fixerSummaryItem {
+	resolvedByID := map[string]checkpointResolvedComment{}
+	resolvedByThread := map[string]checkpointResolvedComment{}
+	if checkpoint.ResolvedComments != nil {
+		for _, item := range checkpoint.ResolvedComments.Items {
+			if item.FixItemID != "" {
+				resolvedByID[item.FixItemID] = item
+			}
+			if item.ThreadID != "" {
+				resolvedByThread[item.ThreadID] = item
+			}
+		}
+	}
+	out := make([]fixerSummaryItem, 0, len(fixItems))
+	for _, item := range fixItems {
+		entry := fixerSummaryItem{FixItem: item, ThreadURL: item.URL, Status: item.Type}
+		if item.Type == "comment" {
+			entry.Explanation = explanationByID[item.ID]
+			resolved, ok := resolvedByID[item.ID]
+			if !ok && item.ThreadID != "" {
+				resolved, ok = resolvedByThread[item.ThreadID]
+			}
+			if ok {
+				entry.Status = resolved.Status
+				entry.ReplyState = resolved.ReplyState
+			} else {
+				entry.Status = "pending"
+			}
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// buildFixerSummaryCommentBody renders the round summary body. The hidden
+// `<!-- looper:fixer-round head=… -->` marker on the first line is what
+// findExistingFixerSummaryCommentID looks up for edit-on-retry behavior; the
+// adapter still appends the disclosure stamp/footer on top.
+func buildFixerSummaryCommentBody(repo string, prNumber int64, headSHA, commitSHA string, items []fixerSummaryItem) string {
+	var b strings.Builder
+	if marker := fixerRoundSummaryMarker(headSHA); marker != "" {
+		b.WriteString(marker)
+		b.WriteString("\n")
+	}
+	b.WriteString("**Looper fixer round complete**")
+	if shortSHA := shortCommitSHA(commitSHA); shortSHA != "" {
+		b.WriteString(" — ")
+		b.WriteString(shortSHA)
+	}
+	b.WriteString("\n\n")
+	for _, item := range items {
+		b.WriteString(formatFixerSummaryBullet(item))
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func formatFixerSummaryBullet(item fixerSummaryItem) string {
+	icon := summaryStatusIcon(item.Status)
+	label := summaryItemLabel(item.FixItem)
+	threadURL := item.ThreadURL
+	if threadURL == "" {
+		threadURL = item.FixItem.URL
+	}
+	var b strings.Builder
+	b.WriteString("- ")
+	b.WriteString(icon)
+	b.WriteString(" ")
+	b.WriteString(label)
+	if item.FixItem.Author != "" && item.FixItem.Type == "comment" {
+		b.WriteString(" (@")
+		b.WriteString(item.FixItem.Author)
+		b.WriteString(")")
+	}
+	if threadURL != "" && item.FixItem.Type == "comment" {
+		b.WriteString(" — [thread](")
+		b.WriteString(threadURL)
+		b.WriteString(")")
+	}
+	if explanation := strings.TrimSpace(item.Explanation); explanation != "" {
+		b.WriteString("\n  - ")
+		b.WriteString(strings.ReplaceAll(explanation, "\n", "\n    "))
+	} else if item.FixItem.Type == "comment" {
+		if summary := summarizeFixItem(item.FixItem); summary != "" {
+			// summarizeFixItem already prefixes lines with "> "; in the bullet
+			// context we want a plain nested bullet for readability.
+			plain := strings.ReplaceAll(summary, "> ", "")
+			plain = strings.TrimSpace(plain)
+			if plain != "" {
+				b.WriteString("\n  - ")
+				b.WriteString(strings.ReplaceAll(plain, "\n", " "))
+			}
+		}
+	}
+	if item.ReplyState != "" && item.ReplyState != "sent" {
+		b.WriteString("\n  - reply: ")
+		b.WriteString(item.ReplyState)
+	}
+	return b.String()
+}
+
+func summaryItemLabel(item FixItem) string {
+	switch item.Type {
+	case "comment":
+		if item.Path != "" {
+			if item.Line > 0 {
+				return fmt.Sprintf("Review comment on `%s:%d`", item.Path, item.Line)
+			}
+			return fmt.Sprintf("Review comment on `%s`", item.Path)
+		}
+		return "Review comment"
+	case "check":
+		if item.Name != "" {
+			return "Failing check `" + item.Name + "`"
+		}
+		return "Failing check"
+	case "conflict":
+		return "Merge conflict"
+	default:
+		if item.Name != "" {
+			return item.Name
+		}
+		return strings.TrimSpace(item.Type)
+	}
+}
+
+func summaryStatusIcon(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "resolved", "already_resolved":
+		return "✅"
+	case "failed":
+		return "⚠️"
+	case "pending":
+		return "🟡"
+	case "conflict":
+		return "🔀"
+	case "check":
+		return "🧪"
+	default:
+		return "•"
+	}
+}
+
+// findExistingFixerSummaryCommentID scans the PR's issue comments for a prior
+// summary keyed by the same head SHA. Used for edit-on-retry when our local
+// checkpoint was wiped (resume across daemon restarts, scheduler re-claim).
+func findExistingFixerSummaryCommentID(detail *checkpointDetail, headSHA string) (int64, string) {
+	if detail == nil || headSHA == "" {
+		return 0, ""
+	}
+	marker := fixerRoundSummaryMarker(headSHA)
+	if marker == "" {
+		return 0, ""
+	}
+	for _, comment := range detail.IssueComments {
+		body, _ := stringFromAny(comment["body"])
+		if !strings.Contains(body, marker) {
+			continue
+		}
+		idVal := comment["id"]
+		var id int64
+		switch v := idVal.(type) {
+		case float64:
+			id = int64(v)
+		case int64:
+			id = v
+		case int:
+			id = int64(v)
+		}
+		if id == 0 {
+			continue
+		}
+		url, _ := stringFromAny(comment["url"])
+		return id, url
+	}
+	return 0, ""
 }
 
 func (r *Runner) runRecheckStep(ctx context.Context, input stepInput) (fixerCheckpoint, error) {
@@ -2660,7 +2972,7 @@ func detailLabels(detail *checkpointDetail) []string {
 }
 
 func mergeCheckpointDetailPreservingLabels(existing *checkpointDetail, live PullRequestDetail) *checkpointDetail {
-	merged := &checkpointDetail{State: live.State, IsDraft: live.IsDraft, Labels: cloneStrings(live.Labels), HeadSHA: live.HeadSHA, HeadRefName: live.HeadRefName, BaseRefName: live.BaseRefName, BaseSHA: live.BaseSHA, ReviewDecision: live.ReviewDecision, Comments: cloneObjectSlice(live.Comments), Checks: cloneObjectSlice(live.Checks), HasConflicts: live.HasConflicts}
+	merged := &checkpointDetail{State: live.State, IsDraft: live.IsDraft, Labels: cloneStrings(live.Labels), HeadSHA: live.HeadSHA, HeadRefName: live.HeadRefName, BaseRefName: live.BaseRefName, BaseSHA: live.BaseSHA, ReviewDecision: live.ReviewDecision, Comments: cloneObjectSlice(live.Comments), IssueComments: cloneObjectSlice(live.IssueComments), Checks: cloneObjectSlice(live.Checks), HasConflicts: live.HasConflicts}
 	if existing != nil {
 		merged.Labels = cloneStrings(existing.Labels)
 	}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1982,20 +1982,19 @@ func findExistingFixerSummaryCommentID(detail *checkpointDetail, headSHA, truste
 	return 0, ""
 }
 
-func isTrustedFixerSummaryComment(comment map[string]any, trustedLogin, body string) bool {
-	if strings.Contains(body, "looper:stamp") {
-		return true
-	}
-	if sameGitHubLogin(issueCommentAuthorLogin(comment), trustedLogin) {
-		return true
-	}
-	return false
+func isTrustedFixerSummaryComment(comment map[string]any, trustedLogin, _ string) bool {
+	return sameGitHubLogin(issueCommentAuthorLogin(comment), trustedLogin)
 }
 
 func issueCommentAuthorLogin(comment map[string]any) string {
-	author, _ := comment["author"].(map[string]any)
-	login, _ := stringFromAny(author["login"])
-	return login
+	for _, key := range []string{"author", "user"} {
+		author, _ := comment[key].(map[string]any)
+		login, _ := stringFromAny(author["login"])
+		if strings.TrimSpace(login) != "" {
+			return login
+		}
+	}
+	return ""
 }
 
 func (r *Runner) runRecheckStep(ctx context.Context, input stepInput) (fixerCheckpoint, error) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -637,10 +638,30 @@ func extractCompletionMarkerPayload(combined string) string {
 	for i := len(lines) - 1; i >= 0; i-- {
 		line := strings.TrimSpace(lines[i])
 		if strings.HasPrefix(line, prefix) {
-			return strings.TrimPrefix(line, prefix)
+			payload := strings.TrimPrefix(line, prefix)
+			if isTemplateCompletionPayload(payload) {
+				continue
+			}
+			return payload
 		}
 	}
 	return ""
+}
+
+func isTemplateCompletionPayload(payload string) bool {
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+		return false
+	}
+	summary, _ := parsed["summary"].(string)
+	if strings.TrimSpace(summary) != "<one-sentence summary>" {
+		return false
+	}
+	if len(parsed) != 1 {
+		return false
+	}
+	_, ok := parsed["summary"]
+	return ok
 }
 
 func sanitizeReplyExplanation(raw string) string {
@@ -1946,16 +1967,7 @@ func findExistingFixerSummaryCommentID(detail *checkpointDetail, headSHA, truste
 		if !isTrustedFixerSummaryComment(comment, trustedLogin, body) {
 			continue
 		}
-		idVal := comment["id"]
-		var id int64
-		switch v := idVal.(type) {
-		case float64:
-			id = int64(v)
-		case int64:
-			id = v
-		case int:
-			id = int64(v)
-		}
+		id := int64FromAny(comment["id"])
 		if id == 0 {
 			continue
 		}
@@ -3097,6 +3109,23 @@ func stringFromAny(value any) (string, bool) {
 		return "", false
 	}
 	return text, true
+}
+
+func int64FromAny(value any) int64 {
+	switch v := value.(type) {
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	case float64:
+		return int64(v)
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if err == nil {
+			return parsed
+		}
+	}
+	return 0
 }
 
 func optionalString(value string) *string {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -73,6 +74,10 @@ type FixItem struct {
 	Name     string   `json:"name,omitempty"`
 	Summary  string   `json:"summary,omitempty"`
 	Files    []string `json:"files,omitempty"`
+	Author   string   `json:"author,omitempty"`
+	URL      string   `json:"url,omitempty"`
+	Path     string   `json:"path,omitempty"`
+	Line     int64    `json:"line,omitempty"`
 }
 
 type PullRequestSummary struct {
@@ -121,6 +126,13 @@ type ResolveReviewThreadInput struct {
 	CWD      string
 }
 
+type AddReviewThreadReplyInput struct {
+	Repo     string
+	ThreadID string
+	Body     string
+	CWD      string
+}
+
 type PullRequestLabelsInput struct {
 	Repo     string
 	PRNumber int64
@@ -134,6 +146,7 @@ type GitHubGateway interface {
 	GetPullRequestAuthor(context.Context, ViewPullRequestInput) (string, error)
 	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
 	ResolveReviewThread(context.Context, ResolveReviewThreadInput) error
+	AddReviewThreadReply(context.Context, AddReviewThreadReplyInput) error
 	AddPullRequestLabels(context.Context, PullRequestLabelsInput) error
 	RemovePullRequestLabels(context.Context, PullRequestLabelsInput) error
 }
@@ -399,18 +412,30 @@ type checkpointWorktree struct {
 }
 
 type checkpointRepair struct {
-	AgentExecutionID             string           `json:"agentExecutionId,omitempty"`
-	Summary                      string           `json:"summary,omitempty"`
-	HeadSHA                      string           `json:"headSha,omitempty"`
-	ParseStatus                  string           `json:"parseStatus,omitempty"`
-	Lifecycle                    *lifecycle.State `json:"gitPrLifecycle,omitempty"`
-	CompletedAt                  string           `json:"completedAt,omitempty"`
-	Status                       string           `json:"status,omitempty"`
-	TimeoutType                  string           `json:"timeoutType,omitempty"`
-	ConfiguredIdleTimeoutSeconds int64            `json:"configuredIdleTimeoutSeconds,omitempty"`
-	ConfiguredMaxRuntimeSeconds  int64            `json:"configuredMaxRuntimeSeconds,omitempty"`
-	ElapsedRuntimeSeconds        int64            `json:"elapsedRuntimeSeconds,omitempty"`
-	LastProgressAt               string           `json:"lastProgressAt,omitempty"`
+	AgentExecutionID             string                  `json:"agentExecutionId,omitempty"`
+	Summary                      string                  `json:"summary,omitempty"`
+	HeadSHA                      string                  `json:"headSha,omitempty"`
+	ParseStatus                  string                  `json:"parseStatus,omitempty"`
+	Lifecycle                    *lifecycle.State        `json:"gitPrLifecycle,omitempty"`
+	CompletedAt                  string                  `json:"completedAt,omitempty"`
+	Status                       string                  `json:"status,omitempty"`
+	TimeoutType                  string                  `json:"timeoutType,omitempty"`
+	ConfiguredIdleTimeoutSeconds int64                   `json:"configuredIdleTimeoutSeconds,omitempty"`
+	ConfiguredMaxRuntimeSeconds  int64                   `json:"configuredMaxRuntimeSeconds,omitempty"`
+	ElapsedRuntimeSeconds        int64                   `json:"elapsedRuntimeSeconds,omitempty"`
+	LastProgressAt               string                  `json:"lastProgressAt,omitempty"`
+	ReplyExplanations            []replyExplanationEntry `json:"replyExplanations,omitempty"`
+	FixItemsHash                 string                  `json:"fixItemsHash,omitempty"`
+}
+
+// replyExplanationEntry holds the agent's per-fix-item explanation for the
+// auto-reply posted before resolving the review thread. Stored on the repair
+// checkpoint so resume/retry reuses the same explanation if it still maps to
+// the current fix items snapshot.
+type replyExplanationEntry struct {
+	FixItemID   string `json:"fixItemId"`
+	ThreadID    string `json:"threadId,omitempty"`
+	Explanation string `json:"explanation"`
 }
 
 type checkpointReconcileCommits struct {
@@ -437,11 +462,13 @@ type checkpointResolvedComments struct {
 }
 
 type checkpointResolvedComment struct {
-	FixItemID string `json:"fixItemId,omitempty"`
-	ThreadID  string `json:"threadId,omitempty"`
-	Status    string `json:"status,omitempty"`
-	Message   string `json:"message,omitempty"`
-	UpdatedAt string `json:"updatedAt,omitempty"`
+	FixItemID  string `json:"fixItemId,omitempty"`
+	ThreadID   string `json:"threadId,omitempty"`
+	Status     string `json:"status,omitempty"`
+	Message    string `json:"message,omitempty"`
+	UpdatedAt  string `json:"updatedAt,omitempty"`
+	ReplyState string `json:"replyState,omitempty"`
+	ReplyError string `json:"replyError,omitempty"`
 }
 
 type checkpointRecheck struct {
@@ -488,6 +515,126 @@ func validateCompletedRepairCheckpoint(repair *checkpointRepair) error {
 func checkpointRepairFromAgentResult(executionID, headSHA string, result AgentResult, nowISO string) *checkpointRepair {
 	return &checkpointRepair{AgentExecutionID: executionID, Status: result.Status, Summary: result.Summary, HeadSHA: headSHA, ParseStatus: result.ParseStatus, Lifecycle: result.Lifecycle, CompletedAt: nowISO, TimeoutType: result.TimeoutType, ConfiguredIdleTimeoutSeconds: result.ConfiguredIdleTimeoutSeconds, ConfiguredMaxRuntimeSeconds: result.ConfiguredMaxRuntimeSeconds, ElapsedRuntimeSeconds: result.ElapsedRuntimeSeconds, LastProgressAt: result.LastProgressAt}
 }
+
+// maxReplyExplanationLength caps each agent-supplied explanation. Replies are
+// posted on review threads where verbose bodies create noise; the cap also
+// limits prompt-injection blast radius if a malicious reviewer plants payload.
+const maxReplyExplanationLength = 500
+
+// parseReplyExplanationsFromStdout extracts the optional review_thread_replies
+// array from the final __LOOPER_RESULT__ JSON line. Failure to parse is not an
+// error: the runner falls back to the generic reply body. Entries are filtered
+// against the current fixItems snapshot (keyed by fixItemId, with a defensive
+// threadId cross-check), deduplicated keeping the first valid occurrence, and
+// truncated. Disclosure markers, @mentions, and HTML tags are stripped so the
+// adapter remains the only path that stamps and templates the reply.
+func parseReplyExplanationsFromStdout(stdout string, fixItems []FixItem) []replyExplanationEntry {
+	if strings.TrimSpace(stdout) == "" {
+		return nil
+	}
+	itemsByID := make(map[string]FixItem, len(fixItems))
+	for _, item := range fixItems {
+		if item.Type != "comment" {
+			continue
+		}
+		if item.ID == "" {
+			continue
+		}
+		itemsByID[item.ID] = item
+	}
+	if len(itemsByID) == 0 {
+		return nil
+	}
+	payload := extractCompletionMarkerPayload(stdout)
+	if payload == "" {
+		return nil
+	}
+	var parsed struct {
+		ReviewThreadReplies []struct {
+			FixItemID   string `json:"fixItemId"`
+			ThreadID    string `json:"threadId"`
+			Explanation string `json:"explanation"`
+		} `json:"review_thread_replies"`
+	}
+	if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+		return nil
+	}
+	if len(parsed.ReviewThreadReplies) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(parsed.ReviewThreadReplies))
+	out := make([]replyExplanationEntry, 0, len(parsed.ReviewThreadReplies))
+	for _, raw := range parsed.ReviewThreadReplies {
+		fixItemID := strings.TrimSpace(raw.FixItemID)
+		if fixItemID == "" {
+			continue
+		}
+		item, ok := itemsByID[fixItemID]
+		if !ok {
+			continue
+		}
+		threadID := strings.TrimSpace(raw.ThreadID)
+		if threadID != "" && item.ThreadID != "" && threadID != item.ThreadID {
+			continue
+		}
+		explanation := sanitizeReplyExplanation(raw.Explanation)
+		if explanation == "" {
+			continue
+		}
+		if _, dup := seen[fixItemID]; dup {
+			continue
+		}
+		seen[fixItemID] = struct{}{}
+		out = append(out, replyExplanationEntry{FixItemID: fixItemID, ThreadID: item.ThreadID, Explanation: explanation})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// extractCompletionMarkerPayload mirrors the agent core's last-line scan but
+// without coupling fixer code to internal/agent's parser. It returns the JSON
+// payload after the final __LOOPER_RESULT__= line, or "" if absent.
+func extractCompletionMarkerPayload(combined string) string {
+	prefix := agent.CompletionMarkerPrefix
+	lines := strings.Split(combined, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	return ""
+}
+
+func sanitizeReplyExplanation(raw string) string {
+	cleaned := strings.TrimSpace(raw)
+	if cleaned == "" {
+		return ""
+	}
+	// Drop any disclosure marker the agent might have echoed; the adapter is
+	// the only place allowed to stamp.
+	cleaned = strings.ReplaceAll(cleaned, "<!-- looper:stamp v=1 -->", "")
+	// Strip leading @mentions; runner controls whom to ping.
+	cleaned = leadingMentionPattern.ReplaceAllString(cleaned, "")
+	// Strip HTML tags conservatively; review thread bodies are markdown.
+	cleaned = htmlTagPattern.ReplaceAllString(cleaned, "")
+	cleaned = strings.TrimSpace(cleaned)
+	if cleaned == "" {
+		return ""
+	}
+	if len([]rune(cleaned)) > maxReplyExplanationLength {
+		runes := []rune(cleaned)
+		cleaned = strings.TrimSpace(string(runes[:maxReplyExplanationLength])) + "…"
+	}
+	return cleaned
+}
+
+var (
+	leadingMentionPattern = regexp.MustCompile(`(?m)^(?:@[A-Za-z0-9][A-Za-z0-9-]{0,38}\s+)+`)
+	htmlTagPattern        = regexp.MustCompile(`</?[A-Za-z][^>]*>`)
+)
 
 func New(options Options) *Runner {
 	now := options.Now
@@ -1183,6 +1330,8 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		return checkpoint, err
 	}
 	checkpoint.Repair = checkpointRepairFromAgentResult(executionID, detailHeadSHA(checkpoint.Detail), result, r.nowISO())
+	checkpoint.Repair.ReplyExplanations = parseReplyExplanationsFromStdout(result.Stdout, checkpoint.FixItems)
+	checkpoint.Repair.FixItemsHash = checkpoint.FixItemsHash
 	checkpoint.ensureLifecycle("fixer", worktree.Branch, detailBaseRefName(checkpoint.Detail), false)
 	if result.Lifecycle != nil {
 		checkpoint.Lifecycle.MergeAgent(result.Lifecycle, r.nowISO())
@@ -1361,7 +1510,16 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	if checkpoint.ResolvedComments == nil {
 		checkpoint.ResolvedComments = &checkpointResolvedComments{Items: []checkpointResolvedComment{}}
 	}
+	commitSHA := ""
+	if checkpoint.ReconcileCommits != nil {
+		if len(checkpoint.ReconcileCommits.NewCommitSHAs) > 0 {
+			commitSHA = checkpoint.ReconcileCommits.NewCommitSHAs[len(checkpoint.ReconcileCommits.NewCommitSHAs)-1]
+		} else {
+			commitSHA = checkpoint.ReconcileCommits.FinalHeadSHA
+		}
+	}
 	failedCount := 0
+	explanationByID := lookupReplyExplanations(checkpoint)
 	for _, item := range fixItems {
 		if item.Type != "comment" {
 			continue
@@ -1369,6 +1527,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
 			continue
 		}
+		replyState, replyError := r.replyToFixedComment(ctx, input, item, commitSHA, explanationByID[item.ID], checkpoint.ResolvedComments.Items)
 		if err := r.github.ResolveReviewThread(ctx, ResolveReviewThreadInput{Repo: input.Repo, ThreadID: item.ThreadID, CWD: input.Project.RepoPath}); err != nil {
 			message := err.Error()
 			status := "failed"
@@ -1377,10 +1536,10 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			} else {
 				failedCount++
 			}
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: status, Message: message, UpdatedAt: r.nowISO()})
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: status, Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 			continue
 		}
-		upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "resolved", UpdatedAt: r.nowISO()})
+		upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "resolved", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 	}
 	r.appendEvent(ctx, eventInput{eventType: "fixer.comments.resolved", projectID: input.Project.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"items": checkpoint.ResolvedComments.Items}})
 	if failedCount > 0 {
@@ -1388,6 +1547,106 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
+}
+
+// replyToFixedComment posts a reply on the review thread acknowledging the fix
+// before the thread is resolved. Replies are best-effort: failures are recorded
+// in the checkpoint but never block the resolve step. The disclosure stamper
+// applied by the GitHub adapter ensures every reply carries the looper exposure
+// marker, so automated replies can be filtered downstream.
+func (r *Runner) replyToFixedComment(ctx context.Context, input stepInput, item FixItem, commitSHA, explanation string, existing []checkpointResolvedComment) (string, string) {
+	if item.ThreadID == "" {
+		return "skipped_no_thread", ""
+	}
+	for _, entry := range existing {
+		if entry.FixItemID == item.ID || (entry.ThreadID != "" && entry.ThreadID == item.ThreadID) {
+			if entry.ReplyState == "sent" || entry.ReplyState == "skipped_self_author" || entry.ReplyState == "skipped_no_thread" {
+				return entry.ReplyState, entry.ReplyError
+			}
+		}
+	}
+	body := buildFixerReplyBody(item, commitSHA, explanation)
+	if err := r.github.AddReviewThreadReply(ctx, AddReviewThreadReplyInput{Repo: input.Repo, ThreadID: item.ThreadID, Body: body, CWD: input.Project.RepoPath}); err != nil {
+		return "failed", err.Error()
+	}
+	return "sent", ""
+}
+
+// lookupReplyExplanations returns a map of fixItemId → sanitized agent
+// explanation, but only when the explanations were captured against the same
+// fix-items snapshot represented by the current checkpoint. If the snapshot
+// changed (e.g. PR rebased, new comments arrived), the agent's explanations no
+// longer describe the threads we are about to reply to and we fall back to the
+// generic body.
+func lookupReplyExplanations(checkpoint fixerCheckpoint) map[string]string {
+	if checkpoint.Repair == nil || len(checkpoint.Repair.ReplyExplanations) == 0 {
+		return nil
+	}
+	if checkpoint.Repair.FixItemsHash != "" && checkpoint.FixItemsHash != "" && checkpoint.Repair.FixItemsHash != checkpoint.FixItemsHash {
+		return nil
+	}
+	out := make(map[string]string, len(checkpoint.Repair.ReplyExplanations))
+	for _, entry := range checkpoint.Repair.ReplyExplanations {
+		if entry.FixItemID == "" || entry.Explanation == "" {
+			continue
+		}
+		out[entry.FixItemID] = entry.Explanation
+	}
+	return out
+}
+
+func buildFixerReplyBody(item FixItem, commitSHA, explanation string) string {
+	var b strings.Builder
+	mention := strings.TrimSpace(item.Author)
+	if mention != "" {
+		b.WriteString("@")
+		b.WriteString(mention)
+		b.WriteString(" ")
+	}
+	b.WriteString("This has been fixed")
+	if shortSHA := shortCommitSHA(commitSHA); shortSHA != "" {
+		b.WriteString(" in ")
+		b.WriteString(shortSHA)
+	}
+	b.WriteString(".")
+	if explanation = strings.TrimSpace(explanation); explanation != "" {
+		b.WriteString("\n\n")
+		b.WriteString(explanation)
+		return b.String()
+	}
+	if summary := summarizeFixItem(item); summary != "" {
+		b.WriteString("\n\n")
+		b.WriteString(summary)
+	}
+	return b.String()
+}
+
+func summarizeFixItem(item FixItem) string {
+	summary := strings.TrimSpace(item.Summary)
+	if summary == "" {
+		return ""
+	}
+	summary = strings.ReplaceAll(summary, "<!-- looper:stamp v=1 -->", "")
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return ""
+	}
+	if len(summary) > 240 {
+		summary = strings.TrimSpace(summary[:240]) + "…"
+	}
+	lines := strings.Split(summary, "\n")
+	for index, line := range lines {
+		lines[index] = "> " + strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func shortCommitSHA(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= 7 {
+		return value
+	}
+	return value[:7]
 }
 
 func (r *Runner) runRecheckStep(ctx context.Context, input stepInput) (fixerCheckpoint, error) {
@@ -1971,7 +2230,19 @@ func normalizeFixItems(comments []map[string]any, checks []map[string]any, hasCo
 		if summary == "" {
 			summary = "Unresolved review comment"
 		}
-		result = append(result, FixItem{Type: "comment", ID: id, ThreadID: threadID, Summary: summary})
+		author, _ := stringFromAny(comment["author"])
+		url, _ := stringFromAny(comment["url"])
+		path, _ := stringFromAny(comment["path"])
+		var line int64
+		switch v := comment["line"].(type) {
+		case float64:
+			line = int64(v)
+		case int64:
+			line = v
+		case int:
+			line = int64(v)
+		}
+		result = append(result, FixItem{Type: "comment", ID: id, ThreadID: threadID, Summary: summary, Author: author, URL: url, Path: path, Line: line})
 	}
 	for _, check := range checks {
 		if !isFailingCheck(check) {
@@ -2127,6 +2398,9 @@ func buildFixerPrompt(projectID string, instructionConfig config.Config, repo st
 		"Fix items:\n"+strings.Join(encodedItems, "\n"),
 		"Only perform repair changes for the listed fix items.",
 	)
+	if instruction := buildFixerReplyExplanationInstruction(fixItems); instruction != "" {
+		parts = append(parts, instruction)
+	}
 	instructionBlock := config.BuildCustomInstructionBlock(instructionConfig, projectID, "fixer")
 	if instructionBlock.Text != "" {
 		parts = append(parts, instructionBlock.Text)
@@ -2148,6 +2422,31 @@ func customInstructionConfig(value *config.Config) config.Config {
 		return cfg
 	}
 	return *value
+}
+
+// buildFixerReplyExplanationInstruction returns the prompt fragment that asks
+// the agent to provide per-fix-item explanations Looper will use as the body of
+// the auto-reply posted before resolving the review thread. The agent supplies
+// only the explanation; Looper owns the @mention, commit reference, and
+// disclosure stamping.
+func buildFixerReplyExplanationInstruction(fixItems []FixItem) string {
+	hasComment := false
+	for _, item := range fixItems {
+		if item.Type == "comment" && item.ID != "" && item.ThreadID != "" {
+			hasComment = true
+			break
+		}
+	}
+	if !hasComment {
+		return ""
+	}
+	return strings.Join([]string{
+		"For each comment-type fix item you actually addressed, include an entry in a top-level `review_thread_replies` array on the final " + agent.CompletionMarker + " JSON line. Each entry must be an object with these fields:",
+		`  - "fixItemId": the exact "id" of the fix item you addressed`,
+		`  - "threadId": the exact "threadId" of the same fix item`,
+		`  - "explanation": one or two sentences (max ~500 chars) describing what you changed and, when relevant, which file(s) or test(s) cover it. No greetings, no @mentions, no markdown headings, no HTML, no disclosure markers.`,
+		"Looper posts the reply itself; do not call any GitHub API or invent URLs. Omit `review_thread_replies` (or any individual entry) if you cannot truthfully describe the fix for that item.",
+	}, "\n")
 }
 
 func noRemoteLifecyclePromptInstruction(runner, branch, baseBranch string, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string) string {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/bootstrap"
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/eventlog"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/shell"
@@ -669,11 +670,14 @@ func sanitizeReplyExplanation(raw string) string {
 	if cleaned == "" {
 		return ""
 	}
-	// Drop any disclosure marker the agent might have echoed; the adapter is
-	// the only place allowed to stamp.
-	cleaned = strings.ReplaceAll(cleaned, "<!-- looper:stamp v=1 -->", "")
-	// Strip leading @mentions; runner controls whom to ping.
+	// Drop any disclosure marker/footer the agent might have echoed; the adapter
+	// is the only place allowed to stamp.
+	cleaned = disclosure.StripMarkdownStamp(cleaned)
+	// Strip leading mention clusters first so leftover punctuation from copied
+	// greetings does not dominate the sanitized explanation.
 	cleaned = leadingMentionPattern.ReplaceAllString(cleaned, "")
+	// Strip @mentions anywhere; runner controls whom to ping.
+	cleaned = inlineMentionPattern.ReplaceAllString(cleaned, `${1}${2}`)
 	// Strip HTML tags conservatively; review thread bodies are markdown.
 	cleaned = htmlTagPattern.ReplaceAllString(cleaned, "")
 	cleaned = strings.TrimSpace(cleaned)
@@ -689,6 +693,7 @@ func sanitizeReplyExplanation(raw string) string {
 
 var (
 	leadingMentionPattern = regexp.MustCompile(`(?m)^(?:@[A-Za-z0-9][A-Za-z0-9-]{0,38}(?:[,:;]+)?\s*)+`)
+	inlineMentionPattern  = regexp.MustCompile(`(^|[^[:alnum:]])@[A-Za-z0-9][A-Za-z0-9-]{0,38}([^[:alnum:]-]|$)`)
 	htmlTagPattern        = regexp.MustCompile(`</?[A-Za-z][^>]*>`)
 )
 

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1972,7 +1972,7 @@ func findExistingFixerSummaryCommentID(detail *checkpointDetail, headSHA, truste
 		if !isTrustedFixerSummaryComment(comment, trustedLogin, body) {
 			continue
 		}
-		id := int64FromAny(comment["id"])
+		id := issueCommentDatabaseID(comment)
 		if id == 0 {
 			continue
 		}
@@ -1995,6 +1995,45 @@ func issueCommentAuthorLogin(comment map[string]any) string {
 		}
 	}
 	return ""
+}
+
+func issueCommentDatabaseID(comment map[string]any) int64 {
+	if id := int64FromAny(comment["id"]); id != 0 {
+		return id
+	}
+	for _, key := range []string{"databaseId", "databaseID", "database_id"} {
+		if id := int64FromAny(comment[key]); id != 0 {
+			return id
+		}
+	}
+	for _, key := range []string{"url", "html_url", "htmlUrl"} {
+		raw, _ := stringFromAny(comment[key])
+		if id := issueCommentIDFromURL(raw); id != 0 {
+			return id
+		}
+	}
+	return 0
+}
+
+func issueCommentIDFromURL(raw string) int64 {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return 0
+	}
+	if fragment := strings.TrimSpace(parsed.Fragment); fragment != "" {
+		if id := int64FromAny(strings.TrimPrefix(fragment, "issuecomment-")); id != 0 {
+			return id
+		}
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) >= 3 && parts[len(parts)-3] == "issues" && parts[len(parts)-2] == "comments" {
+		return int64FromAny(parts[len(parts)-1])
+	}
+	return 0
 }
 
 func (r *Runner) runRecheckStep(ctx context.Context, input stepInput) (fixerCheckpoint, error) {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1517,6 +1517,8 @@ type fakeGitHubGateway struct {
 	resolveCalls     []ResolveReviewThreadInput
 	addLabelCalls    []PullRequestLabelsInput
 	removeLabelCalls []PullRequestLabelsInput
+	replyCalls       []AddReviewThreadReplyInput
+	replyErr         error
 }
 
 func (f *fakeGitHubGateway) ListOpenPullRequests(_ context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
@@ -1568,6 +1570,11 @@ func (f *fakeGitHubGateway) ViewPullRequest(_ context.Context, input ViewPullReq
 func (f *fakeGitHubGateway) ResolveReviewThread(_ context.Context, input ResolveReviewThreadInput) error {
 	f.resolveCalls = append(f.resolveCalls, input)
 	return nil
+}
+
+func (f *fakeGitHubGateway) AddReviewThreadReply(_ context.Context, input AddReviewThreadReplyInput) error {
+	f.replyCalls = append(f.replyCalls, input)
+	return f.replyErr
 }
 
 func (f *fakeGitHubGateway) AddPullRequestLabels(_ context.Context, input PullRequestLabelsInput) error {
@@ -1689,3 +1696,234 @@ func (*testLogger) Warn(string, map[string]any)  {}
 func (*testLogger) Error(string, map[string]any) {}
 
 func contains(haystack, needle string) bool { return strings.Contains(haystack, needle) }
+
+func TestBuildFixerReplyBodyMentionsAuthorAndCommit(t *testing.T) {
+	t.Parallel()
+	got := buildFixerReplyBody(FixItem{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice", Summary: "Use fmt.Errorf instead of errors.New"}, "abcdef1234567", "")
+	if !strings.Contains(got, "@alice") {
+		t.Fatalf("body missing author mention:\n%s", got)
+	}
+	if !strings.Contains(got, "abcdef1") {
+		t.Fatalf("body missing short commit SHA:\n%s", got)
+	}
+	if !strings.Contains(got, "> Use fmt.Errorf") {
+		t.Fatalf("body missing original summary quote:\n%s", got)
+	}
+}
+
+func TestBuildFixerReplyBodyHandlesMissingAuthorAndCommit(t *testing.T) {
+	t.Parallel()
+	got := buildFixerReplyBody(FixItem{Type: "comment", ID: "c1", ThreadID: "t1"}, "", "")
+	if strings.Contains(got, "@") {
+		t.Fatalf("body should not include @mention when author missing:\n%s", got)
+	}
+	if strings.Contains(got, " in ") {
+		t.Fatalf("body should not advertise commit when SHA missing:\n%s", got)
+	}
+	if !strings.Contains(got, "fixed") {
+		t.Fatalf("body should still announce fix:\n%s", got)
+	}
+}
+
+func TestBuildFixerReplyBodyPrefersAgentExplanationOverGenericQuote(t *testing.T) {
+	t.Parallel()
+	got := buildFixerReplyBody(FixItem{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice", Summary: "Original review comment that should be hidden"}, "abcdef1", "Replaced strings.Title with cases.Title and added empty-string coverage in foo_test.go.")
+	if !strings.Contains(got, "Replaced strings.Title") {
+		t.Fatalf("body missing agent explanation:\n%s", got)
+	}
+	if strings.Contains(got, "Original review comment") {
+		t.Fatalf("body should drop original quote when agent explanation present:\n%s", got)
+	}
+}
+
+func TestProcessClaimedItemRepliesToAuthorBeforeResolving(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:  CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+		inspectResults: []InspectHeadResult{
+			{HeadSHA: "base-head"},
+			{HeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}},
+			{HeadSHA: "new-head"},
+		},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success", result)
+	}
+	if len(github.replyCalls) != 1 {
+		t.Fatalf("reply calls = %d, want 1", len(github.replyCalls))
+	}
+	reply := github.replyCalls[0]
+	if reply.ThreadID != "t1" {
+		t.Fatalf("reply thread id = %q, want t1", reply.ThreadID)
+	}
+	if !strings.Contains(reply.Body, "@alice") {
+		t.Fatalf("reply body missing @author mention: %q", reply.Body)
+	}
+	if len(github.resolveCalls) != 1 {
+		t.Fatalf("resolve calls = %d, want 1", len(github.resolveCalls))
+	}
+}
+
+func TestParseReplyExplanationsFromStdoutValid(t *testing.T) {
+	t.Parallel()
+	stdout := strings.Join([]string{
+		"some agent log line",
+		`__LOOPER_RESULT__={"summary":"applied","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Replaced strings.Title with cases.Title."}]}`,
+	}, "\n")
+	got := parseReplyExplanationsFromStdout(stdout, []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
+	if len(got) != 1 || got[0].FixItemID != "c1" || !strings.Contains(got[0].Explanation, "cases.Title") {
+		t.Fatalf("parseReplyExplanationsFromStdout() = %#v", got)
+	}
+}
+
+func TestParseReplyExplanationsFromStdoutDropsUnknownAndMismatchedThread(t *testing.T) {
+	t.Parallel()
+	stdout := `__LOOPER_RESULT__={"review_thread_replies":[` +
+		`{"fixItemId":"c-unknown","explanation":"hi"},` +
+		`{"fixItemId":"c1","threadId":"t-wrong","explanation":"wrong thread"},` +
+		`{"fixItemId":"c1","threadId":"t1","explanation":"  "},` +
+		`{"fixItemId":"c1","threadId":"t1","explanation":"good"},` +
+		`{"fixItemId":"c1","threadId":"t1","explanation":"duplicate, must drop"}` +
+		`]}`
+	got := parseReplyExplanationsFromStdout(stdout, []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
+	if len(got) != 1 || got[0].Explanation != "good" {
+		t.Fatalf("parseReplyExplanationsFromStdout() = %#v, want only the first valid entry", got)
+	}
+}
+
+func TestParseReplyExplanationsFromStdoutMalformedFallsBack(t *testing.T) {
+	t.Parallel()
+	if got := parseReplyExplanationsFromStdout("__LOOPER_RESULT__={bad json}", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}); got != nil {
+		t.Fatalf("parseReplyExplanationsFromStdout() = %#v, want nil on bad JSON", got)
+	}
+	if got := parseReplyExplanationsFromStdout("no marker here", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}); got != nil {
+		t.Fatalf("parseReplyExplanationsFromStdout() = %#v, want nil when marker missing", got)
+	}
+}
+
+func TestSanitizeReplyExplanationStripsDangerousFragments(t *testing.T) {
+	t.Parallel()
+	input := "@looper-bot @another <!-- looper:stamp v=1 --> <script>alert(1)</script>Replaced foo with bar."
+	got := sanitizeReplyExplanation(input)
+	if strings.Contains(got, "@") || strings.Contains(got, "<script") || strings.Contains(got, "looper:stamp") {
+		t.Fatalf("sanitizeReplyExplanation() = %q, did not strip", got)
+	}
+	if !strings.Contains(got, "Replaced foo with bar.") {
+		t.Fatalf("sanitizeReplyExplanation() = %q, lost real content", got)
+	}
+}
+
+func TestLookupReplyExplanationsRejectsStaleSnapshot(t *testing.T) {
+	t.Parallel()
+	checkpoint := fixerCheckpoint{
+		FixItemsHash: "hash-current",
+		Repair: &checkpointRepair{
+			FixItemsHash: "hash-old",
+			ReplyExplanations: []replyExplanationEntry{
+				{FixItemID: "c1", Explanation: "stale"},
+			},
+		},
+	}
+	if got := lookupReplyExplanations(checkpoint); got != nil {
+		t.Fatalf("lookupReplyExplanations() = %#v, want nil on stale snapshot", got)
+	}
+}
+
+func TestLookupReplyExplanationsReturnsCurrent(t *testing.T) {
+	t.Parallel()
+	checkpoint := fixerCheckpoint{
+		FixItemsHash: "h1",
+		Repair: &checkpointRepair{
+			FixItemsHash: "h1",
+			ReplyExplanations: []replyExplanationEntry{
+				{FixItemID: "c1", Explanation: "good"},
+				{FixItemID: "", Explanation: "skip"},
+			},
+		},
+	}
+	got := lookupReplyExplanations(checkpoint)
+	if len(got) != 1 || got["c1"] != "good" {
+		t.Fatalf("lookupReplyExplanations() = %#v", got)
+	}
+}
+
+func TestProcessClaimedItemUsesAgentExplanationInReplyBody(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:  CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+		inspectResults: []InspectHeadResult{
+			{HeadSHA: "base-head"},
+			{HeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}},
+			{HeadSHA: "new-head"},
+		},
+	}
+	stdout := `__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Switched the loop bound to len(items)-1 and added a regression test in foo_test.go."}]}` + "\n"
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success", result)
+	}
+	if len(github.replyCalls) != 1 {
+		t.Fatalf("reply calls = %d, want 1", len(github.replyCalls))
+	}
+	reply := github.replyCalls[0]
+	if !strings.Contains(reply.Body, "@alice") {
+		t.Fatalf("reply body missing @author mention: %q", reply.Body)
+	}
+	if !strings.Contains(reply.Body, "Switched the loop bound") {
+		t.Fatalf("reply body missing agent explanation: %q", reply.Body)
+	}
+	if strings.Contains(reply.Body, "please fix off-by-one") {
+		t.Fatalf("reply body should drop original quote when explanation present: %q", reply.Body)
+	}
+}

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1837,6 +1837,18 @@ func TestParseReplyExplanationsReadsCompletionMarkerFromStderr(t *testing.T) {
 	}
 }
 
+func TestParseReplyExplanationsSkipsTemplateCompletionMarker(t *testing.T) {
+	t.Parallel()
+	stdout := strings.Join([]string{
+		`__LOOPER_RESULT__={"summary":"applied","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Kept scanning backward to the real completion."}]}`,
+		`__LOOPER_RESULT__={"summary":"<one-sentence summary>"}`,
+	}, "\n")
+	got := parseReplyExplanations(stdout, "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
+	if len(got) != 1 || got[0].Explanation != "Kept scanning backward to the real completion." {
+		t.Fatalf("parseReplyExplanations() = %#v", got)
+	}
+}
+
 func TestParseReplyExplanationsDropsUnknownAndMismatchedThread(t *testing.T) {
 	t.Parallel()
 	stdout := `__LOOPER_RESULT__={"review_thread_replies":[` +
@@ -2029,6 +2041,17 @@ func TestFindExistingFixerSummaryCommentIDSkipsUntrustedMarker(t *testing.T) {
 	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567", "looper")
 	if id != 202 {
 		t.Fatalf("findExistingFixerSummaryCommentID() = %d, want trusted comment 202", id)
+	}
+}
+
+func TestFindExistingFixerSummaryCommentIDParsesStringID(t *testing.T) {
+	t.Parallel()
+	detail := &checkpointDetail{IssueComments: []map[string]any{
+		{"id": "202", "body": fixerRoundSummaryMarker("abcdef1234567") + "\nreal summary\n\n<!-- looper:stamp v=1 -->"},
+	}}
+	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567", "looper")
+	if id != 202 {
+		t.Fatalf("findExistingFixerSummaryCommentID() = %d, want 202 from string id", id)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1508,17 +1508,22 @@ func (f *runnerFixture) nowISO() string {
 }
 
 type fakeGitHubGateway struct {
-	currentUser      string
-	listOpen         []PullRequestSummary
-	listOpenByLabel  map[string][]PullRequestSummary
-	listCalls        []ListOpenPullRequestsInput
-	viewResponses    []PullRequestDetail
-	viewIndex        int
-	resolveCalls     []ResolveReviewThreadInput
-	addLabelCalls    []PullRequestLabelsInput
-	removeLabelCalls []PullRequestLabelsInput
-	replyCalls       []AddReviewThreadReplyInput
-	replyErr         error
+	currentUser           string
+	listOpen              []PullRequestSummary
+	listOpenByLabel       map[string][]PullRequestSummary
+	listCalls             []ListOpenPullRequestsInput
+	viewResponses         []PullRequestDetail
+	viewIndex             int
+	resolveCalls          []ResolveReviewThreadInput
+	addLabelCalls         []PullRequestLabelsInput
+	removeLabelCalls      []PullRequestLabelsInput
+	replyCalls            []AddReviewThreadReplyInput
+	replyErr              error
+	createIssueComments   []IssueCommentInput
+	updateIssueComments   []UpdateIssueCommentInput
+	createIssueCommentErr error
+	updateIssueCommentErr error
+	nextIssueCommentID    int64
 }
 
 func (f *fakeGitHubGateway) ListOpenPullRequests(_ context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
@@ -1575,6 +1580,24 @@ func (f *fakeGitHubGateway) ResolveReviewThread(_ context.Context, input Resolve
 func (f *fakeGitHubGateway) AddReviewThreadReply(_ context.Context, input AddReviewThreadReplyInput) error {
 	f.replyCalls = append(f.replyCalls, input)
 	return f.replyErr
+}
+
+func (f *fakeGitHubGateway) CreateIssueComment(_ context.Context, input IssueCommentInput) (IssueCommentResult, error) {
+	f.createIssueComments = append(f.createIssueComments, input)
+	if f.createIssueCommentErr != nil {
+		return IssueCommentResult{}, f.createIssueCommentErr
+	}
+	if f.nextIssueCommentID == 0 {
+		f.nextIssueCommentID = 9000
+	}
+	id := f.nextIssueCommentID
+	f.nextIssueCommentID++
+	return IssueCommentResult{ID: id, URL: fmt.Sprintf("https://example.test/c/%d", id)}, nil
+}
+
+func (f *fakeGitHubGateway) UpdateIssueComment(_ context.Context, input UpdateIssueCommentInput) error {
+	f.updateIssueComments = append(f.updateIssueComments, input)
+	return f.updateIssueCommentErr
 }
 
 func (f *fakeGitHubGateway) AddPullRequestLabels(_ context.Context, input PullRequestLabelsInput) error {
@@ -1937,5 +1960,145 @@ func TestProcessClaimedItemUsesAgentExplanationInReplyBody(t *testing.T) {
 	}
 	if strings.Contains(reply.Body, "please fix off-by-one") {
 		t.Fatalf("reply body should drop original quote when explanation present: %q", reply.Body)
+	}
+}
+
+func TestBuildFixerSummaryCommentBodyIncludesMarkerAndItems(t *testing.T) {
+	t.Parallel()
+	items := []fixerSummaryItem{
+		{FixItem: FixItem{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice", Path: "internal/foo.go", Line: 12, URL: "https://example/threads/t1"}, Status: "resolved", Explanation: "Replaced strings.Title with cases.Title.", ReplyState: "sent"},
+		{FixItem: FixItem{Type: "comment", ID: "c2", ThreadID: "t2", Author: "bob", Path: "internal/bar.go", URL: "https://example/threads/t2"}, Status: "failed", ReplyState: "failed"},
+		{FixItem: FixItem{Type: "check", Name: "ci"}, Status: "check"},
+	}
+	got := buildFixerSummaryCommentBody("acme/looper", 42, "abcdef1234567", "abcdef1234567", items)
+	if !strings.Contains(got, fixerRoundSummaryMarker("abcdef1234567")) {
+		t.Fatalf("body missing round marker:\n%s", got)
+	}
+	if !strings.Contains(got, "abcdef1") {
+		t.Fatalf("body missing short SHA:\n%s", got)
+	}
+	if !strings.Contains(got, "✅") || !strings.Contains(got, "@alice") {
+		t.Fatalf("body missing resolved bullet for alice:\n%s", got)
+	}
+	if !strings.Contains(got, "⚠️") || !strings.Contains(got, "@bob") {
+		t.Fatalf("body missing failed bullet for bob:\n%s", got)
+	}
+	if !strings.Contains(got, "Replaced strings.Title with cases.Title.") {
+		t.Fatalf("body missing explanation:\n%s", got)
+	}
+	if !strings.Contains(got, "Failing check `ci`") {
+		t.Fatalf("body missing failing check item:\n%s", got)
+	}
+	if !strings.Contains(got, "[thread](https://example/threads/t1)") {
+		t.Fatalf("body missing thread link:\n%s", got)
+	}
+}
+
+func TestFindExistingFixerSummaryCommentIDMatchesByMarker(t *testing.T) {
+	t.Parallel()
+	detail := &checkpointDetail{IssueComments: []map[string]any{
+		{"id": float64(101), "body": "unrelated comment"},
+		{"id": float64(202), "body": fixerRoundSummaryMarker("abcdef1234567") + "\nLooper fixer round complete"},
+	}}
+	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567")
+	if id != 202 {
+		t.Fatalf("findExistingFixerSummaryCommentID() = %d, want 202", id)
+	}
+	if other, _ := findExistingFixerSummaryCommentID(detail, "deadbeef0000000"); other != 0 {
+		t.Fatalf("findExistingFixerSummaryCommentID(other head) = %d, want 0", other)
+	}
+}
+
+func TestProcessClaimedItemPostsRoundSummaryComment(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice", "url": "https://example/threads/t1", "path": "foo.go", "line": float64(7)}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice", "url": "https://example/threads/t1", "path": "foo.go", "line": float64(7)}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:  CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+		inspectResults: []InspectHeadResult{
+			{HeadSHA: "base-head"},
+			{HeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}},
+			{HeadSHA: "new-head"},
+		},
+	}
+	stdout := `__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Capped loop bound and added regression test."}]}` + "\n"
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	if _, err := runner.ProcessClaimedItem(context.Background(), *claim); err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if len(github.createIssueComments) != 1 {
+		t.Fatalf("createIssueComments calls = %d, want 1", len(github.createIssueComments))
+	}
+	if len(github.updateIssueComments) != 0 {
+		t.Fatalf("updateIssueComments calls = %d, want 0 on first round", len(github.updateIssueComments))
+	}
+	body := github.createIssueComments[0].Body
+	if !strings.Contains(body, "Looper fixer round complete") {
+		t.Fatalf("summary body missing header:\n%s", body)
+	}
+	if !strings.Contains(body, "Capped loop bound") {
+		t.Fatalf("summary body missing agent explanation:\n%s", body)
+	}
+	if !strings.Contains(body, fixerRoundSummaryMarker("new-head")) {
+		t.Fatalf("summary body missing round marker:\n%s", body)
+	}
+	if !strings.Contains(body, "@alice") {
+		t.Fatalf("summary body missing @author mention:\n%s", body)
+	}
+}
+
+func TestProcessClaimedItemSkipsSummaryWhenNoNewCommits(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "base-head"}},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:  CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+		inspectResults: []InspectHeadResult{
+			{HeadSHA: "base-head"},
+			{HeadSHA: "base-head"},
+			{HeadSHA: "base-head"},
+		},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "blocked before editing because gh could not validate PR metadata", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v)", claim, err)
+	}
+	if _, err := runner.ProcessClaimedItem(context.Background(), *claim); err != nil {
+		// expected to fail in resolve-comments because no new commits; we don't care about the error here.
+		_ = err
+	}
+	if len(github.createIssueComments) != 0 {
+		t.Fatalf("createIssueComments calls = %d, want 0 when no new commits", len(github.createIssueComments))
 	}
 }

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -2081,6 +2081,28 @@ func TestFindExistingFixerSummaryCommentIDParsesStringID(t *testing.T) {
 	}
 }
 
+func TestFindExistingFixerSummaryCommentIDParsesGraphQLIDFromURL(t *testing.T) {
+	t.Parallel()
+	detail := &checkpointDetail{IssueComments: []map[string]any{
+		{"id": "IC_kwDOExample", "url": "https://github.com/acme/looper/pull/42#issuecomment-202", "body": fixerRoundSummaryMarker("abcdef1234567") + "\nreal summary\n\n<!-- looper:stamp v=1 -->", "author": map[string]any{"login": "looper"}},
+	}}
+	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567", "looper")
+	if id != 202 {
+		t.Fatalf("findExistingFixerSummaryCommentID() = %d, want 202 from issue comment URL", id)
+	}
+}
+
+func TestFindExistingFixerSummaryCommentIDUsesDatabaseID(t *testing.T) {
+	t.Parallel()
+	detail := &checkpointDetail{IssueComments: []map[string]any{
+		{"id": "IC_kwDOExample", "databaseId": float64(202), "body": fixerRoundSummaryMarker("abcdef1234567") + "\nreal summary\n\n<!-- looper:stamp v=1 -->", "author": map[string]any{"login": "looper"}},
+	}}
+	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567", "looper")
+	if id != 202 {
+		t.Fatalf("findExistingFixerSummaryCommentID() = %d, want 202 from databaseId", id)
+	}
+}
+
 func TestIssueCommentAuthorLoginFallsBackToUser(t *testing.T) {
 	t.Parallel()
 	comment := map[string]any{"user": map[string]any{"login": "looper"}}
@@ -2143,6 +2165,33 @@ func TestProcessClaimedItemPostsRoundSummaryComment(t *testing.T) {
 	}
 	if !strings.Contains(body, "@alice") {
 		t.Fatalf("summary body missing @author mention:\n%s", body)
+	}
+}
+
+func TestPublishRoundSummaryCommentUpdatesExistingSummaryFromGraphQLID(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+	checkpoint := fixerCheckpoint{
+		Detail:           &checkpointDetail{IssueComments: []map[string]any{{"id": "IC_kwDOExample", "url": "https://github.com/acme/looper/pull/42#issuecomment-202", "body": fixerRoundSummaryMarker("new-head") + "\nold summary\n\n<!-- looper:stamp v=1 -->", "author": map[string]any{"login": "looper"}}}},
+		Push:             &checkpointPush{Pushed: true},
+		ReconcileCommits: &checkpointReconcileCommits{FinalHeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}},
+		ResolvedComments: &checkpointResolvedComments{Items: []checkpointResolvedComment{{FixItemID: "c1", ThreadID: "t1", Status: "resolved", ReplyState: "sent"}}},
+		FixItemsHash:     "fix-items-hash",
+	}
+	fixItems := []FixItem{{ID: "c1", Type: "comment", ThreadID: "t1", Author: "alice", URL: "https://example/threads/t1", Path: "foo.go", Line: 7}}
+
+	runner.publishRoundSummaryComment(context.Background(), stepInput{Repo: "acme/looper", PRNumber: 42, Project: storage.ProjectRecord{RepoPath: t.TempDir()}}, &checkpoint, fixItems, "new-head", map[string]string{"c1": "Capped loop bound and added regression test."})
+
+	if len(github.createIssueComments) != 0 {
+		t.Fatalf("createIssueComments calls = %d, want 0 when reusing prior summary", len(github.createIssueComments))
+	}
+	if len(github.updateIssueComments) != 1 {
+		t.Fatalf("updateIssueComments calls = %d, want 1", len(github.updateIssueComments))
+	}
+	if github.updateIssueComments[0].CommentID != 202 {
+		t.Fatalf("updateIssueComments[0].CommentID = %d, want 202", github.updateIssueComments[0].CommentID)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1874,6 +1874,17 @@ func TestSanitizeReplyExplanationStripsDangerousFragments(t *testing.T) {
 	}
 }
 
+func TestSummarizeFixItemSanitizesFallbackSummary(t *testing.T) {
+	t.Parallel()
+	got := summarizeFixItem(FixItem{Summary: "@looper-bot <!-- looper:stamp v=1 --> <b>Clean up</b> the fallback text."})
+	if strings.Contains(got, "@") || strings.Contains(got, "<b>") || strings.Contains(got, "looper:stamp") {
+		t.Fatalf("summarizeFixItem() = %q, did not sanitize fallback summary", got)
+	}
+	if !strings.Contains(got, "Clean up the fallback text.") {
+		t.Fatalf("summarizeFixItem() = %q, lost sanitized content", got)
+	}
+}
+
 func TestLookupReplyExplanationsRejectsStaleSnapshot(t *testing.T) {
 	t.Parallel()
 	checkpoint := fixerCheckpoint{
@@ -1994,18 +2005,30 @@ func TestBuildFixerSummaryCommentBodyIncludesMarkerAndItems(t *testing.T) {
 	}
 }
 
-func TestFindExistingFixerSummaryCommentIDMatchesByMarker(t *testing.T) {
+func TestFindExistingFixerSummaryCommentIDMatchesTrustedComment(t *testing.T) {
 	t.Parallel()
 	detail := &checkpointDetail{IssueComments: []map[string]any{
 		{"id": float64(101), "body": "unrelated comment"},
-		{"id": float64(202), "body": fixerRoundSummaryMarker("abcdef1234567") + "\nLooper fixer round complete"},
+		{"id": float64(202), "body": fixerRoundSummaryMarker("abcdef1234567") + "\nLooper fixer round complete\n\n<!-- looper:stamp v=1 -->"},
 	}}
-	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567")
+	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567", "looper")
 	if id != 202 {
 		t.Fatalf("findExistingFixerSummaryCommentID() = %d, want 202", id)
 	}
-	if other, _ := findExistingFixerSummaryCommentID(detail, "deadbeef0000000"); other != 0 {
+	if other, _ := findExistingFixerSummaryCommentID(detail, "deadbeef0000000", "looper"); other != 0 {
 		t.Fatalf("findExistingFixerSummaryCommentID(other head) = %d, want 0", other)
+	}
+}
+
+func TestFindExistingFixerSummaryCommentIDSkipsUntrustedMarker(t *testing.T) {
+	t.Parallel()
+	detail := &checkpointDetail{IssueComments: []map[string]any{
+		{"id": float64(101), "body": fixerRoundSummaryMarker("abcdef1234567") + "\nspoofed marker", "author": map[string]any{"login": "someone-else"}},
+		{"id": float64(202), "body": fixerRoundSummaryMarker("abcdef1234567") + "\nreal summary", "author": map[string]any{"login": "looper"}},
+	}}
+	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567", "looper")
+	if id != 202 {
+		t.Fatalf("findExistingFixerSummaryCommentID() = %d, want trusted comment 202", id)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/storage"
@@ -1876,21 +1877,34 @@ func TestParseReplyExplanationsMalformedFallsBack(t *testing.T) {
 
 func TestSanitizeReplyExplanationStripsDangerousFragments(t *testing.T) {
 	t.Parallel()
-	input := "@looper-bot, @another: <!-- looper:stamp v=1 --> <script>alert(1)</script>Replaced foo with bar."
+	input := "@looper-bot, @another: <!-- looper:stamp v=1 --> <script>alert(1)</script>Replaced foo with bar as requested by @octocat."
 	got := sanitizeReplyExplanation(input)
 	if strings.Contains(got, "@") || strings.Contains(got, "<script") || strings.Contains(got, "looper:stamp") {
 		t.Fatalf("sanitizeReplyExplanation() = %q, did not strip", got)
 	}
-	if !strings.Contains(got, "Replaced foo with bar.") {
+	if !strings.Contains(got, "Replaced foo with bar") {
 		t.Fatalf("sanitizeReplyExplanation() = %q, lost real content", got)
+	}
+}
+
+func TestSanitizeReplyExplanationStripsVisibleDisclosureFooter(t *testing.T) {
+	t.Parallel()
+	stamp := disclosure.Stamper{Config: config.DefaultDisclosureConfig(), Agent: "opencode"}.MarkdownStamp("fixer")
+	input := "Kept the real fix summary.\n\n" + stamp
+	if got := sanitizeReplyExplanation(input); got != "Kept the real fix summary." {
+		t.Fatalf("sanitizeReplyExplanation() = %q, want disclosure-free summary", got)
 	}
 }
 
 func TestSummarizeFixItemSanitizesFallbackSummary(t *testing.T) {
 	t.Parallel()
-	got := summarizeFixItem(FixItem{Summary: "@looper-bot <!-- looper:stamp v=1 --> <b>Clean up</b> the fallback text."})
+	stamp := disclosure.Stamper{Config: config.DefaultDisclosureConfig(), Agent: "opencode"}.MarkdownStamp("fixer")
+	got := summarizeFixItem(FixItem{Summary: "@looper-bot <b>Clean up</b> the fallback text.\n\n" + stamp})
 	if strings.Contains(got, "@") || strings.Contains(got, "<b>") || strings.Contains(got, "looper:stamp") {
 		t.Fatalf("summarizeFixItem() = %q, did not sanitize fallback summary", got)
+	}
+	if strings.Contains(got, "Powered by Looper") || strings.Contains(got, disclosure.Slogan) {
+		t.Fatalf("summarizeFixItem() = %q, leaked disclosure footer", got)
 	}
 	if !strings.Contains(got, "Clean up the fallback text.") {
 		t.Fatalf("summarizeFixItem() = %q, lost sanitized content", got)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1790,19 +1790,31 @@ func TestProcessClaimedItemRepliesToAuthorBeforeResolving(t *testing.T) {
 	}
 }
 
-func TestParseReplyExplanationsFromStdoutValid(t *testing.T) {
+func TestParseReplyExplanationsValid(t *testing.T) {
 	t.Parallel()
 	stdout := strings.Join([]string{
 		"some agent log line",
 		`__LOOPER_RESULT__={"summary":"applied","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Replaced strings.Title with cases.Title."}]}`,
 	}, "\n")
-	got := parseReplyExplanationsFromStdout(stdout, []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
+	got := parseReplyExplanations(stdout, "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
 	if len(got) != 1 || got[0].FixItemID != "c1" || !strings.Contains(got[0].Explanation, "cases.Title") {
-		t.Fatalf("parseReplyExplanationsFromStdout() = %#v", got)
+		t.Fatalf("parseReplyExplanations() = %#v", got)
 	}
 }
 
-func TestParseReplyExplanationsFromStdoutDropsUnknownAndMismatchedThread(t *testing.T) {
+func TestParseReplyExplanationsReadsCompletionMarkerFromStderr(t *testing.T) {
+	t.Parallel()
+	stderr := strings.Join([]string{
+		"runtime warning",
+		`__LOOPER_RESULT__={"summary":"applied","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Preserved stderr completion markers."}]}`,
+	}, "\n")
+	got := parseReplyExplanations("", stderr, []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
+	if len(got) != 1 || got[0].Explanation != "Preserved stderr completion markers." {
+		t.Fatalf("parseReplyExplanations() = %#v", got)
+	}
+}
+
+func TestParseReplyExplanationsDropsUnknownAndMismatchedThread(t *testing.T) {
 	t.Parallel()
 	stdout := `__LOOPER_RESULT__={"review_thread_replies":[` +
 		`{"fixItemId":"c-unknown","explanation":"hi"},` +
@@ -1811,25 +1823,25 @@ func TestParseReplyExplanationsFromStdoutDropsUnknownAndMismatchedThread(t *test
 		`{"fixItemId":"c1","threadId":"t1","explanation":"good"},` +
 		`{"fixItemId":"c1","threadId":"t1","explanation":"duplicate, must drop"}` +
 		`]}`
-	got := parseReplyExplanationsFromStdout(stdout, []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
+	got := parseReplyExplanations(stdout, "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
 	if len(got) != 1 || got[0].Explanation != "good" {
-		t.Fatalf("parseReplyExplanationsFromStdout() = %#v, want only the first valid entry", got)
+		t.Fatalf("parseReplyExplanations() = %#v, want only the first valid entry", got)
 	}
 }
 
-func TestParseReplyExplanationsFromStdoutMalformedFallsBack(t *testing.T) {
+func TestParseReplyExplanationsMalformedFallsBack(t *testing.T) {
 	t.Parallel()
-	if got := parseReplyExplanationsFromStdout("__LOOPER_RESULT__={bad json}", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}); got != nil {
-		t.Fatalf("parseReplyExplanationsFromStdout() = %#v, want nil on bad JSON", got)
+	if got := parseReplyExplanations("__LOOPER_RESULT__={bad json}", "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}); got != nil {
+		t.Fatalf("parseReplyExplanations() = %#v, want nil on bad JSON", got)
 	}
-	if got := parseReplyExplanationsFromStdout("no marker here", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}); got != nil {
-		t.Fatalf("parseReplyExplanationsFromStdout() = %#v, want nil when marker missing", got)
+	if got := parseReplyExplanations("no marker here", "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}); got != nil {
+		t.Fatalf("parseReplyExplanations() = %#v, want nil when marker missing", got)
 	}
 }
 
 func TestSanitizeReplyExplanationStripsDangerousFragments(t *testing.T) {
 	t.Parallel()
-	input := "@looper-bot @another <!-- looper:stamp v=1 --> <script>alert(1)</script>Replaced foo with bar."
+	input := "@looper-bot, @another: <!-- looper:stamp v=1 --> <script>alert(1)</script>Replaced foo with bar."
 	got := sanitizeReplyExplanation(input)
 	if strings.Contains(got, "@") || strings.Contains(got, "<script") || strings.Contains(got, "looper:stamp") {
 		t.Fatalf("sanitizeReplyExplanation() = %q, did not strip", got)
@@ -1896,7 +1908,7 @@ func TestProcessClaimedItemUsesAgentExplanationInReplyBody(t *testing.T) {
 		},
 	}
 	stdout := `__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Switched the loop bound to len(items)-1 and added a regression test in foo_test.go."}]}` + "\n"
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: "runtime log", Stderr: stdout}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -2035,7 +2035,7 @@ func TestFindExistingFixerSummaryCommentIDMatchesTrustedComment(t *testing.T) {
 	t.Parallel()
 	detail := &checkpointDetail{IssueComments: []map[string]any{
 		{"id": float64(101), "body": "unrelated comment"},
-		{"id": float64(202), "body": fixerRoundSummaryMarker("abcdef1234567") + "\nLooper fixer round complete\n\n<!-- looper:stamp v=1 -->"},
+		{"id": float64(202), "body": fixerRoundSummaryMarker("abcdef1234567") + "\nLooper fixer round complete\n\n<!-- looper:stamp v=1 -->", "author": map[string]any{"login": "looper"}},
 	}}
 	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567", "looper")
 	if id != 202 {
@@ -2058,14 +2058,34 @@ func TestFindExistingFixerSummaryCommentIDSkipsUntrustedMarker(t *testing.T) {
 	}
 }
 
+func TestFindExistingFixerSummaryCommentIDSkipsStampedCommentFromOtherAuthor(t *testing.T) {
+	t.Parallel()
+	detail := &checkpointDetail{IssueComments: []map[string]any{
+		{"id": float64(101), "body": fixerRoundSummaryMarker("abcdef1234567") + "\nspoofed marker\n\n<!-- looper:stamp v=1 -->", "author": map[string]any{"login": "someone-else"}},
+		{"id": float64(202), "body": fixerRoundSummaryMarker("abcdef1234567") + "\nreal summary\n\n<!-- looper:stamp v=1 -->", "author": map[string]any{"login": "looper"}},
+	}}
+	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567", "looper")
+	if id != 202 {
+		t.Fatalf("findExistingFixerSummaryCommentID() = %d, want trusted comment 202", id)
+	}
+}
+
 func TestFindExistingFixerSummaryCommentIDParsesStringID(t *testing.T) {
 	t.Parallel()
 	detail := &checkpointDetail{IssueComments: []map[string]any{
-		{"id": "202", "body": fixerRoundSummaryMarker("abcdef1234567") + "\nreal summary\n\n<!-- looper:stamp v=1 -->"},
+		{"id": "202", "body": fixerRoundSummaryMarker("abcdef1234567") + "\nreal summary\n\n<!-- looper:stamp v=1 -->", "author": map[string]any{"login": "looper"}},
 	}}
 	id, _ := findExistingFixerSummaryCommentID(detail, "abcdef1234567", "looper")
 	if id != 202 {
 		t.Fatalf("findExistingFixerSummaryCommentID() = %d, want 202 from string id", id)
+	}
+}
+
+func TestIssueCommentAuthorLoginFallsBackToUser(t *testing.T) {
+	t.Parallel()
+	comment := map[string]any{"user": map[string]any{"login": "looper"}}
+	if got := issueCommentAuthorLogin(comment); got != "looper" {
+		t.Fatalf("issueCommentAuthorLogin() = %q, want looper", got)
 	}
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -1577,8 +1577,10 @@ func (g *Gateway) fetchReviewThreadsSummaryPage(ctx context.Context, cwd, owner,
 		"        nodes {",
 		"          id",
 		"          isResolved",
+		"          path",
+		"          line",
 		"          comments(first: 1) {",
-		"            nodes { id body }",
+		"            nodes { id body url path line author { login } }",
 		"          }",
 		"        }",
 		"        pageInfo { hasNextPage endCursor }",
@@ -1845,6 +1847,22 @@ func normalizeReviewThread(value any) (map[string]any, bool) {
 	}
 	if body := asString(first["body"]); body != "" {
 		out["body"] = body
+	}
+	if author := extractAuthor(first["author"]); author != "" {
+		out["author"] = author
+	}
+	if url := asString(first["url"]); url != "" {
+		out["url"] = url
+	}
+	if path := asString(first["path"]); path != "" {
+		out["path"] = path
+	} else if path := asString(row["path"]); path != "" {
+		out["path"] = path
+	}
+	if line := asInt64(first["line"]); line > 0 {
+		out["line"] = line
+	} else if line := asInt64(row["line"]); line > 0 {
+		out["line"] = line
 	}
 	return out, true
 }

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -5271,7 +5271,7 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"wrapper rejects clean APPROVE reviews that do not start with an @mention",
 		"<!-- looper:stamp v=1 -->",
 		`<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=reviewer · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>`,
-		"Every inline review comment you post must include only the hidden looper stamp marker",
+		"Every inline review comment you post must also use looper's configured visible inline disclosure style",
 		"Do not write the footer as plain paragraph text",
 		"Minimal PR seed",
 		"\"repo\": \"acme/looper\"",

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -381,7 +381,10 @@ func (a reviewerAgentExecutionAdapter) Kill(reason string) error {
 	return a.execution.Kill(reason)
 }
 
-type fixerGitHubAdapter struct{ gateway *githubinfra.Gateway }
+type fixerGitHubAdapter struct {
+	gateway *githubinfra.Gateway
+	stamper disclosure.Stamper
+}
 
 func (a fixerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input fixer.ListOpenPullRequestsInput) ([]fixer.PullRequestSummary, error) {
 	pullRequests, err := a.gateway.ListOpenPullRequests(ctx, githubinfra.ListOpenPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: input.Limit, Author: input.Author, Label: input.Label, Labels: input.Labels})
@@ -413,6 +416,11 @@ func (a fixerGitHubAdapter) ViewPullRequest(ctx context.Context, input fixer.Vie
 
 func (a fixerGitHubAdapter) ResolveReviewThread(ctx context.Context, input fixer.ResolveReviewThreadInput) error {
 	return a.gateway.ResolveReviewThread(ctx, githubinfra.ResolveReviewThreadInput{Repo: input.Repo, ThreadID: input.ThreadID, CWD: input.CWD})
+}
+
+func (a fixerGitHubAdapter) AddReviewThreadReply(ctx context.Context, input fixer.AddReviewThreadReplyInput) error {
+	body := a.stamper.ReviewComment(input.Body, "fixer")
+	return a.gateway.AddReviewThreadReply(ctx, githubinfra.AddReviewThreadReplyInput{Repo: input.Repo, ThreadID: input.ThreadID, Body: body, CWD: input.CWD})
 }
 
 func (a fixerGitHubAdapter) AddPullRequestLabels(ctx context.Context, input fixer.PullRequestLabelsInput) error {
@@ -828,7 +836,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 	fixerRunner = fixer.New(fixer.Options{
 		DB:                 coordinator.DB(),
 		Repos:              repos,
-		GitHub:             fixerGitHubAdapter{gateway: githubGateway},
+		GitHub:             fixerGitHubAdapter{gateway: githubGateway, stamper: stamper},
 		Git:                fixerGitAdapter{gateway: gitGateway, stamper: stamper},
 		AgentExecutor:      fixerAgentExecutorAdapter{executor: agentExecutor},
 		Logger:             logger,

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -411,7 +411,7 @@ func (a fixerGitHubAdapter) ViewPullRequest(ctx context.Context, input fixer.Vie
 	if err != nil {
 		return fixer.PullRequestDetail{}, err
 	}
-	return fixer.PullRequestDetail{Number: detail.Number, State: detail.State, IsDraft: detail.IsDraft, Labels: detail.Labels, HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: detail.Comments, Checks: detail.Checks, HasConflicts: detail.HasConflicts, Author: detail.Author}, nil
+	return fixer.PullRequestDetail{Number: detail.Number, State: detail.State, IsDraft: detail.IsDraft, Labels: detail.Labels, HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: detail.Comments, IssueComments: detail.IssueComments, Checks: detail.Checks, HasConflicts: detail.HasConflicts, Author: detail.Author}, nil
 }
 
 func (a fixerGitHubAdapter) ResolveReviewThread(ctx context.Context, input fixer.ResolveReviewThreadInput) error {
@@ -421,6 +421,20 @@ func (a fixerGitHubAdapter) ResolveReviewThread(ctx context.Context, input fixer
 func (a fixerGitHubAdapter) AddReviewThreadReply(ctx context.Context, input fixer.AddReviewThreadReplyInput) error {
 	body := a.stamper.ReviewComment(input.Body, "fixer")
 	return a.gateway.AddReviewThreadReply(ctx, githubinfra.AddReviewThreadReplyInput{Repo: input.Repo, ThreadID: input.ThreadID, Body: body, CWD: input.CWD})
+}
+
+func (a fixerGitHubAdapter) CreateIssueComment(ctx context.Context, input fixer.IssueCommentInput) (fixer.IssueCommentResult, error) {
+	body := a.stamper.Markdown(input.Body, "fixer", disclosure.ChannelIssueComment)
+	comment, err := a.gateway.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: input.Repo, IssueNumber: input.IssueNumber, Body: body, CWD: input.CWD})
+	if err != nil {
+		return fixer.IssueCommentResult{}, err
+	}
+	return fixer.IssueCommentResult{ID: comment.ID, URL: comment.URL}, nil
+}
+
+func (a fixerGitHubAdapter) UpdateIssueComment(ctx context.Context, input fixer.UpdateIssueCommentInput) error {
+	body := a.stamper.Markdown(input.Body, "fixer", disclosure.ChannelIssueComment)
+	return a.gateway.UpdateIssueComment(ctx, githubinfra.UpdateIssueCommentInput{Repo: input.Repo, CommentID: input.CommentID, Body: body, CWD: input.CWD})
 }
 
 func (a fixerGitHubAdapter) AddPullRequestLabels(ctx context.Context, input fixer.PullRequestLabelsInput) error {


### PR DESCRIPTION
## Summary

Implements #252. When the fixer pushes a fix commit, it now posts a contextual reply on each review thread **before** resolving it.

- Reply mentions the original comment author, references the fix commit, and includes a per-thread explanation written by the repair agent.
- Explanations are supplied via the existing `__LOOPER_RESULT__` structured-output channel — new optional `review_thread_replies[{fixItemId, threadId, explanation}]` field. No new parser path, no tool-calling, no MCP exposure.
- Falls back to a generic body when the agent does not supply (or supplies malformed) explanations.
- The disclosure stamper applied by the GitHub adapter ensures every reply carries the looper exposure marker (`<!-- looper:stamp v=1 -->` + visible footer), so automated replies remain filterable downstream.

## Design notes

Picked structured-output over agent tool-calling after consulting the oracle. Trust boundary stays in Go: the agent supplies only the explanation; Looper owns the `@mention`, commit reference, sanitization, and exposure stamping.

Defensive parsing per oracle:
- Keys on `fixItemId` (`threadId` is not a strong PK, used only as a cross-check).
- Drops unknown / mismatched / duplicate / blank entries; first valid entry wins.
- Sanitizes explanations: strips `<!-- looper:stamp v=1 -->`, leading `@mentions`, HTML tags; caps at 500 runes.
- Explanations are bound to the fix-items snapshot via `FixItemsHash` and discarded if the snapshot changed across a resume/rebase.

## Files changed

- `internal/fixer/runner.go` — schema, parser, sanitizer, snapshot-bound lookup, prompt fragment, body builder, resolve-step wiring.
- `internal/runtime/scheduler.go` — fixer GitHub adapter now wraps replies in `disclosure.Stamper.ReviewComment(body, "fixer")`.
- `internal/infra/github/gateway.go` — review-thread normalization surfaces the original commenter's `author`, `url`, `path`, `line`.
- `internal/fixer/runner_test.go` — unit tests for parser / sanitizer / lookup / body builder; end-to-end test that asserts the agent's explanation lands in the posted reply.

## Verification

- `gofmt -l .` clean
- `go vet ./...` clean
- `go build ./...` clean
- `go test ./...` all packages pass