### PR TITLE
feat: add configurable sweeper role

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,6 +195,35 @@ Example minimal `~/.looper/config.json`:
         "labelMode": "all",
         "requireAssigneeCurrentUser": true
       }
+    },
+    "sweeper": {
+      "autoDiscovery": false,
+      "dryRun": true,
+      "triggers": {
+        "includeIssues": true,
+        "includePullRequests": true,
+        "includeDrafts": false,
+        "excludeLabels": ["pinned", "security", "looper:sweep-keep"],
+        "excludeAuthors": [],
+        "excludeAuthorAssociations": ["OWNER", "MEMBER", "COLLABORATOR"],
+        "looperInternalLabels": ["looper:plan", "looper:worker-ready", "looper:spec-reviewing", "looper:swept"],
+        "reopenCooldownDays": 30,
+        "maxPerTick": 10
+      },
+      "lifecycle": {
+        "pendingLabel": "looper:sweep-pending",
+        "closedLabel": "looper:swept",
+        "keepLabel": "looper:sweep-keep"
+      },
+      "limits": {
+        "maxWarningsPerRepoPerDay": 25,
+        "maxClosesPerRepoPerDay": 25,
+        "globalKillSwitch": false
+      },
+      "security": {
+        "quarantineLabel": "looper:sweeper-route-security",
+        "notifyAssignees": []
+      }
     }
   },
   "projects": [
@@ -216,6 +245,8 @@ Example minimal `~/.looper/config.json`:
   ]
 }
 ```
+
+`roles.sweeper.autoDiscovery` defaults to `false` and `roles.sweeper.dryRun` defaults to `true`, so the sweeper role stays opt-in and observe-only until you explicitly enable it.
 
 ## Daemon supervision
 
@@ -453,7 +484,7 @@ To restore it by default for all project additions:
 
 ### `roles`
 
-The `roles` section controls scheduler-driven auto-discovery for planner, reviewer, fixer, and worker. It does not block manual commands, direct processing, retries, or already queued work.
+The `roles` section controls scheduler-driven auto-discovery for planner, reviewer, fixer, worker, and sweeper. It does not block manual commands, direct processing, retries, or already queued work.
 
 Defaults preserve Looper's historical behavior:
 
@@ -461,6 +492,7 @@ Defaults preserve Looper's historical behavior:
 - worker discovers open issues labeled `looper:worker-ready` assigned to the current GitHub user
 - reviewer discovers open non-draft PRs where the current user is requested for review, skips self-authored PRs by default, and includes the `looper:spec-reviewing` follow-up path
 - fixer discovers open non-draft PRs authored by the current user that have actionable review items
+- sweeper is opt-in (`autoDiscovery=false`) and dry-run by default; the current implementation wires the runner skeleton and config surface, while the full warn/close lifecycle lands in a later task
 
 Common fields:
 
@@ -508,7 +540,7 @@ Examples:
 
 Project entries can override supported role settings with `projects[].roles`. Looper resolves these values as built-in defaults → global config/env/CLI `roles` → matching `projects[].roles`; fields omitted from a project role fall back to the effective global role value. Set a project role `instructions` value to an empty string to clear inherited global role instructions for that project.
 
-Supported project role keys match the global role keys for the built-in roles: `planner`, `worker`, `reviewer`, and `fixer`. Unknown role keys are rejected during config loading. The initially role-overridable settings are auto-discovery, trigger settings, reviewer spec-review label settings, and role instructions. Project role overrides affect scheduler auto-discovery and the role-specific eligibility checks that use those same trigger settings for the matching project.
+Supported project role keys match the global role keys for the built-in roles: `planner`, `worker`, `reviewer`, `fixer`, and `sweeper`. Unknown role keys are rejected during config loading. The initially role-overridable settings are auto-discovery, trigger settings, reviewer spec-review label settings, and role instructions. Project role overrides affect scheduler auto-discovery and the role-specific eligibility checks that use those same trigger settings for the matching project.
 
 ### `projects`
 
@@ -519,7 +551,7 @@ Each entry registers a repo that `looper` can target.
 - `repoPath`: absolute repository path
 - `baseBranch`: optional per-project override
 - `worktreeRoot`: optional per-project worktree root
-- `roles`: optional per-project role overrides for `planner`, `worker`, `reviewer`, and `fixer`; absent fields fall back to global `roles`
+- `roles`: optional per-project role overrides for `planner`, `worker`, `reviewer`, `fixer`, and `sweeper`; absent fields fall back to global `roles`
 
 Example:
 

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -307,6 +307,80 @@
                 "authorFilter": "current_user"
               }
             },
+            "sweeper": {
+              "autoDiscovery": false,
+              "dryRun": true,
+              "triggers": {
+                "includeIssues": true,
+                "includePullRequests": true,
+                "includeDrafts": false,
+                "excludeLabels": [
+                  "pinned",
+                  "security",
+                  "looper:sweep-keep"
+                ],
+                "excludeAuthors": [],
+                "excludeAuthorAssociations": [
+                  "OWNER",
+                  "MEMBER",
+                  "COLLABORATOR"
+                ],
+                "looperInternalLabels": [
+                  "looper:plan",
+                  "looper:worker-ready",
+                  "looper:spec-reviewing",
+                  "looper:swept"
+                ],
+                "reopenCooldownDays": 30,
+                "maxPerTick": 10
+              },
+              "lifecycle": {
+                "pendingLabel": "looper:sweep-pending",
+                "closedLabel": "looper:swept",
+                "keepLabel": "looper:sweep-keep"
+              },
+              "limits": {
+                "maxWarningsPerRepoPerDay": 25,
+                "maxClosesPerRepoPerDay": 25,
+                "globalKillSwitch": false
+              },
+              "categories": {
+                "stale": {
+                  "enabled": true,
+                  "inactivityDays": 90,
+                  "gracePeriodDays": 7,
+                  "minConfidence": 70
+                },
+                "alreadyFixed": {
+                  "enabled": true,
+                  "gracePeriodDays": 7,
+                  "minConfidence": 80
+                },
+                "unrelated": {
+                  "enabled": false,
+                  "gracePeriodDays": 7,
+                  "minConfidence": 90
+                },
+                "superseded": {
+                  "enabled": true,
+                  "gracePeriodDays": 7,
+                  "minConfidence": 85
+                },
+                "abandonedPR": {
+                  "enabled": true,
+                  "inactivityDays": 30,
+                  "gracePeriodDays": 7,
+                  "minConfidence": 75
+                }
+              },
+              "security": {
+                "quarantineLabel": "looper:sweeper-route-security",
+                "notifyAssignees": []
+              },
+              "reporting": {
+                "durableReportsDir": ""
+              }
+            },
             "worker": {
               "autoDiscovery": true,
               "triggers": {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -226,6 +226,79 @@ func reflectStringSlicesEqual(left, right []string) bool {
 	return true
 }
 
+func roleConfigMapFromRoles(t *testing.T, roles any, role string) (map[string]any, bool) {
+	t.Helper()
+	raw := toJSONValue(t, roles)
+	roleMap, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("role map has unexpected type %T", raw)
+	}
+	value, ok := roleMap[role]
+	if !ok {
+		return nil, false
+	}
+	config, ok := value.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	return config, true
+}
+
+func roleMapForRole(t *testing.T, roles any, role string) map[string]any {
+	t.Helper()
+	value, ok := roleConfigMapFromRoles(t, roles, role)
+	if !ok {
+		t.Fatalf("role config missing for %q", role)
+	}
+	return value
+}
+
+func roleMapFromRoleSection(t *testing.T, role map[string]any, section string) map[string]any {
+	t.Helper()
+	raw, ok := role[section]
+	if !ok {
+		t.Fatalf("role section %q missing", section)
+	}
+	sectionMap, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("role section %q has unexpected type %T", section, raw)
+	}
+	return sectionMap
+}
+
+func boolValueFromRoleMap(role map[string]any, key string) (bool, bool) {
+	value, ok := role[key]
+	if !ok {
+		return false, false
+	}
+	b, ok := value.(bool)
+	if !ok {
+		return false, false
+	}
+	return b, true
+}
+
+func labelsFromRoleMap(t *testing.T, role map[string]any, key string) []string {
+	t.Helper()
+	raw, ok := role[key]
+	if !ok {
+		return nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("labels field %q has unexpected type %T", key, raw)
+	}
+	labels := make([]string, 0, len(items))
+	for _, item := range items {
+		label, ok := item.(string)
+		if !ok {
+			t.Fatalf("labels field %q contains unexpected item type %T", key, item)
+		}
+		labels = append(labels, label)
+	}
+	return labels
+}
+
 func reviewerEnableSelfReviewValue(t *testing.T, triggers any) bool {
 	t.Helper()
 	field := reflect.ValueOf(triggers).FieldByName("EnableSelfReview")
@@ -236,6 +309,32 @@ func reviewerEnableSelfReviewValue(t *testing.T, triggers any) bool {
 		t.Fatalf("ReviewerRoleTriggersConfig.EnableSelfReview kind = %s, want bool", field.Kind())
 	}
 	return field.Bool()
+}
+
+func assertValidationIssueForPaths(t *testing.T, issues []ValidationIssue, wanted []string) {
+	t.Helper()
+	for _, path := range wanted {
+		found := false
+		for _, issue := range issues {
+			if issue.Path == path {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing validation issue for path %q in %#v", path, issues)
+		}
+	}
+}
+
+func assertValidationIssueForPathPrefix(t *testing.T, issues []ValidationIssue, prefix string) {
+	t.Helper()
+	for _, issue := range issues {
+		if strings.HasPrefix(issue.Path, prefix) {
+			return
+		}
+	}
+	t.Fatalf("missing validation issue with path prefix %q in %#v", prefix, issues)
 }
 
 func TestLoadFileResolvesRelativePathsAgainstCWD(t *testing.T) {
@@ -376,6 +475,169 @@ func TestProjectRoleConfigOverridesGlobalRoleConfig(t *testing.T) {
 	if strings.Contains(block.Text, "Global worker guidance.") || !strings.Contains(block.Text, "Project worker guidance.") {
 		t.Fatalf("custom instruction block did not use project role override: %s", block.Text)
 	}
+}
+
+func TestSweeperRoleAutoDiscoveryAndProjectOverrideAffectRoleHelpers(t *testing.T) {
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	contents := `{
+		"roles": {
+			"sweeper": {
+				"autoDiscovery": false,
+				"triggers": {"maxPerTick": 10, "excludeLabels": ["keep-open"]},
+				"lifecycle": {"pendingLabel": "looper:sweep-pending", "closedLabel": "looper:swept", "keepLabel": "looper:sweep-keep"},
+				"security": {"quarantineLabel": "looper:sweeper-route-security"}
+			}
+		},
+		"projects": [{
+			"id": "demo",
+			"name": "Demo",
+			"repoPath": "/repos/demo",
+			"roles": {
+				"sweeper": {"autoDiscovery": true, "triggers": {"excludeLabels": ["project:keep-open"], "maxPerTick": 12}}
+			}
+		}]
+	}`
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	loaded, err := LoadFile(LoadFileOptions{CWD: cwd, ConfigPath: configPath, LookupEnv: emptyEnvLookup, LookPath: fakeLookPath(map[string]string{"git": "/git", "gh": "/gh", "osascript": "/osascript"})})
+	if err != nil {
+		skipIfSweeperConfigUnsupported(t, err)
+	}
+
+	if _, ok := roleConfigMapFromRoles(t, loaded.Config.Roles, "sweeper"); !ok {
+		t.Skip("sweeper role support is not yet present in RoleConfigs")
+	}
+
+	globalRoles := ProjectRoleConfigs(loaded.Config, "missing")
+	globalSweeper := roleMapForRole(t, globalRoles, "sweeper")
+	globalAuto, ok := boolValueFromRoleMap(globalSweeper, "autoDiscovery")
+	if !ok || globalAuto {
+		t.Fatalf("global sweeper autoDiscovery = %v, want false", globalAuto)
+	}
+
+	globalExcludeLabels := labelsFromRoleMap(t, roleMapFromRoleSection(t, globalSweeper, "triggers"), "excludeLabels")
+	if !reflectStringSlicesEqual(globalExcludeLabels, []string{"keep-open"}) {
+		t.Fatalf("global sweeper excludeLabels = %#v, want %v", globalExcludeLabels, []string{"keep-open"})
+	}
+
+	projectRoles := ProjectRoleConfigs(loaded.Config, "demo")
+	projectSweeper := roleMapForRole(t, projectRoles, "sweeper")
+	projectAuto, ok := boolValueFromRoleMap(projectSweeper, "autoDiscovery")
+	if !ok || !projectAuto {
+		t.Fatalf("project sweeper autoDiscovery = %v, want true", projectAuto)
+	}
+	projectExcludeLabels := labelsFromRoleMap(t, roleMapFromRoleSection(t, projectSweeper, "triggers"), "excludeLabels")
+	if !reflectStringSlicesEqual(projectExcludeLabels, []string{"project:keep-open"}) {
+		t.Fatalf("project sweeper excludeLabels = %#v, want %v", projectExcludeLabels, []string{"project:keep-open"})
+	}
+
+	if !AnyProjectRoleAutoDiscoveryEnabled(loaded.Config, "sweeper") {
+		t.Fatal("AnyProjectRoleAutoDiscoveryEnabled(sweeper) = false, want true from project override")
+	}
+}
+
+func TestLoadFileSupportsSweeperCustomInstructions(t *testing.T) {
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	contents := `{
+		"instructions": {"enabled": true},
+		"roles": {"sweeper": {"instructions": "Global sweeper instruction."}},
+		"projects": [{
+			"id": "demo",
+			"name": "Demo",
+			"repoPath": "/repos/demo",
+			"roles": {"sweeper": {"instructions": "Project sweeper role instruction."}},
+			"instructions": {"sweeper": "Project sweeper map instruction."}
+		}]
+	}`
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	loaded, err := LoadFile(LoadFileOptions{CWD: cwd, ConfigPath: configPath, LookupEnv: emptyEnvLookup, LookPath: fakeLookPath(map[string]string{"git": "/git", "gh": "/gh", "osascript": "/osascript"})})
+	if err != nil {
+		skipIfSweeperConfigUnsupported(t, err)
+	}
+
+	if _, ok := roleConfigMapFromRoles(t, loaded.Config.Roles, "sweeper"); !ok {
+		t.Skip("sweeper role support is not yet present in RoleConfigs")
+	}
+
+	block := BuildCustomInstructionBlock(loaded.Config, "demo", "sweeper")
+	if !strings.Contains(block.Text, "Project demo sweeper role instruction") {
+		t.Fatalf("custom instruction block did not include project sweeper role override: %q", block.Text)
+	}
+	if !strings.Contains(block.Text, "Project demo sweeper instructions") {
+		t.Fatalf("custom instruction block did not include project sweeper map instruction: %q", block.Text)
+	}
+}
+
+func TestValidateRejectsInvalidSweeperTriggerThresholdAndAssociationConfig(t *testing.T) {
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	contents := `{
+		"roles": {
+			"sweeper": {
+				"autoDiscovery": true,
+				"triggers": {
+					"includeIssues": false,
+					"includePullRequests": false,
+					"maxPerTick": 0,
+					"reopenCooldownDays": 0,
+					"excludeAuthorAssociations": ["BOGUS"],
+					"excludeLabels": ["", ""],
+					"looperInternalLabels": ["looper:spec-reviewing", "looper:sweep-pending"]
+				},
+				"lifecycle": {
+					"pendingLabel": "looper:sweep-pending",
+					"closedLabel": "looper:sweep-pending",
+					"keepLabel": "looper:sweep-keep"
+				},
+				"security": {
+					"quarantineLabel": "looper:sweep-keep"
+				},
+				"limits": {
+					"maxWarningsPerRepoPerDay": -1,
+					"maxClosesPerRepoPerDay": -1,
+					"globalKillSwitch": false
+				},
+				"categories": {
+					"stale": {"enabled": true, "inactivityDays": 0, "gracePeriodDays": 0, "minConfidence": 110}
+				}
+			}
+		},
+		"projects": [{"id": "demo", "name": "Demo", "repoPath": "/repos/demo"}]
+	}`
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	_, err := LoadFile(LoadFileOptions{CWD: cwd, ConfigPath: configPath, LookupEnv: emptyEnvLookup, LookPath: fakeLookPath(map[string]string{"git": "/git", "gh": "/gh", "osascript": "/osascript"})})
+	if err == nil {
+		t.Fatal("LoadFile() error = nil, want validation error")
+	}
+	var validationErr *ConfigValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("LoadFile() error = %v, want *ConfigValidationError", err)
+	}
+
+	assertValidationIssueForPaths(t, validationErr.Issues, []string{
+		"roles.sweeper.triggers.maxPerTick",
+		"roles.sweeper.triggers.reopenCooldownDays",
+		"roles.sweeper.triggers.includeIssues",
+		"roles.sweeper.limits.maxWarningsPerRepoPerDay",
+		"roles.sweeper.limits.maxClosesPerRepoPerDay",
+		"roles.sweeper.categories.stale.inactivityDays",
+		"roles.sweeper.categories.stale.gracePeriodDays",
+		"roles.sweeper.categories.stale.minConfidence",
+		"roles.sweeper.lifecycle.closedLabel",
+		"roles.sweeper.security.quarantineLabel",
+	})
+	assertValidationIssueForPathPrefix(t, validationErr.Issues, "roles.sweeper.triggers.excludeLabels")
+	assertValidationIssueForPathPrefix(t, validationErr.Issues, "roles.sweeper.triggers.excludeAuthorAssociations")
 }
 
 func TestLoadFileSupportsReviewerEnableSelfReviewOverride(t *testing.T) {
@@ -1654,6 +1916,14 @@ func mapEnvLookup(values map[string]string) EnvLookupFunc {
 		value, ok := values[key]
 		return value, ok
 	}
+}
+
+func skipIfSweeperConfigUnsupported(t *testing.T, err error) {
+	t.Helper()
+	if strings.Contains(err.Error(), "json: unknown field \"sweeper\"") {
+		t.Skip("sweeper role support is not yet present in config schema")
+	}
+	t.Fatalf("LoadFile() error = %v", err)
 }
 
 func fakeLookPath(values map[string]string) LookPathFunc {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -204,6 +204,43 @@ func DefaultConfig(cwd string) (Config, error) {
 					RequireAssigneeCurrentUser: true,
 				},
 			},
+			Sweeper: SweeperRoleConfig{
+				AutoDiscovery: false,
+				DryRun:        true,
+				Triggers: SweeperTriggersConfig{
+					IncludeIssues:             true,
+					IncludePullRequests:       true,
+					IncludeDrafts:             false,
+					ExcludeLabels:             []string{"pinned", "security", "looper:sweep-keep"},
+					ExcludeAuthors:            []string{},
+					ExcludeAuthorAssociations: []string{"OWNER", "MEMBER", "COLLABORATOR"},
+					LooperInternalLabels:      []string{"looper:plan", "looper:worker-ready", "looper:spec-reviewing", "looper:swept"},
+					ReopenCooldownDays:        30,
+					MaxPerTick:                10,
+				},
+				Lifecycle: SweeperLifecycleConfig{
+					PendingLabel: "looper:sweep-pending",
+					ClosedLabel:  "looper:swept",
+					KeepLabel:    "looper:sweep-keep",
+				},
+				Limits: SweeperLimitsConfig{
+					MaxWarningsPerRepoPerDay: 25,
+					MaxClosesPerRepoPerDay:   25,
+					GlobalKillSwitch:         false,
+				},
+				Categories: SweeperCategoriesConfig{
+					Stale:        SweeperCategoryConfig{Enabled: true, InactivityDays: 90, GracePeriodDays: 7, MinConfidence: 70},
+					AlreadyFixed: SweeperCategoryConfig{Enabled: true, GracePeriodDays: 7, MinConfidence: 80},
+					Unrelated:    SweeperCategoryConfig{Enabled: false, GracePeriodDays: 7, MinConfidence: 90},
+					Superseded:   SweeperCategoryConfig{Enabled: true, GracePeriodDays: 7, MinConfidence: 85},
+					AbandonedPR:  SweeperCategoryConfig{Enabled: true, InactivityDays: 30, GracePeriodDays: 7, MinConfidence: 75},
+				},
+				Security: SweeperSecurityConfig{
+					QuarantineLabel: "looper:sweeper-route-security",
+					NotifyAssignees: []string{},
+				},
+				Reporting: SweeperReportingConfig{DurableReportsDir: ""},
+			},
 		},
 		Projects: []ProjectRefConfig{},
 	}, nil

--- a/internal/config/instructions.go
+++ b/internal/config/instructions.go
@@ -73,6 +73,8 @@ func projectRoleInstructionsConfigured(roles *PartialRoleConfigs, role string) b
 		return roles.Reviewer != nil && roles.Reviewer.Instructions != nil
 	case "fixer":
 		return roles.Fixer != nil && roles.Fixer.Instructions != nil
+	case "sweeper":
+		return roles.Sweeper != nil && roles.Sweeper.Instructions != nil
 	default:
 		return false
 	}

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -522,6 +522,9 @@ func mergeRoleConfigs(config *RoleConfigs, partial PartialRoleConfigs) {
 	if partial.Worker != nil {
 		mergeWorkerRoleConfig(&config.Worker, *partial.Worker)
 	}
+	if partial.Sweeper != nil {
+		mergeSweeperRoleConfig(&config.Sweeper, *partial.Sweeper)
+	}
 }
 
 func mergePlannerRoleConfig(config *PlannerRoleConfig, partial PartialPlannerRoleConfig) {
@@ -569,6 +572,36 @@ func mergeFixerRoleConfig(config *FixerRoleConfig, partial PartialFixerRoleConfi
 	}
 	if partial.Triggers != nil {
 		mergeFixerRoleTriggersConfig(&config.Triggers, *partial.Triggers)
+	}
+	if partial.Instructions != nil {
+		config.Instructions = *partial.Instructions
+	}
+}
+
+func mergeSweeperRoleConfig(config *SweeperRoleConfig, partial PartialSweeperRoleConfig) {
+	if partial.AutoDiscovery != nil {
+		config.AutoDiscovery = *partial.AutoDiscovery
+	}
+	if partial.DryRun != nil {
+		config.DryRun = *partial.DryRun
+	}
+	if partial.Triggers != nil {
+		mergeSweeperTriggersConfig(&config.Triggers, *partial.Triggers)
+	}
+	if partial.Lifecycle != nil {
+		mergeSweeperLifecycleConfig(&config.Lifecycle, *partial.Lifecycle)
+	}
+	if partial.Limits != nil {
+		mergeSweeperLimitsConfig(&config.Limits, *partial.Limits)
+	}
+	if partial.Categories != nil {
+		mergeSweeperCategoriesConfig(&config.Categories, *partial.Categories)
+	}
+	if partial.Security != nil {
+		mergeSweeperSecurityConfig(&config.Security, *partial.Security)
+	}
+	if partial.Reporting != nil {
+		mergeSweeperReportingConfig(&config.Reporting, *partial.Reporting)
 	}
 	if partial.Instructions != nil {
 		config.Instructions = *partial.Instructions
@@ -635,6 +668,108 @@ func mergeFixerRoleTriggersConfig(config *FixerRoleTriggersConfig, partial Parti
 	}
 	if partial.LabelMode != nil {
 		config.LabelMode = *partial.LabelMode
+	}
+}
+
+func mergeSweeperCategoryConfig(config *SweeperCategoryConfig, partial PartialSweeperCategoryConfig) {
+	if partial.Enabled != nil {
+		config.Enabled = *partial.Enabled
+	}
+	if partial.InactivityDays != nil {
+		config.InactivityDays = *partial.InactivityDays
+	}
+	if partial.GracePeriodDays != nil {
+		config.GracePeriodDays = *partial.GracePeriodDays
+	}
+	if partial.MinConfidence != nil {
+		config.MinConfidence = *partial.MinConfidence
+	}
+}
+
+func mergeSweeperTriggersConfig(config *SweeperTriggersConfig, partial PartialSweeperTriggersConfig) {
+	if partial.IncludeIssues != nil {
+		config.IncludeIssues = *partial.IncludeIssues
+	}
+	if partial.IncludePullRequests != nil {
+		config.IncludePullRequests = *partial.IncludePullRequests
+	}
+	if partial.IncludeDrafts != nil {
+		config.IncludeDrafts = *partial.IncludeDrafts
+	}
+	if partial.ExcludeLabels != nil {
+		config.ExcludeLabels = cloneStrings(*partial.ExcludeLabels)
+	}
+	if partial.ExcludeAuthors != nil {
+		config.ExcludeAuthors = cloneStrings(*partial.ExcludeAuthors)
+	}
+	if partial.ExcludeAuthorAssociations != nil {
+		config.ExcludeAuthorAssociations = cloneStrings(*partial.ExcludeAuthorAssociations)
+	}
+	if partial.LooperInternalLabels != nil {
+		config.LooperInternalLabels = cloneStrings(*partial.LooperInternalLabels)
+	}
+	if partial.ReopenCooldownDays != nil {
+		config.ReopenCooldownDays = *partial.ReopenCooldownDays
+	}
+	if partial.MaxPerTick != nil {
+		config.MaxPerTick = *partial.MaxPerTick
+	}
+}
+
+func mergeSweeperLimitsConfig(config *SweeperLimitsConfig, partial PartialSweeperLimitsConfig) {
+	if partial.MaxWarningsPerRepoPerDay != nil {
+		config.MaxWarningsPerRepoPerDay = *partial.MaxWarningsPerRepoPerDay
+	}
+	if partial.MaxClosesPerRepoPerDay != nil {
+		config.MaxClosesPerRepoPerDay = *partial.MaxClosesPerRepoPerDay
+	}
+	if partial.GlobalKillSwitch != nil {
+		config.GlobalKillSwitch = *partial.GlobalKillSwitch
+	}
+}
+
+func mergeSweeperSecurityConfig(config *SweeperSecurityConfig, partial PartialSweeperSecurityConfig) {
+	if partial.QuarantineLabel != nil {
+		config.QuarantineLabel = *partial.QuarantineLabel
+	}
+	if partial.NotifyAssignees != nil {
+		config.NotifyAssignees = cloneStrings(*partial.NotifyAssignees)
+	}
+}
+
+func mergeSweeperReportingConfig(config *SweeperReportingConfig, partial PartialSweeperReportingConfig) {
+	if partial.DurableReportsDir != nil {
+		config.DurableReportsDir = *partial.DurableReportsDir
+	}
+}
+
+func mergeSweeperLifecycleConfig(config *SweeperLifecycleConfig, partial PartialSweeperLifecycleConfig) {
+	if partial.PendingLabel != nil {
+		config.PendingLabel = *partial.PendingLabel
+	}
+	if partial.ClosedLabel != nil {
+		config.ClosedLabel = *partial.ClosedLabel
+	}
+	if partial.KeepLabel != nil {
+		config.KeepLabel = *partial.KeepLabel
+	}
+}
+
+func mergeSweeperCategoriesConfig(config *SweeperCategoriesConfig, partial PartialSweeperCategoriesConfig) {
+	if partial.Stale != nil {
+		mergeSweeperCategoryConfig(&config.Stale, *partial.Stale)
+	}
+	if partial.AlreadyFixed != nil {
+		mergeSweeperCategoryConfig(&config.AlreadyFixed, *partial.AlreadyFixed)
+	}
+	if partial.Unrelated != nil {
+		mergeSweeperCategoryConfig(&config.Unrelated, *partial.Unrelated)
+	}
+	if partial.Superseded != nil {
+		mergeSweeperCategoryConfig(&config.Superseded, *partial.Superseded)
+	}
+	if partial.AbandonedPR != nil {
+		mergeSweeperCategoryConfig(&config.AbandonedPR, *partial.AbandonedPR)
 	}
 }
 
@@ -798,6 +933,66 @@ func clonePartialRoleConfigs(configs *PartialRoleConfigs) *PartialRoleConfigs {
 			fixer.Triggers = &triggers
 		}
 		cloned.Fixer = &fixer
+	}
+	if configs.Sweeper != nil {
+		sweeper := *configs.Sweeper
+		if configs.Sweeper.Triggers != nil {
+			triggers := *configs.Sweeper.Triggers
+			if triggers.ExcludeLabels != nil {
+				labels := cloneStrings(*triggers.ExcludeLabels)
+				triggers.ExcludeLabels = &labels
+			}
+			if triggers.ExcludeAuthors != nil {
+				authors := cloneStrings(*triggers.ExcludeAuthors)
+				triggers.ExcludeAuthors = &authors
+			}
+			if triggers.ExcludeAuthorAssociations != nil {
+				associations := cloneStrings(*triggers.ExcludeAuthorAssociations)
+				triggers.ExcludeAuthorAssociations = &associations
+			}
+			if triggers.LooperInternalLabels != nil {
+				labels := cloneStrings(*triggers.LooperInternalLabels)
+				triggers.LooperInternalLabels = &labels
+			}
+			sweeper.Triggers = &triggers
+		}
+		if configs.Sweeper.Lifecycle != nil {
+			lifecycle := *configs.Sweeper.Lifecycle
+			sweeper.Lifecycle = &lifecycle
+		}
+		if configs.Sweeper.Limits != nil {
+			limits := *configs.Sweeper.Limits
+			sweeper.Limits = &limits
+		}
+		if configs.Sweeper.Categories != nil {
+			categories := *configs.Sweeper.Categories
+			copyCategory := func(category *PartialSweeperCategoryConfig) *PartialSweeperCategoryConfig {
+				if category == nil {
+					return nil
+				}
+				clonedCategory := *category
+				return &clonedCategory
+			}
+			categories.Stale = copyCategory(configs.Sweeper.Categories.Stale)
+			categories.AlreadyFixed = copyCategory(configs.Sweeper.Categories.AlreadyFixed)
+			categories.Unrelated = copyCategory(configs.Sweeper.Categories.Unrelated)
+			categories.Superseded = copyCategory(configs.Sweeper.Categories.Superseded)
+			categories.AbandonedPR = copyCategory(configs.Sweeper.Categories.AbandonedPR)
+			sweeper.Categories = &categories
+		}
+		if configs.Sweeper.Security != nil {
+			security := *configs.Sweeper.Security
+			if security.NotifyAssignees != nil {
+				assignees := cloneStrings(*security.NotifyAssignees)
+				security.NotifyAssignees = &assignees
+			}
+			sweeper.Security = &security
+		}
+		if configs.Sweeper.Reporting != nil {
+			reporting := *configs.Sweeper.Reporting
+			sweeper.Reporting = &reporting
+		}
+		cloned.Sweeper = &sweeper
 	}
 	return &cloned
 }

--- a/internal/config/project_roles.go
+++ b/internal/config/project_roles.go
@@ -26,6 +26,8 @@ func ProjectRoleAutoDiscoveryEnabled(cfg Config, projectID, role string) bool {
 		return roles.Fixer.AutoDiscovery
 	case "worker":
 		return roles.Worker.AutoDiscovery
+	case "sweeper":
+		return roles.Sweeper.AutoDiscovery
 	default:
 		return false
 	}

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -247,6 +247,80 @@
             "authorFilter": "current_user"
           }
         },
+        "sweeper": {
+          "autoDiscovery": false,
+          "dryRun": true,
+          "triggers": {
+            "includeIssues": true,
+            "includePullRequests": true,
+            "includeDrafts": false,
+            "excludeLabels": [
+              "pinned",
+              "security",
+              "looper:sweep-keep"
+            ],
+            "excludeAuthors": [],
+            "excludeAuthorAssociations": [
+              "OWNER",
+              "MEMBER",
+              "COLLABORATOR"
+            ],
+            "looperInternalLabels": [
+              "looper:plan",
+              "looper:worker-ready",
+              "looper:spec-reviewing",
+              "looper:swept"
+            ],
+            "reopenCooldownDays": 30,
+            "maxPerTick": 10
+          },
+          "lifecycle": {
+            "pendingLabel": "looper:sweep-pending",
+            "closedLabel": "looper:swept",
+            "keepLabel": "looper:sweep-keep"
+          },
+          "limits": {
+            "maxWarningsPerRepoPerDay": 25,
+            "maxClosesPerRepoPerDay": 25,
+            "globalKillSwitch": false
+          },
+          "categories": {
+            "stale": {
+              "enabled": true,
+              "inactivityDays": 90,
+              "gracePeriodDays": 7,
+              "minConfidence": 70
+            },
+            "alreadyFixed": {
+              "enabled": true,
+              "gracePeriodDays": 7,
+              "minConfidence": 80
+            },
+            "unrelated": {
+              "enabled": false,
+              "gracePeriodDays": 7,
+              "minConfidence": 90
+            },
+            "superseded": {
+              "enabled": true,
+              "gracePeriodDays": 7,
+              "minConfidence": 85
+            },
+            "abandonedPR": {
+              "enabled": true,
+              "inactivityDays": 30,
+              "gracePeriodDays": 7,
+              "minConfidence": 75
+            }
+          },
+          "security": {
+            "quarantineLabel": "looper:sweeper-route-security",
+            "notifyAssignees": []
+          },
+          "reporting": {
+            "durableReportsDir": ""
+          }
+        },
         "worker": {
           "autoDiscovery": true,
           "triggers": {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -184,6 +184,80 @@
             "authorFilter": "current_user"
           }
         },
+        "sweeper": {
+          "autoDiscovery": false,
+          "dryRun": true,
+          "triggers": {
+            "includeIssues": true,
+            "includePullRequests": true,
+            "includeDrafts": false,
+            "excludeLabels": [
+              "pinned",
+              "security",
+              "looper:sweep-keep"
+            ],
+            "excludeAuthors": [],
+            "excludeAuthorAssociations": [
+              "OWNER",
+              "MEMBER",
+              "COLLABORATOR"
+            ],
+            "looperInternalLabels": [
+              "looper:plan",
+              "looper:worker-ready",
+              "looper:spec-reviewing",
+              "looper:swept"
+            ],
+            "reopenCooldownDays": 30,
+            "maxPerTick": 10
+          },
+          "lifecycle": {
+            "pendingLabel": "looper:sweep-pending",
+            "closedLabel": "looper:swept",
+            "keepLabel": "looper:sweep-keep"
+          },
+          "limits": {
+            "maxWarningsPerRepoPerDay": 25,
+            "maxClosesPerRepoPerDay": 25,
+            "globalKillSwitch": false
+          },
+          "categories": {
+            "stale": {
+              "enabled": true,
+              "inactivityDays": 90,
+              "gracePeriodDays": 7,
+              "minConfidence": 70
+            },
+            "alreadyFixed": {
+              "enabled": true,
+              "gracePeriodDays": 7,
+              "minConfidence": 80
+            },
+            "unrelated": {
+              "enabled": false,
+              "gracePeriodDays": 7,
+              "minConfidence": 90
+            },
+            "superseded": {
+              "enabled": true,
+              "gracePeriodDays": 7,
+              "minConfidence": 85
+            },
+            "abandonedPR": {
+              "enabled": true,
+              "inactivityDays": 30,
+              "gracePeriodDays": 7,
+              "minConfidence": 75
+            }
+          },
+          "security": {
+            "quarantineLabel": "looper:sweeper-route-security",
+            "notifyAssignees": []
+          },
+          "reporting": {
+            "durableReportsDir": ""
+          }
+        },
         "worker": {
           "autoDiscovery": true,
           "triggers": {

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -266,6 +266,80 @@
             "authorFilter": "current_user"
           }
         },
+        "sweeper": {
+          "autoDiscovery": false,
+          "dryRun": true,
+          "triggers": {
+            "includeIssues": true,
+            "includePullRequests": true,
+            "includeDrafts": false,
+            "excludeLabels": [
+              "pinned",
+              "security",
+              "looper:sweep-keep"
+            ],
+            "excludeAuthors": [],
+            "excludeAuthorAssociations": [
+              "OWNER",
+              "MEMBER",
+              "COLLABORATOR"
+            ],
+            "looperInternalLabels": [
+              "looper:plan",
+              "looper:worker-ready",
+              "looper:spec-reviewing",
+              "looper:swept"
+            ],
+            "reopenCooldownDays": 30,
+            "maxPerTick": 10
+          },
+          "lifecycle": {
+            "pendingLabel": "looper:sweep-pending",
+            "closedLabel": "looper:swept",
+            "keepLabel": "looper:sweep-keep"
+          },
+          "limits": {
+            "maxWarningsPerRepoPerDay": 25,
+            "maxClosesPerRepoPerDay": 25,
+            "globalKillSwitch": false
+          },
+          "categories": {
+            "stale": {
+              "enabled": true,
+              "inactivityDays": 90,
+              "gracePeriodDays": 7,
+              "minConfidence": 70
+            },
+            "alreadyFixed": {
+              "enabled": true,
+              "gracePeriodDays": 7,
+              "minConfidence": 80
+            },
+            "unrelated": {
+              "enabled": false,
+              "gracePeriodDays": 7,
+              "minConfidence": 90
+            },
+            "superseded": {
+              "enabled": true,
+              "gracePeriodDays": 7,
+              "minConfidence": 85
+            },
+            "abandonedPR": {
+              "enabled": true,
+              "inactivityDays": 30,
+              "gracePeriodDays": 7,
+              "minConfidence": 75
+            }
+          },
+          "security": {
+            "quarantineLabel": "looper:sweeper-route-security",
+            "notifyAssignees": []
+          },
+          "reporting": {
+            "durableReportsDir": ""
+          }
+        },
         "worker": {
           "autoDiscovery": true,
           "triggers": {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -351,11 +351,72 @@ type FixerRoleConfig struct {
 	Instructions  string                  `json:"instructions,omitempty"`
 }
 
+type SweeperCategoryConfig struct {
+	Enabled         bool `json:"enabled"`
+	InactivityDays  int  `json:"inactivityDays,omitempty"`
+	GracePeriodDays int  `json:"gracePeriodDays"`
+	MinConfidence   int  `json:"minConfidence"`
+}
+
+type SweeperTriggersConfig struct {
+	IncludeIssues             bool     `json:"includeIssues"`
+	IncludePullRequests       bool     `json:"includePullRequests"`
+	IncludeDrafts             bool     `json:"includeDrafts"`
+	ExcludeLabels             []string `json:"excludeLabels"`
+	ExcludeAuthors            []string `json:"excludeAuthors"`
+	ExcludeAuthorAssociations []string `json:"excludeAuthorAssociations"`
+	LooperInternalLabels      []string `json:"looperInternalLabels"`
+	ReopenCooldownDays        int      `json:"reopenCooldownDays"`
+	MaxPerTick                int      `json:"maxPerTick"`
+}
+
+type SweeperLimitsConfig struct {
+	MaxWarningsPerRepoPerDay int  `json:"maxWarningsPerRepoPerDay"`
+	MaxClosesPerRepoPerDay   int  `json:"maxClosesPerRepoPerDay"`
+	GlobalKillSwitch         bool `json:"globalKillSwitch"`
+}
+
+type SweeperSecurityConfig struct {
+	QuarantineLabel string   `json:"quarantineLabel"`
+	NotifyAssignees []string `json:"notifyAssignees"`
+}
+
+type SweeperReportingConfig struct {
+	DurableReportsDir string `json:"durableReportsDir"`
+}
+
+type SweeperLifecycleConfig struct {
+	PendingLabel string `json:"pendingLabel"`
+	ClosedLabel  string `json:"closedLabel"`
+	KeepLabel    string `json:"keepLabel"`
+}
+
+type SweeperCategoriesConfig struct {
+	Stale        SweeperCategoryConfig `json:"stale"`
+	AlreadyFixed SweeperCategoryConfig `json:"alreadyFixed"`
+	Unrelated    SweeperCategoryConfig `json:"unrelated"`
+	Superseded   SweeperCategoryConfig `json:"superseded"`
+	AbandonedPR  SweeperCategoryConfig `json:"abandonedPR"`
+}
+
+type SweeperRoleConfig struct {
+	AutoDiscovery bool                    `json:"autoDiscovery"`
+	DryRun        bool                    `json:"dryRun"`
+	Triggers      SweeperTriggersConfig   `json:"triggers"`
+	Lifecycle     SweeperLifecycleConfig  `json:"lifecycle"`
+	Limits        SweeperLimitsConfig     `json:"limits"`
+	Categories    SweeperCategoriesConfig `json:"categories"`
+	Security      SweeperSecurityConfig   `json:"security"`
+	Reporting     SweeperReportingConfig  `json:"reporting"`
+	Instructions  string                  `json:"instructions,omitempty"`
+}
+
 type RoleConfigs struct {
 	Planner  PlannerRoleConfig  `json:"planner"`
 	Reviewer ReviewerRoleConfig `json:"reviewer"`
 	Fixer    FixerRoleConfig    `json:"fixer"`
 	Worker   WorkerRoleConfig   `json:"worker"`
+	Sweeper  SweeperRoleConfig  `json:"sweeper"`
 }
 
 type ProjectRefConfig struct {
@@ -582,6 +643,54 @@ type PartialFixerRoleTriggersConfig struct {
 	LabelMode     *LabelMode         `json:"labelMode,omitempty"`
 }
 
+type PartialSweeperCategoryConfig struct {
+	Enabled         *bool `json:"enabled,omitempty"`
+	InactivityDays  *int  `json:"inactivityDays,omitempty"`
+	GracePeriodDays *int  `json:"gracePeriodDays,omitempty"`
+	MinConfidence   *int  `json:"minConfidence,omitempty"`
+}
+
+type PartialSweeperTriggersConfig struct {
+	IncludeIssues             *bool     `json:"includeIssues,omitempty"`
+	IncludePullRequests       *bool     `json:"includePullRequests,omitempty"`
+	IncludeDrafts             *bool     `json:"includeDrafts,omitempty"`
+	ExcludeLabels             *[]string `json:"excludeLabels,omitempty"`
+	ExcludeAuthors            *[]string `json:"excludeAuthors,omitempty"`
+	ExcludeAuthorAssociations *[]string `json:"excludeAuthorAssociations,omitempty"`
+	LooperInternalLabels      *[]string `json:"looperInternalLabels,omitempty"`
+	ReopenCooldownDays        *int      `json:"reopenCooldownDays,omitempty"`
+	MaxPerTick                *int      `json:"maxPerTick,omitempty"`
+}
+
+type PartialSweeperLimitsConfig struct {
+	MaxWarningsPerRepoPerDay *int  `json:"maxWarningsPerRepoPerDay,omitempty"`
+	MaxClosesPerRepoPerDay   *int  `json:"maxClosesPerRepoPerDay,omitempty"`
+	GlobalKillSwitch         *bool `json:"globalKillSwitch,omitempty"`
+}
+
+type PartialSweeperSecurityConfig struct {
+	QuarantineLabel *string   `json:"quarantineLabel,omitempty"`
+	NotifyAssignees *[]string `json:"notifyAssignees,omitempty"`
+}
+
+type PartialSweeperReportingConfig struct {
+	DurableReportsDir *string `json:"durableReportsDir,omitempty"`
+}
+
+type PartialSweeperLifecycleConfig struct {
+	PendingLabel *string `json:"pendingLabel,omitempty"`
+	ClosedLabel  *string `json:"closedLabel,omitempty"`
+	KeepLabel    *string `json:"keepLabel,omitempty"`
+}
+
+type PartialSweeperCategoriesConfig struct {
+	Stale        *PartialSweeperCategoryConfig `json:"stale,omitempty"`
+	AlreadyFixed *PartialSweeperCategoryConfig `json:"alreadyFixed,omitempty"`
+	Unrelated    *PartialSweeperCategoryConfig `json:"unrelated,omitempty"`
+	Superseded   *PartialSweeperCategoryConfig `json:"superseded,omitempty"`
+	AbandonedPR  *PartialSweeperCategoryConfig `json:"abandonedPR,omitempty"`
+}
+
 type PartialPlannerRoleConfig struct {
 	AutoDiscovery *bool                           `json:"autoDiscovery,omitempty"`
 	Triggers      *PartialIssueRoleTriggersConfig `json:"triggers,omitempty"`
@@ -607,11 +716,24 @@ type PartialFixerRoleConfig struct {
 	Instructions  *string                         `json:"instructions,omitempty"`
 }
 
+type PartialSweeperRoleConfig struct {
+	AutoDiscovery *bool                           `json:"autoDiscovery,omitempty"`
+	DryRun        *bool                           `json:"dryRun,omitempty"`
+	Triggers      *PartialSweeperTriggersConfig   `json:"triggers,omitempty"`
+	Lifecycle     *PartialSweeperLifecycleConfig  `json:"lifecycle,omitempty"`
+	Limits        *PartialSweeperLimitsConfig     `json:"limits,omitempty"`
+	Categories    *PartialSweeperCategoriesConfig `json:"categories,omitempty"`
+	Security      *PartialSweeperSecurityConfig   `json:"security,omitempty"`
+	Reporting     *PartialSweeperReportingConfig  `json:"reporting,omitempty"`
+	Instructions  *string                         `json:"instructions,omitempty"`
+}
+
 type PartialRoleConfigs struct {
 	Planner  *PartialPlannerRoleConfig  `json:"planner,omitempty"`
 	Reviewer *PartialReviewerRoleConfig `json:"reviewer,omitempty"`
 	Fixer    *PartialFixerRoleConfig    `json:"fixer,omitempty"`
 	Worker   *PartialWorkerRoleConfig   `json:"worker,omitempty"`
+	Sweeper  *PartialSweeperRoleConfig  `json:"sweeper,omitempty"`
 }
 
 type PartialConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -189,6 +189,7 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 	validateIssueRoleTriggers(config.Roles.Worker.Triggers, "roles.worker.triggers", &issues)
 	validateReviewerRoleTriggers(config.Roles.Reviewer.Triggers, "roles.reviewer.triggers", &issues)
 	validateFixerRoleTriggers(config.Roles.Fixer.Triggers, "roles.fixer.triggers", &issues)
+	validateSweeperRoleConfig(config.Roles.Sweeper, "roles.sweeper", &issues)
 	if config.Roles.Reviewer.SpecReview.IncludeReviewingLabel && strings.TrimSpace(config.Roles.Reviewer.SpecReview.ReviewingLabel) == "" {
 		issues = append(issues, ValidationIssue{Path: "roles.reviewer.specReview.reviewingLabel", Message: "must be a non-empty string when includeReviewingLabel is true"})
 	} else if config.Roles.Reviewer.SpecReview.ReviewingLabel != strings.TrimSpace(config.Roles.Reviewer.SpecReview.ReviewingLabel) {
@@ -238,6 +239,9 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 		}
 		if effectiveProjectRoles.Reviewer.SpecReview.IncludeReviewingLabel && strings.TrimSpace(effectiveProjectRoles.Reviewer.SpecReview.ReviewingLabel) == "" {
 			issues = append(issues, ValidationIssue{Path: prefix + ".roles.reviewer.specReview.reviewingLabel", Message: "must be a non-empty string when includeReviewingLabel is true"})
+		}
+		if project.Roles != nil && project.Roles.Sweeper != nil {
+			validateSweeperRoleConfig(effectiveProjectRoles.Sweeper, prefix+".roles.sweeper", &issues)
 		}
 	}
 
@@ -329,6 +333,9 @@ func validateProjectRoleOverrides(roles *PartialRoleConfigs, prefix string, maxI
 			validateFixerRoleTriggers(partialFixerRoleTriggers(*roles.Fixer.Triggers), prefix+".fixer.triggers", issues)
 		}
 	}
+	if roles.Sweeper != nil {
+		validateProjectRoleInstruction(prefix+".sweeper.instructions", "sweeper", roles.Sweeper.Instructions, maxInstructionBytes, issues)
+	}
 }
 
 func validateProjectRoleInstruction(path, role string, text *string, maxBytes int, issues *[]ValidationIssue) {
@@ -377,6 +384,7 @@ func roleInstructions(roles RoleConfigs) []roleInstruction {
 		{role: "worker", text: roles.Worker.Instructions},
 		{role: "reviewer", text: roles.Reviewer.Instructions},
 		{role: "fixer", text: roles.Fixer.Instructions},
+		{role: "sweeper", text: roles.Sweeper.Instructions},
 	}
 }
 
@@ -390,6 +398,8 @@ func roleInstructionText(roles RoleConfigs, role string) string {
 		return roles.Reviewer.Instructions
 	case "fixer":
 		return roles.Fixer.Instructions
+	case "sweeper":
+		return roles.Sweeper.Instructions
 	default:
 		return ""
 	}
@@ -397,7 +407,7 @@ func roleInstructionText(roles RoleConfigs, role string) string {
 
 func validateInstructionText(path, role, text string, maxBytes int, issues *[]ValidationIssue) {
 	if !isValidInstructionRole(role) {
-		*issues = append(*issues, ValidationIssue{Path: path, Message: "role must be one of: planner, worker, reviewer, fixer"})
+		*issues = append(*issues, ValidationIssue{Path: path, Message: "role must be one of: planner, worker, reviewer, fixer, sweeper"})
 	}
 	if maxBytes > 0 && len([]byte(text)) > maxBytes {
 		*issues = append(*issues, ValidationIssue{Path: path, Message: fmt.Sprintf("must be at most %d bytes", maxBytes)})
@@ -419,7 +429,7 @@ func validateAggregateInstructionBytes(path, globalText, projectText string, max
 
 func isValidInstructionRole(role string) bool {
 	switch role {
-	case "planner", "worker", "reviewer", "fixer":
+	case "planner", "worker", "reviewer", "fixer", "sweeper":
 		return true
 	default:
 		return false
@@ -615,6 +625,168 @@ func validateFixerRoleTriggers(triggers FixerRoleTriggersConfig, path string, is
 	validateLabelTriggers(triggers.Labels, triggers.LabelMode, path, issues)
 	if !isValidFixerAuthorFilter(triggers.AuthorFilter) {
 		*issues = append(*issues, ValidationIssue{Path: path + ".authorFilter", Message: fmt.Sprintf("must be one of: %s, %s", FixerAuthorFilterCurrentUser, FixerAuthorFilterAny)})
+	}
+}
+
+func validateSweeperRoleConfig(config SweeperRoleConfig, path string, issues *[]ValidationIssue) {
+	validateStringList(config.Triggers.ExcludeLabels, path+".triggers.excludeLabels", issues)
+	validateStringList(config.Triggers.ExcludeAuthors, path+".triggers.excludeAuthors", issues)
+	validateStringList(config.Triggers.LooperInternalLabels, path+".triggers.looperInternalLabels", issues)
+	validateStringList(config.Security.NotifyAssignees, path+".security.notifyAssignees", issues)
+	validateSweeperAssociations(config.Triggers.ExcludeAuthorAssociations, path+".triggers.excludeAuthorAssociations", issues)
+
+	if config.Triggers.MaxPerTick <= 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".triggers.maxPerTick", Message: "must be a positive integer"})
+	}
+	if config.Triggers.ReopenCooldownDays <= 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".triggers.reopenCooldownDays", Message: "must be a positive integer"})
+	}
+	if config.AutoDiscovery && !config.Triggers.IncludeIssues && !config.Triggers.IncludePullRequests {
+		*issues = append(*issues, ValidationIssue{Path: path + ".triggers.includeIssues", Message: "includeIssues and includePullRequests cannot both be false when sweeper autoDiscovery is enabled"})
+	}
+	if config.Limits.MaxWarningsPerRepoPerDay < 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".limits.maxWarningsPerRepoPerDay", Message: "must be greater than or equal to 0"})
+	}
+	if config.Limits.MaxClosesPerRepoPerDay < 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".limits.maxClosesPerRepoPerDay", Message: "must be greater than or equal to 0"})
+	}
+
+	validateSweeperLabel(config.Lifecycle.PendingLabel, path+".lifecycle.pendingLabel", issues)
+	validateSweeperLabel(config.Lifecycle.ClosedLabel, path+".lifecycle.closedLabel", issues)
+	validateSweeperLabel(config.Lifecycle.KeepLabel, path+".lifecycle.keepLabel", issues)
+	validateSweeperLabel(config.Security.QuarantineLabel, path+".security.quarantineLabel", issues)
+	validateDistinctLabels([]labelPathValue{
+		{Path: path + ".lifecycle.pendingLabel", Value: config.Lifecycle.PendingLabel},
+		{Path: path + ".lifecycle.closedLabel", Value: config.Lifecycle.ClosedLabel},
+		{Path: path + ".lifecycle.keepLabel", Value: config.Lifecycle.KeepLabel},
+		{Path: path + ".security.quarantineLabel", Value: config.Security.QuarantineLabel},
+	}, issues)
+	validateNoLabelOverlap(
+		[]labelPathValue{
+			{Path: path + ".lifecycle.pendingLabel", Value: config.Lifecycle.PendingLabel},
+			{Path: path + ".lifecycle.closedLabel", Value: config.Lifecycle.ClosedLabel},
+			{Path: path + ".security.quarantineLabel", Value: config.Security.QuarantineLabel},
+		},
+		config.Triggers.ExcludeLabels,
+		path+".triggers.excludeLabels",
+		issues,
+	)
+
+	validateSweeperCategory(config.Categories.Stale, path+".categories.stale", true, issues)
+	validateSweeperCategory(config.Categories.AlreadyFixed, path+".categories.alreadyFixed", false, issues)
+	validateSweeperCategory(config.Categories.Unrelated, path+".categories.unrelated", false, issues)
+	validateSweeperCategory(config.Categories.Superseded, path+".categories.superseded", false, issues)
+	validateSweeperCategory(config.Categories.AbandonedPR, path+".categories.abandonedPR", true, issues)
+}
+
+type labelPathValue struct {
+	Path  string
+	Value string
+}
+
+func validateSweeperCategory(config SweeperCategoryConfig, path string, requiresInactivity bool, issues *[]ValidationIssue) {
+	if requiresInactivity && config.Enabled && config.InactivityDays <= 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".inactivityDays", Message: "must be a positive integer when category is enabled"})
+	}
+	if config.GracePeriodDays <= 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".gracePeriodDays", Message: "must be a positive integer"})
+	}
+	if config.MinConfidence < 0 || config.MinConfidence > 100 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".minConfidence", Message: "must be between 0 and 100"})
+	}
+}
+
+func validateSweeperLabel(value, path string, issues *[]ValidationIssue) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		*issues = append(*issues, ValidationIssue{Path: path, Message: "must be a non-empty string"})
+		return
+	}
+	if value != trimmed {
+		*issues = append(*issues, ValidationIssue{Path: path, Message: "must not contain leading or trailing whitespace"})
+	}
+}
+
+func validateDistinctLabels(labels []labelPathValue, issues *[]ValidationIssue) {
+	seen := map[string]string{}
+	for _, label := range labels {
+		trimmed := strings.TrimSpace(label.Value)
+		if trimmed == "" {
+			continue
+		}
+		if firstPath, ok := seen[trimmed]; ok {
+			*issues = append(*issues, ValidationIssue{Path: label.Path, Message: fmt.Sprintf("duplicates %s", firstPath)})
+			continue
+		}
+		seen[trimmed] = label.Path
+	}
+}
+
+func validateNoLabelOverlap(labels []labelPathValue, excluded []string, excludePath string, issues *[]ValidationIssue) {
+	excludedSet := map[string]struct{}{}
+	for _, label := range excluded {
+		trimmed := strings.TrimSpace(label)
+		if trimmed == "" {
+			continue
+		}
+		excludedSet[trimmed] = struct{}{}
+	}
+	for _, label := range labels {
+		trimmed := strings.TrimSpace(label.Value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := excludedSet[trimmed]; ok {
+			*issues = append(*issues, ValidationIssue{Path: excludePath, Message: fmt.Sprintf("must not contain lifecycle/security label %q configured at %s", trimmed, label.Path)})
+		}
+	}
+}
+
+func validateSweeperAssociations(values []string, path string, issues *[]ValidationIssue) {
+	allowed := map[string]struct{}{
+		"OWNER": {}, "MEMBER": {}, "COLLABORATOR": {}, "CONTRIBUTOR": {},
+		"FIRST_TIME_CONTRIBUTOR": {}, "FIRST_TIMER": {}, "MANNEQUIN": {}, "NONE": {},
+	}
+	seen := map[string]struct{}{}
+	for index, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			*issues = append(*issues, ValidationIssue{Path: fmt.Sprintf("%s[%d]", path, index), Message: "must be a non-empty string"})
+			continue
+		}
+		if value != trimmed {
+			*issues = append(*issues, ValidationIssue{Path: fmt.Sprintf("%s[%d]", path, index), Message: "must not contain leading or trailing whitespace"})
+			continue
+		}
+		if _, ok := allowed[value]; !ok {
+			*issues = append(*issues, ValidationIssue{Path: fmt.Sprintf("%s[%d]", path, index), Message: "must be one of: OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, MANNEQUIN, NONE"})
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			*issues = append(*issues, ValidationIssue{Path: path, Message: fmt.Sprintf("contains duplicate value: %s", value)})
+			continue
+		}
+		seen[value] = struct{}{}
+	}
+}
+
+func validateStringList(values []string, path string, issues *[]ValidationIssue) {
+	seen := map[string]struct{}{}
+	for index, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			*issues = append(*issues, ValidationIssue{Path: fmt.Sprintf("%s[%d]", path, index), Message: "must be a non-empty string"})
+			continue
+		}
+		if value != trimmed {
+			*issues = append(*issues, ValidationIssue{Path: fmt.Sprintf("%s[%d]", path, index), Message: "must not contain leading or trailing whitespace"})
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			*issues = append(*issues, ValidationIssue{Path: path, Message: fmt.Sprintf("contains duplicate value: %s", value)})
+			continue
+		}
+		seen[value] = struct{}{}
 	}
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -53,6 +53,7 @@ type PullRequestSummary struct {
 	Title             string
 	URL               string
 	State             string
+	UpdatedAt         string
 	IsDraft           bool
 	ReviewDecision    string
 	Labels            []string
@@ -73,6 +74,7 @@ type PullRequestDetail struct {
 	Body              string
 	URL               string
 	State             string
+	UpdatedAt         string
 	IsDraft           bool
 	ReviewDecision    string
 	Labels            []string
@@ -101,6 +103,7 @@ type IssueSummary struct {
 	Body              string
 	URL               string
 	State             string
+	UpdatedAt         string
 	Author            string
 	AuthorAssociation string
 	Assignees         []string
@@ -401,7 +404,7 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 	if strings.TrimSpace(input.Author) != "" {
 		args = append(args, "--author", strings.TrimSpace(input.Author))
 	}
-	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "authorAssociation", "reviewRequests", "reviews", "mergeStateStatus"}, ","))
+	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "authorAssociation", "reviewRequests", "reviews", "mergeStateStatus"}, ","))
 
 	timeout := input.Timeout
 	if timeout <= 0 {
@@ -422,6 +425,7 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 			Title:             asString(row["title"]),
 			URL:               asString(row["url"]),
 			State:             asString(row["state"]),
+			UpdatedAt:         asString(row["updatedAt"]),
 			IsDraft:           asBool(row["isDraft"]),
 			ReviewDecision:    asString(row["reviewDecision"]),
 			Labels:            extractLabelNames(row["labels"]),
@@ -493,7 +497,7 @@ func (g *Gateway) ListOpenIssues(ctx context.Context, input ListOpenIssuesInput)
 	for _, label := range issueListLabels(input) {
 		args = append(args, "--label", label)
 	}
-	args = append(args, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "author", "authorAssociation", "assignees", "labels"}, ","))
+	args = append(args, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "updatedAt", "author", "authorAssociation", "assignees", "labels"}, ","))
 
 	result, err := g.runGh(ctx, input.CWD, "", args...)
 	if err != nil {
@@ -511,6 +515,7 @@ func (g *Gateway) ListOpenIssues(ctx context.Context, input ListOpenIssuesInput)
 			Body:              asString(row["body"]),
 			URL:               asString(row["url"]),
 			State:             asString(row["state"]),
+			UpdatedAt:         asString(row["updatedAt"]),
 			Author:            extractAuthor(row["author"]),
 			AuthorAssociation: asString(row["authorAssociation"]),
 			Assignees:         extractActorLogins(row["assignees"]),
@@ -557,6 +562,7 @@ func (g *Gateway) ViewIssue(ctx context.Context, input ViewIssueInput) (IssueDet
 		Body:              asString(row["body"]),
 		URL:               firstNonEmpty(asString(row["html_url"]), asString(row["url"])),
 		State:             asString(row["state"]),
+		UpdatedAt:         firstNonEmpty(asString(row["updated_at"]), asString(row["updatedAt"])),
 		Author:            extractAuthor(firstNonNil(row["user"], row["author"])),
 		AuthorAssociation: asString(row["author_association"]),
 		Assignees:         extractActorLogins(row["assignees"]),
@@ -662,7 +668,7 @@ func compactIssueAssignees(values []string) []string {
 }
 
 func (g *Gateway) ViewPullRequest(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
-	result, err := g.runGh(ctx, input.CWD, "", "pr", "view", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "authorAssociation", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}, ","))
+	result, err := g.runGh(ctx, input.CWD, "", "pr", "view", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "authorAssociation", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}, ","))
 	if err != nil {
 		return PullRequestDetail{}, err
 	}
@@ -680,6 +686,7 @@ func (g *Gateway) ViewPullRequest(ctx context.Context, input ViewPullRequestInpu
 		Body:              asString(row["body"]),
 		URL:               asString(row["url"]),
 		State:             asString(row["state"]),
+		UpdatedAt:         asString(row["updatedAt"]),
 		IsDraft:           asBool(row["isDraft"]),
 		ReviewDecision:    asString(row["reviewDecision"]),
 		Labels:            extractLabelNames(row["labels"]),

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -49,43 +49,45 @@ type Gateway struct {
 }
 
 type PullRequestSummary struct {
-	Number         int64
-	Title          string
-	URL            string
-	State          string
-	IsDraft        bool
-	ReviewDecision string
-	Labels         []string
-	HeadRefName    string
-	BaseRefName    string
-	HeadSHA        string
-	BaseSHA        string
-	HasConflicts   bool
-	Author         string
-	ReviewRequests []string
-	Reviews        []map[string]any
+	Number            int64
+	Title             string
+	URL               string
+	State             string
+	IsDraft           bool
+	ReviewDecision    string
+	Labels            []string
+	HeadRefName       string
+	BaseRefName       string
+	HeadSHA           string
+	BaseSHA           string
+	HasConflicts      bool
+	Author            string
+	AuthorAssociation string
+	ReviewRequests    []string
+	Reviews           []map[string]any
 }
 
 type PullRequestDetail struct {
-	Number         int64
-	Title          string
-	Body           string
-	URL            string
-	State          string
-	IsDraft        bool
-	ReviewDecision string
-	Labels         []string
-	HeadRefName    string
-	BaseRefName    string
-	HeadSHA        string
-	BaseSHA        string
-	Author         string
-	ReviewRequests []string
-	HasConflicts   bool
-	Comments       []map[string]any
-	IssueComments  []map[string]any
-	Reviews        []map[string]any
-	Checks         []map[string]any
+	Number            int64
+	Title             string
+	Body              string
+	URL               string
+	State             string
+	IsDraft           bool
+	ReviewDecision    string
+	Labels            []string
+	HeadRefName       string
+	BaseRefName       string
+	HeadSHA           string
+	BaseSHA           string
+	Author            string
+	AuthorAssociation string
+	ReviewRequests    []string
+	HasConflicts      bool
+	Comments          []map[string]any
+	IssueComments     []map[string]any
+	Reviews           []map[string]any
+	Checks            []map[string]any
 }
 
 type PullRequestHeadAndAuthor struct {
@@ -94,15 +96,16 @@ type PullRequestHeadAndAuthor struct {
 }
 
 type IssueSummary struct {
-	Number        int64
-	Title         string
-	Body          string
-	URL           string
-	State         string
-	Author        string
-	Assignees     []string
-	Labels        []string
-	IsPullRequest bool
+	Number            int64
+	Title             string
+	Body              string
+	URL               string
+	State             string
+	Author            string
+	AuthorAssociation string
+	Assignees         []string
+	Labels            []string
+	IsPullRequest     bool
 }
 
 type IssueDetail = IssueSummary
@@ -398,7 +401,7 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 	if strings.TrimSpace(input.Author) != "" {
 		args = append(args, "--author", strings.TrimSpace(input.Author))
 	}
-	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "mergeStateStatus"}, ","))
+	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "authorAssociation", "reviewRequests", "reviews", "mergeStateStatus"}, ","))
 
 	timeout := input.Timeout
 	if timeout <= 0 {
@@ -415,21 +418,22 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 	out := make([]PullRequestSummary, 0, len(rows))
 	for _, row := range rows {
 		out = append(out, PullRequestSummary{
-			Number:         asInt64(row["number"]),
-			Title:          asString(row["title"]),
-			URL:            asString(row["url"]),
-			State:          asString(row["state"]),
-			IsDraft:        asBool(row["isDraft"]),
-			ReviewDecision: asString(row["reviewDecision"]),
-			Labels:         extractLabelNames(row["labels"]),
-			HeadRefName:    asString(row["headRefName"]),
-			BaseRefName:    asString(row["baseRefName"]),
-			HeadSHA:        asString(row["headRefOid"]),
-			BaseSHA:        asString(row["baseRefOid"]),
-			HasConflicts:   asString(row["mergeStateStatus"]) == "DIRTY",
-			Author:         extractAuthor(row["author"]),
-			ReviewRequests: extractReviewRequestLogins(row["reviewRequests"]),
-			Reviews:        toObjectSlice(row["reviews"]),
+			Number:            asInt64(row["number"]),
+			Title:             asString(row["title"]),
+			URL:               asString(row["url"]),
+			State:             asString(row["state"]),
+			IsDraft:           asBool(row["isDraft"]),
+			ReviewDecision:    asString(row["reviewDecision"]),
+			Labels:            extractLabelNames(row["labels"]),
+			HeadRefName:       asString(row["headRefName"]),
+			BaseRefName:       asString(row["baseRefName"]),
+			HeadSHA:           asString(row["headRefOid"]),
+			BaseSHA:           asString(row["baseRefOid"]),
+			HasConflicts:      asString(row["mergeStateStatus"]) == "DIRTY",
+			Author:            extractAuthor(row["author"]),
+			AuthorAssociation: asString(row["authorAssociation"]),
+			ReviewRequests:    extractReviewRequestLogins(row["reviewRequests"]),
+			Reviews:           toObjectSlice(row["reviews"]),
 		})
 	}
 	return out, nil
@@ -489,7 +493,7 @@ func (g *Gateway) ListOpenIssues(ctx context.Context, input ListOpenIssuesInput)
 	for _, label := range issueListLabels(input) {
 		args = append(args, "--label", label)
 	}
-	args = append(args, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "author", "assignees", "labels"}, ","))
+	args = append(args, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "author", "authorAssociation", "assignees", "labels"}, ","))
 
 	result, err := g.runGh(ctx, input.CWD, "", args...)
 	if err != nil {
@@ -502,14 +506,15 @@ func (g *Gateway) ListOpenIssues(ctx context.Context, input ListOpenIssuesInput)
 	out := make([]IssueSummary, 0, len(rows))
 	for _, row := range rows {
 		out = append(out, IssueSummary{
-			Number:    asInt64(row["number"]),
-			Title:     asString(row["title"]),
-			Body:      asString(row["body"]),
-			URL:       asString(row["url"]),
-			State:     asString(row["state"]),
-			Author:    extractAuthor(row["author"]),
-			Assignees: extractActorLogins(row["assignees"]),
-			Labels:    extractLabelNames(row["labels"]),
+			Number:            asInt64(row["number"]),
+			Title:             asString(row["title"]),
+			Body:              asString(row["body"]),
+			URL:               asString(row["url"]),
+			State:             asString(row["state"]),
+			Author:            extractAuthor(row["author"]),
+			AuthorAssociation: asString(row["authorAssociation"]),
+			Assignees:         extractActorLogins(row["assignees"]),
+			Labels:            extractLabelNames(row["labels"]),
 		})
 	}
 	return out, nil
@@ -547,15 +552,16 @@ func (g *Gateway) ViewIssue(ctx context.Context, input ViewIssueInput) (IssueDet
 		return IssueDetail{}, err
 	}
 	return IssueDetail{
-		Number:        asInt64(row["number"]),
-		Title:         asString(row["title"]),
-		Body:          asString(row["body"]),
-		URL:           firstNonEmpty(asString(row["html_url"]), asString(row["url"])),
-		State:         asString(row["state"]),
-		Author:        extractAuthor(firstNonNil(row["user"], row["author"])),
-		Assignees:     extractActorLogins(row["assignees"]),
-		Labels:        extractLabelNames(row["labels"]),
-		IsPullRequest: row["pull_request"] != nil,
+		Number:            asInt64(row["number"]),
+		Title:             asString(row["title"]),
+		Body:              asString(row["body"]),
+		URL:               firstNonEmpty(asString(row["html_url"]), asString(row["url"])),
+		State:             asString(row["state"]),
+		Author:            extractAuthor(firstNonNil(row["user"], row["author"])),
+		AuthorAssociation: asString(row["author_association"]),
+		Assignees:         extractActorLogins(row["assignees"]),
+		Labels:            extractLabelNames(row["labels"]),
+		IsPullRequest:     row["pull_request"] != nil,
 	}, nil
 }
 
@@ -656,7 +662,7 @@ func compactIssueAssignees(values []string) []string {
 }
 
 func (g *Gateway) ViewPullRequest(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
-	result, err := g.runGh(ctx, input.CWD, "", "pr", "view", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}, ","))
+	result, err := g.runGh(ctx, input.CWD, "", "pr", "view", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "authorAssociation", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}, ","))
 	if err != nil {
 		return PullRequestDetail{}, err
 	}
@@ -669,25 +675,26 @@ func (g *Gateway) ViewPullRequest(ctx context.Context, input ViewPullRequestInpu
 		return PullRequestDetail{}, err
 	}
 	return PullRequestDetail{
-		Number:         asInt64(row["number"]),
-		Title:          asString(row["title"]),
-		Body:           asString(row["body"]),
-		URL:            asString(row["url"]),
-		State:          asString(row["state"]),
-		IsDraft:        asBool(row["isDraft"]),
-		ReviewDecision: asString(row["reviewDecision"]),
-		Labels:         extractLabelNames(row["labels"]),
-		HeadRefName:    asString(row["headRefName"]),
-		BaseRefName:    asString(row["baseRefName"]),
-		HeadSHA:        asString(row["headRefOid"]),
-		BaseSHA:        asString(row["baseRefOid"]),
-		Author:         extractAuthor(row["author"]),
-		ReviewRequests: extractReviewRequestLogins(row["reviewRequests"]),
-		HasConflicts:   asString(row["mergeStateStatus"]) == "DIRTY",
-		Comments:       threads,
-		IssueComments:  toObjectSlice(row["comments"]),
-		Reviews:        toObjectSlice(row["reviews"]),
-		Checks:         toObjectSlice(row["statusCheckRollup"]),
+		Number:            asInt64(row["number"]),
+		Title:             asString(row["title"]),
+		Body:              asString(row["body"]),
+		URL:               asString(row["url"]),
+		State:             asString(row["state"]),
+		IsDraft:           asBool(row["isDraft"]),
+		ReviewDecision:    asString(row["reviewDecision"]),
+		Labels:            extractLabelNames(row["labels"]),
+		HeadRefName:       asString(row["headRefName"]),
+		BaseRefName:       asString(row["baseRefName"]),
+		HeadSHA:           asString(row["headRefOid"]),
+		BaseSHA:           asString(row["baseRefOid"]),
+		Author:            extractAuthor(row["author"]),
+		AuthorAssociation: asString(row["authorAssociation"]),
+		ReviewRequests:    extractReviewRequestLogins(row["reviewRequests"]),
+		HasConflicts:      asString(row["mergeStateStatus"]) == "DIRTY",
+		Comments:          threads,
+		IssueComments:     toObjectSlice(row["comments"]),
+		Reviews:           toObjectSlice(row["reviews"]),
+		Checks:            toObjectSlice(row["statusCheckRollup"]),
 	}, nil
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -133,6 +133,19 @@ type UpdateIssueCommentInput struct {
 	CWD       string
 }
 
+type CloseIssueInput struct {
+	Repo        string
+	IssueNumber int64
+	StateReason string
+	CWD         string
+}
+
+type ClosePullRequestInput struct {
+	Repo     string
+	PRNumber int64
+	CWD      string
+}
+
 type SubmitReviewInput struct {
 	Repo       string
 	PRNumber   int64
@@ -556,6 +569,29 @@ func (g *Gateway) UpdateIssueComment(ctx context.Context, input UpdateIssueComme
 	return err
 }
 
+func (g *Gateway) CloseIssue(ctx context.Context, input CloseIssueInput) error {
+	reason, err := validateCloseIssueStateReason(input.StateReason)
+	if err != nil {
+		return err
+	}
+	state, err := g.viewIssueState(ctx, input.Repo, input.IssueNumber, input.CWD)
+	if err != nil {
+		return err
+	}
+	if state == "closed" {
+		return nil
+	}
+	_, err = g.runGh(ctx, input.CWD, "", "issue", "close", strconv.FormatInt(input.IssueNumber, 10), "--repo", input.Repo, "--reason", reason)
+	if err == nil {
+		return nil
+	}
+	state, stateErr := g.viewIssueState(ctx, input.Repo, input.IssueNumber, input.CWD)
+	if stateErr == nil && state == "closed" {
+		return nil
+	}
+	return err
+}
+
 func (g *Gateway) AddIssueAssignees(ctx context.Context, input IssueAssigneesInput) error {
 	assignees := compactIssueAssignees(input.Assignees)
 	if len(assignees) == 0 {
@@ -614,6 +650,25 @@ func (g *Gateway) ViewPullRequest(ctx context.Context, input ViewPullRequestInpu
 		Reviews:        toObjectSlice(row["reviews"]),
 		Checks:         toObjectSlice(row["statusCheckRollup"]),
 	}, nil
+}
+
+func (g *Gateway) ClosePullRequest(ctx context.Context, input ClosePullRequestInput) error {
+	state, err := g.viewPullRequestState(ctx, input.Repo, input.PRNumber, input.CWD)
+	if err != nil {
+		return err
+	}
+	if state == "closed" || state == "merged" {
+		return nil
+	}
+	_, err = g.runGh(ctx, input.CWD, "", "pr", "close", strconv.FormatInt(input.PRNumber, 10), "--repo", input.Repo)
+	if err == nil {
+		return nil
+	}
+	state, stateErr := g.viewPullRequestState(ctx, input.Repo, input.PRNumber, input.CWD)
+	if stateErr == nil && (state == "closed" || state == "merged") {
+		return nil
+	}
+	return err
 }
 
 func (g *Gateway) GetPullRequestHeadSHA(ctx context.Context, input ViewPullRequestInput) (string, error) {
@@ -1847,6 +1902,32 @@ func normalizeReviewThread(value any) (map[string]any, bool) {
 		out["body"] = body
 	}
 	return out, true
+}
+
+func validateCloseIssueStateReason(value string) (string, error) {
+	normalized := strings.TrimSpace(value)
+	switch normalized {
+	case "completed", "not_planned":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("invalid issue close reason %q", value)
+	}
+}
+
+func (g *Gateway) viewIssueState(ctx context.Context, repo string, issueNumber int64, cwd string) (string, error) {
+	result, err := g.runGh(ctx, cwd, "", "api", fmt.Sprintf("repos/%s/issues/%d", repo, issueNumber), "--jq", ".state")
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(strings.TrimSpace(result.Stdout)), nil
+}
+
+func (g *Gateway) viewPullRequestState(ctx context.Context, repo string, prNumber int64, cwd string) (string, error) {
+	result, err := g.runGh(ctx, cwd, "", "pr", "view", strconv.FormatInt(prNumber, 10), "--repo", repo, "--json", "state", "--jq", ".state")
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(strings.TrimSpace(result.Stdout)), nil
 }
 
 func normalizeReaction(value any) (githubReaction, bool) {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -121,6 +121,13 @@ type IssueAssigneesInput struct {
 	CWD         string
 }
 
+type IssueLabelsInput struct {
+	Repo        string
+	IssueNumber int64
+	Labels      []string
+	CWD         string
+}
+
 type IssueCommentResult struct {
 	ID  int64
 	URL string
@@ -603,6 +610,38 @@ func (g *Gateway) AddIssueAssignees(ctx context.Context, input IssueAssigneesInp
 	}
 	_, err := g.runGh(ctx, input.CWD, "", args...)
 	return err
+}
+
+func (g *Gateway) AddIssueLabels(ctx context.Context, input IssueLabelsInput) error {
+	if len(input.Labels) == 0 {
+		return nil
+	}
+	if err := g.ensureLabelsExist(ctx, input.Repo, input.Labels, input.CWD); err != nil {
+		return err
+	}
+	args := []string{"api", fmt.Sprintf("repos/%s/issues/%d/labels", input.Repo, input.IssueNumber), "--method", "POST"}
+	for _, label := range input.Labels {
+		args = append(args, "-f", "labels[]="+label)
+	}
+	_, err := g.runGh(ctx, input.CWD, "", args...)
+	return err
+}
+
+func (g *Gateway) RemoveIssueLabels(ctx context.Context, input IssueLabelsInput) error {
+	if len(input.Labels) == 0 {
+		return nil
+	}
+	for _, label := range input.Labels {
+		_, err := g.runGh(ctx, input.CWD, "", "api", fmt.Sprintf("repos/%s/issues/%d/labels/%s", input.Repo, input.IssueNumber, encodeURIComponent(label)), "--method", "DELETE")
+		if err == nil {
+			continue
+		}
+		if isMissingPullRequestLabelDelete(err) {
+			continue
+		}
+		return err
+	}
+	return nil
 }
 
 func compactIssueAssignees(values []string) []string {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1375,6 +1375,99 @@ func TestGatewayDetectsCurrentEnterpriseRepository(t *testing.T) {
 	}
 }
 
+func TestGatewayCloseIssueUsesTypedReasonAndIsIdempotent(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch args {
+		case "api repos/acme/looper/issues/8 --jq .state":
+			return shell.Result{Stdout: "open\n"}, nil
+		case "issue close 8 --repo acme/looper --reason completed":
+			return shell.Result{Stdout: ""}, nil
+		case "api repos/acme/looper/issues/9 --jq .state":
+			return shell.Result{Stdout: "closed\n"}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	if err := gateway.CloseIssue(context.Background(), CloseIssueInput{Repo: "acme/looper", IssueNumber: 8, StateReason: " completed "}); err != nil {
+		t.Fatalf("CloseIssue(open) error = %v", err)
+	}
+	if err := gateway.CloseIssue(context.Background(), CloseIssueInput{Repo: "acme/looper", IssueNumber: 9, StateReason: "not_planned"}); err != nil {
+		t.Fatalf("CloseIssue(closed) error = %v", err)
+	}
+	log := strings.Join(runner.calls, "\n")
+	if !strings.Contains(log, "issue close 8 --repo acme/looper --reason completed") {
+		t.Fatalf("gh log missing close issue command\n%s", log)
+	}
+	if strings.Contains(log, "issue close 9 --repo acme/looper") {
+		t.Fatalf("gh log unexpectedly closed an already-closed issue\n%s", log)
+	}
+}
+
+func TestGatewayClosePullRequestIsIdempotent(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch args {
+		case "pr view 42 --repo acme/looper --json state --jq .state":
+			return shell.Result{Stdout: "OPEN\n"}, nil
+		case "pr close 42 --repo acme/looper":
+			return shell.Result{Stdout: ""}, nil
+		case "pr view 43 --repo acme/looper --json state --jq .state":
+			return shell.Result{Stdout: "CLOSED\n"}, nil
+		case "pr view 44 --repo acme/looper --json state --jq .state":
+			return shell.Result{Stdout: "MERGED\n"}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	if err := gateway.ClosePullRequest(context.Background(), ClosePullRequestInput{Repo: "acme/looper", PRNumber: 42}); err != nil {
+		t.Fatalf("ClosePullRequest(open) error = %v", err)
+	}
+	if err := gateway.ClosePullRequest(context.Background(), ClosePullRequestInput{Repo: "acme/looper", PRNumber: 43}); err != nil {
+		t.Fatalf("ClosePullRequest(closed) error = %v", err)
+	}
+	if err := gateway.ClosePullRequest(context.Background(), ClosePullRequestInput{Repo: "acme/looper", PRNumber: 44}); err != nil {
+		t.Fatalf("ClosePullRequest(merged) error = %v", err)
+	}
+	log := strings.Join(runner.calls, "\n")
+	if !strings.Contains(log, "pr close 42 --repo acme/looper") {
+		t.Fatalf("gh log missing close pr command\n%s", log)
+	}
+	if strings.Contains(log, "pr close 43 --repo acme/looper") {
+		t.Fatalf("gh log unexpectedly closed an already-closed pr\n%s", log)
+	}
+	if strings.Contains(log, "pr close 44 --repo acme/looper") {
+		t.Fatalf("gh log unexpectedly closed an already-merged pr\n%s", log)
+	}
+	if strings.Contains(log, "--delete-branch") {
+		t.Fatalf("gh log unexpectedly included destructive flags\n%s", log)
+	}
+}
+
+func TestGatewayCloseIssueRejectsUnknownStateReason(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		t.Fatalf("unexpected gh call: %q", strings.Join(options.Args, " "))
+		return shell.Result{}, nil
+	}
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	err := gateway.CloseIssue(context.Background(), CloseIssueInput{Repo: "acme/looper", IssueNumber: 8, StateReason: "bogus"})
+	if err == nil || !strings.Contains(err.Error(), "invalid issue close reason") {
+		t.Fatalf("CloseIssue() error = %v, want invalid reason error", err)
+	}
+}
+
 func TestListOpenPullRequestsPassesAllLabelsToGH(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -23,11 +23,11 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 			runner.stdin = options.Stdin
 			return shell.Result{Stdout: "{}"}, nil
 		case strings.HasPrefix(args, "pr list"):
-			return shell.Result{Stdout: `[{"number":42,"title":"Review me","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"reviewRequests":[{"__typename":"User","login":"OctoCat"},{"__typename":"Team","slug":"platform"}]}]`}, nil
+			return shell.Result{Stdout: `[{"number":42,"title":"Review me","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"authorAssociation":"MEMBER","reviewRequests":[{"__typename":"User","login":"OctoCat"},{"__typename":"Team","slug":"platform"}]}]`}, nil
 		case strings.HasPrefix(args, "issue list"):
-			return shell.Result{Stdout: `[{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","author":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}]`}, nil
+			return shell.Result{Stdout: `[{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","author":{"login":"octocat"},"authorAssociation":"OWNER","assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}]`}, nil
 		case args == "api repos/acme/looper/issues/8":
-			return shell.Result{Stdout: `{"number":8,"title":"Fix gateway","body":"Issue body","html_url":"https://example.test/issues/8","state":"open","user":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}`}, nil
+			return shell.Result{Stdout: `{"number":8,"title":"Fix gateway","body":"Issue body","html_url":"https://example.test/issues/8","state":"open","user":{"login":"octocat"},"author_association":"COLLABORATOR","assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}`}, nil
 		case args == "api repos/acme/looper/issues/8/comments --method POST -f body=Looper started":
 			return shell.Result{Stdout: `{"id":91,"html_url":"https://example.test/issues/8#issuecomment-91"}`}, nil
 		case args == "api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished":
@@ -35,7 +35,7 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 		case args == "api repos/acme/looper/issues/8/assignees --method POST -f assignees[]=reviewer":
 			return shell.Result{Stdout: "{}"}, nil
 		case strings.HasPrefix(args, "pr view"):
-			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"id":"issue-comment-1","body":"conversation notice"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
+			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"authorAssociation":"CONTRIBUTOR","reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"id":"issue-comment-1","body":"conversation notice"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
 		case strings.HasPrefix(args, "pr diff"):
 			return shell.Result{Stdout: "diff --git a/a.ts b/a.ts\n"}, nil
 		case strings.HasPrefix(args, "api user"):
@@ -150,6 +150,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if got := prs[0].ReviewRequests; len(got) != 1 || got[0] != "OctoCat" {
 		t.Fatalf("prs[0].ReviewRequests = %#v, want [OctoCat]", got)
 	}
+	if prs[0].AuthorAssociation != "MEMBER" {
+		t.Fatalf("prs[0].AuthorAssociation = %q, want MEMBER", prs[0].AuthorAssociation)
+	}
 	if prs[0].BaseSHA != "def456" || !prs[0].HasConflicts {
 		t.Fatalf("prs[0] = %#v, want base sha and conflict state", prs[0])
 	}
@@ -159,11 +162,17 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if got := issues[0].Labels; len(got) != 2 || got[0] != "phase-1" || got[1] != "gateway" {
 		t.Fatalf("issues[0].Labels = %#v, want [phase-1 gateway]", got)
 	}
+	if issues[0].AuthorAssociation != "OWNER" {
+		t.Fatalf("issues[0].AuthorAssociation = %q, want OWNER", issues[0].AuthorAssociation)
+	}
 	if issueDetail.Number != 8 {
 		t.Fatalf("issueDetail.Number = %d, want 8", issueDetail.Number)
 	}
 	if issueDetail.State != "open" || issueDetail.IsPullRequest {
 		t.Fatalf("issueDetail = %#v, want open issue not pull request", issueDetail)
+	}
+	if issueDetail.AuthorAssociation != "COLLABORATOR" {
+		t.Fatalf("issueDetail.AuthorAssociation = %q, want COLLABORATOR", issueDetail.AuthorAssociation)
 	}
 	if comment.ID != 91 || comment.URL != "https://example.test/issues/8#issuecomment-91" {
 		t.Fatalf("comment = %#v, want parsed issue comment metadata", comment)
@@ -176,6 +185,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	}
 	if got := detail.ReviewRequests; len(got) != 1 || got[0] != "reviewer" {
 		t.Fatalf("detail.ReviewRequests = %#v, want [reviewer]", got)
+	}
+	if detail.AuthorAssociation != "CONTRIBUTOR" {
+		t.Fatalf("detail.AuthorAssociation = %q, want CONTRIBUTOR", detail.AuthorAssociation)
 	}
 	if !detail.HasConflicts {
 		t.Fatal("detail.HasConflicts = false, want true")
@@ -1473,7 +1485,7 @@ func TestListOpenPullRequestsPassesAllLabelsToGH(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "pr list --repo acme/looper --state open --limit 30 --label bug --label priority --json number,title,url,state,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,baseRefOid,author,reviewRequests,reviews,mergeStateStatus" {
+		if args != "pr list --repo acme/looper --state open --limit 30 --label bug --label priority --json number,title,url,state,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,baseRefOid,author,authorAssociation,reviewRequests,reviews,mergeStateStatus" {
 			t.Fatalf("gh args = %q, want repeated label filters", args)
 		}
 		return shell.Result{Stdout: `[]`}, nil
@@ -1490,7 +1502,7 @@ func TestListOpenIssuesPassesAllLabelsToGH(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "issue list --repo acme/looper --state open --limit 30 --assignee reviewer --label bug --label priority --json number,title,body,url,state,author,assignees,labels" {
+		if args != "issue list --repo acme/looper --state open --limit 30 --assignee reviewer --label bug --label priority --json number,title,body,url,state,author,authorAssociation,assignees,labels" {
 			t.Fatalf("gh args = %q, want repeated label filters", args)
 		}
 		return shell.Result{Stdout: `[]`}, nil

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -23,11 +23,11 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 			runner.stdin = options.Stdin
 			return shell.Result{Stdout: "{}"}, nil
 		case strings.HasPrefix(args, "pr list"):
-			return shell.Result{Stdout: `[{"number":42,"title":"Review me","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"authorAssociation":"MEMBER","reviewRequests":[{"__typename":"User","login":"OctoCat"},{"__typename":"Team","slug":"platform"}]}]`}, nil
+			return shell.Result{Stdout: `[{"number":42,"title":"Review me","url":"https://example.test/pull/42","state":"OPEN","updatedAt":"2026-05-01T12:00:00Z","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"authorAssociation":"MEMBER","reviewRequests":[{"__typename":"User","login":"OctoCat"},{"__typename":"Team","slug":"platform"}]}]`}, nil
 		case strings.HasPrefix(args, "issue list"):
-			return shell.Result{Stdout: `[{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","author":{"login":"octocat"},"authorAssociation":"OWNER","assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}]`}, nil
+			return shell.Result{Stdout: `[{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","updatedAt":"2026-05-02T12:00:00Z","author":{"login":"octocat"},"authorAssociation":"OWNER","assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}]`}, nil
 		case args == "api repos/acme/looper/issues/8":
-			return shell.Result{Stdout: `{"number":8,"title":"Fix gateway","body":"Issue body","html_url":"https://example.test/issues/8","state":"open","user":{"login":"octocat"},"author_association":"COLLABORATOR","assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}`}, nil
+			return shell.Result{Stdout: `{"number":8,"title":"Fix gateway","body":"Issue body","html_url":"https://example.test/issues/8","state":"open","updated_at":"2026-05-03T12:00:00Z","user":{"login":"octocat"},"author_association":"COLLABORATOR","assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}`}, nil
 		case args == "api repos/acme/looper/issues/8/comments --method POST -f body=Looper started":
 			return shell.Result{Stdout: `{"id":91,"html_url":"https://example.test/issues/8#issuecomment-91"}`}, nil
 		case args == "api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished":
@@ -35,7 +35,7 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 		case args == "api repos/acme/looper/issues/8/assignees --method POST -f assignees[]=reviewer":
 			return shell.Result{Stdout: "{}"}, nil
 		case strings.HasPrefix(args, "pr view"):
-			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"authorAssociation":"CONTRIBUTOR","reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"id":"issue-comment-1","body":"conversation notice"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
+			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","updatedAt":"2026-05-04T12:00:00Z","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"authorAssociation":"CONTRIBUTOR","reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"id":"issue-comment-1","body":"conversation notice"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
 		case strings.HasPrefix(args, "pr diff"):
 			return shell.Result{Stdout: "diff --git a/a.ts b/a.ts\n"}, nil
 		case strings.HasPrefix(args, "api user"):
@@ -153,6 +153,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if prs[0].AuthorAssociation != "MEMBER" {
 		t.Fatalf("prs[0].AuthorAssociation = %q, want MEMBER", prs[0].AuthorAssociation)
 	}
+	if prs[0].UpdatedAt != "2026-05-01T12:00:00Z" {
+		t.Fatalf("prs[0].UpdatedAt = %q, want parsed updated timestamp", prs[0].UpdatedAt)
+	}
 	if prs[0].BaseSHA != "def456" || !prs[0].HasConflicts {
 		t.Fatalf("prs[0] = %#v, want base sha and conflict state", prs[0])
 	}
@@ -165,6 +168,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if issues[0].AuthorAssociation != "OWNER" {
 		t.Fatalf("issues[0].AuthorAssociation = %q, want OWNER", issues[0].AuthorAssociation)
 	}
+	if issues[0].UpdatedAt != "2026-05-02T12:00:00Z" {
+		t.Fatalf("issues[0].UpdatedAt = %q, want parsed updated timestamp", issues[0].UpdatedAt)
+	}
 	if issueDetail.Number != 8 {
 		t.Fatalf("issueDetail.Number = %d, want 8", issueDetail.Number)
 	}
@@ -173,6 +179,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	}
 	if issueDetail.AuthorAssociation != "COLLABORATOR" {
 		t.Fatalf("issueDetail.AuthorAssociation = %q, want COLLABORATOR", issueDetail.AuthorAssociation)
+	}
+	if issueDetail.UpdatedAt != "2026-05-03T12:00:00Z" {
+		t.Fatalf("issueDetail.UpdatedAt = %q, want parsed updated timestamp", issueDetail.UpdatedAt)
 	}
 	if comment.ID != 91 || comment.URL != "https://example.test/issues/8#issuecomment-91" {
 		t.Fatalf("comment = %#v, want parsed issue comment metadata", comment)
@@ -188,6 +197,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	}
 	if detail.AuthorAssociation != "CONTRIBUTOR" {
 		t.Fatalf("detail.AuthorAssociation = %q, want CONTRIBUTOR", detail.AuthorAssociation)
+	}
+	if detail.UpdatedAt != "2026-05-04T12:00:00Z" {
+		t.Fatalf("detail.UpdatedAt = %q, want parsed updated timestamp", detail.UpdatedAt)
 	}
 	if !detail.HasConflicts {
 		t.Fatal("detail.HasConflicts = false, want true")
@@ -1485,7 +1497,7 @@ func TestListOpenPullRequestsPassesAllLabelsToGH(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "pr list --repo acme/looper --state open --limit 30 --label bug --label priority --json number,title,url,state,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,baseRefOid,author,authorAssociation,reviewRequests,reviews,mergeStateStatus" {
+		if args != "pr list --repo acme/looper --state open --limit 30 --label bug --label priority --json number,title,url,state,updatedAt,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,baseRefOid,author,authorAssociation,reviewRequests,reviews,mergeStateStatus" {
 			t.Fatalf("gh args = %q, want repeated label filters", args)
 		}
 		return shell.Result{Stdout: `[]`}, nil
@@ -1502,7 +1514,7 @@ func TestListOpenIssuesPassesAllLabelsToGH(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "issue list --repo acme/looper --state open --limit 30 --assignee reviewer --label bug --label priority --json number,title,body,url,state,author,authorAssociation,assignees,labels" {
+		if args != "issue list --repo acme/looper --state open --limit 30 --assignee reviewer --label bug --label priority --json number,title,body,url,state,updatedAt,author,authorAssociation,assignees,labels" {
 			t.Fatalf("gh args = %q, want repeated label filters", args)
 		}
 		return shell.Result{Stdout: `[]`}, nil

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -899,7 +899,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			return notifyWorkerRunCompleted(ctx, workerRunCompletedNotificationInput{ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Subtitle: input.Subtitle, Status: input.Status, Summary: input.Summary, FailureKind: input.FailureKind, PullRequestNumber: input.PullRequestNumber, PullRequestURL: input.PullRequestURL})
 		},
 	})
-	sweeperRunner = sweeper.New(sweeper.Options{Repos: repos, Logger: logger, Now: now, Config: &cfg})
+	sweeperRunner = sweeper.New(sweeper.Options{Repos: repos, GitHub: githubGateway, Logger: logger, Now: now, Config: &cfg})
 
 	return func(ctx context.Context, services Services) error {
 		var runner schedulerAsyncRunner

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -48,6 +48,13 @@ type workerScheduler interface {
 	ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) (*worker.ProcessResult, error)
 }
 
+type sweeperScheduler interface {
+	DiscoverIssues(context.Context, string, string) error
+	DiscoverPullRequests(context.Context, string, string) error
+	DiscoverReconcile(context.Context, string, string) error
+	ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) error
+}
+
 type snapshotScheduler interface {
 	CapturePullRequestSnapshot(context.Context, githubinfra.CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error)
 }
@@ -70,11 +77,13 @@ type defaultSchedulerTickInput struct {
 	Reviewer                 reviewerScheduler
 	Fixer                    fixerScheduler
 	Worker                   workerScheduler
+	Sweeper                  sweeperScheduler
 	Snapshotter              snapshotScheduler
 	PlannerDiscoveryEnabled  *bool
 	ReviewerDiscoveryEnabled *bool
 	FixerDiscoveryEnabled    *bool
 	WorkerDiscoveryEnabled   *bool
+	SweeperDiscoveryEnabled  *bool
 }
 
 type schedulerTaskTracker struct{ wg sync.WaitGroup }
@@ -742,6 +751,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 	var reviewerRunner reviewerScheduler
 	var fixerRunner fixerScheduler
 	var workerRunner workerScheduler
+	var sweeperRunner sweeperScheduler
 
 	agentExecutor := agent.New(agent.ExecutorOptions{
 		Config: agent.ExecutorConfig{
@@ -904,11 +914,13 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			Reviewer:                 reviewerRunner,
 			Fixer:                    fixerRunner,
 			Worker:                   workerRunner,
+			Sweeper:                  sweeperRunner,
 			Snapshotter:              githubGateway,
 			PlannerDiscoveryEnabled:  boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "planner")),
 			ReviewerDiscoveryEnabled: boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "reviewer")),
 			FixerDiscoveryEnabled:    boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "fixer")),
 			WorkerDiscoveryEnabled:   boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "worker")),
+			SweeperDiscoveryEnabled:  boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "sweeper")),
 		})
 	}
 }
