### PR TITLE
fix: prevent split-brain recovery during looperd startup

### DIFF
--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -101,14 +101,13 @@ type signalProcessFunc func(int, syscall.Signal) error
 type executionMatchesProcessFunc func(context.Context, storage.AgentExecutionRecord, int) (bool, bool, error)
 
 func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies) (bootstrap.Runtime, error) {
-	runtimeValue, err := looperdruntime.Start(ctx, deps)
-	if err != nil {
+	rt := looperdruntime.New(looperdruntime.Options{
+		Config:        deps.Config,
+		Logger:        deps.Logger,
+		DeferRecovery: true,
+	})
+	if err := rt.Start(ctx); err != nil {
 		return nil, err
-	}
-
-	rt, ok := runtimeValue.(*looperdruntime.Runtime)
-	if !ok {
-		return nil, fmt.Errorf("unexpected runtime type %T", runtimeValue)
 	}
 
 	handler := looperdapi.NewHandler(looperdapi.Context{
@@ -126,7 +125,16 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 	})
 	server := looperdapi.NewServer(deps.Config, handler)
 	if err := server.Start(); err != nil {
+		if deps.Logger != nil {
+			deps.Logger.Warn("looperd recovery aborted because instance did not acquire ownership", map[string]any{"error": err.Error()})
+		}
 		rt.Stop("api server failed to start")
+		rt.WaitForShutdown()
+		return nil, err
+	}
+	if err := rt.CompleteStartup(ctx); err != nil {
+		_ = server.Stop(context.Background())
+		rt.Stop("runtime startup failed after api server ownership")
 		rt.WaitForShutdown()
 		return nil, err
 	}

--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -132,16 +132,17 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 		rt.WaitForShutdown()
 		return nil, err
 	}
-	if err := rt.CompleteStartup(ctx); err != nil {
-		_ = server.Stop(context.Background())
-		rt.Stop("runtime startup failed after api server ownership")
-		rt.WaitForShutdown()
-		return nil, err
-	}
 
 	shutdownTimeout := time.Duration(deps.Config.Daemon.ShutdownTimeoutMS) * time.Millisecond
 	if shutdownTimeout <= 0 {
 		shutdownTimeout = time.Second
+	}
+
+	if err := rt.CompleteStartup(ctx); err != nil {
+		_ = stopServerWithTimeout(server.Stop, shutdownTimeout)
+		rt.Stop("runtime startup failed after api server ownership")
+		rt.WaitForShutdown()
+		return nil, err
 	}
 
 	return &daemonRuntime{
@@ -149,6 +150,12 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 		server:          server,
 		shutdownTimeout: shutdownTimeout,
 	}, nil
+}
+
+func stopServerWithTimeout(stop func(context.Context) error, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return stop(ctx)
 }
 
 func (d *daemonRuntime) Stop(reason string) {

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -270,6 +270,30 @@ func TestStartRuntimeWithAPIDoesNotRunRecoveryBeforeServerOwnership(t *testing.T
 	}
 }
 
