### PR TITLE
ci: support manual release version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,17 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Existing tag to release, for example v1.2.3"
+      version_bump:
+        description: "Version bump to release from the latest stable vMAJOR.MINOR.PATCH tag"
         required: true
-        type: string
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.ref_name, inputs.version_bump) || github.ref_name }}
 
 permissions:
   contents: write
@@ -37,7 +41,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.sha }}
+          ref: ${{ github.sha }}
+          fetch-depth: 0
 
       - name: Pin release commit
         id: release-commit
@@ -62,10 +67,59 @@ jobs:
       - name: Test
         run: go test ./...
 
-      - name: Read release version and channel from tag
+      - name: Read release version and channel
         id: release-version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          VERSION_BUMP: ${{ inputs.version_bump }}
         run: |
-          tag_name="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            latest_tag=""
+            while IFS= read -r candidate_tag; do
+              if [[ "$candidate_tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+                latest_tag="$candidate_tag"
+                major="${BASH_REMATCH[1]}"
+                minor="${BASH_REMATCH[2]}"
+                patch="${BASH_REMATCH[3]}"
+                break
+              fi
+            done < <(git tag --list 'v*' --sort=-v:refname)
+
+            if [ -z "$latest_tag" ]; then
+              major=0
+              minor=0
+              patch=0
+            fi
+
+            case "$VERSION_BUMP" in
+              patch)
+                patch=$((patch + 1))
+                ;;
+              minor)
+                minor=$((minor + 1))
+                patch=0
+                ;;
+              major)
+                major=$((major + 1))
+                minor=0
+                patch=0
+                ;;
+              *)
+                echo "version_bump must be one of: patch, minor, major" >&2
+                exit 1
+                ;;
+            esac
+
+            tag_name="v${major}.${minor}.${patch}"
+            if git rev-parse -q --verify "refs/tags/${tag_name}" >/dev/null; then
+              echo "Calculated tag already exists: ${tag_name}" >&2
+              exit 1
+            fi
+          else
+            tag_name="$REF_NAME"
+          fi
+
           if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "Tag must match vMAJOR.MINOR.PATCH[-PRERELEASE]: ${tag_name}" >&2
             exit 1
@@ -94,6 +148,14 @@ jobs:
           export LOOPER_BUILD_GIT_SHA="$(git rev-parse HEAD)"
           export LOOPER_BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           go build -ldflags "$(go run ./tools/go-build-flags)" ./...
+
+      - name: Create Git tag for manual release
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ steps.release-version.outputs.tag }}
+        run: |
+          git tag "$RELEASE_TAG" HEAD
+          git push origin "refs/tags/${RELEASE_TAG}"
 
   create-draft-release:
     needs: prepare-go-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,17 @@ on:
           - patch
           - minor
           - major
+      release_channel:
+        description: "Release channel"
+        required: true
+        type: choice
+        default: stable
+        options:
+          - stable
+          - beta
 
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.ref_name, inputs.version_bump) || github.ref_name }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}-{2}', github.ref_name, inputs.version_bump, inputs.release_channel) || github.ref_name }}
 
 permissions:
   contents: write
@@ -73,6 +81,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           VERSION_BUMP: ${{ inputs.version_bump }}
+          RELEASE_CHANNEL: ${{ inputs.release_channel }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             latest_tag=""
@@ -111,11 +120,36 @@ jobs:
                 ;;
             esac
 
-            tag_name="v${major}.${minor}.${patch}"
-            if git rev-parse -q --verify "refs/tags/${tag_name}" >/dev/null; then
-              echo "Calculated tag already exists: ${tag_name}" >&2
-              exit 1
-            fi
+            base_version="${major}.${minor}.${patch}"
+            case "$RELEASE_CHANNEL" in
+              stable)
+                tag_name="v${base_version}"
+                if git rev-parse -q --verify "refs/tags/${tag_name}" >/dev/null; then
+                  echo "Calculated tag already exists: ${tag_name}" >&2
+                  exit 1
+                fi
+                ;;
+              beta)
+                next_beta=1
+                while IFS= read -r candidate_tag; do
+                  if [[ "$candidate_tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)-beta\.([0-9]+)$ ]] && \
+                    [ "${BASH_REMATCH[1]}" = "$major" ] && \
+                    [ "${BASH_REMATCH[2]}" = "$minor" ] && \
+                    [ "${BASH_REMATCH[3]}" = "$patch" ]; then
+                    beta_number="${BASH_REMATCH[4]}"
+                    if [ "$beta_number" -ge "$next_beta" ]; then
+                      next_beta=$((beta_number + 1))
+                    fi
+                  fi
+                done < <(git tag --list "v${base_version}-beta.*")
+
+                tag_name="v${base_version}-beta.${next_beta}"
+                ;;
+              *)
+                echo "release_channel must be one of: stable, beta" >&2
+                exit 1
+                ;;
+            esac
           else
             tag_name="$REF_NAME"
           fi


### PR DESCRIPTION
## Summary
- Replace manual release workflow tag input with a patch/minor/major version bump choice.
- Calculate the next stable release tag from existing tags and create it during manual releases.
- Keep tag-push releases working while preserving generated draft release notes.

## Tests
- git diff --check -- .github/workflows/release.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "YAML OK"'