### PR TITLE
fix: narrow pause semantics across loop recovery

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -824,7 +824,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
-		if loopResult.record.Status == "paused" || loopResult.skipped {
+		if loopResult.record.Status == "paused" || loopResult.record.Status == "failed" || loopResult.skipped {
 			result.Skipped++
 			continue
 		}
@@ -962,6 +962,7 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 				updated.Status = "paused"
 			} else {
 				updated.Status = "failed"
+				stampFixerFailedDiscoveryFingerprint(updated, queueItem)
 			}
 			updated.NextRunAt = nil
 		}
@@ -1054,6 +1055,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "paused"
 				} else {
 					updated.Status = "failed"
+					stampFixerFailedDiscoveryFingerprint(updated, queueItem)
 				}
 				updated.NextRunAt = nil
 			}
@@ -1122,6 +1124,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 						updated.Status = "paused"
 					} else {
 						updated.Status = "failed"
+						stampFixerFailedDiscoveryFingerprint(updated, queueItem)
 					}
 					updated.NextRunAt = nil
 				}
@@ -2227,16 +2230,16 @@ type loopUpsertResult struct {
 
 func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64, headSHA, fixItemsHash string) (loopUpsertResult, error) {
 	nowISO := r.nowISO()
-	loops, err := r.repos.Loops.List(ctx)
+	existingLoops, err := r.repos.Loops.List(ctx)
 	if err != nil {
 		return loopUpsertResult{}, err
 	}
-	for _, existing := range loops {
+	for _, existing := range existingLoops {
 		if existing.Type == "fixer" && existing.ProjectID == project.ID && derefString(existing.Repo) == repo && derefInt64(existing.PRNumber) == prNumber {
 			if existing.Status == "paused" {
 				return loopUpsertResult{record: existing, created: false}, nil
 			}
-			if shouldSkipRediscoveryAfterNoopResolve(existing.MetadataJSON, headSHA, fixItemsHash) {
+			if loops.ShouldSuppressFailedRediscovery(existing.Status, loops.LastFailedDiscoveryFingerprint(existing.MetadataJSON), buildFixerDiscoveryFingerprint(repo, prNumber, headSHA, fixItemsHash)) || shouldSkipRediscoveryAfterNoopResolve(existing.MetadataJSON, headSHA, fixItemsHash) {
 				return loopUpsertResult{record: existing, created: false, skipped: true}, nil
 			}
 			updated := existing
@@ -2301,7 +2304,8 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 	lockKey := fmt.Sprintf("pr:%s:%d", input.Repo, input.PRNumber)
 	projectID := input.ProjectID
 	loopID := input.LoopID
-	queueItem := storage.QueueItemRecord{ID: eventlog.NewEventID("queue"), ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: targetID, Repo: &input.Repo, PRNumber: &input.PRNumber, DedupeKey: dedupeKey, Priority: storage.QueuePriorityFixer, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: r.retryMaxAttempts, LockKey: &lockKey, CreatedAt: nowISO, UpdatedAt: nowISO}
+	payload := mustMarshalJSON(map[string]any{"discoveryFingerprint": buildFixerDiscoveryFingerprint(input.Repo, input.PRNumber, input.HeadSHA, input.FixItemsHash)})
+	queueItem := storage.QueueItemRecord{ID: eventlog.NewEventID("queue"), ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: targetID, Repo: &input.Repo, PRNumber: &input.PRNumber, DedupeKey: dedupeKey, Priority: storage.QueuePriorityFixer, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: r.retryMaxAttempts, LockKey: &lockKey, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := r.repos.Queue.Upsert(ctx, queueItem); err != nil {
 		return storage.QueueItemRecord{}, err
 	}
@@ -3126,6 +3130,26 @@ func shouldSkipRediscoveryAfterNoopResolve(loopMetadataJSON *string, headSHA, fi
 	lastHeadSHA, _ := stringFromAny(metadata["lastNoopResolveHeadSha"])
 	lastFixItemsHash, _ := stringFromAny(metadata["lastNoopResolveFixItemsHash"])
 	return lastHeadSHA != "" && lastHeadSHA == headSHA && lastFixItemsHash != "" && lastFixItemsHash == fixItemsHash
+}
+
+func buildFixerDiscoveryFingerprint(repo string, prNumber int64, headSHA, fixItemsHash string) string {
+	if headSHA == "" {
+		headSHA = "unknown"
+	}
+	return loops.ComputeDiscoveryFingerprint("fixer", repo, fmt.Sprintf("%d", prNumber), headSHA, fixItemsHash)
+}
+
+func stampFixerFailedDiscoveryFingerprint(updated *storage.LoopRecord, queueItem storage.QueueItemRecord) {
+	metadata := parseJSONObject(queueItem.PayloadJSON)
+	fingerprint, _ := stringFromAny(metadata["discoveryFingerprint"])
+	if strings.TrimSpace(fingerprint) == "" {
+		return
+	}
+	merged, err := loops.MergeLastFailedDiscoveryFingerprint(updated.MetadataJSON, fingerprint)
+	if err != nil {
+		return
+	}
+	updated.MetadataJSON = stringPtr(merged)
 }
 
 func detailHeadSHA(detail *checkpointDetail) string {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -819,11 +819,12 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			result.Skipped++
 			continue
 		}
-		loopResult, err := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number)
+		fixItemsHash := hashFixItems(fixItems)
+		loopResult, err := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, detail.HeadSHA, fixItemsHash)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
-		if loopResult.record.Status == "paused" {
+		if loopResult.record.Status == "paused" || loopResult.skipped {
 			result.Skipped++
 			continue
 		}
@@ -840,7 +841,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			Repo:         input.Repo,
 			PRNumber:     pr.Number,
 			HeadSHA:      headSHA,
-			FixItemsHash: hashFixItems(fixItems),
+			FixItemsHash: fixItemsHash,
 		})
 		if err != nil {
 			return DiscoveryResult{}, err
@@ -1569,6 +1570,13 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 	}
 	if shouldBlockResolveWithoutFix(checkpoint, fixItems, verifiedNoPushHeadSHA != "" && verifiedNoPushHeadSHA == detailHeadSHA(checkpoint.Detail)) {
+		metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastNoopResolveHeadSha": detailHeadSHA(checkpoint.Detail), "lastNoopResolveFixItemsHash": currentFixItemsHash, "lastNoopResolveAt": r.nowISO()})
+		if err != nil {
+			return checkpoint, err
+		}
+		if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) { updated.MetadataJSON = stringPtr(metadataJSON) }); err != nil {
+			return checkpoint, err
+		}
 		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
 		return checkpoint, &loopError{message: "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved", kind: FailureRetryableAfterResume}
 	}
@@ -2214,9 +2222,10 @@ func (r *Runner) getLatestCheckpoint(ctx context.Context, run storage.RunRecord,
 type loopUpsertResult struct {
 	record  storage.LoopRecord
 	created bool
+	skipped bool
 }
 
-func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64) (loopUpsertResult, error) {
+func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64, headSHA, fixItemsHash string) (loopUpsertResult, error) {
 	nowISO := r.nowISO()
 	loops, err := r.repos.Loops.List(ctx)
 	if err != nil {
@@ -2226,6 +2235,9 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 		if existing.Type == "fixer" && existing.ProjectID == project.ID && derefString(existing.Repo) == repo && derefInt64(existing.PRNumber) == prNumber {
 			if existing.Status == "paused" {
 				return loopUpsertResult{record: existing, created: false}, nil
+			}
+			if shouldSkipRediscoveryAfterNoopResolve(existing.MetadataJSON, headSHA, fixItemsHash) {
+				return loopUpsertResult{record: existing, created: false, skipped: true}, nil
 			}
 			updated := existing
 			if active, err := r.hasActiveRunningRun(ctx, updated.ID); err == nil && active {
@@ -3104,6 +3116,16 @@ func resolveCommentsVerifiedNoPushHeadSHA(push *checkpointPush, loopMetadataJSON
 		return ""
 	}
 	return lastFixHeadSHA
+}
+
+func shouldSkipRediscoveryAfterNoopResolve(loopMetadataJSON *string, headSHA, fixItemsHash string) bool {
+	if headSHA == "" || fixItemsHash == "" {
+		return false
+	}
+	metadata := parseJSONObject(loopMetadataJSON)
+	lastHeadSHA, _ := stringFromAny(metadata["lastNoopResolveHeadSha"])
+	lastFixItemsHash, _ := stringFromAny(metadata["lastNoopResolveFixItemsHash"])
+	return lastHeadSHA != "" && lastHeadSHA == headSHA && lastFixItemsHash != "" && lastFixItemsHash == fixItemsHash
 }
 
 func detailHeadSHA(detail *checkpointDetail) string {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/lifecycle"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -956,7 +957,7 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 			updated.Status = "queued"
 			updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 		} else {
-			if shouldPauseLoopAfterFailure(failureKind, failedQueue, "") {
+			if loops.ShouldPauseLoopAfterFailure(string(failureKind), failedQueue, "") {
 				updated.Status = "paused"
 			} else {
 				updated.Status = "failed"
@@ -1034,9 +1035,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if err := validateFixerResumeCheckpoint(resumedRun.StartStep, checkpoint); err != nil {
 		failure := r.classifyFailure(err)
 		latest := r.getLatestCheckpoint(ctx, run, checkpoint)
-		if latest.ResumePolicy == "" {
-			latest.ResumePolicy = "replay_step"
-		}
+		latest.ResumePolicy = loops.NormalizeResumePolicy(string(failure.kind), latest.ResumePolicy)
 		if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
 			return ProcessResult{}, err
 		}
@@ -1050,7 +1049,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 				updated.Status = "queued"
 				updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 			} else {
-				if failure.kind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+				if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
 					updated.Status = "paused"
 				} else {
 					updated.Status = "failed"
@@ -1101,22 +1100,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		if err != nil {
 			failure := r.classifyFailure(err)
 			latest := checkpoint
-			resumePolicy := latest.ResumePolicy
-			switch failure.kind {
-			case FailureRetryableAfterResume:
-				if strings.TrimSpace(resumePolicy) == "" {
-					resumePolicy = "advance_from_checkpoint"
-				}
-			case FailureManualIntervention:
-				if strings.TrimSpace(resumePolicy) == "" {
-					resumePolicy = "manual_intervention"
-				}
-			default:
-				if resumePolicy == "" {
-					resumePolicy = "replay_step"
-				}
-			}
-			latest.ResumePolicy = resumePolicy
+			latest.ResumePolicy = loops.NormalizeResumePolicy(string(failure.kind), latest.ResumePolicy)
 			if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
 				return ProcessResult{}, err
 			}
@@ -1133,7 +1117,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "queued"
 					updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 				} else {
-					if shouldPauseLoopAfterFailure(failure.kind, failedQueue, latest.ResumePolicy) {
+					if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
 						updated.Status = "paused"
 					} else {
 						updated.Status = "failed"
@@ -1323,6 +1307,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (f
 		return checkpoint, err
 	}
 	if !prepared.Clean {
+		checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
 		return checkpoint, &loopError{message: fmt.Sprintf("Fixer worktree is dirty for branch %s; manual intervention required", branch), kind: FailureManualIntervention}
 	}
 	preparedAt := r.nowISO()
@@ -1350,9 +1335,8 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	if !r.allowRiskyFixes {
 		for _, item := range checkpoint.FixItems {
 			if item.Type == "conflict" {
-				checkpoint.SkipReason = fmt.Sprintf("Skipped %s#%d because risky conflict fixes require manual intervention", input.Repo, input.PRNumber)
-				checkpoint.ResumePolicy = "manual_intervention"
-				return checkpoint, nil
+				checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+				return checkpoint, &loopError{message: fmt.Sprintf("Skipped %s#%d because risky conflict fixes require manual intervention", input.Repo, input.PRNumber), kind: FailureManualIntervention}
 			}
 		}
 	}
@@ -1485,9 +1469,9 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	}
 	if !r.allowAutoPush {
 		r.appendEvent(ctx, eventInput{eventType: "fixer.push.skipped", projectID: input.Project.ID, loopID: input.Loop.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"branch": branch, "reason": "auto_push_disabled"}})
-		checkpoint.SkipReason = fmt.Sprintf("Auto push disabled; manual fix push required for branch %s", branch)
-		checkpoint.ResumePolicy = "manual_intervention"
-		return checkpoint, nil
+		checkpoint.Push = &checkpointPush{Pushed: false, Branch: branch, Remote: "origin", SkippedReason: "Auto push disabled"}
+		checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+		return checkpoint, &loopError{message: fmt.Sprintf("Auto push disabled; manual fix push required for branch %s", branch), kind: FailureManualIntervention}
 	}
 	if checkpoint.ReconcileCommits == nil {
 		return checkpoint, &loopError{message: "Missing reconcile-commits checkpoint for push step", kind: FailureRetryableAfterResume}
@@ -1571,7 +1555,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 	}
 	if shouldBlockResolveWithoutFix(checkpoint, fixItems) {
-		checkpoint.ResumePolicy = "restart_from_discover"
+		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
 		return checkpoint, &loopError{message: "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved", kind: FailureRetryableAfterResume}
 	}
 	if checkpoint.ResolvedComments == nil {
@@ -2086,7 +2070,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	resumeFromPrepare := false
 	if latestRun != nil {
 		failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage))
-		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, failureSummary) || shouldRestartFromDiscoverByResumePolicy(latestRun.Status, checkpoint)
+		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, failureSummary) || loops.ShouldRestartFromDiscover(latestRun.Status, checkpoint.ResumePolicy)
 		resumeFromPrepare = shouldResumeFromPrepare(latestRun.Status, failedStep, checkpoint)
 	}
 	startStep := stepDiscoverPR
@@ -2362,6 +2346,7 @@ func (r *Runner) reconcileCommits(ctx context.Context, checkpoint fixerCheckpoin
 	committedByLoop := false
 	if initial.HasUncommittedChanges {
 		if !r.allowAutoCommit {
+			checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
 			return checkpoint, &loopError{message: fmt.Sprintf("Auto commit disabled but fixer worktree has uncommitted changes: %s", firstNonEmpty(strings.Join(initial.ChangedFiles, ", "), "unknown files")), kind: FailureManualIntervention}
 		}
 		if _, err := r.git.Commit(ctx, CommitInput{WorktreePath: worktree.Path, Message: commitMessage}); err != nil {
@@ -2914,28 +2899,6 @@ func shouldRestartFromDiscover(status string, failedStep FixerStep, failureSumma
 		return true
 	}
 	return strings.Contains(failureSummary, "PR head changed before resolving comments")
-}
-
-func shouldRestartFromDiscoverByResumePolicy(status string, checkpoint fixerCheckpoint) bool {
-	if status != "failed" && status != "interrupted" {
-		return false
-	}
-	switch checkpoint.ResumePolicy {
-	case "manual_intervention", "restart_from_discover":
-		return true
-	default:
-		return false
-	}
-}
-
-func shouldPauseLoopAfterFailure(failureKind QueueFailureKind, failedQueue *storage.QueueItemRecord, resumePolicy string) bool {
-	if failedQueue != nil && failedQueue.Status == "cancelled" {
-		return true
-	}
-	if strings.TrimSpace(resumePolicy) != "" {
-		return resumePolicy == "manual_intervention"
-	}
-	return failureKind == FailureManualIntervention
 }
 
 func shouldRebuildWorktree(checkpoint fixerCheckpoint) bool {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -956,7 +956,7 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 			updated.Status = "queued"
 			updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 		} else {
-			if failureKind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+			if shouldPauseLoopAfterFailure(failureKind, failedQueue, "") {
 				updated.Status = "paused"
 			} else {
 				updated.Status = "failed"
@@ -1100,13 +1100,17 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		checkpoint, err = r.executeStep(ctx, step, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem, Repo: *queueItem.Repo, PRNumber: *queueItem.PRNumber, Checkpoint: checkpoint})
 		if err != nil {
 			failure := r.classifyFailure(err)
-			latest := r.getLatestCheckpoint(ctx, run, checkpoint)
+			latest := checkpoint
 			resumePolicy := latest.ResumePolicy
 			switch failure.kind {
 			case FailureRetryableAfterResume:
-				resumePolicy = "advance_from_checkpoint"
+				if strings.TrimSpace(resumePolicy) == "" {
+					resumePolicy = "advance_from_checkpoint"
+				}
 			case FailureManualIntervention:
-				resumePolicy = "manual_intervention"
+				if strings.TrimSpace(resumePolicy) == "" {
+					resumePolicy = "manual_intervention"
+				}
 			default:
 				if resumePolicy == "" {
 					resumePolicy = "replay_step"
@@ -1129,7 +1133,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "queued"
 					updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 				} else {
-					if failure.kind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+					if shouldPauseLoopAfterFailure(failure.kind, failedQueue, latest.ResumePolicy) {
 						updated.Status = "paused"
 					} else {
 						updated.Status = "failed"
@@ -1382,11 +1386,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		message := firstNonEmpty(result.Summary, result.Stderr, "Fixer agent "+result.Status)
-		kind := FailureRetryableTransient
-		if agent.IsAgentSetupFailureMessage(message) {
-			kind = FailureManualIntervention
-		}
-		return checkpoint, &loopError{message: message, kind: kind}
+		return checkpoint, &loopError{message: message, kind: FailureRetryableTransient}
 	}
 	if err := validateCompletedRepairCheckpoint(&checkpointRepair{Summary: result.Summary, ParseStatus: result.ParseStatus}); err != nil {
 		return checkpoint, err
@@ -1571,7 +1571,8 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 	}
 	if shouldBlockResolveWithoutFix(checkpoint, fixItems) {
-		return checkpoint, &loopError{message: "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved", kind: FailureManualIntervention}
+		checkpoint.ResumePolicy = "restart_from_discover"
+		return checkpoint, &loopError{message: "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved", kind: FailureRetryableAfterResume}
 	}
 	if checkpoint.ResolvedComments == nil {
 		checkpoint.ResolvedComments = &checkpointResolvedComments{Items: []checkpointResolvedComment{}}
@@ -2085,7 +2086,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	resumeFromPrepare := false
 	if latestRun != nil {
 		failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage))
-		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, failureSummary) || shouldRestartManualInterventionFromDiscover(latestRun.Status, checkpoint)
+		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, failureSummary) || shouldRestartFromDiscoverByResumePolicy(latestRun.Status, checkpoint)
 		resumeFromPrepare = shouldResumeFromPrepare(latestRun.Status, failedStep, checkpoint)
 	}
 	startStep := stepDiscoverPR
@@ -2915,11 +2916,26 @@ func shouldRestartFromDiscover(status string, failedStep FixerStep, failureSumma
 	return strings.Contains(failureSummary, "PR head changed before resolving comments")
 }
 
-func shouldRestartManualInterventionFromDiscover(status string, checkpoint fixerCheckpoint) bool {
+func shouldRestartFromDiscoverByResumePolicy(status string, checkpoint fixerCheckpoint) bool {
 	if status != "failed" && status != "interrupted" {
 		return false
 	}
-	return checkpoint.ResumePolicy == "manual_intervention"
+	switch checkpoint.ResumePolicy {
+	case "manual_intervention", "restart_from_discover":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldPauseLoopAfterFailure(failureKind QueueFailureKind, failedQueue *storage.QueueItemRecord, resumePolicy string) bool {
+	if failedQueue != nil && failedQueue.Status == "cancelled" {
+		return true
+	}
+	if strings.TrimSpace(resumePolicy) != "" {
+		return resumePolicy == "manual_intervention"
+	}
+	return failureKind == FailureManualIntervention
 }
 
 func shouldRebuildWorktree(checkpoint fixerCheckpoint) bool {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -525,6 +525,57 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	}
 }
 
+func TestDiscoverPullRequestsSkipsFailedFixerLoopWhenFingerprintUnchanged(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(77)
+	nowISO := fixture.nowISO()
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "same-head", HeadRefName: "feature/fix-77", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}
+	fingerprint := buildFixerDiscoveryFingerprint(repo, prNumber, detail.HeadSHA, hashFixItems(collectFixItems(detail)))
+	metadata := fmt.Sprintf(`{"autonomousRecovery":{"lastFailedDiscoveryFingerprint":%q}}`, fingerprint)
+	targetID := buildPullRequestTargetID(repo, prNumber)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_failed_same_fp", Seq: 90, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: "same-head"}}, viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want none for unchanged failed fingerprint", result.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsRequeuesFailedFixerLoopWhenFingerprintChanges(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(78)
+	nowISO := fixture.nowISO()
+	oldDetail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "old-head", HeadRefName: "feature/fix-78", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}
+	newDetail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-78", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}
+	fingerprint := buildFixerDiscoveryFingerprint(repo, prNumber, oldDetail.HeadSHA, hashFixItems(collectFixItems(oldDetail)))
+	metadata := fmt.Sprintf(`{"autonomousRecovery":{"lastFailedDiscoveryFingerprint":%q}}`, fingerprint)
+	targetID := buildPullRequestTargetID(repo, prNumber)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_failed_changed_fp", Seq: 91, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: "new-head"}}, viewResponses: []PullRequestDetail{newDetail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want one queue item after fingerprint change", result.QueueItems)
+	}
+}
+
 func TestProcessClaimedItemAllowsNoCommitWhenCommentsAlreadyResolved(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1527,8 +1527,8 @@ func TestProcessClaimedItemAutoPushDisabledSkipsManualIntervention(t *testing.T)
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "skipped" || !contains(result.Summary, "Auto push disabled") {
-		t.Fatalf("result = %#v, want skipped auto-push summary", result)
+	if result.Status != "failed" || result.FailureKind != FailureManualIntervention || !contains(result.Summary, "Auto push disabled") {
+		t.Fatalf("result = %#v, want manual-intervention auto-push summary", result)
 	}
 	if len(git.pushCalls) != 0 {
 		t.Fatalf("len(git.pushCalls) = %d, want 0", len(git.pushCalls))
@@ -1537,15 +1537,103 @@ func TestProcessClaimedItemAutoPushDisabledSkipsManualIntervention(t *testing.T)
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "completed" {
-		t.Fatalf("queue = %#v, want completed", queue)
+	if queue == nil || queue.Status != string(FailureManualIntervention) || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want failed manual_intervention queue item", queue)
 	}
 	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
 	if err != nil {
 		t.Fatalf("Runs.GetByID() error = %v", err)
 	}
-	if run == nil || run.LastCompletedStep == nil || *run.LastCompletedStep != string(stepPush) {
-		t.Fatalf("run = %#v, want lastCompletedStep=push", run)
+	if run == nil || run.Status != "failed" || run.CurrentStep == nil || *run.CurrentStep != string(stepPush) {
+		t.Fatalf("run = %#v, want failed push step run", run)
+	}
+	checkpoint := parseCheckpoint(run.CheckpointJSON)
+	if checkpoint.ResumePolicy != "manual_intervention" {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want manual_intervention", checkpoint.ResumePolicy)
+	}
+	if checkpoint.Push == nil || checkpoint.Push.SkippedReason != "Auto push disabled" {
+		t.Fatalf("checkpoint.Push = %#v, want recorded auto-push-disabled checkpoint", checkpoint.Push)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused hard-hold loop", loop)
+	}
+}
+
+func TestRunPrepareWorktreeStepPausesDirtyWorktree(t *testing.T) {
+	t.Parallel()
+
+	runner := New(Options{Git: &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"}, prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: false}}})
+	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: fixerCheckpoint{Detail: &checkpointDetail{HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main"}},
+	})
+	if err == nil {
+		t.Fatal("runPrepareWorktreeStep() error = nil, want manual intervention")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureManualIntervention {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureManualIntervention)
+	}
+	if checkpoint.ResumePolicy != "manual_intervention" {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want manual_intervention", checkpoint.ResumePolicy)
+	}
+}
+
+func TestRunRepairStepRequiresManualInterventionForRiskyConflictWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	runner := New(Options{AllowRiskyFixes: false})
+	checkpoint, err := runner.runRepairStep(context.Background(), stepInput{
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: fixerCheckpoint{
+			FixItems: []FixItem{{Type: "conflict", Summary: "merge conflict"}},
+		},
+	})
+	if err == nil {
+		t.Fatal("runRepairStep() error = nil, want manual intervention")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureManualIntervention {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureManualIntervention)
+	}
+	if checkpoint.ResumePolicy != "manual_intervention" {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want manual_intervention", checkpoint.ResumePolicy)
+	}
+	if !contains(loopErr.Error(), "risky conflict fixes require manual intervention") {
+		t.Fatalf("error = %q, want risky conflict summary", loopErr.Error())
+	}
+}
+
+func TestReconcileCommitsRequiresManualInterventionWhenAutoCommitDisabledAndDirty(t *testing.T) {
+	t.Parallel()
+
+	runner := New(Options{Git: &fakeGitGateway{inspectResults: []InspectHeadResult{{HeadSHA: "head-1", HasUncommittedChanges: true, ChangedFiles: []string{"file.txt"}}}}, AllowAutoCommit: false})
+	checkpoint, err := runner.reconcileCommits(context.Background(), fixerCheckpoint{Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "head-1", BaseHeadSHA: "head-1"}}, "fix: test")
+	if err == nil {
+		t.Fatal("reconcileCommits() error = nil, want manual intervention")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureManualIntervention {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureManualIntervention)
+	}
+	if checkpoint.ResumePolicy != "manual_intervention" {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want manual_intervention", checkpoint.ResumePolicy)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -479,8 +479,8 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "failed" || result.FailureKind != FailureManualIntervention || !contains(result.Summary, "produced no new commits") {
-		t.Fatalf("result = %#v, want manual intervention failure for no-op repair", result)
+	if result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume || !contains(result.Summary, "produced no new commits") {
+		t.Fatalf("result = %#v, want retryable-after-resume failure for no-op repair", result)
 	}
 	if len(git.commitCalls) != 0 || len(git.pushCalls) != 0 || len(github.resolveCalls) != 0 {
 		t.Fatalf("commit calls=%d push calls=%d resolve calls=%d, want 0/0/0 after no-op repair", len(git.commitCalls), len(git.pushCalls), len(github.resolveCalls))
@@ -496,8 +496,25 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if checkpoint.Push == nil || checkpoint.Push.Pushed || checkpoint.Push.SkippedReason == "" {
 		t.Fatalf("checkpoint.Push = %#v, want recorded no-op push", checkpoint.Push)
 	}
+	if checkpoint.ResumePolicy != "restart_from_discover" {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want restart_from_discover", checkpoint.ResumePolicy)
+	}
 	if checkpoint.ResolvedComments != nil {
 		t.Fatalf("checkpoint.ResolvedComments = %#v, want unresolved comments left untouched", checkpoint.ResolvedComments)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableAfterResume) {
+		t.Fatalf("queue = %#v, want queued retryable-after-resume failure", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
+		t.Fatalf("loop = %#v, want queued loop scheduled for rediscovery retry", loop)
 	}
 }
 
@@ -577,24 +594,27 @@ func TestRunResolveCommentsStepBlocksWithoutVerifiedPushEvidence(t *testing.T) {
 		},
 	}
 
-	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
 		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
 		Repo:       "acme/looper",
 		PRNumber:   42,
 		Checkpoint: checkpoint,
 	})
 	if err == nil {
-		t.Fatal("runResolveCommentsStep() error = nil, want manual intervention")
+		t.Fatal("runResolveCommentsStep() error = nil, want rediscoverable retry")
 	}
 	var loopErr *loopError
 	if !errors.As(err, &loopErr) {
 		t.Fatalf("error = %T, want *loopError", err)
 	}
-	if loopErr.kind != FailureManualIntervention {
-		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureManualIntervention)
+	if loopErr.kind != FailureRetryableAfterResume {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableAfterResume)
 	}
 	if !contains(loopErr.Error(), "produced no new commits") {
 		t.Fatalf("error = %q, want no-new-commits message", loopErr.Error())
+	}
+	if updated.ResumePolicy != "restart_from_discover" {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
 	}
 }
 
@@ -934,7 +954,7 @@ func TestProcessClaimedItemPersistsCheckpointWhenRepairReturnsNonCompleted(t *te
 	}
 }
 
-func TestProcessClaimedItemTreatsAgentSetupFailureAsManualIntervention(t *testing.T) {
+func TestProcessClaimedItemTreatsAgentSetupFailureAsRetryableTransient(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{
@@ -961,15 +981,22 @@ func TestProcessClaimedItemTreatsAgentSetupFailureAsManualIntervention(t *testin
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "failed" || result.FailureKind != FailureManualIntervention || !contains(result.Summary, "requires a newer version") {
-		t.Fatalf("result = %#v, want manual_intervention with real agent error", result)
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient || !contains(result.Summary, "requires a newer version") {
+		t.Fatalf("result = %#v, want retryable_transient with real agent error", result)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != string(FailureManualIntervention) || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want terminal manual_intervention failure", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) {
+		t.Fatalf("queue = %#v, want queued retryable_transient failure", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
+		t.Fatalf("loop = %#v, want queued loop awaiting retry", loop)
 	}
 }
 
@@ -1085,7 +1112,7 @@ func TestCreateRunContextRewindsToPrepareWhenPostRepairResumeCheckpointParseStat
 	}
 }
 
-func TestCreateRunContextRestartsManualInterventionFromDiscover(t *testing.T) {
+func TestCreateRunContextRestartsFromDiscoverForRediscoverableCheckpoint(t *testing.T) {
 	t.Parallel()
 
 	fixture := newRunnerFixture(t)
@@ -1109,7 +1136,7 @@ func TestCreateRunContextRestartsManualInterventionFromDiscover(t *testing.T) {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
-		ResumePolicy: "manual_intervention",
+		ResumePolicy: "restart_from_discover",
 		Detail: &checkpointDetail{
 			State:       "OPEN",
 			HeadSHA:     "head-1",

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -516,6 +516,13 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
 		t.Fatalf("loop = %#v, want queued loop scheduled for rediscovery retry", loop)
 	}
+	loopMeta := parseJSONObject(loop.MetadataJSON)
+	if got, _ := stringFromAny(loopMeta["lastNoopResolveHeadSha"]); got != "base-head" {
+		t.Fatalf("lastNoopResolveHeadSha = %q, want base-head", got)
+	}
+	if got, _ := stringFromAny(loopMeta["lastNoopResolveFixItemsHash"]); got == "" {
+		t.Fatal("lastNoopResolveFixItemsHash = empty, want captured fix-item snapshot")
+	}
 }
 
 func TestProcessClaimedItemAllowsNoCommitWhenCommentsAlreadyResolved(t *testing.T) {
@@ -565,10 +572,87 @@ func TestProcessClaimedItemAllowsNoCommitWhenCommentsAlreadyResolved(t *testing.
 	}
 }
 
+func TestDiscoverPullRequestsSkipsRepeatedNoopResolveRediscovery(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{comment}}
+	fixItemsHash := hashFixItems(collectFixItems(detail))
+	metadata := mustMarshalJSON(map[string]any{"lastNoopResolveHeadSha": detail.HeadSHA, "lastNoopResolveFixItemsHash": fixItemsHash})
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_noop", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: detail.HeadSHA}}, viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want no repeated queue item for unchanged no-op resolve state", result.QueueItems)
+	}
+	if result.Skipped == 0 {
+		t.Fatalf("result = %#v, want skipped discovery count", result)
+	}
+}
+
+func TestDiscoverPullRequestsRequeuesNoopResolveLoopWhenStateChanges(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		detail PullRequestDetail
+	}{
+		{name: "head changes", detail: PullRequestDetail{Number: 42, State: "OPEN", HeadSHA: "head-2", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}},
+		{name: "fix items change", detail: PullRequestDetail{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}, {"id": "c2", "threadId": "t2", "body": "also fix this"}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			baseline := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}
+			metadata := mustMarshalJSON(map[string]any{"lastNoopResolveHeadSha": baseline.HeadSHA, "lastNoopResolveFixItemsHash": hashFixItems(collectFixItems(baseline))})
+			loopTarget := buildPullRequestTargetID(repo, prNumber)
+			if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_noop", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+				t.Fatalf("Loops.Upsert() error = %v", err)
+			}
+
+			github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: tc.detail.HeadSHA}}, viewResponses: []PullRequestDetail{tc.detail}}
+			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+			result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+			if err != nil {
+				t.Fatalf("DiscoverPullRequests() error = %v", err)
+			}
+			if len(result.QueueItems) != 1 {
+				t.Fatalf("QueueItems = %#v, want one queue item after state change", result.QueueItems)
+			}
+		})
+	}
+}
+
 func TestRunResolveCommentsStepBlocksWithoutVerifiedPushEvidence(t *testing.T) {
 	t.Parallel()
 
-	runner := New(Options{GitHub: &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+	fixture := newRunnerFixture(t)
+	loopMetadata := `{}`
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := buildPullRequestTargetID("acme/looper", 42)
+	loop := storage.LoopRecord{ID: "loop_1", ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &loopMetadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
 		Number:      42,
 		State:       "OPEN",
 		HeadSHA:     "base-head",
@@ -580,7 +664,8 @@ func TestRunResolveCommentsStepBlocksWithoutVerifiedPushEvidence(t *testing.T) {
 			"threadId": "t1",
 			"body":     "please fix",
 		}},
-	}}}})
+	}}}
+	runner := New(Options{Repos: fixture.repos, GitHub: github, Now: fixture.now})
 	checkpoint := fixerCheckpoint{
 		FixItems:   []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}},
 		Validation: &ValidationResult{Passed: true, Summary: "ok"},
