### PR TITLE
fix: add reviewer repair workflow

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nexu-io/looper/internal/domain"
 	"github.com/nexu-io/looper/internal/eventlog"
 	"github.com/nexu-io/looper/internal/projects"
+	"github.com/nexu-io/looper/internal/reviewer"
 	looperdruntime "github.com/nexu-io/looper/internal/runtime"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/sweeper"
@@ -126,6 +127,7 @@ type Context struct {
 	RecoverySummary      func() any
 	StopLoop             func(context.Context, string, string) (any, error)
 	StopAll              func(context.Context, string) (any, error)
+	RepairReviewer       func(context.Context, reviewer.RepairInput) (reviewer.RepairResult, error)
 	TriggerSchedulerTick func()
 }
 
@@ -332,6 +334,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case apiBasePath + "/sweeper/stats":
 		payload, err := h.buildSweeperStatsResponse(r)
+		if err != nil {
+			var typed apiError
+			if !asAPIError(err, &typed) {
+				typed = internalServerError(err)
+			}
+			h.writeError(w, requestID, typed)
+			return
+		}
+		h.writeSuccess(w, requestID, payload)
+		return
+	case apiBasePath + "/reviewer/repair":
+		payload, err := h.buildReviewerRepairRouteResponse(r)
 		if err != nil {
 			var typed apiError
 			if !asAPIError(err, &typed) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/domain"
 	"github.com/nexu-io/looper/internal/projects"
+	"github.com/nexu-io/looper/internal/reviewer"
 	looperdruntime "github.com/nexu-io/looper/internal/runtime"
 	"github.com/nexu-io/looper/internal/storage"
 )
@@ -55,6 +56,45 @@ func TestHandlerHealthzSuccessAndRequestIDEcho(t *testing.T) {
 	if _, ok := storageInfo["dbPath"].(string); !ok {
 		t.Fatalf("data.storage.dbPath missing/invalid: %#v", storageInfo["dbPath"])
 	}
+}
+
+func TestHandlerReviewerRepairInvokesContextAndTriggersScheduler(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	var gotInput reviewer.RepairInput
+	triggered := 0
+	h := NewHandler(Context{
+		Config: cfg,
+		RepairReviewer: func(_ context.Context, input reviewer.RepairInput) (reviewer.RepairResult, error) {
+			gotInput = input
+			return reviewer.RepairResult{Repo: input.Repo, PRNumber: input.PRNumber, ProjectID: input.ProjectID, Apply: input.Apply, Applied: true, AppliedChanges: 1}, nil
+		},
+		TriggerSchedulerTick: func() { triggered++ },
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reviewer/repair", strings.NewReader(`{"projectId":"project_1","repo":"acme/looper","prNumber":42,"apply":true}`))
+	req.Header.Set("x-request-id", "repair-request-id")
+	recorder := httptest.NewRecorder()
+
+	h.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if gotInput.Repo != "acme/looper" || gotInput.PRNumber != 42 || gotInput.ProjectID != "project_1" || !gotInput.Apply {
+		t.Fatalf("RepairReviewer input = %#v, want requested repo/pr/project/apply", gotInput)
+	}
+	if triggered != 1 {
+		t.Fatalf("scheduler trigger count = %d, want 1", triggered)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	assertEqual(t, body["ok"], true)
+	data := body["data"].(map[string]any)
+	assertEqual(t, data["repo"], "acme/looper")
+	assertEqual(t, data["applied"], true)
 }
 
 func TestIsTerminalReviewerLoopRecordTreatsFailedAsTerminal(t *testing.T) {

--- a/internal/api/reviewer_repair.go
+++ b/internal/api/reviewer_repair.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/reviewer"
+	pkgapi "github.com/nexu-io/looper/pkg/api"
+)
+
+type reviewerRepairRequest struct {
+	ProjectID string `json:"projectId,omitempty"`
+	Repo      string `json:"repo"`
+	PRNumber  int64  `json:"prNumber"`
+	Apply     bool   `json:"apply"`
+}
+
+func (h *Handler) buildReviewerRepairRouteResponse(r *http.Request) (reviewer.RepairResult, error) {
+	if r.Method != http.MethodPost {
+		return reviewer.RepairResult{}, apiError{
+			code:    pkgapi.ErrorCodeMethodNotAllowed,
+			status:  http.StatusMethodNotAllowed,
+			message: "Unsupported method for /api/v1/reviewer/repair",
+		}
+	}
+	var request reviewerRepairRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return reviewer.RepairResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Invalid repair request: %v", err)}
+	}
+	input := reviewer.RepairInput{
+		ProjectID: strings.TrimSpace(request.ProjectID),
+		Repo:      strings.TrimSpace(request.Repo),
+		PRNumber:  request.PRNumber,
+		Apply:     request.Apply,
+	}
+	if input.Repo == "" || input.PRNumber <= 0 {
+		return reviewer.RepairResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "repo and positive prNumber are required"}
+	}
+	if h.context.RepairReviewer != nil {
+		result, err := h.context.RepairReviewer(r.Context(), input)
+		if err != nil {
+			return result, mapReviewerRepairError(err)
+		}
+		if result.Applied && h.context.TriggerSchedulerTick != nil {
+			h.context.TriggerSchedulerTick()
+		}
+		return result, nil
+	}
+	result, err := h.defaultReviewerRepair(r.Context(), input)
+	if err != nil {
+		return result, mapReviewerRepairError(err)
+	}
+	if result.Applied && h.context.TriggerSchedulerTick != nil {
+		h.context.TriggerSchedulerTick()
+	}
+	return result, nil
+}
+
+func (h *Handler) defaultReviewerRepair(ctx context.Context, input reviewer.RepairInput) (reviewer.RepairResult, error) {
+	if h.context.Runtime == nil {
+		return reviewer.RepairResult{}, fmt.Errorf("runtime is not configured")
+	}
+	services := h.context.Runtime.Services()
+	if services.Coordinator == nil || services.Repositories == nil {
+		return reviewer.RepairResult{}, fmt.Errorf("runtime storage is not configured")
+	}
+	ghPath := ""
+	if h.context.Config.Tools.GHPath != nil {
+		ghPath = strings.TrimSpace(*h.context.Config.Tools.GHPath)
+	}
+	gateway := github.New(github.Options{GHPath: ghPath, Now: h.now})
+	repairer := reviewer.NewRepairer(reviewer.RepairOptions{
+		DB:           services.Coordinator.DB(),
+		Repos:        services.Repositories,
+		GitHub:       reviewerRepairGitHubAdapter{gateway: gateway},
+		Now:          h.now,
+		ReviewEvents: h.context.Config.Roles.Reviewer.Behavior.ReviewEvents,
+	})
+	return repairer.Repair(ctx, input)
+}
+
+func mapReviewerRepairError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, reviewer.ErrRepairLoopNotFound):
+		return apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: err.Error()}
+	case errors.Is(err, reviewer.ErrRepairActiveWork):
+		return apiError{code: pkgapi.ErrorCodeLoopConflict, status: http.StatusConflict, message: err.Error()}
+	default:
+		return err
+	}
+}
+
+type reviewerRepairGitHubAdapter struct {
+	gateway *github.Gateway
+}
+
+func (a reviewerRepairGitHubAdapter) ViewPullRequest(ctx context.Context, input reviewer.ViewPullRequestInput) (reviewer.PullRequestDetail, error) {
+	detail, err := a.gateway.ViewPullRequest(ctx, github.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
+	if err != nil {
+		return reviewer.PullRequestDetail{}, err
+	}
+	return reviewer.PullRequestDetail{
+		Number:         detail.Number,
+		Title:          detail.Title,
+		Body:           detail.Body,
+		State:          detail.State,
+		IsDraft:        detail.IsDraft,
+		ReviewDecision: detail.ReviewDecision,
+		Labels:         detail.Labels,
+		HeadSHA:        detail.HeadSHA,
+		BaseSHA:        detail.BaseSHA,
+		HeadRefName:    detail.HeadRefName,
+		BaseRefName:    detail.BaseRefName,
+		Author:         detail.Author,
+		ReviewRequests: detail.ReviewRequests,
+		HasConflicts:   detail.HasConflicts,
+		Comments:       detail.Comments,
+		IssueComments:  reviewerRepairCommentInfosToObjects(detail.IssueComments),
+		Reviews:        detail.Reviews,
+	}, nil
+}
+
+func (a reviewerRepairGitHubAdapter) GetCurrentUserLogin(ctx context.Context, cwd string) (string, error) {
+	return a.gateway.GetCurrentUserLogin(ctx, cwd)
+}
+
+func reviewerRepairCommentInfosToObjects(items []github.CommentInfo) []map[string]any {
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		out = append(out, map[string]any{
+			"id":                item.ID,
+			"author":            map[string]any{"login": item.Author},
+			"authorAssociation": item.AuthorAssociation,
+			"body":              item.Body,
+			"createdAt":         item.CreatedAt,
+			"updatedAt":         item.UpdatedAt,
+			"url":               item.URL,
+		})
+	}
+	return out
+}

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -343,7 +343,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				short:           "Create a reviewer task for a pull request",
 				args:            cobra.ExactArgs(1),
 				runE:            runtime.reviewCreate,
