### PR TITLE
fix: keep unresolved sandbox review threads blocked

### DIFF
--- a/internal/e2e/harness/cmd/fake-agent/main.go
+++ b/internal/e2e/harness/cmd/fake-agent/main.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	completionMarkerEnv     = "LOOPER_COMPLETION_MARKER"
+	envLooperPrompt         = "LOOPER_PROMPT"
 	envFakeAgentMode        = "LOOPER_E2E_FAKE_AGENT_MODE"
 	envFakeAgentArtifactDir = "LOOPER_E2E_FAKE_AGENT_ARTIFACT_DIR"
 	envFakeAgentStatePath   = "LOOPER_E2E_FAKE_AGENT_STATE_PATH"
@@ -22,6 +23,12 @@ const (
 	envFakeAgentGitPath     = "LOOPER_E2E_FAKE_AGENT_GIT_PATH"
 	defaultCompletionMarker = "__LOOPER_RESULT__="
 )
+
+type promptFixItem struct {
+	Type     string `json:"type"`
+	ID       string `json:"id"`
+	ThreadID string `json:"threadId"`
+}
 
 type evidence struct {
 	CWD       string            `json:"cwd"`
@@ -68,7 +75,11 @@ func main() {
 		mustRun(gitPath, "add", path)
 		mustRun(gitPath, "commit", "-m", "fake agent commit")
 		sha := strings.TrimSpace(mustOutput(gitPath, "rev-parse", "HEAD"))
-		printCompletion(marker, map[string]any{"summary": "fake agent committed changes", "changedFiles": []string{path}, "commits": []string{sha}})
+		payload := map[string]any{"summary": "fake agent committed changes", "changedFiles": []string{path}, "commits": []string{sha}}
+		if replies := promptReviewThreadReplies("Updated fix-target.txt to address the review feedback.", false); len(replies) > 0 {
+			payload["review_thread_replies"] = replies
+		}
+		printCompletion(marker, payload)
 	case "commit-with-review-replies":
 		path := envOr(envFakeAgentWriteFile, "fix-target.txt")
 		mustWriteFile(path, []byte("fixed by fake agent\n"))
@@ -76,15 +87,12 @@ func main() {
 		mustRun(gitPath, "add", path)
 		mustRun(gitPath, "commit", "-m", "fake agent commit")
 		sha := strings.TrimSpace(mustOutput(gitPath, "rev-parse", "HEAD"))
+		replies := promptReviewThreadReplies("Updated fix-target.txt to address the review feedback.", true)
 		printCompletion(marker, map[string]any{
-			"summary":      "fake agent committed changes",
-			"changedFiles": []string{path},
-			"commits":      []string{sha},
-			"review_thread_replies": []map[string]any{{
-				"fixItemId":   "comment-1",
-				"threadId":    "thread-1",
-				"explanation": "Updated fix-target.txt to address the review feedback.",
-			}},
+			"summary":               "fake agent committed changes",
+			"changedFiles":          []string{path},
+			"commits":               []string{sha},
+			"review_thread_replies": replies,
 		})
 	case "transient-failure":
 		statePath := strings.TrimSpace(os.Getenv(envFakeAgentStatePath))
@@ -197,4 +205,41 @@ func printCompletion(marker string, payload map[string]any) {
 		panic(err)
 	}
 	_, _ = fmt.Printf("%s%s\n", marker, string(encoded))
+}
+
+func promptReviewThreadReplies(explanation string, fallback bool) []map[string]any {
+	prompt := os.Getenv(envLooperPrompt)
+	lines := strings.Split(prompt, "\n")
+	replies := make([]map[string]any, 0)
+	seen := map[string]struct{}{}
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "- {") {
+			continue
+		}
+		var item promptFixItem
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "- ")), &item); err != nil {
+			continue
+		}
+		if strings.TrimSpace(item.Type) != "comment" || strings.TrimSpace(item.ID) == "" || strings.TrimSpace(item.ThreadID) == "" {
+			continue
+		}
+		if _, ok := seen[item.ID]; ok {
+			continue
+		}
+		seen[item.ID] = struct{}{}
+		replies = append(replies, map[string]any{
+			"fixItemId":   item.ID,
+			"threadId":    item.ThreadID,
+			"explanation": explanation,
+		})
+	}
+	if len(replies) == 0 && fallback {
+		return []map[string]any{{
+			"fixItemId":   "comment-1",
+			"threadId":    "thread-1",
+			"explanation": explanation,
+		}}
+	}
+	return replies
 }

