### PR TITLE
feat: scaffold coordinator role wiring

### DIFF
--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -243,6 +243,35 @@
             "addSnapshotMode": "async"
           },
           "roles": {
+            "coordinator": {
+              "enabled": false,
+              "pollInterval": "5m",
+              "triage": {
+                "triagedLabel": "triaged",
+                "maxIssueAgeDays": 7,
+                "maxPerTick": 5,
+                "disposition": {
+                  "outOfScopeLabel": "wontfix",
+                  "unclearLabel": "needs-info",
+                  "reTriageOnAuthorReply": true
+                }
+              },
+              "dispatch": {
+                "mode": "human-gated",
+                "humanGate": {
+                  "slashCommands": [
+                    "/plan",
+                    "/implement"
+                  ],
+                  "allowedUsers": []
+                },
+                "autonomous": {
+                  "delayMinutes": 30,
+                  "holdLabel": "looper:hold"
+                },
+                "assignTo": ""
+              }
+            },
             "planner": {
               "autoDiscovery": true,
               "triggers": {
@@ -323,7 +352,10 @@
                 "excludeLabels": [
                   "pinned",
                   "security",
-                  "looper:sweep-keep"
+                  "looper:sweep-keep",
+                  "dispatch/*",
+                  "needs-info",
+                  "looper:hold"
                 ],
                 "excludeAuthors": [],
                 "excludeAuthorAssociations": [

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1513,6 +1513,130 @@ func TestLoadFileSupportsSweeperCustomInstructions(t *testing.T) {
 	}
 }
 
+func TestCoordinatorRoleProjectOverrideAffectsRoleHelpers(t *testing.T) {
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	contents := `{
+		"roles": {
+			"coordinator": {
+				"enabled": false,
+				"pollInterval": "5m",
+				"triage": {
+					"triagedLabel": "triaged",
+					"maxIssueAgeDays": 7,
+					"maxPerTick": 5,
+					"disposition": {
+						"outOfScopeLabel": "wontfix",
+						"unclearLabel": "needs-info",
+						"reTriageOnAuthorReply": true
+					}
+				},
+				"dispatch": {
+					"mode": "human-gated",
+					"humanGate": {"slashCommands": ["/plan"], "allowedUsers": []},
+					"autonomous": {"delayMinutes": 30, "holdLabel": "looper:hold"},
+					"assignTo": ""
+				}
+			}
+		},
+		"projects": [{
+			"id": "demo",
+			"name": "Demo",
+			"repoPath": "/repos/demo",
+			"roles": {
+				"coordinator": {
+					"enabled": true,
+					"pollInterval": "2m",
+					"triage": {"maxPerTick": 3},
+					"dispatch": {"autonomous": {"holdLabel": "project:hold"}}
+				}
+			}
+		}]
+	}`
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	loaded, err := LoadFile(LoadFileOptions{CWD: cwd, ConfigPath: configPath, LookupEnv: emptyEnvLookup, LookPath: fakeLookPath(map[string]string{"git": "/git", "gh": "/gh", "osascript": "/osascript"})})
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+
+	globalRoles := ProjectRoleConfigs(loaded.Config, "missing")
+	if globalRoles.Coordinator.Enabled {
+		t.Fatal("global coordinator enabled = true, want false")
+	}
+	if globalRoles.Coordinator.PollInterval != "5m" || globalRoles.Coordinator.Triage.MaxPerTick != 5 {
+		t.Fatalf("global coordinator = %#v, want configured global defaults", globalRoles.Coordinator)
+	}
+
+	projectRoles := ProjectRoleConfigs(loaded.Config, "demo")
+	if !projectRoles.Coordinator.Enabled {
+		t.Fatal("project coordinator enabled = false, want true from project override")
+	}
+	if projectRoles.Coordinator.PollInterval != "2m" || projectRoles.Coordinator.Triage.MaxPerTick != 3 || projectRoles.Coordinator.Dispatch.Autonomous.HoldLabel != "project:hold" {
+		t.Fatalf("project coordinator = %#v, want project overrides merged", projectRoles.Coordinator)
+	}
+	if !AnyProjectRoleAutoDiscoveryEnabled(loaded.Config, "coordinator") {
+		t.Fatal("AnyProjectRoleAutoDiscoveryEnabled(coordinator) = false, want true from project enablement")
+	}
+}
+
+func TestValidateRejectsInvalidCoordinatorConfig(t *testing.T) {
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	contents := `{
+		"roles": {
+			"coordinator": {
+				"enabled": true,
+				"pollInterval": "",
+				"triage": {
+					"triagedLabel": "",
+					"maxIssueAgeDays": 0,
+					"maxPerTick": 0,
+					"disposition": {
+						"outOfScopeLabel": "",
+						"unclearLabel": " needs-info "
+					}
+				},
+				"dispatch": {
+					"mode": "robot",
+					"humanGate": {"slashCommands": [], "allowedUsers": [""]},
+					"autonomous": {"delayMinutes": 0, "holdLabel": ""},
+					"assignTo": " octo "
+				}
+			}
+		},
+		"projects": [{"id": "demo", "name": "Demo", "repoPath": "/repos/demo"}]
+	}`
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	_, err := LoadFile(LoadFileOptions{CWD: cwd, ConfigPath: configPath, LookupEnv: emptyEnvLookup, LookPath: fakeLookPath(map[string]string{"git": "/git", "gh": "/gh", "osascript": "/osascript"})})
+	if err == nil {
+		t.Fatal("LoadFile() error = nil, want validation error")
+	}
+	var validationErr *ConfigValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("LoadFile() error = %v, want *ConfigValidationError", err)
+	}
+	assertValidationIssueForPaths(t, validationErr.Issues, []string{
+		"roles.coordinator.pollInterval",
+		"roles.coordinator.triage.triagedLabel",
+		"roles.coordinator.triage.maxIssueAgeDays",
+		"roles.coordinator.triage.maxPerTick",
+		"roles.coordinator.triage.disposition.outOfScopeLabel",
+		"roles.coordinator.triage.disposition.unclearLabel",
+		"roles.coordinator.dispatch.mode",
+		"roles.coordinator.dispatch.humanGate.slashCommands",
+		"roles.coordinator.dispatch.autonomous.delayMinutes",
+		"roles.coordinator.dispatch.autonomous.holdLabel",
+		"roles.coordinator.dispatch.assignTo",
+	})
+	assertValidationIssueForPathPrefix(t, validationErr.Issues, "roles.coordinator.dispatch.humanGate.allowedUsers")
+}
+
 func TestValidateRejectsInvalidSweeperTriggerThresholdAndAssociationConfig(t *testing.T) {
 	cwd := t.TempDir()
 	configPath := filepath.Join(cwd, "config.json")

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -136,6 +136,32 @@ func DefaultConfig(cwd string) (Config, error) {
 		},
 		Instructions: InstructionsConfig{Enabled: true, MaxBytes: 8192},
 		Roles: RoleConfigs{
+			Coordinator: CoordinatorRoleConfig{
+				Enabled:      false,
+				PollInterval: "5m",
+				Triage: CoordinatorTriageConfig{
+					TriagedLabel:    "triaged",
+					MaxIssueAgeDays: 7,
+					MaxPerTick:      5,
+					Disposition: CoordinatorTriageDispositionConfig{
+						OutOfScopeLabel:       "wontfix",
+						UnclearLabel:          "needs-info",
+						ReTriageOnAuthorReply: true,
+					},
+				},
+				Dispatch: CoordinatorDispatchConfig{
+					Mode: "human-gated",
+					HumanGate: CoordinatorDispatchHumanGateConfig{
+						SlashCommands: []string{"/plan", "/implement"},
+						AllowedUsers:  []string{},
+					},
+					Autonomous: CoordinatorDispatchAutonomousConfig{
+						DelayMinutes: 30,
+						HoldLabel:    "looper:hold",
+					},
+					AssignTo: "",
+				},
+			},
 			Planner: PlannerRoleConfig{
 				AutoDiscovery: true,
 				Triggers: IssueRoleTriggersConfig{
@@ -214,7 +240,7 @@ func DefaultConfig(cwd string) (Config, error) {
 					IncludeIssues:             true,
 					IncludePullRequests:       true,
 					IncludeDrafts:             false,
-					ExcludeLabels:             []string{"pinned", "security", "looper:sweep-keep"},
+					ExcludeLabels:             []string{"pinned", "security", "looper:sweep-keep", "dispatch/*", "needs-info", "looper:hold"},
 					ExcludeAuthors:            []string{},
 					ExcludeAuthorAssociations: []string{"OWNER", "MEMBER", "COLLABORATOR"},
 					LooperInternalLabels:      []string{"looper:plan", "looper:worker-ready", "looper:spec-reviewing", "looper:swept"},

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -673,6 +673,9 @@ func mergeInstructionsConfig(config *InstructionsConfig, partial PartialInstruct
 }
 
 func mergeRoleConfigs(config *RoleConfigs, partial PartialRoleConfigs) {
+	if partial.Coordinator != nil {
+		mergeCoordinatorRoleConfig(&config.Coordinator, *partial.Coordinator)
+	}
 	if partial.Planner != nil {
 		mergePlannerRoleConfig(&config.Planner, *partial.Planner)
 	}
@@ -687,6 +690,81 @@ func mergeRoleConfigs(config *RoleConfigs, partial PartialRoleConfigs) {
 	}
 	if partial.Sweeper != nil {
 		mergeSweeperRoleConfig(&config.Sweeper, *partial.Sweeper)
+	}
+}
+
+func mergeCoordinatorRoleConfig(config *CoordinatorRoleConfig, partial PartialCoordinatorRoleConfig) {
+	if partial.Enabled != nil {
+		config.Enabled = *partial.Enabled
+	}
+	if partial.PollInterval != nil {
+		config.PollInterval = *partial.PollInterval
+	}
+	if partial.Triage != nil {
+		mergeCoordinatorTriageConfig(&config.Triage, *partial.Triage)
+	}
+	if partial.Dispatch != nil {
+		mergeCoordinatorDispatchConfig(&config.Dispatch, *partial.Dispatch)
+	}
+}
+
+func mergeCoordinatorTriageConfig(config *CoordinatorTriageConfig, partial PartialCoordinatorTriageConfig) {
+	if partial.TriagedLabel != nil {
+		config.TriagedLabel = *partial.TriagedLabel
+	}
+	if partial.MaxIssueAgeDays != nil {
+		config.MaxIssueAgeDays = *partial.MaxIssueAgeDays
+	}
+	if partial.MaxPerTick != nil {
+		config.MaxPerTick = *partial.MaxPerTick
+	}
+	if partial.Disposition != nil {
+		mergeCoordinatorTriageDispositionConfig(&config.Disposition, *partial.Disposition)
+	}
+}
+
+func mergeCoordinatorTriageDispositionConfig(config *CoordinatorTriageDispositionConfig, partial PartialCoordinatorTriageDispositionConfig) {
+	if partial.OutOfScopeLabel != nil {
+		config.OutOfScopeLabel = *partial.OutOfScopeLabel
+	}
+	if partial.UnclearLabel != nil {
+		config.UnclearLabel = *partial.UnclearLabel
+	}
+	if partial.ReTriageOnAuthorReply != nil {
+		config.ReTriageOnAuthorReply = *partial.ReTriageOnAuthorReply
+	}
+}
+
+func mergeCoordinatorDispatchConfig(config *CoordinatorDispatchConfig, partial PartialCoordinatorDispatchConfig) {
+	if partial.Mode != nil {
+		config.Mode = *partial.Mode
+	}
+	if partial.HumanGate != nil {
+		mergeCoordinatorDispatchHumanGateConfig(&config.HumanGate, *partial.HumanGate)
+	}
+	if partial.Autonomous != nil {
+		mergeCoordinatorDispatchAutonomousConfig(&config.Autonomous, *partial.Autonomous)
+	}
+	if partial.AssignTo != nil {
+		config.AssignTo = *partial.AssignTo
+	}
+}
+
+func mergeCoordinatorDispatchHumanGateConfig(config *CoordinatorDispatchHumanGateConfig, partial PartialCoordinatorDispatchHumanGateConfig) {
+	if partial.SlashCommands != nil {
+		config.SlashCommands = cloneStrings(*partial.SlashCommands)
+	}
+	if partial.AllowedUsers != nil {
+		config.AllowedUsers = cloneStrings(*partial.AllowedUsers)
+	}
+}
+
+func mergeCoordinatorDispatchAutonomousConfig(config *CoordinatorDispatchAutonomousConfig, partial PartialCoordinatorDispatchAutonomousConfig) {
+	if partial.DelayMinutes != nil {
+		config.DelayMinutes = *partial.DelayMinutes
+	}
+	if partial.HoldLabel != nil {
+		config.HoldLabel = *partial.HoldLabel
 	}
 }
 
@@ -1135,6 +1213,38 @@ func clonePartialRoleConfigs(configs *PartialRoleConfigs) *PartialRoleConfigs {
 			worker.Triggers = &triggers
 		}
 		cloned.Worker = &worker
+	}
+	if configs.Coordinator != nil {
+		coordinator := *configs.Coordinator
+		if configs.Coordinator.Triage != nil {
+			triage := *configs.Coordinator.Triage
+			if configs.Coordinator.Triage.Disposition != nil {
+				disposition := *configs.Coordinator.Triage.Disposition
+				triage.Disposition = &disposition
+			}
+			coordinator.Triage = &triage
+		}
+		if configs.Coordinator.Dispatch != nil {
+			dispatch := *configs.Coordinator.Dispatch
+			if configs.Coordinator.Dispatch.HumanGate != nil {
+				humanGate := *configs.Coordinator.Dispatch.HumanGate
+				if humanGate.SlashCommands != nil {
+					slashCommands := cloneStrings(*humanGate.SlashCommands)
+					humanGate.SlashCommands = &slashCommands
+				}
+				if humanGate.AllowedUsers != nil {
+					allowedUsers := cloneStrings(*humanGate.AllowedUsers)
+					humanGate.AllowedUsers = &allowedUsers
+				}
+				dispatch.HumanGate = &humanGate
+			}
+			if configs.Coordinator.Dispatch.Autonomous != nil {
+				autonomous := *configs.Coordinator.Dispatch.Autonomous
+				dispatch.Autonomous = &autonomous
+			}
+			coordinator.Dispatch = &dispatch
+		}
+		cloned.Coordinator = &coordinator
 	}
 	if configs.Reviewer != nil {
 		reviewer := *configs.Reviewer

--- a/internal/config/project_roles.go
+++ b/internal/config/project_roles.go
@@ -18,6 +18,8 @@ func ProjectRoleConfigs(cfg Config, projectID string) RoleConfigs {
 func ProjectRoleAutoDiscoveryEnabled(cfg Config, projectID, role string) bool {
 	roles := ProjectRoleConfigs(cfg, projectID)
 	switch role {
+	case "coordinator":
+		return roles.Coordinator.Enabled
 	case "planner":
 		return roles.Planner.AutoDiscovery
 	case "reviewer":

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -183,6 +183,35 @@
         "addSnapshotMode": "async"
       },
       "roles": {
+        "coordinator": {
+          "enabled": false,
+          "pollInterval": "5m",
+          "triage": {
+            "triagedLabel": "triaged",
+            "maxIssueAgeDays": 7,
+            "maxPerTick": 5,
+            "disposition": {
+              "outOfScopeLabel": "wontfix",
+              "unclearLabel": "needs-info",
+              "reTriageOnAuthorReply": true
+            }
+          },
+          "dispatch": {
+            "mode": "human-gated",
+            "humanGate": {
+              "slashCommands": [
+                "/plan",
+                "/implement"
+              ],
+              "allowedUsers": []
+            },
+            "autonomous": {
+              "delayMinutes": 30,
+              "holdLabel": "looper:hold"
+            },
+            "assignTo": ""
+          }
+        },
         "planner": {
           "autoDiscovery": true,
           "triggers": {
@@ -263,7 +292,10 @@
             "excludeLabels": [
               "pinned",
               "security",
-              "looper:sweep-keep"
+              "looper:sweep-keep",
+              "dispatch/*",
+              "needs-info",
+              "looper:hold"
             ],
             "excludeAuthors": [],
             "excludeAuthorAssociations": [

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -120,6 +120,35 @@
         "maxBytes": 8192
       },
       "roles": {
+        "coordinator": {
+          "enabled": false,
+          "pollInterval": "5m",
+          "triage": {
+            "triagedLabel": "triaged",
+            "maxIssueAgeDays": 7,
+            "maxPerTick": 5,
+            "disposition": {
+              "outOfScopeLabel": "wontfix",
+              "unclearLabel": "needs-info",
+              "reTriageOnAuthorReply": true
+            }
+          },
+          "dispatch": {
+            "mode": "human-gated",
+            "humanGate": {
+              "slashCommands": [
+                "/plan",
+                "/implement"
+              ],
+              "allowedUsers": []
+            },
+            "autonomous": {
+              "delayMinutes": 30,
+              "holdLabel": "looper:hold"
+            },
+            "assignTo": ""
+          }
+        },
         "planner": {
           "autoDiscovery": true,
           "triggers": {
@@ -200,7 +229,10 @@
             "excludeLabels": [
               "pinned",
               "security",
-              "looper:sweep-keep"
+              "looper:sweep-keep",
+              "dispatch/*",
+              "needs-info",
+              "looper:hold"
             ],
             "excludeAuthors": [],
             "excludeAuthorAssociations": [

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -202,6 +202,35 @@
         "addSnapshotMode": "async"
       },
       "roles": {
+        "coordinator": {
+          "enabled": false,
+          "pollInterval": "5m",
+          "triage": {
+            "triagedLabel": "triaged",
+            "maxIssueAgeDays": 7,
+            "maxPerTick": 5,
+            "disposition": {
+              "outOfScopeLabel": "wontfix",
+              "unclearLabel": "needs-info",
+              "reTriageOnAuthorReply": true
+            }
+          },
+          "dispatch": {
+            "mode": "human-gated",
+            "humanGate": {
+              "slashCommands": [
+                "/plan",
+                "/implement"
+              ],
+              "allowedUsers": []
+            },
+            "autonomous": {
+              "delayMinutes": 30,
+              "holdLabel": "looper:hold"
+            },
+            "assignTo": ""
+          }
+        },
         "planner": {
           "autoDiscovery": true,
           "triggers": {
@@ -282,7 +311,10 @@
             "excludeLabels": [
               "pinned",
               "security",
-              "looper:sweep-keep"
+              "looper:sweep-keep",
+              "dispatch/*",
+              "needs-info",
+              "looper:hold"
             ],
             "excludeAuthors": [],
             "excludeAuthorAssociations": [

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -422,12 +422,50 @@ type SweeperRoleConfig struct {
 	Instructions  string                  `json:"instructions,omitempty"`
 }
 
+type CoordinatorTriageDispositionConfig struct {
+	OutOfScopeLabel       string `json:"outOfScopeLabel"`
+	UnclearLabel          string `json:"unclearLabel"`
+	ReTriageOnAuthorReply bool   `json:"reTriageOnAuthorReply"`
+}
+
+type CoordinatorTriageConfig struct {
+	TriagedLabel    string                             `json:"triagedLabel"`
+	MaxIssueAgeDays int                                `json:"maxIssueAgeDays"`
+	MaxPerTick      int                                `json:"maxPerTick"`
+	Disposition     CoordinatorTriageDispositionConfig `json:"disposition"`
+}
+
+type CoordinatorDispatchHumanGateConfig struct {
+	SlashCommands []string `json:"slashCommands"`
+	AllowedUsers  []string `json:"allowedUsers"`
+}
+
+type CoordinatorDispatchAutonomousConfig struct {
+	DelayMinutes int    `json:"delayMinutes"`
+	HoldLabel    string `json:"holdLabel"`
+}
+
+type CoordinatorDispatchConfig struct {
+	Mode       string                              `json:"mode"`
+	HumanGate  CoordinatorDispatchHumanGateConfig  `json:"humanGate"`
+	Autonomous CoordinatorDispatchAutonomousConfig `json:"autonomous"`
+	AssignTo   string                              `json:"assignTo"`
+}
+
+type CoordinatorRoleConfig struct {
+	Enabled      bool                      `json:"enabled"`
+	PollInterval string                    `json:"pollInterval"`
+	Triage       CoordinatorTriageConfig   `json:"triage"`
+	Dispatch     CoordinatorDispatchConfig `json:"dispatch"`
+}
+
 type RoleConfigs struct {
-	Planner  PlannerRoleConfig  `json:"planner"`
-	Reviewer ReviewerRoleConfig `json:"reviewer"`
-	Fixer    FixerRoleConfig    `json:"fixer"`
-	Worker   WorkerRoleConfig   `json:"worker"`
-	Sweeper  SweeperRoleConfig  `json:"sweeper"`
+	Planner     PlannerRoleConfig     `json:"planner"`
+	Reviewer    ReviewerRoleConfig    `json:"reviewer"`
+	Fixer       FixerRoleConfig       `json:"fixer"`
+	Worker      WorkerRoleConfig      `json:"worker"`
+	Sweeper     SweeperRoleConfig     `json:"sweeper"`
+	Coordinator CoordinatorRoleConfig `json:"coordinator"`
 }
 
 type ProjectRefConfig struct {
@@ -763,12 +801,50 @@ type PartialSweeperRoleConfig struct {
 	Instructions  *string                         `json:"instructions,omitempty"`
 }
 
+type PartialCoordinatorTriageDispositionConfig struct {
+	OutOfScopeLabel       *string `json:"outOfScopeLabel,omitempty"`
+	UnclearLabel          *string `json:"unclearLabel,omitempty"`
+	ReTriageOnAuthorReply *bool   `json:"reTriageOnAuthorReply,omitempty"`
+}
+
+type PartialCoordinatorTriageConfig struct {
+	TriagedLabel    *string                                    `json:"triagedLabel,omitempty"`
+	MaxIssueAgeDays *int                                       `json:"maxIssueAgeDays,omitempty"`
+	MaxPerTick      *int                                       `json:"maxPerTick,omitempty"`
+	Disposition     *PartialCoordinatorTriageDispositionConfig `json:"disposition,omitempty"`
+}
+
+type PartialCoordinatorDispatchHumanGateConfig struct {
+	SlashCommands *[]string `json:"slashCommands,omitempty"`
+	AllowedUsers  *[]string `json:"allowedUsers,omitempty"`
+}
+
+type PartialCoordinatorDispatchAutonomousConfig struct {
+	DelayMinutes *int    `json:"delayMinutes,omitempty"`
+	HoldLabel    *string `json:"holdLabel,omitempty"`
+}
+
+type PartialCoordinatorDispatchConfig struct {
+	Mode       *string                                     `json:"mode,omitempty"`
+	HumanGate  *PartialCoordinatorDispatchHumanGateConfig  `json:"humanGate,omitempty"`
+	Autonomous *PartialCoordinatorDispatchAutonomousConfig `json:"autonomous,omitempty"`
+	AssignTo   *string                                     `json:"assignTo,omitempty"`
+}
+
+type PartialCoordinatorRoleConfig struct {
+	Enabled      *bool                             `json:"enabled,omitempty"`
+	PollInterval *string                           `json:"pollInterval,omitempty"`
+	Triage       *PartialCoordinatorTriageConfig   `json:"triage,omitempty"`
+	Dispatch     *PartialCoordinatorDispatchConfig `json:"dispatch,omitempty"`
+}
+
 type PartialRoleConfigs struct {
-	Planner  *PartialPlannerRoleConfig  `json:"planner,omitempty"`
-	Reviewer *PartialReviewerRoleConfig `json:"reviewer,omitempty"`
-	Fixer    *PartialFixerRoleConfig    `json:"fixer,omitempty"`
-	Worker   *PartialWorkerRoleConfig   `json:"worker,omitempty"`
-	Sweeper  *PartialSweeperRoleConfig  `json:"sweeper,omitempty"`
+	Planner     *PartialPlannerRoleConfig     `json:"planner,omitempty"`
+	Reviewer    *PartialReviewerRoleConfig    `json:"reviewer,omitempty"`
+	Fixer       *PartialFixerRoleConfig       `json:"fixer,omitempty"`
+	Worker      *PartialWorkerRoleConfig      `json:"worker,omitempty"`
+	Sweeper     *PartialSweeperRoleConfig     `json:"sweeper,omitempty"`
+	Coordinator *PartialCoordinatorRoleConfig `json:"coordinator,omitempty"`
 }
 
 type PartialConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -185,6 +185,7 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 	}
 
 	validateInstructions(config, &issues)
+	validateCoordinatorRoleConfig(config.Roles.Coordinator, "roles.coordinator", &issues)
 	validateIssueRoleTriggers(config.Roles.Planner.Triggers, "roles.planner.triggers", &issues)
 	validateIssueRoleTriggers(config.Roles.Worker.Triggers, "roles.worker.triggers", &issues)
 	validateReviewerRoleTriggers(config.Roles.Reviewer.Discovery.Triggers, "roles.reviewer.discovery.triggers", &issues)
@@ -237,6 +238,9 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 		}
 		if project.Roles != nil && project.Roles.Sweeper != nil {
 			validateSweeperRoleConfig(effectiveProjectRoles.Sweeper, prefix+".roles.sweeper", &issues)
+		}
+		if project.Roles != nil && project.Roles.Coordinator != nil {
+			validateCoordinatorRoleConfig(effectiveProjectRoles.Coordinator, prefix+".roles.coordinator", &issues)
 		}
 	}
 
@@ -341,6 +345,11 @@ func validateProjectRoleOverrides(roles *PartialRoleConfigs, prefix string, maxI
 	}
 	if roles.Sweeper != nil {
 		validateProjectRoleInstruction(prefix+".sweeper.instructions", "sweeper", roles.Sweeper.Instructions, maxInstructionBytes, issues)
+	}
+	if roles.Coordinator != nil {
+		if roles.Coordinator.PollInterval != nil && strings.TrimSpace(*roles.Coordinator.PollInterval) == "" {
+			*issues = append(*issues, ValidationIssue{Path: prefix + ".coordinator.pollInterval", Message: "must be a non-empty duration string"})
+		}
 	}
 }
 
@@ -632,6 +641,58 @@ func validateFixerRoleTriggers(triggers FixerRoleTriggersConfig, path string, is
 	if !isValidFixerAuthorFilter(triggers.AuthorFilter) {
 		*issues = append(*issues, ValidationIssue{Path: path + ".authorFilter", Message: fmt.Sprintf("must be one of: %s, %s", FixerAuthorFilterCurrentUser, FixerAuthorFilterAny)})
 	}
+}
+
+func validateCoordinatorRoleConfig(config CoordinatorRoleConfig, path string, issues *[]ValidationIssue) {
+	if strings.TrimSpace(config.PollInterval) == "" {
+		*issues = append(*issues, ValidationIssue{Path: path + ".pollInterval", Message: "must be a non-empty duration string"})
+	} else if duration, err := time.ParseDuration(strings.TrimSpace(config.PollInterval)); err != nil {
+		*issues = append(*issues, ValidationIssue{Path: path + ".pollInterval", Message: "must be a valid time.Duration string"})
+	} else if duration <= 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".pollInterval", Message: "must be greater than 0"})
+	}
+	if config.Triage.MaxIssueAgeDays <= 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".triage.maxIssueAgeDays", Message: "must be a positive integer"})
+	}
+	if config.Triage.MaxPerTick <= 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".triage.maxPerTick", Message: "must be a positive integer"})
+	}
+	if !isNonEmptyTrimmed(config.Triage.TriagedLabel) {
+		*issues = append(*issues, ValidationIssue{Path: path + ".triage.triagedLabel", Message: "must be a non-empty string without leading or trailing whitespace"})
+	}
+	if !isNonEmptyTrimmed(config.Triage.Disposition.OutOfScopeLabel) {
+		*issues = append(*issues, ValidationIssue{Path: path + ".triage.disposition.outOfScopeLabel", Message: "must be a non-empty string without leading or trailing whitespace"})
+	}
+	if !isNonEmptyTrimmed(config.Triage.Disposition.UnclearLabel) {
+		*issues = append(*issues, ValidationIssue{Path: path + ".triage.disposition.unclearLabel", Message: "must be a non-empty string without leading or trailing whitespace"})
+	}
+	if config.Dispatch.Mode != "human-gated" && config.Dispatch.Mode != "autonomous" {
+		*issues = append(*issues, ValidationIssue{Path: path + ".dispatch.mode", Message: "must be one of: human-gated, autonomous"})
+	}
+	validateStringList(config.Dispatch.HumanGate.SlashCommands, path+".dispatch.humanGate.slashCommands", issues)
+	validateStringList(config.Dispatch.HumanGate.AllowedUsers, path+".dispatch.humanGate.allowedUsers", issues)
+	if len(config.Dispatch.HumanGate.SlashCommands) == 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".dispatch.humanGate.slashCommands", Message: "must contain at least one slash command"})
+	}
+	if config.Dispatch.Autonomous.DelayMinutes <= 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".dispatch.autonomous.delayMinutes", Message: "must be a positive integer"})
+	}
+	if !isNonEmptyTrimmed(config.Dispatch.Autonomous.HoldLabel) {
+		*issues = append(*issues, ValidationIssue{Path: path + ".dispatch.autonomous.holdLabel", Message: "must be a non-empty string without leading or trailing whitespace"})
+	}
+	if config.Dispatch.AssignTo != strings.TrimSpace(config.Dispatch.AssignTo) {
+		*issues = append(*issues, ValidationIssue{Path: path + ".dispatch.assignTo", Message: "must not contain leading or trailing whitespace"})
+	}
+	validateDistinctLabels([]labelPathValue{
+		{Path: path + ".triage.triagedLabel", Value: config.Triage.TriagedLabel},
+		{Path: path + ".triage.disposition.outOfScopeLabel", Value: config.Triage.Disposition.OutOfScopeLabel},
+		{Path: path + ".triage.disposition.unclearLabel", Value: config.Triage.Disposition.UnclearLabel},
+		{Path: path + ".dispatch.autonomous.holdLabel", Value: config.Dispatch.Autonomous.HoldLabel},
+	}, issues)
+}
+
+func isNonEmptyTrimmed(value string) bool {
+	return strings.TrimSpace(value) != "" && value == strings.TrimSpace(value)
 }
 
 func validateSweeperRoleConfig(config SweeperRoleConfig, path string, issues *[]ValidationIssue) {

--- a/internal/coordinator/runner.go
+++ b/internal/coordinator/runner.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -81,7 +82,7 @@ func (r *Runner) pollInterval(projectID string) time.Duration {
 		return 0
 	}
 	roleCfg := config.ProjectRoleConfigs(*r.config, projectID).Coordinator
-	interval, err := time.ParseDuration(roleCfg.PollInterval)
+	interval, err := time.ParseDuration(strings.TrimSpace(roleCfg.PollInterval))
 	if err != nil {
 		return 0
 	}

--- a/internal/coordinator/runner.go
+++ b/internal/coordinator/runner.go
@@ -1,0 +1,98 @@
+package coordinator
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+type DiscoveryInput struct {
+	ProjectID string
+	Repo      string
+}
+
+type DiscoveryResult struct {
+	Skipped bool
+	Ticked  bool
+}
+
+type IssueSummary struct {
+	Labels []string
+}
+
+type Options struct {
+	Config *config.Config
+	Now    func() time.Time
+}
+
+type Runner struct {
+	config *config.Config
+	now    func() time.Time
+
+	mu                sync.Mutex
+	lastTickByProject map[string]time.Time
+}
+
+func New(options Options) *Runner {
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Runner{config: options.Config, now: now, lastTickByProject: map[string]time.Time{}}
+}
+
+func (r *Runner) DiscoverIssues(_ context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	if !r.shouldRunTick(input.ProjectID) {
+		return DiscoveryResult{Skipped: true}, nil
+	}
+	return DiscoveryResult{Ticked: true}, nil
+}
+
+// ShouldSkipIssue reserves the structural cross-role boundary with Sweeper.
+// Future triage discovery must skip issues that Sweeper already marked pending,
+// retired, or quarantined so the two roles never fight over authority.
+func ShouldSkipIssue(issue IssueSummary, roleCfg config.CoordinatorRoleConfig, sweeperCfg config.SweeperRoleConfig) bool {
+	_ = roleCfg
+	return hasLabel(issue.Labels, sweeperCfg.Lifecycle.PendingLabel) ||
+		hasLabel(issue.Labels, sweeperCfg.Lifecycle.ClosedLabel) ||
+		hasLabel(issue.Labels, sweeperCfg.Security.QuarantineLabel)
+}
+
+func (r *Runner) shouldRunTick(projectID string) bool {
+	interval := r.pollInterval(projectID)
+	if interval <= 0 {
+		return true
+	}
+	now := r.now().UTC()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lastRun, ok := r.lastTickByProject[projectID]
+	if ok && now.Sub(lastRun) < interval {
+		return false
+	}
+	r.lastTickByProject[projectID] = now
+	return true
+}
+
+func (r *Runner) pollInterval(projectID string) time.Duration {
+	if r == nil || r.config == nil {
+		return 0
+	}
+	roleCfg := config.ProjectRoleConfigs(*r.config, projectID).Coordinator
+	interval, err := time.ParseDuration(roleCfg.PollInterval)
+	if err != nil {
+		return 0
+	}
+	return interval
+}
+
+func hasLabel(labels []string, want string) bool {
+	for _, label := range labels {
+		if label == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/coordinator/runner_test.go
+++ b/internal/coordinator/runner_test.go
@@ -1,0 +1,79 @@
+package coordinator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestDiscoverIssuesRespectsPollInterval(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.PollInterval = "1m"
+	now := time.Date(2026, time.May, 14, 10, 0, 0, 0, time.UTC)
+	runner := New(Options{Config: &cfg, Now: func() time.Time { return now }})
+
+	first, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "demo", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if !first.Ticked || first.Skipped {
+		t.Fatalf("first DiscoverIssues() = %#v, want first coordinator tick to run", first)
+	}
+
+	second, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "demo", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if !second.Skipped || second.Ticked {
+		t.Fatalf("second DiscoverIssues() = %#v, want poll interval gate to skip", second)
+	}
+
+	now = now.Add(time.Minute)
+	third, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "demo", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if !third.Ticked || third.Skipped {
+		t.Fatalf("third DiscoverIssues() = %#v, want coordinator tick after interval", third)
+	}
+}
+
+func TestShouldSkipIssueForSweeperManagedLabels(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	coordinatorCfg := cfg.Roles.Coordinator
+	sweeperCfg := cfg.Roles.Sweeper
+
+	for _, tc := range []struct {
+		name   string
+		labels []string
+	}{
+		{name: "pending", labels: []string{sweeperCfg.Lifecycle.PendingLabel}},
+		{name: "closed", labels: []string{sweeperCfg.Lifecycle.ClosedLabel}},
+		{name: "quarantine", labels: []string{sweeperCfg.Security.QuarantineLabel}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if !ShouldSkipIssue(IssueSummary{Labels: tc.labels}, coordinatorCfg, sweeperCfg) {
+				t.Fatalf("ShouldSkipIssue(%v) = false, want true", tc.labels)
+			}
+		})
+	}
+
+	if ShouldSkipIssue(IssueSummary{Labels: []string{"dispatch/plan"}}, coordinatorCfg, sweeperCfg) {
+		t.Fatal("ShouldSkipIssue(dispatch/plan) = true, want false for coordinator-owned labels")
+	}
+}

--- a/internal/coordinator/runner_test.go
+++ b/internal/coordinator/runner_test.go
@@ -46,6 +46,35 @@ func TestDiscoverIssuesRespectsPollInterval(t *testing.T) {
 	}
 }
 
+func TestDiscoverIssuesRespectsTrimmedPollInterval(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.PollInterval = " 1m "
+	now := time.Date(2026, time.May, 14, 10, 0, 0, 0, time.UTC)
+	runner := New(Options{Config: &cfg, Now: func() time.Time { return now }})
+
+	first, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "demo", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if !first.Ticked || first.Skipped {
+		t.Fatalf("first DiscoverIssues() = %#v, want first coordinator tick to run", first)
+	}
+
+	second, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "demo", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if !second.Skipped || second.Ticked {
+		t.Fatalf("second DiscoverIssues() = %#v, want poll interval gate to skip", second)
+	}
+}
+
 func TestShouldSkipIssueForSweeperManagedLabels(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/bootstrap"
 	"github.com/nexu-io/looper/internal/config"
+	coordinatorrole "github.com/nexu-io/looper/internal/coordinator"
 	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/fixer"
 	gitinfra "github.com/nexu-io/looper/internal/infra/git"
@@ -30,6 +31,10 @@ type plannerScheduler interface {
 	DiscoverIssues(context.Context, planner.DiscoveryInput) (planner.DiscoveryResult, error)
 	ProcessNext(context.Context, string) (*planner.ProcessResult, error)
 	ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) (*planner.ProcessResult, error)
+}
+
+type coordinatorScheduler interface {
+	DiscoverIssues(context.Context, coordinatorrole.DiscoveryInput) (coordinatorrole.DiscoveryResult, error)
 }
 
 type reviewerScheduler interface {
@@ -76,12 +81,14 @@ type defaultSchedulerTickInput struct {
 	AsyncRunner              schedulerAsyncRunner
 	RequestSchedulerWake     func()
 	Planner                  plannerScheduler
+	Coordinator              coordinatorScheduler
 	Reviewer                 reviewerScheduler
 	Fixer                    fixerScheduler
 	Worker                   workerScheduler
 	Sweeper                  sweeperScheduler
 	Snapshotter              snapshotScheduler
 	PlannerDiscoveryEnabled  *bool
+	CoordinatorEnabled       func(string) bool
 	ReviewerDiscoveryEnabled *bool
 	FixerDiscoveryEnabled    *bool
 	WorkerDiscoveryEnabled   *bool
@@ -834,6 +841,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 	}
 
 	var plannerRunner plannerScheduler
+	var coordinatorRunner coordinatorScheduler
 	var reviewerRunner reviewerScheduler
 	var fixerRunner fixerScheduler
 	var workerRunner workerScheduler
@@ -884,6 +892,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Planner", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
 		},
 	})
