### PR TITLE
fix: clean up fixer runs after pre-start failures

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1088,6 +1088,19 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		}
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 	}
+	checkpoint.RunStartedAt = r.nowISO()
+	checkpoint.RunStartedRunID = run.ID
+	if err := r.persistCheckpoint(ctx, run.ID, resumedRun.StartStep, checkpoint); err != nil {
+		return ProcessResult{}, err
+	}
+	persistedRun, err := r.repos.Runs.GetByID(ctx, run.ID)
+	if err != nil {
+		return ProcessResult{}, err
+	}
+	if persistedRun == nil {
+		return ProcessResult{}, fmt.Errorf("run not found after start checkpoint: %s", resumedRun.Run.ID)
+	}
+	run = *persistedRun
 	if reason, err := r.pullRequestOwnershipSkipReason(ctx, project.ID, project.RepoPath, *queueItem.Repo, *queueItem.PRNumber); err != nil {
 		return ProcessResult{}, err
 	} else if reason != "" {
@@ -1109,19 +1122,6 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: reason}, nil
 	}
-	checkpoint.RunStartedAt = r.nowISO()
-	checkpoint.RunStartedRunID = run.ID
-	if err := r.persistCheckpoint(ctx, run.ID, resumedRun.StartStep, checkpoint); err != nil {
-		return ProcessResult{}, err
-	}
-	persistedRun, err := r.repos.Runs.GetByID(ctx, run.ID)
-	if err != nil {
-		return ProcessResult{}, err
-	}
-	if persistedRun == nil {
-		return ProcessResult{}, fmt.Errorf("run not found after start checkpoint: %s", resumedRun.Run.ID)
-	}
-	run = *persistedRun
 	r.appendEvent(ctx, eventInput{eventType: "loop.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "loop", entityID: loop.ID, payload: map[string]any{"queueItemId": queueItem.ID, "resumed": resumedRun.Resumed, "startStep": string(resumedRun.StartStep)}})
 	r.appendEvent(ctx, eventInput{eventType: "run.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep)}})
 	r.logInfo("fixer loop started", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep), "resumed": resumedRun.Resumed})

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -970,7 +970,7 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 	return err
 }
 
-func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.QueueItemRecord) (ProcessResult, error) {
+func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.QueueItemRecord) (result ProcessResult, retErr error) {
 	if queueItem.Type != "fixer" {
 		return ProcessResult{}, fmt.Errorf("unsupported queue item type: %s", queueItem.Type)
 	}
@@ -997,6 +997,25 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	}
 	run := resumedRun.Run
 	checkpoint := resumedRun.Checkpoint
+	runCreated := true
+	defer func() {
+		if retErr == nil || !runCreated {
+			return
+		}
+		persisted, err := r.repos.Runs.GetByID(context.Background(), run.ID)
+		if err != nil || persisted == nil || persisted.Status != "running" {
+			return
+		}
+		failure := r.classifyFailure(retErr)
+		latest := r.getLatestCheckpoint(context.Background(), run, checkpoint)
+		latest.ResumePolicy = loops.NormalizeResumePolicy(string(failure.kind), latest.ResumePolicy)
+		completed, err := r.completeRun(context.Background(), *persisted, "failed", failure.message, failure.message, latest)
+		if err != nil {
+			r.logWarn("fixer run cleanup after pre-start failure failed", map[string]any{"runId": run.ID, "queueItemId": queueItem.ID, "error": err.Error()})
+			return
+		}
+		run = completed
+	}()
 	claimedLockKey := ""
 	acquiredClaimedLock := false
 	if resumedRun.Resumed && resumedRun.StartStep != stepClaimPR {
@@ -2090,6 +2109,17 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	lastCompleted := FixerStep("")
 	failedStep := FixerStep("")
 	if latestRun != nil {
+		if latestRun.Status == "running" {
+			if err := r.recoverOrphanPreStartRun(ctx, *latestRun); err != nil {
+				return resumedRunContext{}, err
+			}
+			latestRun, err = r.repos.Runs.GetLatestByLoopID(ctx, loop.ID)
+			if err != nil {
+				return resumedRunContext{}, err
+			}
+		}
+	}
+	if latestRun != nil {
 		checkpoint = parseCheckpoint(latestRun.CheckpointJSON)
 		lastCompleted = asFixerStep(derefString(latestRun.LastCompletedStep))
 		failedStep = asFixerStep(derefString(latestRun.CurrentStep))
@@ -2143,6 +2173,35 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		return resumedRunContext{}, err
 	}
 	return resumedRunContext{Run: run, StartStep: startStep, Checkpoint: initialCheckpoint, Resumed: resumed}, nil
+}
+
+func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRecord) error {
+	if r.repos.AgentExecutions != nil {
+		execution, err := r.repos.AgentExecutions.GetLatestByRunID(ctx, run.ID)
+		if err != nil {
+			return err
+		}
+		if execution != nil {
+			return fmt.Errorf("loop %s already has a running fixer run %s with agent execution %s", run.LoopID, run.ID, execution.ID)
+		}
+	}
+	if r.repos.Events != nil {
+		events, err := r.repos.Events.ListByEntity(ctx, "run", run.ID)
+		if err != nil {
+			return err
+		}
+		for _, event := range events {
+			if event.EventType == "run.started" {
+				return fmt.Errorf("loop %s already has a running fixer run %s", run.LoopID, run.ID)
+			}
+		}
+	}
+	checkpoint := parseCheckpoint(run.CheckpointJSON)
+	if checkpoint.ResumePolicy == "" {
+		checkpoint.ResumePolicy = loops.ResumePolicyReplayStep
+	}
+	_, err := r.completeRun(ctx, run, "interrupted", "Interrupted orphaned fixer run before start", "Interrupted orphaned fixer run before start", checkpoint)
+	return err
 }
 
 func (r *Runner) persistStepStarted(ctx context.Context, run storage.RunRecord, step FixerStep, checkpoint fixerCheckpoint) (storage.RunRecord, error) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -935,7 +935,14 @@ func (r *Runner) ProcessClaimedQueueItem(ctx context.Context, queueItem storage.
 
 func (r *Runner) recoverClaimedItem(ctx context.Context, queueItem storage.QueueItemRecord, err error) (*ProcessResult, error) {
 	failure := r.classifyFailure(err)
-	failedQueue, failErr := r.failQueueItem(ctx, queueItem, failure.kind, failure.message)
+	var activeErr *activeRunError
+	var failedQueue *storage.QueueItemRecord
+	var failErr error
+	if errors.As(err, &activeErr) {
+		failedQueue, failErr = r.requeueQueueItem(ctx, queueItem, failure.kind, failure.message, queueItem.Attempts)
+	} else {
+		failedQueue, failErr = r.failQueueItem(ctx, queueItem, failure.kind, failure.message)
+	}
 	if failErr != nil {
 		return nil, failErr
 	}
@@ -2187,10 +2194,10 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	}
 	initialCheckpoint.RunStartedAt = ""
 	initialCheckpoint.RunStartedRunID = ""
-	initialCheckpoint.RunPreStartAt = ""
-	initialCheckpoint.RunPreStartRunID = ""
 	nowISO := r.nowISO()
 	run := storage.RunRecord{ID: eventlog.NewEventID("run"), LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(startStep)), StartedAt: nowISO, LastHeartbeatAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}
