### PR TITLE
fix: restart fixer manual intervention from discovery

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1434,7 +1434,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	resumeFromPrepare := false
 	if latestRun != nil {
 		failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage))
-		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, failureSummary)
+		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, failureSummary) || shouldRestartManualInterventionFromDiscover(latestRun.Status, checkpoint)
 		resumeFromPrepare = shouldResumeFromPrepare(latestRun.Status, failedStep, checkpoint)
 	}
 	startStep := stepDiscoverPR
@@ -2219,6 +2219,13 @@ func shouldRestartFromDiscover(status string, failedStep FixerStep, failureSumma
 		return true
 	}
 	return strings.Contains(failureSummary, "PR head changed before resolving comments")
+}
+
+func shouldRestartManualInterventionFromDiscover(status string, checkpoint fixerCheckpoint) bool {
+	if status != "failed" && status != "interrupted" {
+		return false
+	}
+	return checkpoint.ResumePolicy == "manual_intervention"
 }
 
 func shouldRebuildWorktree(checkpoint fixerCheckpoint) bool {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1028,6 +1028,84 @@ func TestCreateRunContextRewindsToPrepareWhenPostRepairResumeCheckpointParseStat
 	}
 }
 
+func TestCreateRunContextRestartsManualInterventionFromDiscover(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	nowISO := fixture.nowISO()
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:         "loop_fixer_manual_restart",
+		Seq:        1,
+		ProjectID:  "project_1",
+		Type:       "fixer",
+		TargetType: "pull_request",
+		TargetID:   &loopTarget,
+		Repo:       &repo,
+		PRNumber:   &prNumber,
+		Status:     "running",
+		CreatedAt:  nowISO,
+		UpdatedAt:  nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
+		ResumePolicy: "manual_intervention",
+		Detail: &checkpointDetail{
+			State:       "OPEN",
+			HeadSHA:     "head-1",
+			HeadRefName: "feature/fix-42",
+			BaseRefName: "main",
+			Comments:    []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}},
+		},
+		FixItems:   []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}},
+		Worktree:   &checkpointWorktree{Path: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "head-1", BaseHeadSHA: "head-1", PreparedAt: nowISO},
+		Repair:     &checkpointRepair{Status: "completed", Summary: "nothing to change", CompletedAt: nowISO},
+		Validation: &ValidationResult{Passed: true, Summary: "passed"},
+		Push:       &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+	})
+	manualReason := "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved"
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:                "run_manual_intervention",
+		LoopID:            "loop_fixer_manual_restart",
+		Status:            "failed",
+		CurrentStep:       stringPtr(string(stepResolveComments)),
+		LastCompletedStep: stringPtr(string(stepPush)),
+		CheckpointJSON:    &checkpointJSON,
+		Summary:           &manualReason,
+		ErrorMessage:      &manualReason,
+		StartedAt:         nowISO,
+		CreatedAt:         nowISO,
+		UpdatedAt:         nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_fixer_manual_restart")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil {
+		t.Fatal("loop = nil, want fixer loop")
+	}
+
+	resumed, err := runner.createRunContext(context.Background(), *loop)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if resumed.Resumed || resumed.StartStep != stepDiscoverPR {
+		t.Fatalf("resumed = %#v, want fresh discover run", resumed)
+	}
+	if resumed.Checkpoint.Detail != nil || len(resumed.Checkpoint.FixItems) != 0 || resumed.Checkpoint.Worktree != nil || resumed.Checkpoint.Push != nil {
+		t.Fatalf("checkpoint = %#v, want cleared manual-intervention checkpoint", resumed.Checkpoint)
+	}
+	if resumed.Checkpoint.ResumePolicy != "replay_step" {
+		t.Fatalf("ResumePolicy = %q, want replay_step", resumed.Checkpoint.ResumePolicy)
+	}
+}
+
 func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Restart fixer runs from PR discovery after a manual-intervention checkpoint so resumed paused loops collect current review threads instead of replaying stale resolve-comments state.
- Add regression coverage for manual-intervention resume clearing stale fixer checkpoints.

## Why
A fixer can enter `manual_intervention` when `resolve-comments` refuses to resolve unresolved review threads because the current run produced no new commits. That guard is intentional for safety, but it leaves the loop paused with a stale checkpoint whose next step is still `resolve-comments`.

When an operator starts that paused loop again, the useful behavior is to re-read the PR: the PR head and unresolved review threads may have changed, and the fixer should decide from current GitHub state what work remains. Replaying the old checkpoint keeps the loop trapped in the same no-new-commit resolve-comments failure and prevents Looper from handling the unresolved thread.

This change treats a manual-intervention checkpoint as a fresh discovery boundary on explicit restart. It preserves the safety guard that blocks resolving comments without evidence from a new commit, while allowing the operator's restart action to escape the stale checkpoint and rehydrate fix items from the live PR.

## Behavior change
- Before: restarting a paused fixer loop after `manual_intervention` could resume from the stale post-push/resolve-comments checkpoint.
- After: restarting that loop starts at `discover-pr` with a clean checkpoint, then collects current PR details and fix items.

## Validation
- go test ./internal/fixer

Related to #263.
Refs #269.