### PR TITLE
fix: make fixer comment resolution durable across reruns

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1912,6 +1912,11 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	if failedCount == 0 && resolvedCount > 0 {
 		r.publishRoundSummaryComment(ctx, input, &checkpoint, fixItems, defaultCommitSHA, explanationByID)
 	}
+	if failedCount == 0 && shouldPersistNoopResolveMetadata(fixItems, checkpoint.ResolvedComments.Items, resolvedCount) {
+		if _, err := r.mergeLoopMetadata(ctx, input.Loop, map[string]any{"lastNoopResolveHeadSha": detailHeadSHA(checkpoint.Detail), "lastNoopResolveFixItemsHash": currentFixItemsHash, "lastNoopResolveStateHash": currentFixItemsStateHash, "lastNoopResolveAt": r.nowISO()}); err != nil {
+			return checkpoint, err
+		}
+	}
 	if failedCount > 0 {
 		return checkpoint, &loopError{message: fmt.Sprintf("Failed to resolve %d review thread(s)", failedCount), kind: FailureRetryableAfterResume}
 	}
@@ -3528,6 +3533,31 @@ func shouldBlockResolveWithoutFix(checkpoint fixerCheckpoint, fixItems []FixItem
 	return false
 }
 
+func shouldPersistNoopResolveMetadata(fixItems []FixItem, resolvedComments []checkpointResolvedComment, resolvedCount int) bool {
+	if resolvedCount != 0 {
+		return false
+	}
+	hasComment := false
+	for _, item := range fixItems {
+		if item.Type != "comment" {
+			continue
+		}
+		hasComment = true
+		matched := false
+		for _, resolved := range resolvedComments {
+			if resolved.FixItemID != item.ID && (resolved.ThreadID == "" || resolved.ThreadID != item.ThreadID) {
+				continue
+			}
+			matched = resolved.Status == "skipped_no_evidence"
+			break
+		}
+		if !matched {
+			return false
+		}
+	}
+	return hasComment
+}
+
 func resolveCommentCommitSHA(checkpoint fixerCheckpoint, evidence *fixEvidence, verifiedEvidence bool) string {
 	commitSHA := ""
 	if checkpoint.ReconcileCommits != nil {
@@ -4019,6 +4049,9 @@ func (r *Runner) verifyFixEvidence(ctx context.Context, input stepInput, checkpo
 	}
 	ancestor, err := r.git.IsAncestor(ctx, input.Project.RepoPath, evidence.HeadSHA, liveHeadSHA)
 	if err != nil {
+		if shouldTreatMissingGitRevisionAsStale(err) {
+			return false, nil
+		}
 		return false, &loopError{message: fmt.Sprintf("failed to verify fix evidence ancestry: %v", err), kind: FailureRetryableTransient}
 	}
 	return ancestor, nil
@@ -4040,9 +4073,32 @@ func (r *Runner) validationMatchesEvidence(ctx context.Context, input stepInput,
 	}
 	ancestor, err := r.git.IsAncestor(ctx, input.Project.RepoPath, evidence.HeadSHA, validationHeadSHA)
 	if err != nil {
+		if shouldTreatMissingGitRevisionAsStale(err) {
+			return false, nil
+		}
 		return false, &loopError{message: fmt.Sprintf("failed to verify validation ancestry: %v", err), kind: FailureRetryableTransient}
 	}
 	return ancestor, nil
+}
+
+func shouldTreatMissingGitRevisionAsStale(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"unknown revision",
+		"bad revision",
+		"not a valid object name",
+		"not a valid commit name",
+		"unknown commit or path",
+		"ambiguous argument",
+	} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func shouldSkipRediscoveryAfterNoopResolve(loopMetadataJSON *string, headSHA, fixItemsStateHash string) bool {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1824,9 +1824,11 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 	}
 	if verifiedEvidence && !validationBound {
+		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
 		return checkpoint, &loopError{message: "resolve-comments requires validation bound to verified fix evidence head", kind: FailureRetryableAfterResume}
 	}
 	if !verifiedEvidence && hasCommentFixItems(fixItems) && checkpoint.Push != nil && checkpoint.Push.Pushed {
+		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
 		return checkpoint, &loopError{message: "resolve-comments refused because verified fix evidence is missing or stale; leaving review threads unresolved", kind: FailureRetryableAfterResume}
 	}
 	if shouldBlockResolveWithoutFix(checkpoint, fixItems, verifiedEvidence) {
@@ -1885,6 +1887,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "already_resolved", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 			continue
 		case "stale":
+			checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
 			failedCount++
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "stale_state", Message: "PR head or review thread changed before resolve", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 			continue

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -4011,8 +4011,11 @@ func (r *Runner) verifyFixEvidence(ctx context.Context, input stepInput, checkpo
 		if _, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: checkpoint.Worktree.Path, Branch: checkpoint.Worktree.Branch, ExpectedHeadSHA: liveHeadSHA}); err != nil {
 			return false, err
 		}
-	} else if branch := strings.TrimSpace(liveDetail.HeadRefName); branch != "" {
-		_ = r.git.FetchBranch(ctx, input.Project.RepoPath, "origin", branch)
+	} else {
+		if branch := strings.TrimSpace(liveDetail.HeadRefName); branch != "" {
+			_ = r.git.FetchBranch(ctx, input.Project.RepoPath, "origin", branch)
+		}
+		_ = r.git.FetchBranch(ctx, input.Project.RepoPath, "origin", liveHeadSHA)
 	}
 	ancestor, err := r.git.IsAncestor(ctx, input.Project.RepoPath, evidence.HeadSHA, liveHeadSHA)
 	if err != nil {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -77,16 +77,17 @@ const (
 )
 
 type FixItem struct {
-	Type     string   `json:"type"`
-	ID       string   `json:"id,omitempty"`
-	ThreadID string   `json:"threadId,omitempty"`
-	Name     string   `json:"name,omitempty"`
-	Summary  string   `json:"summary,omitempty"`
-	Files    []string `json:"files,omitempty"`
-	Author   string   `json:"author,omitempty"`
-	URL      string   `json:"url,omitempty"`
-	Path     string   `json:"path,omitempty"`
-	Line     int64    `json:"line,omitempty"`
+	Type              string   `json:"type"`
+	ID                string   `json:"id,omitempty"`
+	ThreadID          string   `json:"threadId,omitempty"`
+	ThreadFingerprint string   `json:"threadFingerprint,omitempty"`
+	Name              string   `json:"name,omitempty"`
+	Summary           string   `json:"summary,omitempty"`
+	Files             []string `json:"files,omitempty"`
+	Author            string   `json:"author,omitempty"`
+	URL               string   `json:"url,omitempty"`
+	Path              string   `json:"path,omitempty"`
+	Line              int64    `json:"line,omitempty"`
 }
 
 type PullRequestSummary struct {
@@ -128,6 +129,29 @@ type ViewPullRequestInput struct {
 	Repo     string
 	PRNumber int64
 	CWD      string
+}
+
+type ListReviewThreadsInput struct {
+	Repo     string
+	PRNumber int64
+	CWD      string
+	Limit    int
+}
+
+type ViewReviewThreadInput struct {
+	ThreadID string
+	CWD      string
+}
+
+type ReviewThread struct {
+	ID         string
+	IsResolved bool
+	Comments   []ReviewThreadComment
+}
+
+type ReviewThreadComment struct {
+	ID   string
+	Body string
 }
 
 type ResolveReviewThreadInput struct {
@@ -174,6 +198,8 @@ type GitHubGateway interface {
 	GetCurrentUserLogin(context.Context, string) (string, error)
 	GetPullRequestAuthor(context.Context, ViewPullRequestInput) (string, error)
 	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
+	ListReviewThreads(context.Context, ListReviewThreadsInput) ([]ReviewThread, error)
+	ViewReviewThread(context.Context, ViewReviewThreadInput) (ReviewThread, error)
 	ResolveReviewThread(context.Context, ResolveReviewThreadInput) error
 	AddReviewThreadReply(context.Context, AddReviewThreadReplyInput) error
 	CreateIssueComment(context.Context, IssueCommentInput) (IssueCommentResult, error)
@@ -261,6 +287,7 @@ type GitGateway interface {
 	InspectHead(context.Context, InspectHeadInput) (InspectHeadResult, error)
 	Commit(context.Context, CommitInput) (CommitResult, error)
 	Push(context.Context, PushInput) error
+	FetchBranch(context.Context, string, string, string) error
 	IsAncestor(context.Context, string, string, string) (bool, error)
 	CleanupWorktree(context.Context, CleanupWorktreeInput) error
 }
@@ -520,10 +547,11 @@ type fixEvidence struct {
 }
 
 type fixCommentEvidence struct {
-	FixItemID   string `json:"fixItemId,omitempty"`
-	ThreadID    string `json:"threadId,omitempty"`
-	CommitSHA   string `json:"commitSha,omitempty"`
-	Explanation string `json:"explanation,omitempty"`
+	FixItemID         string `json:"fixItemId,omitempty"`
+	ThreadID          string `json:"threadId,omitempty"`
+	ThreadFingerprint string `json:"threadFingerprint,omitempty"`
+	CommitSHA         string `json:"commitSha,omitempty"`
+	Explanation       string `json:"explanation,omitempty"`
 }
 
 type checkpointResolvedComments struct {
@@ -860,8 +888,8 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			result.Skipped++
 			continue
 		}
-		fixItemsHash := hashFixItems(fixItems)
-		loopResult, err := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, detail.HeadSHA, fixItemsHash)
+		fixItemsStateHash := hashFixItemsState(fixItems)
+		loopResult, err := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, detail.HeadSHA, fixItemsStateHash)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
@@ -882,7 +910,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			Repo:         input.Repo,
 			PRNumber:     pr.Number,
 			HeadSHA:      headSHA,
-			FixItemsHash: fixItemsHash,
+			FixItemsHash: fixItemsStateHash,
 		})
 		if err != nil {
 			return DiscoveryResult{}, err
@@ -1616,7 +1644,7 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	}
 	adopted, updatedCheckpoint, err := r.adoptLifecyclePushEvidence(ctx, input, checkpoint, branch)
 	if err != nil {
-		return checkpoint, err
+		return updatedCheckpoint, err
 	}
 	if adopted {
 		return updatedCheckpoint, nil
@@ -1644,11 +1672,10 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	pushedHeadSHA := resolveCommentsExpectedHeadSHA(checkpoint)
 	evidence := &fixEvidence{Valid: pushedHeadSHA != "" && checkpoint.FixItemsHash != "", HeadSHA: pushedHeadSHA, CommitSHAs: cloneStrings(checkpoint.ReconcileCommits.NewCommitSHAs), BaseHeadSHA: checkpoint.ReconcileCommits.BaseHeadSHA, FixItemsHash: checkpoint.FixItemsHash, CommentRecords: buildFixCommentEvidenceRecords(checkpoint, lastNonEmptyString(checkpoint.ReconcileCommits.NewCommitSHAs, pushedHeadSHA)), Source: "fallback_push", ProducedNewCommits: roundProducedNewCommits(&checkpoint), PushedAt: pushedAt}
 	checkpoint.Push = &checkpointPush{Pushed: true, Branch: branch, Remote: "origin", HeadSHA: pushedHeadSHA, PushedAt: pushedAt, Evidence: evidence}
-	metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastFixHeadSha": pushedHeadSHA, "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": pushedAt, "lastFixEvidence": evidence})
-	if err != nil {
+	if err := r.persistCheckpoint(ctx, input.Run.ID, stepPush, checkpoint); err != nil {
 		return checkpoint, err
 	}
-	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) { updated.MetadataJSON = stringPtr(metadataJSON) }); err != nil {
+	if _, err := r.mergeLoopMetadata(ctx, input.Loop, map[string]any{"lastFixHeadSha": pushedHeadSHA, "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": pushedAt, "lastFixEvidence": evidence}); err != nil {
 		return checkpoint, err
 	}
 	liveDetail, err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: finalHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
@@ -1661,11 +1688,10 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	pushedHeadSHA = resolveCommentsExpectedHeadSHA(checkpoint)
 	checkpoint.Push.HeadSHA = pushedHeadSHA
 	checkpoint.Push.Evidence.HeadSHA = pushedHeadSHA
-	metadataJSON, err = mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastFixHeadSha": pushedHeadSHA, "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": pushedAt, "lastFixEvidence": evidence})
-	if err != nil {
+	if err := r.persistCheckpoint(ctx, input.Run.ID, stepPush, checkpoint); err != nil {
 		return checkpoint, err
 	}
-	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) { updated.MetadataJSON = stringPtr(metadataJSON) }); err != nil {
+	if _, err := r.mergeLoopMetadata(ctx, input.Loop, map[string]any{"lastFixHeadSha": pushedHeadSHA, "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": pushedAt, "lastFixEvidence": evidence}); err != nil {
 		return checkpoint, err
 	}
 	r.appendEvent(ctx, eventInput{eventType: "pr.branch.pushed", projectID: input.Project.ID, loopID: input.Loop.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"branch": branch, "pushedAt": pushedAt, "headSha": nilIfEmpty(pushedHeadSHA)}})
@@ -1747,11 +1773,10 @@ func (r *Runner) adoptLifecyclePushEvidence(ctx context.Context, input stepInput
 	pushedAt := r.nowISO()
 	evidence := &fixEvidence{Valid: true, Source: "agent_push", HeadSHA: adoptedHead, CommitSHAs: cloneStrings(lc.CommitSHAs), BaseHeadSHA: checkpoint.ReconcileCommits.BaseHeadSHA, FixItemsHash: checkpoint.FixItemsHash, CommentRecords: buildFixCommentEvidenceRecords(checkpoint, lastNonEmptyString(lc.CommitSHAs, adoptedHead)), ProducedNewCommits: true, PushedAt: pushedAt}
 	checkpoint.Push = &checkpointPush{Pushed: true, Branch: branch, Remote: "origin", HeadSHA: adoptedHead, PushedAt: pushedAt, Evidence: evidence}
-	metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastFixHeadSha": adoptedHead, "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": pushedAt, "lastFixEvidence": evidence})
-	if err != nil {
+	if err := r.persistCheckpoint(ctx, input.Run.ID, stepPush, checkpoint); err != nil {
 		return false, checkpoint, err
 	}
-	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) { updated.MetadataJSON = stringPtr(metadataJSON) }); err != nil {
+	if _, err := r.mergeLoopMetadata(ctx, input.Loop, map[string]any{"lastFixHeadSha": adoptedHead, "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": pushedAt, "lastFixEvidence": evidence}); err != nil {
 		return false, checkpoint, err
 	}
 	checkpoint.ensureLifecycle("fixer", branch, detailBaseRefName(checkpoint.Detail), false)
@@ -1783,9 +1808,10 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, liveDetail)
 	fixItems := collectFixItems(liveDetail)
 	currentFixItemsHash := hashFixItems(fixItems)
