### PR TITLE
fix: surface fixer declines and stop zero-progress loops

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2146,7 +2146,9 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		case string(replyActionDeclined):
 			decisionFingerprint := buildDeclinedThreadFingerprint(item, liveDetail.HeadSHA)
 			replyState, replyError := r.replyToDeclinedComment(ctx, input, item, decisionFingerprint, decision.Explanation, checkpoint.ResolvedComments.Items)
-			declinedUpdates[decisionFingerprint] = declinedThreadRecord{RecordedAt: r.nowISO(), ThreadID: item.ThreadID, Reason: decision.Explanation}
+			if replyState == "sent" {
+				declinedUpdates[decisionFingerprint] = declinedThreadRecord{RecordedAt: r.nowISO(), ThreadID: item.ThreadID, Reason: decision.Explanation}
+			}
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionDeclined), Status: "agent_declined", Message: decision.Explanation, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 		default:
 			replyState, replyError := r.replyToFixedComment(ctx, input, item, commitSHA, decision.Explanation, checkpoint.ResolvedComments.Items)
@@ -3638,7 +3640,6 @@ func (r *Runner) clearFixerFollowupMetadata(ctx context.Context, loop storage.Lo
 		delete(meta, "lastNoopResolveFixItemsHash")
 		delete(meta, "lastNoopResolveStateHash")
 		delete(meta, "lastNoopResolveAt")
-		delete(meta, "pauseReason")
 		encoded, err := json.Marshal(meta)
 		if err != nil {
 			return err

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -3814,7 +3814,7 @@ func (r *Runner) recordZeroProgressSuccess(ctx context.Context, loop storage.Loo
 		ConsecutiveCount:  1,
 		RecordedAt:        r.nowISO(),
 	}
-	if previous.HeadSHA == current.HeadSHA && previous.FixItemsHash == current.FixItemsHash {
+	if previous.HeadSHA == current.HeadSHA && previous.FixItemsHash == current.FixItemsHash && previous.FixItemsStateHash == current.FixItemsStateHash {
 		current.ConsecutiveCount = previous.ConsecutiveCount + 1
 	}
 	updatedLoop, err := r.mergeLoopMetadata(ctx, loop, map[string]any{"fixerZeroProgress": current})

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2173,6 +2173,11 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		case string(replyActionDeclined):
 			decisionFingerprint := buildDeclinedThreadFingerprint(item, liveDetail.HeadSHA)
 			replyState, replyError := r.replyToDeclinedComment(ctx, input, item, decisionFingerprint, decision.Explanation, checkpoint.ResolvedComments.Items)
+			if replyState == "failed" {
+				mutationFailureCount++
+				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionDeclined), Status: "failed_mutation_retry", Message: decision.Explanation, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+				continue
+			}
 			if replyState == "sent" {
 				declinedUpdates[decisionFingerprint] = declinedThreadRecord{RecordedAt: r.nowISO(), ThreadID: item.ThreadID, Reason: decision.Explanation}
 			}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -738,6 +738,7 @@ const maxReplyExplanationLength = 500
 
 const (
 	agentMissingThreadDecisionExplanation = "Agent did not provide a decision for this thread"
+	agentInvalidThreadDecisionExplanation = "Agent provided an unrecognized decision for this thread"
 	maxDeclinedThreadRecords              = 200
 	zeroProgressPauseReason               = "agent_zero_progress"
 )
@@ -801,7 +802,7 @@ func parseReplyExplanations(stdout, stderr string, fixItems []FixItem) []replyEx
 		if threadID != "" && item.ThreadID != "" && threadID != item.ThreadID {
 			continue
 		}
-		action := normalizeReplyAction(raw.Action)
+		action := canonicalizeReplyAction(raw.Action)
 		if action == "" {
 			action = string(replyActionFixed)
 		}
@@ -830,6 +831,28 @@ func normalizeReplyAction(raw string) string {
 	default:
 		return ""
 	}
+}
+
+func parseReplyAction(raw string) (string, bool) {
+	if strings.TrimSpace(raw) == "" {
+		return "", true
+	}
+	action := normalizeReplyAction(raw)
+	if action == "" {
+		return "", false
+	}
+	return action, true
+}
+
+func canonicalizeReplyAction(raw string) string {
+	action, ok := parseReplyAction(raw)
+	if ok {
+		if action == "" {
+			return string(replyActionFixed)
+		}
+		return action
+	}
+	return strings.TrimSpace(raw)
 }
 
 // extractCompletionMarkerPayload mirrors the agent core's last-line scan but
@@ -1029,16 +1052,17 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			result.Skipped++
 			continue
 		}
+		allFixItemsStateHash := hashFixItemsState(allFixItems)
 		fixItems := suppressDeclinedFixItems(loopMetadataForPR(ctx, r, project.ID, input.Repo, pr.Number), detail.HeadSHA, allFixItems)
 		if len(fixItems) == 0 {
-			if err := r.resumePausedZeroProgressLoopIfStateChanged(ctx, project.ID, input.Repo, pr.Number, detail.HeadSHA, hashFixItemsState(allFixItems)); err != nil {
+			if err := r.resumePausedZeroProgressLoopIfStateChanged(ctx, project.ID, input.Repo, pr.Number, detail.HeadSHA, allFixItemsStateHash); err != nil {
 				return DiscoveryResult{}, err
 			}
 			result.Skipped++
 			continue
 		}
 		fixItemsHash := hashFixItems(fixItems)
-		fixItemsStateHash := hashFixItemsState(fixItems)
+		fixItemsStateHash := allFixItemsStateHash
 		unresolvedThreadIDs := unresolvedThreadIDs(fixItems)
 		if len(unresolvedThreadIDs) == 0 {
 			if err := r.clearFixerFollowupMetadataForPR(ctx, project.ID, input.Repo, pr.Number); err != nil {
@@ -2128,6 +2152,9 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		if !ok {
 			decision = replyExplanationEntry{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionDeclined), Explanation: agentMissingThreadDecisionExplanation}
 			contractViolationCount++
+		} else if _, validAction := parseReplyAction(decision.Action); !validAction {
+			decision = replyExplanationEntry{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionDeclined), Explanation: agentInvalidThreadDecisionExplanation}
+			contractViolationCount++
 		}
 		thread, err := r.github.ViewReviewThread(ctx, ViewReviewThreadInput{ThreadID: item.ThreadID, CWD: input.Project.RepoPath})
 		if err != nil {
@@ -2347,7 +2374,7 @@ func normalizeReplyExplanationActions(entries []replyExplanationEntry) []replyEx
 	}
 	out := make([]replyExplanationEntry, 0, len(entries))
 	for _, entry := range entries {
-		entry.Action = firstNonEmpty(normalizeReplyAction(entry.Action), string(replyActionFixed))
+		entry.Action = canonicalizeReplyAction(entry.Action)
 		out = append(out, entry)
 	}
 	return out
@@ -2380,7 +2407,7 @@ func agentResolveRepliesByFixItemID(checkpoint fixerCheckpoint) map[string]reply
 			continue
 		}
 		if _, exists := out[fixItemID]; !exists {
-			entry.Action = firstNonEmpty(normalizeReplyAction(entry.Action), string(replyActionFixed))
+			entry.Action = canonicalizeReplyAction(entry.Action)
 			out[fixItemID] = entry
 		}
 	}
@@ -2402,7 +2429,7 @@ func agentResolveRepliesByThreadID(checkpoint fixerCheckpoint) map[string]replyE
 			continue
 		}
 		if _, exists := out[threadID]; !exists {
-			entry.Action = firstNonEmpty(normalizeReplyAction(entry.Action), string(replyActionFixed))
+			entry.Action = canonicalizeReplyAction(entry.Action)
 			out[threadID] = entry
 		}
 	}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -461,6 +461,13 @@ type ProcessResult struct {
 	FailureKind QueueFailureKind
 }
 