@@ -1021,6 +1033,13 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 			appendErr(wrapSchedulerError("worker issue discovery", project.ID, repo, err))
 		} else if input.Worker != nil && input.Logger != nil && !discoveryEnabled(input.WorkerDiscoveryEnabled) {
 			input.Logger.Debug("worker auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
+		}
+		if input.Sweeper != nil && discoveryEnabled(input.SweeperDiscoveryEnabled) {
+			appendErr(wrapSchedulerError("sweeper issue discovery", project.ID, repo, input.Sweeper.DiscoverIssues(ctx, project.ID, repo)))
+			appendErr(wrapSchedulerError("sweeper pull request discovery", project.ID, repo, input.Sweeper.DiscoverPullRequests(ctx, project.ID, repo)))
+			appendErr(wrapSchedulerError("sweeper reconciliation discovery", project.ID, repo, input.Sweeper.DiscoverReconcile(ctx, project.ID, repo)))
+		} else if input.Sweeper != nil && input.Logger != nil {
+			input.Logger.Debug("sweeper auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
 		}
 	}
 
@@ -1150,6 +1169,13 @@ func schedulerQueueProcessor(item storage.QueueItemRecord, input defaultSchedule
 		return func(ctx context.Context) error {
 			_, err := input.Worker.ProcessClaimedQueueItem(ctx, item)
 			return wrapSchedulerQueueError(item.Type, err)
+		}, nil
+	case "sweeper", "sweeper:warn", "sweeper:close", "sweeper:reconcile":
+		if input.Sweeper == nil {
+			return nil, fmt.Errorf("sweeper runner is not configured")
+		}
+		return func(ctx context.Context) error {
+			return wrapSchedulerQueueError(item.Type, input.Sweeper.ProcessClaimedQueueItem(ctx, item))
 		}, nil
 	case "snapshot":
 		if input.Snapshotter == nil || input.Repos == nil || input.Repos.Queue == nil || input.Repos.PullRequestSnapshots == nil {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nexu-io/looper/internal/planner"
 	"github.com/nexu-io/looper/internal/reviewer"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/sweeper"
 	"github.com/nexu-io/looper/internal/worker"
 )
 
@@ -49,10 +50,10 @@ type workerScheduler interface {
 }
 
 type sweeperScheduler interface {
-	DiscoverIssues(context.Context, string, string) error
-	DiscoverPullRequests(context.Context, string, string) error
-	DiscoverReconcile(context.Context, string, string) error
-	ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) error
+	DiscoverIssues(context.Context, sweeper.DiscoveryInput) (sweeper.DiscoveryResult, error)
+	DiscoverPullRequests(context.Context, sweeper.DiscoveryInput) (sweeper.DiscoveryResult, error)
+	DiscoverReconcile(context.Context, sweeper.DiscoveryInput) (sweeper.DiscoveryResult, error)
+	ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) (*sweeper.ProcessResult, error)
 }
 
 type snapshotScheduler interface {
@@ -898,6 +899,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			return notifyWorkerRunCompleted(ctx, workerRunCompletedNotificationInput{ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Subtitle: input.Subtitle, Status: input.Status, Summary: input.Summary, FailureKind: input.FailureKind, PullRequestNumber: input.PullRequestNumber, PullRequestURL: input.PullRequestURL})
 		},
 	})
