### PR TITLE
fix: guard checkpoint worktree reuse

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1369,6 +1369,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	}
 	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
 		checkpoint.Worktree = nil
+		checkpoint.Repair = nil
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		input.Checkpoint = checkpoint
 		checkpoint, err = r.runPrepareWorktreeStep(ctx, input)

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1305,7 +1305,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (f
 		worktreeRoot = resolvedRoot
 	}
 	if checkpoint.Worktree != nil {
-		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
 			checkpoint.Worktree = nil
 			checkpoint.ResumePolicy = "advance_from_checkpoint"
 		} else if checkpoint.Worktree.PreparedAt != "" {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worktreesafety"
 )
 
 const (
@@ -194,6 +195,8 @@ type CreateWorktreeResult struct {
 }
 
 type PrepareWorktreeInput struct {
+	RepoPath        string
+	WorktreeRoot    string
 	WorktreePath    string
 	Branch          string
 	ExpectedHeadSHA string
@@ -206,6 +209,8 @@ type PrepareWorktreeResult struct {
 }
 
 type InspectHeadInput struct {
+	RepoPath     string
+	WorktreeRoot string
 	WorktreePath string
 	BaseRef      string
 }
@@ -218,6 +223,8 @@ type InspectHeadResult struct {
 }
 
 type CommitInput struct {
+	RepoPath     string
+	WorktreeRoot string
 	WorktreePath string
 	Message      string
 }
@@ -225,6 +232,8 @@ type CommitInput struct {
 type CommitResult struct{ CommitSHA string }
 
 type PushInput struct {
+	RepoPath              string
+	WorktreeRoot          string
 	WorktreePath          string
 	Branch                string
 	Remote                string
@@ -235,6 +244,7 @@ type PushInput struct {
 type CleanupWorktreeInput struct {
 	ProjectID         string
 	RepoPath          string
+	WorktreeRoot      string
 	WorktreePath      string
 	Branch            string
 	ProtectedBranches []string
@@ -1281,9 +1291,6 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (f
 	if checkpoint.SkipReason != "" {
 		return checkpoint, nil
 	}
-	if checkpoint.Worktree != nil && checkpoint.Worktree.PreparedAt != "" {
-		return checkpoint, nil
-	}
 	branch := detailHeadRefName(checkpoint.Detail)
 	if branch == "" {
 		return checkpoint, fmt.Errorf("detail.headRefName is required")
@@ -1297,8 +1304,16 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (f
 		}
 		worktreeRoot = resolvedRoot
 	}
+	if checkpoint.Worktree != nil {
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+			checkpoint.Worktree = nil
+			checkpoint.ResumePolicy = "advance_from_checkpoint"
+		} else if checkpoint.Worktree.PreparedAt != "" {
+			return checkpoint, nil
+		}
+	}
 	if shouldRebuildWorktree(checkpoint) && checkpoint.Worktree != nil && checkpoint.Worktree.Path != "" && checkpoint.Worktree.Branch != "" {
-		if err := r.git.CleanupWorktree(ctx, CleanupWorktreeInput{ProjectID: input.Project.ID, RepoPath: input.Project.RepoPath, WorktreePath: checkpoint.Worktree.Path, Branch: checkpoint.Worktree.Branch, ProtectedBranches: compactStrings([]string{detailBaseRefName(checkpoint.Detail), derefString(input.Project.BaseBranch)})}); err != nil {
+		if err := r.git.CleanupWorktree(ctx, CleanupWorktreeInput{ProjectID: input.Project.ID, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: checkpoint.Worktree.Path, Branch: checkpoint.Worktree.Branch, ProtectedBranches: compactStrings([]string{detailBaseRefName(checkpoint.Detail), derefString(input.Project.BaseBranch)})}); err != nil {
 			return checkpoint, err
 		}
 	}
@@ -1306,7 +1321,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (f
 	if err != nil {
 		return checkpoint, err
 	}
-	prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{WorktreePath: created.WorktreePath, Branch: branch, ExpectedHeadSHA: detailHeadSHA(checkpoint.Detail)})
+	prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: created.WorktreePath, Branch: branch, ExpectedHeadSHA: detailHeadSHA(checkpoint.Detail)})
 	if err != nil {
 		return checkpoint, err
 	}
@@ -1347,6 +1362,12 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	worktree, err := requireWorktree(checkpoint)
 	if err != nil {
 		return checkpoint, err
+	}
+	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+		checkpoint.Worktree = nil
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		input.Checkpoint = checkpoint
+		return r.runPrepareWorktreeStep(ctx, input)
 	}
 	executionID := eventlog.NewEventID("agent")
 	prompt, instructionBlock := buildFixerPrompt(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint.Detail, checkpoint.FixItems, r.allowAutoPush, r.disclosure, r.agentRuntime, r.agentModel)
@@ -1391,7 +1412,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 }
 
 func (r *Runner) runReconcileCommitsStep(ctx context.Context, input stepInput) (fixerCheckpoint, error) {
-	checkpoint, err := r.reconcileCommits(ctx, input.Checkpoint, buildFixerCommitMessage(input.PRNumber))
+	checkpoint, err := r.reconcileCommits(ctx, input.Project, input.Checkpoint, buildFixerCommitMessage(input.PRNumber))
 	if err != nil {
 		return input.Checkpoint, err
 	}
@@ -1408,6 +1429,10 @@ func (r *Runner) runValidateStep(ctx context.Context, input stepInput) (fixerChe
 	if err != nil {
 		return checkpoint, err
 	}
+	worktreeRoot, rootErr := fixerWorktreeRoot(input.Project)
+	if rootErr != nil {
+		return checkpoint, rootErr
+	}
 	result, err := r.runValidation(ctx, ValidationInput{CWD: worktree.Path, Commands: r.validationCommands})
 	if err != nil {
 		return checkpoint, err
@@ -1415,7 +1440,7 @@ func (r *Runner) runValidateStep(ctx context.Context, input stepInput) (fixerChe
 	if !result.Passed {
 		return checkpoint, &loopError{message: firstNonEmpty(result.Summary, "Validation failed"), kind: FailureRetryableAfterResume}
 	}
-	inspect, err := r.git.InspectHead(ctx, InspectHeadInput{WorktreePath: worktree.Path, BaseRef: reconcileBaseHeadSHA(checkpoint.ReconcileCommits)})
+	inspect, err := r.git.InspectHead(ctx, InspectHeadInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, BaseRef: reconcileBaseHeadSHA(checkpoint.ReconcileCommits)})
 	if err != nil {
 		return checkpoint, err
 	}
@@ -1423,7 +1448,7 @@ func (r *Runner) runValidateStep(ctx context.Context, input stepInput) (fixerChe
 		if checkpoint.Validation != nil && strings.Contains(strings.ToLower(checkpoint.Validation.Summary), "extra reconcile") {
 			return checkpoint, &loopError{message: "Validation keeps producing new modifications after an extra reconcile pass", kind: FailureRetryableAfterResume}
 		}
-		checkpoint, err = r.reconcileCommits(ctx, checkpoint, buildFixerCommitMessage(input.PRNumber))
+		checkpoint, err = r.reconcileCommits(ctx, input.Project, checkpoint, buildFixerCommitMessage(input.PRNumber))
 		if err != nil {
 			return input.Checkpoint, err
 		}
@@ -1438,7 +1463,7 @@ func (r *Runner) runValidateStep(ctx context.Context, input stepInput) (fixerChe
 		if !second.Passed {
 			return checkpoint, &loopError{message: firstNonEmpty(second.Summary, "Validation failed after reconcile"), kind: FailureRetryableAfterResume}
 		}
-		finalInspect, err := r.git.InspectHead(ctx, InspectHeadInput{WorktreePath: worktree.Path, BaseRef: reconcileBaseHeadSHA(checkpoint.ReconcileCommits)})
+		finalInspect, err := r.git.InspectHead(ctx, InspectHeadInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, BaseRef: reconcileBaseHeadSHA(checkpoint.ReconcileCommits)})
 		if err != nil {
 			return checkpoint, err
 		}
@@ -1467,6 +1492,10 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	if err != nil {
 		return checkpoint, err
 	}
+	worktreeRoot, rootErr := fixerWorktreeRoot(input.Project)
+	if rootErr != nil {
+		return checkpoint, rootErr
+	}
 	branch := firstNonEmpty(worktree.Branch, detailHeadRefName(checkpoint.Detail))
 	if branch == "" {
 		return checkpoint, &loopError{message: "Missing PR head branch for push step", kind: FailureRetryableAfterResume}
@@ -1489,7 +1518,7 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		return checkpoint, nil
 	}
-	if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: branch, ExpectedRemoteHeadSHA: worktree.BaseHeadSHA}); err != nil {
+	if err := r.git.Push(ctx, PushInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Branch: branch, ExpectedRemoteHeadSHA: worktree.BaseHeadSHA}); err != nil {
 		message := err.Error()
 		eventType := "fixer.push.retryable"
 		if strings.Contains(strings.ToLower(message), "remote head changed") {
@@ -2360,7 +2389,7 @@ func (r *Runner) classifyFailure(err error) *loopError {
 	return &loopError{message: message, kind: FailureNonRetryable}
 }
 
-func (r *Runner) reconcileCommits(ctx context.Context, checkpoint fixerCheckpoint, commitMessage string) (fixerCheckpoint, error) {
+func (r *Runner) reconcileCommits(ctx context.Context, project storage.ProjectRecord, checkpoint fixerCheckpoint, commitMessage string) (fixerCheckpoint, error) {
 	if checkpoint.SkipReason != "" {
 		return checkpoint, nil
 	}
@@ -2372,7 +2401,11 @@ func (r *Runner) reconcileCommits(ctx context.Context, checkpoint fixerCheckpoin
 		return checkpoint, err
 	}
 	baseHeadSHA := firstNonEmpty(reconcileBaseHeadSHA(checkpoint.ReconcileCommits), worktree.BaseHeadSHA, worktree.HeadSHA)
-	initial, err := r.git.InspectHead(ctx, InspectHeadInput{WorktreePath: worktree.Path, BaseRef: baseHeadSHA})
+	worktreeRoot, rootErr := fixerWorktreeRoot(project)
+	if rootErr != nil {
+		return checkpoint, rootErr
+	}
+	initial, err := r.git.InspectHead(ctx, InspectHeadInput{RepoPath: project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, BaseRef: baseHeadSHA})
 	if err != nil {
 		return checkpoint, err
 	}
@@ -2382,12 +2415,12 @@ func (r *Runner) reconcileCommits(ctx context.Context, checkpoint fixerCheckpoin
 			checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
 			return checkpoint, &loopError{message: fmt.Sprintf("Auto commit disabled but fixer worktree has uncommitted changes: %s", firstNonEmpty(strings.Join(initial.ChangedFiles, ", "), "unknown files")), kind: FailureManualIntervention}
 		}
-		if _, err := r.git.Commit(ctx, CommitInput{WorktreePath: worktree.Path, Message: commitMessage}); err != nil {
+		if _, err := r.git.Commit(ctx, CommitInput{RepoPath: project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Message: commitMessage}); err != nil {
 			return checkpoint, err
 		}
 		committedByLoop = true
 	}
-	final, err := r.git.InspectHead(ctx, InspectHeadInput{WorktreePath: worktree.Path, BaseRef: baseHeadSHA})
+	final, err := r.git.InspectHead(ctx, InspectHeadInput{RepoPath: project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, BaseRef: baseHeadSHA})
 	if err != nil {
 		return checkpoint, err
 	}
@@ -2410,7 +2443,12 @@ func (r *Runner) cleanupFixerWorktreeIfTerminal(ctx context.Context, project sto
 		return
 	}
 	checkpoint.Worktree.CleanupAttemptedAt = r.nowISO()
-	if err := r.git.CleanupWorktree(ctx, CleanupWorktreeInput{ProjectID: project.ID, RepoPath: project.RepoPath, WorktreePath: checkpoint.Worktree.Path, Branch: checkpoint.Worktree.Branch, ProtectedBranches: compactStrings([]string{derefString(project.BaseBranch)})}); err != nil {
+	worktreeRoot, rootErr := fixerWorktreeRoot(project)
+	if rootErr != nil {
+		r.logError("fixer worktree cleanup skipped", map[string]any{"projectId": project.ID, "worktreePath": checkpoint.Worktree.Path, "branch": checkpoint.Worktree.Branch, "message": rootErr.Error()})
+		return
+	}
+	if err := r.git.CleanupWorktree(ctx, CleanupWorktreeInput{ProjectID: project.ID, RepoPath: project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: checkpoint.Worktree.Path, Branch: checkpoint.Worktree.Branch, ProtectedBranches: compactStrings([]string{derefString(project.BaseBranch)})}); err != nil {
 		r.appendEvent(ctx, eventInput{eventType: "fixer.worktree.cleanup_failed", projectID: project.ID, entityType: "pull_request", entityID: project.ID, payload: map[string]any{"path": checkpoint.Worktree.Path, "branch": checkpoint.Worktree.Branch, "message": err.Error()}})
 		r.logError("fixer worktree cleanup failed", map[string]any{"projectId": project.ID, "worktreePath": checkpoint.Worktree.Path, "branch": checkpoint.Worktree.Branch, "message": err.Error()})
 		return
@@ -2882,6 +2920,15 @@ func requireWorktree(checkpoint fixerCheckpoint) (*checkpointWorktree, error) {
 		return nil, &loopError{message: "Missing worktree checkpoint for fixer step", kind: FailureRetryableAfterResume}
 	}
 	return checkpoint.Worktree, nil
+}
+
+func fixerWorktreeRoot(project storage.ProjectRecord) (string, error) {
+	projectMetadata := parseJSONObject(project.MetadataJSON)
+	worktreeRoot, _ := stringFromAny(projectMetadata["worktreeRoot"])
+	if worktreeRoot != "" {
+		return worktreeRoot, nil
+	}
+	return config.DefaultProjectWorktreeRoot(project.ID, project.RepoPath)
 }
 
 func (c *fixerCheckpoint) ensureLifecycle(runner, branch, baseBranch string, expectPR bool) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1363,7 +1363,11 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	if err != nil {
 		return checkpoint, err
 	}
-	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+	worktreeRoot, rootErr := fixerWorktreeRoot(input.Project)
+	if rootErr != nil {
+		return checkpoint, rootErr
+	}
+	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
 		checkpoint.Worktree = nil
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		input.Checkpoint = checkpoint

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1371,7 +1371,17 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		checkpoint.Worktree = nil
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		input.Checkpoint = checkpoint
-		return r.runPrepareWorktreeStep(ctx, input)
+		checkpoint, err = r.runPrepareWorktreeStep(ctx, input)
+		if err != nil {
+			return checkpoint, err
+		}
+		worktree, err = requireWorktree(checkpoint)
+		if err != nil {
+			return checkpoint, err
+		}
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
+			return checkpoint, err
+		}
 	}
 	executionID := eventlog.NewEventID("agent")
 	prompt, instructionBlock := buildFixerPrompt(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint.Detail, checkpoint.FixItems, r.allowAutoPush, r.disclosure, r.agentRuntime, r.agentModel)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1975,7 +1975,7 @@ func TestRunRepairStepRequiresManualInterventionForRiskyConflictWhenDisabled(t *
 	}
 }
 
-func TestRunRepairStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
+func TestRunRepairStepRecreatesCheckpointOutsideWorktreeRootAndRunsAgent(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repoPath := t.TempDir()

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -114,6 +114,7 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 	fixture := newRunnerFixture(t)
 	repoPath := t.TempDir()
 	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	legacyPath := filepath.Join(t.TempDir(), "legacy-wt")
 	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "feature/fix-42", HeadSHA: "base-head"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
@@ -124,7 +125,7 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 		PRNumber: 42,
 		Checkpoint: fixerCheckpoint{
 			Detail:   &checkpointDetail{HeadRefName: "feature/fix-42", BaseRefName: "main", HeadSHA: "head-1"},
-			Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "legacy-wt"), Branch: "feature/fix-42", PreparedAt: "stale"},
+			Worktree: &checkpointWorktree{Path: legacyPath, Branch: "feature/fix-42", PreparedAt: "stale"},
 		},
 	})
 	if err != nil {
@@ -136,8 +137,14 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
 		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
 	}
+	if checkpoint.Worktree.Path == legacyPath {
+		t.Fatalf("checkpoint.Worktree.Path = %q, want recreated path outside legacy prepared worktree", checkpoint.Worktree.Path)
+	}
 	if git.createCalls[0].WorktreeRoot != worktreeRoot {
 		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", git.createCalls[0].WorktreeRoot, worktreeRoot)
+	}
+	if len(git.prepareCalls) != 1 {
+		t.Fatalf("len(git.prepareCalls) = %d, want 1", len(git.prepareCalls))
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -109,6 +109,38 @@ func TestRunPrepareWorktreeStepRecreatesUnsafeCheckpointAtRepoPath(t *testing.T)
 	}
 }
 
+func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "feature/fix-42", HeadSHA: "base-head"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+
+	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: fixerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/fix-42", BaseRefName: "main", HeadSHA: "head-1"},
+			Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "legacy-wt"), Branch: "feature/fix-42", PreparedAt: "stale"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPrepareWorktreeStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if git.createCalls[0].WorktreeRoot != worktreeRoot {
+		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", git.createCalls[0].WorktreeRoot, worktreeRoot)
+	}
+}
+
 func TestBuildFixerMinimalPRSeedUsesEnterpriseHost(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -117,7 +117,8 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 	legacyPath := filepath.Join(t.TempDir(), "legacy-wt")
 	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "feature/fix-42", HeadSHA: "base-head"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
 
 	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
 		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
@@ -1982,7 +1983,8 @@ func TestRunRepairStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
 	legacyPath := filepath.Join(t.TempDir(), "legacy-wt")
 	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "feature/fix-42", HeadSHA: "base-head"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
 
 	checkpoint, err := runner.runRepairStep(context.Background(), stepInput{
 		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
@@ -2010,11 +2012,14 @@ func TestRunRepairStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
 	if git.createCalls[0].WorktreeRoot != worktreeRoot {
 		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", git.createCalls[0].WorktreeRoot, worktreeRoot)
 	}
-	if checkpoint.Repair != nil {
-		t.Fatalf("checkpoint.Repair = %#v, want repair state unchanged during worktree recovery", checkpoint.Repair)
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
 	}
-	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
-		t.Fatalf("ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
+	if agent.starts[0].WorkingDirectory != git.createResult.WorktreePath {
+		t.Fatalf("agent WorkingDirectory = %q, want rebuilt worktree %q", agent.starts[0].WorkingDirectory, git.createResult.WorktreePath)
+	}
+	if checkpoint.Repair == nil || checkpoint.Repair.Summary != "applied fixes" {
+		t.Fatalf("checkpoint.Repair = %#v, want completed repair after worktree recovery", checkpoint.Repair)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -79,6 +79,36 @@ func TestBuildFixerPromptIncludesMinimalPRSeedFetchContract(t *testing.T) {
 	}
 }
 
+func TestRunPrepareWorktreeStepRecreatesUnsafeCheckpointAtRepoPath(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/fix-42", HeadSHA: "base-head"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+
+	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: repoPath},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: fixerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/fix-42", BaseRefName: "main", HeadSHA: "head-1"},
+			Worktree: &checkpointWorktree{Path: repoPath, Branch: "feature/fix-42", PreparedAt: "stale"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPrepareWorktreeStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
+	}
+}
+
 func TestBuildFixerMinimalPRSeedUsesEnterpriseHost(t *testing.T) {
 	t.Parallel()
 
@@ -1909,7 +1939,8 @@ func TestReconcileCommitsRequiresManualInterventionWhenAutoCommitDisabledAndDirt
 	t.Parallel()
 
 	runner := New(Options{Git: &fakeGitGateway{inspectResults: []InspectHeadResult{{HeadSHA: "head-1", HasUncommittedChanges: true, ChangedFiles: []string{"file.txt"}}}}, AllowAutoCommit: false})
-	checkpoint, err := runner.reconcileCommits(context.Background(), fixerCheckpoint{Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "head-1", BaseHeadSHA: "head-1"}}, "fix: test")
+	project := storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()}
+	checkpoint, err := runner.reconcileCommits(context.Background(), project, fixerCheckpoint{Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "head-1", BaseHeadSHA: "head-1"}}, "fix: test")
 	if err == nil {
 		t.Fatal("reconcileCommits() error = nil, want manual intervention")
 	}

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1974,6 +1974,50 @@ func TestRunRepairStepRequiresManualInterventionForRiskyConflictWhenDisabled(t *
 	}
 }
 
+func TestRunRepairStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	legacyPath := filepath.Join(t.TempDir(), "legacy-wt")
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "feature/fix-42", HeadSHA: "base-head"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+
+	checkpoint, err := runner.runRepairStep(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: fixerCheckpoint{
+			Detail:       &checkpointDetail{HeadRefName: "feature/fix-42", BaseRefName: "main", HeadSHA: "head-1"},
+			FixItems:     []FixItem{{ID: "fix-1", Summary: "repair disclosure"}},
+			Worktree:     &checkpointWorktree{Path: legacyPath, Branch: "feature/fix-42", PreparedAt: "stale"},
+			FixItemsHash: "hash-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("runRepairStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if len(git.prepareCalls) != 1 {
+		t.Fatalf("len(git.prepareCalls) = %d, want 1", len(git.prepareCalls))
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if git.createCalls[0].WorktreeRoot != worktreeRoot {
+		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", git.createCalls[0].WorktreeRoot, worktreeRoot)
+	}
+	if checkpoint.Repair != nil {
+		t.Fatalf("checkpoint.Repair = %#v, want repair state unchanged during worktree recovery", checkpoint.Repair)
+	}
+	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
+	}
+}
+
 func TestReconcileCommitsRequiresManualInterventionWhenAutoCommitDisabledAndDirty(t *testing.T) {
 	t.Parallel()
 
@@ -2239,6 +2283,8 @@ func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeI
 	result := f.createResult
 	if result.WorktreePath == "" {
 		result.WorktreePath = filepath.Join(input.WorktreeRoot, "wt")
+	} else if input.WorktreeRoot != "" {
+		result.WorktreePath = filepath.Join(input.WorktreeRoot, filepath.Base(result.WorktreePath))
 	}
 	if result.Branch == "" {
 		result.Branch = input.Branch
@@ -2246,6 +2292,7 @@ func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeI
 	if result.HeadSHA == "" {
 		result.HeadSHA = "base-head"
 	}
+	f.createResult = result
 	return result, nil
 }
 

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worktreesafety"
 )
 
 const javaScriptISOStringLayout = "2006-01-02T15:04:05.000Z"
@@ -63,6 +64,8 @@ type RestoreWorktreeInput struct {
 }
 
 type PrepareWorktreeInput struct {
+	RepoPath        string
+	WorktreeRoot    string
 	WorktreePath    string
 	Branch          string
 	Ref             string
@@ -76,6 +79,8 @@ type PrepareWorktreeResult struct {
 }
 
 type InspectHeadInput struct {
+	RepoPath     string
+	WorktreeRoot string
 	WorktreePath string
 	BaseRef      string
 }
@@ -88,6 +93,8 @@ type InspectHeadResult struct {
 }
 
 type CommitInput struct {
+	RepoPath     string
+	WorktreeRoot string
 	WorktreePath string
 	Message      string
 }
@@ -99,12 +106,15 @@ type CommitResult struct {
 type CleanupWorktreeInput struct {
 	ProjectID         string
 	RepoPath          string
+	WorktreeRoot      string
 	WorktreePath      string
 	Branch            string
 	ProtectedBranches []string
 }
 
 type PushInput struct {
+	RepoPath              string
+	WorktreeRoot          string
 	WorktreePath          string
 	Branch                string
 	Remote                string
@@ -295,7 +305,7 @@ func (g *Gateway) RestoreWorktree(ctx context.Context, input RestoreWorktreeInpu
 		if err != nil {
 			return nil, fmt.Errorf("get stored worktree by branch: %w", err)
 		}
-		if stored != nil && stored.Status != "cleaned" && normalizeComparablePath(stored.RepoPath) == normalizeComparablePath(input.RepoPath) && normalizeComparablePath(stored.WorktreePath) != normalizeComparablePath(input.RepoPath) && (input.WorktreeRoot == "" || isWithinRoot(stored.WorktreePath, input.WorktreeRoot)) {
+		if stored != nil && stored.Status != "cleaned" && normalizeComparablePath(stored.RepoPath) == normalizeComparablePath(input.RepoPath) && worktreesafety.IsSafe(worktreesafety.CheckInput{WorktreePath: stored.WorktreePath, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot}) {
 			storedHealthy, err := g.isHealthyWorktree(ctx, stored.WorktreePath)
 			if err != nil {
 				return nil, err
@@ -347,10 +357,7 @@ func (g *Gateway) RestoreWorktree(ctx context.Context, input RestoreWorktreeInpu
 		} else if candidate.Branch != input.Branch {
 			continue
 		}
-		if normalizeComparablePath(candidate.Path) == normalizeComparablePath(input.RepoPath) {
-			continue
-		}
-		if input.WorktreeRoot != "" && !isWithinRoot(candidate.Path, input.WorktreeRoot) {
+		if !worktreesafety.IsSafe(worktreesafety.CheckInput{WorktreePath: candidate.Path, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot}) {
 			continue
 		}
 		match = &candidate
@@ -427,6 +434,9 @@ func (g *Gateway) CleanupWorktree(ctx context.Context, input CleanupWorktreeInpu
 	if err := g.AssertWritableBranch(input.Branch, input.ProtectedBranches); err != nil {
 		return err
 	}
+	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: input.WorktreePath, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot}); err != nil {
+		return err
+	}
 	if err := g.runGit(ctx, input.RepoPath, nil, "worktree", "remove", "--force", input.WorktreePath); err != nil {
 		if !missingWorktreeErrorPattern.MatchString(err.Error()) {
 			return err
@@ -459,6 +469,9 @@ func (g *Gateway) CleanupWorktree(ctx context.Context, input CleanupWorktreeInpu
 
 func (g *Gateway) Push(ctx context.Context, input PushInput) error {
 	if err := g.AssertWritableBranch(input.Branch, input.ProtectedBranches); err != nil {
+		return err
+	}
+	if err := g.validateMutationWorktree(input.WorktreePath, input.RepoPath, input.WorktreeRoot); err != nil {
 		return err
 	}
 	remote := input.Remote
@@ -500,6 +513,9 @@ func (g *Gateway) Push(ctx context.Context, input PushInput) error {
 }
 
 func (g *Gateway) PrepareWorktree(ctx context.Context, input PrepareWorktreeInput) (PrepareWorktreeResult, error) {
+	if err := g.validateMutationWorktree(input.WorktreePath, input.RepoPath, input.WorktreeRoot); err != nil {
+		return PrepareWorktreeResult{}, err
+	}
 	remote := input.Remote
 	if strings.TrimSpace(remote) == "" {
 		remote = "origin"
@@ -558,6 +574,9 @@ func (g *Gateway) PrepareWorktree(ctx context.Context, input PrepareWorktreeInpu
 }
 
 func (g *Gateway) InspectHead(ctx context.Context, input InspectHeadInput) (InspectHeadResult, error) {
+	if err := g.validateMutationWorktree(input.WorktreePath, input.RepoPath, input.WorktreeRoot); err != nil {
+		return InspectHeadResult{}, err
+	}
 	headSHA, err := g.getHeadSHA(ctx, input.WorktreePath)
 	if err != nil {
 		return InspectHeadResult{}, err
@@ -590,6 +609,9 @@ func (g *Gateway) InspectHead(ctx context.Context, input InspectHeadInput) (Insp
 }
 
 func (g *Gateway) Commit(ctx context.Context, input CommitInput) (CommitResult, error) {
+	if err := g.validateMutationWorktree(input.WorktreePath, input.RepoPath, input.WorktreeRoot); err != nil {
+		return CommitResult{}, err
+	}
 	if err := g.runGit(ctx, input.WorktreePath, nil, "add", "-A"); err != nil {
 		return CommitResult{}, err
 	}
@@ -606,6 +628,15 @@ func (g *Gateway) Commit(ctx context.Context, input CommitInput) (CommitResult, 
 	}
 
 	return CommitResult{CommitSHA: headSHA}, nil
+}
+
+func (g *Gateway) validateMutationWorktree(worktreePath, repoPath, worktreeRoot string) error {
+	if repoPath == "" && worktreeRoot == "" && g.repos != nil {
+		// Legacy callers may not provide safety context. Keep them working while
+		// adapter callers pass repo/root context for the hard safety check.
+		return nil
+	}
+	return worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktreePath, RepoPath: repoPath, WorktreeRoot: worktreeRoot})
 }
 
 func (g *Gateway) AssertWritableBranch(branch string, protectedBranches []string) error {

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -198,6 +198,9 @@ func (g *Gateway) CreateWorktree(ctx context.Context, input CreateWorktreeInput)
 	}
 
 	worktreePath := filepath.Join(input.WorktreeRoot, buildWorktreeDirectoryName(input))
+	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktreePath, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot}); err != nil {
+		return storage.WorktreeRecord{}, err
+	}
 	checkoutMode := normalizeCheckoutMode(input.CheckoutMode)
 
 	restored, err := g.RestoreWorktree(ctx, RestoreWorktreeInput{

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -8,12 +8,89 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/storage"
 )
+
+func TestGatewayRejectsRepoPathAsMutationWorktree(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createMainOnlyRepo(t)
+	gateway := fixture.gateway()
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{name: "prepare", run: func() error {
+			_, err := gateway.PrepareWorktree(ctx, PrepareWorktreeInput{RepoPath: fixture.repoPath, WorktreePath: fixture.repoPath, Branch: "main"})
+			return err
+		}},
+		{name: "commit", run: func() error {
+			_, err := gateway.Commit(ctx, CommitInput{RepoPath: fixture.repoPath, WorktreePath: fixture.repoPath, Message: "test"})
+			return err
+		}},
+		{name: "push", run: func() error {
+			return gateway.Push(ctx, PushInput{RepoPath: fixture.repoPath, WorktreePath: fixture.repoPath, Branch: "feature/test"})
+		}},
+		{name: "cleanup", run: func() error {
+			return gateway.CleanupWorktree(ctx, CleanupWorktreeInput{ProjectID: fixture.projectID, RepoPath: fixture.repoPath, WorktreePath: fixture.repoPath, Branch: "feature/test"})
+		}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.run()
+			if err == nil || !strings.Contains(err.Error(), "must not equal project repo path") {
+				t.Fatalf("error = %v, want repo-path safety failure", err)
+			}
+		})
+	}
+}
+
+func TestGatewayRejectsMutationWorktreeOutsideRoot(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createMainOnlyRepo(t)
+	gateway := fixture.gateway()
+	outsidePath := filepath.Join(fixture.rootDir, "outside-worktree")
+	mustMkdirAll(t, outsidePath)
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{name: "prepare", run: func() error {
+			_, err := gateway.PrepareWorktree(ctx, PrepareWorktreeInput{RepoPath: fixture.repoPath, WorktreeRoot: fixture.worktreeRoot, WorktreePath: outsidePath, Branch: "feature/test"})
+			return err
+		}},
+		{name: "commit", run: func() error {
+			_, err := gateway.Commit(ctx, CommitInput{RepoPath: fixture.repoPath, WorktreeRoot: fixture.worktreeRoot, WorktreePath: outsidePath, Message: "test"})
+			return err
+		}},
+		{name: "push", run: func() error {
+			return gateway.Push(ctx, PushInput{RepoPath: fixture.repoPath, WorktreeRoot: fixture.worktreeRoot, WorktreePath: outsidePath, Branch: "feature/test"})
+		}},
+		{name: "cleanup", run: func() error {
+			return gateway.CleanupWorktree(ctx, CleanupWorktreeInput{ProjectID: fixture.projectID, RepoPath: fixture.repoPath, WorktreeRoot: fixture.worktreeRoot, WorktreePath: outsidePath, Branch: "feature/test"})
+		}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.run()
+			if err == nil || !strings.Contains(err.Error(), "must be under worktree root") {
+				t.Fatalf("error = %v, want worktree-root safety failure", err)
+			}
+		})
+	}
+}
 
 func TestGatewayCreatesRestoresAndCleansWorktreesWithBranchProtection(t *testing.T) {
 	ctx := context.Background()

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worktreesafety"
 )
 
 const (
@@ -189,6 +190,8 @@ type CreateWorktreeResult struct {
 }
 
 type PushInput struct {
+	RepoPath          string
+	WorktreeRoot      string
 	WorktreePath      string
 	Branch            string
 	Remote            string
@@ -196,6 +199,8 @@ type PushInput struct {
 }
 
 type InspectHeadInput struct {
+	RepoPath     string
+	WorktreeRoot string
 	WorktreePath string
 	BaseRef      string
 }
@@ -208,6 +213,8 @@ type InspectHeadResult struct {
 }
 
 type CommitInput struct {
+	RepoPath     string
+	WorktreeRoot string
 	WorktreePath string
 	Message      string
 }
@@ -870,20 +877,28 @@ func (input stepInput) CheckpointIssueLogin() string {
 
 func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (plannerCheckpoint, error) {
 	checkpoint := input.Checkpoint
-	if checkpoint.SkipReason != "" || checkpoint.Worktree != nil {
+	if checkpoint.SkipReason != "" {
 		return checkpoint, nil
-	}
-	issue, err := requireIssue(checkpoint)
-	if err != nil {
-		return checkpoint, err
 	}
 	projectMetadata := parseJSONObject(input.Project.MetadataJSON)
 	worktreeRoot := stringFromAnyDefault(projectMetadata["worktreeRoot"])
+	var err error
 	if worktreeRoot == "" {
 		worktreeRoot, err = config.DefaultProjectWorktreeRoot(input.Project.ID, input.Project.RepoPath)
 		if err != nil {
 			return checkpoint, err
 		}
+	}
+	if checkpoint.Worktree != nil {
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath}); err == nil {
+			return checkpoint, nil
+		}
+		checkpoint.Worktree = nil
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
+	}
+	issue, err := requireIssue(checkpoint)
+	if err != nil {
+		return checkpoint, err
 	}
 	baseBranch := firstNonEmpty(derefString(input.Project.BaseBranch), "main")
 	branch := buildPlannerBranch(issue.IssueNumber, issue.Title)
@@ -913,6 +928,16 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 	worktree, err := requireWorktree(checkpoint)
 	if err != nil {
 		return checkpoint, err
+	}
+	worktreeRoot, rootErr := plannerWorktreeRoot(input.Project)
+	if rootErr != nil {
+		return checkpoint, rootErr
+	}
+	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+		checkpoint.Worktree = nil
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		input.Checkpoint = checkpoint
+		return r.runPrepareWorktreeStep(ctx, input)
 	}
 	if !writeSpecCompleted {
 		executionID := eventlog.NewEventID("agent")
@@ -961,12 +986,12 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 		return checkpoint, wrapRetryableAfterResume(err)
 	}
 	if r.git != nil {
-		inspect, err := r.git.InspectHead(ctx, InspectHeadInput{WorktreePath: worktree.Path, BaseRef: worktree.BaseBranch})
+		inspect, err := r.git.InspectHead(ctx, InspectHeadInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, BaseRef: worktree.BaseBranch})
 		if err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		if inspect.HasUncommittedChanges {
-			committed, err := r.git.Commit(ctx, CommitInput{WorktreePath: worktree.Path, Message: buildPlannerFallbackCommitMessage(issue)})
+			committed, err := r.git.Commit(ctx, CommitInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Message: buildPlannerFallbackCommitMessage(issue)})
 			if err != nil {
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 			}
@@ -1015,7 +1040,11 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (plannerCh
 		checkpoint.Publish.ReviewersAdded = []string{}
 	}
 	if !checkpoint.Publish.Pushed {
-		if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: []string{worktree.BaseBranch}}); err != nil {
+		worktreeRoot, rootErr := plannerWorktreeRoot(input.Project)
+		if rootErr != nil {
+			return checkpoint, rootErr
+		}
+		if err := r.git.Push(ctx, PushInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: []string{worktree.BaseBranch}}); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		checkpoint.Publish.Pushed = true
@@ -1129,6 +1158,15 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (plannerCh
 	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
+}
+
+func plannerWorktreeRoot(project storage.ProjectRecord) (string, error) {
+	projectMetadata := parseJSONObject(project.MetadataJSON)
+	worktreeRoot := stringFromAnyDefault(projectMetadata["worktreeRoot"])
+	if worktreeRoot != "" {
+		return worktreeRoot, nil
+	}
+	return config.DefaultProjectWorktreeRoot(project.ID, project.RepoPath)
 }
 
 func (r *Runner) findOpenPullRequestForBranch(ctx context.Context, repo, branch, baseBranch, cwd string) (*PullRequestSummary, error) {

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -933,7 +933,7 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 	if rootErr != nil {
 		return checkpoint, rootErr
 	}
-	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
 		checkpoint.Worktree = nil
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		input.Checkpoint = checkpoint

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -918,9 +918,6 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 		return checkpoint, nil
 	}
 	writeSpecCompleted := checkpoint.WriteSpec != nil && strings.EqualFold(checkpoint.WriteSpec.Status, "completed")
-	if writeSpecCompleted && checkpoint.WriteSpec.GitReconciled {
-		return checkpoint, nil
-	}
 	issue, err := requireIssue(checkpoint)
 	if err != nil {
 		return checkpoint, err
@@ -935,9 +932,26 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 	}
 	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
 		checkpoint.Worktree = nil
+		if checkpoint.WriteSpec != nil && !checkpoint.WriteSpec.GitReconciled {
+			checkpoint.WriteSpec = nil
+			writeSpecCompleted = false
+		}
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		input.Checkpoint = checkpoint
-		return r.runPrepareWorktreeStep(ctx, input)
+		checkpoint, err = r.runPrepareWorktreeStep(ctx, input)
+		if err != nil {
+			return checkpoint, err
+		}
+		worktree, err = requireWorktree(checkpoint)
+		if err != nil {
+			return checkpoint, err
+		}
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
+			return checkpoint, err
+		}
+	}
+	if writeSpecCompleted && checkpoint.WriteSpec.GitReconciled {
+		return checkpoint, nil
 	}
 	if !writeSpecCompleted {
 		executionID := eventlog.NewEventID("agent")

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -890,7 +890,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (p
 		}
 	}
 	if checkpoint.Worktree != nil {
-		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath}); err == nil {
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err == nil {
 			return checkpoint, nil
 		}
 		checkpoint.Worktree = nil

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -264,7 +264,7 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 	}
 }
 
-func TestRunWriteSpecStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
+func TestRunWriteSpecStepRecreatesCheckpointOutsideWorktreeRootAndRunsAgent(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repoPath := t.TempDir()

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -229,6 +229,36 @@ func TestRunPrepareWorktreeStepRecreatesUnsafeCheckpointAtRepoPath(t *testing.T)
 	}
 }
 
+func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+
+	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Checkpoint: plannerCheckpoint{
+			Issue:    &checkpointIssue{Repo: "acme/looper", IssueNumber: 42, Title: "Plan this", SpecPath: "specs/42.md"},
+			Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "legacy-wt"), Branch: "stale", BaseBranch: "main"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPrepareWorktreeStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if git.createCalls[0].WorktreeRoot != worktreeRoot {
+		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", git.createCalls[0].WorktreeRoot, worktreeRoot)
+	}
+}
+
 func TestProcessClaimedItemManualPlannerBypassesDiscoveryChecks(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -263,6 +263,44 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 	}
 }
 
+func TestRunWriteSpecStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	legacyPath := filepath.Join(t.TempDir(), "legacy-wt")
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+
+	checkpoint, err := runner.runWriteSpecStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Checkpoint: plannerCheckpoint{
+			Issue:     &checkpointIssue{Repo: "acme/looper", IssueNumber: 42, Title: "Plan this", SpecPath: "specs/42.md"},
+			Worktree:  &checkpointWorktree{Path: legacyPath, Branch: "stale", BaseBranch: "main"},
+			WriteSpec: &checkpointWriteSpec{Status: "completed"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runWriteSpecStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if git.createCalls[0].WorktreeRoot != worktreeRoot {
+		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", git.createCalls[0].WorktreeRoot, worktreeRoot)
+	}
+	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
+	}
+	if checkpoint.WriteSpec == nil || checkpoint.WriteSpec.Status != "completed" || checkpoint.WriteSpec.GitReconciled {
+		t.Fatalf("checkpoint.WriteSpec = %#v, want write-spec state preserved while recreating worktree", checkpoint.WriteSpec)
+	}
+}
+
 func TestProcessClaimedItemManualPlannerBypassesDiscoveryChecks(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -1219,6 +1257,8 @@ func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeI
 	result := f.createResult
 	if result.WorktreePath == "" {
 		result.WorktreePath = filepath.Join(input.WorktreeRoot, "wt")
+	} else if input.WorktreeRoot != "" {
+		result.WorktreePath = filepath.Join(input.WorktreeRoot, filepath.Base(result.WorktreePath))
 	}
 	if result.Branch == "" {
 		result.Branch = input.Branch
@@ -1226,6 +1266,7 @@ func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeI
 	if result.BaseBranch == "" {
 		result.BaseBranch = input.BaseBranch
 	}
+	f.createResult = result
 	return result, nil
 }
 

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -234,6 +234,7 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 	fixture := newRunnerFixture(t)
 	repoPath := t.TempDir()
 	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	legacyPath := filepath.Join(t.TempDir(), "legacy-wt")
 	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
@@ -242,7 +243,7 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
 		Checkpoint: plannerCheckpoint{
 			Issue:    &checkpointIssue{Repo: "acme/looper", IssueNumber: 42, Title: "Plan this", SpecPath: "specs/42.md"},
-			Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "legacy-wt"), Branch: "stale", BaseBranch: "main"},
+			Worktree: &checkpointWorktree{Path: legacyPath, Branch: "stale", BaseBranch: "main"},
 		},
 	})
 	if err != nil {
@@ -253,6 +254,9 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 	}
 	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
 		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if checkpoint.Worktree.Path == legacyPath {
+		t.Fatalf("checkpoint.Worktree.Path = %q, want recreated path outside legacy worktree", checkpoint.Worktree.Path)
 	}
 	if git.createCalls[0].WorktreeRoot != worktreeRoot {
 		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", git.createCalls[0].WorktreeRoot, worktreeRoot)

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -237,7 +237,8 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 	legacyPath := filepath.Join(t.TempDir(), "legacy-wt")
 	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "wrote spec"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
 
 	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
 		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
@@ -270,13 +271,25 @@ func TestRunWriteSpecStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
 	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
 	legacyPath := filepath.Join(t.TempDir(), "legacy-wt")
 	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	issue := &checkpointIssue{Repo: "acme/looper", IssueNumber: 42, Title: "Plan this", SpecPath: "specs/42.md"}
+	loopResult, err := (&Runner{repos: fixture.repos, now: fixture.now}).ensureLoopForIssue(context.Background(), storage.ProjectRecord{ID: "project_1"}, issue.Repo, IssueSummary{Number: issue.IssueNumber, Title: issue.Title}, buildPlannerDiscoveryFingerprint(issue.Repo, fixture.now(), IssueSummary{Number: issue.IssueNumber, Title: issue.Title}))
+	if err != nil {
+		t.Fatalf("ensureLoopForIssue() error = %v", err)
+	}
+	runID := "run_write_spec_rebuild"
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: runID, LoopID: loopResult.record.ID, Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "wrote spec"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
 
 	checkpoint, err := runner.runWriteSpecStep(context.Background(), stepInput{
 		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Loop:    loopResult.record,
+		Run:     storage.RunRecord{ID: runID, LoopID: loopResult.record.ID},
 		Checkpoint: plannerCheckpoint{
-			Issue:     &checkpointIssue{Repo: "acme/looper", IssueNumber: 42, Title: "Plan this", SpecPath: "specs/42.md"},
+			Issue:     issue,
 			Worktree:  &checkpointWorktree{Path: legacyPath, Branch: "stale", BaseBranch: "main"},
 			WriteSpec: &checkpointWriteSpec{Status: "completed"},
 		},
@@ -293,11 +306,14 @@ func TestRunWriteSpecStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
 	if git.createCalls[0].WorktreeRoot != worktreeRoot {
 		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", git.createCalls[0].WorktreeRoot, worktreeRoot)
 	}
-	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
-		t.Fatalf("ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
 	}
-	if checkpoint.WriteSpec == nil || checkpoint.WriteSpec.Status != "completed" || checkpoint.WriteSpec.GitReconciled {
-		t.Fatalf("checkpoint.WriteSpec = %#v, want write-spec state preserved while recreating worktree", checkpoint.WriteSpec)
+	if agent.starts[0].WorkingDirectory != git.createResult.WorktreePath {
+		t.Fatalf("agent WorkingDirectory = %q, want rebuilt worktree %q", agent.starts[0].WorkingDirectory, git.createResult.WorktreePath)
+	}
+	if checkpoint.WriteSpec == nil || checkpoint.WriteSpec.Status != "completed" || !checkpoint.WriteSpec.GitReconciled {
+		t.Fatalf("checkpoint.WriteSpec = %#v, want completed and reconciled write-spec after worktree recovery", checkpoint.WriteSpec)
 	}
 }
 

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -201,6 +201,34 @@ func TestDiscoverIssuesRequeuesFailedPlannerLoopWhenFingerprintChanges(t *testin
 	}
 }
 
+func TestRunPrepareWorktreeStepRecreatesUnsafeCheckpointAtRepoPath(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+
+	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath},
+		Checkpoint: plannerCheckpoint{
+			Issue:    &checkpointIssue{Repo: "acme/looper", IssueNumber: 42, Title: "Plan this", SpecPath: "specs/42.md"},
+			Worktree: &checkpointWorktree{Path: repoPath, Branch: "stale", BaseBranch: "main"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPrepareWorktreeStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
+	}
+}
+
 func TestProcessClaimedItemManualPlannerBypassesDiscoveryChecks(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1637,7 +1637,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 		worktreeRoot = resolvedRoot
 	}
 	if checkpoint.Worktree != nil {
-		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
 			checkpoint.Worktree = nil
 			checkpoint.ResumePolicy = "advance_from_checkpoint"
 		} else if reviewerWorktreePrepared(checkpoint) {
@@ -2148,7 +2148,11 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		return checkpoint, &loopError{message: "Missing PR snapshot checkpoint for review step", kind: FailureRetryableTransient}
 	}
 	if reviewerWorktreePrepared(checkpoint) {
-		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+		worktreeRoot, rootErr := reviewerWorktreeRoot(input.Project)
+		if rootErr != nil {
+			return checkpoint, rootErr
+		}
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
 			checkpoint.Worktree = nil
 			checkpoint.ResumePolicy = "advance_from_checkpoint"
 		}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/version"
+	"github.com/nexu-io/looper/internal/worktreesafety"
 )
 
 const (
@@ -145,6 +146,8 @@ type CreateWorktreeResult struct {
 }
 
 type PrepareWorktreeInput struct {
+	RepoPath        string
+	WorktreeRoot    string
 	WorktreePath    string
 	Branch          string
 	Ref             string
@@ -160,6 +163,7 @@ type PrepareWorktreeResult struct {
 type CleanupWorktreeInput struct {
 	ProjectID         string
 	RepoPath          string
+	WorktreeRoot      string
 	WorktreePath      string
 	Branch            string
 	ProtectedBranches []string
@@ -1611,9 +1615,6 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 	if checkpoint.SkipReason != "" {
 		return checkpoint, nil
 	}
-	if reviewerWorktreePrepared(checkpoint) {
-		return checkpoint, nil
-	}
 	if r.git == nil {
 		return checkpoint, fmt.Errorf("reviewer git gateway is not configured")
 	}
@@ -1634,6 +1635,14 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 			return checkpoint, err
 		}
 		worktreeRoot = resolvedRoot
+	}
+	if checkpoint.Worktree != nil {
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+			checkpoint.Worktree = nil
+			checkpoint.ResumePolicy = "advance_from_checkpoint"
+		} else if reviewerWorktreePrepared(checkpoint) {
+			return checkpoint, nil
+		}
 	}
 	protectedBranches := make([]string, 0, 2)
 	if candidate := strings.TrimSpace(checkpoint.Detail.BaseRefName); candidate != "" {
@@ -1656,7 +1665,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 			return checkpoint, err
 		}
 	}
-	prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{WorktreePath: created.WorktreePath, Branch: branch, Ref: prRef, ExpectedHeadSHA: checkpoint.Snapshot.HeadSHA})
+	prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: created.WorktreePath, Branch: branch, Ref: prRef, ExpectedHeadSHA: checkpoint.Snapshot.HeadSHA})
 	if err != nil {
 		var remoteHeadChanged *gitinfra.RemoteHeadChangedError
 		if errors.As(err, &remoteHeadChanged) {
@@ -2137,6 +2146,12 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	}
 	if checkpoint.Snapshot == nil {
 		return checkpoint, &loopError{message: "Missing PR snapshot checkpoint for review step", kind: FailureRetryableTransient}
+	}
+	if reviewerWorktreePrepared(checkpoint) {
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+			checkpoint.Worktree = nil
+			checkpoint.ResumePolicy = "advance_from_checkpoint"
+		}
 	}
 	if !reviewerWorktreePrepared(checkpoint) {
 		checkpoint, err = r.runPrepareWorktreeStep(ctx, input)
@@ -4596,7 +4611,12 @@ func (r *Runner) cleanupReviewerWorktreeIfTerminal(ctx context.Context, project 
 	if baseBranch := strings.TrimSpace(derefString(project.BaseBranch)); baseBranch != "" {
 		protectedBranches = append(protectedBranches, baseBranch)
 	}
-	if err := r.git.CleanupWorktree(ctx, CleanupWorktreeInput{ProjectID: project.ID, RepoPath: project.RepoPath, WorktreePath: checkpoint.Worktree.Path, Branch: checkpoint.Worktree.Branch, ProtectedBranches: protectedBranches}); err != nil {
+	worktreeRoot, rootErr := reviewerWorktreeRoot(project)
+	if rootErr != nil {
+		r.logWarn("reviewer worktree cleanup skipped", map[string]any{"projectId": project.ID, "worktreePath": checkpoint.Worktree.Path, "branch": checkpoint.Worktree.Branch, "error": rootErr.Error()})
+		return
+	}
+	if err := r.git.CleanupWorktree(ctx, CleanupWorktreeInput{ProjectID: project.ID, RepoPath: project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: checkpoint.Worktree.Path, Branch: checkpoint.Worktree.Branch, ProtectedBranches: protectedBranches}); err != nil {
 		r.logWarn("reviewer worktree cleanup failed", map[string]any{"projectId": project.ID, "worktreePath": checkpoint.Worktree.Path, "branch": checkpoint.Worktree.Branch, "error": err.Error()})
 		return
 	}
@@ -4608,6 +4628,15 @@ func requireWorktree(checkpoint reviewerCheckpoint) (*checkpointWorktree, error)
 		return nil, &loopError{message: "Missing reviewer worktree checkpoint for review step", kind: FailureRetryableTransient}
 	}
 	return checkpoint.Worktree, nil
+}
+
+func reviewerWorktreeRoot(project storage.ProjectRecord) (string, error) {
+	projectMetadata := parseJSONObject(project.MetadataJSON)
+	worktreeRoot, _ := stringFromAny(projectMetadata["worktreeRoot"])
+	if worktreeRoot != "" {
+		return worktreeRoot, nil
+	}
+	return config.DefaultProjectWorktreeRoot(project.ID, project.RepoPath)
 }
 
 func reviewerWorktreePrepared(checkpoint reviewerCheckpoint) bool {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4080,6 +4080,37 @@ func TestRunPrepareWorktreeStepFallsBackWhenCheckpointLacksHeadRef(t *testing.T)
 	}
 }
 
