### PR TITLE
fix: compact upgrade download progress output

### DIFF
--- a/internal/cliapp/daemon_install.go
+++ b/internal/cliapp/daemon_install.go
@@ -244,17 +244,37 @@ type downloadProgress struct {
 	total    int64
 	read     int64
 	last     time.Time
+	mode     downloadProgressMode
 	finished bool
 }
 
+type downloadProgressMode uint8
+
+const (
+	downloadProgressModeLive downloadProgressMode = iota
+	downloadProgressModeSummary
+)
+
+type downloadProgressModeWriter interface {
+	io.Writer
+	downloadProgressMode() downloadProgressMode
+}
+
 func newDownloadProgress(w io.Writer, name string, total int64) *downloadProgress {
-	p := &downloadProgress{w: w, name: name, total: total}
+	mode := downloadProgressModeLive
+	if writer, ok := w.(downloadProgressModeWriter); ok {
+		mode = writer.downloadProgressMode()
+	}
+	p := &downloadProgress{w: w, name: name, total: total, mode: mode}
 	p.print(true)
 	return p
 }
 
 func (p *downloadProgress) Write(data []byte) (int, error) {
 	p.read += int64(len(data))
+	if p.mode == downloadProgressModeSummary {
+		return len(data), nil
+	}
 	if time.Since(p.last) >= 200*time.Millisecond {
 		p.print(false)
 	}
@@ -267,6 +287,9 @@ func (p *downloadProgress) finish() {
 	}
 	p.finished = true
 	p.print(false)
+	if p.mode == downloadProgressModeSummary {
+		return
+	}
 	_, _ = fmt.Fprintln(p.w)
 }
 
@@ -285,7 +308,15 @@ func (p *downloadProgress) print(initial bool) {
 		line = fmt.Sprintf("Downloading %s...", p.name)
 	}
 	if initial {
+		if p.mode == downloadProgressModeSummary {
+			_, _ = fmt.Fprintln(p.w, line)
+			return
+		}
 		_, _ = fmt.Fprint(p.w, line)
+		return
+	}
+	if p.mode == downloadProgressModeSummary {
+		_, _ = fmt.Fprintln(p.w, line)
 		return
 	}
 	_, _ = fmt.Fprintf(p.w, "\r%s", line)

--- a/internal/cliapp/download.go
+++ b/internal/cliapp/download.go
@@ -176,9 +176,10 @@ func extractBinaryFromTarGz(archiveBytes []byte, binaryName string) ([]byte, err
 }
 
 // concurrentProgressMux serializes progress writes from multiple goroutines
-// onto a single underlying writer. Carriage returns are rewritten to newlines
-// so concurrent artifact updates do not stomp each other on the same physical
-// line, which keeps both human output and test substring checks reliable.
+// onto a single underlying writer. It also tells download progress emitters to
+// use compact summary mode so concurrent artifact downloads produce a small,
+// readable set of whole-line updates instead of noisy interleaved carriage-
+// return animations.
 type concurrentProgressMux struct {
 	mu sync.Mutex
 	w  io.Writer
@@ -197,6 +198,10 @@ func (m *concurrentProgressMux) writer() io.Writer {
 
 type concurrentLineWriter struct {
 	parent *concurrentProgressMux
+}
+
+func (c *concurrentLineWriter) downloadProgressMode() downloadProgressMode {
+	return downloadProgressModeSummary
 }
 
 func (c *concurrentLineWriter) Write(p []byte) (int, error) {

--- a/internal/cliapp/download_test.go
+++ b/internal/cliapp/download_test.go
@@ -359,6 +359,12 @@ func TestUpgradeUnifiedDownloadsCLIAndDaemonConcurrently(t *testing.T) {
 		!strings.Contains(stdout.String(), "looperd 9.9.9") {
 		t.Fatalf("stdout = %q, want daemon install confirmation", stdout.String())
 	}
+	if got := strings.Count(stderr.String(), "Downloading "); got != 4 {
+		t.Fatalf("stderr download line count = %d, want 4 compact summary lines; stderr=%q", got, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "\r") {
+		t.Fatalf("stderr = %q, did not expect carriage-return progress spam", stderr.String())
+	}
 }
 
 // errDaemonOffline mimics the real "daemon offline" error returned by the


### PR DESCRIPTION
## Summary
- switch concurrent `looper upgrade` downloads to a compact summary-progress mode instead of continuous carriage-return updates
- keep the existing live progress behavior for single-download flows while serializing concurrent output into readable whole lines
- add a regression test that verifies unified upgrades stay concurrent without flooding stderr

## Validation
- go test ./internal/cliapp/...
- go vet ./...
- go test ./...
- go build ./...

Closes #277