### PR TITLE
refactor: simplify fixer review-thread resolution authority

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2018,6 +2018,15 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	}
 	driftCount := 0
 	mutationFailureCount := 0
+	// Drift detection must be anchored to when the agent recorded the
+	// reply explanations, not when the current (possibly retried) run
+	// started. Otherwise a reviewer comment posted between the original
+	// repair and a replay/retry would be classified as "old" and the
+	// stale explanation would be used to resolve fresh feedback.
+	driftSince := input.Run.StartedAt
+	if checkpoint.Repair != nil && strings.TrimSpace(checkpoint.Repair.CompletedAt) != "" {
+		driftSince = checkpoint.Repair.CompletedAt
+	}
 	// If the agent's reply explanations were captured against a different
 	// fix-items snapshot than the live PR shows, the underlying threads or
 	// comments have changed since the agent ran. Treat the whole step as
@@ -2055,7 +2064,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "already_resolved", UpdatedAt: r.nowISO()})
 			continue
 		}
-		if hasNonLooperCommentSince(thread, input.Run.StartedAt) {
+		if hasNonLooperCommentSince(thread, driftSince) {
 			driftCount++
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_thread_drift", Message: "New human comment was added to this thread after the fixer run started", UpdatedAt: r.nowISO()})
 			continue

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2126,8 +2126,23 @@ func lookupReplyExplanations(checkpoint fixerCheckpoint) map[string]string {
 	return out
 }
 
-func agentResolveRepliesByFixItemID(checkpoint fixerCheckpoint) map[string]string {
+// agentResolveReplyExplanationsValid reports whether the agent-provided
+// reply explanations were captured against the same fix-items snapshot
+// represented by the current checkpoint. When the snapshot drifted (e.g.
+// rebase, new comments) the explanations no longer describe the threads
+// we are about to handle and must not be used as resolve authority.
+func agentResolveReplyExplanationsValid(checkpoint fixerCheckpoint) bool {
 	if checkpoint.Repair == nil || len(checkpoint.Repair.ReplyExplanations) == 0 {
+		return false
+	}
+	if checkpoint.Repair.FixItemsHash != "" && checkpoint.FixItemsHash != "" && checkpoint.Repair.FixItemsHash != checkpoint.FixItemsHash {
+		return false
+	}
+	return true
+}
+
+func agentResolveRepliesByFixItemID(checkpoint fixerCheckpoint) map[string]string {
+	if !agentResolveReplyExplanationsValid(checkpoint) {
 		return nil
 	}
 	out := make(map[string]string, len(checkpoint.Repair.ReplyExplanations))
@@ -2148,7 +2163,7 @@ func agentResolveRepliesByFixItemID(checkpoint fixerCheckpoint) map[string]strin
 }
 
 func agentResolveRepliesByThreadID(checkpoint fixerCheckpoint) map[string]string {
-	if checkpoint.Repair == nil || len(checkpoint.Repair.ReplyExplanations) == 0 {
+	if !agentResolveReplyExplanationsValid(checkpoint) {
 		return nil
 	}
 	out := make(map[string]string, len(checkpoint.Repair.ReplyExplanations))
@@ -2181,6 +2196,9 @@ func hasNonLooperCommentSince(thread ReviewThread, rawSince string) bool {
 		if isLooperReviewThreadComment(comment) {
 			continue
 		}
+		if isBotReviewThreadComment(comment) {
+			continue
+		}
 		return true
 	}
 	return false
@@ -2192,6 +2210,18 @@ func isLooperReviewThreadComment(comment ReviewThreadComment) bool {
 		return false
 	}
 	return disclosure.HasMarkdownStamp(body) || strings.Contains(body, "looper-fixer-reply") || strings.Contains(body, "looper:fixer-round")
+}
+
+// isBotReviewThreadComment reports whether the comment was authored by a
+// GitHub bot account (e.g. chatgpt-codex-connector[bot], coderabbitai[bot],
+// github-actions[bot]). Bot comments must not be treated as new human
+// reviewer feedback for drift detection.
+func isBotReviewThreadComment(comment ReviewThreadComment) bool {
+	login := strings.ToLower(strings.TrimSpace(comment.Author))
+	if login == "" {
+		return false
+	}
+	return strings.HasSuffix(login, "[bot]")
 }
 
 func buildFixerReplyBody(item FixItem, commitSHA, explanation string) string {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -170,6 +170,24 @@ type AddReviewThreadReplyInput struct {
 	CWD      string
 }
 
+// CompareCommitsInput asks the gateway to compare two commits on a remote
+// repository (e.g. via the GitHub compare API). Used by the fixer to detect
+// whether a previously-pushed fix commit is still reachable from the live PR
+// head, which distinguishes safe upstream additions from history-rewriting
+// rebases / force-pushes that erase the fix.
+type CompareCommitsInput struct {
+	Repo string
+	Base string
+	Head string
+	CWD  string
+}
+
+// CompareCommitsResult mirrors the GitHub compare API status field.
+// Valid values: "identical", "ahead", "behind", "diverged".
+type CompareCommitsResult struct {
+	Status string
+}
+
 type IssueCommentInput struct {
 	Repo        string
 	IssueNumber int64
@@ -205,6 +223,7 @@ type GitHubGateway interface {
 	ViewReviewThread(context.Context, ViewReviewThreadInput) (ReviewThread, error)
 	ResolveReviewThread(context.Context, ResolveReviewThreadInput) error
 	AddReviewThreadReply(context.Context, AddReviewThreadReplyInput) error
+	CompareCommits(context.Context, CompareCommitsInput) (CompareCommitsResult, error)
 	CreateIssueComment(context.Context, IssueCommentInput) (IssueCommentResult, error)
 	UpdateIssueComment(context.Context, UpdateIssueCommentInput) error
 	AddPullRequestLabels(context.Context, PullRequestLabelsInput) error
@@ -1951,6 +1970,32 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	if err != nil {
 		return checkpoint, err
 	}
+	// Ancestor guard: if we previously pushed a fix commit, make sure the
+	// live PR head still descends from it. If a collaborator force-pushed or
+	// rebased and dropped our commit, replying and resolving threads would
+	// be acknowledging code that no longer exists in the PR. Bail out and
+	// let the next discover round re-derive everything from scratch.
+	//
+	// "identical" or "ahead" means the fix commit is still reachable from
+	// the live head (possibly with extra commits stacked on top from CI
+	// bots, the author, or other collaborators) — that is harmless and we
+	// proceed. "behind" or "diverged" means history was rewritten such
+	// that the fix commit is no longer an ancestor of the head; we must
+	// abandon this round.
+	if expectedHead := resolveCommentsExpectedHeadSHA(checkpoint); expectedHead != "" && liveDetail.HeadSHA != "" && liveDetail.HeadSHA != expectedHead {
+		cmp, cmpErr := r.github.CompareCommits(ctx, CompareCommitsInput{Repo: input.Repo, Base: expectedHead, Head: liveDetail.HeadSHA, CWD: input.Project.RepoPath})
+		if cmpErr != nil {
+			checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
+			return checkpoint, &loopError{message: fmt.Sprintf("Failed to verify fix commit %s is reachable from PR head %s: %v", expectedHead, liveDetail.HeadSHA, cmpErr), kind: FailureRetryableAfterResume}
+		}
+		switch strings.ToLower(strings.TrimSpace(cmp.Status)) {
+		case "identical", "ahead":
+			// fix commit still in head's history; safe to continue
+		default:
+			checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
+			return checkpoint, &loopError{message: fmt.Sprintf("PR head %s no longer descends from fix commit %s (compare status %q); will rediscover", liveDetail.HeadSHA, expectedHead, cmp.Status), kind: FailureRetryableAfterResume}
+		}
+	}
 	checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, liveDetail)
 	fixItems := collectFixItems(liveDetail)
 	checkpoint.FixItems = fixItems
@@ -1973,6 +2018,23 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	}
 	driftCount := 0
 	mutationFailureCount := 0
+	// If the agent's reply explanations were captured against a different
+	// fix-items snapshot than the live PR shows, the underlying threads or
+	// comments have changed since the agent ran. Treat the whole step as
+	// thread drift and rediscover, instead of marking each thread as
+	// skipped_agent_declined (which would silently bypass the drift path).
+	if len(commentItems) > 0 && checkpoint.Repair != nil && len(checkpoint.Repair.ReplyExplanations) > 0 && !agentResolveReplyExplanationsValid(checkpoint) {
+		for _, item := range commentItems {
+			if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
+				continue
+			}
+			driftCount++
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_thread_drift", Message: "Fix-items snapshot changed since the agent recorded reply explanations", UpdatedAt: r.nowISO()})
+		}
+		r.appendEvent(ctx, eventInput{eventType: "fixer.comments.resolved", projectID: input.Project.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"items": checkpoint.ResolvedComments.Items}})
+		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
+		return checkpoint, &loopError{message: fmt.Sprintf("Fix-items snapshot drifted; will rediscover %d thread(s)", driftCount), kind: FailureRetryableAfterResume}
+	}
 	for _, item := range commentItems {
 		if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
 			continue
@@ -2024,7 +2086,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		return checkpoint, &loopError{message: fmt.Sprintf("Skipped %d review thread(s) because new human comments arrived during the fixer run", driftCount), kind: FailureRetryableAfterResume}
 	}
 	if mutationFailureCount > 0 {
-		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
+		checkpoint.ResumePolicy = loops.ResumePolicyReplayStep
 		return checkpoint, &loopError{message: fmt.Sprintf("Failed to resolve %d review thread(s); will retry on next run", mutationFailureCount), kind: FailureRetryableAfterResume}
 	}
 	if _, err := r.clearFixerFollowupMetadata(ctx, input.Loop); err != nil {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1972,6 +1972,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		commitSHA = resolveCommentsExpectedHeadSHA(checkpoint)
 	}
 	driftCount := 0
+	mutationFailureCount := 0
 	for _, item := range commentItems {
 		if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
 			continue
@@ -2003,11 +2004,12 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 		if err := r.github.ResolveReviewThread(ctx, ResolveReviewThreadInput{Repo: input.Repo, ThreadID: item.ThreadID, CWD: input.Project.RepoPath}); err != nil {
 			message := err.Error()
-			status := "failed_mutation_terminal"
 			if strings.Contains(strings.ToLower(message), "already") {
-				status = "already_resolved"
+				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "already_resolved", Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+				continue
 			}
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: status, Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+			mutationFailureCount++
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "failed_mutation_retry", Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 			continue
 		}
 		resolvedCount++
@@ -2020,6 +2022,10 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	if driftCount > 0 {
 		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
 		return checkpoint, &loopError{message: fmt.Sprintf("Skipped %d review thread(s) because new human comments arrived during the fixer run", driftCount), kind: FailureRetryableAfterResume}
+	}
+	if mutationFailureCount > 0 {
+		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
+		return checkpoint, &loopError{message: fmt.Sprintf("Failed to resolve %d review thread(s); will retry on next run", mutationFailureCount), kind: FailureRetryableAfterResume}
 	}
 	if _, err := r.clearFixerFollowupMetadata(ctx, input.Loop); err != nil {
 		return checkpoint, err
@@ -2190,7 +2196,12 @@ func hasNonLooperCommentSince(thread ReviewThread, rawSince string) bool {
 	}
 	for _, comment := range thread.Comments {
 		createdAt := parseRFC3339OrZero(comment.CreatedAt)
-		if createdAt.IsZero() || !createdAt.After(since) {
+		updatedAt := parseRFC3339OrZero(comment.UpdatedAt)
+		latest := createdAt
+		if updatedAt.After(latest) {
+			latest = updatedAt
+		}
+		if latest.IsZero() || !latest.After(since) {
 			continue
 		}
 		if isLooperReviewThreadComment(comment) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -150,8 +150,11 @@ type ReviewThread struct {
 }
 
 type ReviewThreadComment struct {
-	ID   string
-	Body string
+	ID        string
+	Body      string
+	Author    string
+	CreatedAt string
+	UpdatedAt string
 }
 
 type ResolveReviewThreadInput struct {
@@ -1944,64 +1947,17 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	if checkpoint.Push == nil {
 		return checkpoint, &loopError{message: "resolve-comments requires push step to complete", kind: FailureRetryableAfterResume}
 	}
-	roundCheckpoint := checkpoint
-	roundFixItems := cloneFixItems(checkpoint.FixItems)
-	roundFixItemsHash := checkpoint.FixItemsHash
 	liveDetail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 	if err != nil {
 		return checkpoint, err
 	}
 	checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, liveDetail)
 	fixItems := collectFixItems(liveDetail)
-	currentFixItemsStateHash := hashFixItemsState(fixItems)
 	checkpoint.FixItems = fixItems
 	checkpoint.FixItemsHash = hashFixItems(fixItems)
-	threadStore := loadFixEvidenceStoreV2(input.Loop.MetadataJSON)
-	roundEvidence := resolveFixEvidence(roundCheckpoint, input.Loop.MetadataJSON, roundFixItemsHash)
-	roundEvidenceVerified := false
-	if roundEvidence != nil && hasCommentFixItems(roundFixItems) {
-		roundEvidenceVerified, err = r.verifyFixEvidence(ctx, input, roundCheckpoint, roundEvidence, liveDetail)
-		if err != nil {
-			return checkpoint, err
-		}
-		if roundEvidenceVerified {
-			validationBound, verifyErr := r.validationMatchesEvidence(ctx, input, roundCheckpoint, roundEvidence)
-			if verifyErr != nil {
-				return checkpoint, verifyErr
-			}
-			if !validationBound {
-				checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
-				return checkpoint, &loopError{message: "resolve-comments requires validation bound to verified fix evidence head", kind: FailureRetryableAfterResume}
-			}
-			if isSameRoundPushEvidence(roundEvidence) || (roundCheckpoint.Push != nil && roundCheckpoint.Push.Pushed && roundCheckpoint.Push.Evidence == nil && roundProducedNewCommits(&roundCheckpoint)) {
-				threadStore = mergeFixEvidenceStoreV2(threadStore, buildFixEvidenceStoreV2(roundCheckpoint, roundEvidence, input.Run.ID))
-			}
-		}
-	}
-	if checkpoint.Push != nil && checkpoint.Push.Pushed && hasCommentFixItems(roundFixItems) && !roundEvidenceVerified {
-		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
-		return checkpoint, &loopError{message: "resolve-comments refused because verified fix evidence is missing or stale; leaving review threads unresolved", kind: FailureRetryableAfterResume}
-	}
-	if shouldBlockResolveWithoutFix(checkpoint, fixItems, roundEvidenceVerified) && !hasRecoverableThreadEvidence(input.Loop.MetadataJSON, fixItems) {
-		if checkpoint.ResolvedComments == nil {
-			checkpoint.ResolvedComments = &checkpointResolvedComments{Items: []checkpointResolvedComment{}}
-		}
-		for _, item := range fixItems {
-			if item.Type != "comment" || alreadyResolved(checkpoint.ResolvedComments.Items, item) {
-				continue
-			}
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_no_evidence", Message: "No verified pushed fix evidence available for this thread", UpdatedAt: r.nowISO()})
-		}
-		if _, err := r.recordFixerFollowupState(ctx, input.Loop, fixerFollowupReasonMissingEvidence, detailHeadSHA(checkpoint.Detail), currentFixItemsStateHash, skippedNoEvidenceThreadIDs(fixItems, checkpoint.ResolvedComments.Items), r.now()); err != nil {
-			return checkpoint, err
-		}
-		checkpoint.ResumePolicy = "advance_from_checkpoint"
-		return checkpoint, nil
-	}
 	if checkpoint.ResolvedComments == nil {
 		checkpoint.ResolvedComments = &checkpointResolvedComments{Items: []checkpointResolvedComment{}}
 	}
-	failedCount := 0
 	resolvedCount := 0
 	commentItems := make([]FixItem, 0, len(fixItems))
 	for _, item := range fixItems {
@@ -2009,114 +1965,64 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			commentItems = append(commentItems, item)
 		}
 	}
+	repliesByItemID := agentResolveRepliesByFixItemID(checkpoint)
+	repliesByThreadID := agentResolveRepliesByThreadID(checkpoint)
+	commitSHA := resolveCommentCommitSHA(checkpoint, nil, false)
+	if commitSHA == "" {
+		commitSHA = resolveCommentsExpectedHeadSHA(checkpoint)
+	}
+	driftCount := 0
 	for _, item := range commentItems {
 		if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
 			continue
 		}
-		threadEvidence, hasEvidence := findThreadFixEvidence(threadStore, item)
-		if !hasEvidence {
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_no_evidence", Message: "No verified pushed fix evidence available for this thread", UpdatedAt: r.nowISO()})
+		explanation := repliesByItemID[item.ID]
+		if explanation == "" && item.ThreadID != "" {
+			explanation = repliesByThreadID[item.ThreadID]
+		}
+		if strings.TrimSpace(explanation) == "" {
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_agent_declined", Message: "Agent did not include this thread in review_thread_replies", UpdatedAt: r.nowISO()})
 			continue
 		}
-		verifiedEvidence, verifyErr := r.verifyThreadEvidence(ctx, input, checkpoint, liveDetail, threadEvidence)
-		if verifyErr != nil {
-			return checkpoint, verifyErr
-		}
-		if !verifiedEvidence {
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_no_evidence", Message: "No verified pushed fix evidence available for this thread", UpdatedAt: r.nowISO()})
-			continue
-		}
-		if strings.TrimSpace(threadEvidence.Explanation) == "" {
-			threadEvidence.ResolveState = "skipped_no_confirmation"
-			threadStore = upsertThreadFixEvidence(threadStore, threadEvidence)
-			if err := r.persistFixEvidenceStoreV2(ctx, input.Loop, threadStore); err != nil {
-				return checkpoint, err
-			}
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_no_confirmation", Message: "No agent confirmation was captured for this thread", UpdatedAt: r.nowISO()})
-			continue
-		}
-		commitSHA := firstNonEmpty(threadEvidence.CommitSHA, lastNonEmptyString(threadEvidence.CommitSHAs, threadEvidence.EvidenceHeadSHA))
-		explanation := threadEvidence.Explanation
-		replyState, replyError := r.replyToFixedComment(ctx, input, item, commitSHA, explanation, checkpoint.ResolvedComments.Items)
-		threadEvidence.ReplyState = replyState
-		threadStore = upsertThreadFixEvidence(threadStore, threadEvidence)
-		if err := r.persistFixEvidenceStoreV2(ctx, input.Loop, threadStore); err != nil {
+		thread, err := r.github.ViewReviewThread(ctx, ViewReviewThreadInput{ThreadID: item.ThreadID, CWD: input.Project.RepoPath})
+		if err != nil {
 			return checkpoint, err
 		}
-		if replyState == "failed" {
-			failedCount++
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "reply_failed", Message: "Failed to post fixer auto-reply", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+		if thread.IsResolved {
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "already_resolved", UpdatedAt: r.nowISO()})
 			continue
 		}
+		if hasNonLooperCommentSince(thread, input.Run.StartedAt) {
+			driftCount++
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_thread_drift", Message: "New human comment was added to this thread after the fixer run started", UpdatedAt: r.nowISO()})
+			continue
+		}
+		replyState, replyError := r.replyToFixedComment(ctx, input, item, commitSHA, explanation, checkpoint.ResolvedComments.Items)
 		if err := r.persistCheckpoint(ctx, input.Run.ID, stepResolveComments, checkpoint); err != nil {
 			return checkpoint, err
 		}
-		resolveState, resolveDetail, resolveErr := r.refreshResolveCommentState(ctx, input, checkpoint, threadEvidence, item)
-		if resolveErr != nil {
-			return checkpoint, resolveErr
-		}
-		switch resolveState {
-		case "already_resolved":
-			threadEvidence.ResolveState = "already_resolved"
-			threadStore = upsertThreadFixEvidence(threadStore, threadEvidence)
-			if err := r.persistFixEvidenceStoreV2(ctx, input.Loop, threadStore); err != nil {
-				return checkpoint, err
-			}
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "already_resolved", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
-			continue
-		case "stale":
-			checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
-			failedCount++
-			threadEvidence.ResolveState = "stale"
-			threadStore = upsertThreadFixEvidence(threadStore, threadEvidence)
-			if err := r.persistFixEvidenceStoreV2(ctx, input.Loop, threadStore); err != nil {
-				return checkpoint, err
-			}
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "stale_state", Message: "PR head or review thread changed before resolve", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
-			continue
-		case "ok":
-			checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, resolveDetail)
-		}
 		if err := r.github.ResolveReviewThread(ctx, ResolveReviewThreadInput{Repo: input.Repo, ThreadID: item.ThreadID, CWD: input.Project.RepoPath}); err != nil {
 			message := err.Error()
-			status := "failed"
+			status := "failed_mutation_terminal"
 			if strings.Contains(strings.ToLower(message), "already") {
 				status = "already_resolved"
-			} else {
-				failedCount++
-			}
-			threadEvidence.ResolveState = status
-			threadStore = upsertThreadFixEvidence(threadStore, threadEvidence)
-			if err := r.persistFixEvidenceStoreV2(ctx, input.Loop, threadStore); err != nil {
-				return checkpoint, err
 			}
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: status, Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 			continue
 		}
 		resolvedCount++
-		threadEvidence.ResolveState = "resolved"
-		threadStore = upsertThreadFixEvidence(threadStore, threadEvidence)
-		if err := r.persistFixEvidenceStoreV2(ctx, input.Loop, threadStore); err != nil {
-			return checkpoint, err
-		}
 		upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "resolved", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 	}
 	r.appendEvent(ctx, eventInput{eventType: "fixer.comments.resolved", projectID: input.Project.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"items": checkpoint.ResolvedComments.Items}})
-	if failedCount == 0 && resolvedCount > 0 {
-		r.publishRoundSummaryComment(ctx, input, &checkpoint, fixItems, lastNonEmptyString(roundEvidenceCommitSHAs(roundEvidence), ""), buildThreadResolveReplyExplanations(threadStore, fixItems))
+	if resolvedCount > 0 {
+		r.publishRoundSummaryComment(ctx, input, &checkpoint, fixItems, commitSHA, repliesByItemID)
 	}
-	if failedCount == 0 {
-		skippedThreadIDs, followupReason := skippedFollowupThreadIDs(fixItems, checkpoint.ResolvedComments.Items)
-		if len(skippedThreadIDs) > 0 {
-			if _, err := r.recordFixerFollowupState(ctx, input.Loop, followupReason, detailHeadSHA(checkpoint.Detail), currentFixItemsStateHash, skippedThreadIDs, r.now()); err != nil {
-				return checkpoint, err
-			}
-		} else if _, err := r.clearFixerFollowupMetadata(ctx, input.Loop); err != nil {
-			return checkpoint, err
-		}
+	if driftCount > 0 {
+		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
+		return checkpoint, &loopError{message: fmt.Sprintf("Skipped %d review thread(s) because new human comments arrived during the fixer run", driftCount), kind: FailureRetryableAfterResume}
 	}
-	if failedCount > 0 {
-		return checkpoint, &loopError{message: fmt.Sprintf("Failed to resolve %d review thread(s)", failedCount), kind: FailureRetryableAfterResume}
+	if _, err := r.clearFixerFollowupMetadata(ctx, input.Loop); err != nil {
+		return checkpoint, err
 	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
@@ -2218,6 +2124,74 @@ func lookupReplyExplanations(checkpoint fixerCheckpoint) map[string]string {
 		out[entry.FixItemID] = entry.Explanation
 	}
 	return out
+}
+
+func agentResolveRepliesByFixItemID(checkpoint fixerCheckpoint) map[string]string {
+	if checkpoint.Repair == nil || len(checkpoint.Repair.ReplyExplanations) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(checkpoint.Repair.ReplyExplanations))
+	for _, entry := range checkpoint.Repair.ReplyExplanations {
+		fixItemID := strings.TrimSpace(entry.FixItemID)
+		explanation := strings.TrimSpace(entry.Explanation)
+		if fixItemID == "" || explanation == "" {
+			continue
+		}
+		if _, exists := out[fixItemID]; !exists {
+			out[fixItemID] = explanation
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func agentResolveRepliesByThreadID(checkpoint fixerCheckpoint) map[string]string {
+	if checkpoint.Repair == nil || len(checkpoint.Repair.ReplyExplanations) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(checkpoint.Repair.ReplyExplanations))
+	for _, entry := range checkpoint.Repair.ReplyExplanations {
+		threadID := strings.TrimSpace(entry.ThreadID)
+		explanation := strings.TrimSpace(entry.Explanation)
+		if threadID == "" || explanation == "" {
+			continue
+		}
+		if _, exists := out[threadID]; !exists {
+			out[threadID] = explanation
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func hasNonLooperCommentSince(thread ReviewThread, rawSince string) bool {
+	since := parseRFC3339OrZero(rawSince)
+	if since.IsZero() {
+		return false
+	}
+	for _, comment := range thread.Comments {
+		createdAt := parseRFC3339OrZero(comment.CreatedAt)
+		if createdAt.IsZero() || !createdAt.After(since) {
+			continue
+		}
+		if isLooperReviewThreadComment(comment) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func isLooperReviewThreadComment(comment ReviewThreadComment) bool {
+	body := strings.TrimSpace(comment.Body)
+	if body == "" {
+		return false
+	}
+	return disclosure.HasMarkdownStamp(body) || strings.Contains(body, "looper-fixer-reply") || strings.Contains(body, "looper:fixer-round")
 }
 
 func buildFixerReplyBody(item FixItem, commitSHA, explanation string) string {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1373,24 +1373,19 @@ func TestRunResolveCommentsStepSkipsAllWhenLiveFixItemsAddNewThread(t *testing.T
 		PRNumber:   42,
 		Checkpoint: checkpoint,
 	})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	if err == nil || !strings.Contains(err.Error(), "snapshot drifted") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want snapshot-drift retry", err)
 	}
 	if len(github.resolveCalls) != 0 {
 		t.Fatalf("resolve calls = %#v, want 0 when fix-items snapshot drifted", github.resolveCalls)
 	}
-	foundSkipped := false
 	for _, item := range updated.ResolvedComments.Items {
-		if item.FixItemID == "c2" && item.ThreadID == "t2" && item.Status == "skipped_agent_declined" {
-			foundSkipped = true
-			break
+		if item.Status != "skipped_thread_drift" {
+			t.Fatalf("resolved comments = %#v, want all skipped_thread_drift", updated.ResolvedComments.Items)
 		}
 	}
-	if !foundSkipped {
-		t.Fatalf("resolved comments = %#v, want t2 skipped_agent_declined", updated.ResolvedComments.Items)
-	}
-	if updated.ResumePolicy != "advance_from_checkpoint" {
-		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
+	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
 	}
 }
 
@@ -1471,6 +1466,54 @@ func TestRunResolveCommentsStepDetectsDriftFromEditedComment(t *testing.T) {
 	}
 }
 
+func TestRunResolveCommentsStepDriftBeatsSnapshotMismatchWhenBothChange(t *testing.T) {
+	t.Parallel()
+
+	runStartedAt := "2026-04-11T12:00:00Z"
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix (edited)",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{
+		{ID: "c1", Body: "please fix (edited)", Author: "alice", CreatedAt: "2026-04-11T11:59:00Z", UpdatedAt: "2026-04-11T12:05:00Z"},
+	}}}}
+	runner := New(Options{GitHub: github})
+	originalFixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{
+		FixItems:         originalFixItems,
+		FixItemsHash:     hashFixItems(originalFixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(originalFixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err == nil {
+		t.Fatalf("runResolveCommentsStep() error = nil, want retryable drift error")
+	}
+	if !strings.Contains(err.Error(), "snapshot drifted") && !strings.Contains(err.Error(), "new human comments") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want drift-classified retry", err)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 when comment edit drifts both hash and thread", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
+		t.Fatalf("resolved comments = %#v, want skipped_thread_drift (not skipped_agent_declined) when both hash and thread drift", updated.ResolvedComments)
+	}
+	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+}
+
 func TestRunResolveCommentsStepIgnoresBotCommentForDrift(t *testing.T) {
 	t.Parallel()
 
@@ -1535,8 +1578,8 @@ func TestRunResolveCommentsStepSkipsWhenReplyExplanationsSnapshotDrifted(t *test
 	}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	if err == nil || !strings.Contains(err.Error(), "snapshot drifted") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want snapshot-drift retry", err)
 	}
 	if len(github.resolveCalls) != 0 {
 		t.Fatalf("resolve calls = %d, want 0 when reply-explanations snapshot drifted", len(github.resolveCalls))
@@ -1544,8 +1587,11 @@ func TestRunResolveCommentsStepSkipsWhenReplyExplanationsSnapshotDrifted(t *test
 	if len(github.replyCalls) != 0 {
 		t.Fatalf("reply calls = %d, want 0 when reply-explanations snapshot drifted", len(github.replyCalls))
 	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_agent_declined" {
-		t.Fatalf("resolved comments = %#v, want skipped_agent_declined when snapshot drifted", updated.ResolvedComments)
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
+		t.Fatalf("resolved comments = %#v, want skipped_thread_drift when snapshot drifted", updated.ResolvedComments)
+	}
+	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
 	}
 }
 
@@ -1570,6 +1616,63 @@ func TestRunResolveCommentsStepRecordsMutationFailureAsRetryable(t *testing.T) {
 	}
 	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "failed_mutation_retry" {
 		t.Fatalf("resolved comments = %#v, want failed_mutation_retry", updated.ResolvedComments)
+	}
+	if updated.ResumePolicy != loops.ResumePolicyReplayStep {
+		t.Fatalf("updated.ResumePolicy = %q, want replay_step", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepProceedsWhenFixCommitStillReachable(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{
+		viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "live-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}},
+		threads:       []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}},
+		compareStatus: "ahead",
+	}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v, want resolve when fix commit is still reachable", err)
+	}
+	if len(github.compareCalls) != 1 || github.compareCalls[0].Base != "fix-commit" || github.compareCalls[0].Head != "live-head" {
+		t.Fatalf("compare calls = %#v, want one call comparing fix-commit...live-head", github.compareCalls)
+	}
+	if len(github.resolveCalls) != 1 {
+		t.Fatalf("resolve calls = %d, want 1 when fix commit still reachable", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "resolved" {
+		t.Fatalf("resolved comments = %#v, want resolved when fix commit still reachable", updated.ResolvedComments)
+	}
+}
+
+func TestRunResolveCommentsStepAbortsWhenFixCommitNoLongerReachable(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{
+		viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "rebased-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}},
+		threads:       []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}},
+		compareStatus: "diverged",
+	}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err == nil || !strings.Contains(err.Error(), "no longer descends") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want abort when fix commit is no longer reachable", err)
+	}
+	if len(github.compareCalls) != 1 {
+		t.Fatalf("compare calls = %d, want 1", len(github.compareCalls))
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 when fix commit no longer reachable", len(github.resolveCalls))
+	}
+	if len(github.replyCalls) != 0 {
+		t.Fatalf("reply calls = %d, want 0 when fix commit no longer reachable", len(github.replyCalls))
 	}
 	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
 		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
@@ -3385,6 +3488,9 @@ type fakeGitHubGateway struct {
 	createIssueCommentErr error
 	updateIssueCommentErr error
 	nextIssueCommentID    int64
+	compareCalls          []CompareCommitsInput
+	compareStatus         string
+	compareErr            error
 }
 
 func (f *fakeGitHubGateway) ListOpenPullRequests(_ context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
@@ -3520,6 +3626,18 @@ func (f *fakeGitHubGateway) AddPullRequestLabels(_ context.Context, input PullRe
 func (f *fakeGitHubGateway) RemovePullRequestLabels(_ context.Context, input PullRequestLabelsInput) error {
 	f.removeLabelCalls = append(f.removeLabelCalls, input)
 	return nil
+}
+
+func (f *fakeGitHubGateway) CompareCommits(_ context.Context, input CompareCommitsInput) (CompareCommitsResult, error) {
+	f.compareCalls = append(f.compareCalls, input)
+	if f.compareErr != nil {
+		return CompareCommitsResult{}, f.compareErr
+	}
+	status := f.compareStatus
+	if status == "" {
+		status = "identical"
+	}
+	return CompareCommitsResult{Status: status}, nil
 }
 
 type fakeGitGateway struct {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1679,6 +1679,45 @@ func TestRunResolveCommentsStepAbortsWhenFixCommitNoLongerReachable(t *testing.T
 	}
 }
 
+func TestRunResolveCommentsStepDriftAnchorsToRepairCompletionOnReplay(t *testing.T) {
+	t.Parallel()
+
+	repairCompletedAt := "2026-04-11T11:00:00Z"
+	humanReplyAt := "2026-04-11T11:30:00Z"
+	retryRunStartedAt := "2026-04-11T12:00:00Z"
+	github := &fakeGitHubGateway{
+		viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "fix-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}},
+		threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{
+			{ID: "c1", Body: "please fix", CreatedAt: "2026-04-11T10:00:00Z"},
+			{ID: "reply-2", Body: "actually also fix this", Author: "alice", CreatedAt: humanReplyAt},
+		}}},
+	}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}, CompletedAt: repairCompletedAt},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: retryRunStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err == nil || !strings.Contains(err.Error(), "new human comments") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want drift retry anchored to Repair.CompletedAt", err)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 when reviewer commented after repair completion", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
+		t.Fatalf("resolved comments = %#v, want skipped_thread_drift on replay", updated.ResolvedComments)
+	}
+	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+}
+
 func TestRunResolveCommentsStepReplyFailureDoesNotBlockResolve(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1433,6 +1433,44 @@ func TestRunResolveCommentsStepSkipsThreadWhenHumanCommentArrivesAfterRunStart(t
 	}
 }
 
+func TestRunResolveCommentsStepDetectsDriftFromEditedComment(t *testing.T) {
+	t.Parallel()
+
+	runStartedAt := "2026-04-11T12:00:00Z"
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{
+		{ID: "c1", Body: "please fix (edited)", Author: "alice", CreatedAt: "2026-04-11T11:59:00Z", UpdatedAt: "2026-04-11T12:05:00Z"},
+	}}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err == nil || !strings.Contains(err.Error(), "new human comments") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want thread drift retry from edited comment", err)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 after edited-comment drift", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
+		t.Fatalf("resolved comments = %#v, want skipped_thread_drift for edited comment", updated.ResolvedComments)
+	}
+	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+}
+
 func TestRunResolveCommentsStepIgnoresBotCommentForDrift(t *testing.T) {
 	t.Parallel()
 
@@ -1511,7 +1549,7 @@ func TestRunResolveCommentsStepSkipsWhenReplyExplanationsSnapshotDrifted(t *test
 	}
 }
 
-func TestRunResolveCommentsStepRecordsMutationFailureAsTerminal(t *testing.T) {
+func TestRunResolveCommentsStepRecordsMutationFailureAsRetryable(t *testing.T) {
 	t.Parallel()
 
 	github := &fakeGitHubGateway{
@@ -1524,14 +1562,17 @@ func TestRunResolveCommentsStepRecordsMutationFailureAsTerminal(t *testing.T) {
 	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v, want terminal checkpoint outcome", err)
+	if err == nil || !strings.Contains(err.Error(), "Failed to resolve") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want retryable mutation failure error", err)
 	}
 	if len(github.resolveCalls) != 1 {
 		t.Fatalf("resolve calls = %d, want 1", len(github.resolveCalls))
 	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "failed_mutation_terminal" {
-		t.Fatalf("resolved comments = %#v, want failed_mutation_terminal", updated.ResolvedComments)
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "failed_mutation_retry" {
+		t.Fatalf("resolved comments = %#v, want failed_mutation_retry", updated.ResolvedComments)
+	}
+	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1336,7 +1336,7 @@ func TestRunResolveCommentsStepResolvesUsingRepairReplyExplanations(t *testing.T
 	}
 }
 
-func TestRunResolveCommentsStepResolvesMatchingThreadsAndSkipsNewOnes(t *testing.T) {
+func TestRunResolveCommentsStepSkipsAllWhenLiveFixItemsAddNewThread(t *testing.T) {
 	t.Parallel()
 
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
@@ -1376,8 +1376,8 @@ func TestRunResolveCommentsStepResolvesMatchingThreadsAndSkipsNewOnes(t *testing
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t1" {
-		t.Fatalf("resolve calls = %#v, want only t1 resolved", github.resolveCalls)
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %#v, want 0 when fix-items snapshot drifted", github.resolveCalls)
 	}
 	foundSkipped := false
 	for _, item := range updated.ResolvedComments.Items {
@@ -1430,6 +1430,84 @@ func TestRunResolveCommentsStepSkipsThreadWhenHumanCommentArrivesAfterRunStart(t
 	}
 	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
 		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepIgnoresBotCommentForDrift(t *testing.T) {
+	t.Parallel()
+
+	runStartedAt := "2026-04-11T12:00:00Z"
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{
+		{ID: "c1", Body: "please fix", CreatedAt: "2026-04-11T11:59:00Z"},
+		{ID: "bot-1", Body: "automated nitpick", Author: "chatgpt-codex-connector[bot]", CreatedAt: "2026-04-11T12:05:00Z"},
+	}}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v, want resolve through bot comment", err)
+	}
+	if len(github.resolveCalls) != 1 {
+		t.Fatalf("resolve calls = %d, want 1 (bot comment must not block resolve)", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "resolved" {
+		t.Fatalf("resolved comments = %#v, want resolved despite bot comment", updated.ResolvedComments)
+	}
+}
+
+func TestRunResolveCommentsStepSkipsWhenReplyExplanationsSnapshotDrifted(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{FixItemsHash: "stale-hash", ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 when reply-explanations snapshot drifted", len(github.resolveCalls))
+	}
+	if len(github.replyCalls) != 0 {
+		t.Fatalf("reply calls = %d, want 0 when reply-explanations snapshot drifted", len(github.replyCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_agent_declined" {
+		t.Fatalf("resolved comments = %#v, want skipped_agent_declined when snapshot drifted", updated.ResolvedComments)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nexu-io/looper/internal/eventlog"
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/lifecycle"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -592,8 +593,8 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
 		t.Fatalf("checkpoint.ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
 	}
-	if checkpoint.ResolvedComments == nil || len(checkpoint.ResolvedComments.Items) == 0 || checkpoint.ResolvedComments.Items[0].Status != "skipped_no_evidence" {
-		t.Fatalf("checkpoint.ResolvedComments = %#v, want skipped-no-evidence marker", checkpoint.ResolvedComments)
+	if checkpoint.ResolvedComments == nil || len(checkpoint.ResolvedComments.Items) == 0 || checkpoint.ResolvedComments.Items[0].Status != "skipped_agent_declined" {
+		t.Fatalf("checkpoint.ResolvedComments = %#v, want skipped-agent-declined marker", checkpoint.ResolvedComments)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
 	if err != nil {
@@ -606,25 +607,15 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
-		t.Fatalf("loop = %#v, want queued loop with scheduled retry", loop)
-	}
-	loopMeta := parseJSONObject(loop.MetadataJSON)
-	if got, _ := stringFromAny(loopMeta["lastNoopResolveHeadSha"]); got != "base-head" {
-		t.Fatalf("lastNoopResolveHeadSha = %q, want base-head", got)
-	}
-	if got, _ := stringFromAny(loopMeta["lastNoopResolveFixItemsHash"]); got == "" {
-		t.Fatal("lastNoopResolveFixItemsHash = empty, want captured fix-item snapshot")
+	if loop == nil || loop.Status != "completed" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want completed loop without scheduled retry", loop)
 	}
 	activeFollowup, err := fixture.repos.Queue.FindActiveByLoopID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Queue.FindActiveByLoopID() error = %v", err)
 	}
-	if activeFollowup == nil || activeFollowup.ID == claim.ID || activeFollowup.Status != "queued" {
-		t.Fatalf("active follow-up queue item = %#v, want delayed queued retry distinct from original claim", activeFollowup)
-	}
-	if *loop.NextRunAt != activeFollowup.AvailableAt {
-		t.Fatalf("loop.NextRunAt = %q, want %q", *loop.NextRunAt, activeFollowup.AvailableAt)
+	if activeFollowup != nil {
+		t.Fatalf("active follow-up queue item = %#v, want none", activeFollowup)
 	}
 }
 
@@ -1277,14 +1268,17 @@ func TestRunResolveCommentsStepSkipsWithoutVerifiedPushEvidence(t *testing.T) {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
 	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want 0 without verified evidence", len(github.resolveCalls))
+		t.Fatalf("resolve calls = %d, want 0 without agent reply explanation", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || len(updated.ResolvedComments.Items) != 1 || updated.ResolvedComments.Items[0].Status != "skipped_agent_declined" {
+		t.Fatalf("resolved comments = %#v, want skipped_agent_declined", updated.ResolvedComments)
 	}
 	if updated.ResumePolicy != "advance_from_checkpoint" {
 		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
 	}
 }
 
-func TestRunResolveCommentsStepRefreshesVerifiedNoPushHeadBeforeResolve(t *testing.T) {
+func TestRunResolveCommentsStepResolvesUsingRepairReplyExplanations(t *testing.T) {
 	t.Parallel()
 
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
@@ -1299,16 +1293,15 @@ func TestRunResolveCommentsStepRefreshesVerifiedNoPushHeadBeforeResolve(t *testi
 			"threadId": "t1",
 			"body":     "please fix",
 		}},
-	}}}
-	runner := New(Options{GitHub: github, Sleep: func(time.Duration) {}})
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}}}
+	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"new-head\",\"lastFixItemsHash\":\"%s\",\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"new-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"new-head\",\"explanation\":\"Applied the requested fix.\"}]}}", fixItemsHash)
 	checkpoint := fixerCheckpoint{
 		FixItems:     fixItems,
-		FixItemsHash: fixItemsHash,
+		FixItemsHash: hashFixItems(fixItems),
 		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:       &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
 		ReconcileCommits: &checkpointReconcileCommits{
 			BaseHeadSHA:      "base-head",
 			FinalHeadSHA:     "base-head",
@@ -1319,7 +1312,6 @@ func TestRunResolveCommentsStepRefreshesVerifiedNoPushHeadBeforeResolve(t *testi
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
 		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
-		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
 		Repo:       "acme/looper",
 		PRNumber:   42,
 		Checkpoint: checkpoint,
@@ -1327,70 +1319,17 @@ func TestRunResolveCommentsStepRefreshesVerifiedNoPushHeadBeforeResolve(t *testi
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	if github.viewIndex != 2 {
-		t.Fatalf("github.viewIndex = %d, want initial refresh plus pre-resolve recheck", github.viewIndex)
-	}
-	if len(github.resolveCalls) != 1 {
-		t.Fatalf("resolve calls = %d, want 1 after refreshing verified head", len(github.resolveCalls))
-	}
-	if updated.Detail == nil || updated.Detail.HeadSHA != "new-head" {
-		t.Fatalf("updated.Detail = %#v, want refreshed new-head detail", updated.Detail)
-	}
-	if updated.ReconcileCommits == nil || updated.ReconcileCommits.FinalHeadSHA != "base-head" {
-		t.Fatalf("updated.ReconcileCommits = %#v, want stale reconcile head preserved", updated.ReconcileCommits)
-	}
-	if len(github.replyCalls) != 1 || !contains(github.replyCalls[0].Body, "new-hea") {
-		t.Fatalf("reply calls = %#v, want reply referencing verified head", github.replyCalls)
-	}
-	if updated.ResumePolicy != "advance_from_checkpoint" {
-		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
-	}
-}
-
-func TestRunResolveCommentsStepResolvesWhenPersistedFixHeadIsAncestorOfLiveHead(t *testing.T) {
-	t.Parallel()
-
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "newer-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":       "c1",
-			"threadId": "t1",
-			"body":     "please fix",
-		}},
-	}}}
-	git := &fakeGitGateway{ancestor: map[string]bool{"fix-head->newer-head": true}}
-	runner := New(Options{GitHub: github, Git: git, Sleep: func(time.Duration) {}})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":\"%s\",\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"fix-head\",\"explanation\":\"Applied the requested fix.\"}]}}", fixItemsHash)
-	checkpoint := fixerCheckpoint{
-		FixItems:         fixItems,
-		FixItemsHash:     fixItemsHash,
-		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
-		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
-	}
-
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
-		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
-		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
-		Repo:       "acme/looper",
-		PRNumber:   42,
-		Checkpoint: checkpoint,
-	})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	if github.viewIndex != 1 {
+		t.Fatalf("github.viewIndex = %d, want one live PR refresh", github.viewIndex)
 	}
 	if len(github.resolveCalls) != 1 {
 		t.Fatalf("resolve calls = %d, want 1", len(github.resolveCalls))
 	}
-	if len(github.replyCalls) != 1 || !contains(github.replyCalls[0].Body, "fix-hea") {
-		t.Fatalf("reply calls = %#v, want reply referencing persisted fix head", github.replyCalls)
+	if updated.Detail == nil || updated.Detail.HeadSHA != "new-head" {
+		t.Fatalf("updated.Detail = %#v, want refreshed new-head detail", updated.Detail)
+	}
+	if len(github.replyCalls) != 1 || !contains(github.replyCalls[0].Body, "base-hea") {
+		t.Fatalf("reply calls = %#v, want reply referencing resolved commit head", github.replyCalls)
 	}
 	if updated.ResumePolicy != "advance_from_checkpoint" {
 		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
@@ -1416,22 +1355,20 @@ func TestRunResolveCommentsStepResolvesMatchingThreadsAndSkipsNewOnes(t *testing
 			"threadId": "t2",
 			"body":     "new feedback",
 		}},
-	}}}
-	runner := New(Options{GitHub: github, Sleep: func(time.Duration) {}})
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}, {ID: "t2", Comments: []ReviewThreadComment{{ID: "c2", Body: "new feedback"}}}}}
+	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"new-head\",\"lastFixItemsHash\":\"%s\",\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"new-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"new-head\",\"explanation\":\"Applied the requested fix.\"}]}}", fixItemsHash)
 	checkpoint := fixerCheckpoint{
 		FixItems:         fixItems,
-		FixItemsHash:     fixItemsHash,
+		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
 		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
-		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
 		Repo:       "acme/looper",
 		PRNumber:   42,
 		Checkpoint: checkpoint,
@@ -1442,22 +1379,29 @@ func TestRunResolveCommentsStepResolvesMatchingThreadsAndSkipsNewOnes(t *testing
 	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t1" {
 		t.Fatalf("resolve calls = %#v, want only t1 resolved", github.resolveCalls)
 	}
-	if alreadyResolved(updated.ResolvedComments.Items, FixItem{ID: "c2", ThreadID: "t2"}) {
-		t.Fatalf("resolved comments = %#v, want t2 to remain unresolved", updated.ResolvedComments.Items)
+	foundSkipped := false
+	for _, item := range updated.ResolvedComments.Items {
+		if item.FixItemID == "c2" && item.ThreadID == "t2" && item.Status == "skipped_agent_declined" {
+			foundSkipped = true
+			break
+		}
+	}
+	if !foundSkipped {
+		t.Fatalf("resolved comments = %#v, want t2 skipped_agent_declined", updated.ResolvedComments.Items)
 	}
 	if updated.ResumePolicy != "advance_from_checkpoint" {
 		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
 	}
 }
 
-func TestRunResolveCommentsStepDoesNotBackfillLegacyEvidenceFromLiveComments(t *testing.T) {
+func TestRunResolveCommentsStepSkipsThreadWhenHumanCommentArrivesAfterRunStart(t *testing.T) {
 	t.Parallel()
 
-	oldItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: normalizeThreadFingerprint("", "t1", "c1"), Summary: "please fix"}}
+	runStartedAt := "2026-04-11T12:00:00Z"
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
 		Number:      42,
 		State:       "OPEN",
-		HeadSHA:     "new-head",
+		HeadSHA:     "fix-head",
 		HeadRefName: "feature/fix-42",
 		BaseRefName: "main",
 		BaseSHA:     "base-1",
@@ -1465,299 +1409,75 @@ func TestRunResolveCommentsStepDoesNotBackfillLegacyEvidenceFromLiveComments(t *
 			"id":       "c1",
 			"threadId": "t1",
 			"body":     "please fix",
-		}, {
-			"id":       "c2",
-			"threadId": "t2",
-			"body":     "new follow-up",
 		}},
