### PR TITLE
fix: pass --dangerously-skip-permissions to claude-code spawns

### DIFF
--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -1127,10 +1127,13 @@ func resolveArgs(cfg ExecutorConfig, prompt string) []string {
 
 func resolveClaudeArgs(cfg ExecutorConfig, args []string, prompt string) []string {
 	resolved := prependModelFlag(args, cfg.Model, "--model", []string{"--model"})
-	if hasAnyFlag(resolved, []string{"-p", "--print"}) {
-		return resolved
+	if !hasAnyFlag(resolved, []string{"-p", "--print"}) {
+		resolved = append(resolved, "--print", prompt)
 	}
-	return append(resolved, "--print", prompt)
+	if !hasAnyFlag(resolved, []string{"--dangerously-skip-permissions"}) {
+		resolved = append(resolved, "--dangerously-skip-permissions")
+	}
+	return resolved
 }
 
 func resolveCodexArgs(cfg ExecutorConfig, args []string, prompt string) []string {
@@ -1174,6 +1177,9 @@ func resolveNativeResumeArgs(cfg ExecutorConfig, args []string, sessionID string
 		}
 		if !hasAnyFlag(resolved, []string{"-p", "--print"}) {
 			resolved = append(resolved, "--print", prompt)
+		}
+		if !hasAnyFlag(resolved, []string{"--dangerously-skip-permissions"}) {
+			resolved = append(resolved, "--dangerously-skip-permissions")
 		}
 		return resolved
 	case config.AgentVendorCodex:

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -94,7 +94,7 @@ func TestResolveSpawnWithNativeResumeVendorArgs(t *testing.T) {
 		vendor config.AgentVendor
 		want   string
 	}{
-		{name: "claude", vendor: config.AgentVendorClaudeCode, want: "--resume session-123 --print hello"},
+		{name: "claude", vendor: config.AgentVendorClaudeCode, want: "--resume session-123 --print hello --dangerously-skip-permissions"},
 		{name: "codex", vendor: config.AgentVendorCodex, want: "exec resume session-123 hello"},
 		{name: "opencode", vendor: config.AgentVendorOpenCode, want: "run --session session-123 hello"},
 		{name: "cursor", vendor: config.AgentVendorCursorCLI, want: "--resume session-123 --print hello"},


### PR DESCRIPTION
## Summary
- Reviewer/worker/planner/fixer loops were spawning `claude --print <prompt>` with no permission flags, so non-interactive runs hit silent tool denials — the agent could not call `gh`, the `looper review submit` wrapper, or write scratch files in the worktree, and exited without publishing a marker. Looper then retried into the same wall (`retryable_after_resume`) until backoff.
- Append `--dangerously-skip-permissions` idempotently in `resolveClaudeArgs` and the claude branch of `resolveNativeResumeArgs`. Mirrors how the codex path already passes `--sandbox workspace-write` at spawn time.
- Flag is appended after `--print` so the existing "prompt is last positional" parity assertions still hold; only the native-resume claude expectation needed updating.

## Why this is safe
- The worktree the agent runs in is ephemeral and only contains the code under review.
- The user-level `~/.claude/settings.json` only carries `skipDangerousModePermissionPrompt: true`, which suppresses the interactive confirmation and has no effect in `--print` mode, so there is no existing permission allowlist to honor.

## Test plan
- [x] `go test ./...` green on this branch
- [x] Smoke: `claude --print --dangerously-skip-permissions 'echo PERMISSION_TEST_OK && gh --version'` returns the expected output without permission denials
- [ ] First reviewer task after deploy completes its publish step end-to-end (will be observed on next assigned PR review)