+	currentFixItemsStateHash := hashFixItemsState(fixItems)
+	evidence := resolveFixEvidence(checkpoint, input.Loop.MetadataJSON, currentFixItemsHash)
 	checkpoint.FixItems = fixItems
 	checkpoint.FixItemsHash = currentFixItemsHash
-	evidence := resolveFixEvidence(checkpoint, input.Loop.MetadataJSON, currentFixItemsHash)
 	verifiedEvidence, err := r.verifyFixEvidence(ctx, input, checkpoint, evidence, liveDetail)
 	if err != nil {
 		return checkpoint, err
@@ -1813,11 +1839,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			}
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_no_evidence", Message: "No verified pushed fix evidence available for this thread", UpdatedAt: r.nowISO()})
 		}
-		metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastNoopResolveHeadSha": detailHeadSHA(checkpoint.Detail), "lastNoopResolveFixItemsHash": currentFixItemsHash, "lastNoopResolveAt": r.nowISO()})
-		if err != nil {
-			return checkpoint, err
-		}
-		if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) { updated.MetadataJSON = stringPtr(metadataJSON) }); err != nil {
+		if _, err := r.mergeLoopMetadata(ctx, input.Loop, map[string]any{"lastNoopResolveHeadSha": detailHeadSHA(checkpoint.Detail), "lastNoopResolveFixItemsHash": currentFixItemsHash, "lastNoopResolveStateHash": currentFixItemsStateHash, "lastNoopResolveAt": r.nowISO()}); err != nil {
 			return checkpoint, err
 		}
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
@@ -1838,7 +1860,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
 			continue
 		}
-		record, hasRecord := evidenceRecordForItem(evidenceByThread, item)
+		record, hasRecord := evidenceRecordForItem(evidenceByThread, item, evidenceFixItemsHash(evidence), currentFixItemsHash)
 		if !verifiedEvidence || !hasRecord {
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_no_evidence", Message: "No verified pushed fix evidence available for this thread", UpdatedAt: r.nowISO()})
 			continue
@@ -1850,6 +1872,24 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			failedCount++
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "reply_failed", Message: "Failed to post fixer auto-reply", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 			continue
+		}
+		if err := r.persistCheckpoint(ctx, input.Run.ID, stepResolveComments, checkpoint); err != nil {
+			return checkpoint, err
+		}
+		resolveState, resolveDetail, resolveErr := r.refreshResolveCommentState(ctx, input, checkpoint, evidence, item)
+		if resolveErr != nil {
+			return checkpoint, resolveErr
+		}
+		switch resolveState {
+		case "already_resolved":
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "already_resolved", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+			continue
+		case "stale":
+			failedCount++
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "stale_state", Message: "PR head or review thread changed before resolve", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+			continue
+		case "ok":
+			checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, resolveDetail)
 		}
 		if err := r.github.ResolveReviewThread(ctx, ResolveReviewThreadInput{Repo: input.Repo, ThreadID: item.ThreadID, CWD: input.Project.RepoPath}); err != nil {
 			message := err.Error()
@@ -1893,10 +1933,62 @@ func (r *Runner) replyToFixedComment(ctx context.Context, input stepInput, item 
 		}
 	}
 	body := buildFixerReplyBody(item, commitSHA, explanation)
+	existingRemoteReply, err := r.hasExistingFixerReply(ctx, input, item, commitSHA)
+	if err != nil {
+		return "failed", err.Error()
+	}
+	if existingRemoteReply {
+		return "sent", ""
+	}
 	if err := r.github.AddReviewThreadReply(ctx, AddReviewThreadReplyInput{Repo: input.Repo, ThreadID: item.ThreadID, Body: body, CWD: input.Project.RepoPath}); err != nil {
 		return "failed", err.Error()
 	}
 	return "sent", ""