-	}}}
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix", CreatedAt: "2026-04-11T11:59:00Z"}, {ID: "reply-2", Body: "one more thing", CreatedAt: "2026-04-11T12:05:00Z"}}}}}
 	runner := New(Options{GitHub: github})
-	checkpoint := fixerCheckpoint{
-		FixItems:         oldItems,
-		FixItemsHash:     hashFixItems(oldItems),
-		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
-		Push:             &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "new-head", Evidence: &fixEvidence{Valid: true, HeadSHA: "new-head", FixItemsHash: hashFixItems(oldItems), ProducedNewCommits: true}},
-		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}, WorkingTreeClean: true},
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err == nil || !strings.Contains(err.Error(), "new human comments") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want thread drift retry", err)
 	}
+	if len(github.replyCalls) != 0 {
+		t.Fatalf("reply calls = %d, want 0 after thread drift", len(github.replyCalls))
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 after thread drift", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
+		t.Fatalf("resolved comments = %#v, want skipped_thread_drift", updated.ResolvedComments)
+	}
+	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepRecordsMutationFailureAsTerminal(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{
+		viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "fix-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}},
+		threads:       []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}},
+		resolveErr:    errors.New("graphql mutation failed"),
+	}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v, want terminal checkpoint outcome", err)
+	}
+	if len(github.resolveCalls) != 1 {
+		t.Fatalf("resolve calls = %d, want 1", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "failed_mutation_terminal" {
+		t.Fatalf("resolved comments = %#v, want failed_mutation_terminal", updated.ResolvedComments)
+	}
+}
+
+func TestRunResolveCommentsStepReplyFailureDoesNotBlockResolve(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{
+		viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "fix-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}},
+		threads:       []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}},
+		replyErr:      errors.New("reply failed"),
+	}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want 0 when legacy evidence has no safe per-thread records", len(github.resolveCalls))
-	}
-	if updated.ResolvedComments == nil || len(updated.ResolvedComments.Items) != 2 {
-		t.Fatalf("resolved comments = %#v, want both live threads marked without evidence", updated.ResolvedComments)
-	}
-}
-
-func TestRunResolveCommentsStepSkipsWhenEvidenceHasNoAgentConfirmation(t *testing.T) {
-	t.Parallel()
-
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "fix-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":       "c1",
-			"threadId": "t1",
-			"body":     "please fix",
-		}},
-	}}}
-	runner := New(Options{GitHub: github})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"fix-head\"}]}}", fixItemsHash)
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: fixItemsHash, Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
-
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: &loopMetadata}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
-	}
-	if len(github.replyCalls) != 0 {
-		t.Fatalf("reply calls = %d, want 0 without agent confirmation", len(github.replyCalls))
-	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want 0 without agent confirmation", len(github.resolveCalls))
-	}
-	if updated.ResolvedComments == nil || len(updated.ResolvedComments.Items) != 1 || updated.ResolvedComments.Items[0].Status != "skipped_no_confirmation" {
-		t.Fatalf("resolved comments = %#v, want skipped_no_confirmation", updated.ResolvedComments)
-	}
-}
-
-func TestRunResolveCommentsStepSkipsSameThreadWhenFingerprintChanged(t *testing.T) {
-	t.Parallel()
-
-	liveFingerprint := "latest=reply-2|updated=2026-04-11T12:05:00Z|count=2"
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "fix-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":                "c1",
-			"threadId":          "t1",
-			"threadFingerprint": liveFingerprint,
-			"body":              "please fix",
-		}},
-	}}}
-	runner := New(Options{GitHub: github})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "latest=comment-1|updated=2026-04-11T12:00:00Z|count=1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"threadFingerprint\":\"latest=comment-1|updated=2026-04-11T12:00:00Z|count=1\",\"commitSha\":\"fix-head\"}]}}", fixItemsHash)
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: fixItemsHash, Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
-
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: &loopMetadata}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
-	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want 0 after same-thread drift", len(github.resolveCalls))
-	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_no_evidence" {
-		t.Fatalf("resolved comments = %#v, want skipped_no_evidence after fingerprint drift", updated.ResolvedComments)
-	}
-}
-
-func TestRunResolveCommentsStepSkipsDuplicateReplyWhenMarkerAlreadyExists(t *testing.T) {
-	t.Parallel()
-
-	marker := fixerReplyMarker("t1", "fix-head")
-	github := &fakeGitHubGateway{
-		viewResponses: []PullRequestDetail{{
-			Number:      42,
-			State:       "OPEN",
-			HeadSHA:     "fix-head",
-			HeadRefName: "feature/fix-42",
-			BaseRefName: "main",
-			BaseSHA:     "base-1",
-			Comments:    []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}},
-		}, {
-			Number:      42,
-			State:       "OPEN",
-			HeadSHA:     "fix-head",
-			HeadRefName: "feature/fix-42",
-			BaseRefName: "main",
-			BaseSHA:     "base-1",
-			Comments:    []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}},
-		}},
-		threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}, {ID: "reply-1", Body: "already replied\n\n" + marker}}}},
-	}
-	runner := New(Options{GitHub: github})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: normalizeThreadFingerprint("", "t1", "c1"), Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"threadFingerprint\":%q,\"commitSha\":\"fix-head\",\"explanation\":\"Applied the requested fix.\"}]}}", fixItemsHash, normalizeThreadFingerprint("", "t1", "c1"))
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: fixItemsHash, Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
-
-	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: &loopMetadata}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
-	}
-	if len(github.replyCalls) != 0 {
-		t.Fatalf("reply calls = %d, want 0 when marker already exists remotely", len(github.replyCalls))
-	}
 	if len(github.resolveCalls) != 1 {
-		t.Fatalf("resolve calls = %d, want 1 after deduped reply", len(github.resolveCalls))
+		t.Fatalf("resolve calls = %d, want 1 despite reply failure", len(github.resolveCalls))
 	}
