### PR TITLE
fix: fall back to stderr for empty loop logs

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2442,9 +2442,6 @@ func shouldDefaultLoopLogsStreamToStderr(resp loopLogsResponse) bool {
 	if resp.Agent == nil {
 		return false
 	}
-	if strings.TrimSpace(resp.Agent.Vendor) != "codex" {
-		return false
-	}
 	return strings.TrimSpace(resp.Agent.Stdout) == "" && strings.TrimSpace(resp.Agent.Stderr) != ""
 }
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -3357,7 +3357,7 @@ func TestHandlerLoopLogsReturnsPersistedHistoricalAgentOutput(t *testing.T) {
 	assertEqual(t, agent["stderr"], fullStderr)
 }
 
-func TestHandlerLoopLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
+func TestHandlerLoopLogsFollowDefaultsToStderrWhenStdoutEmpty(t *testing.T) {
 	fixture := newTestFixture(t)
 	seedRunRouteData(t, fixture.runtime)
 
@@ -3367,13 +3367,13 @@ func TestHandlerLoopLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T)
 		ProjectID:       stringPtr("project_1"),
 		LoopID:          stringPtr("loop_1"),
 		RunID:           stringPtr("run_1"),
-		Vendor:          "codex",
+		Vendor:          "opencode",
 		Status:          "running",
 		PID:             int64Ptr(1234),
 		HeartbeatCount:  1,
 		LastHeartbeatAt: stringPtr(nowISO),
 		StartedAt:       nowISO,
-		OutputJSON:      stringPtr(`{"stdout":"","stderr":"codex line1\n"}`),
+		OutputJSON:      stringPtr(`{"stdout":"","stderr":"stderr line1\n"}`),
 		CreatedAt:       nowISO,
 		UpdatedAt:       nowISO,
 	}); err != nil {
@@ -3409,7 +3409,7 @@ func TestHandlerLoopLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T)
 		exec := *updatedExec
 		exec.Status = "completed"
 		exec.EndedAt = &completedAt
-		exec.OutputJSON = stringPtr(`{"stdout":"","stderr":"codex line1\ncodex line2\n"}`)
+		exec.OutputJSON = stringPtr(`{"stdout":"","stderr":"stderr line1\nstderr line2\n"}`)
 		exec.UpdatedAt = completedAt
 		_ = fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), exec)
 	}()
@@ -3441,11 +3441,11 @@ func TestHandlerLoopLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T)
 	if !strings.Contains(text, "event: snapshot") {
 		t.Fatalf("stream body = %q, want snapshot event", text)
 	}
-	if !strings.Contains(text, "\"stderr\":\"codex line1\\n\"") {
-		t.Fatalf("stream body = %q, want codex stderr in snapshot", text)
+	if !strings.Contains(text, "\"stderr\":\"stderr line1\\n\"") {
+		t.Fatalf("stream body = %q, want stderr in snapshot", text)
 	}
-	if !strings.Contains(text, "event: chunk") || !strings.Contains(text, "\"content\":\"codex line2\\n\"") {
-		t.Fatalf("stream body = %q, want chunk with appended codex stderr output", text)
+	if !strings.Contains(text, "event: chunk") || !strings.Contains(text, "\"content\":\"stderr line2\\n\"") {
+		t.Fatalf("stream body = %q, want chunk with appended stderr output", text)
 	}
 	if !strings.Contains(text, "event: end") {
 		t.Fatalf("stream body = %q, want end event", text)

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -1621,7 +1621,7 @@ func TestLogsWithoutJSONPrintsRunSummaryWhenAgentOutputEmpty(t *testing.T) {
 	}
 }
 
-func TestLogsWithoutJSONDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
+func TestLogsWithoutJSONDefaultsToStderrWhenStdoutEmpty(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1635,11 +1635,11 @@ func TestLogsWithoutJSONDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
 			"loopStatus": "running",
 			"run":        map[string]any{"runId": "run_1", "currentStep": "review"},
 			"agent": map[string]any{
-				"vendor": "codex",
+				"vendor": "opencode",
 				"pid":    1234,
 				"status": "running",
 				"stdout": "",
-				"stderr": "codex line1\ncodex line2\n",
+				"stderr": "stderr line1\nstderr line2\n",
 			},
 		}))
 	}))
