### PR TITLE
fix: add per-thread freshness gate for resolve-comments

### DIFF
--- a/internal/e2e/github_sandbox_test.go
+++ b/internal/e2e/github_sandbox_test.go
@@ -307,7 +307,7 @@ func ensureSandboxLabel(tb testing.TB, sb sandboxConfig) {
 
 func workerSandboxConfig(tb testing.TB, bins harness.BuiltBinaries, home harness.TempHome, repo harness.SeededRepo, fakeAgent harness.FakeAgent, port int, agentMode string) config.Config {
 	tb.Helper()
-	vendor, command, agentEnv := fakeAgent.AgentConfig(agentMode, "git")
+	vendor, command, agentEnv := fakeAgent.AgentConfig(agentMode, "git", "")
 	cfg := harness.DefaultConfig(tb, home, harness.ConfigOptions{
 		Port:              port,
 		ToolPaths:         harness.TestToolPaths{Git: "git", GH: "gh", Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},
@@ -328,7 +328,7 @@ func workerSandboxConfig(tb testing.TB, bins harness.BuiltBinaries, home harness
 
 func fixerSandboxConfig(tb testing.TB, bins harness.BuiltBinaries, home harness.TempHome, repo harness.SeededRepo, fakeAgent harness.FakeAgent, port int, agentMode string) config.Config {
 	tb.Helper()
-	vendor, command, agentEnv := fakeAgent.AgentConfig(agentMode, "git")
+	vendor, command, agentEnv := fakeAgent.AgentConfig(agentMode, "git", "")
 	cfg := harness.DefaultConfig(tb, home, harness.ConfigOptions{
 		Port:              port,
 		ToolPaths:         harness.TestToolPaths{Git: "git", GH: "gh", Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},

--- a/internal/e2e/harness/cmd/fake-agent/main.go
+++ b/internal/e2e/harness/cmd/fake-agent/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -81,9 +83,10 @@ func main() {
 			"changedFiles": []string{path},
 			"commits":      []string{sha},
 			"review_thread_replies": []map[string]any{{
-				"fixItemId":   "comment-1",
-				"threadId":    "thread-1",
-				"explanation": "Updated fix-target.txt to address the review feedback.",
+				"fixItemId":              "comment-1",
+				"threadId":               "thread-1",
+				"explanation":            "Updated fix-target.txt to address the review feedback.",
+				"threadCommentsObserved": hashCommentIDs("comment-1"),
 			}},
 		})
 	case "transient-failure":
@@ -125,6 +128,11 @@ func collectEnv() map[string]string {
 		}
 	}
 	return result
+}
+
+func hashCommentIDs(ids ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(ids, "|")))
+	return hex.EncodeToString(sum[:])
 }
 
 func envOr(key string, fallback string) string {

--- a/internal/e2e/harness/cmd/fake-agent/main.go
+++ b/internal/e2e/harness/cmd/fake-agent/main.go
@@ -23,6 +23,7 @@ const (
 	envFakeAgentModifyFile  = "LOOPER_E2E_FAKE_AGENT_MODIFY_FILE"
 	envFakeAgentSleepMS     = "LOOPER_E2E_FAKE_AGENT_SLEEP_MS"
 	envFakeAgentGitPath     = "LOOPER_E2E_FAKE_AGENT_GIT_PATH"
+	envFakeAgentGHPath      = "LOOPER_E2E_FAKE_AGENT_GH_PATH"
 	defaultCompletionMarker = "__LOOPER_RESULT__="
 )
 
@@ -30,6 +31,26 @@ type promptFixItem struct {
 	Type     string `json:"type"`
 	ID       string `json:"id"`
 	ThreadID string `json:"threadId"`
+}
+
+type ghThreadCommentsResponse struct {
+	Data struct {
+		Node struct {
+			Comments struct {
+				Nodes    []ghThreadComment `json:"nodes"`
+				PageInfo struct {
+					EndCursor   string `json:"endCursor"`
+					HasNextPage bool   `json:"hasNextPage"`
+				} `json:"pageInfo"`
+			} `json:"comments"`
+		} `json:"node"`
+	} `json:"data"`
+}
+
+type ghThreadComment struct {
+	ID        string `json:"id"`
+	Body      string `json:"body"`
+	UpdatedAt string `json:"updatedAt"`
 }
 
 type evidence struct {
@@ -127,7 +148,7 @@ func writeEvidence(dir string, mode string) error {
 }
 
 func collectEnv() map[string]string {
-	keys := []string{"HOME", completionMarkerEnv, envFakeAgentMode, envFakeAgentArtifactDir, envFakeAgentStatePath, envFakeAgentWriteFile, envFakeAgentModifyFile, envFakeAgentGitPath}
+	keys := []string{"HOME", completionMarkerEnv, envFakeAgentMode, envFakeAgentArtifactDir, envFakeAgentStatePath, envFakeAgentWriteFile, envFakeAgentModifyFile, envFakeAgentGitPath, envFakeAgentGHPath}
 	result := make(map[string]string, len(keys))
 	for _, key := range keys {
 		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
@@ -139,6 +160,31 @@ func collectEnv() map[string]string {
 
 func hashCommentIDs(ids ...string) string {
 	sum := sha256.Sum256([]byte(strings.Join(ids, "|")))
+	return hex.EncodeToString(sum[:])
+}
+
+func hashObservedThreadComments(comments []ghThreadComment) string {
+	type observedThreadComment struct {
+		ID        string `json:"id"`
+		UpdatedAt string `json:"updatedAt,omitempty"`
+	}
+	observed := make([]observedThreadComment, 0, len(comments))
+	for _, comment := range comments {
+		body := strings.TrimSpace(comment.Body)
+		if body == "" || strings.Contains(body, "looper-fixer-reply") || strings.Contains(body, "looper:fixer-round") || strings.Contains(body, "<!-- looper:stamp v=1 -->") {
+			continue
+		}
+		id := strings.TrimSpace(comment.ID)
+		if id == "" {
+			continue
+		}
+		observed = append(observed, observedThreadComment{ID: id, UpdatedAt: strings.TrimSpace(comment.UpdatedAt)})
+	}
+	payload, err := json.Marshal(observed)
+	if err != nil {
+		panic(err)
+	}
+	sum := sha256.Sum256(payload)
 	return hex.EncodeToString(sum[:])
 }
 
@@ -214,10 +260,9 @@ func printCompletion(marker string, payload map[string]any) {
 	_, _ = fmt.Printf("%s%s\n", marker, string(encoded))
 }
 
-func promptReviewThreadReplies(explanation string, fallback bool, includeObserved bool) []map[string]any {
-	prompt := os.Getenv(envLooperPrompt)
+func parsePromptFixItems(prompt string) []promptFixItem {
 	lines := strings.Split(prompt, "\n")
-	replies := make([]map[string]any, 0)
+	items := make([]promptFixItem, 0)
 	seen := map[string]struct{}{}
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -235,13 +280,72 @@ func promptReviewThreadReplies(explanation string, fallback bool, includeObserve
 			continue
 		}
 		seen[item.ID] = struct{}{}
+		items = append(items, item)
+	}
+	return items
+}
+
+func fetchObservedThreadHashes(items []promptFixItem) map[string]string {
+	threadHashes := make(map[string]string, len(items))
+	for _, item := range items {
+		threadID := strings.TrimSpace(item.ThreadID)
+		if threadID == "" {
+			continue
+		}
+		if _, ok := threadHashes[threadID]; ok {
+			continue
+		}
+		comments := make([]ghThreadComment, 0, 8)
+		cursor := ""
+		for {
+			query := strings.Join([]string{
+				"query($threadId: ID!, $after: String) {",
+				"  node(id: $threadId) {",
+				"    ... on PullRequestReviewThread {",
+				"      comments(first: 100, after: $after) {",
+				"        nodes { id body updatedAt }",
+				"        pageInfo { hasNextPage endCursor }",
+				"      }",
+				"    }",
+				"  }",
+				"}",
+			}, "\n")
+			args := []string{"api", "graphql", "-f", "query=" + query, "-F", "threadId=" + threadID}
+			if cursor != "" {
+				args = append(args, "-F", "after="+cursor)
+			}
+			ghPath := envOr(envFakeAgentGHPath, "gh")
+			output := mustOutput(ghPath, args...)
+			var response ghThreadCommentsResponse
+			if err := json.Unmarshal([]byte(output), &response); err != nil {
+				panic(err)
+			}
+			comments = append(comments, response.Data.Node.Comments.Nodes...)
+			if !response.Data.Node.Comments.PageInfo.HasNextPage || strings.TrimSpace(response.Data.Node.Comments.PageInfo.EndCursor) == "" {
+				break
+			}
+			cursor = response.Data.Node.Comments.PageInfo.EndCursor
+		}
+		threadHashes[threadID] = hashObservedThreadComments(comments)
+	}
+	return threadHashes
+}
+
+func buildReviewThreadReplies(items []promptFixItem, explanation string, fallback bool, observedByThread map[string]string) []map[string]any {
+	replies := make([]map[string]any, 0, len(items))
+	seen := map[string]struct{}{}
+	for _, item := range items {
+		if _, ok := seen[item.ID]; ok {
+			continue
+		}
+		seen[item.ID] = struct{}{}
 		reply := map[string]any{
 			"fixItemId":   item.ID,
 			"threadId":    item.ThreadID,
 			"explanation": explanation,
 		}
-		if includeObserved {
-			reply["threadCommentsObserved"] = hashCommentIDs(item.ID)
+		if observed := strings.TrimSpace(observedByThread[item.ThreadID]); observed != "" {
+			reply["threadCommentsObserved"] = observed
 		}
 		replies = append(replies, reply)
 	}
@@ -251,10 +355,21 @@ func promptReviewThreadReplies(explanation string, fallback bool, includeObserve
 			"threadId":    "thread-1",
 			"explanation": explanation,
 		}
-		if includeObserved {
+		if observed := strings.TrimSpace(observedByThread["thread-1"]); observed != "" {
+			reply["threadCommentsObserved"] = observed
+		} else if len(observedByThread) > 0 {
 			reply["threadCommentsObserved"] = hashCommentIDs("comment-1")
 		}
 		return []map[string]any{reply}
 	}
 	return replies
+}
+
+func promptReviewThreadReplies(explanation string, fallback bool, includeObserved bool) []map[string]any {
+	items := parsePromptFixItems(os.Getenv(envLooperPrompt))
+	observedByThread := map[string]string(nil)
+	if includeObserved {
+		observedByThread = fetchObservedThreadHashes(items)
+	}
+	return buildReviewThreadReplies(items, explanation, fallback, observedByThread)
 }

--- a/internal/e2e/harness/cmd/fake-agent/main.go
+++ b/internal/e2e/harness/cmd/fake-agent/main.go
@@ -78,7 +78,7 @@ func main() {
 		mustRun(gitPath, "commit", "-m", "fake agent commit")
 		sha := strings.TrimSpace(mustOutput(gitPath, "rev-parse", "HEAD"))
 		payload := map[string]any{"summary": "fake agent committed changes", "changedFiles": []string{path}, "commits": []string{sha}}
-		if replies := promptReviewThreadReplies("Updated fix-target.txt to address the review feedback.", false, false); len(replies) > 0 {
+		if replies := promptReviewThreadReplies("Updated fix-target.txt to address the review feedback.", false, true); len(replies) > 0 {
 			payload["review_thread_replies"] = replies
 		}
 		printCompletion(marker, payload)

--- a/internal/e2e/harness/cmd/fake-agent/main_test.go
+++ b/internal/e2e/harness/cmd/fake-agent/main_test.go
@@ -16,6 +16,17 @@ func TestPromptReviewThreadRepliesUsesPromptFixItemIDs(t *testing.T) {
 	}
 }
 
+func TestPromptReviewThreadRepliesIncludesObservedHashWhenRequested(t *testing.T) {
+	t.Setenv(envLooperPrompt, "Fix items:\n- {\"type\":\"comment\",\"id\":\"comment-abc\",\"threadId\":\"thread-xyz\"}")
+	replies := promptReviewThreadReplies("done", false, true)
+	if len(replies) != 1 {
+		t.Fatalf("len(replies) = %d, want 1", len(replies))
+	}
+	if got, want := replies[0]["threadCommentsObserved"], hashCommentIDs("comment-abc"); got != want {
+		t.Fatalf("threadCommentsObserved = %#v, want %q", got, want)
+	}
+}
+
 func TestPromptReviewThreadRepliesFallsBackWhenRequested(t *testing.T) {
 	t.Setenv(envLooperPrompt, "")
 	replies := promptReviewThreadReplies("done", true, false)

--- a/internal/e2e/harness/cmd/fake-agent/main_test.go
+++ b/internal/e2e/harness/cmd/fake-agent/main_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 func TestPromptReviewThreadRepliesUsesPromptFixItemIDs(t *testing.T) {
-	t.Setenv(envLooperPrompt, "Fix items:\n- {\"type\":\"comment\",\"id\":\"comment-abc\",\"threadId\":\"thread-xyz\"}\n- {\"type\":\"check\",\"id\":\"check-1\"}")
-	replies := promptReviewThreadReplies("done", false, false)
+	items := parsePromptFixItems("Fix items:\n- {\"type\":\"comment\",\"id\":\"comment-abc\",\"threadId\":\"thread-xyz\"}\n- {\"type\":\"check\",\"id\":\"check-1\"}")
+	replies := buildReviewThreadReplies(items, "done", false, nil)
 	if len(replies) != 1 {
 		t.Fatalf("len(replies) = %d, want 1", len(replies))
 	}
@@ -17,12 +17,12 @@ func TestPromptReviewThreadRepliesUsesPromptFixItemIDs(t *testing.T) {
 }
 
 func TestPromptReviewThreadRepliesIncludesObservedHashWhenRequested(t *testing.T) {
-	t.Setenv(envLooperPrompt, "Fix items:\n- {\"type\":\"comment\",\"id\":\"comment-abc\",\"threadId\":\"thread-xyz\"}")
-	replies := promptReviewThreadReplies("done", false, true)
+	items := parsePromptFixItems("Fix items:\n- {\"type\":\"comment\",\"id\":\"comment-abc\",\"threadId\":\"thread-xyz\"}\n- {\"type\":\"comment\",\"id\":\"comment-def\",\"threadId\":\"thread-xyz\"}")
+	replies := buildReviewThreadReplies(items[:1], "done", false, map[string]string{"thread-xyz": "thread-hash"})
 	if len(replies) != 1 {
 		t.Fatalf("len(replies) = %d, want 1", len(replies))
 	}
-	if got, want := replies[0]["threadCommentsObserved"], hashCommentIDs("comment-abc"); got != want {
+	if got, want := replies[0]["threadCommentsObserved"], "thread-hash"; got != want {
 		t.Fatalf("threadCommentsObserved = %#v, want %q", got, want)
 	}
 }

--- a/internal/e2e/harness/fake_agent.go
+++ b/internal/e2e/harness/fake_agent.go
@@ -16,6 +16,7 @@ const (
 	envFakeAgentModifyFile  = "LOOPER_E2E_FAKE_AGENT_MODIFY_FILE"
 	envFakeAgentSleepMS     = "LOOPER_E2E_FAKE_AGENT_SLEEP_MS"
 	envFakeAgentGitPath     = "LOOPER_E2E_FAKE_AGENT_GIT_PATH"
+	envFakeAgentGHPath      = "LOOPER_E2E_FAKE_AGENT_GH_PATH"
 )
 
 type FakeAgent struct {
@@ -34,7 +35,7 @@ func NewFakeAgent(tb testing.TB, bins BuiltBinaries) FakeAgent {
 	return FakeAgent{Path: bins.FakeAgentPath, ArtifactDir: artifactDir, StatePath: statePath}
 }
 
-func (f FakeAgent) AgentConfig(mode string, gitPath string) (*config.AgentVendor, string, map[string]string) {
+func (f FakeAgent) AgentConfig(mode string, gitPath string, ghPath string) (*config.AgentVendor, string, map[string]string) {
 	vendor := config.AgentVendorCodex
 	env := map[string]string{
 		envFakeAgentMode:        mode,
@@ -43,6 +44,9 @@ func (f FakeAgent) AgentConfig(mode string, gitPath string) (*config.AgentVendor
 	}
 	if gitPath != "" {
 		env[envFakeAgentGitPath] = gitPath
+	}
+	if ghPath != "" {
+		env[envFakeAgentGHPath] = ghPath
 	}
 	return &vendor, f.Path, env
 }

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -254,7 +254,7 @@ func loopLogsPath(home harness.TempHome) string {
 
 func configWithFakeTools(tb testing.TB, bins harness.BuiltBinaries, home harness.TempHome, repo harness.SeededRepo, fakeGH harness.FakeGH, fakeAgent harness.FakeAgent, port int) config.Config {
 	tb.Helper()
-	vendor, command, agentEnv := fakeAgent.AgentConfig("write-file", bins.LooperPath)
+	vendor, command, agentEnv := fakeAgent.AgentConfig("write-file", bins.LooperPath, "")
 	cfg := harness.DefaultConfig(tb, home, harness.ConfigOptions{
 		Port:              port,
 		ToolPaths:         harness.TestToolPaths{Git: "git", GH: fakeGH.Path, Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},

--- a/internal/e2e/invariant_worktree_test.go
+++ b/internal/e2e/invariant_worktree_test.go
@@ -72,7 +72,7 @@ func TestInvariantWorkerCommitStaysOffUserBranch(t *testing.T) {
 	port := harness.MustFreePort(t)
 	fakeAgent := harness.NewFakeAgent(t, bins)
 	fakeGH := harness.NewFakeGH(t, bins, harness.GHSchema{JSONFieldAllowlist: map[string][]string{}})
-	vendor, command, agentEnv := fakeAgent.AgentConfig("commit", "git")
+	vendor, command, agentEnv := fakeAgent.AgentConfig("commit", "git", "")
 	cfg := harness.DefaultConfig(t, home, harness.ConfigOptions{
 		Port:              port,
 		ToolPaths:         harness.TestToolPaths{Git: "git", GH: fakeGH.Path, Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},
@@ -131,7 +131,7 @@ func TestInvariantWorkerRejectsCheckpointWorktreePathAtUserRepo(t *testing.T) {
 	port := harness.MustFreePort(t)
 	fakeAgent := harness.NewFakeAgent(t, bins)
 	fakeGH := harness.NewFakeGH(t, bins, harness.GHSchema{JSONFieldAllowlist: map[string][]string{}})
-	vendor, command, agentEnv := fakeAgent.AgentConfig("write-file", bins.LooperPath)
+	vendor, command, agentEnv := fakeAgent.AgentConfig("write-file", bins.LooperPath, "")
 	cfg := harness.DefaultConfig(t, home, harness.ConfigOptions{
 		Port:              port,
 		ToolPaths:         harness.TestToolPaths{Git: "git", GH: fakeGH.Path, Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},

--- a/internal/e2e/resolve_comments_scenarios_test.go
+++ b/internal/e2e/resolve_comments_scenarios_test.go
@@ -112,6 +112,83 @@ func TestScenarioResolveCommentsRefreshesPRHeadAfterPush(t *testing.T) {
 	proc.Stop(context.Background())
 }
 
+func TestScenarioResolveCommentsRefreshesPRHeadAfterPushWithMultiCommentThread(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	home := harness.NewTempHome(t)
+	repo := harness.CreateSeededRepo(t, "git")
+	originPath := harness.CreateBareOrigin(t, "git", repo.Path)
+	featureHead := harness.CreateBranchCommitAndPush(t, "git", repo.Path, "feature/fix-42", "fix-target.txt", "needs fix\n")
+	port := harness.MustFreePort(t)
+	fakeAgent := harness.NewFakeAgent(t, bins)
+	fakeGH := harness.NewFakeGH(t, bins, loadGHSchemaFixture(t))
+	fakeGH.WriteState(t, harness.GHState{
+		CurrentUserLogin: "looper",
+		PullRequests: map[string]harness.GHPullRequest{
+			"acme/looper#42": {
+				Number:           42,
+				Repo:             "acme/looper",
+				Title:            "Fix review feedback",
+				Author:           "looper",
+				State:            "OPEN",
+				HeadRefName:      "feature/fix-42",
+				BaseRefName:      "main",
+				HeadRef:          "refs/heads/feature/fix-42",
+				BaseRef:          "refs/heads/main",
+				GitDir:           originPath,
+				MergeStateStatus: "CLEAN",
+				Threads: []harness.GHThread{{
+					ID:         "thread-1",
+					IsResolved: false,
+					Path:       "fix-target.txt",
+					Line:       1,
+					Comments: []harness.GHThreadComment{{
+						ID:                "comment-1",
+						Body:              "please fix this",
+						Author:            "alice",
+						Path:              "fix-target.txt",
+						Line:              1,
+						CommitOID:         featureHead,
+						OriginalCommitOID: featureHead,
+						URL:               "https://example.test/thread-1",
+					}, {
+						ID:                "comment-2",
+						Body:              "and handle the edge case",
+						Author:            "alice",
+						Path:              "fix-target.txt",
+						Line:              1,
+						CommitOID:         featureHead,
+						OriginalCommitOID: featureHead,
+						URL:               "https://example.test/thread-1",
+					}},
+				}},
+			},
+		},
+	})
+	cfg := fixerConfigWithFakeTools(t, bins, home, repo, fakeGH, fakeAgent, port, "commit-with-review-replies")
+	harness.WriteConfig(t, home.ConfigPath, cfg, nil)
+	proc := harness.StartLooperd(t, bins, home, home.ConfigPath, fakeGH.EnvMap(), cfg.Server.Host, cfg.Server.Port)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if _, err := proc.WaitForReady(ctx); err != nil {
+		t.Fatalf("wait for ready: %v", err)
+	}
+	client := newAPIClient(proc.BaseURL())
+	var created struct {
+		ID string `json:"id"`
+	}
+	client.post(t, "/api/v1/loops", map[string]any{"projectId": "project_1", "type": "fixer", "targetType": "pull_request", "repo": "acme/looper", "prNumber": 42}, &created)
+	run := waitForRunTerminal(t, client, created.ID, 60*time.Second)
+	if run.Status != "success" {
+		t.Fatalf("run status = %s, want success (error=%v checkpoint=%v)", run.Status, run.ErrorMessage, run.CheckpointJSON)
+	}
+	state := loadFakeGHStateFile(t, fakeGH.StatePath)
+	pr := state.PullRequests["acme/looper#42"]
+	if len(pr.Threads) != 1 || !pr.Threads[0].IsResolved {
+		t.Fatalf("thread state = %#v, want resolved thread", pr.Threads)
+	}
+	proc.Stop(context.Background())
+}
+
 func TestScenarioResolveCommentsSkipsClosedPullRequest(t *testing.T) {
 	bins := harness.MustBinaries(t)
 	home := harness.NewTempHome(t)
@@ -362,7 +439,7 @@ func TestScenarioWorkerNoDiffBranchDoesNotCreatePullRequest(t *testing.T) {
 	fakeAgent := harness.NewFakeAgent(t, bins)
 	fakeGH := harness.NewFakeGH(t, bins, loadGHSchemaFixture(t))
 	fakeGH.WriteState(t, harness.GHState{CurrentUserLogin: "looper"})
-	vendor, command, agentEnv := fakeAgent.AgentConfig("success-no-diff", "git")
+	vendor, command, agentEnv := fakeAgent.AgentConfig("success-no-diff", "git", fakeGH.Path)
 	cfg := harness.DefaultConfig(t, home, harness.ConfigOptions{
 		Port:              port,
 		ToolPaths:         harness.TestToolPaths{Git: "git", GH: fakeGH.Path, Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},
@@ -430,7 +507,7 @@ func TestScenarioResumedFixerStopsWhenPullRequestCloses(t *testing.T) {
 			},
 		},
 	})
-	vendor, command, agentEnv := fakeAgent.AgentConfig("success-no-diff", "git")
+	vendor, command, agentEnv := fakeAgent.AgentConfig("success-no-diff", "git", fakeGH.Path)
 	cfg := harness.DefaultConfig(t, home, harness.ConfigOptions{
 		Port:              port,
 		ToolPaths:         harness.TestToolPaths{Git: "git", GH: fakeGH.Path, Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},
@@ -493,7 +570,7 @@ func TestScenarioResumedFixerStopsWhenPullRequestCloses(t *testing.T) {
 
 func fixerConfigWithFakeTools(tb testing.TB, bins harness.BuiltBinaries, home harness.TempHome, repo harness.SeededRepo, fakeGH harness.FakeGH, fakeAgent harness.FakeAgent, port int, agentMode string) config.Config {
 	tb.Helper()
-	vendor, command, agentEnv := fakeAgent.AgentConfig(agentMode, "git")
+	vendor, command, agentEnv := fakeAgent.AgentConfig(agentMode, "git", fakeGH.Path)
 	cfg := harness.DefaultConfig(tb, home, harness.ConfigOptions{
 		Port:              port,
 		ToolPaths:         harness.TestToolPaths{Git: "git", GH: fakeGH.Path, Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -3,6 +3,7 @@ package fixer
 import (
 	"context"
 	"crypto/sha1"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -589,12 +590,15 @@ type checkpointRepair struct {
 // replyExplanationEntry holds the agent's per-fix-item explanation for the
 // auto-reply posted before resolving the review thread. Stored on the repair
 // checkpoint so resume/retry reuses the same explanation if it still maps to
-// the current fix items snapshot.
+// the current fix items snapshot. ThreadCommentsObserved is optional: when the
+// agent supplies it, resolve-comments verifies the live thread still contains
+// exactly the same comment IDs before auto-resolving.
 type replyExplanationEntry struct {
-	FixItemID   string `json:"fixItemId"`
-	ThreadID    string `json:"threadId,omitempty"`
-	Action      string `json:"action,omitempty"`
-	Explanation string `json:"explanation"`
+	FixItemID              string `json:"fixItemId"`
+	ThreadID               string `json:"threadId,omitempty"`
+	Action                 string `json:"action,omitempty"`
+	Explanation            string `json:"explanation"`
+	ThreadCommentsObserved string `json:"threadCommentsObserved,omitempty"`
 }
 
 type checkpointReconcileCommits struct {
@@ -774,10 +778,11 @@ func parseReplyExplanations(stdout, stderr string, fixItems []FixItem) []replyEx
 	}
 	var parsed struct {
 		ReviewThreadReplies []struct {
-			FixItemID   string `json:"fixItemId"`
-			ThreadID    string `json:"threadId"`
-			Action      string `json:"action"`
-			Explanation string `json:"explanation"`
+			FixItemID              string `json:"fixItemId"`
+			ThreadID               string `json:"threadId"`
+			Action                 string `json:"action"`
+			Explanation            string `json:"explanation"`
+			ThreadCommentsObserved string `json:"threadCommentsObserved"`
 		} `json:"review_thread_replies"`
 	}
 	if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
@@ -813,7 +818,7 @@ func parseReplyExplanations(stdout, stderr string, fixItems []FixItem) []replyEx
 			continue
 		}
 		seen[fixItemID] = struct{}{}
-		out = append(out, replyExplanationEntry{FixItemID: fixItemID, ThreadID: item.ThreadID, Action: action, Explanation: explanation})
+		out = append(out, replyExplanationEntry{FixItemID: fixItemID, ThreadID: item.ThreadID, Action: action, Explanation: explanation, ThreadCommentsObserved: normalizeThreadCommentsObserved(raw.ThreadCommentsObserved)})
 	}
 	if len(out) == 0 {
 		return nil
@@ -2163,6 +2168,11 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_thread_drift", Message: "New human comment was added to this thread after the fixer run started", UpdatedAt: r.nowISO()})
 			continue
 		}
+		if threadCommentsObservedDrifted(decision, thread) {
+			driftCount++
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_thread_drift", Message: "Review thread changed since the fixer inspected it", UpdatedAt: r.nowISO()})
+			continue
+		}
 		switch normalizeReplyAction(decision.Action) {
 		case string(replyActionDeclined):
 			decisionFingerprint := buildDeclinedThreadFingerprint(item, liveDetail.HeadSHA)
@@ -2211,7 +2221,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	}
 	if driftCount > 0 {
 		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
-		return checkpoint, &loopError{message: fmt.Sprintf("Skipped %d review thread(s) because new human comments arrived during the fixer run", driftCount), kind: FailureRetryableAfterResume}
+		return checkpoint, &loopError{message: fmt.Sprintf("Skipped %d review thread(s) because review thread content changed during the fixer run", driftCount), kind: FailureRetryableAfterResume}
 	}
 	if mutationFailureCount > 0 {
 		checkpoint.ResumePolicy = loops.ResumePolicyReplayStep
@@ -2378,6 +2388,10 @@ func normalizeReplyExplanationActions(entries []replyExplanationEntry) []replyEx
 	return out
 }
 
+func normalizeThreadCommentsObserved(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
 // agentResolveReplyExplanationsValid reports whether the agent-provided
 // reply explanations exist on the checkpoint and can be consulted as the
 // per-item reply authority. Per-thread drift (a new human comment posted
@@ -2436,6 +2450,30 @@ func agentResolveRepliesByThreadID(checkpoint fixerCheckpoint) map[string]replyE
 		return nil
 	}
 	return out
+}
+
+func threadCommentsObservedDrifted(decision replyExplanationEntry, thread ReviewThread) bool {
+	observed := normalizeThreadCommentsObserved(decision.ThreadCommentsObserved)
+	if observed == "" {
+		return false
+	}
+	return observed != hashReviewThreadCommentIDs(thread)
+}
+
+func hashReviewThreadCommentIDs(thread ReviewThread) string {
+	ids := make([]string, 0, len(thread.Comments))
+	for _, comment := range thread.Comments {
+		if isLooperReviewThreadComment(comment) {
+			continue
+		}
+		id := strings.TrimSpace(comment.ID)
+		if id == "" {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	sum := sha256.Sum256([]byte(strings.Join(ids, "|")))
+	return hex.EncodeToString(sum[:])
 }
 
 func hasNonLooperCommentSince(thread ReviewThread, rawSince string) bool {
@@ -4513,6 +4551,7 @@ func buildFixerReplyExplanationInstruction(fixItems []FixItem) string {
 		`  - "threadId": the exact "threadId" of the same fix item`,
 		`  - "action": "fixed" or "declined"`,
 		`  - "explanation": one or two sentences (max ~500 chars). If action is "fixed", say what you changed and where. If action is "declined", give a concrete reason why you are not acting. No greetings, no @mentions, no markdown headings, no HTML, no disclosure markers.`,
+		`  - "threadCommentsObserved": sha256 of the non-Looper review-thread comment IDs you observed, in thread order, joined with "|" (example: sha256("c1|c2|c3")). Exclude prior Looper-generated replies. If you only saw comment c1, hash just "c1".`,
 		"Before including an entry, re-read the relevant review thread/comment context.",
 		"Use \"fixed\" only when you can confidently confirm the current branch state actually addresses the thread; in other words, only include items you can confidently confirm are actually addressed by the current branch state. Use \"declined\" if you deliberately are not acting, including cases such as: already implemented on this branch, out of scope for this PR, reviewer request is incorrect, or you cannot safely complete it.",
 		"Do not omit any comment-type fix item. Do not use vague explanations like \"looks fine\" or \"no change needed\".",

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2457,7 +2457,7 @@ func threadCommentsObservedDrifted(decision replyExplanationEntry, thread Review
 	if observed == "" {
 		return false
 	}
-	return observed != hashReviewThreadCommentIDs(thread)
+	return observed != hashReviewThreadComments(thread)
 }
 
 func fixedDecisionMissingThreadSnapshot(decision replyExplanationEntry) bool {
@@ -2468,8 +2468,12 @@ func fixedDecisionMissingThreadSnapshot(decision replyExplanationEntry) bool {
 	return normalizeThreadCommentsObserved(decision.ThreadCommentsObserved) == ""
 }
 
-func hashReviewThreadCommentIDs(thread ReviewThread) string {
-	ids := make([]string, 0, len(thread.Comments))
+func hashReviewThreadComments(thread ReviewThread) string {
+	type observedThreadComment struct {
+		ID        string `json:"id"`
+		UpdatedAt string `json:"updatedAt,omitempty"`
+	}
+	comments := make([]observedThreadComment, 0, len(thread.Comments))
 	for _, comment := range thread.Comments {
 		if isLooperReviewThreadComment(comment) {
 			continue
@@ -2478,9 +2482,13 @@ func hashReviewThreadCommentIDs(thread ReviewThread) string {
 		if id == "" {
 			continue
 		}
-		ids = append(ids, id)
+		comments = append(comments, observedThreadComment{
+			ID:        id,
+			UpdatedAt: strings.TrimSpace(comment.UpdatedAt),
+		})
 	}
-	sum := sha256.Sum256([]byte(strings.Join(ids, "|")))
+	payload, _ := json.Marshal(comments)
+	sum := sha256.Sum256(payload)
 	return hex.EncodeToString(sum[:])
 }
 
@@ -4565,7 +4573,7 @@ func buildFixerReplyExplanationInstruction(fixItems []FixItem) string {
 		`  - "threadId": the exact "threadId" of the same fix item`,
 		`  - "action": "fixed" or "declined"`,
 		`  - "explanation": one or two sentences (max ~500 chars). If action is "fixed", say what you changed and where. If action is "declined", give a concrete reason why you are not acting. No greetings, no @mentions, no markdown headings, no HTML, no disclosure markers.`,
-		`  - "threadCommentsObserved": sha256 of the non-Looper review-thread comment IDs you observed, in thread order, joined with "|" (example: sha256("c1|c2|c3")). Exclude prior Looper-generated replies. If you only saw comment c1, hash just "c1".`,
+		`  - "threadCommentsObserved": sha256 of the JSON array of non-Looper review-thread comments you observed in thread order, where each element is {"id","updatedAt"}. Exclude prior Looper-generated replies.`,
 		"Before including an entry, re-read the relevant review thread/comment context.",
 		"Use \"fixed\" only when you can confidently confirm the current branch state actually addresses the thread; in other words, only include items you can confidently confirm are actually addressed by the current branch state. Use \"declined\" if you deliberately are not acting, including cases such as: already implemented on this branch, out of scope for this PR, reviewer request is incorrect, or you cannot safely complete it.",
 		"Do not omit any comment-type fix item. Do not use vague explanations like \"looks fine\" or \"no change needed\".",

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -590,9 +590,9 @@ type checkpointRepair struct {
 // replyExplanationEntry holds the agent's per-fix-item explanation for the
 // auto-reply posted before resolving the review thread. Stored on the repair
 // checkpoint so resume/retry reuses the same explanation if it still maps to
-// the current fix items snapshot. ThreadCommentsObserved is optional: when the
-// agent supplies it, resolve-comments verifies the live thread still contains
-// exactly the same comment IDs before auto-resolving.
+// the current fix items snapshot. Fixed decisions must include
+// ThreadCommentsObserved so resolve-comments can verify the live thread still
+// contains exactly the same non-Looper comment IDs before auto-resolving.
 type replyExplanationEntry struct {
 	FixItemID              string `json:"fixItemId"`
 	ThreadID               string `json:"threadId,omitempty"`
@@ -2168,9 +2168,9 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_thread_drift", Message: "New human comment was added to this thread after the fixer run started", UpdatedAt: r.nowISO()})
 			continue
 		}
-		if threadCommentsObservedDrifted(decision, thread) {
+		if fixedDecisionMissingThreadSnapshot(decision) || threadCommentsObservedDrifted(decision, thread) {
 			driftCount++
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_thread_drift", Message: "Review thread changed since the fixer inspected it", UpdatedAt: r.nowISO()})
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_thread_drift", Message: "Review thread snapshot was missing or changed since the fixer inspected it", UpdatedAt: r.nowISO()})
 			continue
 		}
 		switch normalizeReplyAction(decision.Action) {
@@ -2458,6 +2458,14 @@ func threadCommentsObservedDrifted(decision replyExplanationEntry, thread Review
 		return false
 	}
 	return observed != hashReviewThreadCommentIDs(thread)
+}
+
+func fixedDecisionMissingThreadSnapshot(decision replyExplanationEntry) bool {
+	action := normalizeReplyAction(decision.Action)
+	if action == string(replyActionDeclined) {
+		return false
+	}
+	return normalizeThreadCommentsObserved(decision.ThreadCommentsObserved) == ""
 }
 
 func hashReviewThreadCommentIDs(thread ReviewThread) string {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -484,7 +484,7 @@ func TestProcessClaimedItemCompletesSuccessfulFlow(t *testing.T) {
 			{HeadSHA: "new-head"},
 		},
 	}
-	stdout := `__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix."}]}` + "\n"
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
 
@@ -1404,7 +1404,7 @@ func TestRunResolveCommentsStepResolvesUsingRepairReplyExplanations(t *testing.T
 		FixItemsHash: hashFixItems(fixItems),
 		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:       &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
+		Repair:       &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
 		ReconcileCommits: &checkpointReconcileCommits{
 			BaseHeadSHA:      "base-head",
 			FinalHeadSHA:     "base-head",
@@ -1627,7 +1627,7 @@ func TestRunResolveCommentsStepHandlesNewThreadAsContractViolationWithoutSkippin
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -1706,7 +1706,7 @@ func TestRunResolveCommentsStepSkipsThreadWhenHumanCommentArrivesAfterRunStart(t
 	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix", CreatedAt: "2026-04-11T11:59:00Z"}, {ID: "reply-2", Body: "one more thing", CreatedAt: "2026-04-11T12:05:00Z"}}}}}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
@@ -1779,6 +1779,98 @@ func TestRunResolveCommentsStepSkipsThreadWhenObservedThreadSnapshotDriftsDuring
 	}
 }
 
+func TestRunResolveCommentsStepRequiresObservedThreadSnapshotForFixedDecision(t *testing.T) {
+	t.Parallel()
+
+	repairCompletedAt := "2026-04-11T12:10:00Z"
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}, {
+			"id":       "c2",
+			"threadId": "t1",
+			"body":     "also handle edge case",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix", Author: "alice", CreatedAt: "2026-04-11T11:59:00Z"}, {ID: "c2", Body: "also handle edge case", Author: "alice", CreatedAt: "2026-04-11T12:05:00Z"}}}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}, CompletedAt: repairCompletedAt},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: "2026-04-11T12:30:00Z"}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want retry after missing thread snapshot", err)
+	}
+	if len(github.replyCalls) != 0 {
+		t.Fatalf("reply calls = %d, want 0 after missing thread snapshot", len(github.replyCalls))
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 after missing thread snapshot", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
+		t.Fatalf("resolved comments = %#v, want skipped_thread_drift", updated.ResolvedComments)
+	}
+	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepAllowsDeclinedDecisionWithoutObservedThreadSnapshot(t *testing.T) {
+	t.Parallel()
+
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix", Author: "alice", CreatedAt: "2026-04-11T11:59:00Z"}}}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionDeclined), Explanation: "Out of scope for this PR."}}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v, want declined path without snapshot", err)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 for declined decision", len(github.resolveCalls))
+	}
+	if len(github.replyCalls) != 1 || github.replyCalls[0].ThreadID != "t1" {
+		t.Fatalf("reply calls = %#v, want one declined reply on t1", github.replyCalls)
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "agent_declined" {
+		t.Fatalf("resolved comments = %#v, want agent_declined", updated.ResolvedComments)
+	}
+}
+
 func TestRunResolveCommentsStepDetectsDriftFromEditedComment(t *testing.T) {
 	t.Parallel()
 
@@ -1800,7 +1892,7 @@ func TestRunResolveCommentsStepDetectsDriftFromEditedComment(t *testing.T) {
 	}}}}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
@@ -1843,7 +1935,7 @@ func TestRunResolveCommentsStepFlagsThreadDriftWhenCommentEdited(t *testing.T) {
 		FixItemsHash:     hashFixItems(originalFixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -1884,7 +1976,7 @@ func TestRunResolveCommentsStepIgnoresBotCommentForDrift(t *testing.T) {
 	}}}}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}, {ID: "bot-1", Author: "chatgpt-codex-connector[bot]"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
@@ -1908,7 +2000,7 @@ func TestRunResolveCommentsStepRecordsMutationFailureAsRetryable(t *testing.T) {
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "Failed to resolve") {
@@ -1969,7 +2061,7 @@ func TestRunResolveCommentsStepProceedsWhenFixCommitStillReachable(t *testing.T)
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
@@ -1996,7 +2088,7 @@ func TestRunResolveCommentsStepAbortsWhenFixCommitNoLongerReachable(t *testing.T
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "no longer descends") {
@@ -2036,7 +2128,7 @@ func TestRunResolveCommentsStepDriftAnchorsToRepairCompletionOnReplay(t *testing
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}, CompletedAt: repairCompletedAt},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}, CompletedAt: repairCompletedAt},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -2123,7 +2215,7 @@ func TestRunResolveCommentsStepReplyFailureDoesNotBlockResolve(t *testing.T) {
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
@@ -2161,7 +2253,7 @@ func TestRunResolveCommentsStepUsesRefreshedPushHeadSHA(t *testing.T) {
 		FixItemsHash: hashFixItems(fixItems),
 		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:         &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "new-head"},
-		Repair:       &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}},
+		Repair:       &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
 		Lifecycle:    &lifecycle.State{Pushed: true},
 		ReconcileCommits: &checkpointReconcileCommits{
 			BaseHeadSHA:      "base-head",
@@ -3466,7 +3558,7 @@ func TestProcessClaimedItemResumeReacquiresPullRequestLock(t *testing.T) {
 		listOpen:      []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
 		viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}},
 	}
-	stdout := `__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix."}]}` + "\n"
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
 	validationCalls := 0
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"}, prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true}, inspectResults: []InspectHeadResult{{HeadSHA: "base-head"}, {HeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}}, {HeadSHA: "new-head"}}}
@@ -4283,7 +4375,7 @@ func TestProcessClaimedItemRepliesToAuthorBeforeResolving(t *testing.T) {
 			{HeadSHA: "new-head"},
 		},
 	}
-	stdout := `__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix."}]}` + "\n"
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
 
@@ -4614,7 +4706,7 @@ func TestProcessClaimedItemUsesAgentExplanationInReplyBody(t *testing.T) {
 			{HeadSHA: "new-head"},
 		},
 	}
-	stdout := `__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Switched the loop bound to len(items)-1 and added a regression test in foo_test.go."}]}` + "\n"
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Switched the loop bound to len(items)-1 and added a regression test in foo_test.go.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: "runtime log", Stderr: stdout}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
 
@@ -4780,7 +4872,7 @@ func TestProcessClaimedItemPostsRoundSummaryComment(t *testing.T) {
 			{HeadSHA: "new-head"},
 		},
 	}
-	stdout := `__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Capped loop bound and added regression test."}]}` + "\n"
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Capped loop bound and added regression test.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1709,7 +1709,7 @@ func TestRunResolveCommentsStepSkipsThreadWhenHumanCommentArrivesAfterRunStart(t
 	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err == nil || !strings.Contains(err.Error(), "new human comments") {
+	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
 		t.Fatalf("runResolveCommentsStep() error = %v, want thread drift retry", err)
 	}
 	if len(github.replyCalls) != 0 {
@@ -1723,6 +1723,59 @@ func TestRunResolveCommentsStepSkipsThreadWhenHumanCommentArrivesAfterRunStart(t
 	}
 	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
 		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepSkipsThreadWhenObservedThreadSnapshotDriftsDuringRepair(t *testing.T) {
+	t.Parallel()
+
+	repairCompletedAt := "2026-04-11T12:10:00Z"
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}, {
+			"id":       "c2",
+			"threadId": "t1",
+			"body":     "also handle edge case",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix", Author: "alice", CreatedAt: "2026-04-11T11:59:00Z"}, {ID: "c2", Body: "also handle edge case", Author: "alice", CreatedAt: "2026-04-11T12:05:00Z"}}}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}, CompletedAt: repairCompletedAt},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: "2026-04-11T12:30:00Z"}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want retry after observed-thread drift", err)
+	}
+	if len(github.replyCalls) != 0 {
+		t.Fatalf("reply calls = %d, want 0 after observed-thread drift", len(github.replyCalls))
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 after observed-thread drift", len(github.resolveCalls))
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
+		t.Fatalf("resolved comments = %#v, want skipped_thread_drift", updated.ResolvedComments)
+	}
+	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+	if len(updated.FixItems) != 2 || updated.FixItems[1].ID != "c2" {
+		t.Fatalf("updated.FixItems = %#v, want live unresolved comments to include c2 for rediscover", updated.FixItems)
 	}
 }
 
@@ -1750,7 +1803,7 @@ func TestRunResolveCommentsStepDetectsDriftFromEditedComment(t *testing.T) {
 	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix."}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err == nil || !strings.Contains(err.Error(), "new human comments") {
+	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
 		t.Fatalf("runResolveCommentsStep() error = %v, want thread drift retry from edited comment", err)
 	}
 	if len(github.resolveCalls) != 0 {
@@ -1795,7 +1848,7 @@ func TestRunResolveCommentsStepFlagsThreadDriftWhenCommentEdited(t *testing.T) {
 	}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err == nil || !strings.Contains(err.Error(), "new human comments") {
+	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
 		t.Fatalf("runResolveCommentsStep() error = %v, want per-thread drift retry", err)
 	}
 	if len(github.resolveCalls) != 0 {
@@ -1869,6 +1922,40 @@ func TestRunResolveCommentsStepRecordsMutationFailureAsRetryable(t *testing.T) {
 	}
 	if updated.ResumePolicy != loops.ResumePolicyReplayStep {
 		t.Fatalf("updated.ResumePolicy = %q, want replay_step", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepRetriesResolveAfterPriorLooperReply(t *testing.T) {
+	t.Parallel()
+
+	item := FixItem{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}
+	github := &fakeGitHubGateway{
+		viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "fix-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}},
+		threads:       []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}, {ID: "reply-1", Body: buildFixerReplyBody(item, "fix-head", "Applied the requested fix.")}}}},
+	}
+	runner := New(Options{GitHub: github})
+	checkpoint := fixerCheckpoint{
+		FixItems:         []FixItem{item},
+		FixItemsHash:     hashFixItems([]FixItem{item}),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}})}}},
+		ResolvedComments: &checkpointResolvedComments{Items: []checkpointResolvedComment{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionFixed), Status: "failed_mutation_retry", ReplyState: "sent"}}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v, want retryable resolve to proceed", err)
+	}
+	if len(github.replyCalls) != 0 {
+		t.Fatalf("reply calls = %#v, want 0 because prior Looper reply should be reused", github.replyCalls)
+	}
+	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t1" {
+		t.Fatalf("resolve calls = %#v, want 1 retry resolve for t1", github.resolveCalls)
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "resolved" {
+		t.Fatalf("resolved comments = %#v, want resolved after retrying with prior Looper reply", updated.ResolvedComments)
 	}
 }
 
@@ -1954,7 +2041,7 @@ func TestRunResolveCommentsStepDriftAnchorsToRepairCompletionOnReplay(t *testing
 	}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: retryRunStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err == nil || !strings.Contains(err.Error(), "new human comments") {
+	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
 		t.Fatalf("runResolveCommentsStep() error = %v, want drift retry anchored to Repair.CompletedAt", err)
 	}
 	if len(github.resolveCalls) != 0 {
@@ -1965,6 +2052,64 @@ func TestRunResolveCommentsStepDriftAnchorsToRepairCompletionOnReplay(t *testing
 	}
 	if updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
 		t.Fatalf("updated.ResumePolicy = %q, want restart_from_discover", updated.ResumePolicy)
+	}
+}
+
+func TestRunResolveCommentsStepOnlySkipsDriftedObservedThread(t *testing.T) {
+	t.Parallel()
+
+	repairCompletedAt := "2026-04-11T12:10:00Z"
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+		}, {
+			"id":       "c2",
+			"threadId": "t1",
+			"body":     "also handle edge case",
+		}, {
+			"id":       "c3",
+			"threadId": "t2",
+			"body":     "rename helper",
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix", Author: "alice", CreatedAt: "2026-04-11T11:59:00Z"}, {ID: "c2", Body: "also handle edge case", Author: "alice", CreatedAt: "2026-04-11T12:05:00Z"}}}, {ID: "t2", Comments: []ReviewThreadComment{{ID: "c3", Body: "rename helper", Author: "alice", CreatedAt: "2026-04-11T11:58:00Z"}}}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}, {Type: "comment", ID: "c3", ThreadID: "t2", Summary: "rename helper"}}
+	checkpoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}, {FixItemID: "c3", ThreadID: "t2", Explanation: "Renamed the helper.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c3"}}})}}, CompletedAt: repairCompletedAt},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: "2026-04-11T12:30:00Z"}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
+		t.Fatalf("runResolveCommentsStep() error = %v, want retry after one observed thread drifted", err)
+	}
+	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t2" {
+		t.Fatalf("resolve calls = %#v, want only t2 resolved", github.resolveCalls)
+	}
+	if len(github.replyCalls) != 1 || github.replyCalls[0].ThreadID != "t2" {
+		t.Fatalf("reply calls = %#v, want only t2 replied", github.replyCalls)
+	}
+	statusByThread := map[string]string{}
+	for _, item := range updated.ResolvedComments.Items {
+		statusByThread[item.ThreadID] = item.Status
+	}
+	if statusByThread["t1"] != "skipped_thread_drift" {
+		t.Fatalf("t1 status = %q, want skipped_thread_drift", statusByThread["t1"])
+	}
+	if statusByThread["t2"] != "resolved" {
+		t.Fatalf("t2 status = %q, want resolved", statusByThread["t2"])
 	}
 }
 
@@ -4175,10 +4320,10 @@ func TestParseReplyExplanationsValid(t *testing.T) {
 	t.Parallel()
 	stdout := strings.Join([]string{
 		"some agent log line",
-		`__LOOPER_RESULT__={"summary":"applied","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Replaced strings.Title with cases.Title."}]}`,
+		`__LOOPER_RESULT__={"summary":"applied","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Replaced strings.Title with cases.Title.","threadCommentsObserved":"ABC123"}]}`,
 	}, "\n")
 	got := parseReplyExplanations(stdout, "", []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}})
-	if len(got) != 1 || got[0].FixItemID != "c1" || !strings.Contains(got[0].Explanation, "cases.Title") {
+	if len(got) != 1 || got[0].FixItemID != "c1" || !strings.Contains(got[0].Explanation, "cases.Title") || got[0].ThreadCommentsObserved != "abc123" {
 		t.Fatalf("parseReplyExplanations() = %#v", got)
 	}
 }

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -484,7 +484,7 @@ func TestProcessClaimedItemCompletesSuccessfulFlow(t *testing.T) {
 			{HeadSHA: "new-head"},
 		},
 	}
-	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
 
@@ -1404,7 +1404,7 @@ func TestRunResolveCommentsStepResolvesUsingRepairReplyExplanations(t *testing.T
 		FixItemsHash: hashFixItems(fixItems),
 		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:       &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
+		Repair:       &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
 		ReconcileCommits: &checkpointReconcileCommits{
 			BaseHeadSHA:      "base-head",
 			FinalHeadSHA:     "base-head",
@@ -1627,7 +1627,7 @@ func TestRunResolveCommentsStepHandlesNewThreadAsContractViolationWithoutSkippin
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -1706,7 +1706,7 @@ func TestRunResolveCommentsStepSkipsThreadWhenHumanCommentArrivesAfterRunStart(t
 	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix", CreatedAt: "2026-04-11T11:59:00Z"}, {ID: "reply-2", Body: "one more thing", CreatedAt: "2026-04-11T12:05:00Z"}}}}}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
@@ -1754,7 +1754,7 @@ func TestRunResolveCommentsStepSkipsThreadWhenObservedThreadSnapshotDriftsDuring
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}, CompletedAt: repairCompletedAt},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}, CompletedAt: repairCompletedAt},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -1892,7 +1892,7 @@ func TestRunResolveCommentsStepDetectsDriftFromEditedComment(t *testing.T) {
 	}}}}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
@@ -1935,7 +1935,7 @@ func TestRunResolveCommentsStepFlagsThreadDriftWhenCommentEdited(t *testing.T) {
 		FixItemsHash:     hashFixItems(originalFixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -1976,7 +1976,7 @@ func TestRunResolveCommentsStepIgnoresBotCommentForDrift(t *testing.T) {
 	}}}}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}, {ID: "bot-1", Author: "chatgpt-codex-connector[bot]"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}, {ID: "bot-1", Author: "chatgpt-codex-connector[bot]"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Run: storage.RunRecord{StartedAt: runStartedAt}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
@@ -2000,7 +2000,7 @@ func TestRunResolveCommentsStepRecordsMutationFailureAsRetryable(t *testing.T) {
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "Failed to resolve") {
@@ -2031,7 +2031,7 @@ func TestRunResolveCommentsStepRetriesResolveAfterPriorLooperReply(t *testing.T)
 		FixItemsHash:     hashFixItems([]FixItem{item}),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}})}}},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}})}}},
 		ResolvedComments: &checkpointResolvedComments{Items: []checkpointResolvedComment{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionFixed), Status: "failed_mutation_retry", ReplyState: "sent"}}},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
