### PR TITLE
feat: [codex] add reviewer head-change re-review resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ralph/
+.task/
 node_modules/
 dist/
 *.test

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,7 +156,8 @@ Example minimal `~/.looper/config.json`:
       "blocking": "COMMENT"
     },
     "nativeResume": {
-      "onHeadChange": false
+      "onHeadChange": false,
+      "reReviewPromptOnHeadChange": false
     }
   },
   "roles": {
@@ -422,7 +423,8 @@ Default values:
 
 - `reviewEvents.clean`: review event for clean reviewer outcomes. Allowed values: `COMMENT`, `APPROVE`. Default: `COMMENT`.
 - `reviewEvents.blocking`: review event for blocking reviewer outcomes. Allowed values: `COMMENT`, `REQUEST_CHANGES`. Default: `COMMENT`.
-- `nativeResume.onHeadChange`: when `true`, a reviewer agent interrupted because the PR head changed can resume its native CLI session on the next review pass with a re-review continuation prompt. Default: `false`.
+- `nativeResume.onHeadChange`: when `true`, a reviewer agent interrupted because the PR head changed can mark its native CLI session as pending for the next review pass. Default: `false`.
+- `nativeResume.reReviewPromptOnHeadChange`: when `true`, pending reviewer native resume sessions that were interrupted by a PR head change use a re-review continuation prompt instead of the generic native resume continuation prompt. Default: `false`.
 - Reviewer loop budget options (`maxIterationsPerPR`, `maxIterationsPerHead`, `maxWallClockSeconds`, `maxConsecutiveFailures`, and `maxAgentExecutionsPerPR`) are deprecated and ignored by the reviewer filter. Reviewer loops keep following PR updates until a clear terminal product state such as the PR closing/merging, an approved Looper review for the current head, or the ready label.
 
 Default reviewer behavior is safe and comment-only:
@@ -435,7 +437,8 @@ Default reviewer behavior is safe and comment-only:
       "blocking": "COMMENT"
     },
     "nativeResume": {
-      "onHeadChange": false
+      "onHeadChange": false,
+      "reReviewPromptOnHeadChange": false
     }
   }
 }
@@ -615,6 +618,7 @@ Supported environment overrides:
 - `LOOPER_REVIEWER_REVIEW_EVENTS_CLEAN`
 - `LOOPER_REVIEWER_REVIEW_EVENTS_BLOCKING`
 - `LOOPER_REVIEWER_NATIVE_RESUME_ON_HEAD_CHANGE`
+- `LOOPER_REVIEWER_NATIVE_RESUME_REREVIEW_PROMPT_ON_HEAD_CHANGE`
 - `LOOPER_FIX_ALL_PULL_REQUESTS`
 - `LOOPER_ROLES_PLANNER_AUTO_DISCOVERY`
 - `LOOPER_ROLES_PLANNER_TRIGGERS_LABELS`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,6 +154,9 @@ Example minimal `~/.looper/config.json`:
     "reviewEvents": {
       "clean": "COMMENT",
       "blocking": "COMMENT"
+    },
+    "nativeResume": {
+      "onHeadChange": false
     }
   },
   "roles": {
@@ -419,6 +422,7 @@ Default values:
 
 - `reviewEvents.clean`: review event for clean reviewer outcomes. Allowed values: `COMMENT`, `APPROVE`. Default: `COMMENT`.
 - `reviewEvents.blocking`: review event for blocking reviewer outcomes. Allowed values: `COMMENT`, `REQUEST_CHANGES`. Default: `COMMENT`.
+- `nativeResume.onHeadChange`: when `true`, a reviewer agent interrupted because the PR head changed can resume its native CLI session on the next review pass with a re-review continuation prompt. Default: `false`.
 - Reviewer loop budget options (`maxIterationsPerPR`, `maxIterationsPerHead`, `maxWallClockSeconds`, `maxConsecutiveFailures`, and `maxAgentExecutionsPerPR`) are deprecated and ignored by the reviewer filter. Reviewer loops keep following PR updates until a clear terminal product state such as the PR closing/merging, an approved Looper review for the current head, or the ready label.
 
 Default reviewer behavior is safe and comment-only:
@@ -429,6 +433,9 @@ Default reviewer behavior is safe and comment-only:
     "reviewEvents": {
       "clean": "COMMENT",
       "blocking": "COMMENT"
+    },
+    "nativeResume": {
+      "onHeadChange": false
     }
   }
 }
@@ -607,6 +614,7 @@ Supported environment overrides:
 - `LOOPER_ALLOW_AUTO_APPROVE`
 - `LOOPER_REVIEWER_REVIEW_EVENTS_CLEAN`
 - `LOOPER_REVIEWER_REVIEW_EVENTS_BLOCKING`
