### PR TITLE
feat: improve auto-upgrade UX with background downloads

### DIFF
--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -91,6 +91,7 @@ type flagSpec struct {
 	valueName   string
 	description string
 	kind        flagKind
+	hidden      bool
 }
 
 type flagKind int
@@ -221,6 +222,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					boolFlag("check", "Check available CLI and daemon updates"),
 					boolFlag("cli", "Upgrade the looper CLI binary when self-upgrade is allowed"),
 					boolFlag("daemon", "Install or upgrade the managed daemon binary"),
+					hiddenBoolFlag("background-auto", "Run the auto-upgrade worker in the background"),
 				},
 				exampleLines: []string{
 					"$ looper upgrade --check",
@@ -489,11 +491,18 @@ func addFlags(flagSet *pflag.FlagSet, flags []flagSpec) {
 		if defined != nil && flag.valueName != "" {
 			defined.Annotations = map[string][]string{"looperValueName": {flag.valueName}}
 		}
+		if defined != nil {
+			defined.Hidden = flag.hidden
+		}
 	}
 }
 
 func boolFlag(name, description string) flagSpec {
 	return flagSpec{name: name, description: description, kind: flagKindBool}
+}
+
+func hiddenBoolFlag(name, description string) flagSpec {
+	return flagSpec{name: name, description: description, kind: flagKindBool, hidden: true}
 }
 
 func stringFlag(name, valueName, description string) flagSpec {

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -502,7 +502,11 @@ func (r *commandRuntime) daemonRestart(cmd *cobra.Command, args []string) error 
 	}
 
 	r.skipAPIStartProbe = stopped
