### PR TITLE
fix: persist pushed PR head for resolve-comments

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -479,6 +479,7 @@ type checkpointPush struct {
 	Pushed        bool   `json:"pushed"`
 	Branch        string `json:"branch,omitempty"`
 	Remote        string `json:"remote,omitempty"`
+	HeadSHA       string `json:"headSha,omitempty"`
 	PushedAt      string `json:"pushedAt,omitempty"`
 	SkippedReason string `json:"skippedReason,omitempty"`
 }
@@ -1513,12 +1514,14 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	if finalHeadSHA == "" {
 		return checkpoint, &loopError{message: "reconcileCommits.finalHeadSha is required", kind: FailureRetryableAfterResume}
 	}
-	if err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: finalHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
+	liveDetail, err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: finalHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
 		return fmt.Sprintf("PR head did not update after push: expected %s, got %s", finalHeadSHA, firstNonEmpty(actual, "unknown"))
-	}}); err != nil {
+	}})
+	if err != nil {
 		return checkpoint, err
 	}
-	metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastFixHeadSha": detailHeadSHA(checkpoint.Detail), "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": r.nowISO()})
+	checkpoint = refreshCheckpointHeadAfterPush(checkpoint, liveDetail)
+	metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastFixHeadSha": resolveCommentsExpectedHeadSHA(checkpoint), "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": r.nowISO()})
 	if err != nil {
 		return checkpoint, err
 	}
@@ -1526,8 +1529,9 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 		return checkpoint, err
 	}
 	pushedAt := r.nowISO()
-	r.appendEvent(ctx, eventInput{eventType: "pr.branch.pushed", projectID: input.Project.ID, loopID: input.Loop.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"branch": branch, "pushedAt": pushedAt, "headSha": nilIfEmpty(detailHeadSHA(checkpoint.Detail))}})
-	checkpoint.Push = &checkpointPush{Pushed: true, Branch: branch, Remote: "origin", PushedAt: pushedAt}
+	pushedHeadSHA := resolveCommentsExpectedHeadSHA(checkpoint)
+	r.appendEvent(ctx, eventInput{eventType: "pr.branch.pushed", projectID: input.Project.ID, loopID: input.Loop.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"branch": branch, "pushedAt": pushedAt, "headSha": nilIfEmpty(pushedHeadSHA)}})
+	checkpoint.Push = &checkpointPush{Pushed: true, Branch: branch, Remote: "origin", HeadSHA: pushedHeadSHA, PushedAt: pushedAt}
 	checkpoint.ensureLifecycle("fixer", branch, detailBaseRefName(checkpoint.Detail), false)
 	checkpoint.Lifecycle.Pushed = true
 	checkpoint.Lifecycle.Actions.Push = lifecycle.ActionSourceFallback
@@ -1558,9 +1562,10 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		fixItems = collectFixItems(detail)
 		checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, detail)
 	}
-	if checkpoint.ReconcileCommits != nil && checkpoint.ReconcileCommits.FinalHeadSHA != "" {
-		if err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: checkpoint.ReconcileCommits.FinalHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
-			return fmt.Sprintf("PR head changed before resolving comments: expected %s, got %s", checkpoint.ReconcileCommits.FinalHeadSHA, firstNonEmpty(actual, "unknown"))
+	expectedHeadSHA := resolveCommentsExpectedHeadSHA(checkpoint)
+	if expectedHeadSHA != "" {
+		if _, err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: expectedHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
+			return fmt.Sprintf("PR head changed before resolving comments: expected %s, got %s", expectedHeadSHA, firstNonEmpty(actual, "unknown"))
 		}}); err != nil {
 			return checkpoint, err
 		}
@@ -2405,22 +2410,24 @@ type waitForPullRequestHeadSHAInput struct {
 	FailureMessage  func(string) string
 }
 
