### PR TITLE
fix: adopt validated agent-created PRs on migrated worker branches

### DIFF
--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -17,6 +17,9 @@ const (
 	ActionSourceNone     = "none"
 	ActionSourceAgent    = "agent"
 	ActionSourceFallback = "fallback"
+
+	BranchProvenancePlanned       = "planned"
+	BranchProvenanceAgentMigrated = "agent_migrated"
 )
 
 type Policy struct {
@@ -36,36 +39,50 @@ type Actions struct {
 }
 
 type State struct {
-	Policy          string   `json:"policy,omitempty"`
-	PolicyVersion   int      `json:"policy_version,omitempty"`
-	Branch          string   `json:"branch,omitempty"`
-	BaseBranch      string   `json:"base_branch,omitempty"`
-	CommitSHAs      []string `json:"commit_shas,omitempty"`
-	Pushed          bool     `json:"pushed,omitempty"`
-	PRNumber        int64    `json:"pr_number,omitempty"`
-	PRURL           string   `json:"pr_url,omitempty"`
-	PRAdopted       bool     `json:"pr_adopted,omitempty"`
-	Actions         Actions  `json:"actions,omitempty"`
-	ReconciledAt    string   `json:"reconciled_at,omitempty"`
-	ReconciledBy    string   `json:"reconciled_by,omitempty"`
-	LastError       string   `json:"last_reconciliation_error,omitempty"`
-	AgentIngestedAt string   `json:"agent_ingested_at,omitempty"`
+	Policy            string   `json:"policy,omitempty"`
+	PolicyVersion     int      `json:"policy_version,omitempty"`
+	Branch            string   `json:"branch,omitempty"`
+	BaseBranch        string   `json:"base_branch,omitempty"`
+	PlannedBranch     string   `json:"planned_branch,omitempty"`
+	PlannedBaseBranch string   `json:"planned_base_branch,omitempty"`
+	AgentBranch       string   `json:"agent_branch,omitempty"`
+	AgentBaseBranch   string   `json:"agent_base_branch,omitempty"`
+	ActiveBranch      string   `json:"active_branch,omitempty"`
+	ActiveBaseBranch  string   `json:"active_base_branch,omitempty"`
+	BranchProvenance  string   `json:"branch_provenance,omitempty"`
+	CommitSHAs        []string `json:"commit_shas,omitempty"`
+	Pushed            bool     `json:"pushed,omitempty"`
+	PRNumber          int64    `json:"pr_number,omitempty"`
+	PRURL             string   `json:"pr_url,omitempty"`
+	PRAdopted         bool     `json:"pr_adopted,omitempty"`
+	Actions           Actions  `json:"actions,omitempty"`
+	ReconciledAt      string   `json:"reconciled_at,omitempty"`
+	ReconciledBy      string   `json:"reconciled_by,omitempty"`
+	LastError         string   `json:"last_reconciliation_error,omitempty"`
+	AgentIngestedAt   string   `json:"agent_ingested_at,omitempty"`
 }
 
 func (s *State) UnmarshalJSON(data []byte) error {
 	type stateAlias State
 	var raw struct {
 		stateAlias
-		PolicyVersionCamel   int      `json:"policyVersion,omitempty"`
-		BaseBranchCamel      string   `json:"baseBranch,omitempty"`
-		CommitSHAsCamel      []string `json:"commitShas,omitempty"`
-		PRNumberCamel        int64    `json:"prNumber,omitempty"`
-		PRURLCamel           string   `json:"prUrl,omitempty"`
-		PRAdoptedCamel       bool     `json:"prAdopted,omitempty"`
-		ReconciledAtCamel    string   `json:"reconciledAt,omitempty"`
-		ReconciledByCamel    string   `json:"reconciledBy,omitempty"`
-		LastErrorCamel       string   `json:"lastReconciliationError,omitempty"`
-		AgentIngestedAtCamel string   `json:"agentIngestedAt,omitempty"`
+		PolicyVersionCamel     int      `json:"policyVersion,omitempty"`
+		BaseBranchCamel        string   `json:"baseBranch,omitempty"`
+		PlannedBranchCamel     string   `json:"plannedBranch,omitempty"`
+		PlannedBaseBranchCamel string   `json:"plannedBaseBranch,omitempty"`
+		AgentBranchCamel       string   `json:"agentBranch,omitempty"`
+		AgentBaseBranchCamel   string   `json:"agentBaseBranch,omitempty"`
+		ActiveBranchCamel      string   `json:"activeBranch,omitempty"`
+		ActiveBaseBranchCamel  string   `json:"activeBaseBranch,omitempty"`
+		BranchProvenanceCamel  string   `json:"branchProvenance,omitempty"`
+		CommitSHAsCamel        []string `json:"commitShas,omitempty"`
+		PRNumberCamel          int64    `json:"prNumber,omitempty"`
+		PRURLCamel             string   `json:"prUrl,omitempty"`
+		PRAdoptedCamel         bool     `json:"prAdopted,omitempty"`
+		ReconciledAtCamel      string   `json:"reconciledAt,omitempty"`
+		ReconciledByCamel      string   `json:"reconciledBy,omitempty"`
+		LastErrorCamel         string   `json:"lastReconciliationError,omitempty"`
+		AgentIngestedAtCamel   string   `json:"agentIngestedAt,omitempty"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -76,6 +93,27 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	}
 	if s.BaseBranch == "" {
 		s.BaseBranch = raw.BaseBranchCamel
+	}
+	if s.PlannedBranch == "" {
+		s.PlannedBranch = raw.PlannedBranchCamel
+	}
+	if s.PlannedBaseBranch == "" {
+		s.PlannedBaseBranch = raw.PlannedBaseBranchCamel
+	}
+	if s.AgentBranch == "" {
+		s.AgentBranch = raw.AgentBranchCamel
+	}
+	if s.AgentBaseBranch == "" {
+		s.AgentBaseBranch = raw.AgentBaseBranchCamel
+	}
+	if s.ActiveBranch == "" {
+		s.ActiveBranch = raw.ActiveBranchCamel
+	}
+	if s.ActiveBaseBranch == "" {
+		s.ActiveBaseBranch = raw.ActiveBaseBranchCamel
+	}
+	if s.BranchProvenance == "" {
+		s.BranchProvenance = raw.BranchProvenanceCamel
 	}
 	if len(s.CommitSHAs) == 0 {
 		s.CommitSHAs = raw.CommitSHAsCamel
@@ -109,7 +147,9 @@ func AgentManagedWithFallbackPolicy(runner string, expectPR bool) Policy {
 }
 
 func NewState(policy Policy, branch, baseBranch string) *State {
-	return &State{Policy: policy.Name, PolicyVersion: policy.Version, Branch: strings.TrimSpace(branch), BaseBranch: strings.TrimSpace(baseBranch), Actions: Actions{Commit: ActionSourceNone, Push: ActionSourceNone, PR: ActionSourceNone}}
+	branch = strings.TrimSpace(branch)
+	baseBranch = strings.TrimSpace(baseBranch)
+	return &State{Policy: policy.Name, PolicyVersion: policy.Version, Branch: branch, BaseBranch: baseBranch, PlannedBranch: branch, PlannedBaseBranch: baseBranch, ActiveBranch: branch, ActiveBaseBranch: baseBranch, BranchProvenance: BranchProvenancePlanned, Actions: Actions{Commit: ActionSourceNone, Push: ActionSourceNone, PR: ActionSourceNone}}
 }
 
 func FromMap(value any) (*State, error) {
@@ -140,6 +180,37 @@ func (s *State) Normalize() {
 	}
 	s.Branch = strings.TrimSpace(s.Branch)
 	s.BaseBranch = strings.TrimSpace(s.BaseBranch)
+	s.PlannedBranch = strings.TrimSpace(s.PlannedBranch)
+	s.PlannedBaseBranch = strings.TrimSpace(s.PlannedBaseBranch)
+	s.AgentBranch = strings.TrimSpace(s.AgentBranch)
+	s.AgentBaseBranch = strings.TrimSpace(s.AgentBaseBranch)
+	s.ActiveBranch = strings.TrimSpace(s.ActiveBranch)
+	s.ActiveBaseBranch = strings.TrimSpace(s.ActiveBaseBranch)
+	s.BranchProvenance = strings.TrimSpace(s.BranchProvenance)
+	if s.Branch == "" {
+		s.Branch = firstNonEmpty(s.ActiveBranch, s.PlannedBranch)
+	}
+	if s.BaseBranch == "" {
+		s.BaseBranch = firstNonEmpty(s.ActiveBaseBranch, s.PlannedBaseBranch)
+	}
+	if s.PlannedBranch == "" {
+		s.PlannedBranch = s.Branch
+	}
+	if s.PlannedBaseBranch == "" {
+		s.PlannedBaseBranch = s.BaseBranch
+	}
+	if s.ActiveBranch == "" {
+		s.ActiveBranch = firstNonEmpty(s.AgentBranch, s.Branch)
+	}
+	if s.ActiveBaseBranch == "" {
+		s.ActiveBaseBranch = firstNonEmpty(s.AgentBaseBranch, s.BaseBranch)
+	}
+	if s.BranchProvenance == "" {
+		s.BranchProvenance = BranchProvenancePlanned
+		if s.PlannedBranch != "" && s.ActiveBranch != "" && s.PlannedBranch != s.ActiveBranch {
+			s.BranchProvenance = BranchProvenanceAgentMigrated
+		}
+	}
 	s.CommitSHAs = compact(s.CommitSHAs)
 	if s.Actions.Commit == "" {
 		s.Actions.Commit = actionSourceFromBool(len(s.CommitSHAs) > 0)
@@ -169,6 +240,27 @@ func (s *State) MergeAgent(agent *State, ingestedAt string) {
 	if s.BaseBranch == "" && agent.BaseBranch != "" {
 		s.BaseBranch = agent.BaseBranch
 	}
+	if s.PlannedBranch == "" {
+		s.PlannedBranch = firstNonEmpty(agent.PlannedBranch, agent.Branch)
+	}
+	if s.PlannedBaseBranch == "" {
+		s.PlannedBaseBranch = firstNonEmpty(agent.PlannedBaseBranch, agent.BaseBranch)
+	}
+	if branch := firstNonEmpty(agent.AgentBranch, agent.Branch); branch != "" {
+		s.AgentBranch = branch
+	}
+	if baseBranch := firstNonEmpty(agent.AgentBaseBranch, agent.BaseBranch); baseBranch != "" {
+		s.AgentBaseBranch = baseBranch
+	}
+	if s.ActiveBranch == "" {
+		s.ActiveBranch = firstNonEmpty(agent.ActiveBranch, agent.Branch)
+	}
+	if s.ActiveBaseBranch == "" {
+		s.ActiveBaseBranch = firstNonEmpty(agent.ActiveBaseBranch, agent.BaseBranch)
+	}
+	if agent.BranchProvenance != "" {
+		s.BranchProvenance = agent.BranchProvenance
+	}
 	s.CommitSHAs = appendUnique(s.CommitSHAs, agent.CommitSHAs...)
 	if agent.Pushed {
 		s.Pushed = true
@@ -193,6 +285,35 @@ func (s *State) MergeAgent(agent *State, ingestedAt string) {
 	}
 	if ingestedAt != "" {
 		s.AgentIngestedAt = ingestedAt
+	}
+	s.Normalize()
+}
+
+func (s *State) RecordAgentBranch(branch, baseBranch string) {
+	if s == nil {
+		return
+	}
+	if branch = strings.TrimSpace(branch); branch != "" {
+		s.AgentBranch = branch
+	}
+	if baseBranch = strings.TrimSpace(baseBranch); baseBranch != "" {
+		s.AgentBaseBranch = baseBranch
+	}
+	s.Normalize()
+}
+
+func (s *State) SetActiveBranch(branch, baseBranch, provenance string) {
+	if s == nil {
+		return
+	}
+	if branch = strings.TrimSpace(branch); branch != "" {
+		s.ActiveBranch = branch
+	}
+	if baseBranch = strings.TrimSpace(baseBranch); baseBranch != "" {
+		s.ActiveBaseBranch = baseBranch
+	}
+	if provenance = strings.TrimSpace(provenance); provenance != "" {
+		s.BranchProvenance = provenance
 	}
 	s.Normalize()
 }
@@ -294,4 +415,13 @@ func appendUnique(dst []string, values ...string) []string {
 		dst = append(dst, value)
 	}
 	return dst
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -36,7 +36,7 @@ func TestMergeAgentPreservesFallbackMetadata(t *testing.T) {
 	state.Actions.PR = ActionSourceFallback
 	state.PRNumber = 84
 
-	agent := &State{CommitSHAs: []string{"abc123"}, Pushed: true, Actions: Actions{Commit: ActionSourceAgent, Push: ActionSourceAgent}}
+	agent := &State{Branch: "fix/test", BaseBranch: "main", CommitSHAs: []string{"abc123"}, Pushed: true, Actions: Actions{Commit: ActionSourceAgent, Push: ActionSourceAgent}}
 	state.MergeAgent(agent, "2026-04-26T00:00:00.000Z")
 
 	if state.Actions.PR != ActionSourceFallback || state.PRNumber != 84 {
@@ -44,6 +44,19 @@ func TestMergeAgentPreservesFallbackMetadata(t *testing.T) {
 	}
 	if state.Actions.Commit != ActionSourceAgent || state.Actions.Push != ActionSourceAgent || state.AgentIngestedAt == "" {
 		t.Fatalf("merged agent metadata = %#v, want agent commit/push", state)
+	}
+	if state.PlannedBranch != "looper/test" || state.AgentBranch != "fix/test" || state.ActiveBranch != "looper/test" || state.BranchProvenance != BranchProvenancePlanned {
+		t.Fatalf("merged branch provenance = %#v, want planned branch preserved alongside agent branch", state)
+	}
+}
+
+func TestStateSetActiveBranchMarksAgentMigration(t *testing.T) {
+	state := NewState(AgentManagedWithFallbackPolicy("worker", true), "looper/test", "main")
+	state.RecordAgentBranch("fix/test", "main")
+	state.SetActiveBranch("fix/test", "main", BranchProvenanceAgentMigrated)
+
+	if state.PlannedBranch != "looper/test" || state.AgentBranch != "fix/test" || state.ActiveBranch != "fix/test" || state.BranchProvenance != BranchProvenanceAgentMigrated {
+		t.Fatalf("state = %#v, want migrated active branch with provenance", state)
 	}
 }
 

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1601,7 +1601,7 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		if err != nil {
 			var loopErr *loopError
 			if errors.As(err, &loopErr) {
-				if loopErr.kind != FailureManualIntervention && input.Loop.PRNumber != nil {
+				if input.Loop.PRNumber != nil {
 					loopErr = nil
 				} else {
 					if loopErr.kind == FailureManualIntervention {
@@ -2797,6 +2797,8 @@ func (r *Runner) lifecycleAgentCreatedPullRequest(ctx context.Context, currentLo
 	if r.github == nil || state == nil || state.Actions.PR != lifecycle.ActionSourceAgent || state.PRNumber <= 0 {
 		return checkpointPullPR{}, "", false, nil
 	}
+	expectedBranch = strings.TrimSpace(expectedBranch)
+	expectedBaseBranch = strings.TrimSpace(expectedBaseBranch)
 	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: state.PRNumber, CWD: cwd})
 	if err != nil {
 		return checkpointPullPR{}, "", false, err
@@ -2805,27 +2807,38 @@ func (r *Runner) lifecycleAgentCreatedPullRequest(ctx context.Context, currentLo
 	headBranch := strings.TrimSpace(detail.HeadRefName)
 	baseBranch := strings.TrimSpace(detail.BaseRefName)
 	agentBranch := firstNonEmpty(state.AgentBranch, headBranch)
-	migratedBranch := strings.TrimSpace(expectedBranch) != "" && headBranch != "" && !strings.EqualFold(headBranch, strings.TrimSpace(expectedBranch))
+	migratedBranch := expectedBranch != "" && headBranch != "" && !strings.EqualFold(headBranch, expectedBranch)
 	reject := func(reason string) (checkpointPullPR, string, bool, error) {
 		message := fmt.Sprintf("Agent created PR #%d on branch %s but worker could not adopt it: %s", prNumber, firstNonEmpty(headBranch, agentBranch, "unknown"), reason)
 		return checkpointPullPR{}, "", false, &loopError{message: message, kind: FailureManualIntervention}
 	}
+	if !migratedBranch {
+		if prState := strings.TrimSpace(detail.State); prState != "" && !strings.EqualFold(prState, "open") {
+			return checkpointPullPR{}, "", false, nil
+		}
+		if expectedBaseBranch != "" {
+			if reportedBase := strings.TrimSpace(state.AgentBaseBranch); reportedBase != "" && !strings.EqualFold(reportedBase, expectedBaseBranch) {
+				return checkpointPullPR{}, "", false, nil
+			}
+			if baseBranch != "" && !strings.EqualFold(baseBranch, expectedBaseBranch) {
+				return checkpointPullPR{}, "", false, nil
+			}
+		}
+		return checkpointPullPR{Number: prNumber, URL: firstNonEmpty(strings.TrimSpace(detail.URL), strings.TrimSpace(state.PRURL))}, firstNonEmpty(headBranch, expectedBranch), true, nil
+	}
 	if prState := strings.TrimSpace(detail.State); prState != "" && !strings.EqualFold(prState, "open") {
 		return reject(fmt.Sprintf("PR is %s", prState))
 	}
-	if expectedBranch = strings.TrimSpace(expectedBranch); migratedBranch && agentBranch != "" && strings.EqualFold(agentBranch, expectedBranch) && headBranch != "" && !strings.EqualFold(headBranch, expectedBranch) {
+	if agentBranch != "" && strings.EqualFold(agentBranch, expectedBranch) && headBranch != "" && !strings.EqualFold(headBranch, expectedBranch) {
 		return reject(fmt.Sprintf("expected head branch %s, got %s", expectedBranch, firstNonEmpty(headBranch, "unknown")))
 	}
-	if expectedBaseBranch = strings.TrimSpace(expectedBaseBranch); expectedBaseBranch != "" {
+	if expectedBaseBranch != "" {
 		if reportedBase := strings.TrimSpace(state.AgentBaseBranch); reportedBase != "" && !strings.EqualFold(reportedBase, expectedBaseBranch) {
 			return reject(fmt.Sprintf("expected base %s, got %s", expectedBaseBranch, reportedBase))
 		}
 		if baseBranch != "" && !strings.EqualFold(baseBranch, expectedBaseBranch) {
 			return reject(fmt.Sprintf("expected base %s, got %s", expectedBaseBranch, firstNonEmpty(baseBranch, "unknown")))
 		}
-	}
-	if !migratedBranch {
-		return checkpointPullPR{Number: prNumber, URL: firstNonEmpty(strings.TrimSpace(detail.URL), strings.TrimSpace(state.PRURL))}, firstNonEmpty(headBranch, expectedBranch), true, nil
 	}
 	if len(state.CommitSHAs) == 0 {
 		return reject("missing lifecycle commit evidence")

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1597,14 +1597,27 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
 	if work.ExecutionMode == "create-pr" && checkpoint.PullRequest == nil {
-		pr, ok, err := r.lifecycleAgentCreatedPullRequest(ctx, work.Repo, checkpoint.Lifecycle, worktree.Branch, work.BaseBranch, input.Project.RepoPath)
+		pr, branch, ok, err := r.lifecycleAgentCreatedPullRequest(ctx, input.Loop.ID, work.Repo, checkpoint.Lifecycle, worktree.Branch, work.BaseBranch, input.Project.RepoPath)
 		if err != nil {
-			if input.Loop.PRNumber == nil {
+			var loopErr *loopError
+			if errors.As(err, &loopErr) {
+				if loopErr.kind != FailureManualIntervention && input.Loop.PRNumber != nil {
+					loopErr = nil
+				} else {
+					if loopErr.kind == FailureManualIntervention {
+						checkpoint.SkipReason = loopErr.message
+						checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+					}
+					return checkpoint, loopErr
+				}
+			}
+			if err != nil && input.Loop.PRNumber == nil {
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 			}
 		}
 		if ok {
 			checkpoint.PullRequest = &pr
+			checkpoint.markLifecycleAgentPullRequest(branch, work.BaseBranch, pr)
 		}
 	}
 	if work.ExecutionMode == "create-pr" && (checkpoint.PullRequest != nil || input.Loop.PRNumber != nil) {
@@ -2095,6 +2108,47 @@ func (r *Runner) findOpenPullRequestForBranch(ctx context.Context, repo string, 
 		}
 	}
 	return nil, nil
+}
+
+func (r *Runner) activeWorkerLoopClaimingPullRequest(ctx context.Context, currentLoopID, repo string, prNumber int64) (string, error) {
+	if r.repos == nil || prNumber <= 0 {
+		return "", nil
+	}
+	loopsList, err := r.repos.Loops.List(ctx)
+	if err != nil {
+		return "", &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	for _, loop := range loopsList {
+		if loop.ID == currentLoopID || loop.Type != "worker" {
+			continue
+		}
+		if loop.Status != "queued" && loop.Status != "running" && loop.Status != "paused" {
+			continue
+		}
+		if !strings.EqualFold(derefString(loop.Repo), repo) {
+			continue
+		}
+		candidatePR := derefInt64(loop.PRNumber)
+		if candidatePR == 0 && loop.TargetType == "pull_request" {
+			candidatePR = parsePullRequestNumberFromTargetID(derefString(loop.TargetID))
+		}
+		if candidatePR == prNumber {
+			return fmt.Sprintf("pull request is already claimed by active worker loop %s", loop.ID), nil
+		}
+	}
+	return "", nil
+}
+
+func parsePullRequestNumberFromTargetID(targetID string) int64 {
+	parts := strings.Split(strings.TrimSpace(targetID), ":")
+	if len(parts) != 3 || parts[0] != "pr" {
+		return 0
+	}
+	prNumber, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return prNumber
 }
 
 func (r *Runner) assignReviewersIfNeeded(ctx context.Context, work workerInput, prNumber int64, cwd string) error {
@@ -2620,6 +2674,15 @@ func (c *workerCheckpoint) ensureLifecycle(runner, branch, baseBranch string, ex
 
 func (c *workerCheckpoint) markLifecyclePushAndPR(branch, baseBranch string, prNumber int64, prURL string, pushed, adopted bool) {
 	c.ensureLifecycle("worker", branch, baseBranch, true)
+	activeBranch := branch
+	activeBaseBranch := baseBranch
+	provenance := lifecycle.BranchProvenancePlanned
+	if c.Lifecycle.BranchProvenance == lifecycle.BranchProvenanceAgentMigrated && strings.TrimSpace(c.Lifecycle.ActiveBranch) != "" {
+		activeBranch = c.Lifecycle.ActiveBranch
+		activeBaseBranch = firstNonEmpty(c.Lifecycle.ActiveBaseBranch, baseBranch)
+		provenance = lifecycle.BranchProvenanceAgentMigrated
+	}
+	c.Lifecycle.SetActiveBranch(activeBranch, activeBaseBranch, provenance)
 	c.Lifecycle.Pushed = c.Lifecycle.Pushed || pushed
 	if pushed {
 		c.Lifecycle.Actions.Push = lifecycle.ActionSourceFallback
@@ -2636,6 +2699,23 @@ func (c *workerCheckpoint) markLifecyclePushAndPR(branch, baseBranch string, prN
 	if (prNumber > 0 || prURL != "") && c.Lifecycle.Actions.PR == lifecycle.ActionSourceNone {
 		c.Lifecycle.Actions.PR = lifecycle.ActionSourceFallback
 	}
+	c.Lifecycle.Normalize()
+}
+
+func (c *workerCheckpoint) markLifecycleAgentPullRequest(branch, baseBranch string, pr checkpointPullPR) {
+	c.ensureLifecycle("worker", branch, baseBranch, true)
+	c.Lifecycle.RecordAgentBranch(branch, baseBranch)
+	provenance := lifecycle.BranchProvenancePlanned
+	if plannedBranch := strings.TrimSpace(c.Lifecycle.PlannedBranch); plannedBranch != "" && !strings.EqualFold(plannedBranch, strings.TrimSpace(branch)) {
+		provenance = lifecycle.BranchProvenanceAgentMigrated
+	}
+	c.Lifecycle.SetActiveBranch(branch, baseBranch, provenance)
+	c.Lifecycle.Pushed = true
+	c.Lifecycle.Actions.Push = lifecycle.ActionSourceAgent
+	c.Lifecycle.PRNumber = pr.Number
+	c.Lifecycle.PRURL = pr.URL
+	c.Lifecycle.PRAdopted = true
+	c.Lifecycle.Actions.PR = lifecycle.ActionSourceAgent
 	c.Lifecycle.Normalize()
 }
 
@@ -2713,29 +2793,56 @@ func (r *Runner) normalizePullRequestDisclosure(ctx context.Context, repo string
 	return r.github.UpdatePullRequestBody(ctx, UpdatePullRequestBodyInput{Repo: repo, PRNumber: prNumber, Body: body, CWD: cwd})
 }
 
-func (r *Runner) lifecycleAgentCreatedPullRequest(ctx context.Context, repo string, state *lifecycle.State, expectedBranch, expectedBaseBranch, cwd string) (checkpointPullPR, bool, error) {
+func (r *Runner) lifecycleAgentCreatedPullRequest(ctx context.Context, currentLoopID, repo string, state *lifecycle.State, expectedBranch, expectedBaseBranch, cwd string) (checkpointPullPR, string, bool, error) {
 	if r.github == nil || state == nil || state.Actions.PR != lifecycle.ActionSourceAgent || state.PRNumber <= 0 {
-		return checkpointPullPR{}, false, nil
-	}
-	if expectedBranch = strings.TrimSpace(expectedBranch); expectedBranch != "" {
-		if branch := strings.TrimSpace(state.Branch); branch != "" && branch != expectedBranch {
-			return checkpointPullPR{}, false, nil
-		}
+		return checkpointPullPR{}, "", false, nil
 	}
 	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: state.PRNumber, CWD: cwd})
 	if err != nil {
-		return checkpointPullPR{}, false, err
+		return checkpointPullPR{}, "", false, err
+	}
+	prNumber := firstNonZero(detail.Number, state.PRNumber)
+	headBranch := strings.TrimSpace(detail.HeadRefName)
+	baseBranch := strings.TrimSpace(detail.BaseRefName)
+	agentBranch := firstNonEmpty(state.AgentBranch, headBranch)
+	migratedBranch := strings.TrimSpace(expectedBranch) != "" && headBranch != "" && !strings.EqualFold(headBranch, strings.TrimSpace(expectedBranch))
+	reject := func(reason string) (checkpointPullPR, string, bool, error) {
+		message := fmt.Sprintf("Agent created PR #%d on branch %s but worker could not adopt it: %s", prNumber, firstNonEmpty(headBranch, agentBranch, "unknown"), reason)
+		return checkpointPullPR{}, "", false, &loopError{message: message, kind: FailureManualIntervention}
 	}
 	if prState := strings.TrimSpace(detail.State); prState != "" && !strings.EqualFold(prState, "open") {
-		return checkpointPullPR{}, false, nil
+		return reject(fmt.Sprintf("PR is %s", prState))
 	}
-	if expectedBranch != "" && strings.TrimSpace(detail.HeadRefName) != expectedBranch {
-		return checkpointPullPR{}, false, nil
+	if expectedBranch = strings.TrimSpace(expectedBranch); migratedBranch && agentBranch != "" && strings.EqualFold(agentBranch, expectedBranch) && headBranch != "" && !strings.EqualFold(headBranch, expectedBranch) {
+		return reject(fmt.Sprintf("expected head branch %s, got %s", expectedBranch, firstNonEmpty(headBranch, "unknown")))
 	}
-	if expectedBaseBranch = strings.TrimSpace(expectedBaseBranch); expectedBaseBranch != "" && strings.TrimSpace(detail.BaseRefName) != expectedBaseBranch {
-		return checkpointPullPR{}, false, nil
+	if expectedBaseBranch = strings.TrimSpace(expectedBaseBranch); expectedBaseBranch != "" {
+		if reportedBase := strings.TrimSpace(state.AgentBaseBranch); reportedBase != "" && !strings.EqualFold(reportedBase, expectedBaseBranch) {
+			return reject(fmt.Sprintf("expected base %s, got %s", expectedBaseBranch, reportedBase))
+		}
+		if baseBranch != "" && !strings.EqualFold(baseBranch, expectedBaseBranch) {
+			return reject(fmt.Sprintf("expected base %s, got %s", expectedBaseBranch, firstNonEmpty(baseBranch, "unknown")))
+		}
 	}
-	return checkpointPullPR{Number: detail.Number, URL: firstNonEmpty(strings.TrimSpace(detail.URL), strings.TrimSpace(state.PRURL))}, true, nil
+	if !migratedBranch {
+		return checkpointPullPR{Number: prNumber, URL: firstNonEmpty(strings.TrimSpace(detail.URL), strings.TrimSpace(state.PRURL))}, firstNonEmpty(headBranch, expectedBranch), true, nil
+	}
+	if len(state.CommitSHAs) == 0 {
+		return reject("missing lifecycle commit evidence")
+	}
+	headSHA := strings.TrimSpace(detail.HeadSHA)
+	if headSHA == "" {
+		return reject("missing PR head SHA")
+	}
+	if !containsString(state.CommitSHAs, headSHA) {
+		return reject(fmt.Sprintf("PR head %s does not match lifecycle commits", headSHA))
+	}
+	if conflict, err := r.activeWorkerLoopClaimingPullRequest(ctx, currentLoopID, repo, prNumber); err != nil {
+		return checkpointPullPR{}, "", false, err
+	} else if conflict != "" {
+		return reject(conflict)
+	}
+	return checkpointPullPR{Number: prNumber, URL: firstNonEmpty(strings.TrimSpace(detail.URL), strings.TrimSpace(state.PRURL))}, headBranch, true, nil
 }
 
 func shouldPersistPullRequestReference(loop storage.LoopRecord, pr checkpointPullPR) bool {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -2608,6 +2608,39 @@ func TestProcessClaimedItemFailsWithSpecificReasonWhenMigratedPRHeadSHAMismatche
 	}
 }
 
+func TestLifecycleAgentCreatedPullRequestSkipsHardFailureForSameBranchRejectedPRs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		detail PullRequestDetail
+		state  *lifecycle.State
+	}{
+		{
+			name:   "closed PR",
+			detail: PullRequestDetail{Number: 311, URL: "https://example/pr/311", State: "closed", HeadRefName: "feature/pr-311", BaseRefName: "main"},
+			state:  &lifecycle.State{PRNumber: 311, PRURL: "https://example/pr/311", Actions: lifecycle.Actions{PR: lifecycle.ActionSourceAgent}},
+		},
+		{
+			name:   "base mismatch",
+			detail: PullRequestDetail{Number: 311, URL: "https://example/pr/311", State: "open", HeadRefName: "feature/pr-311", BaseRefName: "release"},
+			state:  &lifecycle.State{PRNumber: 311, PRURL: "https://example/pr/311", Actions: lifecycle.Actions{PR: lifecycle.ActionSourceAgent}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runner := New(Options{GitHub: &fakeGitHubGateway{prDetail: tt.detail}, Git: &fakeGitGateway{}})
+			pr, branch, ok, err := runner.lifecycleAgentCreatedPullRequest(context.Background(), "loop-1", "acme/looper", tt.state, "feature/pr-311", "main", t.TempDir())
+			if err != nil {
+				t.Fatalf("lifecycleAgentCreatedPullRequest() error = %v", err)
+			}
+			if ok {
+				t.Fatalf("lifecycleAgentCreatedPullRequest() ok = true, want false with pr=%#v branch=%q", pr, branch)
+			}
+		})
+	}
+}
+
 func TestProcessClaimedItemFailsWhenCreatedPRNumberIsMissing(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -3058,6 +3091,65 @@ func TestRunOpenPRStepUsesPersistedPRWhenLifecycleLookupFailsOnResume(t *testing
 	github := runner.github.(*fakeGitHubGateway)
 	if len(github.viewPRCalls) != 1 {
 		t.Fatalf("viewPRCalls = %#v, want single lifecycle lookup", github.viewPRCalls)
+	}
+}
+
+func TestRunOpenPRStepUsesPersistedPRWhenLifecycleAdoptionRejectsOnResume(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	prNumber := int64(559)
+	now := fixture.nowISO()
+	loopTarget := "pr:acme/looper:559"
+	loopMeta := `{"worker":{"title":"Existing PR lifecycle rejection","repo":"acme/looper","baseBranch":"main"},"prUrl":"https://example/pr/559"}`
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_559", Seq: 2, ProjectID: "project_1", Type: "worker", TargetType: "pull_request", TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "queued", MetadataJSON: &loopMeta, NextRunAt: &now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	disclosureCfg := config.DefaultDisclosureConfig()
+	disclosureCfg.Enabled = false
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{prDetail: PullRequestDetail{Number: prNumber, URL: "https://example/pr/559", State: "open", HeadRefName: "fix/migrated-pr-559", BaseRefName: "release", HeadSHA: "agentsha"}}, Git: &fakeGitGateway{}, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, Disclosure: &disclosureCfg})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_worker_559", LoopID: "loop_worker_559", Status: "running", CurrentStep: stringPtr(string(stepOpenPR)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_559")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+	queueItem, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_1")
+	if err != nil || queueItem == nil {
+		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue item", queueItem, err)
+	}
+	checkpoint := workerCheckpoint{
+		Work:       &workerInput{Title: "Existing PR lifecycle rejection", ExecutionMode: "create-pr", Repo: "acme/looper", BaseBranch: "main", PRNumber: prNumber, Branch: "feature/pr-559"},
+		Worktree:   &checkpointWorktree{Path: filepath.Join(t.TempDir(), "wt"), Branch: "feature/pr-559", BaseBranch: "main", HeadSHA: "abc123", ID: "worktree_559"},
+		Validation: &ValidationResult{Passed: true, Summary: "ok"},
+		Lifecycle: &lifecycle.State{
+			Policy:        lifecycle.PolicyAgentManagedWithFallback,
+			PolicyVersion: lifecycle.PolicyVersion,
+			Branch:        "feature/pr-559",
+			BaseBranch:    "main",
+			CommitSHAs:    []string{"agentsha"},
+			Pushed:        true,
+			PRNumber:      prNumber,
+			PRURL:         "https://example/pr/559",
+			Actions:       lifecycle.Actions{Push: lifecycle.ActionSourceAgent, PR: lifecycle.ActionSourceAgent},
+		},
+	}
+	input := stepInput{Project: *project, Loop: *loop, QueueItem: *queueItem, Run: storage.RunRecord{ID: "run_worker_559"}, Checkpoint: checkpoint}
+
+	checkpointAfter, err := runner.runOpenPRStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("runOpenPRStep() error = %v", err)
+	}
+	if checkpointAfter.PullRequest == nil || checkpointAfter.PullRequest.Number != prNumber || checkpointAfter.PullRequest.URL != "https://example/pr/559" {
+		t.Fatalf("checkpointAfter.PullRequest = %#v, want persisted PR reference", checkpointAfter.PullRequest)
+	}
+	if checkpointAfter.SkipReason != "" {
+		t.Fatalf("checkpointAfter.SkipReason = %q, want empty", checkpointAfter.SkipReason)
 	}
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -2519,6 +2519,95 @@ func TestProcessClaimedItemFindsExistingPRAfterPushAndStampsWorkerDisclosure(t *
 	}
 }
 
+func TestProcessClaimedItemAdoptsAgentCreatedPROnMigratedBranch(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	plannedBranch := "looper/feature"
+	agentBranch := "fix/migrated-branch"
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: plannedBranch, BaseBranch: "main", HeadSHA: "base123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{prDetail: PullRequestDetail{Number: 311, URL: "https://example/pr/311", State: "OPEN", HeadRefName: agentBranch, BaseRefName: "main", HeadSHA: "agentsha"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed", Lifecycle: &lifecycle.State{Branch: agentBranch, BaseBranch: "main", CommitSHAs: []string{"agentsha"}, Pushed: true, PRNumber: 311, PRURL: "https://example/pr/311", Actions: lifecycle.Actions{Commit: lifecycle.ActionSourceAgent, Push: lifecycle.ActionSourceAgent, PR: lifecycle.ActionSourceAgent}}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" || result.PullRequestNumber != 311 {
+		t.Fatalf("result = %#v, want success with adopted PR 311", result)
+	}
+	if len(git.pushCalls) != 0 || len(github.createPRCalls) != 0 || len(github.compareCalls) != 0 {
+		t.Fatalf("push/createPR/compare = %d/%d/%d, want 0/0/0 after lifecycle adoption", len(git.pushCalls), len(github.createPRCalls), len(github.compareCalls))
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	checkpoint, err := parseCheckpoint(run.CheckpointJSON)
+	if err != nil {
+		t.Fatalf("parseCheckpoint() error = %v", err)
+	}
+	if checkpoint.Lifecycle == nil || checkpoint.Lifecycle.PlannedBranch != plannedBranch || checkpoint.Lifecycle.AgentBranch != agentBranch || checkpoint.Lifecycle.ActiveBranch != agentBranch || checkpoint.Lifecycle.BranchProvenance != lifecycle.BranchProvenanceAgentMigrated || !checkpoint.Lifecycle.Pushed || checkpoint.Lifecycle.Actions.PR != lifecycle.ActionSourceAgent {
+		t.Fatalf("checkpoint lifecycle = %#v, want adopted migrated branch lifecycle", checkpoint.Lifecycle)
+	}
+	if checkpoint.SkipReason != "" {
+		t.Fatalf("checkpoint.SkipReason = %q, want empty", checkpoint.SkipReason)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.PRNumber == nil || *loop.PRNumber != 311 {
+		t.Fatalf("loop = %#v, want adopted PR persisted", loop)
+	}
+}
+
+func TestProcessClaimedItemFailsWithSpecificReasonWhenMigratedPRBaseMismatches(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "base123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{prDetail: PullRequestDetail{Number: 311, URL: "https://example/pr/311", State: "OPEN", HeadRefName: "fix/migrated-branch", BaseRefName: "release", HeadSHA: "agentsha"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed", Lifecycle: &lifecycle.State{Branch: "fix/migrated-branch", BaseBranch: "main", CommitSHAs: []string{"agentsha"}, Pushed: true, PRNumber: 311, PRURL: "https://example/pr/311", Actions: lifecycle.Actions{Commit: lifecycle.ActionSourceAgent, Push: lifecycle.ActionSourceAgent, PR: lifecycle.ActionSourceAgent}}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureManualIntervention || !strings.Contains(result.Summary, "Agent created PR #311 on branch fix/migrated-branch but worker could not adopt it: expected base main, got release") {
+		t.Fatalf("result = %#v, want specific manual-intervention adoption failure", result)
+	}
+	if strings.Contains(result.Summary, "has no commits ahead of main") {
+		t.Fatalf("result.Summary = %q, want migrated-PR adoption reason instead of no-ahead skip", result.Summary)
+	}
+	if len(git.pushCalls) != 0 || len(github.createPRCalls) != 0 || len(github.compareCalls) != 0 {
+		t.Fatalf("push/createPR/compare = %d/%d/%d, want 0/0/0 after rejection", len(git.pushCalls), len(github.createPRCalls), len(github.compareCalls))
+	}
+}
+
+func TestProcessClaimedItemFailsWithSpecificReasonWhenMigratedPRHeadSHAMismatches(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/feature", BaseBranch: "main", HeadSHA: "base123", WorktreeID: "worktree_1"}}
+	github := &fakeGitHubGateway{prDetail: PullRequestDetail{Number: 311, URL: "https://example/pr/311", State: "OPEN", HeadRefName: "fix/migrated-branch", BaseRefName: "main", HeadSHA: "unexpected"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed", Lifecycle: &lifecycle.State{Branch: "fix/migrated-branch", BaseBranch: "main", CommitSHAs: []string{"agentsha"}, Pushed: true, PRNumber: 311, PRURL: "https://example/pr/311", Actions: lifecycle.Actions{Commit: lifecycle.ActionSourceAgent, Push: lifecycle.ActionSourceAgent, PR: lifecycle.ActionSourceAgent}}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	claim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureManualIntervention || !strings.Contains(result.Summary, "PR head unexpected does not match lifecycle commits") {
+		t.Fatalf("result = %#v, want specific SHA-mismatch adoption failure", result)
+	}
+	if strings.Contains(result.Summary, "has no commits ahead of main") {
+		t.Fatalf("result.Summary = %q, want migrated-PR adoption reason instead of no-ahead skip", result.Summary)
+	}
+}
+
 func TestProcessClaimedItemFailsWhenCreatedPRNumberIsMissing(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)


### PR DESCRIPTION
## Summary
- preserve planned, agent, and active branch provenance in worker lifecycle state so migrated branch adoption stays explainable and resumable
- validate and adopt agent-created PRs on migrated branches when the PR is open, targets the expected base, matches lifecycle commit evidence, and is not already claimed by another worker loop
- surface specific manual-intervention reasons for unsafe migrated PR adoption attempts instead of falling back to misleading no-ahead branch skips

## Validation
- go test ./internal/lifecycle ./internal/worker
- go vet ./...
- go build ./...

Closes #313