-	return r.daemonStart(cmd, nil)
+	if err := r.daemonStart(cmd, nil); err != nil {
+		return err
+	}
+	_ = r.clearAutoUpgradeReadyState(cmd.Context())
+	return nil
 }
 
 func (r *commandRuntime) daemonStop(cmd *cobra.Command, args []string) error {
@@ -1243,11 +1247,16 @@ func (r *commandRuntime) spawnDetached(command string, args []string, cwd string
 	}
 	defer devNull.Close()
 
-	startupLog, err := os.OpenFile(r.startupOutputPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-	if err != nil {
-		return 0, err
+	startupLog := devNull
+	if r.startupOutputPath == "" {
+		startupLog = devNull
+	} else {
+		startupLog, err = os.OpenFile(r.startupOutputPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			return 0, err
+		}
+		defer startupLog.Close()
 	}
-	defer startupLog.Close()
 
 	cmd := exec.Command(command, args...)
 	cmd.Dir = cwd

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -437,11 +437,11 @@ func (r *commandRuntime) shouldBreakAutoUpgradeLock(path string) bool {
 	if err != nil {
 		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
 	}
-	if !r.isBackgroundAutoUpgradeProcess(process) {
+	if !r.isExpectedAutoUpgradeLockProcess(path, process) {
 		return true
 	}
 	if lock.Executable == "" || lock.Command == "" || lock.ObservedAt == "" {
-		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
+		return false
 	}
 	observedAt, err := time.Parse(time.RFC3339Nano, lock.ObservedAt)
 	if err != nil {
@@ -455,6 +455,28 @@ func (r *commandRuntime) shouldBreakAutoUpgradeLock(path string) bool {
 	}
 	earliestPossibleStart := time.Now().UTC().Add(-time.Duration(process.ElapsedSeconds+1) * time.Second)
 	return earliestPossibleStart.After(observedAt)
+}
+
+func (r *commandRuntime) isExpectedAutoUpgradeLockProcess(path string, process autoUpgradeLockProcessState) bool {
+	if process.Executable == "" || process.Command == "" {
+		return false
+	}
+	if process.Executable != r.autoUpgradeLockExecutable() {
+		return false
+	}
+	switch filepath.Base(path) {
+	case "auto-upgrade.run.lock":
+		for _, token := range splitProcessCommand(process.Command)[1:] {
+			if token == "upgrade" {
+				return true
+			}
+		}
+		return false
+	case "auto-upgrade.state.lock":
+		return true
+	default:
+		return r.isBackgroundAutoUpgradeProcess(process)
+	}
 }
 
 func parseAutoUpgradeLockState(raw []byte) (autoUpgradeLockState, bool) {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -433,6 +433,13 @@ func (r *commandRuntime) shouldBreakAutoUpgradeLock(path string) bool {
 	if !r.isProcessAlive(lock.PID) {
 		return true
 	}
+	process, err := r.readAutoUpgradeLockProcess(context.Background(), lock.PID)
+	if err != nil {
+		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
+	}
+	if !r.isBackgroundAutoUpgradeProcess(process) {
+		return true
+	}
 	if lock.Executable == "" || lock.Command == "" || lock.ObservedAt == "" {
 		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
 	}
@@ -440,11 +447,7 @@ func (r *commandRuntime) shouldBreakAutoUpgradeLock(path string) bool {
 	if err != nil {
 		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
 	}
-	process, err := r.readAutoUpgradeLockProcess(context.Background(), lock.PID)
-	if err != nil {
-		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
-	}
-	if process.Executable == "" || process.Command == "" || process.ElapsedSeconds < 0 {
+	if process.ElapsedSeconds < 0 {
 		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
 	}
 	if process.Executable != lock.Executable || process.Command != lock.Command {
@@ -503,6 +506,30 @@ func (r *commandRuntime) readAutoUpgradeLockProcess(ctx context.Context, pid int
 		return autoUpgradeLockProcessState{}, nil
 	}
 	return autoUpgradeLockProcessState{Executable: filepath.Base(tokens[0]), Command: command, ElapsedSeconds: elapsedSeconds}, nil
+}
+
+func (r *commandRuntime) isBackgroundAutoUpgradeProcess(process autoUpgradeLockProcessState) bool {
+	if process.Executable == "" || process.Command == "" {
+		return false
+	}
+	if process.Executable != r.autoUpgradeLockExecutable() {
+		return false
+	}
+	tokens := splitProcessCommand(process.Command)
+	if len(tokens) < 3 {
+		return false
+	}
+	hasUpgrade := false
+	hasBackgroundAuto := false
+	for _, token := range tokens[1:] {
+		switch token {
+		case "upgrade":
+			hasUpgrade = true
+		case "--background-auto":
+			hasBackgroundAuto = true
+		}
+	}
+	return hasUpgrade && hasBackgroundAuto
 }
 
 func (r *commandRuntime) readProcessElapsedSeconds(ctx context.Context, pid int) (int, error) {
@@ -610,7 +637,7 @@ func (r *commandRuntime) shouldClearAutoUpgradeInFlight(ctx context.Context, sta
 	if err != nil || result.ExitCode != 0 {
 		return false
 	}
-	return !strings.Contains(result.Stdout, "--background-auto")
+	return !r.isBackgroundAutoUpgradeProcess(autoUpgradeLockProcessState{Executable: r.autoUpgradeLockExecutable(), Command: result.Stdout})
 }
 
 func (r *commandRuntime) clearAutoUpgradeReadyState(ctx context.Context) error {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -385,7 +385,9 @@ func (r *commandRuntime) tryAcquireAutoUpgradeLock(path string) (func(), bool, e
 	if err != nil {
 		if os.IsExist(err) {
 			if r.shouldBreakAutoUpgradeLock(path) {
-				_ = os.Remove(path)
+				if err := os.Remove(path); err != nil {
+					return nil, false, err
+				}
 				return r.tryAcquireAutoUpgradeLock(path)
 			}
 			return func() {}, false, nil

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -48,6 +48,19 @@ type autoUpgradeReadyState struct {
 	CompletedAt           time.Time `json:"completedAt"`
 }
 
+type autoUpgradeLockState struct {
+	PID        int    `json:"pid"`
+	Executable string `json:"executable,omitempty"`
+	Command    string `json:"command,omitempty"`
+	ObservedAt string `json:"observedAt,omitempty"`
+}
+
+type autoUpgradeLockProcessState struct {
+	Executable     string
+	Command        string
+	ElapsedSeconds int
+}
+
 type upgradeCheckSummary struct {
 	CLI    upgradeCLISummary    `json:"cli"`
 	Daemon upgradeDaemonSummary `json:"daemon"`
@@ -381,25 +394,27 @@ func (r *commandRuntime) tryAcquireAutoUpgradeLock(path string) (func(), bool, e
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, false, err
 	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
-	if err != nil {
-		if os.IsExist(err) {
-			if r.shouldBreakAutoUpgradeLock(path) {
-				if err := os.Remove(path); err != nil {
-					return nil, false, err
-				}
-				return r.tryAcquireAutoUpgradeLock(path)
+	for {
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err != nil {
+			if !os.IsExist(err) {
+				return nil, false, err
 			}
-			return func() {}, false, nil
+			if !r.shouldBreakAutoUpgradeLock(path) {
+				return func() {}, false, nil
+			}
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return nil, false, err
+			}
+			continue
 		}
-		return nil, false, err
+		_ = json.NewEncoder(file).Encode(r.currentAutoUpgradeLockState())
+		unlock := func() {
+			_ = file.Close()
+			_ = os.Remove(path)
+		}
+		return unlock, true, nil
 	}
-	_, _ = fmt.Fprintf(file, "%d\n", os.Getpid())
-	unlock := func() {
-		_ = file.Close()
-		_ = os.Remove(path)
-	}
-	return unlock, true, nil
 }
 
 func (r *commandRuntime) shouldBreakAutoUpgradeLock(path string) bool {
@@ -411,11 +426,136 @@ func (r *commandRuntime) shouldBreakAutoUpgradeLock(path string) bool {
 	if err != nil {
 		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
-	if err != nil || pid <= 0 {
+	lock, ok := parseAutoUpgradeLockState(raw)
+	if !ok || lock.PID <= 0 {
 		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
 	}
-	return !r.isProcessAlive(pid)
+	if !r.isProcessAlive(lock.PID) {
+		return true
+	}
+	if lock.Executable == "" || lock.Command == "" || lock.ObservedAt == "" {
+		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, lock.ObservedAt)
+	if err != nil {
+		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
+	}
+	process, err := r.readAutoUpgradeLockProcess(context.Background(), lock.PID)
+	if err != nil {
+		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
+	}
+	if process.Executable == "" || process.Command == "" || process.ElapsedSeconds < 0 {
+		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
+	}
+	if process.Executable != lock.Executable || process.Command != lock.Command {
+		return true
+	}
+	earliestPossibleStart := time.Now().UTC().Add(-time.Duration(process.ElapsedSeconds+1) * time.Second)
+	return earliestPossibleStart.After(observedAt)
+}
+
+func parseAutoUpgradeLockState(raw []byte) (autoUpgradeLockState, bool) {
+	var lock autoUpgradeLockState
+	if err := json.Unmarshal(raw, &lock); err == nil {
+		return lock, true
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil {
+		return autoUpgradeLockState{}, false
+	}
+	return autoUpgradeLockState{PID: pid}, true
+}
+
+func (r *commandRuntime) autoUpgradeLockExecutable() string {
+	if base := filepath.Base(strings.TrimSpace(r.app.deps.ExecutablePath)); base != "" && base != "." {
+		return base
+	}
+	return "looper"
+}
+
+func (r *commandRuntime) currentAutoUpgradeLockState() autoUpgradeLockState {
+	lock := autoUpgradeLockState{PID: os.Getpid(), Executable: r.autoUpgradeLockExecutable(), ObservedAt: time.Now().UTC().Format(time.RFC3339Nano)}
+	process, err := r.readAutoUpgradeLockProcess(context.Background(), lock.PID)
+	if err != nil {
+		return lock
+	}
+	if process.Executable != "" {
+		lock.Executable = process.Executable
+	}
+	lock.Command = process.Command
+	return lock
+}
+
+func (r *commandRuntime) readAutoUpgradeLockProcess(ctx context.Context, pid int) (autoUpgradeLockProcessState, error) {
+	command, err := r.readProcessCommand(ctx, pid)
+	if err != nil {
+		return autoUpgradeLockProcessState{}, err
+	}
+	elapsedSeconds, err := r.readProcessElapsedSeconds(ctx, pid)
+	if err != nil {
+		return autoUpgradeLockProcessState{}, err
+	}
+	if command == "" {
+		return autoUpgradeLockProcessState{}, nil
+	}
+	tokens := splitProcessCommand(command)
+	if len(tokens) == 0 {
+		return autoUpgradeLockProcessState{}, nil
+	}
+	return autoUpgradeLockProcessState{Executable: filepath.Base(tokens[0]), Command: command, ElapsedSeconds: elapsedSeconds}, nil
+}
+
+func (r *commandRuntime) readProcessElapsedSeconds(ctx context.Context, pid int) (int, error) {
+	result, err := r.runCommand(ctx, "ps", []string{"-p", fmt.Sprintf("%d", pid), "-o", "etime="}, daemonCommandTimeout)
+	if err != nil {
+		return -1, fmt.Errorf("inspect process %d elapsed time with ps: %w", pid, err)
+	}
+	if result.ExitCode != 0 {
+		return -1, nil
+	}
+	elapsed, err := parsePSElapsedSeconds(strings.TrimSpace(result.Stdout))
+	if err != nil {
+		return -1, fmt.Errorf("parse process %d elapsed time %q: %w", pid, strings.TrimSpace(result.Stdout), err)
+	}
+	return elapsed, nil
+}
+
+func parsePSElapsedSeconds(raw string) (int, error) {
+	if raw == "" {
+		return 0, fmt.Errorf("empty elapsed time")
+	}
+	dayParts := strings.SplitN(raw, "-", 2)
+	days := 0
+	timePart := raw
+	if len(dayParts) == 2 {
+		parsedDays, err := strconv.Atoi(dayParts[0])
+		if err != nil {
+			return 0, err
+		}
+		days = parsedDays
+		timePart = dayParts[1]
+	}
+	parts := strings.Split(timePart, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return 0, fmt.Errorf("unexpected elapsed time format")
+	}
+	values := make([]int, len(parts))
+	for i, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return 0, err
+		}
+		values[i] = value
+	}
+	hours := 0
+	minutes := values[0]
+	seconds := values[1]
+	if len(values) == 3 {
+		hours = values[0]
+		minutes = values[1]
+		seconds = values[2]
+	}
+	return (((days*24)+hours)*60+minutes)*60 + seconds, nil
 }
 
 func (r *commandRuntime) reconcileAutoUpgradeState(ctx context.Context, state *autoUpgradeState) (*autoUpgradeState, bool, error) {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,11 +21,31 @@ import (
 const (
 	autoUpgradeStateSchemaVersion = 1
 	autoUpgradeCheckInterval      = 24 * time.Hour
+	autoUpgradeInFlightTimeout    = 30 * time.Minute
+	autoUpgradeBusyRetryDelay     = 5 * time.Minute
 )
 
 type autoUpgradeState struct {
-	SchemaVersion int        `json:"schemaVersion"`
-	LastCheckedAt *time.Time `json:"lastCheckedAt,omitempty"`
+	SchemaVersion int                       `json:"schemaVersion"`
+	LastCheckedAt *time.Time                `json:"lastCheckedAt,omitempty"`
+	RetryAfter    *time.Time                `json:"retryAfter,omitempty"`
+	InFlight      *autoUpgradeInFlightState `json:"inFlight,omitempty"`
+	Ready         *autoUpgradeReadyState    `json:"ready,omitempty"`
+}
+
+type autoUpgradeInFlightState struct {
+	PID       int        `json:"pid"`
+	StartedAt *time.Time `json:"startedAt,omitempty"`
+}
+
+type autoUpgradeReadyState struct {
+	CLIChanged            bool      `json:"cliChanged,omitempty"`
+	CLIVersion            string    `json:"cliVersion,omitempty"`
+	DaemonChanged         bool      `json:"daemonChanged,omitempty"`
+	DaemonVersion         string    `json:"daemonVersion,omitempty"`
+	DaemonRestartRequired bool      `json:"daemonRestartRequired,omitempty"`
+	RunningDaemonVersion  string    `json:"runningDaemonVersion,omitempty"`
+	CompletedAt           time.Time `json:"completedAt"`
 }
 
 type upgradeCheckSummary struct {
@@ -141,19 +162,83 @@ func (r *commandRuntime) maybeRunAutoUpgrade(cmd *cobra.Command, args []string) 
 	if err != nil {
 		return nil
 	}
+	lockPath, err := r.resolveAutoUpgradeLockPath()
+	if err != nil {
+		return nil
+	}
+	unlock, acquired, err := r.tryAcquireAutoUpgradeLock(lockPath)
+	if err != nil || !acquired {
+		return nil
+	}
+	defer unlock()
 	state, err := r.readAutoUpgradeState(statePath)
 	if err != nil {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade skipped: read state: %v\n", err)
 		return nil
 	}
-	if !shouldRunAutoUpgradeCheck(state, time.Now()) {
+	state, changed, err := r.reconcileAutoUpgradeState(cmd.Context(), state)
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade skipped: reconcile state: %v\n", err)
+		return nil
+	}
+	if changed {
+		if err := r.writeAutoUpgradeState(statePath, *state); err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade state update failed: %v\n", err)
+		}
+	}
+	if state != nil && state.Ready != nil {
+		if err := r.writeAutoUpgradeReadyNotice(cmd.ErrOrStderr(), *state.Ready); err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade notice failed: %v\n", err)
+		}
+		if !state.Ready.DaemonRestartRequired {
+			state.Ready = nil
+			if err := r.writeAutoUpgradeState(statePath, *state); err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade state update failed: %v\n", err)
+			}
+		} else {
+			return nil
+		}
+	}
+	if state != nil && state.InFlight != nil {
+		return nil
+	}
+	now := time.Now().UTC()
+	if state != nil && state.RetryAfter != nil {
+		if now.Before(*state.RetryAfter) {
+			return nil
+		}
+		state.RetryAfter = nil
+		if err := r.writeAutoUpgradeState(statePath, *state); err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade state update failed: %v\n", err)
+		}
+	}
+	if !shouldRunAutoUpgradeCheck(state, now) {
 		return nil
 	}
 
-	autoCmd := newAutoUpgradeCommand(cmd)
-	r.runAutoUpgrade(autoCmd)
-	if err := r.writeAutoUpgradeState(statePath, autoUpgradeState{LastCheckedAt: timePtr(time.Now())}); err != nil {
+	state, started, err := r.startBackgroundAutoUpgrade(cmd, state)
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade skipped: start background download: %v\n", err)
+		return nil
+	}
+	if !started {
+		return nil
+	}
+	state, err = r.persistAutoUpgradeInFlightState(statePath, *state)
+	if err != nil {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade state update failed: %v\n", err)
+		return nil
+	}
+	if state != nil && state.Ready != nil {
+		if err := r.writeAutoUpgradeReadyNotice(cmd.ErrOrStderr(), *state.Ready); err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade notice failed: %v\n", err)
+		}
+		if !state.Ready.DaemonRestartRequired {
+			state.Ready = nil
+			if err := r.writeAutoUpgradeState(statePath, *state); err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade state update failed: %v\n", err)
+			}
+		}
 	}
 	return nil
 }
@@ -184,57 +269,29 @@ func newAutoUpgradeCommand(parent *cobra.Command) *cobra.Command {
 	return cmd
 }
 
-func (r *commandRuntime) runAutoUpgrade(cmd *cobra.Command) {
-	cliOutput, cliErr := r.upgradeCLIWithOutput(cmd, false)
-	if cliErr != nil {
-		var refused *cliUpgradeRefusedError
-		if errors.As(cliErr, &refused) {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: CLI skipped: %s\n", refused.message)
-		} else {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: CLI check failed: %v\n", cliErr)
-		}
-	} else if cliOutput.Changed {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: upgraded looper %s → %s\n", cliOutput.CurrentVersion, cliOutput.LatestVersion)
-	}
-
-	managedDaemon, err := r.readManagedUpgradeDaemonVersion(cmd.Context())
+func (r *commandRuntime) startBackgroundAutoUpgrade(cmd *cobra.Command, state *autoUpgradeState) (*autoUpgradeState, bool, error) {
+	execPath, err := r.executablePath()
 	if err != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: daemon check failed: %v\n", err)
-		return
+		return state, false, err
 	}
-	if managedDaemon == nil {
-		return
+	if state == nil {
+		state = &autoUpgradeState{}
 	}
-
-	statusPayload, statusErr := r.currentDaemonStatusPayload(cmd.Context())
-	if statusErr != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: daemon status check failed: %v\n", statusErr)
-		return
+	workingDir, err := r.getwd()
+	if err != nil {
+		workingDir = ""
 	}
-	pathDaemon, pathErr := r.readPathUpgradeDaemonVersion(cmd.Context())
-	if pathErr != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: daemon path version check failed: %v\n", pathErr)
-		return
+	forwardedArgs := normalizeForwardedConfigPathArgs(ExtractConfigArgs(r.argv), workingDir)
+	args := append([]string{"upgrade", "--background-auto"}, forwardedArgs...)
+	pid, err := r.spawnDetached(execPath, args, workingDir, os.Environ())
+	if err != nil {
+		return state, false, err
 	}
-	runningDaemon := selectUpgradeDaemonVersionState(statusPayload, managedDaemon, pathDaemon)
-
-	daemonOutput, daemonErr := r.upgradeDaemonWithOutput(cmd, false)
-	if daemonErr != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: daemon check failed: %v\n", daemonErr)
-		return
-	}
-	if !daemonOutput.Changed {
-		return
-	}
-
-	if daemonOutput.PreviousVersion != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: installed looperd %s → %s\n", *daemonOutput.PreviousVersion, daemonOutput.LatestVersion)
-	} else {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: installed looperd %s\n", daemonOutput.LatestVersion)
-	}
-	if len(statusPayload) > 0 && runningDaemon != nil && runningDaemon.Source == "installed-binary" && runningDaemon.Version != daemonOutput.LatestVersion {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Auto-upgrade: looperd %s is installed on disk, but the running daemon is still %s. Run `looper daemon restart`.\n", daemonOutput.LatestVersion, runningDaemon.Version)
-	}
+	now := time.Now().UTC()
+	state.InFlight = &autoUpgradeInFlightState{PID: pid, StartedAt: &now}
+	state.RetryAfter = nil
+	state.Ready = nil
+	return state, true, nil
 }
 
 func (r *commandRuntime) resolveAutoUpgradeStatePath() (string, error) {
@@ -243,6 +300,22 @@ func (r *commandRuntime) resolveAutoUpgradeStatePath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(homeDir, ".looper", "auto-upgrade.state.json"), nil
+}
+
+func (r *commandRuntime) resolveAutoUpgradeLockPath() (string, error) {
+	homeDir, err := r.homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".looper", "auto-upgrade.state.lock"), nil
+}
+
+func (r *commandRuntime) resolveAutoUpgradeRunLockPath() (string, error) {
+	homeDir, err := r.homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".looper", "auto-upgrade.run.lock"), nil
 }
 
 func (r *commandRuntime) readAutoUpgradeState(path string) (*autoUpgradeState, error) {
@@ -284,6 +357,166 @@ func (r *commandRuntime) writeAutoUpgradeState(path string, state autoUpgradeSta
 	return nil
 }
 
+func (r *commandRuntime) persistAutoUpgradeInFlightState(path string, pending autoUpgradeState) (*autoUpgradeState, error) {
+	current, err := r.readAutoUpgradeState(path)
+	if err != nil {
+		return nil, err
+	}
+	if current != nil && current.Ready != nil && current.InFlight == nil {
+		return current, nil
+	}
+	if current != nil && current.LastCheckedAt != nil {
+		pending.LastCheckedAt = current.LastCheckedAt
+	}
+	if current != nil && current.RetryAfter != nil {
+		pending.RetryAfter = current.RetryAfter
+	}
+	if err := r.writeAutoUpgradeState(path, pending); err != nil {
+		return nil, err
+	}
+	return &pending, nil
+}
+
+func (r *commandRuntime) tryAcquireAutoUpgradeLock(path string) (func(), bool, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, false, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			if r.shouldBreakAutoUpgradeLock(path) {
+				_ = os.Remove(path)
+				return r.tryAcquireAutoUpgradeLock(path)
+			}
+			return func() {}, false, nil
+		}
+		return nil, false, err
+	}
+	_, _ = fmt.Fprintf(file, "%d\n", os.Getpid())
+	unlock := func() {
+		_ = file.Close()
+		_ = os.Remove(path)
+	}
+	return unlock, true, nil
+}
+
+func (r *commandRuntime) shouldBreakAutoUpgradeLock(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		return time.Since(info.ModTime()) >= autoUpgradeBusyRetryDelay
+	}
+	return !r.isProcessAlive(pid)
+}
+
+func (r *commandRuntime) reconcileAutoUpgradeState(ctx context.Context, state *autoUpgradeState) (*autoUpgradeState, bool, error) {
+	if state == nil {
+		return nil, false, nil
+	}
+	changed := false
+	if state.InFlight != nil && r.shouldClearAutoUpgradeInFlight(ctx, state.InFlight) {
+		state.InFlight = nil
+		changed = true
+	}
+	if state.Ready == nil {
+		return state, changed, nil
+	}
+	if !state.Ready.DaemonRestartRequired {
+		return state, changed, nil
+	}
+	managedDaemon, err := r.readManagedUpgradeDaemonVersion(ctx)
+	if err != nil {
+		return state, changed, err
+	}
+	statusPayload, err := r.currentDaemonStatusPayload(ctx)
+	if err != nil {
+		return state, changed, err
+	}
+	pathDaemon, err := r.readPathUpgradeDaemonVersion(ctx)
+	if err != nil {
+		return state, changed, err
+	}
+	runningDaemon := selectUpgradeDaemonVersionState(statusPayload, managedDaemon, pathDaemon)
+	if managedDaemon == nil || runningDaemon == nil || runningDaemon.Version == managedDaemon.Version {
+		state.Ready = nil
+		changed = true
+		return state, changed, nil
+	}
+	state.Ready.DaemonVersion = managedDaemon.Version
+	state.Ready.RunningDaemonVersion = runningDaemon.Version
+	return state, changed, nil
+}
+
+func (r *commandRuntime) shouldClearAutoUpgradeInFlight(ctx context.Context, state *autoUpgradeInFlightState) bool {
+	if state == nil {
+		return false
+	}
+	if state.PID <= 0 {
+		return true
+	}
+	if !r.isProcessAlive(state.PID) {
+		return true
+	}
+	result, err := r.runCommand(ctx, "ps", []string{"-p", fmt.Sprintf("%d", state.PID), "-o", "command="}, daemonCommandTimeout)
+	if err != nil || result.ExitCode != 0 {
+		return false
+	}
+	return !strings.Contains(result.Stdout, "--background-auto")
+}
+
+func (r *commandRuntime) clearAutoUpgradeReadyState(ctx context.Context) error {
+	statePath, err := r.resolveAutoUpgradeStatePath()
+	if err != nil {
+		return err
+	}
+	state, err := r.readAutoUpgradeState(statePath)
+	if err != nil || state == nil || state.Ready == nil {
+		return err
+	}
+	state, changed, err := r.reconcileAutoUpgradeState(ctx, state)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	return r.writeAutoUpgradeState(statePath, *state)
+}
+
+func (r *commandRuntime) writeAutoUpgradeReadyNotice(w io.Writer, ready autoUpgradeReadyState) error {
+	if ready.CLIChanged {
+		if _, err := fmt.Fprintf(w, "Auto-upgrade ready: looper %s is installed.\n", ready.CLIVersion); err != nil {
+			return err
+		}
+	}
+	if ready.DaemonChanged {
+		if ready.DaemonRestartRequired {
+			if strings.TrimSpace(ready.RunningDaemonVersion) != "" {
+				if _, err := fmt.Fprintf(w, "Auto-upgrade ready: looperd %s is installed, but the running daemon is still %s. Restart to activate it:\n", ready.DaemonVersion, ready.RunningDaemonVersion); err != nil {
+					return err
+				}
+			} else {
+				if _, err := fmt.Fprintf(w, "Auto-upgrade ready: looperd %s is installed. Restart to activate it:\n", ready.DaemonVersion); err != nil {
+					return err
+				}
+			}
+			_, err := fmt.Fprintln(w, "  looper daemon restart")
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "Auto-upgrade ready: looperd %s is installed.\n", ready.DaemonVersion); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func shouldRunAutoUpgradeCheck(state *autoUpgradeState, now time.Time) bool {
 	if state == nil || state.LastCheckedAt == nil {
 		return true
@@ -297,6 +530,9 @@ func timePtr(value time.Time) *time.Time {
 
 func (r *commandRuntime) upgrade(cmd *cobra.Command, args []string) error {
 	_ = args
+	if getBoolFlag(cmd, "background-auto") {
+		return r.runBackgroundAutoUpgrade(cmd)
+	}
 
 	check := getBoolFlag(cmd, "check")
 	cliOnly := getBoolFlag(cmd, "cli")
@@ -326,6 +562,18 @@ func (r *commandRuntime) upgrade(cmd *cobra.Command, args []string) error {
 		}
 		return writeHumanUpgradeSummary(cmd.OutOrStdout(), summary)
 	}
+	runLockPath, err := r.resolveAutoUpgradeRunLockPath()
+	if err != nil {
+		return err
+	}
+	unlock, acquired, err := r.tryAcquireAutoUpgradeLock(runLockPath)
+	if err != nil {
+		return err
+	}
+	if !acquired {
+		return fmt.Errorf("another looper upgrade is already running; try again in a moment")
+	}
+	defer unlock()
 
 	if daemonOnly {
 		return r.upgradeDaemon(cmd)
@@ -337,6 +585,96 @@ func (r *commandRuntime) upgrade(cmd *cobra.Command, args []string) error {
 	}
 
 	return r.upgradeUnified(cmd)
+}
+
+func (r *commandRuntime) runBackgroundAutoUpgrade(cmd *cobra.Command) error {
+	statePath, err := r.resolveAutoUpgradeStatePath()
+	if err != nil {
+		return err
+	}
+	state, err := r.readAutoUpgradeState(statePath)
+	if err != nil {
+		return err
+	}
+	runLockPath, err := r.resolveAutoUpgradeRunLockPath()
+	if err != nil {
+		return err
+	}
+	unlock, acquired, err := r.tryAcquireAutoUpgradeLock(runLockPath)
+	if err != nil {
+		return err
+	}
+	if !acquired {
+		if state == nil {
+			state = &autoUpgradeState{}
+		}
+		retryAfter := time.Now().UTC().Add(autoUpgradeBusyRetryDelay)
+		state.RetryAfter = &retryAfter
+		state.InFlight = nil
+		return r.writeAutoUpgradeState(statePath, *state)
+	}
+	defer unlock()
+	workerCtx, cancel := context.WithTimeout(cmd.Context(), autoUpgradeInFlightTimeout)
+	defer cancel()
+	autoCmd := newAutoUpgradeCommand(cmd)
+	autoCmd.SetContext(workerCtx)
+	ready := r.collectBackgroundAutoUpgradeResult(autoCmd)
+	if state == nil {
+		state = &autoUpgradeState{}
+	}
+	if ready == nil && state.Ready != nil && state.Ready.DaemonRestartRequired {
+		ready = state.Ready
+	}
+	now := time.Now().UTC()
+	state.LastCheckedAt = &now
+	state.RetryAfter = nil
+	state.InFlight = nil
+	state.Ready = ready
+	return r.writeAutoUpgradeState(statePath, *state)
+}
+
+func (r *commandRuntime) collectBackgroundAutoUpgradeResult(cmd *cobra.Command) *autoUpgradeReadyState {
+	ready := &autoUpgradeReadyState{CompletedAt: time.Now().UTC()}
+	cliOutput, cliErr := r.upgradeCLIWithOutput(cmd, false)
+	if cliErr == nil && cliOutput.Changed {
+		ready.CLIChanged = true
+		ready.CLIVersion = cliOutput.LatestVersion
+	}
+
+	managedDaemon, managedErr := r.readManagedUpgradeDaemonVersion(cmd.Context())
+	if managedErr != nil {
+		return autoUpgradeReadyOrNil(ready)
+	}
+	statusPayload, statusErr := r.currentDaemonStatusPayload(cmd.Context())
+	if statusErr != nil {
+		return autoUpgradeReadyOrNil(ready)
+	}
+	pathDaemon, pathErr := r.readPathUpgradeDaemonVersion(cmd.Context())
+	if pathErr != nil {
+		return autoUpgradeReadyOrNil(ready)
+	}
+	runningDaemon := selectUpgradeDaemonVersionState(statusPayload, managedDaemon, pathDaemon)
+
+	daemonOutput, daemonErr := r.upgradeDaemonWithOutput(cmd, false)
+	if daemonErr == nil && daemonOutput.Changed {
+		ready.DaemonChanged = true
+		ready.DaemonVersion = daemonOutput.LatestVersion
+		if len(statusPayload) > 0 && runningDaemon != nil && runningDaemon.Source == "installed-binary" && runningDaemon.Version != daemonOutput.LatestVersion {
+			ready.DaemonRestartRequired = true
+			ready.RunningDaemonVersion = runningDaemon.Version
+		}
+	}
+	return autoUpgradeReadyOrNil(ready)
+}
+
+func autoUpgradeReadyOrNil(ready *autoUpgradeReadyState) *autoUpgradeReadyState {
+	if ready == nil {
+		return nil
+	}
+	if !ready.CLIChanged && !ready.DaemonChanged {
+		return nil
+	}
+	return ready
 }
 
 func (r *commandRuntime) collectUpgradeCheckSummary(ctx context.Context) (upgradeCheckSummary, error) {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -787,6 +787,9 @@ func (r *commandRuntime) collectBackgroundAutoUpgradeResult(cmd *cobra.Command) 
 	if managedErr != nil {
 		return autoUpgradeReadyOrNil(ready)
 	}
+	if managedDaemon == nil {
+		return autoUpgradeReadyOrNil(ready)
+	}
 	statusPayload, statusErr := r.currentDaemonStatusPayload(cmd.Context())
 	if statusErr != nil {
 		return autoUpgradeReadyOrNil(ready)

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -446,6 +446,39 @@ func TestShouldBreakAutoUpgradeLockBreaksWhenProcessStartTimeChanges(t *testing.
 	}
 }
 
+func TestShouldBreakAutoUpgradeLockBreaksLegacyPIDLockForDifferentProcess(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	lockPath := filepath.Join(homeDir, ".looper", "auto-upgrade.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o600); err != nil {
+		t.Fatalf("WriteFile(lockPath) error = %v", err)
+	}
+
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir, RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+		_ = ctx
+		_ = timeout
+		if command != "ps" {
+			t.Fatalf("RunCommand command = %q, want ps", command)
+		}
+		switch strings.Join(args, " ") {
+		case fmt.Sprintf("-p %d -o command=", os.Getpid()):
+			return commandExecutionResult{Stdout: "/usr/bin/vim /tmp/note.txt\n", ExitCode: 0}, nil
+		case fmt.Sprintf("-p %d -o etime=", os.Getpid()):
+			return commandExecutionResult{Stdout: "0:10\n", ExitCode: 0}, nil
+		default:
+			t.Fatalf("RunCommand args = %q, want ps query for command or elapsed time", strings.Join(args, " "))
+			return commandExecutionResult{}, nil
+		}
+	}}), nil)
+	if !runtime.shouldBreakAutoUpgradeLock(lockPath) {
+		t.Fatal("shouldBreakAutoUpgradeLock() = false, want true")
+	}
+}
+
 func TestParsePSElapsedSeconds(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -318,6 +318,156 @@ func TestTryAcquireAutoUpgradeLockReturnsRemoveErrorForStaleLock(t *testing.T) {
 	}
 }
 
+func TestTryAcquireAutoUpgradeLockBreaksLegacyStaleLockWhenPIDIsReused(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	lockPath := filepath.Join(homeDir, ".looper", "auto-upgrade.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o600); err != nil {
+		t.Fatalf("WriteFile(lockPath) error = %v", err)
+	}
+	staleTime := time.Now().Add(-autoUpgradeBusyRetryDelay - time.Second)
+	if err := os.Chtimes(lockPath, staleTime, staleTime); err != nil {
+		t.Fatalf("Chtimes(lockPath) error = %v", err)
+	}
+
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir, ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper")}), nil)
+	unlock, acquired, err := runtime.tryAcquireAutoUpgradeLock(lockPath)
+	if err != nil {
+		t.Fatalf("tryAcquireAutoUpgradeLock() error = %v", err)
+	}
+	if !acquired {
+		t.Fatal("tryAcquireAutoUpgradeLock() acquired = false, want true")
+	}
+	defer unlock()
+
+	raw, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadFile(lockPath) error = %v", err)
+	}
+	lock, ok := parseAutoUpgradeLockState(raw)
+	if !ok {
+		t.Fatalf("parseAutoUpgradeLockState(lock file) = false, want true; raw=%q", string(raw))
+	}
+	if lock.PID != os.Getpid() {
+		t.Fatalf("lock.PID = %d, want %d", lock.PID, os.Getpid())
+	}
+	if lock.Executable == "" {
+		t.Fatal("lock.Executable = empty, want process metadata")
+	}
+	if lock.Command == "" {
+		t.Fatal("lock.Command = empty, want process metadata")
+	}
+	if lock.ObservedAt == "" {
+		t.Fatal("lock.ObservedAt = empty, want process metadata")
+	}
+}
+
+func TestShouldBreakAutoUpgradeLockKeepsMatchingExecutableLockActive(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	lockPath := filepath.Join(homeDir, ".looper", "auto-upgrade.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	commandLine := "/usr/local/bin/looper upgrade --background-auto"
+	observedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	raw, err := json.Marshal(autoUpgradeLockState{PID: os.Getpid(), Executable: "looper", Command: commandLine, ObservedAt: observedAt})
+	if err != nil {
+		t.Fatalf("Marshal(lock state) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile(lockPath) error = %v", err)
+	}
+	staleTime := time.Now().Add(-autoUpgradeBusyRetryDelay - time.Second)
+	if err := os.Chtimes(lockPath, staleTime, staleTime); err != nil {
+		t.Fatalf("Chtimes(lockPath) error = %v", err)
+	}
+
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir, RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+		_ = ctx
+		_ = timeout
+		if command != "ps" {
+			t.Fatalf("RunCommand command = %q, want ps", command)
+		}
+		switch strings.Join(args, " ") {
+		case fmt.Sprintf("-p %d -o command=", os.Getpid()):
+			return commandExecutionResult{Stdout: commandLine + "\n", ExitCode: 0}, nil
+		case fmt.Sprintf("-p %d -o etime=", os.Getpid()):
+			return commandExecutionResult{Stdout: "0:00\n", ExitCode: 0}, nil
+		default:
+			t.Fatalf("RunCommand args = %q, want ps query for command or elapsed time", strings.Join(args, " "))
+			return commandExecutionResult{}, nil
+		}
+	}}), nil)
+	if runtime.shouldBreakAutoUpgradeLock(lockPath) {
+		t.Fatal("shouldBreakAutoUpgradeLock() = true, want false")
+	}
+}
+
+func TestShouldBreakAutoUpgradeLockBreaksWhenProcessStartTimeChanges(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	lockPath := filepath.Join(homeDir, ".looper", "auto-upgrade.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	raw, err := json.Marshal(autoUpgradeLockState{PID: os.Getpid(), Executable: "looper", Command: "/usr/local/bin/looper upgrade --background-auto", ObservedAt: time.Now().UTC().Add(-10 * time.Second).Format(time.RFC3339Nano)})
+	if err != nil {
+		t.Fatalf("Marshal(lock state) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile(lockPath) error = %v", err)
+	}
+
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir, RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+		_ = ctx
+		_ = timeout
+		if command != "ps" {
+			t.Fatalf("RunCommand command = %q, want ps", command)
+		}
+		switch strings.Join(args, " ") {
+		case fmt.Sprintf("-p %d -o command=", os.Getpid()):
+			return commandExecutionResult{Stdout: "/usr/local/bin/looper upgrade --background-auto\n", ExitCode: 0}, nil
+		case fmt.Sprintf("-p %d -o etime=", os.Getpid()):
+			return commandExecutionResult{Stdout: "0:01\n", ExitCode: 0}, nil
+		default:
+			t.Fatalf("RunCommand args = %q, want ps query for command or elapsed time", strings.Join(args, " "))
+			return commandExecutionResult{}, nil
+		}
+	}}), nil)
+	if !runtime.shouldBreakAutoUpgradeLock(lockPath) {
+		t.Fatal("shouldBreakAutoUpgradeLock() = false, want true")
+	}
+}
+
+func TestParsePSElapsedSeconds(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		raw  string
+		want int
+	}{
+		{raw: "0:07", want: 7},
+		{raw: "12:34", want: 12*60 + 34},
+		{raw: "1:02:03", want: 3723},
+		{raw: "2-03:04:05", want: (((2*24)+3)*60+4)*60 + 5},
+	} {
+		got, err := parsePSElapsedSeconds(tc.raw)
+		if err != nil {
+			t.Fatalf("parsePSElapsedSeconds(%q) error = %v", tc.raw, err)
+		}
+		if got != tc.want {
+			t.Fatalf("parsePSElapsedSeconds(%q) = %d, want %d", tc.raw, got, tc.want)
+		}
+	}
+}
+
 func TestBackgroundAutoUpgradeCommandPersistsReadyRestartState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -409,6 +409,84 @@ func TestShouldBreakAutoUpgradeLockKeepsMatchingExecutableLockActive(t *testing.
 	}
 }
 
+func TestShouldBreakAutoUpgradeLockKeepsForegroundUpgradeRunLockActive(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	lockPath := filepath.Join(homeDir, ".looper", "auto-upgrade.run.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	commandLine := "/usr/local/bin/looper upgrade"
+	observedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	raw, err := json.Marshal(autoUpgradeLockState{PID: os.Getpid(), Executable: "looper", Command: commandLine, ObservedAt: observedAt})
+	if err != nil {
+		t.Fatalf("Marshal(lock state) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile(lockPath) error = %v", err)
+	}
+
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir, RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+		_ = ctx
+		_ = timeout
+		if command != "ps" {
+			t.Fatalf("RunCommand command = %q, want ps", command)
+		}
+		switch strings.Join(args, " ") {
+		case fmt.Sprintf("-p %d -o command=", os.Getpid()):
+			return commandExecutionResult{Stdout: commandLine + "\n", ExitCode: 0}, nil
+		case fmt.Sprintf("-p %d -o etime=", os.Getpid()):
+			return commandExecutionResult{Stdout: "0:00\n", ExitCode: 0}, nil
+		default:
+			t.Fatalf("RunCommand args = %q, want ps query for command or elapsed time", strings.Join(args, " "))
+			return commandExecutionResult{}, nil
+		}
+	}}), nil)
+	if runtime.shouldBreakAutoUpgradeLock(lockPath) {
+		t.Fatal("shouldBreakAutoUpgradeLock() = true, want false")
+	}
+}
+
+func TestShouldBreakAutoUpgradeLockKeepsStateLockForActiveLooperCommand(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	lockPath := filepath.Join(homeDir, ".looper", "auto-upgrade.state.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	commandLine := "/usr/local/bin/looper version --config /tmp/config.json"
+	observedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	raw, err := json.Marshal(autoUpgradeLockState{PID: os.Getpid(), Executable: "looper", Command: commandLine, ObservedAt: observedAt})
+	if err != nil {
+		t.Fatalf("Marshal(lock state) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile(lockPath) error = %v", err)
+	}
+
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir, RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+		_ = ctx
+		_ = timeout
+		if command != "ps" {
+			t.Fatalf("RunCommand command = %q, want ps", command)
+		}
+		switch strings.Join(args, " ") {
+		case fmt.Sprintf("-p %d -o command=", os.Getpid()):
+			return commandExecutionResult{Stdout: commandLine + "\n", ExitCode: 0}, nil
+		case fmt.Sprintf("-p %d -o etime=", os.Getpid()):
+			return commandExecutionResult{Stdout: "0:00\n", ExitCode: 0}, nil
+		default:
+			t.Fatalf("RunCommand args = %q, want ps query for command or elapsed time", strings.Join(args, " "))
+			return commandExecutionResult{}, nil
+		}
+	}}), nil)
+	if runtime.shouldBreakAutoUpgradeLock(lockPath) {
+		t.Fatal("shouldBreakAutoUpgradeLock() = true, want false")
+	}
+}
+
 func TestShouldBreakAutoUpgradeLockBreaksWhenProcessStartTimeChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -571,6 +571,100 @@ func TestBackgroundAutoUpgradeCommandPersistsReadyRestartState(t *testing.T) {
 	}
 }
 
