### PR TITLE
fix: ignore unknown config fields in config files

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,33 @@ func TestLoadFileUsesDefaultsWhenConfigMissing(t *testing.T) {
 	}
 }
 
+func TestLoadFileUsesDefaultsWhenConfigFileIsTopLevelNull(t *testing.T) {
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	if err := os.WriteFile(configPath, []byte(`null`), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	loaded, err := LoadFile(LoadFileOptions{
+		CWD:        cwd,
+		ConfigPath: configPath,
+		LookupEnv:  emptyEnvLookup,
+		LookPath:   fakeLookPath(map[string]string{"git": "/detected/git", "gh": "/detected/gh", "osascript": "/detected/osascript"}),
+	})
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if !loaded.Metadata.ConfigFilePresent {
+		t.Fatal("LoadFile().Metadata.ConfigFilePresent = false, want true")
+	}
+	if loaded.Partial != (PartialConfig{}) {
+		t.Fatalf("LoadFile().Partial = %#v, want empty config", loaded.Partial)
+	}
+	if loaded.Config.Server.Host != "127.0.0.1" {
+		t.Fatalf("LoadFile().Config.Server.Host = %q, want default %q", loaded.Config.Server.Host, "127.0.0.1")
+	}
+}
+
 func TestReadConfigFileIgnoresUnknownTopLevelKeys(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	contents := `{"futureSection":{"enabled":true},"server":{"host":"0.0.0.0"}}`
@@ -73,6 +100,24 @@ func TestReadConfigFileIgnoresUnknownTopLevelKeys(t *testing.T) {
 	}
 	if partial.Scheduler != nil {
 		t.Fatalf("readConfigFile() scheduler = %#v, want nil", partial.Scheduler)
+	}
+}
+
+func TestReadConfigFileAcceptsTopLevelNull(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`null`), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	partial, present, err := readConfigFile(path)
+	if err != nil {
+		t.Fatalf("readConfigFile() error = %v", err)
+	}
+	if !present {
+		t.Fatal("readConfigFile() present = false, want true")
+	}
+	if partial != (PartialConfig{}) {
+		t.Fatalf("readConfigFile() partial = %#v, want empty config", partial)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,6 +95,66 @@ func TestReadConfigFileRejectsUnknownNestedKeys(t *testing.T) {
 	}
 }
 
+func TestReadConfigFileMatchesTopLevelKeysCaseInsensitively(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	contents := `{"Server":{"host":"0.0.0.0"},"SCHEDULER":{"pollIntervalSeconds":7}}`
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	partial, present, err := readConfigFile(path)
+	if err != nil {
+		t.Fatalf("readConfigFile() error = %v", err)
+	}
+	if !present {
+		t.Fatal("readConfigFile() present = false, want true")
+	}
+	if partial.Server == nil || partial.Server.Host == nil || *partial.Server.Host != "0.0.0.0" {
+		t.Fatalf("readConfigFile() server host = %#v, want 0.0.0.0", partial.Server)
+	}
+	if partial.Scheduler == nil || partial.Scheduler.PollIntervalSeconds == nil || *partial.Scheduler.PollIntervalSeconds != 7 {
+		t.Fatalf("readConfigFile() scheduler = %#v, want pollIntervalSeconds 7", partial.Scheduler)
+	}
+}
+
+func TestReadConfigFileLastMatchingTopLevelKeyWinsAcrossCaseVariants(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	contents := `{"SERVER":{"host":"0.0.0.0"},"Server":{"host":"127.0.0.2"}}`
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	partial, present, err := readConfigFile(path)
+	if err != nil {
+		t.Fatalf("readConfigFile() error = %v", err)
+	}
+	if !present {
+		t.Fatal("readConfigFile() present = false, want true")
+	}
+	if partial.Server == nil || partial.Server.Host == nil || *partial.Server.Host != "127.0.0.2" {
+		t.Fatalf("readConfigFile() server host = %#v, want 127.0.0.2", partial.Server)
+	}
+}
+
+func TestReadConfigFileLastMatchingTopLevelKeyCanOverrideInvalidEarlierCaseVariant(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	contents := `{"SERVER":{"bad":1},"Server":{"host":"127.0.0.2"}}`
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	partial, present, err := readConfigFile(path)
+	if err != nil {
+		t.Fatalf("readConfigFile() error = %v", err)
+	}
+	if !present {
+		t.Fatal("readConfigFile() present = false, want true")
+	}
+	if partial.Server == nil || partial.Server.Host == nil || *partial.Server.Host != "127.0.0.2" {
+		t.Fatalf("readConfigFile() server host = %#v, want 127.0.0.2", partial.Server)
+	}
+}
+
 func TestRoleDefaultsMirrorCurrentDiscoveryPolicy(t *testing.T) {
 	cfg, err := Normalize(t.TempDir())
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -117,9 +117,9 @@ func TestReadConfigFileMatchesTopLevelKeysCaseInsensitively(t *testing.T) {
 	}
 }
 
-func TestReadConfigFileLastMatchingTopLevelKeyWinsAcrossCaseVariants(t *testing.T) {
+func TestReadConfigFileMergesDuplicateTopLevelSectionsInEncounterOrder(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
-	contents := `{"SERVER":{"host":"0.0.0.0"},"Server":{"host":"127.0.0.2"}}`
+	contents := `{"SERVER":{"host":"0.0.0.0"},"Server":{"port":8123}}`
 	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}
@@ -131,27 +131,30 @@ func TestReadConfigFileLastMatchingTopLevelKeyWinsAcrossCaseVariants(t *testing.
 	if !present {
 		t.Fatal("readConfigFile() present = false, want true")
 	}
-	if partial.Server == nil || partial.Server.Host == nil || *partial.Server.Host != "127.0.0.2" {
-		t.Fatalf("readConfigFile() server host = %#v, want 127.0.0.2", partial.Server)
+	if partial.Server == nil || partial.Server.Host == nil || *partial.Server.Host != "0.0.0.0" {
+		t.Fatalf("readConfigFile() server host = %#v, want 0.0.0.0", partial.Server)
+	}
+	if partial.Server.Port == nil || *partial.Server.Port != 8123 {
+		t.Fatalf("readConfigFile() server port = %#v, want 8123", partial.Server)
 	}
 }
 
-func TestReadConfigFileLastMatchingTopLevelKeyCanOverrideInvalidEarlierCaseVariant(t *testing.T) {
+func TestReadConfigFileRejectsInvalidEarlierDuplicateKnownSection(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	contents := `{"SERVER":{"bad":1},"Server":{"host":"127.0.0.2"}}`
 	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}
 
-	partial, present, err := readConfigFile(path)
-	if err != nil {
-		t.Fatalf("readConfigFile() error = %v", err)
-	}
+	_, present, err := readConfigFile(path)
 	if !present {
 		t.Fatal("readConfigFile() present = false, want true")
 	}
-	if partial.Server == nil || partial.Server.Host == nil || *partial.Server.Host != "127.0.0.2" {
-		t.Fatalf("readConfigFile() server host = %#v, want 127.0.0.2", partial.Server)
+	if err == nil {
+		t.Fatal("readConfigFile() error = nil, want unknown field error")
+	}
+	if !strings.Contains(err.Error(), `json: unknown field "bad"`) {
+		t.Fatalf("readConfigFile() error = %v, want unknown field bad", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,47 @@ func TestLoadFileUsesDefaultsWhenConfigMissing(t *testing.T) {
 	}
 }
 
+func TestReadConfigFileIgnoresUnknownTopLevelKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	contents := `{"futureSection":{"enabled":true},"server":{"host":"0.0.0.0"}}`
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	partial, present, err := readConfigFile(path)
+	if err != nil {
+		t.Fatalf("readConfigFile() error = %v", err)
+	}
+	if !present {
+		t.Fatal("readConfigFile() present = false, want true")
+	}
+	if partial.Server == nil || partial.Server.Host == nil || *partial.Server.Host != "0.0.0.0" {
+		t.Fatalf("readConfigFile() server host = %#v, want 0.0.0.0", partial.Server)
+	}
+	if partial.Scheduler != nil {
+		t.Fatalf("readConfigFile() scheduler = %#v, want nil", partial.Scheduler)
+	}
+}
+
+func TestReadConfigFileRejectsUnknownNestedKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	contents := `{"scheduler":{"pollIntervalSecond":5}}`
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	_, present, err := readConfigFile(path)
+	if !present {
+		t.Fatal("readConfigFile() present = false, want true")
+	}
+	if err == nil {
+		t.Fatal("readConfigFile() error = nil, want unknown field error")
+	}
+	if !strings.Contains(err.Error(), `json: unknown field "pollIntervalSecond"`) {
+		t.Fatalf("readConfigFile() error = %v, want unknown field pollIntervalSecond", err)
+	}
+}
+
 func TestRoleDefaultsMirrorCurrentDiscoveryPolicy(t *testing.T) {
 	cfg, err := Normalize(t.TempDir())
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -139,6 +139,25 @@ func TestReadConfigFileMergesDuplicateTopLevelSectionsInEncounterOrder(t *testin
 	}
 }
 
+func TestReadConfigFileLaterNullClearsDuplicateKnownSection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	contents := `{"server":{"host":"0.0.0.0"},"server":null}`
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	partial, present, err := readConfigFile(path)
+	if err != nil {
+		t.Fatalf("readConfigFile() error = %v", err)
+	}
+	if !present {
+		t.Fatal("readConfigFile() present = false, want true")
+	}
+	if partial.Server != nil {
+		t.Fatalf("readConfigFile() server = %#v, want nil", partial.Server)
+	}
+}
+
 func TestReadConfigFileRejectsInvalidEarlierDuplicateKnownSection(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	contents := `{"SERVER":{"bad":1},"Server":{"host":"127.0.0.2"}}`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -396,6 +396,31 @@ func TestLoadFileReturnsClearErrorForInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestLoadFileIgnoresUnknownConfigFields(t *testing.T) {
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	contents := `{
+		"futureFeature": {"enabled": true},
+		"server": {"port": 6123}
+	}`
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	loaded, err := LoadFile(LoadFileOptions{CWD: cwd, ConfigPath: configPath, LookupEnv: emptyEnvLookup})
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+
+	if loaded.Config.Server.Port != 6123 {
+		t.Fatalf("LoadFile().Config.Server.Port = %d, want %d", loaded.Config.Server.Port, 6123)
+	}
+
+	if loaded.Partial.Server == nil || loaded.Partial.Server.Port == nil || *loaded.Partial.Server.Port != 6123 {
+		t.Fatalf("LoadFile().Partial.Server.Port = %#v, want 6123", loaded.Partial.Server)
+	}
+}
+
 func TestLoadFileSupportsCustomInstructions(t *testing.T) {
 	cwd := t.TempDir()
 	configPath := filepath.Join(cwd, "config.json")

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 )
@@ -273,7 +272,7 @@ func decodeTopLevelConfigSections(decoder *json.Decoder, partialConfig *PartialC
 	return nil
 }
 
-func decodeTopLevelConfigSection[T any](raw json.RawMessage, key string, target *T) error {
+func decodeTopLevelConfigSection[T any](raw json.RawMessage, key string, target **T) error {
 	if len(raw) == 0 {
 		return nil
 	}
@@ -281,11 +280,9 @@ func decodeTopLevelConfigSection[T any](raw json.RawMessage, key string, target 
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.DisallowUnknownFields()
 	decodeTarget := any(target)
-	targetValue := reflect.ValueOf(target)
-	if targetValue.Kind() == reflect.Ptr && !targetValue.IsNil() {
-		elem := targetValue.Elem()
-		if elem.Kind() == reflect.Ptr && !elem.IsNil() {
-			decodeTarget = elem.Interface()
+	if !bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		if target != nil && *target != nil {
+			decodeTarget = *target
 		}
 	}
 	if err := decoder.Decode(decodeTarget); err != nil {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -172,7 +173,6 @@ func readConfigFile(path string) (PartialConfig, bool, error) {
 func decodeTopLevelConfigSections(decoder *json.Decoder, partialConfig *PartialConfig) error {
 	type topLevelConfigSection struct {
 		key    string
-		raw    json.RawMessage
 		decode func(json.RawMessage) error
 	}
 
@@ -248,11 +248,19 @@ func decodeTopLevelConfigSections(decoder *json.Decoder, partialConfig *PartialC
 			return err
 		}
 
+		matched := false
 		for index := range sections {
 			if strings.EqualFold(key, sections[index].key) {
-				sections[index].raw = value
+				if err := sections[index].decode(value); err != nil {
+					return err
+				}
+				matched = true
 				break
 			}
+		}
+
+		if !matched {
+			continue
 		}
 	}
 
@@ -260,12 +268,6 @@ func decodeTopLevelConfigSections(decoder *json.Decoder, partialConfig *PartialC
 		return err
 	} else if delimiter, ok := token.(json.Delim); !ok || delimiter != '}' {
 		return fmt.Errorf("invalid JSON value for config: expected object terminator")
-	}
-
-	for _, section := range sections {
-		if err := section.decode(section.raw); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -278,7 +280,15 @@ func decodeTopLevelConfigSection[T any](raw json.RawMessage, key string, target 
 
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(target); err != nil {
+	decodeTarget := any(target)
+	targetValue := reflect.ValueOf(target)
+	if targetValue.Kind() == reflect.Ptr && !targetValue.IsNil() {
+		elem := targetValue.Elem()
+		if elem.Kind() == reflect.Ptr && !elem.IsNil() {
+			decodeTarget = elem.Interface()
+		}
+	}
+	if err := decoder.Decode(decodeTarget); err != nil {
 		return err
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -157,16 +157,89 @@ func readConfigFile(path string) (PartialConfig, bool, error) {
 		return PartialConfig{}, false, fmt.Errorf("failed to read config file at %s: %w", path, err)
 	}
 
-	var partialConfig PartialConfig
+	var topLevel map[string]json.RawMessage
 	decoder := json.NewDecoder(bytes.NewReader(raw))
-	if err := decoder.Decode(&partialConfig); err != nil {
+	if err := decoder.Decode(&topLevel); err != nil {
 		return PartialConfig{}, true, fmt.Errorf("failed to read config file at %s: %w", path, err)
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
 		return PartialConfig{}, true, fmt.Errorf("failed to read config file at %s: trailing JSON value", path)
 	}
 
+	var partialConfig PartialConfig
+	if err := decodeTopLevelConfigSections(topLevel, &partialConfig); err != nil {
+		return PartialConfig{}, true, fmt.Errorf("failed to read config file at %s: %w", path, err)
+	}
+
 	return partialConfig, true, nil
+}
+
+func decodeTopLevelConfigSections(topLevel map[string]json.RawMessage, partialConfig *PartialConfig) error {
+	if err := decodeTopLevelConfigSection(topLevel, "server", &partialConfig.Server); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "storage", &partialConfig.Storage); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "scheduler", &partialConfig.Scheduler); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "agent", &partialConfig.Agent); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "logging", &partialConfig.Logging); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "notifications", &partialConfig.Notifications); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "disclosure", &partialConfig.Disclosure); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "tools", &partialConfig.Tools); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "daemon", &partialConfig.Daemon); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "package", &partialConfig.Package); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "defaults", &partialConfig.Defaults); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "reviewer", &partialConfig.Reviewer); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "instructions", &partialConfig.Instructions); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "roles", &partialConfig.Roles); err != nil {
+		return err
+	}
+	if err := decodeTopLevelConfigSection(topLevel, "projects", &partialConfig.Projects); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func decodeTopLevelConfigSection[T any](topLevel map[string]json.RawMessage, key string, target *T) error {
+	raw, ok := topLevel[key]
+	if !ok {
+		return nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("invalid JSON value for %q", key)
+	}
+
+	return nil
 }
 
 func parseCLIArgs(args []string) (parsedCLIArgs, error) {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -159,7 +159,6 @@ func readConfigFile(path string) (PartialConfig, bool, error) {
 
 	var partialConfig PartialConfig
 	decoder := json.NewDecoder(bytes.NewReader(raw))
-	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&partialConfig); err != nil {
 		return PartialConfig{}, true, fmt.Errorf("failed to read config file at %s: %w", path, err)
 	}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -227,6 +227,9 @@ func decodeTopLevelConfigSections(decoder *json.Decoder, partialConfig *PartialC
 	if err != nil {
 		return err
 	}
+	if token == nil {
+		return nil
+	}
 	if delimiter, ok := token.(json.Delim); !ok || delimiter != '{' {
 		return fmt.Errorf("invalid JSON value for config: expected object")
 	}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -157,76 +157,122 @@ func readConfigFile(path string) (PartialConfig, bool, error) {
 		return PartialConfig{}, false, fmt.Errorf("failed to read config file at %s: %w", path, err)
 	}
 
-	var topLevel map[string]json.RawMessage
+	var partialConfig PartialConfig
 	decoder := json.NewDecoder(bytes.NewReader(raw))
-	if err := decoder.Decode(&topLevel); err != nil {
+	if err := decodeTopLevelConfigSections(decoder, &partialConfig); err != nil {
 		return PartialConfig{}, true, fmt.Errorf("failed to read config file at %s: %w", path, err)
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
 		return PartialConfig{}, true, fmt.Errorf("failed to read config file at %s: trailing JSON value", path)
 	}
 
-	var partialConfig PartialConfig
-	if err := decodeTopLevelConfigSections(topLevel, &partialConfig); err != nil {
-		return PartialConfig{}, true, fmt.Errorf("failed to read config file at %s: %w", path, err)
-	}
-
 	return partialConfig, true, nil
 }
 
-func decodeTopLevelConfigSections(topLevel map[string]json.RawMessage, partialConfig *PartialConfig) error {
-	if err := decodeTopLevelConfigSection(topLevel, "server", &partialConfig.Server); err != nil {
+func decodeTopLevelConfigSections(decoder *json.Decoder, partialConfig *PartialConfig) error {
+	type topLevelConfigSection struct {
+		key    string
+		raw    json.RawMessage
+		decode func(json.RawMessage) error
+	}
+
+	sections := []topLevelConfigSection{
+		{key: "server", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "server", &partialConfig.Server)
+		}},
+		{key: "storage", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "storage", &partialConfig.Storage)
+		}},
+		{key: "scheduler", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "scheduler", &partialConfig.Scheduler)
+		}},
+		{key: "agent", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "agent", &partialConfig.Agent)
+		}},
+		{key: "logging", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "logging", &partialConfig.Logging)
+		}},
+		{key: "notifications", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "notifications", &partialConfig.Notifications)
+		}},
+		{key: "disclosure", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "disclosure", &partialConfig.Disclosure)
+		}},
+		{key: "tools", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "tools", &partialConfig.Tools)
+		}},
+		{key: "daemon", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "daemon", &partialConfig.Daemon)
+		}},
+		{key: "package", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "package", &partialConfig.Package)
+		}},
+		{key: "defaults", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "defaults", &partialConfig.Defaults)
+		}},
+		{key: "reviewer", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "reviewer", &partialConfig.Reviewer)
+		}},
+		{key: "instructions", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "instructions", &partialConfig.Instructions)
+		}},
+		{key: "roles", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "roles", &partialConfig.Roles)
+		}},
+		{key: "projects", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "projects", &partialConfig.Projects)
+		}},
+	}
+
+	token, err := decoder.Token()
+	if err != nil {
 		return err
 	}