@@ -2061,7 +2061,7 @@ func TestRunResolveCommentsStepProceedsWhenFixCommitStillReachable(t *testing.T)
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
@@ -2088,7 +2088,7 @@ func TestRunResolveCommentsStepAbortsWhenFixCommitNoLongerReachable(t *testing.T
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-commit"}, Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "fix-commit"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "fix-commit", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "no longer descends") {
@@ -2128,7 +2128,7 @@ func TestRunResolveCommentsStepDriftAnchorsToRepairCompletionOnReplay(t *testing
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}, CompletedAt: repairCompletedAt},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}, CompletedAt: repairCompletedAt},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -2179,7 +2179,7 @@ func TestRunResolveCommentsStepOnlySkipsDriftedObservedThread(t *testing.T) {
 		FixItemsHash:     hashFixItems(fixItems),
 		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
 		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
-		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}, {FixItemID: "c3", ThreadID: "t2", Explanation: "Renamed the helper.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c3"}}})}}, CompletedAt: repairCompletedAt},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}, {FixItemID: "c3", ThreadID: "t2", Explanation: "Renamed the helper.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c3"}}})}}, CompletedAt: repairCompletedAt},
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
@@ -2215,7 +2215,7 @@ func TestRunResolveCommentsStepReplyFailureDoesNotBlockResolve(t *testing.T) {
 	}
 	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
