### PR TITLE
fix: drop fix-items-hash gate that drift-loops resolve-comments

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -584,7 +584,6 @@ type checkpointRepair struct {
 	ElapsedRuntimeSeconds        int64                   `json:"elapsedRuntimeSeconds,omitempty"`
 	LastProgressAt               string                  `json:"lastProgressAt,omitempty"`
 	ReplyExplanations            []replyExplanationEntry `json:"replyExplanations,omitempty"`
-	FixItemsHash                 string                  `json:"fixItemsHash,omitempty"`
 }
 
 // replyExplanationEntry holds the agent's per-fix-item explanation for the
@@ -1778,7 +1777,6 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	}
 	checkpoint.Repair = checkpointRepairFromAgentResult(executionID, detailHeadSHA(checkpoint.Detail), result, r.nowISO())
 	checkpoint.Repair.ReplyExplanations = normalizeReplyExplanationActions(parseReplyExplanations(result.Stdout, result.Stderr, checkpoint.FixItems))
-	checkpoint.Repair.FixItemsHash = checkpoint.FixItemsHash
 	checkpoint.ensureLifecycle("fixer", worktree.Branch, detailBaseRefName(checkpoint.Detail), false)
 	if result.Lifecycle != nil {
 		checkpoint.Lifecycle.MergeAgent(result.Lifecycle, r.nowISO())
@@ -1985,9 +1983,11 @@ func (r *Runner) adoptLifecyclePushEvidence(ctx context.Context, input stepInput
 	if strings.TrimSpace(lc.Branch) != "" && strings.TrimSpace(lc.Branch) != branch {
 		return false, checkpoint, nil
 	}
-	if checkpoint.Repair.FixItemsHash != "" && checkpoint.FixItemsHash != "" && checkpoint.Repair.FixItemsHash != checkpoint.FixItemsHash {
-		return false, checkpoint, nil
-	}
+	// PRNumber/Branch/HeadRefName/HeadSHA are validated independently
+	// against the live PR detail below; we deliberately do not gate
+	// adoption on a fix-items hash match. New review threads arriving
+	// during repair routinely shift the snapshot hash without
+	// invalidating the agent's claim that it pushed the right commit.
 	liveDetail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 	if err != nil {
 		return false, checkpoint, err
@@ -2124,23 +2124,17 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	if checkpoint.Repair != nil && strings.TrimSpace(checkpoint.Repair.CompletedAt) != "" {
 		driftSince = checkpoint.Repair.CompletedAt
 	}
-	// If the agent's reply explanations were captured against a different
-	// fix-items snapshot than the live PR shows, the underlying threads or
-	// comments have changed since the agent ran. Treat the whole step as
-	// thread drift and rediscover, instead of marking each thread as
-	// skipped_agent_declined (which would silently bypass the drift path).
-	if len(commentItems) > 0 && checkpoint.Repair != nil && len(checkpoint.Repair.ReplyExplanations) > 0 && !agentResolveReplyExplanationsValid(checkpoint) {
-		for _, item := range commentItems {
-			if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
-				continue
-			}
-			driftCount++
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_thread_drift", Message: "Fix-items snapshot changed since the agent recorded reply explanations", UpdatedAt: r.nowISO()})
-		}
-		r.appendEvent(ctx, eventInput{eventType: "fixer.comments.resolved", projectID: input.Project.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"items": checkpoint.ResolvedComments.Items}})
-		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
-		return checkpoint, &loopError{message: fmt.Sprintf("Fix-items snapshot drifted; will rediscover %d thread(s)", driftCount), kind: FailureRetryableAfterResume}
-	}
+	// Per-thread drift detection (hasNonLooperCommentSince below) handles
+	// the case where a reviewer added or edited a comment on an existing
+	// thread after the agent recorded its decisions. New threads that
+	// appeared after the snapshot are not present in the agent's payload
+	// and fall through to the contract-violation → synthetic-decline path,
+	// which posts a visible reply without resolving the thread. Both
+	// behaviours are correct without invalidating the entire reply set on
+	// a fix-items hash mismatch — doing so threw away every successful
+	// "fixed" decision whenever a single new thread appeared, which on PRs
+	// receiving a steady stream of bot comments produced an unbreakable
+	// drift loop.
 	for _, item := range commentItems {
 		if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
 			continue
@@ -2351,16 +2345,15 @@ func (r *Runner) refreshResolveCommentState(ctx context.Context, input stepInput
 }
 
 // lookupReplyExplanations returns a map of fixItemId → sanitized agent
-// explanation, but only when the explanations were captured against the same
-// fix-items snapshot represented by the current checkpoint. If the snapshot
-// changed (e.g. PR rebased, new comments arrived), the agent's explanations no
-// longer describe the threads we are about to handle, so they do not count as
-// durable confirmation for auto-reply/resolve.
+// explanation. Per-thread drift (a new human comment posted after the
+// agent's decision) is detected separately by hasNonLooperCommentSince.
+// We deliberately do not invalidate the whole reply set when the
+// fix-items hash differs from the snapshot the agent saw: keeping the
+// per-item explanations available preserves round summary text and
+// evidence records for the threads the agent actually decided about,
+// without affecting how new (unknown) threads are handled downstream.
 func lookupReplyExplanations(checkpoint fixerCheckpoint) map[string]string {
 	if checkpoint.Repair == nil || len(checkpoint.Repair.ReplyExplanations) == 0 {
-		return nil
-	}
-	if checkpoint.Repair.FixItemsHash != "" && checkpoint.FixItemsHash != "" && checkpoint.Repair.FixItemsHash != checkpoint.FixItemsHash {
 		return nil
 	}
 	out := make(map[string]string, len(checkpoint.Repair.ReplyExplanations))
@@ -2386,15 +2379,16 @@ func normalizeReplyExplanationActions(entries []replyExplanationEntry) []replyEx
 }
 
 // agentResolveReplyExplanationsValid reports whether the agent-provided
-// reply explanations were captured against the same fix-items snapshot
-// represented by the current checkpoint. When the snapshot drifted (e.g.
-// rebase, new comments) the explanations no longer describe the threads
-// we are about to handle and must not be used as resolve authority.
+// reply explanations exist on the checkpoint and can be consulted as the
+// per-item reply authority. Per-thread drift (a new human comment posted
+// after the agent's decision) is detected separately by
+// hasNonLooperCommentSince. We deliberately do not invalidate the whole
+// reply set when the fix-items hash differs from the snapshot the agent
+// saw: new threads simply fall through to the contract-violation path and
+// receive synthetic declines, while previously decided threads continue to
+// be replied/resolved as the agent intended.
 func agentResolveReplyExplanationsValid(checkpoint fixerCheckpoint) bool {
 	if checkpoint.Repair == nil || len(checkpoint.Repair.ReplyExplanations) == 0 {
-		return false
-	}
-	if checkpoint.Repair.FixItemsHash != "" && checkpoint.FixItemsHash != "" && checkpoint.Repair.FixItemsHash != checkpoint.FixItemsHash {
 		return false
 	}
 	return true

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1404,7 +1404,7 @@ func TestRunResolveCommentsStepResolvesUsingRepairReplyExplanations(t *testing.T
 		FixItemsHash: hashFixItems(fixItems),
 		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:       &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
+		Repair:       &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
 		ReconcileCommits: &checkpointReconcileCommits{
 			BaseHeadSHA:      "base-head",
 			FinalHeadSHA:     "base-head",
@@ -1462,7 +1462,7 @@ func TestRunResolveCommentsStepPostsDeclinedReplyWithoutResolving(t *testing.T) 
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionDeclined), Explanation: "Out of scope for this PR."}}},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionDeclined), Explanation: "Out of scope for this PR."}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -1512,7 +1512,7 @@ func TestRunResolveCommentsStepDoesNotPersistDeclinedFingerprintWhenReplyFails(t
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionDeclined), Explanation: "Out of scope for this PR."}}},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionDeclined), Explanation: "Out of scope for this PR."}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -1569,7 +1569,7 @@ func TestRunResolveCommentsStepTreatsUnknownActionAsContractViolation(t *testing
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: "decliend", Explanation: "Out of scope for this PR."}}},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: "decliend", Explanation: "Out of scope for this PR."}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -1596,7 +1596,7 @@ func TestRunResolveCommentsStepTreatsUnknownActionAsContractViolation(t *testing
 	}
 }
 