-	if err := decodeTopLevelConfigSection(topLevel, "storage", &partialConfig.Storage); err != nil {
-		return err
+	if delimiter, ok := token.(json.Delim); !ok || delimiter != '{' {
+		return fmt.Errorf("invalid JSON value for config: expected object")
 	}
-	if err := decodeTopLevelConfigSection(topLevel, "scheduler", &partialConfig.Scheduler); err != nil {
-		return err
+
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+
+		key, ok := token.(string)
+		if !ok {
+			return fmt.Errorf("invalid JSON value for config: expected object key")
+		}
+
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return err
+		}
+
+		for index := range sections {
+			if strings.EqualFold(key, sections[index].key) {
+				sections[index].raw = value
+				break
+			}
+		}
 	}
-	if err := decodeTopLevelConfigSection(topLevel, "agent", &partialConfig.Agent); err != nil {
+
+	if token, err = decoder.Token(); err != nil {
 		return err
+	} else if delimiter, ok := token.(json.Delim); !ok || delimiter != '}' {
+		return fmt.Errorf("invalid JSON value for config: expected object terminator")
 	}
-	if err := decodeTopLevelConfigSection(topLevel, "logging", &partialConfig.Logging); err != nil {
-		return err
-	}
-	if err := decodeTopLevelConfigSection(topLevel, "notifications", &partialConfig.Notifications); err != nil {
-		return err
-	}
-	if err := decodeTopLevelConfigSection(topLevel, "disclosure", &partialConfig.Disclosure); err != nil {
-		return err
-	}
-	if err := decodeTopLevelConfigSection(topLevel, "tools", &partialConfig.Tools); err != nil {
-		return err
-	}
-	if err := decodeTopLevelConfigSection(topLevel, "daemon", &partialConfig.Daemon); err != nil {
-		return err
-	}
-	if err := decodeTopLevelConfigSection(topLevel, "package", &partialConfig.Package); err != nil {
-		return err
-	}
-	if err := decodeTopLevelConfigSection(topLevel, "defaults", &partialConfig.Defaults); err != nil {
-		return err
-	}
-	if err := decodeTopLevelConfigSection(topLevel, "reviewer", &partialConfig.Reviewer); err != nil {
-		return err
-	}
-	if err := decodeTopLevelConfigSection(topLevel, "instructions", &partialConfig.Instructions); err != nil {
-		return err
-	}
-	if err := decodeTopLevelConfigSection(topLevel, "roles", &partialConfig.Roles); err != nil {
-		return err
-	}
-	if err := decodeTopLevelConfigSection(topLevel, "projects", &partialConfig.Projects); err != nil {
-		return err
+
+	for _, section := range sections {
+		if err := section.decode(section.raw); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func decodeTopLevelConfigSection[T any](topLevel map[string]json.RawMessage, key string, target *T) error {
-	raw, ok := topLevel[key]
-	if !ok {
+func decodeTopLevelConfigSection[T any](raw json.RawMessage, key string, target *T) error {
+	if len(raw) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- stop rejecting config files that contain unknown top-level JSON fields during load
- add regression coverage to ensure known settings still apply when extra fields are present
- keep startup compatible across older/newer binaries that share a config file

## Validation
- go test ./internal/config
- go vet ./...
- go test ./...
- go build ./...

Closes #264

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href=\"https://github.com/nexu-io/looper\">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>