### PR TITLE
fix: stamp PR disclosure footer in Looper instead of agent-authored HTML

### DIFF
--- a/internal/cliapp/prompt_commands.go
+++ b/internal/cliapp/prompt_commands.go
@@ -148,6 +148,7 @@ func previewNoRemoteLifecyclePromptInstruction(runner, branch, baseBranch string
 		"Agent-managed git/PR lifecycle policy: remote actions disabled by Looper configuration.",
 		"Before finishing: inspect git status, staged and unstaged diffs, untracked files, and recent commit style; commit only relevant non-secret changes if needed; do not push branches, create pull requests, update pull request metadata, or otherwise change remote review state.",
 		lifecycle.DisclosurePromptInstruction(runner, disclosureCfg, agentRuntime, agentModel),
+		"Because remote PR actions are disabled for this run, do not create or update PR bodies; any PR disclosure stamping can only happen during a later Looper-managed remote reconciliation step.",
 		"Include a git_pr_lifecycle object in the final " + "__LOOPER_RESULT__" + " JSON with branch, baseBranch, commitShas, pushed, prNumber, prUrl, prAdopted, and actions {commit,push,pr}; use action source \"agent\" only for local commits you completed and \"none\" for disabled remote actions.",
 		fmt.Sprintf("Expected lifecycle runner=%q branch=%q baseBranch=%q expectPush=%t expectPR=%t fallbackAllowed=%t.", runner, branch, baseBranch, false, false, true),
 	}, "\n")

--- a/internal/disclosure/disclosure.go
+++ b/internal/disclosure/disclosure.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	markdownStampPattern = regexp.MustCompile(`(?s)\n*(?:<!-- looper:stamp v=1 -->\n)?<sub>(?:🔁 )?(?:Generated|Powered) by (?:Looper(?: [0-9A-Za-z.-]+)?|\[Looper\]\(https://github\.com/(?:nexu-io|powerformer)/looper\)|<a href=\\?"https://github\.com/nexu-io/looper\\?">Looper</a>).*?</sub>\s*`)
+	markdownStampPattern = regexp.MustCompile(`(?s)\n*(?:<!-- looper:stamp v=1 -->\n)?<sub>(?:🔁 )?(?:Generated|Powered) by (?:Looper|\[Looper\]\(https://github\.com/(?:nexu-io|powerformer)/looper\)|<a href=\\?"https://github\.com/nexu-io/looper\\?">Looper</a>)(?: [0-9A-Za-z.-]+)?\s*· .*?</sub>\s*`)
 	markerOnlyPattern    = regexp.MustCompile(`(?m)\n*<!-- looper:stamp v=1 -->\s*`)
 	commitTrailerPattern = regexp.MustCompile(`(?m)^Generated-By: looper .*$`)
 )

--- a/internal/disclosure/disclosure.go
+++ b/internal/disclosure/disclosure.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	markdownStampPattern = regexp.MustCompile(`(?s)\n*(?:<!-- looper:stamp v=1 -->\n)?<sub>(?:🔁 )?(?:Generated|Powered) by (?:looper|Looper|\[Looper\]\(https://github\.com/(?:nexu-io|powerformer)/looper\)|<a href="https://github\.com/nexu-io/looper">Looper</a>).*?</sub>\s*`)
+	markdownStampPattern = regexp.MustCompile(`(?s)\n*(?:<!-- looper:stamp v=1 -->\n)?<sub>(?:🔁 )?(?:Generated|Powered) by (?:Looper(?: [0-9A-Za-z.-]+)?|\[Looper\]\(https://github\.com/(?:nexu-io|powerformer)/looper\)|<a href=\\?"https://github\.com/nexu-io/looper\\?">Looper</a>).*?</sub>\s*`)
 	markerOnlyPattern    = regexp.MustCompile(`(?m)\n*<!-- looper:stamp v=1 -->\s*`)
 	commitTrailerPattern = regexp.MustCompile(`(?m)^Generated-By: looper .*$`)
 )