+func TestBackgroundAutoUpgradeCommandSkipsDaemonInstallWithoutManagedBinary(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	statePath := filepath.Join(homeDir, ".looper", "auto-upgrade.state.json")
+	execPath := filepath.Join(homeDir, ".looper", "bin", "looper")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if err := os.MkdirAll(filepath.Dir(execPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(exec dir) error = %v", err)
+	}
+	if err := os.WriteFile(execPath, []byte("old looper"), 0o755); err != nil {
+		t.Fatalf("WriteFile(execPath) error = %v", err)
+	}
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir}), nil)
+	if err := runtime.writeAutoUpgradeState(statePath, autoUpgradeState{InFlight: &autoUpgradeInFlightState{PID: 4321, StartedAt: timePtr(time.Now().UTC())}}); err != nil {
+		t.Fatalf("writeAutoUpgradeState() error = %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cliBinary := []byte("new looper")
+	cliChecksum := sha256.Sum256(cliBinary)
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		Platform:       "darwin",
+		Arch:           "arm64",
+		ExecutablePath: execPath,
+		CLIChannel:     cliInstallChannelStable,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://api.github.com/repos/nexu-io/looper/releases/latest":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.3.0","assets":[{"name":"looper-darwin-arm64","browser_download_url":"https://example.invalid/looper-darwin-arm64"},{"name":"looper-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looper-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looper-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, cliBinary), nil
+			case "https://example.invalid/looper-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, hex.EncodeToString(cliChecksum[:])+"  looper-darwin-arm64\n"), nil
+			case "http://127.0.0.1:4321/api/v1/status":
+				t.Fatalf("unexpected daemon status request %q", req.URL.String())
+				return nil, nil
+			case "https://api.github.com/repos/nexu-io/looper/releases/tags/v0.3.0":
+				t.Fatalf("unexpected daemon release fetch %q", req.URL.String())
+				return nil, nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+			}
+			if command == looperdBinaryName && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	if exitCode := app.Run(context.Background(), []string{"upgrade", "--background-auto", "--config", configPath}); exitCode != 0 {
+		t.Fatalf("Run([upgrade --background-auto]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile(auto-upgrade state) error = %v", err)
+	}
+	var state autoUpgradeState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("Unmarshal(auto-upgrade state) error = %v", err)
+	}
+	if state.Ready == nil {
+		t.Fatal("state.Ready = nil, want ready notification")
+	}
+	if !state.Ready.CLIChanged || state.Ready.CLIVersion != "0.3.0" {
+		t.Fatalf("state.Ready CLI = %#v, want changed version 0.3.0", state.Ready)
+	}
+	if state.Ready.DaemonChanged {
+		t.Fatalf("state.Ready.DaemonChanged = true, want false; ready=%#v", state.Ready)
+	}
+	if state.Ready.DaemonRestartRequired {
+		t.Fatalf("state.Ready.DaemonRestartRequired = true, want false; ready=%#v", state.Ready)
+	}
+	if _, err := os.Stat(managedPath); !os.IsNotExist(err) {
+		t.Fatalf("Stat(managedPath) error = %v, want no managed daemon install", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty string", stdout.String())
+	}
+}
+
 func TestAutoUpgradeReadyNoticePrintsRestartCommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -278,6 +278,46 @@ func TestAutoUpgradeStartsBackgroundWorkerAndCachesInFlightState(t *testing.T) {
 	}
 }
 
