### PR TITLE
fix: preserve sweeper filtering without unsupported gh fields

### DIFF
--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -404,7 +404,7 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 	if strings.TrimSpace(input.Author) != "" {
 		args = append(args, "--author", strings.TrimSpace(input.Author))
 	}
-	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "authorAssociation", "reviewRequests", "reviews", "mergeStateStatus"}, ","))
+	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "mergeStateStatus"}, ","))
 
 	timeout := input.Timeout
 	if timeout <= 0 {
@@ -497,7 +497,7 @@ func (g *Gateway) ListOpenIssues(ctx context.Context, input ListOpenIssuesInput)
 	for _, label := range issueListLabels(input) {
 		args = append(args, "--label", label)
 	}
-	args = append(args, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "updatedAt", "author", "authorAssociation", "assignees", "labels"}, ","))
+	args = append(args, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "updatedAt", "author", "assignees", "labels"}, ","))
 
 	result, err := g.runGh(ctx, input.CWD, "", args...)
 	if err != nil {
@@ -668,7 +668,7 @@ func compactIssueAssignees(values []string) []string {
 }
 
 func (g *Gateway) ViewPullRequest(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
-	result, err := g.runGh(ctx, input.CWD, "", "pr", "view", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "authorAssociation", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}, ","))
+	result, err := g.runGh(ctx, input.CWD, "", "pr", "view", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}, ","))
 	if err != nil {
 		return PullRequestDetail{}, err
 	}

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -548,7 +548,12 @@ func issueListLabels(input ListOpenIssuesInput) []string {
 }
 
 func (g *Gateway) ViewIssue(ctx context.Context, input ViewIssueInput) (IssueDetail, error) {
-	result, err := g.runGh(ctx, input.CWD, "", "api", fmt.Sprintf("repos/%s/issues/%d", input.Repo, input.IssueNumber))
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/issues/%d", repo, input.IssueNumber)}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
 	if err != nil {
 		return IssueDetail{}, err
 	}
@@ -1891,6 +1896,14 @@ func hostQualifiedRepo(nameWithOwner string, repoURL string) string {
 		return repo
 	}
 	return parsed.Hostname() + "/" + repo
+}
+
+func splitRepoHostname(repo string) (string, string) {
+	parts := strings.Split(strings.TrimSpace(repo), "/")
+	if len(parts) == 3 && strings.TrimSpace(parts[0]) != "" {
+		return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]) + "/" + strings.TrimSpace(parts[2])
+	}
+	return "", strings.TrimSpace(repo)
 }
 
 func summarizeChecks(checks []map[string]any) string {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1107,6 +1107,26 @@ func TestGatewayIsAuthenticatedScopesStatusToHostname(t *testing.T) {
 	}
 }
 