+}
+
+func (r *Runner) hasExistingFixerReply(ctx context.Context, input stepInput, item FixItem, commitSHA string) (bool, error) {
+	marker := fixerReplyMarker(item.ThreadID, commitSHA)
+	if marker == "" {
+		return false, nil
+	}
+	thread, err := r.github.ViewReviewThread(ctx, ViewReviewThreadInput{ThreadID: item.ThreadID, CWD: input.Project.RepoPath})
+	if err != nil {
+		return false, err
+	}
+	for _, comment := range thread.Comments {
+		if strings.Contains(comment.Body, marker) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *Runner) refreshResolveCommentState(ctx context.Context, input stepInput, checkpoint fixerCheckpoint, evidence *fixEvidence, item FixItem) (string, PullRequestDetail, error) {
+	liveDetail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
+	if err != nil {
+		return "", PullRequestDetail{}, err
+	}
+	refreshCheckpoint := checkpoint
+	refreshCheckpoint.Detail = mergeCheckpointDetailPreservingLabels(refreshCheckpoint.Detail, liveDetail)
+	refreshCheckpoint.FixItems = collectFixItems(liveDetail)
+	refreshCheckpoint.FixItemsHash = hashFixItems(refreshCheckpoint.FixItems)
+	verified, err := r.verifyFixEvidence(ctx, input, refreshCheckpoint, evidence, liveDetail)
+	if err != nil {
+		return "", PullRequestDetail{}, err
+	}
+	if !verified {
+		return "stale", liveDetail, nil
+	}
+	for _, liveItem := range refreshCheckpoint.FixItems {
+		if strings.TrimSpace(liveItem.ThreadID) != strings.TrimSpace(item.ThreadID) {
+			continue
+		}
+		if _, ok := evidenceRecordForItem(evidenceCommentRecordsByThread(evidence), liveItem, evidenceFixItemsHash(evidence), refreshCheckpoint.FixItemsHash); !ok {
+			return "stale", liveDetail, nil
+		}
+		return "ok", liveDetail, nil
+	}
+	return "already_resolved", liveDetail, nil
 }
 
 // lookupReplyExplanations returns a map of fixItemId → sanitized agent
@@ -1939,13 +2031,24 @@ func buildFixerReplyBody(item FixItem, commitSHA, explanation string) string {
 	if explanation = strings.TrimSpace(explanation); explanation != "" {
 		b.WriteString("\n\n")
 		b.WriteString(explanation)
-		return b.String()
-	}
-	if summary := summarizeFixItem(item); summary != "" {
+	} else if summary := summarizeFixItem(item); summary != "" {
 		b.WriteString("\n\n")
 		b.WriteString(summary)
 	}
+	if marker := fixerReplyMarker(item.ThreadID, commitSHA); marker != "" {
+		b.WriteString("\n\n")
+		b.WriteString(marker)
+	}
 	return b.String()
+}
+
+func fixerReplyMarker(threadID, commitSHA string) string {
+	threadID = strings.TrimSpace(threadID)
+	commitSHA = strings.TrimSpace(commitSHA)
+	if threadID == "" || commitSHA == "" {
+		return ""
+	}
+	return fmt.Sprintf("<!-- looper-fixer-reply thread:%s commit:%s -->", threadID, commitSHA)
 }
 
 func summarizeFixItem(item FixItem) string {
@@ -2583,6 +2686,9 @@ func (r *Runner) completeRun(ctx context.Context, run storage.RunRecord, status,
 }
 
 func (r *Runner) persistCheckpoint(ctx context.Context, runID string, step FixerStep, checkpoint fixerCheckpoint) error {
+	if r.repos == nil || r.repos.Runs == nil || strings.TrimSpace(runID) == "" {
+		return nil
+	}
 	run, err := r.repos.Runs.GetByID(ctx, runID)
 	if err != nil || run == nil {
 		return err
@@ -2728,6 +2834,36 @@ func (r *Runner) updateLoop(ctx context.Context, loop storage.LoopRecord, mutate
 		updated = *current
 	}
 	mutate(&updated)
+	updated.UpdatedAt = r.nowISO()
+	if err := r.repos.Loops.Upsert(ctx, updated); err != nil {
+		return storage.LoopRecord{}, err
+	}
+	return updated, nil
+}
+
+func (r *Runner) mergeLoopMetadata(ctx context.Context, loop storage.LoopRecord, updates map[string]any) (storage.LoopRecord, error) {
+	if r.repos == nil || r.repos.Loops == nil || strings.TrimSpace(loop.ID) == "" {
+		updated := loop
+		metadataJSON, err := mergeLoopMetadataJSON(updated.MetadataJSON, updates)
+		if err != nil {
+			return storage.LoopRecord{}, err
+		}
+		updated.MetadataJSON = stringPtr(metadataJSON)
+		return updated, nil
+	}
+	current, err := r.repos.Loops.GetByID(ctx, loop.ID)
+	if err != nil {
+		return storage.LoopRecord{}, err
+	}
+	updated := loop
+	if current != nil {
+		updated = *current
+	}
+	metadataJSON, err := mergeLoopMetadataJSON(updated.MetadataJSON, updates)
+	if err != nil {
+		return storage.LoopRecord{}, err
+	}
+	updated.MetadataJSON = stringPtr(metadataJSON)
 	updated.UpdatedAt = r.nowISO()
 	if err := r.repos.Loops.Upsert(ctx, updated); err != nil {
 		return storage.LoopRecord{}, err
@@ -3045,6 +3181,8 @@ func normalizeFixItems(comments []map[string]any, checks []map[string]any, hasCo
 		author, _ := stringFromAny(comment["author"])
 		url, _ := stringFromAny(comment["url"])
 		path, _ := stringFromAny(comment["path"])
+		threadFingerprint, _ := stringFromAny(comment["threadFingerprint"])
+		threadFingerprint = normalizeThreadFingerprint(threadFingerprint, threadID, id)
 		var line int64
 		switch v := comment["line"].(type) {
 		case float64:
@@ -3054,7 +3192,7 @@ func normalizeFixItems(comments []map[string]any, checks []map[string]any, hasCo
 		case int:
 			line = int64(v)
 		}
-		result = append(result, FixItem{Type: "comment", ID: id, ThreadID: threadID, Summary: summary, Author: author, URL: url, Path: path, Line: line})
+		result = append(result, FixItem{Type: "comment", ID: id, ThreadID: threadID, ThreadFingerprint: threadFingerprint, Summary: summary, Author: author, URL: url, Path: path, Line: line})
 	}
 	for _, check := range checks {
 		if !isFailingCheck(check) {
@@ -3114,6 +3252,26 @@ func buildFixerDedupeKey(projectID, loopID, repo string, prNumber int64, headSHA
 func hashFixItems(items []FixItem) string {
 	parts := make([]string, 0, len(items))
 	for _, item := range items {
+		if item.Type == "comment" {
+			item.ThreadFingerprint = ""
+		}
+		encoded, _ := json.Marshal(item)
+		parts = append(parts, string(encoded))
+	}
+	sort.Strings(parts)
+	sum := sha1.Sum([]byte(strings.Join(parts, "|")))
+	return hex.EncodeToString(sum[:])
+}
+
+func hashFixItemsState(items []FixItem) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Type == "comment" {
+			item.ThreadFingerprint = strings.TrimSpace(item.ThreadFingerprint)
+			if strings.HasPrefix(item.ThreadFingerprint, "legacy:") {
+				item.ThreadFingerprint = ""
+			}
+		}
 		encoded, _ := json.Marshal(item)
 		parts = append(parts, string(encoded))
 	}
@@ -3398,17 +3556,96 @@ func buildResolveReplyExplanations(checkpoint fixerCheckpoint, evidence *fixEvid
 	return out
 }
 
-func evidenceRecordForItem(records map[string]fixCommentEvidence, item FixItem) (fixCommentEvidence, bool) {
+func evidenceRecordForItem(records map[string]fixCommentEvidence, item FixItem, evidenceFixItemsHash, currentFixItemsHash string) (fixCommentEvidence, bool) {
 	if len(records) == 0 {
 		return fixCommentEvidence{}, false
 	}
 	if record, ok := records[strings.TrimSpace(item.ThreadID)]; ok {
-		return record, true
+		if evidenceRecordMatchesItem(record, item, evidenceFixItemsHash, currentFixItemsHash) {
+			return record, true
+		}
 	}
 	if record, ok := records[strings.TrimSpace(item.ID)]; ok {
-		return record, true
+		if evidenceRecordMatchesItem(record, item, evidenceFixItemsHash, currentFixItemsHash) {
+			return record, true
+		}
 	}
 	return fixCommentEvidence{}, false
+}
+
+func evidenceRecordMatchesItem(record fixCommentEvidence, item FixItem, evidenceFixItemsHash, currentFixItemsHash string) bool {
+	if strings.TrimSpace(record.ThreadID) != "" && strings.TrimSpace(item.ThreadID) != "" && strings.TrimSpace(record.ThreadID) != strings.TrimSpace(item.ThreadID) {
+		return false
+	}
+	if strings.TrimSpace(record.FixItemID) != "" && strings.TrimSpace(item.ID) != "" && strings.TrimSpace(record.FixItemID) != strings.TrimSpace(item.ID) {
+		return false
+	}
+	rawRecordFingerprint := strings.TrimSpace(record.ThreadFingerprint)
+	recordFingerprint := normalizeThreadFingerprint(record.ThreadFingerprint, record.ThreadID, record.FixItemID)
+	itemFingerprint := normalizeThreadFingerprint(item.ThreadFingerprint, item.ThreadID, item.ID)
+	if rawRecordFingerprint == "" {
+		latestID := threadFingerprintLatestCommentID(item.ThreadFingerprint)
+		if latestID == "" {
+			latestID = item.ID
+		}
+		if latestID == "" || latestID != strings.TrimSpace(record.FixItemID) {
+			return false
+		}
+		if strings.TrimSpace(evidenceFixItemsHash) == "" {
+			return false
+		}
+		if evidenceFixItemsHash == currentFixItemsHash {
+			return true
+		}
+		return evidenceFixItemsHash == hashFixItems([]FixItem{item})
+	}
+	if itemFingerprint == "" {
+		return false
+	}
+	return recordFingerprint == itemFingerprint
+}
+
+func evidenceFixItemsHash(evidence *fixEvidence) string {
+	if evidence == nil {
+		return ""
+	}
+	return strings.TrimSpace(evidence.FixItemsHash)
+}
+
+func normalizeThreadFingerprint(fingerprint, threadID, itemID string) string {
+	if fingerprint = strings.TrimSpace(fingerprint); fingerprint != "" {
+		return fingerprint
+	}
+	threadID = strings.TrimSpace(threadID)
+	itemID = strings.TrimSpace(itemID)
+	if threadID == "" || itemID == "" {
+		return ""
+	}
+	return fmt.Sprintf("legacy:%s:%s", threadID, itemID)
+}
+
+func threadFingerprintLatestCommentID(fingerprint string) string {
+	fingerprint = strings.TrimSpace(fingerprint)
+	if fingerprint == "" {
+		return ""
+	}
+	if strings.HasPrefix(fingerprint, "latest=") {
+		parts := strings.Split(fingerprint, "|")
+		return strings.TrimPrefix(parts[0], "latest=")
+	}
+	if strings.Contains(fingerprint, "@") {
+		parts := strings.Split(fingerprint, "|")
+		last := strings.TrimSpace(parts[len(parts)-1])
+		commentParts := strings.SplitN(last, "@", 2)
+		return strings.TrimSpace(commentParts[0])
+	}
+	if strings.HasPrefix(fingerprint, "legacy:") {
+		parts := strings.Split(fingerprint, ":")
+		if len(parts) == 3 {
+			return parts[2]
+		}
+	}
+	return ""
 }
 
 func evidenceCommentRecordsByThread(evidence *fixEvidence) map[string]fixCommentEvidence {
@@ -3593,8 +3830,11 @@ func resolveFixEvidence(checkpoint fixerCheckpoint, loopMetadataJSON *string, fi
 			evidence.HeadSHA = checkpoint.Push.HeadSHA
 		}
 		if evidence.Valid && evidence.HeadSHA != "" && evidence.ProducedNewCommits {
-			if len(evidence.CommentRecords) == 0 {
+			if len(evidence.CommentRecords) == 0 && canBackfillEvidenceRecords(checkpoint, evidence.FixItemsHash, fixItemsHash) {
 				evidence.CommentRecords = buildFixCommentEvidenceRecords(checkpoint, resolveCommentCommitSHA(checkpoint, &evidence, true))
+			}
+			if !evidenceSafeForCurrentFixItems(&evidence, fixItemsHash) {
+				return nil
 			}
 			return &evidence
 		}
@@ -3605,18 +3845,65 @@ func resolveFixEvidence(checkpoint fixerCheckpoint, loopMetadataJSON *string, fi
 		if !producedNewCommits {
 			return nil
 		}
-		return &fixEvidence{Valid: true, Source: "prior_verified_push", HeadSHA: checkpoint.Push.HeadSHA, CommitSHAs: cloneStrings(commitEvidenceSHAs(checkpoint)), FixItemsHash: fixItemsHash, CommentRecords: buildFixCommentEvidenceRecords(checkpoint, resolveCommentCommitSHA(checkpoint, nil, false)), ProducedNewCommits: producedNewCommits, PushedAt: checkpoint.Push.PushedAt}
+		evidence := &fixEvidence{Valid: true, Source: "prior_verified_push", HeadSHA: checkpoint.Push.HeadSHA, CommitSHAs: cloneStrings(commitEvidenceSHAs(checkpoint)), FixItemsHash: fixItemsHash, ProducedNewCommits: producedNewCommits, PushedAt: checkpoint.Push.PushedAt}
+		if canBackfillEvidenceRecords(checkpoint, fixItemsHash, fixItemsHash) {
+			evidence.CommentRecords = buildFixCommentEvidenceRecords(checkpoint, resolveCommentCommitSHA(checkpoint, nil, false))
+		}
+		if !evidenceSafeForCurrentFixItems(evidence, fixItemsHash) {
+			return nil
+		}
+		return evidence
 	}
 	if persisted := persistedFixEvidence(loopMetadataJSON); persisted != nil && persisted.Valid && persisted.HeadSHA != "" && persisted.ProducedNewCommits {
+		if !evidenceSafeForCurrentFixItems(persisted, fixItemsHash) {
+			return nil
+		}
 		return persisted
 	}
 	if fixItemsHash == "" {
 		return nil
 	}
 	if headSHA := resolveCommentsVerifiedNoPushHeadSHA(checkpoint.Push, loopMetadataJSON, fixItemsHash); headSHA != "" {
-		return &fixEvidence{Valid: true, Source: "prior_verified_push", HeadSHA: headSHA, FixItemsHash: fixItemsHash, CommentRecords: buildFixCommentEvidenceRecords(checkpoint, resolveCommentCommitSHA(checkpoint, nil, false)), ProducedNewCommits: true}
+		evidence := &fixEvidence{Valid: true, Source: "prior_verified_push", HeadSHA: headSHA, FixItemsHash: fixItemsHash, ProducedNewCommits: true}
+		if canBackfillEvidenceRecords(checkpoint, fixItemsHash, fixItemsHash) {
+			evidence.CommentRecords = buildFixCommentEvidenceRecords(checkpoint, resolveCommentCommitSHA(checkpoint, nil, false))
+		}
+		if !evidenceSafeForCurrentFixItems(evidence, fixItemsHash) {
+			return nil
+		}
+		return evidence
 	}
 	return nil
+}
+
+func evidenceSafeForCurrentFixItems(evidence *fixEvidence, currentFixItemsHash string) bool {
+	if evidence == nil {
+		return false
+	}
+	if !evidenceUsesLegacyThreadMatching(evidence) {
+		return true
+	}
+	return strings.TrimSpace(evidence.FixItemsHash) != ""
+}
+
+func evidenceUsesLegacyThreadMatching(evidence *fixEvidence) bool {
+	for _, record := range evidence.CommentRecords {
+		fingerprint := strings.TrimSpace(record.ThreadFingerprint)
+		if fingerprint == "" || strings.HasPrefix(fingerprint, "legacy:") {
+			return true
+		}
+	}
+	return false
+}
+
+func canBackfillEvidenceRecords(checkpoint fixerCheckpoint, storedFixItemsHash, liveFixItemsHash string) bool {
+	if strings.TrimSpace(storedFixItemsHash) == "" || strings.TrimSpace(liveFixItemsHash) == "" {
+		return false
+	}
+	if strings.TrimSpace(checkpoint.FixItemsHash) == "" || checkpoint.FixItemsHash != storedFixItemsHash || storedFixItemsHash != liveFixItemsHash {
+		return false
+	}
+	return len(checkpoint.FixItems) > 0
 }
 
 func evidenceHeadSHA(evidence *fixEvidence) string {
@@ -3656,6 +3943,9 @@ func persistedFixEvidence(loopMetadataJSON *string) *fixEvidence {
 	if evidence.HeadSHA == "" {
 		return nil
 	}
+	if evidence.FixItemsHash == "" {
+		evidence.FixItemsHash, _ = stringFromAny(metadata["lastFixItemsHash"])
+	}
 	evidence.CommentRecords = cloneFixCommentEvidence(evidence.CommentRecords)
 	evidence.CommitSHAs = cloneStrings(evidence.CommitSHAs)
 	return &evidence
@@ -3671,7 +3961,7 @@ func buildFixCommentEvidenceRecords(checkpoint fixerCheckpoint, commitSHA string
 		if item.Type != "comment" {
 			continue
 		}
-		records = append(records, fixCommentEvidence{FixItemID: item.ID, ThreadID: item.ThreadID, CommitSHA: commitSHA, Explanation: explanationByID[item.ID]})
+		records = append(records, fixCommentEvidence{FixItemID: item.ID, ThreadID: item.ThreadID, ThreadFingerprint: normalizeThreadFingerprint(item.ThreadFingerprint, item.ThreadID, item.ID), CommitSHA: commitSHA, Explanation: explanationByID[item.ID]})
 	}
 	return records
 }
@@ -3718,10 +4008,14 @@ func (r *Runner) verifyFixEvidence(ctx context.Context, input stepInput, checkpo
 		if _, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: checkpoint.Worktree.Path, Branch: checkpoint.Worktree.Branch, ExpectedHeadSHA: liveHeadSHA}); err != nil {
 			return false, err
 		}
+	} else if branch := strings.TrimSpace(liveDetail.HeadRefName); branch != "" {
+		if err := r.git.FetchBranch(ctx, input.Project.RepoPath, "origin", branch); err != nil {
+			return false, &loopError{message: fmt.Sprintf("failed to fetch live PR head for evidence verification: %v", err), kind: FailureRetryableTransient}
+		}
 	}
 	ancestor, err := r.git.IsAncestor(ctx, input.Project.RepoPath, evidence.HeadSHA, liveHeadSHA)
 	if err != nil {
-		return false, nil
+		return false, &loopError{message: fmt.Sprintf("failed to verify fix evidence ancestry: %v", err), kind: FailureRetryableTransient}
 	}
 	return ancestor, nil
 }
@@ -3742,19 +4036,22 @@ func (r *Runner) validationMatchesEvidence(ctx context.Context, input stepInput,
 	}
 	ancestor, err := r.git.IsAncestor(ctx, input.Project.RepoPath, evidence.HeadSHA, validationHeadSHA)
 	if err != nil {
-		return false, nil
+		return false, &loopError{message: fmt.Sprintf("failed to verify validation ancestry: %v", err), kind: FailureRetryableTransient}
 	}
 	return ancestor, nil
 }
 
-func shouldSkipRediscoveryAfterNoopResolve(loopMetadataJSON *string, headSHA, fixItemsHash string) bool {
-	if headSHA == "" || fixItemsHash == "" {
+func shouldSkipRediscoveryAfterNoopResolve(loopMetadataJSON *string, headSHA, fixItemsStateHash string) bool {
+	if headSHA == "" || fixItemsStateHash == "" {
 		return false
 	}
 	metadata := parseJSONObject(loopMetadataJSON)
 	lastHeadSHA, _ := stringFromAny(metadata["lastNoopResolveHeadSha"])
-	lastFixItemsHash, _ := stringFromAny(metadata["lastNoopResolveFixItemsHash"])
-	return lastHeadSHA != "" && lastHeadSHA == headSHA && lastFixItemsHash != "" && lastFixItemsHash == fixItemsHash
+	lastFixItemsStateHash, _ := stringFromAny(metadata["lastNoopResolveStateHash"])
+	if lastFixItemsStateHash == "" {
+		lastFixItemsStateHash, _ = stringFromAny(metadata["lastNoopResolveFixItemsHash"])
+	}
+	return lastHeadSHA != "" && lastHeadSHA == headSHA && lastFixItemsStateHash != "" && lastFixItemsStateHash == fixItemsStateHash
 }
 
 func buildFixerDiscoveryFingerprint(repo string, prNumber int64, headSHA, fixItemsHash string) string {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -261,6 +261,7 @@ type GitGateway interface {
 	InspectHead(context.Context, InspectHeadInput) (InspectHeadResult, error)
 	Commit(context.Context, CommitInput) (CommitResult, error)
 	Push(context.Context, PushInput) error
+	IsAncestor(context.Context, string, string, string) (bool, error)
 	CleanupWorktree(context.Context, CleanupWorktreeInput) error
 }
 
@@ -507,14 +508,22 @@ type checkpointPush struct {
 }
 
 type fixEvidence struct {
-	Valid              bool     `json:"valid,omitempty"`
-	Source             string   `json:"source,omitempty"`
-	HeadSHA            string   `json:"headSha,omitempty"`
-	CommitSHAs         []string `json:"commitShas,omitempty"`
-	BaseHeadSHA        string   `json:"baseHeadSha,omitempty"`
-	FixItemsHash       string   `json:"fixItemsHash,omitempty"`
-	ProducedNewCommits bool     `json:"producedNewCommits,omitempty"`
-	PushedAt           string   `json:"pushedAt,omitempty"`
+	Valid              bool                 `json:"valid,omitempty"`
+	Source             string               `json:"source,omitempty"`
+	HeadSHA            string               `json:"headSha,omitempty"`
+	CommitSHAs         []string             `json:"commitShas,omitempty"`
+	BaseHeadSHA        string               `json:"baseHeadSha,omitempty"`
+	FixItemsHash       string               `json:"fixItemsHash,omitempty"`
+	CommentRecords     []fixCommentEvidence `json:"commentRecords,omitempty"`
+	ProducedNewCommits bool                 `json:"producedNewCommits,omitempty"`
+	PushedAt           string               `json:"pushedAt,omitempty"`
+}
+
+type fixCommentEvidence struct {
+	FixItemID   string `json:"fixItemId,omitempty"`
+	ThreadID    string `json:"threadId,omitempty"`
+	CommitSHA   string `json:"commitSha,omitempty"`
+	Explanation string `json:"explanation,omitempty"`
 }
 
 type checkpointResolvedComments struct {
@@ -1631,6 +1640,17 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	if finalHeadSHA == "" {
 		return checkpoint, &loopError{message: "reconcileCommits.finalHeadSha is required", kind: FailureRetryableAfterResume}
 	}
+	pushedAt := r.nowISO()
+	pushedHeadSHA := resolveCommentsExpectedHeadSHA(checkpoint)
+	evidence := &fixEvidence{Valid: pushedHeadSHA != "" && checkpoint.FixItemsHash != "", HeadSHA: pushedHeadSHA, CommitSHAs: cloneStrings(checkpoint.ReconcileCommits.NewCommitSHAs), BaseHeadSHA: checkpoint.ReconcileCommits.BaseHeadSHA, FixItemsHash: checkpoint.FixItemsHash, CommentRecords: buildFixCommentEvidenceRecords(checkpoint, lastNonEmptyString(checkpoint.ReconcileCommits.NewCommitSHAs, pushedHeadSHA)), Source: "fallback_push", ProducedNewCommits: roundProducedNewCommits(&checkpoint), PushedAt: pushedAt}
+	checkpoint.Push = &checkpointPush{Pushed: true, Branch: branch, Remote: "origin", HeadSHA: pushedHeadSHA, PushedAt: pushedAt, Evidence: evidence}
+	metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastFixHeadSha": pushedHeadSHA, "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": pushedAt, "lastFixEvidence": evidence})
+	if err != nil {
+		return checkpoint, err
+	}
+	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) { updated.MetadataJSON = stringPtr(metadataJSON) }); err != nil {
+		return checkpoint, err
+	}
 	liveDetail, err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: finalHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
 		return fmt.Sprintf("PR head did not update after push: expected %s, got %s", finalHeadSHA, firstNonEmpty(actual, "unknown"))
 	}})
@@ -1638,17 +1658,17 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 		return checkpoint, err
 	}
 	checkpoint = refreshCheckpointHeadAfterPush(checkpoint, liveDetail)
-	metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastFixHeadSha": resolveCommentsExpectedHeadSHA(checkpoint), "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": r.nowISO()})
+	pushedHeadSHA = resolveCommentsExpectedHeadSHA(checkpoint)
+	checkpoint.Push.HeadSHA = pushedHeadSHA
+	checkpoint.Push.Evidence.HeadSHA = pushedHeadSHA
+	metadataJSON, err = mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastFixHeadSha": pushedHeadSHA, "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": pushedAt, "lastFixEvidence": evidence})
 	if err != nil {
 		return checkpoint, err
 	}
 	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) { updated.MetadataJSON = stringPtr(metadataJSON) }); err != nil {
 		return checkpoint, err
 	}
-	pushedAt := r.nowISO()
-	pushedHeadSHA := resolveCommentsExpectedHeadSHA(checkpoint)
 	r.appendEvent(ctx, eventInput{eventType: "pr.branch.pushed", projectID: input.Project.ID, loopID: input.Loop.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"branch": branch, "pushedAt": pushedAt, "headSha": nilIfEmpty(pushedHeadSHA)}})
-	checkpoint.Push = &checkpointPush{Pushed: true, Branch: branch, Remote: "origin", HeadSHA: pushedHeadSHA, PushedAt: pushedAt, Evidence: &fixEvidence{Valid: pushedHeadSHA != "" && checkpoint.FixItemsHash != "", HeadSHA: pushedHeadSHA, CommitSHAs: cloneStrings(checkpoint.ReconcileCommits.NewCommitSHAs), BaseHeadSHA: checkpoint.ReconcileCommits.BaseHeadSHA, FixItemsHash: checkpoint.FixItemsHash, Source: "fallback_push", ProducedNewCommits: roundProducedNewCommits(&checkpoint), PushedAt: pushedAt}}
 	checkpoint.ensureLifecycle("fixer", branch, detailBaseRefName(checkpoint.Detail), false)
 	checkpoint.Lifecycle.Pushed = true
 	checkpoint.Lifecycle.Actions.Push = lifecycle.ActionSourceFallback
@@ -1725,8 +1745,9 @@ func (r *Runner) adoptLifecyclePushEvidence(ctx context.Context, input stepInput
 	}
 	checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, liveDetail)
 	pushedAt := r.nowISO()
-	checkpoint.Push = &checkpointPush{Pushed: true, Branch: branch, Remote: "origin", HeadSHA: adoptedHead, PushedAt: pushedAt, Evidence: &fixEvidence{Valid: true, Source: "agent_push", HeadSHA: adoptedHead, CommitSHAs: cloneStrings(lc.CommitSHAs), BaseHeadSHA: checkpoint.ReconcileCommits.BaseHeadSHA, FixItemsHash: checkpoint.FixItemsHash, ProducedNewCommits: true, PushedAt: pushedAt}}
-	metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastFixHeadSha": adoptedHead, "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": pushedAt})
+	evidence := &fixEvidence{Valid: true, Source: "agent_push", HeadSHA: adoptedHead, CommitSHAs: cloneStrings(lc.CommitSHAs), BaseHeadSHA: checkpoint.ReconcileCommits.BaseHeadSHA, FixItemsHash: checkpoint.FixItemsHash, CommentRecords: buildFixCommentEvidenceRecords(checkpoint, lastNonEmptyString(lc.CommitSHAs, adoptedHead)), ProducedNewCommits: true, PushedAt: pushedAt}
+	checkpoint.Push = &checkpointPush{Pushed: true, Branch: branch, Remote: "origin", HeadSHA: adoptedHead, PushedAt: pushedAt, Evidence: evidence}
+	metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastFixHeadSha": adoptedHead, "lastFixItemsHash": checkpoint.FixItemsHash, "lastFixPushedAt": pushedAt, "lastFixEvidence": evidence})
 	if err != nil {
 		return false, checkpoint, err
 	}
@@ -1755,46 +1776,43 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	if checkpoint.Push == nil {
 		return checkpoint, &loopError{message: "resolve-comments requires push step to complete", kind: FailureRetryableAfterResume}
 	}
-	fixItems := checkpoint.FixItems
-	currentFixItemsHash := checkpoint.FixItemsHash
+	liveDetail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
+	if err != nil {
+		return checkpoint, err
+	}
+	checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, liveDetail)
+	fixItems := collectFixItems(liveDetail)
+	currentFixItemsHash := hashFixItems(fixItems)
+	checkpoint.FixItems = fixItems
+	checkpoint.FixItemsHash = currentFixItemsHash
 	evidence := resolveFixEvidence(checkpoint, input.Loop.MetadataJSON, currentFixItemsHash)
