### PR TITLE
fix: stop exposing agent model in disclosures

### DIFF
--- a/internal/disclosure/disclosure.go
+++ b/internal/disclosure/disclosure.go
@@ -1,7 +1,6 @@
 package disclosure
 
 import (
-	"fmt"
 	"regexp"
 	"runtime"
 	"strings"
@@ -148,9 +147,6 @@ func (s Stamper) attributes(runner string) []string {
 		if agent := strings.TrimSpace(s.Agent); agent != "" {
 			attrs = append(attrs, "agent="+agent)
 		}
-		if model := safeAttributeValue(s.Model); model != "" {
-			attrs = append(attrs, "model="+model)
-		}
 	}
 	if s.Config.IncludeOS {
 		if osFamily := osFamily(runtime.GOOS); osFamily != "" {
@@ -179,29 +175,4 @@ func safeValue(value string) string {
 		return "0.0.0-dev"
 	}
 	return value
-}
-
-func safeAttributeValue(value string) string {
-	value = strings.Join(strings.Fields(value), " ")
-	if value == "" {
-		return ""
-	}
-
-	var b strings.Builder
-	for i := 0; i < len(value); i++ {
-		c := value[i]
-		if isSafeAttributeByte(c) {
-			b.WriteByte(c)
-			continue
-		}
-		_, _ = fmt.Fprintf(&b, "%%%02X", c)
-	}
-	return b.String()
-}
-
-func isSafeAttributeByte(c byte) bool {
-	return (c >= 'a' && c <= 'z') ||
-		(c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') ||
-		c == '-' || c == '_' || c == '.' || c == '/' || c == ':' || c == '+' || c == '@'
 }

--- a/internal/disclosure/disclosure_test.go
+++ b/internal/disclosure/disclosure_test.go
@@ -107,26 +107,29 @@ func TestDisclosureIncludesAgentVendorAndModelSeparately(t *testing.T) {
 	s.Version = "1.2.3"
 
 	footer := s.Markdown("Body", "worker", ChannelPullRequest)
-	if !strings.Contains(footer, `🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · model=openai/gpt-5.5 · An autonomous AI dev team for your GitHub repos.`) {
+	if !strings.Contains(footer, `🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.`) {
 		t.Fatalf("footer missing linked slogan disclosure: %q", footer)
 	}
 	if !strings.Contains(footer, "agent=opencode") {
 		t.Fatalf("footer missing agent attribute: %q", footer)
 	}
-	if !strings.Contains(footer, "model=openai/gpt-5.5") {
-		t.Fatalf("footer missing model attribute: %q", footer)
+	if strings.Contains(footer, "model=") {
+		t.Fatalf("footer should not expose model attribute: %q", footer)
 	}
 
 	commit := s.CommitMessage("fix: disclose agent", "worker")
-	if !strings.Contains(commit, "Generated-By: looper 1.2.3 (runner=worker, agent=opencode, model=openai/gpt-5.5)") {
-		t.Fatalf("commit trailer missing separate agent and model attributes: %q", commit)
+	if !strings.Contains(commit, "Generated-By: looper 1.2.3 (runner=worker, agent=opencode)") {
+		t.Fatalf("commit trailer missing runner and agent attributes: %q", commit)
+	}
+	if strings.Contains(commit, "model=") {
+		t.Fatalf("commit trailer should not expose model attribute: %q", commit)
 	}
 	if strings.Contains(commit, "agent=openai/gpt-5.5") || strings.Contains(footer, "agent=openai/gpt-5.5") {
 		t.Fatalf("model leaked into agent attribute: footer=%q commit=%q", footer, commit)
 	}
 }
 
-func TestDisclosureSanitizesModelAttribute(t *testing.T) {
+func TestDisclosureIgnoresModelAttribute(t *testing.T) {
 	vendor := config.AgentVendorOpenCode
 	model := " openai/gpt-5.5\nGenerated-By: looper injected, model)</sub> "
 	s := FromConfig(config.Config{
@@ -153,16 +156,16 @@ func TestDisclosureSanitizesModelAttribute(t *testing.T) {
 	if strings.Contains(commit, "\nGenerated-By: looper injected") {
 		t.Fatalf("model included a raw newline trailer: %q", commit)
 	}
-	if !strings.Contains(commit, "model=openai/gpt-5.5%20Generated-By:%20looper%20injected%2C%20model%29%3C/sub%3E") {
-		t.Fatalf("commit trailer missing sanitized model: %q", commit)
+	if strings.Contains(commit, "model=") || strings.Contains(commit, "openai/gpt-5.5") {
+		t.Fatalf("commit trailer should not expose model: %q", commit)
 	}
 
 	footer := s.Markdown("Body", "worker", ChannelPullRequest)
 	if strings.Count(footer, "<sub>") != 1 || strings.Count(footer, "</sub>") != 1 {
 		t.Fatalf("model broke footer markup: %q", footer)
 	}
-	if !strings.Contains(footer, "model=openai/gpt-5.5%20Generated-By:%20looper%20injected%2C%20model%29%3C/sub%3E") {
-		t.Fatalf("footer missing sanitized model attribute: %q", footer)
+	if strings.Contains(footer, "model=") {
+		t.Fatalf("footer should not expose model attribute: %q", footer)
 	}
 	if strings.Contains(footer, "\nGenerated-By: looper injected") || strings.Contains(footer, "model)</sub>") {
 		t.Fatalf("footer included unsanitized model: %q", footer)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -25,12 +25,12 @@ func TestBuildFixerPromptUsesConcreteDisclosureMetadata(t *testing.T) {
 
 	detail := &checkpointDetail{State: "OPEN", HeadSHA: "abc123", BaseRefName: "main", HeadRefName: "feature"}
 	prompt, _ := buildFixerPrompt("project_1", customInstructionConfig(nil), "acme/looper", 42, detail, []FixItem{{ID: "fix-1", Summary: "repair disclosure"}}, true, config.DefaultDisclosureConfig(), "opencode", "openai/gpt-5.5")
-	for _, want := range []string{"agent=opencode", "model=openai/gpt-5.5"} {
+	for _, want := range []string{"agent=opencode"} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
 		}
 	}
-	for _, unwanted := range []string{"agent=<agent-runtime>", "model=<agent-model>", "agent=gpt-5.5", "agent=openai/gpt-5.5"} {
+	for _, unwanted := range []string{"agent=<agent-runtime>", "model=<agent-model>", "model=openai/gpt-5.5", "agent=gpt-5.5", "agent=openai/gpt-5.5"} {
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("prompt contains %q:\n%s", unwanted, prompt)
 		}
@@ -45,8 +45,8 @@ func TestBuildFixerPromptOmitsMissingAgentRuntime(t *testing.T) {
 	if strings.Contains(prompt, "agent=") {
 		t.Fatalf("prompt should omit missing agent runtime:\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "model=openai/gpt-5.5") {
-		t.Fatalf("prompt should include configured model:\n%s", prompt)
+	if strings.Contains(prompt, "model=") || strings.Contains(prompt, "openai/gpt-5.5") {
+		t.Fatalf("prompt should not expose configured model:\n%s", prompt)
 	}
 }
 
@@ -4874,7 +4874,8 @@ func TestProcessClaimedItemPostsRoundSummaryComment(t *testing.T) {
 	}
 	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"done","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Capped loop bound and added regression test.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+	agentModel := "openai/gpt-5.5"
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now, AgentModel: &agentModel})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
 		t.Fatalf("DiscoverPullRequests() error = %v", err)
@@ -4904,6 +4905,9 @@ func TestProcessClaimedItemPostsRoundSummaryComment(t *testing.T) {
 	}
 	if !strings.Contains(body, "@alice") {
 		t.Fatalf("summary body missing @author mention:\n%s", body)
+	}
+	if strings.Contains(body, "model=") {
+		t.Fatalf("summary body should not expose agent model:\n%s", body)
 	}
 }
 

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -71,12 +71,12 @@ func TestPromptInstructionDocumentsLifecycleContract(t *testing.T) {
 
 func TestPromptInstructionDocumentsAgentModelWhenConfigured(t *testing.T) {
 	prompt := PromptInstruction("worker", "looper/test", "main", true, true, config.DefaultDisclosureConfig(), "opencode", "openai/gpt-5.5")
-	for _, want := range []string{"agent=opencode", "model=openai/gpt-5.5", "Generated-By: looper", `🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a>`} {
+	for _, want := range []string{"agent=opencode", "Generated-By: looper", `🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a>`} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("PromptInstruction missing %q in:\n%s", want, prompt)
 		}
 	}
-	for _, unwanted := range []string{"agent=<agent-runtime>", "model=<agent-model>", "agent=gpt-5.5", "agent=openai/gpt-5.5"} {
+	for _, unwanted := range []string{"agent=<agent-runtime>", "model=<agent-model>", "model=openai/gpt-5.5", "agent=gpt-5.5", "agent=openai/gpt-5.5"} {
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("PromptInstruction contains %q in:\n%s", unwanted, prompt)
 		}
@@ -89,8 +89,8 @@ func TestPromptInstructionOmitsMissingAgentRuntime(t *testing.T) {
 	if strings.Contains(prompt, "agent=") {
 		t.Fatalf("PromptInstruction should omit agent when runtime is missing:\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "model=openai/gpt-5.5") {
-		t.Fatalf("PromptInstruction should still include configured model:\n%s", prompt)
+	if strings.Contains(prompt, "model=") || strings.Contains(prompt, "openai/gpt-5.5") {
+		t.Fatalf("PromptInstruction should not expose configured model:\n%s", prompt)
 	}
 }
 

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -20,12 +20,12 @@ func TestBuildPlannerPromptUsesConcreteDisclosureMetadata(t *testing.T) {
 
 	repoPath := t.TempDir()
 	prompt, _ := buildPlannerPrompt(storage.ProjectRecord{ID: "project_1", RepoPath: repoPath}, customInstructionConfig(nil), &checkpointIssue{Repo: "acme/looper", IssueNumber: 156, Title: "fix disclosure", SpecPath: "docs/spec.md"}, &checkpointWorktree{Branch: "looper/fix", BaseBranch: "main"}, true, config.DefaultDisclosureConfig(), "opencode", "openai/gpt-5.5")
-	for _, want := range []string{"agent=opencode", "model=openai/gpt-5.5"} {
+	for _, want := range []string{"agent=opencode"} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
 		}
 	}
-	for _, unwanted := range []string{"agent=<agent-runtime>", "model=<agent-model>", "agent=gpt-5.5", "agent=openai/gpt-5.5"} {
+	for _, unwanted := range []string{"agent=<agent-runtime>", "model=<agent-model>", "model=openai/gpt-5.5", "agent=gpt-5.5", "agent=openai/gpt-5.5"} {
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("prompt contains %q:\n%s", unwanted, prompt)
 		}
@@ -40,8 +40,8 @@ func TestBuildPlannerPromptOmitsMissingAgentRuntime(t *testing.T) {
 	if strings.Contains(prompt, "agent=") {
 		t.Fatalf("prompt should omit missing agent runtime:\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "model=openai/gpt-5.5") {
-		t.Fatalf("prompt should include configured model:\n%s", prompt)
+	if strings.Contains(prompt, "model=") || strings.Contains(prompt, "openai/gpt-5.5") {
+		t.Fatalf("prompt should not expose configured model:\n%s", prompt)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -6223,14 +6223,14 @@ func TestBuildReviewPromptUsesConfiguredDisclosure(t *testing.T) {
 	cfg := config.DefaultDisclosureConfig()
 	model := "openai/gpt-5.5"
 	prompt := buildReviewPrompt("acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, config.ReviewerScopeChangedRanges, cfg, "claude-code", model, "/opt/looper/bin/looper")
-	if !strings.Contains(prompt, `🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=reviewer · agent=claude-code · model=openai/gpt-5.5 · An autonomous AI dev team for your GitHub repos.`) {
+	if !strings.Contains(prompt, `🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=reviewer · agent=claude-code · An autonomous AI dev team for your GitHub repos.`) {
 		t.Fatalf("prompt missing configured linked disclosure:\n%s", prompt)
 	}
 	if !strings.Contains(prompt, "agent=claude-code") {
 		t.Fatalf("prompt missing agent in visible disclosure:\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "model=openai/gpt-5.5") {
-		t.Fatalf("prompt missing model in visible disclosure:\n%s", prompt)
+	if strings.Contains(prompt, "model=openai/gpt-5.5") {
+		t.Fatalf("prompt exposes model in visible Markdown disclosure:\n%s", prompt)
 	}
 	if strings.Contains(prompt, "agent=opencode") {
 		t.Fatalf("prompt should use configured agent runtime, not hardcoded opencode:\n%s", prompt)

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -422,12 +422,12 @@ func TestBuildWorkerPromptUsesConcreteDisclosureMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildWorkerPrompt() error = %v", err)
 	}
-	for _, want := range []string{"agent=opencode", "model=openai/gpt-5.5"} {
+	for _, want := range []string{"agent=opencode"} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
 		}
 	}
-	for _, unwanted := range []string{"agent=<agent-runtime>", "model=<agent-model>", "agent=gpt-5.5", "agent=openai/gpt-5.5"} {
+	for _, unwanted := range []string{"agent=<agent-runtime>", "model=<agent-model>", "model=openai/gpt-5.5", "agent=gpt-5.5", "agent=openai/gpt-5.5"} {
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("prompt contains %q:\n%s", unwanted, prompt)
 		}
@@ -444,8 +444,8 @@ func TestBuildWorkerPromptOmitsMissingAgentRuntime(t *testing.T) {
 	if strings.Contains(prompt, "agent=") {
 		t.Fatalf("prompt should omit missing agent runtime:\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "model=openai/gpt-5.5") {
-		t.Fatalf("prompt should include configured model:\n%s", prompt)
+	if strings.Contains(prompt, "model=") || strings.Contains(prompt, "openai/gpt-5.5") {
+		t.Fatalf("prompt should not expose configured model:\n%s", prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Stop including configured agent model values in Looper disclosure attributes.
- Keep runner/agent disclosure metadata while preventing model details from appearing in GitHub comments, prompts, and commit trailers.
- Update coverage across disclosure, lifecycle, worker, fixer, planner, and reviewer prompt behavior.

## Tests
- go test ./...