-				helpSubcommands: []helpSubcommand{{name: "submit", description: "Submit a validated PR review payload"}},
+				helpSubcommands: []helpSubcommand{{name: "submit", description: "Submit a validated PR review payload"}, {name: "repair", description: "Diagnose and repair reviewer local state"}},
 				localFlags: []flagSpec{
 					stringFlag("project", "projectId", "Project id"),
 					boolFlag("loop", "Keep reviewing when new commits are pushed"),
@@ -353,11 +353,14 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				},
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "submit <pr>", short: "Submit a validated PR review payload", args: cobra.ExactArgs(1), runE: runtime.reviewSubmit, localFlags: []flagSpec{stringFlag("event", "event", "Review event: COMMENT, APPROVE, or REQUEST_CHANGES"), stringFlag("commit-id", "sha", "Expected PR head commit SHA"), stringFlag("clean-review-event", "event", "Effective clean review event policy"), stringFlag("blocking-review-event", "event", "Effective blocking review event policy")}}),
+					newCommand(commandSpec{use: "repair <pr>", short: "Diagnose and repair reviewer local state", args: cobra.ExactArgs(1), runE: runtime.reviewRepair, localFlags: []flagSpec{stringFlag("project", "projectId", "Project id"), boolFlag("apply", "Apply planned local repair actions")}}),
 				},
 				exampleLines: []string{
 					"$ looper review 123",
 					"$ looper review acme/looper#42 --loop",
 					"$ looper review submit acme/looper#42 --event COMMENT --commit-id abc123 < review.json",
+					"$ looper review repair acme/looper#42",
+					"$ looper review repair acme/looper#42 --apply",
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -2971,6 +2971,80 @@ func TestReviewCreateAcceptsNumericPRRefFromCurrentProject(t *testing.T) {
 	}
 }
 