-func (r *Runner) waitForPullRequestHeadSHA(ctx context.Context, input waitForPullRequestHeadSHAInput) error {
+func (r *Runner) waitForPullRequestHeadSHA(ctx context.Context, input waitForPullRequestHeadSHAInput) (PullRequestDetail, error) {
 	actual := ""
+	var latest PullRequestDetail
 	for attempt := 0; attempt < input.Attempts; attempt++ {
 		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 		if err != nil {
-			return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+			return PullRequestDetail{}, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
+		latest = detail
 		actual = detail.HeadSHA
 		if actual == input.ExpectedHeadSHA {
-			return nil
+			return detail, nil
 		}
 		if attempt < input.Attempts-1 {
 			r.sleep(input.Delay)
 		}
 	}
-	return &loopError{message: input.FailureMessage(actual), kind: FailureRetryableAfterResume}
+	return latest, &loopError{message: input.FailureMessage(actual), kind: FailureRetryableAfterResume}
 }
 
 func (r *Runner) runValidation(ctx context.Context, input ValidationInput) (ValidationResult, error) {
@@ -3051,6 +3058,32 @@ func mergeCheckpointDetailPreservingLabels(existing *checkpointDetail, live Pull
 		merged.Labels = cloneStrings(existing.Labels)
 	}
 	return merged
+}
+
+func refreshCheckpointHeadAfterPush(checkpoint fixerCheckpoint, live PullRequestDetail) fixerCheckpoint {
+	if live.HeadSHA == "" {
+		return checkpoint
+	}
+	checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, live)
+	if checkpoint.Worktree != nil {
+		checkpoint.Worktree.HeadSHA = live.HeadSHA
+	}
+	if checkpoint.ReconcileCommits != nil {
+		checkpoint.ReconcileCommits.FinalHeadSHA = live.HeadSHA
+	}
+	return checkpoint
+}
+
+func resolveCommentsExpectedHeadSHA(checkpoint fixerCheckpoint) string {
+	if checkpoint.Push != nil && checkpoint.Push.Pushed {
+		if headSHA := checkpoint.Push.HeadSHA; headSHA != "" {
+			return headSHA
+		}
+	}
+	if checkpoint.ReconcileCommits != nil && checkpoint.ReconcileCommits.FinalHeadSHA != "" {
+		return checkpoint.ReconcileCommits.FinalHeadSHA
+	}
+	return detailHeadSHA(checkpoint.Detail)
 }
 
 func detailHeadSHA(detail *checkpointDetail) string {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -433,6 +433,16 @@ func TestProcessClaimedItemCompletesSuccessfulFlow(t *testing.T) {
 	if run == nil || run.Status != "success" || run.LastCompletedStep == nil || *run.LastCompletedStep != string(stepRecheck) {
 		t.Fatalf("run = %#v, want success through recheck", run)
 	}
+	checkpoint := parseCheckpoint(run.CheckpointJSON)
+	if checkpoint.Detail == nil || checkpoint.Detail.HeadSHA != "new-head" {
+		t.Fatalf("checkpoint.Detail = %#v, want pushed head new-head", checkpoint.Detail)
+	}
+	if checkpoint.Push == nil || checkpoint.Push.HeadSHA != "new-head" {
+		t.Fatalf("checkpoint.Push = %#v, want recorded pushed head new-head", checkpoint.Push)
+	}
+	if checkpoint.ReconcileCommits == nil || checkpoint.ReconcileCommits.FinalHeadSHA != "new-head" {
+		t.Fatalf("checkpoint.ReconcileCommits = %#v, want refreshed final head new-head", checkpoint.ReconcileCommits)
+	}
 }
 
 func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *testing.T) {
@@ -656,6 +666,52 @@ func TestRunResolveCommentsStepChecksHeadDriftBeforeNoFixBlock(t *testing.T) {
 	}
 	if len(github.resolveCalls) != 0 {
 		t.Fatalf("resolve calls = %d, want none on stale head", len(github.resolveCalls))
+	}
+}
+
+func TestRunResolveCommentsStepUsesRefreshedPushHeadSHA(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "new-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+	}}}
+	runner := New(Options{GitHub: github})
+	checkpoint := fixerCheckpoint{
+		Detail:     &checkpointDetail{HeadSHA: "old-head", HeadRefName: "feature/fix-42", BaseRefName: "main"},
+		FixItems:   []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}},
+		Validation: &ValidationResult{Passed: true, Summary: "ok"},
+		Push:       &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "new-head"},
+		Lifecycle:  &lifecycle.State{Pushed: true},
+		ReconcileCommits: &checkpointReconcileCommits{
+			BaseHeadSHA:      "base-head",
+			FinalHeadSHA:     "old-head",
+			NewCommitSHAs:    []string{"new-head"},
+			WorkingTreeClean: true,
+		},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if len(github.resolveCalls) != 1 {
+		t.Fatalf("resolve calls = %d, want 1", len(github.resolveCalls))
+	}
+	if len(github.replyCalls) != 1 || !contains(github.replyCalls[0].Body, "new-hea") {
+		t.Fatalf("reply calls = %#v, want reply referencing pushed head", github.replyCalls)
+	}
+	if updated.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
 	}
 }
 


### PR DESCRIPTION
## Summary
- persist the verified PR head SHA after a successful fixer push so later steps use the same checkpointed head
- refresh the fixer checkpoint's PR/worktree head state after push instead of leaving stale pre-push metadata behind
- add regression coverage for successful push checkpoints and resolve-comments using the refreshed pushed head

## Testing
- go vet ./...
- go test ./...
- go build ./...

Closes #262

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href=\"https://github.com/nexu-io/looper\">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>