+	initialCheckpoint.RunPreStartAt = nowISO
+	initialCheckpoint.RunPreStartRunID = run.ID
 	if resumed {
 		switch {
 		case restartFromDiscover:
@@ -2231,16 +2238,8 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 	if r.preStartMarkerActive(checkpoint, run) {
 		return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s in pre-start checks", run.LoopID, run.ID))
 	}
-	if r.repos.Events != nil {
-		events, err := r.repos.Events.ListByEntity(ctx, "run", run.ID)
-		if err != nil {
-			return err
-		}
-		for _, event := range events {
-			if event.EventType == "run.started" {
-				return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s", run.LoopID, run.ID))
-			}
-		}
+	if r.freshMarkerlessRunningRunActive(checkpoint, run) {
+		return activeFixerRunError(fmt.Sprintf("loop %s already has a freshly-created running fixer run %s", run.LoopID, run.ID))
 	}
 	if checkpoint.ResumePolicy == "" {
 		checkpoint.ResumePolicy = loops.ResumePolicyReplayStep
@@ -2250,7 +2249,15 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 }
 
 func activeFixerRunError(message string) error {
-	return &loopError{message: message, kind: FailureRetryableTransient}
+	return &activeRunError{loopError: &loopError{message: message, kind: FailureRetryableTransient}}
+}
+
+type activeRunError struct {
+	*loopError
+}
+
+func (e *activeRunError) Unwrap() error {
+	return e.loopError
 }
 
 func checkpointStartedCurrentRun(checkpoint fixerCheckpoint, run storage.RunRecord) bool {
@@ -2264,13 +2271,17 @@ func checkpointStartedCurrentRun(checkpoint fixerCheckpoint, run storage.RunReco
 }
 
 func (r *Runner) preStartMarkerActive(checkpoint fixerCheckpoint, run storage.RunRecord) bool {
-	if checkpoint.RunPreStartAt == "" {
-		return false
-	}
-	if checkpoint.RunPreStartRunID != "" && checkpoint.RunPreStartRunID != run.ID {
+	if checkpoint.RunPreStartAt == "" || checkpoint.RunPreStartRunID != run.ID {
 		return false
 	}
 	return timestampWithin(checkpoint.RunPreStartAt, r.now(), r.claimTTL)
+}
+
+func (r *Runner) freshMarkerlessRunningRunActive(checkpoint fixerCheckpoint, run storage.RunRecord) bool {
+	if checkpoint.RunStartedAt != "" || checkpoint.RunPreStartAt != "" {
+		return false
+	}
+	return timestampWithin(firstNonEmpty(run.CreatedAt, run.StartedAt), r.now(), r.claimTTL)
 }
 
 func timestampWithin(raw string, now time.Time, ttl time.Duration) bool {
@@ -2471,6 +2482,19 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {
 	nextAttempts := queueItem.Attempts + 1
+	return r.requeueOrFailQueueItem(ctx, queueItem, kind, message, nextAttempts)
+}
+
+func (r *Runner) requeueQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string, attempts int64) (*storage.QueueItemRecord, error) {
+	nowISO := r.nowISO()
+	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, attempts+1)))
+	if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: attempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
+		return nil, err
+	}
+	return r.repos.Queue.GetByID(ctx, queueItem.ID)
+}
+
+func (r *Runner) requeueOrFailQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string, nextAttempts int64) (*storage.QueueItemRecord, error) {
 	nowISO := r.nowISO()
 	if isRetryableFailure(kind) && nextAttempts < queueItem.MaxAttempts {
 		retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, nextAttempts)))

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2198,7 +2198,7 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 		if err != nil {
 			return err
 		}
-		if execution != nil {
+		if execution != nil && isActiveAgentExecutionStatus(execution.Status) {
 			return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s with agent execution %s", run.LoopID, run.ID, execution.ID))
 		}
 	}
@@ -2226,6 +2226,15 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 
 func activeFixerRunError(message string) error {
 	return &loopError{message: message, kind: FailureRetryableTransient}
+}
+
+func isActiveAgentExecutionStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "running", "cancelling":
+		return true
+	default:
+		return false
+	}
 }
 
 func checkpointStartedCurrentRun(checkpoint fixerCheckpoint, run storage.RunRecord) bool {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -66,8 +66,13 @@ const (
 
 	defaultAgentTimeout = 30 * time.Minute
 	defaultClaimTTL     = 5 * time.Minute
-	defaultRetryDelay   = 5 * time.Second
-	defaultRetryMax     = 3
+	// defaultLegacyMarkerlessRunGrace protects running fixer runs that predate
+	// durable start/pre-start checkpoint markers during rollout. It must be much
+	// longer than claim TTL because non-agent fixer steps may legitimately run
+	// longer than a queue claim window without an active agent execution.
+	defaultLegacyMarkerlessRunGrace = 24 * time.Hour
+	defaultRetryDelay               = 5 * time.Second
+	defaultRetryMax                 = 3
 )
 
 type FixItem struct {
@@ -2238,8 +2243,8 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 	if r.preStartMarkerActive(checkpoint, run) {
 		return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s in pre-start checks", run.LoopID, run.ID))
 	}
-	if r.freshMarkerlessRunningRunActive(checkpoint, run) {
-		return activeFixerRunError(fmt.Sprintf("loop %s already has a freshly-created running fixer run %s", run.LoopID, run.ID))
+	if r.markerlessRunningRunActive(checkpoint, run) {
+		return activeFixerRunError(fmt.Sprintf("loop %s already has a markerless running fixer run %s", run.LoopID, run.ID))
 	}
 	if checkpoint.ResumePolicy == "" {
 		checkpoint.ResumePolicy = loops.ResumePolicyReplayStep
@@ -2277,11 +2282,31 @@ func (r *Runner) preStartMarkerActive(checkpoint fixerCheckpoint, run storage.Ru
 	return timestampWithin(checkpoint.RunPreStartAt, r.now(), r.claimTTL)
 }
 
-func (r *Runner) freshMarkerlessRunningRunActive(checkpoint fixerCheckpoint, run storage.RunRecord) bool {
-	if checkpoint.RunStartedAt != "" || checkpoint.RunPreStartAt != "" {
+func (r *Runner) markerlessRunningRunActive(checkpoint fixerCheckpoint, run storage.RunRecord) bool {
+	if checkpoint.RunStartedAt != "" || checkpoint.RunStartedRunID != "" || checkpoint.RunPreStartAt != "" || checkpoint.RunPreStartRunID != "" {
 		return false
 	}
-	return timestampWithin(firstNonEmpty(run.CreatedAt, run.StartedAt), r.now(), r.claimTTL)
+	return timestampWithin(freshestTimestamp(derefString(run.LastHeartbeatAt), run.UpdatedAt, run.StartedAt, run.CreatedAt), r.now(), defaultLegacyMarkerlessRunGrace)
+}
+
+func freshestTimestamp(values ...string) string {
+	var freshest time.Time
+	var freshestRaw string
+	for _, raw := range values {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		timestamp, err := time.Parse(time.RFC3339Nano, raw)
+		if err != nil {
+			continue
+		}
+		if freshestRaw == "" || timestamp.After(freshest) {
+			freshest = timestamp
+			freshestRaw = raw
+		}
+	}
+	return freshestRaw
 }
 
 func timestampWithin(raw string, now time.Time, ttl time.Duration) bool {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2182,7 +2182,7 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 			return err
 		}
 		if execution != nil {
-			return fmt.Errorf("loop %s already has a running fixer run %s with agent execution %s", run.LoopID, run.ID, execution.ID)
+			return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s with agent execution %s", run.LoopID, run.ID, execution.ID))
 		}
 	}
 	if r.repos.Events != nil {
@@ -2192,7 +2192,7 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 		}
 		for _, event := range events {
 			if event.EventType == "run.started" {
-				return fmt.Errorf("loop %s already has a running fixer run %s", run.LoopID, run.ID)
+				return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s", run.LoopID, run.ID))
 			}
 		}
 	}
@@ -2202,6 +2202,10 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 	}
 	_, err := r.completeRun(ctx, run, "interrupted", "Interrupted orphaned fixer run before start", "Interrupted orphaned fixer run before start", checkpoint)
 	return err
+}
+
+func activeFixerRunError(message string) error {
+	return &loopError{message: message, kind: FailureRetryableTransient}
 }
 
 func (r *Runner) persistStepStarted(ctx context.Context, run storage.RunRecord, step FixerStep, checkpoint fixerCheckpoint) (storage.RunRecord, error) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -398,6 +398,7 @@ type ProcessResult struct {
 type fixerCheckpoint struct {
 	ResumePolicy     string                      `json:"resumePolicy,omitempty"`
 	RunStartedAt     string                      `json:"runStartedAt,omitempty"`
+	RunStartedRunID  string                      `json:"runStartedRunId,omitempty"`
 	Detail           *checkpointDetail           `json:"detail,omitempty"`
 	ClaimedLockKey   string                      `json:"claimedLockKey,omitempty"`
 	FixItems         []FixItem                   `json:"fixItems,omitempty"`
@@ -1109,6 +1110,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: reason}, nil
 	}
 	checkpoint.RunStartedAt = r.nowISO()
+	checkpoint.RunStartedRunID = run.ID
 	if err := r.persistCheckpoint(ctx, run.ID, resumedRun.StartStep, checkpoint); err != nil {
 		return ProcessResult{}, err
 	}
@@ -2166,6 +2168,8 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		initialCheckpoint = resumedCheckpoint
 		initialCheckpoint.ResumePolicy = "advance_from_checkpoint"
 	}
+	initialCheckpoint.RunStartedAt = ""
+	initialCheckpoint.RunStartedRunID = ""
 	nowISO := r.nowISO()
 	run := storage.RunRecord{ID: eventlog.NewEventID("run"), LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(startStep)), StartedAt: nowISO, LastHeartbeatAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}
 	if resumed {
@@ -2199,7 +2203,7 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 		}
 	}
 	checkpoint := parseCheckpoint(run.CheckpointJSON)