+func TestReviewRepairPostsReviewerRepairRequest(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			writeEnvelope(t, w, pkgapi.Success("req_projects", map[string]any{"items": []map[string]any{{"id": "project_1", "name": "Looper", "repoPath": "/tmp/repos/looper", "repo": "acme/looper", "updatedAt": "2026-04-20T10:00:00.000Z"}}}))
+		case "/api/v1/reviewer/repair":
+			if got, want := r.Method, http.MethodPost; got != want {
+				t.Fatalf("request method = %q, want %q", got, want)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got, want := body["projectId"], "project_1"; got != want {
+				t.Fatalf("body.projectId = %#v, want %#v", got, want)
+			}
+			if got, want := body["repo"], "acme/looper"; got != want {
+				t.Fatalf("body.repo = %#v, want %#v", got, want)
+			}
+			if got, want := body["prNumber"], float64(42); got != want {
+				t.Fatalf("body.prNumber = %#v, want %#v", got, want)
+			}
+			if got, want := body["apply"], true; got != want {
+				t.Fatalf("body.apply = %#v, want %#v", got, want)
+			}
+			writeEnvelope(t, w, pkgapi.Success("req_repair", map[string]any{
+				"repo":           "acme/looper",
+				"prNumber":       42,
+				"projectId":      "project_1",
+				"loopId":         "loop_1",
+				"loopSeq":        7,
+				"apply":          true,
+				"applied":        true,
+				"appliedChanges": 1,
+				"github": map[string]any{
+					"currentLogin":         "octocat",
+					"state":                "OPEN",
+					"headSha":              "abc123",
+					"reviewRequests":       []string{"octocat"},
+					"currentUserRequested": true,
+					"currentUserReviewed":  false,
+				},
+				"local": map[string]any{
+					"status":               "completed",
+					"cleanPolicy":          "COMMENT",
+					"blockingPolicy":       "COMMENT",
+					"lastPublishedHeadSha": "abc123",
+				},
+				"diagnoses": []map[string]any{{"code": "stale_local_published_head", "message": "local suppressor is stale"}},
+				"actions":   []map[string]any{{"code": "clear_local_published_head", "message": "clear local suppressors"}},
+			}))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "review", "repair", "acme/looper#42", "--apply", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([review repair ...]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([review repair ...]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Reviewer repair", "acme/looper#42", "stale_local_published_head", "clear_local_published_head"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([review repair ...]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
 func TestWorkCreateIssueResolvesProjectFromCurrentProject(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -88,6 +88,47 @@ type loopOutput struct {
 	Status     string  `json:"status"`
 }
 
+type reviewRepairOutput struct {
+	Repo           string `json:"repo"`
+	PRNumber       int64  `json:"prNumber"`
+	ProjectID      string `json:"projectId"`
+	LoopID         string `json:"loopId"`
+	LoopSeq        int64  `json:"loopSeq"`
+	Apply          bool   `json:"apply"`
+	Applied        bool   `json:"applied"`
+	AppliedChanges int    `json:"appliedChanges"`
+	GitHub         struct {
+		CurrentLogin         string   `json:"currentLogin"`
+		State                string   `json:"state"`
+		IsDraft              bool     `json:"isDraft"`
+		HasConflicts         bool     `json:"hasConflicts"`
+		ReviewDecision       string   `json:"reviewDecision"`
+		HeadSHA              string   `json:"headSha"`
+		ReviewRequests       []string `json:"reviewRequests"`
+		CurrentUserRequested bool     `json:"currentUserRequested"`
+		CurrentUserReviewed  bool     `json:"currentUserReviewed"`
+	} `json:"github"`
+	Local struct {
+		Status               string `json:"status"`
+		CleanPolicy          string `json:"cleanPolicy"`
+		BlockingPolicy       string `json:"blockingPolicy"`
+		LastPublishedHeadSHA string `json:"lastPublishedHeadSha"`
+		LastReviewEvent      string `json:"lastReviewEvent"`
+		LastFilterSkipKind   string `json:"lastFilterSkipKind"`
+		LastFilterSkipReason string `json:"lastFilterSkipReason"`
+		HasActiveRun         bool   `json:"hasActiveRun"`
+		HasActiveQueue       bool   `json:"hasActiveQueue"`
+		LatestQueueStatus    string `json:"latestQueueStatus"`
+	} `json:"local"`
+	Diagnoses []reviewRepairLine `json:"diagnoses"`
+	Actions   []reviewRepairLine `json:"actions"`
+}
+
+type reviewRepairLine struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 type pullRequestsListOutput struct {
 	Items []pullRequestOutput `json:"items"`
 }
@@ -322,6 +363,41 @@ func writeHumanReviewCreate(w io.Writer, payload json.RawMessage, loopSetting st
 	}
 	printSection(w, "Reviewer started", [][2]any{{"id", data.ID}, {"projectId", data.ProjectID}, {"pr", formatPullRequestRef(data.Repo, data.PRNumber)}, {"status", data.Status}, {"loop", loopSetting}})
 	return nil
+}
+
+func writeHumanReviewRepair(w io.Writer, payload json.RawMessage) error {
+	var data reviewRepairOutput
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return fmt.Errorf("decode reviewer repair response: %w", err)
+	}
+
+	mode := "dry-run"
+	if data.Apply {
+		mode = "apply"
+	}
+	printSection(w, "Reviewer repair", [][2]any{{"pr", fmt.Sprintf("%s#%d", data.Repo, data.PRNumber)}, {"projectId", data.ProjectID}, {"loopId", data.LoopID}, {"loopSeq", data.LoopSeq}, {"mode", mode}, {"applied", data.Applied}, {"appliedChanges", data.AppliedChanges}})
+	fmt.Fprintln(w)
+	printSection(w, "GitHub", [][2]any{{"currentLogin", data.GitHub.CurrentLogin}, {"state", data.GitHub.State}, {"headSha", data.GitHub.HeadSHA}, {"reviewDecision", data.GitHub.ReviewDecision}, {"reviewRequests", joinOrNone(data.GitHub.ReviewRequests)}, {"currentUserRequested", data.GitHub.CurrentUserRequested}, {"currentUserReviewed", data.GitHub.CurrentUserReviewed}, {"draft", data.GitHub.IsDraft}, {"conflicts", data.GitHub.HasConflicts}})
+	fmt.Fprintln(w)
+	printSection(w, "Local", [][2]any{{"status", data.Local.Status}, {"cleanPolicy", data.Local.CleanPolicy}, {"blockingPolicy", data.Local.BlockingPolicy}, {"lastPublishedHeadSha", data.Local.LastPublishedHeadSHA}, {"lastReviewEvent", data.Local.LastReviewEvent}, {"lastFilterSkipKind", data.Local.LastFilterSkipKind}, {"lastFilterSkipReason", data.Local.LastFilterSkipReason}, {"activeRun", data.Local.HasActiveRun}, {"activeQueue", data.Local.HasActiveQueue}, {"latestQueueStatus", data.Local.LatestQueueStatus}})
+	fmt.Fprintln(w)
+	printReviewRepairLines(w, "Diagnoses", data.Diagnoses, "No reviewer state issues detected.")
+	fmt.Fprintln(w)
+	printReviewRepairLines(w, "Actions", data.Actions, "No repair actions needed.")
+	return nil
+}
+
+func printReviewRepairLines(w io.Writer, title string, lines []reviewRepairLine, empty string) {
+	_, _ = fmt.Fprintln(w, title)
+	if len(lines) == 0 {
+		_, _ = fmt.Fprintf(w, "  %s\n", empty)
+		return
+	}
+	rows := make([]tableRow, 0, len(lines))
+	for _, line := range lines {
+		rows = append(rows, tableRow{"code": line.Code, "message": line.Message})
+	}
+	printTable(w, []string{"code", "message"}, rows)
 }
 
 func writeHumanFixCreate(w io.Writer, payload json.RawMessage) error {

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -264,6 +264,24 @@ func (r *commandRuntime) reviewCreate(cmd *cobra.Command, args []string) error {
 	})
 }
 
+func (r *commandRuntime) reviewRepair(cmd *cobra.Command, args []string) error {
+	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
+		projectID, repo, prNumber, err := r.resolveReviewTarget(ctx, strings.TrimSpace(args[0]), strings.TrimSpace(getStringFlag(cmd, "project")))
+		if err != nil {
+			return nil, err
+		}
+
+		body := map[string]any{
+			"projectId": projectID,
+			"repo":      repo,
+			"prNumber":  prNumber,
+			"apply":     getBoolFlag(cmd, "apply"),
+		}
+
+		return r.postJSON(ctx, "/api/v1/reviewer/repair", body)
+	}, writeHumanReviewRepair)
+}
+
 func (r *commandRuntime) fixCreate(cmd *cobra.Command, args []string) error {
 	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
 		projectID, repo, prNumber, err := r.resolveReviewTarget(ctx, strings.TrimSpace(args[0]), strings.TrimSpace(getStringFlag(cmd, "project")))

--- a/internal/reviewer/repair.go
+++ b/internal/reviewer/repair.go
@@ -1,0 +1,461 @@
+package reviewer
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/domain"
+	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+var (
+	ErrRepairActiveWork   = errors.New("reviewer repair active work")
+	ErrRepairLoopNotFound = errors.New("reviewer repair loop not found")
+)
+
+type RepairGitHub interface {
+	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
+	GetCurrentUserLogin(context.Context, string) (string, error)
+}
+
+type RepairOptions struct {
+	DB           *sql.DB
+	Repos        *storage.Repositories
+	GitHub       RepairGitHub
+	Now          func() time.Time
+	ReviewEvents config.ReviewerReviewEventsConfig
+}
+
+type Repairer struct {
+	db           *sql.DB
+	repos        *storage.Repositories
+	github       RepairGitHub
+	now          func() time.Time
+	reviewEvents config.ReviewerReviewEventsConfig
+}
+
+type RepairInput struct {
+	ProjectID string `json:"projectId,omitempty"`
+	Repo      string `json:"repo"`
+	PRNumber  int64  `json:"prNumber"`
+	Apply     bool   `json:"apply"`
+}
+
+type RepairResult struct {
+	Repo           string                `json:"repo"`
+	PRNumber       int64                 `json:"prNumber"`
+	ProjectID      string                `json:"projectId,omitempty"`
+	LoopID         string                `json:"loopId,omitempty"`
+	LoopSeq        int64                 `json:"loopSeq,omitempty"`
+	Apply          bool                  `json:"apply"`
+	Applied        bool                  `json:"applied"`
+	AppliedChanges int                   `json:"appliedChanges"`
+	GitHub         RepairGitHubSnapshot  `json:"github"`
+	Local          RepairLocalSnapshot   `json:"local"`
+	Diagnoses      []RepairDiagnosis     `json:"diagnoses"`
+	Actions        []RepairPlannedAction `json:"actions"`
+}
+
+type RepairGitHubSnapshot struct {
+	CurrentLogin         string   `json:"currentLogin,omitempty"`
+	State                string   `json:"state,omitempty"`
+	IsDraft              bool     `json:"isDraft"`
+	HasConflicts         bool     `json:"hasConflicts"`
+	ReviewDecision       string   `json:"reviewDecision,omitempty"`
+	HeadSHA              string   `json:"headSha,omitempty"`
+	ReviewRequests       []string `json:"reviewRequests,omitempty"`
+	CurrentUserRequested bool     `json:"currentUserRequested"`
+	CurrentUserReviewed  bool     `json:"currentUserReviewed"`
+}
+
+type RepairLocalSnapshot struct {
+	Status               string `json:"status,omitempty"`
+	CleanPolicy          string `json:"cleanPolicy,omitempty"`
+	BlockingPolicy       string `json:"blockingPolicy,omitempty"`
+	LastPublishedHeadSHA string `json:"lastPublishedHeadSha,omitempty"`
+	LastReviewEvent      string `json:"lastReviewEvent,omitempty"`
+	LastFilterSkipKind   string `json:"lastFilterSkipKind,omitempty"`
+	LastFilterSkipReason string `json:"lastFilterSkipReason,omitempty"`
+	HasActiveRun         bool   `json:"hasActiveRun"`
+	HasActiveQueue       bool   `json:"hasActiveQueue"`
+	LatestQueueStatus    string `json:"latestQueueStatus,omitempty"`
+}
+
+type RepairDiagnosis struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type RepairPlannedAction struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func NewRepairer(options RepairOptions) *Repairer {
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Repairer{db: options.DB, repos: options.Repos, github: options.GitHub, now: now, reviewEvents: options.ReviewEvents}
+}
+
+func (r *Repairer) Repair(ctx context.Context, input RepairInput) (RepairResult, error) {
+	input.Repo = strings.TrimSpace(input.Repo)
+	if input.Repo == "" || input.PRNumber <= 0 {
+		return RepairResult{}, fmt.Errorf("repair requires repo and positive prNumber")
+	}
+	if r.repos == nil || r.repos.Loops == nil || r.repos.Projects == nil || r.repos.Runs == nil || r.repos.Queue == nil || r.repos.Events == nil {
+		return RepairResult{}, fmt.Errorf("repair repositories are not configured")
+	}
+	if r.github == nil {
+		return RepairResult{}, fmt.Errorf("repair github gateway is not configured")
+	}
+
+	loop, err := r.findReviewerLoop(ctx, input)
+	if err != nil {
+		return RepairResult{}, err
+	}
+	if loop == nil {
+		return RepairResult{}, fmt.Errorf("%w: %s#%d", ErrRepairLoopNotFound, input.Repo, input.PRNumber)
+	}
+	project, err := r.repos.Projects.GetByID(ctx, loop.ProjectID)
+	if err != nil {
+		return RepairResult{}, err
+	}
+	if project == nil {
+		return RepairResult{}, fmt.Errorf("project %s for loop %s was not found", loop.ProjectID, loop.ID)
+	}
+
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: project.RepoPath})
+	if err != nil {
+		return RepairResult{}, err
+	}
+	currentLogin, err := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+	if err != nil {
+		return RepairResult{}, err
+	}
+
+	latestQueue, err := r.repos.Queue.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return RepairResult{}, err
+	}
+	activeRun, err := r.repos.Runs.HasRunningByLoopID(ctx, loop.ID)
+	if err != nil {
+		return RepairResult{}, err
+	}
+	activeQueue, err := r.repos.Queue.FindActiveByLoopID(ctx, loop.ID)
+	if err != nil {
+		return RepairResult{}, err
+	}
+
+	result := r.buildPlan(*loop, detail, normalizeLogin(currentLogin), latestQueue, activeRun, activeQueue != nil, input.Apply)
+	result.Repo = input.Repo
+	result.PRNumber = input.PRNumber
+	result.ProjectID = loop.ProjectID
+	result.LoopID = loop.ID
+	result.LoopSeq = loop.Seq
+
+	if !input.Apply || len(result.Actions) == 0 {
+		return result, nil
+	}
+	if result.Local.HasActiveRun || result.Local.HasActiveQueue {
+		return result, fmt.Errorf("%w: cannot repair loop %s while it has an active run or queue item", ErrRepairActiveWork, loop.ID)
+	}
+	if r.db == nil {
+		return result, fmt.Errorf("repair database is not configured")
+	}
+
+	applied, err := storage.WithTransactionValue(ctx, r.db, nil, func(tx *sql.Tx) (int, error) {
+		transactionRepos := storage.NewRepositories(tx)
+		current, err := transactionRepos.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return 0, err
+		}
+		if current == nil {
+			return 0, fmt.Errorf("loop %s was not found", loop.ID)
+		}
+		hasRun, err := transactionRepos.Runs.HasRunningByLoopID(ctx, loop.ID)
+		if err != nil {
+			return 0, err
+		}
+		hasQueue, err := transactionRepos.Queue.FindActiveByLoopID(ctx, loop.ID)
+		if err != nil {
+			return 0, err
+		}
+		if hasRun || hasQueue != nil {
+			return 0, fmt.Errorf("%w: cannot repair loop %s while it has an active run or queue item", ErrRepairActiveWork, loop.ID)
+		}
+		return r.applyPlan(ctx, transactionRepos, *current, result)
+	})
+	if err != nil {
+		return result, err
+	}
+	result.Applied = applied > 0
+	result.AppliedChanges = applied
+	return result, nil
+}
+
+func (r *Repairer) findReviewerLoop(ctx context.Context, input RepairInput) (*storage.LoopRecord, error) {
+	loops, err := r.repos.Loops.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var selected *storage.LoopRecord
+	for _, loop := range loops {
+		if loop.Type != string(domain.LoopTypeReviewer) || loop.Repo == nil || loop.PRNumber == nil {
+			continue
+		}
+		if *loop.Repo != input.Repo || *loop.PRNumber != input.PRNumber {
+			continue
+		}
+		if input.ProjectID != "" && loop.ProjectID != input.ProjectID {
+			continue
+		}
+		candidate := loop
+		if selected == nil || preferRepairLoop(candidate, *selected) {
+			selected = &candidate
+		}
+	}
+	return selected, nil
+}
+
+func preferRepairLoop(candidate, current storage.LoopRecord) bool {
+	candidateTerminal := candidate.Status == string(domain.LoopStatusTerminated)
+	currentTerminal := current.Status == string(domain.LoopStatusTerminated)
+	if candidateTerminal != currentTerminal {
+		return !candidateTerminal
+	}
+	return candidate.Seq > current.Seq
+}
+
+func (r *Repairer) buildPlan(loop storage.LoopRecord, detail PullRequestDetail, currentLogin string, latestQueue *storage.QueueItemRecord, activeRun bool, activeQueue bool, apply bool) RepairResult {
+	meta := parseJSONObject(loop.MetadataJSON)
+	reviewEvents := r.effectiveRepairReviewEvents(meta)
+	lastFilterSkip, _ := meta["lastFilterSkip"].(map[string]any)
+	lastPublished, _ := stringFromAny(meta["lastPublishedHeadSha"])
+	lastReviewEvent, _ := stringFromAny(meta["lastReviewEvent"])
+	skipKind, _ := stringFromAny(lastFilterSkip["kind"])
+	skipReason, _ := stringFromAny(lastFilterSkip["reason"])
+	currentUserRequested := isCurrentUserRequested(detail.ReviewRequests, currentLogin)
+	currentUserReviewed := hasReviewByAuthorForHead(detail.Reviews, currentLogin, detail.HeadSHA)
+	latestQueueStatus := ""
+	if latestQueue != nil {
+		latestQueueStatus = latestQueue.Status
+	}
+
+	result := RepairResult{
+		Apply: apply,
+		GitHub: RepairGitHubSnapshot{
+			CurrentLogin:         currentLogin,
+			State:                detail.State,
+			IsDraft:              detail.IsDraft,
+			HasConflicts:         detail.HasConflicts,
+			ReviewDecision:       detail.ReviewDecision,
+			HeadSHA:              detail.HeadSHA,
+			ReviewRequests:       append([]string(nil), detail.ReviewRequests...),
+			CurrentUserRequested: currentUserRequested,
+			CurrentUserReviewed:  currentUserReviewed,
+		},
+		Local: RepairLocalSnapshot{
+			Status:               loop.Status,
+			CleanPolicy:          string(reviewEvents.Clean),
+			BlockingPolicy:       string(reviewEvents.Blocking),
+			LastPublishedHeadSHA: lastPublished,
+			LastReviewEvent:      lastReviewEvent,
+			LastFilterSkipKind:   skipKind,
+			LastFilterSkipReason: skipReason,
+			HasActiveRun:         activeRun,
+			HasActiveQueue:       activeQueue,
+			LatestQueueStatus:    latestQueueStatus,
+		},
+	}
+
+	if activeRun || activeQueue {
+		result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "active_local_work", Message: "Local loop has active work; repair will not modify it until it is idle."})
+		return result
+	}
+	if !strings.EqualFold(detail.State, "OPEN") {
+		result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "github_pr_not_open", Message: "GitHub PR is closed or merged while local reviewer state is still live."})
+		if loop.Status != string(domain.LoopStatusTerminated) {
+			result.Actions = append(result.Actions, RepairPlannedAction{Code: "terminate_local_loop", Message: "Mark the local reviewer loop terminated and cancel active queue items."})
+		}
+		return result
+	}
+	if lastPublished != "" && detail.HeadSHA != "" && lastPublished == detail.HeadSHA && currentUserRequested && !currentUserReviewed {
+		result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "stale_local_published_head", Message: "Local state marks the current head as published, but GitHub still requests the current user and has no current-head review by that user."})
+		result.Actions = append(result.Actions, RepairPlannedAction{Code: "clear_local_published_head", Message: "Clear local publish/review suppressors and resnapshot reviewer review-event policy."})
+	}
+	if staleFilterSkip(lastFilterSkip, detail, currentLogin) {
+		result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "stale_filter_skip", Message: "Local discovery skip metadata no longer matches current GitHub PR state."})
+		result.Actions = append(result.Actions, RepairPlannedAction{Code: "clear_filter_skip", Message: "Clear local lastFilterSkip metadata so discovery can reconsider the PR."})
+	}
+	if loop.Status == string(domain.LoopStatusFailed) && currentUserRequested && !detail.IsDraft && !detail.HasConflicts {
+		result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "failed_loop_still_requested", Message: "Local reviewer loop is failed while GitHub still requests current-user review."})
+		result.Actions = append(result.Actions, RepairPlannedAction{Code: "reactivate_failed_loop", Message: "Move the failed loop back to waiting and cancel the latest failed queue item."})
+	}
+	return result
+}
+
+func (r *Repairer) effectiveRepairReviewEvents(meta map[string]any) config.ReviewerReviewEventsConfig {
+	policy := r.reviewEvents
+	if policy.Clean == "" {
+		policy.Clean = config.ReviewerReviewEventComment
+	}
+	if policy.Blocking == "" {
+		policy.Blocking = config.ReviewerReviewEventComment
+	}
+	if reviewEvents, ok := meta["reviewEvents"].(map[string]any); ok {
+		if clean, ok := stringFromAny(reviewEvents["clean"]); ok && isValidCleanReviewEvent(clean) {
+			policy.Clean = config.ReviewerReviewEvent(strings.ToUpper(strings.TrimSpace(clean)))
+		}
+		if blocking, ok := stringFromAny(reviewEvents["blocking"]); ok && isValidBlockingReviewEvent(blocking) {
+			policy.Blocking = config.ReviewerReviewEvent(strings.ToUpper(strings.TrimSpace(blocking)))
+		}
+	}
+	return policy
+}
+
+func staleFilterSkip(skip map[string]any, detail PullRequestDetail, currentLogin string) bool {
+	if len(skip) == 0 {
+		return false
+	}
+	headSHA, _ := stringFromAny(skip["headSha"])
+	if headSHA != "" && detail.HeadSHA != "" && headSHA != detail.HeadSHA {
+		return false
+	}
+	kind, _ := stringFromAny(skip["kind"])
+	switch kind {
+	case "conflicted":
+		return !detail.HasConflicts
+	case "draft":
+		return !detail.IsDraft
+	case "already_reviewed_by_current_user":
+		return !hasReviewByAuthorForHead(detail.Reviews, currentLogin, detail.HeadSHA)
+	case "approved":
+		return !strings.EqualFold(strings.TrimSpace(detail.ReviewDecision), "APPROVED")
+	case "self_authored":
+		return !strings.EqualFold(normalizeLogin(detail.Author), normalizeLogin(currentLogin))
+	case "ready_label":
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *Repairer) applyPlan(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, plan RepairResult) (int, error) {
+	now := r.now().UTC()
+	nowISO := eventlog.FormatJavaScriptISOString(now)
+	applied := 0
+	meta := parseJSONObject(loop.MetadataJSON)
+	loopMeta := reviewerLoopMetadata(meta)
+
+	for _, action := range plan.Actions {
+		switch action.Code {
+		case "terminate_local_loop":
+			loop.Status = string(domain.LoopStatusTerminated)
+			loop.NextRunAt = nil
+			loopMeta["status"] = string(domain.LoopStatusTerminated)
+			loopMeta["terminationReason"] = "reviewer_repair_pr_not_open"
+			applied++
+			reason := "reviewer repair: GitHub PR is not open"
+			if _, err := repos.Queue.CancelByLoop(ctx, loop.ID, nowISO, &reason); err != nil {
+				return applied, err
+			}
+		case "clear_local_published_head":
+			delete(meta, "lastPublishedHeadSha")
+			delete(meta, "lastPublishedAt")
+			delete(meta, "lastReviewEvent")
+			delete(meta, "lastReviewSummary")
+			delete(meta, "lastOutputFingerprint")
+			delete(loopMeta, "lastReviewedHeadSha")
+			delete(loopMeta, "lastOutputFingerprint")
+			reviewEventsMeta, _ := meta["reviewEvents"].(map[string]any)
+			if reviewEventsMeta == nil {
+				reviewEventsMeta = map[string]any{}
+			}
+			if r.reviewEvents.Clean != "" {
+				reviewEventsMeta["clean"] = string(r.reviewEvents.Clean)
+			}
+			if r.reviewEvents.Blocking != "" {
+				reviewEventsMeta["blocking"] = string(r.reviewEvents.Blocking)
+			}
+			meta["reviewEvents"] = reviewEventsMeta
+			loop.Status = string(domain.LoopStatusWaiting)
+			loop.NextRunAt = nil
+			loopMeta["status"] = string(domain.LoopStatusWaiting)
+			applied++
+		case "clear_filter_skip":
+			delete(meta, "lastFilterSkip")
+			loop.Status = string(domain.LoopStatusWaiting)
+			loop.NextRunAt = nil
+			loopMeta["status"] = string(domain.LoopStatusWaiting)
+			applied++
+		case "reactivate_failed_loop":
+			loop.Status = string(domain.LoopStatusWaiting)
+			loop.NextRunAt = nil
+			loopMeta["status"] = string(domain.LoopStatusWaiting)
+			loopMeta["consecutiveFailures"] = 0
+			delete(loopMeta, "lastFailure")
+			if latest, err := repos.Queue.GetLatestByLoopID(ctx, loop.ID); err != nil {
+				return applied, err
+			} else if latest != nil && latest.Status == "failed" {
+				latest.Status = "cancelled"
+				latest.FinishedAt = stringPtr(nowISO)
+				latest.UpdatedAt = nowISO
+				if err := repos.Queue.Upsert(ctx, *latest); err != nil {
+					return applied, err
+				}
+			}
+			applied++
+		}
+	}
+
+	if applied == 0 {
+		return 0, nil
+	}
+	loopMeta["lastManualRepairAt"] = nowISO
+	loopMeta["lastManualRepairReason"] = repairActionCodes(plan.Actions)
+	meta["loop"] = loopMeta
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		return applied, fmt.Errorf("marshal repaired loop metadata: %w", err)
+	}
+	loop.MetadataJSON = stringPtr(string(encoded))
+	loop.UpdatedAt = nowISO
+	if err := repos.Loops.Upsert(ctx, loop); err != nil {
+		return applied, err
+	}
+	entityID := fmt.Sprintf("%s#%d", plan.Repo, plan.PRNumber)
+	if err := eventlog.Append(ctx, repos, eventlog.AppendInput{
+		EventType:  "reviewer.loop.repair",
+		ProjectID:  stringPtr(loop.ProjectID),
+		LoopID:     stringPtr(loop.ID),
+		EntityType: stringPtr("pull_request"),
+		EntityID:   stringPtr(entityID),
+		Payload: map[string]any{
+			"repo":      plan.Repo,
+			"prNumber":  plan.PRNumber,
+			"diagnoses": plan.Diagnoses,
+			"actions":   plan.Actions,
+		},
+		CreatedAt: now,
+	}); err != nil {
+		return applied, err
+	}
+	return applied, nil
+}
+
+func repairActionCodes(actions []RepairPlannedAction) []string {
+	codes := make([]string, 0, len(actions))
+	for _, action := range actions {
+		codes = append(codes, action.Code)
+	}
+	return codes
+}

