### PR TITLE
fix: sanitize agent cwd env for isolated worktrees

### DIFF
--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -24,6 +26,25 @@ const (
 	maxPersistedLogReadBytes = 16 * 1024 * 1024
 	completionMarkerEnv      = "LOOPER_COMPLETION_MARKER"
 )
+
+var unsafeAgentEnvKeys = []string{
+	"OLDPWD",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_CONFIG",
+	"GIT_CONFIG_PARAMETERS",
+	"GIT_CONFIG_COUNT",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_IMPLICIT_WORK_TREE",
+	"GIT_GRAFT_FILE",
+	"GIT_COMMON_DIR",
+	"GIT_INDEX_FILE",
+	"GIT_NO_REPLACE_OBJECTS",
+	"GIT_REPLACE_REF_BASE",
+	"GIT_PREFIX",
+	"GIT_SHALLOW_FILE",
+}
 
 type ExecutorConfig struct {
 	Vendor              config.AgentVendor
@@ -200,22 +221,12 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 	if resume.Enabled && strings.TrimSpace(input.NativeResumePrompt) != "" {
 		spawnPrompt = input.NativeResumePrompt
 	}
-	command, args := ResolveSpawnWithNativeResume(e.config, spawnPrompt, resume.SessionID, resume.Enabled)
+	command, args := ResolveSpawnWithNativeResume(e.config, input.WorkingDirectory, spawnPrompt, resume.SessionID, resume.Enabled)
 
 	cmd := exec.Command(command, args...)
 	cmd.Dir = input.WorkingDirectory
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Env = os.Environ()
-	for key, value := range e.config.Env {
-		cmd.Env = append(cmd.Env, key+"="+value)
-	}
-	for key, value := range input.Env {
-		cmd.Env = append(cmd.Env, key+"="+value)
-	}
-	cmd.Env = append(cmd.Env,
-		"LOOPER_PROMPT="+spawnPrompt,
-		completionMarkerEnv+"="+CompletionMarkerPrefix,
-	)
+	cmd.Env = buildCommandEnv(input.WorkingDirectory, spawnPrompt, e.config.Env, input.Env)
 
 	maxOutputBytes := input.MaxOutputBytes
 	if maxOutputBytes <= 0 {
@@ -253,21 +264,11 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 			if markErr := e.markNativeResumeFailed(ctx, resume.SourceExecutionID, err.Error()); markErr == nil && e.logDir != "" {
 				// best-effort marker only; command fallback is the important recovery behavior
 			}
-			command, args = ResolveSpawn(e.config, input.Prompt)
+			command, args = ResolveSpawn(e.config, input.WorkingDirectory, input.Prompt)
 			cmd = exec.Command(command, args...)
 			cmd.Dir = input.WorkingDirectory
 			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-			cmd.Env = os.Environ()
-			for key, value := range e.config.Env {
-				cmd.Env = append(cmd.Env, key+"="+value)
-			}
-			for key, value := range input.Env {
-				cmd.Env = append(cmd.Env, key+"="+value)
-			}
-			cmd.Env = append(cmd.Env,
-				"LOOPER_PROMPT="+input.Prompt,
-				completionMarkerEnv+"="+CompletionMarkerPrefix,
-			)
+			cmd.Env = buildCommandEnv(input.WorkingDirectory, input.Prompt, e.config.Env, input.Env)
 			cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stdout", chunk) }}
 			cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stderr", chunk) }}
 			x.mu.Lock()
@@ -606,21 +607,11 @@ func normalizeNativeResumeErrorLine(line string) string {
 }
 
 func (x *execution) runCheckpointFallback(ctx context.Context, nativeError string) (Result, string, bool) {
-	command, args := ResolveSpawn(x.executor.config, x.input.Prompt)
+	command, args := ResolveSpawn(x.executor.config, x.input.WorkingDirectory, x.input.Prompt)
 	cmd := exec.Command(command, args...)
 	cmd.Dir = x.input.WorkingDirectory
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Env = os.Environ()
-	for key, value := range x.executor.config.Env {
-		cmd.Env = append(cmd.Env, key+"="+value)
-	}
-	for key, value := range x.input.Env {
-		cmd.Env = append(cmd.Env, key+"="+value)
-	}
-	cmd.Env = append(cmd.Env,
-		"LOOPER_PROMPT="+x.input.Prompt,
-		completionMarkerEnv+"="+CompletionMarkerPrefix,
-	)
+	cmd.Env = buildCommandEnv(x.input.WorkingDirectory, x.input.Prompt, x.executor.config.Env, x.input.Env)
 	cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stdout", chunk) }}
 	cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stderr", chunk) }}
 
@@ -1080,18 +1071,18 @@ func (w *streamCapture) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func ResolveSpawn(cfg ExecutorConfig, prompt string) (string, []string) {
+func ResolveSpawn(cfg ExecutorConfig, workingDirectory string, prompt string) (string, []string) {
 	command := resolveCommand(cfg)
-	args := resolveArgs(cfg, prompt)
+	args := resolveArgs(cfg, workingDirectory, prompt)
 	return command, args
 }
 
-func ResolveSpawnWithNativeResume(cfg ExecutorConfig, prompt string, sessionID string, enabled bool) (string, []string) {
+func ResolveSpawnWithNativeResume(cfg ExecutorConfig, workingDirectory string, prompt string, sessionID string, enabled bool) (string, []string) {
 	if !enabled || strings.TrimSpace(sessionID) == "" || !nativeResumeSupported(cfg.Vendor) {
-		return ResolveSpawn(cfg, prompt)
+		return ResolveSpawn(cfg, workingDirectory, prompt)
 	}
 	command := resolveCommand(cfg)
-	args := resolveNativeResumeArgs(cfg, stringArgs(cfg.Params["args"]), strings.TrimSpace(sessionID), prompt)
+	args := resolveNativeResumeArgs(cfg, workingDirectory, stringArgs(cfg.Params["args"]), strings.TrimSpace(sessionID), prompt)
 	return command, args
 }
 
@@ -1109,7 +1100,7 @@ func resolveCommand(cfg ExecutorConfig) string {
 	}
 }
 
-func resolveArgs(cfg ExecutorConfig, prompt string) []string {
+func resolveArgs(cfg ExecutorConfig, workingDirectory string, prompt string) []string {
 	resolvedArgs := stringArgs(cfg.Params["args"])
 	switch cfg.Vendor {
 	case config.AgentVendorClaudeCode:
@@ -1117,7 +1108,7 @@ func resolveArgs(cfg ExecutorConfig, prompt string) []string {
 	case config.AgentVendorCodex:
 		return resolveCodexArgs(cfg, resolvedArgs, prompt)
 	case config.AgentVendorOpenCode:
-		return resolveOpenCodeArgs(cfg, resolvedArgs, prompt)
+		return resolveOpenCodeArgs(cfg, resolvedArgs, workingDirectory, prompt)
 	case config.AgentVendorCursorCLI:
 		return resolveCursorArgs(cfg, resolvedArgs, prompt)
 	default:
@@ -1148,10 +1139,13 @@ func resolveCodexArgs(cfg ExecutorConfig, args []string, prompt string) []string
 	return append(withModel, prompt)
 }
 
-func resolveOpenCodeArgs(cfg ExecutorConfig, args []string, prompt string) []string {
+func resolveOpenCodeArgs(cfg ExecutorConfig, args []string, workingDirectory string, prompt string) []string {
 	resolved := append([]string{}, args...)
 	if !containsArg(resolved, "run") {
 		resolved = append([]string{"run"}, resolved...)
+	}
+	if strings.TrimSpace(workingDirectory) != "" && !hasAnyFlag(resolved, []string{"--dir"}) {
+		resolved = appendDirFlag(resolved, workingDirectory)
 	}
 	withModel := prependModelFlag(resolved, cfg.Model, "--model", []string{"--model", "-m"})
 	if hasAnyFlag(withModel, []string{"-p", "--prompt", "-f", "--file"}) {
@@ -1168,7 +1162,7 @@ func resolveCursorArgs(cfg ExecutorConfig, args []string, prompt string) []strin
 	return append(resolved, "--print", prompt)
 }
 
-func resolveNativeResumeArgs(cfg ExecutorConfig, args []string, sessionID string, prompt string) []string {
+func resolveNativeResumeArgs(cfg ExecutorConfig, workingDirectory string, args []string, sessionID string, prompt string) []string {
 	switch cfg.Vendor {
 	case config.AgentVendorClaudeCode:
 		resolved := prependModelFlag(args, cfg.Model, "--model", []string{"--model"})
@@ -1194,11 +1188,14 @@ func resolveNativeResumeArgs(cfg ExecutorConfig, args []string, sessionID string
 		return append(base, prompt)
 	case config.AgentVendorOpenCode:
 		resolved := prependModelFlag(args, cfg.Model, "--model", []string{"--model", "-m"})
-		if !hasAnyFlag(resolved, []string{"--session", "--continue"}) {
-			resolved = append(resolved, "--session", sessionID)
-		}
 		if !containsArg(resolved, "run") {
 			resolved = append([]string{"run"}, resolved...)
+		}
+		if strings.TrimSpace(workingDirectory) != "" && !hasAnyFlag(resolved, []string{"--dir"}) {
+			resolved = appendDirFlag(resolved, workingDirectory)
+		}
+		if !hasAnyFlag(resolved, []string{"--session", "--continue"}) {
+			resolved = append(resolved, "--session", sessionID)
 		}
 		if !hasAnyFlag(resolved, []string{"-p", "--prompt", "-f", "--file"}) {
 			resolved = append(resolved, prompt)
@@ -1216,6 +1213,63 @@ func resolveNativeResumeArgs(cfg ExecutorConfig, args []string, sessionID string
 	default:
 		return append([]string{}, args...)
 	}
+}
+
+func buildCommandEnv(workingDirectory string, prompt string, envSources ...map[string]string) []string {
+	envMap := envSliceToMap(os.Environ())
+	for _, source := range envSources {
+		maps.Copy(envMap, source)
+	}
+	for _, key := range unsafeAgentEnvKeys {
+		delete(envMap, key)
+	}
+	if strings.TrimSpace(workingDirectory) != "" {
+		envMap["PWD"] = workingDirectory
+	}
+	envMap["LOOPER_PROMPT"] = prompt
+	envMap[completionMarkerEnv] = CompletionMarkerPrefix
+	return envMapToSlice(envMap)
+}
+
+func BuildCommandEnv(workingDirectory string, prompt string, envSources ...map[string]string) []string {
+	return buildCommandEnv(workingDirectory, prompt, envSources...)
+}
+
+func envSliceToMap(env []string) map[string]string {
+	envMap := make(map[string]string, len(env))
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || key == "" {
+			continue
+		}
+		envMap[key] = value
+	}
+	return envMap
+}
+
+func envMapToSlice(env map[string]string) []string {
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	resolved := make([]string, 0, len(keys))
+	for _, key := range keys {
+		resolved = append(resolved, key+"="+env[key])
+	}
+	return resolved
+}
+
+func appendDirFlag(args []string, workingDirectory string) []string {
+	for idx, arg := range args {
+		if arg != "run" {
+			continue
+		}
+		resolved := append([]string{}, args[:idx+1]...)
+		resolved = append(resolved, "--dir", workingDirectory)
+		return append(resolved, args[idx+1:]...)
+	}
+	return append([]string{"--dir", workingDirectory}, args...)
 }
 
 func prependModelFlag(args []string, model *string, flag string, recognizedFlags []string) []string {

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -19,7 +19,8 @@ func TestResolveSpawnVendorParity(t *testing.T) {
 	t.Parallel()
 
 	model := "gpt-5"
-	command, args := ResolveSpawn(ExecutorConfig{Vendor: config.AgentVendorClaudeCode, Model: &model}, "hello")
+	workDir := "/tmp/looper-worktree"
+	command, args := ResolveSpawn(ExecutorConfig{Vendor: config.AgentVendorClaudeCode, Model: &model}, workDir, "hello")
 	if command != "claude" {
 		t.Fatalf("claude command = %q, want claude", command)
 	}
@@ -27,7 +28,7 @@ func TestResolveSpawnVendorParity(t *testing.T) {
 		t.Fatalf("claude args = %#v, want --model <model> --print <prompt>", args)
 	}
 
-	command, args = ResolveSpawn(ExecutorConfig{Vendor: config.AgentVendorCodex, Model: &model}, "hello")
+	command, args = ResolveSpawn(ExecutorConfig{Vendor: config.AgentVendorCodex, Model: &model}, workDir, "hello")
 	if command != "codex" {
 		t.Fatalf("codex command = %q, want codex", command)
 	}
@@ -35,15 +36,15 @@ func TestResolveSpawnVendorParity(t *testing.T) {
 		t.Fatalf("codex args = %#v, want exec --model <model> <prompt>", args)
 	}
 
-	command, args = ResolveSpawn(ExecutorConfig{Vendor: config.AgentVendorOpenCode, Model: &model}, "hello")
+	command, args = ResolveSpawn(ExecutorConfig{Vendor: config.AgentVendorOpenCode, Model: &model}, workDir, "hello")
 	if command != "opencode" {
 		t.Fatalf("opencode command = %q, want opencode", command)
 	}
-	if len(args) < 4 || args[0] != "run" || args[1] != "--model" || args[len(args)-1] != "hello" {
-		t.Fatalf("opencode args = %#v, want run --model <model> <prompt>", args)
+	if len(args) < 6 || args[0] != "run" || args[1] != "--model" || args[3] != "--dir" || args[4] != workDir || args[len(args)-1] != "hello" {
+		t.Fatalf("opencode args = %#v, want run --model <model> --dir <cwd> <prompt>", args)
 	}
 
-	command, args = ResolveSpawn(ExecutorConfig{Vendor: config.AgentVendorCursorCLI, Model: &model}, "hello")
+	command, args = ResolveSpawn(ExecutorConfig{Vendor: config.AgentVendorCursorCLI, Model: &model}, workDir, "hello")
 	if command != "agent" {
 		t.Fatalf("cursor command = %q, want agent", command)
 	}
@@ -60,7 +61,7 @@ func TestResolveSpawnCodexDoesNotDuplicateExecSubcommand(t *testing.T) {
 		Vendor: config.AgentVendorCodex,
 		Model:  &model,
 		Params: map[string]any{"args": []any{"--profile", "test", "exec"}},
-	}, "hello")
+	}, "/tmp/looper-worktree", "hello")
 	if command != "codex" {
 		t.Fatalf("codex command = %q, want codex", command)
 	}
@@ -77,12 +78,12 @@ func TestResolveSpawnOpenCodeDoesNotDuplicateRunSubcommand(t *testing.T) {
 		Vendor: config.AgentVendorOpenCode,
 		Model:  &model,
 		Params: map[string]any{"args": []any{"--profile", "test", "run"}},
-	}, "hello")
+	}, "/tmp/looper-worktree", "hello")
 	if command != "opencode" {
 		t.Fatalf("opencode command = %q, want opencode", command)
 	}
-	if strings.Join(args, " ") != "--model gpt-5 --profile test run hello" {
-		t.Fatalf("opencode args = %#v, want single run subcommand preserved", args)
+	if strings.Join(args, " ") != "--model gpt-5 --profile test run --dir /tmp/looper-worktree hello" {
+		t.Fatalf("opencode args = %#v, want single run subcommand preserved with --dir", args)
 	}
 }
 
@@ -96,14 +97,14 @@ func TestResolveSpawnWithNativeResumeVendorArgs(t *testing.T) {
 	}{
 		{name: "claude", vendor: config.AgentVendorClaudeCode, want: "--resume session-123 --print hello --dangerously-skip-permissions"},
 		{name: "codex", vendor: config.AgentVendorCodex, want: "exec resume session-123 hello"},
-		{name: "opencode", vendor: config.AgentVendorOpenCode, want: "run --session session-123 hello"},
+		{name: "opencode", vendor: config.AgentVendorOpenCode, want: "run --dir /tmp/looper-worktree --session session-123 hello"},
 		{name: "cursor", vendor: config.AgentVendorCursorCLI, want: "--resume session-123 --print hello"},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, args := ResolveSpawnWithNativeResume(ExecutorConfig{Vendor: tc.vendor}, "hello", "session-123", true)
+			_, args := ResolveSpawnWithNativeResume(ExecutorConfig{Vendor: tc.vendor}, "/tmp/looper-worktree", "hello", "session-123", true)
 			if got := strings.Join(args, " "); got != tc.want {
 				t.Fatalf("args = %q, want %q", got, tc.want)
 			}
@@ -119,7 +120,7 @@ func TestResolveSpawnWithNativeResumeCodexPreservesExecOptions(t *testing.T) {
 		Vendor: config.AgentVendorCodex,
 		Model:  &model,
 		Params: map[string]any{"args": []any{"exec", "--json", "--sandbox", "workspace-write"}},
-	}, "hello", "session-123", true)
+	}, "/tmp/looper-worktree", "hello", "session-123", true)
 	if got, want := strings.Join(args, " "), "exec --model gpt-5 --json --sandbox workspace-write resume session-123 hello"; got != want {
 		t.Fatalf("args = %q, want %q", got, want)
 	}
@@ -133,9 +134,103 @@ func TestResolveSpawnWithNativeResumeDoesNotDuplicateEqualsFlags(t *testing.T) {
 		Vendor: config.AgentVendorOpenCode,
 		Model:  &model,
 		Params: map[string]any{"args": []any{"run", "--model=gpt-4", "--session=existing", "--prompt=from-args"}},
-	}, "hello", "session-123", true)
-	if got, want := strings.Join(args, " "), "run --model=gpt-4 --session=existing --prompt=from-args"; got != want {
+	}, "/tmp/looper-worktree", "hello", "session-123", true)
+	if got, want := strings.Join(args, " "), "run --dir /tmp/looper-worktree --model=gpt-4 --session=existing --prompt=from-args"; got != want {
 		t.Fatalf("args = %q, want %q", got, want)
+	}
+}
+
+func TestBuildCommandEnvSanitizesInheritedCWDAndGitOverrides(t *testing.T) {
+	t.Setenv("PWD", "/Users/mrc/Projects/looper")
+	t.Setenv("OLDPWD", "/Users/mrc")
+	t.Setenv("GIT_DIR", "/tmp/unsafe-git-dir")
+	t.Setenv("GIT_WORK_TREE", "/tmp/unsafe-git-worktree")
+	t.Setenv("GIT_PREFIX", "unsafe-prefix")
+	t.Setenv("KEEP_ME", "1")
+
+	env := envSliceToMap(buildCommandEnv("/tmp/worktree", "hello", map[string]string{"CONFIG_ONLY": "true", "PWD": "/tmp/config-override", "GIT_DIR": "/tmp/config-git-dir"}, map[string]string{"INPUT_ONLY": "yes", "OLDPWD": "/tmp/input-oldpwd"}))
+
+	if got := env["PWD"]; got != "/tmp/worktree" {
+		t.Fatalf("PWD = %q, want /tmp/worktree", got)
+	}
+	for _, key := range unsafeAgentEnvKeys {
+		if _, ok := env[key]; ok {
+			t.Fatalf("%s present in sanitized env, want removed", key)
+		}
+	}
+	if got := env["KEEP_ME"]; got != "1" {
+		t.Fatalf("KEEP_ME = %q, want inherited value", got)
+	}
+	if got := env["CONFIG_ONLY"]; got != "true" {
+		t.Fatalf("CONFIG_ONLY = %q, want true", got)
+	}
+	if got := env["INPUT_ONLY"]; got != "yes" {
+		t.Fatalf("INPUT_ONLY = %q, want yes", got)
+	}
+	if got := env["LOOPER_PROMPT"]; got != "hello" {
+		t.Fatalf("LOOPER_PROMPT = %q, want hello", got)
+	}
+	if got := env[completionMarkerEnv]; got != CompletionMarkerPrefix {
+		t.Fatalf("%s = %q, want %q", completionMarkerEnv, got, CompletionMarkerPrefix)
+	}
+}
+
+func TestExecutorStartSanitizesChildEnvAndUsesWorkingDirectory(t *testing.T) {
+	t.Setenv("PWD", "/Users/mrc/Projects/looper")
+	t.Setenv("OLDPWD", "/Users/mrc")
+	t.Setenv("GIT_DIR", "/tmp/unsafe-git-dir")
+	t.Setenv("GIT_PREFIX", "unsafe-prefix")
+
+	workDir := t.TempDir()
+	scriptDir := t.TempDir()
+	outputPath := filepath.Join(scriptDir, "child.json")
+	scriptPath := filepath.Join(scriptDir, "dump-env")
+	script := "#!/bin/sh\nactual_cwd=$(pwd)\nprintf '{\"pwd\":\"%s\",\"oldpwd\":\"%s\",\"git_dir\":\"%s\",\"looper_prompt\":\"%s\",\"cwd\":\"%s\"}\n' \"$PWD\" \"$OLDPWD\" \"$GIT_DIR\" \"$LOOPER_PROMPT\" \"$actual_cwd\" > \"$OUTPUT_PATH\"\nprintf '__LOOPER_RESULT__={\"summary\":\"done\"}\n'\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(scriptPath) error = %v", err)
+	}
+
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": scriptPath}}})
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_env", WorkingDirectory: workDir, Prompt: "ignored", Timeout: time.Second, Env: map[string]string{"OUTPUT_PATH": outputPath, "PWD": "/tmp/input-override", "GIT_DIR": "/tmp/input-git-dir", "OLDPWD": "/tmp/input-oldpwd"}})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("result.Status = %q, want completed", result.Status)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(outputPath) error = %v", err)
+	}
+	var observed struct {
+		PWD          string `json:"pwd"`
+		OLDPWD       string `json:"oldpwd"`
+		GitDir       string `json:"git_dir"`
+		LooperPrompt string `json:"looper_prompt"`
+		CWD          string `json:"cwd"`
+	}
+	if err := json.Unmarshal(data, &observed); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v, data=%q", err, string(data))
+	}
+	if observed.PWD != workDir {
+		t.Fatalf("child PWD = %q, want %q", observed.PWD, workDir)
+	}
+	if observed.CWD != workDir {
+		t.Fatalf("child cwd = %q, want %q", observed.CWD, workDir)
+	}
+	if observed.OLDPWD != "" {
+		t.Fatalf("child OLDPWD = %q, want empty", observed.OLDPWD)
+	}
+	if observed.GitDir != "" {
+		t.Fatalf("child GIT_DIR = %q, want empty", observed.GitDir)
+	}
+	if observed.LooperPrompt != "ignored" {
+		t.Fatalf("child LOOPER_PROMPT = %q, want ignored", observed.LooperPrompt)
 	}
 }
 