-	if checkpoint.RunStartedAt != "" {
+	if checkpointStartedCurrentRun(checkpoint, run) {
 		return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s", run.LoopID, run.ID))
 	}
 	if r.repos.Events != nil {
@@ -2222,6 +2226,33 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 
 func activeFixerRunError(message string) error {
 	return &loopError{message: message, kind: FailureRetryableTransient}
+}
+
+func checkpointStartedCurrentRun(checkpoint fixerCheckpoint, run storage.RunRecord) bool {
+	if checkpoint.RunStartedAt == "" {
+		return false
+	}
+	if checkpoint.RunStartedRunID != "" {
+		return checkpoint.RunStartedRunID == run.ID
+	}
+	return !timestampBefore(checkpoint.RunStartedAt, firstNonEmpty(run.CreatedAt, run.StartedAt))
+}
+
+func timestampBefore(raw, floor string) bool {
+	raw = strings.TrimSpace(raw)
+	floor = strings.TrimSpace(floor)
+	if raw == "" || floor == "" {
+		return false
+	}
+	timestamp, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return false
+	}
+	floorTimestamp, err := time.Parse(time.RFC3339Nano, floor)
+	if err != nil {
+		return false
+	}
+	return timestamp.Before(floorTimestamp)
 }
 
 func (r *Runner) persistStepStarted(ctx context.Context, run storage.RunRecord, step FixerStep, checkpoint fixerCheckpoint) (storage.RunRecord, error) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -399,6 +399,8 @@ type fixerCheckpoint struct {
 	ResumePolicy     string                      `json:"resumePolicy,omitempty"`
 	RunStartedAt     string                      `json:"runStartedAt,omitempty"`
 	RunStartedRunID  string                      `json:"runStartedRunId,omitempty"`
+	RunPreStartAt    string                      `json:"runPreStartAt,omitempty"`
+	RunPreStartRunID string                      `json:"runPreStartRunId,omitempty"`
 	Detail           *checkpointDetail           `json:"detail,omitempty"`
 	ClaimedLockKey   string                      `json:"claimedLockKey,omitempty"`
 	FixItems         []FixItem                   `json:"fixItems,omitempty"`
@@ -1088,8 +1090,8 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		}
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 	}
-	checkpoint.RunStartedAt = r.nowISO()
-	checkpoint.RunStartedRunID = run.ID
+	checkpoint.RunPreStartAt = r.nowISO()
+	checkpoint.RunPreStartRunID = run.ID
 	if err := r.persistCheckpoint(ctx, run.ID, resumedRun.StartStep, checkpoint); err != nil {
 		return ProcessResult{}, err
 	}
@@ -1122,6 +1124,21 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: reason}, nil
 	}
