### PR TITLE
fix: align loop pause usage with supported arguments

### DIFF
--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -270,19 +270,14 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				short:           "Loop commands",
 				helpSubcommands: []helpSubcommand{{name: "list", description: "List loops"}, {name: "start", description: "Start a loop"}, {name: "pause", description: "Pause a loop"}},
 				helpWhenNoArgs:  true,
-				persistentFlags: []flagSpec{
-					stringFlag("id", "id", "Loop id"),
-					stringFlag("type", "type", "Loop type"),
-					stringFlag("pr", "repo#number", "Pull request reference"),
-				},
 				exampleLines: []string{
 					"$ looper loop list",
 					"$ looper loop start --type reviewer --pr acme/looper#42",
 				},
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "list", short: "List loops", runE: runtime.loopList}),
-					newCommand(commandSpec{use: "start", short: "Start a loop", runE: runtime.loopStart, localFlags: []flagSpec{stringFlag("project", "projectId", "Project id")}}),
-					newCommand(commandSpec{use: "pause", short: "Pause a loop", args: cobra.MaximumNArgs(1), runE: runtime.loopPause}),
+					newCommand(commandSpec{use: "start", short: "Start a loop", runE: runtime.loopStart, localFlags: []flagSpec{stringFlag("type", "type", "Loop type"), stringFlag("pr", "repo#number", "Pull request reference"), stringFlag("project", "projectId", "Project id")}}),
+					newCommand(commandSpec{use: "pause [id]", short: "Pause a loop", args: cobra.MaximumNArgs(1), runE: runtime.loopPause, localFlags: []flagSpec{stringFlag("id", "id", "Loop id")}}),
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -2271,6 +2271,85 @@ func TestLoopStartRequiresExplicitProjectWhenRepoMatchesMultipleProjects(t *test
 	}
 }
 
+func TestLoopPauseHelpOnlyShowsSupportedIDForms(t *testing.T) {
+	t.Parallel()
+
+	exitCode, stdout, stderr := runApp(t, "loop", "pause", "--help")
+	if exitCode != 0 {
+		t.Fatalf("Run([loop pause --help]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([loop pause --help]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Usage:\n  looper loop pause [id]", "--id <id>"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([loop pause --help]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+	for _, unwanted := range []string{"--type <type>", "--pr <repo#number>"} {
+		if strings.Contains(stdout, unwanted) {
+			t.Fatalf("Run([loop pause --help]) stdout = %q, want not to contain %q", stdout, unwanted)
+		}
+	}
+}
+
+func TestLoopPauseRequiresID(t *testing.T) {
+	t.Parallel()
+
+	exitCode, stdout, stderr := runApp(t, "loop", "pause")
+	if exitCode == 0 {
+		t.Fatalf("Run([loop pause]) exit code = %d, want non-zero", exitCode)
+	}
+	if stdout != "" {
+		t.Fatalf("Run([loop pause]) stdout = %q, want empty string", stdout)
+	}
+	if !strings.Contains(stderr, "loop pause requires [id] or --id <id>") {
+		t.Fatalf("Run([loop pause]) stderr = %q, want missing id error", stderr)
+	}
+}
+
+func TestLoopPauseAcceptsPositionalAndFlagID(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		wantPath string
+	}{
+		{name: "positional", args: []string{"loop", "pause", "loop_123"}, wantPath: "/api/v1/loops/loop_123/pause"},
+		{name: "flag", args: []string{"loop", "pause", "--id", "loop_456"}, wantPath: "/api/v1/loops/loop_456/pause"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got, want := r.Method, http.MethodPost; got != want {
+					t.Fatalf("request method = %q, want %q", got, want)
+				}
+				if got, want := r.URL.Path, tc.wantPath; got != want {
+					t.Fatalf("request path = %q, want %q", got, want)
+				}
+				writeEnvelope(t, w, pkgapi.Success("req_loop_pause", map[string]any{"id": strings.TrimSuffix(strings.TrimPrefix(tc.wantPath, "/api/v1/loops/"), "/pause"), "status": "paused"}))
+			}))
+			defer server.Close()
+
+			configPath := writeCLIConfig(t, server.URL, "")
+			args := append(tc.args, "--config", configPath)
+			exitCode, stdout, stderr := runApp(t, args...)
+			if exitCode != 0 {
+				t.Fatalf("Run(%v) exit code = %d, want 0", args, exitCode)
+			}
+			if stderr != "" {
+				t.Fatalf("Run(%v) stderr = %q, want empty string", args, stderr)
+			}
+			if !strings.Contains(stdout, "Loop paused") {
+				t.Fatalf("Run(%v) stdout = %q, want pause success output", args, stdout)
+			}
+		})
+	}
+}
+
 func TestInProcessSmokeWorkerWorkflowSucceedsWithManualPROpeningAndMutatesWorktree(t *testing.T) {
 	repoPath := initSampleGitRepo(t)
 	runtimeRoot := t.TempDir()

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -172,7 +172,7 @@ func (r *commandRuntime) loopPause(cmd *cobra.Command, args []string) error {
 			loopID = strings.TrimSpace(args[0])
 		}
 		if loopID == "" {
-			return nil, fmt.Errorf("Usage: looper loop pause <id>")
+			return nil, fmt.Errorf("loop pause requires [id] or --id <id>")
 		}
 
 		return r.postJSON(ctx, "/api/v1/loops/"+url.PathEscape(loopID)+"/pause", nil)


### PR DESCRIPTION
## Summary
- move `loop` flags onto the subcommands that actually support them so `loop pause --help` no longer advertises unsupported `--type` and `--pr` lookups
- clarify `loop pause` usage to accept either a positional loop id or `--id`, matching the command behavior and error text
- add CLI coverage for pause help, missing-id errors, and both supported pause invocation forms

## Validation
- `gofmt -w internal/cliapp/app.go internal/cliapp/json_output.go internal/cliapp/app_test.go`
- `go test ./internal/cliapp -run 'TestLoopPause|TestLoopStartUsesExplicitProjectForPullRequestTarget|TestLoopStartRequiresExplicitProjectWhenRepoMatchesMultipleProjects'`
- `go build ./...`
- `go test ./...` *(fails in `internal/agent` on pre-existing timeout assertions: `TestExecutorResumesPersistedNativeSession`, `TestExecutorNativeResumeFailureAfterAttachDoesNotFallback`, and `TestExecutorFallsBackAfterFailedNativeResumeAttempt`)*

Closes #260