--- a/internal/e2e/harness/cmd/fake-agent/main_test.go
+++ b/internal/e2e/harness/cmd/fake-agent/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPromptReviewThreadRepliesUsesPromptFixItemIDs(t *testing.T) {
+	t.Setenv(envLooperPrompt, "Fix items:\n- {\"type\":\"comment\",\"id\":\"comment-abc\",\"threadId\":\"thread-xyz\"}\n- {\"type\":\"check\",\"id\":\"check-1\"}")
+	replies := promptReviewThreadReplies("done", false)
+	if len(replies) != 1 {
+		t.Fatalf("len(replies) = %d, want 1", len(replies))
+	}
+	if replies[0]["fixItemId"] != "comment-abc" || replies[0]["threadId"] != "thread-xyz" || replies[0]["explanation"] != "done" {
+		t.Fatalf("replies = %#v, want prompt-derived review-thread reply", replies)
+	}
+}
+
+func TestPromptReviewThreadRepliesFallsBackWhenRequested(t *testing.T) {
+	t.Setenv(envLooperPrompt, "")
+	replies := promptReviewThreadReplies("done", true)
+	if len(replies) != 1 {
+		t.Fatalf("len(replies) = %d, want 1", len(replies))
+	}
+	if replies[0]["fixItemId"] != "comment-1" || replies[0]["threadId"] != "thread-1" {
+		t.Fatalf("replies = %#v, want default fallback ids", replies)
+	}
+	if _, ok := os.LookupEnv(envLooperPrompt); !ok {
+		t.Fatal("LOOPER_PROMPT env should remain set by test")
+	}
+}

--- a/internal/e2e/resolve_comments_scenarios_test.go
+++ b/internal/e2e/resolve_comments_scenarios_test.go
@@ -221,12 +221,12 @@ func TestScenarioResolveCommentsSkipsWhenNoNewCommitLeavesThreadsUnresolved(t *t
 	}
 	client.post(t, "/api/v1/loops", map[string]any{"projectId": "project_1", "type": "fixer", "targetType": "pull_request", "repo": "acme/looper", "prNumber": 42}, &created)
 	run := waitForRunTerminal(t, client, created.ID, 30*time.Second)