+func TestRunPrepareWorktreeStepRecreatesUnsafeCheckpointAtRepoPath(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	git := &fakeGitGateway{worktreePath: filepath.Join(t.TempDir(), "wt")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: repoPath},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadSHA: "abc123", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: repoPath, Branch: "stale", BaseBranch: "main"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPrepareWorktreeStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.worktreePath {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
+	}
+}
+
 func TestReviewerWorktreeBranchIgnoresHeadRefName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4111,6 +4111,40 @@ func TestRunPrepareWorktreeStepRecreatesUnsafeCheckpointAtRepoPath(t *testing.T)
 	}
 }
 
+func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "looper-worktrees")
+	outsidePath := filepath.Join(t.TempDir(), "outside", "wt")
+	git := &fakeGitGateway{worktreePath: filepath.Join(worktreeRoot, "wt")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+
+	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadSHA: "abc123", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: outsidePath, Branch: "stale", BaseBranch: "main", PreparedAt: "stale"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPrepareWorktreeStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.worktreePath {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if got := git.createCalls[0].WorktreeRoot; got != worktreeRoot {
+		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", got, worktreeRoot)
+	}
+}
+
 func TestReviewerWorktreeBranchIgnoresHeadRefName(t *testing.T) {
 	t.Parallel()
 
@@ -4133,7 +4167,7 @@ func TestReviewerWorktreeBranchIgnoresHeadRefName(t *testing.T) {
 func TestRunReviewStepRepreparesMissingReviewerWorktree(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	git := &fakeGitGateway{worktreePath: filepath.Join(t.TempDir(), "reviewer-worktree")}
+	git := &fakeGitGateway{}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
 
@@ -4462,8 +4496,8 @@ func TestProcessClaimedItemRetryAfterReviewFailureRepreparesWorktree(t *testing.
 	if retryResult.Status != "success" {
 		t.Fatalf("retry result = %#v, want success", retryResult)
 	}
-	if len(git.createCalls) != 2 || len(git.prepareCalls) != 2 {
-		t.Fatalf("createCalls=%d prepareCalls=%d, want 2 each", len(git.createCalls), len(git.prepareCalls))
+	if len(git.createCalls) != 3 || len(git.prepareCalls) != 3 {
+		t.Fatalf("createCalls=%d prepareCalls=%d, want 3 each", len(git.createCalls), len(git.prepareCalls))
 	}
 	if len(agent.starts) != 2 {
 		t.Fatalf("len(agent.starts) = %d, want 2", len(agent.starts))
@@ -6637,7 +6671,7 @@ func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeI
 	f.createCalls = append(f.createCalls, input)
 	path := f.worktreePath
 	if path == "" {
-		path = filepath.Join("/tmp", "reviewer-worktree")
+		path = filepath.Join(input.WorktreeRoot, "reviewer-worktree")
 		f.worktreePath = path
 	}
 	if err := os.MkdirAll(path, 0o755); err != nil {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -214,7 +214,7 @@ func (a plannerGitAdapter) CreateWorktree(ctx context.Context, input planner.Cre
 }
 
 func (a plannerGitAdapter) InspectHead(ctx context.Context, input planner.InspectHeadInput) (planner.InspectHeadResult, error) {
-	result, err := a.gateway.InspectHead(ctx, gitinfra.InspectHeadInput{WorktreePath: input.WorktreePath, BaseRef: input.BaseRef})
+	result, err := a.gateway.InspectHead(ctx, gitinfra.InspectHeadInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, BaseRef: input.BaseRef})
 	if err != nil {
 		return planner.InspectHeadResult{}, err
 	}
@@ -223,7 +223,7 @@ func (a plannerGitAdapter) InspectHead(ctx context.Context, input planner.Inspec
 
 func (a plannerGitAdapter) Commit(ctx context.Context, input planner.CommitInput) (planner.CommitResult, error) {
 	message := a.stamper.CommitMessage(input.Message, "planner")
-	result, err := a.gateway.Commit(ctx, gitinfra.CommitInput{WorktreePath: input.WorktreePath, Message: message})
+	result, err := a.gateway.Commit(ctx, gitinfra.CommitInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Message: message})
 	if err != nil {
 		return planner.CommitResult{}, err
 	}
@@ -231,7 +231,7 @@ func (a plannerGitAdapter) Commit(ctx context.Context, input planner.CommitInput
 }
 
 func (a plannerGitAdapter) Push(ctx context.Context, input planner.PushInput) error {
-	return a.gateway.Push(ctx, gitinfra.PushInput{WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ProtectedBranches: input.ProtectedBranches})
+	return a.gateway.Push(ctx, gitinfra.PushInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ProtectedBranches: input.ProtectedBranches})
 }
 
 type plannerAgentExecutorAdapter struct{ executor *agent.ConfiguredExecutor }
@@ -366,7 +366,7 @@ func (a reviewerGitAdapter) CreateWorktree(ctx context.Context, input reviewer.C
 }
 
 func (a reviewerGitAdapter) PrepareWorktree(ctx context.Context, input reviewer.PrepareWorktreeInput) (reviewer.PrepareWorktreeResult, error) {
-	result, err := a.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{WorktreePath: input.WorktreePath, Branch: input.Branch, Ref: input.Ref, ExpectedHeadSHA: input.ExpectedHeadSHA, Remote: input.Remote})
+	result, err := a.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, Ref: input.Ref, ExpectedHeadSHA: input.ExpectedHeadSHA, Remote: input.Remote})
 	if err != nil {
 		return reviewer.PrepareWorktreeResult{}, err
 	}
@@ -374,7 +374,7 @@ func (a reviewerGitAdapter) PrepareWorktree(ctx context.Context, input reviewer.
 }
 
 func (a reviewerGitAdapter) CleanupWorktree(ctx context.Context, input reviewer.CleanupWorktreeInput) error {
-	return a.gateway.CleanupWorktree(ctx, gitinfra.CleanupWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreePath: input.WorktreePath, Branch: input.Branch, ProtectedBranches: input.ProtectedBranches})
+	return a.gateway.CleanupWorktree(ctx, gitinfra.CleanupWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, ProtectedBranches: input.ProtectedBranches})
 }
 
 func (a reviewerAgentExecutorAdapter) Start(ctx context.Context, input reviewer.AgentRunInput) (reviewer.AgentExecution, error) {
@@ -475,7 +475,7 @@ func (a fixerGitAdapter) CreateWorktree(ctx context.Context, input fixer.CreateW
 }
 
 func (a fixerGitAdapter) PrepareWorktree(ctx context.Context, input fixer.PrepareWorktreeInput) (fixer.PrepareWorktreeResult, error) {
-	result, err := a.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{WorktreePath: input.WorktreePath, Branch: input.Branch, ExpectedHeadSHA: input.ExpectedHeadSHA, Remote: input.Remote})
+	result, err := a.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, ExpectedHeadSHA: input.ExpectedHeadSHA, Remote: input.Remote})
 	if err != nil {
 		return fixer.PrepareWorktreeResult{}, err
 	}
@@ -483,7 +483,7 @@ func (a fixerGitAdapter) PrepareWorktree(ctx context.Context, input fixer.Prepar
 }
 
 func (a fixerGitAdapter) InspectHead(ctx context.Context, input fixer.InspectHeadInput) (fixer.InspectHeadResult, error) {
-	result, err := a.gateway.InspectHead(ctx, gitinfra.InspectHeadInput{WorktreePath: input.WorktreePath, BaseRef: input.BaseRef})
+	result, err := a.gateway.InspectHead(ctx, gitinfra.InspectHeadInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, BaseRef: input.BaseRef})
 	if err != nil {
 		return fixer.InspectHeadResult{}, err
 	}
@@ -492,7 +492,7 @@ func (a fixerGitAdapter) InspectHead(ctx context.Context, input fixer.InspectHea
 
 func (a fixerGitAdapter) Commit(ctx context.Context, input fixer.CommitInput) (fixer.CommitResult, error) {
 	message := a.stamper.CommitMessage(input.Message, "fixer")
-	result, err := a.gateway.Commit(ctx, gitinfra.CommitInput{WorktreePath: input.WorktreePath, Message: message})
+	result, err := a.gateway.Commit(ctx, gitinfra.CommitInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Message: message})
 	if err != nil {
 		return fixer.CommitResult{}, err
 	}
@@ -500,11 +500,11 @@ func (a fixerGitAdapter) Commit(ctx context.Context, input fixer.CommitInput) (f
 }
 
 func (a fixerGitAdapter) Push(ctx context.Context, input fixer.PushInput) error {
-	return a.gateway.Push(ctx, gitinfra.PushInput{WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ExpectedRemoteHeadSHA: input.ExpectedRemoteHeadSHA, ProtectedBranches: input.ProtectedBranches})
+	return a.gateway.Push(ctx, gitinfra.PushInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ExpectedRemoteHeadSHA: input.ExpectedRemoteHeadSHA, ProtectedBranches: input.ProtectedBranches})
 }
 
 func (a fixerGitAdapter) CleanupWorktree(ctx context.Context, input fixer.CleanupWorktreeInput) error {
-	return a.gateway.CleanupWorktree(ctx, gitinfra.CleanupWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreePath: input.WorktreePath, Branch: input.Branch, ProtectedBranches: input.ProtectedBranches})
+	return a.gateway.CleanupWorktree(ctx, gitinfra.CleanupWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, ProtectedBranches: input.ProtectedBranches})
 }
 
 type fixerAgentExecutorAdapter struct{ executor *agent.ConfiguredExecutor }
@@ -641,7 +641,7 @@ func (a workerGitAdapter) RestoreWorktree(ctx context.Context, input worker.Rest
 }
 
 func (a workerGitAdapter) PrepareWorktree(ctx context.Context, input worker.PrepareWorktreeInput) (worker.PrepareWorktreeResult, error) {
-	result, err := a.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{WorktreePath: input.WorktreePath, Branch: input.Branch, ExpectedHeadSHA: input.ExpectedHeadSHA, Remote: input.Remote})
+	result, err := a.gateway.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, ExpectedHeadSHA: input.ExpectedHeadSHA, Remote: input.Remote})
 	if err != nil {
 		return worker.PrepareWorktreeResult{}, err
 	}