@@ -595,7 +680,8 @@ func TestRunResolveCommentsStepBlocksWithoutVerifiedPushEvidence(t *testing.T) {
 	}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
-		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Project:    storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:       loop,
 		Repo:       "acme/looper",
 		PRNumber:   42,
 		Checkpoint: checkpoint,

--- a/internal/loops/discovery_fingerprint.go
+++ b/internal/loops/discovery_fingerprint.go
@@ -1,0 +1,137 @@
+package loops
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// DiscoveryFingerprintVersion is bumped whenever the canonical discovery
+// fingerprint payload changes shape so old persisted fingerprints become
+// non-comparable instead of silently mismatching.
+const DiscoveryFingerprintVersion = "v1"
+
+// metadataAutonomousRecoveryKey is the top-level key under LoopRecord.MetadataJSON
+// where autonomous-recovery state lives.
+const metadataAutonomousRecoveryKey = "autonomousRecovery"
+
+// metadataLastFailedDiscoveryFingerprintKey is the field under
+// metadataAutonomousRecoveryKey where the last terminal-failed discovery
+// fingerprint is stored.
+const metadataLastFailedDiscoveryFingerprintKey = "lastFailedDiscoveryFingerprint"
+
+// ComputeDiscoveryFingerprint produces a stable hash over the supplied parts.
+// Input order is preserved so callers must pass a canonical, role-specific
+// ordering. Slice values are sorted in place by the caller before hashing.
+func ComputeDiscoveryFingerprint(parts ...string) string {
+	h := sha256.New()
+	for i, part := range parts {
+		if i > 0 {
+			h.Write([]byte{0x1f}) // ASCII unit separator avoids collisions with normal text.
+		}
+		h.Write([]byte(part))
+	}
+	return DiscoveryFingerprintVersion + ":" + hex.EncodeToString(h.Sum(nil))
+}
+
+// CanonicalSortedStrings returns a copy of values trimmed, lowercased, sorted,
+// and deduplicated. Used to normalize labels/assignees before fingerprinting.
+func CanonicalSortedStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		v = strings.ToLower(v)
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LastFailedDiscoveryFingerprint returns the persisted fingerprint of the last
+// terminal-failed discovery attempt, or empty string if none. metadataJSON may
+// be nil.
+func LastFailedDiscoveryFingerprint(metadataJSON *string) string {
+	if metadataJSON == nil {
+		return ""
+	}
+	raw := strings.TrimSpace(*metadataJSON)
+	if raw == "" {
+		return ""
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return ""
+	}
+	autonomous, _ := parsed[metadataAutonomousRecoveryKey].(map[string]any)
+	if autonomous == nil {
+		return ""
+	}
+	fingerprint, _ := autonomous[metadataLastFailedDiscoveryFingerprintKey].(string)
+	return strings.TrimSpace(fingerprint)
+}
+
+// MergeLastFailedDiscoveryFingerprint returns a JSON object encoded as a string
+// containing the existing metadata merged with the supplied fingerprint under
+// the autonomousRecovery namespace. The fingerprint may be empty, in which case
+// the field is cleared so the next discovery is allowed to revive the loop.
+func MergeLastFailedDiscoveryFingerprint(metadataJSON *string, fingerprint string) (string, error) {
+	parsed := map[string]any{}
+	if metadataJSON != nil {
+		raw := strings.TrimSpace(*metadataJSON)
+		if raw != "" {
+			if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+				return "", err
+			}
+		}
+	}
+	autonomous, _ := parsed[metadataAutonomousRecoveryKey].(map[string]any)
+	if autonomous == nil {
+		autonomous = map[string]any{}
+	}
+	if strings.TrimSpace(fingerprint) == "" {
+		delete(autonomous, metadataLastFailedDiscoveryFingerprintKey)
+	} else {
+		autonomous[metadataLastFailedDiscoveryFingerprintKey] = fingerprint
+	}
+	if len(autonomous) == 0 {
+		delete(parsed, metadataAutonomousRecoveryKey)
+	} else {
+		parsed[metadataAutonomousRecoveryKey] = autonomous
+	}
+	encoded, err := json.Marshal(parsed)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+// ShouldSuppressFailedRediscovery reports whether autonomous discovery should
+// leave a previously-failed loop in failed state instead of reviving it.
+//
+// The contract is: suppress only when (a) loop is currently failed, (b) we have
+// a recorded last-failed fingerprint, and (c) the current discovery fingerprint
+// matches it exactly.
+//
+// All other cases (no stored fingerprint, status not failed, mismatched
+// fingerprint) return false so the loop is revived as before.
+func ShouldSuppressFailedRediscovery(loopStatus, storedFingerprint, currentFingerprint string) bool {
+	if strings.TrimSpace(loopStatus) != "failed" {
+		return false
+	}
+	stored := strings.TrimSpace(storedFingerprint)
+	current := strings.TrimSpace(currentFingerprint)
+	if stored == "" || current == "" {
+		return false
+	}
+	return stored == current
+}

--- a/internal/loops/discovery_fingerprint_test.go
+++ b/internal/loops/discovery_fingerprint_test.go
@@ -1,0 +1,106 @@
+package loops
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestComputeDiscoveryFingerprintIsStableAndOrderSensitive(t *testing.T) {
+	t.Parallel()
+	a := ComputeDiscoveryFingerprint("repo", "1", "head")
+	b := ComputeDiscoveryFingerprint("repo", "1", "head")
+	if a != b {
+		t.Fatalf("expected stable fingerprint, got %q vs %q", a, b)
+	}
+	c := ComputeDiscoveryFingerprint("1", "repo", "head")
+	if a == c {
+		t.Fatalf("expected order-sensitive fingerprint, got equal")
+	}
+	if !strings.HasPrefix(a, DiscoveryFingerprintVersion+":") {
+		t.Fatalf("expected version prefix on fingerprint, got %q", a)
+	}
+}
+
+func TestCanonicalSortedStringsTrimsLowercasesDedupesAndSorts(t *testing.T) {
+	t.Parallel()
+	got := CanonicalSortedStrings([]string{"  Bug ", "feature", "BUG", "", "feature"})
+	want := []string{"bug", "feature"}
+	if len(got) != len(want) {
+		t.Fatalf("CanonicalSortedStrings = %#v, want %#v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("CanonicalSortedStrings = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestMergeAndReadLastFailedDiscoveryFingerprintRoundTrip(t *testing.T) {
+	t.Parallel()
+	merged, err := MergeLastFailedDiscoveryFingerprint(nil, "v1:abc")
+	if err != nil {
+		t.Fatalf("merge into nil error = %v", err)
+	}
+	got := LastFailedDiscoveryFingerprint(&merged)
+	if got != "v1:abc" {
+		t.Fatalf("LastFailedDiscoveryFingerprint = %q, want %q", got, "v1:abc")
+	}
+
+	// Existing unrelated metadata must survive.
+	existing := `{"prUrl":"https://example.com/pr/1"}`
+	merged2, err := MergeLastFailedDiscoveryFingerprint(&existing, "v1:def")
+	if err != nil {
+		t.Fatalf("merge into existing error = %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(merged2), &decoded); err != nil {
+		t.Fatalf("merged JSON invalid: %v", err)
+	}
+	if decoded["prUrl"] != "https://example.com/pr/1" {
+		t.Fatalf("prUrl lost after merge, got %#v", decoded)
+	}
+	if got := LastFailedDiscoveryFingerprint(&merged2); got != "v1:def" {
+		t.Fatalf("LastFailedDiscoveryFingerprint after merge = %q, want %q", got, "v1:def")
+	}
+
+	// Clearing should remove the field but keep other metadata.
+	cleared, err := MergeLastFailedDiscoveryFingerprint(&merged2, "")
+	if err != nil {
+		t.Fatalf("clear merge error = %v", err)
+	}
+	if got := LastFailedDiscoveryFingerprint(&cleared); got != "" {
+		t.Fatalf("LastFailedDiscoveryFingerprint after clear = %q, want empty", got)
+	}
+	if !strings.Contains(cleared, "prUrl") {
+		t.Fatalf("expected prUrl preserved after clear, got %q", cleared)
+	}
+}
+
+func TestShouldSuppressFailedRediscoveryRules(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		status  string
+		stored  string
+		current string
+		want    bool
+	}{
+		{name: "failed equal", status: "failed", stored: "v1:a", current: "v1:a", want: true},
+		{name: "failed mismatch", status: "failed", stored: "v1:a", current: "v1:b", want: false},
+		{name: "failed missing stored", status: "failed", stored: "", current: "v1:a", want: false},
+		{name: "failed missing current", status: "failed", stored: "v1:a", current: "", want: false},
+		{name: "queued never suppress", status: "queued", stored: "v1:a", current: "v1:a", want: false},
+		{name: "running never suppress", status: "running", stored: "v1:a", current: "v1:a", want: false},
+		{name: "paused never suppress", status: "paused", stored: "v1:a", current: "v1:a", want: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ShouldSuppressFailedRediscovery(tc.status, tc.stored, tc.current); got != tc.want {
+				t.Fatalf("ShouldSuppressFailedRediscovery(%q,%q,%q) = %v, want %v", tc.status, tc.stored, tc.current, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/loops/policy.go
+++ b/internal/loops/policy.go
@@ -1,0 +1,61 @@
+package loops
+
+import (
+	"strings"
+
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+const (
+	FailureKindRetryableAfterResume = "retryable_after_resume"
+	FailureKindManualIntervention   = "manual_intervention"
+
+	ResumePolicyAdvanceFromCheckpoint = "advance_from_checkpoint"
+	ResumePolicyManualIntervention    = "manual_intervention"
+	ResumePolicyReplayStep            = "replay_step"
+	ResumePolicyRestartFromDiscover   = "restart_from_discover"
+)
+
+func NormalizeResumePolicy(failureKind, resumePolicy string) string {
+	policy := strings.TrimSpace(resumePolicy)
+	if policy != "" {
+		return policy
+	}
+	switch strings.TrimSpace(failureKind) {
+	case FailureKindRetryableAfterResume:
+		return ResumePolicyAdvanceFromCheckpoint
+	case FailureKindManualIntervention:
+		return ResumePolicyManualIntervention
+	default:
+		return ResumePolicyReplayStep
+	}
+}
+
+func IsManualHoldResumePolicy(resumePolicy string) bool {
+	return strings.TrimSpace(resumePolicy) == ResumePolicyManualIntervention
+}
+
+func IsHardHold(failureKind, resumePolicy string) bool {
+	if IsManualHoldResumePolicy(resumePolicy) {
+		return true
+	}
+	return strings.TrimSpace(failureKind) == FailureKindManualIntervention
+}
+
+func SuppressesAutonomousRecovery(failureKind, resumePolicy string) bool {
+	return IsHardHold(failureKind, resumePolicy)
+}
+
+func ShouldRestartFromDiscover(status, resumePolicy string) bool {
+	if status != "failed" && status != "interrupted" {
+		return false
+	}
+	return strings.TrimSpace(resumePolicy) == ResumePolicyRestartFromDiscover
+}
+
+func ShouldPauseLoopAfterFailure(failureKind string, failedQueue *storage.QueueItemRecord, resumePolicy string) bool {
+	if failedQueue != nil && failedQueue.Status == "cancelled" {
+		return true
+	}
+	return IsHardHold(failureKind, resumePolicy)
+}

--- a/internal/loops/policy_test.go
+++ b/internal/loops/policy_test.go
@@ -1,0 +1,66 @@
+package loops
+
+import (
+	"testing"
+
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestNormalizeResumePolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		failureKind  string
+		resumePolicy string
+		want         string
+	}{
+		{name: "preserves explicit", failureKind: FailureKindManualIntervention, resumePolicy: ResumePolicyRestartFromDiscover, want: ResumePolicyRestartFromDiscover},
+		{name: "retryable after resume defaults to checkpoint advance", failureKind: FailureKindRetryableAfterResume, want: ResumePolicyAdvanceFromCheckpoint},
+		{name: "manual intervention defaults to manual hold", failureKind: FailureKindManualIntervention, want: ResumePolicyManualIntervention},
+		{name: "other failures default to replay", failureKind: "retryable_transient", want: ResumePolicyReplayStep},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := NormalizeResumePolicy(tt.failureKind, tt.resumePolicy); got != tt.want {
+				t.Fatalf("NormalizeResumePolicy(%q, %q) = %q, want %q", tt.failureKind, tt.resumePolicy, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldRestartFromDiscover(t *testing.T) {
+	t.Parallel()
+
+	if !ShouldRestartFromDiscover("failed", ResumePolicyRestartFromDiscover) {
+		t.Fatal("ShouldRestartFromDiscover() = false, want true for restart_from_discover")
+	}
+	if ShouldRestartFromDiscover("failed", ResumePolicyManualIntervention) {
+		t.Fatal("ShouldRestartFromDiscover() = true, want false for manual_intervention")
+	}
+}
+
+func TestShouldPauseLoopAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	if !ShouldPauseLoopAfterFailure(FailureKindManualIntervention, nil, "") {
+		t.Fatal("ShouldPauseLoopAfterFailure() = false, want true for manual_intervention")
+	}
+	if ShouldPauseLoopAfterFailure(FailureKindRetryableAfterResume, nil, ResumePolicyRestartFromDiscover) {
+		t.Fatal("ShouldPauseLoopAfterFailure() = true, want false for rediscoverable retry")
+	}
+	if !ShouldPauseLoopAfterFailure("retryable_transient", &storage.QueueItemRecord{Status: "cancelled"}, "") {
+		t.Fatal("ShouldPauseLoopAfterFailure() = false, want true for cancelled queue item")
+	}
+	if !SuppressesAutonomousRecovery(FailureKindManualIntervention, "") {
+		t.Fatal("SuppressesAutonomousRecovery() = false, want true for hard hold")
+	}
+	if SuppressesAutonomousRecovery(FailureKindRetryableAfterResume, ResumePolicyRestartFromDiscover) {
+		t.Fatal("SuppressesAutonomousRecovery() = true, want false for safe rediscovery")
+	}
+	if !IsManualHoldResumePolicy(ResumePolicyManualIntervention) {
+		t.Fatal("IsManualHoldResumePolicy() = false, want true")
+	}
+}

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -20,6 +20,7 @@ import (
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/lifecycle"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -599,7 +600,7 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 			updated.Status = "queued"
 			updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 		} else {
-			if failureKind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+			if loops.ShouldPauseLoopAfterFailure(string(failureKind), failedQueue, "") {
 				updated.Status = "paused"
 			} else {
 				updated.Status = "failed"
@@ -679,18 +680,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		if err != nil {
 			failure := r.classifyFailure(err)
 			latest := r.getLatestCheckpoint(ctx, run, checkpoint)
-			resumePolicy := latest.ResumePolicy
-			switch failure.kind {
-			case FailureRetryableAfterResume:
-				resumePolicy = "advance_from_checkpoint"
-			case FailureManualIntervention:
-				resumePolicy = "manual_intervention"
-			default:
-				if resumePolicy == "" {
-					resumePolicy = "replay_step"
-				}
-			}
-			latest.ResumePolicy = resumePolicy
+			latest.ResumePolicy = loops.NormalizeResumePolicy(string(failure.kind), latest.ResumePolicy)
 			if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
 				return ProcessResult{}, err
 			}
@@ -708,7 +698,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "queued"
 					updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 				} else {
-					if failure.kind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+					if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
 						updated.Status = "paused"
 					} else {
 						updated.Status = "failed"
@@ -943,7 +933,7 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 			message := firstNonEmpty(result.Summary, result.Stderr, "Planner agent "+result.Status)
 			kind := FailureRetryableTransient
 			if agent.IsAgentSetupFailureMessage(message) {
-				kind = FailureManualIntervention
+				kind = FailureRetryableTransient
 			}
 			return checkpoint, &loopError{message: message, kind: kind}
 		}
@@ -992,9 +982,10 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (plannerCh
 		return checkpoint, nil
 	}
 	if !r.allowAutoPush {
-		checkpoint.SkipReason = fmt.Sprintf("Auto push disabled; manual publish required for planner %s", input.Loop.ID)
-		checkpoint.ResumePolicy = "manual_intervention"
-		return checkpoint, nil
+		message := fmt.Sprintf("Auto push disabled; manual publish required for planner %s", input.Loop.ID)
+		checkpoint.SkipReason = message
+		checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+		return checkpoint, &loopError{message: message, kind: FailureManualIntervention}
 	}
 	issue, err := requireIssue(checkpoint)
 	if err != nil {
@@ -1245,7 +1236,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		check = parseCheckpoint(latestRun.CheckpointJSON)
 		lastCompleted = asPlannerStep(derefString(latestRun.LastCompletedStep))
 	}
-	shouldResume := latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && check.ResumePolicy != "manual_intervention" && lastCompleted != ""
+	shouldResume := latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && !loops.IsManualHoldResumePolicy(check.ResumePolicy) && lastCompleted != ""
 	startStep := stepDiscoverIssues
 	if shouldResume {
 		if next := nextPlannerStep(lastCompleted); next != "" {

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -519,7 +519,8 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 			result.Skipped++
 			continue
 		}
-		loopResult, err := r.ensureLoopForIssue(ctx, *project, input.Repo, issue)
+		fingerprint := buildPlannerDiscoveryFingerprint(input.Repo, r.now(), issue)
+		loopResult, err := r.ensureLoopForIssue(ctx, *project, input.Repo, issue, fingerprint)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
@@ -530,7 +531,14 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 			result.Skipped++
 			continue
 		}
-		queueItem, err := r.enqueue(ctx, enqueueInput{ProjectID: project.ID, LoopID: loopResult.record.ID, Repo: input.Repo, IssueNumber: issue.Number, Payload: map[string]any{"issueNumber": issue.Number, "title": issue.Title, "body": issue.Body, "url": issue.URL, "assignees": issue.Assignees, "labels": issue.Labels, "currentUserLogin": login}})
+		// Anti-thrash: skip enqueue when ensureLoopForIssue left a previously
+		// failed loop in place because its discovery inputs match the last
+		// terminal failure.
+		if loopResult.record.Status == "failed" {
+			result.Skipped++
+			continue
+		}
+		queueItem, err := r.enqueue(ctx, enqueueInput{ProjectID: project.ID, LoopID: loopResult.record.ID, Repo: input.Repo, IssueNumber: issue.Number, Payload: map[string]any{"issueNumber": issue.Number, "title": issue.Title, "body": issue.Body, "url": issue.URL, "assignees": issue.Assignees, "labels": issue.Labels, "currentUserLogin": login, plannerQueuePayloadFPKey: fingerprint}})
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
@@ -604,6 +612,7 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 				updated.Status = "paused"
 			} else {
 				updated.Status = "failed"
+				r.stampFailedDiscoveryFingerprint(updated, queueItem)
 			}
 			updated.NextRunAt = nil
 		}
@@ -702,6 +711,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 						updated.Status = "paused"
 					} else {
 						updated.Status = "failed"
+						r.stampFailedDiscoveryFingerprint(updated, queueItem)
 					}
 					updated.NextRunAt = nil
 				}
@@ -1358,19 +1368,20 @@ type loopUpsertResult struct {
 	created bool
 }
 
-func (r *Runner) ensureLoopForIssue(ctx context.Context, project storage.ProjectRecord, repo string, issue IssueSummary) (loopUpsertResult, error) {
+func (r *Runner) ensureLoopForIssue(ctx context.Context, project storage.ProjectRecord, repo string, issue IssueSummary, currentFingerprint string) (loopUpsertResult, error) {
 	nowISO := r.nowISO()
 	targetID := buildIssueTargetID(repo, issue.Number)
-	loops, err := r.repos.Loops.List(ctx)
+	existingLoops, err := r.repos.Loops.List(ctx)
 	if err != nil {
 		return loopUpsertResult{}, err
 	}
-	for _, existing := range loops {
+	for _, existing := range existingLoops {
 		if existing.Type == "planner" && existing.ProjectID == project.ID && existing.TargetType == "issue" && derefString(existing.TargetID) == targetID {
 			pausedOrCompleted := existing.Status == "paused" || existing.Status == "completed"
 			updated := existing
 			updated.Repo = stringPtr(repo)
-			if !pausedOrCompleted && updated.Status != "running" {
+			suppressFailedRevival := loops.ShouldSuppressFailedRediscovery(existing.Status, loops.LastFailedDiscoveryFingerprint(existing.MetadataJSON), currentFingerprint)
+			if !pausedOrCompleted && !suppressFailedRevival && updated.Status != "running" {
 				updated.Status = "queued"
 				updated.NextRunAt = &nowISO
 			}
@@ -1826,6 +1837,70 @@ func hasRequestedReviewerSources(project storage.ProjectRecord, loop storage.Loo
 func buildIssueTargetID(repo string, issueNumber int64) string {
 	return fmt.Sprintf("issue:%s:%d", repo, issueNumber)
 }
+
+// plannerQueuePayloadFPKey is the JSON key used to forward the planner
+// discovery fingerprint into the queue payload so failure handlers can stamp
+// it onto the loop without recomputing inputs from scratch.
+const plannerQueuePayloadFPKey = "discoveryFingerprint"
+
+// buildPlannerDiscoveryFingerprint returns a stable fingerprint over the
+// inputs that planner discovery uses to decide whether a previously-failed
+// loop should be revived. specPath is included so deliberate spec-path
+// changes (e.g. issue title edits affecting slug, or day rollover) trigger
+// rediscovery.
+func buildPlannerDiscoveryFingerprint(repo string, now time.Time, issue IssueSummary) string {
+	labels := loops.CanonicalSortedStrings(issue.Labels)
+	assignees := loops.CanonicalSortedStrings(issue.Assignees)
+	specPath := buildSpecPath(now, issue.Number, issue.Title)
+	return loops.ComputeDiscoveryFingerprint(
+		"planner",
+		repo,
+		fmt.Sprintf("%d", issue.Number),
+		strings.TrimSpace(issue.Title),
+		strings.TrimSpace(issue.Body),
+		strings.TrimSpace(issue.URL),
+		specPath,
+		strings.Join(labels, ","),
+		strings.Join(assignees, ","),
+	)
+}
+
+// plannerQueueDiscoveryFingerprint reads the persisted fingerprint from a
+// queue item's payload, returning empty when missing or invalid.
+func plannerQueueDiscoveryFingerprint(payloadJSON *string) string {
+	if payloadJSON == nil {
+		return ""
+	}
+	raw := strings.TrimSpace(*payloadJSON)
+	if raw == "" {
+		return ""
+	}
+	parsed := map[string]any{}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return ""
+	}
+	value, _ := parsed[plannerQueuePayloadFPKey].(string)
+	return strings.TrimSpace(value)
+}
+
+// stampFailedDiscoveryFingerprint records the queue item's discovery
+// fingerprint on the loop's metadata so the next discovery tick can suppress
+// autonomous rediscovery while inputs are unchanged.
+func (r *Runner) stampFailedDiscoveryFingerprint(updated *storage.LoopRecord, queueItem storage.QueueItemRecord) {
+	fingerprint := plannerQueueDiscoveryFingerprint(queueItem.PayloadJSON)
+	if fingerprint == "" {
+		return
+	}
+	merged, err := loops.MergeLastFailedDiscoveryFingerprint(updated.MetadataJSON, fingerprint)
+	if err != nil {
+		if r.logger != nil {
+			r.logger.Warn("planner fingerprint stamp failed", map[string]any{"loopId": updated.ID, "error": err.Error()})
+		}
+		return
+	}
+	updated.MetadataJSON = stringPtr(merged)
+}
+
 func buildPlannerDedupeKey(projectID, loopID, repo string, issueNumber int64) string {
 	return fmt.Sprintf("planner:%s:%s:%s:%d", projectID, loopID, repo, issueNumber)
 }

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -81,7 +81,7 @@ func TestDiscoverIssuesEnqueuesAcrossProjectsForSameIssue(t *testing.T) {
 	if err != nil || project1Loop != nil {
 		t.Fatalf("Loops.GetByID(missing) = (%#v, %v), want (nil, nil)", project1Loop, err)
 	}
-	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue)
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue, buildPlannerDiscoveryFingerprint("acme/looper", fixture.now(), issue))
 	if err != nil {
 		t.Fatalf("ensureLoopForIssue(project_1) error = %v", err)
 	}
@@ -152,11 +152,60 @@ func TestDiscoverIssuesQueriesEachServerSideLabelWhenConfiguredWithAnyLabelMode(
 	}
 }
 
+func TestDiscoverIssuesSkipsFailedPlannerLoopWhenFingerprintUnchanged(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	issue := IssueSummary{Number: 77, Title: "Plan this", Body: "same body", URL: "https://github.com/acme/looper/issues/77", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}
+	fingerprint := buildPlannerDiscoveryFingerprint(repo, fixture.now(), issue)
+	metadata := fmt.Sprintf(`{"autonomousRecovery":{"lastFailedDiscoveryFingerprint":%q}}`, fingerprint)
+	targetID := buildIssueTargetID(repo, issue.Number)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_planner_failed_same_fp", Seq: 88, ProjectID: "project_1", Type: "planner", TargetType: "issue", TargetID: &targetID, Repo: &repo, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{issues: []IssueSummary{issue}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoPush: boolPtr(true)})
+
+	result, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want none for unchanged failed fingerprint", result.QueueItems)
+	}
+}
+
+func TestDiscoverIssuesRequeuesFailedPlannerLoopWhenFingerprintChanges(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	oldIssue := IssueSummary{Number: 78, Title: "Plan this", Body: "old body", URL: "https://github.com/acme/looper/issues/78", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}
+	newIssue := IssueSummary{Number: 78, Title: "Plan this", Body: "new body", URL: "https://github.com/acme/looper/issues/78", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}
+	fingerprint := buildPlannerDiscoveryFingerprint(repo, fixture.now(), oldIssue)
+	metadata := fmt.Sprintf(`{"autonomousRecovery":{"lastFailedDiscoveryFingerprint":%q}}`, fingerprint)
+	targetID := buildIssueTargetID(repo, newIssue.Number)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_planner_failed_changed_fp", Seq: 89, ProjectID: "project_1", Type: "planner", TargetType: "issue", TargetID: &targetID, Repo: &repo, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{issues: []IssueSummary{newIssue}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, AllowAutoPush: boolPtr(true)})
+
+	result, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want one queue item after fingerprint change", result.QueueItems)
+	}
+}
+
 func TestProcessClaimedItemManualPlannerBypassesDiscoveryChecks(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	issue := IssueSummary{Number: 42, Title: "Plan this"}
-	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue)
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue, buildPlannerDiscoveryFingerprint("acme/looper", fixture.now(), issue))
 	if err != nil {
 		t.Fatalf("ensureLoopForIssue() error = %v", err)
 	}
@@ -196,7 +245,7 @@ func TestProcessClaimedItemPlannerSkipsWhenNotManualAndIneligible(t *testing.T) 
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	issue := IssueSummary{Number: 42, Title: "Plan this"}
-	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue)
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue, buildPlannerDiscoveryFingerprint("acme/looper", fixture.now(), issue))
 	if err != nil {
 		t.Fatalf("ensureLoopForIssue() error = %v", err)
 	}
@@ -235,7 +284,7 @@ func TestProcessClaimedItemDiscoveryQueueIgnoresManualLoopMetadata(t *testing.T)
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	issue := IssueSummary{Number: 42, Title: "Plan this"}
-	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue)
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue, buildPlannerDiscoveryFingerprint("acme/looper", fixture.now(), issue))
 	if err != nil {
 		t.Fatalf("ensureLoopForIssue() error = %v", err)
 	}
@@ -376,7 +425,7 @@ func TestProcessClaimedItemSelfAssignsIssue(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	issue := IssueSummary{Number: 42, Title: "Plan this"}
-	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue)
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue, buildPlannerDiscoveryFingerprint("acme/looper", fixture.now(), issue))
 	if err != nil {
 		t.Fatalf("ensureLoopForIssue() error = %v", err)
 	}
@@ -411,7 +460,7 @@ func TestProcessClaimedItemSurfacesIssueSelfAssignmentFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	issue := IssueSummary{Number: 42, Title: "Plan this"}
-	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue)
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue, buildPlannerDiscoveryFingerprint("acme/looper", fixture.now(), issue))
 	if err != nil {
 		t.Fatalf("ensureLoopForIssue() error = %v", err)
 	}
@@ -618,7 +667,7 @@ func TestProcessClaimedItemResumeReleasesClaimedLockWhenSetupFails(t *testing.T)
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	issue := IssueSummary{Number: 42, Title: "Plan this", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}
-	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue)
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, "acme/looper", issue, buildPlannerDiscoveryFingerprint("acme/looper", fixture.now(), issue))
 	if err != nil {
 		t.Fatalf("ensureLoopForIssue() error = %v", err)
 	}

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -718,6 +718,72 @@ func TestWriteSpecFailureMarksRunQueueLoop(t *testing.T) {
 	}
 }
 
+func TestWriteSpecSetupFailureStaysRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{issues: []IssueSummary{{Number: 42, Title: "Plan this", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}}, issueDetail: IssueDetail{Number: 42, Title: "Plan this", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{ID: "worktree_1", WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed", Summary: "unsupported model in agent configuration for codex"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoPush: boolPtr(true)})
+
+	_, _ = runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "planner-worker-1", "planner")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient {
+		t.Fatalf("result = %#v, want retryable_transient setup failure", result)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "queued" {
+		t.Fatalf("queue = %#v, want queued retry", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued", loop)
+	}
+}
+
+func TestPublishAutoPushDisabledPausesPlannerLoop(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{issues: []IssueSummary{{Number: 42, Title: "Plan this", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}}, issueDetail: IssueDetail{Number: 42, Title: "Plan this", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{ID: "worktree_1", WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "wrote spec"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoPush: boolPtr(false)})
+
+	_, _ = runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "planner-worker-1", "planner")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureManualIntervention || !strings.Contains(result.Summary, "manual publish required") {
+		t.Fatalf("result = %#v, want manual_intervention manual publish failure", result)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want terminal manual_intervention item", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused", loop)
+	}
+}
+
 func TestProcessClaimedItemPreservesPausedLoopOnRetryableFailureAfterPause(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -26,6 +26,7 @@ import (
 	gitinfra "github.com/nexu-io/looper/internal/infra/git"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/specpr"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/version"
 )
@@ -987,7 +988,7 @@ func (r *Runner) finalizeClaimSetupFailure(ctx context.Context, queueItem storag
 			updated.Status = "queued"
 			updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 		} else {
-			if failure.kind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+			if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, "") {
 				updated.Status = "paused"
 			} else {
 				updated.Status = "failed"
@@ -1098,14 +1099,14 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			resumePolicy := latest.ResumePolicy
 			switch failure.kind {
 			case FailureRetryableAfterResume:
-				if resumePolicy != "restart_from_discover" && resumePolicy != "rerun_review" {
-					resumePolicy = "advance_from_checkpoint"
+				if resumePolicy != loops.ResumePolicyRestartFromDiscover && resumePolicy != "rerun_review" {
+					resumePolicy = loops.ResumePolicyAdvanceFromCheckpoint
 				}
 			case FailureManualIntervention:
-				resumePolicy = "manual_intervention"
+				resumePolicy = loops.ResumePolicyManualIntervention
 			default:
 				if resumePolicy == "" {
-					resumePolicy = "replay_step"
+					resumePolicy = loops.ResumePolicyReplayStep
 				}
 			}
 			latest.ResumePolicy = resumePolicy
@@ -1150,7 +1151,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "queued"
 					updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 				} else {
-					if failure.kind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+					if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
 						updated.Status = "paused"
 					} else {
 						updated.Status = "failed"
@@ -3147,7 +3148,8 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if latestQueue.LastErrorKind != nil {
 		queueKind = *latestQueue.LastErrorKind
 	}
-	if queueKind == string(FailureManualIntervention) || checkpoint.ResumePolicy == "manual_intervention" {
+	resumePolicy := loops.NormalizeResumePolicy(queueKind, checkpoint.ResumePolicy)
+	if loops.SuppressesAutonomousRecovery(queueKind, resumePolicy) {
 		return false, "", "manual_intervention", nil
 	}
 	approvedByCurrentUser := func() (bool, error) {
@@ -3160,7 +3162,7 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 		}
 		return hasApprovedReviewByAuthorForHead(pr.Reviews, currentLogin, pr.HeadSHA), nil
 	}
-	if queueKind == string(FailureRetryableAfterResume) && (checkpoint.ResumePolicy == "restart_from_discover" || checkpoint.ResumePolicy == "rerun_review") {
+	if queueKind == string(FailureRetryableAfterResume) && (resumePolicy == loops.ResumePolicyRestartFromDiscover || resumePolicy == "rerun_review") {
 		approved, err := approvedByCurrentUser()
 		if err != nil {
 			return false, "", "", err

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2215,7 +2215,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		if isGitHubSelfApprovalFailure(message) {
 			kind = FailureNonRetryable
 		} else if agent.IsAgentSetupFailureMessage(message) {
-			kind = FailureManualIntervention
+			kind = FailureRetryableTransient
 		}
 		if kind == FailureRetryableTransient {
 			r.markAgentExecutionNativeResumePendingForTransientProvider(ctx, executionID, message)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -89,10 +89,12 @@ func TestReviewerFailedLoopRecoveryEligibilityWhitelist(t *testing.T) {
 		want bool
 	}{
 		{name: "retryable rerun review", seed: failedReviewerRecoverySeed{ResumePolicy: "rerun_review", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "marker missing"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
+		{name: "retryable restart from discover", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
 		{name: "retryable transient attempts remaining", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureRetryableTransient), ErrorMessage: "reviewer agent timed out", QueueAttempts: 3, QueueMaxAttempts: 5}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
 		{name: "historical guardrail non retryable", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureNonRetryable), ErrorMessage: "review request removed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
 		{name: "retryable transient exhausted on final allowed run", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureRetryableTransient), ErrorMessage: "reviewer agent timed out", QueueAttempts: 4, QueueMaxAttempts: 5}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
-		{name: "manual intervention", seed: failedReviewerRecoverySeed{ResumePolicy: "manual_intervention", QueueErrorKind: string(FailureManualIntervention), ErrorMessage: "operator needed"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
+		{name: "manual intervention kind", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureManualIntervention), ErrorMessage: "operator needed"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
+		{name: "manual intervention resume policy", seed: failedReviewerRecoverySeed{ResumePolicy: "manual_intervention", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "operator needed"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 		{name: "closed pr", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "CLOSED"}, want: false},
 		{name: "approved by current user on head", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN", ReviewDecision: "APPROVED", HeadSHA: "abc123", Reviews: []map[string]any{{"author": map[string]any{"login": "octocat"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}}, want: false},
 		{name: "approved by another user", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN", ReviewDecision: "APPROVED", HeadSHA: "abc123", Reviews: []map[string]any{{"author": map[string]any{"login": "other"}, "state": "APPROVED", "commit": map[string]any{"oid": "abc123"}}}}, want: true},
@@ -226,7 +228,8 @@ func TestReviewerFailedLoopRecoveryEligibilitySkipsCurrentLoginForDeterministicB
 				}
 			},
 		},
-		{name: "manual intervention", seed: failedReviewerRecoverySeed{ResumePolicy: "manual_intervention", QueueErrorKind: string(FailureManualIntervention), ErrorMessage: "operator needed"}, wantReason: "manual_intervention"},
+		{name: "manual intervention kind", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureManualIntervention), ErrorMessage: "operator needed"}, wantReason: "manual_intervention"},
+		{name: "manual intervention resume policy", seed: failedReviewerRecoverySeed{ResumePolicy: "manual_intervention", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "operator needed"}, wantReason: "manual_intervention"},
 		{name: "not whitelisted", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureNonRetryable), ErrorMessage: "marker missing"}, wantReason: "not_whitelisted"},
 	}
 	for _, tt := range tests {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4930,6 +4930,40 @@ func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemTreatsReviewerAgentSetupFailureAsRetryableTransient(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewMarkerMissing: true}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed", Summary: "OpenAI API error: model gpt-5-reviewer not found for project", Stderr: "OpenAI API error: model gpt-5-reviewer not found for project"}}}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+		RetryMaxAttempts: 3,
+		LoopConfig:       config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 1, MaxAgentExecutionsPerPR: 25},
+	})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed reviewer queue item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient {
+		t.Fatalf("result = %#v, want retryable transient setup failure", result)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) {
+		t.Fatalf("queue = %#v, want queued retryable transient queue kind", queue)
+	}
+}
+
 func TestProcessClaimedItemReturnsWhenCompleteRunFails(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1686,7 +1686,8 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 	checkpoint := parseRuntimeReviewerCheckpoint(latestRun.CheckpointJSON)
 	queueKind := derefString(latestQueue.LastErrorKind)
 	queueMessage := derefString(latestQueue.LastError)
-	if loops.SuppressesAutonomousRecovery(queueKind, checkpoint.ResumePolicy) {
+	resumePolicy := loops.NormalizeResumePolicy(queueKind, checkpoint.ResumePolicy)
+	if loops.SuppressesAutonomousRecovery(queueKind, resumePolicy) {
 		return false
 	}
 	if checkpoint.Detail == nil {
@@ -1709,7 +1710,7 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 		return false
 	}
 	failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage), queueMessage)
-	return (queueKind == "retryable_after_resume" && (checkpoint.ResumePolicy == "restart_from_discover" || checkpoint.ResumePolicy == "rerun_review")) || isRuntimeRetryableTransientWithRemainingAttempts(*latestQueue) || (isKnownReviewerRediscoveryGuardrail(failureSummary) && isRuntimeReviewerRediscoveryRunStep(latestRun))
+	return (queueKind == loops.FailureKindRetryableAfterResume && (resumePolicy == loops.ResumePolicyRestartFromDiscover || resumePolicy == "rerun_review")) || isRuntimeRetryableTransientWithRemainingAttempts(*latestQueue) || (isKnownReviewerRediscoveryGuardrail(failureSummary) && isRuntimeReviewerRediscoveryRunStep(latestRun))
 }
 
 func requeueFailedReviewerQueueItemForRecovery(ctx context.Context, repositories *storage.Repositories, loopID string, latestQueue *storage.QueueItemRecord, queuedAt string) (int64, error) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1684,12 +1684,9 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 		return false
 	}
 	checkpoint := parseRuntimeReviewerCheckpoint(latestRun.CheckpointJSON)
-	if checkpoint.ResumePolicy == "manual_intervention" {
-		return false
-	}
 	queueKind := derefString(latestQueue.LastErrorKind)
 	queueMessage := derefString(latestQueue.LastError)
-	if queueKind == "manual_intervention" {
+	if loops.SuppressesAutonomousRecovery(queueKind, checkpoint.ResumePolicy) {
 		return false
 	}
 	if checkpoint.Detail == nil {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1895,6 +1895,12 @@ func TestShouldAutoRecoverFailedReviewerLoopRefusesUnsafeStates(t *testing.T) {
 			q.LastErrorKind = &kind
 			return q
 		}()},
+		{name: "manual intervention resume policy", loop: baseLoop, run: func() storage.RunRecord {
+			r := baseRun
+			checkpointJSON := `{"resumePolicy":"manual_intervention","detail":{"state":"OPEN","reviewDecision":"","labels":[]}}`
+			r.CheckpointJSON = &checkpointJSON
+			return r
+		}(), queue: baseQueue},
 		{name: "closed checkpoint", loop: baseLoop, run: func() storage.RunRecord {
 			r := baseRun
 			r.CheckpointJSON = checkpoint(`"detail":{"state":"CLOSED","reviewDecision":"","labels":[]}`)
@@ -1964,6 +1970,14 @@ func TestShouldAutoRecoverFailedReviewerLoopRefusesUnsafeStates(t *testing.T) {
 				t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = true, want false")
 			}
 		})
+	}
+}
+
+func TestShouldRequeueLoopKeepsPausedLoopsExcluded(t *testing.T) {
+	t.Parallel()
+
+	if shouldRequeueLoop(storage.LoopRecord{Status: "paused"}, &storage.RunRecord{Status: "interrupted"}, false) {
+		t.Fatal("shouldRequeueLoop() = true, want false for paused loop")
 	}
 }
 

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/lifecycle"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -785,7 +786,7 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 			updated.Status = "queued"
 			updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 		} else {
-			if failureKind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+			if loops.ShouldPauseLoopAfterFailure(string(failureKind), failedQueue, "") {
 				updated.Status = "paused"
 			} else {
 				updated.Status = "failed"
@@ -890,7 +891,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 				updated.Status = "queued"
 				updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 			} else {
-				if failure.kind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+				if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
 					updated.Status = "paused"
 				} else {
 					updated.Status = "failed"
@@ -912,16 +913,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		if err != nil {
 			failure := r.classifyFailure(err)
 			latest := r.getLatestCheckpoint(ctx, run, checkpoint)
-			switch failure.kind {
-			case FailureRetryableAfterResume:
-				latest.ResumePolicy = "advance_from_checkpoint"
-			case FailureManualIntervention:
-				latest.ResumePolicy = "manual_intervention"
-			default:
-				if latest.ResumePolicy == "" {
-					latest.ResumePolicy = "replay_step"
-				}
-			}
+			latest.ResumePolicy = loops.NormalizeResumePolicy(string(failure.kind), latest.ResumePolicy)
 			if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
 				return ProcessResult{}, err
 			}
@@ -940,7 +932,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "queued"
 					updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 				} else {
-					if failure.kind == FailureManualIntervention || (failedQueue != nil && failedQueue.Status == "cancelled") {
+					if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
 						updated.Status = "paused"
 					} else {
 						updated.Status = "failed"
@@ -1292,7 +1284,7 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 			message := firstNonEmpty(result.Summary, result.Stderr, fmt.Sprintf("Worker agent %s", result.Status))
 			kind := FailureRetryableTransient
 			if agent.IsAgentSetupFailureMessage(message) {
-				kind = FailureManualIntervention
+				kind = FailureRetryableTransient
 			}
 			return checkpoint, &loopError{message: message, kind: kind}
 		}
@@ -1396,6 +1388,11 @@ func (r *Runner) runValidateStep(ctx context.Context, input stepInput) (workerCh
 		return checkpoint, err
 	}
 	checkpoint.Validation = &result
+	if !result.Passed {
+		failure := classifyValidationFailure(result)
+		checkpoint.ResumePolicy = failure.resumePolicy
+		return checkpoint, &loopError{message: failure.message, kind: failure.kind}
+	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }
@@ -1407,7 +1404,9 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		return checkpoint, err
 	}
 	if checkpoint.Validation != nil && !checkpoint.Validation.Passed {
-		return checkpoint, &loopError{message: firstNonEmpty(checkpoint.Validation.Summary, "Validation failed"), kind: FailureManualIntervention}
+		failure := classifyValidationFailure(*checkpoint.Validation)
+		checkpoint.ResumePolicy = failure.resumePolicy
+		return checkpoint, &loopError{message: failure.message, kind: failure.kind}
 	}
 	worktree, err := requireWorktree(checkpoint)
 	if err != nil {
@@ -1430,9 +1429,10 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		pushedByFallback := false
 		if !checkpoint.Lifecycle.Pushed {
 			if !r.allowAutoPush {
-				checkpoint.SkipReason = fmt.Sprintf("Auto push disabled; manual PR opening required for worker %s", input.Loop.ID)
-				checkpoint.ResumePolicy = "manual_intervention"
-				return checkpoint, nil
+				message := fmt.Sprintf("Auto push disabled; manual PR opening required for worker %s", input.Loop.ID)
+				checkpoint.SkipReason = message
+				checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+				return checkpoint, &loopError{message: message, kind: FailureManualIntervention}
 			}
 			if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
@@ -1449,9 +1449,10 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 	}
 	if work.ExecutionMode == "push-existing" {
 		if !r.allowAutoPush {
-			checkpoint.SkipReason = fmt.Sprintf("Auto push disabled; manual PR opening required for worker %s", input.Loop.ID)
-			checkpoint.ResumePolicy = "manual_intervention"
-			return checkpoint, nil
+			message := fmt.Sprintf("Auto push disabled; manual PR opening required for worker %s", input.Loop.ID)
+			checkpoint.SkipReason = message
+			checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+			return checkpoint, &loopError{message: message, kind: FailureManualIntervention}
 		}
 		if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: firstNonEmpty(work.Branch, worktree.Branch), ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
@@ -1472,18 +1473,20 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 	}
 	if r.openPRStrategy == config.OpenPRStrategyManual {
 		checkpoint.SkipReason = fmt.Sprintf("Worker completed; PR opening is manual for %s", input.Loop.ID)
-		checkpoint.ResumePolicy = "manual_intervention"
+		checkpoint.ResumePolicy = loops.ResumePolicyAdvanceFromCheckpoint
 		return checkpoint, nil
 	}
 	if !r.githubCLIAutoPROpeningAvailable(ctx, work.Repo, input.Project.RepoPath) {
-		checkpoint.SkipReason = fmt.Sprintf("GitHub CLI unavailable; PR opening is manual for worker %s", input.Loop.ID)
-		checkpoint.ResumePolicy = "manual_intervention"
-		return checkpoint, nil
+		message := fmt.Sprintf("GitHub CLI unavailable; PR opening is manual for worker %s", input.Loop.ID)
+		checkpoint.SkipReason = message
+		checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+		return checkpoint, &loopError{message: message, kind: FailureManualIntervention}
 	}
 	if !r.allowAutoPush {
-		checkpoint.SkipReason = fmt.Sprintf("Auto push disabled; manual PR opening required for worker %s", input.Loop.ID)
-		checkpoint.ResumePolicy = "manual_intervention"
-		return checkpoint, nil
+		message := fmt.Sprintf("Auto push disabled; manual PR opening required for worker %s", input.Loop.ID)
+		checkpoint.SkipReason = message
+		checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+		return checkpoint, &loopError{message: message, kind: FailureManualIntervention}
 	}
 	aliases := buildWorkerBranchAliases(work, input.Loop.ID)
 	if existing, err := r.findOpenPullRequestForBranch(ctx, work.Repo, aliases, work.BaseBranch, input.Project.RepoPath); err == nil && existing != nil {
@@ -1636,6 +1639,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	checkpoint := workerCheckpoint{}
 	var lastCompletedStep WorkerStep
 	var failedStep WorkerStep
+	restartFromDiscover := false
 	if latestRun != nil {
 		checkpoint, err = parseCheckpoint(latestRun.CheckpointJSON)
 		if err != nil {
@@ -1646,11 +1650,15 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 			return resumedRunContext{}, fmt.Errorf("unknown worker last completed step %q", derefString(latestRun.LastCompletedStep))
 		}
 		failedStep = asWorkerStep(derefString(latestRun.CurrentStep))
+		restartFromDiscover = loops.ShouldRestartFromDiscover(latestRun.Status, checkpoint.ResumePolicy)
 	}
 	startStep := stepPrepareWork
 	resumedCheckpoint := checkpoint
-	if latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && lastCompletedStep != "" {
-		if shouldReplayExecuteOnResume(latestRun.Status, failedStep, checkpoint) {
+	if latestRun != nil && (latestRun.Status == "failed" || latestRun.Status == "interrupted") && !loops.IsManualHoldResumePolicy(checkpoint.ResumePolicy) && lastCompletedStep != "" {
+		if restartFromDiscover {
+			startStep = stepPrepareWork
+			resumedCheckpoint = workerCheckpoint{ResumePolicy: loops.ResumePolicyReplayStep}
+		} else if shouldReplayExecuteOnResume(latestRun.Status, failedStep, checkpoint) {
 			startStep = stepExecute
 			resumedCheckpoint = rewindCheckpointForExecuteRetry(checkpoint)
 		} else if next := nextWorkerStep(lastCompletedStep); next != "" {
@@ -1662,7 +1670,9 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	encoded := mustMarshalJSON(workerCheckpoint{ResumePolicy: ternary(resumed, "advance_from_checkpoint", "replay_step"), Work: resumedCheckpoint.Work, ClaimedLockKey: resumedCheckpoint.ClaimedLockKey, Worktree: resumedCheckpoint.Worktree, Plan: resumedCheckpoint.Plan, Execution: resumedCheckpoint.Execution, Lifecycle: resumedCheckpoint.Lifecycle, Validation: resumedCheckpoint.Validation, PullRequest: resumedCheckpoint.PullRequest, SkipReason: resumedCheckpoint.SkipReason})
 	run := storage.RunRecord{ID: eventlog.NewEventID("run"), LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(startStep)), LastCompletedStep: nil, CheckpointJSON: &encoded, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
 	if resumed {
-		if shouldReplayExecuteOnResume(latestRun.Status, failedStep, checkpoint) {
+		if restartFromDiscover {
+			run.LastCompletedStep = nil
+		} else if shouldReplayExecuteOnResume(latestRun.Status, failedStep, checkpoint) {
 			if prev := previousWorkerStep(startStep); prev != "" {
 				value := string(prev)
 				run.LastCompletedStep = &value
@@ -1764,6 +1774,36 @@ func (r *Runner) getLatestCheckpoint(ctx context.Context, run storage.RunRecord,
 	if err != nil {
 		return fallback
 	}
+	if fallback.ResumePolicy != "" {
+		checkpoint.ResumePolicy = fallback.ResumePolicy
+	}
+	if fallback.Work != nil {
+		checkpoint.Work = fallback.Work
+	}
+	if fallback.Worktree != nil {
+		checkpoint.Worktree = fallback.Worktree
+	}
+	if fallback.Plan != nil {
+		checkpoint.Plan = fallback.Plan
+	}
+	if fallback.Execution != nil {
+		checkpoint.Execution = fallback.Execution
+	}
+	if fallback.Lifecycle != nil {
+		checkpoint.Lifecycle = fallback.Lifecycle
+	}
+	if fallback.Validation != nil {
+		checkpoint.Validation = fallback.Validation
+	}
+	if fallback.PullRequest != nil {
+		checkpoint.PullRequest = fallback.PullRequest
+	}
+	if fallback.SkipReason != "" {
+		checkpoint.SkipReason = fallback.SkipReason
+	}
+	if fallback.ClaimedLockKey != "" {
+		checkpoint.ClaimedLockKey = fallback.ClaimedLockKey
+	}
 	return checkpoint
 }
 
@@ -1797,6 +1837,36 @@ func (r *Runner) runValidation(ctx context.Context, input ValidationInput) (Vali
 	}
 
 	return ValidationResult{Passed: true, Summary: "Validation passed", Output: strings.Join(outputs, "\n")}, nil
+}
+
+type validationFailure struct {
+	message      string
+	kind         QueueFailureKind
+	resumePolicy string
+}
+
+func classifyValidationFailure(result ValidationResult) validationFailure {
+	message := firstNonEmpty(strings.TrimSpace(result.Summary), "Validation failed")
+	details := strings.ToLower(strings.TrimSpace(strings.Join([]string{result.Summary, result.Output}, "\n")))
+	if containsAnyValidationHint(details, []string{"dirty worktree", "uncommitted changes", "merge conflict", "conflict markers", "ambiguous repo", "unsafe repo"}) {
+		return validationFailure{message: message, kind: FailureManualIntervention, resumePolicy: loops.ResumePolicyManualIntervention}
+	}
+	if containsAnyValidationHint(details, []string{"stale checkpoint", "stale repo", "stale repo context", "stale worktree", "head changed", "base changed", "branch changed", "out of date", "no longer matches"}) {
+		return validationFailure{message: message, kind: FailureRetryableAfterResume, resumePolicy: loops.ResumePolicyRestartFromDiscover}
+	}
+	if containsAnyValidationHint(details, []string{"command not found", "executable file not found", "timed out", "timeout", "connection reset", "connection refused", "temporary failure", "service unavailable", "network is unreachable", "transport error"}) {
+		return validationFailure{message: message, kind: FailureRetryableTransient, resumePolicy: loops.ResumePolicyReplayStep}
+	}
+	return validationFailure{message: message, kind: FailureRetryableAfterResume, resumePolicy: loops.ResumePolicyReplayStep}
+}
+
+func containsAnyValidationHint(message string, hints []string) bool {
+	for _, hint := range hints {
+		if strings.Contains(message, hint) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Runner) findOpenPullRequestForBranch(ctx context.Context, repo string, branches []string, baseBranch, cwd string) (*PullRequestSummary, error) {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -705,18 +705,19 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 			result.Skipped++
 			continue
 		}
-		loopResult, err := r.ensureLoopForDiscoveredIssue(ctx, *project, input.Repo, issue)
+		fingerprint := buildWorkerDiscoveryFingerprint(input.Repo, firstNonEmpty(derefString(project.BaseBranch), "main"), issue)
+		loopResult, err := r.ensureLoopForDiscoveredIssue(ctx, *project, input.Repo, issue, fingerprint)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
 		if loopResult.created {
 			result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
 		}
-		if loopResult.record.Status == "paused" || loopResult.record.Status == "completed" {
+		if loopResult.record.Status == "paused" || loopResult.record.Status == "completed" || loopResult.record.Status == "failed" {
 			result.Skipped++
 			continue
 		}
-		queueItem, err := r.enqueueDiscoveredIssue(ctx, *project, loopResult.record, input.Repo, issue)
+		queueItem, err := r.enqueueDiscoveredIssue(ctx, *project, loopResult.record, input.Repo, issue, fingerprint)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
@@ -790,6 +791,7 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 				updated.Status = "paused"
 			} else {
 				updated.Status = "failed"
+				stampWorkerFailedDiscoveryFingerprint(updated, queueItem)
 			}
 			updated.NextRunAt = nil
 		}
@@ -895,6 +897,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "paused"
 				} else {
 					updated.Status = "failed"
+					stampWorkerFailedDiscoveryFingerprint(updated, queueItem)
 				}
 				updated.NextRunAt = nil
 			}
@@ -936,6 +939,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 						updated.Status = "paused"
 					} else {
 						updated.Status = "failed"
+						stampWorkerFailedDiscoveryFingerprint(updated, queueItem)
 					}
 					updated.NextRunAt = nil
 				}
@@ -1940,22 +1944,23 @@ func (r *Runner) persistPullRequestReference(ctx context.Context, loop storage.L
 	})
 }
 
-func (r *Runner) ensureLoopForDiscoveredIssue(ctx context.Context, project storage.ProjectRecord, repo string, issue IssueSummary) (loopUpsertResult, error) {
+func (r *Runner) ensureLoopForDiscoveredIssue(ctx context.Context, project storage.ProjectRecord, repo string, issue IssueSummary, currentFingerprint string) (loopUpsertResult, error) {
 	nowISO := r.nowISO()
 	targetID := buildIssueTargetID(repo, issue.Number)
 	baseBranch := firstNonEmpty(derefString(project.BaseBranch), "main")
 	work := workerInput{Title: firstNonEmpty(issue.Title, buildDefaultIssueWorkerTitle(repo, issue.Number)), Repo: repo, BaseBranch: baseBranch, ExecutionMode: "create-pr", IssueNumber: issue.Number, IssueURL: issue.URL, AutoDiscovered: true}
 	workerMeta := map[string]any{"worker": mergeWorkerMetadata(parseJSONObject(nil), work)}
-	loops, err := r.repos.Loops.List(ctx)
+	existingLoops, err := r.repos.Loops.List(ctx)
 	if err != nil {
 		return loopUpsertResult{}, err
 	}
-	for _, existing := range loops {
+	for _, existing := range existingLoops {
 		if existing.Type == "worker" && existing.ProjectID == project.ID && existing.TargetType == "issue" && derefString(existing.TargetID) == targetID {
 			pausedOrCompleted := existing.Status == "paused" || existing.Status == "completed"
 			updated := existing
 			updated.Repo = &repo
-			if !pausedOrCompleted && updated.Status != "running" {
+			suppressFailedRevival := loops.ShouldSuppressFailedRediscovery(existing.Status, loops.LastFailedDiscoveryFingerprint(existing.MetadataJSON), currentFingerprint)
+			if !pausedOrCompleted && !suppressFailedRevival && updated.Status != "running" {
 				updated.Status = "queued"
 				updated.NextRunAt = &nowISO
 			}
@@ -1982,7 +1987,7 @@ func (r *Runner) ensureLoopForDiscoveredIssue(ctx context.Context, project stora
 	return loopUpsertResult{record: loop, created: true}, nil
 }
 
-func (r *Runner) enqueueDiscoveredIssue(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord, repo string, issue IssueSummary) (storage.QueueItemRecord, error) {
+func (r *Runner) enqueueDiscoveredIssue(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord, repo string, issue IssueSummary, fingerprint string) (storage.QueueItemRecord, error) {
 	dedupeKey := buildWorkerIssueDedupeKey(project.ID, repo, issue.Number)
 	existing, err := r.repos.Queue.FindActiveByDedupe(ctx, dedupeKey)
 	if err != nil {
@@ -1993,7 +1998,7 @@ func (r *Runner) enqueueDiscoveredIssue(ctx context.Context, project storage.Pro
 	}
 	nowISO := r.nowISO()
 	baseBranch := firstNonEmpty(derefString(project.BaseBranch), "main")
-	payload := mustMarshalJSON(workerInput{Title: firstNonEmpty(issue.Title, buildDefaultIssueWorkerTitle(repo, issue.Number)), Repo: repo, BaseBranch: baseBranch, ExecutionMode: "create-pr", IssueNumber: issue.Number, IssueURL: issue.URL, AutoDiscovered: true})
+	payload := mustMarshalJSON(map[string]any{"title": firstNonEmpty(issue.Title, buildDefaultIssueWorkerTitle(repo, issue.Number)), "repo": repo, "baseBranch": baseBranch, "executionMode": "create-pr", "issueNumber": issue.Number, "issueUrl": issue.URL, "autoDiscovered": true, "discoveryFingerprint": fingerprint})
 	targetID := buildIssueTargetID(repo, issue.Number)
 	lockKey := targetID
 	projectID := project.ID
@@ -2768,6 +2773,33 @@ func buildIssueTargetID(repo string, issueNumber int64) string {
 
 func buildWorkerIssueDedupeKey(projectID, repo string, issueNumber int64) string {
 	return fmt.Sprintf("worker:%s:%s:%d", projectID, repo, issueNumber)
+}
+
+func buildWorkerDiscoveryFingerprint(repo, baseBranch string, issue IssueSummary) string {
+	return loops.ComputeDiscoveryFingerprint(
+		"worker",
+		repo,
+		fmt.Sprintf("%d", issue.Number),
+		strings.TrimSpace(baseBranch),
+		strings.TrimSpace(issue.Title),
+		strings.TrimSpace(issue.Body),
+		strings.TrimSpace(issue.URL),
+		strings.Join(loops.CanonicalSortedStrings(issue.Labels), ","),
+		strings.Join(loops.CanonicalSortedStrings(issue.Assignees), ","),
+	)
+}
+
+func stampWorkerFailedDiscoveryFingerprint(updated *storage.LoopRecord, queueItem storage.QueueItemRecord) {
+	metadata := parseJSONObject(queueItem.PayloadJSON)
+	fingerprint := stringFromAnyDefault(metadata["discoveryFingerprint"])
+	if strings.TrimSpace(fingerprint) == "" {
+		return
+	}
+	merged, err := loops.MergeLastFailedDiscoveryFingerprint(updated.MetadataJSON, fingerprint)
+	if err != nil {
+		return
+	}
+	updated.MetadataJSON = stringPtr(merged)
 }
 
 func normalizeLogin(login string) string { return strings.ToLower(strings.TrimSpace(login)) }

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1348,17 +1348,49 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume {
+		t.Fatalf("result = %#v, want retryable_after_resume validation failure", result)
+	}
+	if len(completed) != 0 {
+		t.Fatalf("len(completed) = %d, want 0 for queued retry", len(completed))
+	}
+	if len(github.updateIssueCommentCalls) > 0 {
+		body := github.updateIssueCommentCalls[len(github.updateIssueCommentCalls)-1].Body
+		if strings.Contains(body, "paused work") || strings.Contains(body, "stopped work") {
+			t.Fatalf("issue comment updates = %#v, want no paused/stopped marker while queued retry is pending", github.updateIssueCommentCalls)
+		}
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "queued" {
+		t.Fatalf("queue = %#v, want queued retry item", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued", loop)
+	}
+}
+
+func TestProcessClaimedItemKeepsUnsafeValidationFailurePaused(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}, AgentExecutor: &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, ValidationRunner: func(context.Context, ValidationInput) (ValidationResult, error) {
+		return ValidationResult{Passed: false, Summary: "Unsafe repo ambiguity", Output: "dirty worktree detected"}, nil
+	}})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
 	if result.Status != "failed" || result.FailureKind != FailureManualIntervention {
-		t.Fatalf("result = %#v, want manual_intervention failure", result)
-	}
-	if len(completed) != 1 {
-		t.Fatalf("len(completed) = %d, want 1", len(completed))
-	}
-	if completed[0].Status != "failed" || completed[0].FailureKind != FailureManualIntervention || completed[0].Summary != "Validation failed" {
-		t.Fatalf("completed[0] = %#v, want manual intervention completion notice", completed[0])
-	}
-	if len(github.updateIssueCommentCalls) == 0 || !strings.Contains(github.updateIssueCommentCalls[len(github.updateIssueCommentCalls)-1].Body, "paused work") {
-		t.Fatalf("terminal issue comment updates = %#v, want paused marker body", github.updateIssueCommentCalls)
+		t.Fatalf("result = %#v, want manual_intervention unsafe validation failure", result)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
 	if err != nil {
@@ -1373,6 +1405,97 @@ func TestProcessClaimedItemValidationFailureRequeues(t *testing.T) {
 	}
 	if loop == nil || loop.Status != "paused" {
 		t.Fatalf("loop = %#v, want paused", loop)
+	}
+}
+
+func TestProcessClaimedItemTreatsWorkerSetupFailureAsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "failed", Summary: "agent setup: unsupported model for codex agent configuration"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient {
+		t.Fatalf("result = %#v, want retryable_transient setup failure", result)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "queued" {
+		t.Fatalf("queue = %#v, want queued retry", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued", loop)
+	}
+}
+
+func TestProcessClaimedItemRestartsFromDiscoverAfterStaleValidationFailure(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}, {Status: "completed", Summary: "done again", Stdout: "ok", ParseStatus: "parsed"}}}
+	validationCalls := 0
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone, ValidationRunner: func(context.Context, ValidationInput) (ValidationResult, error) {
+		validationCalls++
+		if validationCalls == 1 {
+			return ValidationResult{Passed: false, Summary: "Stale repo context", Output: "head changed while validation was pending"}, nil
+		}
+		return ValidationResult{Passed: true, Summary: "Validation passed"}, nil
+	}})
+
+	firstClaim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	first, err := runner.ProcessClaimedItem(context.Background(), *firstClaim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(first) error = %v", err)
+	}
+	if first.Status != "failed" || first.FailureKind != FailureRetryableAfterResume {
+		t.Fatalf("first = %#v, want retryable_after_resume stale validation failure", first)
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), first.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID(first) error = %v", err)
+	}
+	if run == nil {
+		t.Fatal("run = nil, want failed run")
+	}
+	checkpoint, err := parseCheckpoint(run.CheckpointJSON)
+	if err != nil {
+		t.Fatalf("parseCheckpoint(first) error = %v", err)
+	}
+	if checkpoint.ResumePolicy != "restart_from_discover" {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want restart_from_discover", checkpoint.ResumePolicy)
+	}
+	fixture.advance(5 * time.Second)
+	secondClaim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	second, err := runner.ProcessClaimedItem(context.Background(), *secondClaim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(second) error = %v", err)
+	}
+	if second.Status != "success" || second.PullRequestNumber != 101 {
+		t.Fatalf("second = %#v, want success after rediscovery-style restart", second)
+	}
+	if len(agent.starts) != 2 {
+		t.Fatalf("len(agent.starts) = %d, want 2 after restarting from discover", len(agent.starts))
+	}
+	if len(git.createCalls) != 2 {
+		t.Fatalf("len(git.createCalls) = %d, want 2 after restarting from discover", len(git.createCalls))
+	}
+	latestRun, err := fixture.repos.Runs.GetByID(context.Background(), second.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID(second) error = %v", err)
+	}
+	if latestRun == nil || latestRun.LastCompletedStep == nil || *latestRun.LastCompletedStep != string(stepOpenPR) {
+		t.Fatalf("latestRun = %#v, want successful rerun through open-pr", latestRun)
 	}
 }
 
@@ -1651,11 +1774,25 @@ func TestProcessClaimedItemSkippedFlowEmitsCompletionNotification(t *testing.T) 
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "skipped" || !strings.Contains(result.Summary, "manual PR opening required") {
-		t.Fatalf("result = %#v, want skipped manual intervention summary", result)
+	if result.Status != "failed" || result.FailureKind != FailureManualIntervention || !strings.Contains(result.Summary, "manual PR opening required") {
+		t.Fatalf("result = %#v, want manual_intervention summary", result)
 	}
-	if len(completed) != 1 || completed[0].Status != "skipped" || !strings.Contains(completed[0].Summary, "manual PR opening required") {
-		t.Fatalf("completed = %#v, want skipped completion notification", completed)
+	if len(completed) != 1 || completed[0].Status != "failed" || completed[0].FailureKind != FailureManualIntervention || !strings.Contains(completed[0].Summary, "manual PR opening required") {
+		t.Fatalf("completed = %#v, want manual_intervention completion notification", completed)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want terminal manual_intervention item", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused", loop)
 	}
 }
 
@@ -1689,14 +1826,28 @@ func TestProcessClaimedItemSkipsAutoPROpenWhenGitHubCLIUnavailable(t *testing.T)
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "skipped" || !strings.Contains(result.Summary, "GitHub CLI unavailable") {
-		t.Fatalf("result = %#v, want skipped GitHub CLI unavailable summary", result)
+	if result.Status != "failed" || result.FailureKind != FailureManualIntervention || !strings.Contains(result.Summary, "GitHub CLI unavailable") {
+		t.Fatalf("result = %#v, want manual_intervention GitHub CLI unavailable failure", result)
 	}
 	if len(git.pushCalls) != 0 {
 		t.Fatalf("len(git.pushCalls) = %d, want 0 when PR opening is gated before push", len(git.pushCalls))
 	}
-	if len(completed) != 1 || completed[0].Status != "skipped" || !strings.Contains(completed[0].Summary, "GitHub CLI unavailable") {
-		t.Fatalf("completed = %#v, want skipped completion notification for missing GitHub CLI", completed)
+	if len(completed) != 1 || completed[0].Status != "failed" || completed[0].FailureKind != FailureManualIntervention || !strings.Contains(completed[0].Summary, "GitHub CLI unavailable") {
+		t.Fatalf("completed = %#v, want manual_intervention completion notification for missing GitHub CLI", completed)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want terminal manual_intervention item", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused", loop)
 	}
 }
 
@@ -2054,8 +2205,8 @@ func TestProcessClaimedItemUsesIssueScopedLockForIssueWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "skipped" {
-		t.Fatalf("result = %#v, want skipped after manual PR gating", result)
+	if result.Status != "failed" || result.FailureKind != FailureManualIntervention {
+		t.Fatalf("result = %#v, want manual_intervention after manual PR gating", result)
 	}
 	lock, err := fixture.repos.Locks.Get(context.Background(), "issue:acme/looper:27")
 	if err != nil {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -176,6 +176,62 @@ func TestDiscoverIssuesPreservesExistingWorkerMetadataOnRediscovery(t *testing.T
 	}
 }
 
+func TestDiscoverIssuesSkipsFailedWorkerLoopWhenFingerprintUnchanged(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	issue := IssueSummary{Number: 91, Title: "Implement worker-ready", Body: "same body", URL: "https://github.com/acme/looper/issues/91", Assignees: []string{"octocat"}, Labels: []string{"looper:worker-ready"}}
+	fingerprint := buildWorkerDiscoveryFingerprint(repo, "main", issue)
+	metadata := fmt.Sprintf(`{"autonomousRecovery":{"lastFailedDiscoveryFingerprint":%q}}`, fingerprint)
+	targetID := buildIssueTargetID(repo, issue.Number)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_failed_same_fp", Seq: 99, ProjectID: "project_1", Type: "worker", TargetType: "issue", TargetID: &targetID, Repo: &repo, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{currentLogin: "octocat", issues: []IssueSummary{issue}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want none for unchanged failed fingerprint", result.QueueItems)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_failed_same_fp")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "failed" {
+		t.Fatalf("loop = %#v, want failed loop preserved", loop)
+	}
+}
+
+func TestDiscoverIssuesRequeuesFailedWorkerLoopWhenFingerprintChanges(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	oldIssue := IssueSummary{Number: 92, Title: "Implement worker-ready", Body: "old body", URL: "https://github.com/acme/looper/issues/92", Assignees: []string{"octocat"}, Labels: []string{"looper:worker-ready"}}
+	newIssue := IssueSummary{Number: 92, Title: "Implement worker-ready", Body: "new body", URL: "https://github.com/acme/looper/issues/92", Assignees: []string{"octocat"}, Labels: []string{"looper:worker-ready"}}
+	fingerprint := buildWorkerDiscoveryFingerprint(repo, "main", oldIssue)
+	metadata := fmt.Sprintf(`{"autonomousRecovery":{"lastFailedDiscoveryFingerprint":%q}}`, fingerprint)
+	targetID := buildIssueTargetID(repo, newIssue.Number)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_failed_changed_fp", Seq: 100, ProjectID: "project_1", Type: "worker", TargetType: "issue", TargetID: &targetID, Repo: &repo, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{currentLogin: "octocat", issues: []IssueSummary{newIssue}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want one queue item after fingerprint change", result.QueueItems)
+	}
+}
+
 func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -1532,11 +1588,12 @@ func TestProcessClaimedItemAutoDiscoveredIssueSkipsSelfAssignWhenAssigneePolicyD
 		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
 	}
 	issue := IssueSummary{Number: 52, Title: "Implement worker loop", URL: "https://example/issues/52", Labels: []string{"looper:worker-ready"}}
-	loopResult, err := runner.ensureLoopForDiscoveredIssue(context.Background(), *project, "acme/looper", issue)
+	fingerprint := buildWorkerDiscoveryFingerprint("acme/looper", derefString(project.BaseBranch), issue)
+	loopResult, err := runner.ensureLoopForDiscoveredIssue(context.Background(), *project, "acme/looper", issue, fingerprint)
 	if err != nil {
 		t.Fatalf("ensureLoopForDiscoveredIssue() error = %v", err)
 	}
-	queueItem, err := runner.enqueueDiscoveredIssue(context.Background(), *project, loopResult.record, "acme/looper", issue)
+	queueItem, err := runner.enqueueDiscoveredIssue(context.Background(), *project, loopResult.record, "acme/looper", issue, fingerprint)
 	if err != nil {
 		t.Fatalf("enqueueDiscoveredIssue() error = %v", err)
 	}

--- a/specs/2026-05-11-issue-269-pause-semantics/checklist.md
+++ b/specs/2026-05-11-issue-269-pause-semantics/checklist.md
@@ -1,0 +1,140 @@
+# Issue #269 — Pause Semantics Checklist
+
+## Phase 0 - Lock the semantics
+
+- [x] Document `paused` as “explicit operator hold or unsafe autonomous continuation only”
+- [x] Document that `manual_intervention` does not automatically imply discovery suppression
+- [ ] Document the allowed re-entry modes:
+  - [x] `advance_from_checkpoint`
+  - [x] `replay_step`
+  - [x] `restart_from_discover`
+  - [x] queue retry via retryable failure kinds
+- [x] Confirm that this issue does **not** introduce a large new persisted loop-status matrix
+- [x] Confirm that historical paused loops are not auto-unpaused in this change
+
+## Phase 1 - Shared policy helpers
+
+- [ ] Introduce shared helper(s) for “should this failure pause the loop?”
+- [ ] Introduce shared helper(s) for “should this state restart from discover?”
+- [ ] Introduce shared helper(s) for “is this a true hard hold?”
+- [ ] Introduce shared helper(s) for “should autonomous recovery be suppressed?”
+- [ ] Introduce shared helper(s) for default resume-policy normalization
+- [ ] Centralize the meaning of `manual_intervention` vs `restart_from_discover`
+- [ ] Remove duplicated ad hoc `FailureManualIntervention => paused` logic where practical
+- [ ] Ensure helper behavior can inspect queue outcome + resume policy together
+- [ ] Audit all `createRunContext` / resume-gating logic for `manual_intervention`
+- [ ] Audit all rediscovery/recovery filters that exclude loops by `paused`, `failed`, or `manual_intervention`
+- [ ] Centralize hard-hold vs safe-blocked semantics in one shared policy path
+
+## Phase 2 - Fixer
+
+- [x] Keep fixer agent setup failures retryable rather than permanently paused
+- [x] Keep fixer no-new-commit `resolve-comments` path rediscoverable
+- [x] Preserve explicit `restart_from_discover` semantics through run failure handling
+- [ ] Keep dirty worktree / unsafe repo states paused
+- [ ] Keep risky conflict gates paused when explicit human approval is required
+- [ ] Split auto-commit-disabled cases into:
+  - [ ] safe policy-blocked states
+  - [ ] genuinely unsafe manual-hold states
+- [ ] Decide v1 semantics for `allowAutoPush=false`
+- [ ] If `allowAutoPush=false` remains a hard hold in v1, document it as an explicit temporary exception
+- [ ] For fixer safe policy blockers, specify:
+  - [ ] expected loop status
+  - [ ] expected failure kind
+  - [ ] expected resume policy
+  - [ ] expected re-entry trigger
+  - [ ] expected user-facing summary/message
+- [ ] Ensure fixer discover still skips genuinely paused loops
+- [ ] Add/update fixer tests for:
+  - [x] agent setup failure
+  - [x] no-new-commit resolve-comments path
+  - [ ] dirty worktree unsafe hold
+  - [ ] risky conflict gate
+  - [ ] auto-commit-disabled safe vs unsafe split
+  - [ ] auto-push-disabled behavior
+
+## Phase 3 - Worker
+
+- [ ] Audit all worker `FailureManualIntervention` mappings
+- [ ] Reclassify transient setup / env / tooling failures to retryable states
+- [ ] Reclassify worker validation failure away from default permanent pause
+- [ ] Add bounded autonomous retry / resume semantics for validation failures
+- [ ] Split worker validation failures into:
+  - [ ] transient/tooling/transport
+  - [ ] stale checkpoint / stale repo-context
+  - [ ] unsafe repo ambiguity
+  - [ ] deterministic policy/spec/content
+- [ ] Define for each worker validation subtype:
+  - [ ] retry from checkpoint vs replay step vs restart from discover vs hard hold
+  - [ ] re-entry trigger
+- [ ] Reclassify safe policy blockers (`auto-push`, manual PR creation, external action required) away from unsafe pause semantics
+- [ ] Decide v1 semantics for manual PR opening mode
+- [ ] For each worker safe policy blocker, specify:
+  - [ ] hard hold vs safe blocked
+  - [ ] resume policy
+  - [ ] recovery trigger
+  - [ ] expected loop status
+  - [ ] expected user-facing summary/message
+- [ ] Keep truly unsafe repo/worktree states paused
+- [ ] Add/update worker tests for:
+  - [ ] validation failure no longer permanently pausing by default
+  - [ ] retryable transient setup failure
+  - [ ] safe policy blocker behavior
+  - [ ] unsafe repo-state hold
+
+## Phase 4 - Planner
+
+- [ ] Audit planner `manual_intervention` / paused mappings
+- [ ] Reclassify planner transient setup / env failures to retryable states
+- [ ] Keep explicit human-gated unsafe states paused
+- [ ] Ensure planner `createRunContext` only treats true hard holds as non-autonomous
+- [ ] For planner safe blocked states, specify:
+  - [ ] expected loop status
+  - [ ] expected failure kind
+  - [ ] expected resume policy
+  - [ ] expected re-entry trigger
+- [ ] Add/update planner tests for:
+  - [ ] transient agent/setup failure
+  - [ ] hard manual hold behavior
+  - [ ] safe re-entry behavior after non-paused failure
+
+## Phase 5 - Runtime / reviewer recovery
+
+- [ ] Keep `paused` loops excluded from runtime requeue
+- [ ] Keep reviewer auto-recovery blocked on true hard holds (`manual_intervention` policy/kind)
+- [ ] Ensure reviewer/runtime paths do not depend on over-broad upstream use of `manual_intervention`
+- [ ] Audit reviewer follow-up loop selection for over-broad exclusion of failed loops
+- [ ] Audit reviewer recovery gating for `manual_intervention` assumptions
+- [ ] Add reviewer tests distinguishing hard hold vs safe retryable blocked states
+- [ ] Add/update runtime tests for:
+  - [ ] paused loops never requeue
+  - [ ] reviewer hard-hold states do not auto-recover
+  - [ ] safe retryable reviewer states can still auto-recover when eligible
+
+## Phase 6 - Anti-thrash and recovery safety
+
+- [ ] Confirm retry budgets still bound newly retryable states
+- [ ] Confirm exponential backoff still applies where queue retries are used
+- [ ] Confirm rediscoverable states have a concrete state-change boundary or dedupe guard
+- [ ] Verify no hot-loop regression in the newly rediscoverable fixer/worker/planner paths
+
+## Phase 7 - Migration and follow-up policy
+
+- [ ] Confirm this issue only changes new-write semantics by default
+- [ ] Define cancellation semantics:
+  - [ ] operator/human stop implying `paused`
+  - [ ] terminal stop without pause
+  - [ ] retry suppression without unsafe-pause semantics
+- [ ] Decide whether a separate reconciliation pass is needed for old paused loops
+- [ ] If reconciliation is added later, define how to distinguish safe old pauses from unsafe old pauses
+
+## Phase 8 - Verification
+
+- [ ] Verify CLI/API/user-facing outputs do not label safe blocked states as “paused”
+- [ ] Verify notifications/comments distinguish hard hold vs retryable/safe blocked failures
+- [x] Run fixer tests
+- [ ] Run worker tests
+- [ ] Run planner tests
+- [ ] Run runtime tests
+- [x] Run full `go test ./...`
+- [x] Verify any unrelated pre-existing failures separately from issue-269 changes

--- a/specs/2026-05-11-issue-269-pause-semantics/checklist.md
+++ b/specs/2026-05-11-issue-269-pause-semantics/checklist.md
@@ -33,24 +33,24 @@
 - [x] Preserve explicit `restart_from_discover` semantics through run failure handling
 - [x] Keep dirty worktree / unsafe repo states paused
 - [x] Keep risky conflict gates paused when explicit human approval is required
-- [ ] Split auto-commit-disabled cases into:
-  - [ ] safe policy-blocked states
-  - [x] genuinely unsafe manual-hold states
+- [x] Clarify fixer `allowAutoCommit=false` semantics:
+  - [x] no separate safe policy-blocked state exists in current fixer behavior
+  - [x] genuinely unsafe manual-hold states stay paused
 - [x] Decide v1 semantics for `allowAutoPush=false`
 - [x] If `allowAutoPush=false` remains a hard hold in v1, document it as an explicit temporary exception
-- [ ] For fixer safe policy blockers, specify:
-  - [ ] expected loop status
-  - [ ] expected failure kind
-  - [ ] expected resume policy
-  - [ ] expected re-entry trigger
-  - [ ] expected user-facing summary/message
+- [x] For the current fixer v1 policy-blocker exception (`allowAutoPush=false`), specify:
+  - [x] expected loop status
+  - [x] expected failure kind
+  - [x] expected resume policy
+  - [x] expected re-entry trigger
+  - [x] expected user-facing summary/message
 - [x] Ensure fixer discover still skips genuinely paused loops
-- [ ] Add/update fixer tests for:
+- [x] Add/update fixer tests for:
   - [x] agent setup failure
   - [x] no-new-commit resolve-comments path
   - [x] dirty worktree unsafe hold
   - [x] risky conflict gate
-  - [ ] auto-commit-disabled safe vs unsafe split
+  - [x] auto-commit-disabled semantics are documented as unsafe/manual only
   - [x] auto-push-disabled behavior
 
 ## Phase 3 - Worker

--- a/specs/2026-05-11-issue-269-pause-semantics/checklist.md
+++ b/specs/2026-05-11-issue-269-pause-semantics/checklist.md
@@ -55,48 +55,49 @@
 
 ## Phase 3 - Worker
 
-- [ ] Audit all worker `FailureManualIntervention` mappings
-- [ ] Reclassify transient setup / env / tooling failures to retryable states
-- [ ] Reclassify worker validation failure away from default permanent pause
-- [ ] Add bounded autonomous retry / resume semantics for validation failures
+- [x] Audit all worker `FailureManualIntervention` mappings
+- [x] Reclassify transient setup / env / tooling failures to retryable states
+- [x] Reclassify worker validation failure away from default permanent pause
+- [x] Add bounded autonomous retry / resume semantics for validation failures
 - [ ] Split worker validation failures into:
-  - [ ] transient/tooling/transport
-  - [ ] stale checkpoint / stale repo-context
-  - [ ] unsafe repo ambiguity
-  - [ ] deterministic policy/spec/content
+  - [x] transient/tooling/transport
+  - [x] stale checkpoint / stale repo-context
+  - [x] unsafe repo ambiguity
+  - [x] deterministic policy/spec/content
 - [ ] Define for each worker validation subtype:
-  - [ ] retry from checkpoint vs replay step vs restart from discover vs hard hold
-  - [ ] re-entry trigger
-- [ ] Reclassify safe policy blockers (`auto-push`, manual PR creation, external action required) away from unsafe pause semantics
-- [ ] Decide v1 semantics for manual PR opening mode
+  - [x] retry from checkpoint vs replay step vs restart from discover vs hard hold
+  - [x] re-entry trigger
+- [x] Reclassify safe policy blockers (`auto-push`, manual PR creation, external action required) away from unsafe pause semantics
+- [x] Decide v1 semantics for manual PR opening mode
 - [ ] For each worker safe policy blocker, specify:
-  - [ ] hard hold vs safe blocked
-  - [ ] resume policy
-  - [ ] recovery trigger
-  - [ ] expected loop status
-  - [ ] expected user-facing summary/message
-- [ ] Keep truly unsafe repo/worktree states paused
+  - [x] hard hold vs safe blocked
+  - [x] resume policy
+  - [x] recovery trigger
+  - [x] expected loop status
+  - [x] expected user-facing summary/message
+- [x] Keep truly unsafe repo/worktree states paused
 - [ ] Add/update worker tests for:
-  - [ ] validation failure no longer permanently pausing by default
-  - [ ] retryable transient setup failure
+  - [x] validation failure no longer permanently pausing by default
+  - [x] retryable transient setup failure
   - [ ] safe policy blocker behavior
-  - [ ] unsafe repo-state hold
+  - [x] unsafe repo-state hold
+  - [x] stale validation rediscovery behavior
 
 ## Phase 4 - Planner
 
-- [ ] Audit planner `manual_intervention` / paused mappings
-- [ ] Reclassify planner transient setup / env failures to retryable states
-- [ ] Keep explicit human-gated unsafe states paused
-- [ ] Ensure planner `createRunContext` only treats true hard holds as non-autonomous
+- [x] Audit planner `manual_intervention` / paused mappings
+- [x] Reclassify planner transient setup / env failures to retryable states
+- [x] Keep explicit human-gated unsafe states paused
+- [x] Ensure planner `createRunContext` only treats true hard holds as non-autonomous
 - [ ] For planner safe blocked states, specify:
-  - [ ] expected loop status
-  - [ ] expected failure kind
-  - [ ] expected resume policy
-  - [ ] expected re-entry trigger
+  - [x] expected loop status
+  - [x] expected failure kind
+  - [x] expected resume policy
+  - [x] expected re-entry trigger
 - [ ] Add/update planner tests for:
-  - [ ] transient agent/setup failure
+  - [x] transient agent/setup failure
   - [ ] hard manual hold behavior
-  - [ ] safe re-entry behavior after non-paused failure
+  - [x] safe re-entry behavior after non-paused failure
 
 ## Phase 5 - Runtime / reviewer recovery
 

--- a/specs/2026-05-11-issue-269-pause-semantics/checklist.md
+++ b/specs/2026-05-11-issue-269-pause-semantics/checklist.md
@@ -14,44 +14,44 @@
 
 ## Phase 1 - Shared policy helpers
 
-- [ ] Introduce shared helper(s) for “should this failure pause the loop?”
-- [ ] Introduce shared helper(s) for “should this state restart from discover?”
-- [ ] Introduce shared helper(s) for “is this a true hard hold?”
-- [ ] Introduce shared helper(s) for “should autonomous recovery be suppressed?”
-- [ ] Introduce shared helper(s) for default resume-policy normalization
-- [ ] Centralize the meaning of `manual_intervention` vs `restart_from_discover`
-- [ ] Remove duplicated ad hoc `FailureManualIntervention => paused` logic where practical
-- [ ] Ensure helper behavior can inspect queue outcome + resume policy together
-- [ ] Audit all `createRunContext` / resume-gating logic for `manual_intervention`
+- [x] Introduce shared helper(s) for “should this failure pause the loop?”
+- [x] Introduce shared helper(s) for “should this state restart from discover?”
+- [x] Introduce shared helper(s) for “is this a true hard hold?”
+- [x] Introduce shared helper(s) for “should autonomous recovery be suppressed?”
+- [x] Introduce shared helper(s) for default resume-policy normalization
+- [x] Centralize the meaning of `manual_intervention` vs `restart_from_discover`
+- [x] Remove duplicated ad hoc `FailureManualIntervention => paused` logic where practical
+- [x] Ensure helper behavior can inspect queue outcome + resume policy together
+- [x] Audit all `createRunContext` / resume-gating logic for `manual_intervention`
 - [ ] Audit all rediscovery/recovery filters that exclude loops by `paused`, `failed`, or `manual_intervention`
-- [ ] Centralize hard-hold vs safe-blocked semantics in one shared policy path
+- [x] Centralize hard-hold vs safe-blocked semantics in one shared policy path
 
 ## Phase 2 - Fixer
 
 - [x] Keep fixer agent setup failures retryable rather than permanently paused
 - [x] Keep fixer no-new-commit `resolve-comments` path rediscoverable
 - [x] Preserve explicit `restart_from_discover` semantics through run failure handling
-- [ ] Keep dirty worktree / unsafe repo states paused
-- [ ] Keep risky conflict gates paused when explicit human approval is required
+- [x] Keep dirty worktree / unsafe repo states paused
+- [x] Keep risky conflict gates paused when explicit human approval is required
 - [ ] Split auto-commit-disabled cases into:
   - [ ] safe policy-blocked states
-  - [ ] genuinely unsafe manual-hold states
-- [ ] Decide v1 semantics for `allowAutoPush=false`
-- [ ] If `allowAutoPush=false` remains a hard hold in v1, document it as an explicit temporary exception
+  - [x] genuinely unsafe manual-hold states
+- [x] Decide v1 semantics for `allowAutoPush=false`
+- [x] If `allowAutoPush=false` remains a hard hold in v1, document it as an explicit temporary exception
 - [ ] For fixer safe policy blockers, specify:
   - [ ] expected loop status
   - [ ] expected failure kind
   - [ ] expected resume policy
   - [ ] expected re-entry trigger
   - [ ] expected user-facing summary/message
-- [ ] Ensure fixer discover still skips genuinely paused loops
+- [x] Ensure fixer discover still skips genuinely paused loops
 - [ ] Add/update fixer tests for:
   - [x] agent setup failure
   - [x] no-new-commit resolve-comments path
-  - [ ] dirty worktree unsafe hold
-  - [ ] risky conflict gate
+  - [x] dirty worktree unsafe hold
+  - [x] risky conflict gate
   - [ ] auto-commit-disabled safe vs unsafe split
-  - [ ] auto-push-disabled behavior
+  - [x] auto-push-disabled behavior
 
 ## Phase 3 - Worker
 
@@ -133,8 +133,8 @@
 - [ ] Verify CLI/API/user-facing outputs do not label safe blocked states as “paused”
 - [ ] Verify notifications/comments distinguish hard hold vs retryable/safe blocked failures
 - [x] Run fixer tests
-- [ ] Run worker tests
-- [ ] Run planner tests
-- [ ] Run runtime tests
+- [x] Run worker tests
+- [x] Run planner tests
+- [x] Run runtime tests
 - [x] Run full `go test ./...`
 - [x] Verify any unrelated pre-existing failures separately from issue-269 changes

--- a/specs/2026-05-11-issue-269-pause-semantics/checklist.md
+++ b/specs/2026-05-11-issue-269-pause-semantics/checklist.md
@@ -4,7 +4,7 @@
 
 - [x] Document `paused` as “explicit operator hold or unsafe autonomous continuation only”
 - [x] Document that `manual_intervention` does not automatically imply discovery suppression
-- [ ] Document the allowed re-entry modes:
+- [x] Document the allowed re-entry modes:
   - [x] `advance_from_checkpoint`
   - [x] `replay_step`
   - [x] `restart_from_discover`
@@ -23,7 +23,7 @@
 - [x] Remove duplicated ad hoc `FailureManualIntervention => paused` logic where practical
 - [x] Ensure helper behavior can inspect queue outcome + resume policy together
 - [x] Audit all `createRunContext` / resume-gating logic for `manual_intervention`
-- [ ] Audit all rediscovery/recovery filters that exclude loops by `paused`, `failed`, or `manual_intervention`
+- [x] Audit all rediscovery/recovery filters that exclude loops by `paused`, `failed`, or `manual_intervention`
 - [x] Centralize hard-hold vs safe-blocked semantics in one shared policy path
 
 ## Phase 2 - Fixer
@@ -59,27 +59,27 @@
 - [x] Reclassify transient setup / env / tooling failures to retryable states
 - [x] Reclassify worker validation failure away from default permanent pause
 - [x] Add bounded autonomous retry / resume semantics for validation failures
-- [ ] Split worker validation failures into:
+- [x] Split worker validation failures into:
   - [x] transient/tooling/transport
   - [x] stale checkpoint / stale repo-context
   - [x] unsafe repo ambiguity
   - [x] deterministic policy/spec/content
-- [ ] Define for each worker validation subtype:
+- [x] Define for each worker validation subtype:
   - [x] retry from checkpoint vs replay step vs restart from discover vs hard hold
   - [x] re-entry trigger
 - [x] Reclassify safe policy blockers (`auto-push`, manual PR creation, external action required) away from unsafe pause semantics
 - [x] Decide v1 semantics for manual PR opening mode
-- [ ] For each worker safe policy blocker, specify:
+- [x] For each worker safe policy blocker, specify:
   - [x] hard hold vs safe blocked
   - [x] resume policy
   - [x] recovery trigger
   - [x] expected loop status
   - [x] expected user-facing summary/message
 - [x] Keep truly unsafe repo/worktree states paused
-- [ ] Add/update worker tests for:
+- [x] Add/update worker tests for:
   - [x] validation failure no longer permanently pausing by default
   - [x] retryable transient setup failure
-  - [ ] safe policy blocker behavior
+  - [x] safe policy blocker behavior
   - [x] unsafe repo-state hold
   - [x] stale validation rediscovery behavior
 
@@ -89,50 +89,50 @@
 - [x] Reclassify planner transient setup / env failures to retryable states
 - [x] Keep explicit human-gated unsafe states paused
 - [x] Ensure planner `createRunContext` only treats true hard holds as non-autonomous
-- [ ] For planner safe blocked states, specify:
+- [x] For planner safe blocked states, specify:
   - [x] expected loop status
   - [x] expected failure kind
   - [x] expected resume policy
   - [x] expected re-entry trigger
-- [ ] Add/update planner tests for:
+- [x] Add/update planner tests for:
   - [x] transient agent/setup failure
-  - [ ] hard manual hold behavior
+  - [x] hard manual hold behavior
   - [x] safe re-entry behavior after non-paused failure
 
 ## Phase 5 - Runtime / reviewer recovery
 
-- [ ] Keep `paused` loops excluded from runtime requeue
-- [ ] Keep reviewer auto-recovery blocked on true hard holds (`manual_intervention` policy/kind)
-- [ ] Ensure reviewer/runtime paths do not depend on over-broad upstream use of `manual_intervention`
-- [ ] Audit reviewer follow-up loop selection for over-broad exclusion of failed loops
-- [ ] Audit reviewer recovery gating for `manual_intervention` assumptions
-- [ ] Add reviewer tests distinguishing hard hold vs safe retryable blocked states
-- [ ] Add/update runtime tests for:
-  - [ ] paused loops never requeue
-  - [ ] reviewer hard-hold states do not auto-recover
-  - [ ] safe retryable reviewer states can still auto-recover when eligible
+- [x] Keep `paused` loops excluded from runtime requeue
+- [x] Keep reviewer auto-recovery blocked on true hard holds (`manual_intervention` policy/kind)
+- [x] Ensure reviewer/runtime paths do not depend on over-broad upstream use of `manual_intervention`
+- [x] Audit reviewer follow-up loop selection for over-broad exclusion of failed loops
+- [x] Audit reviewer recovery gating for `manual_intervention` assumptions
+- [x] Add reviewer tests distinguishing hard hold vs safe retryable blocked states
+- [x] Add/update runtime tests for:
+  - [x] paused loops never requeue
+  - [x] reviewer hard-hold states do not auto-recover
+  - [x] safe retryable reviewer states can still auto-recover when eligible
 
 ## Phase 6 - Anti-thrash and recovery safety
 
-- [ ] Confirm retry budgets still bound newly retryable states
-- [ ] Confirm exponential backoff still applies where queue retries are used
-- [ ] Confirm rediscoverable states have a concrete state-change boundary or dedupe guard
-- [ ] Verify no hot-loop regression in the newly rediscoverable fixer/worker/planner paths
+- [x] Confirm retry budgets still bound newly retryable states
+- [x] Confirm exponential backoff still applies where queue retries are used
+- [x] Confirm rediscoverable states have a concrete state-change boundary or dedupe guard
+- [x] Verify no hot-loop regression in the newly rediscoverable fixer/worker/planner paths
 
 ## Phase 7 - Migration and follow-up policy
 
-- [ ] Confirm this issue only changes new-write semantics by default
-- [ ] Define cancellation semantics:
-  - [ ] operator/human stop implying `paused`
-  - [ ] terminal stop without pause
-  - [ ] retry suppression without unsafe-pause semantics
-- [ ] Decide whether a separate reconciliation pass is needed for old paused loops
-- [ ] If reconciliation is added later, define how to distinguish safe old pauses from unsafe old pauses
+- [x] Confirm this issue only changes new-write semantics by default
+- [x] Define cancellation semantics:
+  - [x] operator/human stop implying `paused`
+  - [x] terminal stop without pause
+  - [x] retry suppression without unsafe-pause semantics
+- [x] Decide whether a separate reconciliation pass is needed for old paused loops
+- [x] If reconciliation is added later, define how to distinguish safe old pauses from unsafe old pauses
 
 ## Phase 8 - Verification
 
-- [ ] Verify CLI/API/user-facing outputs do not label safe blocked states as “paused”
-- [ ] Verify notifications/comments distinguish hard hold vs retryable/safe blocked failures
+- [x] Verify CLI/API/user-facing outputs do not label safe blocked states as “paused”
+- [x] Verify notifications/comments distinguish hard hold vs retryable/safe blocked failures
 - [x] Run fixer tests
 - [x] Run worker tests
 - [x] Run planner tests

--- a/specs/2026-05-11-issue-269-pause-semantics/spec.md
+++ b/specs/2026-05-11-issue-269-pause-semantics/spec.md
@@ -228,6 +228,13 @@ Required semantics:
 - risky conflict states requiring explicit human approval
 - auto-commit-disabled cases only when the repo is left in a genuinely unsafe/manual state
 
+Current Phase 2 implementation decision for `allowAutoCommit=false`:
+
+- fixer has no separate safe policy-blocked `allowAutoCommit=false` path today
+- `allowAutoCommit` is only consulted when reconcile detects uncommitted changes
+- that case is treated as an unsafe/manual hold because Looper cannot safely infer whether to commit, amend, discard, or wait for human inspection
+- any future safe `allowAutoCommit=false` semantics require an explicit autonomous re-entry model and are deferred beyond fixer Phase 2
+
 ### Policy blockers
 
 `allowAutoPush=false` should not disappear into a hidden permanent pause.

--- a/specs/2026-05-11-issue-269-pause-semantics/spec.md
+++ b/specs/2026-05-11-issue-269-pause-semantics/spec.md
@@ -274,6 +274,15 @@ Validation failures must be split at least into:
 
 These categories should not all map to the same resume policy or loop status.
 
+Current implementation slice:
+
+- transient worker agent setup failures are retryable rather than hard-held
+- generic validation failures no longer default to `manual_intervention`
+- transient/tooling-style validation failures now stay autonomous with retry semantics
+- stale worker validation failures now restart from discovery rather than pausing
+- unsafe repo-ambiguity validation failures still hard-hold and pause
+- safe policy-blocker refinements are still pending follow-up work
+
 ### Still pause
 
 - stale/inconsistent repo state that is unsafe to continue
@@ -283,6 +292,13 @@ These categories should not all map to the same resume policy or loop status.
 
 - auto-push / manual-PR / safe policy blockers away from “unsafe pause” semantics
 - transient GitHub/tooling/setup failures to retryable states
+
+Current implementation slice for worker policy blockers:
+
+- `openPRStrategy=manual` is treated as an intentional terminal handoff, not a blocked autonomous failure
+- worker `allowAutoPush=false` remains a temporary v1 hard-hold exception
+- worker GitHub CLI unavailable remains a temporary v1 hard-hold exception
+- the `allowAutoPush=false` / missing-CLI exceptions should only be relaxed once there is a concrete trigger model for config/tool/manual-completion changes that does not cause rediscovery thrash
 
 For each worker blocker moved out of `paused`, the implementation must define:
 
@@ -301,6 +317,12 @@ Planner should follow the same rule:
 - `manual_intervention` should only mean actual hard hold
 
 Planner `createRunContext` should only suppress automatic continuation when the prior run truly represents a hard hold, not just any blocked state.
+
+Current implementation slice:
+
+- transient planner agent setup failures now stay retryable
+- planner pause/recovery updates now use the shared hard-hold semantics instead of ad hoc `manual_intervention` checks
+- planner `allowAutoPush=false` remains a temporary v1 hard-hold exception until there is a concrete non-thrashing re-entry trigger
 
 ## 7.4 Reviewer / runtime auto-recovery
 

--- a/specs/2026-05-11-issue-269-pause-semantics/spec.md
+++ b/specs/2026-05-11-issue-269-pause-semantics/spec.md
@@ -238,6 +238,12 @@ Recommended v1 treatment:
 - keep the loop visible for rediscovery only when there is a meaningful state change trigger
 - if that state-change gate is not yet implemented, explicitly treat it as a temporary hard-hold exception and document that exception clearly
 
+Current Phase 2 implementation decision:
+
+- `allowAutoPush=false` remains a temporary hard-hold exception in v1
+- the fixer run now fails with `manual_intervention` and leaves the loop `paused` rather than silently completing as skipped
+- this exception should be revisited once there is a concrete autonomous re-entry trigger for policy changes or manual push completion
+
 Safe policy blockers must **not** keep using `manual_intervention` as a compatibility label while still being considered autonomous. If a v1 path still uses `manual_intervention`, it must be treated as a true hard hold and excluded from the “issue solved” set for that scenario.
 
 ## 7.2 Worker

--- a/specs/2026-05-11-issue-269-pause-semantics/spec.md
+++ b/specs/2026-05-11-issue-269-pause-semantics/spec.md
@@ -346,6 +346,14 @@ Reviewer-side logic must also be audited for over-broad suppression outside loop
 
 No safe blocked state should remain effectively treated as a hard hold just because one of these secondary gates still assumes `manual_intervention` means “no autonomy forever”.
 
+Current implementation slice:
+
+- runtime reviewer auto-recovery now uses the shared loop policy helper to determine whether a failed reviewer loop is a true hard hold
+- reviewer failed-loop recovery gating now normalizes resume policy before deciding whether autonomy is suppressed
+- reviewer failure finalization now uses the shared pause helper, so only true hard holds and cancelled queue items settle into `paused`
+- runtime `shouldRequeueLoop(...)` remains strict: paused loops are still excluded from requeue, and the fix is entirely upstream classification rather than redefining `paused`
+- reviewer follow-up discovery still intentionally excludes failed loops, because failed reviewer loops recover through the dedicated failed-loop recovery path rather than generic follow-up rediscovery
+
 ## 7.5 Cancellation semantics
 
 Current code sometimes treats cancelled queue items as pause-adjacent, but this issue needs an explicit rule.
@@ -357,6 +365,12 @@ The implementation must define when cancellation means:
 3. retry suppression without redefining the loop as unsafe
 
 Cancellation semantics should not remain an implicit side effect of existing queue-state checks.
+
+Current implementation decision:
+
+- cancelling active queue items as part of an explicit operator/human stop remains pause-adjacent and leaves the loop `paused`
+- terminal non-paused stops continue to use the existing lifecycle states (`completed`, `failed`, `terminated`) rather than queue cancellation
+- retry suppression without unsafe-pause semantics continues to use non-paused failed states plus retry-budget/whitelist gating, not queue cancellation
 
 ---
 
@@ -387,6 +401,12 @@ If a reconciliation pass is added later, it must distinguish:
 
 - unsafe historical pauses that must remain paused
 - safe historical pauses that can be reintroduced into discovery/recovery
+
+Current implementation decision:
+
+- this issue changes only new writes and new recovery decisions
+- no automatic reconciliation pass is added in this issue
+- any later reconciliation pass must distinguish explicit/manual or unsafe historical pauses from safe historical pauses using persisted failure kind, resume policy, and contextual loop metadata rather than blindly unpausing all paused loops
 
 ---
 

--- a/specs/2026-05-11-issue-269-pause-semantics/spec.md
+++ b/specs/2026-05-11-issue-269-pause-semantics/spec.md
@@ -1,0 +1,397 @@
+# Issue #269 — Narrow `paused` Semantics and Restore Safe Autonomous Re-entry
+
+## 1. Background
+
+Looper currently uses three concepts too loosely and too interchangeably:
+
+- queue failure kind: `manual_intervention`
+- checkpoint resume policy: `manual_intervention`
+- loop status: `paused`
+
+In practice, many non-terminal or still-safe situations eventually land in `paused`, and `paused` currently means “removed from autonomous recovery”. That is too strong for transient infra failures, policy blockers, validation failures, stale checkpoint mismatches, or missing context that could safely re-enter later.
+
+The result is a product mismatch:
+
+> Looper is supposed to minimize human intervention, but today many blocked-but-safe loops become effectively invisible to autonomous recovery.
+
+This spec defines a minimal implementation path that fixes that behavior without first exploding the lifecycle model into many new persisted statuses.
+
+---
+
+## 2. Problem summary
+
+Today the main suppression bit is not merely the string `manual_intervention`.
+
+The real problem is that many code paths map a blocked or ambiguous outcome to:
+
+- `ResumePolicy = "manual_intervention"`
+- `Loop.Status = "paused"`
+
+and the runtime then treats `paused` as a hard exclusion from:
+
+- requeue
+- rediscovery
+- reviewer auto-recovery
+
+This conflates several different situations:
+
+1. explicit human/operator hold
+2. unsafe repository or worktree state
+3. transient environment or infrastructure failure
+4. policy/config blockers
+5. stale checkpoint / workflow mismatch that should rediscover
+6. validation failure during autonomous execution
+
+Those categories should not share the same scheduling semantics.
+
+---
+
+## 3. Goals
+
+### 3.1 Primary goals
+
+1. Make `paused` mean only:
+   - explicit operator hold, or
+   - unsafe / ambiguous autonomous continuation
+2. Stop using `paused` as the default sink for blocked-but-safe states.
+3. Give every stopped loop an explicit re-entry mode.
+4. Preserve anti-thrash behavior when making more states autonomous.
+
+### 3.2 Non-goals
+
+1. Do not introduce a large new persisted loop-status matrix in this change.
+2. Do not auto-unpause all historical paused loops blindly.
+3. Do not broaden autonomy for unsafe repository states.
+
+---
+
+## 4. Design principles
+
+### 4.1 Keep lifecycle status narrow
+
+Loop lifecycle status should remain narrow:
+
+- `queued`
+- `running`
+- `failed`
+- `completed`
+- `paused`
+
+The nuance should live primarily in failure classification, resume policy, and scheduler behavior.
+
+### 4.2 Separate “blocked” from “hard hold”
+
+`manual_intervention` should no longer automatically imply `paused`.
+
+Instead, Looper must decide independently:
+
+1. is this unsafe enough to pause?
+2. if not paused, how does it re-enter?
+3. what retry/backoff limits apply?
+
+### 4.3 No broadened autonomy without re-entry semantics
+
+Any scenario moved out of `paused` must define one of these re-entry modes:
+
+- `advance_from_checkpoint`
+- `replay_step`
+- `restart_from_discover`
+- queued retry after backoff (`retryable_transient` / `retryable_after_resume`)
+- explicit human-only hold (`manual_intervention`)
+
+---
+
+## 5. Classification model
+
+## 5.1 States that should still end in `paused`
+
+These remain hard holds because autonomous continuation is unsafe or intentionally human-gated:
+
+1. explicit operator pause
+2. unsafe / dirty / ambiguous worktree state
+3. high-risk conflict states intentionally gated on manual approval
+4. any case where the current repo/worktree state cannot safely be retried or rediscovered automatically
+
+## 5.2 States that should become retryable or rediscoverable instead
+
+These should remain visible to autonomous recovery:
+
+1. transient agent setup / environment / network failures
+2. GitHub / CLI / tooling failures that are transient rather than fundamentally unsafe
+3. policy blockers that are safe but external-action-dependent
+4. validation failures, after bounded retry semantics
+5. stale checkpoint mismatches that should restart from discovery
+6. fixer no-op resolve-comments paths where the code state is safe but the current run cannot prove push evidence
+
+---
+
+## 6. Proposed implementation shape
+
+## 6.1 Shared decision helper at the runner layer
+
+Introduce a small shared helper package for scheduling semantics rather than duplicating ad hoc `if failure == manual_intervention { paused }` logic in each runner.
+
+The helper should answer:
+
+1. is this a true hard hold?
+2. should autonomous recovery be suppressed?
+3. should the loop be paused after this failure?
+4. should the loop become `queued` again?
+5. should the loop become `failed` but remain rediscoverable later?
+6. which resume policy / re-entry mode applies?
+
+It does **not** need to persist a new entity type. It can be a small policy function over:
+
+- failure kind
+- queue terminal/retry outcome
+- explicit resume policy
+- optional reason category
+
+Recommended shape:
+
+- package-local shared helper under `internal/loops` or another low-dependency internal package
+- explicit helpers such as:
+  - `IsHardHold(...)`
+  - `SuppressesAutonomousRecovery(...)`
+  - `ShouldPauseLoopAfterFailure(...)`
+  - `ShouldRestartFromDiscover(...)`
+  - `IsManualHoldResumePolicy(...)`
+  - `DefaultResumePolicy(...)`
+
+The exact name is less important than centralizing the rule.
+
+This policy must be reused by all places that currently infer semantics indirectly, including:
+
+- runner failure handling
+- `createRunContext` / resume gating
+- rediscovery filters
+- runtime recovery / auto-recovery gates
+- user-facing status/message generation where pause semantics are surfaced
+
+## 6.2 Resume-policy meanings
+
+Standardize the semantic meaning of these resume policies:
+
+- `manual_intervention`
+  - human-only hold
+  - should suppress autonomous resume/rediscovery
+- `restart_from_discover`
+  - safe to re-enter, but not by replaying stale checkpoint state
+- `advance_from_checkpoint`
+  - safe to continue from later step after queue retry
+- `replay_step`
+  - safe to rerun the current step
+- `retry_from_timeout_context`
+  - safe bounded retry from stored timeout context
+
+`manual_intervention` must no longer be the default label for every non-successful blocked state.
+
+## 6.3 Re-entry mode and re-entry trigger are both required
+
+It is not enough to mark a state as merely “rediscoverable later”.
+
+Every blocked-but-non-paused state must declare both:
+
+1. **re-entry mode**
+2. **re-entry trigger / source**
+
+Allowed trigger categories include:
+
+- queue retry after backoff
+- PR/head SHA or fix-items hash change
+- fresh discovery pass
+- explicit human resume action
+- timeout-context retry
+- config / policy change
+
+If a scenario cannot name a concrete re-entry trigger, it must not be treated as a safe autonomous state yet.
+
+---
+
+## 7. Role-by-role plan
+
+## 7.1 Fixer
+
+Fixer is the first implementation lane because it already exposes the product mismatch clearly.
+
+Required semantics:
+
+### Stay autonomous
+
+- agent setup failures → `retryable_transient`
+- no-new-commit `resolve-comments` path → `retryable_after_resume` + `restart_from_discover`
+- any safe checkpoint mismatch that should rediscover rather than pause
+
+### Stay paused
+
+- dirty worktree / unsafe repo state
+- risky conflict states requiring explicit human approval
+- auto-commit-disabled cases only when the repo is left in a genuinely unsafe/manual state
+
+### Policy blockers
+
+`allowAutoPush=false` should not disappear into a hidden permanent pause.
+
+Recommended v1 treatment:
+
+- classify as human-action-required but safe
+- keep the loop visible for rediscovery only when there is a meaningful state change trigger
+- if that state-change gate is not yet implemented, explicitly treat it as a temporary hard-hold exception and document that exception clearly
+
+Safe policy blockers must **not** keep using `manual_intervention` as a compatibility label while still being considered autonomous. If a v1 path still uses `manual_intervention`, it must be treated as a true hard hold and excluded from the “issue solved” set for that scenario.
+
+## 7.2 Worker
+
+Worker needs the same split, but validation is especially important.
+
+### Move away from permanent pause
+
+- validation failure should no longer default to permanent pause
+- safe validation failures should get bounded retry semantics and then either:
+  - retry from checkpoint, or
+  - restart from a safe rediscovery path, or
+  - settle into a visible blocked state that does not hide the loop forever
+
+Validation failures must be split at least into:
+
+- transient / tooling / transport validation failures
+- stale checkpoint / stale repo-context failures
+- unsafe repo ambiguity failures
+- deterministic policy / spec / content validation failures
+
+These categories should not all map to the same resume policy or loop status.
+
+### Still pause
+
+- stale/inconsistent repo state that is unsafe to continue
+- genuinely ambiguous repo/worktree states
+
+### Reclassify
+
+- auto-push / manual-PR / safe policy blockers away from “unsafe pause” semantics
+- transient GitHub/tooling/setup failures to retryable states
+
+For each worker blocker moved out of `paused`, the implementation must define:
+
+- expected loop status
+- expected failure kind
+- expected resume policy
+- expected re-entry trigger
+- expected user-facing summary/message
+
+## 7.3 Planner
+
+Planner should follow the same rule:
+
+- transient agent/setup/env failures stay autonomous
+- human-gated unsafe or explicit manual states stay paused
+- `manual_intervention` should only mean actual hard hold
+
+Planner `createRunContext` should only suppress automatic continuation when the prior run truly represents a hard hold, not just any blocked state.
+
+## 7.4 Reviewer / runtime auto-recovery
+
+Reviewer auto-recovery in runtime should continue to refuse:
+
+- explicit `manual_intervention` resume policy
+- queue items explicitly marked `manual_intervention`
+
+But reviewer states that are safe and retryable should not be funneled into those markers by default.
+
+Runtime `paused` semantics remain strict:
+
+- `paused` loops should still not auto-requeue
+- the fix is to make fewer states become `paused`, not to redefine paused as soft-blocked
+
+Reviewer-side logic must also be audited for over-broad suppression outside loop status, including:
+
+- reviewer runner resume gating
+- reviewer follow-up loop selection
+- runtime reviewer auto-recovery filtering
+
+No safe blocked state should remain effectively treated as a hard hold just because one of these secondary gates still assumes `manual_intervention` means “no autonomy forever”.
+
+## 7.5 Cancellation semantics
+
+Current code sometimes treats cancelled queue items as pause-adjacent, but this issue needs an explicit rule.
+
+The implementation must define when cancellation means:
+
+1. explicit operator/human stop that should imply `paused`
+2. terminal stop without pause
+3. retry suppression without redefining the loop as unsafe
+
+Cancellation semantics should not remain an implicit side effect of existing queue-state checks.
+
+---
+
+## 8. Anti-thrash requirements
+
+Making pause rarer increases the risk of hot loops. The implementation must preserve or tighten these controls:
+
+1. queue retry budgets (`MaxAttempts`)
+2. exponential backoff for retryable queue failures
+3. rediscovery only when the role’s existing dedupe / head SHA / fix-items hash model can prevent immediate replay storms
+4. no unconditional “failed instantly rediscover forever” behavior
+
+For this issue, existing queue retries and dedupe are acceptable as the minimal baseline, but any newly rediscoverable path must have a concrete state-change boundary.
+
+---
+
+## 9. Migration and backward compatibility
+
+This issue should not auto-release all existing paused loops.
+
+Minimal safe approach:
+
+1. change new writes first
+2. leave historical paused loops untouched unless a later targeted reconciliation pass is added
+3. document that previously paused loops remain paused under old semantics
+
+If a reconciliation pass is added later, it must distinguish:
+
+- unsafe historical pauses that must remain paused
+- safe historical pauses that can be reintroduced into discovery/recovery
+
+---
+
+## 10. Current branch state
+
+The current branch has already started the fixer-first slice:
+
+- fixer agent setup failures were reclassified to stay retryable
+- fixer no-new-commit resolve-comments path was changed to `restart_from_discover`
+
+The rest of this spec describes the full intended issue-level completion, not only the changes already landed in the branch.
+
+---
+
+## 11. Acceptance criteria
+
+The issue is complete when all of the following are true:
+
+1. `paused` is only used for explicit operator holds or unsafe autonomous continuation.
+2. blocked-but-safe states are not permanently hidden from autonomous recovery by default.
+3. every non-paused blocked state has an explicit re-entry mode.
+4. fixer no-op resolve-comments paths no longer end in permanent paused semantics.
+5. worker validation failure no longer defaults to permanent pause.
+6. transient setup / environment failures do not map to permanent pause across roles.
+7. runtime still refuses to auto-recover genuinely paused loops.
+8. retry/backoff behavior prevents immediate hot-loop regressions.
+9. tests clearly distinguish unsafe pauses from safe blocked/retryable states.
+10. no safe blocked state is treated as a hard hold in any of:
+   - loop status
+   - resume gating
+   - runtime/reviewer recovery gating
+   - user-facing status or messaging
+
+---
+
+## 12. Recommended implementation order
+
+1. Land and stabilize the fixer-first slice.
+2. Introduce shared helper(s) for pause / re-entry policy.
+3. Apply the shared policy to worker, especially validation and policy blockers.
+4. Apply the same split to planner.
+5. Tighten runtime reviewer auto-recovery tests around true hard holds vs safe retryable states.
+6. Add or document follow-up migration logic only after new-write semantics are stable.


### PR DESCRIPTION
## Summary
- centralize hard-hold vs safe autonomous re-entry policy for fixer, worker, planner, reviewer, and runtime recovery paths
- keep transient and rediscoverable failures visible to autonomous recovery while reserving `paused` for true manual or unsafe holds
- update the issue #269 spec/checklist and add regression coverage for retry, rediscovery, and hard-hold behavior across roles

Closes #269.

## Testing
- go test ./internal/runtime ./internal/reviewer
- go test ./...