+type replyAction string
+
+const (
+	replyActionFixed    replyAction = "fixed"
+	replyActionDeclined replyAction = "declined"
+)
+
 type fixerFollowupReason string
 
 const (
@@ -486,6 +493,20 @@ type fixerFollowupState struct {
 	LastAttemptAt          string   `json:"lastAttemptAt,omitempty"`
 	NextEligibleAt         string   `json:"nextEligibleAt,omitempty"`
 	Terminal               bool     `json:"terminal,omitempty"`
+}
+
+type declinedThreadRecord struct {
+	RecordedAt string `json:"recordedAt,omitempty"`
+	ThreadID   string `json:"threadId,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+}
+
+type zeroProgressState struct {
+	HeadSHA           string `json:"headSha,omitempty"`
+	FixItemsHash      string `json:"fixItemsHash,omitempty"`
+	FixItemsStateHash string `json:"fixItemsStateHash,omitempty"`
+	ConsecutiveCount  int    `json:"consecutiveCount,omitempty"`
+	RecordedAt        string `json:"recordedAt,omitempty"`
 }
 
 type rediscoveryAction string
@@ -573,6 +594,7 @@ type checkpointRepair struct {
 type replyExplanationEntry struct {
 	FixItemID   string `json:"fixItemId"`
 	ThreadID    string `json:"threadId,omitempty"`
+	Action      string `json:"action,omitempty"`
 	Explanation string `json:"explanation"`
 }
 
@@ -646,6 +668,7 @@ type checkpointResolvedComments struct {
 type checkpointResolvedComment struct {
 	FixItemID  string `json:"fixItemId,omitempty"`
 	ThreadID   string `json:"threadId,omitempty"`
+	Action     string `json:"action,omitempty"`
 	Status     string `json:"status,omitempty"`
 	Message    string `json:"message,omitempty"`
 	UpdatedAt  string `json:"updatedAt,omitempty"`
@@ -713,6 +736,12 @@ func checkpointRepairFromAgentResult(executionID, headSHA string, result AgentRe
 // limits prompt-injection blast radius if a malicious reviewer plants payload.
 const maxReplyExplanationLength = 500
 
+const (
+	agentMissingThreadDecisionExplanation = "Agent did not provide a decision for this thread"
+	maxDeclinedThreadRecords              = 200
+	zeroProgressPauseReason               = "agent_zero_progress"
+)
+
 // parseReplyExplanations extracts the optional review_thread_replies array from
 // the final __LOOPER_RESULT__ JSON line. Failure to parse is not an error: the
 // runner simply treats the affected threads as lacking agent confirmation for
@@ -747,6 +776,7 @@ func parseReplyExplanations(stdout, stderr string, fixItems []FixItem) []replyEx
 		ReviewThreadReplies []struct {
 			FixItemID   string `json:"fixItemId"`
 			ThreadID    string `json:"threadId"`
+			Action      string `json:"action"`
 			Explanation string `json:"explanation"`
 		} `json:"review_thread_replies"`
 	}
@@ -771,6 +801,10 @@ func parseReplyExplanations(stdout, stderr string, fixItems []FixItem) []replyEx
 		if threadID != "" && item.ThreadID != "" && threadID != item.ThreadID {
 			continue
 		}
+		action := normalizeReplyAction(raw.Action)
+		if action == "" {
+			action = string(replyActionFixed)
+		}
 		explanation := sanitizeReplyExplanation(raw.Explanation)
 		if explanation == "" {
 			continue
@@ -779,12 +813,23 @@ func parseReplyExplanations(stdout, stderr string, fixItems []FixItem) []replyEx
 			continue
 		}
 		seen[fixItemID] = struct{}{}
-		out = append(out, replyExplanationEntry{FixItemID: fixItemID, ThreadID: item.ThreadID, Explanation: explanation})
+		out = append(out, replyExplanationEntry{FixItemID: fixItemID, ThreadID: item.ThreadID, Action: action, Explanation: explanation})
 	}
 	if len(out) == 0 {
 		return nil
 	}
 	return out
+}
+
+func normalizeReplyAction(raw string) string {
+	switch replyAction(strings.ToLower(strings.TrimSpace(raw))) {
+	case replyActionFixed:
+		return string(replyActionFixed)
+	case replyActionDeclined:
+		return string(replyActionDeclined)
+	default:
+		return ""
+	}
 }
 
 // extractCompletionMarkerPayload mirrors the agent core's last-line scan but
@@ -976,9 +1021,17 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
-		fixItems := collectFixItems(detail)
-		if len(fixItems) == 0 {
+		allFixItems := collectFixItems(detail)
+		if len(allFixItems) == 0 {
 			if err := r.clearFixerFollowupStateForPR(ctx, project.ID, input.Repo, pr.Number); err != nil {
+				return DiscoveryResult{}, err
+			}
+			result.Skipped++
+			continue
+		}
+		fixItems := suppressDeclinedFixItems(loopMetadataForPR(ctx, r, project.ID, input.Repo, pr.Number), detail.HeadSHA, allFixItems)
+		if len(fixItems) == 0 {
+			if err := r.resumePausedZeroProgressLoopIfStateChanged(ctx, project.ID, input.Repo, pr.Number, detail.HeadSHA, hashFixItemsState(allFixItems)); err != nil {
 				return DiscoveryResult{}, err
 			}
 			result.Skipped++
@@ -1398,6 +1451,20 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
 		return ProcessResult{}, err
 	}
+	if hasProgressed(checkpoint) {
+		if _, err := r.clearZeroProgressMetadata(ctx, *loop); err != nil {
+			return ProcessResult{}, err
+		}
+	} else {
+		paused, err := r.recordZeroProgressSuccess(ctx, *loop, checkpoint)
+		if err != nil {
+			return ProcessResult{}, err
+		}
+		if paused {
+			r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
+			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: statusForSkip(checkpoint.SkipReason), Summary: summary}, nil
+		}
+	}
 	if scheduled, err := r.scheduleFollowupRetryAfterSuccess(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber, checkpoint.SkipReason == ""); err != nil {
 		return ProcessResult{}, err
 	} else if !scheduled {
@@ -1410,11 +1477,15 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		}
 	}
 	r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
-	status := "success"
-	if checkpoint.SkipReason != "" {
-		status = "skipped"
-	}
+	status := statusForSkip(checkpoint.SkipReason)
 	return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
+}
+
+func statusForSkip(skipReason string) string {
+	if skipReason != "" {
+		return "skipped"
+	}
+	return "success"
 }
 
 func (r *Runner) scheduleFollowupRetryAfterSuccess(ctx context.Context, loop storage.LoopRecord, repo string, prNumber int64, allow bool) (bool, error) {
@@ -1682,7 +1753,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		return checkpoint, err
 	}
 	checkpoint.Repair = checkpointRepairFromAgentResult(executionID, detailHeadSHA(checkpoint.Detail), result, r.nowISO())
-	checkpoint.Repair.ReplyExplanations = parseReplyExplanations(result.Stdout, result.Stderr, checkpoint.FixItems)
+	checkpoint.Repair.ReplyExplanations = normalizeReplyExplanationActions(parseReplyExplanations(result.Stdout, result.Stderr, checkpoint.FixItems))
 	checkpoint.Repair.FixItemsHash = checkpoint.FixItemsHash
 	checkpoint.ensureLifecycle("fixer", worktree.Branch, detailBaseRefName(checkpoint.Detail), false)
 	if result.Lifecycle != nil {
@@ -2004,6 +2075,8 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		checkpoint.ResolvedComments = &checkpointResolvedComments{Items: []checkpointResolvedComment{}}
 	}
 	resolvedCount := 0
+	contractViolationCount := 0
+	declinedUpdates := map[string]declinedThreadRecord{}
 	commentItems := make([]FixItem, 0, len(fixItems))
 	for _, item := range fixItems {
 		if item.Type == "comment" {
@@ -2048,13 +2121,13 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
 			continue
 		}
-		explanation := repliesByItemID[item.ID]
-		if explanation == "" && item.ThreadID != "" {
-			explanation = repliesByThreadID[item.ThreadID]
+		decision, ok := repliesByItemID[item.ID]
+		if !ok && item.ThreadID != "" {
+			decision, ok = repliesByThreadID[item.ThreadID]
 		}
-		if strings.TrimSpace(explanation) == "" {
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_agent_declined", Message: "Agent did not include this thread in review_thread_replies", UpdatedAt: r.nowISO()})
-			continue
+		if !ok {
+			decision = replyExplanationEntry{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionDeclined), Explanation: agentMissingThreadDecisionExplanation}
+			contractViolationCount++
 		}
 		thread, err := r.github.ViewReviewThread(ctx, ViewReviewThreadInput{ThreadID: item.ThreadID, CWD: input.Project.RepoPath})
 		if err != nil {
@@ -2069,26 +2142,44 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_thread_drift", Message: "New human comment was added to this thread after the fixer run started", UpdatedAt: r.nowISO()})
 			continue
 		}
-		replyState, replyError := r.replyToFixedComment(ctx, input, item, commitSHA, explanation, checkpoint.ResolvedComments.Items)
-		if err := r.persistCheckpoint(ctx, input.Run.ID, stepResolveComments, checkpoint); err != nil {
-			return checkpoint, err
-		}
-		if err := r.github.ResolveReviewThread(ctx, ResolveReviewThreadInput{Repo: input.Repo, ThreadID: item.ThreadID, CWD: input.Project.RepoPath}); err != nil {
-			message := err.Error()
-			if strings.Contains(strings.ToLower(message), "already") {
-				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "already_resolved", Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+		switch normalizeReplyAction(decision.Action) {
+		case string(replyActionDeclined):
+			decisionFingerprint := buildDeclinedThreadFingerprint(item, liveDetail.HeadSHA)
+			replyState, replyError := r.replyToDeclinedComment(ctx, input, item, decisionFingerprint, decision.Explanation, checkpoint.ResolvedComments.Items)
+			declinedUpdates[decisionFingerprint] = declinedThreadRecord{RecordedAt: r.nowISO(), ThreadID: item.ThreadID, Reason: decision.Explanation}
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionDeclined), Status: "agent_declined", Message: decision.Explanation, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+		default:
+			replyState, replyError := r.replyToFixedComment(ctx, input, item, commitSHA, decision.Explanation, checkpoint.ResolvedComments.Items)
+			if err := r.persistCheckpoint(ctx, input.Run.ID, stepResolveComments, checkpoint); err != nil {
+				return checkpoint, err
+			}
+			if err := r.github.ResolveReviewThread(ctx, ResolveReviewThreadInput{Repo: input.Repo, ThreadID: item.ThreadID, CWD: input.Project.RepoPath}); err != nil {
+				message := err.Error()
+				if strings.Contains(strings.ToLower(message), "already") {
+					upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionFixed), Status: "already_resolved", Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+					continue
+				}
+				mutationFailureCount++
+				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionFixed), Status: "failed_mutation_retry", Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 				continue
 			}
-			mutationFailureCount++
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "failed_mutation_retry", Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
-			continue
+			resolvedCount++
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionFixed), Status: "resolved", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 		}
-		resolvedCount++
-		upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "resolved", UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+	}
+	if contractViolationCount > 0 {
+		if _, err := r.incrementContractViolationCount(ctx, input.Loop, contractViolationCount); err != nil {
+			return checkpoint, err
+		}
+	}
+	if len(declinedUpdates) > 0 {
+		if _, err := r.persistDeclinedThreadRecords(ctx, input.Loop, declinedUpdates); err != nil {
+			return checkpoint, err
+		}
 	}
 	r.appendEvent(ctx, eventInput{eventType: "fixer.comments.resolved", projectID: input.Project.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"items": checkpoint.ResolvedComments.Items}})
 	if resolvedCount > 0 {
-		r.publishRoundSummaryComment(ctx, input, &checkpoint, fixItems, commitSHA, repliesByItemID)
+		r.publishRoundSummaryComment(ctx, input, &checkpoint, fixItems, commitSHA, lookupReplyExplanations(checkpoint))
 	}
 	if driftCount > 0 {
 		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
@@ -2135,8 +2226,53 @@ func (r *Runner) replyToFixedComment(ctx context.Context, input stepInput, item 
 	return "sent", ""
 }
 
+func (r *Runner) replyToDeclinedComment(ctx context.Context, input stepInput, item FixItem, decisionFingerprint, explanation string, existing []checkpointResolvedComment) (string, string) {
+	if item.ThreadID == "" {
+		return "skipped_no_thread", ""
+	}
+	for _, entry := range existing {
+		if entry.Action != string(replyActionDeclined) {
+			continue
+		}
+		if entry.FixItemID == item.ID || (entry.ThreadID != "" && entry.ThreadID == item.ThreadID) {
+			if entry.ReplyState == "sent" || entry.ReplyState == "skipped_self_author" || entry.ReplyState == "skipped_no_thread" {
+				return entry.ReplyState, entry.ReplyError
+			}
+		}
+	}
+	body := buildFixerDeclinedReplyBody(item, explanation, decisionFingerprint)
+	existingRemoteReply, err := r.hasExistingFixerDeclinedReply(ctx, input, item, decisionFingerprint)
+	if err != nil {
+		return "failed", err.Error()
+	}
+	if existingRemoteReply {
+		return "sent", ""
+	}
+	if err := r.github.AddReviewThreadReply(ctx, AddReviewThreadReplyInput{Repo: input.Repo, ThreadID: item.ThreadID, Body: body, CWD: input.Project.RepoPath}); err != nil {
+		return "failed", err.Error()
+	}
+	return "sent", ""
+}
+
 func (r *Runner) hasExistingFixerReply(ctx context.Context, input stepInput, item FixItem, commitSHA string) (bool, error) {
 	marker := fixerReplyMarker(item.ThreadID, commitSHA)
+	if marker == "" {
+		return false, nil
+	}
+	thread, err := r.github.ViewReviewThread(ctx, ViewReviewThreadInput{ThreadID: item.ThreadID, CWD: input.Project.RepoPath})
+	if err != nil {
+		return false, err
+	}
+	for _, comment := range thread.Comments {
+		if strings.Contains(comment.Body, marker) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *Runner) hasExistingFixerDeclinedReply(ctx context.Context, input stepInput, item FixItem, decisionFingerprint string) (bool, error) {
+	marker := fixerDeclinedReplyMarker(item.ThreadID, decisionFingerprint)
 	if marker == "" {
 		return false, nil
 	}
@@ -2203,6 +2339,18 @@ func lookupReplyExplanations(checkpoint fixerCheckpoint) map[string]string {
 	return out
 }
 
+func normalizeReplyExplanationActions(entries []replyExplanationEntry) []replyExplanationEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]replyExplanationEntry, 0, len(entries))
+	for _, entry := range entries {
+		entry.Action = firstNonEmpty(normalizeReplyAction(entry.Action), string(replyActionFixed))
+		out = append(out, entry)
+	}
+	return out
+}
+
 // agentResolveReplyExplanationsValid reports whether the agent-provided
 // reply explanations were captured against the same fix-items snapshot
 // represented by the current checkpoint. When the snapshot drifted (e.g.
@@ -2218,11 +2366,11 @@ func agentResolveReplyExplanationsValid(checkpoint fixerCheckpoint) bool {
 	return true
 }
 
-func agentResolveRepliesByFixItemID(checkpoint fixerCheckpoint) map[string]string {
+func agentResolveRepliesByFixItemID(checkpoint fixerCheckpoint) map[string]replyExplanationEntry {
 	if !agentResolveReplyExplanationsValid(checkpoint) {
 		return nil
 	}
-	out := make(map[string]string, len(checkpoint.Repair.ReplyExplanations))
+	out := make(map[string]replyExplanationEntry, len(checkpoint.Repair.ReplyExplanations))
 	for _, entry := range checkpoint.Repair.ReplyExplanations {
 		fixItemID := strings.TrimSpace(entry.FixItemID)
 		explanation := strings.TrimSpace(entry.Explanation)
@@ -2230,7 +2378,8 @@ func agentResolveRepliesByFixItemID(checkpoint fixerCheckpoint) map[string]strin
 			continue
 		}
 		if _, exists := out[fixItemID]; !exists {
-			out[fixItemID] = explanation
+			entry.Action = firstNonEmpty(normalizeReplyAction(entry.Action), string(replyActionFixed))
+			out[fixItemID] = entry
 		}
 	}
 	if len(out) == 0 {
@@ -2239,11 +2388,11 @@ func agentResolveRepliesByFixItemID(checkpoint fixerCheckpoint) map[string]strin
 	return out
 }
 
-func agentResolveRepliesByThreadID(checkpoint fixerCheckpoint) map[string]string {
+func agentResolveRepliesByThreadID(checkpoint fixerCheckpoint) map[string]replyExplanationEntry {
 	if !agentResolveReplyExplanationsValid(checkpoint) {
 		return nil
 	}
-	out := make(map[string]string, len(checkpoint.Repair.ReplyExplanations))
+	out := make(map[string]replyExplanationEntry, len(checkpoint.Repair.ReplyExplanations))
 	for _, entry := range checkpoint.Repair.ReplyExplanations {
 		threadID := strings.TrimSpace(entry.ThreadID)
 		explanation := strings.TrimSpace(entry.Explanation)
@@ -2251,7 +2400,8 @@ func agentResolveRepliesByThreadID(checkpoint fixerCheckpoint) map[string]string
 			continue
 		}
 		if _, exists := out[threadID]; !exists {
-			out[threadID] = explanation
+			entry.Action = firstNonEmpty(normalizeReplyAction(entry.Action), string(replyActionFixed))
+			out[threadID] = entry
 		}
 	}
 	if len(out) == 0 {
@@ -2334,6 +2484,26 @@ func buildFixerReplyBody(item FixItem, commitSHA, explanation string) string {
 	return b.String()
 }
 
+func buildFixerDeclinedReplyBody(item FixItem, explanation, decisionFingerprint string) string {
+	var b strings.Builder
+	mention := strings.TrimSpace(item.Author)
+	if mention != "" {
+		b.WriteString("@")
+		b.WriteString(mention)
+		b.WriteString(" ")
+	}
+	b.WriteString("I'm not making a code change for this thread.")
+	if explanation = strings.TrimSpace(explanation); explanation != "" {
+		b.WriteString("\n\n")
+		b.WriteString(explanation)
+	}
+	if marker := fixerDeclinedReplyMarker(item.ThreadID, decisionFingerprint); marker != "" {
+		b.WriteString("\n\n")
+		b.WriteString(marker)
+	}
+	return b.String()
+}
+
 func fixerReplyMarker(threadID, commitSHA string) string {
 	threadID = strings.TrimSpace(threadID)
 	commitSHA = strings.TrimSpace(commitSHA)
@@ -2341,6 +2511,15 @@ func fixerReplyMarker(threadID, commitSHA string) string {
 		return ""
 	}
 	return fmt.Sprintf("<!-- looper-fixer-reply thread:%s commit:%s -->", threadID, commitSHA)
+}
+
+func fixerDeclinedReplyMarker(threadID, decisionFingerprint string) string {
+	threadID = strings.TrimSpace(threadID)
+	decisionFingerprint = strings.TrimSpace(decisionFingerprint)
+	if threadID == "" || decisionFingerprint == "" {
+		return ""
+	}
+	return fmt.Sprintf("<!-- looper-fixer-reply-declined thread:%s fingerprint:%s -->", threadID, decisionFingerprint)
 }
 
 func summarizeFixItem(item FixItem) string {
@@ -2495,6 +2674,9 @@ func summaryCommentItems(fixItems []FixItem, checkpoint *fixerCheckpoint, explan
 			if ok {
 				entry.Status = resolved.Status
 				entry.ReplyState = resolved.ReplyState
+				if entry.Explanation == "" && strings.TrimSpace(resolved.Message) != "" {
+					entry.Explanation = resolved.Message
+				}
 			} else {
 				entry.Status = "pending"
 			}
@@ -2600,6 +2782,8 @@ func summaryStatusIcon(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "resolved", "already_resolved":
 		return "✅"
+	case "agent_declined":
+		return "⏸️"
 	case "failed":
 		return "⚠️"
 	case "pending":
@@ -3014,7 +3198,13 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 	for _, existing := range existingLoops {
 		if existing.Type == "fixer" && existing.ProjectID == project.ID && derefString(existing.Repo) == repo && derefInt64(existing.PRNumber) == prNumber {
 			if existing.Status == "paused" {
-				return loopUpsertResult{record: existing, created: false}, nil
+				if resumed, updated, err := r.resumePausedZeroProgressLoop(ctx, existing, headSHA, fixItemsStateHash); err != nil {
+					return loopUpsertResult{}, err
+				} else if !resumed {
+					return loopUpsertResult{record: existing, created: false}, nil
+				} else {
+					existing = updated
+				}
 			}
 			if loops.ShouldSuppressFailedRediscovery(existing.Status, loops.LastFailedDiscoveryFingerprint(existing.MetadataJSON), buildFixerDiscoveryFingerprint(repo, prNumber, headSHA, fixItemsStateHash)) {
 				return loopUpsertResult{record: existing, created: false, skipped: true}, nil
@@ -3056,6 +3246,46 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 		return loopUpsertResult{}, err
 	}
 	return loopUpsertResult{record: loop, created: true, availableAt: now}, nil
+}
+
+func (r *Runner) resumePausedZeroProgressLoopIfStateChanged(ctx context.Context, projectID, repo string, prNumber int64, headSHA, fixItemsStateHash string) error {
+	loop, err := r.findFixerLoopByPR(ctx, projectID, repo, prNumber)
+	if err != nil || loop == nil {
+		return err
+	}
+	_, _, err = r.resumePausedZeroProgressLoop(ctx, *loop, headSHA, fixItemsStateHash)
+	return err
+}
+
+func (r *Runner) resumePausedZeroProgressLoop(ctx context.Context, loop storage.LoopRecord, headSHA, fixItemsStateHash string) (bool, storage.LoopRecord, error) {
+	if loop.Status != "paused" {
+		return false, loop, nil
+	}
+	metadata := parseJSONObject(loop.MetadataJSON)
+	pauseReason, _ := stringFromAny(metadata["pauseReason"])
+	if pauseReason != zeroProgressPauseReason {
+		return false, loop, nil
+	}
+	state, ok := parseZeroProgressState(metadata)
+	if !ok {
+		return false, loop, nil
+	}
+	if state.HeadSHA == strings.TrimSpace(headSHA) && state.FixItemsStateHash == strings.TrimSpace(fixItemsStateHash) {
+		return false, loop, nil
+	}
+	updated, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+		updated.Status = "queued"
+		nextRunAt := r.nowISO()
+		updated.NextRunAt = &nextRunAt
+	})
+	if err != nil {
+		return false, storage.LoopRecord{}, err
+	}
+	updated, err = r.clearZeroProgressMetadata(ctx, updated)
+	if err != nil {
+		return false, storage.LoopRecord{}, err
+	}
+	return true, updated, nil
 }
 
 func (r *Runner) recoverLegacyNoopFollowupLoops(ctx context.Context, project storage.ProjectRecord, repo string, policy DiscoveryPolicy, currentUser string) ([]storage.QueueItemRecord, error) {
@@ -3351,6 +3581,17 @@ func (r *Runner) findFixerLoopByPR(ctx context.Context, projectID, repo string, 
 	return nil, nil
 }
 
+func loopMetadataForPR(ctx context.Context, runner *Runner, projectID, repo string, prNumber int64) *string {
+	if runner == nil {
+		return nil
+	}
+	loop, err := runner.findFixerLoopByPR(ctx, projectID, repo, prNumber)
+	if err != nil || loop == nil {
+		return nil
+	}
+	return loop.MetadataJSON
+}
+
 func (r *Runner) clearFixerFollowupStateForPR(ctx context.Context, projectID, repo string, prNumber int64) error {
 	loop, err := r.findFixerLoopByPR(ctx, projectID, repo, prNumber)
 	if err != nil || loop == nil {
@@ -3397,6 +3638,7 @@ func (r *Runner) clearFixerFollowupMetadata(ctx context.Context, loop storage.Lo
 		delete(meta, "lastNoopResolveFixItemsHash")
 		delete(meta, "lastNoopResolveStateHash")
 		delete(meta, "lastNoopResolveAt")
+		delete(meta, "pauseReason")
 		encoded, err := json.Marshal(meta)
 		if err != nil {
 			return err
@@ -3411,6 +3653,29 @@ func (r *Runner) clearFixerFollowupMetadata(ctx context.Context, loop storage.Lo
 			return storage.LoopRecord{}, err
 		}
 		return updated, nil
+	}
+	var mutateErr error
+	updated, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+		mutateErr = apply(updated)
+	})
+	if mutateErr != nil {
+		return storage.LoopRecord{}, mutateErr
+	}
+	return updated, err
+}
+
+func (r *Runner) clearZeroProgressMetadata(ctx context.Context, loop storage.LoopRecord) (storage.LoopRecord, error) {
+	apply := func(updated *storage.LoopRecord) error {
+		meta := parseJSONObject(updated.MetadataJSON)
+		delete(meta, "fixerZeroProgress")
+		delete(meta, "pauseReason")
+		encoded, err := json.Marshal(meta)
+		if err != nil {
+			return err
+		}
+		metadataJSON := string(encoded)
+		updated.MetadataJSON = &metadataJSON
+		return nil
 	}
 	var mutateErr error
 	updated, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
@@ -3508,6 +3773,84 @@ func (r *Runner) mergeLoopMetadata(ctx context.Context, loop storage.LoopRecord,
 		return storage.LoopRecord{}, err
 	}
 	return updated, nil
+}
+
+func (r *Runner) incrementContractViolationCount(ctx context.Context, loop storage.LoopRecord, count int) (storage.LoopRecord, error) {
+	metadata := parseJSONObject(loop.MetadataJSON)
+	current := int(int64FromAny(metadata["fixerContractViolationCount"]))
+	return r.mergeLoopMetadata(ctx, loop, map[string]any{"fixerContractViolationCount": current + count})
+}
+
+func (r *Runner) persistDeclinedThreadRecords(ctx context.Context, loop storage.LoopRecord, updates map[string]declinedThreadRecord) (storage.LoopRecord, error) {
+	metadata := parseJSONObject(loop.MetadataJSON)
+	records := parseDeclinedThreadRecords(metadata)
+	if records == nil {
+		records = map[string]declinedThreadRecord{}
+	}
+	for fingerprint, record := range updates {
+		records[fingerprint] = record
+	}
+	records = trimDeclinedThreadRecords(records, maxDeclinedThreadRecords)
+	return r.mergeLoopMetadata(ctx, loop, map[string]any{"declinedThreads": records})
+}
+
+func (r *Runner) recordZeroProgressSuccess(ctx context.Context, loop storage.LoopRecord, checkpoint fixerCheckpoint) (bool, error) {
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		current, err := r.repos.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return false, err
+		}
+		if current != nil {
+			loop = *current
+		}
+	}
+	metadata := parseJSONObject(loop.MetadataJSON)
+	previous, _ := parseZeroProgressState(metadata)
+	current := zeroProgressState{
+		HeadSHA:           detailHeadSHA(checkpoint.Detail),
+		FixItemsHash:      strings.TrimSpace(checkpoint.FixItemsHash),
+		FixItemsStateHash: hashFixItemsState(checkpoint.FixItems),
+		ConsecutiveCount:  1,
+		RecordedAt:        r.nowISO(),
+	}
+	if previous.HeadSHA == current.HeadSHA && previous.FixItemsHash == current.FixItemsHash {
+		current.ConsecutiveCount = previous.ConsecutiveCount + 1
+	}
+	updatedLoop, err := r.mergeLoopMetadata(ctx, loop, map[string]any{"fixerZeroProgress": current})
+	if err != nil {
+		return false, err
+	}
+	if current.ConsecutiveCount < 3 {
+		_ = updatedLoop
+		return false, nil
+	}
+	updatedLoop, err = r.mergeLoopMetadata(ctx, updatedLoop, map[string]any{"pauseReason": zeroProgressPauseReason})
+	if err != nil {
+		return false, err
+	}
+	_, err = r.updateLoop(ctx, updatedLoop, func(updated *storage.LoopRecord) {
+		updated.Status = "paused"
+		updated.NextRunAt = nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func hasProgressed(checkpoint fixerCheckpoint) bool {
+	if checkpoint.ReconcileCommits != nil && len(checkpoint.ReconcileCommits.NewCommitSHAs) > 0 {
+		return true
+	}
+	if checkpoint.ResolvedComments == nil {
+		return false
+	}
+	for _, item := range checkpoint.ResolvedComments.Items {
+		if item.Status == "resolved" || item.Action == string(replyActionFixed) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Runner) classifyFailure(err error) *loopError {
@@ -3785,6 +4128,66 @@ func mergeLoopMetadataJSON(current *string, updates map[string]any) (string, err
 	return string(encoded), nil
 }
 
+func parseDeclinedThreadRecords(metadata map[string]any) map[string]declinedThreadRecord {
+	raw, ok := metadata["declinedThreads"]
+	if !ok || raw == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var records map[string]declinedThreadRecord
+	if err := json.Unmarshal(encoded, &records); err != nil {
+		return nil
+	}
+	return records
+}
+
+func parseZeroProgressState(metadata map[string]any) (zeroProgressState, bool) {
+	raw, ok := metadata["fixerZeroProgress"]
+	if !ok || raw == nil {
+		return zeroProgressState{}, false
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return zeroProgressState{}, false
+	}
+	var state zeroProgressState
+	if err := json.Unmarshal(encoded, &state); err != nil {
+		return zeroProgressState{}, false
+	}
+	if state.HeadSHA == "" && state.FixItemsHash == "" && state.FixItemsStateHash == "" {
+		return zeroProgressState{}, false
+	}
+	return state, true
+}
+
+func trimDeclinedThreadRecords(records map[string]declinedThreadRecord, max int) map[string]declinedThreadRecord {
+	if len(records) <= max || max <= 0 {
+		return records
+	}
+	type declinedEntry struct {
+		fingerprint string
+		recordedAt  time.Time
+	}
+	entries := make([]declinedEntry, 0, len(records))
+	for fingerprint, record := range records {
+		entries = append(entries, declinedEntry{fingerprint: fingerprint, recordedAt: parseRFC3339OrZero(record.RecordedAt)})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].recordedAt.Equal(entries[j].recordedAt) {
+			return entries[i].fingerprint < entries[j].fingerprint
+		}
+		return entries[i].recordedAt.After(entries[j].recordedAt)
+	})
+	trimmed := make(map[string]declinedThreadRecord, max)
+	for _, entry := range entries[:max] {
+		trimmed[entry.fingerprint] = records[entry.fingerprint]
+	}
+	return trimmed
+}
+
 func collectFixItemsFromCheckpoint(checkpoint fixerCheckpoint) []FixItem {
 	if checkpoint.Detail == nil {
 		return nil
@@ -3919,6 +4322,33 @@ func hashFixItemsState(items []FixItem) string {
 	return hex.EncodeToString(sum[:])
 }
 
+func buildDeclinedThreadFingerprint(item FixItem, headSHA string) string {
+	payload := strings.Join([]string{
+		strings.TrimSpace(item.ThreadID),
+		normalizeThreadFingerprint(item.ThreadFingerprint, item.ThreadID, item.ID),
+		strings.TrimSpace(headSHA),
+	}, "|")
+	sum := sha1.Sum([]byte(payload))
+	return hex.EncodeToString(sum[:])
+}
+
+func suppressDeclinedFixItems(loopMetadataJSON *string, headSHA string, fixItems []FixItem) []FixItem {
+	records := parseDeclinedThreadRecords(parseJSONObject(loopMetadataJSON))
+	if len(records) == 0 {
+		return fixItems
+	}
+	filtered := make([]FixItem, 0, len(fixItems))
+	for _, item := range fixItems {
+		if item.Type == "comment" {
+			if _, ok := records[buildDeclinedThreadFingerprint(item, headSHA)]; ok {
+				continue
+			}
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
 func buildFixerMinimalPRSeed(repo string, prNumber int64, detail *checkpointDetail, fixItems []FixItem) string {
 	seed := map[string]any{
 		"repo":           repo,
@@ -4050,11 +4480,15 @@ func buildFixerReplyExplanationInstruction(fixItems []FixItem) string {
 		return ""
 	}
 	return strings.Join([]string{
-		"For each comment-type fix item you actually addressed, include an entry in a top-level `review_thread_replies` array on the final " + agent.CompletionMarker + " JSON line. Each entry must be an object with these fields:",
-		`  - "fixItemId": the exact "id" of the fix item you addressed`,
+		"For EVERY comment-type fix item, you MUST include exactly one entry in a top-level `review_thread_replies` array on the final " + agent.CompletionMarker + " JSON line.",
+		"Each entry must be an object with these fields:",
+		`  - "fixItemId": the exact "id" of the fix item`,
 		`  - "threadId": the exact "threadId" of the same fix item`,
-		`  - "explanation": one or two sentences (max ~500 chars) describing what you changed and, when relevant, which file(s) or test(s) cover it. No greetings, no @mentions, no markdown headings, no HTML, no disclosure markers.`,
-		"Before including an entry, re-read the relevant review thread/comment context and only include items you can confidently confirm are actually addressed by the current branch state. If anything is ambiguous, partially fixed, or still pending, omit that entry.",
+		`  - "action": "fixed" or "declined"`,
+		`  - "explanation": one or two sentences (max ~500 chars). If action is "fixed", say what you changed and where. If action is "declined", give a concrete reason why you are not acting. No greetings, no @mentions, no markdown headings, no HTML, no disclosure markers.`,
+		"Before including an entry, re-read the relevant review thread/comment context.",
+		"Use \"fixed\" only when you can confidently confirm the current branch state actually addresses the thread; in other words, only include items you can confidently confirm are actually addressed by the current branch state. Use \"declined\" if you deliberately are not acting, including cases such as: already implemented on this branch, out of scope for this PR, reviewer request is incorrect, or you cannot safely complete it.",
+		"Do not omit any comment-type fix item. Do not use vague explanations like \"looks fine\" or \"no change needed\".",
 		"Read-only GitHub fetches are allowed for that verification. Do not post replies, resolve threads, submit reviews, edit PR metadata, or perform any other mutating GitHub API action; Looper owns those remote review-state changes after validation and push. Do not invent URLs.",
 	}, "\n")
 }

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1438,6 +1438,60 @@ func TestRunResolveCommentsStepPostsDeclinedReplyWithoutResolving(t *testing.T) 
 	}
 }
 
+func TestRunResolveCommentsStepDoesNotPersistDeclinedFingerprintWhenReplyFails(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	loop := storage.LoopRecord{ID: "loop_decline_reply_failure", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "new-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+			"author":   "alice",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}}, replyErr: errors.New("reply failed")}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice", Summary: "please fix", ThreadFingerprint: "thread-hash-1"}}
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionDeclined), Explanation: "Out of scope for this PR."}}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].ReplyState != "failed" {
+		t.Fatalf("resolved comments = %#v, want failed reply state", updated.ResolvedComments)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if records := parseDeclinedThreadRecords(parseJSONObject(persisted.MetadataJSON)); len(records) != 0 {
+		t.Fatalf("declined thread records = %#v, want none after failed reply", records)
+	}
+	if got := suppressDeclinedFixItems(persisted.MetadataJSON, "new-head", fixItems); len(got) != 1 || got[0].ID != "c1" {
+		t.Fatalf("suppressDeclinedFixItems() = %#v, want original fix item after failed reply", got)
+	}
+}
+
 func TestRunResolveCommentsStepSkipsAllWhenLiveFixItemsAddNewThread(t *testing.T) {
 	t.Parallel()
 
@@ -4133,6 +4187,41 @@ func TestRecordZeroProgressSuccessPausesAfterThreeRunsAndResumesOnStateChange(t 
 	}
 	if !resumed {
 		t.Fatal("resumePausedZeroProgressLoop() = false, want resume on head change")
+	}
+}
+
+func TestClearFixerFollowupMetadataPreservesZeroProgressPauseReason(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(81)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	metadata := mustMarshalJSON(map[string]any{
+		"fixerFollowup":            map[string]any{"reason": "missing_evidence"},
+		"lastNoopResolveHeadSha":   "head-1",
+		"lastNoopResolveStateHash": "same-hash",
+		"lastNoopResolveAt":        fixture.nowISO(),
+		"pauseReason":              zeroProgressPauseReason,
+	})
+	loop := storage.LoopRecord{ID: "loop_zero_progress_cleanup", Seq: 95, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &metadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+
+	updated, err := runner.clearFixerFollowupMetadata(context.Background(), loop)
+	if err != nil {
+		t.Fatalf("clearFixerFollowupMetadata() error = %v", err)
+	}
+	meta := parseJSONObject(updated.MetadataJSON)
+	if _, ok := meta["fixerFollowup"]; ok {
+		t.Fatalf("fixerFollowup still present in %#v", meta)
+	}
+	if _, ok := meta["lastNoopResolveHeadSha"]; ok {
+		t.Fatalf("lastNoopResolveHeadSha still present in %#v", meta)
+	}
+	if got, _ := stringFromAny(meta["pauseReason"]); got != zeroProgressPauseReason {
+		t.Fatalf("pauseReason = %q, want %q", got, zeroProgressPauseReason)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -4225,6 +4225,56 @@ func TestClearFixerFollowupMetadataPreservesZeroProgressPauseReason(t *testing.T
 	}
 }
 
+func TestRecordZeroProgressSuccessResetsCountWhenFixItemStateChanges(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(82)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	loop := storage.LoopRecord{ID: "loop_zero_progress_state_reset", Seq: 96, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+
+	baseItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "thread-fingerprint-1"}}
+	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{HeadSHA: "head-1"}, FixItems: baseItems, FixItemsHash: hashFixItems(baseItems)}
+	for i := 0; i < 2; i++ {
+		paused, err := runner.recordZeroProgressSuccess(context.Background(), loop, checkpoint)
+		if err != nil {
+			t.Fatalf("recordZeroProgressSuccess() error = %v", err)
+		}
+		if paused {
+			t.Fatalf("recordZeroProgressSuccess() paused early on run %d", i+1)
+		}
+	}
+
+	changedItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "thread-fingerprint-2"}}
+	changedCheckpoint := fixerCheckpoint{Detail: &checkpointDetail{HeadSHA: "head-1"}, FixItems: changedItems, FixItemsHash: hashFixItems(changedItems)}
+	paused, err := runner.recordZeroProgressSuccess(context.Background(), loop, changedCheckpoint)
+	if err != nil {
+		t.Fatalf("recordZeroProgressSuccess() changed state error = %v", err)
+	}
+	if paused {
+		t.Fatal("recordZeroProgressSuccess() = true, want streak reset when fix-item state changes")
+	}
+
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	state, ok := parseZeroProgressState(parseJSONObject(persisted.MetadataJSON))
+	if !ok {
+		t.Fatal("parseZeroProgressState() = false, want persisted zero-progress state")
+	}
+	if state.ConsecutiveCount != 1 {
+		t.Fatalf("ConsecutiveCount = %d, want 1 after state change", state.ConsecutiveCount)
+	}
+	if state.FixItemsStateHash != hashFixItemsState(changedItems) {
+		t.Fatalf("FixItemsStateHash = %q, want %q", state.FixItemsStateHash, hashFixItemsState(changedItems))
+	}
+}
+
 func TestParseReplyExplanationsMalformedFallsBack(t *testing.T) {
 	t.Parallel()
 	if got := parseReplyExplanations("__LOOPER_RESULT__={bad json}", "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}); got != nil {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -727,6 +727,49 @@ func TestDiscoverPullRequestsRequeuesDeclinedThreadWhenHeadChanges(t *testing.T)
 	}
 }
 
+func TestDiscoverPullRequestsKeepsPausedZeroProgressLoopWhenOnlySuppressedDeclinesDiffer(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(80)
+	nowISO := fixture.nowISO()
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "same-head", HeadRefName: "feature/fix-80", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix", "threadFingerprint": "thread-hash-1"}, {"id": "c2", "threadId": "t2", "body": "please fix too", "threadFingerprint": "thread-hash-2"}}}
+	allFixItems := collectFixItems(detail)
+	declinedFingerprint := buildDeclinedThreadFingerprint(allFixItems[0], detail.HeadSHA)
+	metadata := mustMarshalJSON(map[string]any{
+		"pauseReason": zeroProgressPauseReason,
+		"fixerZeroProgress": map[string]any{
+			"headSha":           detail.HeadSHA,
+			"fixItemsHash":      hashFixItems(allFixItems),
+			"fixItemsStateHash": hashFixItemsState(allFixItems),
+			"consecutiveCount":  3,
+			"recordedAt":        nowISO,
+		},
+		"declinedThreads": map[string]any{declinedFingerprint: map[string]any{"recordedAt": nowISO, "threadId": "t1", "reason": "already declined"}},
+	})
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_declined_mixed", Seq: 94, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: detail.HeadSHA}}, viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want none when full fix-item state is unchanged", result.QueueItems)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), "loop_paused_declined_mixed")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused loop to remain paused", persisted)
+	}
+}
+
 func TestProcessClaimedItemAllowsNoCommitWhenCommentsAlreadyResolved(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -1489,6 +1532,64 @@ func TestRunResolveCommentsStepDoesNotPersistDeclinedFingerprintWhenReplyFails(t
 	}
 	if got := suppressDeclinedFixItems(persisted.MetadataJSON, "new-head", fixItems); len(got) != 1 || got[0].ID != "c1" {
 		t.Fatalf("suppressDeclinedFixItems() = %#v, want original fix item after failed reply", got)
+	}
+}
+
+func TestRunResolveCommentsStepTreatsUnknownActionAsContractViolation(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	loop := storage.LoopRecord{ID: "loop_invalid_action", Seq: 2, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "new-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+			"author":   "alice",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice", Summary: "please fix", ThreadFingerprint: "thread-hash-1"}}
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: "decliend", Explanation: "Out of scope for this PR."}}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %#v, want none for invalid action", github.resolveCalls)
+	}
+	if len(github.replyCalls) != 1 || !strings.Contains(github.replyCalls[0].Body, agentInvalidThreadDecisionExplanation) {
+		t.Fatalf("reply calls = %#v, want invalid-action decline reply", github.replyCalls)
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "agent_declined" {
+		t.Fatalf("resolved comments = %#v, want agent_declined", updated.ResolvedComments)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	meta := parseJSONObject(persisted.MetadataJSON)
+	if got := int(int64FromAny(meta["fixerContractViolationCount"])); got != 1 {
+		t.Fatalf("fixerContractViolationCount = %d, want 1", got)
 	}
 }
 
@@ -4143,6 +4244,15 @@ func TestParseReplyExplanationsPreservesDeclinedAction(t *testing.T) {
 	got := parseReplyExplanations(stdout, "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
 	if len(got) != 1 || got[0].Action != string(replyActionDeclined) {
 		t.Fatalf("parseReplyExplanations() = %#v, want declined action", got)
+	}
+}
+
+func TestParseReplyExplanationsPreservesUnknownActionForContractViolationHandling(t *testing.T) {
+	t.Parallel()
+	stdout := `__LOOPER_RESULT__={"review_thread_replies":[{"fixItemId":"c1","threadId":"t1","action":"decliend","explanation":"already implemented"}]}`
+	got := parseReplyExplanations(stdout, "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
+	if len(got) != 1 || got[0].Action != "decliend" {
+		t.Fatalf("parseReplyExplanations() = %#v, want preserved unknown action", got)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -593,8 +593,11 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
 		t.Fatalf("checkpoint.ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
 	}
-	if checkpoint.ResolvedComments == nil || len(checkpoint.ResolvedComments.Items) == 0 || checkpoint.ResolvedComments.Items[0].Status != "skipped_agent_declined" {
-		t.Fatalf("checkpoint.ResolvedComments = %#v, want skipped-agent-declined marker", checkpoint.ResolvedComments)
+	if checkpoint.ResolvedComments == nil || len(checkpoint.ResolvedComments.Items) == 0 || checkpoint.ResolvedComments.Items[0].Status != "agent_declined" {
+		t.Fatalf("checkpoint.ResolvedComments = %#v, want agent_declined marker", checkpoint.ResolvedComments)
+	}
+	if len(github.replyCalls) != 1 || !strings.Contains(github.replyCalls[0].Body, agentMissingThreadDecisionExplanation) {
+		t.Fatalf("reply calls = %#v, want synthetic decline reply", github.replyCalls)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
 	if err != nil {
@@ -667,6 +670,60 @@ func TestDiscoverPullRequestsRequeuesFailedFixerLoopWhenFingerprintChanges(t *te
 	}
 	if len(result.QueueItems) != 1 {
 		t.Fatalf("QueueItems = %#v, want one queue item after fingerprint change", result.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsSkipsDeclinedThreadWhenFingerprintMatches(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(79)
+	nowISO := fixture.nowISO()
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "same-head", HeadRefName: "feature/fix-79", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix", "threadFingerprint": "thread-hash-1"}}}
+	fixItems := collectFixItems(detail)
+	declinedFingerprint := buildDeclinedThreadFingerprint(fixItems[0], detail.HeadSHA)
+	metadata := mustMarshalJSON(map[string]any{"declinedThreads": map[string]any{declinedFingerprint: map[string]any{"recordedAt": nowISO, "threadId": "t1", "reason": "already fixed"}}})
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_declined_same_fp", Seq: 92, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: detail.HeadSHA}}, viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want none for declined fingerprint match", result.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsRequeuesDeclinedThreadWhenHeadChanges(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(80)
+	nowISO := fixture.nowISO()
+	oldDetail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "old-head", HeadRefName: "feature/fix-80", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix", "threadFingerprint": "thread-hash-1"}}}
+	oldFixItems := collectFixItems(oldDetail)
+	declinedFingerprint := buildDeclinedThreadFingerprint(oldFixItems[0], oldDetail.HeadSHA)
+	metadata := mustMarshalJSON(map[string]any{"declinedThreads": map[string]any{declinedFingerprint: map[string]any{"recordedAt": nowISO, "threadId": "t1", "reason": "already fixed"}}})
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_declined_changed_head", Seq: 93, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	newDetail := oldDetail
+	newDetail.HeadSHA = "new-head"
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: newDetail.HeadSHA}}, viewResponses: []PullRequestDetail{newDetail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want one queue item after head change", result.QueueItems)
 	}
 }
 
@@ -1270,8 +1327,11 @@ func TestRunResolveCommentsStepSkipsWithoutVerifiedPushEvidence(t *testing.T) {
 	if len(github.resolveCalls) != 0 {
 		t.Fatalf("resolve calls = %d, want 0 without agent reply explanation", len(github.resolveCalls))
 	}
-	if updated.ResolvedComments == nil || len(updated.ResolvedComments.Items) != 1 || updated.ResolvedComments.Items[0].Status != "skipped_agent_declined" {
-		t.Fatalf("resolved comments = %#v, want skipped_agent_declined", updated.ResolvedComments)
+	if updated.ResolvedComments == nil || len(updated.ResolvedComments.Items) != 1 || updated.ResolvedComments.Items[0].Status != "agent_declined" {
+		t.Fatalf("resolved comments = %#v, want agent_declined", updated.ResolvedComments)
+	}
+	if len(github.replyCalls) != 1 || !strings.Contains(github.replyCalls[0].Body, agentMissingThreadDecisionExplanation) {
+		t.Fatalf("reply calls = %#v, want synthetic decline reply", github.replyCalls)
 	}
 	if updated.ResumePolicy != "advance_from_checkpoint" {
 		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
@@ -1333,6 +1393,48 @@ func TestRunResolveCommentsStepResolvesUsingRepairReplyExplanations(t *testing.T
 	}
 	if updated.ResumePolicy != "advance_from_checkpoint" {
 		t.Fatalf("updated.ResumePolicy = %q, want advance_from_checkpoint", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepPostsDeclinedReplyWithoutResolving(t *testing.T) {
+	t.Parallel()
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "new-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+			"author":   "alice",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice", Summary: "please fix", ThreadFingerprint: "thread-hash-1"}}
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionDeclined), Explanation: "Out of scope for this PR."}}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %#v, want none for declined reply", github.resolveCalls)
+	}
+	if len(github.replyCalls) != 1 || !strings.Contains(github.replyCalls[0].Body, "Out of scope for this PR.") {
+		t.Fatalf("reply calls = %#v, want declined explanation reply", github.replyCalls)
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "agent_declined" {
+		t.Fatalf("resolved comments = %#v, want agent_declined", updated.ResolvedComments)
 	}
 }
 
@@ -3969,6 +4071,68 @@ func TestParseReplyExplanationsDropsUnknownAndMismatchedThread(t *testing.T) {
 	got := parseReplyExplanations(stdout, "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
 	if len(got) != 1 || got[0].Explanation != "good" {
 		t.Fatalf("parseReplyExplanations() = %#v, want only the first valid entry", got)
+	}
+}
+
+func TestParseReplyExplanationsDefaultsMissingActionToFixed(t *testing.T) {
+	t.Parallel()
+	stdout := `__LOOPER_RESULT__={"review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"good"}]}`
+	got := parseReplyExplanations(stdout, "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
+	if len(got) != 1 || got[0].Action != string(replyActionFixed) {
+		t.Fatalf("parseReplyExplanations() = %#v, want default fixed action", got)
+	}
+}
+
+func TestParseReplyExplanationsPreservesDeclinedAction(t *testing.T) {
+	t.Parallel()
+	stdout := `__LOOPER_RESULT__={"review_thread_replies":[{"fixItemId":"c1","threadId":"t1","action":"declined","explanation":"already implemented"}]}`
+	got := parseReplyExplanations(stdout, "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
+	if len(got) != 1 || got[0].Action != string(replyActionDeclined) {
+		t.Fatalf("parseReplyExplanations() = %#v, want declined action", got)
+	}
+}
+
+func TestRecordZeroProgressSuccessPausesAfterThreeRunsAndResumesOnStateChange(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(81)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	loop := storage.LoopRecord{ID: "loop_zero_progress", Seq: 94, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "completed", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{HeadSHA: "head-1"}, FixItems: []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "thread-hash-1"}}, FixItemsHash: "fix-hash-1"}
+	for i := 0; i < 2; i++ {
+		paused, err := runner.recordZeroProgressSuccess(context.Background(), loop, checkpoint)
+		if err != nil {
+			t.Fatalf("recordZeroProgressSuccess() error = %v", err)
+		}
+		if paused {
+			t.Fatalf("recordZeroProgressSuccess() paused early on run %d", i+1)
+		}
+	}
+	paused, err := runner.recordZeroProgressSuccess(context.Background(), loop, checkpoint)
+	if err != nil {
+		t.Fatalf("recordZeroProgressSuccess() third run error = %v", err)
+	}
+	if !paused {
+		t.Fatal("recordZeroProgressSuccess() = false, want paused on third zero-progress run")
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused", persisted)
+	}
+	resumed, _, err := runner.resumePausedZeroProgressLoop(context.Background(), *persisted, "head-2", hashFixItemsState([]FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "thread-hash-1"}}))
+	if err != nil {
+		t.Fatalf("resumePausedZeroProgressLoop() error = %v", err)
+	}
+	if !resumed {
+		t.Fatal("resumePausedZeroProgressLoop() = false, want resume on head change")
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1517,11 +1517,14 @@ func TestRunResolveCommentsStepDoesNotPersistDeclinedFingerprintWhenReplyFails(t
 	}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: checkpoint})
-	if err != nil {
-		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	if err == nil || !strings.Contains(err.Error(), "Failed to resolve") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want retryable mutation failure error", err)
 	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].ReplyState != "failed" {
-		t.Fatalf("resolved comments = %#v, want failed reply state", updated.ResolvedComments)
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "failed_mutation_retry" || updated.ResolvedComments.Items[0].ReplyState != "failed" {
+		t.Fatalf("resolved comments = %#v, want failed_mutation_retry with failed reply state", updated.ResolvedComments)
+	}
+	if updated.ResumePolicy != loops.ResumePolicyReplayStep {
+		t.Fatalf("updated.ResumePolicy = %q, want replay_step", updated.ResumePolicy)
 	}
 	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- require fixer agents to emit a `fixed` or `declined` decision for every comment thread, post visible decline replies for explicit or synthetic declines, and persist decline metadata for telemetry
- suppress unchanged declined threads during fixer rediscovery so the same branch state does not re-trigger the same decline loop
- pause fixer loops after three consecutive zero-progress runs and automatically resume them when PR thread state or head SHA changes

## Validation
- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- `go build ./...`

Closes #324