+- `LOOPER_REVIEWER_NATIVE_RESUME_ON_HEAD_CHANGE`
 - `LOOPER_FIX_ALL_PULL_REQUESTS`
 - `LOOPER_ROLES_PLANNER_AUTO_DISCOVERY`
 - `LOOPER_ROLES_PLANNER_TRIGGERS_LABELS`

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -152,6 +152,8 @@ func TestHandlerConfigSuccessContainsExpectedSections(t *testing.T) {
 	assertEqual(t, reviewer["scope"], string(cfg.Reviewer.Scope))
 	assertEqual(t, reviewer["publishMode"], string(cfg.Reviewer.PublishMode))
 	assertEqual(t, reviewer["detectDuplicateFindings"], cfg.Reviewer.DetectDuplicateFindings)
+	nativeResume := reviewer["nativeResume"].(map[string]any)
+	assertEqual(t, nativeResume["onHeadChange"], cfg.Reviewer.NativeResume.OnHeadChange)
 	threadResolution := reviewer["threadResolution"].(map[string]any)
 	assertEqual(t, threadResolution["enabled"], cfg.Reviewer.ThreadResolution.Enabled)
 	assertEqual(t, threadResolution["mode"], string(cfg.Reviewer.ThreadResolution.Mode))

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -154,6 +154,7 @@ func TestHandlerConfigSuccessContainsExpectedSections(t *testing.T) {
 	assertEqual(t, reviewer["detectDuplicateFindings"], cfg.Reviewer.DetectDuplicateFindings)
 	nativeResume := reviewer["nativeResume"].(map[string]any)
 	assertEqual(t, nativeResume["onHeadChange"], cfg.Reviewer.NativeResume.OnHeadChange)
+	assertEqual(t, nativeResume["reReviewPromptOnHeadChange"], cfg.Reviewer.NativeResume.ReReviewPromptOnHeadChange)
 	threadResolution := reviewer["threadResolution"].(map[string]any)
 	assertEqual(t, threadResolution["enabled"], cfg.Reviewer.ThreadResolution.Enabled)
 	assertEqual(t, threadResolution["mode"], string(cfg.Reviewer.ThreadResolution.Mode))

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -264,7 +264,8 @@
             },
             "detectDuplicateFindings": true,
             "nativeResume": {
-              "onHeadChange": false
+              "onHeadChange": false,
+              "reReviewPromptOnHeadChange": false
             },
             "threadResolution": {
               "autoResolve": "objective_only",

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -263,6 +263,9 @@
               "blocking": "COMMENT"
             },
             "detectDuplicateFindings": true,
+            "nativeResume": {
+              "onHeadChange": false
+            },
             "threadResolution": {
               "autoResolve": "objective_only",
               "enabled": false,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1306,15 +1306,38 @@ func TestLoadFileReviewerReviewEventsPrecedenceDefaultsFileEnvCLI(t *testing.T) 
 }
 
 func TestLoadFileReviewerNativeResumeOnHeadChangeEnvOverride(t *testing.T) {
+	cwd := t.TempDir()
 	loaded, err := LoadFile(LoadFileOptions{
-		CWD:       t.TempDir(),
-		LookupEnv: mapEnvLookup(map[string]string{"LOOPER_REVIEWER_NATIVE_RESUME_ON_HEAD_CHANGE": "true"}),
+		CWD:        cwd,
+		ConfigPath: filepath.Join(cwd, "missing.json"),
+		LookupEnv:  mapEnvLookup(map[string]string{"LOOPER_REVIEWER_NATIVE_RESUME_ON_HEAD_CHANGE": "true"}),
 	})
 	if err != nil {
 		t.Fatalf("LoadFile() error = %v", err)
 	}
 	if !loaded.Config.Reviewer.NativeResume.OnHeadChange {
 		t.Fatalf("reviewer.nativeResume.onHeadChange = false, want true")
+	}
+	if loaded.Config.Reviewer.NativeResume.ReReviewPromptOnHeadChange {
+		t.Fatalf("reviewer.nativeResume.reReviewPromptOnHeadChange = true, want false")
+	}
+}
+
+func TestLoadFileReviewerNativeResumeReReviewPromptOnHeadChangeEnvOverride(t *testing.T) {
+	cwd := t.TempDir()
+	loaded, err := LoadFile(LoadFileOptions{
+		CWD:        cwd,
+		ConfigPath: filepath.Join(cwd, "missing.json"),
+		LookupEnv:  mapEnvLookup(map[string]string{"LOOPER_REVIEWER_NATIVE_RESUME_REREVIEW_PROMPT_ON_HEAD_CHANGE": "true"}),
+	})
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if !loaded.Config.Reviewer.NativeResume.ReReviewPromptOnHeadChange {
+		t.Fatalf("reviewer.nativeResume.reReviewPromptOnHeadChange = false, want true")
+	}
+	if loaded.Config.Reviewer.NativeResume.OnHeadChange {
+		t.Fatalf("reviewer.nativeResume.onHeadChange = true, want false")
 	}
 }
 
@@ -1736,6 +1759,9 @@ func TestDefaultConfigMatchesDaemonDefaults(t *testing.T) {
 
 	if config.Reviewer.NativeResume.OnHeadChange {
 		t.Fatal("DefaultConfig().Reviewer.NativeResume.OnHeadChange = true, want false")
+	}
+	if config.Reviewer.NativeResume.ReReviewPromptOnHeadChange {
+		t.Fatal("DefaultConfig().Reviewer.NativeResume.ReReviewPromptOnHeadChange = true, want false")
 	}
 
 	if len(config.Projects) != 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1305,6 +1305,19 @@ func TestLoadFileReviewerReviewEventsPrecedenceDefaultsFileEnvCLI(t *testing.T) 
 	}
 }
 