+	sweeperRunner = sweeper.New(sweeper.Options{Repos: repos, Logger: logger, Now: now, Config: &cfg})
 
 	return func(ctx context.Context, services Services) error {
 		var runner schedulerAsyncRunner
@@ -1035,9 +1037,12 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 			input.Logger.Debug("worker auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
 		}
 		if input.Sweeper != nil && discoveryEnabled(input.SweeperDiscoveryEnabled) {
-			appendErr(wrapSchedulerError("sweeper issue discovery", project.ID, repo, input.Sweeper.DiscoverIssues(ctx, project.ID, repo)))
-			appendErr(wrapSchedulerError("sweeper pull request discovery", project.ID, repo, input.Sweeper.DiscoverPullRequests(ctx, project.ID, repo)))
-			appendErr(wrapSchedulerError("sweeper reconciliation discovery", project.ID, repo, input.Sweeper.DiscoverReconcile(ctx, project.ID, repo)))
+			_, err := input.Sweeper.DiscoverIssues(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+			appendErr(wrapSchedulerError("sweeper issue discovery", project.ID, repo, err))
+			_, err = input.Sweeper.DiscoverPullRequests(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+			appendErr(wrapSchedulerError("sweeper pull request discovery", project.ID, repo, err))
+			_, err = input.Sweeper.DiscoverReconcile(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+			appendErr(wrapSchedulerError("sweeper reconciliation discovery", project.ID, repo, err))
 		} else if input.Sweeper != nil && input.Logger != nil {
 			input.Logger.Debug("sweeper auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
 		}
@@ -1175,7 +1180,8 @@ func schedulerQueueProcessor(item storage.QueueItemRecord, input defaultSchedule
 			return nil, fmt.Errorf("sweeper runner is not configured")
 		}
 		return func(ctx context.Context) error {
-			return wrapSchedulerQueueError(item.Type, input.Sweeper.ProcessClaimedQueueItem(ctx, item))
+			_, err := input.Sweeper.ProcessClaimedQueueItem(ctx, item)
+			return wrapSchedulerQueueError(item.Type, err)
 		}, nil
 	case "snapshot":
 		if input.Snapshotter == nil || input.Repos == nil || input.Repos.Queue == nil || input.Repos.PullRequestSnapshots == nil {

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -68,6 +68,7 @@ func TestRunDefaultSchedulerTickDiscoversStoredProjectsAndProcessesQueue(t *test
 	reviewerRunner := &stubReviewerScheduler{}
 	fixerRunner := &stubFixerScheduler{}
 	workerRunner := &stubWorkerScheduler{}
+	sweeperRunner := &stubSweeperScheduler{}
 
 	err := runDefaultSchedulerTick(context.Background(), defaultSchedulerTickInput{
 		Repos:             repos,
@@ -77,6 +78,7 @@ func TestRunDefaultSchedulerTickDiscoversStoredProjectsAndProcessesQueue(t *test
 		Reviewer:          reviewerRunner,
 		Fixer:             fixerRunner,
 		Worker:            workerRunner,
+		Sweeper:           sweeperRunner,
 	})
 	if err != nil {
 		t.Fatalf("runDefaultSchedulerTick() error = %v", err)
@@ -92,6 +94,15 @@ func TestRunDefaultSchedulerTickDiscoversStoredProjectsAndProcessesQueue(t *test
 	}
 	if len(workerRunner.discoverCalls) != 1 || workerRunner.discoverCalls[0].Repo != "nexu-io/looper" {
 		t.Fatalf("worker discover calls = %#v, want stored project repo", workerRunner.discoverCalls)
+	}
+	if len(sweeperRunner.issueDiscoverCalls) != 1 || sweeperRunner.issueDiscoverCalls[0].Repo != "nexu-io/looper" {
+		t.Fatalf("sweeper issue discovery calls = %#v, want stored project repo", sweeperRunner.issueDiscoverCalls)
+	}
+	if len(sweeperRunner.pullRequestDiscoverCalls) != 1 || sweeperRunner.pullRequestDiscoverCalls[0].Repo != "nexu-io/looper" {
+		t.Fatalf("sweeper pull request discovery calls = %#v, want stored project repo", sweeperRunner.pullRequestDiscoverCalls)
+	}
+	if len(sweeperRunner.reconcileDiscoverCalls) != 1 || sweeperRunner.reconcileDiscoverCalls[0].Repo != "nexu-io/looper" {
+		t.Fatalf("sweeper reconcile discovery calls = %#v, want stored project repo", sweeperRunner.reconcileDiscoverCalls)
 	}
 	waitForSchedulerCondition(t, func() bool {
 		return workerRunner.processItemCount() == 1
@@ -144,26 +155,28 @@ func TestRunDefaultSchedulerTickClaimsQueuedWorkBeforeDiscovery(t *testing.T) {
 func TestRunScheduledQueueItemsDispatchesEachSupportedType(t *testing.T) {
 	t.Parallel()
 
-	queueItems := []storage.QueueItemRecord{{Type: "planner"}, {Type: "reviewer"}, {Type: "fixer"}, {Type: "worker"}}
+	queueItems := []storage.QueueItemRecord{{ID: "planner-item", Type: "planner"}, {ID: "reviewer-item", Type: "reviewer"}, {ID: "fixer-item", Type: "fixer"}, {ID: "worker-item", Type: "worker"}, {ID: "sweeper-warn-item", Type: "sweeper:warn"}, {ID: "sweeper-close-item", Type: "sweeper:close"}, {ID: "sweeper-reconcile-item", Type: "sweeper:reconcile"}}
 	plannerRunner := &stubPlannerScheduler{}
 	reviewerRunner := &stubReviewerScheduler{}
 	fixerRunner := &stubFixerScheduler{}
 	workerRunner := &stubWorkerScheduler{}
+	sweeperRunner := &stubSweeperScheduler{}
 
 	err := runScheduledQueueItems(context.Background(), queueItems, defaultSchedulerTickInput{
 		Planner:  plannerRunner,
 		Reviewer: reviewerRunner,
 		Fixer:    fixerRunner,
 		Worker:   workerRunner,
+		Sweeper:  sweeperRunner,
 	})
 	if err != nil {
 		t.Fatalf("runScheduledQueueItems() error = %v", err)
 	}
 	waitForSchedulerCondition(t, func() bool {
-		return plannerRunner.processItemCount() == 1 && reviewerRunner.processItemCount() == 1 && fixerRunner.processItemCount() == 1 && workerRunner.processItemCount() == 1
+		return plannerRunner.processItemCount() == 1 && reviewerRunner.processItemCount() == 1 && fixerRunner.processItemCount() == 1 && workerRunner.processItemCount() == 1 && sweeperRunner.processItemCount() == 3
 	})
-	if plannerRunner.processItemCount() != 1 || reviewerRunner.processItemCount() != 1 || fixerRunner.processItemCount() != 1 || workerRunner.processItemCount() != 1 {
-		t.Fatalf("processed items = planner:%#v reviewer:%#v fixer:%#v worker:%#v, want one each", plannerRunner.processedItems, reviewerRunner.processedItems, fixerRunner.processedItems, workerRunner.processedItems)
+	if plannerRunner.processItemCount() != 1 || reviewerRunner.processItemCount() != 1 || fixerRunner.processItemCount() != 1 || workerRunner.processItemCount() != 1 || sweeperRunner.processItemCount() != 3 {
+		t.Fatalf("processed items = planner:%#v reviewer:%#v fixer:%#v worker:%#v sweeper:%#v, want planner/reviewer/fixer/worker once and sweeper three times", plannerRunner.processedItems, reviewerRunner.processedItems, fixerRunner.processedItems, workerRunner.processedItems, sweeperRunner.processedItems)
 	}
 }
 
@@ -274,6 +287,15 @@ func TestRunScheduledQueueItemsErrorsWhenRunnerMissing(t *testing.T) {
 	err := runScheduledQueueItems(context.Background(), []storage.QueueItemRecord{{Type: "worker"}}, defaultSchedulerTickInput{})
 	if err == nil || !strings.Contains(err.Error(), "worker runner is not configured") {
 		t.Fatalf("runScheduledQueueItems() error = %v, want missing worker runner error", err)
+	}
+}
+
+func TestRunScheduledQueueItemsErrorsWhenSweeperRunnerMissing(t *testing.T) {
+	t.Parallel()
+
+	err := runScheduledQueueItems(context.Background(), []storage.QueueItemRecord{{Type: "sweeper:warn"}}, defaultSchedulerTickInput{})
+	if err == nil || !strings.Contains(err.Error(), "sweeper runner is not configured") {
+		t.Fatalf("runScheduledQueueItems() error = %v, want missing sweeper runner error", err)
 	}
 }
 
@@ -798,6 +820,55 @@ func (s *stubWorkerScheduler) processClaimCount() int {
 }
 
 func (s *stubWorkerScheduler) processItemCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.processedItems)
+}
+
+type stubSweeperDiscoveryCall struct {
+	ProjectID string
+	Repo      string
+}
+
+type stubSweeperScheduler struct {
+	mu                       sync.Mutex
+	issueDiscoverCalls       []stubSweeperDiscoveryCall
+	pullRequestDiscoverCalls []stubSweeperDiscoveryCall
+	reconcileDiscoverCalls   []stubSweeperDiscoveryCall
+	processedItems           []string
+	discoverErr              error
+	processErr               error
+}
+
+func (s *stubSweeperScheduler) DiscoverIssues(_ context.Context, projectID, repo string) error {
+	s.mu.Lock()
+	s.issueDiscoverCalls = append(s.issueDiscoverCalls, stubSweeperDiscoveryCall{ProjectID: projectID, Repo: repo})
+	s.mu.Unlock()
+	return s.discoverErr
+}
+
+func (s *stubSweeperScheduler) DiscoverPullRequests(_ context.Context, projectID, repo string) error {
+	s.mu.Lock()
+	s.pullRequestDiscoverCalls = append(s.pullRequestDiscoverCalls, stubSweeperDiscoveryCall{ProjectID: projectID, Repo: repo})
+	s.mu.Unlock()
+	return s.discoverErr
+}
+
+func (s *stubSweeperScheduler) DiscoverReconcile(_ context.Context, projectID, repo string) error {
+	s.mu.Lock()
+	s.reconcileDiscoverCalls = append(s.reconcileDiscoverCalls, stubSweeperDiscoveryCall{ProjectID: projectID, Repo: repo})
+	s.mu.Unlock()
+	return s.discoverErr
+}
+
+func (s *stubSweeperScheduler) ProcessClaimedQueueItem(_ context.Context, queueItem storage.QueueItemRecord) error {
+	s.mu.Lock()
+	s.processedItems = append(s.processedItems, queueItem.ID)
+	s.mu.Unlock()
+	return s.processErr
+}
+
+func (s *stubSweeperScheduler) processItemCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.processedItems)

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nexu-io/looper/internal/planner"
 	"github.com/nexu-io/looper/internal/reviewer"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/sweeper"
 	"github.com/nexu-io/looper/internal/worker"
 )
 
@@ -840,32 +841,32 @@ type stubSweeperScheduler struct {
 	processErr               error
 }
 
-func (s *stubSweeperScheduler) DiscoverIssues(_ context.Context, projectID, repo string) error {
+func (s *stubSweeperScheduler) DiscoverIssues(_ context.Context, input sweeper.DiscoveryInput) (sweeper.DiscoveryResult, error) {
 	s.mu.Lock()
-	s.issueDiscoverCalls = append(s.issueDiscoverCalls, stubSweeperDiscoveryCall{ProjectID: projectID, Repo: repo})
+	s.issueDiscoverCalls = append(s.issueDiscoverCalls, stubSweeperDiscoveryCall{ProjectID: input.ProjectID, Repo: input.Repo})
 	s.mu.Unlock()
-	return s.discoverErr
+	return sweeper.DiscoveryResult{}, s.discoverErr
 }
 
-func (s *stubSweeperScheduler) DiscoverPullRequests(_ context.Context, projectID, repo string) error {
+func (s *stubSweeperScheduler) DiscoverPullRequests(_ context.Context, input sweeper.DiscoveryInput) (sweeper.DiscoveryResult, error) {
 	s.mu.Lock()
-	s.pullRequestDiscoverCalls = append(s.pullRequestDiscoverCalls, stubSweeperDiscoveryCall{ProjectID: projectID, Repo: repo})
+	s.pullRequestDiscoverCalls = append(s.pullRequestDiscoverCalls, stubSweeperDiscoveryCall{ProjectID: input.ProjectID, Repo: input.Repo})
 	s.mu.Unlock()
-	return s.discoverErr
+	return sweeper.DiscoveryResult{}, s.discoverErr
 }
 
-func (s *stubSweeperScheduler) DiscoverReconcile(_ context.Context, projectID, repo string) error {
+func (s *stubSweeperScheduler) DiscoverReconcile(_ context.Context, input sweeper.DiscoveryInput) (sweeper.DiscoveryResult, error) {
 	s.mu.Lock()
-	s.reconcileDiscoverCalls = append(s.reconcileDiscoverCalls, stubSweeperDiscoveryCall{ProjectID: projectID, Repo: repo})
+	s.reconcileDiscoverCalls = append(s.reconcileDiscoverCalls, stubSweeperDiscoveryCall{ProjectID: input.ProjectID, Repo: input.Repo})
 	s.mu.Unlock()
-	return s.discoverErr
+	return sweeper.DiscoveryResult{}, s.discoverErr
 }
 
-func (s *stubSweeperScheduler) ProcessClaimedQueueItem(_ context.Context, queueItem storage.QueueItemRecord) error {
+func (s *stubSweeperScheduler) ProcessClaimedQueueItem(_ context.Context, queueItem storage.QueueItemRecord) (*sweeper.ProcessResult, error) {
 	s.mu.Lock()
 	s.processedItems = append(s.processedItems, queueItem.ID)
 	s.mu.Unlock()
-	return s.processErr
+	return &sweeper.ProcessResult{QueueItemID: queueItem.ID, Status: "skipped"}, s.processErr
 }
 
 func (s *stubSweeperScheduler) processItemCount() int {

--- a/internal/sweeper/doc.go
+++ b/internal/sweeper/doc.go
@@ -1,0 +1,2 @@
+// Package sweeper scaffolds the sweeper role lifecycle.
+package sweeper

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -1,0 +1,149 @@
+package sweeper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nexu-io/looper/internal/bootstrap"
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+const (
+	QueueType              = "sweeper"
+	QueueTypeWarn          = "sweeper:warn"
+	QueueTypeClose         = "sweeper:close"
+	QueueTypeReconcile     = "sweeper:reconcile"
+	defaultClaimedBy       = "sweeper"
+	defaultSkippedSummary  = "sweeper runner skeleton: no-op"
+	javaScriptISOStringUTC = "2006-01-02T15:04:05.000Z"
+)
+
+type DiscoveryInput struct {
+	ProjectID string
+	Repo      string
+	Limit     int
+}
+
+type DiscoveryResult struct {
+	QueueItems []storage.QueueItemRecord
+	Skipped    int
+}
+
+type ProcessResult struct {
+	QueueItemID string
+	Status      string
+	Summary     string
+}
+
+type Options struct {
+	Repos  *storage.Repositories
+	Logger bootstrap.Logger
+	Now    func() time.Time
+	Config *config.Config
+}
+
+type Runner struct {
+	repos   *storage.Repositories
+	logger  bootstrap.Logger
+	now     func() time.Time
+	config  *config.Config
+	claimer string
+}
+
+func New(options Options) *Runner {
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Runner{repos: options.Repos, logger: options.Logger, now: now, config: options.Config, claimer: defaultClaimedBy}
+}
+
+func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	return r.discover(ctx, input)
+}
+
+func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	return r.discover(ctx, input)
+}
+
+func (r *Runner) DiscoverReconcile(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	return r.discover(ctx, input)
+}
+
+func (r *Runner) ProcessNext(ctx context.Context, claimedBy string) (*ProcessResult, error) {
+	if r.repos == nil || r.repos.Queue == nil {
+		return nil, fmt.Errorf("sweeper queue repository is not configured")
+	}
+	claimedBy = strings.TrimSpace(claimedBy)
+	if claimedBy == "" {
+		claimedBy = r.claimer
+	}
+	for _, queueType := range []string{QueueTypeWarn, QueueTypeClose, QueueTypeReconcile, QueueType} {
+		item, err := r.repos.Queue.ClaimNextOfType(ctx, r.nowISO(), claimedBy, queueType)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			continue
+		}
+		return r.ProcessClaimedQueueItem(ctx, *item)
+	}
+	return nil, nil
+}
+
+func (r *Runner) ProcessClaimedQueueItem(ctx context.Context, queueItem storage.QueueItemRecord) (*ProcessResult, error) {
+	if !isSupportedQueueType(queueItem.Type) {
+		return nil, fmt.Errorf("unsupported sweeper queue item type %q", queueItem.Type)
+	}
+	if strings.TrimSpace(queueItem.ID) == "" {
+		return nil, fmt.Errorf("sweeper queue item id is required")
+	}
+	if r.repos == nil || r.repos.Queue == nil {
+		return nil, fmt.Errorf("sweeper queue repository is not configured")
+	}
+	result := &ProcessResult{QueueItemID: queueItem.ID, Status: "skipped", Summary: defaultSkippedSummary}
+	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (r *Runner) discover(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	if r.repos == nil || r.repos.Projects == nil {
+		return DiscoveryResult{}, fmt.Errorf("sweeper project repository is not configured")
+	}
+	project, err := r.repos.Projects.GetByID(ctx, input.ProjectID)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if project == nil {
+		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
+	}
+	if project.Archived || !r.autoDiscoveryEnabled(input.ProjectID) {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	return DiscoveryResult{}, nil
+}
+
+func (r *Runner) autoDiscoveryEnabled(projectID string) bool {
+	if r.config == nil {
+		return true
+	}
+	return config.ProjectRoleConfigs(*r.config, projectID).Sweeper.AutoDiscovery
+}
+
+func (r *Runner) nowISO() string {
+	return r.now().UTC().Format(javaScriptISOStringUTC)
+}
+
+func isSupportedQueueType(queueType string) bool {
+	switch queueType {
+	case QueueType, QueueTypeWarn, QueueTypeClose, QueueTypeReconcile:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -257,6 +257,9 @@ func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryI
 	if project.Archived || !roleCfg.AutoDiscovery {
 		return DiscoveryResult{Skipped: 1}, nil
 	}
+	if !roleCfg.Triggers.IncludeIssues {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
 	if r.github == nil {
 		return DiscoveryResult{Skipped: 1}, nil
 	}
@@ -268,8 +271,10 @@ func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryI
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
-	warnLimit := r.discoveryLimit(input.Limit, roleCfg.Triggers.MaxPerTick)
-	closeLimit := warnLimit * 3
+	warnLimit, closeLimit, err := r.discoveryBudgets(ctx, input, roleCfg)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
 	result := DiscoveryResult{QueueItems: make([]storage.QueueItemRecord, 0, warnLimit+closeLimit)}
 	warnCount := 0
 	closeCount := 0
@@ -278,7 +283,7 @@ func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryI
 			continue
 		}
 		targetID := buildTargetID(input.Repo, issue.Number)
-		if r.shouldSkipSummary(issue.Labels, issue.Author, roleCfg) {
+		if r.shouldSkipSummary(issue.Labels, issue.Author, issue.AuthorAssociation, roleCfg) {
 			result.Skipped++
 			continue
 		}
@@ -320,6 +325,9 @@ func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input Disc
 	if project.Archived || !roleCfg.AutoDiscovery {
 		return DiscoveryResult{Skipped: 1}, nil
 	}
+	if !roleCfg.Triggers.IncludePullRequests {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
 	if r.github == nil {
 		return DiscoveryResult{Skipped: 1}, nil
 	}
@@ -331,8 +339,10 @@ func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input Disc
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
-	warnLimit := r.discoveryLimit(input.Limit, roleCfg.Triggers.MaxPerTick)
-	closeLimit := warnLimit * 3
+	warnLimit, closeLimit, err := r.discoveryBudgets(ctx, input, roleCfg)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
 	result := DiscoveryResult{QueueItems: make([]storage.QueueItemRecord, 0, warnLimit+closeLimit)}
 	warnCount := 0
 	closeCount := 0
@@ -342,7 +352,7 @@ func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input Disc
 			continue
 		}
 		targetID := buildTargetID(input.Repo, pr.Number)
-		if r.shouldSkipSummary(pr.Labels, pr.Author, roleCfg) {
+		if r.shouldSkipSummary(pr.Labels, pr.Author, pr.AuthorAssociation, roleCfg) {
 			result.Skipped++
 			continue
 		}
@@ -577,11 +587,11 @@ func (r *Runner) processReconcile(ctx context.Context, queueItem storage.QueueIt
 	if err != nil {
 		return payload, "failed", "", err
 	}
-	payload.Phase = "reconcile"
 	if hasLabel(target.Labels, roleCfg.Lifecycle.PendingLabel) {
 		payload.Summary = "sweeper reconcile: still pending"
 		return payload, "skipped", payload.Summary, nil
 	}
+	payload.Phase = "reconcile"
 	if payload.WarningCommentID > 0 && !roleCfg.DryRun {
 		_ = r.github.UpdateIssueComment(ctx, githubinfra.UpdateIssueCommentInput{Repo: derefString(queueItem.Repo), CommentID: payload.WarningCommentID, Body: payload.CommentBody + "\n\nCancellation acknowledged because the pending label was removed."})
 	}
@@ -659,7 +669,7 @@ func gracePeriodForCategory(category string, roleCfg config.SweeperRoleConfig) i
 	}
 }
 
-func (r *Runner) shouldSkipSummary(labels []string, author string, roleCfg config.SweeperRoleConfig) bool {
+func (r *Runner) shouldSkipSummary(labels []string, author string, authorAssociation string, roleCfg config.SweeperRoleConfig) bool {
 	if hasAnyLabel(labels, roleCfg.Triggers.ExcludeLabels) || hasAnyLabel(labels, roleCfg.Triggers.LooperInternalLabels) || hasLabel(labels, roleCfg.Security.QuarantineLabel) || hasLabel(labels, roleCfg.Lifecycle.ClosedLabel) {
 		return true
 	}
@@ -668,7 +678,67 @@ func (r *Runner) shouldSkipSummary(labels []string, author string, roleCfg confi
 			return true
 		}
 	}
+	for _, excluded := range roleCfg.Triggers.ExcludeAuthorAssociations {
+		if strings.EqualFold(strings.TrimSpace(excluded), strings.TrimSpace(authorAssociation)) {
+			return true
+		}
+	}
 	return false
+}
+
+func (r *Runner) discoveryBudgets(ctx context.Context, input DiscoveryInput, roleCfg config.SweeperRoleConfig) (int, int, error) {
+	warnLimit := r.discoveryLimit(input.Limit, roleCfg.Triggers.MaxPerTick)
+	closeLimit := warnLimit * 3
+	remainingWarn, remainingClose, err := r.remainingDailyDiscoveryBudget(ctx, input.Repo, roleCfg)
+	if err != nil {
+		return 0, 0, err
+	}
+	if warnLimit > remainingWarn {
+		warnLimit = remainingWarn
+	}
+	if closeLimit > remainingClose {
+		closeLimit = remainingClose
+	}
+	if warnLimit < 0 {
+		warnLimit = 0
+	}
+	if closeLimit < 0 {
+		closeLimit = 0
+	}
+	return warnLimit, closeLimit, nil
+}
+
+func (r *Runner) remainingDailyDiscoveryBudget(ctx context.Context, repo string, roleCfg config.SweeperRoleConfig) (int, int, error) {
+	if r.repos == nil || r.repos.Queue == nil {
+		return 0, 0, fmt.Errorf("sweeper queue repository is not configured")
+	}
+	items, err := r.repos.Queue.List(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	today := r.now().UTC().Format("2006-01-02")
+	warnUsed := 0
+	closeUsed := 0
+	for _, item := range items {
+		if derefString(item.Repo) != repo || !strings.HasPrefix(item.CreatedAt, today) {
+			continue
+		}
+		switch item.Type {
+		case QueueTypeWarn:
+			warnUsed++
+		case QueueTypeClose:
+			closeUsed++
+		}
+	}
+	return remainingCount(roleCfg.Limits.MaxWarningsPerRepoPerDay, warnUsed), remainingCount(roleCfg.Limits.MaxClosesPerRepoPerDay, closeUsed), nil
+}
+
+func remainingCount(limit, used int) int {
+	remaining := limit - used
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
 }
 
 func (r *Runner) latestSweeperState(ctx context.Context) (map[string]sweeperPayload, error) {

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -118,14 +118,15 @@ type sweeperPayload struct {
 }
 
 type liveTarget struct {
-	Number int64
-	State  string
-	Title  string
-	Body   string
-	Author string
-	Labels []string
-	IsPR   bool
-	Draft  bool
+	Number    int64
+	State     string
+	Title     string
+	Body      string
+	UpdatedAt string
+	Author    string
+	Labels    []string
+	IsPR      bool
+	Draft     bool
 }
 
 func New(options Options) *Runner {
@@ -443,7 +444,7 @@ func (r *Runner) processWarn(ctx context.Context, queueItem storage.QueueItemRec
 	if err != nil {
 		return payload, "failed", "", err
 	}
-	category, confidence, rationale := classifyTarget(target, roleCfg)
+	category, confidence, rationale := classifyTarget(target, roleCfg, r.now())
 	payload.Phase = "warn"
 	payload.Outcome = outcomeNoAction
 	payload.Category = category
@@ -515,7 +516,7 @@ func (r *Runner) processClose(ctx context.Context, queueItem storage.QueueItemRe
 		payload.Summary = "target already closed"
 		return payload, "completed", payload.Summary, nil
 	}
-	if !hasLabel(target.Labels, roleCfg.Lifecycle.PendingLabel) || hasLabel(target.Labels, roleCfg.Lifecycle.KeepLabel) {
+	if !hasLabel(target.Labels, roleCfg.Lifecycle.PendingLabel) {
 		payload.Outcome = outcomeCancelled
 		payload.Summary = "sweeper warning cancelled"
 		if payload.WarningCommentID > 0 && r.github != nil && !roleCfg.DryRun {
@@ -523,7 +524,20 @@ func (r *Runner) processClose(ctx context.Context, queueItem storage.QueueItemRe
 		}
 		return payload, "completed", payload.Summary, nil
 	}
-	category, _, rationale := classifyTarget(target, roleCfg)
+	if hasLabel(target.Labels, roleCfg.Lifecycle.KeepLabel) {
+		payload.Outcome = outcomeCancelled
+		payload.Summary = "sweeper warning cancelled"
+		if r.github != nil && !roleCfg.DryRun {
+			if err := r.github.RemoveIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: payload.Repo, IssueNumber: target.Number, Labels: []string{roleCfg.Lifecycle.PendingLabel}}); err != nil {
+				return payload, "failed", "", err
+			}
+		}
+		if payload.WarningCommentID > 0 && r.github != nil && !roleCfg.DryRun {
+			_ = r.github.UpdateIssueComment(ctx, githubinfra.UpdateIssueCommentInput{Repo: payload.Repo, CommentID: payload.WarningCommentID, Body: payload.CommentBody + "\n\nCancellation noted by sweeper."})
+		}
+		return payload, "completed", payload.Summary, nil
+	}
+	category, _, rationale := classifyTarget(target, roleCfg, r.now())
 	if category == categoryRouteSecurity {
 		if roleCfg.DryRun || roleCfg.Limits.GlobalKillSwitch || r.github == nil {
 			payload.Outcome = outcomeDryRun
@@ -614,16 +628,16 @@ func (r *Runner) loadTarget(ctx context.Context, item storage.QueueItemRecord) (
 		if err != nil {
 			return liveTarget{}, err
 		}
-		return liveTarget{Number: detail.Number, State: detail.State, Title: detail.Title, Body: detail.Body, Author: detail.Author, Labels: append([]string(nil), detail.Labels...), IsPR: true, Draft: detail.IsDraft}, nil
+		return liveTarget{Number: detail.Number, State: detail.State, Title: detail.Title, Body: detail.Body, UpdatedAt: detail.UpdatedAt, Author: detail.Author, Labels: append([]string(nil), detail.Labels...), IsPR: true, Draft: detail.IsDraft}, nil
 	}
 	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: number})
 	if err != nil {
 		return liveTarget{}, err
 	}
-	return liveTarget{Number: detail.Number, State: detail.State, Title: detail.Title, Body: detail.Body, Author: detail.Author, Labels: append([]string(nil), detail.Labels...)}, nil
+	return liveTarget{Number: detail.Number, State: detail.State, Title: detail.Title, Body: detail.Body, UpdatedAt: detail.UpdatedAt, Author: detail.Author, Labels: append([]string(nil), detail.Labels...)}, nil
 }
 
-func classifyTarget(target liveTarget, roleCfg config.SweeperRoleConfig) (string, int, string) {
+func classifyTarget(target liveTarget, roleCfg config.SweeperRoleConfig, now time.Time) (string, int, string) {
 	text := strings.ToLower(target.Title + "\n" + target.Body)
 	if strings.Contains(text, "security") {
 		return categoryRouteSecurity, 100, "security-sensitive content detected"
@@ -637,10 +651,10 @@ func classifyTarget(target liveTarget, roleCfg config.SweeperRoleConfig) (string
 	if !target.IsPR && roleCfg.Categories.Unrelated.Enabled && (strings.Contains(text, "support") || strings.Contains(text, "question")) {
 		return categoryUnrelated, maxConfidence(roleCfg.Categories.Unrelated.MinConfidence), "target appears unrelated to repository work"
 	}
-	if target.IsPR && roleCfg.Categories.AbandonedPR.Enabled {
+	if target.IsPR && roleCfg.Categories.AbandonedPR.Enabled && inactiveLongEnough(target.UpdatedAt, roleCfg.Categories.AbandonedPR.InactivityDays, now) {
 		return categoryAbandonedPR, maxConfidence(roleCfg.Categories.AbandonedPR.MinConfidence), "open pull request matched sweeper abandoned-pr heuristics"
 	}
-	if roleCfg.Categories.Stale.Enabled {
+	if roleCfg.Categories.Stale.Enabled && inactiveLongEnough(target.UpdatedAt, roleCfg.Categories.Stale.InactivityDays, now) {
 		return categoryStale, maxConfidence(roleCfg.Categories.Stale.MinConfidence), "open item matched stale sweeper heuristics"
 	}
 	return categoryNone, 0, "no enabled sweeper category matched"
@@ -856,14 +870,38 @@ func dueForClose(closeBy string, now time.Time) bool {
 	if strings.TrimSpace(closeBy) == "" {
 		return false
 	}
-	parsed, err := time.Parse(time.RFC3339Nano, closeBy)
-	if err != nil {
-		parsed, err = time.Parse(javaScriptISOStringUTC, closeBy)
-		if err != nil {
-			return false
-		}
+	parsed, ok := parseGitHubTimestamp(closeBy)
+	if !ok {
+		return false
 	}
 	return !parsed.After(now.UTC())
+}
+
+func inactiveLongEnough(updatedAt string, inactivityDays int, now time.Time) bool {
+	if inactivityDays <= 0 {
+		return false
+	}
+	parsed, ok := parseGitHubTimestamp(updatedAt)
+	if !ok {
+		return false
+	}
+	threshold := now.UTC().Add(-time.Duration(inactivityDays) * 24 * time.Hour)
+	return !parsed.After(threshold)
+}
+
+func parseGitHubTimestamp(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		parsed, err = time.Parse(javaScriptISOStringUTC, value)
+		if err != nil {
+			return time.Time{}, false
+		}
+	}
+	return parsed.UTC(), true
 }
 
 func hasLabel(labels []string, want string) bool {

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -2,12 +2,16 @@ package sweeper
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/nexu-io/looper/internal/bootstrap"
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/eventlog"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -17,8 +21,27 @@ const (
 	QueueTypeClose         = "sweeper:close"
 	QueueTypeReconcile     = "sweeper:reconcile"
 	defaultClaimedBy       = "sweeper"
-	defaultSkippedSummary  = "sweeper runner skeleton: no-op"
+	defaultSkippedSummary  = "sweeper: no action"
 	javaScriptISOStringUTC = "2006-01-02T15:04:05.000Z"
+	defaultRetryMax        = int64(3)
+	defaultQueuePriority   = storage.QueuePriorityWorker
+
+	categoryNone          = "none"
+	categoryStale         = "stale"
+	categoryAlreadyFixed  = "already_fixed"
+	categoryUnrelated     = "unrelated"
+	categorySuperseded    = "superseded"
+	categoryAbandonedPR   = "abandoned_pr"
+	categoryRouteSecurity = "route_security"
+
+	outcomeNoAction                = "no_action"
+	outcomePending                 = "pending"
+	outcomeClosed                  = "closed"
+	outcomeCancelled               = "cancelled"
+	outcomeCancelledByLabelRemoval = "cancelled_by_label_removal"
+	outcomeAlreadyClosedByHuman    = "already_closed_by_human"
+	outcomeQuarantined             = "quarantined"
+	outcomeDryRun                  = "dry_run"
 )
 
 type DiscoveryInput struct {
@@ -38,8 +61,22 @@ type ProcessResult struct {
 	Summary     string
 }
 
+type GitHubGateway interface {
+	ListOpenIssues(context.Context, githubinfra.ListOpenIssuesInput) ([]githubinfra.IssueSummary, error)
+	ListOpenPullRequests(context.Context, githubinfra.ListOpenPullRequestsInput) ([]githubinfra.PullRequestSummary, error)
+	ViewIssue(context.Context, githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error)
+	ViewPullRequest(context.Context, githubinfra.ViewPullRequestInput) (githubinfra.PullRequestDetail, error)
+	CreateIssueComment(context.Context, githubinfra.IssueCommentInput) (githubinfra.IssueCommentResult, error)
+	UpdateIssueComment(context.Context, githubinfra.UpdateIssueCommentInput) error
+	CloseIssue(context.Context, githubinfra.CloseIssueInput) error
+	ClosePullRequest(context.Context, githubinfra.ClosePullRequestInput) error
+	AddIssueLabels(context.Context, githubinfra.IssueLabelsInput) error
+	RemoveIssueLabels(context.Context, githubinfra.IssueLabelsInput) error
+}
+
 type Options struct {
 	Repos  *storage.Repositories
+	GitHub GitHubGateway
 	Logger bootstrap.Logger
 	Now    func() time.Time
 	Config *config.Config
@@ -47,10 +84,48 @@ type Options struct {
 
 type Runner struct {
 	repos   *storage.Repositories
+	github  GitHubGateway
 	logger  bootstrap.Logger
 	now     func() time.Time
 	config  *config.Config
 	claimer string
+	maxTry  int64
+}
+
+type payloadEnvelope struct {
+	Sweeper sweeperPayload `json:"sweeper"`
+}
+
+type sweeperPayload struct {
+	Phase             string `json:"phase,omitempty"`
+	Outcome           string `json:"outcome,omitempty"`
+	Category          string `json:"category,omitempty"`
+	Confidence        int    `json:"confidence,omitempty"`
+	Rationale         string `json:"rationale,omitempty"`
+	Repo              string `json:"repo,omitempty"`
+	TargetType        string `json:"target_type,omitempty"`
+	TargetNumber      int64  `json:"target_number,omitempty"`
+	WarningCommentID  int64  `json:"warning_comment_id,omitempty"`
+	WarningMarkerUUID string `json:"warning_marker_uuid,omitempty"`
+	WarningPostedAt   string `json:"warning_posted_at,omitempty"`
+	CloseBy           string `json:"close_by,omitempty"`
+	CommentBody       string `json:"comment_body,omitempty"`
+	Summary           string `json:"summary,omitempty"`
+	PendingLabel      string `json:"pending_label,omitempty"`
+	ClosedLabel       string `json:"closed_label,omitempty"`
+	KeepLabel         string `json:"keep_label,omitempty"`
+	QuarantineLabel   string `json:"quarantine_label,omitempty"`
+}
+
+type liveTarget struct {
+	Number int64
+	State  string
+	Title  string
+	Body   string
+	Author string
+	Labels []string
+	IsPR   bool
+	Draft  bool
 }
 
 func New(options Options) *Runner {
@@ -58,19 +133,51 @@ func New(options Options) *Runner {
 	if now == nil {
 		now = time.Now
 	}
-	return &Runner{repos: options.Repos, logger: options.Logger, now: now, config: options.Config, claimer: defaultClaimedBy}
+	return &Runner{repos: options.Repos, github: options.GitHub, logger: options.Logger, now: now, config: options.Config, claimer: defaultClaimedBy, maxTry: defaultRetryMax}
 }
 
 func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
-	return r.discover(ctx, input)
+	return r.discoverIssuesAndClosures(ctx, input)
 }
 
 func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
-	return r.discover(ctx, input)
+	return r.discoverPullRequestsAndClosures(ctx, input)
 }
 
 func (r *Runner) DiscoverReconcile(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
-	return r.discover(ctx, input)
+	if r.repos == nil || r.repos.Projects == nil || r.repos.Queue == nil {
+		return DiscoveryResult{}, fmt.Errorf("sweeper repositories are not configured")
+	}
+	project, roleCfg, err := r.projectConfig(ctx, input.ProjectID)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if project.Archived || !roleCfg.AutoDiscovery {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	states, err := r.latestSweeperState(ctx)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	limit := r.discoveryLimit(input.Limit, roleCfg.Triggers.MaxPerTick)
+	items := make([]storage.QueueItemRecord, 0, limit)
+	for targetID, state := range states {
+		if len(items) >= limit {
+			break
+		}
+		if state.Repo != input.Repo || state.Outcome != outcomePending || state.Phase != "warn" {
+			continue
+		}
+		queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeReconcile, TargetType: state.TargetType, TargetID: targetID, Number: state.TargetNumber, Payload: state})
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		if !ok {
+			continue
+		}
+		items = append(items, queueItem)
+	}
+	return DiscoveryResult{QueueItems: items}, nil
 }
 
 func (r *Runner) ProcessNext(ctx context.Context, claimedBy string) (*ProcessResult, error) {
@@ -104,28 +211,540 @@ func (r *Runner) ProcessClaimedQueueItem(ctx context.Context, queueItem storage.
 	if r.repos == nil || r.repos.Queue == nil {
 		return nil, fmt.Errorf("sweeper queue repository is not configured")
 	}
-	result := &ProcessResult{QueueItemID: queueItem.ID, Status: "skipped", Summary: defaultSkippedSummary}
+	stored, err := r.repos.Queue.GetByID(ctx, queueItem.ID)
+	if err != nil {
+		return nil, err
+	}
+	if stored != nil {
+		queueItem = *stored
+	}
+	payload := r.readPayload(queueItem)
+	if payload.Repo == "" && queueItem.Repo != nil {
+		payload.Repo = *queueItem.Repo
+	}
+	var summary string
+	var status string
+	switch queueItem.Type {
+	case QueueTypeWarn:
+		payload, status, summary, err = r.processWarn(ctx, queueItem, payload)
+	case QueueTypeClose:
+		payload, status, summary, err = r.processClose(ctx, queueItem, payload)
+	case QueueTypeReconcile:
+		payload, status, summary, err = r.processReconcile(ctx, queueItem, payload)
+	default:
+		status = "skipped"
+		summary = defaultSkippedSummary
+	}
+	if err != nil {
+		return nil, err
+	}
+	queueItem.PayloadJSON = stringPtr(mustMarshalPayload(payload))
+	queueItem.UpdatedAt = r.nowISO()
+	if err := r.repos.Queue.Upsert(ctx, queueItem); err != nil {
+		return nil, err
+	}
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
 		return nil, err
+	}
+	return &ProcessResult{QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
+}
+
+func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	project, roleCfg, err := r.projectConfig(ctx, input.ProjectID)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if project.Archived || !roleCfg.AutoDiscovery {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	if r.github == nil {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	issues, err := r.github.ListOpenIssues(ctx, githubinfra.ListOpenIssuesInput{Repo: input.Repo, Limit: r.discoveryLimit(input.Limit, roleCfg.Triggers.MaxPerTick*6), CWD: project.RepoPath})
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	states, err := r.latestSweeperState(ctx)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	warnLimit := r.discoveryLimit(input.Limit, roleCfg.Triggers.MaxPerTick)
+	closeLimit := warnLimit * 3
+	result := DiscoveryResult{QueueItems: make([]storage.QueueItemRecord, 0, warnLimit+closeLimit)}
+	warnCount := 0
+	closeCount := 0
+	for _, issue := range issues {
+		if issue.IsPullRequest {
+			continue
+		}
+		targetID := buildTargetID(input.Repo, issue.Number)
+		if r.shouldSkipSummary(issue.Labels, issue.Author, roleCfg) {
+			result.Skipped++
+			continue
+		}
+		if hasLabel(issue.Labels, roleCfg.Lifecycle.PendingLabel) {
+			state, ok := states[targetID]
+			if !ok || state.Outcome != outcomePending || state.Phase != "warn" || !dueForClose(state.CloseBy, r.now()) || closeCount >= closeLimit {
+				continue
+			}
+			queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeClose, TargetType: "issue", TargetID: targetID, Number: issue.Number, Payload: state})
+			if err != nil {
+				return DiscoveryResult{}, err
+			}
+			if ok {
+				result.QueueItems = append(result.QueueItems, queueItem)
+				closeCount++
+			}
+			continue
+		}
+		if warnCount >= warnLimit {
+			continue
+		}
+		queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeWarn, TargetType: "issue", TargetID: targetID, Number: issue.Number, Payload: sweeperPayload{Phase: "warn", Repo: input.Repo, TargetType: "issue", TargetNumber: issue.Number, PendingLabel: roleCfg.Lifecycle.PendingLabel, ClosedLabel: roleCfg.Lifecycle.ClosedLabel, KeepLabel: roleCfg.Lifecycle.KeepLabel, QuarantineLabel: roleCfg.Security.QuarantineLabel}})
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		if ok {
+			result.QueueItems = append(result.QueueItems, queueItem)
+			warnCount++
+		}
 	}
 	return result, nil
 }
 
-func (r *Runner) discover(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
-	if r.repos == nil || r.repos.Projects == nil {
-		return DiscoveryResult{}, fmt.Errorf("sweeper project repository is not configured")
-	}
-	project, err := r.repos.Projects.GetByID(ctx, input.ProjectID)
+func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	project, roleCfg, err := r.projectConfig(ctx, input.ProjectID)
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
-	if project == nil {
-		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
-	}
-	if project.Archived || !r.autoDiscoveryEnabled(input.ProjectID) {
+	if project.Archived || !roleCfg.AutoDiscovery {
 		return DiscoveryResult{Skipped: 1}, nil
 	}
-	return DiscoveryResult{}, nil
+	if r.github == nil {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	prs, err := r.github.ListOpenPullRequests(ctx, githubinfra.ListOpenPullRequestsInput{Repo: input.Repo, Limit: r.discoveryLimit(input.Limit, roleCfg.Triggers.MaxPerTick*6), CWD: project.RepoPath})
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	states, err := r.latestSweeperState(ctx)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	warnLimit := r.discoveryLimit(input.Limit, roleCfg.Triggers.MaxPerTick)
+	closeLimit := warnLimit * 3
+	result := DiscoveryResult{QueueItems: make([]storage.QueueItemRecord, 0, warnLimit+closeLimit)}
+	warnCount := 0
+	closeCount := 0
+	for _, pr := range prs {
+		if pr.IsDraft && !roleCfg.Triggers.IncludeDrafts {
+			result.Skipped++
+			continue
+		}
+		targetID := buildTargetID(input.Repo, pr.Number)
+		if r.shouldSkipSummary(pr.Labels, pr.Author, roleCfg) {
+			result.Skipped++
+			continue
+		}
+		if hasLabel(pr.Labels, roleCfg.Lifecycle.PendingLabel) {
+			state, ok := states[targetID]
+			if !ok || state.Outcome != outcomePending || state.Phase != "warn" || !dueForClose(state.CloseBy, r.now()) || closeCount >= closeLimit {
+				continue
+			}
+			queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeClose, TargetType: "pull_request", TargetID: targetID, Number: pr.Number, Payload: state})
+			if err != nil {
+				return DiscoveryResult{}, err
+			}
+			if ok {
+				result.QueueItems = append(result.QueueItems, queueItem)
+				closeCount++
+			}
+			continue
+		}
+		if warnCount >= warnLimit {
+			continue
+		}
+		queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeWarn, TargetType: "pull_request", TargetID: targetID, Number: pr.Number, Payload: sweeperPayload{Phase: "warn", Repo: input.Repo, TargetType: "pull_request", TargetNumber: pr.Number, PendingLabel: roleCfg.Lifecycle.PendingLabel, ClosedLabel: roleCfg.Lifecycle.ClosedLabel, KeepLabel: roleCfg.Lifecycle.KeepLabel, QuarantineLabel: roleCfg.Security.QuarantineLabel}})
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		if ok {
+			result.QueueItems = append(result.QueueItems, queueItem)
+			warnCount++
+		}
+	}
+	return result, nil
+}
+
+type queueSeed struct {
+	ProjectID  string
+	Repo       string
+	QueueType  string
+	TargetType string
+	TargetID   string
+	Number     int64
+	Payload    sweeperPayload
+}
+
+func (r *Runner) buildQueueItem(ctx context.Context, seed queueSeed) (storage.QueueItemRecord, bool, error) {
+	dedupeKey := fmt.Sprintf("sweeper:%s:%s", strings.TrimPrefix(seed.QueueType, "sweeper:"), seed.TargetID)
+	existing, err := r.repos.Queue.FindActiveByDedupe(ctx, dedupeKey)
+	if err != nil {
+		return storage.QueueItemRecord{}, false, err
+	}
+	if existing != nil {
+		return storage.QueueItemRecord{}, false, nil
+	}
+	nowISO := r.nowISO()
+	repo := seed.Repo
+	var prNumber *int64
+	if seed.TargetType == "pull_request" {
+		prNumber = &seed.Number
+	}
+	payloadJSON := mustMarshalPayload(seed.Payload)
+	item := storage.QueueItemRecord{
+		ID:          eventlog.NewEventID("queue"),
+		ProjectID:   stringPtr(seed.ProjectID),
+		Type:        seed.QueueType,
+		TargetType:  seed.TargetType,
+		TargetID:    seed.TargetID,
+		Repo:        &repo,
+		PRNumber:    prNumber,
+		DedupeKey:   dedupeKey,
+		Priority:    defaultQueuePriority,
+		Status:      "queued",
+		AvailableAt: nowISO,
+		Attempts:    0,
+		MaxAttempts: r.maxTry,
+		LockKey:     stringPtr("sweeper:" + seed.TargetID),
+		PayloadJSON: &payloadJSON,
+		CreatedAt:   nowISO,
+		UpdatedAt:   nowISO,
+	}
+	if err := r.repos.Queue.Upsert(ctx, item); err != nil {
+		return storage.QueueItemRecord{}, false, err
+	}
+	return item, true, nil
+}
+
+func (r *Runner) processWarn(ctx context.Context, queueItem storage.QueueItemRecord, payload sweeperPayload) (sweeperPayload, string, string, error) {
+	roleCfg := r.roleConfig(derefString(queueItem.ProjectID))
+	target, err := r.loadTarget(ctx, queueItem)
+	if err != nil {
+		return payload, "failed", "", err
+	}
+	category, confidence, rationale := classifyTarget(target, roleCfg)
+	payload.Phase = "warn"
+	payload.Outcome = outcomeNoAction
+	payload.Category = category
+	payload.Confidence = confidence
+	payload.Rationale = rationale
+	payload.Repo = derefString(queueItem.Repo)
+	payload.TargetType = queueItem.TargetType
+	payload.TargetNumber = target.Number
+	payload.PendingLabel = roleCfg.Lifecycle.PendingLabel
+	payload.ClosedLabel = roleCfg.Lifecycle.ClosedLabel
+	payload.KeepLabel = roleCfg.Lifecycle.KeepLabel
+	payload.QuarantineLabel = roleCfg.Security.QuarantineLabel
+	if category == categoryNone {
+		payload.Summary = defaultSkippedSummary
+		return payload, "skipped", defaultSkippedSummary, nil
+	}
+	if category == categoryRouteSecurity {
+		if roleCfg.DryRun || roleCfg.Limits.GlobalKillSwitch || r.github == nil {
+			payload.Outcome = outcomeDryRun
+			payload.Summary = "sweeper dry-run quarantine"
+			return payload, "skipped", payload.Summary, nil
+		}
+		if err := r.github.AddIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: payload.Repo, IssueNumber: target.Number, Labels: []string{roleCfg.Security.QuarantineLabel}}); err != nil {
+			return payload, "failed", "", err
+		}
+		payload.Outcome = outcomeQuarantined
+		payload.Summary = "sweeper quarantined target"
+		return payload, "completed", payload.Summary, nil
+	}
+	graceDays := gracePeriodForCategory(category, roleCfg)
+	payload.WarningMarkerUUID = eventlog.NewEventID("sweeper")
+	payload.WarningPostedAt = r.nowISO()
+	payload.CloseBy = r.now().UTC().Add(time.Duration(graceDays) * 24 * time.Hour).Format(javaScriptISOStringUTC)
+	payload.CommentBody = buildWarningComment(target, payload, graceDays)
+	if roleCfg.DryRun || roleCfg.Limits.GlobalKillSwitch || r.github == nil {
+		payload.Outcome = outcomeDryRun
+		payload.Summary = "sweeper dry-run warning"
+		return payload, "skipped", payload.Summary, nil
+	}
+	comment, err := r.github.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: payload.Repo, IssueNumber: target.Number, Body: payload.CommentBody})
+	if err != nil {
+		return payload, "failed", "", err
+	}
+	payload.WarningCommentID = comment.ID
+	if err := r.github.AddIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: payload.Repo, IssueNumber: target.Number, Labels: []string{roleCfg.Lifecycle.PendingLabel}}); err != nil {
+		return payload, "failed", "", err
+	}
+	payload.Outcome = outcomePending
+	payload.Summary = fmt.Sprintf("sweeper warned %s #%d", targetKind(target.IsPR), target.Number)
+	return payload, "completed", payload.Summary, nil
+}
+
+func (r *Runner) processClose(ctx context.Context, queueItem storage.QueueItemRecord, payload sweeperPayload) (sweeperPayload, string, string, error) {
+	roleCfg := r.roleConfig(derefString(queueItem.ProjectID))
+	target, err := r.loadTarget(ctx, queueItem)
+	if err != nil {
+		return payload, "failed", "", err
+	}
+	payload.Phase = "close"
+	payload.Repo = derefString(queueItem.Repo)
+	payload.TargetType = queueItem.TargetType
+	payload.TargetNumber = target.Number
+	payload.PendingLabel = roleCfg.Lifecycle.PendingLabel
+	payload.ClosedLabel = roleCfg.Lifecycle.ClosedLabel
+	payload.KeepLabel = roleCfg.Lifecycle.KeepLabel
+	payload.QuarantineLabel = roleCfg.Security.QuarantineLabel
+	if strings.EqualFold(target.State, "closed") {
+		payload.Outcome = outcomeAlreadyClosedByHuman
+		payload.Summary = "target already closed"
+		return payload, "completed", payload.Summary, nil
+	}
+	if !hasLabel(target.Labels, roleCfg.Lifecycle.PendingLabel) || hasLabel(target.Labels, roleCfg.Lifecycle.KeepLabel) {
+		payload.Outcome = outcomeCancelled
+		payload.Summary = "sweeper warning cancelled"
+		if payload.WarningCommentID > 0 && r.github != nil && !roleCfg.DryRun {
+			_ = r.github.UpdateIssueComment(ctx, githubinfra.UpdateIssueCommentInput{Repo: payload.Repo, CommentID: payload.WarningCommentID, Body: payload.CommentBody + "\n\nCancellation noted by sweeper."})
+		}
+		return payload, "completed", payload.Summary, nil
+	}
+	category, _, rationale := classifyTarget(target, roleCfg)
+	if category == categoryRouteSecurity {
+		if roleCfg.DryRun || roleCfg.Limits.GlobalKillSwitch || r.github == nil {
+			payload.Outcome = outcomeDryRun
+			payload.Summary = "sweeper dry-run quarantine"
+			return payload, "skipped", payload.Summary, nil
+		}
+		if err := r.github.AddIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: payload.Repo, IssueNumber: target.Number, Labels: []string{roleCfg.Security.QuarantineLabel}}); err != nil {
+			return payload, "failed", "", err
+		}
+		_ = r.github.RemoveIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: payload.Repo, IssueNumber: target.Number, Labels: []string{roleCfg.Lifecycle.PendingLabel}})
+		payload.Outcome = outcomeQuarantined
+		payload.Summary = "sweeper quarantined target"
+		return payload, "completed", payload.Summary, nil
+	}
+	if category == categoryNone || (payload.Category != "" && category != payload.Category) {
+		payload.Outcome = outcomeCancelled
+		payload.Summary = "sweeper close cancelled"
+		return payload, "completed", payload.Summary, nil
+	}
+	closeComment := buildCloseComment(target, payload, rationale)
+	if roleCfg.DryRun || roleCfg.Limits.GlobalKillSwitch || r.github == nil {
+		payload.Outcome = outcomeDryRun
+		payload.Summary = "sweeper dry-run close"
+		return payload, "skipped", payload.Summary, nil
+	}
+	if _, err := r.github.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: payload.Repo, IssueNumber: target.Number, Body: closeComment}); err != nil {
+		return payload, "failed", "", err
+	}
+	if target.IsPR {
+		if err := r.github.ClosePullRequest(ctx, githubinfra.ClosePullRequestInput{Repo: payload.Repo, PRNumber: target.Number}); err != nil {
+			return payload, "failed", "", err
+		}
+	} else {
+		reason := "not_planned"
+		if category == categoryAlreadyFixed {
+			reason = "completed"
+		}
+		if err := r.github.CloseIssue(ctx, githubinfra.CloseIssueInput{Repo: payload.Repo, IssueNumber: target.Number, StateReason: reason}); err != nil {
+			return payload, "failed", "", err
+		}
+	}
+	if err := r.github.RemoveIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: payload.Repo, IssueNumber: target.Number, Labels: []string{roleCfg.Lifecycle.PendingLabel}}); err != nil {
+		return payload, "failed", "", err
+	}
+	if err := r.github.AddIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: payload.Repo, IssueNumber: target.Number, Labels: []string{roleCfg.Lifecycle.ClosedLabel}}); err != nil {
+		return payload, "failed", "", err
+	}
+	payload.Outcome = outcomeClosed
+	payload.Summary = fmt.Sprintf("sweeper closed %s #%d", targetKind(target.IsPR), target.Number)
+	return payload, "completed", payload.Summary, nil
+}
+
+func (r *Runner) processReconcile(ctx context.Context, queueItem storage.QueueItemRecord, payload sweeperPayload) (sweeperPayload, string, string, error) {
+	roleCfg := r.roleConfig(derefString(queueItem.ProjectID))
+	if r.github == nil {
+		payload.Outcome = outcomeNoAction
+		payload.Summary = defaultSkippedSummary
+		return payload, "skipped", payload.Summary, nil
+	}
+	target, err := r.loadTarget(ctx, queueItem)
+	if err != nil {
+		return payload, "failed", "", err
+	}
+	payload.Phase = "reconcile"
+	if hasLabel(target.Labels, roleCfg.Lifecycle.PendingLabel) {
+		payload.Summary = "sweeper reconcile: still pending"
+		return payload, "skipped", payload.Summary, nil
+	}
+	if payload.WarningCommentID > 0 && !roleCfg.DryRun {
+		_ = r.github.UpdateIssueComment(ctx, githubinfra.UpdateIssueCommentInput{Repo: derefString(queueItem.Repo), CommentID: payload.WarningCommentID, Body: payload.CommentBody + "\n\nCancellation acknowledged because the pending label was removed."})
+	}
+	payload.Outcome = outcomeCancelledByLabelRemoval
+	payload.Summary = "sweeper reconciled removed pending label"
+	return payload, "completed", payload.Summary, nil
+}
+
+func (r *Runner) loadTarget(ctx context.Context, item storage.QueueItemRecord) (liveTarget, error) {
+	if r.github == nil {
+		return liveTarget{}, nil
+	}
+	repo := derefString(item.Repo)
+	number, err := parseTargetNumber(item)
+	if err != nil {
+		return liveTarget{}, err
+	}
+	if item.TargetType == "pull_request" {
+		detail, err := r.github.ViewPullRequest(ctx, githubinfra.ViewPullRequestInput{Repo: repo, PRNumber: number})
+		if err != nil {
+			return liveTarget{}, err
+		}
+		return liveTarget{Number: detail.Number, State: detail.State, Title: detail.Title, Body: detail.Body, Author: detail.Author, Labels: append([]string(nil), detail.Labels...), IsPR: true, Draft: detail.IsDraft}, nil
+	}
+	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: number})
+	if err != nil {
+		return liveTarget{}, err
+	}
+	return liveTarget{Number: detail.Number, State: detail.State, Title: detail.Title, Body: detail.Body, Author: detail.Author, Labels: append([]string(nil), detail.Labels...)}, nil
+}
+
+func classifyTarget(target liveTarget, roleCfg config.SweeperRoleConfig) (string, int, string) {
+	text := strings.ToLower(target.Title + "\n" + target.Body)
+	if strings.Contains(text, "security") {
+		return categoryRouteSecurity, 100, "security-sensitive content detected"
+	}
+	if roleCfg.Categories.Superseded.Enabled && (strings.Contains(text, "duplicate of #") || strings.Contains(text, "superseded by #")) {
+		return categorySuperseded, maxConfidence(roleCfg.Categories.Superseded.MinConfidence), "target appears superseded by another issue or pull request"
+	}
+	if roleCfg.Categories.AlreadyFixed.Enabled && (strings.Contains(text, "fixed by #") || strings.Contains(text, "already fixed")) {
+		return categoryAlreadyFixed, maxConfidence(roleCfg.Categories.AlreadyFixed.MinConfidence), "target appears already fixed"
+	}
+	if !target.IsPR && roleCfg.Categories.Unrelated.Enabled && (strings.Contains(text, "support") || strings.Contains(text, "question")) {
+		return categoryUnrelated, maxConfidence(roleCfg.Categories.Unrelated.MinConfidence), "target appears unrelated to repository work"
+	}
+	if target.IsPR && roleCfg.Categories.AbandonedPR.Enabled {
+		return categoryAbandonedPR, maxConfidence(roleCfg.Categories.AbandonedPR.MinConfidence), "open pull request matched sweeper abandoned-pr heuristics"
+	}
+	if roleCfg.Categories.Stale.Enabled {
+		return categoryStale, maxConfidence(roleCfg.Categories.Stale.MinConfidence), "open item matched stale sweeper heuristics"
+	}
+	return categoryNone, 0, "no enabled sweeper category matched"
+}
+
+func buildWarningComment(target liveTarget, payload sweeperPayload, graceDays int) string {
+	return fmt.Sprintf("Looper sweeper flagged this %s as **%s**.\n\nReason: %s\n\nThis will be eligible for closure after %s unless someone comments or removes `%s`.\n<!-- looper:sweeper:warn id=%s -->", targetKind(target.IsPR), payload.Category, payload.Rationale, strings.TrimSpace(payload.CloseBy), payload.PendingLabel, payload.WarningMarkerUUID)
+}
+
+func buildCloseComment(target liveTarget, payload sweeperPayload, rationale string) string {
+	return fmt.Sprintf("Closing this %s as **%s**.\n\n%s\n\nOriginal notice comment id: %d\n<!-- looper:sweeper:close id=%s -->", targetKind(target.IsPR), payload.Category, rationale, payload.WarningCommentID, eventlog.NewEventID("sweeper"))
+}
+
+func gracePeriodForCategory(category string, roleCfg config.SweeperRoleConfig) int {
+	switch category {
+	case categoryAlreadyFixed:
+		return positiveOr(roleCfg.Categories.AlreadyFixed.GracePeriodDays, 7)
+	case categoryUnrelated:
+		return positiveOr(roleCfg.Categories.Unrelated.GracePeriodDays, 7)
+	case categorySuperseded:
+		return positiveOr(roleCfg.Categories.Superseded.GracePeriodDays, 7)
+	case categoryAbandonedPR:
+		return positiveOr(roleCfg.Categories.AbandonedPR.GracePeriodDays, 7)
+	default:
+		return positiveOr(roleCfg.Categories.Stale.GracePeriodDays, 7)
+	}
+}
+
+func (r *Runner) shouldSkipSummary(labels []string, author string, roleCfg config.SweeperRoleConfig) bool {
+	if hasAnyLabel(labels, roleCfg.Triggers.ExcludeLabels) || hasAnyLabel(labels, roleCfg.Triggers.LooperInternalLabels) || hasLabel(labels, roleCfg.Security.QuarantineLabel) || hasLabel(labels, roleCfg.Lifecycle.ClosedLabel) {
+		return true
+	}
+	for _, excluded := range roleCfg.Triggers.ExcludeAuthors {
+		if strings.EqualFold(strings.TrimSpace(excluded), strings.TrimSpace(author)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Runner) latestSweeperState(ctx context.Context) (map[string]sweeperPayload, error) {
+	items, err := r.repos.Queue.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]sweeperPayload{}
+	for _, item := range items {
+		if !strings.HasPrefix(item.Type, "sweeper") {
+			continue
+		}
+		payload := r.readPayload(item)
+		if payload.TargetNumber <= 0 && item.TargetID == "" {
+			continue
+		}
+		key := item.TargetID
+		if key == "" && item.Repo != nil {
+			key = buildTargetID(*item.Repo, payload.TargetNumber)
+		}
+		if key == "" {
+			continue
+		}
+		if _, exists := out[key]; exists {
+			continue
+		}
+		out[key] = payload
+	}
+	return out, nil
+}
+
+func (r *Runner) readPayload(item storage.QueueItemRecord) sweeperPayload {
+	if item.PayloadJSON == nil || strings.TrimSpace(*item.PayloadJSON) == "" {
+		return sweeperPayload{}
+	}
+	var envelope payloadEnvelope
+	if err := json.Unmarshal([]byte(*item.PayloadJSON), &envelope); err != nil {
+		return sweeperPayload{}
+	}
+	return envelope.Sweeper
+}
+
+func mustMarshalPayload(payload sweeperPayload) string {
+	encoded, _ := json.Marshal(payloadEnvelope{Sweeper: payload})
+	return string(encoded)
+}
+
+func (r *Runner) projectConfig(ctx context.Context, projectID string) (*storage.ProjectRecord, config.SweeperRoleConfig, error) {
+	if r.repos == nil || r.repos.Projects == nil {
+		return nil, config.SweeperRoleConfig{}, fmt.Errorf("sweeper project repository is not configured")
+	}
+	project, err := r.repos.Projects.GetByID(ctx, projectID)
+	if err != nil {
+		return nil, config.SweeperRoleConfig{}, err
+	}
+	if project == nil {
+		return nil, config.SweeperRoleConfig{}, fmt.Errorf("project not found: %s", projectID)
+	}
+	return project, r.roleConfig(projectID), nil
+}
+
+func (r *Runner) roleConfig(projectID string) config.SweeperRoleConfig {
+	if r.config == nil {
+		return config.SweeperRoleConfig{AutoDiscovery: true}
+	}
+	return config.ProjectRoleConfigs(*r.config, projectID).Sweeper
+}
+
+func (r *Runner) discoveryLimit(requested, fallback int) int {
+	if requested > 0 {
+		return requested
+	}
+	if fallback > 0 {
+		return fallback
+	}
+	return 10
 }
 
 func (r *Runner) autoDiscoveryEnabled(projectID string) bool {
@@ -146,4 +765,87 @@ func isSupportedQueueType(queueType string) bool {
 	default:
 		return false
 	}
+}
+
+func buildTargetID(repo string, number int64) string {
+	return fmt.Sprintf("%s#%d", repo, number)
+}
+
+func parseTargetNumber(item storage.QueueItemRecord) (int64, error) {
+	if item.PRNumber != nil && *item.PRNumber > 0 {
+		return *item.PRNumber, nil
+	}
+	parts := strings.Split(item.TargetID, "#")
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("invalid sweeper target id %q", item.TargetID)
+	}
+	return strconv.ParseInt(parts[1], 10, 64)
+}
+
+func dueForClose(closeBy string, now time.Time) bool {
+	if strings.TrimSpace(closeBy) == "" {
+		return false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, closeBy)
+	if err != nil {
+		parsed, err = time.Parse(javaScriptISOStringUTC, closeBy)
+		if err != nil {
+			return false
+		}
+	}
+	return !parsed.After(now.UTC())
+}
+
+func hasLabel(labels []string, want string) bool {
+	want = strings.TrimSpace(want)
+	if want == "" {
+		return false
+	}
+	for _, label := range labels {
+		if label == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAnyLabel(labels []string, want []string) bool {
+	for _, label := range want {
+		if hasLabel(labels, label) {
+			return true
+		}
+	}
+	return false
+}
+
+func targetKind(isPR bool) string {
+	if isPR {
+		return "pull request"
+	}
+	return "issue"
+}
+
+func maxConfidence(min int) int {
+	if min < 100 {
+		return min + (100-min)/2
+	}
+	return 100
+}
+
+func positiveOr(value, fallback int) int {
+	if value > 0 {
+		return value
+	}
+	return fallback
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -117,6 +117,11 @@ type sweeperPayload struct {
 	QuarantineLabel   string `json:"quarantine_label,omitempty"`
 }
 
+type sweeperStateRecord struct {
+	item    storage.QueueItemRecord
+	payload sweeperPayload
+}
+
 type liveTarget struct {
 	Number    int64
 	State     string
@@ -156,7 +161,7 @@ func (r *Runner) DiscoverReconcile(ctx context.Context, input DiscoveryInput) (D
 	if project.Archived || !roleCfg.AutoDiscovery {
 		return DiscoveryResult{Skipped: 1}, nil
 	}
-	states, err := r.latestSweeperState(ctx)
+	states, err := r.latestSweeperRecords(ctx)
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
@@ -166,10 +171,10 @@ func (r *Runner) DiscoverReconcile(ctx context.Context, input DiscoveryInput) (D
 		if len(items) >= limit {
 			break
 		}
-		if state.Repo != input.Repo || state.Outcome != outcomePending || state.Phase != "warn" {
+		if state.payload.Repo != input.Repo || state.payload.Outcome != outcomePending || state.payload.Phase != "warn" {
 			continue
 		}
-		queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeReconcile, TargetType: state.TargetType, TargetID: targetID, Number: state.TargetNumber, Payload: state})
+		queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeReconcile, TargetType: state.payload.TargetType, TargetID: targetID, Number: state.payload.TargetNumber, Payload: state.payload})
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
@@ -268,7 +273,7 @@ func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryI
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
-	states, err := r.latestSweeperState(ctx)
+	states, err := r.latestSweeperRecords(ctx)
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
@@ -284,16 +289,16 @@ func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryI
 			continue
 		}
 		targetID := buildTargetID(input.Repo, issue.Number)
-		if r.shouldSkipSummary(issue.Labels, issue.Author, issue.AuthorAssociation, roleCfg) {
+		if r.shouldSkipSummary(issue.Labels, issue.Author, issue.AuthorAssociation, states[targetID], roleCfg) {
 			result.Skipped++
 			continue
 		}
 		if hasLabel(issue.Labels, roleCfg.Lifecycle.PendingLabel) {
 			state, ok := states[targetID]
-			if !ok || state.Outcome != outcomePending || state.Phase != "warn" || !dueForClose(state.CloseBy, r.now()) || closeCount >= closeLimit {
+			if !ok || state.payload.Outcome != outcomePending || state.payload.Phase != "warn" || !dueForClose(state.payload.CloseBy, r.now()) || closeCount >= closeLimit {
 				continue
 			}
-			queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeClose, TargetType: "issue", TargetID: targetID, Number: issue.Number, Payload: state})
+			queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeClose, TargetType: "issue", TargetID: targetID, Number: issue.Number, Payload: state.payload})
 			if err != nil {
 				return DiscoveryResult{}, err
 			}
@@ -336,7 +341,7 @@ func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input Disc
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
-	states, err := r.latestSweeperState(ctx)
+	states, err := r.latestSweeperRecords(ctx)
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
@@ -353,16 +358,16 @@ func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input Disc
 			continue
 		}
 		targetID := buildTargetID(input.Repo, pr.Number)
-		if r.shouldSkipSummary(pr.Labels, pr.Author, pr.AuthorAssociation, roleCfg) {
+		if r.shouldSkipSummary(pr.Labels, pr.Author, pr.AuthorAssociation, states[targetID], roleCfg) {
 			result.Skipped++
 			continue
 		}
 		if hasLabel(pr.Labels, roleCfg.Lifecycle.PendingLabel) {
 			state, ok := states[targetID]
-			if !ok || state.Outcome != outcomePending || state.Phase != "warn" || !dueForClose(state.CloseBy, r.now()) || closeCount >= closeLimit {
+			if !ok || state.payload.Outcome != outcomePending || state.payload.Phase != "warn" || !dueForClose(state.payload.CloseBy, r.now()) || closeCount >= closeLimit {
 				continue
 			}
-			queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeClose, TargetType: "pull_request", TargetID: targetID, Number: pr.Number, Payload: state})
+			queueItem, ok, err := r.buildQueueItem(ctx, queueSeed{ProjectID: input.ProjectID, Repo: input.Repo, QueueType: QueueTypeClose, TargetType: "pull_request", TargetID: targetID, Number: pr.Number, Payload: state.payload})
 			if err != nil {
 				return DiscoveryResult{}, err
 			}
@@ -512,6 +517,9 @@ func (r *Runner) processClose(ctx context.Context, queueItem storage.QueueItemRe
 	payload.KeepLabel = roleCfg.Lifecycle.KeepLabel
 	payload.QuarantineLabel = roleCfg.Security.QuarantineLabel
 	if strings.EqualFold(target.State, "closed") {
+		if err := r.removePendingLabel(ctx, roleCfg, payload.Repo, target.Number); err != nil {
+			return payload, "failed", "", err
+		}
 		payload.Outcome = outcomeAlreadyClosedByHuman
 		payload.Summary = "target already closed"
 		return payload, "completed", payload.Summary, nil
@@ -553,6 +561,9 @@ func (r *Runner) processClose(ctx context.Context, queueItem storage.QueueItemRe
 		return payload, "completed", payload.Summary, nil
 	}
 	if category == categoryNone || (payload.Category != "" && category != payload.Category) {
+		if err := r.removePendingLabel(ctx, roleCfg, payload.Repo, target.Number); err != nil {
+			return payload, "failed", "", err
+		}
 		payload.Outcome = outcomeCancelled
 		payload.Summary = "sweeper close cancelled"
 		return payload, "completed", payload.Summary, nil
@@ -683,8 +694,11 @@ func gracePeriodForCategory(category string, roleCfg config.SweeperRoleConfig) i
 	}
 }
 
-func (r *Runner) shouldSkipSummary(labels []string, author string, authorAssociation string, roleCfg config.SweeperRoleConfig) bool {
-	if hasAnyLabel(labels, roleCfg.Triggers.ExcludeLabels) || hasAnyLabel(labels, roleCfg.Triggers.LooperInternalLabels) || hasLabel(labels, roleCfg.Security.QuarantineLabel) || hasLabel(labels, roleCfg.Lifecycle.ClosedLabel) {
+func (r *Runner) shouldSkipSummary(labels []string, author string, authorAssociation string, state sweeperStateRecord, roleCfg config.SweeperRoleConfig) bool {
+	if hasAnyLabel(labels, roleCfg.Triggers.ExcludeLabels) || hasAnyLabelExcept(labels, roleCfg.Triggers.LooperInternalLabels, roleCfg.Lifecycle.ClosedLabel) || hasLabel(labels, roleCfg.Security.QuarantineLabel) {
+		return true
+	}
+	if hasLabel(labels, roleCfg.Lifecycle.ClosedLabel) && r.reopenCooldownActive(state, roleCfg) {
 		return true
 	}
 	for _, excluded := range roleCfg.Triggers.ExcludeAuthors {
@@ -698,6 +712,18 @@ func (r *Runner) shouldSkipSummary(labels []string, author string, authorAssocia
 		}
 	}
 	return false
+}
+
+func (r *Runner) reopenCooldownActive(state sweeperStateRecord, roleCfg config.SweeperRoleConfig) bool {
+	if state.payload.Outcome != outcomeClosed {
+		return true
+	}
+	closedAt, ok := parseGitHubTimestamp(firstNonEmpty(state.item.UpdatedAt, state.item.CreatedAt))
+	if !ok {
+		return true
+	}
+	threshold := closedAt.Add(time.Duration(roleCfg.Triggers.ReopenCooldownDays) * 24 * time.Hour)
+	return r.now().UTC().Before(threshold)
 }
 
 func (r *Runner) discoveryBudgets(ctx context.Context, input DiscoveryInput, roleCfg config.SweeperRoleConfig) (int, int, error) {
@@ -755,12 +781,12 @@ func remainingCount(limit, used int) int {
 	return remaining
 }
 
-func (r *Runner) latestSweeperState(ctx context.Context) (map[string]sweeperPayload, error) {
+func (r *Runner) latestSweeperRecords(ctx context.Context) (map[string]sweeperStateRecord, error) {
 	items, err := r.repos.Queue.List(ctx)
 	if err != nil {
 		return nil, err
 	}
-	out := map[string]sweeperPayload{}
+	out := map[string]sweeperStateRecord{}
 	for _, item := range items {
 		if !strings.HasPrefix(item.Type, "sweeper") {
 			continue
@@ -779,7 +805,19 @@ func (r *Runner) latestSweeperState(ctx context.Context) (map[string]sweeperPayl
 		if _, exists := out[key]; exists {
 			continue
 		}
-		out[key] = payload
+		out[key] = sweeperStateRecord{item: item, payload: payload}
+	}
+	return out, nil
+}
+
+func (r *Runner) latestSweeperState(ctx context.Context) (map[string]sweeperPayload, error) {
+	records, err := r.latestSweeperRecords(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]sweeperPayload, len(records))
+	for key, record := range records {
+		out[key] = record.payload
 	}
 	return out, nil
 }
@@ -866,6 +904,13 @@ func parseTargetNumber(item storage.QueueItemRecord) (int64, error) {
 	return strconv.ParseInt(parts[1], 10, 64)
 }
 
+func (r *Runner) removePendingLabel(ctx context.Context, roleCfg config.SweeperRoleConfig, repo string, issueNumber int64) error {
+	if roleCfg.DryRun || r.github == nil {
+		return nil
+	}
+	return r.github.RemoveIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: repo, IssueNumber: issueNumber, Labels: []string{roleCfg.Lifecycle.PendingLabel}})
+}
+
 func dueForClose(closeBy string, now time.Time) bool {
 	if strings.TrimSpace(closeBy) == "" {
 		return false
@@ -902,6 +947,27 @@ func parseGitHubTimestamp(value string) (time.Time, bool) {
 		}
 	}
 	return parsed.UTC(), true
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func hasAnyLabelExcept(labels []string, candidates []string, except string) bool {
+	for _, candidate := range candidates {
+		if strings.EqualFold(strings.TrimSpace(candidate), strings.TrimSpace(except)) {
+			continue
+		}
+		if hasLabel(labels, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func hasLabel(labels []string, want string) bool {

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -274,6 +274,62 @@ func TestProcessCloseRemovesPendingLabelWhenKeepLabelCancelsClose(t *testing.T) 
 	}
 }
 
+func TestProcessCloseRemovesPendingLabelWhenTargetAlreadyClosed(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.DryRun = false
+	payload := sweeperPayload{Phase: "warn", Outcome: outcomePending, Category: categoryStale, Repo: "acme/looper", TargetType: "issue", TargetNumber: 42, WarningCommentID: 99, WarningMarkerUUID: "marker", CommentBody: "warning", PendingLabel: "looper:sweep-pending"}
+	payloadJSON := mustMarshalPayload(payload)
+	fixture.github.issueDetails["acme/looper#42"] = githubinfra.IssueDetail{Number: 42, Title: "Bug", Body: "stale", State: "closed", UpdatedAt: fixture.now.Add(-91 * 24 * time.Hour).Format(time.RFC3339), Author: "octo", Labels: []string{"looper:sweep-pending"}}
+	queueID := "queue_sweeper_close_already_closed"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &fixture.projectID, Type: QueueTypeClose, TargetType: "issue", TargetID: "acme/looper#42", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:close:acme/looper#42", Priority: 1, Status: "running", AvailableAt: fixture.nowISO, MaxAttempts: 3, PayloadJSON: &payloadJSON, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeClose})
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "completed" {
+		t.Fatalf("ProcessClaimedQueueItem() = %#v, want completed result", result)
+	}
+	if !containsString(fixture.github.removedLabels["acme/looper#42"], "looper:sweep-pending") {
+		t.Fatalf("removed labels = %#v, want pending removed for already closed target", fixture.github.removedLabels)
+	}
+	if len(fixture.github.closedIssues) != 0 {
+		t.Fatalf("closedIssues = %#v, want no close when target is already closed", fixture.github.closedIssues)
+	}
+}
+
+func TestProcessCloseRemovesPendingLabelWhenReclassificationCancelsClose(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.DryRun = false
+	payload := sweeperPayload{Phase: "warn", Outcome: outcomePending, Category: categoryStale, Repo: "acme/looper", TargetType: "issue", TargetNumber: 42, WarningCommentID: 99, WarningMarkerUUID: "marker", CommentBody: "warning", PendingLabel: "looper:sweep-pending"}
+	payloadJSON := mustMarshalPayload(payload)
+	fixture.github.issueDetails["acme/looper#42"] = githubinfra.IssueDetail{Number: 42, Title: "Bug", Body: "fresh activity", State: "open", UpdatedAt: fixture.now.Format(time.RFC3339), Author: "octo", Labels: []string{"looper:sweep-pending"}}
+	queueID := "queue_sweeper_close_reclassified"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &fixture.projectID, Type: QueueTypeClose, TargetType: "issue", TargetID: "acme/looper#42", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:close:acme/looper#42", Priority: 1, Status: "running", AvailableAt: fixture.nowISO, MaxAttempts: 3, PayloadJSON: &payloadJSON, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeClose})
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "completed" {
+		t.Fatalf("ProcessClaimedQueueItem() = %#v, want completed result", result)
+	}
+	if !containsString(fixture.github.removedLabels["acme/looper#42"], "looper:sweep-pending") {
+		t.Fatalf("removed labels = %#v, want pending removed when close is cancelled", fixture.github.removedLabels)
+	}
+	if len(fixture.github.closedIssues) != 0 {
+		t.Fatalf("closedIssues = %#v, want no close when classification changes", fixture.github.closedIssues)
+	}
+}
+
 func TestProcessReconcileCancelsWhenPendingLabelRemoved(t *testing.T) {
 	t.Parallel()
 
@@ -341,6 +397,49 @@ func TestDiscoverIssuesSkipsExcludedAuthorAssociations(t *testing.T) {
 	}
 	if len(result.QueueItems) != 0 || result.Skipped != 1 {
 		t.Fatalf("DiscoverIssues() = %#v, want excluded association to be skipped", result)
+	}
+}
+
+func TestDiscoverIssuesSkipsReopenedSweptItemWithinCooldown(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo", Labels: []string{fixture.cfg.Roles.Sweeper.Lifecycle.ClosedLabel}}}
+	closedAt := fixture.now.Add(-10 * 24 * time.Hour).Format(javaScriptISOStringUTC)
+	payloadJSON := mustMarshalPayload(sweeperPayload{Phase: "close", Outcome: outcomeClosed, Repo: "acme/looper", TargetType: "issue", TargetNumber: 1, ClosedLabel: fixture.cfg.Roles.Sweeper.Lifecycle.ClosedLabel})
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_sweeper_closed_recent", ProjectID: &fixture.projectID, Type: QueueTypeClose, TargetType: "issue", TargetID: "acme/looper#1", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:close:acme/looper#1", Priority: 1, Status: "completed", AvailableAt: closedAt, MaxAttempts: 3, PayloadJSON: &payloadJSON, CreatedAt: closedAt, UpdatedAt: closedAt}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || result.Skipped != 1 {
+		t.Fatalf("DiscoverIssues() = %#v, want reopened swept item skipped within cooldown", result)
+	}
+}
+
+func TestDiscoverIssuesAllowsReopenedSweptItemAfterCooldown(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo", Labels: []string{fixture.cfg.Roles.Sweeper.Lifecycle.ClosedLabel}}}
+	closedAt := fixture.now.Add(-31 * 24 * time.Hour).Format(javaScriptISOStringUTC)
+	payloadJSON := mustMarshalPayload(sweeperPayload{Phase: "close", Outcome: outcomeClosed, Repo: "acme/looper", TargetType: "issue", TargetNumber: 1, ClosedLabel: fixture.cfg.Roles.Sweeper.Lifecycle.ClosedLabel})
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_sweeper_closed_old", ProjectID: &fixture.projectID, Type: QueueTypeClose, TargetType: "issue", TargetID: "acme/looper#1", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:close:acme/looper#1", Priority: 1, Status: "completed", AvailableAt: closedAt, MaxAttempts: 3, PayloadJSON: &payloadJSON, CreatedAt: closedAt, UpdatedAt: closedAt}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("DiscoverIssues() queue items = %#v, want reopened swept item re-queued after cooldown", result.QueueItems)
+	}
+	if result.QueueItems[0].Type != QueueTypeWarn {
+		t.Fatalf("QueueItems[0].Type = %q, want %q", result.QueueItems[0].Type, QueueTypeWarn)
 	}
 }
 

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -3,10 +3,13 @@ package sweeper
 import (
 	"context"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -35,31 +38,118 @@ func TestDiscoverIssuesSkipsWhenAutoDiscoveryDisabledForProject(t *testing.T) {
 	}
 }
 
-func TestProcessClaimedQueueItemCompletesSupportedTypesAsSkipped(t *testing.T) {
+func TestDiscoverIssuesEnqueuesWarnAndCloseCandidates(t *testing.T) {
 	t.Parallel()
 
-	repos := newTestRepositories(t)
-	now := time.Date(2026, time.May, 9, 12, 0, 0, 0, time.UTC)
-	nowISO := now.Format(javaScriptISOStringUTC)
-	queueID := "queue_sweeper_warn_1"
-	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeWarn, TargetType: "issue", TargetID: "acme/looper#42", DedupeKey: "sweeper:warn:acme/looper#42", Priority: 1, Status: "running", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+	fixture := newRunnerFixture(t)
+	fixture.github.issues = []githubinfra.IssueSummary{
+		{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo", Labels: nil},
+		{Number: 2, Title: "pending bug", Body: "already warned", Author: "octo", Labels: []string{"looper:sweep-pending"}},
+	}
+	payload := mustMarshalPayload(sweeperPayload{Phase: "warn", Outcome: outcomePending, Repo: "acme/looper", TargetType: "issue", TargetNumber: 2, CloseBy: fixture.now.Add(-24 * time.Hour).Format(javaScriptISOStringUTC)})
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "prior-warn", ProjectID: stringPtr(fixture.projectID), Type: QueueTypeWarn, TargetType: "issue", TargetID: "acme/looper#2", Repo: stringPtr("acme/looper"), DedupeKey: "done:warn:2", Priority: 1, Status: "completed", AvailableAt: fixture.nowISO, PayloadJSON: &payload, MaxAttempts: 3, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
 		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
 
-	runner := New(Options{Repos: repos, Now: func() time.Time { return now }})
-	result, err := runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeWarn})
+	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 2 {
+		t.Fatalf("len(QueueItems) = %d, want 2", len(result.QueueItems))
+	}
+	types := []string{result.QueueItems[0].Type, result.QueueItems[1].Type}
+	if !(containsString(types, QueueTypeWarn) && containsString(types, QueueTypeClose)) {
+		t.Fatalf("queue types = %v, want warn and close", types)
+	}
+}
+
+func TestProcessWarnPostsWarningAndMarksPending(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.DryRun = false
+	fixture.github.issueDetails["acme/looper#42"] = githubinfra.IssueDetail{Number: 42, Title: "Bug", Body: "already fixed by #9", State: "open", Author: "octo", Labels: nil}
+	queueID := "queue_sweeper_warn_1"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &fixture.projectID, Type: QueueTypeWarn, TargetType: "issue", TargetID: "acme/looper#42", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:warn:acme/looper#42", Priority: 1, Status: "running", AvailableAt: fixture.nowISO, MaxAttempts: 3, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeWarn})
 	if err != nil {
 		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
 	}
-	if result == nil || result.Status != "skipped" || result.QueueItemID != queueID {
-		t.Fatalf("ProcessClaimedQueueItem() = %#v, want skipped result for %s", result, queueID)
+	if result == nil || result.Status != "completed" {
+		t.Fatalf("ProcessClaimedQueueItem() = %#v, want completed result", result)
 	}
-	stored, err := repos.Queue.GetByID(context.Background(), queueID)
+	if len(fixture.github.createdComments) != 1 {
+		t.Fatalf("createdComments = %d, want 1", len(fixture.github.createdComments))
+	}
+	if len(fixture.github.addedLabels["acme/looper#42"]) != 1 || fixture.github.addedLabels["acme/looper#42"][0] != "looper:sweep-pending" {
+		t.Fatalf("addedLabels = %#v, want pending label", fixture.github.addedLabels)
+	}
+	stored, err := fixture.repos.Queue.GetByID(context.Background(), queueID)
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if stored == nil || stored.Status != "completed" {
-		t.Fatalf("stored queue item = %#v, want completed status", stored)
+	payload := fixture.runner.readPayload(*stored)
+	if payload.Outcome != outcomePending || payload.WarningCommentID == 0 {
+		t.Fatalf("payload = %#v, want pending outcome with comment id", payload)
+	}
+}
+
+func TestProcessCloseClosesAndReconcilesLabels(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.DryRun = false
+	payload := sweeperPayload{Phase: "warn", Outcome: outcomePending, Category: categoryAlreadyFixed, Repo: "acme/looper", TargetType: "issue", TargetNumber: 42, WarningCommentID: 99, WarningMarkerUUID: "marker", CommentBody: "warning", PendingLabel: "looper:sweep-pending"}
+	payloadJSON := mustMarshalPayload(payload)
+	fixture.github.issueDetails["acme/looper#42"] = githubinfra.IssueDetail{Number: 42, Title: "Bug", Body: "already fixed by #9", State: "open", Author: "octo", Labels: []string{"looper:sweep-pending"}}
+	queueID := "queue_sweeper_close_1"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &fixture.projectID, Type: QueueTypeClose, TargetType: "issue", TargetID: "acme/looper#42", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:close:acme/looper#42", Priority: 1, Status: "running", AvailableAt: fixture.nowISO, MaxAttempts: 3, PayloadJSON: &payloadJSON, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeClose})
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "completed" {
+		t.Fatalf("ProcessClaimedQueueItem() = %#v, want completed result", result)
+	}
+	if fixture.github.closedIssues[0].StateReason != "completed" {
+		t.Fatalf("closed issue reason = %#v, want completed", fixture.github.closedIssues)
+	}
+	if !containsString(fixture.github.removedLabels["acme/looper#42"], "looper:sweep-pending") {
+		t.Fatalf("removed labels = %#v, want pending removed", fixture.github.removedLabels)
+	}
+	if !containsString(fixture.github.addedLabels["acme/looper#42"], "looper:swept") {
+		t.Fatalf("added labels = %#v, want swept label", fixture.github.addedLabels)
+	}
+}
+
+func TestProcessReconcileCancelsWhenPendingLabelRemoved(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.DryRun = false
+	payloadJSON := mustMarshalPayload(sweeperPayload{Phase: "warn", Outcome: outcomePending, Repo: "acme/looper", TargetType: "issue", TargetNumber: 7, WarningCommentID: 123, CommentBody: "warning"})
+	fixture.github.issueDetails["acme/looper#7"] = githubinfra.IssueDetail{Number: 7, Title: "Bug", Body: "stale", State: "open", Author: "octo", Labels: nil}
+	queueID := "queue_sweeper_reconcile_1"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &fixture.projectID, Type: QueueTypeReconcile, TargetType: "issue", TargetID: "acme/looper#7", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:reconcile:acme/looper#7", Priority: 1, Status: "running", AvailableAt: fixture.nowISO, MaxAttempts: 3, PayloadJSON: &payloadJSON, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeReconcile})
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "completed" {
+		t.Fatalf("ProcessClaimedQueueItem() = %#v, want completed result", result)
+	}
+	if len(fixture.github.updatedComments) != 1 || !strings.Contains(fixture.github.updatedComments[0].Body, "pending label was removed") {
+		t.Fatalf("updatedComments = %#v, want cancellation note", fixture.github.updatedComments)
 	}
 }
 
@@ -74,6 +164,35 @@ func TestProcessClaimedQueueItemRejectsUnsupportedQueueType(t *testing.T) {
 	if result != nil {
 		t.Fatalf("ProcessClaimedQueueItem() result = %#v, want nil on unsupported type", result)
 	}
+}
+
+type runnerFixture struct {
+	repos     *storage.Repositories
+	runner    *Runner
+	github    *stubGitHub
+	cfg       *config.Config
+	projectID string
+	now       time.Time
+	nowISO    string
+}
+
+func newRunnerFixture(t *testing.T) runnerFixture {
+	t.Helper()
+	repos := newTestRepositories(t)
+	now := time.Date(2026, time.May, 9, 12, 0, 0, 0, time.UTC)
+	nowISO := now.Format(javaScriptISOStringUTC)
+	projectID := "demo"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Demo", RepoPath: filepath.Join(t.TempDir(), "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Sweeper.AutoDiscovery = true
+	github := &stubGitHub{issueDetails: map[string]githubinfra.IssueDetail{}, prDetails: map[string]githubinfra.PullRequestDetail{}, addedLabels: map[string][]string{}, removedLabels: map[string][]string{}}
+	runner := New(Options{Repos: repos, GitHub: github, Now: func() time.Time { return now }, Config: &cfg})
+	return runnerFixture{repos: repos, runner: runner, github: github, cfg: &cfg, projectID: projectID, now: now, nowISO: nowISO}
 }
 
 func newTestRepositories(t *testing.T) *storage.Repositories {
@@ -91,4 +210,78 @@ func newTestRepositories(t *testing.T) *storage.Repositories {
 		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
 	}
 	return storage.NewRepositories(coordinator.DB())
+}
+
+type stubGitHub struct {
+	issues          []githubinfra.IssueSummary
+	prs             []githubinfra.PullRequestSummary
+	issueDetails    map[string]githubinfra.IssueDetail
+	prDetails       map[string]githubinfra.PullRequestDetail
+	createdComments []githubinfra.IssueCommentInput
+	updatedComments []githubinfra.UpdateIssueCommentInput
+	closedIssues    []githubinfra.CloseIssueInput
+	closedPRs       []githubinfra.ClosePullRequestInput
+	addedLabels     map[string][]string
+	removedLabels   map[string][]string
+}
+
+func (g *stubGitHub) ListOpenIssues(context.Context, githubinfra.ListOpenIssuesInput) ([]githubinfra.IssueSummary, error) {
+	return append([]githubinfra.IssueSummary(nil), g.issues...), nil
+}
+
+func (g *stubGitHub) ListOpenPullRequests(context.Context, githubinfra.ListOpenPullRequestsInput) ([]githubinfra.PullRequestSummary, error) {
+	return append([]githubinfra.PullRequestSummary(nil), g.prs...), nil
+}
+
+func (g *stubGitHub) ViewIssue(_ context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
+	return g.issueDetails[input.Repo+"#"+itoa(input.IssueNumber)], nil
+}
+
+func (g *stubGitHub) ViewPullRequest(_ context.Context, input githubinfra.ViewPullRequestInput) (githubinfra.PullRequestDetail, error) {
+	return g.prDetails[input.Repo+"#"+itoa(input.PRNumber)], nil
+}
+
+func (g *stubGitHub) CreateIssueComment(_ context.Context, input githubinfra.IssueCommentInput) (githubinfra.IssueCommentResult, error) {
+	g.createdComments = append(g.createdComments, input)
+	return githubinfra.IssueCommentResult{ID: int64(len(g.createdComments))}, nil
+}
+
+func (g *stubGitHub) UpdateIssueComment(_ context.Context, input githubinfra.UpdateIssueCommentInput) error {
+	g.updatedComments = append(g.updatedComments, input)
+	return nil
+}
+
+func (g *stubGitHub) CloseIssue(_ context.Context, input githubinfra.CloseIssueInput) error {
+	g.closedIssues = append(g.closedIssues, input)
+	return nil
+}
+
+func (g *stubGitHub) ClosePullRequest(_ context.Context, input githubinfra.ClosePullRequestInput) error {
+	g.closedPRs = append(g.closedPRs, input)
+	return nil
+}
+
+func (g *stubGitHub) AddIssueLabels(_ context.Context, input githubinfra.IssueLabelsInput) error {
+	key := input.Repo + "#" + itoa(input.IssueNumber)
+	g.addedLabels[key] = append(g.addedLabels[key], input.Labels...)
+	return nil
+}
+
+func (g *stubGitHub) RemoveIssueLabels(_ context.Context, input githubinfra.IssueLabelsInput) error {
+	key := input.Repo + "#" + itoa(input.IssueNumber)
+	g.removedLabels[key] = append(g.removedLabels[key], input.Labels...)
+	return nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func itoa(value int64) string {
+	return strings.TrimSpace(strconv.FormatInt(value, 10))
 }

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -1,0 +1,94 @@
+package sweeper
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestDiscoverIssuesSkipsWhenAutoDiscoveryDisabledForProject(t *testing.T) {
+	t.Parallel()
+
+	repos := newTestRepositories(t)
+	now := time.Date(2026, time.May, 9, 12, 0, 0, 0, time.UTC)
+	nowISO := now.Format(javaScriptISOStringUTC)
+	projectID := "demo"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Demo", RepoPath: filepath.Join(t.TempDir(), "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	defaultConfig, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	runner := New(Options{Repos: repos, Now: func() time.Time { return now }, Config: &defaultConfig})
+	result, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if result.Skipped != 1 || len(result.QueueItems) != 0 {
+		t.Fatalf("DiscoverIssues() = %#v, want one skipped result with no queue items", result)
+	}
+}
+
+func TestProcessClaimedQueueItemCompletesSupportedTypesAsSkipped(t *testing.T) {
+	t.Parallel()
+
+	repos := newTestRepositories(t)
+	now := time.Date(2026, time.May, 9, 12, 0, 0, 0, time.UTC)
+	nowISO := now.Format(javaScriptISOStringUTC)
+	queueID := "queue_sweeper_warn_1"
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeWarn, TargetType: "issue", TargetID: "acme/looper#42", DedupeKey: "sweeper:warn:acme/looper#42", Priority: 1, Status: "running", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	runner := New(Options{Repos: repos, Now: func() time.Time { return now }})
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeWarn})
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "skipped" || result.QueueItemID != queueID {
+		t.Fatalf("ProcessClaimedQueueItem() = %#v, want skipped result for %s", result, queueID)
+	}
+	stored, err := repos.Queue.GetByID(context.Background(), queueID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if stored == nil || stored.Status != "completed" {
+		t.Fatalf("stored queue item = %#v, want completed status", stored)
+	}
+}
+
+func TestProcessClaimedQueueItemRejectsUnsupportedQueueType(t *testing.T) {
+	t.Parallel()
+
+	runner := New(Options{})
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: "queue_1", Type: "worker"})
+	if err == nil {
+		t.Fatal("ProcessClaimedQueueItem() error = nil, want unsupported type error")
+	}
+	if result != nil {
+		t.Fatalf("ProcessClaimedQueueItem() result = %#v, want nil on unsupported type", result)
+	}
+}
+
+func newTestRepositories(t *testing.T) *storage.Repositories {
+	t.Helper()
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := coordinator.Close(); err != nil {
+			t.Fatalf("coordinator.Close() error = %v", err)
+		}
+	})
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
+	}
+	return storage.NewRepositories(coordinator.DB())
+}

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -43,7 +43,7 @@ func TestDiscoverIssuesEnqueuesWarnAndCloseCandidates(t *testing.T) {
 
 	fixture := newRunnerFixture(t)
 	fixture.github.issues = []githubinfra.IssueSummary{
-		{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo", Labels: nil},
+		{Number: 1, Title: "stale bug", Body: "needs cleanup", UpdatedAt: fixture.now.Add(-91 * 24 * time.Hour).Format(time.RFC3339), Author: "octo", Labels: nil},
 		{Number: 2, Title: "pending bug", Body: "already warned", Author: "octo", Labels: []string{"looper:sweep-pending"}},
 	}
 	payload := mustMarshalPayload(sweeperPayload{Phase: "warn", Outcome: outcomePending, Repo: "acme/looper", TargetType: "issue", TargetNumber: 2, CloseBy: fixture.now.Add(-24 * time.Hour).Format(javaScriptISOStringUTC)})
@@ -61,6 +61,29 @@ func TestDiscoverIssuesEnqueuesWarnAndCloseCandidates(t *testing.T) {
 	types := []string{result.QueueItems[0].Type, result.QueueItems[1].Type}
 	if !(containsString(types, QueueTypeWarn) && containsString(types, QueueTypeClose)) {
 		t.Fatalf("queue types = %v, want warn and close", types)
+	}
+}
+
+func TestProcessWarnSkipsFreshStaleIssueCandidates(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.DryRun = false
+	fixture.github.issueDetails["acme/looper#1"] = githubinfra.IssueDetail{Number: 1, Title: "fresh bug", Body: "needs cleanup", State: "open", UpdatedAt: fixture.now.Add(-24 * time.Hour).Format(time.RFC3339), Author: "octo"}
+	queueID := "queue_sweeper_warn_fresh_issue"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &fixture.projectID, Type: QueueTypeWarn, TargetType: "issue", TargetID: "acme/looper#1", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:warn:acme/looper#1", Priority: 1, Status: "running", AvailableAt: fixture.nowISO, MaxAttempts: 3, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeWarn})
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "skipped" {
+		t.Fatalf("ProcessClaimedQueueItem() = %#v, want skipped result", result)
+	}
+	if len(fixture.github.createdComments) != 0 {
+		t.Fatalf("createdComments = %#v, want no warning comment for a recently updated issue", fixture.github.createdComments)
 	}
 }
 
@@ -99,6 +122,29 @@ func TestDiscoverPullRequestsSkipsWhenPRLaneDisabled(t *testing.T) {
 	}
 	if fixture.github.listPRCalls != 0 {
 		t.Fatalf("ListOpenPullRequests() calls = %d, want 0", fixture.github.listPRCalls)
+	}
+}
+
+func TestProcessWarnSkipsFreshAbandonedPRCandidates(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.DryRun = false
+	fixture.github.prDetails["acme/looper#1"] = githubinfra.PullRequestDetail{Number: 1, Title: "fresh pr", Body: "work in progress", State: "open", UpdatedAt: fixture.now.Add(-24 * time.Hour).Format(time.RFC3339), Author: "octo"}
+	queueID := "queue_sweeper_warn_fresh_pr"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &fixture.projectID, Type: QueueTypeWarn, TargetType: "pull_request", TargetID: "acme/looper#1", Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(1), DedupeKey: "sweeper:warn:acme/looper#1", Priority: 1, Status: "running", AvailableAt: fixture.nowISO, MaxAttempts: 3, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeWarn})
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "skipped" {
+		t.Fatalf("ProcessClaimedQueueItem() = %#v, want skipped result", result)
+	}
+	if len(fixture.github.createdComments) != 0 {
+		t.Fatalf("createdComments = %#v, want no warning comment for a recently updated pull request", fixture.github.createdComments)
 	}
 }
 
@@ -176,7 +222,7 @@ func TestProcessCloseClosesAndReconcilesLabels(t *testing.T) {
 	fixture.cfg.Roles.Sweeper.DryRun = false
 	payload := sweeperPayload{Phase: "warn", Outcome: outcomePending, Category: categoryAlreadyFixed, Repo: "acme/looper", TargetType: "issue", TargetNumber: 42, WarningCommentID: 99, WarningMarkerUUID: "marker", CommentBody: "warning", PendingLabel: "looper:sweep-pending"}
 	payloadJSON := mustMarshalPayload(payload)
-	fixture.github.issueDetails["acme/looper#42"] = githubinfra.IssueDetail{Number: 42, Title: "Bug", Body: "already fixed by #9", State: "open", Author: "octo", Labels: []string{"looper:sweep-pending"}}
+	fixture.github.issueDetails["acme/looper#42"] = githubinfra.IssueDetail{Number: 42, Title: "Bug", Body: "already fixed by #9", State: "open", UpdatedAt: fixture.now.Add(-8 * 24 * time.Hour).Format(time.RFC3339), Author: "octo", Labels: []string{"looper:sweep-pending"}}
 	queueID := "queue_sweeper_close_1"
 	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &fixture.projectID, Type: QueueTypeClose, TargetType: "issue", TargetID: "acme/looper#42", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:close:acme/looper#42", Priority: 1, Status: "running", AvailableAt: fixture.nowISO, MaxAttempts: 3, PayloadJSON: &payloadJSON, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
 		t.Fatalf("Queue.Upsert() error = %v", err)
@@ -197,6 +243,34 @@ func TestProcessCloseClosesAndReconcilesLabels(t *testing.T) {
 	}
 	if !containsString(fixture.github.addedLabels["acme/looper#42"], "looper:swept") {
 		t.Fatalf("added labels = %#v, want swept label", fixture.github.addedLabels)
+	}
+}
+
+func TestProcessCloseRemovesPendingLabelWhenKeepLabelCancelsClose(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.DryRun = false
+	payload := sweeperPayload{Phase: "warn", Outcome: outcomePending, Category: categoryStale, Repo: "acme/looper", TargetType: "issue", TargetNumber: 42, WarningCommentID: 99, WarningMarkerUUID: "marker", CommentBody: "warning", PendingLabel: "looper:sweep-pending"}
+	payloadJSON := mustMarshalPayload(payload)
+	fixture.github.issueDetails["acme/looper#42"] = githubinfra.IssueDetail{Number: 42, Title: "Bug", Body: "stale", State: "open", UpdatedAt: fixture.now.Add(-91 * 24 * time.Hour).Format(time.RFC3339), Author: "octo", Labels: []string{"looper:sweep-pending", fixture.cfg.Roles.Sweeper.Lifecycle.KeepLabel}}
+	queueID := "queue_sweeper_close_keep"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &fixture.projectID, Type: QueueTypeClose, TargetType: "issue", TargetID: "acme/looper#42", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:close:acme/looper#42", Priority: 1, Status: "running", AvailableAt: fixture.nowISO, MaxAttempts: 3, PayloadJSON: &payloadJSON, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeClose})
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "completed" {
+		t.Fatalf("ProcessClaimedQueueItem() = %#v, want completed result", result)
+	}
+	if !containsString(fixture.github.removedLabels["acme/looper#42"], "looper:sweep-pending") {
+		t.Fatalf("removed labels = %#v, want pending removed when keep label cancels close", fixture.github.removedLabels)
+	}
+	if len(fixture.github.closedIssues) != 0 {
+		t.Fatalf("closedIssues = %#v, want no close when keep label is present", fixture.github.closedIssues)
 	}
 }
 
@@ -405,4 +479,8 @@ func containsString(values []string, want string) bool {
 
 func itoa(value int64) string {
 	return strings.TrimSpace(strconv.FormatInt(value, 10))
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
 }

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -64,6 +64,77 @@ func TestDiscoverIssuesEnqueuesWarnAndCloseCandidates(t *testing.T) {
 	}
 }
 
+func TestDiscoverIssuesSkipsWhenIssueLaneDisabled(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.Triggers.IncludeIssues = false
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo"}}
+
+	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if result.Skipped != 1 || len(result.QueueItems) != 0 {
+		t.Fatalf("DiscoverIssues() = %#v, want one skipped result with no queue items", result)
+	}
+	if fixture.github.listIssuesCalls != 0 {
+		t.Fatalf("ListOpenIssues() calls = %d, want 0", fixture.github.listIssuesCalls)
+	}
+}
+
+func TestDiscoverPullRequestsSkipsWhenPRLaneDisabled(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.Triggers.IncludePullRequests = false
+	fixture.github.prs = []githubinfra.PullRequestSummary{{Number: 1, Title: "stale pr", Author: "octo"}}
+
+	result, err := fixture.runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if result.Skipped != 1 || len(result.QueueItems) != 0 {
+		t.Fatalf("DiscoverPullRequests() = %#v, want one skipped result with no queue items", result)
+	}
+	if fixture.github.listPRCalls != 0 {
+		t.Fatalf("ListOpenPullRequests() calls = %d, want 0", fixture.github.listPRCalls)
+	}
+}
+
+func TestDiscoverIssuesHonorsDailyWarnAndCloseLimits(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.Limits.MaxWarningsPerRepoPerDay = 1
+	fixture.cfg.Roles.Sweeper.Limits.MaxClosesPerRepoPerDay = 1
+	fixture.github.issues = []githubinfra.IssueSummary{
+		{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo", Labels: nil},
+		{Number: 2, Title: "pending bug", Body: "already warned", Author: "octo", Labels: []string{"looper:sweep-pending"}},
+	}
+	priorWarn := mustMarshalPayload(sweeperPayload{Phase: "warn", Outcome: outcomePending, Repo: "acme/looper", TargetType: "issue", TargetNumber: 9})
+	priorClose := mustMarshalPayload(sweeperPayload{Phase: "close", Outcome: outcomeClosed, Repo: "acme/looper", TargetType: "issue", TargetNumber: 10})
+	closeState := mustMarshalPayload(sweeperPayload{Phase: "warn", Outcome: outcomePending, Repo: "acme/looper", TargetType: "issue", TargetNumber: 2, CloseBy: fixture.now.Add(-24 * time.Hour).Format(javaScriptISOStringUTC)})
+	for _, item := range []storage.QueueItemRecord{
+		{ID: "prior-warn", ProjectID: stringPtr(fixture.projectID), Type: QueueTypeWarn, TargetType: "issue", TargetID: "acme/looper#9", Repo: stringPtr("acme/looper"), DedupeKey: "done:warn:9", Priority: 1, Status: "completed", AvailableAt: fixture.nowISO, PayloadJSON: &priorWarn, MaxAttempts: 3, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO},
+		{ID: "prior-close", ProjectID: stringPtr(fixture.projectID), Type: QueueTypeClose, TargetType: "issue", TargetID: "acme/looper#10", Repo: stringPtr("acme/looper"), DedupeKey: "done:close:10", Priority: 1, Status: "completed", AvailableAt: fixture.nowISO, PayloadJSON: &priorClose, MaxAttempts: 3, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO},
+		{ID: "close-state", ProjectID: stringPtr(fixture.projectID), Type: QueueTypeWarn, TargetType: "issue", TargetID: "acme/looper#2", Repo: stringPtr("acme/looper"), DedupeKey: "done:warn:2", Priority: 1, Status: "completed", AvailableAt: fixture.nowISO, PayloadJSON: &closeState, MaxAttempts: 3, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO},
+	} {
+		item := item
+		if err := fixture.repos.Queue.Upsert(context.Background(), item); err != nil {
+			t.Fatalf("Queue.Upsert() error = %v", err)
+		}
+	}
+
+	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want none after daily budgets exhausted", result.QueueItems)
+	}
+}
+
 func TestProcessWarnPostsWarningAndMarksPending(t *testing.T) {
 	t.Parallel()
 
@@ -153,6 +224,52 @@ func TestProcessReconcileCancelsWhenPendingLabelRemoved(t *testing.T) {
 	}
 }
 
+func TestProcessReconcileKeepsWarnPhaseWhilePendingLabelRemains(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.DryRun = false
+	payloadJSON := mustMarshalPayload(sweeperPayload{Phase: "warn", Outcome: outcomePending, Repo: "acme/looper", TargetType: "issue", TargetNumber: 7, WarningCommentID: 123, CommentBody: "warning"})
+	fixture.github.issueDetails["acme/looper#7"] = githubinfra.IssueDetail{Number: 7, Title: "Bug", Body: "stale", State: "open", Author: "octo", Labels: []string{"looper:sweep-pending"}}
+	queueID := "queue_sweeper_reconcile_pending"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: &fixture.projectID, Type: QueueTypeReconcile, TargetType: "issue", TargetID: "acme/looper#7", Repo: stringPtr("acme/looper"), DedupeKey: "sweeper:reconcile:acme/looper#7", Priority: 1, Status: "running", AvailableAt: fixture.nowISO, MaxAttempts: 3, PayloadJSON: &payloadJSON, CreatedAt: fixture.nowISO, UpdatedAt: fixture.nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := fixture.runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: queueID, Type: QueueTypeReconcile})
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "skipped" {
+		t.Fatalf("ProcessClaimedQueueItem() = %#v, want skipped result", result)
+	}
+	stored, err := fixture.repos.Queue.GetByID(context.Background(), queueID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if payload := fixture.runner.readPayload(*stored); payload.Phase != "warn" || payload.Outcome != outcomePending {
+		t.Fatalf("payload = %#v, want warn phase with pending outcome preserved", payload)
+	}
+	if len(fixture.github.updatedComments) != 0 {
+		t.Fatalf("updatedComments = %#v, want none while pending label remains", fixture.github.updatedComments)
+	}
+}
+
+func TestDiscoverIssuesSkipsExcludedAuthorAssociations(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo", AuthorAssociation: "OWNER"}}
+
+	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || result.Skipped != 1 {
+		t.Fatalf("DiscoverIssues() = %#v, want excluded association to be skipped", result)
+	}
+}
+
 func TestProcessClaimedQueueItemRejectsUnsupportedQueueType(t *testing.T) {
 	t.Parallel()
 
@@ -217,6 +334,8 @@ type stubGitHub struct {
 	prs             []githubinfra.PullRequestSummary
 	issueDetails    map[string]githubinfra.IssueDetail
 	prDetails       map[string]githubinfra.PullRequestDetail
+	listIssuesCalls int
+	listPRCalls     int
 	createdComments []githubinfra.IssueCommentInput
 	updatedComments []githubinfra.UpdateIssueCommentInput
 	closedIssues    []githubinfra.CloseIssueInput
@@ -226,10 +345,12 @@ type stubGitHub struct {
 }
 
 func (g *stubGitHub) ListOpenIssues(context.Context, githubinfra.ListOpenIssuesInput) ([]githubinfra.IssueSummary, error) {
+	g.listIssuesCalls++
 	return append([]githubinfra.IssueSummary(nil), g.issues...), nil
 }
 
 func (g *stubGitHub) ListOpenPullRequests(context.Context, githubinfra.ListOpenPullRequestsInput) ([]githubinfra.PullRequestSummary, error) {
+	g.listPRCalls++
 	return append([]githubinfra.PullRequestSummary(nil), g.prs...), nil
 }
 

--- a/specs/2026-05-09-sweeper-role.md
+++ b/specs/2026-05-09-sweeper-role.md
@@ -1,0 +1,752 @@
+# Sweeper role: auto-close stale, fixed, unrelated, and abandoned issues/PRs
+
+Issue: TBD
+Base branch: `main`
+
+## Problem
+
+Open-source repos and active project trackers accumulate issues and PRs that should not stay open:
+
+- **Stale** issues/PRs with no activity for an extended period.
+- **Already-fixed** issues that were resolved by a merged PR but never linked with a `Closes #N` reference, so GitHub never auto-closed them.
+- **Unrelated / out-of-scope** issues (spam, off-topic, wrong repo, support questions in a bug tracker).
+- **Superseded / duplicate** issues or PRs replaced by a newer one.
+- **Abandoned PRs** where the author stopped responding to review, the branch has unresolvable conflicts, or a draft has sat untouched for weeks.
+
+Today, Looper has four roles — `planner`, `worker`, `reviewer`, `fixer` — that all *create* or *advance* work. Nothing in the system is responsible for *retiring* work. Maintainers do this manually, infrequently, and inconsistently. Bots like `actions/stale` cover only the time-based slice and cannot reason about whether an issue is already fixed, unrelated, or duplicated.
+
+A new `sweeper` role should own this lifecycle: scan open issues/PRs on a schedule, classify each candidate, post a transparent warning comment with rationale, and close the item after a grace period if nobody objects.
+
+## Goals
+
+- Add a first-class `sweeper` role alongside `planner`, `worker`, `reviewer`, `fixer`.
+- Detect five close-worthy categories: `stale`, `already_fixed`, `unrelated`, `superseded`, `abandoned_pr`, plus a non-mutating `route_security` outcome that quarantines the item without closing or commenting.
+- Use a two-phase **warn → grace-period → close** lifecycle so humans always have a chance to push back before anything is closed.
+- Strictly separate a **propose lane** (read-only classification, never mutates GitHub) from an **apply lane** (the only path that comments / labels / closes), and require the apply lane to re-fetch live GitHub state immediately before every mutation.
+- Make every close auditable: every close action ties back to a prior warning comment by the same actor, with a rationale, and is mirrored to a durable per-item markdown report in addition to structured queue metadata.
+- Be conservative by default: small batch sizes, opt-in per project, configurable thresholds, dry-run mode.
+- Honor existing scheduler/queue/runner architecture — sweeper looks like every other role to `looperd`.
+- Add `CloseIssue` and `ClosePullRequest` to `internal/infra/github/gateway.go` so closing is a typed, testable gateway operation, not a free-form shell call.
+- Preserve existing roles' behavior exactly. No discovery, processing, or queue semantics for `planner`/`reviewer`/`fixer`/`worker` change.
+
+## Non-goals
+
+- Do **not** reopen, merge, rebase, or modify code/branches. Sweeper only comments, labels, and closes.
+- Do **not** delete or hide content. Closed issues/PRs remain visible.
+- Do **not** override human decisions. Once a maintainer comments on, labels, or interacts with a candidate after the warning, sweeper steps back.
+- Do **not** close items the agent is uncertain about. Low confidence → no action.
+- Do **not** close, comment on, or label items the classifier flags as security-class. Those are routed to a quarantine outcome and surfaced for human handling only.
+- Do **not** close locked issues/PRs, items pinned by GitHub, or items whose author is a current maintainer/collaborator on the repo.
+- Do **not** close an item that is paired with the other side of an open issue/PR link (e.g. an issue with an open PR that references it via `Closes #N`, or a PR whose linked issue is still actively being worked).
+- Do **not** mutate GitHub from the propose lane under any circumstance — propose is strictly read-only.
+- Do **not** introduce per-issue config; sweeper is configured at the project/role level only.
+- Do **not** auto-merge anything. That is out of scope and explicitly forbidden.
+- Do **not** change `defaults.fixAllPullRequests`, label conventions, or other roles' triggers.
+
+## Proposed approach
+
+### 1. Add `sweeper` as a registered role
+
+Sweeper lands as a peer of the existing four roles, following the patterns established by issue 120 (configurable role triggers).
+
+- Create `internal/sweeper/` with `runner.go`, `runner_test.go`, `doc.go`, mirroring `internal/planner/` layout.
+- Add `"sweeper"` to the role allowlist in `internal/config/validate.go` (alongside `planner`, `reviewer`, `fixer`, `worker`).
+- Extend `internal/config/project_roles.go` so projects can enable/disable sweeper per project, identical to other roles.
+- Extend `RoleConfigs` in `internal/config/types.go`:
+
+```go
+type RoleConfigs struct {
+    Planner  PlannerRoleConfig  `json:"planner"`
+    Reviewer ReviewerRoleConfig `json:"reviewer"`
+    Fixer    FixerRoleConfig    `json:"fixer"`
+    Worker   WorkerRoleConfig   `json:"worker"`
+    Sweeper  SweeperRoleConfig  `json:"sweeper"`
+}
+```
+
+- Add `SweeperRoleConfig` (see §3 for field definitions).
+- Add defaults in `internal/config/defaults.go` with `autoDiscovery=false` so sweeper is **opt-in** at first rollout.
+
+### 2. Two-phase lifecycle (warn → grace → close) and propose/apply lanes
+
+Every close goes through two scheduler ticks separated by a grace period **and** through two strictly separated lanes within each tick. This is the central safety property of the role.
+
+**Propose lane (read-only):**
+
+- Loads the item, builds the prompt, runs the agent, parses the structured decision.
+- Never calls `gh` write operations, never posts comments, never applies labels, never closes anything.
+- Emits a `SweeperProposal` record (in-memory + durable per-item report) describing the intended action.
+
+**Apply lane (the only mutator — including for `route_security`):**
+
+- Consumes a `SweeperProposal`.
+- **Marker pre-check (idempotency).** Before any mutation, the apply lane lists comments on the target and searches for an existing marker UUID matching the proposal's intended marker. If one exists, the apply lane treats the warning as already posted: it skips `AddComment`, reuses the existing comment ID, and idempotently reconciles labels. This protects against crash-after-comment-before-label and double-tick races.
+- Re-fetches the item's live state (issue/PR JSON + recent timeline + comment list with markers + reactions on the warning comment) immediately before mutation.
+- Computes a drift check (see drift fingerprint below). If drift is detected, the apply step **aborts** the mutation, records `outcome=stale_proposal`, and re-enqueues a fresh propose pass.
+- Only on a clean drift check does it call gateway methods (`AddComment`, `UpdateIssueComment`, `AddLabels`, `RemoveLabels`, `CloseIssue`, `ClosePullRequest`).
+- **Mutation ordering** (must match across all apply paths):
+  - Phase A apply: (1) check marker, (2) post comment if absent, (3) persist comment ID + marker, (4) add `pendingLabel`. If step 2 succeeds but 3 or 4 fails, the next tick's marker pre-check finds the comment and resumes from step 3.
+  - Phase B close apply: (1) post final close comment with `close` marker, (2) persist close-comment ID, (3) `CloseIssue`/`ClosePullRequest`, (4) remove `pendingLabel`, (5) add `closedLabel`. Steps 3–5 are individually idempotent (gateway close is no-op on already-closed; label add/remove are idempotent). Recovery re-enters at the first uncompleted step, identified by which side-effects are visible on GitHub.
+  - Phase B cancel apply: (1) `UpdateIssueComment` to append cancellation note onto the existing warning, (2) remove `pendingLabel`. Both idempotent.
+
+**Drift fingerprint** (computed at propose, re-verified at apply):
+
+- target `updated_at`,
+- target `state` and `state_reason`,
+- target `locked` flag,
+- label set (sorted),
+- assignees set (sorted),
+- comment count,
+- for PRs: head SHA, base SHA, `mergeable_state`, draft flag,
+- for warned items in Phase B: warning comment's `updated_at` (detects human edits) and reaction summary,
+- linked-work fingerprint: sorted list of `(referenced_PR_number, state)` pairs from `Closes #N` / `Fixes #N` cross-references.
+
+**Queue model.** Sweeper uses **two** queue item types, both reusing `storage.QueueItemRecord`:
+
+- `sweeper:warn` — covers Phase A. The runner internally executes propose then apply within the same claim. The propose step writes its `SweeperProposal` to `PayloadJSON`; the apply step re-fetches state and runs the marker pre-check + drift check + mutation ordering above. If apply aborts on drift, the queue item is requeued (`Status=retrying`) so the next tick redoes propose+apply with fresh state.
+- `sweeper:close` — covers Phase B. Same shape: propose (re-evaluate, decide `close | cancel | extend | route_security`), then apply.
+
+The scheduler dispatches both via the same `Sweeper.ProcessClaimedQueueItem` entry point. Lanes remain logically separate inside the runner — the propose function never touches `gh` write APIs and is the only path that calls the agent.
+
+**Dedupe and lock keys.** Sweeper sets:
+
+- `DedupeKey = "sweeper:" + phase + ":" + repo + "#" + number` so duplicate discovery ticks collapse to one queue item per (phase, target).
+- `LockKey = "sweeper:" + repo + "#" + number` so Phase A and Phase B for the same target serialize, preventing concurrent comment/label mutations.
+
+**Phase B cap.** Phase B re-evaluation is capped at `triggers.maxPerTick * 3` per tick (3× the warn cap). This keeps re-evaluation ahead of warning intake without monopolizing scheduler slots (`internal/runtime/scheduler.go:981-988`).
+
+**Global mutation ceilings.** Independent of `maxPerTick`, sweeper enforces hard daily ceilings per repo before any apply mutation:
+
+- `roles.sweeper.limits.maxWarningsPerRepoPerDay` (default `25`)
+- `roles.sweeper.limits.maxClosesPerRepoPerDay` (default `25`)
+- `roles.sweeper.limits.globalKillSwitch` (default `false`) — when `true`, the apply lane unconditionally aborts every mutation across all projects. Propose continues so audit records still accumulate.
+
+Counters reset at UTC midnight and are read from `PayloadJSON` audit metadata. When a ceiling is hit, the apply lane records `outcome=ceiling_reached` and the queue item is deferred to the next day.
+
+**Phase A — Warn:**
+
+1. *Propose:* Sweeper scans open issues/PRs (see §4) and enqueues `sweeper:warn` items. The runner's propose step builds the fact bundle and runs the agent before the apply step touches GitHub.
+2. *Propose:* For each candidate, the agent classifies it into one of the configured outcomes with a confidence score and rationale.
+3. *Propose:* If confidence passes the per-category threshold and no "never-close" rule fires (see below), the runner emits an apply step containing the warning comment body, the target labels, and the snapshot fingerprint used for drift detection.
+4. *Apply:* The apply lane re-fetches state, verifies the drift fingerprint, then posts a single comment with:
+   - the category (e.g. `stale`, `already_fixed`),
+   - the rationale (specific evidence — last activity date, the merged PR that fixed it, the duplicate it points at, etc.),
+   - the close-by date (now + `gracePeriodDays`),
+   - a short instruction for how to keep the item open: "Comment, push, or remove the `looper:sweep-pending` label to cancel.",
+   - a stable HTML-comment marker (e.g. `<!-- looper:sweeper:warn id=<uuid> -->`) so future ticks can locate and edit the same comment in place rather than posting duplicates.
+5. *Apply:* Sweeper applies a tracking label (default: `looper:sweep-pending`) and persists the warning comment ID, marker UUID, snapshot fingerprint, and decision metadata in the queue/checkpoint record and the per-item markdown report.
+
+**Phase B — Close:**
+
+1. On a later tick (after the grace period elapses), sweeper enqueues `sweeper:close` for every item carrying `looper:sweep-pending` whose warning comment is older than `gracePeriodDays`.
+2. *Propose:* Re-evaluates the item. If any of the following happened since the warning, the proposal is `cancel`:
+   - any new human comment, commit, push, label change, or assignee change;
+   - the warning comment received a thumbs-down reaction;
+   - the item received a `looper:sweep-keep` label;
+   - the item is now locked, pinned, or assigned to a maintainer;
+   - the original close criteria no longer hold (e.g. activity occurred, the duplicate was unmerged, the linked-fixing PR was reverted);
+   - any "never-close" rule fires (see list below).
+3. *Apply:* On `cancel`, removes `pendingLabel`, edits the warning comment (located via the marker) to append a cancellation note instead of deleting it (preserves audit trail), and persists `cancelled` outcome metadata.
+4. *Apply:* On `close`, after a clean drift re-check, sweeper:
+   - calls the new `CloseIssue` / `ClosePullRequest` gateway methods with the appropriate `state_reason` (`completed` for `already_fixed`, `not_planned` for everything else),
+   - posts a final close comment using the close-comment template (see §5b) referencing the original warning,
+   - removes `looper:sweep-pending`, applies a terminal label (e.g. `looper:swept`).
+
+The grace period is configured per category and defaults to **7 days**.
+
+**"Never close" rules (hard gates evaluated in both propose and apply lanes):**
+
+- Item is locked.
+- Item is pinned (issues only).
+- Item author is a current maintainer/collaborator on the repo.
+- Item carries any label in `excludeLabels` (re-checked at apply time, not just discovery).
+- Item is referenced as the target of an open PR (`Closes #N` / `Fixes #N`) that is not itself in `abandoned_pr` state.
+- For PRs: the PR is the open implementation of an actively-worked issue (issue was updated within the last `inactivityDays / 2` window).
+- Item carries any looper-internal label (`looper:plan`, `looper:worker-ready`, `looper:spec-reviewing`, `looper:swept`).
+- Item's classification is `route_security` (see §5a).
+- The agent's `confidence` is below `category.minConfidence`.
+
+### 3. `SweeperRoleConfig`
+
+Following the partial-config pointer pattern used by issue 120:
+
+```go
+type SweeperCategoryConfig struct {
+    Enabled               bool `json:"enabled"`
+    InactivityDays        int  `json:"inactivityDays,omitempty"`        // for stale/abandoned
+    GracePeriodDays       int  `json:"gracePeriodDays"`
+    MinConfidence         int  `json:"minConfidence"`                   // 0-100
+}
+
+type SweeperTriggersConfig struct {
+    IncludeIssues                 bool     `json:"includeIssues"`
+    IncludePullRequests           bool     `json:"includePullRequests"`
+    IncludeDrafts                 bool     `json:"includeDrafts"`
+    ExcludeLabels                 []string `json:"excludeLabels"`               // e.g. ["pinned","keep-open","security"]
+    ExcludeAuthors                []string `json:"excludeAuthors"`              // e.g. trusted maintainers
+    ExcludeAuthorAssociations     []string `json:"excludeAuthorAssociations"`   // ["OWNER","MEMBER","COLLABORATOR"]
+    LooperInternalLabels          []string `json:"looperInternalLabels"`        // never-close labels managed elsewhere in Looper
+    ReopenCooldownDays            int      `json:"reopenCooldownDays"`          // default 30
+    MaxPerTick                    int      `json:"maxPerTick"`                  // batch cap (warn phase)
+}
+
+type SweeperLimitsConfig struct {
+    MaxWarningsPerRepoPerDay int  `json:"maxWarningsPerRepoPerDay"` // default 25
+    MaxClosesPerRepoPerDay   int  `json:"maxClosesPerRepoPerDay"`   // default 25
+    GlobalKillSwitch         bool `json:"globalKillSwitch"`         // default false
+}
+
+type SweeperSecurityConfig struct {
+    QuarantineLabel      string   `json:"quarantineLabel"`   // default looper:sweeper-route-security
+    NotifyAssignees      []string `json:"notifyAssignees"`   // optional: GitHub usernames to assign
+}
+
+type SweeperReportingConfig struct {
+    DurableReportsDir    string   `json:"durableReportsDir"` // default ~/.looper/sweeper/<repo-slug>/items/<n>.md; "" disables
+}
+
+type SweeperLifecycleConfig struct {
+    PendingLabel  string `json:"pendingLabel"`  // default looper:sweep-pending
+    ClosedLabel   string `json:"closedLabel"`   // default looper:swept
+    KeepLabel     string `json:"keepLabel"`     // default looper:sweep-keep
+}
+
+type SweeperRoleConfig struct {
+    AutoDiscovery     bool                     `json:"autoDiscovery"`
+    DryRun            bool                     `json:"dryRun"`
+    Triggers          SweeperTriggersConfig    `json:"triggers"`
+    Lifecycle         SweeperLifecycleConfig   `json:"lifecycle"`
+    Limits            SweeperLimitsConfig      `json:"limits"`
+    Categories        struct {
+        Stale         SweeperCategoryConfig    `json:"stale"`
+        AlreadyFixed  SweeperCategoryConfig    `json:"alreadyFixed"`
+        Unrelated     SweeperCategoryConfig    `json:"unrelated"`
+        Superseded    SweeperCategoryConfig    `json:"superseded"`
+        AbandonedPR   SweeperCategoryConfig    `json:"abandonedPR"`
+    } `json:"categories"`
+    Security          SweeperSecurityConfig    `json:"security"`
+    Reporting         SweeperReportingConfig   `json:"reporting"`
+    Instructions      string                   `json:"instructions,omitempty"`
+}
+```
+
+**v1 deferrals (explicit non-features).** The following were considered and deferred to a follow-up spec to keep v1 shippable:
+
+- *Localization / language mirroring of comments.* v1 posts comments in English. Item-body language detection and mirrored prose are deferred.
+- *Low-signal-PR mode.* Heuristic-based PR closing (blank template, docs-only typo, churn, etc.) is too subjective without operator data. Add later, gated behind its own opt-in config block.
+- *Extension flow.* Phase B decisions are limited to `close | cancel | route_security`. No `extend` action; if the situation is borderline, the agent emits `cancel` with rationale and a fresh discovery pass will re-warn after another `inactivityDays` window. Removing `extend` eliminates `MaxExtensions` state and a class of unbounded-deferral bugs.
+- *Per-category copy override files.* Only `roles.sweeper.instructions` and auto-injected project metadata (project name, default branch, optional `CONTRIBUTING.md` URL) are honored.
+
+**Defaults (conservative, opt-in):**
+
+```json
+{
+  "sweeper": {
+    "autoDiscovery": false,
+    "dryRun": true,
+    "triggers": {
+      "includeIssues": true,
+      "includePullRequests": true,
+      "includeDrafts": false,
+      "excludeLabels": ["pinned", "security", "looper:sweep-keep"],
+      "excludeAuthors": [],
+      "excludeAuthorAssociations": ["OWNER", "MEMBER", "COLLABORATOR"],
+      "looperInternalLabels": ["looper:plan", "looper:worker-ready", "looper:spec-reviewing", "looper:swept"],
+      "reopenCooldownDays": 30,
+      "maxPerTick": 10
+    },
+    "lifecycle": {
+      "pendingLabel": "looper:sweep-pending",
+      "closedLabel":  "looper:swept",
+      "keepLabel":    "looper:sweep-keep"
+    },
+    "limits": {
+      "maxWarningsPerRepoPerDay": 25,
+      "maxClosesPerRepoPerDay":   25,
+      "globalKillSwitch":         false
+    },
+    "categories": {
+      "stale":        {"enabled": true,  "inactivityDays": 90, "gracePeriodDays": 7, "minConfidence": 70},
+      "alreadyFixed": {"enabled": true,                          "gracePeriodDays": 7, "minConfidence": 80},
+      "unrelated":    {"enabled": false,                         "gracePeriodDays": 7, "minConfidence": 90},
+      "superseded":   {"enabled": true,                          "gracePeriodDays": 7, "minConfidence": 85},
+      "abandonedPR":  {"enabled": true,  "inactivityDays": 30, "gracePeriodDays": 7, "minConfidence": 75}
+    },
+    "security": {
+      "quarantineLabel": "looper:sweeper-route-security",
+      "notifyAssignees": []
+    },
+    "reporting": {
+      "durableReportsDir": ""
+    }
+  }
+}
+```
+
+`unrelated` defaults off because it is the most subjective category; operators must opt in. `dryRun=true` defaults on at the role level so first-run behavior is observe-only — operators flip it off explicitly once they trust the classifier. `durableReportsDir` defaults empty (disabled); `PayloadJSON` audit on the queue record is the v1 source of truth.
+
+Validation (in `internal/config/validate.go`) must reject:
+
+- empty/duplicate label values for `lifecycle.pendingLabel`, `lifecycle.closedLabel`, `lifecycle.keepLabel`, `security.quarantineLabel`;
+- overlap between `lifecycle.*` labels and `triggers.excludeLabels` (would create permanent self-exclusion);
+- non-positive `inactivityDays` when the corresponding category is enabled and uses inactivity;
+- non-positive `gracePeriodDays`;
+- non-positive `triggers.reopenCooldownDays`;
+- `minConfidence` outside `[0, 100]`;
+- `maxPerTick` <= 0;
+- `limits.maxWarningsPerRepoPerDay` or `limits.maxClosesPerRepoPerDay` < 0 (zero = freeze the lane);
+- both `includeIssues=false` and `includePullRequests=false` while sweeper is enabled;
+- unknown values in `excludeAuthorAssociations` (must be one of GitHub's `OWNER|MEMBER|COLLABORATOR|CONTRIBUTOR|FIRST_TIME_CONTRIBUTOR|FIRST_TIMER|MANNEQUIN|NONE`).
+
+### 4. Discovery
+
+Sweeper does a **periodic full scan** of open issues and PRs. It does not require an opt-in label per item; instead it uses exclude rules.
+
+`sweeper.DiscoveryInput` and `sweeper.DiscoveryResult` mirror the existing per-runner shape. The sweeper runner exposes:
+
+```go
+DiscoverIssues(context.Context, sweeper.DiscoveryInput) (sweeper.DiscoveryResult, error)
+DiscoverPullRequests(context.Context, sweeper.DiscoveryInput) (sweeper.DiscoveryResult, error)
+DiscoverReconcile(context.Context, sweeper.DiscoveryInput) (sweeper.DiscoveryResult, error)
+ProcessNext(context.Context, string) (*sweeper.ProcessResult, error)
+ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) (*sweeper.ProcessResult, error)
+```
+
+The scheduler in `internal/runtime/scheduler.go` gains a sweeper branch in its discovery tick (lines 995-1033 region), gated on `roles.sweeper.autoDiscovery && discoveryEnabled(...)`, identical in shape to the four existing role gates.
+
+Discovery walks open issues and open PRs (both via existing `ListOpenIssues` / `ListOpenPullRequests`), then locally filters out anything that:
+
+- carries any label in `triggers.excludeLabels` (matched exact-string, case-sensitive);
+- carries any label in `triggers.looperInternalLabels`;
+- carries `security.quarantineLabel`;
+- was authored by a user in `triggers.excludeAuthors`;
+- has `authorAssociation` in `triggers.excludeAuthorAssociations`;
+- is a draft when `includeDrafts=false`;
+- is already labeled `lifecycle.pendingLabel` (those are evaluated in Phase B instead);
+- is already labeled `lifecycle.closedLabel` and somehow still open (defensive skip + warn log);
+- was closed by sweeper less than `triggers.reopenCooldownDays` ago (read from queue audit history).
+
+Three queue types are produced per tick:
+
+- **`sweeper:warn`** — Phase A candidates (no `pendingLabel`). Capped at `triggers.maxPerTick`. Each item carries `DedupeKey = "sweeper:warn:" + repo + "#" + number` and `LockKey = "sweeper:" + repo + "#" + number`.
+- **`sweeper:close`** — Phase B candidates (items with `pendingLabel` whose warning is older than the relevant `gracePeriodDays`). Capped at `triggers.maxPerTick * 3`. Same dedupe/lock pattern with phase prefix `close`.
+- **`sweeper:reconcile`** — items with active proposals whose `pendingLabel` may have been removed manually, or whose warning comment may have been deleted/edited. Runs once per discovery tick over current `outcome=pending` records. Capped at `triggers.maxPerTick`.
+
+All three reuse the existing `storage.QueueItemRecord` shape (per `internal/storage/repositories.go:163-215`). Claim/retry/fail/complete semantics are unchanged. The scheduler routes all three through `Sweeper.ProcessClaimedQueueItem`; the runner branches by `item.Type` internally.
+
+### 5. Agent contract for classification
+
+Sweeper, like other implementation roles, is fundamentally agent-driven for the judgment call. The runner assembles a **structured fact bundle** (see §5b), passes it to the agent, and the agent returns a structured decision whose comment prose must be grounded in those facts.
+
+**Phase A prompt (warn) input — the structured fact bundle:**
+
+- *Item facts:* repo full name, item type (issue/PR), number, URL, title, body (preserving original language), labels, assignees, author + author association (`OWNER`/`MEMBER`/`COLLABORATOR`/`CONTRIBUTOR`/`FIRST_TIME_CONTRIBUTOR`/`NONE`), created/updated timestamps, locked/pinned state.
+- *Timeline facts:* last 20 timeline events (comments, label changes, commits if PR, review requests), with `last_human_comment_at`, `last_commit_at`, `last_label_change_at`, `last_assignee_change_at` pre-computed so the agent does not have to scan.
+- *Linked-work facts:* for issues — referencing PRs (via `gh issue view --json projectItems,timelineItems` cross-references) with their state and merged_at; for PRs — head branch, base branch, mergeable state, draft state, review state, last review submitted_at, head SHA, conflicts, linked issues from `Closes #N` parsing.
+- *Project facts:* project display name, default branch, configured `instructions` block, optional `contributingURL` (auto-detected from `CONTRIBUTING.md` presence at repo root), repo description.
+- *Author-relationship facts:* `is_first_time_contributor`, `is_bot` (heuristic: login ends in `[bot]`), `prior_merged_prs_count`, `prior_closed_issues_count`.
+- *Language facts:* detected language code of the item body (e.g. `en`, `ja`, `zh`); the agent is instructed to mirror this language for prose unless the project config forces English.
+- *Policy facts:* the configured category set with their confidence thresholds; the "never-close" rules already evaluated and any that fired (so the agent never argues against a hard gate); exclusion rules already applied.
+
+**Phase A agent output contract (parsed by runner via the existing completion-marker scheme in `internal/agent/prompt.go`):**
+
+```json
+{
+  "sweeper_decision": {
+    "category": "stale | already_fixed | unrelated | superseded | abandoned_pr | route_security | none",
+    "confidence": 0-100,
+    "rationale": "human-readable explanation, 1-3 sentences",
+    "evidence": {
+      "last_activity_at": "2026-01-15T...",
+      "last_human_comment_at": "2025-11-02T...",
+      "linked_fixing_pr": 1234,           // only for already_fixed
+      "linked_fixing_pr_merged_at": "...",
+      "duplicate_of": 5678,               // only for superseded
+      "merge_conflict": true,             // only for abandoned_pr
+      "head_sha": "abc123",               // only for PRs (used for drift check)
+      "snapshot_updated_at": "..."        // item updated_at at proposal time (used for drift check)
+    },
+    "warning_comment": {
+      "body": "the exact comment body to post, in English; must include category-required evidence references (see §5b)",
+      "addressed_to": "@octocat",
+      "tone": "warm | neutral | terse"
+    }
+  }
+}
+```
+
+If `category=none` or `confidence < category.minConfidence`, runner records "no action" and completes the queue item.
+If `category=route_security`, the **apply lane** (not propose) applies `security.quarantineLabel`, optionally assigns `security.notifyAssignees`, and adds the quarantine label to the runtime exclusion set so future discovery passes skip the item. The apply lane also follows the marker pre-check + drift check rules above. **No comment is posted and no close is performed.** If the item already carries `pendingLabel` from a prior warning, the apply lane additionally removes `pendingLabel` and edits the original warning comment via marker to append a quarantine notice (`This item has been routed to security review; the previous sweeper notice no longer applies.`).
+Otherwise the runner validates the comment (see §5b grounding rules), then the apply lane re-fetches state and posts.
+
+**Missing-state reconciliation** (covers the gaps the lifecycle leaves open):
+
+- *Pending label removed manually:* a separate reconciliation discovery pass — `sweeper:reconcile` queue type, run once per scheduler tick — looks at queue records whose `outcome=pending` and re-fetches the target. If `pendingLabel` is no longer present, the runner edits the warning comment via marker to append a "cancellation acknowledged (label removed)" note and persists `outcome=cancelled_by_label_removal`.
+- *Warning comment deleted by a human:* on Phase B propose, if the runner cannot locate the marker via the recorded comment ID *or* via comment search, it persists `outcome=cancelled_warning_deleted`, drops `pendingLabel`, and does **not** close.
+- *Warning comment edited beyond recognition:* if the marker is still present but the body no longer contains the original close-by date, the runner treats this as cancellation (same path as deletion) — humans editing a warning is an opt-out signal.
+- *Item already closed by a human:* Phase B propose re-fetches state; if the item is closed, persists `outcome=already_closed_by_human`, drops `pendingLabel`, no further action.
+- *Item reopened after a sweeper close:* the reopened item is treated as a fresh candidate. The `swept` label is left in place as historical signal but is added to the runtime exclusion set for one full grace period (configurable via `triggers.reopenCooldownDays`, default `30`) so sweeper does not immediately re-warn.
+- *Item becomes security-class after a warning:* covered above by the `route_security` apply path — pending label removed, warning comment edited to a quarantine notice, quarantine label applied.
+- *Label bootstrap:* before any tick that would post a warning or apply a label, the runner ensures `pendingLabel`, `keepLabel`, `closedLabel`, and `security.quarantineLabel` exist on each enabled repo via a one-time-per-process `EnsureLabel(repo, name, color, description)` call (gateway addition). If creation fails (permission denied), sweeper disables itself for that repo this run with a clear log line; it does not retry forever.
+
+**Phase B prompt (close) input includes:**
+
+- everything from Phase A (re-fetched, not cached, so the agent reasons on live state),
+- the original warning comment id, marker UUID, body, and timestamp,
+- every event since the warning (comments, reactions on the warning comment, label changes, pushes for PRs).
+
+**Phase B agent output contract:**
+
+```json
+{
+  "sweeper_followup": {
+    "action": "close | cancel | route_security",
+    "reason": "human-readable explanation",
+    "close_comment": {
+      "body": "final comment body if action=close, following the close-comment template (§5b) and category-required evidence rules",
+      "addressed_to": "@octocat"
+    },
+    "cancel_comment": {
+      "body": "optional comment body if action=cancel — appended to the original warning via in-place edit, not a new comment"
+    }
+  }
+}
+```
+
+There is no `extend` action. If the situation is borderline, the agent emits `cancel` with rationale; a fresh discovery pass after another `inactivityDays` window will produce a new warning if conditions still apply. This eliminates unbounded-deferral state.
+
+### 5b. Context-aware comment composition
+
+The warning and close comments must read as *informed by this specific item*, not generic boilerplate. The runner enforces this through three mechanisms.
+
+**(a) Structured fact bundle (above) — the agent never invents facts.** The agent works only from the provided bundle. The runner does not trust prose alone — it validates each generated comment against **category-specific required-evidence rules** (below), not a generic regex. If a comment fails the required-evidence check for its category, the runner downgrades the decision to `none`, persists the failure with the offending body for tuning, and never silently posts a generic comment.
+
+**Required-evidence rules (mechanically verified against `warning_comment.body` and `close_comment.body`):**
+
+| Category | Required references in body |
+|---|---|
+| `stale` | At least one ISO-8601 date that matches `evidence.last_human_comment_at` or `last_activity_at` (within tolerance), and the literal string for `inactivity_days` |
+| `already_fixed` | The string `#<linked_fixing_pr>` and an ISO-8601 date matching `evidence.linked_fixing_pr_merged_at` |
+| `superseded` | The string `#<duplicate_of>` |
+| `unrelated` | One of: a redirect URL, a `@<handle>` mention of a maintainer, or a phrase from the project's `instructions` block |
+| `abandoned_pr` | The string for `evidence.head_sha` (first 7+ hex) and an ISO-8601 date matching `last_commit_at` |
+
+In addition, every body must include the close-by ISO date and the comment marker token. These are mechanical string checks, not regex heuristics. A `@handle` or a backticked `` `label` `` alone never satisfies the evidence rule by itself.
+
+**(b) Per-category copy spine.** Each category has a single default copy spine per item type (no `tone` axis in v1) that the agent fills using bundle facts. Spines live in `internal/sweeper/copy/` as Go strings keyed by `(category, item_type)`. The agent receives the spine as a soft template — it may rewrite for readability, but the runner verifies the resulting body still satisfies the required-evidence rule above and includes the standard "how to keep open" instruction line plus the comment marker.
+
+Example category spines (illustrative, not the final wording):
+
+| Category | Item type | Spine slots |
+|---|---|---|
+| `stale` | issue | `{addressed_to}`, `{last_human_comment_at}`, `{inactivity_days}`, `{close_by}`, `{keep_open_instructions}` |
+| `already_fixed` | issue | `{addressed_to}`, `{linked_fixing_pr}`, `{linked_fixing_pr_merged_at}`, `{verification_hint}`, `{close_by}` |
+| `superseded` | issue | `{addressed_to}`, `{duplicate_of}`, `{rationale_one_sentence}`, `{close_by}` |
+| `unrelated` | issue | `{addressed_to}`, `{out_of_scope_reason}`, `{redirect_target_url_or_none}`, `{close_by}` |
+| `abandoned_pr` | PR | `{addressed_to}`, `{last_commit_at}`, `{head_sha}`, `{review_state}`, `{close_by}`, `{credit_preservation_line}` |
+
+**(c) Per-dimension adaptation rules.** The agent prompt instructs the agent to vary prose along these dimensions, and the runner verifies a few of them mechanically:
+
+- **Per-category copy & evidence:** category-specific spine (above); `evidence` block must populate the fields relevant to the category (mechanically verified).
+- **Issue vs PR phrasing:** PR comments mention head branch (by SHA), conflicts, and review state; address the PR author. Issue comments mention reproduction status and last activity; address the reporter. The spine is selected by item type; runner forbids cross-use.
+- **Project-level voice & links:** the project's display name appears at most once; `contributingURL` is appended as a footer line *only if configured*; the project's `instructions` block is injected verbatim above the close-by line.
+- **Author-relationship aware:** if `is_first_time_contributor`, tone defaults to warm and the comment includes a one-line thank-you and a link to `contributingURL` if set; if `is_bot`, the runner **skips the item entirely** — sweeper does not act on bot-authored items in v1 (no comment, no label, no close); for `OWNER`/`MEMBER`/`COLLABORATOR` authors, sweeper does not act at all (a "never-close" rule, evaluated upstream).
+- **Recency & timeline aware:** required-evidence rules above mechanically enforce the right date references per category.
+- **Localization:** v1 posts comments in English. Item-body language detection is captured in the fact bundle for future use but is not used to switch comment language.
+- **Project-specific instructions block:** `roles.sweeper.instructions` (already in `SweeperRoleConfig`) is passed into the bundle and rendered verbatim immediately before the close-by line. Maintainers use this for project-specific guidance (e.g., "Please open Q&A in Discussions instead.").
+
+**Close-comment template** (used by Phase B `close_comment.body`):
+
+```
+{addressed_to}, closing this {issue|pull request} as **{category}**.
+
+{rationale_one_sentence_grounded_in_evidence}
+
+{credit_preservation_line_if_PR_and_has_commits}
+
+If this was wrong, please reopen — your feedback helps us tune the sweeper.
+Original notice: {warning_comment_permalink}
+
+—
+Looper sweeper · {project_name}{footer_links_if_configured}
+<!-- looper:sweeper:close id={uuid} category={category} -->
+```
+
+The credit-preservation line for PRs explicitly thanks the author for the work and notes that the commits remain in the branch history, addressing the contributor-attribution concern raised by clawsweeper's closure policy.
+
+**v1 customization surface** is intentionally small:
+
+- `roles.sweeper.instructions` (free-form maintainer preamble, already present).
+- Auto-injected project metadata: project name, default branch, `contributingURL` (if `CONTRIBUTING.md` exists at repo root).
+- No template override files. No per-category overrides. Future spec can add `roles.sweeper.copyOverrides.<category>.<itemType>` if real demand emerges.
+
+### 6. Extend the GitHub gateway
+
+`internal/infra/github/gateway.go` already provides `UpdateIssueComment` (lines 129-134, 554-557), `AddIssueLabels` / `RemoveIssueLabel` (lines 1316, 1329), `RequestReviewers`, and reaction helpers. Sweeper still needs these new typed operations:
+
+```go
+type CloseIssueInput struct {
+    Repo        string
+    IssueNumber int64
+    StateReason string // "completed" or "not_planned"
+    CWD         string
+}
+
+func (g *Gateway) CloseIssue(ctx context.Context, input CloseIssueInput) error
+
+type ClosePullRequestInput struct {
+    Repo     string
+    PRNumber int64           // matches existing convention (gateway.go:138, 160, 180, ...)
+    CWD      string
+}
+
+func (g *Gateway) ClosePullRequest(ctx context.Context, input ClosePullRequestInput) error
+
+type EnsureLabelInput struct {
+    Repo        string
+    Name        string
+    Color       string  // 6-char hex without leading '#'
+    Description string
+    CWD         string
+}
+
+// EnsureLabel is idempotent: creates the label if missing, updates color/description
+// if drifted, returns nil if already correct. Used at startup and before each apply
+// mutation that depends on a sweeper-managed label.
+func (g *Gateway) EnsureLabel(ctx context.Context, input EnsureLabelInput) error
+```
+
+Implementation goes through `gh` CLI (`gh issue close --reason ...`, `gh pr close`, `gh label create|edit|view`) consistent with the rest of the gateway. All three methods must:
+
+- be idempotent: closing an already-closed item returns `nil` (after a status check), not an error; `EnsureLabel` is also idempotent;
+- never delete branches or comments (sweeper never passes destructive flags); explicitly: `ClosePullRequest` must **not** support `--delete-branch`;
+- surface auth failures as the same wrapped error type as other gateway methods so retry/fail logic in the queue layer is unchanged.
+
+Reactions on the warning comment are needed for the cancel-on-thumbs-down rule. Add `ListIssueCommentReactions(ctx, ListIssueCommentReactionsInput) ([]Reaction, error)` to gateway. v1 may also fall back to "any new human comment cancels" if reaction-listing proves rate-limit-heavy in practice, but the contract above is the target.
+
+### 7. Scheduler wiring
+
+`internal/runtime/scheduler.go` changes:
+
+- Add `sweeperScheduler` interface alongside `plannerScheduler`/`workerScheduler`/etc. (currently at lines 28-57).
+- Wire a `Sweeper` field into the scheduler `Input` and runtime composition root (around lines 749-920).
+- In the discovery tick (around lines 995-1033), add:
+
+```go
+if input.Sweeper != nil && discoveryEnabled(input.SweeperDiscoveryEnabled) {
+    if cfg.Roles.Sweeper.Triggers.IncludeIssues {
+        _, _ = input.Sweeper.DiscoverIssues(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+    }
+    if cfg.Roles.Sweeper.Triggers.IncludePullRequests {
+        _, _ = input.Sweeper.DiscoverPullRequests(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+    }
+    _, _ = input.Sweeper.DiscoverReconcile(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+}
+```
+
+- Queue processing (lines 1063-1171) gains a sweeper claim path that calls `Sweeper.ProcessClaimedQueueItem`. All three queue item types (`sweeper:warn`, `sweeper:close`, `sweeper:reconcile`) route through the same processor; the runner branches by `item.Type` internally.
+
+**All Looper integration sites that must register `"sweeper"`** (the council review identified these beyond the role allowlist; spec must land each):
+
+- `internal/config/validate.go:188-191` (role allowlist) and `:374-427` (role-specific validation).
+- `internal/config/project_roles.go:18-31` (`ProjectRoleAutoDiscoveryEnabled` and per-role enable/disable accessors).
+- `internal/config/load.go:836-906` (config load/merge sites that walk known roles).
+- `internal/config/normalize.go:512-576` (config normalization that walks known roles).
+- `internal/cliapp/prompt_commands.go:24-26, 62-68, 165-177` (prompt-preview role allowlist and dispatch).
+- `internal/cliapp/app.go:178-179, 300-345, 429-470` (role command registration).
+
+Implementation must touch each of these sites; missing any will silently disable sweeper in a subsystem.
+
+### 8. CLI surface
+
+`internal/cliapp/app.go` (around 300-345 where role commands are registered) adds:
+
+- `looper sweep` — manually trigger one sweeper discovery tick + processing pass for the current project (mirrors `looper plan`/`review`/`work`).
+- `looper sweep --dry-run` — force `dryRun=true` for this invocation regardless of config; useful for previewing what *would* be warned/closed.
+- `looper sweep --kill-switch` (and `--no-kill-switch`) — flip `roles.sweeper.limits.globalKillSwitch` for this project at runtime; persists to config.
+- `looper prompt preview --role sweeper --issue <N>` / `--pr <N>` — print the assembled fact bundle and selected spine for a given target. The sweeper preview requires a target (issue or PR number); without one it errors out, because sweeper prompts are item-specific. Extends `internal/cliapp/prompt_commands.go`.
+
+Config commands (`looper config get/set/unset/show`) must register the common sweeper fields:
+
+- `roles.sweeper.autoDiscovery`
+- `roles.sweeper.dryRun`
+- `roles.sweeper.triggers.includeIssues`
+- `roles.sweeper.triggers.includePullRequests`
+- `roles.sweeper.triggers.includeDrafts`
+- `roles.sweeper.triggers.excludeLabels`
+- `roles.sweeper.triggers.excludeAuthors`
+- `roles.sweeper.triggers.excludeAuthorAssociations`
+- `roles.sweeper.triggers.looperInternalLabels`
+- `roles.sweeper.triggers.reopenCooldownDays`
+- `roles.sweeper.triggers.maxPerTick`
+- `roles.sweeper.lifecycle.pendingLabel`
+- `roles.sweeper.lifecycle.closedLabel`
+- `roles.sweeper.lifecycle.keepLabel`
+- `roles.sweeper.limits.maxWarningsPerRepoPerDay`
+- `roles.sweeper.limits.maxClosesPerRepoPerDay`
+- `roles.sweeper.limits.globalKillSwitch`
+- `roles.sweeper.security.quarantineLabel`
+- `roles.sweeper.security.notifyAssignees`
+- `roles.sweeper.reporting.durableReportsDir`
+- `roles.sweeper.categories.<name>.enabled`
+- `roles.sweeper.categories.<name>.inactivityDays`
+- `roles.sweeper.categories.<name>.gracePeriodDays`
+- `roles.sweeper.categories.<name>.minConfidence`
+
+Environment variables follow the existing `LOOPER_ROLES_*` shape established by issue 120 (e.g. `LOOPER_ROLES_SWEEPER_AUTO_DISCOVERY`, `LOOPER_ROLES_SWEEPER_DRY_RUN`, `LOOPER_ROLES_SWEEPER_TRIGGERS_MAX_PER_TICK`, `LOOPER_ROLES_SWEEPER_LIMITS_GLOBAL_KILL_SWITCH`, etc.). Booleans, integers, and comma-separated lists parse identically to the existing role envs.
+
+### 9. Persistence and audit
+
+Sweeper decisions must be queryable later, both for debugging false positives and for "show me what looper closed last week" reporting.
+
+The audit lives in `QueueItemRecord.PayloadJSON` (no sibling table needed for v1 — `internal/storage/repositories.go:163-215` already exposes `PayloadJSON`, `DedupeKey`, `LockKey`). Sweeper writes a stable JSON structure:
+
+```json
+{
+  "sweeper": {
+    "phase": "warn | close | reconcile",
+    "category": "stale | already_fixed | unrelated | superseded | abandoned_pr | route_security | none",
+    "confidence": 78,
+    "rationale": "...",
+    "warning_comment_id": 123456,
+    "warning_marker_uuid": "...",
+    "warning_posted_at": "2026-05-16T00:00:00Z",
+    "close_by": "2026-05-23T00:00:00Z",
+    "fingerprint": {
+      "updated_at": "...",
+      "state": "open",
+      "labels": ["bug","triage"],
+      "assignees": ["alice"],
+      "comment_count": 12,
+      "head_sha": "abc1234",
+      "linked_work": [{"number": 1234, "state": "merged"}],
+      "warning_updated_at": "...",
+      "warning_reactions": {"-1": 0, "+1": 0}
+    },
+    "outcome": "pending | warned | closed | cancelled | cancelled_by_label_removal | cancelled_warning_deleted | already_closed_by_human | stale_proposal | ceiling_reached | route_security | skipped | failed",
+    "outcome_reason": "...",
+    "dry_run": false
+  }
+}
+```
+
+**All times are UTC** (ISO-8601 with `Z`). `close_by` is formatted in UTC and rendered in user-facing comments as `YYYY-MM-DD UTC` to avoid time-zone ambiguity.
+
+**Daily counters** for `limits.maxWarningsPerRepoPerDay` / `maxClosesPerRepoPerDay` are computed by counting matching audit records with `outcome IN ('warned','closed')` and `warning_posted_at >= <UTC midnight>`; no separate counter table.
+
+This is the audit trail. It powers a future `looper sweep history` command and is the source of truth when reconciling Phase B and the daily ceilings.
+
+### 10. Dry-run behavior
+
+When `dryRun=true` (role-level or per-invocation), the runner performs every classification step and persists the same metadata, but **does not** post comments, apply labels, or call `CloseIssue`/`ClosePullRequest`. Logs and the audit record show `dry_run: true` so operators can see what would have happened.
+
+This is the primary safe-rollout mechanism: enable sweeper with `dryRun=true`, observe a few ticks, then flip to `false`. The global kill switch (`limits.globalKillSwitch`) is the matching emergency-stop after rollout.
+
+## Risks and mitigations
+
+- **Closing something a maintainer wanted to keep.** Mitigations: two-phase lifecycle, grace period, `keepLabel` exclude, cancel on any human activity, dry-run default, conservative confidence thresholds, `unrelated` category off by default, never-close rule for maintainer-authored items.
+- **Confidence inflation by the agent.** Mitigations: per-category `minConfidence`; log every decision (including ones below threshold) so operators can tune thresholds with real data; review in `dryRun` mode before trusting the classifier.
+- **Comment/label spam.** Mitigations: `maxPerTick` cap; marker-pre-check guarantees one warning comment per item; daily ceilings (`maxWarningsPerRepoPerDay`).
+- **Closing already-closed items.** Mitigations: gateway `CloseIssue`/`ClosePullRequest` idempotency; runner re-checks state before acting; `outcome=already_closed_by_human` reconciliation path.
+- **Race with humans during grace period.** Mitigations: drift fingerprint covers `updated_at`, labels, assignees, comments, reactions, head SHA, linked-work; apply lane aborts on drift and re-proposes.
+- **Crash mid-apply leaves duplicates or inconsistent state.** Mitigations: marker pre-check + documented mutation ordering + idempotent gateway methods. Each apply step is independently safe to retry; recovery re-enters at first uncompleted step identified by visible side-effects on GitHub.
+- **Permission gaps and missing labels.** Mitigations: `EnsureLabel` at startup per-repo; sweeper disables itself for that repo on permission failure with a clear log line, does not retry forever.
+- **Coupling with future agent-managed lifecycle work (issue 51).** Mitigations: keep sweeper closes inside the typed gateway; do not push close ownership into the agent's tool environment unless/until the agent-managed lifecycle policy formally extends to sweeper.
+- **Spec-reviewing/looper-internal items getting swept.** Mitigations: `triggers.looperInternalLabels` excludes them by default; `excludeAuthorAssociations` defaults skip OWNER/MEMBER/COLLABORATOR.
+- **Phase B starving other roles.** Mitigations: Phase B cap at `maxPerTick * 3`; sweeper queue items share scheduler slots fairly with other roles.
+- **Daily ceiling miscounted on crash.** Mitigations: counters derived from `PayloadJSON` audit records, not in-memory state; survives restarts.
+- **Operator wants emergency stop.** Mitigations: `limits.globalKillSwitch` flips all apply mutations off without touching the rest of Looper.
+
+## Validation plan
+
+Automated tests in `internal/sweeper/runner_test.go`, plus config and scheduler tests:
+
+- config defaults are validated; invalid combinations rejected (including label-overlap and unknown author associations);
+- partial config merging preserves omitted defaults;
+- discovery filters honor `excludeLabels`, `excludeAuthors`, `excludeAuthorAssociations`, `looperInternalLabels`, `security.quarantineLabel`, `includeDrafts`, `pendingLabel`, `closedLabel`, and `reopenCooldownDays`;
+- Phase A: each category's classifier produces the right decision shape; below-threshold confidence becomes "no action"; warnings are posted and labels applied;
+- **Required-evidence rules (§5b):** `stale` / `already_fixed` / `superseded` / `unrelated` / `abandoned_pr` comments each contain their category's mandatory references; failing comments are downgraded to `none` and not posted;
+- **Per-category spine selection:** the right spine is chosen for each `(category, item_type)` pair; cross-use (e.g., PR spine for an issue) is rejected;
+- **Author branching:** first-time-contributor items get the warm spine variant with `contributingURL` link when configured; bot-authored items are skipped entirely (no comment, no label, no close); maintainer-authored items skipped upstream;
+- **Drift detection:** apply lane aborts and re-enqueues a fresh proposal when any of `{updated_at, state, labels, assignees, comment_count, head SHA, warning comment updated_at, warning reactions, linked_work state}` changed between propose and apply;
+- **Marker pre-check / idempotency:** if a warning comment with the proposal's marker UUID already exists on the target, apply skips `AddComment`, reuses the existing ID, and reconciles labels;
+- **Crash recovery:**
+  - crash after warning comment posted but before `pendingLabel` applied → next tick finds marker, applies label only;
+  - crash after `CloseIssue` but before final comment / label cleanup → next tick is a no-op for `CloseIssue` (idempotent) and completes remaining steps;
+  - crash after Phase B close-comment posted but before `CloseIssue` → next tick uses marker pre-check to avoid duplicate close-comment and proceeds;
+- **Reconciliation:**
+  - `pendingLabel` removed by human → `outcome=cancelled_by_label_removal`, warning comment edited via marker;
+  - warning comment deleted → `outcome=cancelled_warning_deleted`, label dropped, no close;
+  - warning comment edited beyond recognition → same as deletion path;
+  - item already closed by human → `outcome=already_closed_by_human`, label dropped;
+  - item reopened after sweep → not re-warned for `reopenCooldownDays`;
+  - item becomes security-class after warning → `outcome=route_security`, pending label dropped, warning edited to quarantine notice, quarantine label applied;
+- **`route_security`:** classification routes through the apply lane (not propose), applies `quarantineLabel`, optionally assigns reviewers, never posts a comment or closes;
+- **Hard "never close" gates:** locked, pinned, maintainer-authored, paired-with-open-PR, looper-internal-labeled, quarantine-labeled, and sub-threshold-confidence items are skipped in both lanes;
+- **Drift fingerprint** specifically detects: human-edited warning comment, assignee-only changes, reaction-only changes, linked-PR state changes;
+- Phase B cancel path: edits the warning comment via marker (does not delete) and persists `cancelled` outcome;
+- Phase B close path calls `CloseIssue`/`ClosePullRequest` with the right `state_reason`, posts the close comment, removes `pendingLabel`, applies `closedLabel`;
+- No `extend` action is ever produced or accepted (test that runner rejects it);
+- `dryRun=true` performs no GitHub mutations but produces full audit records in `PayloadJSON`;
+- `triggers.maxPerTick` caps `sweeper:warn` only; `sweeper:close` is capped at `maxPerTick * 3`; `sweeper:reconcile` capped at `maxPerTick`;
+- **Daily ceilings:** `maxWarningsPerRepoPerDay` and `maxClosesPerRepoPerDay` block apply mutations once reached; counters reset at UTC midnight; defer to next day with `outcome=ceiling_reached`;
+- **Global kill switch:** when `limits.globalKillSwitch=true`, propose runs but apply unconditionally aborts every mutation;
+- gateway `CloseIssue`/`ClosePullRequest`/`EnsureLabel` are idempotent;
+- `DedupeKey` collapses duplicate discovery enqueues; `LockKey` serializes Phase A and Phase B for the same target;
+- queue fairness: many `sweeper:close` items do not starve other roles' queue items;
+- scheduler skips sweeper discovery when `autoDiscovery=false`, but still processes already-claimed sweeper queue items;
+- per-project override + env var merge for sweeper config works at every integration site listed in §7;
+- CLI: `looper sweep`, `looper sweep --dry-run`, `looper sweep --kill-switch`, `looper prompt preview --role sweeper --issue <N>`, and the new `looper config` registrations;
+- the bot-author and maintainer-author skip paths do not increment daily ceilings;
+- sweeper does not falsely cancel its own warnings on its next tick (own actor's marker comments are recognized).
+
+Repository-level verification uses the standard Go-first command set per AGENTS.md:
+
+```sh
+go test ./...
+go vet ./...
+go build ./...
+```
+
+Manual validation (narrow-to-broad rollout, blast-radius first):
+
+1. Enable sweeper on a low-traffic test project with `dryRun=true` and only `categories.stale.enabled=true`. Run for one full grace cycle (default 7 days). Inspect `PayloadJSON` audit records.
+2. Sample 20 stale decisions, verify rationale matches reality, tune `minConfidence`. Confirm `EnsureLabel` created the four sweeper-managed labels.
+3. Flip `dryRun=false` for `stale` only. Watch the first warn batch, then the first close batch one grace period later. Confirm cancellation paths work by commenting on a pending item, removing the pending label, and editing the warning comment.
+4. Enable `already_fixed`, repeat the cycle. Then `superseded`. Then `abandoned_pr`. Leave `unrelated` off until each prior category has produced at least 50 decisions with no false positives in audit review.
+5. Verify daily ceilings (`maxWarningsPerRepoPerDay`, `maxClosesPerRepoPerDay`) by temporarily lowering them and confirming `outcome=ceiling_reached` records appear.
+6. Verify `globalKillSwitch=true` halts every apply mutation in flight while propose continues.
+7. Roll out to wider projects only after one full grace cycle has passed cleanly with all enabled categories.
+
+## Implementation checklist
+
+- [ ] Create `internal/sweeper/` package with `runner.go`, `runner_test.go`, `doc.go`.
+- [ ] Create `internal/sweeper/copy/` with one spine per `(category, item_type)` pair and a `Spine(category, itemType)` lookup. Include a warm-variant for `is_first_time_contributor=true`.
+- [ ] Create `internal/sweeper/factbundle.go` that builds the structured fact bundle (item, timeline, linked-work, project, author-relationship, policy facts). Language is captured but not used to switch comment language in v1.
+- [ ] Add `SweeperRoleConfig` and partial-config types in `internal/config/types.go` (`Triggers`, `Lifecycle`, `Limits`, `Categories`, `Security`, `Reporting`).
+- [ ] Add sweeper defaults in `internal/config/defaults.go` per §3 (opt-in, dry-run on, `excludeAuthorAssociations=["OWNER","MEMBER","COLLABORATOR"]`, daily ceilings 25/25, `globalKillSwitch=false`).
+- [ ] Add sweeper validation in `internal/config/validate.go` per §3 (label overlap, unknown author associations, non-positive integers, etc.).
+- [ ] Register `"sweeper"` at every integration site listed in §7: `internal/config/validate.go:188-191, 374-427`, `internal/config/project_roles.go:18-31`, `internal/config/load.go:836-906`, `internal/config/normalize.go:512-576`, `internal/cliapp/prompt_commands.go:24-26, 62-68, 165-177`, `internal/cliapp/app.go:178-179, 300-345, 429-470`.
+- [ ] Add `CloseIssue`, `ClosePullRequest`, `EnsureLabel`, `ListIssueCommentReactions` to `internal/infra/github/gateway.go` with idempotency. (Note: `UpdateIssueComment` already exists at gateway.go:129-134, 554-557 — reuse, do not re-add.)
+- [ ] Implement propose lane: read-only fact-bundle build, agent classification, decision parsing, snapshot fingerprint capture; never mutates `gh` write APIs.
+- [ ] Implement apply lane: marker pre-check, live re-fetch, drift check against fingerprint, documented mutation ordering with idempotent recovery, then mutation calls.
+- [ ] Implement category-specific required-evidence validation per §5b; downgrade-to-`none` on failure; log every failure with the offending body and category for tuning.
+- [ ] Implement Phase A discovery → `sweeper:warn` queue items with `DedupeKey` and `LockKey` per §2.
+- [ ] Implement Phase B discovery → `sweeper:close` queue items, capped at `triggers.maxPerTick * 3`.
+- [ ] Implement reconcile discovery → `sweeper:reconcile` queue items covering label-removed, comment-deleted, comment-edited, already-closed-by-human, item-reopened, and security-after-warn paths.
+- [ ] Implement Phase A apply processor: marker pre-check, post comment with marker UUID, persist metadata in `PayloadJSON`, apply `pendingLabel`. Mutation ordering survives crash mid-sequence.
+- [ ] Implement Phase B apply processor: re-fetch, drift-check, then `close` (close-comment → CloseIssue/ClosePR → remove pending → add closed) or `cancel` (UpdateIssueComment via marker → remove pending). No `extend` action.
+- [ ] Implement `route_security` outcome via the apply lane: apply `security.quarantineLabel`, optionally assign reviewers, drop `pendingLabel` and edit warning to quarantine notice if previously warned, never close.
+- [ ] Implement bot-author and maintainer-author skip branches (sweeper takes no action; does not increment daily ceilings).
+- [ ] Implement daily ceilings (`maxWarningsPerRepoPerDay`, `maxClosesPerRepoPerDay`) by counting matching `PayloadJSON` audit records since UTC midnight; emit `outcome=ceiling_reached` when hit.
+- [ ] Implement `globalKillSwitch`: propose runs, apply unconditionally aborts every mutation.
+- [ ] Implement `EnsureLabel` startup pass per enabled repo for the four sweeper-managed labels; disable sweeper for that repo on permission failure with a clear log line.
+- [ ] Implement `reopenCooldownDays`: discovery skips items whose most recent sweeper close is younger than the cooldown.
+- [ ] Wire sweeper into scheduler (`internal/runtime/scheduler.go`) discovery tick and queue processing for all three queue types (`sweeper:warn`, `sweeper:close`, `sweeper:reconcile`).
+- [ ] Add `looper sweep`, `looper sweep --dry-run`, `looper sweep --kill-switch` / `--no-kill-switch` commands.
+- [ ] Extend `looper prompt preview --role sweeper --issue <N>` / `--pr <N>` to print the assembled fact bundle and selected spine. Error if neither flag is supplied (sweeper prompts are item-specific).
+- [ ] Register sweeper config fields in `internal/cliapp/config_commands.go` and matching `LOOPER_ROLES_SWEEPER_*` env vars (full list in §8).
+- [ ] Persist sweeper decision metadata in `QueueItemRecord.PayloadJSON` (UTC timestamps; `outcome` enum per §9). Optional per-item markdown reports under `reporting.durableReportsDir` when configured.
+- [ ] Add tests covering: required-evidence rules, spine selection, author branching, drift detection, marker pre-check, all crash-recovery scenarios, all reconciliation scenarios, `route_security`, daily ceilings, `globalKillSwitch`, `reopenCooldownDays`, dedupe/lock keys, queue fairness, `EnsureLabel` permission failure, sweeper not falsely cancelling its own warnings.
+- [ ] Document sweeper config, defaults, full example, rollout guide (stale-only → all categories), comment composition model, and the warn → grace → close lifecycle.
+- [ ] Run `go test ./...`, `go vet ./...`, `go build ./...`.


### PR DESCRIPTION
## Summary
- add the sweeper runner and scheduler integration to support an automated sweeper role
- extend config defaults, normalization, validation, and parity fixtures for sweeper-role settings
- document the sweeper role behavior and configuration in the spec and configuration docs