+	checkpoint.RunStartedAt = r.nowISO()
+	checkpoint.RunStartedRunID = run.ID
+	checkpoint.RunPreStartAt = ""
+	checkpoint.RunPreStartRunID = ""
+	if err := r.persistCheckpoint(ctx, run.ID, resumedRun.StartStep, checkpoint); err != nil {
+		return ProcessResult{}, err
+	}
+	persistedRun, err = r.repos.Runs.GetByID(ctx, run.ID)
+	if err != nil {
+		return ProcessResult{}, err
+	}
+	if persistedRun == nil {
+		return ProcessResult{}, fmt.Errorf("run not found after start checkpoint: %s", resumedRun.Run.ID)
+	}
+	run = *persistedRun
 	r.appendEvent(ctx, eventInput{eventType: "loop.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "loop", entityID: loop.ID, payload: map[string]any{"queueItemId": queueItem.ID, "resumed": resumedRun.Resumed, "startStep": string(resumedRun.StartStep)}})
 	r.appendEvent(ctx, eventInput{eventType: "run.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep)}})
 	r.logInfo("fixer loop started", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep), "resumed": resumedRun.Resumed})
@@ -2170,6 +2187,8 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	}
 	initialCheckpoint.RunStartedAt = ""
 	initialCheckpoint.RunStartedRunID = ""
+	initialCheckpoint.RunPreStartAt = ""
+	initialCheckpoint.RunPreStartRunID = ""
 	nowISO := r.nowISO()
 	run := storage.RunRecord{ID: eventlog.NewEventID("run"), LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(startStep)), StartedAt: nowISO, LastHeartbeatAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}
 	if resumed {
@@ -2209,6 +2228,9 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 	if checkpointStartedCurrentRun(checkpoint, run) {
 		return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s", run.LoopID, run.ID))
 	}
+	if r.preStartMarkerActive(checkpoint, run) {
+		return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s in pre-start checks", run.LoopID, run.ID))
+	}
 	if r.repos.Events != nil {
 		events, err := r.repos.Events.ListByEntity(ctx, "run", run.ID)
 		if err != nil {
@@ -2239,6 +2261,28 @@ func checkpointStartedCurrentRun(checkpoint fixerCheckpoint, run storage.RunReco
 		return checkpoint.RunStartedRunID == run.ID
 	}
 	return !timestampBefore(checkpoint.RunStartedAt, firstNonEmpty(run.CreatedAt, run.StartedAt))
+}
+
+func (r *Runner) preStartMarkerActive(checkpoint fixerCheckpoint, run storage.RunRecord) bool {
+	if checkpoint.RunPreStartAt == "" {
+		return false
+	}
+	if checkpoint.RunPreStartRunID != "" && checkpoint.RunPreStartRunID != run.ID {
+		return false
+	}
+	return timestampWithin(checkpoint.RunPreStartAt, r.now(), r.claimTTL)
+}
+
+func timestampWithin(raw string, now time.Time, ttl time.Duration) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || ttl <= 0 {
+		return false
+	}
+	timestamp, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return false
+	}
+	return !timestamp.After(now) && now.Sub(timestamp) <= ttl
 }
 
 func timestampBefore(raw, floor string) bool {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2187,6 +2187,9 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	encoded := mustMarshalJSON(initialCheckpoint)
 	run.CheckpointJSON = &encoded
 	if err := r.repos.Runs.Upsert(ctx, run); err != nil {
+		if hasRunning, checkErr := r.repos.Runs.HasRunningByLoopID(ctx, loop.ID); checkErr == nil && hasRunning {
+			return resumedRunContext{}, activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run", loop.ID))
+		}
 		return resumedRunContext{}, err
 	}
 	return resumedRunContext{Run: run, StartStep: startStep, Checkpoint: initialCheckpoint, Resumed: resumed}, nil
@@ -2194,11 +2197,11 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 
 func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRecord) error {
 	if r.repos.AgentExecutions != nil {
-		execution, err := r.repos.AgentExecutions.GetLatestByRunID(ctx, run.ID)
+		execution, err := r.repos.AgentExecutions.GetLatestActiveByRunID(ctx, run.ID)
 		if err != nil {
 			return err
 		}
-		if execution != nil && isActiveAgentExecutionStatus(execution.Status) {
+		if execution != nil {
 			return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s with agent execution %s", run.LoopID, run.ID, execution.ID))
 		}
 	}
@@ -2226,15 +2229,6 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 
 func activeFixerRunError(message string) error {
 	return &loopError{message: message, kind: FailureRetryableTransient}
-}
-
-func isActiveAgentExecutionStatus(status string) bool {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "running", "cancelling":
-		return true
-	default:
-		return false
-	}
 }
 
 func checkpointStartedCurrentRun(checkpoint fixerCheckpoint, run storage.RunRecord) bool {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -397,6 +397,7 @@ type ProcessResult struct {
 
 type fixerCheckpoint struct {
 	ResumePolicy     string                      `json:"resumePolicy,omitempty"`
+	RunStartedAt     string                      `json:"runStartedAt,omitempty"`
 	Detail           *checkpointDetail           `json:"detail,omitempty"`
 	ClaimedLockKey   string                      `json:"claimedLockKey,omitempty"`
 	FixItems         []FixItem                   `json:"fixItems,omitempty"`
@@ -1107,6 +1108,18 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: reason}, nil
 	}
+	checkpoint.RunStartedAt = r.nowISO()
+	if err := r.persistCheckpoint(ctx, run.ID, resumedRun.StartStep, checkpoint); err != nil {
+		return ProcessResult{}, err
+	}
+	persistedRun, err := r.repos.Runs.GetByID(ctx, run.ID)
+	if err != nil {
+		return ProcessResult{}, err
+	}
+	if persistedRun == nil {
+		return ProcessResult{}, fmt.Errorf("run not found after start checkpoint: %s", resumedRun.Run.ID)
+	}
+	run = *persistedRun
 	r.appendEvent(ctx, eventInput{eventType: "loop.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "loop", entityID: loop.ID, payload: map[string]any{"queueItemId": queueItem.ID, "resumed": resumedRun.Resumed, "startStep": string(resumedRun.StartStep)}})
 	r.appendEvent(ctx, eventInput{eventType: "run.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep)}})
 	r.logInfo("fixer loop started", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep), "resumed": resumedRun.Resumed})
@@ -2185,6 +2198,10 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 			return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s with agent execution %s", run.LoopID, run.ID, execution.ID))
 		}
 	}
+	checkpoint := parseCheckpoint(run.CheckpointJSON)
+	if checkpoint.RunStartedAt != "" {
+		return activeFixerRunError(fmt.Sprintf("loop %s already has a running fixer run %s", run.LoopID, run.ID))
+	}
 	if r.repos.Events != nil {
 		events, err := r.repos.Events.ListByEntity(ctx, "run", run.ID)
 		if err != nil {
@@ -2196,7 +2213,6 @@ func (r *Runner) recoverOrphanPreStartRun(ctx context.Context, run storage.RunRe
 			}
 		}
 	}
-	checkpoint := parseCheckpoint(run.CheckpointJSON)
 	if checkpoint.ResumePolicy == "" {
 		checkpoint.ResumePolicy = loops.ResumePolicyReplayStep
 	}

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1258,6 +1258,66 @@ func TestCreateRunContextTreatsRunningAgentExecutionAsRetryable(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedQueueItemRequeuesWhenActiveRunHasAgentExecution(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	nowISO := fixture.nowISO()
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_active_agent_execution_queue", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	activeRun := storage.RunRecord{ID: "run_active_agent_execution_queue", LoopID: "loop_active_agent_execution_queue", Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), activeRun); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	runID := activeRun.ID
+	loopID := activeRun.LoopID
+	if err := fixture.repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_active_execution_queue", LoopID: &loopID, RunID: &runID, Vendor: "opencode", Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_active_agent_execution", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: loopTarget, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:active-agent-execution", Priority: 1, Status: "queued", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "failed" || result.FailureKind != FailureRetryableTransient || !contains(result.Summary, "already has a running fixer run") {
+		t.Fatalf("result = %#v, want retryable_transient active-run recovery", result)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "queued" || queue.Attempts != 1 || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) {
+		t.Fatalf("queue = %#v, want requeued retryable_transient failure", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
+		t.Fatalf("loop = %#v, want loop requeued for retry", loop)
+	}
+	preservedRun, err := fixture.repos.Runs.GetByID(context.Background(), activeRun.ID)
+	if err != nil || preservedRun == nil {
+		t.Fatalf("Runs.GetByID() = (%#v, %v), want active run", preservedRun, err)
+	}
+	if preservedRun.Status != "running" || preservedRun.EndedAt != nil {
+		t.Fatalf("preservedRun = %#v, want original run preserved", preservedRun)
+	}
+}
+
 func TestCreateRunContextTreatsStartedRunAsRetryable(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -1327,6 +1387,13 @@ func TestCreateRunContextTreatsDurablyStartedRunAsRetryableWhenEventMissing(t *t
 	}
 	if activeRun.Status != "running" || activeRun.EndedAt != nil {
 		t.Fatalf("activeRun = %#v, want still-running started run", activeRun)
+	}
+	latestRun, err := fixture.repos.Runs.GetLatestByLoopID(context.Background(), loop.ID)
+	if err != nil || latestRun == nil {
+		t.Fatalf("Runs.GetLatestByLoopID() = (%#v, %v), want preserved run", latestRun, err)
+	}
+	if latestRun.ID != startedRun.ID {
+		t.Fatalf("latestRun.ID = %q, want preserved run %q", latestRun.ID, startedRun.ID)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1258,6 +1258,49 @@ func TestCreateRunContextTreatsRunningAgentExecutionAsRetryable(t *testing.T) {
 	}
 }
 
+func TestCreateRunContextTreatsOlderActiveAgentExecutionAsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	activeStartedAt := fixture.current.Add(-time.Minute).UTC().Format(time.RFC3339Nano)
+	loop := storage.LoopRecord{ID: "loop_older_active_agent_execution", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	orphan := storage.RunRecord{ID: "run_older_active_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	runID := orphan.ID
+	loopID := loop.ID
+	if err := fixture.repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_older_active_execution", LoopID: &loopID, RunID: &runID, Vendor: "opencode", Status: "running", StartedAt: activeStartedAt, CreatedAt: activeStartedAt, UpdatedAt: activeStartedAt}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(active) error = %v", err)
+	}
+	endedAt := nowISO
+	if err := fixture.repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_newer_terminal_execution", LoopID: &loopID, RunID: &runID, Vendor: "opencode", Status: "completed", StartedAt: nowISO, EndedAt: &endedAt, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(terminal) error = %v", err)
+	}
+
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable active-run error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
+	}
+	activeRun, err := fixture.repos.Runs.GetByID(context.Background(), orphan.ID)
+	if err != nil || activeRun == nil {
+		t.Fatalf("Runs.GetByID(active) = (%#v, %v), want run", activeRun, err)
+	}
+	if activeRun.Status != "running" || activeRun.EndedAt != nil {
+		t.Fatalf("activeRun = %#v, want still-running active run", activeRun)
+	}
+}
+
 func TestCreateRunContextInterruptsOrphanWithTerminalAgentExecution(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1367,7 +1367,7 @@ func TestCreateRunContextTreatsDurablyStartedRunAsRetryableWhenEventMissing(t *t
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
-	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step", RunStartedAt: nowISO})
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step", RunStartedAt: nowISO, RunStartedRunID: "run_started_missing_event"})
 	startedRun := storage.RunRecord{ID: "run_started_missing_event", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Runs.Upsert(context.Background(), startedRun); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
@@ -1394,6 +1394,43 @@ func TestCreateRunContextTreatsDurablyStartedRunAsRetryableWhenEventMissing(t *t
 	}
 	if latestRun.ID != startedRun.ID {
 		t.Fatalf("latestRun.ID = %q, want preserved run %q", latestRun.ID, startedRun.ID)
+	}
+}
+
+func TestCreateRunContextInterruptsResumedRunWithStaleStartMarker(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	staleStartedAt := fixture.current.Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+	loop := storage.LoopRecord{ID: "loop_stale_started_run", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "advance_from_checkpoint", RunStartedAt: staleStartedAt, RunStartedRunID: "previous_run"})
+	orphan := storage.RunRecord{ID: "run_stale_started_marker", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	created, err := runner.createRunContext(context.Background(), loop)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if created.Run.ID == orphan.ID || created.Run.Status != "running" {
+		t.Fatalf("created.Run = %#v, want replacement running run", created.Run)
+	}
+	if created.Checkpoint.RunStartedAt != "" || created.Checkpoint.RunStartedRunID != "" {
+		t.Fatalf("created.Checkpoint = %#v, want cleared start marker", created.Checkpoint)
+	}
+	oldRun, err := fixture.repos.Runs.GetByID(context.Background(), orphan.ID)
+	if err != nil || oldRun == nil {
+		t.Fatalf("Runs.GetByID(orphan) = (%#v, %v), want run", oldRun, err)
+	}
+	if oldRun.Status != "interrupted" || oldRun.EndedAt == nil {
+		t.Fatalf("oldRun = %#v, want interrupted stale pre-start run", oldRun)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1220,6 +1220,82 @@ func TestCreateRunContextInterruptsOrphanPreStartRunningRun(t *testing.T) {
 	}
 }
 
+func TestCreateRunContextTreatsRunningAgentExecutionAsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{ID: "loop_active_agent_execution", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	orphan := storage.RunRecord{ID: "run_active_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	runID := orphan.ID
+	loopID := loop.ID
+	if err := fixture.repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_active_execution", LoopID: &loopID, RunID: &runID, Vendor: "opencode", Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable active-run error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
+	}
+	activeRun, err := fixture.repos.Runs.GetByID(context.Background(), orphan.ID)
+	if err != nil || activeRun == nil {
+		t.Fatalf("Runs.GetByID(active) = (%#v, %v), want run", activeRun, err)
+	}
+	if activeRun.Status != "running" || activeRun.EndedAt != nil {
+		t.Fatalf("activeRun = %#v, want still-running active run", activeRun)
+	}
+}
+
+func TestCreateRunContextTreatsStartedRunAsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{ID: "loop_started_run", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	startedRun := storage.RunRecord{ID: "run_started", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), startedRun); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	entityType := "run"
+	entityID := startedRun.ID
+	if err := fixture.repos.Events.Append(context.Background(), storage.EventLogRecord{ID: "event_started_run", EventType: "run.started", LoopID: &loop.ID, RunID: &startedRun.ID, EntityType: &entityType, EntityID: &entityID, PayloadJSON: "{}", CreatedAt: nowISO}); err != nil {
+		t.Fatalf("Events.Append() error = %v", err)
+	}
+
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable started-run error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
+	}
+	activeRun, err := fixture.repos.Runs.GetByID(context.Background(), startedRun.ID)
+	if err != nil || activeRun == nil {
+		t.Fatalf("Runs.GetByID(started) = (%#v, %v), want run", activeRun, err)
+	}
+	if activeRun.Status != "running" || activeRun.EndedAt != nil {
+		t.Fatalf("activeRun = %#v, want still-running started run", activeRun)
+	}
+}
+
 func TestProcessClaimedItemFailsWhenRepairCompletionResultMissing(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1137,6 +1137,89 @@ func TestProcessClaimedItemSkipsPRsNotOwnedByCurrentUser(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemMarksRunFailedWhenOwnershipCheckErrorsBeforeStart(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentUserErr: errors.New("github timeout")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{ID: "loop_ownership_error", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue := storage.QueueItemRecord{ID: "queue_ownership_error", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "fixer", TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:ownership-error", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Queue.Upsert(context.Background(), queue); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	_, err := runner.ProcessClaimedItem(context.Background(), queue)
+	if err == nil || !strings.Contains(err.Error(), "github timeout") {
+		t.Fatalf("ProcessClaimedItem() error = %v, want github timeout", err)
+	}
+	latest, err := fixture.repos.Runs.GetLatestByLoopID(context.Background(), loop.ID)
+	if err != nil || latest == nil {
+		t.Fatalf("Runs.GetLatestByLoopID() = (%#v, %v), want run", latest, err)
+	}
+	if latest.Status != "failed" || latest.EndedAt == nil {
+		t.Fatalf("latest run = %#v, want failed terminal run", latest)
+	}
+	if latest.CurrentStep == nil || *latest.CurrentStep != string(stepDiscoverPR) {
+		t.Fatalf("latest.CurrentStep = %#v, want discover-pr", latest.CurrentStep)
+	}
+	events, err := fixture.repos.Events.ListByEntity(context.Background(), "run", latest.ID)
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	for _, event := range events {
+		if event.EventType == "run.started" {
+			t.Fatalf("events = %#v, want no run.started before ownership failure", events)
+		}
+	}
+
+	resumed, err := runner.createRunContext(context.Background(), loop)
+	if err != nil {
+		t.Fatalf("createRunContext() retry error = %v", err)
+	}
+	if resumed.Run.ID == latest.ID || resumed.Run.Status != "running" {
+		t.Fatalf("resumed.Run = %#v, want new running run", resumed.Run)
+	}
+}
+
+func TestCreateRunContextInterruptsOrphanPreStartRunningRun(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{ID: "loop_orphan_prestart", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step"})
+	orphan := storage.RunRecord{ID: "run_orphan_prestart", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	created, err := runner.createRunContext(context.Background(), loop)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if created.Run.ID == orphan.ID || created.Run.Status != "running" {
+		t.Fatalf("created.Run = %#v, want new running run", created.Run)
+	}
+	oldRun, err := fixture.repos.Runs.GetByID(context.Background(), orphan.ID)
+	if err != nil || oldRun == nil {
+		t.Fatalf("Runs.GetByID(orphan) = (%#v, %v), want run", oldRun, err)
+	}
+	if oldRun.Status != "interrupted" || oldRun.EndedAt == nil {
+		t.Fatalf("oldRun = %#v, want interrupted terminal orphan", oldRun)
+	}
+}
+
 func TestProcessClaimedItemFailsWhenRepairCompletionResultMissing(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -2047,6 +2130,7 @@ func (f *runnerFixture) nowISO() string {
 
 type fakeGitHubGateway struct {
 	currentUser           string
+	currentUserErr        error
 	listOpen              []PullRequestSummary
 	listOpenByLabel       map[string][]PullRequestSummary
 	listCalls             []ListOpenPullRequestsInput
@@ -2079,6 +2163,9 @@ func (f *fakeGitHubGateway) ListOpenPullRequests(_ context.Context, input ListOp
 }
 
 func (f *fakeGitHubGateway) GetCurrentUserLogin(context.Context, string) (string, error) {
+	if f.currentUserErr != nil {
+		return "", f.currentUserErr
+	}
 	return firstNonEmpty(f.currentUser, "looper"), nil
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1169,8 +1169,11 @@ func TestProcessClaimedItemMarksRunFailedWhenOwnershipCheckErrorsBeforeStart(t *
 		t.Fatalf("latest.CurrentStep = %#v, want discover-pr", latest.CurrentStep)
 	}
 	checkpoint := parseCheckpoint(latest.CheckpointJSON)
-	if checkpoint.RunStartedAt == "" || checkpoint.RunStartedRunID != latest.ID {
-		t.Fatalf("checkpoint start marker = (%q, %q), want current run marker", checkpoint.RunStartedAt, checkpoint.RunStartedRunID)
+	if checkpoint.RunStartedAt != "" || checkpoint.RunStartedRunID != "" {
+		t.Fatalf("checkpoint start marker = (%q, %q), want no start marker before ownership failure", checkpoint.RunStartedAt, checkpoint.RunStartedRunID)
+	}
+	if checkpoint.RunPreStartAt == "" || checkpoint.RunPreStartRunID != latest.ID {
+		t.Fatalf("checkpoint pre-start marker = (%q, %q), want current run marker", checkpoint.RunPreStartAt, checkpoint.RunPreStartRunID)
 	}
 	events, err := fixture.repos.Events.ListByEntity(context.Background(), "run", latest.ID)
 	if err != nil {
@@ -1259,6 +1262,74 @@ func TestCreateRunContextTreatsRunningAgentExecutionAsRetryable(t *testing.T) {
 	}
 	if activeRun.Status != "running" || activeRun.EndedAt != nil {
 		t.Fatalf("activeRun = %#v, want still-running active run", activeRun)
+	}
+}
+
+func TestCreateRunContextTreatsFreshPreStartRunAsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{ID: "loop_fresh_prestart", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step", RunPreStartAt: nowISO, RunPreStartRunID: "run_fresh_prestart"})
+	preStartRun := storage.RunRecord{ID: "run_fresh_prestart", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), preStartRun); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable pre-start error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
+	}
+	activeRun, err := fixture.repos.Runs.GetByID(context.Background(), preStartRun.ID)
+	if err != nil || activeRun == nil {
+		t.Fatalf("Runs.GetByID(preStart) = (%#v, %v), want run", activeRun, err)
+	}
+	if activeRun.Status != "running" || activeRun.EndedAt != nil {
+		t.Fatalf("activeRun = %#v, want still-running pre-start run", activeRun)
+	}
+}
+
+func TestCreateRunContextInterruptsStalePreStartRun(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	stalePreStartAt := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
+	loop := storage.LoopRecord{ID: "loop_stale_prestart", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step", RunPreStartAt: stalePreStartAt, RunPreStartRunID: "run_stale_prestart"})
+	orphan := storage.RunRecord{ID: "run_stale_prestart", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	created, err := runner.createRunContext(context.Background(), loop)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if created.Run.ID == orphan.ID || created.Run.Status != "running" {
+		t.Fatalf("created.Run = %#v, want replacement running run", created.Run)
+	}
+	oldRun, err := fixture.repos.Runs.GetByID(context.Background(), orphan.ID)
+	if err != nil || oldRun == nil {
+		t.Fatalf("Runs.GetByID(orphan) = (%#v, %v), want run", oldRun, err)
+	}
+	if oldRun.Status != "interrupted" || oldRun.EndedAt == nil {
+		t.Fatalf("oldRun = %#v, want interrupted stale pre-start run", oldRun)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1197,16 +1197,17 @@ func TestProcessClaimedItemMarksRunFailedWhenOwnershipCheckErrorsBeforeStart(t *
 func TestCreateRunContextInterruptsOrphanPreStartRunningRun(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
+	oldISO := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
 	loop := storage.LoopRecord{ID: "loop_orphan_prestart", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step"})
-	orphan := storage.RunRecord{ID: "run_orphan_prestart", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	orphan := storage.RunRecord{ID: "run_orphan_prestart", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
 	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -1227,18 +1228,46 @@ func TestCreateRunContextInterruptsOrphanPreStartRunningRun(t *testing.T) {
 	}
 }
 
-func TestCreateRunContextTreatsRunningAgentExecutionAsRetryable(t *testing.T) {
+func TestCreateRunContextTreatsFreshMarkerlessRunAsRetryable(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{ID: "loop_fresh_markerless", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step"})
+	active := storage.RunRecord{ID: "run_fresh_markerless", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), active); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable fresh-run error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
+	}
+}
+
+func TestCreateRunContextTreatsRunningAgentExecutionAsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	oldISO := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
 	loop := storage.LoopRecord{ID: "loop_active_agent_execution", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
-	orphan := storage.RunRecord{ID: "run_active_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	orphan := storage.RunRecord{ID: "run_active_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
 	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -1268,16 +1297,17 @@ func TestCreateRunContextTreatsRunningAgentExecutionAsRetryable(t *testing.T) {
 func TestCreateRunContextTreatsFreshPreStartRunAsRetryable(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
+	oldISO := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
 	loop := storage.LoopRecord{ID: "loop_fresh_prestart", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step", RunPreStartAt: nowISO, RunPreStartRunID: "run_fresh_prestart"})
-	preStartRun := storage.RunRecord{ID: "run_fresh_prestart", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	preStartRun := storage.RunRecord{ID: "run_fresh_prestart", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
 	if err := fixture.repos.Runs.Upsert(context.Background(), preStartRun); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -1312,7 +1342,7 @@ func TestCreateRunContextInterruptsStalePreStartRun(t *testing.T) {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step", RunPreStartAt: stalePreStartAt, RunPreStartRunID: "run_stale_prestart"})
-	orphan := storage.RunRecord{ID: "run_stale_prestart", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	orphan := storage.RunRecord{ID: "run_stale_prestart", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: stalePreStartAt, LastHeartbeatAt: &stalePreStartAt, CreatedAt: stalePreStartAt, UpdatedAt: stalePreStartAt}
 	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -1336,16 +1366,16 @@ func TestCreateRunContextInterruptsStalePreStartRun(t *testing.T) {
 func TestCreateRunContextTreatsOlderActiveAgentExecutionAsRetryable(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
-	activeStartedAt := fixture.current.Add(-time.Minute).UTC().Format(time.RFC3339Nano)
+	activeStartedAt := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
 	loop := storage.LoopRecord{ID: "loop_older_active_agent_execution", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
-	orphan := storage.RunRecord{ID: "run_older_active_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	orphan := storage.RunRecord{ID: "run_older_active_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: activeStartedAt, LastHeartbeatAt: &activeStartedAt, CreatedAt: activeStartedAt, UpdatedAt: activeStartedAt}
 	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -1379,7 +1409,7 @@ func TestCreateRunContextTreatsOlderActiveAgentExecutionAsRetryable(t *testing.T
 func TestCreateRunContextInterruptsOrphanWithTerminalAgentExecution(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
@@ -1387,7 +1417,8 @@ func TestCreateRunContextInterruptsOrphanWithTerminalAgentExecution(t *testing.T
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
-	orphan := storage.RunRecord{ID: "run_terminal_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	oldISO := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
+	orphan := storage.RunRecord{ID: "run_terminal_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
 	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -1455,8 +1486,8 @@ func TestProcessClaimedQueueItemRequeuesWhenActiveRunHasAgentExecution(t *testin
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.Attempts != 1 || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) {
-		t.Fatalf("queue = %#v, want requeued retryable_transient failure", queue)
+	if queue == nil || queue.Status != "queued" || queue.Attempts != 0 || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) {
+		t.Fatalf("queue = %#v, want requeued retryable_transient active-run failure without consuming attempts", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil {
@@ -1474,18 +1505,19 @@ func TestProcessClaimedQueueItemRequeuesWhenActiveRunHasAgentExecution(t *testin
 	}
 }
 
-func TestCreateRunContextTreatsStartedRunAsRetryable(t *testing.T) {
+func TestCreateRunContextDoesNotTreatStartedEventAsDurableSignal(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
+	oldISO := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
 	loop := storage.LoopRecord{ID: "loop_started_run", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
-	startedRun := storage.RunRecord{ID: "run_started", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	startedRun := storage.RunRecord{ID: "run_started", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
 	if err := fixture.repos.Runs.Upsert(context.Background(), startedRun); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -1495,36 +1527,36 @@ func TestCreateRunContextTreatsStartedRunAsRetryable(t *testing.T) {
 		t.Fatalf("Events.Append() error = %v", err)
 	}
 
-	_, err := runner.createRunContext(context.Background(), loop)
-	if err == nil {
-		t.Fatal("createRunContext() error = nil, want retryable started-run error")
+	created, err := runner.createRunContext(context.Background(), loop)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
 	}
-	var loopErr *loopError
-	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
-		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
+	if created.Run.ID == startedRun.ID || created.Run.Status != "running" {
+		t.Fatalf("created.Run = %#v, want replacement running run", created.Run)
 	}
-	activeRun, err := fixture.repos.Runs.GetByID(context.Background(), startedRun.ID)
-	if err != nil || activeRun == nil {
-		t.Fatalf("Runs.GetByID(started) = (%#v, %v), want run", activeRun, err)
+	interrupted, err := fixture.repos.Runs.GetByID(context.Background(), startedRun.ID)
+	if err != nil || interrupted == nil {
+		t.Fatalf("Runs.GetByID(started) = (%#v, %v), want run", interrupted, err)
 	}
-	if activeRun.Status != "running" || activeRun.EndedAt != nil {
-		t.Fatalf("activeRun = %#v, want still-running started run", activeRun)
+	if interrupted.Status != "interrupted" || interrupted.EndedAt == nil {
+		t.Fatalf("interrupted = %#v, want interrupted run despite best-effort event", interrupted)
 	}
 }
 
 func TestCreateRunContextTreatsDurablyStartedRunAsRetryableWhenEventMissing(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
+	oldISO := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
 	loop := storage.LoopRecord{ID: "loop_started_run_missing_event", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step", RunStartedAt: nowISO, RunStartedRunID: "run_started_missing_event"})
-	startedRun := storage.RunRecord{ID: "run_started_missing_event", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	startedRun := storage.RunRecord{ID: "run_started_missing_event", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
 	if err := fixture.repos.Runs.Upsert(context.Background(), startedRun); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -1553,6 +1585,69 @@ func TestCreateRunContextTreatsDurablyStartedRunAsRetryableWhenEventMissing(t *t
 	}
 }
 
+func TestCreateRunContextTreatsLegacyStartedRunAsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	oldISO := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
+	loop := storage.LoopRecord{ID: "loop_legacy_started_run", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step", RunStartedAt: nowISO})
+	startedRun := storage.RunRecord{ID: "run_legacy_started", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), startedRun); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable legacy started-run error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
+	}
+}
+
+func TestCreateRunContextInterruptsLegacyStaleStartedMarker(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	createdAt := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
+	staleStartedAt := fixture.current.Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+	loop := storage.LoopRecord{ID: "loop_legacy_stale_started", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "advance_from_checkpoint", RunStartedAt: staleStartedAt})
+	orphan := storage.RunRecord{ID: "run_legacy_stale_started", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: createdAt, LastHeartbeatAt: &createdAt, CreatedAt: createdAt, UpdatedAt: createdAt}
+	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	created, err := runner.createRunContext(context.Background(), loop)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if created.Run.ID == orphan.ID || created.Run.Status != "running" {
+		t.Fatalf("created.Run = %#v, want replacement running run", created.Run)
+	}
+	oldRun, err := fixture.repos.Runs.GetByID(context.Background(), orphan.ID)
+	if err != nil || oldRun == nil {
+		t.Fatalf("Runs.GetByID(orphan) = (%#v, %v), want run", oldRun, err)
+	}
+	if oldRun.Status != "interrupted" || oldRun.EndedAt == nil {
+		t.Fatalf("oldRun = %#v, want interrupted legacy stale-start run", oldRun)
+	}
+}
+
 func TestCreateRunContextInterruptsResumedRunWithStaleStartMarker(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -1566,7 +1661,7 @@ func TestCreateRunContextInterruptsResumedRunWithStaleStartMarker(t *testing.T) 
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "advance_from_checkpoint", RunStartedAt: staleStartedAt, RunStartedRunID: "previous_run"})
-	orphan := storage.RunRecord{ID: "run_stale_started_marker", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	orphan := storage.RunRecord{ID: "run_stale_started_marker", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: staleStartedAt, LastHeartbeatAt: &staleStartedAt, CreatedAt: staleStartedAt, UpdatedAt: staleStartedAt}
 	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -1580,6 +1675,9 @@ func TestCreateRunContextInterruptsResumedRunWithStaleStartMarker(t *testing.T) 
 	}
 	if created.Checkpoint.RunStartedAt != "" || created.Checkpoint.RunStartedRunID != "" {
 		t.Fatalf("created.Checkpoint = %#v, want cleared start marker", created.Checkpoint)
+	}
+	if created.Checkpoint.RunPreStartAt == "" || created.Checkpoint.RunPreStartRunID != created.Run.ID {
+		t.Fatalf("created.Checkpoint = %#v, want current pre-start marker", created.Checkpoint)
 	}
 	oldRun, err := fixture.repos.Runs.GetByID(context.Background(), orphan.ID)
 	if err != nil || oldRun == nil {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1194,7 +1194,7 @@ func TestProcessClaimedItemMarksRunFailedWhenOwnershipCheckErrorsBeforeStart(t *
 	}
 }
 
-func TestCreateRunContextInterruptsOrphanPreStartRunningRun(t *testing.T) {
+func TestCreateRunContextTreatsLegacyMarkerlessRunAsRetryable(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
@@ -1202,12 +1202,47 @@ func TestCreateRunContextInterruptsOrphanPreStartRunningRun(t *testing.T) {
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
 	oldISO := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
-	loop := storage.LoopRecord{ID: "loop_orphan_prestart", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	loop := storage.LoopRecord{ID: "loop_legacy_markerless", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step"})
-	orphan := storage.RunRecord{ID: "run_orphan_prestart", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
+	active := storage.RunRecord{ID: "run_legacy_markerless", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), active); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable legacy markerless error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
+	}
+	preservedRun, err := fixture.repos.Runs.GetByID(context.Background(), active.ID)
+	if err != nil || preservedRun == nil {
+		t.Fatalf("Runs.GetByID(active) = (%#v, %v), want run", preservedRun, err)
+	}
+	if preservedRun.Status != "running" || preservedRun.EndedAt != nil {
+		t.Fatalf("preservedRun = %#v, want still-running legacy markerless run", preservedRun)
+	}
+}
+
+func TestCreateRunContextInterruptsLegacyMarkerlessRunAfterGrace(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	staleISO := fixture.current.Add(-25 * time.Hour).UTC().Format(time.RFC3339Nano)
+	loop := storage.LoopRecord{ID: "loop_stale_legacy_markerless", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step"})
+	orphan := storage.RunRecord{ID: "run_stale_legacy_markerless", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: staleISO, LastHeartbeatAt: &staleISO, CreatedAt: staleISO, UpdatedAt: staleISO}
 	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -1217,14 +1252,14 @@ func TestCreateRunContextInterruptsOrphanPreStartRunningRun(t *testing.T) {
 		t.Fatalf("createRunContext() error = %v", err)
 	}
 	if created.Run.ID == orphan.ID || created.Run.Status != "running" {
-		t.Fatalf("created.Run = %#v, want new running run", created.Run)
+		t.Fatalf("created.Run = %#v, want replacement running run", created.Run)
 	}
 	oldRun, err := fixture.repos.Runs.GetByID(context.Background(), orphan.ID)
 	if err != nil || oldRun == nil {
 		t.Fatalf("Runs.GetByID(orphan) = (%#v, %v), want run", oldRun, err)
 	}
 	if oldRun.Status != "interrupted" || oldRun.EndedAt == nil {
-		t.Fatalf("oldRun = %#v, want interrupted terminal orphan", oldRun)
+		t.Fatalf("oldRun = %#v, want interrupted stale legacy markerless run", oldRun)
 	}
 }
 
@@ -1406,7 +1441,7 @@ func TestCreateRunContextTreatsOlderActiveAgentExecutionAsRetryable(t *testing.T
 	}
 }
 
-func TestCreateRunContextInterruptsOrphanWithTerminalAgentExecution(t *testing.T) {
+func TestCreateRunContextTreatsMarkerlessRunWithTerminalAgentExecutionAsRetryable(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
@@ -1418,30 +1453,31 @@ func TestCreateRunContextInterruptsOrphanWithTerminalAgentExecution(t *testing.T
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	oldISO := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
-	orphan := storage.RunRecord{ID: "run_terminal_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
-	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
+	active := storage.RunRecord{ID: "run_terminal_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), active); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
-	runID := orphan.ID
+	runID := active.ID
 	loopID := loop.ID
 	endedAt := nowISO
 	if err := fixture.repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_terminal_execution", LoopID: &loopID, RunID: &runID, Vendor: "opencode", Status: "completed", StartedAt: nowISO, EndedAt: &endedAt, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
 	}
 
-	created, err := runner.createRunContext(context.Background(), loop)
-	if err != nil {
-		t.Fatalf("createRunContext() error = %v", err)
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable markerless active-run error")
 	}
-	if created.Run.ID == orphan.ID || created.Run.Status != "running" {
-		t.Fatalf("created.Run = %#v, want replacement running run", created.Run)
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
 	}
-	oldRun, err := fixture.repos.Runs.GetByID(context.Background(), orphan.ID)
-	if err != nil || oldRun == nil {
-		t.Fatalf("Runs.GetByID(orphan) = (%#v, %v), want run", oldRun, err)
+	preservedRun, err := fixture.repos.Runs.GetByID(context.Background(), active.ID)
+	if err != nil || preservedRun == nil {
+		t.Fatalf("Runs.GetByID(active) = (%#v, %v), want run", preservedRun, err)
 	}
-	if oldRun.Status != "interrupted" || oldRun.EndedAt == nil {
-		t.Fatalf("oldRun = %#v, want interrupted terminal-execution orphan", oldRun)
+	if preservedRun.Status != "running" || preservedRun.EndedAt != nil {
+		t.Fatalf("preservedRun = %#v, want still-running markerless run", preservedRun)
 	}
 }
 
@@ -1505,7 +1541,58 @@ func TestProcessClaimedQueueItemRequeuesWhenActiveRunHasAgentExecution(t *testin
 	}
 }
 
-func TestCreateRunContextDoesNotTreatStartedEventAsDurableSignal(t *testing.T) {
+func TestProcessClaimedQueueItemRequeuesLegacyMarkerlessRunWithoutConsumingAttempts(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := "pr:acme/looper:42"
+	nowISO := fixture.nowISO()
+	oldISO := fixture.current.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_legacy_markerless_queue", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step"})
+	activeRun := storage.RunRecord{ID: "run_legacy_markerless_queue", LoopID: "loop_legacy_markerless_queue", Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), activeRun); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	loopID := activeRun.LoopID
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_legacy_markerless", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: loopTarget, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:legacy-markerless", Priority: 1, Status: "queued", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedQueueItem() error = %v", err)
+	}
+	if result == nil || result.Status != "failed" || result.FailureKind != FailureRetryableTransient || !contains(result.Summary, "markerless running fixer run") {
+		t.Fatalf("result = %#v, want retryable_transient markerless active-run recovery", result)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "queued" || queue.Attempts != 1 || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) {
+		t.Fatalf("queue = %#v, want requeued markerless active-run failure without consuming attempts", queue)
+	}
+	preservedRun, err := fixture.repos.Runs.GetByID(context.Background(), activeRun.ID)
+	if err != nil || preservedRun == nil {
+		t.Fatalf("Runs.GetByID() = (%#v, %v), want active run", preservedRun, err)
+	}
+	if preservedRun.Status != "running" || preservedRun.EndedAt != nil {
+		t.Fatalf("preservedRun = %#v, want original run preserved", preservedRun)
+	}
+}
+
+func TestCreateRunContextPreservesMarkerlessRunDespiteStartedEvent(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, ClaimTTL: time.Minute})
@@ -1527,19 +1614,20 @@ func TestCreateRunContextDoesNotTreatStartedEventAsDurableSignal(t *testing.T) {
 		t.Fatalf("Events.Append() error = %v", err)
 	}
 
-	created, err := runner.createRunContext(context.Background(), loop)
-	if err != nil {
-		t.Fatalf("createRunContext() error = %v", err)
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable markerless active-run error")
 	}
-	if created.Run.ID == startedRun.ID || created.Run.Status != "running" {
-		t.Fatalf("created.Run = %#v, want replacement running run", created.Run)
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
 	}
-	interrupted, err := fixture.repos.Runs.GetByID(context.Background(), startedRun.ID)
-	if err != nil || interrupted == nil {
-		t.Fatalf("Runs.GetByID(started) = (%#v, %v), want run", interrupted, err)
+	preserved, err := fixture.repos.Runs.GetByID(context.Background(), startedRun.ID)
+	if err != nil || preserved == nil {
+		t.Fatalf("Runs.GetByID(started) = (%#v, %v), want run", preserved, err)
 	}
-	if interrupted.Status != "interrupted" || interrupted.EndedAt == nil {
-		t.Fatalf("interrupted = %#v, want interrupted run despite best-effort event", interrupted)
+	if preserved.Status != "running" || preserved.EndedAt != nil {
+		t.Fatalf("preserved = %#v, want markerless run preserved despite best-effort event", preserved)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1258,6 +1258,44 @@ func TestCreateRunContextTreatsRunningAgentExecutionAsRetryable(t *testing.T) {
 	}
 }
 
+func TestCreateRunContextInterruptsOrphanWithTerminalAgentExecution(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{ID: "loop_terminal_agent_execution", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	orphan := storage.RunRecord{ID: "run_terminal_agent_execution", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), orphan); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	runID := orphan.ID
+	loopID := loop.ID
+	endedAt := nowISO
+	if err := fixture.repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_terminal_execution", LoopID: &loopID, RunID: &runID, Vendor: "opencode", Status: "completed", StartedAt: nowISO, EndedAt: &endedAt, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	created, err := runner.createRunContext(context.Background(), loop)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if created.Run.ID == orphan.ID || created.Run.Status != "running" {
+		t.Fatalf("created.Run = %#v, want replacement running run", created.Run)
+	}
+	oldRun, err := fixture.repos.Runs.GetByID(context.Background(), orphan.ID)
+	if err != nil || oldRun == nil {
+		t.Fatalf("Runs.GetByID(orphan) = (%#v, %v), want run", oldRun, err)
+	}
+	if oldRun.Status != "interrupted" || oldRun.EndedAt == nil {
+		t.Fatalf("oldRun = %#v, want interrupted terminal-execution orphan", oldRun)
+	}
+}
+
 func TestProcessClaimedQueueItemRequeuesWhenActiveRunHasAgentExecution(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1168,6 +1168,10 @@ func TestProcessClaimedItemMarksRunFailedWhenOwnershipCheckErrorsBeforeStart(t *
 	if latest.CurrentStep == nil || *latest.CurrentStep != string(stepDiscoverPR) {
 		t.Fatalf("latest.CurrentStep = %#v, want discover-pr", latest.CurrentStep)
 	}
+	checkpoint := parseCheckpoint(latest.CheckpointJSON)
+	if checkpoint.RunStartedAt == "" || checkpoint.RunStartedRunID != latest.ID {
+		t.Fatalf("checkpoint start marker = (%q, %q), want current run marker", checkpoint.RunStartedAt, checkpoint.RunStartedRunID)
+	}
 	events, err := fixture.repos.Events.ListByEntity(context.Background(), "run", latest.ID)
 	if err != nil {
 		t.Fatalf("Events.ListByEntity() error = %v", err)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1296,6 +1296,40 @@ func TestCreateRunContextTreatsStartedRunAsRetryable(t *testing.T) {
 	}
 }
 
+func TestCreateRunContextTreatsDurablyStartedRunAsRetryableWhenEventMissing(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{ID: "loop_started_run_missing_event", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: "replay_step", RunStartedAt: nowISO})
+	startedRun := storage.RunRecord{ID: "run_started_missing_event", LoopID: loop.ID, Status: "running", CurrentStep: stringPtr(string(stepDiscoverPR)), CheckpointJSON: &checkpointJSON, StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), startedRun); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable started-run error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable transient loopError", err)
+	}
+	activeRun, err := fixture.repos.Runs.GetByID(context.Background(), startedRun.ID)
+	if err != nil || activeRun == nil {
+		t.Fatalf("Runs.GetByID(started) = (%#v, %v), want run", activeRun, err)
+	}
+	if activeRun.Status != "running" || activeRun.EndedAt != nil {
+		t.Fatalf("activeRun = %#v, want still-running started run", activeRun)
+	}
+}
+
 func TestProcessClaimedItemFailsWhenRepairCompletionResultMissing(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -696,6 +696,19 @@ func (r *AgentExecutionsRepository) GetLatestByRunID(ctx context.Context, runID 
 	return &record, nil
 }
 
+func (r *AgentExecutionsRepository) GetLatestActiveByRunID(ctx context.Context, runID string) (*AgentExecutionRecord, error) {
+	row := r.q.QueryRowContext(ctx, `SELECT `+agentExecutionColumns+` FROM agent_executions WHERE run_id = ? AND status IN ('running', 'cancelling') ORDER BY started_at DESC, id DESC LIMIT 1`, runID)
+	record, err := scanAgentExecution(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get latest active agent execution by run id: %w", err)
+	}
+
+	return &record, nil
+}
+
 func (r *AgentExecutionsRepository) GetLatestByLoopID(ctx context.Context, loopID string) (*AgentExecutionRecord, error) {
 	row := r.q.QueryRowContext(ctx, `SELECT `+agentExecutionColumns+` FROM agent_executions WHERE loop_id = ? ORDER BY started_at DESC, id DESC LIMIT 1`, loopID)
 	record, err := scanAgentExecution(row)


### PR DESCRIPTION
## Summary
- Mark fixer runs terminal when a pre-start error occurs after run creation, preventing orphan `running` runs.
- Interrupt orphan pre-start running fixer runs before creating a retry run, while preserving active/started runs with a clear invariant error.
- Add regression coverage for GitHub ownership-check failures and retry recovery from orphan pre-start runs.

## Validation
- `go test ./internal/fixer`
- `go vet ./...`
- `go test ./...`
- `go build ./...`

Closes #259