+func TestLoadFileReviewerNativeResumeOnHeadChangeEnvOverride(t *testing.T) {
+	loaded, err := LoadFile(LoadFileOptions{
+		CWD:       t.TempDir(),
+		LookupEnv: mapEnvLookup(map[string]string{"LOOPER_REVIEWER_NATIVE_RESUME_ON_HEAD_CHANGE": "true"}),
+	})
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if !loaded.Config.Reviewer.NativeResume.OnHeadChange {
+		t.Fatalf("reviewer.nativeResume.onHeadChange = false, want true")
+	}
+}
+
 func TestNormalizeAllowAutoApproveLegacyAliasRespectsExplicitReviewerCleanEvent(t *testing.T) {
 	trueValue := true
 	comment := ReviewerReviewEventComment
@@ -1719,6 +1732,10 @@ func TestDefaultConfigMatchesDaemonDefaults(t *testing.T) {
 
 	if len(config.Agent.Params) != 0 || len(config.Agent.Env) != 0 {
 		t.Fatalf("DefaultConfig().Agent maps = %#v / %#v, want empty maps", config.Agent.Params, config.Agent.Env)
+	}
+
+	if config.Reviewer.NativeResume.OnHeadChange {
+		t.Fatal("DefaultConfig().Reviewer.NativeResume.OnHeadChange = true, want false")
 	}
 
 	if len(config.Projects) != 0 {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -152,6 +152,7 @@ func DefaultConfig(cwd string) (Config, error) {
 			PublishMode:             ReviewerPublishModeSingleReview,
 			ReviewEvents:            ReviewerReviewEventsConfig{Clean: ReviewerReviewEventComment, Blocking: ReviewerReviewEventComment},
 			DetectDuplicateFindings: true,
+			NativeResume:            ReviewerNativeResumeConfig{OnHeadChange: false},
 			ThreadResolution: ReviewerThreadResolutionConfig{
 				Enabled:                     false,
 				Mode:                        ReviewerThreadResolutionModeReportOnly,

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -152,7 +152,7 @@ func DefaultConfig(cwd string) (Config, error) {
 			PublishMode:             ReviewerPublishModeSingleReview,
 			ReviewEvents:            ReviewerReviewEventsConfig{Clean: ReviewerReviewEventComment, Blocking: ReviewerReviewEventComment},
 			DetectDuplicateFindings: true,
-			NativeResume:            ReviewerNativeResumeConfig{OnHeadChange: false},
+			NativeResume:            ReviewerNativeResumeConfig{OnHeadChange: false, ReReviewPromptOnHeadChange: false},
 			ThreadResolution: ReviewerThreadResolutionConfig{
 				Enabled:                     false,
 				Mode:                        ReviewerThreadResolutionModeReportOnly,

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -826,6 +826,13 @@ func buildEnvOverrides(lookupEnv EnvLookupFunc) (PartialConfig, error) {
 		}
 		ensureReviewerLoopConfig(&overrides).MaxIterationsPerHead = parsed
 	}
+	if value, ok := lookupEnv("LOOPER_REVIEWER_NATIVE_RESUME_ON_HEAD_CHANGE"); ok {
+		parsed, err := parseBoolean(value)
+		if err != nil {
+			return PartialConfig{}, fmt.Errorf("invalid value for LOOPER_REVIEWER_NATIVE_RESUME_ON_HEAD_CHANGE: %q is not a boolean", value)
+		}
+		ensureReviewerNativeResumeConfig(&overrides).OnHeadChange = parsed
+	}
 	if value, ok := lookupEnv("LOOPER_REVIEWER_THREAD_RESOLUTION_ENABLED"); ok {
 		parsed, err := parseBoolean(value)
 		if err != nil {
@@ -1154,6 +1161,14 @@ func ensureReviewerReviewEventsConfig(partial *PartialConfig) *PartialReviewerRe
 		reviewer.ReviewEvents = &PartialReviewerReviewEventsConfig{}
 	}
 	return reviewer.ReviewEvents
+}
+
+func ensureReviewerNativeResumeConfig(partial *PartialConfig) *PartialReviewerNativeResumeConfig {
+	reviewer := ensureReviewerConfig(partial)
+	if reviewer.NativeResume == nil {
+		reviewer.NativeResume = &PartialReviewerNativeResumeConfig{}
+	}
+	return reviewer.NativeResume
 }
 
 func ensureInstructionsConfig(partial *PartialConfig) *PartialInstructionsConfig {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -833,6 +833,13 @@ func buildEnvOverrides(lookupEnv EnvLookupFunc) (PartialConfig, error) {
 		}
 		ensureReviewerNativeResumeConfig(&overrides).OnHeadChange = parsed
 	}
+	if value, ok := lookupEnv("LOOPER_REVIEWER_NATIVE_RESUME_REREVIEW_PROMPT_ON_HEAD_CHANGE"); ok {
+		parsed, err := parseBoolean(value)
+		if err != nil {
+			return PartialConfig{}, fmt.Errorf("invalid value for LOOPER_REVIEWER_NATIVE_RESUME_REREVIEW_PROMPT_ON_HEAD_CHANGE: %q is not a boolean", value)
+		}
+		ensureReviewerNativeResumeConfig(&overrides).ReReviewPromptOnHeadChange = parsed
+	}
 	if value, ok := lookupEnv("LOOPER_REVIEWER_THREAD_RESOLUTION_ENABLED"); ok {
 		parsed, err := parseBoolean(value)
 		if err != nil {

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -423,8 +423,17 @@ func mergeReviewerConfig(config *ReviewerConfig, partial PartialReviewerConfig) 
 	} else if partial.DedupeFindings != nil {
 		config.DetectDuplicateFindings = *partial.DedupeFindings
 	}
+	if partial.NativeResume != nil {
+		mergeReviewerNativeResumeConfig(&config.NativeResume, *partial.NativeResume)
+	}
 	if partial.ThreadResolution != nil {
 		mergeReviewerThreadResolutionConfig(&config.ThreadResolution, *partial.ThreadResolution)
+	}
+}
+
+func mergeReviewerNativeResumeConfig(config *ReviewerNativeResumeConfig, partial PartialReviewerNativeResumeConfig) {
+	if partial.OnHeadChange != nil {
+		config.OnHeadChange = *partial.OnHeadChange
 	}
 }
 

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -435,6 +435,9 @@ func mergeReviewerNativeResumeConfig(config *ReviewerNativeResumeConfig, partial
 	if partial.OnHeadChange != nil {
 		config.OnHeadChange = *partial.OnHeadChange
 	}
+	if partial.ReReviewPromptOnHeadChange != nil {
+		config.ReReviewPromptOnHeadChange = *partial.ReReviewPromptOnHeadChange
+	}
 }
 
 func mergeReviewerThreadResolutionConfig(config *ReviewerThreadResolutionConfig, partial PartialReviewerThreadResolutionConfig) {

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -203,6 +203,9 @@
           "blocking": "COMMENT"
         },
         "detectDuplicateFindings": true,
+        "nativeResume": {
+          "onHeadChange": false
+        },
         "threadResolution": {
           "autoResolve": "objective_only",
           "enabled": false,

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -204,7 +204,8 @@
         },
         "detectDuplicateFindings": true,
         "nativeResume": {
-          "onHeadChange": false
+          "onHeadChange": false,
+          "reReviewPromptOnHeadChange": false
         },
         "threadResolution": {
           "autoResolve": "objective_only",

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -136,6 +136,9 @@
           "blocking": "COMMENT"
         },
         "detectDuplicateFindings": true,
+        "nativeResume": {
+          "onHeadChange": false
+        },
         "threadResolution": {
           "autoResolve": "objective_only",
           "enabled": false,

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -137,7 +137,8 @@
         },
         "detectDuplicateFindings": true,
         "nativeResume": {
-          "onHeadChange": false
+          "onHeadChange": false,
+          "reReviewPromptOnHeadChange": false
         },
         "threadResolution": {
           "autoResolve": "objective_only",

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -223,7 +223,8 @@
         },
         "detectDuplicateFindings": true,
         "nativeResume": {
-          "onHeadChange": false
+          "onHeadChange": false,
+          "reReviewPromptOnHeadChange": false
         },
         "threadResolution": {
           "autoResolve": "objective_only",

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -222,6 +222,9 @@
           "blocking": "COMMENT"
         },
         "detectDuplicateFindings": true,
+        "nativeResume": {
+          "onHeadChange": false
+        },
         "threadResolution": {
           "autoResolve": "objective_only",
           "enabled": false,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -276,12 +276,17 @@ type ReviewerConfig struct {
 	PublishMode             ReviewerPublishMode            `json:"publishMode"`
 	ReviewEvents            ReviewerReviewEventsConfig     `json:"reviewEvents"`
 	DetectDuplicateFindings bool                           `json:"detectDuplicateFindings"`
+	NativeResume            ReviewerNativeResumeConfig     `json:"nativeResume"`
 	ThreadResolution        ReviewerThreadResolutionConfig `json:"threadResolution"`
 }
 
 type ReviewerReviewEventsConfig struct {
 	Clean    ReviewerReviewEvent `json:"clean"`
 	Blocking ReviewerReviewEvent `json:"blocking"`
+}
+
+type ReviewerNativeResumeConfig struct {
+	OnHeadChange bool `json:"onHeadChange"`
 }
 
 type ReviewerThreadResolutionConfig struct {
@@ -588,12 +593,17 @@ type PartialReviewerConfig struct {
 	ReviewEvents            *PartialReviewerReviewEventsConfig     `json:"reviewEvents,omitempty"`
 	DetectDuplicateFindings *bool                                  `json:"detectDuplicateFindings,omitempty"`
 	DedupeFindings          *bool                                  `json:"dedupeFindings,omitempty"`
+	NativeResume            *PartialReviewerNativeResumeConfig     `json:"nativeResume,omitempty"`
 	ThreadResolution        *PartialReviewerThreadResolutionConfig `json:"threadResolution,omitempty"`
 }
 
 type PartialReviewerReviewEventsConfig struct {
 	Clean    *ReviewerReviewEvent `json:"clean,omitempty"`
 	Blocking *ReviewerReviewEvent `json:"blocking,omitempty"`
+}
+
+type PartialReviewerNativeResumeConfig struct {
+	OnHeadChange *bool `json:"onHeadChange,omitempty"`
 }
 
 type PartialReviewerThreadResolutionConfig struct {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -286,7 +286,8 @@ type ReviewerReviewEventsConfig struct {
 }
 
 type ReviewerNativeResumeConfig struct {
-	OnHeadChange bool `json:"onHeadChange"`
+	OnHeadChange               bool `json:"onHeadChange"`
+	ReReviewPromptOnHeadChange bool `json:"reReviewPromptOnHeadChange"`
 }
 
 type ReviewerThreadResolutionConfig struct {
@@ -603,7 +604,8 @@ type PartialReviewerReviewEventsConfig struct {
 }
 
 type PartialReviewerNativeResumeConfig struct {
-	OnHeadChange *bool `json:"onHeadChange,omitempty"`
+	OnHeadChange               *bool `json:"onHeadChange,omitempty"`
+	ReReviewPromptOnHeadChange *bool `json:"reReviewPromptOnHeadChange,omitempty"`
 }
 
 type PartialReviewerThreadResolutionConfig struct {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -57,6 +57,11 @@ var reviewMarkerCommentPattern = regexp.MustCompile(`(?is)<!--\s*looper:review\b
 var reviewHumanHTMLCommentPattern = regexp.MustCompile(`(?s)<!--.*?-->`)
 var reviewHumanReferenceDefinitionPattern = regexp.MustCompile(`(?m)^\s{0,3}\[[^\]\n]+\]:[^\n]*(?:\n[ \t]+[^\n]*)*`)
 
+const (
+	reviewerNativeResumeMetadataKey      = "reviewerNativeResume"
+	reviewerNativeResumeReasonHeadChange = "head_change"
+)
+
 type ReviewerStep string
 
 type ReviewEvent string
@@ -370,6 +375,7 @@ type Options struct {
 	DiscoveryPolicy         DiscoveryPolicy
 	Scope                   config.ReviewerScope
 	DetectDuplicateFindings bool
+	NativeResume            config.ReviewerNativeResumeConfig
 	ThreadResolution        config.ReviewerThreadResolutionConfig
 	Disclosure              *config.DisclosureConfig
 	CustomInstructions      *config.Config
@@ -410,6 +416,7 @@ type Runner struct {
 	discoveryPolicy         DiscoveryPolicy
 	scope                   config.ReviewerScope
 	detectDuplicateFindings bool
+	nativeResume            config.ReviewerNativeResumeConfig
 	threadResolution        config.ReviewerThreadResolutionConfig
 	disclosure              config.DisclosureConfig
 	customInstructions      config.Config
@@ -609,6 +616,7 @@ func New(options Options) *Runner {
 		discoveryPolicy:         policy,
 		scope:                   scope,
 		detectDuplicateFindings: options.DetectDuplicateFindings,
+		nativeResume:            options.NativeResume,
 		threadResolution:        threadResolution,
 		disclosure:              disclosureCfg,
 		customInstructions:      customInstructionConfig(options.CustomInstructions),
@@ -1696,6 +1704,9 @@ func (r *Runner) runThreadResolutionStep(ctx context.Context, input stepInput) (
 	if checkpoint.Detail == nil || checkpoint.Snapshot == nil {
 		return checkpoint, &loopError{message: "Missing PR detail or snapshot checkpoint for thread resolution step", kind: FailureRetryableTransient}
 	}
+	if r.hasPendingHeadChangeNativeResume(ctx, input.Loop.ID) {
+		return checkpoint, nil
+	}
 	if normalizePRState(checkpoint.Detail.State) != "open" {
 		return checkpoint, nil
 	}
@@ -2062,20 +2073,26 @@ func latestThreadFeedbackCommitOID(thread ReviewThread) string {
 type reviewerHeadChangeMonitor struct {
 	cancel func()
 	done   chan struct{}
-	reason chan string
+	signal chan reviewerHeadChangeSignal
 }
 
-func (m reviewerHeadChangeMonitor) stop() string {
+type reviewerHeadChangeSignal struct {
+	OldHeadSHA string
+	NewHeadSHA string
+	Reason     string
+}
+
+func (m reviewerHeadChangeMonitor) stop() reviewerHeadChangeSignal {
 	if m.cancel == nil {
-		return ""
+		return reviewerHeadChangeSignal{}
 	}
 	m.cancel()
 	<-m.done
 	select {
-	case reason := <-m.reason:
-		return reason
+	case signal := <-m.signal:
+		return signal
 	default:
-		return ""
+		return reviewerHeadChangeSignal{}
 	}
 }
 
@@ -2085,7 +2102,7 @@ func (r *Runner) startReviewerHeadChangeMonitor(ctx context.Context, input stepI
 		return reviewerHeadChangeMonitor{}
 	}
 	monitorCtx, cancel := context.WithCancel(ctx)
-	monitor := reviewerHeadChangeMonitor{cancel: cancel, done: make(chan struct{}), reason: make(chan string, 1)}
+	monitor := reviewerHeadChangeMonitor{cancel: cancel, done: make(chan struct{}), signal: make(chan reviewerHeadChangeSignal, 1)}
 	go func() {
 		defer close(monitor.done)
 		ticker := time.NewTicker(r.headChangePollInterval)
@@ -2106,10 +2123,11 @@ func (r *Runner) startReviewerHeadChangeMonitor(ctx context.Context, input stepI
 					continue
 				}
 				reason := fmt.Sprintf("PR head changed while reviewer was running: expected %s, got %s", expectedHead, headSHA)
+				signal := reviewerHeadChangeSignal{OldHeadSHA: expectedHead, NewHeadSHA: headSHA, Reason: reason}
 				r.appendReviewerAgentEvent(context.Background(), input, "reviewer.agent.interrupted", "review", executionID, map[string]any{"headSha": expectedHead, "newHeadSha": headSHA, "reason": reason})
 				r.logInfo("reviewer agent interrupted for newer PR head", map[string]any{"projectId": input.Project.ID, "loopId": input.Loop.ID, "runId": input.Run.ID, "repo": input.Repo, "prNumber": input.PRNumber, "executionId": executionID, "expectedHeadSha": expectedHead, "actualHeadSha": headSHA})
 				select {
-				case monitor.reason <- reason:
+				case monitor.signal <- signal:
 				default:
 				}
 				if err := execution.Kill(reason); err != nil {
@@ -2158,10 +2176,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	idempotencyKey := agentNativeReviewID(input.Loop.ID, checkpoint.Snapshot.HeadSHA)
 	policy := r.discoveryPolicyForProject(input.Project.ID)
 	prompt, instructionBlock := buildReviewPromptWithInstructions(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint, input.Run.ID, idempotencyKey, r.effectiveReviewEvents(input.Loop.MetadataJSON), isManualReviewerLoop(input.Loop), policy.RequireReviewRequest, r.scope, r.disclosure, r.agentRuntime, r.agentModel, r.looperCLIPath)
-	nativeResumePrompt := ""
-	if r.hasPendingNativeResume(ctx, input.Loop.ID) {
-		nativeResumePrompt = nativeResumeContinuationPrompt("review", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, idempotencyKey)
-	}
+	nativeResumePrompt := r.nativeResumePromptForReview(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey)
 	metadata := map[string]any{"loopType": "reviewer", "repo": input.Repo, "prNumber": input.PRNumber}
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 		metadata[key] = value
@@ -2182,11 +2197,14 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	}
 	headMonitor := r.startReviewerHeadChangeMonitor(ctx, input, checkpoint, execution, executionID)
 	result, err := execution.Wait(ctx)
-	headChangeReason := headMonitor.stop()
-	if headChangeReason != "" {
+	headChange := headMonitor.stop()
+	if headChange.Reason != "" {
+		if r.nativeResume.OnHeadChange {
+			r.markAgentExecutionNativeResumePendingForHeadChange(ctx, executionID, input, headChange)
+		}
 		checkpoint.PendingReview = nil
 		checkpoint.ResumePolicy = "restart_from_discover"
-		return checkpoint, &loopError{message: headChangeReason, kind: FailureRetryableAfterResume, interrupted: true}
+		return checkpoint, &loopError{message: headChange.Reason, kind: FailureRetryableAfterResume, interrupted: true}
 	}
 	if err != nil {
 		r.appendReviewerAgentEvent(ctx, input, "reviewer.agent.failed", "review", executionID, reviewerAgentWaitErrorPayload(err, r.now().Sub(agentStartedAt)))
@@ -3451,16 +3469,91 @@ func (r *Runner) markAgentExecutionNativeResumePendingForTransientProvider(ctx c
 	return true
 }
 
-func (r *Runner) hasPendingNativeResume(ctx context.Context, loopID string) bool {
-	if strings.TrimSpace(loopID) == "" || r.repos == nil || r.repos.AgentExecutions == nil {
+func (r *Runner) markAgentExecutionNativeResumePendingForHeadChange(ctx context.Context, executionID string, input stepInput, signal reviewerHeadChangeSignal) bool {
+	if strings.TrimSpace(executionID) == "" || strings.TrimSpace(signal.Reason) == "" || r.repos == nil || r.repos.AgentExecutions == nil {
 		return false
+	}
+	record, err := r.repos.AgentExecutions.GetByID(ctx, executionID)
+	if err != nil {
+		r.logWarn("reviewer native resume head-change source lookup failed", map[string]any{"executionId": executionID, "error": err.Error()})
+		return false
+	}
+	if record == nil || record.NativeSessionID == nil || strings.TrimSpace(*record.NativeSessionID) == "" {
+		return false
+	}
+	currentVendor := config.AgentVendor(strings.TrimSpace(r.agentRuntime))
+	if currentVendor != "" && (!nativeResumeSupportedForReviewer(currentVendor) || record.Vendor != string(currentVendor)) {
+		return false
+	}
+	metadata := parseJSONObject(record.MetadataJSON)
+	metadata[reviewerNativeResumeMetadataKey] = map[string]any{
+		"reason":     reviewerNativeResumeReasonHeadChange,
+		"phase":      "review",
+		"repo":       input.Repo,
+		"prNumber":   input.PRNumber,
+		"oldHeadSha": signal.OldHeadSHA,
+		"newHeadSha": signal.NewHeadSHA,
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		r.logWarn("reviewer native resume head-change metadata marshal failed", map[string]any{"executionId": executionID, "error": err.Error()})
+		return false
+	}
+	record.MetadataJSON = stringPtr(string(metadataJSON))
+	record.NativeResumeMode = stringPtr("native_resume")
+	record.NativeResumeStatus = stringPtr("pending")
+	record.NativeResumeError = stringPtr(strings.TrimSpace(signal.Reason))
+	record.UpdatedAt = r.nowISO()
+	if err := r.repos.AgentExecutions.Upsert(ctx, *record); err != nil {
+		r.logWarn("reviewer native resume head-change source mark failed", map[string]any{"executionId": executionID, "error": err.Error()})
+		return false
+	}
+	r.logInfo("reviewer native resume re-review queued", map[string]any{"executionId": executionID, "loopId": derefString(record.LoopID), "runId": derefString(record.RunID), "oldHeadSha": signal.OldHeadSHA, "newHeadSha": signal.NewHeadSHA})
+	return true
+}
+
+func (r *Runner) pendingNativeResume(ctx context.Context, loopID string) *storage.AgentExecutionRecord {
+	if strings.TrimSpace(loopID) == "" || r.repos == nil || r.repos.AgentExecutions == nil {
+		return nil
 	}
 	latest, err := r.repos.AgentExecutions.GetLatestByLoopID(ctx, loopID)
 	if err != nil {
 		r.logWarn("reviewer native resume pending lookup failed", map[string]any{"loopId": loopID, "error": err.Error()})
+		return nil
+	}
+	if !r.isResumableNativeSession(latest) {
+		return nil
+	}
+	return latest
+}
+
+func (r *Runner) hasPendingNativeResume(ctx context.Context, loopID string) bool {
+	return r.pendingNativeResume(ctx, loopID) != nil
+}
+
+func (r *Runner) hasPendingHeadChangeNativeResume(ctx context.Context, loopID string) bool {
+	if !r.nativeResume.OnHeadChange {
 		return false
 	}
-	return r.isResumableNativeSession(latest)
+	record := r.pendingNativeResume(ctx, loopID)
+	if record == nil {
+		return false
+	}
+	_, ok := reviewerNativeResumeHeadChange(record)
+	return ok
+}
+
+func (r *Runner) nativeResumePromptForReview(ctx context.Context, input stepInput, currentHeadSHA string, idempotencyKey string) string {
+	record := r.pendingNativeResume(ctx, input.Loop.ID)
+	if record == nil {
+		return ""
+	}
+	if r.nativeResume.OnHeadChange {
+		if headChange, ok := reviewerNativeResumeHeadChange(record); ok && headChange.matches(input.Repo, input.PRNumber) {
+			return nativeResumeReReviewPrompt(input.Repo, input.PRNumber, headChange.OldHeadSHA, headChange.NewHeadSHA, currentHeadSHA, idempotencyKey)
+		}
+	}
+	return nativeResumeContinuationPrompt("review", input.Repo, input.PRNumber, currentHeadSHA, idempotencyKey)
 }
 
 func (r *Runner) shouldSkipTransientRetryDelayForNativeResume(ctx context.Context, loopID string, err error) bool {
@@ -3531,6 +3624,40 @@ func isRecoverableReviewerNativeResumeSource(status string, resumeStatus *string
 	}
 }
 
+type reviewerNativeResumeHeadChangeInfo struct {
+	Repo       string
+	PRNumber   int64
+	OldHeadSHA string
+	NewHeadSHA string
+}
+
+func (h reviewerNativeResumeHeadChangeInfo) matches(repo string, prNumber int64) bool {
+	return strings.TrimSpace(h.Repo) == strings.TrimSpace(repo) && h.PRNumber == prNumber
+}
+
+func reviewerNativeResumeHeadChange(record *storage.AgentExecutionRecord) (reviewerNativeResumeHeadChangeInfo, bool) {
+	if record == nil {
+		return reviewerNativeResumeHeadChangeInfo{}, false
+	}
+	metadata := parseJSONObject(record.MetadataJSON)
+	raw, _ := metadata[reviewerNativeResumeMetadataKey].(map[string]any)
+	if raw == nil {
+		return reviewerNativeResumeHeadChangeInfo{}, false
+	}
+	reason, _ := stringFromAny(raw["reason"])
+	if reason != reviewerNativeResumeReasonHeadChange {
+		return reviewerNativeResumeHeadChangeInfo{}, false
+	}
+	repo, _ := stringFromAny(raw["repo"])
+	oldHeadSHA, _ := stringFromAny(raw["oldHeadSha"])
+	newHeadSHA, _ := stringFromAny(raw["newHeadSha"])
+	prNumber := int64(intFromAny(raw["prNumber"]))
+	if repo == "" || prNumber == 0 || oldHeadSHA == "" || newHeadSHA == "" {
+		return reviewerNativeResumeHeadChangeInfo{}, false
+	}
+	return reviewerNativeResumeHeadChangeInfo{Repo: repo, PRNumber: prNumber, OldHeadSHA: oldHeadSHA, NewHeadSHA: newHeadSHA}, true
+}
+
 func nativeResumeContinuationPrompt(phase string, repo string, prNumber int64, headSHA string, idempotencyKey string) string {
 	return fmt.Sprintf(`Continue the existing Looper reviewer %s task in this resumed native session.
 
@@ -3542,6 +3669,23 @@ Before any GitHub side effect, re-check the current PR/head/idempotency guards f
 - idempotency key: %s
 
 If the review or thread-resolution result was already posted, report the existing completion marker instead of posting a duplicate.`, strings.TrimSpace(phase), repo, prNumber, headSHA, idempotencyKey)
+}
+
+func nativeResumeReReviewPrompt(repo string, prNumber int64, oldHeadSHA string, interruptedHeadSHA string, currentHeadSHA string, idempotencyKey string) string {
+	return fmt.Sprintf(`Continue the existing Looper reviewer review task in this resumed native session, but treat it as a PR update re-review.
+
+The pull request changed while the prior review was running:
+- PR: %s#%d
+- previous reviewed head SHA: %s
+- head SHA observed at interruption: %s
+- current expected head SHA for this run: %s
+- idempotency key for this run: %s
+
+Use the prior session context only as background. Re-review the current expected head before publishing anything. Discard findings, assumptions, anchors, or conclusions that only apply to the previous head. Keep only findings that are still concrete, actionable, and valid against the current head.
+
+Before any GitHub side effect, re-check that the PR is open, the current head SHA still matches the current expected head SHA, and the current-user review-request/idempotency guards from the existing instructions still pass.
+
+If a matching review for the current expected head and idempotency key was already posted, report the existing completion marker instead of posting a duplicate.`, repo, prNumber, oldHeadSHA, interruptedHeadSHA, currentHeadSHA, idempotencyKey)
 }
 
 func transientProviderMessageFromAgentResult(result AgentResult) string {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3532,7 +3532,7 @@ func (r *Runner) hasPendingNativeResume(ctx context.Context, loopID string) bool
 }
 
 func (r *Runner) hasPendingHeadChangeNativeResume(ctx context.Context, loopID string) bool {
-	if !r.nativeResume.OnHeadChange {
+	if !r.nativeResume.OnHeadChange && !r.nativeResume.ReReviewPromptOnHeadChange {
 		return false
 	}
 	record := r.pendingNativeResume(ctx, loopID)
@@ -3548,7 +3548,7 @@ func (r *Runner) nativeResumePromptForReview(ctx context.Context, input stepInpu
 	if record == nil {
 		return ""
 	}
-	if r.nativeResume.OnHeadChange {
+	if r.nativeResume.ReReviewPromptOnHeadChange {
 		if headChange, ok := reviewerNativeResumeHeadChange(record); ok && headChange.matches(input.Repo, input.PRNumber) {
 			return nativeResumeReReviewPrompt(input.Repo, input.PRNumber, headChange.OldHeadSHA, headChange.NewHeadSHA, currentHeadSHA, idempotencyKey)
 		}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -4350,7 +4350,7 @@ func TestRunReviewStepUsesReReviewPromptForHeadChangeNativeResume(t *testing.T) 
 	fixture := newRunnerFixture(t)
 	ctx := context.Background()
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AgentRuntime: string(config.AgentVendorOpenCode), NativeResume: config.ReviewerNativeResumeConfig{OnHeadChange: true}})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AgentRuntime: string(config.AgentVendorOpenCode), NativeResume: config.ReviewerNativeResumeConfig{ReReviewPromptOnHeadChange: true}})
 	project, err := fixture.repos.Projects.GetByID(ctx, "project_1")
 	if err != nil || project == nil {
 		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
@@ -4400,6 +4400,57 @@ func TestRunReviewStepUsesReReviewPromptForHeadChangeNativeResume(t *testing.T) 
 	}
 	if strings.Contains(nativeResumePrompt, "transient provider interruption") {
 		t.Fatalf("native resume prompt = %q, want re-review prompt instead of transient continuation", nativeResumePrompt)
+	}
+}
+
+func TestRunReviewStepKeepsGenericPromptWhenReReviewPromptFlagDisabled(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AgentRuntime: string(config.AgentVendorOpenCode), NativeResume: config.ReviewerNativeResumeConfig{OnHeadChange: true}})
+	project, err := fixture.repos.Projects.GetByID(ctx, "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_native_rereview_prompt_disabled", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_native_rereview_prompt_disabled", LoopID: loop.ID, Status: "running", StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	metadata := mustMarshalJSON(map[string]any{reviewerNativeResumeMetadataKey: map[string]any{"reason": reviewerNativeResumeReasonHeadChange, "phase": "review", "repo": repo, "prNumber": prNumber, "oldHeadSha": "old-head", "newHeadSha": "new-head"}})
+	if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: "agent_previous_head_change_prompt_disabled", ProjectID: stringPtr(project.ID), LoopID: stringPtr(loop.ID), RunID: stringPtr(run.ID), Vendor: string(config.AgentVendorOpenCode), Status: "killed", NativeSessionID: stringPtr("session-123"), NativeResumeStatus: stringPtr("pending"), MetadataJSON: stringPtr(metadata), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	_, err = runner.runReviewStep(ctx, stepInput{
+		Project:  *project,
+		Loop:     loop,
+		Run:      run,
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "current-head"},
+			Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: fixture.nowISO()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runReviewStep() error = %v", err)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
+	}
+	nativeResumePrompt := agent.starts[0].NativeResumePrompt
+	if strings.Contains(nativeResumePrompt, "PR update re-review") || strings.Contains(nativeResumePrompt, "Discard findings") {
+		t.Fatalf("native resume prompt = %q, want generic continuation when re-review prompt flag is disabled", nativeResumePrompt)
+	}
+	if !strings.Contains(nativeResumePrompt, "transient provider interruption") {
+		t.Fatalf("native resume prompt = %q, want generic continuation prompt", nativeResumePrompt)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2707,6 +2707,113 @@ func TestProcessClaimedItemInterruptsRunningReviewerWhenHeadChanges(t *testing.T
 	}
 }
 
+func TestProcessClaimedItemMarksNativeResumePendingWhenHeadChangesAndFlagEnabled(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	github := &fakeGitHubGateway{changeHeadOnSecondView: true, reviewRequests: []string{"octocat"}, reviewMarkerMissing: true}
+	agent := &fakeAgentExecutor{
+		results: []AgentResult{{Status: "completed", Summary: "stale review", Stdout: `__LOOPER_RESULT__={"summary":"stale review"}`, ParseStatus: "parsed"}},
+		wait: func(context.Context) error {
+			time.Sleep(25 * time.Millisecond)
+			return nil
+		},
+	}
+	agent.onStart = func(input AgentRunInput) {
+		nowISO := fixture.nowISO()
+		if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: input.ExecutionID, ProjectID: stringPtr(input.ProjectID), LoopID: stringPtr(input.LoopID), RunID: stringPtr(input.RunID), Vendor: string(config.AgentVendorOpenCode), Status: "running", NativeSessionID: stringPtr("session-head-change"), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+			t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+		}
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AgentRuntime: string(config.AgentVendorOpenCode), NativeResume: config.ReviewerNativeResumeConfig{OnHeadChange: true}, HeadChangePollInterval: time.Millisecond, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 2, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25}})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"followUpdates":true,"loop":{"enabled":true}}`
+	loop := storage.LoopRecord{ID: "loop_interrupt_head_changed_native_resume", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue, err := runner.enqueue(ctx, enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+	}
+
+	result, err := runner.ProcessClaimedItem(ctx, *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "interrupted" {
+		t.Fatalf("result.Status = %q, want interrupted", result.Status)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
+	}
+	record, err := fixture.repos.AgentExecutions.GetByID(ctx, agent.starts[0].ExecutionID)
+	if err != nil || record == nil {
+		t.Fatalf("AgentExecutions.GetByID() = (%#v, %v), want record", record, err)
+	}
+	if record.NativeResumeMode == nil || *record.NativeResumeMode != "native_resume" || record.NativeResumeStatus == nil || *record.NativeResumeStatus != "pending" {
+		t.Fatalf("native resume fields = mode:%v status:%v, want native_resume/pending", record.NativeResumeMode, record.NativeResumeStatus)
+	}
+	headChange, ok := reviewerNativeResumeHeadChange(record)
+	if !ok || headChange.OldHeadSHA != "abc123" || headChange.NewHeadSHA != "new-head" || !headChange.matches(repo, prNumber) {
+		t.Fatalf("reviewerNativeResume metadata = (%#v, %v), want head-change abc123 -> new-head", headChange, ok)
+	}
+}
+
+func TestProcessClaimedItemDoesNotMarkNativeResumePendingWhenHeadChangeFlagDisabled(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	github := &fakeGitHubGateway{changeHeadOnSecondView: true, reviewRequests: []string{"octocat"}, reviewMarkerMissing: true}
+	agent := &fakeAgentExecutor{
+		results: []AgentResult{{Status: "completed", Summary: "stale review", Stdout: `__LOOPER_RESULT__={"summary":"stale review"}`, ParseStatus: "parsed"}},
+		wait: func(context.Context) error {
+			time.Sleep(25 * time.Millisecond)
+			return nil
+		},
+	}
+	agent.onStart = func(input AgentRunInput) {
+		nowISO := fixture.nowISO()
+		if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: input.ExecutionID, ProjectID: stringPtr(input.ProjectID), LoopID: stringPtr(input.LoopID), RunID: stringPtr(input.RunID), Vendor: string(config.AgentVendorOpenCode), Status: "running", NativeSessionID: stringPtr("session-head-change"), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+			t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+		}
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AgentRuntime: string(config.AgentVendorOpenCode), HeadChangePollInterval: time.Millisecond, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 2, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25}})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"followUpdates":true,"loop":{"enabled":true}}`
+	loop := storage.LoopRecord{ID: "loop_interrupt_head_changed_native_resume_disabled", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue, err := runner.enqueue(ctx, enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+	}
+
+	if _, err := runner.ProcessClaimedItem(ctx, *claimed); err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	record, err := fixture.repos.AgentExecutions.GetByID(ctx, agent.starts[0].ExecutionID)
+	if err != nil || record == nil {
+		t.Fatalf("AgentExecutions.GetByID() = (%#v, %v), want record", record, err)
+	}
+	if record.NativeResumeStatus != nil && *record.NativeResumeStatus == "pending" {
+		t.Fatalf("NativeResumeStatus = %q, want not pending when feature flag is disabled", *record.NativeResumeStatus)
+	}
+}
+
 func TestProcessClaimedItemMarksStaleWhenPullRequestStateDriftsBeforePublish(t *testing.T) {
 	t.Parallel()
 
@@ -4236,6 +4343,63 @@ func TestRunReviewStepKeepsFullPromptForPendingNativeResumeFallback(t *testing.T
 	nativeResumePrompt := agent.starts[0].NativeResumePrompt
 	if !strings.Contains(nativeResumePrompt, "Continue the existing Looper reviewer review task") || !strings.Contains(nativeResumePrompt, "idempotency key: reviewer:loop_native_resume_prompt:abc123") {
 		t.Fatalf("native resume prompt = %q, want short native resume continuation prompt", nativeResumePrompt)
+	}
+}
+
+func TestRunReviewStepUsesReReviewPromptForHeadChangeNativeResume(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Looks good", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AgentRuntime: string(config.AgentVendorOpenCode), NativeResume: config.ReviewerNativeResumeConfig{OnHeadChange: true}})
+	project, err := fixture.repos.Projects.GetByID(ctx, "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_native_rereview_prompt", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_native_rereview_prompt", LoopID: loop.ID, Status: "running", StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	metadata := mustMarshalJSON(map[string]any{reviewerNativeResumeMetadataKey: map[string]any{"reason": reviewerNativeResumeReasonHeadChange, "phase": "review", "repo": repo, "prNumber": prNumber, "oldHeadSha": "old-head", "newHeadSha": "new-head"}})
+	if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: "agent_previous_head_change", ProjectID: stringPtr(project.ID), LoopID: stringPtr(loop.ID), RunID: stringPtr(run.ID), Vendor: string(config.AgentVendorOpenCode), Status: "killed", NativeSessionID: stringPtr("session-123"), NativeResumeStatus: stringPtr("pending"), MetadataJSON: stringPtr(metadata), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	_, err = runner.runReviewStep(ctx, stepInput{
+		Project:  *project,
+		Loop:     loop,
+		Run:      run,
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "current-head"},
+			Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: fixture.nowISO()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runReviewStep() error = %v", err)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want 1", len(agent.starts))
+	}
+	prompt := agent.starts[0].Prompt
+	if strings.Contains(prompt, "PR update re-review") {
+		t.Fatalf("full prompt = %q, want checkpoint fallback full review prompt without re-review continuation", prompt)
+	}
+	nativeResumePrompt := agent.starts[0].NativeResumePrompt
+	for _, want := range []string{"PR update re-review", "previous reviewed head SHA: old-head", "head SHA observed at interruption: new-head", "current expected head SHA for this run: current-head", "idempotency key for this run: reviewer:loop_native_rereview_prompt:current-head", "Discard findings"} {
+		if !strings.Contains(nativeResumePrompt, want) {
+			t.Fatalf("native resume prompt missing %q:\n%s", want, nativeResumePrompt)
+		}
+	}
+	if strings.Contains(nativeResumePrompt, "transient provider interruption") {
+		t.Fatalf("native resume prompt = %q, want re-review prompt instead of transient continuation", nativeResumePrompt)
 	}
 }
 
@@ -6639,11 +6803,15 @@ type fakeAgentExecutor struct {
 	waitErr       error
 	waitErrs      []error
 	wait          func(context.Context) error
+	onStart       func(AgentRunInput)
 	killedReasons []string
 }
 
 func (f *fakeAgentExecutor) Start(_ context.Context, input AgentRunInput) (AgentExecution, error) {
 	f.starts = append(f.starts, input)
+	if f.onStart != nil {
+		f.onStart(input)
+	}
 	if f.startErr != nil {
 		return nil, f.startErr
 	}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -855,6 +855,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 		},
 		Scope:                   cfg.Reviewer.Scope,
 		DetectDuplicateFindings: cfg.Reviewer.DetectDuplicateFindings,
+		NativeResume:            cfg.Reviewer.NativeResume,
 		ThreadResolution:        cfg.Reviewer.ThreadResolution,
 		Disclosure:              &cfg.Disclosure,
 		AgentRuntime:            agentRuntime,

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -153,6 +153,9 @@ Use this as a map of supported sections, not as a template to paste wholesale:
     "reviewEvents": {
       "clean": "COMMENT",
       "blocking": "COMMENT"
+    },
+    "nativeResume": {
+      "onHeadChange": false
     }
   },
   "roles": {
@@ -399,6 +402,7 @@ Defaults: `mode=foreground`, `restartPolicy=on-failure`, `restartThrottleSeconds
 
 - `reviewEvents.clean`: `COMMENT` or `APPROVE`, default `COMMENT`.
 - `reviewEvents.blocking`: `COMMENT` or `REQUEST_CHANGES`, default `COMMENT`.
+- `nativeResume.onHeadChange`: resume an interrupted native reviewer session after a PR head change with a re-review continuation prompt, default `false`.
 - Deprecated reviewer budget options are ignored by the reviewer filter.
 
 Safe default comment-only behavior:
@@ -409,6 +413,9 @@ Safe default comment-only behavior:
     "reviewEvents": {
       "clean": "COMMENT",
       "blocking": "COMMENT"
+    },
+    "nativeResume": {
+      "onHeadChange": false
     }
   }
 }
@@ -567,6 +574,7 @@ Supported environment overrides:
 - `LOOPER_ALLOW_AUTO_APPROVE`
 - `LOOPER_REVIEWER_REVIEW_EVENTS_CLEAN`
 - `LOOPER_REVIEWER_REVIEW_EVENTS_BLOCKING`
+- `LOOPER_REVIEWER_NATIVE_RESUME_ON_HEAD_CHANGE`
 - `LOOPER_FIX_ALL_PULL_REQUESTS`
 - `LOOPER_ROLES_PLANNER_AUTO_DISCOVERY`
 - `LOOPER_ROLES_PLANNER_TRIGGERS_LABELS`

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -155,7 +155,8 @@ Use this as a map of supported sections, not as a template to paste wholesale:
       "blocking": "COMMENT"
     },
     "nativeResume": {
-      "onHeadChange": false
+      "onHeadChange": false,
+      "reReviewPromptOnHeadChange": false
     }
   },
   "roles": {
@@ -402,7 +403,8 @@ Defaults: `mode=foreground`, `restartPolicy=on-failure`, `restartThrottleSeconds
 
 - `reviewEvents.clean`: `COMMENT` or `APPROVE`, default `COMMENT`.
 - `reviewEvents.blocking`: `COMMENT` or `REQUEST_CHANGES`, default `COMMENT`.
-- `nativeResume.onHeadChange`: resume an interrupted native reviewer session after a PR head change with a re-review continuation prompt, default `false`.
+- `nativeResume.onHeadChange`: mark an interrupted native reviewer session as pending after a PR head change, default `false`.
+- `nativeResume.reReviewPromptOnHeadChange`: use the re-review continuation prompt for pending native reviewer sessions interrupted by a PR head change, default `false`.
 - Deprecated reviewer budget options are ignored by the reviewer filter.
 
 Safe default comment-only behavior:
@@ -415,7 +417,8 @@ Safe default comment-only behavior:
       "blocking": "COMMENT"
     },
     "nativeResume": {
-      "onHeadChange": false
+      "onHeadChange": false,
+      "reReviewPromptOnHeadChange": false
     }
   }
 }
@@ -575,6 +578,7 @@ Supported environment overrides:
 - `LOOPER_REVIEWER_REVIEW_EVENTS_CLEAN`
 - `LOOPER_REVIEWER_REVIEW_EVENTS_BLOCKING`
 - `LOOPER_REVIEWER_NATIVE_RESUME_ON_HEAD_CHANGE`
+- `LOOPER_REVIEWER_NATIVE_RESUME_REREVIEW_PROMPT_ON_HEAD_CHANGE`
 - `LOOPER_FIX_ALL_PULL_REQUESTS`
 - `LOOPER_ROLES_PLANNER_AUTO_DISCOVERY`
 - `LOOPER_ROLES_PLANNER_TRIGGERS_LABELS`


### PR DESCRIPTION
## Summary

- Add `reviewer.nativeResume.onHeadChange` and `LOOPER_REVIEWER_NATIVE_RESUME_ON_HEAD_CHANGE`, defaulting off.
- Add independent `reviewer.nativeResume.reReviewPromptOnHeadChange` and `LOOPER_REVIEWER_NATIVE_RESUME_REREVIEW_PROMPT_ON_HEAD_CHANGE`, defaulting off.
- Mark reviewer executions as pending native resume when a running review is interrupted by PR head drift and a native session id is available.
- Use a PR update re-review native resume prompt only when the prompt switch is enabled, while keeping the full review prompt as checkpoint fallback.
- Preserve head-change resume sessions for review by skipping thread-resolution classifier work while a head-change native resume flow is enabled.
- Update config parity fixtures, API contract expectations, docs, and focused reviewer/config tests.

## Impact

This keeps Looper as the source of truth for review state while allowing supported native CLI sessions to be reused after PR updates. Publishing remains head-bound because the resumed prompt explicitly requires live PR/head and idempotency checks before any GitHub side effect.

The head-change native-resume marking and the head-change re-review prompt are separate reviewer-scoped switches, both disabled by default.

## Validation

- `go test ./internal/reviewer -run 'TestProcessClaimedItemMarksNativeResumePendingWhenHeadChangesAndFlagEnabled|TestProcessClaimedItemDoesNotMarkNativeResumePendingWhenHeadChangeFlagDisabled|TestRunReviewStepUsesReReviewPromptForHeadChangeNativeResume|TestRunReviewStepKeepsGenericPromptWhenReReviewPromptFlagDisabled|TestRunReviewStepKeepsFullPromptForPendingNativeResumeFallback'`
- `go test ./internal/config -run 'TestLoadFileReviewerNativeResumeOnHeadChangeEnvOverride|TestLoadFileReviewerNativeResumeReReviewPromptOnHeadChangeEnvOverride|TestDefaultConfig'`
- `go test ./internal/api -run Test`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`