-	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
+	checkpoint := fixerCheckpoint{FixItems: fixItems, FixItemsHash: hashFixItems(fixItems), Validation: &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"}, Push: &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true}}
 
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
@@ -2253,7 +2253,7 @@ func TestRunResolveCommentsStepUsesRefreshedPushHeadSHA(t *testing.T) {
 		FixItemsHash: hashFixItems(fixItems),
 		Validation:   &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "new-head"},
 		Push:         &checkpointPush{Pushed: true, Branch: "feature/fix-42", Remote: "origin", HeadSHA: "new-head"},
-		Repair:       &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
+		Repair:       &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}})}}},
 		Lifecycle:    &lifecycle.State{Pushed: true},
 		ReconcileCommits: &checkpointReconcileCommits{
 			BaseHeadSHA:      "base-head",
@@ -3558,7 +3558,7 @@ func TestProcessClaimedItemResumeReacquiresPullRequestLock(t *testing.T) {
 		listOpen:      []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
 		viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}},
 	}
-	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
 	validationCalls := 0
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"}, prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true}, inspectResults: []InspectHeadResult{{HeadSHA: "base-head"}, {HeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}}, {HeadSHA: "new-head"}}}
@@ -4375,7 +4375,7 @@ func TestProcessClaimedItemRepliesToAuthorBeforeResolving(t *testing.T) {
 			{HeadSHA: "new-head"},
 		},
 	}