-func TestRunResolveCommentsStepSkipsAllWhenLiveFixItemsAddNewThread(t *testing.T) {
+func TestRunResolveCommentsStepHandlesNewThreadAsContractViolationWithoutSkippingExisting(t *testing.T) {
 	t.Parallel()
 
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
@@ -1616,36 +1616,74 @@ func TestRunResolveCommentsStepSkipsAllWhenLiveFixItemsAddNewThread(t *testing.T
 			"body":     "new feedback",
 		}},
 	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}, {ID: "t2", Comments: []ReviewThreadComment{{ID: "c2", Body: "new feedback"}}}}}
-	runner := New(Options{GitHub: github})
+	// fixItems mirrors the snapshot the agent saw: only c1/t1.
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	// Live PR has gained thread t2/c2 since the agent ran. The agent's
+	// existing decision for c1 must still be honoured (reply + resolve);
+	// the unknown thread t2 falls through to the contract-violation path
+	// and receives a synthetic-decline reply without being resolved.
 	checkpoint := fixerCheckpoint{
 		FixItems:         fixItems,
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	loop := storage.LoopRecord{ID: "loop_new_thread_contract", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{
 		Project:    storage.ProjectRecord{RepoPath: t.TempDir()},
-		Repo:       "acme/looper",
-		PRNumber:   42,
+		Repo:       repo,
+		PRNumber:   prNumber,
+		Loop:       loop,
 		Checkpoint: checkpoint,
 	})
-	if err == nil || !strings.Contains(err.Error(), "snapshot drifted") {
-		t.Fatalf("runResolveCommentsStep() error = %v, want snapshot-drift retry", err)
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v, want nil", err)
 	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %#v, want 0 when fix-items snapshot drifted", github.resolveCalls)
+	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t1" {
+		t.Fatalf("resolve calls = %#v, want exactly 1 resolve for t1", github.resolveCalls)
 	}
-	for _, item := range updated.ResolvedComments.Items {
-		if item.Status != "skipped_thread_drift" {
-			t.Fatalf("resolved comments = %#v, want all skipped_thread_drift", updated.ResolvedComments.Items)
+	if len(github.replyCalls) != 2 {
+		t.Fatalf("reply calls = %d, want 2 (fixed reply for t1, synthetic decline for t2)", len(github.replyCalls))
+	}
+	var (
+		t1Reply *AddReviewThreadReplyInput
+		t2Reply *AddReviewThreadReplyInput
+	)
+	for i, call := range github.replyCalls {
+		switch call.ThreadID {
+		case "t1":
+			t1Reply = &github.replyCalls[i]
+		case "t2":
+			t2Reply = &github.replyCalls[i]
 		}
 	}
-	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
-		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	if t1Reply == nil || !strings.Contains(t1Reply.Body, "Applied the requested fix.") {
+		t.Fatalf("t1 reply = %#v, want fixed explanation", t1Reply)
+	}
+	if t2Reply == nil || !strings.Contains(t2Reply.Body, agentMissingThreadDecisionExplanation) {
+		t.Fatalf("t2 reply = %#v, want synthetic decline reply", t2Reply)
+	}
+	statusByThread := map[string]string{}
+	for _, item := range updated.ResolvedComments.Items {
+		statusByThread[item.ThreadID] = item.Status
+	}
+	if statusByThread["t1"] != "resolved" {
+		t.Fatalf("t1 status = %q, want resolved", statusByThread["t1"])
+	}
+	if statusByThread["t2"] != "agent_declined" {
+		t.Fatalf("t2 status = %q, want agent_declined", statusByThread["t2"])
 	}
 }
 
@@ -1668,7 +1706,7 @@ func TestRunResolveCommentsStepSkipsThreadWhenHumanCommentArrivesAfterRunStart(t
 	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix", CreatedAt: "2026-04-11T11:59:00Z"}, {ID: "reply-2", Body: "one more thing", CreatedAt: "2026-04-11T12:05:00Z"}}}}}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "new human comments") {
@@ -1709,7 +1747,7 @@ func TestRunResolveCommentsStepDetectsDriftFromEditedComment(t *testing.T) {
 	}}}}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "new human comments") {
@@ -1726,7 +1764,7 @@ func TestRunResolveCommentsStepDetectsDriftFromEditedComment(t *testing.T) {
 	}
 }
 