--- a/internal/cliapp/feedback.go
+++ b/internal/cliapp/feedback.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -52,12 +51,11 @@ func (r *commandRuntime) feedback(cmd *cobra.Command, args []string) error {
 		Params: loaded.Config.Agent.Params,
 		Env:    loaded.Config.Agent.Env,
 	}
-	command, commandArgs := agent.ResolveSpawn(agentCfg, prompt)
-
 	cwd, err := r.getwd()
 	if err != nil {
 		return fmt.Errorf("resolve working directory: %w", err)
 	}
+	command, commandArgs := agent.ResolveSpawn(agentCfg, cwd, prompt)
 
 	runCtx, cancel := context.WithTimeout(cmd.Context(), feedbackCommandTimeout)
 	defer cancel()
@@ -68,14 +66,7 @@ func (r *commandRuntime) feedback(cmd *cobra.Command, args []string) error {
 	process.Dir = cwd
 	process.Stdout = stdout
 	process.Stderr = stderr
-	process.Env = os.Environ()
-	for key, value := range loaded.Config.Agent.Env {
-		process.Env = append(process.Env, key+"="+value)
-	}
-	process.Env = append(process.Env,
-		"LOOPER_PROMPT="+prompt,
-		"LOOPER_COMPLETION_MARKER="+agent.CompletionMarkerPrefix,
-	)
+	process.Env = agent.BuildCommandEnv(cwd, prompt, loaded.Config.Agent.Env)
 
 	if err := process.Run(); err != nil {
 		return feedbackRunError(err, stdout.String(), stderr.String())


### PR DESCRIPTION
## Summary
- sanitize agent child process environments so `PWD` is forced to the worktree and cwd-sensitive `GIT_*` overrides are stripped after config/input env merges
- pass the working directory through spawn resolution and add explicit `--dir <worktree>` for OpenCode runs and resume paths
- extend executor regression coverage for env sanitization, OpenCode arg construction, and feedback command agent spawning