@@ -1653,7 +1653,7 @@ func TestLogsWithoutJSONDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("Run([logs loop_1 --tail 2]) stderr = %q, want empty string", stderr)
 	}
-	for _, want := range []string{"Loop #12 · reviewer · running", "Run run_1 · step: review", "Agent: codex · pid 1234 · running", "codex line1", "codex line2"} {
+	for _, want := range []string{"Loop #12 · reviewer · running", "Run run_1 · step: review", "Agent: opencode · pid 1234 · running", "stderr line1", "stderr line2"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("Run([logs loop_1 --tail 2]) stdout = %q, want to contain %q", stdout, want)
 		}
@@ -1695,7 +1695,7 @@ func TestLogsFollowStreamsNewOutput(t *testing.T) {
 	}
 }
 
-func TestLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
+func TestLogsFollowDefaultsToStderrWhenStdoutEmpty(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1710,9 +1710,9 @@ func TestLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = io.WriteString(w, "event: snapshot\n")
-		_, _ = io.WriteString(w, "data: {\"seq\":12,\"loopType\":\"reviewer\",\"loopStatus\":\"running\",\"run\":{\"runId\":\"run_1\",\"status\":\"running\",\"currentStep\":\"review\"},\"agent\":{\"executionId\":\"exec_1\",\"vendor\":\"codex\",\"pid\":1234,\"status\":\"running\",\"stdout\":\"\",\"stderr\":\"codex line1\\n\"}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"seq\":12,\"loopType\":\"reviewer\",\"loopStatus\":\"running\",\"run\":{\"runId\":\"run_1\",\"status\":\"running\",\"currentStep\":\"review\"},\"agent\":{\"executionId\":\"exec_1\",\"vendor\":\"opencode\",\"pid\":1234,\"status\":\"running\",\"stdout\":\"\",\"stderr\":\"stderr line1\\n\"}}\n\n")
 		_, _ = io.WriteString(w, "event: chunk\n")
-		_, _ = io.WriteString(w, "data: {\"runId\":\"run_1\",\"currentStep\":\"review\",\"executionId\":\"exec_1\",\"vendor\":\"codex\",\"pid\":1234,\"status\":\"running\",\"content\":\"codex line2\\n\"}\n\n")
+		_, _ = io.WriteString(w, "data: {\"runId\":\"run_1\",\"currentStep\":\"review\",\"executionId\":\"exec_1\",\"vendor\":\"opencode\",\"pid\":1234,\"status\":\"running\",\"content\":\"stderr line2\\n\"}\n\n")
 		_, _ = io.WriteString(w, "event: end\n")
 		_, _ = io.WriteString(w, "data: {\"reason\":\"run_completed\"}\n\n")
 	}))
@@ -1726,7 +1726,7 @@ func TestLogsFollowDefaultsToCodexStderrWhenStdoutEmpty(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("Run([logs loop_1 --follow]) stderr = %q, want empty string", stderr)
 	}
-	for _, want := range []string{"Loop #12 · reviewer · running", "Run run_1 · step: review", "Agent: codex · pid 1234 · running", "codex line1", "codex line2"} {
+	for _, want := range []string{"Loop #12 · reviewer · running", "Run run_1 · step: review", "Agent: opencode · pid 1234 · running", "stderr line1", "stderr line2"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("Run([logs loop_1 --follow]) stdout = %q, want to contain %q", stdout, want)
 		}

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -470,9 +470,6 @@ func shouldDefaultLoopLogsToStderr(data loopLogsOutput) bool {
 	if data.Agent == nil {
 		return false
 	}
-	if strings.TrimSpace(data.Agent.Vendor) != "codex" {
-		return false
-	}
 	return strings.TrimSpace(data.Agent.Stdout) == "" && strings.TrimSpace(data.Agent.Stderr) != ""
 }
 


### PR DESCRIPTION
## Summary
- make loop log rendering fall back to stderr whenever stdout is empty but stderr has content
- cover the fallback in CLI and API log-stream tests using an opencode reviewer payload
- keep running reviewer logs visible without requiring `--stderr`

## Testing
- go test ./internal/cliapp
- go test ./internal/api
- go test ./...
- go build ./...
- go vet ./...