-func TestRunResolveCommentsStepDriftBeatsSnapshotMismatchWhenBothChange(t *testing.T) {
+func TestRunResolveCommentsStepFlagsThreadDriftWhenCommentEdited(t *testing.T) {
 	t.Parallel()
 
 	runStartedAt := "2026-04-11T12:00:00Z"
@@ -1752,22 +1790,19 @@ func TestRunResolveCommentsStepDriftBeatsSnapshotMismatchWhenBothChange(t *testi
 		FixItemsHash:     hashFixItems(originalFixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(originalFixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err == nil {
-		t.Fatalf("runResolveCommentsStep() error = nil, want retryable drift error")
-	}
-	if !strings.Contains(err.Error(), "snapshot drifted") && !strings.Contains(err.Error(), "new human comments") {
-		t.Fatalf("runResolveCommentsStep() error = %v, want drift-classified retry", err)
+	if err == nil || !strings.Contains(err.Error(), "new human comments") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want per-thread drift retry", err)
 	}
 	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want 0 when comment edit drifts both hash and thread", len(github.resolveCalls))
+		t.Fatalf("resolve calls = %d, want 0 when the thread comment was edited after run start", len(github.resolveCalls))
 	}
 	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
-		t.Fatalf("resolved comments = %#v, want skipped_thread_drift (not skipped_agent_declined) when both hash and thread drift", updated.ResolvedComments)
+		t.Fatalf("resolved comments = %#v, want skipped_thread_drift", updated.ResolvedComments)
 	}
 	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
 		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
@@ -1796,7 +1831,7 @@ func TestRunResolveCommentsStepIgnoresBotCommentForDrift(t *testing.T) {
 	}}}}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
