### PR TITLE
fix: use io.nexu reverse-DNS for looperd LaunchAgent label

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -261,7 +261,7 @@ Restart options:
 
 - `daemon.restartPolicy`: `never`, `on-failure`, or `always` (default `on-failure`). For launchd, `on-failure` maps to `KeepAlive` with unsuccessful-exit semantics, and `always` maps to `KeepAlive=true`.
 - `daemon.restartThrottleSeconds`: positive integer throttle passed to the supervisor to avoid tight crash loops (default `10`).
-- `daemon.plistPath`: optional macOS LaunchAgent plist path. If omitted, Looper uses `~/Library/LaunchAgents/com.nexu-io.looper.looperd.plist`.
+- `daemon.plistPath`: optional macOS LaunchAgent plist path. If omitted, Looper uses `~/Library/LaunchAgents/io.nexu.looper.looperd.plist`.
 
 Runtime diagnostics are discoverable from `looper daemon status` and `looper daemon status --json`:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,7 +82,7 @@ looper daemon logs
 
 Launchd mode:
 
-- creates a user LaunchAgent plist at `~/Library/LaunchAgents/com.nexu-io.looper.looperd.plist` unless `daemon.plistPath` is set
+- creates a user LaunchAgent plist at `~/Library/LaunchAgents/io.nexu.looper.looperd.plist` unless `daemon.plistPath` is set (any leftover plist at the legacy `com.nexu-io.looper.looperd.plist` path is unloaded and removed automatically on the next `daemon start --daemon-mode launchd`)
 - stores launchd stdout/stderr logs under `~/.looper/logs/launchd/`
 - stores startup logs under `~/.looper/logs/startup/`
 - stores lifecycle state in `~/.looper/looperd.state.json`

--- a/internal/cliapp/daemon_runtime_test.go
+++ b/internal/cliapp/daemon_runtime_test.go
@@ -500,6 +500,95 @@ func TestStopLaunchdDaemonUsesPersistedStatePlistPath(t *testing.T) {
 	}
 }
 
+func TestMigrateLegacyLaunchdPlistBootsOutAndRemovesWhenLegacyPresent(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	legacyDir := filepath.Join(homeDir, "Library", "LaunchAgents")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(legacyDir) error = %v", err)
+	}
+	legacyPath := filepath.Join(legacyDir, launchdLooperdLegacyLabel+".plist")
+	if err := os.WriteFile(legacyPath, []byte("<plist/>\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(legacy plist) error = %v", err)
+	}
+
+	var bootoutArgs []string
+	var removed []string
+	runtime := newCommandRuntime(New(Deps{
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		LookPath: func(file string) (string, error) {
+			if file == "launchctl" {
+				return "/bin/launchctl", nil
+			}
+			return "", os.ErrNotExist
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = command
+			_ = timeout
+			bootoutArgs = append([]string{}, args...)
+			return commandExecutionResult{ExitCode: 0}, nil
+		},
+		RemoveFile: func(path string) error {
+			removed = append(removed, path)
+			return nil
+		},
+	}), nil)
+
+	runtime.migrateLegacyLaunchdPlist(context.Background(), "/bin/launchctl", "gui/1000")
+
+	if len(bootoutArgs) != 3 || bootoutArgs[0] != "bootout" || bootoutArgs[1] != "gui/1000" || bootoutArgs[2] != legacyPath {
+		t.Fatalf("launchctl args = %#v, want bootout of legacy plist %q in domain gui/1000", bootoutArgs, legacyPath)
+	}
+	if len(removed) != 1 || removed[0] != legacyPath {
+		t.Fatalf("removed files = %#v, want exactly the legacy plist %q", removed, legacyPath)
+	}
+}
+
+func TestMigrateLegacyLaunchdPlistNoopWhenLegacyAbsent(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	// Intentionally do not create the legacy plist on disk.
+
+	var runCommandCalls int
+	var removeCalls int
+	runtime := newCommandRuntime(New(Deps{
+		HomeDir:  homeDir,
+		Platform: "darwin",
+		LookPath: func(file string) (string, error) {
+			if file == "launchctl" {
+				return "/bin/launchctl", nil
+			}
+			return "", os.ErrNotExist
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = command
+			_ = args
+			_ = timeout
+			runCommandCalls++
+			return commandExecutionResult{ExitCode: 0}, nil
+		},
+		RemoveFile: func(path string) error {
+			_ = path
+			removeCalls++
+			return nil
+		},
+	}), nil)
+
+	runtime.migrateLegacyLaunchdPlist(context.Background(), "/bin/launchctl", "gui/1000")
+
+	if runCommandCalls != 0 {
+		t.Fatalf("runCommand invocations = %d, want 0 (no legacy plist to migrate)", runCommandCalls)
+	}
+	if removeCalls != 0 {
+		t.Fatalf("removeFile invocations = %d, want 0 (no legacy plist to migrate)", removeCalls)
+	}
+}
+
 func TestRefreshLaunchdLifecycleStateClearsStalePIDWhenServiceAbsent(t *testing.T) {
 	t.Parallel()
 
@@ -1298,6 +1387,7 @@ func TestDaemonRestartStopsExistingPIDAndStartsReplacement(t *testing.T) {
 	t.Parallel()
 
 	homeDir := t.TempDir()
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
 	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -1396,7 +1486,7 @@ func TestDaemonRestartStopsExistingPIDAndStartsReplacement(t *testing.T) {
 		},
 	})
 