--- a/internal/reviewer/repair.go
+++ b/internal/reviewer/repair.go
@@ -281,6 +281,18 @@ func (r *Repairer) buildPlan(loop storage.LoopRecord, detail PullRequestDetail, 
 		result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "active_local_work", Message: "Local loop has active work; repair will not modify it until it is idle."})
 		return result
 	}
+	canReactivateLocalLoop := repairCanReactivateLocalLoop(loop.Status)
+	terminalDiagnosisAdded := false
+	addReactivationAction := func(action RepairPlannedAction) {
+		if canReactivateLocalLoop {
+			result.Actions = append(result.Actions, action)
+			return
+		}
+		if !terminalDiagnosisAdded {
+			result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "terminal_local_loop", Message: "Local reviewer loop is terminal; repair will not reactivate it."})
+			terminalDiagnosisAdded = true
+		}
+	}
 	if !strings.EqualFold(detail.State, "OPEN") {
 		result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "github_pr_not_open", Message: "GitHub PR is closed or merged while local reviewer state is still live."})
 		if loop.Status != string(domain.LoopStatusTerminated) {
@@ -290,17 +302,26 @@ func (r *Repairer) buildPlan(loop storage.LoopRecord, detail PullRequestDetail, 
 	}
 	if lastPublished != "" && detail.HeadSHA != "" && lastPublished == detail.HeadSHA && currentUserRequested && !currentUserReviewed {
 		result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "stale_local_published_head", Message: "Local state marks the current head as published, but GitHub still requests the current user and has no current-head review by that user."})