-}
-
-func TestRunResolveCommentsStepFailsWhenThreadChangesAfterReply(t *testing.T) {
-	t.Parallel()
-
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "fix-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":                "c1",
-			"threadId":          "t1",
-			"threadFingerprint": "latest=comment-1|updated=2026-04-11T12:00:00Z|count=1",
-			"body":              "please fix",
-		}},
-	}, {
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "fix-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":                "c1",
-			"threadId":          "t1",
-			"threadFingerprint": "latest=comment-2|updated=2026-04-11T12:01:00Z|count=2",
-			"body":              "please fix",
-		}},
-	}}}
-	runner := New(Options{GitHub: github})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "latest=comment-1|updated=2026-04-11T12:00:00Z|count=1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"threadFingerprint\":\"latest=comment-1|updated=2026-04-11T12:00:00Z|count=1\",\"commitSha\":\"fix-head\",\"explanation\":\"Applied the requested fix.\"}]}}", fixItemsHash)
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: fixItemsHash, Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
-
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: &loopMetadata}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err == nil || !strings.Contains(err.Error(), "Failed to resolve 1 review thread") {
-		t.Fatalf("runResolveCommentsStep() error = %v, want stale-state retry failure", err)
-	}
-	if len(github.replyCalls) != 1 {
-		t.Fatalf("reply calls = %d, want 1 before stale recheck aborts resolve", len(github.replyCalls))
-	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want 0 after stale recheck", len(github.resolveCalls))
-	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "stale_state" {
-		t.Fatalf("resolved comments = %#v, want stale_state marker", updated.ResolvedComments)
-	}
-	if updated.ResumePolicy != "restart_from_discover" {
-		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
-	}
-}
-
-func TestRunResolveCommentsStepRequestsRediscoveryWhenVerifiedEvidenceIsStale(t *testing.T) {
-	t.Parallel()
-
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "new-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":       "c1",
-			"threadId": "t1",
-			"body":     "please fix",
-		}},
-	}}}
-	runner := New(Options{GitHub: github})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	checkpoint := fixerCheckpoint{
-		FixItems:     fixItems,
-		FixItemsHash: fixItemsHash,
-		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "old-head"},
-		Push:         &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "old-head"},
-		Lifecycle:    &lifecycle.State{Pushed: true},
-		ReconcileCommits: &checkpointReconcileCommits{
-			BaseHeadSHA:      "base-head",
-			FinalHeadSHA:     "old-head",
-			NewCommitSHAs:    []string{"old-head"},
-			WorkingTreeClean: true,
-		},
-	}
-
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
-		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
-		Repo:       "acme/looper",
-		PRNumber:   42,
-		Checkpoint: checkpoint,
-	})
-	if err == nil || !strings.Contains(err.Error(), "verified fix evidence is missing or stale") {
-		t.Fatalf("runResolveCommentsStep() error = %v, want stale-evidence retry failure", err)
-	}
-	if updated.ResumePolicy != "restart_from_discover" {
-		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
-	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want 0 when evidence is stale", len(github.resolveCalls))
-	}
-}
-
-func TestRunResolveCommentsStepRequestsRediscoveryWhenValidationIsNotBoundToEvidence(t *testing.T) {
-	t.Parallel()
-
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "fix-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":       "c1",
-			"threadId": "t1",
-			"body":     "please fix",
-		}},
-	}}}
-	runner := New(Options{GitHub: github})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"fix-head\",\"explanation\":\"Applied the requested fix.\"}]}}", fixItemsHash)
-	checkpoint := fixerCheckpoint{
-		FixItems:     fixItems,
-		FixItemsHash: fixItemsHash,
-		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "older-head"},
-		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		ReconcileCommits: &checkpointReconcileCommits{
-			BaseHeadSHA:      "base-head",
-			FinalHeadSHA:     "base-head",
-			WorkingTreeClean: true,
-		},
-	}
-
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
-		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
-		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
-		Repo:       "acme/looper",
-		PRNumber:   42,
-		Checkpoint: checkpoint,
-	})
-	if err == nil || !strings.Contains(err.Error(), "validation bound to verified fix evidence head") {
-		t.Fatalf("runResolveCommentsStep() error = %v, want validation/evidence mismatch failure", err)
-	}
-	if updated.ResumePolicy != "restart_from_discover" {
-		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
-	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want 0 when validation is stale", len(github.resolveCalls))
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "resolved" || updated.ResolvedComments.Items[0].ReplyState != "failed" {
+		t.Fatalf("resolved comments = %#v, want resolved with failed reply state", updated.ResolvedComments)
 	}
 }
 
