### PR TITLE
fix: skip auto-upgrade for non-stable channel CLI builds

### DIFF
--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -39,6 +39,12 @@ type Deps struct {
 	// spawned looperd process to become API-ready. It is primarily intended for
 	// tests; production uses the CLI default.
 	DaemonStartTimeout time.Duration
+
+	// CLIChannel overrides the install-source channel used to decide whether
+	// auto-upgrade may run. Defaults to version.Channel when empty. Tests that
+	// need to exercise the upgrade path with mock binaries inject "stable"
+	// here so the dev-build channel guard does not short-circuit them.
+	CLIChannel string
 }
 
 type App struct {

--- a/internal/cliapp/download_test.go
+++ b/internal/cliapp/download_test.go
@@ -295,6 +295,7 @@ func TestUpgradeUnifiedDownloadsCLIAndDaemonConcurrently(t *testing.T) {
 		Platform:       "darwin",
 		Arch:           "arm64",
 		ExecutablePath: execPath,
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.String() {
 			case "http://daemon.test/api/v1/status":

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -96,6 +96,11 @@ const (
 	cliInstallSourceUnknown  cliInstallSource = "unknown"
 )
 
+// cliInstallChannelStable is the value of version.Channel for tagged release
+// builds; anything else (notably the "dev" default) must be treated as a
+// non-upgradable local build.
+const cliInstallChannelStable = "stable"
+
 type cliUpgradeRefusedError struct {
 	message string
 }
@@ -120,7 +125,7 @@ func (r *commandRuntime) maybeRunAutoUpgrade(cmd *cobra.Command, args []string) 
 	if err != nil {
 		return nil
 	}
-	if detectCLIInstallSource(execPath) != cliInstallSourceRelease {
+	if r.detectCLIInstallSource(execPath) != cliInstallSourceRelease {
 		return nil
 	}
 
@@ -738,7 +743,7 @@ func (r *commandRuntime) upgradeCLIWithOutput(cmd *cobra.Command, emitOutput boo
 	if err != nil {
 		return cliUpgradeOutput{}, fmt.Errorf("resolve current looper path: %w", err)
 	}
-	installSource := detectCLIInstallSource(execPath)
+	installSource := r.detectCLIInstallSource(execPath)
 	guidance := cliRefusalGuidance(installSource, execPath)
 	if installSource != cliInstallSourceRelease {
 		refused := true
@@ -830,7 +835,28 @@ func (r *commandRuntime) upgradeCLIWithOutput(cmd *cobra.Command, emitOutput boo
 	return result, nil
 }
 
-func detectCLIInstallSource(execPath string) cliInstallSource {
+func (r *commandRuntime) cliChannel() string {
+	if c := strings.TrimSpace(r.app.deps.CLIChannel); c != "" {
+		return c
+	}
+	return version.Channel
+}
+
+func (r *commandRuntime) detectCLIInstallSource(execPath string) cliInstallSource {
+	return detectCLIInstallSourceForChannel(execPath, r.cliChannel())
+}
+
+// detectCLIInstallSourceForChannel returns the install source for a CLI
+// binary, short-circuiting to dev whenever the binary itself reports a
+// non-stable channel. Without this guard a locally-built `go build -o
+// ~/.local/bin/looper` — the same path the public installer uses — is
+// classified by path alone as release-binary and auto-upgrade silently
+// replaces it with the latest release, which is a downgrade for any source
+// build that is ahead of the most recent tag.
+func detectCLIInstallSourceForChannel(execPath, channel string) cliInstallSource {
+	if channel != cliInstallChannelStable {
+		return cliInstallSourceDev
+	}
 	path := strings.ToLower(execPath)
 	if strings.Contains(path, "/cellar/") || strings.Contains(path, "/homebrew/") {
 		return cliInstallSourceHomebrew

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -71,6 +71,7 @@ func TestRootPreRunSkipsAutoUpgradeForUnsupportedInstallSource(t *testing.T) {
 		Stdout:         stdout,
 		Stderr:         stderr,
 		ExecutablePath: "/opt/homebrew/Cellar/looper/0.2.1/bin/looper",
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
 			return nil, nil
@@ -100,6 +101,7 @@ func TestRootPreRunSkipsAutoUpgradeForBareRootHelp(t *testing.T) {
 		Stderr:         stderr,
 		HomeDir:        homeDir,
 		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
 			return nil, nil
@@ -129,6 +131,7 @@ func TestRootPreRunSkipsAutoUpgradeForHelpOnlySubcommand(t *testing.T) {
 		Stderr:         stderr,
 		HomeDir:        homeDir,
 		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
 			return nil, nil
@@ -159,6 +162,7 @@ func TestVersionNoAutoUpgradeFlagDisablesAutoUpgrade(t *testing.T) {
 		Stderr:         stderr,
 		HomeDir:        homeDir,
 		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
 			return nil, nil
@@ -185,6 +189,7 @@ func TestEnvDisablesAutoUpgrade(t *testing.T) {
 		Stderr:         stderr,
 		HomeDir:        homeDir,
 		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
 			return nil, nil
@@ -214,6 +219,7 @@ func TestAutoUpgradeCachesLatestReleaseCheck(t *testing.T) {
 		Stderr:         stderr,
 		HomeDir:        homeDir,
 		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.String() {
 			case "https://api.github.com/repos/nexu-io/looper/releases/latest":
@@ -267,6 +273,7 @@ func TestCorruptAutoUpgradeStateSkipsNetworkAndPreservesFile(t *testing.T) {
 		Stderr:         stderr,
 		HomeDir:        homeDir,
 		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
 			return nil, nil
@@ -494,6 +501,7 @@ func TestUpgradeWithoutFlagsContinuesWithDaemonWhenCLISelfUpgradeRefused(t *test
 		Platform:       "darwin",
 		Arch:           "arm64",
 		ExecutablePath: "/opt/homebrew/Cellar/looper/0.2.1/bin/looper",
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.String() {
 			case "http://127.0.0.1:4321/api/v1/status":
@@ -570,6 +578,7 @@ func TestUpgradeWithoutFlagsDoesNotInstallDaemonWhenCLIUpgradeFails(t *testing.T
 		Platform:       "darwin",
 		Arch:           "arm64",
 		ExecutablePath: execPath,
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.String() {
 			case "http://127.0.0.1:4321/api/v1/status":
@@ -628,6 +637,7 @@ func TestUpgradeWithoutFlagsWritesSingleJSONDocument(t *testing.T) {
 		Platform:       "darwin",
 		Arch:           "arm64",
 		ExecutablePath: "/opt/homebrew/Cellar/looper/0.2.1/bin/looper",
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.String() {
 			case "http://127.0.0.1:4321/api/v1/status":
@@ -690,6 +700,7 @@ func TestUpgradeCLIRefusesHomebrewInstallWithGuidance(t *testing.T) {
 		Stdout:         stdout,
 		Stderr:         stderr,
 		ExecutablePath: "/opt/homebrew/Cellar/looper/0.2.1/bin/looper",
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected request before Homebrew refusal: %q", req.URL.String())
 			return nil, nil
@@ -731,6 +742,7 @@ func TestUpgradeCLIRefusesHomebrewSymlinkWithGuidance(t *testing.T) {
 		Stdout:         stdout,
 		Stderr:         stderr,
 		ExecutablePath: symlinkPath,
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected request before Homebrew refusal: %q", req.URL.String())
 			return nil, nil
@@ -762,6 +774,7 @@ func TestUpgradeCLIPreflightsInstallPathBeforeDownload(t *testing.T) {
 		Stdout:         stdout,
 		Stderr:         stderr,
 		ExecutablePath: execPath,
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.String() {
 			case "https://api.github.com/repos/nexu-io/looper/releases/latest":
@@ -808,6 +821,7 @@ func TestUpgradeCLIPrintsDownloadProgressToStderr(t *testing.T) {
 		Platform:       "darwin",
 		Arch:           "arm64",
 		ExecutablePath: execPath,
+		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.String() {
 			case "https://api.github.com/repos/nexu-io/looper/releases/latest":
@@ -843,9 +857,9 @@ func TestDetectCLIInstallSourceTreatsInstallerSelectedUserBinAsRelease(t *testin
 	userBin := filepath.Join(homeDir, "bin")
 	t.Setenv("PATH", userBin)
 
-	got := detectCLIInstallSource(filepath.Join(userBin, "looper"))
+	got := detectCLIInstallSourceForChannel(filepath.Join(userBin, "looper"), cliInstallChannelStable)
 	if got != cliInstallSourceRelease {
-		t.Fatalf("detectCLIInstallSource(user PATH bin) = %q, want %q", got, cliInstallSourceRelease)
+		t.Fatalf("detectCLIInstallSourceForChannel(user PATH bin, stable) = %q, want %q", got, cliInstallSourceRelease)
 	}
 }
 
@@ -857,9 +871,39 @@ func TestDetectCLIInstallSourceTreatsGoBinAsDevBeforeUserBinRelease(t *testing.T
 	goBin := filepath.Join(homeDir, "go", "bin")
 	t.Setenv("PATH", goBin)
 
-	got := detectCLIInstallSource(filepath.Join(goBin, "looper"))
+	got := detectCLIInstallSourceForChannel(filepath.Join(goBin, "looper"), cliInstallChannelStable)
 	if got != cliInstallSourceDev {
-		t.Fatalf("detectCLIInstallSource(go PATH bin) = %q, want %q", got, cliInstallSourceDev)
+		t.Fatalf("detectCLIInstallSourceForChannel(go PATH bin, stable) = %q, want %q", got, cliInstallSourceDev)
+	}
+}
+
+func TestDetectCLIInstallSourceTreatsDevChannelAsDevRegardlessOfPath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		t.Skipf("cannot resolve user home directory: %v", err)
+	}
+	// Paths that would normally be classified as release binaries.
+	releasePaths := []string{
+		filepath.Join(homeDir, ".local", "bin", "looper"),
+		"/usr/local/bin/looper",
+		filepath.Join(homeDir, ".looper", "bin", "looper"),
+		"/opt/homebrew/Cellar/looper/1.0.0/bin/looper",
+	}
+	for _, p := range releasePaths {
+		if got := detectCLIInstallSourceForChannel(p, "dev"); got != cliInstallSourceDev {
+			t.Errorf("detectCLIInstallSourceForChannel(%q, dev) = %q, want %q", p, got, cliInstallSourceDev)
+		}
+	}
+}
+
+func TestDetectCLIInstallSourceTreatsUnknownChannelAsDev(t *testing.T) {
+	// Any non-stable channel (rc, nightly, custom builds) must opt out of
+	// auto-upgrade by default; auto-upgrade is gated on release-binary so
+	// returning dev for unknown channels is the safe choice.
+	for _, channel := range []string{"", "rc", "nightly", "unknown"} {
+		if got := detectCLIInstallSourceForChannel("/usr/local/bin/looper", channel); got != cliInstallSourceDev {
+			t.Errorf("detectCLIInstallSourceForChannel(release path, %q) = %q, want %q", channel, got, cliInstallSourceDev)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- `detectCLIInstallSource` now short-circuits to `cliInstallSourceDev` whenever `version.Channel` is not `"stable"`, so source/dev builds at conventional release paths (`~/.local/bin/looper`, `/usr/local/bin/looper`, `~/.looper/bin/looper`, or any user-PATH dir) stop being treated as release binaries.
- New `Deps.CLIChannel` lets tests inject `"stable"` when they need to exercise the upgrade flow with mocked HTTP; the existing path-heuristic tests now call `detectCLIInstallSourceForChannel` directly so they keep validating path classification on its own.

## Why
Following `docs/installation.md`'s "From source" workflow (or just running the public `scripts/install.sh` on top of a manually-built binary), a `go build -o ~/.local/bin/looper` lands at the exact path the installer uses. On the next `looper` invocation, `runAutoUpgrade`:

1. Classifies the path as `release-binary` regardless of `version.Channel == "dev"`.
2. Computes `isSemverUpgradeAvailable("0.0.0-dev", latest)` → true (pre-release sorts below `0.0.0`).
3. Replaces the binary in place via `replaceBinaryAtomically` — but does **not** re-exec.
4. The still-running source code finishes its command, writing newer config fields the downgraded daemon does not recognize.

End result: a freshly bootstrapped local install can produce a config with `roles.sweeper` that the just-downloaded `looperd v0.7.0` refuses with `json: unknown field "sweeper"`, leaving the daemon unable to start. Reproduces today on `main` against the current release.

## Approach
Channel is a stronger signal than path: a binary built without ldflags reports `Channel == "dev"`, which is exactly the population we must not auto-upgrade. Route those through the same refusal path as Homebrew installs so users get an appropriate guidance message (`go install ./cmd/looper`) instead of a silent downgrade. Tagged release builds (`channel == "stable"`) keep their existing behavior unchanged.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (all 35 packages, ~10s for `internal/cliapp`)
- [x] New tests: `TestDetectCLIInstallSourceTreatsDevChannelAsDevRegardlessOfPath`, `TestDetectCLIInstallSourceTreatsUnknownChannelAsDev`
- [x] Existing path-heuristic tests refactored to call `detectCLIInstallSourceForChannel(path, "stable")` so they continue to assert what they were designed for
- [x] Manual repro: previously a fresh `go build -o ~/.local/bin/looper && looper bootstrap` would silently downgrade and then fail to start the daemon with the sweeper schema error; with this patch the dev binary refuses to self-upgrade and bootstrap proceeds with the local build

🤖 Generated with [Claude Code](https://claude.com/claude-code)