-		result.Actions = append(result.Actions, RepairPlannedAction{Code: "clear_local_published_head", Message: "Clear local publish/review suppressors and resnapshot reviewer review-event policy."})
+		addReactivationAction(RepairPlannedAction{Code: "clear_local_published_head", Message: "Clear local publish/review suppressors and resnapshot reviewer review-event policy."})
 	}
 	if staleFilterSkip(lastFilterSkip, detail, currentLogin) {
 		result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "stale_filter_skip", Message: "Local discovery skip metadata no longer matches current GitHub PR state."})
-		result.Actions = append(result.Actions, RepairPlannedAction{Code: "clear_filter_skip", Message: "Clear local lastFilterSkip metadata so discovery can reconsider the PR."})
+		addReactivationAction(RepairPlannedAction{Code: "clear_filter_skip", Message: "Clear local lastFilterSkip metadata so discovery can reconsider the PR."})
 	}
 	if loop.Status == string(domain.LoopStatusFailed) && currentUserRequested && !detail.IsDraft && !detail.HasConflicts {
 		result.Diagnoses = append(result.Diagnoses, RepairDiagnosis{Code: "failed_loop_still_requested", Message: "Local reviewer loop is failed while GitHub still requests current-user review."})
 		result.Actions = append(result.Actions, RepairPlannedAction{Code: "reactivate_failed_loop", Message: "Move the failed loop back to waiting and cancel the latest failed queue item."})
 	}
 	return result