@@ -1812,408 +1532,6 @@ func TestRunResolveCommentsStepUsesRefreshedPushHeadSHA(t *testing.T) {
 	}
 	if updated.ResumePolicy != "advance_from_checkpoint" {
 		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
-	}
-}
-
-func TestRunResolveCommentsStepIgnoresForkBranchFetchFailureDuringEvidenceVerification(t *testing.T) {
-	t.Parallel()
-
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "new-head",
-		HeadRefName: "fork-owner:feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":       "c1",
-			"threadId": "t1",
-			"body":     "please fix",
-		}},
-	}}}
-	git := &fakeGitGateway{fetchErrors: []error{errors.New("remote ref not found"), nil}, ancestor: map[string]bool{"old-head->new-head": true}}
-	runner := New(Options{GitHub: github, Git: git})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"old-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"old-head\",\"fixItemsHash\":%q,\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"old-head\",\"explanation\":\"Applied the requested fix.\"}]}}", fixItemsHash, fixItemsHash)
-	checkpoint := fixerCheckpoint{
-		FixItems:     fixItems,
-		FixItemsHash: fixItemsHash,
-		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
-		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		ReconcileCommits: &checkpointReconcileCommits{
-			BaseHeadSHA:      "base-head",
-			FinalHeadSHA:     "base-head",
-			WorkingTreeClean: true,
-		},
-	}
-
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
-		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
-		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
-		Repo:       "acme/looper",
-		PRNumber:   42,
-		Checkpoint: checkpoint,
-	})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
-	}
-	if len(git.fetchCalls) < 2 {
-		t.Fatalf("fetch calls = %d, want at least 2", len(git.fetchCalls))
-	}
-	if !strings.HasSuffix(git.fetchCalls[0], "|fork-owner:feature/fix-42") {
-		t.Fatalf("first fetch = %q, want fork branch fetch", git.fetchCalls[0])
-	}
-	if !strings.HasSuffix(git.fetchCalls[1], "|new-head") {
-		t.Fatalf("second fetch = %q, want head SHA fetch", git.fetchCalls[1])
-	}
-	if len(github.resolveCalls) != 1 {
-		t.Fatalf("resolve calls = %d, want 1", len(github.resolveCalls))
-	}
-	if updated.ResumePolicy != "advance_from_checkpoint" {
-		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
-	}
-}
-
-func TestRunResolveCommentsStepTreatsMissingLiveHeadObjectAsStaleEvidence(t *testing.T) {
-	t.Parallel()
-
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "new-head",
-		HeadRefName: "fork-owner:feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":       "c1",
-			"threadId": "t1",
-			"body":     "please fix",
-		}},
-	}}}
-	git := &fakeGitGateway{
-		fetchErrors: []error{errors.New("remote ref not found"), errors.New("fatal: couldn't find remote ref new-head")},
-		ancestorErr: errors.New("fatal: Not a valid object name new-head"),
-	}
-	runner := New(Options{GitHub: github, Git: git})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	checkpoint := fixerCheckpoint{
-		FixItems:     fixItems,
-		FixItemsHash: fixItemsHash,
-		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "old-head"},
-		Push:         &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "old-head"},
-		Lifecycle:    &lifecycle.State{Pushed: true},
-		ReconcileCommits: &checkpointReconcileCommits{
-			BaseHeadSHA:      "base-head",
-			FinalHeadSHA:     "old-head",
-			NewCommitSHAs:    []string{"old-head"},
-			WorkingTreeClean: true,
-		},
-	}
-
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
-		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
-		Repo:       "acme/looper",
-		PRNumber:   42,
-		Checkpoint: checkpoint,
-	})
-	if err == nil || !strings.Contains(err.Error(), "verified fix evidence is missing or stale") {
-		t.Fatalf("runResolveCommentsStep() error = %v, want stale-evidence failure", err)
-	}
-	if updated.ResumePolicy != "restart_from_discover" {
-		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
-	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want 0", len(github.resolveCalls))
-	}
-	if len(git.fetchCalls) < 2 {
-		t.Fatalf("fetch calls = %d, want at least 2", len(git.fetchCalls))
-	}
-}
-
-func TestRunResolveCommentsStepTreatsMissingValidationHeadObjectAsUnboundEvidence(t *testing.T) {
-	t.Parallel()
-
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "fix-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":       "c1",
-			"threadId": "t1",
-			"body":     "please fix",
-		}},
-	}}}
-	git := &fakeGitGateway{ancestorErr: errors.New("fatal: ambiguous argument older-head")}
-	runner := New(Options{GitHub: github, Git: git})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	fixItemsHash := hashFixItems(fixItems)
-	loopMetadata := fmt.Sprintf("{\"lastFixHeadSha\":\"fix-head\",\"lastFixItemsHash\":%q,\"lastFixEvidence\":{\"valid\":true,\"headSha\":\"fix-head\",\"producedNewCommits\":true,\"commentRecords\":[{\"fixItemId\":\"c1\",\"threadId\":\"t1\",\"commitSha\":\"fix-head\"}]}}", fixItemsHash)
-	checkpoint := fixerCheckpoint{
-		FixItems:     fixItems,
-		FixItemsHash: fixItemsHash,
-		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "older-head"},
-		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		ReconcileCommits: &checkpointReconcileCommits{
-			BaseHeadSHA:      "base-head",
-			FinalHeadSHA:     "base-head",
-			WorkingTreeClean: true,
-		},
-	}
-
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
-		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
-		Loop:       storage.LoopRecord{MetadataJSON: &loopMetadata},
-		Repo:       "acme/looper",
-		PRNumber:   42,
-		Checkpoint: checkpoint,
-	})
-	if err == nil || !strings.Contains(err.Error(), "validation bound to verified fix evidence head") {
-		t.Fatalf("runResolveCommentsStep() error = %v, want validation-bound failure", err)
-	}
-	if updated.ResumePolicy != "restart_from_discover" {
-		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
-	}
-}
-
-func TestRunResolveCommentsStepPersistsNoopResolveMetadataWhenAllThreadsSkipForMissingEvidence(t *testing.T) {
-	t.Parallel()
-
-	fixture := newRunnerFixture(t)
-	repo := "acme/looper"
-	prNumber := int64(42)
-	nowISO := fixture.nowISO()
-	loopTarget := buildPullRequestTargetID(repo, prNumber)
-	loopMetadata := `{"lastFixHeadSha":"fix-head","lastFixItemsHash":"old-hash","lastFixEvidence":{"valid":true,"headSha":"fix-head","producedNewCommits":true,"commentRecords":[{"fixItemId":"c1","threadId":"t1","commitSha":"fix-head"}]}}`
-	loop := storage.LoopRecord{ID: "loop_fixer_skip_no_evidence", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &loopMetadata, CreatedAt: nowISO, UpdatedAt: nowISO}
-	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
-		t.Fatalf("Loops.Upsert() error = %v", err)
-	}
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      prNumber,
-		State:       "OPEN",
-		HeadSHA:     "fix-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":       "c2",
-			"threadId": "t2",
-			"body":     "new feedback",
-		}},
-	}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
-	liveFixItems := []FixItem{{Type: "comment", ID: "c2", ThreadID: "t2", Summary: "new feedback"}}
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
-		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
-		Loop:     loop,
-		Repo:     repo,
-		PRNumber: prNumber,
-		Checkpoint: fixerCheckpoint{
-			FixItems:         liveFixItems,
-			FixItemsHash:     hashFixItems(liveFixItems),
-			Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
-			Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-			ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
-		},
-	})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
-	}
-	if updated.ResumePolicy != "advance_from_checkpoint" {
-		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
-	}
-	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
-	if err != nil {
-		t.Fatalf("Loops.GetByID() error = %v", err)
-	}
-	meta := parseJSONObject(persisted.MetadataJSON)
-	if got, _ := stringFromAny(meta["lastNoopResolveHeadSha"]); got != "fix-head" {
-		t.Fatalf("lastNoopResolveHeadSha = %q, want fix-head", got)
-	}
-	if got, _ := stringFromAny(meta["lastNoopResolveStateHash"]); got != hashFixItemsState(liveFixItems) {
-		t.Fatalf("lastNoopResolveStateHash = %q, want %q", got, hashFixItemsState(liveFixItems))
-	}
-	followup, ok := parseFixerFollowupState(meta)
-	if !ok {
-		t.Fatalf("parseFixerFollowupState() = false, want follow-up metadata")
-	}
-	if followup.Reason != string(fixerFollowupReasonMissingEvidence) {
-		t.Fatalf("followup.Reason = %q, want %q", followup.Reason, fixerFollowupReasonMissingEvidence)
-	}
-	if !sameStringSlices(followup.UnresolvedThreadIDs, []string{"t2"}) {
-		t.Fatalf("followup.UnresolvedThreadIDs = %#v, want [t2]", followup.UnresolvedThreadIDs)
-	}
-	if followup.AttemptsForFingerprint != 1 {
-		t.Fatalf("followup.AttemptsForFingerprint = %d, want 1", followup.AttemptsForFingerprint)
-	}
-}
-
-func TestRunResolveCommentsStepPersistsNoopResolveMetadataWhenAllThreadsSkipForMissingConfirmation(t *testing.T) {
-	t.Parallel()
-
-	fixture := newRunnerFixture(t)
-	repo := "acme/looper"
-	prNumber := int64(42)
-	nowISO := fixture.nowISO()
-	loopTarget := buildPullRequestTargetID(repo, prNumber)
-	loopMetadata := `{"lastFixHeadSha":"fix-head","lastFixItemsHash":"same-hash","lastFixEvidence":{"valid":true,"headSha":"fix-head","producedNewCommits":true,"commentRecords":[{"fixItemId":"c1","threadId":"t1","commitSha":"fix-head"}]}}`
-	loop := storage.LoopRecord{ID: "loop_fixer_skip_no_confirmation", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &loopMetadata, CreatedAt: nowISO, UpdatedAt: nowISO}
-	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
-		t.Fatalf("Loops.Upsert() error = %v", err)
-	}
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      prNumber,
-		State:       "OPEN",
-		HeadSHA:     "fix-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":       "c1",
-			"threadId": "t1",
-			"body":     "please fix",
-		}},
-	}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
-	liveFixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
-		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
-		Loop:     loop,
-		Repo:     repo,
-		PRNumber: prNumber,
-		Checkpoint: fixerCheckpoint{
-			FixItems:         liveFixItems,
-			FixItemsHash:     hashFixItems(liveFixItems),
-			Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
-			Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-			ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
-		},
-	})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
-	}
-	if updated.ResumePolicy != "advance_from_checkpoint" {
-		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
-	}
-	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
-	if err != nil {
-		t.Fatalf("Loops.GetByID() error = %v", err)
-	}
-	meta := parseJSONObject(persisted.MetadataJSON)
-	followup, ok := parseFixerFollowupState(meta)
-	if !ok {
-		t.Fatalf("parseFixerFollowupState() = false, want follow-up metadata")
-	}
-	if followup.Reason != string(fixerFollowupReasonMissingConfirmation) {
-		t.Fatalf("followup.Reason = %q, want %q", followup.Reason, fixerFollowupReasonMissingConfirmation)
-	}
-	if !sameStringSlices(followup.UnresolvedThreadIDs, []string{"t1"}) {
-		t.Fatalf("followup.UnresolvedThreadIDs = %#v, want [t1]", followup.UnresolvedThreadIDs)
-	}
-}
-
-func TestRunResolveCommentsStepHandlesMixedMultiRoundThreadEvidenceIndependently(t *testing.T) {
-	t.Parallel()
-
-	fixture := newRunnerFixture(t)
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "new-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":                "c1",
-			"threadId":          "t1",
-			"threadFingerprint": "latest=c1|updated=2026-04-11T12:00:00Z|count=1",
-			"body":              "please fix a",
-		}, {
-			"id":                "c2",
-			"threadId":          "t2",
-			"threadFingerprint": "latest=c2|updated=2026-04-11T12:10:00Z|count=1",
-			"body":              "please fix b",
-		}},
-	}}}
-	git := &fakeGitGateway{ancestor: map[string]bool{"round-1-head->new-head": true, "round-2-head->new-head": true}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, Logger: fixture.logger, Now: fixture.now})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "latest=c1|updated=2026-04-11T12:00:00Z|count=1", Summary: "please fix a"}, {Type: "comment", ID: "c2", ThreadID: "t2", ThreadFingerprint: "latest=c2|updated=2026-04-11T12:10:00Z|count=1", Summary: "please fix b"}}
-	loopMetadata := mustJSON(t, map[string]any{"fixEvidenceStoreV2": &fixEvidenceStoreV2{Version: 2, Threads: map[string][]threadFixEvidence{
-		"t1": {{ThreadID: "t1", ThreadFingerprint: "latest=c1|updated=2026-04-11T12:00:00Z|count=1", EvidenceHeadSHA: "round-1-head", ValidationHeadSHA: "round-1-head", CommitSHA: "commit-a", ProducedNewCommits: true, Explanation: "Fixed A.", ResolveState: "pending"}},
-		"t2": {{ThreadID: "t2", ThreadFingerprint: "latest=c2|updated=2026-04-11T12:10:00Z|count=1", EvidenceHeadSHA: "round-2-head", ValidationHeadSHA: "round-2-head", CommitSHA: "commit-b", ProducedNewCommits: true, Explanation: "Fixed B.", ResolveState: "pending"}},
-	}}})
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
-
-	repo := "acme/looper"
-	prNumber := int64(42)
-	targetID := buildPullRequestTargetID(repo, prNumber)
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()}, Loop: storage.LoopRecord{ID: "loop_mixed_evidence", ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, MetadataJSON: &loopMetadata}, Run: storage.RunRecord{ID: "run_mixed_evidence"}, Repo: repo, PRNumber: prNumber, Checkpoint: checkpoint})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
-	}
-	if len(github.resolveCalls) != 2 {
-		t.Fatalf("resolve calls = %#v, want both threads resolved independently", github.resolveCalls)
-	}
-	if len(github.replyCalls) != 2 || !contains(github.replyCalls[0].Body, "commit-") || !contains(github.replyCalls[1].Body, "commit-") {
-		t.Fatalf("reply calls = %#v, want per-thread commit replies", github.replyCalls)
-	}
-	if updated.ResumePolicy != "advance_from_checkpoint" {
-		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
-	}
-}
-
-func TestRunResolveCommentsStepRecoversAfterCrashBetweenReplyAndResolve(t *testing.T) {
-	t.Parallel()
-
-	fixture := newRunnerFixture(t)
-	marker := fixerReplyMarker("t1", "fix-head")
-	github := &fakeGitHubGateway{
-		viewResponses: []PullRequestDetail{{
-			Number:      42,
-			State:       "OPEN",
-			HeadSHA:     "fix-head",
-			HeadRefName: "feature/fix-42",
-			BaseRefName: "main",
-			BaseSHA:     "base-1",
-			Comments:    []map[string]any{{"id": "c1", "threadId": "t1", "threadFingerprint": "latest=c1|updated=2026-04-11T12:00:00Z|count=1", "body": "please fix"}},
-		}, {
-			Number:      42,
-			State:       "OPEN",
-			HeadSHA:     "fix-head",
-			HeadRefName: "feature/fix-42",
-			BaseRefName: "main",
-			BaseSHA:     "base-1",
-			Comments:    []map[string]any{{"id": "c1", "threadId": "t1", "threadFingerprint": "latest=c1|updated=2026-04-11T12:00:00Z|count=1", "body": "please fix"}},
-		}},
-		threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}, {ID: "reply-1", Body: "already replied\n\n" + marker}}}},
-	}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "latest=c1|updated=2026-04-11T12:00:00Z|count=1", Summary: "please fix"}}
-	loopMetadata := mustJSON(t, map[string]any{"fixEvidenceStoreV2": &fixEvidenceStoreV2{Version: 2, Threads: map[string][]threadFixEvidence{
-		"t1": {{ThreadID: "t1", ThreadFingerprint: "latest=c1|updated=2026-04-11T12:00:00Z|count=1", EvidenceHeadSHA: "fix-head", ValidationHeadSHA: "fix-head", CommitSHA: "fix-head", ProducedNewCommits: true, Explanation: "Recovered confirmation.", ReplyState: "sent", ResolveState: "pending"}},
-	}}})
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
-
-	repo := "acme/looper"
-	prNumber := int64(42)
-	targetID := buildPullRequestTargetID(repo, prNumber)
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()}, Loop: storage.LoopRecord{ID: "loop_crash_recovery", ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, MetadataJSON: &loopMetadata}, Run: storage.RunRecord{ID: "run_crash_recovery"}, Repo: repo, PRNumber: prNumber, Checkpoint: checkpoint})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
-	}
-	if len(github.replyCalls) != 0 {
-		t.Fatalf("reply calls = %#v, want no duplicate reply after crash recovery", github.replyCalls)
-	}
-	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t1" {
-		t.Fatalf("resolve calls = %#v, want recovered resolve", github.resolveCalls)
-	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "resolved" {
-		t.Fatalf("resolved comments = %#v, want resolved after crash recovery", updated.ResolvedComments)
 	}
 }
 