-	if run.Status != "success" {
-		t.Fatalf("run status = %s, want success no-op resolve path (error=%v checkpoint=%v)", run.Status, run.ErrorMessage, run.CheckpointJSON)
+	if run.Status != "failed" {
+		t.Fatalf("run status = %s, want failed no-op resolve path (error=%v checkpoint=%v)", run.Status, run.ErrorMessage, run.CheckpointJSON)
 	}
 	checkpoint := parseJSONObject(t, run.CheckpointJSON)
-	if got, _ := checkpoint["resumePolicy"].(string); got != "advance_from_checkpoint" {
-		t.Fatalf("resumePolicy = %q, want advance_from_checkpoint", got)
+	if got, _ := checkpoint["resumePolicy"].(string); got != "manual_intervention" {
+		t.Fatalf("resumePolicy = %q, want manual_intervention", got)
 	}
 	push, _ := checkpoint["push"].(map[string]any)
 	if push == nil || push["pushed"] != false {
@@ -243,10 +243,6 @@ func TestScenarioResolveCommentsSkipsWhenNoNewCommitLeavesThreadsUnresolved(t *t
 	first, _ := items[0].(map[string]any)
 	if first["status"] != "agent_declined" {
 		t.Fatalf("resolvedComments item = %#v, want agent_declined", first)
-	}
-	loop := loadSingleLoop(t, client, created.ID)
-	if loop.Status != "completed" {
-		t.Fatalf("loop status = %s, want completed after no-op resolve", loop.Status)
 	}
 	state := loadFakeGHStateFile(t, fakeGH.StatePath)
 	pr := state.PullRequests["acme/looper#42"]
@@ -329,8 +325,8 @@ func TestScenarioResolveCommentsIgnoresStaleNoPushMetadataAndLeavesThreadsUnreso
 	}
 	client.post(t, "/api/v1/loops/"+created.ID+"/start", nil, &started)
 	run := waitForRunTerminal(t, client, created.ID, 30*time.Second)
-	if run.Status != "success" {
-		t.Fatalf("run status = %s, want success for stale no-push metadata (error=%v checkpoint=%v)", run.Status, run.ErrorMessage, run.CheckpointJSON)
+	if run.Status != "failed" {
+		t.Fatalf("run status = %s, want failed for stale no-push metadata (error=%v checkpoint=%v)", run.Status, run.ErrorMessage, run.CheckpointJSON)
 	}
 	checkpoint := parseJSONObject(t, run.CheckpointJSON)
 	push, _ := checkpoint["push"].(map[string]any)
@@ -348,10 +344,6 @@ func TestScenarioResolveCommentsIgnoresStaleNoPushMetadataAndLeavesThreadsUnreso
 	first, _ := items[0].(map[string]any)
 	if first["status"] != "agent_declined" {
 		t.Fatalf("resolvedComments item = %#v, want agent_declined", first)
-	}
-	loop := loadSingleLoop(t, client, created.ID)
-	if loop.Status != "completed" {
-		t.Fatalf("loop status = %s, want completed after stale no-push metadata", loop.Status)
 	}
 	state := loadFakeGHStateFile(t, fakeGH.StatePath)
 	pr := state.PullRequests["acme/looper#42"]

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2931,6 +2931,12 @@ func (r *Runner) runRecheckStep(ctx context.Context, input stepInput) (fixerChec
 		}
 	}
 	checkpoint.Recheck = &checkpointRecheck{RemainingFixItems: collectFixItems(detail)}
+	verifiedNoPushHead := resolveCommentsVerifiedNoPushHeadSHA(checkpoint.Push, input.Loop.MetadataJSON, checkpoint.FixItemsHash)
+	hasVerifiedNoPushHead := verifiedNoPushHead != "" && strings.TrimSpace(detail.HeadSHA) == verifiedNoPushHead
+	if shouldBlockResolveWithoutFix(checkpoint, checkpoint.Recheck.RemainingFixItems, hasVerifiedNoPushHead) {
+		checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+		return checkpoint, &loopError{message: "resolve-comments left review threads unresolved because fixer produced no new commits to push", kind: FailureManualIntervention}
+	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -573,8 +573,8 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "success" {
-		t.Fatalf("result = %#v, want successful no-op completion", result)
+	if result.Status != "failed" || result.FailureKind != FailureManualIntervention {
+		t.Fatalf("result = %#v, want failed manual-intervention completion", result)
 	}
 	if len(git.commitCalls) != 0 || len(git.pushCalls) != 0 || len(github.resolveCalls) != 0 {
 		t.Fatalf("commit calls=%d push calls=%d resolve calls=%d, want 0/0/0 after no-op repair", len(git.commitCalls), len(git.pushCalls), len(github.resolveCalls))
@@ -583,15 +583,15 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if err != nil {
 		t.Fatalf("Runs.GetByID() error = %v", err)
 	}
-	if run == nil || run.Status != "success" || run.CurrentStep != nil {
-		t.Fatalf("run = %#v, want successful completed run", run)
+	if run == nil || run.Status != "failed" || run.CurrentStep == nil || *run.CurrentStep != string(stepRecheck) {
+		t.Fatalf("run = %#v, want failed run at recheck", run)
 	}
 	checkpoint := parseCheckpoint(run.CheckpointJSON)
 	if checkpoint.Push == nil || checkpoint.Push.Pushed || checkpoint.Push.SkippedReason == "" {
 		t.Fatalf("checkpoint.Push = %#v, want recorded no-op push", checkpoint.Push)
 	}
-	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
-		t.Fatalf("checkpoint.ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
+	if checkpoint.ResumePolicy != loops.ResumePolicyManualIntervention {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want manual_intervention", checkpoint.ResumePolicy)
 	}
 	if checkpoint.ResolvedComments == nil || len(checkpoint.ResolvedComments.Items) == 0 || checkpoint.ResolvedComments.Items[0].Status != "agent_declined" {
 		t.Fatalf("checkpoint.ResolvedComments = %#v, want agent_declined marker", checkpoint.ResolvedComments)
@@ -603,15 +603,15 @@ func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "completed" {
-		t.Fatalf("queue = %#v, want completed queue item", queue)
+	if queue == nil || queue.Status != string(FailureManualIntervention) || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want manual_intervention queue item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "completed" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want completed loop without scheduled retry", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused loop without scheduled retry", loop)
 	}
 	activeFollowup, err := fixture.repos.Queue.FindActiveByLoopID(context.Background(), result.LoopID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- derive sandbox fake-agent review-thread replies from prompt fix-item IDs so real GitHub sandbox runs can reply to the actual thread IDs
- fail fixer runs with manual intervention when a no-new-commit path still leaves review threads unresolved, and do not let stale prior-push metadata bypass that block
- update fixer and resolve-comments regression coverage for the blocked unresolved-thread path

## Validation
- go test ./internal/e2e/harness/cmd/fake-agent ./internal/fixer ./internal/e2e
- go test ./...
- go build ./...

Closes #328