@@ -84,6 +84,10 @@ func StripMarkdownStamp(body string) string {
 	cleaned := markdownStampPattern.ReplaceAllString(body, "")
 	cleaned = markerOnlyPattern.ReplaceAllString(cleaned, "")
 	return strings.TrimSpace(cleaned)
+}
+
+func HasMarkdownStamp(body string) bool {
+	return markerOnlyPattern.MatchString(body) || markdownStampPattern.MatchString(body)
 }
 
 func (s Stamper) ReviewComment(body, runner string) string {

--- a/internal/disclosure/disclosure.go
+++ b/internal/disclosure/disclosure.go
@@ -87,7 +87,7 @@ func StripMarkdownStamp(body string) string {
 }
 
 func HasMarkdownStamp(body string) bool {
-	return markerOnlyPattern.MatchString(body) || markdownStampPattern.MatchString(body)
+	return markdownStampPattern.MatchString(body)
 }
 
 func (s Stamper) ReviewComment(body, runner string) string {

--- a/internal/disclosure/disclosure_test.go
+++ b/internal/disclosure/disclosure_test.go
@@ -68,6 +68,24 @@ func TestMarkdownFooterLinksToLooperRepository(t *testing.T) {
 	}
 }
 
+func TestMarkdownFooterReplacesEscapedAgentAuthoredFooter(t *testing.T) {
+	s := testStamper()
+	body := "Body\n\n" + Marker + "\n<sub>🔁 Powered by <a href=\\\"https://github.com/nexu-io/looper\\\">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>"
+	got := s.Markdown(body, "worker", ChannelPullRequest)
+	if strings.Count(got, Marker) != 1 {
+		t.Fatalf("duplicate marker: %q", got)
+	}
+	if strings.Contains(got, `href=\"https://github.com/nexu-io/looper\"`) {
+		t.Fatalf("escaped footer was not removed: %q", got)
+	}
+	if !strings.Contains(got, `🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.`) {
+		t.Fatalf("footer was not normalized: %q", got)
+	}
+	if strings.Count(got, `<sub>`) != 1 {
+		t.Fatalf("duplicate footer markup: %q", got)
+	}
+}
+
 func TestDisclosureIncludesAgentVendorAndModelSeparately(t *testing.T) {
 	vendor := config.AgentVendorOpenCode
 	model := "openai/gpt-5.5"
@@ -191,6 +209,13 @@ func TestDisclosureUsesAllowlistedMachineDetails(t *testing.T) {
 	}
 	if strings.Contains(got, "darwin") || strings.Contains(got, "linux") || strings.Contains(got, "windows") {
 		t.Fatalf("disclosure included raw GOOS instead of OS family: %q", got)
+	}
+}
+
+func TestStripMarkdownStampDoesNotRemoveUnrelatedSubtext(t *testing.T) {
+	body := "Body\n\n<sub>Powered by looper metrics for this benchmark.</sub>"
+	if got := StripMarkdownStamp(body); got != body {
+		t.Fatalf("StripMarkdownStamp() = %q, want unrelated subtext preserved", got)
 	}
 }
 

--- a/internal/disclosure/disclosure_test.go
+++ b/internal/disclosure/disclosure_test.go
@@ -225,6 +225,11 @@ func TestHasMarkdownStampRequiresFooter(t *testing.T) {
 		t.Fatalf("HasMarkdownStamp() = true, want false for bare marker")
 	}
 
+	generic := "Body\n\n<sub>Powered by Looper metrics for this benchmark.</sub>"
+	if HasMarkdownStamp(generic) {
+		t.Fatalf("HasMarkdownStamp() = true, want false for generic subtext")
+	}
+
 	stamped := body + "\n<sub>🔁 Powered by <a href=\"https://github.com/nexu-io/looper\">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>"
 	if !HasMarkdownStamp(stamped) {
 		t.Fatalf("HasMarkdownStamp() = false, want true for stamped footer")

--- a/internal/disclosure/disclosure_test.go
+++ b/internal/disclosure/disclosure_test.go
@@ -219,6 +219,18 @@ func TestStripMarkdownStampDoesNotRemoveUnrelatedSubtext(t *testing.T) {
 	}
 }
 
+func TestHasMarkdownStampRequiresFooter(t *testing.T) {
+	body := "Body\n\n" + Marker
+	if HasMarkdownStamp(body) {
+		t.Fatalf("HasMarkdownStamp() = true, want false for bare marker")
+	}
+
+	stamped := body + "\n<sub>🔁 Powered by <a href=\"https://github.com/nexu-io/looper\">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>"
+	if !HasMarkdownStamp(stamped) {
+		t.Fatalf("HasMarkdownStamp() = false, want true for stamped footer")
+	}
+}
+
 func testStamper() Stamper {
 	return Stamper{
 		Version: "1.2.3",

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2848,6 +2848,7 @@ func noRemoteLifecyclePromptInstruction(runner, branch, baseBranch string, discl
 		"Agent-managed git/PR lifecycle policy: remote actions disabled by Looper configuration.",
 		"Before finishing: inspect git status, staged and unstaged diffs, untracked files, and recent commit style; commit only relevant non-secret changes if needed; do not push branches, create pull requests, update pull request metadata, or otherwise change remote review state.",
 		lifecycle.DisclosurePromptInstruction(runner, disclosureCfg, agentRuntime, agentModel),
+		"Because remote PR actions are disabled for this run, do not create or update PR bodies; any PR disclosure stamping can only happen during a later Looper-managed remote reconciliation step.",
 		"Include a git_pr_lifecycle object in the final " + "__LOOPER_RESULT__" + " JSON with branch, baseBranch, commitShas, pushed, prNumber, prUrl, prAdopted, and actions {commit,push,pr}; use action source \"agent\" only for local commits you completed and \"none\" for disabled remote actions.",
 		fmt.Sprintf("Expected lifecycle runner=%q branch=%q baseBranch=%q expectPush=%t expectPR=%t fallbackAllowed=%t.", runner, branch, baseBranch, false, false, true),
 	}, "\n")

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -250,6 +250,13 @@ type UpdatePullRequestTitleInput struct {
 	CWD      string
 }
 
+type UpdatePullRequestBodyInput struct {
+	Repo     string
+	PRNumber int64
+	Body     string
+	CWD      string
+}
+
 type ListOpenPullRequestsInput struct {
 	Repo    string
 	CWD     string
@@ -1477,6 +1484,11 @@ func (g *Gateway) CreatePullRequest(ctx context.Context, input CreatePullRequest
 
 func (g *Gateway) UpdatePullRequestTitle(ctx context.Context, input UpdatePullRequestTitleInput) error {
 	_, err := g.runGh(ctx, input.CWD, "", "pr", "edit", strconv.FormatInt(input.PRNumber, 10), "--repo", input.Repo, "--title", input.Title)
+	return err
+}
+
+func (g *Gateway) UpdatePullRequestBody(ctx context.Context, input UpdatePullRequestBodyInput) error {
+	_, err := g.runGh(ctx, input.CWD, "", "pr", "edit", strconv.FormatInt(input.PRNumber, 10), "--repo", input.Repo, "--body", input.Body)
 	return err
 }
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -68,6 +68,8 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 			return shell.Result{Stdout: "https://example.test/pull/88\n"}, nil
 		case args == "pr edit 42 --repo acme/looper --title Implement support":
 			return shell.Result{Stdout: ""}, nil
+		case args == "pr edit 42 --repo acme/looper --body Updated body":
+			return shell.Result{Stdout: ""}, nil
 		default:
 			t.Fatalf("unexpected gh args: %q", args)
 			return shell.Result{}, nil
@@ -134,6 +136,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	}
 	if err := gateway.UpdatePullRequestTitle(context.Background(), UpdatePullRequestTitleInput{Repo: "acme/looper", PRNumber: 42, Title: "Implement support"}); err != nil {
 		t.Fatalf("UpdatePullRequestTitle() error = %v", err)
+	}
+	if err := gateway.UpdatePullRequestBody(context.Background(), UpdatePullRequestBodyInput{Repo: "acme/looper", PRNumber: 42, Body: "Updated body"}); err != nil {
+		t.Fatalf("UpdatePullRequestBody() error = %v", err)
 	}
 	detail, err := gateway.ViewPullRequest(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42})
 	if err != nil {

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -239,20 +239,14 @@ func disclosurePromptInstruction(runner string, cfg config.DisclosureConfig, age
 	} else {
 		parts = append(parts, "Do not add looper Generated-By trailers to commit messages.")
 	}
-	if cfg.Channels.PullRequest || cfg.Channels.IssueComment {
-		channels := []string{}
-		if cfg.Channels.PullRequest {
-			channels = append(channels, "PR bodies")
-		}
-		if cfg.Channels.IssueComment {
-			channels = append(channels, "issue bodies or normal comments")
-		}
-		parts = append(parts, "For generated "+strings.Join(channels, " and ")+", add this Markdown footer: `<!-- looper:stamp v=1 -->` followed by `"+markdownFooter+"`.")
-	}
-	if !cfg.Channels.PullRequest {
+	if cfg.Channels.PullRequest {
+		parts = append(parts, "For PR bodies, do not add looper Markdown disclosure footers yourself; Looper will append or normalize the PR disclosure footer during PR creation or update.")
+	} else {
 		parts = append(parts, "Do not add looper Markdown disclosure footers to PR bodies.")
 	}
-	if !cfg.Channels.IssueComment {
+	if cfg.Channels.IssueComment {
+		parts = append(parts, "For generated issue bodies or normal comments, add this Markdown footer: `<!-- looper:stamp v=1 -->` followed by `"+markdownFooter+"`.")
+	} else {
 		parts = append(parts, "Do not add looper Markdown disclosure footers to issue bodies or normal comments.")
 	}
 	if cfg.Channels.ReviewComment {

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -108,3 +108,13 @@ func TestPromptInstructionRespectsDisclosureChannelOptOuts(t *testing.T) {
 		t.Fatalf("PromptInstruction should still mention enabled issue-comment disclosure:\n%s", prompt)
 	}
 }
+
+func TestPromptInstructionLeavesPRDisclosureStampingToLooper(t *testing.T) {
+	prompt := PromptInstruction("worker", "looper/test", "main", true, true, config.DefaultDisclosureConfig(), "opencode", "")
+	if !strings.Contains(prompt, "For PR bodies, do not add looper Markdown disclosure footers yourself; Looper will append or normalize the PR disclosure footer during PR creation or update.") {
+		t.Fatalf("PromptInstruction missing PR stamping guidance:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "For generated issue bodies or normal comments, add this Markdown footer") {
+		t.Fatalf("PromptInstruction should preserve issue comment disclosure guidance:\n%s", prompt)
+	}
+}

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -1032,7 +1032,7 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (plannerCh
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 			}
 			if adopted != nil {
-				if err := r.normalizePullRequestDisclosure(ctx, issue.Repo, adopted.Number, input.Project.RepoPath, true); err != nil {
+				if err := r.normalizePullRequestDisclosure(ctx, issue.Repo, adopted.Number, input.Project.RepoPath, false); err != nil {
 					return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 				}
 				checkpoint.Publish.PullRequest = adopted
@@ -1060,7 +1060,7 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (plannerCh
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		if adopted != nil {
-			if err := r.normalizePullRequestDisclosure(ctx, issue.Repo, adopted.Number, input.Project.RepoPath, true); err != nil {
+			if err := r.normalizePullRequestDisclosure(ctx, issue.Repo, adopted.Number, input.Project.RepoPath, false); err != nil {
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 			}
 			checkpoint.Publish.PullRequest = &checkpointPullRequest{Number: adopted.Number, URL: adopted.URL, Body: ""}

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -1032,7 +1032,7 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (plannerCh
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 			}
 			if adopted != nil {
-				if err := r.normalizePullRequestDisclosure(ctx, issue.Repo, adopted.Number, input.Project.RepoPath, false); err != nil {
+				if err := r.normalizePullRequestDisclosure(ctx, issue.Repo, adopted.Number, input.Project.RepoPath, true); err != nil {
 					return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 				}
 				checkpoint.Publish.PullRequest = adopted

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/bootstrap"
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/eventlog"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/specpr"
@@ -121,6 +122,8 @@ type ViewPullRequestInput struct {
 
 type PullRequestDetail struct {
 	Number      int64
+	Title       string
+	Body        string
 	URL         string
 	State       string
 	HeadRefName string
@@ -141,6 +144,13 @@ type PullRequestReviewersInput struct {
 	CWD       string
 }
 
+type UpdatePullRequestBodyInput struct {
+	Repo     string
+	PRNumber int64
+	Body     string
+	CWD      string
+}
+
 type IssueAssigneesInput struct {
 	Repo        string
 	IssueNumber int64
@@ -156,6 +166,7 @@ type GitHubGateway interface {
 	ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error)
 	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
 	CreatePullRequest(context.Context, CreatePullRequestInput) (CreatePullRequestResult, error)
+	UpdatePullRequestBody(context.Context, UpdatePullRequestBodyInput) error
 	AddPullRequestLabels(context.Context, PullRequestLabelsInput) error
 	AddPullRequestReviewers(context.Context, PullRequestReviewersInput) error
 }
@@ -1021,6 +1032,9 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (plannerCh
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 			}
 			if adopted != nil {
+				if err := r.normalizePullRequestDisclosure(ctx, issue.Repo, adopted.Number, input.Project.RepoPath, true); err != nil {
+					return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+				}
 				checkpoint.Publish.PullRequest = adopted
 				checkpoint.Lifecycle.PRNumber = adopted.Number
 				checkpoint.Lifecycle.PRURL = adopted.URL
@@ -1046,6 +1060,9 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (plannerCh
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		if adopted != nil {
+			if err := r.normalizePullRequestDisclosure(ctx, issue.Repo, adopted.Number, input.Project.RepoPath, true); err != nil {
+				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+			}
 			checkpoint.Publish.PullRequest = &checkpointPullRequest{Number: adopted.Number, URL: adopted.URL, Body: ""}
 			checkpoint.ensureLifecycle("planner", worktree.Branch, worktree.BaseBranch, true)
 			checkpoint.Lifecycle.PRNumber = adopted.Number
@@ -1160,6 +1177,25 @@ func (r *Runner) validatedLifecyclePullRequest(ctx context.Context, input stepIn
 		prNumber = state.PRNumber
 	}
 	return &checkpointPullRequest{Number: prNumber, URL: firstNonEmpty(detail.URL, state.PRURL), Body: ""}, nil
+}
+
+func (r *Runner) normalizePullRequestDisclosure(ctx context.Context, repo string, prNumber int64, cwd string, force bool) error {
+	if r.github == nil || prNumber <= 0 || !r.disclosure.Enabled || !r.disclosure.Channels.PullRequest {
+		return nil
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: cwd})
+	if err != nil {
+		return err
+	}
+	if !force && !disclosure.HasMarkdownStamp(detail.Body) {
+		return nil
+	}
+	stamper := disclosure.Stamper{Config: r.disclosure, Agent: r.agentRuntime, Model: r.agentModel}
+	body := stamper.Markdown(detail.Body, "planner", disclosure.ChannelPullRequest)
+	if body == detail.Body {
+		return nil
+	}
+	return r.github.UpdatePullRequestBody(ctx, UpdatePullRequestBodyInput{Repo: repo, PRNumber: prNumber, Body: body, CWD: cwd})
 }
 
 func (r *Runner) persistPlannerPullRequestReference(ctx context.Context, input stepInput, issue checkpointIssue, worktree checkpointWorktree, pr checkpointPullRequest) error {
@@ -1604,6 +1640,7 @@ func noRemoteLifecyclePromptInstruction(runner, branch, baseBranch string, discl
 		"Agent-managed git/PR lifecycle policy: remote actions disabled by Looper configuration.",
 		"Before finishing: inspect git status, staged and unstaged diffs, untracked files, and recent commit style; commit only relevant non-secret changes if needed; do not push branches, create pull requests, update pull request metadata, or otherwise change remote review state.",
 		lifecycle.DisclosurePromptInstruction(runner, disclosureCfg, agentRuntime, agentModel),
+		"Because remote PR actions are disabled for this run, do not create or update PR bodies; any PR disclosure stamping can only happen during a later Looper-managed remote reconciliation step.",
 		"Include a git_pr_lifecycle object in the final " + "__LOOPER_RESULT__" + " JSON with branch, baseBranch, commitShas, pushed, prNumber, prUrl, prAdopted, and actions {commit,push,pr}; use action source \"agent\" only for local commits you completed and \"none\" for disabled remote actions.",
 		fmt.Sprintf("Expected lifecycle runner=%q branch=%q baseBranch=%q expectPush=%t expectPR=%t fallbackAllowed=%t.", runner, branch, baseBranch, false, false, true),
 	}, "\n")

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/storage"
@@ -476,6 +477,42 @@ func TestProcessClaimedItemAdoptsOpenBranchPRWithoutRewritingHumanBody(t *testin
 	}
 	if loop == nil || loop.PRNumber == nil || *loop.PRNumber != 202 || loop.MetadataJSON == nil || !strings.Contains(*loop.MetadataJSON, `"prNumber":202`) {
 		t.Fatalf("loop = %#v, want adopted PR persisted", loop)
+	}
+}
+
+func TestProcessClaimedItemAdoptsLifecyclePRAndStampsMissingDisclosure(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	branch := "looper/planner/42-plan-this"
+	github := &fakeGitHubGateway{
+		issues:      []IssueSummary{{Number: 42, Title: "Plan this", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}},
+		issueDetail: IssueDetail{Number: 42, Title: "Plan this", Body: "details", URL: "https://example/issues/42", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}},
+		prDetail:    PullRequestDetail{Number: 202, URL: "https://example/pr/202", State: "OPEN", HeadRefName: branch, BaseRefName: "main", Body: "## Summary\n\nLifecycle-created body"},
+	}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{ID: "worktree_1", WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: branch, BaseBranch: "main"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "wrote spec", Lifecycle: &lifecycle.State{Branch: branch, BaseBranch: "main", PRNumber: 202, PRURL: "https://example/pr/202", Actions: lifecycle.Actions{PR: lifecycle.ActionSourceAgent}}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoPush: boolPtr(true)})
+
+	_, _ = runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "planner-worker-1", "planner")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" || result.PullRequestNumber != 202 {
+		t.Fatalf("result = %#v, want success with adopted PR 202", result)
+	}
+	if len(github.updatePRBodyCalls) != 1 {
+		t.Fatalf("updatePRBodyCalls = %#v, want one disclosure rewrite", github.updatePRBodyCalls)
+	}
+	if !strings.Contains(github.updatePRBodyCalls[0].Body, disclosure.Marker) {
+		t.Fatalf("updated body = %q, want disclosure marker", github.updatePRBodyCalls[0].Body)
+	}
+	if !strings.Contains(github.updatePRBodyCalls[0].Body, "runner=planner") {
+		t.Fatalf("updated body = %q, want planner disclosure footer", github.updatePRBodyCalls[0].Body)
 	}
 }
 

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -440,7 +440,7 @@ func TestProcessClaimedItemSurfacesIssueSelfAssignmentFailure(t *testing.T) {
 	}
 }
 
-func TestProcessClaimedItemAdoptsOpenBranchPRWhenLifecycleLacksPRNumber(t *testing.T) {
+func TestProcessClaimedItemAdoptsOpenBranchPRWithoutRewritingHumanBody(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	branch := "looper/planner/42-plan-this"
@@ -464,8 +464,8 @@ func TestProcessClaimedItemAdoptsOpenBranchPRWhenLifecycleLacksPRNumber(t *testi
 	if len(github.createPRCalls) != 0 {
 		t.Fatalf("createPRCalls = %#v, want no fallback CreatePullRequest", github.createPRCalls)
 	}
-	if len(github.updatePRBodyCalls) != 1 {
-		t.Fatalf("updatePRBodyCalls = %#v, want disclosure normalization", github.updatePRBodyCalls)
+	if len(github.updatePRBodyCalls) != 0 {
+		t.Fatalf("updatePRBodyCalls = %#v, want no body rewrite for human-authored PR", github.updatePRBodyCalls)
 	}
 	if len(github.listOpenPRCalls) != 1 {
 		t.Fatalf("listOpenPRCalls = %d, want 1", len(github.listOpenPRCalls))

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -464,6 +464,9 @@ func TestProcessClaimedItemAdoptsOpenBranchPRWhenLifecycleLacksPRNumber(t *testi
 	if len(github.createPRCalls) != 0 {
 		t.Fatalf("createPRCalls = %#v, want no fallback CreatePullRequest", github.createPRCalls)
 	}
+	if len(github.updatePRBodyCalls) != 1 {
+		t.Fatalf("updatePRBodyCalls = %#v, want disclosure normalization", github.updatePRBodyCalls)
+	}
 	if len(github.listOpenPRCalls) != 1 {
 		t.Fatalf("listOpenPRCalls = %d, want 1", len(github.listOpenPRCalls))
 	}
@@ -901,6 +904,7 @@ type fakeGitHubGateway struct {
 	createPRIndex      int
 	listOpenPRCalls    []ListOpenPullRequestsInput
 	createPRCalls      []CreatePullRequestInput
+	updatePRBodyCalls  []UpdatePullRequestBodyInput
 	addLabelCalls      []PullRequestLabelsInput
 	addReviewerCalls   []PullRequestReviewersInput
 	addAssigneeCalls   []IssueAssigneesInput
@@ -967,6 +971,11 @@ func (f *fakeGitHubGateway) CreatePullRequest(_ context.Context, input CreatePul
 	}
 	f.createPRIndex++
 	return f.createPRResult, nil
+}
+
+func (f *fakeGitHubGateway) UpdatePullRequestBody(_ context.Context, input UpdatePullRequestBodyInput) error {
+	f.updatePRBodyCalls = append(f.updatePRBodyCalls, input)
+	return nil
 }
 
 func (f *fakeGitHubGateway) AddPullRequestLabels(_ context.Context, input PullRequestLabelsInput) error {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -174,7 +174,7 @@ func (a plannerGitHubAdapter) ViewPullRequest(ctx context.Context, input planner
 	if err != nil {
 		return planner.PullRequestDetail{}, err
 	}
-	return planner.PullRequestDetail{Number: pr.Number, URL: pr.URL, State: pr.State, HeadRefName: pr.HeadRefName, BaseRefName: pr.BaseRefName}, nil
+	return planner.PullRequestDetail{Number: pr.Number, Title: pr.Title, Body: pr.Body, URL: pr.URL, State: pr.State, HeadRefName: pr.HeadRefName, BaseRefName: pr.BaseRefName}, nil
 }
 
 func (a plannerGitHubAdapter) CreatePullRequest(ctx context.Context, input planner.CreatePullRequestInput) (planner.CreatePullRequestResult, error) {
@@ -184,6 +184,11 @@ func (a plannerGitHubAdapter) CreatePullRequest(ctx context.Context, input plann
 		return planner.CreatePullRequestResult{}, err
 	}
 	return planner.CreatePullRequestResult{Number: pr.Number, URL: pr.URL}, nil
+}
+
+func (a plannerGitHubAdapter) UpdatePullRequestBody(ctx context.Context, input planner.UpdatePullRequestBodyInput) error {
+	body := a.stamper.Markdown(input.Body, "planner", disclosure.ChannelPullRequest)
+	return a.gateway.UpdatePullRequestBody(ctx, githubinfra.UpdatePullRequestBodyInput{Repo: input.Repo, PRNumber: input.PRNumber, Body: body, CWD: input.CWD})
 }
 
 func (a plannerGitHubAdapter) AddPullRequestLabels(ctx context.Context, input planner.PullRequestLabelsInput) error {
@@ -594,6 +599,11 @@ func (a workerGitHubAdapter) CreatePullRequest(ctx context.Context, input worker
 		return worker.CreatePullRequestResult{}, err
 	}
 	return worker.CreatePullRequestResult{Number: pr.Number, URL: pr.URL}, nil
+}
+
+func (a workerGitHubAdapter) UpdatePullRequestBody(ctx context.Context, input worker.UpdatePullRequestBodyInput) error {
+	body := a.stamper.Markdown(input.Body, "worker", disclosure.ChannelPullRequest)
+	return a.gateway.UpdatePullRequestBody(ctx, githubinfra.UpdatePullRequestBodyInput{Repo: input.Repo, PRNumber: input.PRNumber, Body: body, CWD: input.CWD})
 }
 
 func (a workerGitHubAdapter) UpdatePullRequestTitle(ctx context.Context, input worker.UpdatePullRequestTitleInput) error {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1440,7 +1440,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 			pushedByFallback = true
 		}
 		checkpoint.markLifecyclePushAndPR(worktree.Branch, work.BaseBranch, checkpoint.PullRequest.Number, checkpoint.PullRequest.URL, pushedByFallback, input.Loop.PRNumber != nil)
-		if err := r.normalizePullRequestDisclosure(ctx, work.Repo, checkpoint.PullRequest.Number, input.Project.RepoPath, false); err != nil {
+		if err := r.normalizePullRequestDisclosure(ctx, work.Repo, checkpoint.PullRequest.Number, input.Project.RepoPath, checkpoint.Lifecycle != nil && checkpoint.Lifecycle.Actions.PR == lifecycle.ActionSourceAgent); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		checkpoint.ResumePolicy = "advance_from_checkpoint"

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/bootstrap"
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/eventlog"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/shell"
@@ -150,6 +151,13 @@ type UpdatePullRequestTitleInput struct {
 	CWD      string
 }
 
+type UpdatePullRequestBodyInput struct {
+	Repo     string
+	PRNumber int64
+	Body     string
+	CWD      string
+}
+
 type PullRequestLabelsInput struct {
 	Repo     string
 	PRNumber int64
@@ -202,6 +210,7 @@ type GitHubGateway interface {
 	CreateIssueComment(context.Context, IssueCommentInput) (IssueCommentResult, error)
 	UpdateIssueComment(context.Context, UpdateIssueCommentInput) error
 	CreatePullRequest(context.Context, CreatePullRequestInput) (CreatePullRequestResult, error)
+	UpdatePullRequestBody(context.Context, UpdatePullRequestBodyInput) error
 	UpdatePullRequestTitle(context.Context, UpdatePullRequestTitleInput) error
 	RemovePullRequestLabels(context.Context, PullRequestLabelsInput) error
 	AddPullRequestReviewers(context.Context, PullRequestReviewersInput) error
@@ -1431,6 +1440,9 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 			pushedByFallback = true
 		}
 		checkpoint.markLifecyclePushAndPR(worktree.Branch, work.BaseBranch, checkpoint.PullRequest.Number, checkpoint.PullRequest.URL, pushedByFallback, input.Loop.PRNumber != nil)
+		if err := r.normalizePullRequestDisclosure(ctx, work.Repo, checkpoint.PullRequest.Number, input.Project.RepoPath, false); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		r.syncIssueClaim(ctx, input, &checkpoint, issueClaimStatusPRLinked, "")
 		return checkpoint, nil
@@ -1445,6 +1457,9 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		_ = r.renamePlannerSpecPullRequestAfterTakeover(ctx, work, input.Project.RepoPath)
+		if err := r.normalizePullRequestDisclosure(ctx, work.Repo, work.PRNumber, input.Project.RepoPath, false); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
 		if len(work.Reviewers) > 0 && work.PRNumber > 0 && r.github != nil {
 			_ = r.github.AddPullRequestReviewers(ctx, PullRequestReviewersInput{Repo: work.Repo, PRNumber: work.PRNumber, Reviewers: append([]string(nil), work.Reviewers...), CWD: input.Project.RepoPath})
 		}
@@ -1476,6 +1491,9 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		_ = r.assignReviewersIfNeeded(ctx, work, existing.Number, input.Project.RepoPath)
+		if err := r.normalizePullRequestDisclosure(ctx, work.Repo, existing.Number, input.Project.RepoPath, true); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
 		if err := r.persistPullRequestReference(ctx, input.Loop, input.QueueItem, work.Repo, checkpointPullPR{Number: existing.Number, URL: existing.URL}); err != nil {
 			return checkpoint, err
 		}
@@ -1490,6 +1508,9 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 	}
 	if existing, err := r.findOpenPullRequestForBranch(ctx, work.Repo, aliases, work.BaseBranch, input.Project.RepoPath); err == nil && existing != nil {
 		_ = r.assignReviewersIfNeeded(ctx, work, existing.Number, input.Project.RepoPath)
+		if err := r.normalizePullRequestDisclosure(ctx, work.Repo, existing.Number, input.Project.RepoPath, true); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
 		if err := r.persistPullRequestReference(ctx, input.Loop, input.QueueItem, work.Repo, checkpointPullPR{Number: existing.Number, URL: existing.URL}); err != nil {
 			return checkpoint, err
 		}
@@ -2392,6 +2413,25 @@ func implementationPullRequestTitle(work workerInput) string {
 	return title
 }
 
+func (r *Runner) normalizePullRequestDisclosure(ctx context.Context, repo string, prNumber int64, cwd string, force bool) error {
+	if r.github == nil || prNumber <= 0 || !r.disclosure.Enabled || !r.disclosure.Channels.PullRequest {
+		return nil
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: cwd})
+	if err != nil {
+		return err
+	}
+	if !force && !disclosure.HasMarkdownStamp(detail.Body) {
+		return nil
+	}
+	stamper := disclosure.Stamper{Config: r.disclosure, Agent: r.agentRuntime, Model: r.agentModel}
+	body := stamper.Markdown(detail.Body, "worker", disclosure.ChannelPullRequest)
+	if body == detail.Body {
+		return nil
+	}
+	return r.github.UpdatePullRequestBody(ctx, UpdatePullRequestBodyInput{Repo: repo, PRNumber: prNumber, Body: body, CWD: cwd})
+}
+
 func buildWorkerPrompt(repoRootPath string, work workerInput, plan *checkpointPlan, allowAgentPRCreation bool, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string) (string, error) {
 	cfg, _ := config.Normalize("")
 	cfg.Instructions.Enabled = false
@@ -2452,6 +2492,7 @@ func noRemoteLifecyclePromptInstruction(runner, branch, baseBranch string, discl
 		"Agent-managed git/PR lifecycle policy: remote actions disabled by Looper configuration.",
 		"Before finishing: inspect git status, staged and unstaged diffs, untracked files, and recent commit style; commit only relevant non-secret changes if needed; do not push branches, create pull requests, update pull request metadata, or otherwise change remote review state.",
 		lifecycle.DisclosurePromptInstruction(runner, disclosureCfg, agentRuntime, agentModel),
+		"Because remote PR actions are disabled for this run, do not create or update PR bodies; any PR disclosure stamping can only happen during a later Looper-managed remote reconciliation step.",
 		"Include a git_pr_lifecycle object in the final " + "__LOOPER_RESULT__" + " JSON with branch, baseBranch, commitShas, pushed, prNumber, prUrl, prAdopted, and actions {commit,push,pr}; use action source \"agent\" only for local commits you completed and \"none\" for disabled remote actions.",
 		fmt.Sprintf("Expected lifecycle runner=%q branch=%q baseBranch=%q expectPush=%t expectPR=%t fallbackAllowed=%t.", runner, branch, baseBranch, false, false, true),
 	}, "\n")

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1491,7 +1491,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		_ = r.assignReviewersIfNeeded(ctx, work, existing.Number, input.Project.RepoPath)
-		if err := r.normalizePullRequestDisclosure(ctx, work.Repo, existing.Number, input.Project.RepoPath, true); err != nil {
+		if err := r.normalizePullRequestDisclosure(ctx, work.Repo, existing.Number, input.Project.RepoPath, false); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		if err := r.persistPullRequestReference(ctx, input.Loop, input.QueueItem, work.Repo, checkpointPullPR{Number: existing.Number, URL: existing.URL}); err != nil {
@@ -1508,7 +1508,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 	}
 	if existing, err := r.findOpenPullRequestForBranch(ctx, work.Repo, aliases, work.BaseBranch, input.Project.RepoPath); err == nil && existing != nil {
 		_ = r.assignReviewersIfNeeded(ctx, work, existing.Number, input.Project.RepoPath)
-		if err := r.normalizePullRequestDisclosure(ctx, work.Repo, existing.Number, input.Project.RepoPath, true); err != nil {
+		if err := r.normalizePullRequestDisclosure(ctx, work.Repo, existing.Number, input.Project.RepoPath, false); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		if err := r.persistPullRequestReference(ctx, input.Loop, input.QueueItem, work.Repo, checkpointPullPR{Number: existing.Number, URL: existing.URL}); err != nil {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1897,11 +1897,14 @@ func TestProcessClaimedItemPreservesPRTitleEditedDuringTakeover(t *testing.T) {
 	if result.Status != "success" || result.PullRequestNumber != 42 {
 		t.Fatalf("result = %#v, want success with PR 42", result)
 	}
-	if len(github.viewPRCalls) != 2 {
-		t.Fatalf("len(github.viewPRCalls) = %d, want re-fetch before rename", len(github.viewPRCalls))
+	if len(github.viewPRCalls) != 3 {
+		t.Fatalf("len(github.viewPRCalls) = %d, want re-fetch before rename plus disclosure normalization", len(github.viewPRCalls))
 	}
 	if len(github.updatePRTitleCalls) != 0 {
 		t.Fatalf("len(github.updatePRTitleCalls) = %d, want 0", len(github.updatePRTitleCalls))
+	}
+	if len(github.updatePRBodyCalls) != 0 {
+		t.Fatalf("updatePRBodyCalls = %#v, want no body rewrite for human-authored PR", github.updatePRBodyCalls)
 	}
 }
 
@@ -2198,6 +2201,9 @@ func TestProcessClaimedItemPushExistingReconcilesDirtyWorktreeBeforePush(t *test
 	if len(git.pushCalls) != 1 {
 		t.Fatalf("len(git.pushCalls) = %d, want push after fallback commit", len(git.pushCalls))
 	}
+	if len(github.updatePRBodyCalls) != 0 {
+		t.Fatalf("updatePRBodyCalls = %#v, want no body rewrite for existing PR without disclosure footer", github.updatePRBodyCalls)
+	}
 	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
 	if err != nil || run == nil {
 		t.Fatalf("Runs.GetByID() = (%#v, %v), want run", run, err)
@@ -2350,6 +2356,7 @@ type fakeGitHubGateway struct {
 	createPRErrors          []error
 	createPRCalls           []CreatePullRequestInput
 	updatePRTitleCalls      []UpdatePullRequestTitleInput
+	updatePRBodyCalls       []UpdatePullRequestBodyInput
 	updatePRTitleErrors     []error
 	updatePRTitleIndex      int
 	removeLabels            []PullRequestLabelsInput
@@ -2453,6 +2460,11 @@ func (f *fakeGitHubGateway) UpdatePullRequestTitle(_ context.Context, input Upda
 		f.updatePRTitleIndex++
 		return err
 	}
+	return nil
+}
+
+func (f *fakeGitHubGateway) UpdatePullRequestBody(_ context.Context, input UpdatePullRequestBodyInput) error {
+	f.updatePRBodyCalls = append(f.updatePRBodyCalls, input)
 	return nil
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/storage"
 )
@@ -2284,6 +2285,56 @@ func TestRunOpenPRStepPushesWhenFallbackCommitCreatedAndLifecycleAlreadyPushed(t
 	}
 	if checkpointAfter.Lifecycle == nil || !checkpointAfter.Lifecycle.Pushed || checkpointAfter.Lifecycle.Actions.Commit != lifecycle.ActionSourceFallback || checkpointAfter.Lifecycle.Actions.Push != lifecycle.ActionSourceFallback {
 		t.Fatalf("updated lifecycle = %#v, want fallback actions and pushed", checkpointAfter.Lifecycle)
+	}
+}
+
+func TestRunOpenPRStepStampsLifecycleAgentPRWithoutExistingFooter(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	prNumber := int64(555)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{prDetail: PullRequestDetail{Number: prNumber, URL: "https://example/pr/555", Body: "## Summary\n\nLifecycle-created body", BaseRefName: "main", HeadRefName: "feature/pr-555"}}, Git: &fakeGitGateway{}, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_worker_1", LoopID: "loop_worker_1", Status: "running", CurrentStep: stringPtr(string(stepOpenPR)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	checkpoint := workerCheckpoint{
+		Work:        &workerInput{Title: "Existing PR lifecycle", ExecutionMode: "create-pr", Repo: "acme/looper", BaseBranch: "main", PRNumber: prNumber, Branch: "feature/pr-555"},
+		Worktree:    &checkpointWorktree{Path: filepath.Join(t.TempDir(), "wt"), Branch: "feature/pr-555", BaseBranch: "main", HeadSHA: "abc123", ID: "worktree_555"},
+		Validation:  &ValidationResult{Passed: true, Summary: "ok"},
+		PullRequest: &checkpointPullPR{Number: prNumber, URL: "https://example/pr/555"},
+		Lifecycle: &lifecycle.State{
+			Policy:        lifecycle.PolicyAgentManagedWithFallback,
+			PolicyVersion: lifecycle.PolicyVersion,
+			Branch:        "feature/pr-555",
+			BaseBranch:    "main",
+			Pushed:        true,
+			PRNumber:      prNumber,
+			PRURL:         "https://example/pr/555",
+			Actions:       lifecycle.Actions{Push: lifecycle.ActionSourceAgent, PR: lifecycle.ActionSourceAgent},
+		},
+	}
+	input := stepInput{Project: *project, Loop: storage.LoopRecord{ID: "loop_worker_1", ProjectID: "project_1"}, Run: storage.RunRecord{ID: "run_worker_1"}, Checkpoint: checkpoint}
+
+	checkpointAfter, err := runner.runOpenPRStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("runOpenPRStep() error = %v", err)
+	}
+	github := runner.github.(*fakeGitHubGateway)
+	if len(github.updatePRBodyCalls) != 1 {
+		t.Fatalf("updatePRBodyCalls = %#v, want one disclosure rewrite", github.updatePRBodyCalls)
+	}
+	if !strings.Contains(github.updatePRBodyCalls[0].Body, disclosure.Marker) {
+		t.Fatalf("updated body = %q, want disclosure marker", github.updatePRBodyCalls[0].Body)
+	}
+	if !strings.Contains(github.updatePRBodyCalls[0].Body, "runner=worker") {
+		t.Fatalf("updated body = %q, want worker disclosure footer", github.updatePRBodyCalls[0].Body)
+	}
+	if checkpointAfter.PullRequest == nil || checkpointAfter.PullRequest.Number != prNumber {
+		t.Fatalf("checkpointAfter.PullRequest = %#v, want preserved PR", checkpointAfter.PullRequest)
 	}
 }
 


### PR DESCRIPTION
## Summary
- move PR disclosure footer stamping into Looper PR reconciliation instead of asking agents to author the footer HTML
- normalize malformed or escaped disclosure footers on Looper-created PR flows while avoiding rewrites of human-authored PR bodies
- add regression coverage for escaped disclosure markup, PR normalization, and no-remote prompt guidance

## Testing
- go test ./...
- go build ./...

Closes #271

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href=\"https://github.com/nexu-io/looper\">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>