@@ -3942,6 +3260,7 @@ type fakeGitHubGateway struct {
 	removeLabelCalls      []PullRequestLabelsInput
 	replyCalls            []AddReviewThreadReplyInput
 	replyErr              error
+	resolveErr            error
 	createIssueComments   []IssueCommentInput
 	updateIssueComments   []UpdateIssueCommentInput
 	createIssueCommentErr error
@@ -4042,7 +3361,7 @@ func (f *fakeGitHubGateway) ViewReviewThread(_ context.Context, input ViewReview
 
 func (f *fakeGitHubGateway) ResolveReviewThread(_ context.Context, input ResolveReviewThreadInput) error {
 	f.resolveCalls = append(f.resolveCalls, input)
-	return nil
+	return f.resolveErr
 }
 
 func (f *fakeGitHubGateway) AddReviewThreadReply(_ context.Context, input AddReviewThreadReplyInput) error {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -349,6 +349,17 @@ type AddReviewThreadReplyInput struct {
 	CWD      string
 }
 
+type CompareCommitsInput struct {
+	Repo string
+	Base string
+	Head string
+	CWD  string
+}
+
+type CompareCommitsResult struct {
+	Status string
+}
+
 type GetPullRequestDiffInput struct {
 	Repo     string
 	PRNumber int64
@@ -901,6 +912,25 @@ func (g *Gateway) AddReviewThreadReply(ctx context.Context, input AddReviewThrea
 		return fmt.Errorf("failed to add review thread reply %s", input.ThreadID)
 	}
 	return nil
+}
+
+// CompareCommits returns the GitHub compare API status between Base and Head
+// (one of "identical", "ahead", "behind", "diverged"). It is used by the
+// fixer to decide whether a previously-pushed fix commit is still reachable
+// from the live PR head.
+func (g *Gateway) CompareCommits(ctx context.Context, input CompareCommitsInput) (CompareCommitsResult, error) {
+	if input.Repo == "" || input.Base == "" || input.Head == "" {
+		return CompareCommitsResult{}, fmt.Errorf("compare commits requires repo, base, and head")
+	}
+	result, err := g.runGh(ctx, input.CWD, "", "api", fmt.Sprintf("repos/%s/compare/%s...%s", input.Repo, input.Base, input.Head))
+	if err != nil {
+		return CompareCommitsResult{}, err
+	}
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return CompareCommitsResult{}, err
+	}
+	return CompareCommitsResult{Status: asString(row["status"])}, nil
 }
 
 func (g *Gateway) GetPullRequestDiff(ctx context.Context, input GetPullRequestDiffInput) (string, error) {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -467,6 +467,14 @@ func (a fixerGitHubAdapter) AddReviewThreadReply(ctx context.Context, input fixe
 	return a.gateway.AddReviewThreadReply(ctx, githubinfra.AddReviewThreadReplyInput{Repo: input.Repo, ThreadID: input.ThreadID, Body: body, CWD: input.CWD})
 }
 
+func (a fixerGitHubAdapter) CompareCommits(ctx context.Context, input fixer.CompareCommitsInput) (fixer.CompareCommitsResult, error) {
+	out, err := a.gateway.CompareCommits(ctx, githubinfra.CompareCommitsInput{Repo: input.Repo, Base: input.Base, Head: input.Head, CWD: input.CWD})
+	if err != nil {
+		return fixer.CompareCommitsResult{}, err
+	}
+	return fixer.CompareCommitsResult{Status: out.Status}, nil
+}
+
 func (a fixerGitHubAdapter) CreateIssueComment(ctx context.Context, input fixer.IssueCommentInput) (fixer.IssueCommentResult, error) {
 	body := a.stamper.Markdown(input.Body, "fixer", disclosure.ChannelIssueComment)
 	comment, err := a.gateway.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: input.Repo, IssueNumber: input.IssueNumber, Body: body, CWD: input.CWD})

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -439,7 +439,7 @@ func (a fixerGitHubAdapter) ListReviewThreads(ctx context.Context, input fixer.L
 	for _, thread := range threads {
 		comments := make([]fixer.ReviewThreadComment, 0, len(thread.Comments))
 		for _, comment := range thread.Comments {
-			comments = append(comments, fixer.ReviewThreadComment{ID: comment.ID, Body: comment.Body})
+			comments = append(comments, fixer.ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt})
 		}
 		out = append(out, fixer.ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved, Comments: comments})
 	}
@@ -453,7 +453,7 @@ func (a fixerGitHubAdapter) ViewReviewThread(ctx context.Context, input fixer.Vi
 	}
 	comments := make([]fixer.ReviewThreadComment, 0, len(thread.Comments))
 	for _, comment := range thread.Comments {
-		comments = append(comments, fixer.ReviewThreadComment{ID: comment.ID, Body: comment.Body})
+		comments = append(comments, fixer.ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt})
 	}
 	return fixer.ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved, Comments: comments}, nil
 }


### PR DESCRIPTION
## Summary
- replace fixer resolve authority with the agent's `review_thread_replies` / `ReplyExplanations` output instead of evidence-based gating
- keep a single drift check for new non-Looper human thread comments and treat reply failures as non-blocking while making mutation failures terminal
- update fixer/runtime tests and adapters for the simplified resolve flow, including drift and terminal failure coverage

Closes #315.