+	coordinatorRunner = coordinatorrole.New(coordinatorrole.Options{Config: &cfg, Now: now})
 	reviewerRunner = reviewer.New(reviewer.Options{
 		DB:               coordinator.DB(),
 		Repos:            repos,
@@ -1000,12 +1009,14 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			AsyncRunner:              runner,
 			RequestSchedulerWake:     requestWake,
 			Planner:                  plannerRunner,
+			Coordinator:              coordinatorRunner,
 			Reviewer:                 reviewerRunner,
 			Fixer:                    fixerRunner,
 			Worker:                   workerRunner,
 			Sweeper:                  sweeperRunner,
 			Snapshotter:              githubGateway,
 			PlannerDiscoveryEnabled:  boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "planner")),
+			CoordinatorEnabled:       func(projectID string) bool { return config.ProjectRoleConfigs(cfg, projectID).Coordinator.Enabled },
 			ReviewerDiscoveryEnabled: boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "reviewer")),
 			FixerDiscoveryEnabled:    boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "fixer")),
 			WorkerDiscoveryEnabled:   boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "worker")),
@@ -1113,6 +1124,10 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		} else if input.Planner != nil && input.Logger != nil {
 			input.Logger.Debug("planner auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
 		}
+		if input.Coordinator != nil && coordinatorEnabledForProject(input, project.ID) {
+			_, err := input.Coordinator.DiscoverIssues(ctx, coordinatorrole.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+			appendErr(wrapSchedulerError("coordinator discovery", project.ID, repo, err))
+		}
 		if input.Reviewer != nil && discoveryEnabled(input.ReviewerDiscoveryEnabled) {
 			result, err := input.Reviewer.DiscoverPullRequests(ctx, reviewer.DiscoveryInput{ProjectID: project.ID, Repo: repo})
 			trackRunnableDiscovery(result.QueueItems)
@@ -1178,6 +1193,13 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 
 func discoveryEnabled(value *bool) bool {
 	return value == nil || *value
+}
+
+func coordinatorEnabledForProject(input defaultSchedulerTickInput, projectID string) bool {
+	if input.CoordinatorEnabled == nil {
+		return false
+	}
+	return input.CoordinatorEnabled(projectID)
 }
 
 func runnableSchedulerQueueItemIDs(queueItems []storage.QueueItemRecord, now func() time.Time) []string {

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/coordinator"
 	"github.com/nexu-io/looper/internal/fixer"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/planner"
@@ -66,26 +67,32 @@ func TestRunDefaultSchedulerTickDiscoversStoredProjectsAndProcessesQueue(t *test
 	}
 
 	plannerRunner := &stubPlannerScheduler{}
+	coordinatorRunner := &stubCoordinatorScheduler{}
 	reviewerRunner := &stubReviewerScheduler{}
 	fixerRunner := &stubFixerScheduler{}
 	workerRunner := &stubWorkerScheduler{}
 	sweeperRunner := &stubSweeperScheduler{}
 
 	err := runDefaultSchedulerTick(context.Background(), defaultSchedulerTickInput{
-		Repos:             repos,
-		Now:               func() time.Time { return now },
-		MaxConcurrentRuns: 1,
-		Planner:           plannerRunner,
-		Reviewer:          reviewerRunner,
-		Fixer:             fixerRunner,
-		Worker:            workerRunner,
-		Sweeper:           sweeperRunner,
+		Repos:              repos,
+		Now:                func() time.Time { return now },
+		MaxConcurrentRuns:  1,
+		Planner:            plannerRunner,
+		Coordinator:        coordinatorRunner,
+		CoordinatorEnabled: func(string) bool { return true },
+		Reviewer:           reviewerRunner,
+		Fixer:              fixerRunner,
+		Worker:             workerRunner,
+		Sweeper:            sweeperRunner,
 	})
 	if err != nil {
 		t.Fatalf("runDefaultSchedulerTick() error = %v", err)
 	}
 	if len(plannerRunner.discoverCalls) != 1 || plannerRunner.discoverCalls[0].ProjectID != "looper" || plannerRunner.discoverCalls[0].Repo != "nexu-io/looper" {
 		t.Fatalf("planner discover calls = %#v, want stored project discovery", plannerRunner.discoverCalls)
+	}
+	if len(coordinatorRunner.discoverCalls) != 1 || coordinatorRunner.discoverCalls[0].Repo != "nexu-io/looper" {
+		t.Fatalf("coordinator discover calls = %#v, want stored project repo", coordinatorRunner.discoverCalls)
 	}
 	if len(reviewerRunner.discoverCalls) != 1 || reviewerRunner.discoverCalls[0].Repo != "nexu-io/looper" {
 		t.Fatalf("reviewer discover calls = %#v, want stored project repo", reviewerRunner.discoverCalls)
@@ -150,6 +157,31 @@ func TestRunDefaultSchedulerTickClaimsQueuedWorkBeforeDiscovery(t *testing.T) {
 	}
 	if !plannerRunner.checkedClaimedStatus {
 		t.Fatal("planner discovery did not verify claimed queue item status")
+	}
+}
+
+func TestRunDefaultSchedulerTickSkipsCoordinatorWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinatorDB := openMigratedCoordinator(t, filepath.Join(workingDir, "scheduler-coordinator-disabled.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinatorDB.DB())
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	insertSchedulerProject(t, repos, workingDir, nowISO)
+
+	runner := &stubCoordinatorScheduler{}
+	if err := runDefaultSchedulerTick(context.Background(), defaultSchedulerTickInput{
+		Repos:              repos,
+		Now:                func() time.Time { return now },
+		Coordinator:        runner,
+		CoordinatorEnabled: func(string) bool { return false },
+	}); err != nil {
+		t.Fatalf("runDefaultSchedulerTick() error = %v", err)
+	}
+	if len(runner.discoverCalls) != 0 {
+		t.Fatalf("coordinator discover calls = %#v, want none when disabled", runner.discoverCalls)
 	}
 }
 
@@ -823,6 +855,12 @@ type stubPlannerScheduler struct {
 	processErr     error
 }
 
+type stubCoordinatorScheduler struct {
+	mu            sync.Mutex
+	discoverCalls []coordinator.DiscoveryInput
+	discoverErr   error
+}
+
 type immediateSchedulerRunner struct{}
 
 func (immediateSchedulerRunner) Go(fn func()) { fn() }
@@ -981,6 +1019,13 @@ func (s *stubPlannerScheduler) processItemCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.processedItems)
+}
+
+func (s *stubCoordinatorScheduler) DiscoverIssues(_ context.Context, input coordinator.DiscoveryInput) (coordinator.DiscoveryResult, error) {
+	s.mu.Lock()
+	s.discoverCalls = append(s.discoverCalls, input)
+	s.mu.Unlock()
+	return coordinator.DiscoveryResult{Ticked: true}, s.discoverErr
 }
 
 type stubReviewerScheduler struct {

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -1014,6 +1014,18 @@ func hasLabel(labels []string, want string) bool {
 	if want == "" {
 		return false
 	}
+	if strings.HasSuffix(want, "*") {
+		prefix := strings.TrimSuffix(want, "*")
+		if prefix == "" {
+			return false
+		}
+		for _, label := range labels {
+			if strings.HasPrefix(label, prefix) {
+				return true
+			}
+		}
+		return false
+	}
 	for _, label := range labels {
 		if label == want {
 			return true

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -146,6 +146,49 @@ func TestDiscoverIssuesSkipsExcludedLabelBeforeAuthorAssociationLookup(t *testin
 	}
 }
 
+func TestDiscoverIssuesSkipsCoordinatorManagedExemptLabels(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		label string
+	}{
+		{name: "dispatch prefix", label: "dispatch/plan"},
+		{name: "needs info", label: "needs-info"},
+		{name: "hold", label: "looper:hold"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Title: "stale bug", Body: "needs cleanup", Author: "octo", Labels: []string{tc.label}}}
+
+			result, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+			if err != nil {
+				t.Fatalf("DiscoverIssues() error = %v", err)
+			}
+			if len(result.QueueItems) != 0 || result.Skipped != 1 {
+				t.Fatalf("DiscoverIssues() = %#v, want exempt label to be skipped", result)
+			}
+		})
+	}
+}
+
+func TestHasLabelSupportsPrefixWithoutBreakingExactMatch(t *testing.T) {
+	t.Parallel()
+
+	labels := []string{"dispatch/plan", "needs-info", "looper:hold"}
+	if !hasLabel(labels, "dispatch/*") {
+		t.Fatal("hasLabel(dispatch/*) = false, want true")
+	}
+	if !hasLabel(labels, "needs-info") {
+		t.Fatal("hasLabel(needs-info) = false, want true")
+	}
+	if hasLabel(labels, "dispatch") {
+		t.Fatal("hasLabel(dispatch) = true, want false for non-prefix exact mismatch")
+	}
+}
+
 func TestDiscoverPullRequestsSkipsExcludedAuthorBeforeAuthorAssociationLookup(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add the Coordinator role config surface, project override merge/validation, and a scheduler-wired no-op runner with poll-interval gating for the slice 1 scaffold
- extend Sweeper's exempt-label contract to support prefix matches plus the default coordinator-managed holds (`dispatch/*`, `needs-info`, `looper:hold`)
- add coordinator/scheduler/sweeper coverage, update frozen config artifacts, and verify `internal/disclosure/disclosure.go` remains untouched

## Why
- land the coordinator integration seams now so later triage and dispatch slices can layer behavior on top without renegotiating config or scheduler wiring
- keep Coordinator stateless while preventing Sweeper from retiring issues that Coordinator is managing

## References
- Closes #335
- PRD #334
- ADR 0001 (`docs/adr/0001-coordinator-stateless-role.md`)
- ADR 0002 (`docs/adr/0002-coordinator-authority-via-durable-labels.md`)
- ADR 0003 (`docs/adr/0003-coordinator-sweeper-label-contract.md`)

## Validation
- `go test ./...`
- `go vet ./...`