+func TestTryAcquireAutoUpgradeLockReturnsRemoveErrorForStaleLock(t *testing.T) {
+	homeDir := t.TempDir()
+	lockDir := filepath.Join(homeDir, ".looper")
+	lockPath := filepath.Join(lockDir, "auto-upgrade.lock")
+	if err := os.MkdirAll(lockDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, []byte("invalid-pid\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(lockPath) error = %v", err)
+	}
+	staleTime := time.Now().Add(-autoUpgradeBusyRetryDelay - time.Second)
+	if err := os.Chtimes(lockPath, staleTime, staleTime); err != nil {
+		t.Fatalf("Chtimes(lockPath) error = %v", err)
+	}
+	if err := os.Chmod(lockDir, 0o555); err != nil {
+		t.Fatalf("Chmod(lockDir) error = %v", err)
+	}
+	defer func() {
+		_ = os.Chmod(lockDir, 0o755)
+	}()
+
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir}), nil)
+	unlock, acquired, err := runtime.tryAcquireAutoUpgradeLock(lockPath)
+	if err == nil {
+		if unlock != nil {
+			unlock()
+		}
+		t.Fatal("tryAcquireAutoUpgradeLock() error = nil, want stale lock removal failure")
+	}
+	if acquired {
+		t.Fatal("tryAcquireAutoUpgradeLock() acquired = true, want false")
+	}
+	if unlock != nil {
+		t.Fatal("tryAcquireAutoUpgradeLock() unlock != nil, want nil")
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("Stat(lockPath) error = %v, want stale lock to remain", statErr)
+	}
+}
+
 func TestBackgroundAutoUpgradeCommandPersistsReadyRestartState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -70,6 +70,7 @@ func TestRootPreRunSkipsAutoUpgradeForUnsupportedInstallSource(t *testing.T) {
 	app := New(Deps{
 		Stdout:         stdout,
 		Stderr:         stderr,
+		HomeDir:        t.TempDir(),
 		ExecutablePath: "/opt/homebrew/Cellar/looper/0.2.1/bin/looper",
 		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -205,7 +206,7 @@ func TestEnvDisablesAutoUpgrade(t *testing.T) {
 	}
 }
 
-func TestAutoUpgradeCachesLatestReleaseCheck(t *testing.T) {
+func TestAutoUpgradeStartsBackgroundWorkerAndCachesInFlightState(t *testing.T) {
 	t.Parallel()
 
 	homeDir := t.TempDir()
@@ -213,7 +214,9 @@ func TestAutoUpgradeCachesLatestReleaseCheck(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	statePath := filepath.Join(homeDir, ".looper", "auto-upgrade.state.json")
-	var latestCalls int
+	workerPID := os.Getpid()
+	var spawnCalls int
+	var spawnedArgs []string
 	app := New(Deps{
 		Stdout:         stdout,
 		Stderr:         stderr,
@@ -221,18 +224,26 @@ func TestAutoUpgradeCachesLatestReleaseCheck(t *testing.T) {
 		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
 		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch req.URL.String() {
-			case "https://api.github.com/repos/nexu-io/looper/releases/latest":
-				latestCalls++
-				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.0.0-dev","assets":[]}`), nil
-			default:
-				t.Fatalf("unexpected request URL %q", req.URL.String())
-				return nil, nil
-			}
+			t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
+			return nil, nil
 		}),
+		SpawnDetached: func(command string, args []string, cwd string, env []string) (int, error) {
+			_ = command
+			_ = cwd
+			_ = env
+			spawnCalls++
+			spawnedArgs = append([]string{}, args...)
+			return workerPID, nil
+		},
+		Getwd: func() (string, error) {
+			return homeDir, nil
+		},
 		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
 			_ = ctx
 			_ = timeout
+			if command == "ps" {
+				return commandExecutionResult{Stdout: filepath.Join(homeDir, ".looper", "bin", "looper") + " upgrade --background-auto\n", ExitCode: 0}, nil
+			}
 			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
 		},
 	})
@@ -245,11 +256,188 @@ func TestAutoUpgradeCachesLatestReleaseCheck(t *testing.T) {
 			t.Fatalf("run %d Run([version --config]) exit code = %d, want 0; stderr=%q", i+1, exitCode, stderr.String())
 		}
 	}
-	if latestCalls != 1 {
-		t.Fatalf("latest release calls = %d, want 1", latestCalls)
+	if spawnCalls != 1 {
+		t.Fatalf("spawnDetached calls = %d, want 1", spawnCalls)
 	}
-	if _, err := os.Stat(statePath); err != nil {
-		t.Fatalf("Stat(auto-upgrade state) error = %v, want file to exist", err)
+	if got, want := strings.Join(spawnedArgs, " "), "upgrade --background-auto --config "+configPath; got != want {
+		t.Fatalf("spawned args = %q, want %q", got, want)
+	}
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile(auto-upgrade state) error = %v", err)
+	}
+	var state autoUpgradeState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("Unmarshal(auto-upgrade state) error = %v", err)
+	}
+	if state.InFlight == nil || state.InFlight.PID != workerPID {
+		t.Fatalf("state.InFlight = %#v, want pid %d", state.InFlight, workerPID)
+	}
+	if state.LastCheckedAt != nil {
+		t.Fatalf("state.LastCheckedAt = %v, want nil until background worker finishes", state.LastCheckedAt)
+	}
+}
+
+func TestBackgroundAutoUpgradeCommandPersistsReadyRestartState(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	statePath := filepath.Join(homeDir, ".looper", "auto-upgrade.state.json")
+	execPath := filepath.Join(homeDir, ".looper", "bin", "looper")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if err := os.MkdirAll(filepath.Dir(execPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(exec dir) error = %v", err)
+	}
+	if err := os.WriteFile(execPath, []byte("old looper"), 0o755); err != nil {
+		t.Fatalf("WriteFile(execPath) error = %v", err)
+	}
+	if err := os.WriteFile(managedPath, []byte("old looperd"), 0o755); err != nil {
+		t.Fatalf("WriteFile(managedPath) error = %v", err)
+	}
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir}), nil)
+	if err := runtime.writeAutoUpgradeState(statePath, autoUpgradeState{InFlight: &autoUpgradeInFlightState{PID: 4321, StartedAt: timePtr(time.Now().UTC())}}); err != nil {
+		t.Fatalf("writeAutoUpgradeState() error = %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cliBinary := []byte("new looper")
+	cliChecksum := sha256.Sum256(cliBinary)
+	daemonBinary := []byte("new looperd")
+	daemonChecksum := sha256.Sum256(daemonBinary)
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		Platform:       "darwin",
+		Arch:           "arm64",
+		ExecutablePath: execPath,
+		CLIChannel:     cliInstallChannelStable,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "http://127.0.0.1:4321/api/v1/status":
+				return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"requestId":"req_status","data":{"service":{"version":"0.2.1","binary":{"name":"looperd","path":%q}}}}`, managedPath)), nil
+			case "https://api.github.com/repos/nexu-io/looper/releases/latest",
+				"https://api.github.com/repos/nexu-io/looper/releases/tags/v0.3.0":
+				return jsonResponse(t, http.StatusOK, `{"tag_name":"v0.3.0","assets":[{"name":"looper-darwin-arm64","browser_download_url":"https://example.invalid/looper-darwin-arm64"},{"name":"looper-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looper-darwin-arm64.sha256"},{"name":"looperd-darwin-arm64","browser_download_url":"https://example.invalid/looperd-darwin-arm64"},{"name":"looperd-darwin-arm64.sha256","browser_download_url":"https://example.invalid/looperd-darwin-arm64.sha256"}]}`), nil
+			case "https://example.invalid/looper-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, cliBinary), nil
+			case "https://example.invalid/looper-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, hex.EncodeToString(cliChecksum[:])+"  looper-darwin-arm64\n"), nil
+			case "https://example.invalid/looperd-darwin-arm64":
+				return binaryResponse(t, http.StatusOK, daemonBinary), nil
+			case "https://example.invalid/looperd-darwin-arm64.sha256":
+				return textResponse(t, http.StatusOK, hex.EncodeToString(daemonChecksum[:])+"  looperd-darwin-arm64\n"), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{Stdout: "0.2.1\n", ExitCode: 0}, nil
+			}
+			if command == looperdBinaryName && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	if exitCode := app.Run(context.Background(), []string{"upgrade", "--background-auto", "--config", configPath}); exitCode != 0 {
+		t.Fatalf("Run([upgrade --background-auto]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile(auto-upgrade state) error = %v", err)
+	}
+	var state autoUpgradeState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("Unmarshal(auto-upgrade state) error = %v", err)
+	}
+	if state.InFlight != nil {
+		t.Fatalf("state.InFlight = %#v, want nil", state.InFlight)
+	}
+	if state.LastCheckedAt == nil {
+		t.Fatal("state.LastCheckedAt = nil, want timestamp")
+	}
+	if state.Ready == nil {
+		t.Fatal("state.Ready = nil, want ready notification")
+	}
+	if !state.Ready.CLIChanged || state.Ready.CLIVersion != "0.3.0" {
+		t.Fatalf("state.Ready CLI = %#v, want changed version 0.3.0", state.Ready)
+	}
+	if !state.Ready.DaemonChanged || state.Ready.DaemonVersion != "0.3.0" {
+		t.Fatalf("state.Ready daemon = %#v, want changed version 0.3.0", state.Ready)
+	}
+	if !state.Ready.DaemonRestartRequired || state.Ready.RunningDaemonVersion != "0.2.1" {
+		t.Fatalf("state.Ready restart = %#v, want restart from 0.2.1", state.Ready)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty string", stdout.String())
+	}
+}
+
+func TestAutoUpgradeReadyNoticePrintsRestartCommand(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	configPath := writeCLIConfig(t, "http://127.0.0.1:4321", "")
+	statePath := filepath.Join(homeDir, ".looper", "auto-upgrade.state.json")
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	if err := os.MkdirAll(filepath.Dir(managedPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(managed dir) error = %v", err)
+	}
+	if err := os.WriteFile(managedPath, []byte("managed looperd"), 0o755); err != nil {
+		t.Fatalf("WriteFile(managedPath) error = %v", err)
+	}
+	now := time.Now().UTC()
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir}), nil)
+	if err := runtime.writeAutoUpgradeState(statePath, autoUpgradeState{LastCheckedAt: &now, Ready: &autoUpgradeReadyState{DaemonChanged: true, DaemonVersion: "0.3.0", DaemonRestartRequired: true, CompletedAt: now}}); err != nil {
+		t.Fatalf("writeAutoUpgradeState() error = %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout:         stdout,
+		Stderr:         stderr,
+		HomeDir:        homeDir,
+		ExecutablePath: filepath.Join(homeDir, ".looper", "bin", "looper"),
+		CLIChannel:     cliInstallChannelStable,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "http://127.0.0.1:4321/api/v1/status":
+				return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"requestId":"req_status","data":{"service":{"version":"0.2.0","binary":{"name":"looperd","path":%q}}}}`, managedPath)), nil
+			default:
+				t.Fatalf("unexpected request URL %q", req.URL.String())
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{Stdout: "0.3.0\n", ExitCode: 0}, nil
+			}
+			if command == looperdBinaryName && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	if exitCode := app.Run(context.Background(), []string{"version", "--config", configPath}); exitCode != 0 {
+		t.Fatalf("Run([version --config]) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Auto-upgrade ready: looperd 0.3.0 is installed") {
+		t.Fatalf("stderr = %q, want daemon ready message", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "looper daemon restart") {
+		t.Fatalf("stderr = %q, want restart command", stderr.String())
 	}
 }
 
@@ -741,6 +929,7 @@ func TestUpgradeCLIRefusesHomebrewSymlinkWithGuidance(t *testing.T) {
 	app := New(Deps{
 		Stdout:         stdout,
 		Stderr:         stderr,
+		HomeDir:        homebrewRoot,
 		ExecutablePath: symlinkPath,
 		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -773,6 +962,7 @@ func TestUpgradeCLIPreflightsInstallPathBeforeDownload(t *testing.T) {
 	app := New(Deps{
 		Stdout:         stdout,
 		Stderr:         stderr,
+		HomeDir:        t.TempDir(),
 		ExecutablePath: execPath,
 		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -818,6 +1008,7 @@ func TestUpgradeCLIPrintsDownloadProgressToStderr(t *testing.T) {
 	app := New(Deps{
 		Stdout:         stdout,
 		Stderr:         stderr,
+		HomeDir:        root,
 		Platform:       "darwin",
 		Arch:           "arm64",
 		ExecutablePath: execPath,
@@ -1079,6 +1270,7 @@ func TestUpgradeDaemonInstallsManagedBinaryWhenOnlyPathBinaryExists(t *testing.T
 func TestManagedDaemonInstallUpgradeLifecycleEndToEnd(t *testing.T) {
 	homeDir := t.TempDir()
 	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	statePath := filepath.Join(homeDir, ".looper", "auto-upgrade.state.json")
 	configPath := writeCLIConfig(t, "http://daemon.test", "")
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -1245,6 +1437,11 @@ func TestManagedDaemonInstallUpgradeLifecycleEndToEnd(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Upgraded looperd 0.2.0 → 0.3.0") {
 		t.Fatalf("stdout = %q, want upgrade confirmation", stdout.String())
 	}
+	upgradeCompletedAt := time.Now().UTC()
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir}), nil)
+	if err := runtime.writeAutoUpgradeState(statePath, autoUpgradeState{Ready: &autoUpgradeReadyState{DaemonChanged: true, DaemonVersion: "0.3.0", DaemonRestartRequired: true, RunningDaemonVersion: "0.2.0", CompletedAt: upgradeCompletedAt}}); err != nil {
+		t.Fatalf("writeAutoUpgradeState() error = %v", err)
+	}
 
 	stdout.Reset()
 	stderr.Reset()
@@ -1260,4 +1457,15 @@ func TestManagedDaemonInstallUpgradeLifecycleEndToEnd(t *testing.T) {
 	assertJSONContains(t, stdout.String(), "apiReachable", true)
 	assertJSONContains(t, stdout.String(), "daemonVersion", "0.3.0")
 	assertJSONContains(t, stdout.String(), "daemonVersionSource", "api")
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile(auto-upgrade state) error = %v", err)
+	}
+	var state autoUpgradeState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("Unmarshal(auto-upgrade state) error = %v", err)
+	}
+	if state.Ready != nil {
+		t.Fatalf("state.Ready = %#v, want cleared after restart", state.Ready)
+	}
 }


### PR DESCRIPTION
## Summary
- move auto-upgrade downloads out of normal command execution by launching a detached background worker and persisting upgrade state
- surface a clear follow-up notice when new CLI or daemon bits are ready, including a direct `looper daemon restart` path when the running daemon still needs a restart
- add locking and regression coverage around background workers, busy upgrades, and restart-state cleanup

## Validation
- go vet ./...
- go test ./...
- go build ./...

Closes #299