-	exitCode := app.Run(context.Background(), []string{"daemon", "restart"})
+	exitCode := app.Run(context.Background(), []string{"daemon", "restart", "--config", configPath})
 	if exitCode != 0 {
 		t.Fatalf("Run([daemon restart]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
@@ -1505,17 +1595,19 @@ func TestDaemonStopStopsExistingPIDAndRemovesPIDFile(t *testing.T) {
 func TestDaemonStopWithoutPIDFileReportsNothingToStop(t *testing.T) {
 	t.Parallel()
 
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	app := New(Deps{
-		Stdout: stdout,
-		Stderr: stderr,
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: t.TempDir(),
 		ReadFile: func(path string) ([]byte, error) {
 			return nil, os.ErrNotExist
 		},
 	})
 
-	exitCode := app.Run(context.Background(), []string{"daemon", "stop"})
+	exitCode := app.Run(context.Background(), []string{"daemon", "stop", "--config", configPath})
 	if exitCode != 0 {
 		t.Fatalf("Run([daemon stop]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}

--- a/internal/cliapp/daemon_supervision.go
+++ b/internal/cliapp/daemon_supervision.go
@@ -19,7 +19,15 @@ import (
 
 const (
 	daemonStateSchemaVersion = 1
-	launchdLooperdLabel      = "com.nexu-io.looper.looperd"
+	// launchdLooperdLabel is the reverse-DNS LaunchAgent label for the
+	// looperd daemon supervised by launchd on macOS. The nexu.io domain
+	// maps to "io.nexu" in reverse-DNS form.
+	launchdLooperdLabel = "io.nexu.looper.looperd"
+	// launchdLooperdLegacyLabel is the prior, malformed label used before
+	// the reverse-DNS fix. Kept so that fresh `daemon start --daemon-mode
+	// launchd` invocations can clean up any leftover plist installed by an
+	// older Looper build.
+	launchdLooperdLegacyLabel = "com.nexu-io.looper.looperd"
 )
 
 type daemonLifecycleState struct {
@@ -285,6 +293,24 @@ func (r *commandRuntime) refreshLaunchdLifecycleState(ctx context.Context, loade
 	return &updated, nil
 }
 
+// migrateLegacyLaunchdPlist removes any LaunchAgent installed under the
+// previous, malformed label so the new install does not race with a leftover
+// daemon under the legacy name. The previous label was
+// "com.nexu-io.looper.looperd"; the corrected reverse-DNS form is
+// "io.nexu.looper.looperd". Best effort — failures do not block start.
+func (r *commandRuntime) migrateLegacyLaunchdPlist(ctx context.Context, launchctlPath, domain string) {
+	homeDir, err := r.homeDir()
+	if err != nil {
+		return
+	}
+	legacyPlistPath := filepath.Join(homeDir, "Library", "LaunchAgents", launchdLooperdLegacyLabel+".plist")
+	if _, readErr := r.readFile(legacyPlistPath); readErr != nil {
+		return
+	}
+	_, _ = r.runCommand(ctx, launchctlPath, []string{"bootout", domain, legacyPlistPath}, daemonCommandTimeout)
+	_ = r.removeFile(legacyPlistPath)
+}
+
 func (r *commandRuntime) startLaunchdDaemon(ctx context.Context, out io.Writer, loaded config.LoadedFileConfig, binary *resolvedDaemonBinary, args []string, cwd string, env []string, client *DaemonAPIClient, apiURL string) error {
 	if r.platform() != "darwin" {
 		return fmt.Errorf("daemon.mode=launchd is only supported on macOS. Use daemon.mode=foreground for detached-only mode on this platform, or configure a platform supervisor when support is added")
@@ -317,6 +343,7 @@ func (r *commandRuntime) startLaunchdDaemon(ctx context.Context, out io.Writer, 
 		return fmt.Errorf("write launchd plist: %w", err)
 	}
 	domain := fmt.Sprintf("gui/%d", os.Getuid())
+	r.migrateLegacyLaunchdPlist(ctx, launchctlPath, domain)
 	_, _ = r.runCommand(ctx, launchctlPath, []string{"bootout", domain, plistPath}, daemonCommandTimeout)
 	result, err := r.runCommand(ctx, launchctlPath, []string{"bootstrap", domain, plistPath}, daemonCommandTimeout)
 	if err != nil {

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -246,7 +246,7 @@ Restart options:
 
 - `daemon.restartPolicy`: `never`, `on-failure`, or `always` (default `on-failure`).
 - `daemon.restartThrottleSeconds`: positive integer throttle, default `10`.
-- `daemon.plistPath`: optional macOS LaunchAgent plist path. Default: `~/Library/LaunchAgents/com.nexu-io.looper.looperd.plist`.
+- `daemon.plistPath`: optional macOS LaunchAgent plist path. Default: `~/Library/LaunchAgents/io.nexu.looper.looperd.plist`.
 
 Runtime diagnostics:
 


### PR DESCRIPTION
## Summary
- Rename the looperd LaunchAgent label / default plist filename from \`com.nexu-io.looper.looperd\` to \`io.nexu.looper.looperd\` (correct reverse-DNS for the \`nexu.io\` domain).
- On \`daemon start --daemon-mode launchd\`, auto-migrate any leftover plist installed under the legacy label: \`launchctl bootout\` it and unlink the file. Best-effort, never blocks start.
- Pin two existing daemon tests to a temp config so they stop leaking the developer's real \`~/.looper/config.json\` (\`daemon.mode\`) into the test environment.

## Why
\`com.nexu-io.looper.looperd\` is not a valid reverse-DNS label — Looper's domain is \`nexu.io\`, which reverses to \`io.nexu\`. \`com.nexu-io\` parses as \"a subdomain of \`.com\`\" that Looper does not own; Apple's convention for LaunchAgent labels is strict reverse-DNS of a domain you control.

Renaming without migration would also be unsafe: an existing user who has already loaded the legacy plist (\`~/Library/LaunchAgents/com.nexu-io.looper.looperd.plist\`) would, after upgrading, have a fresh \`daemon start --daemon-mode launchd\` install a new plist under the new label while the old daemon is still loaded under the old label. Both daemons would race for the \`127.0.0.1:17310\` API port. The migration shim removes that risk.

## Test isolation fix
\`TestDaemonRestartStopsExistingPIDAndStartsReplacement\` and \`TestDaemonStopWithoutPIDFileReportsNothingToStop\` do not set a config-file override, so \`loadConfig\` reads the developer's real \`~/.looper/config.json\`. On a machine where the user has actually adopted \`daemon.mode=launchd\` (the very state the launchd plist concerns), \`daemonStop\` and \`daemonRestart\` shell out to real \`launchctl\` and fail. The fix is one line each: pass \`--config <writeCLIConfig>\` so those code paths see a known, minimal config.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all 35 packages green (verified twice: once on a clean \$HOME, once with the developer's launchd-mode config present)
- [x] New tests: \`TestMigrateLegacyLaunchdPlistBootsOutAndRemovesWhenLegacyPresent\`, \`TestMigrateLegacyLaunchdPlistNoopWhenLegacyAbsent\`
- [x] Manual smoke: on a host with the legacy plist installed and loaded, running the patched \`looper daemon start --daemon-mode launchd\` cleanly removes the legacy plist and installs the new one without port conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)