+func TestGatewayViewIssueScopesAPIToHostname(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		if args != "api repos/acme/looper/issues/8 --hostname github.example.com" {
+			t.Fatalf("unexpected gh args: %q", args)
+		}
+		return shell.Result{Stdout: `{"number":8,"title":"Issue","body":"Body","state":"open","updated_at":"2026-05-01T00:00:00Z","user":{"login":"octo"},"author_association":"MEMBER","labels":[]}`}, nil
+	}
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	detail, err := gateway.ViewIssue(context.Background(), ViewIssueInput{Repo: "github.example.com/acme/looper", IssueNumber: 8})
+	if err != nil {
+		t.Fatalf("ViewIssue() error = %v", err)
+	}
+	if detail.Number != 8 || detail.AuthorAssociation != "MEMBER" {
+		t.Fatalf("ViewIssue() = %#v, want parsed enterprise issue detail", detail)
+	}
+}
+
 func TestGatewayIgnoresPlainPullRequestCommentsAsReviewThreads(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -23,9 +23,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 			runner.stdin = options.Stdin
 			return shell.Result{Stdout: "{}"}, nil
 		case strings.HasPrefix(args, "pr list"):
-			return shell.Result{Stdout: `[{"number":42,"title":"Review me","url":"https://example.test/pull/42","state":"OPEN","updatedAt":"2026-05-01T12:00:00Z","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"authorAssociation":"MEMBER","reviewRequests":[{"__typename":"User","login":"OctoCat"},{"__typename":"Team","slug":"platform"}]}]`}, nil
+			return shell.Result{Stdout: `[{"number":42,"title":"Review me","url":"https://example.test/pull/42","state":"OPEN","updatedAt":"2026-05-01T12:00:00Z","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"reviewRequests":[{"__typename":"User","login":"OctoCat"},{"__typename":"Team","slug":"platform"}]}]`}, nil
 		case strings.HasPrefix(args, "issue list"):
-			return shell.Result{Stdout: `[{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","updatedAt":"2026-05-02T12:00:00Z","author":{"login":"octocat"},"authorAssociation":"OWNER","assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}]`}, nil
+			return shell.Result{Stdout: `[{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","updatedAt":"2026-05-02T12:00:00Z","author":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}]`}, nil
 		case args == "api repos/acme/looper/issues/8":
 			return shell.Result{Stdout: `{"number":8,"title":"Fix gateway","body":"Issue body","html_url":"https://example.test/issues/8","state":"open","updated_at":"2026-05-03T12:00:00Z","user":{"login":"octocat"},"author_association":"COLLABORATOR","assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}`}, nil
 		case args == "api repos/acme/looper/issues/8/comments --method POST -f body=Looper started":
@@ -35,7 +35,7 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 		case args == "api repos/acme/looper/issues/8/assignees --method POST -f assignees[]=reviewer":
 			return shell.Result{Stdout: "{}"}, nil
 		case strings.HasPrefix(args, "pr view"):
-			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","updatedAt":"2026-05-04T12:00:00Z","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"authorAssociation":"CONTRIBUTOR","reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"id":"issue-comment-1","body":"conversation notice"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
+			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","updatedAt":"2026-05-04T12:00:00Z","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"DIRTY","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}},{"requestedReviewer":{"__typename":"Team","slug":"platform"}}],"comments":[{"id":"issue-comment-1","body":"conversation notice"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
 		case strings.HasPrefix(args, "pr diff"):
 			return shell.Result{Stdout: "diff --git a/a.ts b/a.ts\n"}, nil
 		case strings.HasPrefix(args, "api user"):
@@ -150,8 +150,8 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if got := prs[0].ReviewRequests; len(got) != 1 || got[0] != "OctoCat" {
 		t.Fatalf("prs[0].ReviewRequests = %#v, want [OctoCat]", got)
 	}
-	if prs[0].AuthorAssociation != "MEMBER" {
-		t.Fatalf("prs[0].AuthorAssociation = %q, want MEMBER", prs[0].AuthorAssociation)
+	if prs[0].AuthorAssociation != "" {
+		t.Fatalf("prs[0].AuthorAssociation = %q, want empty unsupported field", prs[0].AuthorAssociation)
 	}
 	if prs[0].UpdatedAt != "2026-05-01T12:00:00Z" {
 		t.Fatalf("prs[0].UpdatedAt = %q, want parsed updated timestamp", prs[0].UpdatedAt)
@@ -165,8 +165,8 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if got := issues[0].Labels; len(got) != 2 || got[0] != "phase-1" || got[1] != "gateway" {
 		t.Fatalf("issues[0].Labels = %#v, want [phase-1 gateway]", got)
 	}
-	if issues[0].AuthorAssociation != "OWNER" {
-		t.Fatalf("issues[0].AuthorAssociation = %q, want OWNER", issues[0].AuthorAssociation)
+	if issues[0].AuthorAssociation != "" {
+		t.Fatalf("issues[0].AuthorAssociation = %q, want empty unsupported field", issues[0].AuthorAssociation)
 	}
 	if issues[0].UpdatedAt != "2026-05-02T12:00:00Z" {
 		t.Fatalf("issues[0].UpdatedAt = %q, want parsed updated timestamp", issues[0].UpdatedAt)
@@ -195,8 +195,8 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if got := detail.ReviewRequests; len(got) != 1 || got[0] != "reviewer" {
 		t.Fatalf("detail.ReviewRequests = %#v, want [reviewer]", got)
 	}
-	if detail.AuthorAssociation != "CONTRIBUTOR" {
-		t.Fatalf("detail.AuthorAssociation = %q, want CONTRIBUTOR", detail.AuthorAssociation)
+	if detail.AuthorAssociation != "" {
+		t.Fatalf("detail.AuthorAssociation = %q, want empty unsupported field", detail.AuthorAssociation)
 	}
 	if detail.UpdatedAt != "2026-05-04T12:00:00Z" {
 		t.Fatalf("detail.UpdatedAt = %q, want parsed updated timestamp", detail.UpdatedAt)
@@ -1497,7 +1497,7 @@ func TestListOpenPullRequestsPassesAllLabelsToGH(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "pr list --repo acme/looper --state open --limit 30 --label bug --label priority --json number,title,url,state,updatedAt,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,baseRefOid,author,authorAssociation,reviewRequests,reviews,mergeStateStatus" {
+		if args != "pr list --repo acme/looper --state open --limit 30 --label bug --label priority --json number,title,url,state,updatedAt,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,baseRefOid,author,reviewRequests,reviews,mergeStateStatus" {
 			t.Fatalf("gh args = %q, want repeated label filters", args)
 		}
 		return shell.Result{Stdout: `[]`}, nil
@@ -1514,7 +1514,7 @@ func TestListOpenIssuesPassesAllLabelsToGH(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "issue list --repo acme/looper --state open --limit 30 --assignee reviewer --label bug --label priority --json number,title,body,url,state,updatedAt,author,authorAssociation,assignees,labels" {
+		if args != "issue list --repo acme/looper --state open --limit 30 --assignee reviewer --label bug --label priority --json number,title,body,url,state,updatedAt,author,assignees,labels" {
 			t.Fatalf("gh args = %q, want repeated label filters", args)
 		}
 		return shell.Result{Stdout: `[]`}, nil

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -288,7 +288,12 @@ func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryI
 		if issue.IsPullRequest {
 			continue
 		}
-		issue.AuthorAssociation = r.summaryAuthorAssociation(ctx, input.Repo, issue.Number, issue.AuthorAssociation, roleCfg)
+		var associationOK bool
+		issue.AuthorAssociation, associationOK = r.summaryAuthorAssociation(ctx, input.Repo, issue.Number, issue.AuthorAssociation, roleCfg)
+		if !associationOK {
+			result.Skipped++
+			continue
+		}
 		targetID := buildTargetID(input.Repo, issue.Number)
 		if r.shouldSkipSummary(issue.Labels, issue.Author, issue.AuthorAssociation, states[targetID], roleCfg) {
 			result.Skipped++
@@ -358,7 +363,12 @@ func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input Disc
 			result.Skipped++
 			continue
 		}
-		pr.AuthorAssociation = r.summaryAuthorAssociation(ctx, input.Repo, pr.Number, pr.AuthorAssociation, roleCfg)
+		var associationOK bool
+		pr.AuthorAssociation, associationOK = r.summaryAuthorAssociation(ctx, input.Repo, pr.Number, pr.AuthorAssociation, roleCfg)
+		if !associationOK {
+			result.Skipped++
+			continue
+		}
 		targetID := buildTargetID(input.Repo, pr.Number)
 		if r.shouldSkipSummary(pr.Labels, pr.Author, pr.AuthorAssociation, states[targetID], roleCfg) {
 			result.Skipped++
@@ -716,15 +726,19 @@ func (r *Runner) shouldSkipSummary(labels []string, author string, authorAssocia
 	return false
 }
 
-func (r *Runner) summaryAuthorAssociation(ctx context.Context, repo string, number int64, current string, roleCfg config.SweeperRoleConfig) string {
+func (r *Runner) summaryAuthorAssociation(ctx context.Context, repo string, number int64, current string, roleCfg config.SweeperRoleConfig) (string, bool) {
 	if strings.TrimSpace(current) != "" || len(roleCfg.Triggers.ExcludeAuthorAssociations) == 0 || r.github == nil {
-		return current
+		return current, true
 	}
 	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: number})
 	if err != nil {
-		return current
+		return "", false
 	}
-	return detail.AuthorAssociation
+	association := strings.TrimSpace(detail.AuthorAssociation)
+	if association == "" {
+		return current, true
+	}
+	return association, true
 }
 
 func (r *Runner) reopenCooldownActive(state sweeperStateRecord, roleCfg config.SweeperRoleConfig) bool {

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -738,19 +738,11 @@ func authorAssociationExcluded(authorAssociation string, roleCfg config.SweeperR
 	return false
 }
 
-func issueDetailLookupRepo(repo string) string {
-	parts := strings.Split(strings.TrimSpace(repo), "/")
-	if len(parts) == 3 && strings.TrimSpace(parts[0]) != "" {
-		return strings.TrimSpace(parts[1]) + "/" + strings.TrimSpace(parts[2])
-	}
-	return strings.TrimSpace(repo)
-}
-
 func (r *Runner) summaryAuthorAssociation(ctx context.Context, repo string, cwd string, number int64, current string, roleCfg config.SweeperRoleConfig) (string, bool) {
 	if strings.TrimSpace(current) != "" || len(roleCfg.Triggers.ExcludeAuthorAssociations) == 0 || r.github == nil {
 		return current, true
 	}
-	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: issueDetailLookupRepo(repo), IssueNumber: number, CWD: cwd})
+	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: strings.TrimSpace(repo), IssueNumber: number, CWD: cwd})
 	if err != nil {
 		return "", false
 	}

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -288,14 +288,18 @@ func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryI
 		if issue.IsPullRequest {
 			continue
 		}
+		targetID := buildTargetID(input.Repo, issue.Number)
+		if r.shouldSkipSummary(issue.Labels, issue.Author, states[targetID], roleCfg) {
+			result.Skipped++
+			continue
+		}
 		var associationOK bool
 		issue.AuthorAssociation, associationOK = r.summaryAuthorAssociation(ctx, input.Repo, issue.Number, issue.AuthorAssociation, roleCfg)
 		if !associationOK {
 			result.Skipped++
 			continue
 		}
-		targetID := buildTargetID(input.Repo, issue.Number)
-		if r.shouldSkipSummary(issue.Labels, issue.Author, issue.AuthorAssociation, states[targetID], roleCfg) {
+		if authorAssociationExcluded(issue.AuthorAssociation, roleCfg) {
 			result.Skipped++
 			continue
 		}
@@ -363,14 +367,18 @@ func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input Disc
 			result.Skipped++
 			continue
 		}
+		targetID := buildTargetID(input.Repo, pr.Number)
+		if r.shouldSkipSummary(pr.Labels, pr.Author, states[targetID], roleCfg) {
+			result.Skipped++
+			continue
+		}
 		var associationOK bool
 		pr.AuthorAssociation, associationOK = r.summaryAuthorAssociation(ctx, input.Repo, pr.Number, pr.AuthorAssociation, roleCfg)
 		if !associationOK {
 			result.Skipped++
 			continue
 		}
-		targetID := buildTargetID(input.Repo, pr.Number)
-		if r.shouldSkipSummary(pr.Labels, pr.Author, pr.AuthorAssociation, states[targetID], roleCfg) {
+		if authorAssociationExcluded(pr.AuthorAssociation, roleCfg) {
 			result.Skipped++
 			continue
 		}
@@ -706,7 +714,7 @@ func gracePeriodForCategory(category string, roleCfg config.SweeperRoleConfig) i
 	}
 }
 
-func (r *Runner) shouldSkipSummary(labels []string, author string, authorAssociation string, state sweeperStateRecord, roleCfg config.SweeperRoleConfig) bool {
+func (r *Runner) shouldSkipSummary(labels []string, author string, state sweeperStateRecord, roleCfg config.SweeperRoleConfig) bool {
 	if hasAnyLabel(labels, roleCfg.Triggers.ExcludeLabels) || hasAnyLabelExcept(labels, roleCfg.Triggers.LooperInternalLabels, roleCfg.Lifecycle.ClosedLabel) || hasLabel(labels, roleCfg.Security.QuarantineLabel) {
 		return true
 	}
@@ -718,6 +726,10 @@ func (r *Runner) shouldSkipSummary(labels []string, author string, authorAssocia
 			return true
 		}
 	}
+	return false
+}
+
+func authorAssociationExcluded(authorAssociation string, roleCfg config.SweeperRoleConfig) bool {
 	for _, excluded := range roleCfg.Triggers.ExcludeAuthorAssociations {
 		if strings.EqualFold(strings.TrimSpace(excluded), strings.TrimSpace(authorAssociation)) {
 			return true

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -738,11 +738,19 @@ func authorAssociationExcluded(authorAssociation string, roleCfg config.SweeperR
 	return false
 }
 
+func issueDetailLookupRepo(repo string) string {
+	parts := strings.Split(strings.TrimSpace(repo), "/")
+	if len(parts) == 3 && strings.TrimSpace(parts[0]) != "" {
+		return strings.TrimSpace(parts[1]) + "/" + strings.TrimSpace(parts[2])
+	}
+	return strings.TrimSpace(repo)
+}
+
 func (r *Runner) summaryAuthorAssociation(ctx context.Context, repo string, number int64, current string, roleCfg config.SweeperRoleConfig) (string, bool) {
 	if strings.TrimSpace(current) != "" || len(roleCfg.Triggers.ExcludeAuthorAssociations) == 0 || r.github == nil {
 		return current, true
 	}
-	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: number})
+	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: issueDetailLookupRepo(repo), IssueNumber: number})
 	if err != nil {
 		return "", false
 	}

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -294,7 +294,7 @@ func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryI
 			continue
 		}
 		var associationOK bool
-		issue.AuthorAssociation, associationOK = r.summaryAuthorAssociation(ctx, input.Repo, issue.Number, issue.AuthorAssociation, roleCfg)
+		issue.AuthorAssociation, associationOK = r.summaryAuthorAssociation(ctx, input.Repo, project.RepoPath, issue.Number, issue.AuthorAssociation, roleCfg)
 		if !associationOK {
 			result.Skipped++
 			continue
@@ -373,7 +373,7 @@ func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input Disc
 			continue
 		}
 		var associationOK bool
-		pr.AuthorAssociation, associationOK = r.summaryAuthorAssociation(ctx, input.Repo, pr.Number, pr.AuthorAssociation, roleCfg)
+		pr.AuthorAssociation, associationOK = r.summaryAuthorAssociation(ctx, input.Repo, project.RepoPath, pr.Number, pr.AuthorAssociation, roleCfg)
 		if !associationOK {
 			result.Skipped++
 			continue
@@ -746,11 +746,11 @@ func issueDetailLookupRepo(repo string) string {
 	return strings.TrimSpace(repo)
 }
 
-func (r *Runner) summaryAuthorAssociation(ctx context.Context, repo string, number int64, current string, roleCfg config.SweeperRoleConfig) (string, bool) {
+func (r *Runner) summaryAuthorAssociation(ctx context.Context, repo string, cwd string, number int64, current string, roleCfg config.SweeperRoleConfig) (string, bool) {
 	if strings.TrimSpace(current) != "" || len(roleCfg.Triggers.ExcludeAuthorAssociations) == 0 || r.github == nil {
 		return current, true
 	}
-	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: issueDetailLookupRepo(repo), IssueNumber: number})
+	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: issueDetailLookupRepo(repo), IssueNumber: number, CWD: cwd})
 	if err != nil {
 		return "", false
 	}

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -288,6 +288,7 @@ func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryI
 		if issue.IsPullRequest {
 			continue
 		}
+		issue.AuthorAssociation = r.summaryAuthorAssociation(ctx, input.Repo, issue.Number, issue.AuthorAssociation, roleCfg)
 		targetID := buildTargetID(input.Repo, issue.Number)
 		if r.shouldSkipSummary(issue.Labels, issue.Author, issue.AuthorAssociation, states[targetID], roleCfg) {
 			result.Skipped++
@@ -357,6 +358,7 @@ func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input Disc
 			result.Skipped++
 			continue
 		}
+		pr.AuthorAssociation = r.summaryAuthorAssociation(ctx, input.Repo, pr.Number, pr.AuthorAssociation, roleCfg)
 		targetID := buildTargetID(input.Repo, pr.Number)
 		if r.shouldSkipSummary(pr.Labels, pr.Author, pr.AuthorAssociation, states[targetID], roleCfg) {
 			result.Skipped++
@@ -712,6 +714,17 @@ func (r *Runner) shouldSkipSummary(labels []string, author string, authorAssocia
 		}
 	}
 	return false
+}
+
+func (r *Runner) summaryAuthorAssociation(ctx context.Context, repo string, number int64, current string, roleCfg config.SweeperRoleConfig) string {
+	if strings.TrimSpace(current) != "" || len(roleCfg.Triggers.ExcludeAuthorAssociations) == 0 || r.github == nil {
+		return current
+	}
+	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: number})
+	if err != nil {
+		return current
+	}
+	return detail.AuthorAssociation
 }
 
 func (r *Runner) reopenCooldownActive(state sweeperStateRecord, roleCfg config.SweeperRoleConfig) bool {

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -126,6 +126,46 @@ func TestDiscoverPullRequestsSkipsWhenPRLaneDisabled(t *testing.T) {
 	}
 }
 
+func TestDiscoverIssuesSkipsExcludedLabelBeforeAuthorAssociationLookup(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.Triggers.ExcludeLabels = []string{"skip-me"}
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo", Labels: []string{"skip-me"}}}
+	fixture.github.viewIssueErr = errors.New("transient gh failure")
+
+	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || result.Skipped != 1 {
+		t.Fatalf("DiscoverIssues() = %#v, want excluded label to be skipped", result)
+	}
+	if fixture.github.viewIssueCalls != 0 {
+		t.Fatalf("ViewIssue() calls = %d, want 0", fixture.github.viewIssueCalls)
+	}
+}
+
+func TestDiscoverPullRequestsSkipsExcludedAuthorBeforeAuthorAssociationLookup(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.Triggers.ExcludeAuthors = []string{"octo"}
+	fixture.github.prs = []githubinfra.PullRequestSummary{{Number: 1, Title: "stale pr", Author: "octo", UpdatedAt: fixture.now.Add(-40 * 24 * time.Hour).Format(javaScriptISOStringUTC)}}
+	fixture.github.viewIssueErr = errors.New("transient gh failure")
+
+	result, err := fixture.runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || result.Skipped != 1 {
+		t.Fatalf("DiscoverPullRequests() = %#v, want excluded author to be skipped", result)
+	}
+	if fixture.github.viewIssueCalls != 0 {
+		t.Fatalf("ViewIssue() calls = %d, want 0", fixture.github.viewIssueCalls)
+	}
+}
+
 func TestProcessWarnSkipsFreshAbandonedPRCandidates(t *testing.T) {
 	t.Parallel()
 
@@ -558,6 +598,7 @@ type stubGitHub struct {
 	issueDetails    map[string]githubinfra.IssueDetail
 	prDetails       map[string]githubinfra.PullRequestDetail
 	viewIssueErr    error
+	viewIssueCalls  int
 	listIssuesCalls int
 	listPRCalls     int
 	createdComments []githubinfra.IssueCommentInput
@@ -579,6 +620,7 @@ func (g *stubGitHub) ListOpenPullRequests(context.Context, githubinfra.ListOpenP
 }
 
 func (g *stubGitHub) ViewIssue(_ context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
+	g.viewIssueCalls++
 	if g.viewIssueErr != nil {
 		return githubinfra.IssueDetail{}, g.viewIssueErr
 	}

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -187,6 +187,9 @@ func TestDiscoverIssuesBackfillsAssociationUsingOwnerRepoPath(t *testing.T) {
 	if got := fixture.github.viewIssueRepos; len(got) != 1 || got[0] != "acme/looper" {
 		t.Fatalf("ViewIssue() repos = %v, want [acme/looper]", got)
 	}
+	if got := fixture.github.viewIssueCWDs; len(got) != 1 || got[0] == "" {
+		t.Fatalf("ViewIssue() CWDs = %v, want project repo path", got)
+	}
 }
 
 func TestDiscoverPullRequestsBackfillsAssociationUsingOwnerRepoPath(t *testing.T) {
@@ -209,6 +212,9 @@ func TestDiscoverPullRequestsBackfillsAssociationUsingOwnerRepoPath(t *testing.T
 	}
 	if got := fixture.github.viewIssueRepos; len(got) != 1 || got[0] != "acme/looper" {
 		t.Fatalf("ViewIssue() repos = %v, want [acme/looper]", got)
+	}
+	if got := fixture.github.viewIssueCWDs; len(got) != 1 || got[0] == "" {
+		t.Fatalf("ViewIssue() CWDs = %v, want project repo path", got)
 	}
 }
 
@@ -646,6 +652,7 @@ type stubGitHub struct {
 	viewIssueErr    error
 	viewIssueCalls  int
 	viewIssueRepos  []string
+	viewIssueCWDs   []string
 	listIssuesCalls int
 	listPRCalls     int
 	createdComments []githubinfra.IssueCommentInput
@@ -669,6 +676,7 @@ func (g *stubGitHub) ListOpenPullRequests(context.Context, githubinfra.ListOpenP
 func (g *stubGitHub) ViewIssue(_ context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
 	g.viewIssueCalls++
 	g.viewIssueRepos = append(g.viewIssueRepos, input.Repo)
+	g.viewIssueCWDs = append(g.viewIssueCWDs, input.CWD)
 	if g.viewIssueErr != nil {
 		return githubinfra.IssueDetail{}, g.viewIssueErr
 	}

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -2,6 +2,7 @@ package sweeper
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -417,6 +418,38 @@ func TestDiscoverPullRequestsSkipsExcludedAuthorAssociations(t *testing.T) {
 	}
 }
 
+func TestDiscoverIssuesSkipsWhenAuthorAssociationLookupFails(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 3, Title: "stale bug", Body: "needs cleanup", Author: "octo"}}
+	fixture.github.viewIssueErr = errors.New("transient gh failure")
+
+	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || result.Skipped != 1 {
+		t.Fatalf("DiscoverIssues() = %#v, want lookup failure to fail closed", result)
+	}
+}
+
+func TestDiscoverPullRequestsSkipsWhenAuthorAssociationLookupFails(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.github.prs = []githubinfra.PullRequestSummary{{Number: 4, Title: "stale pr", Author: "octo", UpdatedAt: fixture.now.Add(-40 * 24 * time.Hour).Format(javaScriptISOStringUTC)}}
+	fixture.github.viewIssueErr = errors.New("transient gh failure")
+
+	result, err := fixture.runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || result.Skipped != 1 {
+		t.Fatalf("DiscoverPullRequests() = %#v, want lookup failure to fail closed", result)
+	}
+}
+
 func TestDiscoverIssuesSkipsReopenedSweptItemWithinCooldown(t *testing.T) {
 	t.Parallel()
 
@@ -524,6 +557,7 @@ type stubGitHub struct {
 	prs             []githubinfra.PullRequestSummary
 	issueDetails    map[string]githubinfra.IssueDetail
 	prDetails       map[string]githubinfra.PullRequestDetail
+	viewIssueErr    error
 	listIssuesCalls int
 	listPRCalls     int
 	createdComments []githubinfra.IssueCommentInput
@@ -545,6 +579,9 @@ func (g *stubGitHub) ListOpenPullRequests(context.Context, githubinfra.ListOpenP
 }
 
 func (g *stubGitHub) ViewIssue(_ context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
+	if g.viewIssueErr != nil {
+		return githubinfra.IssueDetail{}, g.viewIssueErr
+	}
 	return g.issueDetails[input.Repo+"#"+itoa(input.IssueNumber)], nil
 }
 

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -389,7 +389,8 @@ func TestDiscoverIssuesSkipsExcludedAuthorAssociations(t *testing.T) {
 	t.Parallel()
 
 	fixture := newRunnerFixture(t)
-	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo", AuthorAssociation: "OWNER"}}
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo"}}
+	fixture.github.issueDetails["acme/looper#1"] = githubinfra.IssueDetail{Number: 1, AuthorAssociation: "OWNER"}
 
 	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
 	if err != nil {
@@ -397,6 +398,22 @@ func TestDiscoverIssuesSkipsExcludedAuthorAssociations(t *testing.T) {
 	}
 	if len(result.QueueItems) != 0 || result.Skipped != 1 {
 		t.Fatalf("DiscoverIssues() = %#v, want excluded association to be skipped", result)
+	}
+}
+
+func TestDiscoverPullRequestsSkipsExcludedAuthorAssociations(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.github.prs = []githubinfra.PullRequestSummary{{Number: 2, Title: "stale pr", Author: "octo", UpdatedAt: fixture.now.Add(-40 * 24 * time.Hour).Format(javaScriptISOStringUTC)}}
+	fixture.github.issueDetails["acme/looper#2"] = githubinfra.IssueDetail{Number: 2, AuthorAssociation: "OWNER", IsPullRequest: true}
+
+	result, err := fixture.runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || result.Skipped != 1 {
+		t.Fatalf("DiscoverPullRequests() = %#v, want excluded association to be skipped", result)
 	}
 }
 

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -166,6 +166,52 @@ func TestDiscoverPullRequestsSkipsExcludedAuthorBeforeAuthorAssociationLookup(t 
 	}
 }
 
+func TestDiscoverIssuesBackfillsAssociationUsingOwnerRepoPath(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.Triggers.ExcludeAuthorAssociations = []string{"OWNER"}
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo"}}
+	fixture.github.issueDetails["acme/looper#1"] = githubinfra.IssueDetail{Number: 1, AuthorAssociation: "OWNER"}
+
+	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "github.example.com/acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || result.Skipped != 1 {
+		t.Fatalf("DiscoverIssues() = %#v, want excluded owner issue to be skipped", result)
+	}
+	if fixture.github.viewIssueCalls != 1 {
+		t.Fatalf("ViewIssue() calls = %d, want 1", fixture.github.viewIssueCalls)
+	}
+	if got := fixture.github.viewIssueRepos; len(got) != 1 || got[0] != "acme/looper" {
+		t.Fatalf("ViewIssue() repos = %v, want [acme/looper]", got)
+	}
+}
+
+func TestDiscoverPullRequestsBackfillsAssociationUsingOwnerRepoPath(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Roles.Sweeper.Triggers.ExcludeAuthorAssociations = []string{"MEMBER"}
+	fixture.github.prs = []githubinfra.PullRequestSummary{{Number: 1, Title: "stale pr", Author: "octo", UpdatedAt: fixture.now.Add(-40 * 24 * time.Hour).Format(javaScriptISOStringUTC)}}
+	fixture.github.issueDetails["acme/looper#1"] = githubinfra.IssueDetail{Number: 1, AuthorAssociation: "MEMBER"}
+
+	result, err := fixture.runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "github.example.com/acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || result.Skipped != 1 {
+		t.Fatalf("DiscoverPullRequests() = %#v, want excluded member PR to be skipped", result)
+	}
+	if fixture.github.viewIssueCalls != 1 {
+		t.Fatalf("ViewIssue() calls = %d, want 1", fixture.github.viewIssueCalls)
+	}
+	if got := fixture.github.viewIssueRepos; len(got) != 1 || got[0] != "acme/looper" {
+		t.Fatalf("ViewIssue() repos = %v, want [acme/looper]", got)
+	}
+}
+
 func TestProcessWarnSkipsFreshAbandonedPRCandidates(t *testing.T) {
 	t.Parallel()
 
@@ -599,6 +645,7 @@ type stubGitHub struct {
 	prDetails       map[string]githubinfra.PullRequestDetail
 	viewIssueErr    error
 	viewIssueCalls  int
+	viewIssueRepos  []string
 	listIssuesCalls int
 	listPRCalls     int
 	createdComments []githubinfra.IssueCommentInput
@@ -621,6 +668,7 @@ func (g *stubGitHub) ListOpenPullRequests(context.Context, githubinfra.ListOpenP
 
 func (g *stubGitHub) ViewIssue(_ context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
 	g.viewIssueCalls++
+	g.viewIssueRepos = append(g.viewIssueRepos, input.Repo)
 	if g.viewIssueErr != nil {
 		return githubinfra.IssueDetail{}, g.viewIssueErr
 	}

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -166,13 +166,13 @@ func TestDiscoverPullRequestsSkipsExcludedAuthorBeforeAuthorAssociationLookup(t 
 	}
 }
 
-func TestDiscoverIssuesBackfillsAssociationUsingOwnerRepoPath(t *testing.T) {
+func TestDiscoverIssuesBackfillsAssociationUsingHostQualifiedRepo(t *testing.T) {
 	t.Parallel()
 
 	fixture := newRunnerFixture(t)
 	fixture.cfg.Roles.Sweeper.Triggers.ExcludeAuthorAssociations = []string{"OWNER"}
 	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo"}}
-	fixture.github.issueDetails["acme/looper#1"] = githubinfra.IssueDetail{Number: 1, AuthorAssociation: "OWNER"}
+	fixture.github.issueDetails["github.example.com/acme/looper#1"] = githubinfra.IssueDetail{Number: 1, AuthorAssociation: "OWNER"}
 
 	result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "github.example.com/acme/looper"})
 	if err != nil {
@@ -184,21 +184,21 @@ func TestDiscoverIssuesBackfillsAssociationUsingOwnerRepoPath(t *testing.T) {
 	if fixture.github.viewIssueCalls != 1 {
 		t.Fatalf("ViewIssue() calls = %d, want 1", fixture.github.viewIssueCalls)
 	}
-	if got := fixture.github.viewIssueRepos; len(got) != 1 || got[0] != "acme/looper" {
-		t.Fatalf("ViewIssue() repos = %v, want [acme/looper]", got)
+	if got := fixture.github.viewIssueRepos; len(got) != 1 || got[0] != "github.example.com/acme/looper" {
+		t.Fatalf("ViewIssue() repos = %v, want [github.example.com/acme/looper]", got)
 	}
 	if got := fixture.github.viewIssueCWDs; len(got) != 1 || got[0] == "" {
 		t.Fatalf("ViewIssue() CWDs = %v, want project repo path", got)
 	}
 }
 
-func TestDiscoverPullRequestsBackfillsAssociationUsingOwnerRepoPath(t *testing.T) {
+func TestDiscoverPullRequestsBackfillsAssociationUsingHostQualifiedRepo(t *testing.T) {
 	t.Parallel()
 
 	fixture := newRunnerFixture(t)
 	fixture.cfg.Roles.Sweeper.Triggers.ExcludeAuthorAssociations = []string{"MEMBER"}
 	fixture.github.prs = []githubinfra.PullRequestSummary{{Number: 1, Title: "stale pr", Author: "octo", UpdatedAt: fixture.now.Add(-40 * 24 * time.Hour).Format(javaScriptISOStringUTC)}}
-	fixture.github.issueDetails["acme/looper#1"] = githubinfra.IssueDetail{Number: 1, AuthorAssociation: "MEMBER"}
+	fixture.github.issueDetails["github.example.com/acme/looper#1"] = githubinfra.IssueDetail{Number: 1, AuthorAssociation: "MEMBER"}
 
 	result, err := fixture.runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "github.example.com/acme/looper"})
 	if err != nil {
@@ -210,8 +210,8 @@ func TestDiscoverPullRequestsBackfillsAssociationUsingOwnerRepoPath(t *testing.T
 	if fixture.github.viewIssueCalls != 1 {
 		t.Fatalf("ViewIssue() calls = %d, want 1", fixture.github.viewIssueCalls)
 	}
-	if got := fixture.github.viewIssueRepos; len(got) != 1 || got[0] != "acme/looper" {
-		t.Fatalf("ViewIssue() repos = %v, want [acme/looper]", got)
+	if got := fixture.github.viewIssueRepos; len(got) != 1 || got[0] != "github.example.com/acme/looper" {
+		t.Fatalf("ViewIssue() repos = %v, want [github.example.com/acme/looper]", got)
 	}
 	if got := fixture.github.viewIssueCWDs; len(got) != 1 || got[0] == "" {
 		t.Fatalf("ViewIssue() CWDs = %v, want project repo path", got)


### PR DESCRIPTION
## Summary
- stop requesting the unsupported `authorAssociation` field from shared `gh issue/pr` JSON queries so planner, reviewer, fixer, and worker discovery can run again
- preserve sweeper's `excludeAuthorAssociations` behavior by backfilling author association from issue details only when that filter is configured
- update gateway and sweeper tests to cover the new fallback path and supported gh command shapes

## Testing
- go test ./internal/infra/github ./internal/sweeper
- go test ./...