-	if checkpoint.Push != nil && !checkpoint.Push.Pushed {
-		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
+	verifiedEvidence, err := r.verifyFixEvidence(ctx, input, checkpoint, evidence, liveDetail)
+	if err != nil {
+		return checkpoint, err
+	}
+	validationBound := false
+	if verifiedEvidence {
+		validationBound, err = r.validationMatchesEvidence(ctx, input, checkpoint, evidence)
 		if err != nil {
 			return checkpoint, err
 		}
-		fixItems = collectFixItems(detail)
-		currentFixItemsHash = hashFixItems(fixItems)
-		checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, detail)
-		evidence = resolveFixEvidence(checkpoint, input.Loop.MetadataJSON, currentFixItemsHash)
 	}
-	expectedHeadSHA := resolveCommentsExpectedHeadSHA(checkpoint)
-	if evidence != nil && evidence.Valid && evidence.HeadSHA != "" {
-		expectedHeadSHA = evidence.HeadSHA
-	}
-	if expectedHeadSHA != "" {
-		liveDetail, err := r.waitForPullRequestHeadSHA(ctx, waitForPullRequestHeadSHAInput{Repo: input.Repo, PRNumber: input.PRNumber, ExpectedHeadSHA: expectedHeadSHA, CWD: input.Project.RepoPath, Attempts: 5, Delay: time.Second, FailureMessage: func(actual string) string {
-			return fmt.Sprintf("PR head changed before resolving comments: expected %s, got %s", expectedHeadSHA, firstNonEmpty(actual, "unknown"))
-		}})
-		if err != nil {
-			return checkpoint, err
-		}
-		checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, liveDetail)
-		if checkpoint.Push != nil && !checkpoint.Push.Pushed {
-			fixItems = collectFixItems(liveDetail)
-			currentFixItemsHash = hashFixItems(fixItems)
-			evidence = resolveFixEvidence(checkpoint, input.Loop.MetadataJSON, currentFixItemsHash)
-		}
-	}
-	verifiedEvidence := evidence != nil && evidence.Valid && evidence.HeadSHA != "" && evidence.HeadSHA == detailHeadSHA(checkpoint.Detail)
-	if verifiedEvidence && (checkpoint.Validation == nil || !checkpoint.Validation.Passed || checkpoint.Validation.HeadSHA != evidence.HeadSHA) {
+	if verifiedEvidence && !validationBound {
 		return checkpoint, &loopError{message: "resolve-comments requires validation bound to verified fix evidence head", kind: FailureRetryableAfterResume}
 	}
 	if !verifiedEvidence && hasCommentFixItems(fixItems) && checkpoint.Push != nil && checkpoint.Push.Pushed {
-		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
 		return checkpoint, &loopError{message: "resolve-comments refused because verified fix evidence is missing or stale; leaving review threads unresolved", kind: FailureRetryableAfterResume}
 	}
 	if shouldBlockResolveWithoutFix(checkpoint, fixItems, verifiedEvidence) {
+		if checkpoint.ResolvedComments == nil {
+			checkpoint.ResolvedComments = &checkpointResolvedComments{Items: []checkpointResolvedComment{}}
+		}
+		for _, item := range fixItems {
+			if item.Type != "comment" || alreadyResolved(checkpoint.ResolvedComments.Items, item) {
+				continue
+			}
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_no_evidence", Message: "No verified pushed fix evidence available for this thread", UpdatedAt: r.nowISO()})
+		}
 		metadataJSON, err := mergeLoopMetadataJSON(input.Loop.MetadataJSON, map[string]any{"lastNoopResolveHeadSha": detailHeadSHA(checkpoint.Detail), "lastNoopResolveFixItemsHash": currentFixItemsHash, "lastNoopResolveAt": r.nowISO()})
 		if err != nil {
 			return checkpoint, err
@@ -1802,25 +1820,17 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) { updated.MetadataJSON = stringPtr(metadataJSON) }); err != nil {
 			return checkpoint, err
 		}
-		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
-		return checkpoint, &loopError{message: "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved", kind: FailureRetryableAfterResume}
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		return checkpoint, nil
 	}
 	if checkpoint.ResolvedComments == nil {
 		checkpoint.ResolvedComments = &checkpointResolvedComments{Items: []checkpointResolvedComment{}}
 	}
-	commitSHA := ""
-	if checkpoint.ReconcileCommits != nil {
-		if len(checkpoint.ReconcileCommits.NewCommitSHAs) > 0 {
-			commitSHA = checkpoint.ReconcileCommits.NewCommitSHAs[len(checkpoint.ReconcileCommits.NewCommitSHAs)-1]
-		} else {
-			commitSHA = checkpoint.ReconcileCommits.FinalHeadSHA
-		}
-	}
-	if commitSHA == "" || (verifiedEvidence && commitSHA == reconcileBaseHeadSHA(checkpoint.ReconcileCommits)) {
-		commitSHA = firstNonEmpty(evidenceHeadSHA(evidence), commitSHA)
-	}
+	defaultCommitSHA := resolveCommentCommitSHA(checkpoint, evidence, verifiedEvidence)
 	failedCount := 0
-	explanationByID := lookupReplyExplanations(checkpoint)
+	resolvedCount := 0
+	evidenceByThread := evidenceCommentRecordsByThread(evidence)
+	explanationByID := buildResolveReplyExplanations(checkpoint, evidence)
 	for _, item := range fixItems {
 		if item.Type != "comment" {
 			continue
@@ -1828,7 +1838,19 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
 			continue
 		}
-		replyState, replyError := r.replyToFixedComment(ctx, input, item, commitSHA, explanationByID[item.ID], checkpoint.ResolvedComments.Items)
+		record, hasRecord := evidenceRecordForItem(evidenceByThread, item)
+		if !verifiedEvidence || !hasRecord {
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_no_evidence", Message: "No verified pushed fix evidence available for this thread", UpdatedAt: r.nowISO()})
+			continue
+		}
+		commitSHA := firstNonEmpty(record.CommitSHA, defaultCommitSHA)
+		explanation := firstNonEmpty(explanationByID[item.ID], record.Explanation)
+		replyState, replyError := r.replyToFixedComment(ctx, input, item, commitSHA, explanation, checkpoint.ResolvedComments.Items)
+		if replyState == "failed" {
+			failedCount++
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "reply_failed", Message: "Failed to post fixer auto-reply", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+			continue
+		}
 		if err := r.github.ResolveReviewThread(ctx, ResolveReviewThreadInput{Repo: input.Repo, ThreadID: item.ThreadID, CWD: input.Project.RepoPath}); err != nil {
 			message := err.Error()
 			status := "failed"
@@ -1840,11 +1862,12 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: status, Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 			continue
 		}
+		resolvedCount++
 		upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "resolved", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 	}
 	r.appendEvent(ctx, eventInput{eventType: "fixer.comments.resolved", projectID: input.Project.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"items": checkpoint.ResolvedComments.Items}})
