### PR TITLE
feat: add manual fixer CLI trigger

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -44,7 +44,7 @@ If no project matches the current directory, or multiple projects match, pass `-
 | --- | --- | --- |
 | `planner` | Generates a spec from an issue and opens a spec PR | `looper plan --project <id> --issue <num>` |
 | `reviewer` | Reviews a PR or spec PR and publishes GitHub reviews | `looper review <repo>#<pr> [--loop]` or `looper review <pr> [--loop]` from inside the repo |
-| `fixer` | Fixes PR issues based on review comments and tries to resolve threads | `looper loop start --type fixer --pr <repo>#<pr>` |
+| `fixer` | Fixes PR issues based on review comments and tries to resolve threads | `looper fix <repo>#<pr>` |
 | `worker` | Implements the actual work from a spec or issue, and can reuse an existing PR | `looper work --issue <num>` or `looper work --project <id> --issue <num>` |
 
 ## 4. Recommended flow
@@ -149,8 +149,16 @@ If reviewer considers the spec review clean, it will:
 The most direct way to use fixer is to start it for a specific PR:
 
 ```bash
-looper loop start --type fixer --pr owner/repo#42
+looper fix owner/repo#42
 ```
+
+If you are already inside the registered repo, you can usually use the PR number by itself:
+
+```bash
+looper fix 42
+```
+
+Use this when you want to force a repair pass on demand before waiting for any automatic fixer trigger.
 
 Fixer will:
 

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -106,7 +106,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 	root := newCommand(commandSpec{
 		use:             "looper",
 		short:           "Looper command-line interface",
-		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "prompt", description: "Prompt inspection commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "labels", description: "GitHub label commands"}, {name: "queue", description: "Queue inspection and maintenance commands"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
+		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "prompt", description: "Prompt inspection commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "labels", description: "GitHub label commands"}, {name: "queue", description: "Queue inspection and maintenance commands"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "fix", description: "Create a fixer task for a pull request"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "stop", description: "Stop an active loop"}, {name: "run", description: "Run commands"}},
 		helpWhenNoArgs:  true,
 		subcommands: []*cobra.Command{
 			newCommand(commandSpec{use: "status", short: "Show service status", runE: runtime.status}),
@@ -326,6 +326,19 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					newCommand(commandSpec{use: "list", short: "List pull requests", runE: runtime.pullRequestList}),
 					newCommand(commandSpec{use: "show", short: "Show a pull request", args: cobra.ExactArgs(1), runE: runtime.pullRequestShow}),
 					newCommand(commandSpec{use: "status", short: "Show pull request status", args: cobra.ExactArgs(1), runE: runtime.pullRequestStatus}),
+				},
+			}),
+			newCommand(commandSpec{
+				use:   "fix <pr>",
+				short: "Create a fixer task for a pull request",
+				args:  cobra.ExactArgs(1),
+				runE:  runtime.fixCreate,
+				localFlags: []flagSpec{
+					stringFlag("project", "projectId", "Project id"),
+				},
+				exampleLines: []string{
+					"$ looper fix 42",
+					"$ looper fix acme/looper#42",
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -94,6 +94,110 @@ func TestCommandGroupHelpListsExpectedSubcommands(t *testing.T) {
 	}
 }
 
+func TestFixCreateAcceptsNumericPRRefFromCurrentProject(t *testing.T) {
+	t.Parallel()
+
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", repoPath, err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			writeEnvelope(t, w, pkgapi.Success("req_projects", map[string]any{"items": []map[string]any{{"id": "project_1", "name": "Looper", "repoPath": repoPath, "repo": "acme/looper", "updatedAt": "2026-04-20T10:00:00.000Z"}}}))
+		case "/api/v1/loops":
+			if got, want := r.Method, http.MethodPost; got != want {
+				t.Fatalf("request method = %q, want %q", got, want)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got, want := body["projectId"], "project_1"; got != want {
+				t.Fatalf("body.projectId = %#v, want %#v", got, want)
+			}
+			if got, want := body["type"], "fixer"; got != want {
+				t.Fatalf("body.type = %#v, want %#v", got, want)
+			}
+			if got, want := body["repo"], "acme/looper"; got != want {
+				t.Fatalf("body.repo = %#v, want %#v", got, want)
+			}
+			if got, want := body["prNumber"], float64(123); got != want {
+				t.Fatalf("body.prNumber = %#v, want %#v", got, want)
+			}
+			writeEnvelope(t, w, pkgapi.Success("req_loop", map[string]any{"id": "loop_fix_1", "projectId": "project_1", "repo": "acme/looper", "prNumber": 123, "status": "queued"}))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		Getwd: func() (string, error) {
+			return repoPath, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"fix", "123", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([fix 123]) exit code = %d, want 0", exitCode)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("Run([fix 123]) stderr = %q, want empty string", got)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Fixer started") || !strings.Contains(got, "acme/looper#123") {
+		t.Fatalf("Run([fix 123]) stdout = %q, want fixer summary for %q", got, "acme/looper#123")
+	}
+}
+
+func TestFixCreateRequiresExplicitProjectWhenCurrentProjectIsAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	rootPath := t.TempDir()
+	repoPath := filepath.Join(rootPath, "repo")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", repoPath, err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			writeEnvelope(t, w, pkgapi.Success("req_projects", map[string]any{"items": []map[string]any{{"id": "project_1", "name": "Looper A", "repoPath": repoPath, "repo": "acme/looper", "updatedAt": "2026-04-20T10:00:00.000Z"}, {"id": "project_2", "name": "Looper B", "repoPath": repoPath, "repo": "acme/looper", "updatedAt": "2026-04-20T10:01:00.000Z"}}}))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		Getwd: func() (string, error) {
+			return repoPath, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"fix", "123", "--config", configPath})
+	if exitCode == 0 {
+		t.Fatalf("Run([fix 123]) exit code = 0, want non-zero")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("Run([fix 123]) stdout = %q, want empty string", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "--project is required") {
+		t.Fatalf("Run([fix 123]) stderr = %q, want to contain %q", got, "--project is required")
+	}
+}
+
 func TestLabelsInitDryRunPrintsPlannedChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -324,6 +324,15 @@ func writeHumanReviewCreate(w io.Writer, payload json.RawMessage, loopSetting st
 	return nil
 }
 
+func writeHumanFixCreate(w io.Writer, payload json.RawMessage) error {
+	var data loopOutput
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return fmt.Errorf("decode fixer response: %w", err)
+	}
+	printSection(w, "Fixer started", [][2]any{{"id", data.ID}, {"projectId", data.ProjectID}, {"pr", formatPullRequestRef(data.Repo, data.PRNumber)}, {"status", data.Status}})
+	return nil
+}
+
 func writeHumanActiveRuns(w io.Writer, payload json.RawMessage) error {
 	var data activeRunsOutput
 	if err := json.Unmarshal(payload, &data); err != nil {

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -263,6 +263,26 @@ func (r *commandRuntime) reviewCreate(cmd *cobra.Command, args []string) error {
 	})
 }
 