@@ -1810,51 +1845,6 @@ func TestRunResolveCommentsStepIgnoresBotCommentForDrift(t *testing.T) {
 	}
 }
 
-func TestRunResolveCommentsStepSkipsWhenReplyExplanationsSnapshotDrifted(t *testing.T) {
-	t.Parallel()
-
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
-		Number:      42,
-		State:       "OPEN",
-		HeadSHA:     "fix-head",
-		HeadRefName: "feature/fix-42",
-		BaseRefName: "main",
-		BaseSHA:     "base-1",
-		Comments: []map[string]any{{
-			"id":       "c1",
-			"threadId": "t1",
-			"body":     "please fix",
-		}},
-	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}}}
-	runner := New(Options{GitHub: github})
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{
-		FixItems:         fixItems,
-		FixItemsHash:     hashFixItems(fixItems),
-		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
-		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{FixItemsHash: "stale-hash", ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
-		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
-	}
-
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err == nil || !strings.Contains(err.Error(), "snapshot drifted") {
-		t.Fatalf("runResolveCommentsStep() error = %v, want snapshot-drift retry", err)
-	}
-	if len(github.resolveCalls) != 0 {
-		t.Fatalf("resolve calls = %d, want 0 when reply-explanations snapshot drifted", len(github.resolveCalls))
-	}
-	if len(github.replyCalls) != 0 {
-		t.Fatalf("reply calls = %d, want 0 when reply-explanations snapshot drifted", len(github.replyCalls))
-	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
-		t.Fatalf("resolved comments = %#v, want skipped_thread_drift when snapshot drifted", updated.ResolvedComments)
-	}
-	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
-		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
-	}
-}
-
 func TestRunResolveCommentsStepRecordsMutationFailureAsRetryable(t *testing.T) {
 	t.Parallel()
 
@@ -1865,7 +1855,7 @@ func TestRunResolveCommentsStepRecordsMutationFailureAsRetryable(t *testing.T) {
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "Failed to resolve") {
@@ -1892,7 +1882,7 @@ func TestRunResolveCommentsStepProceedsWhenFixCommitStillReachable(t *testing.T)
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
@@ -1919,7 +1909,7 @@ func TestRunResolveCommentsStepAbortsWhenFixCommitNoLongerReachable(t *testing.T
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "no longer descends") {
@@ -1959,7 +1949,7 @@ func TestRunResolveCommentsStepDriftAnchorsToRepairCompletionOnReplay(t *testing
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}, CompletedAt: repairCompletedAt},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}, CompletedAt: repairCompletedAt},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -1988,7 +1978,7 @@ func TestRunResolveCommentsStepReplyFailureDoesNotBlockResolve(t *testing.T) {
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
@@ -2026,7 +2016,7 @@ func TestRunResolveCommentsStepUsesRefreshedPushHeadSHA(t *testing.T) {
 		FixItemsHash: hashFixItems(fixItems),
 		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:         &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "new-head"},
-		Repair:       &checkpointRepair{FixItemsHash: hashFixItems(fixItems), ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
+		Repair:       &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
 		Lifecycle:    &lifecycle.State{Pushed: true},
 		ReconcileCommits: &checkpointReconcileCommits{
 			BaseHeadSHA:      "base-head",
@@ -4434,37 +4424,26 @@ func TestSummarizeFixItemSanitizesFallbackSummary(t *testing.T) {
 	}
 }
 
-func TestLookupReplyExplanationsRejectsStaleSnapshot(t *testing.T) {
+func TestLookupReplyExplanationsReturnsExplanationsAndSkipsEmpty(t *testing.T) {
 	t.Parallel()
+	// Per-thread drift detection (hasNonLooperCommentSince) handles
+	// reviewer comments added after the agent's decision; the round
+	// summary and evidence records surface the agent's explanations
+	// regardless of how the fix-items snapshot has shifted, and entries
+	// without a fix item id or explanation text are dropped so summary
+	// rendering does not emit blanks.
 	checkpoint := fixerCheckpoint{
-		FixItemsHash: "hash-current",
 		Repair: &checkpointRepair{
-			FixItemsHash: "hash-old",
-			ReplyExplanations: []replyExplanationEntry{
-				{FixItemID: "c1", Explanation: "stale"},
-			},
-		},
-	}
-	if got := lookupReplyExplanations(checkpoint); got != nil {
-		t.Fatalf("lookupReplyExplanations() = %#v, want nil on stale snapshot", got)
-	}
-}
-
-func TestLookupReplyExplanationsReturnsCurrent(t *testing.T) {
-	t.Parallel()
-	checkpoint := fixerCheckpoint{
-		FixItemsHash: "h1",
-		Repair: &checkpointRepair{
-			FixItemsHash: "h1",
 			ReplyExplanations: []replyExplanationEntry{
 				{FixItemID: "c1", Explanation: "good"},
 				{FixItemID: "", Explanation: "skip"},
+				{FixItemID: "c2", Explanation: ""},
 			},
 		},
 	}
 	got := lookupReplyExplanations(checkpoint)
 	if len(got) != 1 || got["c1"] != "good" {
-		t.Fatalf("lookupReplyExplanations() = %#v", got)
+		t.Fatalf("lookupReplyExplanations() = %#v, want only c1=good", got)
 	}
 }
 
@@ -4771,7 +4750,7 @@ func TestRunPushStepAdoptsAgentLifecyclePushEvidence(t *testing.T) {
 		Detail:           &checkpointDetail{HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main"},
 		Worktree:         &checkpointWorktree{Path: t.TempDir(), Branch: "feature/fix-42", BaseHeadSHA: "base-head"},
 		FixItemsHash:     "fix-hash",
-		Repair:           &checkpointRepair{Status: "completed", FixItemsHash: "fix-hash", Lifecycle: &lifecycle.State{Branch: "feature/fix-42", CommitSHAs: []string{"agent-head"}, Pushed: true, Actions: lifecycle.Actions{Push: lifecycle.ActionSourceAgent}}},
+		Repair:           &checkpointRepair{Status: "completed", Lifecycle: &lifecycle.State{Branch: "feature/fix-42", CommitSHAs: []string{"agent-head"}, Pushed: true, Actions: lifecycle.Actions{Push: lifecycle.ActionSourceAgent}}},
 		Validation:       &ValidationResult{Passed: true, HeadSHA: "base-head"},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
@@ -4812,7 +4791,7 @@ func TestRunPushStepDoesNotAdoptAgentLifecyclePushEvidenceOnLiveHeadMismatch(t *
 		Detail:           &checkpointDetail{HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main"},
 		Worktree:         &checkpointWorktree{Path: t.TempDir(), Branch: "feature/fix-42", BaseHeadSHA: "base-head"},
 		FixItemsHash:     "fix-hash",
-		Repair:           &checkpointRepair{Status: "completed", FixItemsHash: "fix-hash", Lifecycle: &lifecycle.State{Branch: "feature/fix-42", CommitSHAs: []string{"agent-head"}, Pushed: true, Actions: lifecycle.Actions{Push: lifecycle.ActionSourceAgent}}},
+		Repair:           &checkpointRepair{Status: "completed", Lifecycle: &lifecycle.State{Branch: "feature/fix-42", CommitSHAs: []string{"agent-head"}, Pushed: true, Actions: lifecycle.Actions{Push: lifecycle.ActionSourceAgent}}},
 		Validation:       &ValidationResult{Passed: true, HeadSHA: "agent-head"},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
@@ -4841,7 +4820,7 @@ func TestRunPushStepDoesNotAdoptAgentLifecyclePushEvidenceOnBranchOrPRMismatch(t
 			t.Parallel()
 			github := &fakeGitHubGateway{}
 			runner := New(Options{GitHub: github, Git: &fakeGitGateway{}, AllowAutoPush: true})
-			checkpoint := fixerCheckpoint{Detail: &checkpointDetail{HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main"}, Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/fix-42", BaseHeadSHA: "base-head"}, FixItemsHash: "fix-hash", Repair: &checkpointRepair{Status: "completed", FixItemsHash: "fix-hash", Lifecycle: tc.lifecycle}, Validation: &ValidationResult{Passed: true, HeadSHA: "agent-head"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+			checkpoint := fixerCheckpoint{Detail: &checkpointDetail{HeadSHA: "base-head", HeadRefName: "feature/fix-42", BaseRefName: "main"}, Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/fix-42", BaseHeadSHA: "base-head"}, FixItemsHash: "fix-hash", Repair: &checkpointRepair{Status: "completed", Lifecycle: tc.lifecycle}, Validation: &ValidationResult{Passed: true, HeadSHA: "agent-head"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 			updated, err := runner.runPushStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 			if err != nil {
 				t.Fatalf("runPushStep() error = %v", err)


### PR DESCRIPTION
## Symptom

Looper PR #318 (and similarly nexu-io/open-design#1515) entered an unbreakable fixer loop. Every round:

1. discover snapshots N comment-type fix items, computes top-level `fixItemsHash = X`
2. repair runs ~10 minutes; while it runs Codex (or any bot) appends a new P1/P2 review comment
3. repair persists the agent's `review_thread_replies` plus `Repair.FixItemsHash = X`
4. resolve-comments re-fetches the PR detail, recomputes `fixItemsHash = Y` (one extra thread), sees `X != Y`, marks **every** thread `skipped_thread_drift`, fails the run with `Fix-items snapshot drifted; will rediscover N thread(s)`
5. next round: same shape, hash shifts again, same failure

DB evidence on PR #318 loop `loop_f506a121160b871fa980d6008eb8680d`:

```
rep_hash → live_hash    repl_n
1c52720… → a630633…     19
031b9ad… → 1c52720…     18
5d23886… → 031b9ad…      1
44721c0… → 5d23886…      2
4cf42b6… → 44721c0…      2
b93a714… → 328f0e4…     13
709ee6e… → b93a714…     12
a616955… → 709ee6e…      3
```

Eight consecutive `failed` runs over ~80 minutes, every run completed agent work but resolved nothing.

## Root cause

Three places gated behaviour on `Repair.FixItemsHash == checkpoint.FixItemsHash`:

1. `runResolveCommentsStep` — batch drift block: invalidated **every** agent decision when the snapshot shifted by a single thread
2. `lookupReplyExplanations` — round summary + evidence record path: silently dropped per-item explanations
3. `adoptLifecyclePushEvidence` — refused to adopt agent-reported pushes when the snapshot shifted, forcing a fallback push probe each round

All three triggered routinely whenever a bot added a comment during repair, which on busy PRs is most rounds.

## Fix

Remove the three checks and delete the now-unused `Repair.FixItemsHash` field. The remaining defences are sufficient and already in place:

- **Per-thread drift** (`hasNonLooperCommentSince`): if a reviewer adds or edits a comment on an *existing* thread after the agent decided, that one thread is marked `skipped_thread_drift`. Other threads continue normally.
- **Contract violation → synthetic decline**: a *new* thread that did not exist when the agent ran is absent from `review_thread_replies`; it falls through to the existing contract path which posts a visible decline reply without resolving the thread.
- **Live PR identity check** (`adoptLifecyclePushEvidence`): PR number, branch, head ref name, and head SHA are validated against `ViewPullRequest` independently of the snapshot hash.

Net effect: previously-decided threads are replied/resolved as the agent intended; newly arrived threads receive a synthetic decline; reviewer edits on existing threads still defer to a re-discover. No code path silently drops the agent's decisions.

## Authority statement

Per AGENTS.md design guidelines:

> What is the authority for this action, and why is it not the agent's own structured output?

Authority remains the agent's `review_thread_replies` (`fixed`/`declined` action + explanation). The fix-items hash was not authority — it was a coarse staleness heuristic on top of the agent's output that conflicted with the v4 \"trust the agent\" direction. Per-thread drift and contract violation paths still cover the cases the hash check was nominally defending.

## Why deletion over another layer

Following AGENTS.md \"Prefer deletion over another layer\": removing the hash gate eliminates a path that has already received fixes (#320 wired the contract; this PR completes the cleanup) rather than stacking another layer on top. Net diff is -27 lines.

## Tests

- `TestRunResolveCommentsStepHandlesNewThreadAsContractViolationWithoutSkippingExisting` — new test reproducing PR #318: known thread → reply+resolve, new thread → synthetic-decline reply (no resolve)
- `TestRunResolveCommentsStepFlagsThreadDriftWhenCommentEdited` — replaces the old \"snapshot mismatch\" test; per-thread drift still kicks in when a comment is edited after run start
- `TestLookupReplyExplanationsReturnsExplanationsAndSkipsEmpty` — replaces the old \"rejects stale snapshot\" test; explanations are returned regardless of any hash, empty entries are still filtered
- All other existing tests adjusted to drop the obsolete `Repair.FixItemsHash` field

Verification: `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green, `go build ./...` clean.

## References

- triggering observation: looper PR #318 (8+ consecutive zero-progress fixer runs in 80 min)
- related: nexu-io/open-design#1515 (same death-loop pattern from Codex review pressure)
- predecessor PR (which laid down the contract-violation path that now does the heavy lifting): #320
- design context: issue #324 (the broader fixer authority/contract problem)