-	if failedCount == 0 {
-		r.publishRoundSummaryComment(ctx, input, &checkpoint, fixItems, commitSHA, explanationByID)
+	if failedCount == 0 && resolvedCount > 0 {
+		r.publishRoundSummaryComment(ctx, input, &checkpoint, fixItems, defaultCommitSHA, explanationByID)
 	}
 	if failedCount > 0 {
 		return checkpoint, &loopError{message: fmt.Sprintf("Failed to resolve %d review thread(s)", failedCount), kind: FailureRetryableAfterResume}
@@ -1854,10 +1877,10 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 }
 
 // replyToFixedComment posts a reply on the review thread acknowledging the fix
-// before the thread is resolved. Replies are best-effort: failures are recorded
-// in the checkpoint but never block the resolve step. The disclosure stamper
-// applied by the GitHub adapter ensures every reply carries the looper exposure
-// marker, so automated replies can be filtered downstream.
+// before the thread is resolved. Reply failures are recorded so the caller can
+// retry before resolving the thread. The disclosure stamper applied by the
+// GitHub adapter ensures every reply carries the looper exposure marker, so
+// automated replies can be filtered downstream.
 func (r *Runner) replyToFixedComment(ctx context.Context, input stepInput, item FixItem, commitSHA, explanation string, existing []checkpointResolvedComment) (string, string) {
 	if item.ThreadID == "" {
 		return "skipped_no_thread", ""
@@ -3313,10 +3336,7 @@ func shouldRestartFromDiscover(status string, failedStep FixerStep, failureSumma
 	if failedStep != stepResolveComments {
 		return false
 	}
-	if status == "interrupted" {
-		return true
-	}
-	return strings.Contains(failureSummary, "PR head changed before resolving comments")
+	return status == "interrupted"
 }
 
 func shouldRebuildWorktree(checkpoint fixerCheckpoint) bool {
@@ -3345,6 +3365,69 @@ func shouldBlockResolveWithoutFix(checkpoint fixerCheckpoint, fixItems []FixItem
 		}
 	}
 	return false
+}
+
+func resolveCommentCommitSHA(checkpoint fixerCheckpoint, evidence *fixEvidence, verifiedEvidence bool) string {
+	commitSHA := ""
+	if checkpoint.ReconcileCommits != nil {
+		if len(checkpoint.ReconcileCommits.NewCommitSHAs) > 0 {
+			commitSHA = checkpoint.ReconcileCommits.NewCommitSHAs[len(checkpoint.ReconcileCommits.NewCommitSHAs)-1]
+		} else {
+			commitSHA = checkpoint.ReconcileCommits.FinalHeadSHA
+		}
+	}
+	if commitSHA == "" || (verifiedEvidence && commitSHA == reconcileBaseHeadSHA(checkpoint.ReconcileCommits)) {
+		commitSHA = firstNonEmpty(evidenceHeadSHA(evidence), commitSHA)
+	}
+	return commitSHA
+}
+
+func buildResolveReplyExplanations(checkpoint fixerCheckpoint, evidence *fixEvidence) map[string]string {
+	out := lookupReplyExplanations(checkpoint)
+	for _, record := range evidenceCommentRecords(evidence) {
+		if strings.TrimSpace(record.FixItemID) == "" || strings.TrimSpace(record.Explanation) == "" {
+			continue
+		}
+		if out == nil {
+			out = map[string]string{}
+		}
+		if _, exists := out[record.FixItemID]; !exists {
+			out[record.FixItemID] = record.Explanation
+		}
+	}
+	return out
+}
+
+func evidenceRecordForItem(records map[string]fixCommentEvidence, item FixItem) (fixCommentEvidence, bool) {
+	if len(records) == 0 {
+		return fixCommentEvidence{}, false
+	}
+	if record, ok := records[strings.TrimSpace(item.ThreadID)]; ok {
+		return record, true
+	}
+	if record, ok := records[strings.TrimSpace(item.ID)]; ok {
+		return record, true
+	}
+	return fixCommentEvidence{}, false
+}
+
+func evidenceCommentRecordsByThread(evidence *fixEvidence) map[string]fixCommentEvidence {
+	items := evidenceCommentRecords(evidence)
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]fixCommentEvidence, len(items)*2)
+	for _, item := range items {
+		if key := strings.TrimSpace(item.ThreadID); key != "" {
+			out[key] = item
+		}
+		if key := strings.TrimSpace(item.FixItemID); key != "" {
+			if _, exists := out[key]; !exists {
+				out[key] = item
+			}
+		}
+	}
+	return out
 }
 
 func hasCommentFixItems(fixItems []FixItem) bool {
@@ -3504,15 +3587,15 @@ func resolveCommentsExpectedHeadSHA(checkpoint fixerCheckpoint) string {
 }
 
 func resolveFixEvidence(checkpoint fixerCheckpoint, loopMetadataJSON *string, fixItemsHash string) *fixEvidence {
-	if fixItemsHash == "" {
-		return nil
-	}
 	if checkpoint.Push != nil && checkpoint.Push.Evidence != nil {
 		evidence := *checkpoint.Push.Evidence
 		if evidence.HeadSHA == "" {
 			evidence.HeadSHA = checkpoint.Push.HeadSHA
 		}
-		if evidence.Valid && evidence.HeadSHA != "" && evidence.FixItemsHash != "" && evidence.FixItemsHash == fixItemsHash && evidence.ProducedNewCommits {
+		if evidence.Valid && evidence.HeadSHA != "" && evidence.ProducedNewCommits {
+			if len(evidence.CommentRecords) == 0 {
+				evidence.CommentRecords = buildFixCommentEvidenceRecords(checkpoint, resolveCommentCommitSHA(checkpoint, &evidence, true))
+			}
 			return &evidence
 		}
 		return nil
@@ -3522,10 +3605,16 @@ func resolveFixEvidence(checkpoint fixerCheckpoint, loopMetadataJSON *string, fi
 		if !producedNewCommits {
 			return nil
 		}
-		return &fixEvidence{Valid: true, Source: "prior_verified_push", HeadSHA: checkpoint.Push.HeadSHA, FixItemsHash: fixItemsHash, ProducedNewCommits: producedNewCommits, PushedAt: checkpoint.Push.PushedAt}
+		return &fixEvidence{Valid: true, Source: "prior_verified_push", HeadSHA: checkpoint.Push.HeadSHA, CommitSHAs: cloneStrings(commitEvidenceSHAs(checkpoint)), FixItemsHash: fixItemsHash, CommentRecords: buildFixCommentEvidenceRecords(checkpoint, resolveCommentCommitSHA(checkpoint, nil, false)), ProducedNewCommits: producedNewCommits, PushedAt: checkpoint.Push.PushedAt}
+	}
+	if persisted := persistedFixEvidence(loopMetadataJSON); persisted != nil && persisted.Valid && persisted.HeadSHA != "" && persisted.ProducedNewCommits {
+		return persisted
+	}
+	if fixItemsHash == "" {
+		return nil
 	}
 	if headSHA := resolveCommentsVerifiedNoPushHeadSHA(checkpoint.Push, loopMetadataJSON, fixItemsHash); headSHA != "" {
-		return &fixEvidence{Valid: true, Source: "prior_verified_push", HeadSHA: headSHA, FixItemsHash: fixItemsHash, ProducedNewCommits: true}
+		return &fixEvidence{Valid: true, Source: "prior_verified_push", HeadSHA: headSHA, FixItemsHash: fixItemsHash, CommentRecords: buildFixCommentEvidenceRecords(checkpoint, resolveCommentCommitSHA(checkpoint, nil, false)), ProducedNewCommits: true}
 	}
 	return nil
 }
@@ -3548,6 +3637,114 @@ func resolveCommentsVerifiedNoPushHeadSHA(push *checkpointPush, loopMetadataJSON
 		return ""
 	}
 	return lastFixHeadSHA
+}
+
+func persistedFixEvidence(loopMetadataJSON *string) *fixEvidence {
+	metadata := parseJSONObject(loopMetadataJSON)
+	raw, ok := metadata["lastFixEvidence"]
+	if !ok || raw == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var evidence fixEvidence
+	if err := json.Unmarshal(encoded, &evidence); err != nil {
+		return nil
+	}
+	if evidence.HeadSHA == "" {
+		return nil
+	}
+	evidence.CommentRecords = cloneFixCommentEvidence(evidence.CommentRecords)
+	evidence.CommitSHAs = cloneStrings(evidence.CommitSHAs)
+	return &evidence
+}
+
+func buildFixCommentEvidenceRecords(checkpoint fixerCheckpoint, commitSHA string) []fixCommentEvidence {
+	if len(checkpoint.FixItems) == 0 {
+		return nil
+	}
+	explanationByID := lookupReplyExplanations(checkpoint)
+	records := make([]fixCommentEvidence, 0, len(checkpoint.FixItems))
+	for _, item := range checkpoint.FixItems {
+		if item.Type != "comment" {
+			continue
+		}
+		records = append(records, fixCommentEvidence{FixItemID: item.ID, ThreadID: item.ThreadID, CommitSHA: commitSHA, Explanation: explanationByID[item.ID]})
+	}
+	return records
+}
+
+func evidenceCommentRecords(evidence *fixEvidence) []fixCommentEvidence {
+	if evidence == nil {
+		return nil
+	}
+	return cloneFixCommentEvidence(evidence.CommentRecords)
+}
+
+func commitEvidenceSHAs(checkpoint fixerCheckpoint) []string {
+	if checkpoint.ReconcileCommits == nil {
+		return nil
+	}
+	if len(checkpoint.ReconcileCommits.NewCommitSHAs) > 0 {
+		return cloneStrings(checkpoint.ReconcileCommits.NewCommitSHAs)
+	}
+	if checkpoint.ReconcileCommits.FinalHeadSHA != "" {
+		return []string{checkpoint.ReconcileCommits.FinalHeadSHA}
+	}
+	return nil
+}
+
+func (r *Runner) verifyFixEvidence(ctx context.Context, input stepInput, checkpoint fixerCheckpoint, evidence *fixEvidence, liveDetail PullRequestDetail) (bool, error) {
+	if evidence == nil || !evidence.Valid || strings.TrimSpace(evidence.HeadSHA) == "" {
+		return false, nil
+	}
+	liveHeadSHA := strings.TrimSpace(liveDetail.HeadSHA)
+	if liveHeadSHA == "" {
+		return false, nil
+	}
+	if liveHeadSHA == strings.TrimSpace(evidence.HeadSHA) {
+		return true, nil
+	}
+	if r.git == nil {
+		return false, nil
+	}
+	if checkpoint.Worktree != nil && checkpoint.Worktree.Path != "" && checkpoint.Worktree.Branch != "" {
+		worktreeRoot, err := fixerWorktreeRoot(input.Project)
+		if err != nil {
+			return false, err
+		}
+		if _, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: checkpoint.Worktree.Path, Branch: checkpoint.Worktree.Branch, ExpectedHeadSHA: liveHeadSHA}); err != nil {
+			return false, err
+		}
+	}
+	ancestor, err := r.git.IsAncestor(ctx, input.Project.RepoPath, evidence.HeadSHA, liveHeadSHA)
+	if err != nil {
+		return false, nil
+	}
+	return ancestor, nil
+}
+
+func (r *Runner) validationMatchesEvidence(ctx context.Context, input stepInput, checkpoint fixerCheckpoint, evidence *fixEvidence) (bool, error) {
+	if checkpoint.Validation == nil || !checkpoint.Validation.Passed || evidence == nil || strings.TrimSpace(evidence.HeadSHA) == "" {
+		return false, nil
+	}
+	validationHeadSHA := strings.TrimSpace(checkpoint.Validation.HeadSHA)
+	if validationHeadSHA == "" {
+		return false, nil
+	}
+	if validationHeadSHA == strings.TrimSpace(evidence.HeadSHA) {
+		return true, nil
+	}
+	if r.git == nil {
+		return false, nil
+	}
+	ancestor, err := r.git.IsAncestor(ctx, input.Project.RepoPath, evidence.HeadSHA, validationHeadSHA)
+	if err != nil {
+		return false, nil
+	}
+	return ancestor, nil
 }
 
 func shouldSkipRediscoveryAfterNoopResolve(loopMetadataJSON *string, headSHA, fixItemsHash string) bool {
@@ -3619,10 +3816,17 @@ func compactStrings(values []string) []string {
 }
 
 func cloneStrings(values []string) []string {
-	if values == nil {
+	if len(values) == 0 {
 		return nil
 	}
 	return append([]string(nil), values...)
+}
+
+func cloneFixCommentEvidence(values []fixCommentEvidence) []fixCommentEvidence {
+	if len(values) == 0 {
+		return nil
+	}
+	return append([]fixCommentEvidence(nil), values...)
 }
 
 func cloneObjectSlice(values []map[string]any) []map[string]any {
@@ -3679,6 +3883,15 @@ func stringFromAny(value any) (string, bool) {
 		return "", false
 	}
 	return text, true
+}
+
+func lastNonEmptyString(values []string, fallback string) string {
+	for i := len(values) - 1; i >= 0; i-- {
+		if strings.TrimSpace(values[i]) != "" {
+			return values[i]
+		}
+	}
+	return fallback
 }
 
 func int64FromAny(value any) int64 {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -4012,9 +4012,7 @@ func (r *Runner) verifyFixEvidence(ctx context.Context, input stepInput, checkpo
 			return false, err
 		}
 	} else if branch := strings.TrimSpace(liveDetail.HeadRefName); branch != "" {
-		if err := r.git.FetchBranch(ctx, input.Project.RepoPath, "origin", branch); err != nil {
-			return false, &loopError{message: fmt.Sprintf("failed to fetch live PR head for evidence verification: %v", err), kind: FailureRetryableTransient}
-		}
+		_ = r.git.FetchBranch(ctx, input.Project.RepoPath, "origin", branch)
 	}
 	ancestor, err := r.git.IsAncestor(ctx, input.Project.RepoPath, evidence.HeadSHA, liveHeadSHA)
 	if err != nil {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1311,6 +1311,60 @@ func TestRunResolveCommentsStepUsesRefreshedPushHeadSHA(t *testing.T) {
 	}
 }
 
+func TestRunResolveCommentsStepIgnoresForkBranchFetchFailureDuringEvidenceVerification(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "new-head",
+		HeadRefName: "fork-owner:feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}}
+	git := &fakeGitGateway{fetchErr: errors.New("remote ref not found"), ancestor: map[string]bool{"old-head->new-head": true}}
+	runner := New(Options{GitHub: github, Git: git})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"old-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"old-head\",\"fixItemsHash\":%q,\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"old-head\"}]}}", fixItemsHash, fixItemsHash)
+	checkpoint := fixerCheckpoint{
+		FixItems:     fixItems,
+		FixItemsHash: fixItemsHash,
+		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
+		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		ReconcileCommits: &checkpointReconcileCommits{
+			BaseHeadSHA:      "base-head",
+			FinalHeadSHA:     "base-head",
+			WorkingTreeClean: true,
+		},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if len(git.fetchCalls) != 2 {
+		t.Fatalf("fetch calls = %d, want 2", len(git.fetchCalls))
+	}
+	if len(github.resolveCalls) != 1 {
+		t.Fatalf("resolve calls = %d, want 1", len(github.resolveCalls))
+	}
+	if updated.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
+	}
+}
+
 func TestRunResolveCommentsStepPreservesCheckpointLabelSnapshotOnLiveRefresh(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1371,6 +1371,171 @@ func TestRunResolveCommentsStepIgnoresForkBranchFetchFailureDuringEvidenceVerifi
 	}
 }
 
+func TestRunResolveCommentsStepTreatsMissingLiveHeadObjectAsStaleEvidence(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "new-head",
+		HeadRefName: "fork-owner:feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}}
+	git := &fakeGitGateway{
+		fetchErrors: []error{errors.New("remote ref not found"), errors.New("fatal: couldn't find remote ref new-head")},
+		ancestorErr: errors.New("fatal: Not a valid object name new-head"),
+	}
+	runner := New(Options{GitHub: github, Git: git})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	checkpoint := fixerCheckpoint{
+		FixItems:     fixItems,
+		FixItemsHash: fixItemsHash,
+		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "old-head"},
+		Push:         &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "old-head"},
+		Lifecycle:    &lifecycle.State{Pushed: true},
+		ReconcileCommits: &checkpointReconcileCommits{
+			BaseHeadSHA:      "base-head",
+			FinalHeadSHA:     "old-head",
+			NewCommitSHAs:    []string{"old-head"},
+			WorkingTreeClean: true,
+		},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err == nil || !strings.Contains(err.Error(), "verified fix evidence is missing or stale") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want stale-evidence failure", err)
+	}
+	if updated.ResumePolicy != "restart_from_discover" {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0", len(github.resolveCalls))
+	}
+	if len(git.fetchCalls) < 2 {
+		t.Fatalf("fetch calls = %d, want at least 2", len(git.fetchCalls))
+	}
+}
+
+func TestRunResolveCommentsStepTreatsMissingValidationHeadObjectAsUnboundEvidence(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}}
+	git := &fakeGitGateway{ancestorErr: errors.New("fatal: ambiguous argument older-head")}
+	runner := New(Options{GitHub: github, Git: git})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"fix-head\"}]}}", fixItemsHash)
+	checkpoint := fixerCheckpoint{
+		FixItems:     fixItems,
+		FixItemsHash: fixItemsHash,
+		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "older-head"},
+		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		ReconcileCommits: &checkpointReconcileCommits{
+			BaseHeadSHA:      "base-head",
+			FinalHeadSHA:     "base-head",
+			WorkingTreeClean: true,
+		},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err == nil || !strings.Contains(err.Error(), "validation bound to verified fix evidence head") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want validation-bound failure", err)
+	}
+	if updated.ResumePolicy != "restart_from_discover" {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepPersistsNoopResolveMetadataWhenAllThreadsSkipForMissingEvidence(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	loopMetadata := `{"lastFixHeadSha":"fix-head","lastFixItemsHash":"old-hash","lastFixEvidence":{"valid":true,"headSha":"fix-head","producedNewCommits":true,"commentRecords":[{"fixItemId":"c1","threadId":"t1","commitSha":"fix-head"}]}}`
+	loop := storage.LoopRecord{ID: "loop_fixer_skip_no_evidence", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &loopMetadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      prNumber,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c2",
+			"threadId": "t2",
+			"body":     "new feedback",
+		}},
+	}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+	liveFixItems := []FixItem{{Type: "comment", ID: "c2", ThreadID: "t2", Summary: "new feedback"}}
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:     loop,
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: fixerCheckpoint{
+			FixItems:         liveFixItems,
+			FixItemsHash:     hashFixItems(liveFixItems),
+			Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
+			Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+			ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if updated.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	meta := parseJSONObject(persisted.MetadataJSON)
+	if got, _ := stringFromAny(meta["lastNoopResolveHeadSha"]); got != "fix-head" {
+		t.Fatalf("lastNoopResolveHeadSha = %q, want fix-head", got)
+	}
+	if got, _ := stringFromAny(meta["lastNoopResolveStateHash"]); got != hashFixItemsState(liveFixItems) {
+		t.Fatalf("lastNoopResolveStateHash = %q, want %q", got, hashFixItemsState(liveFixItems))
+	}
+}
+
 func TestRunResolveCommentsStepPreservesCheckpointLabelSnapshotOnLiveRefresh(t *testing.T) {
 	t.Parallel()
 
@@ -3243,6 +3408,7 @@ type fakeGitGateway struct {
 	inspectResults []InspectHeadResult
 	inspectIndex   int
 	ancestor       map[string]bool
+	ancestorErr    error
 	fetchErrors    []error
 	fetchIndex     int
 	fetchErr       error
@@ -3329,6 +3495,9 @@ func (f *fakeGitGateway) FetchBranch(_ context.Context, repoPath, remote, branch
 }
 
 func (f *fakeGitGateway) IsAncestor(_ context.Context, _ string, ancestor, descendant string) (bool, error) {
+	if f.ancestorErr != nil {
+		return false, f.ancestorErr
+	}
 	if f.ancestor == nil {
 		return ancestor == descendant, nil
 	}

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -447,9 +447,9 @@ func TestProcessClaimedItemCompletesSuccessfulFlow(t *testing.T) {
 		viewResponses: []PullRequestDetail{
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
 		},
 	}
 	git := &fakeGitGateway{
@@ -549,8 +549,8 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume || !contains(result.Summary, "produced no new commits") {
-		t.Fatalf("result = %#v, want retryable-after-resume failure for no-op repair", result)
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want successful no-op completion", result)
 	}
 	if len(git.commitCalls) != 0 || len(git.pushCalls) != 0 || len(github.resolveCalls) != 0 {
 		t.Fatalf("commit calls=%d push calls=%d resolve calls=%d, want 0/0/0 after no-op repair", len(git.commitCalls), len(git.pushCalls), len(github.resolveCalls))
@@ -559,32 +559,32 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if err != nil {
 		t.Fatalf("Runs.GetByID() error = %v", err)
 	}
-	if run == nil || run.Status != "failed" || run.CurrentStep == nil || *run.CurrentStep != string(stepResolveComments) {
-		t.Fatalf("run = %#v, want failed run at resolve-comments step", run)
+	if run == nil || run.Status != "success" || run.CurrentStep != nil {
+		t.Fatalf("run = %#v, want successful completed run", run)
 	}
 	checkpoint := parseCheckpoint(run.CheckpointJSON)
 	if checkpoint.Push == nil || checkpoint.Push.Pushed || checkpoint.Push.SkippedReason == "" {
 		t.Fatalf("checkpoint.Push = %#v, want recorded no-op push", checkpoint.Push)
 	}
-	if checkpoint.ResumePolicy != "restart_from_discover" {
-		t.Fatalf("checkpoint.ResumePolicy = %q, want restart_from_discover", checkpoint.ResumePolicy)
+	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
 	}
-	if checkpoint.ResolvedComments != nil {
-		t.Fatalf("checkpoint.ResolvedComments = %#v, want unresolved comments left untouched", checkpoint.ResolvedComments)
+	if checkpoint.ResolvedComments == nil || len(checkpoint.ResolvedComments.Items) == 0 || checkpoint.ResolvedComments.Items[0].Status != "skipped_no_evidence" {
+		t.Fatalf("checkpoint.ResolvedComments = %#v, want skipped-no-evidence marker", checkpoint.ResolvedComments)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableAfterResume) {
-		t.Fatalf("queue = %#v, want queued retryable-after-resume failure", queue)
+	if queue == nil || queue.Status != "completed" {
+		t.Fatalf("queue = %#v, want completed queue item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
-		t.Fatalf("loop = %#v, want queued loop scheduled for rediscovery retry", loop)
+	if loop == nil || loop.Status != "completed" {
+		t.Fatalf("loop = %#v, want completed loop", loop)
 	}
 	loopMeta := parseJSONObject(loop.MetadataJSON)
 	if got, _ := stringFromAny(loopMeta["lastNoopResolveHeadSha"]); got != "base-head" {
@@ -761,7 +761,7 @@ func TestDiscoverPullRequestsRequeuesNoopResolveLoopWhenStateChanges(t *testing.
 	}
 }
 
-func TestRunResolveCommentsStepBlocksWithoutVerifiedPushEvidence(t *testing.T) {
+func TestRunResolveCommentsStepSkipsWithoutVerifiedPushEvidence(t *testing.T) {
 	t.Parallel()
 
 	fixture := newRunnerFixture(t)
@@ -807,59 +807,37 @@ func TestRunResolveCommentsStepBlocksWithoutVerifiedPushEvidence(t *testing.T) {
 		PRNumber:   42,
 		Checkpoint: checkpoint,
 	})
-	if err == nil {
-		t.Fatal("runResolveCommentsStep() error = nil, want rediscoverable retry")
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	var loopErr *loopError
-	if !errors.As(err, &loopErr) {
-		t.Fatalf("error = %T, want *loopError", err)
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 without verified evidence", len(github.resolveCalls))
 	}
-	if loopErr.kind != FailureRetryableAfterResume {
-		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableAfterResume)
-	}
-	if !contains(loopErr.Error(), "produced no new commits") {
-		t.Fatalf("error = %q, want no-new-commits message", loopErr.Error())
-	}
-	if updated.ResumePolicy != "restart_from_discover" {
-		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	if updated.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
 	}
 }
 
 func TestRunResolveCommentsStepRefreshesVerifiedNoPushHeadBeforeResolve(t *testing.T) {
 	t.Parallel()
 
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{
-		{
-			Number:      42,
-			State:       "OPEN",
-			HeadSHA:     "old-head",
-			HeadRefName: "feature/fix-42",
-			BaseRefName: "main",
-			BaseSHA:     "base-1",
-			Comments: []map[string]any{{
-				"id":       "c1",
-				"threadId": "t1",
-				"body":     "please fix",
-			}},
-		},
-		{
-			Number:      42,
-			State:       "OPEN",
-			HeadSHA:     "new-head",
-			HeadRefName: "feature/fix-42",
-			BaseRefName: "main",
-			BaseSHA:     "base-1",
-			Comments: []map[string]any{{
-				"id":       "c1",
-				"threadId": "t1",
-				"body":     "please fix",
-			}},
-		},
-	}}
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "new-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}}
 	runner := New(Options{GitHub: github, Sleep: func(time.Duration) {}})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
 	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"new-head\",\"lastFixItemsHash\":\"%s\"}", fixItemsHash)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"new-head\",\"lastFixItemsHash\":\"%s\",\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"new-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"new-head\",\"explanation\":\"Applied the requested fix.\"}]}}", fixItemsHash)
 	checkpoint := fixerCheckpoint{
 		FixItems:     fixItems,
 		FixItemsHash: fixItemsHash,
@@ -883,8 +861,8 @@ func TestRunResolveCommentsStepRefreshesVerifiedNoPushHeadBeforeResolve(t *testi
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	if github.viewIndex < 2 {
-		t.Fatalf("github.viewIndex = %d, want live refresh plus head check", github.viewIndex)
+	if github.viewIndex != 1 {
+		t.Fatalf("github.viewIndex = %d, want single live refresh", github.viewIndex)
 	}
 	if len(github.resolveCalls) != 1 {
 		t.Fatalf("resolve calls = %d, want 1 after refreshing verified head", len(github.resolveCalls))
@@ -903,117 +881,80 @@ func TestRunResolveCommentsStepRefreshesVerifiedNoPushHeadBeforeResolve(t *testi
 	}
 }
 
-func TestRunResolveCommentsStepFailsWhenHeadChangesAfterVerifiedNoPushRefresh(t *testing.T) {
+func TestRunResolveCommentsStepResolvesWhenPersistedFixHeadIsAncestorOfLiveHead(t *testing.T) {
 	t.Parallel()
 
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{
-		{
-			Number:      42,
-			State:       "OPEN",
-			HeadSHA:     "new-head",
-			HeadRefName: "feature/fix-42",
-			BaseRefName: "main",
-			BaseSHA:     "base-1",
-			Comments: []map[string]any{{
-				"id":       "c1",
-				"threadId": "t1",
-				"body":     "please fix",
-			}},
-		},
-		{
-			Number:      42,
-			State:       "OPEN",
-			HeadSHA:     "newer-head",
-			HeadRefName: "feature/fix-42",
-			BaseRefName: "main",
-			BaseSHA:     "base-1",
-			Comments: []map[string]any{{
-				"id":       "c1",
-				"threadId": "t1",
-				"body":     "please fix",
-			}},
-		},
-	}}
-	runner := New(Options{GitHub: github, Sleep: func(time.Duration) {}})
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "newer-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}}
+	git := &fakeGitGateway{ancestor: map[string]bool{"fix-head->newer-head": true}}
+	runner := New(Options{GitHub: github, Git: git, Sleep: func(time.Duration) {}})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
 	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"new-head\",\"lastFixItemsHash\":\"%s\"}", fixItemsHash)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":\"%s\",\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"fix-head\",\"explanation\":\"Applied the requested fix.\"}]}}", fixItemsHash)
 	checkpoint := fixerCheckpoint{
 		FixItems:         fixItems,
 		FixItemsHash:     fixItemsHash,
-		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
-	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
 		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
 		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
 		Repo:       "acme/looper",
 		PRNumber:   42,
 		Checkpoint: checkpoint,
 	})
-	if err == nil {
-		t.Fatal("runResolveCommentsStep() error = nil, want stale-head retry")
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	var loopErr *loopError
-	if !errors.As(err, &loopErr) {
-		t.Fatalf("error = %T, want *loopError", err)
+	if len(github.resolveCalls) != 1 {
+		t.Fatalf("resolve calls = %d, want 1", len(github.resolveCalls))
 	}
-	if loopErr.kind != FailureRetryableAfterResume {
-		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableAfterResume)
+	if len(github.replyCalls) != 1 || !contains(github.replyCalls[0].Body, "fix-hea") {
+		t.Fatalf("reply calls = %#v, want reply referencing persisted fix head", github.replyCalls)
 	}
-	if !contains(loopErr.Error(), "PR head changed before resolving comments") {
-		t.Fatalf("error = %q, want stale-head message", loopErr.Error())
-	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want none on concurrent head change", len(github.resolveCalls))
+	if updated.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
 	}
 }
 
-func TestRunResolveCommentsStepFailsWhenLiveFixItemsDriftFromVerifiedNoPushSnapshot(t *testing.T) {
+func TestRunResolveCommentsStepResolvesMatchingThreadsAndSkipsNewOnes(t *testing.T) {
 	t.Parallel()
 
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{
-		{
-			Number:      42,
-			State:       "OPEN",
-			HeadSHA:     "new-head",
-			HeadRefName: "feature/fix-42",
-			BaseRefName: "main",
-			BaseSHA:     "base-1",
-			Comments: []map[string]any{{
-				"id":       "c1",
-				"threadId": "t1",
-				"body":     "please fix",
-			}, {
-				"id":       "c2",
-				"threadId": "t2",
-				"body":     "new feedback",
-			}},
-		},
-		{
-			Number:      42,
-			State:       "OPEN",
-			HeadSHA:     "new-head",
-			HeadRefName: "feature/fix-42",
-			BaseRefName: "main",
-			BaseSHA:     "base-1",
-			Comments: []map[string]any{{
-				"id":       "c1",
-				"threadId": "t1",
-				"body":     "please fix",
-			}, {
-				"id":       "c2",
-				"threadId": "t2",
-				"body":     "new feedback",
-			}},
-		},
-	}}
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "new-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}, {
+			"id":       "c2",
+			"threadId": "t2",
+			"body":     "new feedback",
+		}},
+	}}}
 	runner := New(Options{GitHub: github, Sleep: func(time.Duration) {}})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
 	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"new-head\",\"lastFixItemsHash\":\"%s\"}", fixItemsHash)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"new-head\",\"lastFixItemsHash\":\"%s\",\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"new-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"new-head\",\"explanation\":\"Applied the requested fix.\"}]}}", fixItemsHash)
 	checkpoint := fixerCheckpoint{
 		FixItems:         fixItems,
 		FixItemsHash:     fixItemsHash,
@@ -1022,28 +963,24 @@ func TestRunResolveCommentsStepFailsWhenLiveFixItemsDriftFromVerifiedNoPushSnaps
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
-	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
 		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
 		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
 		Repo:       "acme/looper",
 		PRNumber:   42,
 		Checkpoint: checkpoint,
 	})
-	if err == nil {
-		t.Fatal("runResolveCommentsStep() error = nil, want stale-head retry")
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	var loopErr *loopError
-	if !errors.As(err, &loopErr) {
-		t.Fatalf("error = %T, want *loopError", err)
+	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t1" {
+		t.Fatalf("resolve calls = %#v, want only t1 resolved", github.resolveCalls)
 	}
-	if loopErr.kind != FailureRetryableAfterResume {
-		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureRetryableAfterResume)
+	if alreadyResolved(updated.ResolvedComments.Items, FixItem{ID: "c2", ThreadID: "t2"}) {
+		t.Fatalf("resolved comments = %#v, want t2 to remain unresolved", updated.ResolvedComments.Items)
 	}
-	if !contains(loopErr.Error(), "PR head changed before resolving comments") {
-		t.Fatalf("error = %q, want stale-head message when verified snapshot no longer matches live comments", loopErr.Error())
-	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want none when live fix items drift", len(github.resolveCalls))
+	if updated.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
 	}
 }
 
@@ -1057,6 +994,11 @@ func TestRunResolveCommentsStepUsesRefreshedPushHeadSHA(t *testing.T) {
 		HeadRefName: "feature/fix-42",
 		BaseRefName: "main",
 		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
 	}}}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
@@ -2917,6 +2859,7 @@ type fakeGitGateway struct {
 	prepareResult  PrepareWorktreeResult
 	inspectResults []InspectHeadResult
 	inspectIndex   int
+	ancestor       map[string]bool
 	pushErrors     []error
 	pushIndex      int
 
@@ -2986,6 +2929,13 @@ func (f *fakeGitGateway) Push(_ context.Context, input PushInput) error {
 	}
 	f.pushIndex++
 	return nil
+}
+
+func (f *fakeGitGateway) IsAncestor(_ context.Context, _ string, ancestor, descendant string) (bool, error) {
+	if f.ancestor == nil {
+		return ancestor == descendant, nil
+	}
+	return f.ancestor[ancestor+"->"+descendant], nil
 }
 
 func (f *fakeGitGateway) CleanupWorktree(_ context.Context, input CleanupWorktreeInput) error {
@@ -3072,9 +3022,9 @@ func TestProcessClaimedItemRepliesToAuthorBeforeResolving(t *testing.T) {
 		viewResponses: []PullRequestDetail{
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
 		},
 	}
 	git := &fakeGitGateway{
@@ -3257,9 +3207,9 @@ func TestProcessClaimedItemUsesAgentExplanationInReplyBody(t *testing.T) {
 		viewResponses: []PullRequestDetail{
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice"}}},
 		},
 	}
 	git := &fakeGitGateway{
@@ -3423,9 +3373,9 @@ func TestProcessClaimedItemPostsRoundSummaryComment(t *testing.T) {
 		viewResponses: []PullRequestDetail{
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice", "url": "https://example/threads/t1", "path": "foo.go", "line": float64(7)}}},
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice", "url": "https://example/threads/t1", "path": "foo.go", "line": float64(7)}}},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
-			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1"},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice", "url": "https://example/threads/t1", "path": "foo.go", "line": float64(7)}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice", "url": "https://example/threads/t1", "path": "foo.go", "line": float64(7)}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix off-by-one", "author": "alice", "url": "https://example/threads/t1", "path": "foo.go", "line": float64(7)}}},
 		},
 	}
 	git := &fakeGitGateway{

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -861,8 +861,8 @@ func TestRunResolveCommentsStepRefreshesVerifiedNoPushHeadBeforeResolve(t *testi
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	if github.viewIndex != 1 {
-		t.Fatalf("github.viewIndex = %d, want single live refresh", github.viewIndex)
+	if github.viewIndex != 2 {
+		t.Fatalf("github.viewIndex = %d, want initial refresh plus pre-resolve recheck", github.viewIndex)
 	}
 	if len(github.resolveCalls) != 1 {
 		t.Fatalf("resolve calls = %d, want 1 after refreshing verified head", len(github.resolveCalls))
@@ -981,6 +981,177 @@ func TestRunResolveCommentsStepResolvesMatchingThreadsAndSkipsNewOnes(t *testing
 	}
 	if updated.ResumePolicy != "advance_from_checkpoint" {
 		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepDoesNotBackfillLegacyEvidenceFromLiveComments(t *testing.T) {
+	t.Parallel()
+
+	oldItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: normalizeThreadFingerprint("", "t1", "c1"), Summary: "please fix"}}
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "new-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}, {
+			"id":       "c2",
+			"threadId": "t2",
+			"body":     "new follow-up",
+		}},
+	}}}
+	runner := New(Options{GitHub: github})
+	checkpoint := fixerCheckpoint{
+		FixItems:         oldItems,
+		FixItemsHash:     hashFixItems(oldItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
+		Push:             &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "new-head", Evidence: &fixEvidence{Valid: true, HeadSHA: "new-head", FixItemsHash: hashFixItems(oldItems), ProducedNewCommits: true}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}, WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 when legacy evidence has no safe per-thread records", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || len(updated.ResolvedComments.Items) != 2 {
+		t.Fatalf("resolved comments = %#v, want both live threads marked without evidence", updated.ResolvedComments)
+	}
+}
+
+func TestRunResolveCommentsStepSkipsSameThreadWhenFingerprintChanged(t *testing.T) {
+	t.Parallel()
+
+	liveFingerprint := "latest=reply-2|updated=2026-04-11T12:05:00Z|count=2"
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":                "c1",
+			"threadId":          "t1",
+			"threadFingerprint": liveFingerprint,
+			"body":              "please fix",
+		}},
+	}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "latest=comment-1|updated=2026-04-11T12:00:00Z|count=1", Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"threadFingerprint\":\"latest=comment-1|updated=2026-04-11T12:00:00Z|count=1\",\"commitSha\":\"fix-head\"}]}}", fixItemsHash)
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: fixItemsHash, Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: &loopMetadata}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 after same-thread drift", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_no_evidence" {
+		t.Fatalf("resolved comments = %#v, want skipped_no_evidence after fingerprint drift", updated.ResolvedComments)
+	}
+}
+
+func TestRunResolveCommentsStepSkipsDuplicateReplyWhenMarkerAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	marker := fixerReplyMarker("t1", "fix-head")
+	github := &fakeGitHubGateway{
+		viewResponses: []PullRequestDetail{{
+			Number:      42,
+			State:       "OPEN",
+			HeadSHA:     "fix-head",
+			HeadRefName: "feature/fix-42",
+			BaseRefName: "main",
+			BaseSHA:     "base-1",
+			Comments:    []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}},
+		}, {
+			Number:      42,
+			State:       "OPEN",
+			HeadSHA:     "fix-head",
+			HeadRefName: "feature/fix-42",
+			BaseRefName: "main",
+			BaseSHA:     "base-1",
+			Comments:    []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}},
+		}},
+		threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}, {ID: "reply-1", Body: "already replied\n\n" + marker}}}},
+	}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: normalizeThreadFingerprint("", "t1", "c1"), Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"threadFingerprint\":%q,\"commitSha\":\"fix-head\"}]}}", fixItemsHash, normalizeThreadFingerprint("", "t1", "c1"))
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: fixItemsHash, Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+
+	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: &loopMetadata}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if len(github.replyCalls) != 0 {
+		t.Fatalf("reply calls = %d, want 0 when marker already exists remotely", len(github.replyCalls))
+	}
+	if len(github.resolveCalls) != 1 {
+		t.Fatalf("resolve calls = %d, want 1 after deduped reply", len(github.resolveCalls))
+	}
+}
+
+func TestRunResolveCommentsStepFailsWhenThreadChangesAfterReply(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":                "c1",
+			"threadId":          "t1",
+			"threadFingerprint": "latest=comment-1|updated=2026-04-11T12:00:00Z|count=1",
+			"body":              "please fix",
+		}},
+	}, {
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":                "c1",
+			"threadId":          "t1",
+			"threadFingerprint": "latest=comment-2|updated=2026-04-11T12:01:00Z|count=2",
+			"body":              "please fix",
+		}},
+	}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "latest=comment-1|updated=2026-04-11T12:00:00Z|count=1", Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"threadFingerprint\":\"latest=comment-1|updated=2026-04-11T12:00:00Z|count=1\",\"commitSha\":\"fix-head\"}]}}", fixItemsHash)
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: fixItemsHash, Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: &loopMetadata}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err == nil || !strings.Contains(err.Error(), "Failed to resolve 1 review thread") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want stale-state retry failure", err)
+	}
+	if len(github.replyCalls) != 1 {
+		t.Fatalf("reply calls = %d, want 1 before stale recheck aborts resolve", len(github.replyCalls))
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 after stale recheck", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "stale_state" {
+		t.Fatalf("resolved comments = %#v, want stale_state marker", updated.ResolvedComments)
 	}
 }
 
@@ -2754,6 +2925,7 @@ type fakeGitHubGateway struct {
 	listOpenByLabel       map[string][]PullRequestSummary
 	listCalls             []ListOpenPullRequestsInput
 	viewResponses         []PullRequestDetail
+	threads               []ReviewThread
 	viewIndex             int
 	resolveCalls          []ResolveReviewThreadInput
 	addLabelCalls         []PullRequestLabelsInput
@@ -2813,7 +2985,49 @@ func (f *fakeGitHubGateway) ViewPullRequest(_ context.Context, input ViewPullReq
 	if result.Author == "" {
 		result.Author = firstNonEmpty(f.currentUser, "looper")
 	}
+	for i := range result.Comments {
+		if _, ok := stringFromAny(result.Comments[i]["threadFingerprint"]); ok {
+			continue
+		}
+		threadID, _ := stringFromAny(result.Comments[i]["threadId"])
+		commentID, _ := stringFromAny(result.Comments[i]["id"])
+		result.Comments[i]["threadFingerprint"] = normalizeThreadFingerprint("", threadID, commentID)
+	}
 	return result, nil
+}
+
+func (f *fakeGitHubGateway) ListReviewThreads(_ context.Context, _ ListReviewThreadsInput) ([]ReviewThread, error) {
+	if f.threads != nil {
+		return append([]ReviewThread(nil), f.threads...), nil
+	}
+	threads := make([]ReviewThread, 0)
+	if f.viewIndex == 0 || len(f.viewResponses) == 0 {
+		return threads, nil
+	}
+	idx := f.viewIndex - 1
+	if idx >= len(f.viewResponses) {
+		idx = len(f.viewResponses) - 1
+	}
+	for _, comment := range f.viewResponses[idx].Comments {
+		threadID, _ := stringFromAny(comment["threadId"])
+		commentID, _ := stringFromAny(comment["id"])
+		body, _ := stringFromAny(comment["body"])
+		if threadID == "" {
+			threadID = commentID
+		}
+		threads = append(threads, ReviewThread{ID: threadID, Comments: []ReviewThreadComment{{ID: commentID, Body: body}}})
+	}
+	return threads, nil
+}
+
+func (f *fakeGitHubGateway) ViewReviewThread(_ context.Context, input ViewReviewThreadInput) (ReviewThread, error) {
+	threads, _ := f.ListReviewThreads(context.Background(), ListReviewThreadsInput{})
+	for _, thread := range threads {
+		if thread.ID == input.ThreadID {
+			return thread, nil
+		}
+	}
+	return ReviewThread{ID: input.ThreadID}, nil
 }
 
 func (f *fakeGitHubGateway) ResolveReviewThread(_ context.Context, input ResolveReviewThreadInput) error {
@@ -2823,6 +3037,12 @@ func (f *fakeGitHubGateway) ResolveReviewThread(_ context.Context, input Resolve
 
 func (f *fakeGitHubGateway) AddReviewThreadReply(_ context.Context, input AddReviewThreadReplyInput) error {
 	f.replyCalls = append(f.replyCalls, input)
+	for i := range f.threads {
+		if f.threads[i].ID == input.ThreadID {
+			f.threads[i].Comments = append(f.threads[i].Comments, ReviewThreadComment{ID: fmt.Sprintf("reply-%d", len(f.replyCalls)), Body: input.Body})
+			return f.replyErr
+		}
+	}
 	return f.replyErr
 }
 
@@ -2860,6 +3080,7 @@ type fakeGitGateway struct {
 	inspectResults []InspectHeadResult
 	inspectIndex   int
 	ancestor       map[string]bool
+	fetchErr       error
 	pushErrors     []error
 	pushIndex      int
 
@@ -2868,6 +3089,7 @@ type fakeGitGateway struct {
 	inspectCalls []InspectHeadInput
 	commitCalls  []CommitInput
 	pushCalls    []PushInput
+	fetchCalls   []string
 	cleanupCalls []CleanupWorktreeInput
 }
 
@@ -2929,6 +3151,11 @@ func (f *fakeGitGateway) Push(_ context.Context, input PushInput) error {
 	}
 	f.pushIndex++
 	return nil
+}
+
+func (f *fakeGitGateway) FetchBranch(_ context.Context, repoPath, remote, branch string) error {
+	f.fetchCalls = append(f.fetchCalls, repoPath+"|"+remote+"|"+branch)
+	return f.fetchErr
 }
 
 func (f *fakeGitGateway) IsAncestor(_ context.Context, _ string, ancestor, descendant string) (bool, error) {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1327,7 +1327,7 @@ func TestRunResolveCommentsStepIgnoresForkBranchFetchFailureDuringEvidenceVerifi
 			"body":     "please fix",
 		}},
 	}}}