+}
+
+func repairCanReactivateLocalLoop(status string) bool {
+	switch domain.LoopStatus(status) {
+	case domain.LoopStatusTerminated, domain.LoopStatusStopped:
+		return false
+	default:
+		return true
+	}
 }
 
 func (r *Repairer) effectiveRepairReviewEvents(meta map[string]any) config.ReviewerReviewEventsConfig {
@@ -357,6 +378,9 @@ func (r *Repairer) applyPlan(ctx context.Context, repos *storage.Repositories, l
 	loopMeta := reviewerLoopMetadata(meta)
 
 	for _, action := range plan.Actions {
+		if repairActionReactivatesLocalLoop(action.Code) && !repairCanReactivateLocalLoop(loop.Status) {
+			continue
+		}
 		switch action.Code {
 		case "terminate_local_loop":
 			loop.Status = string(domain.LoopStatusTerminated)
@@ -450,6 +474,15 @@ func (r *Repairer) applyPlan(ctx context.Context, repos *storage.Repositories, l
 		return applied, err
 	}
 	return applied, nil
+}
+
+func repairActionReactivatesLocalLoop(code string) bool {
+	switch code {
+	case "clear_local_published_head", "clear_filter_skip", "reactivate_failed_loop":
+		return true
+	default:
+		return false
+	}
 }
 
 func repairActionCodes(actions []RepairPlannedAction) []string {

--- a/internal/reviewer/repair.go
+++ b/internal/reviewer/repair.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/domain"
 	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -364,7 +365,11 @@ func staleFilterSkip(skip map[string]any, detail PullRequestDetail, currentLogin
 	case "self_authored":
 		return !strings.EqualFold(normalizeLogin(detail.Author), normalizeLogin(currentLogin))
 	case "ready_label":
-		return true
+		label, _ := stringFromAny(skip["requiredLabel"])
+		if label == "" {
+			return false
+		}
+		return !specpr.HasLabel(detail.Labels, label)
 	default:
 		return false
 	}

--- a/internal/reviewer/repair_test.go
+++ b/internal/reviewer/repair_test.go
@@ -1,0 +1,227 @@
+package reviewer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/domain"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestRepairDetectsStaleLocalPublishedHeadDryRun(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	loopID := seedReviewerRepairLoop(t, fixture, string(domain.LoopStatusCompleted), stalePublishedRepairMetadata())
+	repairer := newTestRepairer(fixture, &fakeGitHubGateway{currentLogin: "octocat", reviewRequests: []string{"octocat"}, viewHeadSHA: "abc123"})
+
+	result, err := repairer.Repair(context.Background(), RepairInput{Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("Repair() error = %v", err)
+	}
+	if result.Applied {
+		t.Fatalf("Repair() applied in dry-run mode")
+	}
+	if !repairHasDiagnosis(result, "stale_local_published_head") {
+		t.Fatalf("Repair() diagnoses = %#v, want stale_local_published_head", result.Diagnoses)
+	}
+	if !repairHasAction(result, "clear_local_published_head") {
+		t.Fatalf("Repair() actions = %#v, want clear_local_published_head", result.Actions)
+	}
+	if got, want := result.Local.CleanPolicy, "COMMENT"; got != want {
+		t.Fatalf("result.Local.CleanPolicy = %q, want stale snapshot %q", got, want)
+	}
+
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	meta := parseJSONObject(loop.MetadataJSON)
+	if got, _ := stringFromAny(meta["lastPublishedHeadSha"]); got != "abc123" {
+		t.Fatalf("dry-run metadata lastPublishedHeadSha = %q, want abc123", got)
+	}
+}
+
+func TestRepairApplyClearsStalePublishedHeadAndResnapshotsPolicy(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	loopID := seedReviewerRepairLoop(t, fixture, string(domain.LoopStatusCompleted), stalePublishedRepairMetadata())
+	repairer := newTestRepairer(fixture, &fakeGitHubGateway{currentLogin: "octocat", reviewRequests: []string{"octocat"}, viewHeadSHA: "abc123"})
+
+	result, err := repairer.Repair(context.Background(), RepairInput{Repo: "acme/looper", PRNumber: 42, Apply: true})
+	if err != nil {
+		t.Fatalf("Repair(apply) error = %v", err)
+	}
+	if !result.Applied || result.AppliedChanges != 1 {
+		t.Fatalf("Repair(apply) applied=%v changes=%d, want one applied change", result.Applied, result.AppliedChanges)
+	}
+
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if got, want := loop.Status, string(domain.LoopStatusWaiting); got != want {
+		t.Fatalf("loop.Status = %q, want %q", got, want)
+	}
+	meta := parseJSONObject(loop.MetadataJSON)
+	for _, key := range []string{"lastPublishedHeadSha", "lastReviewEvent", "lastOutputFingerprint"} {
+		if _, ok := meta[key]; ok {
+			t.Fatalf("metadata still has %s after repair: %#v", key, meta)
+		}
+	}
+	reviewEvents, _ := meta["reviewEvents"].(map[string]any)
+	if got, _ := stringFromAny(reviewEvents["clean"]); got != "APPROVE" {
+		t.Fatalf("metadata.reviewEvents.clean = %q, want APPROVE", got)
+	}
+	loopMeta, _ := meta["loop"].(map[string]any)
+	if _, ok := loopMeta["lastReviewedHeadSha"]; ok {
+		t.Fatalf("metadata.loop still has lastReviewedHeadSha after repair: %#v", loopMeta)
+	}
+	if got, _ := stringFromAny(loopMeta["status"]); got != string(domain.LoopStatusWaiting) {
+		t.Fatalf("metadata.loop.status = %q, want waiting", got)
+	}
+
+	events, err := fixture.repos.Events.ListByEntity(context.Background(), "pull_request", "acme/looper#42")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	if len(events) != 1 || events[0].EventType != "reviewer.loop.repair" {
+		t.Fatalf("repair events = %#v, want one reviewer.loop.repair", events)
+	}
+}
+
+func TestRepairDoesNotClearPublishedHeadWhenCurrentHeadWasReviewed(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	seedReviewerRepairLoop(t, fixture, string(domain.LoopStatusCompleted), stalePublishedRepairMetadata())
+	repairer := newTestRepairer(fixture, &fakeGitHubGateway{
+		currentLogin:   "octocat",
+		reviewRequests: []string{"octocat"},
+		viewHeadSHA:    "abc123",
+		reviews: []map[string]any{
+			{"author": map[string]any{"login": "octocat"}, "state": "COMMENTED", "commit": map[string]any{"oid": "abc123"}},
+		},
+	})
+
+	result, err := repairer.Repair(context.Background(), RepairInput{Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("Repair() error = %v", err)
+	}
+	if repairHasAction(result, "clear_local_published_head") {
+		t.Fatalf("Repair() actions = %#v, did not expect clear_local_published_head", result.Actions)
+	}
+}
+
+func TestRepairApplyReactivatesFailedRequestedLoop(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	loopID := seedReviewerRepairLoop(t, fixture, string(domain.LoopStatusFailed), mustMarshalJSON(map[string]any{
+		"loop": map[string]any{"status": "failed", "consecutiveFailures": 3, "lastFailure": "gh api EOF"},
+	}))
+	queueID := seedReviewerRepairFailedQueue(t, fixture, loopID)
+	repairer := newTestRepairer(fixture, &fakeGitHubGateway{currentLogin: "octocat", reviewRequests: []string{"octocat"}, viewHeadSHA: "abc123"})
+
+	result, err := repairer.Repair(context.Background(), RepairInput{Repo: "acme/looper", PRNumber: 42, Apply: true})
+	if err != nil {
+		t.Fatalf("Repair(apply) error = %v", err)
+	}
+	if !result.Applied || !repairHasAction(result, "reactivate_failed_loop") {
+		t.Fatalf("Repair(apply) result = %#v, want reactivate_failed_loop applied", result)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if got, want := loop.Status, string(domain.LoopStatusWaiting); got != want {
+		t.Fatalf("loop.Status = %q, want %q", got, want)
+	}
+	meta := parseJSONObject(loop.MetadataJSON)
+	loopMeta, _ := meta["loop"].(map[string]any)
+	if got := loopMeta["consecutiveFailures"]; got != float64(0) {
+		t.Fatalf("metadata.loop.consecutiveFailures = %#v, want 0", got)
+	}
+	if _, ok := loopMeta["lastFailure"]; ok {
+		t.Fatalf("metadata.loop.lastFailure still present after repair: %#v", loopMeta)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), queueID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if got, want := queue.Status, "cancelled"; got != want {
+		t.Fatalf("queue.Status = %q, want %q", got, want)
+	}
+}
+
+func newTestRepairer(fixture *runnerFixture, github RepairGitHub) *Repairer {
+	return NewRepairer(RepairOptions{
+		DB:     fixture.coordinator.DB(),
+		Repos:  fixture.repos,
+		GitHub: github,
+		Now:    fixture.now,
+		ReviewEvents: config.ReviewerReviewEventsConfig{
+			Clean:    config.ReviewerReviewEventApprove,
+			Blocking: config.ReviewerReviewEventComment,
+		},
+	})
+}
+
+func seedReviewerRepairLoop(t *testing.T, fixture *runnerFixture, status string, metadata string) string {
+	t.Helper()
+	ctx := context.Background()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	loopID := "loop_reviewer_repair"
+	nowISO := fixture.nowISO()
+	if err := fixture.repos.Loops.Upsert(ctx, storage.LoopRecord{ID: loopID, Seq: 42, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: status, MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	return loopID
+}
+
+func seedReviewerRepairFailedQueue(t *testing.T, fixture *runnerFixture, loopID string) string {
+	t.Helper()
+	ctx := context.Background()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	queueID := "queue_reviewer_repair_failed"
+	nowISO := fixture.nowISO()
+	if err := fixture.repos.Queue.Upsert(ctx, storage.QueueItemRecord{ID: queueID, ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: buildReviewerDedupeKey("project_1", loopID, repo, prNumber), Priority: storage.QueuePriorityReviewer, Status: "failed", AvailableAt: nowISO, Attempts: 3, MaxAttempts: 3, FinishedAt: &nowISO, LastError: stringPtr("gh api EOF"), LastErrorKind: stringPtr("non_retryable"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	return queueID
+}
+
+func stalePublishedRepairMetadata() string {
+	return mustMarshalJSON(map[string]any{
+		"lastPublishedHeadSha":  "abc123",
+		"lastPublishedAt":       "2026-05-13T06:00:00.000Z",
+		"lastReviewEvent":       "COMMENT",
+		"lastOutputFingerprint": "fingerprint-1",
+		"reviewEvents":          map[string]any{"clean": "COMMENT", "blocking": "COMMENT"},
+		"loop":                  map[string]any{"status": "completed", "lastReviewedHeadSha": "abc123", "lastOutputFingerprint": "fingerprint-1"},
+	})
+}
+
+func repairHasDiagnosis(result RepairResult, code string) bool {
+	for _, diagnosis := range result.Diagnoses {
+		if diagnosis.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func repairHasAction(result RepairResult, code string) bool {
+	for _, action := range result.Actions {
+		if action.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/reviewer/repair_test.go
+++ b/internal/reviewer/repair_test.go
@@ -92,6 +92,58 @@ func TestRepairApplyClearsStalePublishedHeadAndResnapshotsPolicy(t *testing.T) {
 	}
 }
 
+func TestRepairDoesNotReactivateTerminatedLoop(t *testing.T) {
+	t.Parallel()
+
+	for _, apply := range []bool{false, true} {
+		apply := apply
+		t.Run(map[bool]string{false: "dry-run", true: "apply"}[apply], func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newRunnerFixture(t)
+			loopID := seedReviewerRepairLoop(t, fixture, string(domain.LoopStatusTerminated), terminatedStaleRepairMetadata())
+			repairer := newTestRepairer(fixture, &fakeGitHubGateway{currentLogin: "octocat", reviewRequests: []string{"octocat"}, viewHeadSHA: "abc123"})
+
+			result, err := repairer.Repair(context.Background(), RepairInput{Repo: "acme/looper", PRNumber: 42, Apply: apply})
+			if err != nil {
+				t.Fatalf("Repair(apply=%v) error = %v", apply, err)
+			}
+			if result.Applied || result.AppliedChanges != 0 {
+				t.Fatalf("Repair(apply=%v) applied=%v changes=%d, want no changes", apply, result.Applied, result.AppliedChanges)
+			}
+			for _, code := range []string{"stale_local_published_head", "stale_filter_skip", "terminal_local_loop"} {
+				if !repairHasDiagnosis(result, code) {
+					t.Fatalf("Repair(apply=%v) diagnoses = %#v, want %s", apply, result.Diagnoses, code)
+				}
+			}
+			for _, code := range []string{"clear_local_published_head", "clear_filter_skip"} {
+				if repairHasAction(result, code) {
+					t.Fatalf("Repair(apply=%v) actions = %#v, did not expect %s", apply, result.Actions, code)
+				}
+			}
+
+			loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+			if err != nil {
+				t.Fatalf("Loops.GetByID() error = %v", err)
+			}
+			if got, want := loop.Status, string(domain.LoopStatusTerminated); got != want {
+				t.Fatalf("loop.Status = %q, want %q", got, want)
+			}
+			meta := parseJSONObject(loop.MetadataJSON)
+			if got, _ := stringFromAny(meta["lastPublishedHeadSha"]); got != "abc123" {
+				t.Fatalf("metadata.lastPublishedHeadSha = %q, want abc123", got)
+			}
+			if _, ok := meta["lastFilterSkip"]; !ok {
+				t.Fatalf("metadata.lastFilterSkip missing after repair: %#v", meta)
+			}
+			loopMeta, _ := meta["loop"].(map[string]any)
+			if got, _ := stringFromAny(loopMeta["status"]); got != string(domain.LoopStatusTerminated) {
+				t.Fatalf("metadata.loop.status = %q, want terminated", got)
+			}
+		})
+	}
+}
+
 func TestRepairDoesNotClearPublishedHeadWhenCurrentHeadWasReviewed(t *testing.T) {
 	t.Parallel()
 
@@ -205,6 +257,24 @@ func stalePublishedRepairMetadata() string {
 		"lastOutputFingerprint": "fingerprint-1",
 		"reviewEvents":          map[string]any{"clean": "COMMENT", "blocking": "COMMENT"},
 		"loop":                  map[string]any{"status": "completed", "lastReviewedHeadSha": "abc123", "lastOutputFingerprint": "fingerprint-1"},
+	})
+}
+
+func terminatedStaleRepairMetadata() string {
+	return mustMarshalJSON(map[string]any{
+		"lastPublishedHeadSha":  "abc123",
+		"lastPublishedAt":       "2026-05-13T06:00:00.000Z",
+		"lastReviewEvent":       "COMMENT",
+		"lastOutputFingerprint": "fingerprint-1",
+		"lastFilterSkip": map[string]any{
+			"kind":       "draft",
+			"reason":     "PR is draft",
+			"headSha":    "abc123",
+			"isDraft":    true,
+			"recordedAt": "2026-05-13T06:00:00.000Z",
+		},
+		"reviewEvents": map[string]any{"clean": "COMMENT", "blocking": "COMMENT"},
+		"loop":         map[string]any{"status": "terminated", "terminationReason": "manual_stop", "lastReviewedHeadSha": "abc123", "lastOutputFingerprint": "fingerprint-1"},
 	})
 }
 

--- a/internal/reviewer/repair_test.go
+++ b/internal/reviewer/repair_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/domain"
+	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -167,6 +168,53 @@ func TestRepairDoesNotClearPublishedHeadWhenCurrentHeadWasReviewed(t *testing.T)
 	}
 }
 
+func TestRepairKeepsReadyLabelSkipWhileLabelPresent(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	seedReviewerRepairLoop(t, fixture, string(domain.LoopStatusWaiting), readyLabelFilterSkipMetadata())
+	repairer := newTestRepairer(fixture, &fakeGitHubGateway{
+		currentLogin:   "octocat",
+		reviewRequests: []string{"octocat"},
+		viewHeadSHA:    "abc123",
+		labels:         []string{specpr.ReadyLabel},
+	})
+
+	result, err := repairer.Repair(context.Background(), RepairInput{Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("Repair() error = %v", err)
+	}
+	if repairHasDiagnosis(result, "stale_filter_skip") {
+		t.Fatalf("Repair() diagnoses = %#v, did not expect stale_filter_skip", result.Diagnoses)
+	}
+	if repairHasAction(result, "clear_filter_skip") {
+		t.Fatalf("Repair() actions = %#v, did not expect clear_filter_skip", result.Actions)
+	}
+}
+
+func TestRepairClearsReadyLabelSkipWhenLabelRemoved(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	seedReviewerRepairLoop(t, fixture, string(domain.LoopStatusWaiting), readyLabelFilterSkipMetadata())
+	repairer := newTestRepairer(fixture, &fakeGitHubGateway{
+		currentLogin:   "octocat",
+		reviewRequests: []string{"octocat"},
+		viewHeadSHA:    "abc123",
+	})
+
+	result, err := repairer.Repair(context.Background(), RepairInput{Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("Repair() error = %v", err)
+	}
+	if !repairHasDiagnosis(result, "stale_filter_skip") {
+		t.Fatalf("Repair() diagnoses = %#v, want stale_filter_skip", result.Diagnoses)
+	}
+	if !repairHasAction(result, "clear_filter_skip") {
+		t.Fatalf("Repair() actions = %#v, want clear_filter_skip", result.Actions)
+	}
+}
+
 func TestRepairApplyReactivatesFailedRequestedLoop(t *testing.T) {
 	t.Parallel()
 
@@ -275,6 +323,18 @@ func terminatedStaleRepairMetadata() string {
 		},
 		"reviewEvents": map[string]any{"clean": "COMMENT", "blocking": "COMMENT"},
 		"loop":         map[string]any{"status": "terminated", "terminationReason": "manual_stop", "lastReviewedHeadSha": "abc123", "lastOutputFingerprint": "fingerprint-1"},
+	})
+}
+
+func readyLabelFilterSkipMetadata() string {
+	return mustMarshalJSON(map[string]any{
+		"lastFilterSkip": map[string]any{
+			"kind":          "ready_label",
+			"reason":        "PR has ready label",
+			"headSha":       "abc123",
+			"requiredLabel": specpr.ReadyLabel,
+			"recordedAt":    "2026-05-17T06:00:00.000Z",
+		},
 	})
 }
 


### PR DESCRIPTION
## Why

#1438 exposed a local/GitHub state mismatch that can keep a reviewer loop stuck without any active work: local metadata recorded the current head as published after a clean COMMENT no-op, while GitHub still requested the current user and had no current-head review by that user. Discovery then trusted `lastPublishedHeadSha` and skipped the PR indefinitely.

Manually editing SQLite is the wrong long-term tool for this class of problem because a running daemon can overwrite those edits from in-memory state, and it gives us no reusable audit trail. This PR adds a daemon-owned repair path that can be dry-run first, applies only narrow local state fixes, and lets the normal scheduler rediscover/requeue the PR naturally.

This is intentionally not a new GitHub mutation path. The repair flow reads live GitHub facts to validate whether local suppressors are stale, but it does not submit reviews, comments, labels, reactions, or review-request changes.

## How

- Adds `reviewer.Repairer`, which compares the selected local reviewer loop against live PR state and returns diagnoses plus planned actions.
- Exposes `POST /api/v1/reviewer/repair` and CLI `looper review repair <pr> [--apply]`; default mode is dry-run.
- Applies repairs only when the loop has no active run and no active queued/running queue item.
- Repairs the concrete stuck cases by clearing stale `lastPublishedHeadSha`/review suppressors, resnapshotting current `reviewer.reviewEvents`, clearing stale discovery skip metadata, reactivating failed loops that GitHub still requests, or terminating local loops for non-open PRs.
- Persists applied changes inside a storage transaction, emits `reviewer.loop.repair`, and triggers a scheduler tick so normal discovery handles the next queue item.

## Review Notes

- Core planning/apply logic: `internal/reviewer/repair.go`.
- Daemon route and GitHub adapter: `internal/api/reviewer_repair.go` plus route wiring in `internal/api/handler.go`.
- CLI entry and human output: `internal/cliapp/json_output.go`, `internal/cliapp/app.go`, `internal/cliapp/human_output.go`.
- Tests cover dry-run detection, apply behavior, active reviewed-head avoidance, failed-loop reactivation, API scheduler trigger, and CLI request shape/output.

## Verification

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check origin/main...HEAD`