-	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
 
@@ -4706,7 +4706,7 @@ func TestProcessClaimedItemUsesAgentExplanationInReplyBody(t *testing.T) {
 			{HeadSHA: "new-head"},
 		},
 	}
-	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Switched the loop bound to len(items)-1 and added a regression test in foo_test.go.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Switched the loop bound to len(items)-1 and added a regression test in foo_test.go.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: "runtime log", Stderr: stdout}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
 
@@ -4872,7 +4872,7 @@ func TestProcessClaimedItemPostsRoundSummaryComment(t *testing.T) {
 			{HeadSHA: "new-head"},
 		},
 	}
-	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Capped loop bound and added regression test.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadCommentIDs(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Capped loop bound and added regression test.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
 


### PR DESCRIPTION
## Summary
- extend fixer `review_thread_replies` entries with optional `threadCommentsObserved` snapshots and document the prompt contract
- skip only the drifted review thread items when the live non-Looper thread comment IDs no longer match what the agent observed, instead of invalidating the whole batch
- add regressions for the during-repair same-thread race, mixed drift/non-drift batches, and replay after a prior Looper reply

## Why
The agent remains the authority for resolve-comments decisions: it declares the thread snapshot it inspected, and Looper only checks that the live thread still matches before resolving. This closes the same-thread repair race from #327 without reintroducing the old fix-items-hash batch gate that caused drift loops under bot review pressure.

## Tradeoffs
- prevents burying new same-thread feedback that arrives during repair by refusing to auto-resolve only the stale thread
- adds one optional agent field plus a deterministic equality check, but avoids new persisted discovery-side snapshot state and keeps unrelated thread decisions flowing
- ignores prior Looper-generated replies in the freshness hash so replay can still finish a resolve after a transient mutation failure

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #327