### PR TITLE
fix: verify no-push resolve-comments reruns against persisted head

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1554,23 +1554,37 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		return checkpoint, &loopError{message: "resolve-comments requires push step to complete", kind: FailureRetryableAfterResume}
 	}
 	fixItems := checkpoint.FixItems
+	currentFixItemsHash := checkpoint.FixItemsHash
+	verifiedNoPushHeadSHA := ""
 	if checkpoint.Push != nil && !checkpoint.Push.Pushed {
 		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 		if err != nil {
 			return checkpoint, err
 		}
 		fixItems = collectFixItems(detail)
+		currentFixItemsHash = hashFixItems(fixItems)
 		checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, detail)
+		verifiedNoPushHeadSHA = resolveCommentsVerifiedNoPushHeadSHA(checkpoint.Push, input.Loop.MetadataJSON, currentFixItemsHash)
 	}
 	expectedHeadSHA := resolveCommentsExpectedHeadSHA(checkpoint)
+	if verifiedNoPushHeadSHA != "" {
+		expectedHeadSHA = verifiedNoPushHeadSHA
+	}
 	if expectedHeadSHA != "" {
-		if _, err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: expectedHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
+		liveDetail, err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: expectedHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
 			return fmt.Sprintf("PR head changed before resolving comments: expected %s, got %s", expectedHeadSHA, firstNonEmpty(actual, "unknown"))
-		}}); err != nil {
+		}})
+		if err != nil {
 			return checkpoint, err
 		}
+		checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, liveDetail)
+		if checkpoint.Push != nil && !checkpoint.Push.Pushed {
+			fixItems = collectFixItems(liveDetail)
+			currentFixItemsHash = hashFixItems(fixItems)
+			verifiedNoPushHeadSHA = resolveCommentsVerifiedNoPushHeadSHA(checkpoint.Push, input.Loop.MetadataJSON, currentFixItemsHash)
+		}
 	}
-	if shouldBlockResolveWithoutFix(checkpoint, fixItems) {
+	if shouldBlockResolveWithoutFix(checkpoint, fixItems, verifiedNoPushHeadSHA != "" && verifiedNoPushHeadSHA == detailHeadSHA(checkpoint.Detail)) {
 		return checkpoint, &loopError{message: "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved", kind: FailureManualIntervention}
 	}
 	if checkpoint.ResolvedComments == nil {
@@ -1583,6 +1597,9 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		} else {
 			commitSHA = checkpoint.ReconcileCommits.FinalHeadSHA
 		}
+	}
+	if commitSHA == "" || (verifiedNoPushHeadSHA != "" && commitSHA == reconcileBaseHeadSHA(checkpoint.ReconcileCommits)) {
+		commitSHA = firstNonEmpty(verifiedNoPushHeadSHA, commitSHA)
 	}
 	failedCount := 0
 	explanationByID := lookupReplyExplanations(checkpoint)
@@ -2926,7 +2943,10 @@ func shouldRebuildWorktree(checkpoint fixerCheckpoint) bool {
 	return checkpoint.Worktree != nil && checkpoint.Worktree.Path != "" && checkpoint.Worktree.PreparedAt == ""
 }
 
-func shouldBlockResolveWithoutFix(checkpoint fixerCheckpoint, fixItems []FixItem) bool {
+func shouldBlockResolveWithoutFix(checkpoint fixerCheckpoint, fixItems []FixItem, hasVerifiedNoPushHead bool) bool {
+	if hasVerifiedNoPushHead {
+		return false
+	}
 	if checkpoint.Push == nil || checkpoint.Push.Pushed {
 		return false
 	}
@@ -3092,6 +3112,19 @@ func resolveCommentsExpectedHeadSHA(checkpoint fixerCheckpoint) string {
 		return checkpoint.ReconcileCommits.FinalHeadSHA
 	}
 	return detailHeadSHA(checkpoint.Detail)
+}
+
+func resolveCommentsVerifiedNoPushHeadSHA(push *checkpointPush, loopMetadataJSON *string, fixItemsHash string) string {
+	if push == nil || push.Pushed || fixItemsHash == "" {
+		return ""
+	}
+	metadata := parseJSONObject(loopMetadataJSON)
+	lastFixHeadSHA, _ := stringFromAny(metadata["lastFixHeadSha"])
+	lastFixItemsHash, _ := stringFromAny(metadata["lastFixItemsHash"])
+	if lastFixHeadSHA == "" || lastFixItemsHash == "" || lastFixItemsHash != fixItemsHash {
+		return ""
+	}
+	return lastFixHeadSHA
 }
 
 func detailHeadSHA(detail *checkpointDetail) string {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -598,14 +598,14 @@ func TestRunResolveCommentsStepBlocksWithoutVerifiedPushEvidence(t *testing.T) {
 	}
 }
 
-func TestRunResolveCommentsStepChecksHeadDriftBeforeNoFixBlock(t *testing.T) {
+func TestRunResolveCommentsStepRefreshesVerifiedNoPushHeadBeforeResolve(t *testing.T) {
 	t.Parallel()
 
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{
 		{
 			Number:      42,
 			State:       "OPEN",
-			HeadSHA:     "base-head",
+			HeadSHA:     "old-head",
 			HeadRefName: "feature/fix-42",
 			BaseRefName: "main",
 			BaseSHA:     "base-1",
@@ -630,10 +630,14 @@ func TestRunResolveCommentsStepChecksHeadDriftBeforeNoFixBlock(t *testing.T) {
 		},
 	}}
 	runner := New(Options{GitHub: github, Sleep: func(time.Duration) {}})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"new-head\",\"lastFixItemsHash\":\"%s\"}", fixItemsHash)
 	checkpoint := fixerCheckpoint{
-		FixItems:   []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}},
-		Validation: &ValidationResult{Passed: true, Summary: "ok"},
-		Push:       &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		FixItems:     fixItems,
+		FixItemsHash: fixItemsHash,
+		Validation:   &ValidationResult{Passed: true, Summary: "ok"},
+		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
 		ReconcileCommits: &checkpointReconcileCommits{
 			BaseHeadSHA:      "base-head",
 			FinalHeadSHA:     "base-head",
@@ -642,8 +646,82 @@ func TestRunResolveCommentsStepChecksHeadDriftBeforeNoFixBlock(t *testing.T) {
 		},
 	}
 
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if github.viewIndex < 2 {
+		t.Fatalf("github.viewIndex = %d, want live refresh plus head check", github.viewIndex)
+	}
+	if len(github.resolveCalls) != 1 {
+		t.Fatalf("resolve calls = %d, want 1 after refreshing verified head", len(github.resolveCalls))
+	}
+	if updated.Detail == nil || updated.Detail.HeadSHA != "new-head" {
+		t.Fatalf("updated.Detail = %#v, want refreshed new-head detail", updated.Detail)
+	}
+	if updated.ReconcileCommits == nil || updated.ReconcileCommits.FinalHeadSHA != "base-head" {
+		t.Fatalf("updated.ReconcileCommits = %#v, want stale reconcile head preserved", updated.ReconcileCommits)
+	}
+	if len(github.replyCalls) != 1 || !contains(github.replyCalls[0].Body, "new-hea") {
+		t.Fatalf("reply calls = %#v, want reply referencing verified head", github.replyCalls)
+	}
+	if updated.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepFailsWhenHeadChangesAfterVerifiedNoPushRefresh(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{
+		{
+			Number:      42,
+			State:       "OPEN",
+			HeadSHA:     "new-head",
+			HeadRefName: "feature/fix-42",
+			BaseRefName: "main",
+			BaseSHA:     "base-1",
+			Comments: []map[string]any{{
+				"id":       "c1",
+				"threadId": "t1",
+				"body":     "please fix",
+			}},
+		},
+		{
+			Number:      42,
+			State:       "OPEN",
+			HeadSHA:     "newer-head",
+			HeadRefName: "feature/fix-42",
+			BaseRefName: "main",
+			BaseSHA:     "base-1",
+			Comments: []map[string]any{{
+				"id":       "c1",
+				"threadId": "t1",
+				"body":     "please fix",
+			}},
+		},
+	}}
+	runner := New(Options{GitHub: github, Sleep: func(time.Duration) {}})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"new-head\",\"lastFixItemsHash\":\"%s\"}", fixItemsHash)
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     fixItemsHash,
+		Validation:       &ValidationResult{Passed: true, Summary: "ok"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
 	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{
 		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
 		Repo:       "acme/looper",
 		PRNumber:   42,
 		Checkpoint: checkpoint,
@@ -661,11 +739,84 @@ func TestRunResolveCommentsStepChecksHeadDriftBeforeNoFixBlock(t *testing.T) {
 	if !contains(loopErr.Error(), "PR head changed before resolving comments") {
 		t.Fatalf("error = %q, want stale-head message", loopErr.Error())
 	}
-	if github.viewIndex < 2 {
-		t.Fatalf("github.viewIndex = %d, want live refresh plus head check before no-fix block", github.viewIndex)
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want none on concurrent head change", len(github.resolveCalls))
+	}
+}
+
+func TestRunResolveCommentsStepFailsWhenLiveFixItemsDriftFromVerifiedNoPushSnapshot(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{
+		{
+			Number:      42,
+			State:       "OPEN",
+			HeadSHA:     "new-head",
+			HeadRefName: "feature/fix-42",
+			BaseRefName: "main",
+			BaseSHA:     "base-1",
+			Comments: []map[string]any{{
+				"id":       "c1",
+				"threadId": "t1",
+				"body":     "please fix",
+			}, {
+				"id":       "c2",
+				"threadId": "t2",
+				"body":     "new feedback",
+			}},
+		},
+		{
+			Number:      42,
+			State:       "OPEN",
+			HeadSHA:     "new-head",
+			HeadRefName: "feature/fix-42",
+			BaseRefName: "main",
+			BaseSHA:     "base-1",
+			Comments: []map[string]any{{
+				"id":       "c1",
+				"threadId": "t1",
+				"body":     "please fix",
+			}, {
+				"id":       "c2",
+				"threadId": "t2",
+				"body":     "new feedback",
+			}},
+		},
+	}}
+	runner := New(Options{GitHub: github, Sleep: func(time.Duration) {}})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"new-head\",\"lastFixItemsHash\":\"%s\"}", fixItemsHash)
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     fixItemsHash,
+		Validation:       &ValidationResult{Passed: true, Summary: "ok"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err == nil {
+		t.Fatal("runResolveCommentsStep() error = nil, want stale-head retry")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("error = %T, want *loopError", err)
+	}
+	if loopErr.kind != FailureRetryableAfterResume {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableAfterResume)
+	}
+	if !contains(loopErr.Error(), "PR head changed before resolving comments") {
+		t.Fatalf("error = %q, want stale-head message when verified snapshot no longer matches live comments", loopErr.Error())
 	}
 	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want none on stale head", len(github.resolveCalls))
+		t.Fatalf("resolve calls = %d, want none when live fix items drift", len(github.resolveCalls))
 	}
 }
 


### PR DESCRIPTION
## Summary
- verify `resolve-comments` no-push reruns against persisted `lastFixHeadSha` and `lastFixItemsHash` metadata instead of stale reconcile state
- refresh PR detail from the successful head poll before resolving threads, and invalidate the no-push bypass if the live fix-item snapshot changes
- add coverage for the safe rerun path, real concurrent head drift, and live review snapshot drift

## Testing
- go test ./internal/fixer
- go test ./...
- go vet ./...
- go build ./...

Closes #279