+func (r *commandRuntime) fixCreate(cmd *cobra.Command, args []string) error {
+	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
+		projectID, repo, prNumber, err := r.resolveReviewTarget(ctx, strings.TrimSpace(args[0]), strings.TrimSpace(getStringFlag(cmd, "project")))
+		if err != nil {
+			return nil, err
+		}
+
+		body := map[string]any{
+			"projectId":  projectID,
+			"type":       "fixer",
+			"targetType": "pull_request",
+			"repo":       repo,
+			"prNumber":   prNumber,
+			"status":     "running",
+		}
+
+		return r.postJSON(ctx, "/api/v1/loops", body)
+	}, writeHumanFixCreate)
+}
+
 func (r *commandRuntime) jump(cmd *cobra.Command, args []string) error {
 	shell := strings.TrimSpace(getStringFlag(cmd, "shell-integration"))
 	if shell != "" {

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -20,6 +20,7 @@ Subcommands:
   plan       Create a planner run
   pr         Pull request commands
   review     Create a reviewer task for a pull request
+  fix        Create a fixer task for a pull request
   feedback   Submit feedback as a GitHub issue
   ps         Show running loops
   jump       Print shell command for a loop worktree

--- a/skills/looper/references/cli.md
+++ b/skills/looper/references/cli.md
@@ -101,6 +101,15 @@ looper jump <id>
 looper stop <id>
 ```
 
+Manual fixer trigger:
+
+```bash
+looper fix owner/repo#42
+looper fix 42
+```
+
+Use `looper fix` when you want to trigger the fixer pipeline for a specific pull request on demand instead of waiting for automatic pickup.
+
 Upgrade commands:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a dedicated `looper fix <pr>` CLI command that enqueues a manual fixer run using the existing PR/project resolution flow
- add human-facing output and CLI coverage for numeric PR refs from the current repo plus ambiguous-project failures
- document when to use `looper fix` in the user guide and Looper CLI reference

## Testing
- `go test ./internal/cliapp/...`
- `go build ./...`
- `go vet ./...`
- `go test ./...` *(fails in pre-existing `internal/agent` resume tests: `TestExecutorFallsBackAfterFailedNativeResumeAttempt`, `TestExecutorResumesPersistedNativeSession`, `TestExecutorNativeResumeFailureAfterAttachDoesNotFallback`)*

Closes #257