-	git := &fakeGitGateway{fetchErr: errors.New("remote ref not found"), ancestor: map[string]bool{"old-head->new-head": true}}
+	git := &fakeGitGateway{fetchErrors: []error{errors.New("remote ref not found"), nil}, ancestor: map[string]bool{"old-head->new-head": true}}
 	runner := New(Options{GitHub: github, Git: git})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
 	fixItemsHash := hashFixItems(fixItems)
@@ -1354,8 +1354,14 @@ func TestRunResolveCommentsStepIgnoresForkBranchFetchFailureDuringEvidenceVerifi
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	if len(git.fetchCalls) != 2 {
-		t.Fatalf("fetch calls = %d, want 2", len(git.fetchCalls))
+	if len(git.fetchCalls) < 2 {
+		t.Fatalf("fetch calls = %d, want at least 2", len(git.fetchCalls))
+	}
+	if !strings.HasSuffix(git.fetchCalls[0], "|fork-owner:feature/fix-42") {
+		t.Fatalf("first fetch = %q, want fork branch fetch", git.fetchCalls[0])
+	}
+	if !strings.HasSuffix(git.fetchCalls[1], "|new-head") {
+		t.Fatalf("second fetch = %q, want head SHA fetch", git.fetchCalls[1])
 	}
 	if len(github.resolveCalls) != 1 {
 		t.Fatalf("resolve calls = %d, want 1", len(github.resolveCalls))
@@ -3237,6 +3243,8 @@ type fakeGitGateway struct {
 	inspectResults []InspectHeadResult
 	inspectIndex   int
 	ancestor       map[string]bool
+	fetchErrors    []error
+	fetchIndex     int
 	fetchErr       error
 	pushErrors     []error
 	pushIndex      int
@@ -3312,6 +3320,11 @@ func (f *fakeGitGateway) Push(_ context.Context, input PushInput) error {
 
 func (f *fakeGitGateway) FetchBranch(_ context.Context, repoPath, remote, branch string) error {
 	f.fetchCalls = append(f.fetchCalls, repoPath+"|"+remote+"|"+branch)
+	if f.fetchIndex < len(f.fetchErrors) {
+		err := f.fetchErrors[f.fetchIndex]
+		f.fetchIndex++
+		return err
+	}
 	return f.fetchErr
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1153,6 +1153,109 @@ func TestRunResolveCommentsStepFailsWhenThreadChangesAfterReply(t *testing.T) {
 	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "stale_state" {
 		t.Fatalf("resolved comments = %#v, want stale_state marker", updated.ResolvedComments)
 	}
+	if updated.ResumePolicy != "restart_from_discover" {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepRequestsRediscoveryWhenVerifiedEvidenceIsStale(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "new-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	checkpoint := fixerCheckpoint{
+		FixItems:     fixItems,
+		FixItemsHash: fixItemsHash,
+		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "old-head"},
+		Push:         &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "old-head"},
+		Lifecycle:    &lifecycle.State{Pushed: true},
+		ReconcileCommits: &checkpointReconcileCommits{
+			BaseHeadSHA:      "base-head",
+			FinalHeadSHA:     "old-head",
+			NewCommitSHAs:    []string{"old-head"},
+			WorkingTreeClean: true,
+		},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err == nil || !strings.Contains(err.Error(), "verified fix evidence is missing or stale") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want stale-evidence retry failure", err)
+	}
+	if updated.ResumePolicy != "restart_from_discover" {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 when evidence is stale", len(github.resolveCalls))
+	}
+}
+
+func TestRunResolveCommentsStepRequestsRediscoveryWhenValidationIsNotBoundToEvidence(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	fixItemsHash := hashFixItems(fixItems)
+	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"fix-head\"}]}}", fixItemsHash)
+	checkpoint := fixerCheckpoint{
+		FixItems:     fixItems,
+		FixItemsHash: fixItemsHash,
+		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "older-head"},
+		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		ReconcileCommits: &checkpointReconcileCommits{
+			BaseHeadSHA:      "base-head",
+			FinalHeadSHA:     "base-head",
+			WorkingTreeClean: true,
+		},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
+		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err == nil || !strings.Contains(err.Error(), "validation bound to verified fix evidence head") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want validation/evidence mismatch failure", err)
+	}
+	if updated.ResumePolicy != "restart_from_discover" {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 when validation is stale", len(github.resolveCalls))
+	}
 }
 
 func TestRunResolveCommentsStepUsesRefreshedPushHeadSHA(t *testing.T) {

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -737,6 +737,18 @@ func (g *Gateway) IsAncestor(ctx context.Context, repoPath, ancestor, descendant
 	return g.isAncestor(ctx, repoPath, ancestor, descendant)
 }
 
+func (g *Gateway) FetchBranch(ctx context.Context, repoPath, remote, branch string) error {
+	remote = strings.TrimSpace(remote)
+	branch = strings.TrimSpace(branch)
+	if remote == "" {
+		remote = "origin"
+	}
+	if branch == "" {
+		return fmt.Errorf("branch is required")
+	}
+	return g.runGit(ctx, repoPath, nil, "fetch", remote, branch)
+}
+
 func (g *Gateway) isAncestor(ctx context.Context, repoPath, ancestor, descendant string) (bool, error) {
 	_, err := g.runGitResult(ctx, repoPath, nil, "merge-base", "--is-ancestor", ancestor, descendant)
 	if err == nil {

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -733,6 +733,10 @@ func (g *Gateway) hasRemote(ctx context.Context, repoPath, remote string) (bool,
 	return false, err
 }
 
+func (g *Gateway) IsAncestor(ctx context.Context, repoPath, ancestor, descendant string) (bool, error) {
+	return g.isAncestor(ctx, repoPath, ancestor, descendant)
+}
+
 func (g *Gateway) isAncestor(ctx context.Context, repoPath, ancestor, descendant string) (bool, error) {
 	_, err := g.runGitResult(ctx, repoPath, nil, "merge-base", "--is-ancestor", ancestor, descendant)
 	if err == nil {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -301,6 +301,11 @@ type ListReviewThreadsInput struct {
 	Limit    int
 }
 
+type ViewReviewThreadInput struct {
+	ThreadID string
+	CWD      string
+}
+
 type ReviewThread struct {
 	ID         string
 	IsResolved bool
@@ -780,6 +785,30 @@ func (g *Gateway) ResolveReviewThread(ctx context.Context, input ResolveReviewTh
 		return fmt.Errorf("failed to resolve review thread %s", input.ThreadID)
 	}
 	return nil
+}
+
+func (g *Gateway) ViewReviewThread(ctx context.Context, input ViewReviewThreadInput) (ReviewThread, error) {
+	thread, err := g.getReviewThread(ctx, input.ThreadID, input.CWD)
+	if err != nil {
+		return ReviewThread{}, err
+	}
+	if thread == nil {
+		return ReviewThread{}, nil
+	}
+	out := ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved}
+	cursor := ""
+	for {
+		nodes, nextCursor, hasNextPage, err := g.fetchReviewThreadCommentsPage(ctx, input.CWD, input.ThreadID, cursor)
+		if err != nil {
+			return ReviewThread{}, err
+		}
+		out.Comments = appendReviewThreadComments(out.Comments, nodes)
+		if !hasNextPage {
+			break
+		}
+		cursor = nextCursor
+	}
+	return out, nil
 }
 
 func (g *Gateway) ListReviewThreads(ctx context.Context, input ListReviewThreadsInput) ([]ReviewThread, error) {
@@ -1648,6 +1677,25 @@ func (g *Gateway) fetchReviewThreads(ctx context.Context, repo string, prNumber 
 		for _, node := range nodes {
 			normalized, ok := normalizeReviewThread(node)
 			if ok {
+				threadRow, _ := node.(map[string]any)
+				commentsRow, _ := threadRow["comments"].(map[string]any)
+				commentNodes, _ := commentsRow["nodes"].([]any)
+				pageInfo, _ := commentsRow["pageInfo"].(map[string]any)
+				commentCursor := asString(pageInfo["endCursor"])
+				hasMoreComments := asBool(pageInfo["hasNextPage"])
+				allCommentNodes := append([]any(nil), commentNodes...)
+				for hasMoreComments {
+					moreComments, nextCommentCursor, hasMore, err := g.fetchReviewThreadCommentsPage(ctx, cwd, asString(normalized["threadId"]), commentCursor)
+					if err != nil {
+						return nil, err
+					}
+					allCommentNodes = append(allCommentNodes, moreComments...)
+					commentCursor = nextCommentCursor
+					hasMoreComments = hasMore
+				}
+				if fingerprint := reviewThreadFingerprintFromNodes(allCommentNodes); fingerprint != "" {
+					normalized["threadFingerprint"] = fingerprint
+				}
 				out = append(out, normalized)
 			}
 		}
@@ -1704,8 +1752,9 @@ func (g *Gateway) fetchReviewThreadsSummaryPage(ctx context.Context, cwd, owner,
 		"          isResolved",
 		"          path",
 		"          line",
-		"          comments(first: 1) {",
-		"            nodes { id body url path line author { login } }",
+		"          comments(first: 100) {",
+		"            nodes { id body updatedAt url path line author { login } }",
+		"            pageInfo { hasNextPage endCursor }",
 		"          }",
 		"        }",
 		"        pageInfo { hasNextPage endCursor }",
@@ -1997,7 +2046,33 @@ func normalizeReviewThread(value any) (map[string]any, bool) {
 	} else if line := asInt64(row["line"]); line > 0 {
 		out["line"] = line
 	}
+	if fingerprint := reviewThreadFingerprintFromNodes(nodes); fingerprint != "" {
+		out["threadFingerprint"] = fingerprint
+	}
 	return out, true
+}
+
+func reviewThreadFingerprintFromNodes(nodes []any) string {
+	parts := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		comment, _ := node.(map[string]any)
+		if comment == nil {
+			continue
+		}
+		if strings.Contains(asString(comment["body"]), "<!-- looper-fixer-reply ") {
+			continue
+		}
+		id := strings.TrimSpace(asString(comment["id"]))
+		updatedAt := strings.TrimSpace(asString(comment["updatedAt"]))
+		if id == "" && updatedAt == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s@%s", id, updatedAt))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "|")
 }
 
 func validateCloseIssueStateReason(value string) (string, error) {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -430,6 +430,34 @@ func (a fixerGitHubAdapter) ViewPullRequest(ctx context.Context, input fixer.Vie
 	return fixer.PullRequestDetail{Number: detail.Number, State: detail.State, IsDraft: detail.IsDraft, Labels: detail.Labels, HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: detail.Comments, IssueComments: detail.IssueComments, Checks: detail.Checks, HasConflicts: detail.HasConflicts, Author: detail.Author}, nil
 }
 
+func (a fixerGitHubAdapter) ListReviewThreads(ctx context.Context, input fixer.ListReviewThreadsInput) ([]fixer.ReviewThread, error) {
+	threads, err := a.gateway.ListReviewThreads(ctx, githubinfra.ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, Limit: input.Limit})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]fixer.ReviewThread, 0, len(threads))
+	for _, thread := range threads {
+		comments := make([]fixer.ReviewThreadComment, 0, len(thread.Comments))
+		for _, comment := range thread.Comments {
+			comments = append(comments, fixer.ReviewThreadComment{ID: comment.ID, Body: comment.Body})
+		}
+		out = append(out, fixer.ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved, Comments: comments})
+	}
+	return out, nil
+}
+
+func (a fixerGitHubAdapter) ViewReviewThread(ctx context.Context, input fixer.ViewReviewThreadInput) (fixer.ReviewThread, error) {
+	thread, err := a.gateway.ViewReviewThread(ctx, githubinfra.ViewReviewThreadInput{ThreadID: input.ThreadID, CWD: input.CWD})
+	if err != nil {
+		return fixer.ReviewThread{}, err
+	}
+	comments := make([]fixer.ReviewThreadComment, 0, len(thread.Comments))
+	for _, comment := range thread.Comments {
+		comments = append(comments, fixer.ReviewThreadComment{ID: comment.ID, Body: comment.Body})
+	}
+	return fixer.ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved, Comments: comments}, nil
+}
+
 func (a fixerGitHubAdapter) ResolveReviewThread(ctx context.Context, input fixer.ResolveReviewThreadInput) error {
 	return a.gateway.ResolveReviewThread(ctx, githubinfra.ResolveReviewThreadInput{Repo: input.Repo, ThreadID: input.ThreadID, CWD: input.CWD})
 }
@@ -501,6 +529,10 @@ func (a fixerGitAdapter) Commit(ctx context.Context, input fixer.CommitInput) (f
 
 func (a fixerGitAdapter) Push(ctx context.Context, input fixer.PushInput) error {
 	return a.gateway.Push(ctx, gitinfra.PushInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ExpectedRemoteHeadSHA: input.ExpectedRemoteHeadSHA, ProtectedBranches: input.ProtectedBranches})
+}
+
+func (a fixerGitAdapter) FetchBranch(ctx context.Context, repoPath, remote, branch string) error {
+	return a.gateway.FetchBranch(ctx, repoPath, remote, branch)
 }
 
 func (a fixerGitAdapter) IsAncestor(ctx context.Context, repoPath, ancestor, descendant string) (bool, error) {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -503,6 +503,10 @@ func (a fixerGitAdapter) Push(ctx context.Context, input fixer.PushInput) error 
 	return a.gateway.Push(ctx, gitinfra.PushInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ExpectedRemoteHeadSHA: input.ExpectedRemoteHeadSHA, ProtectedBranches: input.ProtectedBranches})
 }
 
+func (a fixerGitAdapter) IsAncestor(ctx context.Context, repoPath, ancestor, descendant string) (bool, error) {
+	return a.gateway.IsAncestor(ctx, repoPath, ancestor, descendant)
+}
+
 func (a fixerGitAdapter) CleanupWorktree(ctx context.Context, input fixer.CleanupWorktreeInput) error {
 	return a.gateway.CleanupWorktree(ctx, gitinfra.CleanupWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, ProtectedBranches: input.ProtectedBranches})
 }


### PR DESCRIPTION
## Summary
- persist per-thread fixer evidence so pushed fixes can still auto-reply and resolve matching inline threads on later reruns
- verify pushed fix commits by ancestry instead of exact PR head equality, and require reply success before resolving threads
- skip unmatched new feedback without requeue loops and add coverage for no-push reruns, descendant heads, and thread-level matching