+func TestStopServerWithTimeoutUsesDeadline(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 25 * time.Millisecond
+	started := make(chan struct{})
+	err := stopServerWithTimeout(func(ctx context.Context) error {
+		close(started)
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("stop context missing deadline")
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > timeout {
+			t.Fatalf("stop context remaining = %v, want within (0,%v]", remaining, timeout)
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}, timeout)
+	<-started
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("stopServerWithTimeout() error = %v, want %v", err, context.DeadlineExceeded)
+	}
+}
+
 func TestStopLoopPausesLoopAndSignalsActiveExecution(t *testing.T) {
 	ctx := context.Background()
 	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -184,6 +185,88 @@ func TestRunPrintsBootstrapErrors(t *testing.T) {
 	}
 	if got := stdout.String(); got != "" {
 		t.Fatalf("runWithDeps([]) stdout = %q, want empty string", got)
+	}
+}
+
+func TestStartRuntimeWithAPIDoesNotRunRecoveryBeforeServerOwnership(t *testing.T) {
+	ctx := context.Background()
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	addr := listener.Addr().(*net.TCPAddr)
+	cfg.Server.Host = "127.0.0.1"
+	cfg.Server.Port = addr.Port
+
+	coordinator, err := storage.OpenSQLiteCoordinator(ctx, cfg.Storage.DBPath, storage.SQLiteCoordinatorOptions{BackupDir: backupDir, Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(ctx); err != nil {
+		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	nowISO := "2026-05-01T10:00:00.000Z"
+	project := storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: workingDir, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Projects.Upsert(ctx, project); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "nexu-io/looper"
+	prNumber := int64(266)
+	targetID := "pr:nexu-io/looper:266"
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 266, ProjectID: project.ID, Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_1", LoopID: loop.ID, Status: "running", StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+
+	_, err = startRuntimeWithAPI(ctx, bootstrap.RuntimeDependencies{Config: cfg})
+	if err == nil {
+		t.Fatal("startRuntimeWithAPI() error = nil, want listen failure")
+	}
+
+	coordinator, err = storage.OpenSQLiteCoordinator(ctx, cfg.Storage.DBPath, storage.SQLiteCoordinatorOptions{BackupDir: backupDir, Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() reopen error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	repos = storage.NewRepositories(coordinator.DB())
+	restoredLoop, err := repos.Loops.GetByID(ctx, loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if restoredLoop == nil || restoredLoop.Status != "running" {
+		t.Fatalf("Loops.GetByID(%s) = %#v, want preserved running loop", loop.ID, restoredLoop)
+	}
+	restoredRun, err := repos.Runs.GetByID(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	if restoredRun == nil || restoredRun.Status != "running" || restoredRun.EndedAt != nil {
+		t.Fatalf("Runs.GetByID(%s) = %#v, want preserved running run", run.ID, restoredRun)
+	}
+	events, err := repos.Events.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("Events.List() error = %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("Events.List() = %#v, want no startup or recovery mutations after ownership loss", events)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -62,6 +62,7 @@ type Options struct {
 	RunSchedulerTick       RunSchedulerTickFunc
 	ReadProcessCommand     ReadProcessCommandFunc
 	SignalProcess          SignalProcessFunc
+	DeferRecovery          bool
 }
 
 type Services struct {
@@ -86,24 +87,30 @@ type Runtime struct {
 	readProcessCommand     ReadProcessCommandFunc
 	signalProcess          SignalProcessFunc
 	shutdownTimeout        time.Duration
+	deferRecovery          bool
 
-	mu               sync.RWMutex
-	startedAt        *time.Time
-	recovery         RecoverySummary
-	stopped          bool
-	services         Services
-	startErr         error
-	startOnce        sync.Once
-	shutdownOnce     sync.Once
-	shutdownCh       chan struct{}
-	schedulerStop    chan struct{}
-	schedulerDone    chan struct{}
-	schedulerWake    chan struct{}
-	schedulerCancel  context.CancelFunc
-	schedulerTasks   *schedulerTaskTracker
-	recoveryCancel   context.CancelFunc
-	recoveryDone     chan struct{}
-	activeExecutions *ActiveExecutionRegistry
+	mu                sync.RWMutex
+	startedAt         *time.Time
+	recovery          RecoverySummary
+	stopped           bool
+	services          Services
+	startErr          error
+	startOnce         sync.Once
+	shutdownOnce      sync.Once
+	shutdownCh        chan struct{}
+	schedulerStop     chan struct{}
+	schedulerDone     chan struct{}
+	schedulerWake     chan struct{}
+	schedulerCancel   context.CancelFunc
+	schedulerTasks    *schedulerTaskTracker
+	recoveryCancel    context.CancelFunc
+	recoveryDone      chan struct{}
+	activeExecutions  *ActiveExecutionRegistry
+	githubGateway     *githubinfra.Gateway
+	schedulerDisabled bool
+	startupReadyOnce  sync.Once
+	startupReadyErr   error
+	ownershipAcquired bool
 }
 
 const reviewerRecoveryLoginTimeout = 3 * time.Second
@@ -156,6 +163,7 @@ func New(options Options) *Runtime {
 		readProcessCommand:     readProcessCommand,
 		signalProcess:          signalProcess,
 		shutdownTimeout:        shutdownTimeout,
+		deferRecovery:          options.DeferRecovery,
 		recovery:               createEmptyRecoverySummary(),
 		shutdownCh:             make(chan struct{}),
 		activeExecutions:       NewActiveExecutionRegistry(),
@@ -199,9 +207,10 @@ func (r *Runtime) Stop(reason string) {
 		r.stopped = true
 		coordinator := r.services.Coordinator
 		repositories := r.services.Repositories
+		ownershipAcquired := r.ownershipAcquired
 		r.mu.Unlock()
 
-		if repositories != nil {
+		if ownershipAcquired && repositories != nil {
 			if err := r.appendStoppedEvent(context.Background(), repositories, reason); err != nil && r.logger != nil {
 				r.logger.Warn("looperd runtime stop event failed", map[string]any{"error": err.Error()})
 			}
@@ -351,18 +360,12 @@ func (r *Runtime) start(ctx context.Context) error {
 	if err := r.syncConfiguredProjects(ctx, projectService, r.config, startedAt); err != nil {
 		return err
 	}
-	recoverySummary, err := r.runRecoveryPipeline(ctx, repositories, nil, startedAt)
-	if err != nil {
-		return err
-	}
-
 	r.mu.Lock()
 	if r.stopped {
 		r.mu.Unlock()
 		return fmt.Errorf("runtime already stopped")
 	}
 	r.startedAt = &startedAt
-	r.recovery = recoverySummary
 	r.services = Services{
 		Coordinator:      coordinator,
 		Repositories:     repositories,
@@ -380,33 +383,76 @@ func (r *Runtime) start(ctx context.Context) error {
 		}, r.now)
 		schedulerDisabled = r.config.Agent.Vendor == nil
 	}
+	r.githubGateway = githubGateway
+	r.schedulerDisabled = schedulerDisabled
 	r.mu.Unlock()
-	if schedulerDisabled && r.logger != nil {
-		r.logger.Warn("looperd scheduler disabled", map[string]any{"reason": "config.agent.vendor is not set"})
-	}
-
-	if err := r.appendStartedEvent(context.Background(), startedAt); err != nil {
-		return err
-	}
-	if !schedulerDisabled {
-		r.startSchedulerLoop()
-	}
-	r.startDeferredReviewerRecovery(githubGateway)
 
 	started = true
-
-	if r.logger != nil {
-		r.logger.Info("looperd runtime assembled", map[string]any{
-			"dbPath":                 r.config.Storage.DBPath,
-			"projectCount":           len(r.config.Projects),
-			"autoMigrate":            r.config.Package.AutoMigrateOnStartup,
-			"backupRequired":         r.config.Package.RequireBackupBeforeMigrate,
-			"recoverySummary":        recoverySummary,
-			"schedulerDefaultActive": !r.customSchedulerTick && !schedulerDisabled,
-		})
+	if r.deferRecovery {
+		return nil
 	}
 
-	return nil
+	return r.CompleteStartup(ctx)
+}
+
+func (r *Runtime) CompleteStartup(ctx context.Context) error {
+	r.startupReadyOnce.Do(func() {
+		r.mu.RLock()
+		if r.stopped {
+			r.mu.RUnlock()
+			r.startupReadyErr = fmt.Errorf("runtime already stopped")
+			return
+		}
+		startedAt := r.startedAt
+		repositories := r.services.Repositories
+		githubGateway := r.githubGateway
+		schedulerDisabled := r.schedulerDisabled
+		r.mu.RUnlock()
+
+		if startedAt == nil {
+			r.startupReadyErr = fmt.Errorf("runtime has not been started")
+			return
+		}
+		if repositories == nil {
+			r.startupReadyErr = fmt.Errorf("runtime repositories are not configured")
+			return
+		}
+		if err := r.appendStartedEvent(context.Background(), *startedAt); err != nil {
+			r.startupReadyErr = err
+			return
+		}
+		recoverySummary, err := r.runRecoveryPipeline(ctx, repositories, githubGateway, *startedAt)
+		if err != nil {
+			r.startupReadyErr = err
+			return
+		}
+
+		r.mu.Lock()
+		r.recovery = recoverySummary
+		r.ownershipAcquired = true
+		r.mu.Unlock()
+
+		if schedulerDisabled && r.logger != nil {
+			r.logger.Warn("looperd scheduler disabled", map[string]any{"reason": "config.agent.vendor is not set"})
+		}
+		if !schedulerDisabled {
+			r.startSchedulerLoop()
+		}
+		r.startDeferredReviewerRecovery(githubGateway)
+
+		if r.logger != nil {
+			r.logger.Info("looperd runtime assembled", map[string]any{
+				"dbPath":                 r.config.Storage.DBPath,
+				"projectCount":           len(r.config.Projects),
+				"autoMigrate":            r.config.Package.AutoMigrateOnStartup,
+				"backupRequired":         r.config.Package.RequireBackupBeforeMigrate,
+				"recoverySummary":        recoverySummary,
+				"schedulerDefaultActive": !r.customSchedulerTick && !schedulerDisabled,
+			})
+		}
+	})
+
+	return r.startupReadyErr
 }
 
 func (r *Runtime) startSchedulerLoop() {
@@ -608,6 +654,39 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 	summary := createEmptyRecoverySummary()
 	summary.StartedAt = nowISO
 	summary.OrphanAgentCleanup.Attempted = true
+	uncertainAgentRunIDs := make(map[string]struct{})
+	uncertainExecutionIDs := make(map[string]struct{})
+	recordUncertainExecution := func(execution storage.AgentExecutionRecord, pid int, scope string) error {
+		if _, ok := uncertainExecutionIDs[execution.ID]; ok {
+			return nil
+		}
+		uncertainExecutionIDs[execution.ID] = struct{}{}
+		if execution.RunID != nil && strings.TrimSpace(*execution.RunID) != "" {
+			uncertainAgentRunIDs[*execution.RunID] = struct{}{}
+		}
+		if r.logger != nil {
+			r.logger.Warn("recovery skipped due to uncertain process identity", map[string]any{"executionId": execution.ID, "pid": pid, "scope": scope})
+		}
+		if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
+			ID:         newRuntimeEventID(),
+			EventType:  "looperd.recovery.process_identity_uncertain",
+			ProjectID:  execution.ProjectID,
+			LoopID:     execution.LoopID,
+			RunID:      execution.RunID,
+			EntityType: stringPtr("agent_execution"),
+			EntityID:   stringPtr(execution.ID),
+			PayloadJSON: mustMarshalJSON(map[string]any{
+				"pid":    pid,
+				"reason": "command_mismatch",
+				"scope":  scope,
+			}),
+			CreatedAt: nowISO,
+		}); err != nil {
+			return err
+		}
+		eventsWritten += 1
+		return nil
+	}
 	if repositories.AgentExecutions != nil {
 		activeExecutions, err := repositories.AgentExecutions.ListActive(ctx)
 		if err != nil {
@@ -626,8 +705,8 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				continue
 			}
 			if running && !matches {
-				if r.logger != nil {
-					r.logger.Warn("skipped orphan agent cleanup for mismatched pid", map[string]any{"executionId": execution.ID, "pid": pid})
+				if err := recordUncertainExecution(execution, pid, "orphan_cleanup"); err != nil {
+					return RecoverySummary{}, err
 				}
 				continue
 			}
@@ -742,10 +821,17 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				if execution.RunID == nil || strings.TrimSpace(*execution.RunID) == "" || execution.PID == nil || *execution.PID <= 0 {
 					continue
 				}
-				matches, running, err := r.executionMatchesProcess(ctx, execution, int(*execution.PID))
+				pid := int(*execution.PID)
+				matches, running, err := r.executionMatchesProcess(ctx, execution, pid)
 				if err != nil {
 					if r.logger != nil {
 						r.logger.Warn("failed to verify active agent execution identity", map[string]any{"executionId": execution.ID, "pid": *execution.PID, "error": err.Error()})
+					}
+					continue
+				}
+				if running && !matches {
+					if err := recordUncertainExecution(execution, pid, "active_run_detection"); err != nil {
+						return RecoverySummary{}, err
 					}
 					continue
 				}
@@ -764,7 +850,8 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				return RecoverySummary{}, err
 			}
 			_, hasActiveAgent := activeAgentRunIDs[run.ID]
-			if !shouldInterruptStaleRunningRun(run, latestRun, hasActiveAgent) {
+			_, hasUncertainAgent := uncertainAgentRunIDs[run.ID]
+			if !shouldInterruptStaleRunningRun(run, latestRun, hasActiveAgent, hasUncertainAgent) {
 				continue
 			}
 			if err := interruptRecoveryRun(ctx, repositories, run, loop, nowISO, "Interrupted stale/orphaned running run during looperd recovery"); err != nil {
@@ -832,7 +919,8 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 		}
 
 		_, latestRunHasActiveAgent := activeAgentRunIDs[derefRunID(latestRun)]
-		if shouldRequeueLoop(loop, latestRun, latestRunHasActiveAgent) {
+		_, latestRunHasUncertainAgent := uncertainAgentRunIDs[derefRunID(latestRun)]
+		if shouldRequeueLoop(loop, latestRun, latestRunHasActiveAgent || latestRunHasUncertainAgent) {
 			requeuedLoop := loop
 			requeuedLoop.Status = "queued"
 			requeuedLoop.NextRunAt = stringPtr(nowISO)
@@ -1147,14 +1235,14 @@ func ensureRecoveryQueueItem(ctx context.Context, repositories *storage.Reposito
 	return repositories.Queue.Upsert(ctx, queueRecord)
 }
 
-func shouldInterruptStaleRunningRun(run storage.RunRecord, latestRun *storage.RunRecord, hasActiveAgent bool) bool {
+func shouldInterruptStaleRunningRun(run storage.RunRecord, latestRun *storage.RunRecord, hasActiveAgent bool, hasUncertainAgent bool) bool {
 	if run.Status != string(domain.RunStatusRunning) {
 		return false
 	}
 	if latestRun == nil || latestRun.ID != run.ID {
 		return true
 	}
-	if hasActiveAgent {
+	if hasActiveAgent || hasUncertainAgent {
 		return false
 	}
 	// Recovery runs during daemon startup, so a persisted running run without an
@@ -1409,7 +1497,9 @@ func commandPrefixMatches(expected, actual []string) bool {
 			return false
 		}
 	}
-	return strings.Join(actual[len(expected)-1:], " ") == expected[len(expected)-1]
+	actualTail := strings.Join(actual[len(expected)-1:], " ")
+	expectedTail := expected[len(expected)-1]
+	return actualTail == expectedTail || strings.HasPrefix(expectedTail, actualTail)
 }
 
 func splitProcessCommand(command string) []string {
@@ -1803,7 +1893,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func shouldRequeueLoop(loop storage.LoopRecord, latestRun *storage.RunRecord, latestRunHasActiveAgent bool) bool {
+func shouldRequeueLoop(loop storage.LoopRecord, latestRun *storage.RunRecord, latestRunHasLiveAgent bool) bool {
 	if loop.Status == "paused" {
 		return false
 	}
@@ -1813,7 +1903,7 @@ func shouldRequeueLoop(loop storage.LoopRecord, latestRun *storage.RunRecord, la
 	if latestRun == nil {
 		return loop.Status == "running"
 	}
-	if latestRun.Status == string(domain.RunStatusRunning) && latestRunHasActiveAgent {
+	if latestRun.Status == string(domain.RunStatusRunning) && latestRunHasLiveAgent {
 		return false
 	}
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -387,12 +387,16 @@ func (r *Runtime) start(ctx context.Context) error {
 	r.schedulerDisabled = schedulerDisabled
 	r.mu.Unlock()
 
-	started = true
 	if r.deferRecovery {
+		started = true
 		return nil
 	}
 
-	return r.CompleteStartup(ctx)
+	if err := r.CompleteStartup(ctx); err != nil {
+		return err
+	}
+	started = true
+	return nil
 }
 
 func (r *Runtime) CompleteStartup(ctx context.Context) error {
@@ -1499,7 +1503,7 @@ func commandPrefixMatches(expected, actual []string) bool {
 	}
 	actualTail := strings.Join(actual[len(expected)-1:], " ")
 	expectedTail := expected[len(expected)-1]
-	return actualTail == expectedTail || strings.HasPrefix(expectedTail, actualTail)
+	return actualTail == expectedTail || (actualTail != "" && strings.HasPrefix(expectedTail, actualTail))
 }
 
 func splitProcessCommand(command string) []string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1503,7 +1503,7 @@ func commandPrefixMatches(expected, actual []string) bool {
 	}
 	actualTail := strings.Join(actual[len(expected)-1:], " ")
 	expectedTail := expected[len(expected)-1]
-	return actualTail == expectedTail || (actualTail != "" && strings.HasPrefix(expectedTail, actualTail))
+	return actualTail == expectedTail
 }
 
 func splitProcessCommand(command string) []string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -421,12 +421,12 @@ func (r *Runtime) CompleteStartup(ctx context.Context) error {
 			r.startupReadyErr = fmt.Errorf("runtime repositories are not configured")
 			return
 		}
-		if err := r.appendStartedEvent(context.Background(), *startedAt); err != nil {
+		recoverySummary, err := r.runRecoveryPipeline(ctx, repositories, githubGateway, *startedAt)
+		if err != nil {
 			r.startupReadyErr = err
 			return
 		}
-		recoverySummary, err := r.runRecoveryPipeline(ctx, repositories, githubGateway, *startedAt)
-		if err != nil {
+		if err := r.appendStartedEvent(context.Background(), *startedAt, recoverySummary); err != nil {
 			r.startupReadyErr = err
 			return
 		}
@@ -1144,7 +1144,7 @@ func (r *Runtime) runDeferredReviewerRecovery(ctx context.Context, repositories 
 	return requeued, nil
 }
 
-func (r *Runtime) appendStartedEvent(ctx context.Context, startedAt time.Time) error {
+func (r *Runtime) appendStartedEvent(ctx context.Context, startedAt time.Time, recoverySummary RecoverySummary) error {
 	services := r.Services()
 	if services.Repositories == nil {
 		return nil
@@ -1159,9 +1159,9 @@ func (r *Runtime) appendStartedEvent(ctx context.Context, startedAt time.Time) e
 			"daemonMode": r.config.Daemon.Mode,
 			"host":       r.config.Server.Host,
 			"port":       r.config.Server.Port,
-			"recovery":   r.RecoverySummary(),
+			"recovery":   recoverySummary,
 		}),
-		CreatedAt: formatJavaScriptISOString(startedAt),
+		CreatedAt: formatJavaScriptISOString(startedAt.Add(time.Millisecond)),
 	})
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1208,14 +1208,14 @@ func TestRuntimeRecoveryPreservesRunWithUncertainActiveAgentExecution(t *testing
 	}
 }
 
-func TestCommandPrefixMatchesTruncatedPromptTail(t *testing.T) {
+func TestCommandPrefixMatchesRejectsTruncatedPromptTail(t *testing.T) {
 	t.Parallel()
 
-	if !commandPrefixMatches(
+	if commandPrefixMatches(
 		[]string{"codex", "exec", "very long reviewer prompt that may be truncated by ps output"},
 		[]string{"codex", "exec", "very long reviewer prompt"},
 	) {
-		t.Fatal("commandPrefixMatches() = false, want true for truncated prompt tail")
+		t.Fatal("commandPrefixMatches() = true, want false for truncated prompt tail")
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -180,6 +180,24 @@ func TestRuntimeStartClosesCoordinatorWhenCompleteStartupFails(t *testing.T) {
 	if rt.startupReadyErr == nil {
 		t.Fatal("startupReadyErr = nil, want completion failure recorded")
 	}
+
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), cfg.Storage.DBPath, storage.SQLiteCoordinatorOptions{
+		BackupDir:  backupDir,
+		Migrations: storage.EmbeddedMigrations,
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() reopen error = %v", err)
+	}
+	defer func() { _ = coordinator.Close() }()
+	reopenedRepos := storage.NewRepositories(coordinator.DB())
+	events, err := reopenedRepos.Events.List(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("Events.List() error = %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("Events.List() = %#v, want no startup event after failed completion", events)
+	}
+
 	rt.Stop("cleanup after failed startup")
 }
 
@@ -372,6 +390,21 @@ func TestRuntimeStartRunsRecoveryBeforeImmediateSchedulerTick(t *testing.T) {
 	}
 	if !containsEventType(allEvents, "looperd.started") {
 		t.Fatalf("all events = %#v, want looperd.started", allEvents)
+	}
+	if len(allEvents) == 0 || allEvents[0].EventType != "looperd.started" {
+		t.Fatalf("all events = %#v, want looperd.started listed after recovery events", allEvents)
+	}
+	if allEvents[0].PayloadJSON == "" {
+		t.Fatal("looperd.started payload = nil, want recovery summary")
+	}
+	var startedPayload struct {
+		Recovery RecoverySummary `json:"recovery"`
+	}
+	if err := json.Unmarshal([]byte(allEvents[0].PayloadJSON), &startedPayload); err != nil {
+		t.Fatalf("json.Unmarshal(looperd.started payload) error = %v", err)
+	}
+	if startedPayload.Recovery != recovery {
+		t.Fatalf("started event recovery = %#v, want %#v", startedPayload.Recovery, recovery)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -133,6 +133,56 @@ func TestRuntimeStartIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestRuntimeStartClosesCoordinatorWhenCompleteStartupFails(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+
+	startCtx, cancel := context.WithCancel(context.Background())
+	rt := New(Options{
+		Config: cfg,
+		Logger: &testLogger{},
+		SyncConfiguredProjects: func(ctx context.Context, service *projects.Service, cfg config.Config, now time.Time) error {
+			cancel()
+			return nil
+		},
+	})
+
+	err = rt.Start(startCtx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Start() error = %v, want %v", err, context.Canceled)
+	}
+
+	services := rt.Services()
+	if services.Coordinator == nil {
+		t.Fatal("Services().Coordinator = nil, want closed coordinator for failed startup")
+	}
+	if err := services.Coordinator.DB().PingContext(context.Background()); err == nil {
+		t.Fatal("Services().Coordinator.DB().PingContext() error = nil, want closed database after startup failure")
+	}
+	if _, ok := rt.StartedAt(); !ok {
+		t.Fatal("StartedAt() ok = false, want startup timestamp recorded before completion failure")
+	}
+	if recovery := rt.RecoverySummary(); recovery != createEmptyRecoverySummary() {
+		t.Fatalf("RecoverySummary() = %#v, want empty recovery summary after failed completion", recovery)
+	}
+	if rt.ownershipAcquired {
+		t.Fatal("ownershipAcquired = true, want false after failed CompleteStartup")
+	}
+	if rt.startupReadyErr == nil {
+		t.Fatal("startupReadyErr = nil, want completion failure recorded")
+	}
+	rt.Stop("cleanup after failed startup")
+}
+
 func TestRuntimeStartRunsRecoveryBeforeImmediateSchedulerTick(t *testing.T) {
 	t.Parallel()
 
@@ -1133,6 +1183,17 @@ func TestCommandPrefixMatchesTruncatedPromptTail(t *testing.T) {
 		[]string{"codex", "exec", "very long reviewer prompt"},
 	) {
 		t.Fatal("commandPrefixMatches() = false, want true for truncated prompt tail")
+	}
+}
+
+func TestCommandPrefixMatchesRejectsMissingTail(t *testing.T) {
+	t.Parallel()
+
+	if commandPrefixMatches(
+		[]string{"codex", "exec", "very long reviewer prompt that may be truncated by ps output"},
+		[]string{"codex", "exec"},
+	) {
+		t.Fatal("commandPrefixMatches() = true, want false when actual command is missing the trailing token")
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1003,16 +1003,19 @@ func TestRuntimeRecoverySkipsMismatchedRecoveredPID(t *testing.T) {
 	if containsEventType(events, "agent.killed") {
 		t.Fatalf("agent_execution events = %#v, want no agent.killed for mismatched pid", events)
 	}
+	if !containsEventType(events, "looperd.recovery.process_identity_uncertain") {
+		t.Fatalf("agent_execution events = %#v, want uncertain-identity event", events)
+	}
 	recovery := rt.RecoverySummary()
 	if recovery.OrphanAgentCleanup.CleanedCount != 0 {
 		t.Fatalf("RecoverySummary().OrphanAgentCleanup = %#v, want cleanedCount=0", recovery.OrphanAgentCleanup)
 	}
-	if !logger.containsMessage("skipped orphan agent cleanup for mismatched pid") {
-		t.Fatalf("logger entries = %#v, want mismatched pid warning", logger.messages())
+	if !logger.containsMessage("recovery skipped due to uncertain process identity") {
+		t.Fatalf("logger entries = %#v, want uncertain process identity warning", logger.messages())
 	}
 }
 
-func TestRuntimeRecoveryInterruptsRunWithMismatchedActiveAgentExecution(t *testing.T) {
+func TestRuntimeRecoveryPreservesRunWithUncertainActiveAgentExecution(t *testing.T) {
 	t.Parallel()
 
 	workingDir := t.TempDir()
@@ -1066,9 +1069,10 @@ func TestRuntimeRecoveryInterruptsRunWithMismatchedActiveAgentExecution(t *testi
 		t.Fatalf("seed coordinator close error = %v", err)
 	}
 
+	logger := &testLogger{}
 	rt := New(Options{
 		Config: cfg,
-		Logger: &testLogger{},
+		Logger: logger,
 		Now: func() time.Time {
 			return startedAt
 		},
@@ -1089,8 +1093,15 @@ func TestRuntimeRecoveryInterruptsRunWithMismatchedActiveAgentExecution(t *testi
 	if err != nil {
 		t.Fatalf("Runs.GetByID() error = %v", err)
 	}
-	if run == nil || run.Status != "interrupted" || run.EndedAt == nil {
-		t.Fatalf("Runs.GetByID(%s) = %#v, want interrupted with ended_at", runID, run)
+	if run == nil || run.Status != "running" || run.EndedAt != nil {
+		t.Fatalf("Runs.GetByID(%s) = %#v, want preserved running run", runID, run)
+	}
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "running" {
+		t.Fatalf("Loops.GetByID(%s) = %#v, want preserved running loop", loopID, loop)
 	}
 	agentExecution, err := services.Repositories.AgentExecutions.GetByID(context.Background(), "agent_mismatched_running_run")
 	if err != nil {
@@ -1099,8 +1110,29 @@ func TestRuntimeRecoveryInterruptsRunWithMismatchedActiveAgentExecution(t *testi
 	if agentExecution == nil || agentExecution.Status != "running" {
 		t.Fatalf("AgentExecutions.GetByID(agent_mismatched_running_run) = %#v, want still running stale row", agentExecution)
 	}
-	if recovery := rt.RecoverySummary(); recovery.InterruptedRunsMarked != 1 || recovery.OrphanAgentCleanup.CleanedCount != 0 {
-		t.Fatalf("RecoverySummary() = %#v, want interrupted run without cleaned orphan agent", recovery)
+	events, err := services.Repositories.Events.ListByEntity(context.Background(), "agent_execution", "agent_mismatched_running_run")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity(agent_mismatched_running_run) error = %v", err)
+	}
+	if !containsEventType(events, "looperd.recovery.process_identity_uncertain") {
+		t.Fatalf("agent_execution events = %#v, want uncertain-identity event", events)
+	}
+	if recovery := rt.RecoverySummary(); recovery.InterruptedRunsMarked != 0 || recovery.LoopsRequeued != 0 || recovery.OrphanAgentCleanup.CleanedCount != 0 {
+		t.Fatalf("RecoverySummary() = %#v, want preserved run and loop for uncertain live execution", recovery)
+	}
+	if !logger.containsMessage("recovery skipped due to uncertain process identity") {
+		t.Fatalf("logger entries = %#v, want uncertain process identity warning", logger.messages())
+	}
+}
+
+func TestCommandPrefixMatchesTruncatedPromptTail(t *testing.T) {
+	t.Parallel()
+
+	if !commandPrefixMatches(
+		[]string{"codex", "exec", "very long reviewer prompt that may be truncated by ps output"},
+		[]string{"codex", "exec", "very long reviewer prompt"},
+	) {
+		t.Fatal("commandPrefixMatches() = false, want true for truncated prompt tail")
 	}
 }
 


### PR DESCRIPTION
## Summary
- defer looperd recovery and lifecycle event writes until the daemon has actually acquired API ownership, so failed startups cannot mutate live runtime state
- treat mismatched-but-running agent PIDs as uncertain/live, emit recovery observability events, and block interrupts or loop requeues in that case
- add regression coverage for losing startup races, uncertain process identity, and truncated prompt command matching

## Validation
- go vet ./...
- go test ./...
- go build ./...

Closes #266

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href=\"https://github.com/nexu-io/looper\">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>