@@ -649,7 +649,7 @@ func (a workerGitAdapter) PrepareWorktree(ctx context.Context, input worker.Prep
 }
 
 func (a workerGitAdapter) InspectHead(ctx context.Context, input worker.InspectHeadInput) (worker.InspectHeadResult, error) {
-	result, err := a.gateway.InspectHead(ctx, gitinfra.InspectHeadInput{WorktreePath: input.WorktreePath, BaseRef: input.BaseRef})
+	result, err := a.gateway.InspectHead(ctx, gitinfra.InspectHeadInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, BaseRef: input.BaseRef})
 	if err != nil {
 		return worker.InspectHeadResult{}, err
 	}
@@ -658,7 +658,7 @@ func (a workerGitAdapter) InspectHead(ctx context.Context, input worker.InspectH
 
 func (a workerGitAdapter) Commit(ctx context.Context, input worker.CommitInput) (worker.CommitResult, error) {
 	message := a.stamper.CommitMessage(input.Message, "worker")
-	result, err := a.gateway.Commit(ctx, gitinfra.CommitInput{WorktreePath: input.WorktreePath, Message: message})
+	result, err := a.gateway.Commit(ctx, gitinfra.CommitInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Message: message})
 	if err != nil {
 		return worker.CommitResult{}, err
 	}
@@ -666,7 +666,7 @@ func (a workerGitAdapter) Commit(ctx context.Context, input worker.CommitInput) 
 }
 
 func (a workerGitAdapter) Push(ctx context.Context, input worker.PushInput) error {
-	return a.gateway.Push(ctx, gitinfra.PushInput{WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ProtectedBranches: input.ProtectedBranches})
+	return a.gateway.Push(ctx, gitinfra.PushInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ProtectedBranches: input.ProtectedBranches})
 }
 
 type workerAgentExecutorAdapter struct {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1154,7 +1154,11 @@ func (r *Runner) ensureWorkerWorktreeUsable(ctx context.Context, input stepInput
 	if strings.TrimSpace(worktree.Path) == "" {
 		return worktree, nil
 	}
-	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+	worktreeRoot, rootErr := workerWorktreeRoot(input.Project)
+	if rootErr != nil {
+		return worktree, &loopError{message: rootErr.Error(), kind: FailureRetryableTransient}
+	}
+	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
 		return r.recoverWorkerWorktree(ctx, input, checkpoint, work, worktree, err.Error())
 	}
 	info, err := os.Stat(worktree.Path)

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worktreesafety"
 )
 
 const (
@@ -254,6 +255,8 @@ type RestoreWorktreeResult struct {
 }
 
 type PrepareWorktreeInput struct {
+	RepoPath        string
+	WorktreeRoot    string
 	WorktreePath    string
 	Branch          string
 	ExpectedHeadSHA string
@@ -266,6 +269,8 @@ type PrepareWorktreeResult struct {
 }
 
 type PushInput struct {
+	RepoPath          string
+	WorktreeRoot      string
 	WorktreePath      string
 	Branch            string
 	Remote            string
@@ -273,6 +278,8 @@ type PushInput struct {
 }
 
 type InspectHeadInput struct {
+	RepoPath     string
+	WorktreeRoot string
 	WorktreePath string
 	BaseRef      string
 }
@@ -285,6 +292,8 @@ type InspectHeadResult struct {
 }
 
 type CommitInput struct {
+	RepoPath     string
+	WorktreeRoot string
 	WorktreePath string
 	Message      string
 }
@@ -1076,7 +1085,11 @@ func (r *Runner) selfAssignIssue(ctx context.Context, work workerInput, cwd stri
 func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (workerCheckpoint, error) {
 	checkpoint := input.Checkpoint
 	if checkpoint.Worktree != nil {
-		return checkpoint, nil
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath}); err == nil {
+			return checkpoint, nil
+		}
+		checkpoint.Worktree = nil
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
 	}
 	work, err := requireWork(checkpoint)
 	if err != nil {
@@ -1111,7 +1124,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (w
 		return checkpoint, err
 	}
 	if work.ExecutionMode == "push-existing" {
-		prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{WorktreePath: created.WorktreePath, Branch: created.Branch, ExpectedHeadSHA: work.HeadSHA})
+		prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: created.WorktreePath, Branch: created.Branch, ExpectedHeadSHA: work.HeadSHA})
 		if err != nil {
 			return checkpoint, err
 		}
@@ -1140,6 +1153,9 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (w
 func (r *Runner) ensureWorkerWorktreeUsable(ctx context.Context, input stepInput, checkpoint *workerCheckpoint, work workerInput, worktree checkpointWorktree) (checkpointWorktree, error) {
 	if strings.TrimSpace(worktree.Path) == "" {
 		return worktree, nil
+	}
+	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath}); err != nil {
+		return r.recoverWorkerWorktree(ctx, input, checkpoint, work, worktree, err.Error())
 	}
 	info, err := os.Stat(worktree.Path)
 	if err == nil {
@@ -1308,7 +1324,7 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 	if err := r.persistCheckpoint(ctx, input.Run.ID, checkpoint); err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
-	if err := r.reconcileWorkerGitState(ctx, &checkpoint, work, worktree); err != nil {
+	if err := r.reconcileWorkerGitState(ctx, &checkpoint, input.Project, work, worktree); err != nil {
 		return checkpoint, err
 	}
 	checkpoint.Execution.GitReconciled = true
@@ -1316,13 +1332,17 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 	return checkpoint, nil
 }
 
-func (r *Runner) reconcileWorkerGitState(ctx context.Context, checkpoint *workerCheckpoint, work workerInput, worktree checkpointWorktree) error {
+func (r *Runner) reconcileWorkerGitState(ctx context.Context, checkpoint *workerCheckpoint, project storage.ProjectRecord, work workerInput, worktree checkpointWorktree) error {
 	checkpoint.ensureLifecycle("worker", worktree.Branch, worktree.BaseBranch, work.ExecutionMode == "create-pr")
 	if r.git == nil {
 		return nil
 	}
 	baseRef := firstNonEmpty(worktree.HeadSHA, worktree.BaseBranch)
-	inspect, err := r.git.InspectHead(ctx, InspectHeadInput{WorktreePath: worktree.Path, BaseRef: baseRef})
+	worktreeRoot, rootErr := workerWorktreeRoot(project)
+	if rootErr != nil {
+		return &loopError{message: rootErr.Error(), kind: FailureRetryableTransient}
+	}
+	inspect, err := r.git.InspectHead(ctx, InspectHeadInput{RepoPath: project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, BaseRef: baseRef})
 	if err != nil {
 		checkpoint.Lifecycle.LastError = err.Error()
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
@@ -1343,12 +1363,12 @@ func (r *Runner) reconcileWorkerGitState(ctx context.Context, checkpoint *worker
 		checkpoint.Lifecycle.LastError = message
 		return &loopError{message: message, kind: FailureManualIntervention}
 	}
-	committed, err := r.git.Commit(ctx, CommitInput{WorktreePath: worktree.Path, Message: buildWorkerFallbackCommitMessage(work)})
+	committed, err := r.git.Commit(ctx, CommitInput{RepoPath: project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Message: buildWorkerFallbackCommitMessage(work)})
 	if err != nil {
 		checkpoint.Lifecycle.LastError = err.Error()
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
-	finalInspect, err := r.git.InspectHead(ctx, InspectHeadInput{WorktreePath: worktree.Path, BaseRef: baseRef})
+	finalInspect, err := r.git.InspectHead(ctx, InspectHeadInput{RepoPath: project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, BaseRef: baseRef})
 	if err != nil {
 		checkpoint.Lifecycle.LastError = err.Error()
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
@@ -1420,7 +1440,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 	if err != nil {
 		return checkpoint, err
 	}
-	if err := r.reconcileWorkerGitState(ctx, &checkpoint, work, worktree); err != nil {
+	if err := r.reconcileWorkerGitState(ctx, &checkpoint, input.Project, work, worktree); err != nil {
 		return checkpoint, err
 	}
 	if err := r.persistCheckpoint(ctx, input.Run.ID, checkpoint); err != nil {
@@ -1438,7 +1458,11 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 				checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
 				return checkpoint, &loopError{message: message, kind: FailureManualIntervention}
 			}
-			if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
+			worktreeRoot, rootErr := workerWorktreeRoot(input.Project)
+			if rootErr != nil {
+				return checkpoint, rootErr
+			}
+			if err := r.git.Push(ctx, PushInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 			}
 			pushedByFallback = true
@@ -1458,7 +1482,11 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 			checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
 			return checkpoint, &loopError{message: message, kind: FailureManualIntervention}
 		}
-		if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: firstNonEmpty(work.Branch, worktree.Branch), ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
+		worktreeRoot, rootErr := workerWorktreeRoot(input.Project)
+		if rootErr != nil {
+			return checkpoint, rootErr
+		}
+		if err := r.git.Push(ctx, PushInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Branch: firstNonEmpty(work.Branch, worktree.Branch), ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		_ = r.renamePlannerSpecPullRequestAfterTakeover(ctx, work, input.Project.RepoPath)
@@ -1493,8 +1521,12 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		return checkpoint, &loopError{message: message, kind: FailureManualIntervention}
 	}
 	aliases := buildWorkerBranchAliases(work, input.Loop.ID)
+	worktreeRoot, rootErr := workerWorktreeRoot(input.Project)
+	if rootErr != nil {
+		return checkpoint, rootErr
+	}
 	if existing, err := r.findOpenPullRequestForBranch(ctx, work.Repo, aliases, work.BaseBranch, input.Project.RepoPath); err == nil && existing != nil {
-		if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: firstNonEmpty(existing.HeadRefName, worktree.Branch), ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
+		if err := r.git.Push(ctx, PushInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Branch: firstNonEmpty(existing.HeadRefName, worktree.Branch), ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		_ = r.assignReviewersIfNeeded(ctx, work, existing.Number, input.Project.RepoPath)
@@ -1510,7 +1542,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		r.syncIssueClaim(ctx, input, &checkpoint, issueClaimStatusPRLinked, "")
 		return checkpoint, nil
 	}
-	if err := r.git.Push(ctx, PushInput{WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
+	if err := r.git.Push(ctx, PushInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
 	if existing, err := r.findOpenPullRequestForBranch(ctx, work.Repo, aliases, work.BaseBranch, input.Project.RepoPath); err == nil && existing != nil {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1084,13 +1084,6 @@ func (r *Runner) selfAssignIssue(ctx context.Context, work workerInput, cwd stri
 
 func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (workerCheckpoint, error) {
 	checkpoint := input.Checkpoint
-	if checkpoint.Worktree != nil {
-		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath}); err == nil {
-			return checkpoint, nil
-		}
-		checkpoint.Worktree = nil
-		checkpoint.ResumePolicy = "advance_from_checkpoint"
-	}
 	work, err := requireWork(checkpoint)
 	if err != nil {
 		return checkpoint, err
@@ -1102,6 +1095,13 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (w
 		if err != nil {
 			return checkpoint, err
 		}
+	}
+	if checkpoint.Worktree != nil {
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err == nil {
+			return checkpoint, nil
+		}
+		checkpoint.Worktree = nil
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
 	}
 	branch := work.Branch
 	if branch == "" {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -261,6 +261,37 @@ func TestRunPrepareWorktreeStepRecreatesUnsafeCheckpointAtRepoPath(t *testing.T)
 	}
 }
 
+func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "looper/worker/loop_worker_1", BaseBranch: "main", WorktreeID: "worktree_1"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+
+	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Loop:    storage.LoopRecord{ID: "loop_worker_1"},
+		Checkpoint: workerCheckpoint{
+			Work:     &workerInput{Repo: "acme/looper", IssueNumber: 42, BaseBranch: "main"},
+			Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "legacy-wt"), Branch: "stale", BaseBranch: "main"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPrepareWorktreeStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if git.createCalls[0].WorktreeRoot != worktreeRoot {
+		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", git.createCalls[0].WorktreeRoot, worktreeRoot)
+	}
+}
+
 func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -670,6 +670,54 @@ func TestRunExecuteStepRecoversStaleWorktreePathBeforeAgentStart(t *testing.T) {
 	}
 }
 
+func TestRunExecuteStepRecoversWorktreeOutsideWorktreeRootBeforeAgentStart(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	legacyPath := filepath.Join(t.TempDir(), "legacy-wt")
+	recoveredPath := filepath.Join(worktreeRoot, "recovered")
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	branch := "looper/feature"
+	git := &fakeGitGateway{
+		restoreResult: &RestoreWorktreeResult{WorktreePath: recoveredPath, Branch: branch, BaseBranch: "main", HeadSHA: "def456", WorktreeID: "worktree_recovered"},
+		inspectResult: InspectHeadResult{HeadSHA: "def456"},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true})
+	run := storage.RunRecord{ID: "run_outside_root_worktree", LoopID: "loop_worker_1", Status: "running", CurrentStep: stringPtr(string(stepExecute)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+
+	checkpoint, err := runner.runExecuteStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Loop:    *loop,
+		Run:     run,
+		Checkpoint: workerCheckpoint{
+			Work:     &workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", ExecutionMode: "create-pr"},
+			Worktree: &checkpointWorktree{ID: "worktree_old", Path: legacyPath, Branch: branch, BaseBranch: "main", HeadSHA: "abc123"},
+			Plan:     &checkpointPlan{Summary: "Implement worker loop", Items: []string{"Do it"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runExecuteStep() error = %v", err)
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != recoveredPath || checkpoint.Worktree.ID != "worktree_recovered" {
+		t.Fatalf("checkpoint.Worktree = %#v, want recovered worktree", checkpoint.Worktree)
+	}
+	if len(git.restoreCalls) != 1 || git.restoreCalls[0].WorktreeRoot != worktreeRoot || git.restoreCalls[0].ExpectedWorktreePath != legacyPath {
+		t.Fatalf("restoreCalls = %#v, want recovery using configured worktree root", git.restoreCalls)
+	}
+	if len(agent.starts) != 1 || agent.starts[0].WorkingDirectory != recoveredPath {
+		t.Fatalf("agent starts = %#v, want recovered working directory", agent.starts)
+	}
+}
+
 func TestCreateRunContextReplaysExecuteWhenResumeCheckpointParseStatusIsInvalid(t *testing.T) {
 	t.Parallel()
 
@@ -2837,7 +2885,20 @@ type fakeGitGateway struct {
 
 func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeInput) (CreateWorktreeResult, error) {
 	f.createCalls = append(f.createCalls, input)
-	return f.createResult, nil
+	result := f.createResult
+	if result.WorktreePath == "" {
+		result.WorktreePath = filepath.Join(input.WorktreeRoot, "wt")
+	} else if input.WorktreeRoot != "" {
+		result.WorktreePath = filepath.Join(input.WorktreeRoot, filepath.Base(result.WorktreePath))
+	}
+	if result.Branch == "" {
+		result.Branch = input.Branch
+	}
+	if result.BaseBranch == "" {
+		result.BaseBranch = input.BaseBranch
+	}
+	f.createResult = result
+	return result, nil
 }
 
 func (f *fakeGitGateway) RestoreWorktree(_ context.Context, input RestoreWorktreeInput) (*RestoreWorktreeResult, error) {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -266,6 +266,7 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 	fixture := newRunnerFixture(t)
 	repoPath := t.TempDir()
 	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	legacyPath := filepath.Join(t.TempDir(), "legacy-wt")
 	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "looper/worker/loop_worker_1", BaseBranch: "main", WorktreeID: "worktree_1"}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
@@ -275,7 +276,7 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 		Loop:    storage.LoopRecord{ID: "loop_worker_1"},
 		Checkpoint: workerCheckpoint{
 			Work:     &workerInput{Repo: "acme/looper", IssueNumber: 42, BaseBranch: "main"},
-			Worktree: &checkpointWorktree{Path: filepath.Join(t.TempDir(), "legacy-wt"), Branch: "stale", BaseBranch: "main"},
+			Worktree: &checkpointWorktree{Path: legacyPath, Branch: "stale", BaseBranch: "main"},
 		},
 	})
 	if err != nil {
@@ -286,6 +287,9 @@ func TestRunPrepareWorktreeStepRecreatesCheckpointOutsideWorktreeRoot(t *testing
 	}
 	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
 		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if checkpoint.Worktree.Path == legacyPath {
+		t.Fatalf("checkpoint.Worktree.Path = %q, want recreated path outside legacy worktree", checkpoint.Worktree.Path)
 	}
 	if git.createCalls[0].WorktreeRoot != worktreeRoot {
 		t.Fatalf("CreateWorktree().WorktreeRoot = %q, want %q", git.createCalls[0].WorktreeRoot, worktreeRoot)

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -232,6 +232,35 @@ func TestDiscoverIssuesRequeuesFailedWorkerLoopWhenFingerprintChanges(t *testing
 	}
 }
 
+func TestRunPrepareWorktreeStepRecreatesUnsafeCheckpointAtRepoPath(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/worker/loop_worker_1", BaseBranch: "main", WorktreeID: "worktree_1"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now})
+
+	checkpoint, err := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath},
+		Loop:    storage.LoopRecord{ID: "loop_worker_1"},
+		Checkpoint: workerCheckpoint{
+			Work:     &workerInput{Repo: "acme/looper", IssueNumber: 42, BaseBranch: "main"},
+			Worktree: &checkpointWorktree{Path: repoPath, Branch: "stale", BaseBranch: "main"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPrepareWorktreeStep() error = %v", err)
+	}
+	if len(git.createCalls) != 1 {
+		t.Fatalf("len(git.createCalls) = %d, want 1", len(git.createCalls))
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != git.createResult.WorktreePath {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree", checkpoint.Worktree)
+	}
+	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
+	}
+}
+
 func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/worktreesafety/safety.go
+++ b/internal/worktreesafety/safety.go
@@ -57,24 +57,62 @@ func withinRoot(path, root string) bool {
 	}
 	normalizedPath := normalizePath(path)
 	normalizedRoot := normalizePath(root)
-	if normalizedPath == normalizedRoot {
-		return true
+	rel, err := filepath.Rel(normalizedRoot, normalizedPath)
+	if err != nil {
+		return false
 	}
-	return strings.HasPrefix(normalizedPath, normalizedRoot+string(filepath.Separator))
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
 }
 
 func normalizePath(path string) string {
-	abs, err := filepath.Abs(filepath.Clean(path))
-	if err != nil {
-		abs = filepath.Clean(path)
+	return normalizePathDepth(path, 0)
+}
+
+func normalizePathDepth(path string, depth int) string {
+	if depth > 255 {
+		return filepath.Clean(path)
 	}
-	if evaluated, err := os.Readlink(abs); err == nil && !filepath.IsAbs(evaluated) {
-		abs = filepath.Join(filepath.Dir(abs), evaluated)
-	} else if err == nil {
-		abs = evaluated
+	abs := path
+	if !filepath.IsAbs(abs) {
+		wd, err := os.Getwd()
+		if err != nil {
+			return filepath.Clean(path)
+		}
+		abs = wd + string(filepath.Separator) + path
 	}
-	if evaluated, err := filepath.EvalSymlinks(abs); err == nil {
-		abs = evaluated
+	volume := filepath.VolumeName(abs)
+	rest := strings.TrimPrefix(abs, volume)
+	current := volume + string(filepath.Separator)
+	parts := strings.FieldsFunc(rest, func(r rune) bool { return r == filepath.Separator })
+	for index, part := range parts {
+		switch part {
+		case "", ".":
+			continue
+		case "..":
+			current = filepath.Dir(current)
+			continue
+		}
+
+		candidate := filepath.Join(current, part)
+		info, err := os.Lstat(candidate)
+		if err != nil {
+			remaining := append([]string{candidate}, parts[index+1:]...)
+			return filepath.Clean(filepath.Join(remaining...))
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			current = candidate
+			continue
+		}
+		target, err := os.Readlink(candidate)
+		if err != nil {
+			current = candidate
+			continue
+		}
+		if filepath.IsAbs(target) {
+			current = normalizePathDepth(target, depth+1)
+		} else {
+			current = normalizePathDepth(current+string(filepath.Separator)+target, depth+1)
+		}
 	}
-	return filepath.Clean(abs)
+	return filepath.Clean(current)
 }

--- a/internal/worktreesafety/safety.go
+++ b/internal/worktreesafety/safety.go
@@ -1,0 +1,80 @@
+package worktreesafety
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type CheckInput struct {
+	WorktreePath string
+	RepoPath     string
+	WorktreeRoot string
+}
+
+func Validate(input CheckInput) error {
+	worktreePath := strings.TrimSpace(input.WorktreePath)
+	if worktreePath == "" {
+		return fmt.Errorf("unsafe worktree path: path is required")
+	}
+
+	if samePath(worktreePath, input.RepoPath) {
+		return fmt.Errorf("unsafe worktree path %q: path must not equal project repo path", worktreePath)
+	}
+
+	root := strings.TrimSpace(input.WorktreeRoot)
+	if root != "" {
+		if samePath(worktreePath, root) {
+			return fmt.Errorf("unsafe worktree path %q: path must not equal worktree root", worktreePath)
+		}
+		if !withinRoot(worktreePath, root) {
+			return fmt.Errorf("unsafe worktree path %q: path must be under worktree root %q", worktreePath, root)
+		}
+	}
+
+	return nil
+}
+
+func IsSafe(input CheckInput) bool {
+	return Validate(input) == nil
+}
+
+func samePath(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	return normalizePath(a) == normalizePath(b)
+}
+
+func withinRoot(path, root string) bool {
+	path = strings.TrimSpace(path)
+	root = strings.TrimSpace(root)
+	if path == "" || root == "" {
+		return false
+	}
+	normalizedPath := normalizePath(path)
+	normalizedRoot := normalizePath(root)
+	if normalizedPath == normalizedRoot {
+		return true
+	}
+	return strings.HasPrefix(normalizedPath, normalizedRoot+string(filepath.Separator))
+}
+
+func normalizePath(path string) string {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		abs = filepath.Clean(path)
+	}
+	if evaluated, err := os.Readlink(abs); err == nil && !filepath.IsAbs(evaluated) {
+		abs = filepath.Join(filepath.Dir(abs), evaluated)
+	} else if err == nil {
+		abs = evaluated
+	}
+	if evaluated, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = evaluated
+	}
+	return filepath.Clean(abs)
+}

--- a/internal/worktreesafety/safety_test.go
+++ b/internal/worktreesafety/safety_test.go
@@ -42,6 +42,39 @@ func TestValidateRejectsSiblingPrefixOutsideRoot(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsRepoPathThroughSymlink(t *testing.T) {
+	t.Parallel()
+
+	repoPath := t.TempDir()
+	link := filepath.Join(t.TempDir(), "repo-link")
+	if err := os.Symlink(repoPath, link); err != nil {
+		t.Skipf("Symlink() unsupported: %v", err)
+	}
+	if err := Validate(CheckInput{WorktreePath: link, RepoPath: repoPath}); err == nil {
+		t.Fatal("Validate() error = nil, want repo path rejection")
+	}
+}
+
+func TestValidateAllowsExistingWorktreeUnderSymlinkedRoot(t *testing.T) {
+	t.Parallel()
+
+	realRoot := filepath.Join(t.TempDir(), "real-worktrees")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(realRoot) error = %v", err)
+	}
+	symlinkRoot := filepath.Join(t.TempDir(), "worktrees")
+	if err := os.Symlink(realRoot, symlinkRoot); err != nil {
+		t.Skipf("Symlink() unsupported: %v", err)
+	}
+	worktreePath := filepath.Join(symlinkRoot, "existing-worktree")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktreePath) error = %v", err)
+	}
+	if err := Validate(CheckInput{WorktreePath: worktreePath, RepoPath: filepath.Join(t.TempDir(), "repo"), WorktreeRoot: realRoot}); err != nil {
+		t.Fatalf("Validate() error = %v, want existing symlinked child accepted", err)
+	}
+}
+
 func TestValidateRejectsSymlinkDotDotEscape(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worktreesafety/safety_test.go
+++ b/internal/worktreesafety/safety_test.go
@@ -1,0 +1,88 @@
+package worktreesafety
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateAllowsNonexistentChildUnderSymlinkedRoot(t *testing.T) {
+	t.Parallel()
+
+	realRoot := filepath.Join(t.TempDir(), "real-worktrees")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(realRoot) error = %v", err)
+	}
+	symlinkParent := t.TempDir()
+	symlinkRoot := filepath.Join(symlinkParent, "worktrees")
+	if err := os.Symlink(realRoot, symlinkRoot); err != nil {
+		t.Skipf("Symlink() unsupported: %v", err)
+	}
+
+	worktreePath := filepath.Join(symlinkRoot, "new-worktree")
+	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+		t.Fatalf("worktree path existence error = %v, want not exist", err)
+	}
+	if err := Validate(CheckInput{WorktreePath: worktreePath, RepoPath: filepath.Join(t.TempDir(), "repo"), WorktreeRoot: realRoot}); err != nil {
+		t.Fatalf("Validate() error = %v, want symlinked nonexistent child accepted", err)
+	}
+}
+
+func TestValidateRejectsSiblingPrefixOutsideRoot(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	sibling := filepath.Join(parent, "root-other", "wt")
+	if err := os.MkdirAll(filepath.Dir(sibling), 0o755); err != nil {
+		t.Fatalf("MkdirAll(sibling parent) error = %v", err)
+	}
+	if err := Validate(CheckInput{WorktreePath: sibling, RepoPath: filepath.Join(parent, "repo"), WorktreeRoot: root}); err == nil {
+		t.Fatal("Validate() error = nil, want sibling outside root rejected")
+	}
+}
+
+func TestValidateRejectsSymlinkDotDotEscape(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	outside := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll(root) error = %v", err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("MkdirAll(outside) error = %v", err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(filepath.Join(outside, "dir"), link); err != nil {
+		t.Skipf("Symlink() unsupported: %v", err)
+	}
+	worktreePath := root + string(filepath.Separator) + "link" + string(filepath.Separator) + ".." + string(filepath.Separator) + "evil-wt"
+	if err := Validate(CheckInput{WorktreePath: worktreePath, RepoPath: filepath.Join(parent, "repo"), WorktreeRoot: root}); err == nil {
+		t.Fatal("Validate() error = nil, want symlink plus dot-dot escape rejected")
+	}
+}
+
+func TestValidateRejectsNestedRelativeSymlinkDotDotEscape(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	outside := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll(root) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(outside, "dir"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(outside dir) error = %v", err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "dir"), filepath.Join(root, "a")); err != nil {
+		t.Skipf("Symlink(a) unsupported: %v", err)
+	}
+	if err := os.Symlink("a"+string(filepath.Separator)+".."+string(filepath.Separator)+"evil-wt", filepath.Join(root, "link")); err != nil {
+		t.Skipf("Symlink(link) unsupported: %v", err)
+	}
+	if err := Validate(CheckInput{WorktreePath: filepath.Join(root, "link"), RepoPath: filepath.Join(parent, "repo"), WorktreeRoot: root}); err == nil {
+		t.Fatal("Validate() error = nil, want nested relative symlink plus dot-dot escape rejected")
+	}
+}


### PR DESCRIPTION
## Summary
- Add centralized worktree path safety checks and enforce them in checkpoint reuse paths.
- Forward repo/root safety context to git mutation methods and reject unsafe prepare/commit/push/cleanup targets.
- Cover worker, planner, reviewer, fixer, and git gateway regressions for repo-root and outside-root worktree paths.

Fixes #289

## Validation
- go test ./...
- go vet ./...
- go build ./...