### PR TITLE
fix: stop obsolete resumed workers

### DIFF
--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -243,6 +243,20 @@ type CreatePullRequestResult struct {
 	URL    string
 }
 
+type CompareBranchesInput struct {
+	Repo       string
+	BaseBranch string
+	HeadBranch string
+	CWD        string
+}
+
+type CompareBranchesResult struct {
+	AheadBy      int
+	BehindBy     int
+	Status       string
+	TotalCommits int
+}
+
 type UpdatePullRequestTitleInput struct {
 	Repo     string
 	PRNumber int64
@@ -1480,6 +1494,29 @@ func (g *Gateway) CreatePullRequest(ctx context.Context, input CreatePullRequest
 		return CreatePullRequestResult{}, &shell.CommandExecutionError{Message: "gh pr create returned an empty URL", Result: result}
 	}
 	return CreatePullRequestResult{Number: parsePRNumberFromURL(prURL), URL: prURL}, nil
+}
+
+func (g *Gateway) CompareBranches(ctx context.Context, input CompareBranchesInput) (CompareBranchesResult, error) {
+	hostname, repo := splitRepoHostname(input.Repo)
+	comparison := encodeURIComponent(input.BaseBranch) + "..." + encodeURIComponent(input.HeadBranch)
+	args := []string{"api", fmt.Sprintf("repos/%s/compare/%s", repo, comparison)}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
+	if err != nil {
+		return CompareBranchesResult{}, err
+	}
+	var payload struct {
+		AheadBy      int    `json:"ahead_by"`
+		BehindBy     int    `json:"behind_by"`
+		Status       string `json:"status"`
+		TotalCommits int    `json:"total_commits"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &payload); err != nil {
+		return CompareBranchesResult{}, err
+	}
+	return CompareBranchesResult{AheadBy: payload.AheadBy, BehindBy: payload.BehindBy, Status: payload.Status, TotalCommits: payload.TotalCommits}, nil
 }
 
 func (g *Gateway) UpdatePullRequestTitle(ctx context.Context, input UpdatePullRequestTitleInput) error {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -602,6 +602,14 @@ func (a workerGitHubAdapter) CreatePullRequest(ctx context.Context, input worker
 	return worker.CreatePullRequestResult{Number: pr.Number, URL: pr.URL}, nil
 }
 
+func (a workerGitHubAdapter) CompareBranches(ctx context.Context, input worker.CompareBranchesInput) (worker.CompareBranchesResult, error) {
+	comparison, err := a.gateway.CompareBranches(ctx, githubinfra.CompareBranchesInput{Repo: input.Repo, BaseBranch: input.BaseBranch, HeadBranch: input.HeadBranch, CWD: input.CWD})
+	if err != nil {
+		return worker.CompareBranchesResult{}, err
+	}
+	return worker.CompareBranchesResult{AheadBy: comparison.AheadBy, BehindBy: comparison.BehindBy, Status: comparison.Status, TotalCommits: comparison.TotalCommits}, nil
+}
+
 func (a workerGitHubAdapter) UpdatePullRequestBody(ctx context.Context, input worker.UpdatePullRequestBodyInput) error {
 	body := a.stamper.Markdown(input.Body, "worker", disclosure.ChannelPullRequest)
 	return a.gateway.UpdatePullRequestBody(ctx, githubinfra.UpdatePullRequestBodyInput{Repo: input.Repo, PRNumber: input.PRNumber, Body: body, CWD: input.CWD})

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -877,6 +877,24 @@ func (r *LocksRepository) Get(ctx context.Context, key string) (*LockRecord, err
 	return &record, nil
 }
 
+func (r *LocksRepository) Refresh(ctx context.Context, record LockRecord) (bool, error) {
+	result, err := r.q.ExecContext(ctx, `
+		UPDATE locks
+		SET reason = ?, expires_at = ?, updated_at = ?
+		WHERE key = ? AND owner = ?
+	`, record.Reason, record.ExpiresAt, record.UpdatedAt, record.Key, record.Owner)
+	if err != nil {
+		return false, fmt.Errorf("refresh lock: %w", err)
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read refresh lock rows affected: %w", err)
+	}
+
+	return affected > 0, nil
+}
+
 func (r *LocksRepository) ListExpired(ctx context.Context, nowISO string) ([]LockRecord, error) {
 	rows, err := r.q.QueryContext(ctx, `SELECT * FROM locks WHERE expires_at <= ? ORDER BY expires_at ASC`, nowISO)
 	if err != nil {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -850,21 +850,13 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	}
 	run := resumedRun.Run
 	checkpoint := resumedRun.Checkpoint
-	if resumedRun.Resumed {
-		result, handled, err := r.stopObsoleteResumedIssueRun(ctx, *project, *loop, run, queueItem, checkpoint)
-		if err != nil || handled {
-			return result, err
-		}
-	}
 	claimedLockKey := ""
 	acquiredClaimedLock := false
 	if resumedRun.StartStep != stepPrepareWork {
 		claimedLockKey = checkpoint.ClaimedLockKey
 	}
 	if claimedLockKey != "" {
-		nowISO := r.nowISO()
-		reason := "worker-run-resume"
-		acquired, err := r.repos.Locks.Acquire(ctx, storage.LockRecord{Key: claimedLockKey, Owner: queueItem.ID, Reason: &reason, ExpiresAt: eventlog.FormatJavaScriptISOString(r.now().Add(r.claimTTL)), CreatedAt: nowISO, UpdatedAt: nowISO})
+		acquired, err := r.reacquireClaimedLock(ctx, claimedLockKey, queueItem.ID)
 		if err != nil {
 			return ProcessResult{}, err
 		}
@@ -892,6 +884,12 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			}
 		}
 	}()
+	if resumedRun.Resumed {
+		result, handled, err := r.stopObsoleteResumedIssueRun(ctx, *project, *loop, run, queueItem, checkpoint)
+		if err != nil || handled {
+			return result, err
+		}
+	}
 	if _, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
 		updated.Status = "running"
 		updated.LastRunAt = stringPtr(run.StartedAt)
@@ -1038,6 +1036,23 @@ func (r *Runner) executeStep(ctx context.Context, step WorkerStep, input stepInp
 	}
 }
 
+func (r *Runner) reacquireClaimedLock(ctx context.Context, claimedLockKey string, owner string) (bool, error) {
+	nowISO := r.nowISO()
+	reason := "worker-run-resume"
+	acquired, err := r.repos.Locks.Acquire(ctx, storage.LockRecord{Key: claimedLockKey, Owner: owner, Reason: &reason, ExpiresAt: eventlog.FormatJavaScriptISOString(r.now().Add(r.claimTTL)), CreatedAt: nowISO, UpdatedAt: nowISO})
+	if err != nil {
+		return false, err
+	}
+	if acquired {
+		return true, nil
+	}
+	lock, err := r.repos.Locks.Get(ctx, claimedLockKey)
+	if err != nil {
+		return false, err
+	}
+	return lock != nil && lock.Owner == owner, nil
+}
+
 func (r *Runner) stopObsoleteResumedIssueRun(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord, run storage.RunRecord, queueItem storage.QueueItemRecord, checkpoint workerCheckpoint) (ProcessResult, bool, error) {
 	if checkpoint.Work == nil || checkpoint.Work.ExecutionMode != "create-pr" || checkpoint.Work.IssueNumber <= 0 || r.github == nil {
 		return ProcessResult{}, false, nil
@@ -1048,15 +1063,6 @@ func (r *Runner) stopObsoleteResumedIssueRun(ctx context.Context, project storag
 		return ProcessResult{}, false, nil
 	} else {
 		if checkpoint.ClaimedLockKey != "" {
-			lock, err := r.repos.Locks.Get(ctx, checkpoint.ClaimedLockKey)
-			if err != nil {
-				return ProcessResult{}, true, err
-			}
-			if lock != nil && lock.Owner == queueItem.ID {
-				if err := r.repos.Locks.Release(context.Background(), checkpoint.ClaimedLockKey); err != nil {
-					return ProcessResult{}, true, err
-				}
-			}
 			checkpoint.ClaimedLockKey = ""
 		}
 		checkpoint.SkipReason = fmt.Sprintf("Worker stopped because %s is no longer an open issue", formatIssueReference(issueLookupRepo(*checkpoint.Work), checkpoint.Work.IssueNumber))

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -146,6 +146,20 @@ type CreatePullRequestResult struct {
 	URL    string
 }
 
+type CompareBranchesInput struct {
+	Repo       string
+	BaseBranch string
+	HeadBranch string
+	CWD        string
+}
+
+type CompareBranchesResult struct {
+	AheadBy      int
+	BehindBy     int
+	Status       string
+	TotalCommits int
+}
+
 type UpdatePullRequestTitleInput struct {
 	Repo     string
 	PRNumber int64
@@ -212,6 +226,7 @@ type GitHubGateway interface {
 	CreateIssueComment(context.Context, IssueCommentInput) (IssueCommentResult, error)
 	UpdateIssueComment(context.Context, UpdateIssueCommentInput) error
 	CreatePullRequest(context.Context, CreatePullRequestInput) (CreatePullRequestResult, error)
+	CompareBranches(context.Context, CompareBranchesInput) (CompareBranchesResult, error)
 	UpdatePullRequestBody(context.Context, UpdatePullRequestBodyInput) error
 	UpdatePullRequestTitle(context.Context, UpdatePullRequestTitleInput) error
 	RemovePullRequestLabels(context.Context, PullRequestLabelsInput) error
@@ -835,6 +850,12 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	}
 	run := resumedRun.Run
 	checkpoint := resumedRun.Checkpoint
+	if resumedRun.Resumed {
+		result, handled, err := r.stopObsoleteResumedIssueRun(ctx, *project, *loop, run, queueItem, checkpoint)
+		if err != nil || handled {
+			return result, err
+		}
+	}
 	claimedLockKey := ""
 	acquiredClaimedLock := false
 	if resumedRun.StartStep != stepPrepareWork {
@@ -958,7 +979,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			r.syncIssueClaim(ctx, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem}, &latest, issueClaimStatusForFailure(latest, failedQueue, failure.kind), failure.message)
 			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 		}
-		if step == stepPrepareWork {
+		if step == stepPrepareWork && checkpoint.SkipReason == "" {
 			claimedLockKey = checkpoint.ClaimedLockKey
 			acquiredClaimedLock = claimedLockKey != ""
 		}
@@ -1017,8 +1038,93 @@ func (r *Runner) executeStep(ctx context.Context, step WorkerStep, input stepInp
 	}
 }
 
+func (r *Runner) stopObsoleteResumedIssueRun(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord, run storage.RunRecord, queueItem storage.QueueItemRecord, checkpoint workerCheckpoint) (ProcessResult, bool, error) {
+	if checkpoint.Work == nil || checkpoint.Work.ExecutionMode != "create-pr" || checkpoint.Work.IssueNumber <= 0 || r.github == nil {
+		return ProcessResult{}, false, nil
+	}
+	if err := r.validateWorkerIssueStillOpen(ctx, project.RepoPath, *checkpoint.Work); err == nil {
+		return ProcessResult{}, false, nil
+	} else if !isWorkerIssueTargetObsolete(err) {
+		return ProcessResult{}, false, nil
+	} else {
+		checkpoint.SkipReason = fmt.Sprintf("Worker stopped because %s is no longer an open issue", formatIssueReference(issueLookupRepo(*checkpoint.Work), checkpoint.Work.IssueNumber))
+		checkpoint.ResumePolicy = loops.ResumePolicyAdvanceFromCheckpoint
+		summary := r.buildSuccessSummary(loop, checkpoint)
+		completedRun, err := r.completeRun(ctx, run, "success", summary, "", checkpoint)
+		if err != nil {
+			return ProcessResult{}, true, err
+		}
+		if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
+			return ProcessResult{}, true, err
+		}
+		if _, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+			updated.Status = "completed"
+			updated.LastRunAt = stringPtr(r.nowISO())
+			updated.NextRunAt = nil
+		}); err != nil {
+			return ProcessResult{}, true, err
+		}
+		r.syncIssueClaim(ctx, stepInput{Project: project, Loop: loop, Run: completedRun, QueueItem: queueItem}, &checkpoint, issueClaimStatusPaused, summary)
+		r.notifyRunCompleted(ctx, buildRunCompletedInput(project, loop, completedRun, checkpoint, statusForCheckpoint(checkpoint), "", summary))
+		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, true, nil
+	}
+}
+
+func (r *Runner) validateWorkerIssueStillOpen(ctx context.Context, cwd string, work workerInput) error {
+	if r.github == nil || work.ExecutionMode != "create-pr" || work.IssueNumber <= 0 {
+		return nil
+	}
+	lookupRepo := issueLookupRepo(work)
+	issue, err := r.github.ViewIssue(ctx, ViewIssueInput{Repo: lookupRepo, IssueNumber: work.IssueNumber, CWD: cwd})
+	if err != nil {
+		return err
+	}
+	return validateWorkerIssueTarget(lookupRepo, work.IssueNumber, issue)
+}
+
+func isWorkerIssueTargetObsolete(err error) bool {
+	var loopErr *loopError
+	return errors.As(err, &loopErr) && loopErr.kind == FailureNonRetryable
+}
+
+func (r *Runner) workerBranchAheadOfBase(ctx context.Context, project storage.ProjectRecord, work workerInput, worktree checkpointWorktree) (bool, error) {
+	branch := firstNonEmpty(worktree.Branch, work.Branch)
+	if branch == "" || work.BaseBranch == "" {
+		return true, nil
+	}
+	if r.github != nil && work.Repo != "" {
+		comparison, err := r.github.CompareBranches(ctx, CompareBranchesInput{Repo: work.Repo, BaseBranch: work.BaseBranch, HeadBranch: branch, CWD: project.RepoPath})
+		if err != nil {
+			return false, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
+		return comparison.AheadBy > 0, nil
+	}
+	if r.git == nil {
+		return true, nil
+	}
+	worktreeRoot, err := workerWorktreeRoot(project)
+	if err != nil {
+		return false, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	}
+	inspect, err := r.git.InspectHead(ctx, InspectHeadInput{RepoPath: project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, BaseRef: work.BaseBranch})
+	if err != nil {
+		return false, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	return len(inspect.NewCommitSHAs) > 0, nil
+}
+
 func (r *Runner) runPrepareWorkStep(ctx context.Context, input stepInput) (workerCheckpoint, error) {
 	checkpoint := input.Checkpoint
+	if checkpoint.Work != nil {
+		if err := r.validateWorkerIssueStillOpen(ctx, input.Project.RepoPath, *checkpoint.Work); err != nil {
+			if isWorkerIssueTargetObsolete(err) {
+				checkpoint.SkipReason = fmt.Sprintf("Worker stopped because %s is no longer an open issue", formatIssueReference(issueLookupRepo(*checkpoint.Work), checkpoint.Work.IssueNumber))
+				checkpoint.ResumePolicy = loops.ResumePolicyAdvanceFromCheckpoint
+				return checkpoint, nil
+			}
+			return checkpoint, err
+		}
+	}
 	work, err := r.resolveWorkerInput(ctx, input.Project, input.Loop, input.QueueItem, checkpoint)
 	if err != nil {
 		return checkpoint, err
@@ -1444,6 +1550,14 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 	if err != nil {
 		return checkpoint, err
 	}
+	if err := r.validateWorkerIssueStillOpen(ctx, input.Project.RepoPath, work); err != nil {
+		if isWorkerIssueTargetObsolete(err) {
+			checkpoint.SkipReason = fmt.Sprintf("Worker stopped because %s is no longer an open issue", formatIssueReference(issueLookupRepo(work), work.IssueNumber))
+			checkpoint.ResumePolicy = loops.ResumePolicyAdvanceFromCheckpoint
+			return checkpoint, nil
+		}
+		return checkpoint, err
+	}
 	if err := r.reconcileWorkerGitState(ctx, &checkpoint, input.Project, work, worktree); err != nil {
 		return checkpoint, err
 	}
@@ -1548,6 +1662,15 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 	}
 	if err := r.git.Push(ctx, PushInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	ahead, err := r.workerBranchAheadOfBase(ctx, input.Project, work, worktree)
+	if err != nil {
+		return checkpoint, err
+	}
+	if !ahead {
+		checkpoint.SkipReason = fmt.Sprintf("Worker stopped because branch %s has no commits ahead of %s", worktree.Branch, work.BaseBranch)
+		checkpoint.ResumePolicy = loops.ResumePolicyAdvanceFromCheckpoint
+		return checkpoint, nil
 	}
 	if existing, err := r.findOpenPullRequestForBranch(ctx, work.Repo, aliases, work.BaseBranch, input.Project.RepoPath); err == nil && existing != nil {
 		_ = r.assignReviewersIfNeeded(ctx, work, existing.Number, input.Project.RepoPath)

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -885,7 +885,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		}
 	}()
 	if resumedRun.Resumed {
-		result, handled, err := r.stopObsoleteResumedIssueRun(ctx, *project, *loop, run, queueItem, checkpoint)
+		result, handled, err := r.stopObsoleteResumedIssueRun(ctx, *project, *loop, run, queueItem, &checkpoint, &claimedLockKey)
 		if err != nil || handled {
 			return result, err
 		}
@@ -1039,7 +1039,8 @@ func (r *Runner) executeStep(ctx context.Context, step WorkerStep, input stepInp
 func (r *Runner) reacquireClaimedLock(ctx context.Context, claimedLockKey string, owner string) (bool, error) {
 	nowISO := r.nowISO()
 	reason := "worker-run-resume"
-	acquired, err := r.repos.Locks.Acquire(ctx, storage.LockRecord{Key: claimedLockKey, Owner: owner, Reason: &reason, ExpiresAt: eventlog.FormatJavaScriptISOString(r.now().Add(r.claimTTL)), CreatedAt: nowISO, UpdatedAt: nowISO})
+	expiresAt := eventlog.FormatJavaScriptISOString(r.now().Add(r.claimTTL))
+	acquired, err := r.repos.Locks.Acquire(ctx, storage.LockRecord{Key: claimedLockKey, Owner: owner, Reason: &reason, ExpiresAt: expiresAt, CreatedAt: nowISO, UpdatedAt: nowISO})
 	if err != nil {
 		return false, err
 	}
@@ -1050,11 +1051,18 @@ func (r *Runner) reacquireClaimedLock(ctx context.Context, claimedLockKey string
 	if err != nil {
 		return false, err
 	}
-	return lock != nil && lock.Owner == owner, nil
+	if lock == nil || lock.Owner != owner {
+		return false, nil
+	}
+	refreshed, err := r.repos.Locks.Refresh(ctx, storage.LockRecord{Key: claimedLockKey, Owner: owner, Reason: &reason, ExpiresAt: expiresAt, UpdatedAt: nowISO})
+	if err != nil {
+		return false, err
+	}
+	return refreshed, nil
 }
 
-func (r *Runner) stopObsoleteResumedIssueRun(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord, run storage.RunRecord, queueItem storage.QueueItemRecord, checkpoint workerCheckpoint) (ProcessResult, bool, error) {
-	if checkpoint.Work == nil || checkpoint.Work.ExecutionMode != "create-pr" || checkpoint.Work.IssueNumber <= 0 || r.github == nil {
+func (r *Runner) stopObsoleteResumedIssueRun(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord, run storage.RunRecord, queueItem storage.QueueItemRecord, checkpoint *workerCheckpoint, claimedLockKey *string) (ProcessResult, bool, error) {
+	if checkpoint == nil || checkpoint.Work == nil || checkpoint.Work.ExecutionMode != "create-pr" || checkpoint.Work.IssueNumber <= 0 || r.github == nil {
 		return ProcessResult{}, false, nil
 	}
 	if err := r.validateWorkerIssueStillOpen(ctx, project.RepoPath, *checkpoint.Work); err == nil {
@@ -1063,12 +1071,18 @@ func (r *Runner) stopObsoleteResumedIssueRun(ctx context.Context, project storag
 		return ProcessResult{}, false, nil
 	} else {
 		if checkpoint.ClaimedLockKey != "" {
+			if err := r.repos.Locks.Release(context.Background(), checkpoint.ClaimedLockKey); err != nil {
+				return ProcessResult{}, true, err
+			}
 			checkpoint.ClaimedLockKey = ""
+		}
+		if claimedLockKey != nil {
+			*claimedLockKey = ""
 		}
 		checkpoint.SkipReason = fmt.Sprintf("Worker stopped because %s is no longer an open issue", formatIssueReference(issueLookupRepo(*checkpoint.Work), checkpoint.Work.IssueNumber))
 		checkpoint.ResumePolicy = loops.ResumePolicyAdvanceFromCheckpoint
-		summary := r.buildSuccessSummary(loop, checkpoint)
-		completedRun, err := r.completeRun(ctx, run, "success", summary, "", checkpoint)
+		summary := r.buildSuccessSummary(loop, *checkpoint)
+		completedRun, err := r.completeRun(ctx, run, "success", summary, "", *checkpoint)
 		if err != nil {
 			return ProcessResult{}, true, err
 		}
@@ -1082,8 +1096,8 @@ func (r *Runner) stopObsoleteResumedIssueRun(ctx context.Context, project storag
 		}); err != nil {
 			return ProcessResult{}, true, err
 		}
-		r.syncIssueClaim(ctx, stepInput{Project: project, Loop: loop, Run: completedRun, QueueItem: queueItem}, &checkpoint, issueClaimStatusPaused, summary)
-		r.notifyRunCompleted(ctx, buildRunCompletedInput(project, loop, completedRun, checkpoint, statusForCheckpoint(checkpoint), "", summary))
+		r.syncIssueClaim(ctx, stepInput{Project: project, Loop: loop, Run: completedRun, QueueItem: queueItem}, checkpoint, issueClaimStatusPaused, summary)
+		r.notifyRunCompleted(ctx, buildRunCompletedInput(project, loop, completedRun, *checkpoint, statusForCheckpoint(*checkpoint), "", summary))
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, true, nil
 	}
 }

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1047,6 +1047,18 @@ func (r *Runner) stopObsoleteResumedIssueRun(ctx context.Context, project storag
 	} else if !isWorkerIssueTargetObsolete(err) {
 		return ProcessResult{}, false, nil
 	} else {
+		if checkpoint.ClaimedLockKey != "" {
+			lock, err := r.repos.Locks.Get(ctx, checkpoint.ClaimedLockKey)
+			if err != nil {
+				return ProcessResult{}, true, err
+			}
+			if lock != nil && lock.Owner == queueItem.ID {
+				if err := r.repos.Locks.Release(context.Background(), checkpoint.ClaimedLockKey); err != nil {
+					return ProcessResult{}, true, err
+				}
+			}
+			checkpoint.ClaimedLockKey = ""
+		}
 		checkpoint.SkipReason = fmt.Sprintf("Worker stopped because %s is no longer an open issue", formatIssueReference(issueLookupRepo(*checkpoint.Work), checkpoint.Work.IssueNumber))
 		checkpoint.ResumePolicy = loops.ResumePolicyAdvanceFromCheckpoint
 		summary := r.buildSuccessSummary(loop, checkpoint)

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1441,6 +1441,48 @@ func TestProcessClaimedItemStopsResumedWorkerWhenIssueClosed(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemStopsResumedWorkerWhenIssueClosedReleasesPersistedLock(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	lockKey := "issue:acme/looper:27"
+	checkpointJSON := mustMarshalJSON(workerCheckpoint{
+		Work:           &workerInput{Repo: "acme/looper", IssueNumber: 27, ExecutionMode: "create-pr", BaseBranch: "main"},
+		ClaimedLockKey: lockKey,
+	})
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_failed_resume_issue_closed", LoopID: "loop_worker_1", Status: "failed", LastCompletedStep: stringPtr(string(stepPlan)), CheckpointJSON: &checkpointJSON, StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{issueDetailResponses: []IssueDetail{{Number: 27, Title: "Implement worker loop", State: "CLOSED"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	acquired, err := fixture.repos.Locks.Acquire(context.Background(), storage.LockRecord{Key: lockKey, Owner: claim.ID, ExpiresAt: fixture.now().Add(time.Minute).UTC().Format("2006-01-02T15:04:05.000Z"), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()})
+	if err != nil {
+		t.Fatalf("Locks.Acquire() seed error = %v", err)
+	}
+	if !acquired {
+		t.Fatal("Locks.Acquire() seed = false, want persisted lock held by resumed queue item")
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" || !strings.Contains(result.Summary, "no longer an open issue") {
+		t.Fatalf("result = %#v, want skipped obsolete issue", result)
+	}
+	lock, err := fixture.repos.Locks.Get(context.Background(), lockKey)
+	if err != nil {
+		t.Fatalf("Locks.Get() error = %v", err)
+	}
+	if lock != nil {
+		t.Fatalf("lock = %#v, want persisted claimed lock released", lock)
+	}
+}
+
 func TestProcessClaimedItemSkipsPRCreationWhenBranchNotAhead(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1448,6 +1448,7 @@ func TestProcessClaimedItemStopsResumedWorkerWhenIssueClosedReleasesPersistedLoc
 	checkpointJSON := mustMarshalJSON(workerCheckpoint{
 		Work:           &workerInput{Repo: "acme/looper", IssueNumber: 27, ExecutionMode: "create-pr", BaseBranch: "main"},
 		ClaimedLockKey: lockKey,
+		PullRequest:    &checkpointPullPR{Number: 101, URL: "https://example/pr/101"},
 	})
 	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_failed_resume_issue_closed", LoopID: "loop_worker_1", Status: "failed", LastCompletedStep: stringPtr(string(stepPlan)), CheckpointJSON: &checkpointJSON, StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
@@ -1481,6 +1482,23 @@ func TestProcessClaimedItemStopsResumedWorkerWhenIssueClosedReleasesPersistedLoc
 	if lock != nil {
 		t.Fatalf("lock = %#v, want persisted claimed lock released", lock)
 	}
+	latestRun, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	if latestRun == nil {
+		t.Fatal("latestRun = nil, want persisted skipped run")
+	}
+	latestCheckpoint, err := parseCheckpoint(latestRun.CheckpointJSON)
+	if err != nil {
+		t.Fatalf("parseCheckpoint(latestRun) error = %v", err)
+	}
+	if latestCheckpoint.ClaimedLockKey != "" {
+		t.Fatalf("latestCheckpoint.ClaimedLockKey = %q, want cleared lock key", latestCheckpoint.ClaimedLockKey)
+	}
+	if latestCheckpoint.SkipReason == "" || !strings.Contains(latestCheckpoint.SkipReason, "no longer an open issue") {
+		t.Fatalf("latestCheckpoint.SkipReason = %q, want obsolete issue skip reason", latestCheckpoint.SkipReason)
+	}
 }
 
 func TestReacquireClaimedLockAllowsSameOwnerLiveLock(t *testing.T) {
@@ -1503,6 +1521,20 @@ func TestReacquireClaimedLockAllowsSameOwnerLiveLock(t *testing.T) {
 	}
 	if !acquired {
 		t.Fatal("reacquireClaimedLock() = false, want same-owner live lock to be adopted")
+	}
+	lock, err := fixture.repos.Locks.Get(context.Background(), lockKey)
+	if err != nil {
+		t.Fatalf("Locks.Get() error = %v", err)
+	}
+	if lock == nil {
+		t.Fatal("lock = nil, want refreshed lock")
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, lock.ExpiresAt)
+	if err != nil {
+		t.Fatalf("time.Parse(lock.ExpiresAt) error = %v", err)
+	}
+	if !expiresAt.After(fixture.now().Add(9 * time.Minute)) {
+		t.Fatalf("lock.ExpiresAt = %q, want refreshed TTL near claim duration", lock.ExpiresAt)
 	}
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1483,6 +1483,29 @@ func TestProcessClaimedItemStopsResumedWorkerWhenIssueClosedReleasesPersistedLoc
 	}
 }
 
+func TestReacquireClaimedLockAllowsSameOwnerLiveLock(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	lockKey := "issue:acme/looper:27"
+	nowISO := fixture.nowISO()
+	acquired, err := fixture.repos.Locks.Acquire(context.Background(), storage.LockRecord{Key: lockKey, Owner: "queue_worker_1", ExpiresAt: fixture.now().Add(time.Minute).UTC().Format("2006-01-02T15:04:05.000Z"), CreatedAt: nowISO, UpdatedAt: nowISO})
+	if err != nil {
+		t.Fatalf("Locks.Acquire() seed error = %v", err)
+	}
+	if !acquired {
+		t.Fatal("Locks.Acquire() seed = false, want live lock for same owner")
+	}
+
+	acquired, err = runner.reacquireClaimedLock(context.Background(), lockKey, "queue_worker_1")
+	if err != nil {
+		t.Fatalf("reacquireClaimedLock() error = %v", err)
+	}
+	if !acquired {
+		t.Fatal("reacquireClaimedLock() = false, want same-owner live lock to be adopted")
+	}
+}
+
 func TestProcessClaimedItemSkipsPRCreationWhenBranchNotAhead(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1499,6 +1499,22 @@ func TestProcessClaimedItemStopsResumedWorkerWhenIssueClosedReleasesPersistedLoc
 	if latestCheckpoint.SkipReason == "" || !strings.Contains(latestCheckpoint.SkipReason, "no longer an open issue") {
 		t.Fatalf("latestCheckpoint.SkipReason = %q, want obsolete issue skip reason", latestCheckpoint.SkipReason)
 	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil {
+		t.Fatal("queue = nil, want completed queue item")
+	}
+	if queue.TargetType != "issue" || queue.TargetID != lockKey {
+		t.Fatalf("queue target = (%q, %q), want original issue target", queue.TargetType, queue.TargetID)
+	}
+	if queue.LockKey == nil || *queue.LockKey != lockKey {
+		t.Fatalf("queue.LockKey = %#v, want original issue lock key", queue.LockKey)
+	}
+	if queue.PRNumber != nil {
+		t.Fatalf("queue.PRNumber = %#v, want nil after obsolete resume skip", queue.PRNumber)
+	}
 }
 
 func TestReacquireClaimedLockAllowsSameOwnerLiveLock(t *testing.T) {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1400,6 +1400,75 @@ func TestProcessClaimedItemResumesFromOpenPRAfterRetryableFailure(t *testing.T) 
 	}
 }
 
+func TestProcessClaimedItemStopsResumedWorkerWhenIssueClosed(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{
+		createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"},
+		createPRErrors: []error{fmt.Errorf("temporary create pr failure")},
+		issueDetailResponses: []IssueDetail{
+			{Number: 27, Title: "Implement worker loop", State: "OPEN"},
+			{Number: 27, Title: "Implement worker loop", State: "OPEN"},
+			{Number: 27, Title: "Implement worker loop", State: "CLOSED"},
+		},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim1, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	first, err := runner.ProcessClaimedItem(context.Background(), *claim1)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(first) error = %v", err)
+	}
+	if first.Status != "failed" || first.FailureKind != FailureRetryableAfterResume {
+		t.Fatalf("first = %#v, want retryable_after_resume failure", first)
+	}
+	fixture.advance(5 * time.Second)
+	claim2, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	second, err := runner.ProcessClaimedItem(context.Background(), *claim2)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(second) error = %v", err)
+	}
+	if second.Status != "skipped" || !strings.Contains(second.Summary, "no longer an open issue") {
+		t.Fatalf("second = %#v, want skipped obsolete issue", second)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want resumed worker not to rerun agent", len(agent.starts))
+	}
+	if len(github.createPRCalls) != 1 {
+		t.Fatalf("len(github.createPRCalls) = %d, want no PR creation on obsolete resume", len(github.createPRCalls))
+	}
+}
+
+func TestProcessClaimedItemSkipsPRCreationWhenBranchNotAhead(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}}
+	compare := CompareBranchesResult{AheadBy: 0, BehindBy: 2, Status: "behind", TotalCommits: 0}
+	github := &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}, compareResult: &compare}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" || !strings.Contains(result.Summary, "has no commits ahead of main") {
+		t.Fatalf("result = %#v, want skipped no-ahead branch", result)
+	}
+	if len(github.compareCalls) != 1 {
+		t.Fatalf("len(github.compareCalls) = %d, want branch comparison", len(github.compareCalls))
+	}
+	if len(github.createPRCalls) != 0 {
+		t.Fatalf("len(github.createPRCalls) = %d, want no PR creation", len(github.createPRCalls))
+	}
+}
+
 func TestFindPreviousIssueClaimPrefersNewestMatchingRun(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -2733,6 +2802,8 @@ type fakeGitHubGateway struct {
 	prDetailResponses       []PullRequestDetail
 	viewPRIndex             int
 	issueDetail             IssueDetail
+	issueDetailResponses    []IssueDetail
+	viewIssueIndex          int
 	viewPRCalls             []ViewPullRequestInput
 	viewIssueCalls          []ViewIssueInput
 	createIssueCommentCalls []IssueCommentInput
@@ -2741,6 +2812,8 @@ type fakeGitHubGateway struct {
 	createPRResult          CreatePullRequestResult
 	createPRErrors          []error
 	createPRCalls           []CreatePullRequestInput
+	compareResult           *CompareBranchesResult
+	compareCalls            []CompareBranchesInput
 	updatePRTitleCalls      []UpdatePullRequestTitleInput
 	updatePRBodyCalls       []UpdatePullRequestBodyInput
 	updatePRTitleErrors     []error
@@ -2806,6 +2879,10 @@ func (f *fakeGitHubGateway) ViewPullRequest(_ context.Context, input ViewPullReq
 func (f *fakeGitHubGateway) ViewIssue(_ context.Context, input ViewIssueInput) (IssueDetail, error) {
 	f.viewIssueCalls = append(f.viewIssueCalls, input)
 	detail := f.issueDetail
+	if f.viewIssueIndex < len(f.issueDetailResponses) {
+		detail = f.issueDetailResponses[f.viewIssueIndex]
+	}
+	f.viewIssueIndex++
 	if detail.Number == 0 {
 		detail.Number = input.IssueNumber
 	}
@@ -2837,6 +2914,14 @@ func (f *fakeGitHubGateway) CreatePullRequest(_ context.Context, input CreatePul
 	}
 	f.createPRIndex++
 	return f.createPRResult, nil
+}
+
+func (f *fakeGitHubGateway) CompareBranches(_ context.Context, input CompareBranchesInput) (CompareBranchesResult, error) {
+	f.compareCalls = append(f.compareCalls, input)
+	if f.compareResult != nil {
+		return *f.compareResult, nil
+	}
+	return CompareBranchesResult{AheadBy: 1, Status: "ahead", TotalCommits: 1}, nil
 }
 
 func (f *fakeGitHubGateway) UpdatePullRequestTitle(_ context.Context, input UpdatePullRequestTitleInput) error {


### PR DESCRIPTION
## Summary
- Re-check resumed issue workers against the current GitHub issue state before continuing from a checkpoint.
- Stop obsolete issue workers cleanly when the target issue is no longer open instead of rerunning the agent.
- Compare the worker branch against the base branch before creating a PR and skip PR creation when there are no commits ahead.

## Validation
- go vet ./...
- go test ./...
- go build ./...

Closes #290