### PR TITLE
feat: implement coordinator dispatch end-to-end

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,7 @@ All role-specific config lives under `roles.<role>`.
 
 ## Coordinator config reference
 
-Coordinator is the proactive, stateless issue-intake role. In slice 2 it owns Triage end-to-end; Dispatch remains scaffolded for the next slice, but its config shape is already present.
+Coordinator is the proactive, stateless issue-intake role. It owns both Triage and Dispatch. Triage writes `triaged` plus the coordinator-owned label namespace. Dispatch consumes `triaged` + `dispatch/*` and derives the actual trigger label from Planner or Worker config instead of redeclaring those labels.
 
 ### Triage settings
 
@@ -135,18 +135,26 @@ Coordinator triage lives under `roles.coordinator.triage.*`:
 
 Coordinator clears and rewrites its own label namespace on each successful triage pass: `kind/*`, `area/*`, `complexity/*`, `dispatch/*`, `wontfix`, and `needs-info`. It then posts or edits the marker comment and writes `triaged` last.
 
-### Dispatch settings (scaffolded for slice 3)
+### Dispatch settings
 
-The full Coordinator config shape already includes `roles.coordinator.dispatch.*` so project overrides remain stable across slices:
+Coordinator dispatch lives under `roles.coordinator.dispatch.*`:
 
-- `roles.coordinator.dispatch.mode`
-- `roles.coordinator.dispatch.humanGate.slashCommands`
-- `roles.coordinator.dispatch.humanGate.allowedUsers`
-- `roles.coordinator.dispatch.autonomous.delayMinutes`
-- `roles.coordinator.dispatch.autonomous.holdLabel`
-- `roles.coordinator.dispatch.assignTo`
+| Path | Purpose | Default |
+| --- | --- | --- |
+| `roles.coordinator.dispatch.mode` | Chooses `human-gated` or `autonomous` dispatch | `"human-gated"` |
+| `roles.coordinator.dispatch.assignTo` | Optional GitHub assignee added before the trigger label commit | `""` |
+| `roles.coordinator.dispatch.humanGate.slashCommands` | Accepted start-of-line slash commands | `[`"/plan"`, `"/implement"`]` |
+| `roles.coordinator.dispatch.humanGate.allowedUsers` | Extra users allowed to dispatch even without repo write access | `[]` |
+| `roles.coordinator.dispatch.autonomous.delayMinutes` | Grace window after `triaged` before autonomous dispatch can commit | `30` |
+| `roles.coordinator.dispatch.autonomous.holdLabel` | Global hold / veto label for autonomous dispatch | `"looper:hold"` |
 
-Slice 2 does not execute Dispatch yet, but these fields remain part of the canonical config and merge the same way as other project-level role overrides.
+Behavior notes:
+
+- `/plan` maps to the first planner trigger label at `roles.planner.triggers.labels[0]`
+- `/implement` maps to the first worker trigger label at `roles.worker.triggers.labels[0]`
+- autonomous mode uses the existing `dispatch/*` label to choose the same derived trigger labels
+- Coordinator never stores its own dispatch state; the authority chain stays on GitHub labels, comments, and timeline events
+- `roles.coordinator.dispatch.autonomous.holdLabel` is also a veto signal, alongside removing `dispatch/*` or manually applying the destination trigger label
 
 Coordinator example:
 
@@ -394,7 +402,7 @@ holdLabel = "looper:hold"
 [roles.planner.discovery]
 autoDiscovery = true
 
-[roles.planner.discovery.triggers]
+[roles.planner.triggers]
 labels = ["looper:plan"]
 labelMode = "all"
 requireAssigneeCurrentUser = true
@@ -445,7 +453,7 @@ labelMode = "all"
 [roles.worker.discovery]
 autoDiscovery = true
 
-[roles.worker.discovery.triggers]
+[roles.worker.triggers]
 labels = ["looper:worker-ready"]
 labelMode = "all"
 requireAssigneeCurrentUser = true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,6 +114,70 @@ All role-specific config lives under `roles.<role>`.
 - discovery policy lives at `roles.<role>.discovery.*`
 - runtime behavior lives at `roles.<role>.behavior.*` when that split is useful for the role
 
+## Coordinator config reference
+
+Coordinator is the proactive, stateless issue-intake role. In slice 2 it owns Triage end-to-end; Dispatch remains scaffolded for the next slice, but its config shape is already present.
+
+### Triage settings
+
+Coordinator triage lives under `roles.coordinator.triage.*`:
+
+| Path | Purpose | Default |
+| --- | --- | --- |
+| `roles.coordinator.enabled` | Turns Coordinator on for the project or globally | `false` |
+| `roles.coordinator.pollInterval` | Minimum delay between Coordinator ticks for the same project | `"5m"` |
+| `roles.coordinator.triage.triagedLabel` | Durability-commit label written last after comment posting succeeds | `"triaged"` |
+| `roles.coordinator.triage.maxIssueAgeDays` | Bootstrap guard for fresh issues only | `7` |
+| `roles.coordinator.triage.maxPerTick` | Per-tick cap on issues processed for triage | `5` |
+| `roles.coordinator.triage.disposition.outOfScopeLabel` | Label reused for `out-of-scope` | `"wontfix"` |
+| `roles.coordinator.triage.disposition.unclearLabel` | Label used for `unclear` | `"needs-info"` |
+| `roles.coordinator.triage.disposition.reTriageOnAuthorReply` | Re-opens the triage loop when the original author clarifies a `needs-info` issue | `true` |
+
+Coordinator clears and rewrites its own label namespace on each successful triage pass: `kind/*`, `area/*`, `complexity/*`, `dispatch/*`, `wontfix`, and `needs-info`. It then posts or edits the marker comment and writes `triaged` last.
+
+### Dispatch settings (scaffolded for slice 3)
+
+The full Coordinator config shape already includes `roles.coordinator.dispatch.*` so project overrides remain stable across slices:
+
+- `roles.coordinator.dispatch.mode`
+- `roles.coordinator.dispatch.humanGate.slashCommands`
+- `roles.coordinator.dispatch.humanGate.allowedUsers`
+- `roles.coordinator.dispatch.autonomous.delayMinutes`
+- `roles.coordinator.dispatch.autonomous.holdLabel`
+- `roles.coordinator.dispatch.assignTo`
+
+Slice 2 does not execute Dispatch yet, but these fields remain part of the canonical config and merge the same way as other project-level role overrides.
+
+Coordinator example:
+
+```toml
+[roles.coordinator]
+enabled = true
+pollInterval = "5m"
+
+[roles.coordinator.triage]
+triagedLabel = "triaged"
+maxIssueAgeDays = 7
+maxPerTick = 5
+
+[roles.coordinator.triage.disposition]
+outOfScopeLabel = "wontfix"
+unclearLabel = "needs-info"
+reTriageOnAuthorReply = true
+
+[roles.coordinator.dispatch]
+mode = "human-gated"
+assignTo = ""
+
+[roles.coordinator.dispatch.humanGate]
+slashCommands = ["/plan", "/implement"]
+allowedUsers = []
+
+[roles.coordinator.dispatch.autonomous]
+delayMinutes = 30
+holdLabel = "looper:hold"
+```
+
 Reviewer is the main migration example:
 
 - legacy top-level `reviewer.*` is compatibility input only
@@ -300,6 +364,32 @@ addSnapshotMode = "async"
 
 # `allowAutoApprove` is a legacy compatibility alias.
 # Prefer `roles.reviewer.behavior.reviewEvents.clean = "APPROVE"` in new config.
+
+[roles.coordinator]
+enabled = false
+pollInterval = "5m"
+
+[roles.coordinator.triage]
+triagedLabel = "triaged"
+maxIssueAgeDays = 7
+maxPerTick = 5
+
+[roles.coordinator.triage.disposition]
+outOfScopeLabel = "wontfix"
+unclearLabel = "needs-info"
+reTriageOnAuthorReply = true
+
+[roles.coordinator.dispatch]
+mode = "human-gated"
+assignTo = ""
+
+[roles.coordinator.dispatch.humanGate]
+slashCommands = ["/plan", "/implement"]
+allowedUsers = []
+
+[roles.coordinator.dispatch.autonomous]
+delayMinutes = 30
+holdLabel = "looper:hold"
 
 [roles.planner.discovery]
 autoDiscovery = true

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1,6 +1,6 @@
 # Looper Quick User Guide
 
-This guide is for everyday users. It focuses on how to use `planner`, `reviewer`, `fixer`, and `worker`, and how they interact with GitHub issues and PRs.
+This guide is for everyday users. It focuses on how `coordinator`, `planner`, `reviewer`, `fixer`, and `worker` interact with GitHub issues and PRs.
 
 ## 1. Prerequisites
 
@@ -42,6 +42,7 @@ If no project matches the current directory, or multiple projects match, pass `-
 
 | Role | Purpose | Common entrypoint |
 | --- | --- | --- |
+| `coordinator` | Proactively triages fresh issues and commits a Disposition with durable labels | runs automatically inside `looperd` |
 | `planner` | Generates a spec from an issue and opens a spec PR | `looper plan --project <id> --issue <num>` |
 | `reviewer` | Reviews a PR or spec PR and publishes GitHub reviews | `looper review <repo>#<pr> [--loop]` or `looper review <pr> [--loop]` from inside the repo |
 | `fixer` | Fixes PR issues based on review comments and tries to resolve threads | `looper fix <repo>#<pr>` |
@@ -62,7 +63,48 @@ If no project matches the current directory, or multiple projects match, pass `-
 
 This is the smoothest current Looper workflow.
 
-## 5. Planner: from issue to spec PR
+## 5. Coordinator: proactive triage on fresh issues
+
+Coordinator is Looper's intake role. It is proactive, not trigger-driven: on each poll it scans fresh open issues, runs a shallow repository-aware triage pass, then commits a durable Disposition back to GitHub.
+
+### What Coordinator writes
+
+For each fresh issue inside the configured bootstrap window, Coordinator picks one Disposition:
+
+- `valid`
+- `out-of-scope`
+- `unclear`
+
+It then:
+
+1. clears any prior coordinator-owned labels (`kind/*`, `area/*`, `complexity/*`, `dispatch/*`, `wontfix`, `needs-info`)
+2. applies the new labels for the chosen Disposition
+3. posts or edits a triage comment marked with `<!-- looper:coordinator:triage -->`
+4. applies `triaged` last as the durability commit
+
+The `triaged` label means Coordinator has formed an opinion about the issue. Because that label is written last, the triage action is safe to re-run after a partial failure.
+
+### Current triage outcomes
+
+- `valid` adds one each of `kind/*`, `area/*`, `complexity/*`, and `dispatch/*`
+- `out-of-scope` reuses the existing `wontfix` label and leaves the issue open
+- `unclear` adds `needs-info` and asks the author for clarification
+
+### Re-triage loop for `needs-info`
+
+If an issue is in the `unclear` state and the original author replies after `needs-info` was applied, Coordinator removes both `needs-info` and `triaged`. That returns the issue to the triage candidate set on a later poll without requiring the author to know Looper's label vocabulary.
+
+### Cross-role boundary
+
+Coordinator stays out of issues already under Sweeper lifecycle control. It skips issues carrying:
+
+- `roles.sweeper.lifecycle.pendingLabel`
+- `roles.sweeper.lifecycle.closedLabel`
+- `roles.sweeper.security.quarantineLabel`
+
+Sweeper, in turn, exempts active coordinator-managed issues such as `dispatch/*`, `needs-info`, and `looper:hold`.
+
+## 6. Planner: from issue to spec PR
 
 ### Start it manually
 
@@ -101,7 +143,7 @@ Planner will:
 
 If planner cannot assign the issue in GitHub, it reports a retryable failure rather than continuing with ambiguous ownership.
 
-## 6. Reviewer: review a spec PR or a normal PR
+## 7. Reviewer: review a spec PR or a normal PR
 
 ### One-time review
 
@@ -144,7 +186,7 @@ If reviewer considers the spec review clean, it will:
 - there are no unresolved review threads
 - the review decision is not `CHANGES_REQUESTED`
 
-## 7. Fixer: repair a PR based on review feedback
+## 8. Fixer: repair a PR based on review feedback
 
 The most direct way to use fixer is to start it for a specific PR:
 
@@ -174,7 +216,7 @@ If the PR is still in the spec review phase and the review becomes clean, fixer 
 
 In practice, `reviewer` and `fixer` often alternate until the spec PR is ready for `worker`.
 
-## 8. Worker: do the actual implementation
+## 9. Worker: do the actual implementation
 
 ### Start from an issue
 
@@ -213,12 +255,15 @@ When worker starts against a PR target, it first removes:
 
 That signals the PR has been claimed for implementation.
 
-## 9. How the GitHub label system works
+## 10. How the GitHub label system works
 
 These are the most important labels right now:
 
 | Label | Used on | Meaning |
 | --- | --- | --- |
+| `triaged` | issue | Coordinator finished triage and committed a Disposition |
+| `needs-info` | issue | Coordinator marked the issue `unclear` and is waiting for the author |
+| `dispatch/*` | issue | Coordinator's durable dispatch intent for later hand-off |
 | `looper:plan` | issue | This issue is eligible for planner auto-pickup |
 | `looper:spec-reviewing` | PR | This PR is in the spec review phase |
 | `looper:spec-ready` | PR | The spec is approved and ready for worker |
@@ -226,7 +271,7 @@ These are the most important labels right now:
 
 Treat these as stage signals, not just descriptive labels.
 
-## 10. How assign and review-request trigger automation
+## 11. How assign and review-request trigger automation
 
 The two most important assignment-related rules are:
 
@@ -250,7 +295,7 @@ Reviewer automatically pays attention to:
 
 The `looper:spec-reviewing` label is a phase marker; automatic review still requires a review request unless the loop was explicitly started locally.
 
-## 11. Common GitHub / PR commands
+## 12. Common GitHub / PR commands
 
 Inspect PRs:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -104,6 +104,51 @@ Coordinator stays out of issues already under Sweeper lifecycle control. It skip
 
 Sweeper, in turn, exempts active coordinator-managed issues such as `dispatch/*`, `needs-info`, and `looper:hold`.
 
+### Dispatch after triage
+
+Once an issue is already `triaged` and carries exactly one `dispatch/*` label, Coordinator can hand it off in one of two modes:
+
+- **human-gated** (default)
+- **autonomous**
+
+#### Human-gated slash commands
+
+Coordinator watches issue comments for slash commands at the **start of a line**:
+
+- `/plan` → applies the planner trigger label from `roles.planner.triggers.labels[0]`
+- `/implement` → applies the worker trigger label from `roles.worker.triggers.labels[0]`
+
+The commenter must either:
+
+- have repository permission `write`, `maintain`, or `admin`, or
+- be listed in `roles.coordinator.dispatch.humanGate.allowedUsers`
+
+On success, Coordinator:
+
+1. assigns `roles.coordinator.dispatch.assignTo` when configured
+2. applies the derived trigger label as the durability commit
+3. reacts 👍 on the slash-command comment
+
+If the trigger label is already present, Coordinator treats the command as an idempotent re-issue and still reacts 👍.
+
+If the issue is missing `triaged` or a matching `dispatch/*`, Coordinator reacts with GitHub's `confused` reaction and posts one short failure comment marked with `<!-- looper:coordinator:dispatch-failure -->`.
+
+#### Autonomous mode
+
+When `roles.coordinator.dispatch.mode = "autonomous"`, Coordinator no longer waits for a slash command. Instead it dispatches after the issue has stayed `triaged` for `roles.coordinator.dispatch.autonomous.delayMinutes`.
+
+Autonomous dispatch still derives the trigger label from Planner or Worker config and still writes that trigger label last.
+
+#### Veto signals
+
+Autonomous dispatch stops immediately when any veto signal is present:
+
+- the `dispatch/*` label is gone
+- the global hold label `looper:hold` (or the configured override) is present
+- the destination trigger label is already present because a human dispatched manually
+
+`looper:hold` is the operator-facing global hold contract for Coordinator dispatch.
+
 ## 6. Planner: from issue to spec PR
 
 ### Start it manually

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -674,6 +674,11 @@ func validateCoordinatorRoleConfig(config CoordinatorRoleConfig, path string, is
 	if len(config.Dispatch.HumanGate.SlashCommands) == 0 {
 		*issues = append(*issues, ValidationIssue{Path: path + ".dispatch.humanGate.slashCommands", Message: "must contain at least one slash command"})
 	}
+	for _, command := range config.Dispatch.HumanGate.SlashCommands {
+		if command != "/plan" && command != "/implement" {
+			*issues = append(*issues, ValidationIssue{Path: path + ".dispatch.humanGate.slashCommands", Message: fmt.Sprintf("contains unsupported slash command: %s", command)})
+		}
+	}
 	if config.Dispatch.Autonomous.DelayMinutes <= 0 {
 		*issues = append(*issues, ValidationIssue{Path: path + ".dispatch.autonomous.delayMinutes", Message: "must be a positive integer"})
 	}

--- a/internal/coordinator/agent_llm.go
+++ b/internal/coordinator/agent_llm.go
@@ -1,0 +1,54 @@
+package coordinator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nexu-io/looper/internal/agent"
+	"github.com/nexu-io/looper/internal/coordinator/triage"
+	"github.com/nexu-io/looper/internal/eventlog"
+)
+
+type agentLLM struct {
+	executor    *agent.ConfiguredExecutor
+	now         func() time.Time
+	timeout     time.Duration
+	idleTimeout time.Duration
+}
+
+func NewAgentLLM(executor *agent.ConfiguredExecutor, now func() time.Time, timeout time.Duration, idleTimeout time.Duration) triage.LLM {
+	if now == nil {
+		now = time.Now
+	}
+	return agentLLM{executor: executor, now: now, timeout: timeout, idleTimeout: idleTimeout}
+}
+
+func (l agentLLM) Complete(ctx context.Context, req triage.Request) (string, error) {
+	if l.executor == nil {
+		return "", fmt.Errorf("coordinator triage executor is not configured")
+	}
+	workingDir := strings.TrimSpace(req.WorkingDirectory)
+	if workingDir == "" {
+		return "", fmt.Errorf("coordinator triage working directory is required")
+	}
+	execHandle, err := l.executor.Start(ctx, agent.RunInput{
+		ExecutionID:      eventlog.NewEventID("coordtriage"),
+		Prompt:           req.Prompt,
+		WorkingDirectory: workingDir,
+		Timeout:          l.timeout,
+		HeartbeatTimeout: l.idleTimeout,
+	})
+	if err != nil {
+		return "", err
+	}
+	result, err := execHandle.Wait(ctx)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(result.Stdout) == "" {
+		return "", fmt.Errorf("coordinator triage returned empty stdout")
+	}
+	return strings.TrimSpace(result.Stdout), nil
+}

--- a/internal/coordinator/dispatch/autonomous_test.go
+++ b/internal/coordinator/dispatch/autonomous_test.go
@@ -9,7 +9,7 @@ func TestAutonomousGraceNotElapsedDoesNothing(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
 	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-29 * time.Minute)}, autonomousConfig(), now)
-	if !action.NoOp || action.TriggerLabel != "" {
+	if !action.NoOp || len(action.TriggerLabels) != 0 {
 		t.Fatalf("action = %#v, want no-op", action)
 	}
 }
@@ -18,8 +18,19 @@ func TestAutonomousGraceElapsedAppliesTrigger(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
 	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now)
-	if action.TriggerLabel != "looper:plan" || action.AssignTo != "octocat" {
+	if len(action.TriggerLabels) != 1 || action.TriggerLabels[0] != "looper:plan" || action.AssignTo != "octocat" {
 		t.Fatalf("action = %#v, want autonomous planner dispatch", action)
+	}
+}
+
+func TestAutonomousGraceElapsedAppliesAllPlannerTriggersWhenConfigured(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
+	cfg := autonomousConfig()
+	cfg.PlannerTriggerLabels = []string{"looper:plan", "team:planner"}
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-31 * time.Minute)}, cfg, now)
+	if len(action.TriggerLabels) != 2 || action.TriggerLabels[0] != "looper:plan" || action.TriggerLabels[1] != "team:planner" {
+		t.Fatalf("action = %#v, want all planner triggers", action)
 	}
 }
 
@@ -52,12 +63,12 @@ func TestAutonomousTriggerAlreadyPresentVetoesDispatch(t *testing.T) {
 
 func autonomousConfig() Config {
 	return Config{
-		Mode:                ModeAutonomous,
-		TriagedLabel:        "triaged",
-		HoldLabel:           "looper:hold",
-		AutonomousDelay:     30 * time.Minute,
-		AssignTo:            "octocat",
-		PlannerTriggerLabel: "looper:plan",
-		WorkerTriggerLabel:  "looper:worker-ready",
+		Mode:                 ModeAutonomous,
+		TriagedLabel:         "triaged",
+		HoldLabel:            "looper:hold",
+		AutonomousDelay:      30 * time.Minute,
+		AssignTo:             "octocat",
+		PlannerTriggerLabels: []string{"looper:plan"},
+		WorkerTriggerLabels:  []string{"looper:worker-ready"},
 	}
 }

--- a/internal/coordinator/dispatch/autonomous_test.go
+++ b/internal/coordinator/dispatch/autonomous_test.go
@@ -1,0 +1,63 @@
+package dispatch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAutonomousGraceNotElapsedDoesNothing(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-29 * time.Minute)}, autonomousConfig(), now)
+	if !action.NoOp || action.TriggerLabel != "" {
+		t.Fatalf("action = %#v, want no-op", action)
+	}
+}
+
+func TestAutonomousGraceElapsedAppliesTrigger(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now)
+	if action.TriggerLabel != "looper:plan" || action.AssignTo != "octocat" {
+		t.Fatalf("action = %#v, want autonomous planner dispatch", action)
+	}
+}
+
+func TestAutonomousDispatchRemovedDoesNothing(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
+	action := Decide(Issue{Labels: []string{"triaged"}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now)
+	if !action.NoOp {
+		t.Fatalf("action = %#v, want no-op", action)
+	}
+}
+
+func TestAutonomousHoldLabelVetoesDispatch(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan, "looper:hold"}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now)
+	if !action.NoOp {
+		t.Fatalf("action = %#v, want no-op", action)
+	}
+}
+
+func TestAutonomousTriggerAlreadyPresentVetoesDispatch(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan, "looper:plan"}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now)
+	if !action.NoOp {
+		t.Fatalf("action = %#v, want no-op", action)
+	}
+}
+
+func autonomousConfig() Config {
+	return Config{
+		Mode:                ModeAutonomous,
+		TriagedLabel:        "triaged",
+		HoldLabel:           "looper:hold",
+		AutonomousDelay:     30 * time.Minute,
+		AssignTo:            "octocat",
+		PlannerTriggerLabel: "looper:plan",
+		WorkerTriggerLabel:  "looper:worker-ready",
+	}
+}

--- a/internal/coordinator/dispatch/dispatch.go
+++ b/internal/coordinator/dispatch/dispatch.go
@@ -1,0 +1,241 @@
+package dispatch
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	ModeHumanGated = "human-gated"
+	ModeAutonomous = "autonomous"
+
+	DispatchPlan      = "dispatch/plan"
+	DispatchImplement = "dispatch/implement"
+
+	ReactionSuccess = "+1"
+	ReactionFailure = "confused"
+)
+
+type Comment struct {
+	ID                int64
+	Author            string
+	AuthorAssociation string
+	HasWriteAccess    bool
+	Body              string
+	CreatedAt         time.Time
+}
+
+type Issue struct {
+	Number    int64
+	Labels    []string
+	Comments  []Comment
+	TriagedAt time.Time
+}
+
+type Config struct {
+	Mode                string
+	TriagedLabel        string
+	HoldLabel           string
+	AutonomousDelay     time.Duration
+	AllowedUsers        []string
+	SlashCommands       []string
+	AssignTo            string
+	PlannerTriggerLabel string
+	WorkerTriggerLabel  string
+}
+
+type Action struct {
+	NoOp               bool
+	TriggerLabel       string
+	AssignTo           string
+	ReactionCommentID  int64
+	ReactionContent    string
+	FailureCommentBody string
+}
+
+func Decide(issue Issue, cfg Config, now time.Time) Action {
+	if cfg.Mode == ModeAutonomous {
+		return decideAutonomous(issue, cfg, now)
+	}
+	return decideHumanGated(issue, cfg)
+}
+
+func decideHumanGated(issue Issue, cfg Config) Action {
+	comment, command, ok := latestCommandAttempt(issue.Comments, cfg.SlashCommands)
+	if !ok {
+		return Action{NoOp: true}
+	}
+	if !isAllowedUser(comment, cfg.AllowedUsers) {
+		return Action{NoOp: true}
+	}
+
+	action := Action{ReactionCommentID: comment.ID}
+	if !hasLabel(issue.Labels, cfg.TriagedLabel) {
+		return fail(action, "Coordinator can't dispatch until triage finishes.")
+	}
+
+	dispatchLabel, ok := singleDispatchLabel(issue.Labels)
+	if !ok {
+		return fail(action, "Coordinator can't dispatch because triage did not set a dispatch label.")
+	}
+	if dispatchLabel != commandDispatchLabel(command) {
+		return fail(action, "Coordinator can't dispatch because the slash command does not match triage.")
+	}
+
+	triggerLabel := triggerLabelForDispatch(dispatchLabel, cfg)
+	if strings.TrimSpace(triggerLabel) == "" {
+		return fail(action, "Coordinator can't dispatch because the trigger label is not configured.")
+	}
+	if hasLabel(issue.Labels, triggerLabel) {
+		action.NoOp = true
+		action.ReactionContent = ReactionSuccess
+		return action
+	}
+
+	action.AssignTo = strings.TrimSpace(cfg.AssignTo)
+	action.TriggerLabel = triggerLabel
+	action.ReactionContent = ReactionSuccess
+	return action
+}
+
+func decideAutonomous(issue Issue, cfg Config, now time.Time) Action {
+	if !hasLabel(issue.Labels, cfg.TriagedLabel) {
+		return Action{NoOp: true}
+	}
+	dispatchLabel, ok := singleDispatchLabel(issue.Labels)
+	if !ok {
+		return Action{NoOp: true}
+	}
+	triggerLabel := triggerLabelForDispatch(dispatchLabel, cfg)
+	if strings.TrimSpace(triggerLabel) == "" {
+		return Action{NoOp: true}
+	}
+	if hasLabel(issue.Labels, strings.TrimSpace(cfg.HoldLabel)) || hasLabel(issue.Labels, triggerLabel) {
+		return Action{NoOp: true}
+	}
+	if issue.TriagedAt.IsZero() || now.UTC().Before(issue.TriagedAt.UTC().Add(cfg.AutonomousDelay)) {
+		return Action{NoOp: true}
+	}
+	return Action{AssignTo: strings.TrimSpace(cfg.AssignTo), TriggerLabel: triggerLabel}
+}
+
+func fail(action Action, body string) Action {
+	action.NoOp = true
+	action.ReactionContent = ReactionFailure
+	action.FailureCommentBody = strings.TrimSpace(body)
+	return action
+}
+
+func latestCommandAttempt(comments []Comment, slashCommands []string) (Comment, string, bool) {
+	for index := len(comments) - 1; index >= 0; index-- {
+		comment := comments[index]
+		command, ok := ParseSlashCommand(comment.Body, slashCommands)
+		if !ok {
+			continue
+		}
+		return comment, command, true
+	}
+	return Comment{}, "", false
+}
+func ParseSlashCommand(body string, configured []string) (string, bool) {
+	allowed := configuredCommands(configured)
+	inFence := false
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence || strings.HasPrefix(trimmed, ">") {
+			continue
+		}
+		switch {
+		case allowed["/plan"] && strings.HasPrefix(trimmed, "/plan") && commandBoundary(trimmed, len("/plan")):
+			return "/plan", true
+		case allowed["/implement"] && strings.HasPrefix(trimmed, "/implement") && commandBoundary(trimmed, len("/implement")):
+			return "/implement", true
+		}
+	}
+	return "", false
+}
+
+func configuredCommands(configured []string) map[string]bool {
+	allowed := map[string]bool{"/plan": false, "/implement": false}
+	for _, command := range configured {
+		command = strings.TrimSpace(command)
+		if _, ok := allowed[command]; ok {
+			allowed[command] = true
+		}
+	}
+	return allowed
+}
+
+func commandBoundary(value string, index int) bool {
+	if len(value) == index {
+		return true
+	}
+	switch value[index] {
+	case ' ', '\t', '\r':
+		return true
+	default:
+		return false
+	}
+}
+
+func isAllowedUser(comment Comment, allowedUsers []string) bool {
+	for _, user := range allowedUsers {
+		if strings.EqualFold(strings.TrimSpace(user), comment.Author) {
+			return true
+		}
+	}
+	return comment.HasWriteAccess
+}
+
+func singleDispatchLabel(labels []string) (string, bool) {
+	match := ""
+	for _, label := range labels {
+		if !strings.HasPrefix(label, "dispatch/") {
+			continue
+		}
+		if match != "" {
+			return "", false
+		}
+		match = label
+	}
+	return match, match != ""
+}
+
+func triggerLabelForDispatch(dispatchLabel string, cfg Config) string {
+	switch dispatchLabel {
+	case DispatchPlan:
+		return strings.TrimSpace(cfg.PlannerTriggerLabel)
+	case DispatchImplement:
+		return strings.TrimSpace(cfg.WorkerTriggerLabel)
+	default:
+		return ""
+	}
+}
+
+func commandDispatchLabel(command string) string {
+	switch command {
+	case "/plan":
+		return DispatchPlan
+	case "/implement":
+		return DispatchImplement
+	default:
+		return ""
+	}
+}
+
+func hasLabel(labels []string, want string) bool {
+	want = strings.TrimSpace(want)
+	if want == "" {
+		return false
+	}
+	for _, label := range labels {
+		if label == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/coordinator/dispatch/dispatch.go
+++ b/internal/coordinator/dispatch/dispatch.go
@@ -61,11 +61,8 @@ func Decide(issue Issue, cfg Config, now time.Time) Action {
 }
 
 func decideHumanGated(issue Issue, cfg Config) Action {
-	comment, command, ok := latestCommandAttempt(issue.Comments, cfg.SlashCommands)
+	comment, command, ok := latestCommandAttempt(issue.Comments, cfg.SlashCommands, cfg.AllowedUsers)
 	if !ok {
-		return Action{NoOp: true}
-	}
-	if !isAllowedUser(comment, cfg.AllowedUsers) {
 		return Action{NoOp: true}
 	}
 
@@ -126,11 +123,14 @@ func fail(action Action, body string) Action {
 	return action
 }
 
-func latestCommandAttempt(comments []Comment, slashCommands []string) (Comment, string, bool) {
+func latestCommandAttempt(comments []Comment, slashCommands []string, allowedUsers []string) (Comment, string, bool) {
 	for index := len(comments) - 1; index >= 0; index-- {
 		comment := comments[index]
 		command, ok := ParseSlashCommand(comment.Body, slashCommands)
 		if !ok {
+			continue
+		}
+		if !isAllowedUser(comment, allowedUsers) {
 			continue
 		}
 		return comment, command, true

--- a/internal/coordinator/dispatch/dispatch.go
+++ b/internal/coordinator/dispatch/dispatch.go
@@ -33,20 +33,20 @@ type Issue struct {
 }
 
 type Config struct {
-	Mode                string
-	TriagedLabel        string
-	HoldLabel           string
-	AutonomousDelay     time.Duration
-	AllowedUsers        []string
-	SlashCommands       []string
-	AssignTo            string
-	PlannerTriggerLabel string
-	WorkerTriggerLabel  string
+	Mode                 string
+	TriagedLabel         string
+	HoldLabel            string
+	AutonomousDelay      time.Duration
+	AllowedUsers         []string
+	SlashCommands        []string
+	AssignTo             string
+	PlannerTriggerLabels []string
+	WorkerTriggerLabels  []string
 }
 
 type Action struct {
 	NoOp               bool
-	TriggerLabel       string
+	TriggerLabels      []string
 	AssignTo           string
 	ReactionCommentID  int64
 	ReactionContent    string
@@ -79,18 +79,19 @@ func decideHumanGated(issue Issue, cfg Config) Action {
 		return fail(action, "Coordinator can't dispatch because the slash command does not match triage.")
 	}
 
-	triggerLabel := triggerLabelForDispatch(dispatchLabel, cfg)
-	if strings.TrimSpace(triggerLabel) == "" {
+	triggerLabels := triggerLabelsForDispatch(dispatchLabel, cfg)
+	if len(triggerLabels) == 0 {
 		return fail(action, "Coordinator can't dispatch because the trigger label is not configured.")
 	}
-	if hasLabel(issue.Labels, triggerLabel) {
+	missingLabels := missingLabels(issue.Labels, triggerLabels)
+	if len(missingLabels) == 0 {
 		action.NoOp = true
 		action.ReactionContent = ReactionSuccess
 		return action
 	}
 
 	action.AssignTo = strings.TrimSpace(cfg.AssignTo)
-	action.TriggerLabel = triggerLabel
+	action.TriggerLabels = missingLabels
 	action.ReactionContent = ReactionSuccess
 	return action
 }
@@ -103,17 +104,17 @@ func decideAutonomous(issue Issue, cfg Config, now time.Time) Action {
 	if !ok {
 		return Action{NoOp: true}
 	}
-	triggerLabel := triggerLabelForDispatch(dispatchLabel, cfg)
-	if strings.TrimSpace(triggerLabel) == "" {
+	triggerLabels := triggerLabelsForDispatch(dispatchLabel, cfg)
+	if len(triggerLabels) == 0 {
 		return Action{NoOp: true}
 	}
-	if hasLabel(issue.Labels, strings.TrimSpace(cfg.HoldLabel)) || hasLabel(issue.Labels, triggerLabel) {
+	if hasLabel(issue.Labels, strings.TrimSpace(cfg.HoldLabel)) || len(missingLabels(issue.Labels, triggerLabels)) == 0 {
 		return Action{NoOp: true}
 	}
 	if issue.TriagedAt.IsZero() || now.UTC().Before(issue.TriagedAt.UTC().Add(cfg.AutonomousDelay)) {
 		return Action{NoOp: true}
 	}
-	return Action{AssignTo: strings.TrimSpace(cfg.AssignTo), TriggerLabel: triggerLabel}
+	return Action{AssignTo: strings.TrimSpace(cfg.AssignTo), TriggerLabels: missingLabels(issue.Labels, triggerLabels)}
 }
 
 func fail(action Action, body string) Action {
@@ -205,15 +206,36 @@ func singleDispatchLabel(labels []string) (string, bool) {
 	return match, match != ""
 }
 
-func triggerLabelForDispatch(dispatchLabel string, cfg Config) string {
+func triggerLabelsForDispatch(dispatchLabel string, cfg Config) []string {
 	switch dispatchLabel {
 	case DispatchPlan:
-		return strings.TrimSpace(cfg.PlannerTriggerLabel)
+		return compactLabels(cfg.PlannerTriggerLabels)
 	case DispatchImplement:
-		return strings.TrimSpace(cfg.WorkerTriggerLabel)
+		return compactLabels(cfg.WorkerTriggerLabels)
 	default:
-		return ""
+		return nil
 	}
+}
+
+func compactLabels(labels []string) []string {
+	out := make([]string, 0, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label != "" {
+			out = append(out, label)
+		}
+	}
+	return out
+}
+
+func missingLabels(existing []string, want []string) []string {
+	missing := make([]string, 0, len(want))
+	for _, label := range want {
+		if !hasLabel(existing, label) {
+			missing = append(missing, label)
+		}
+	}
+	return missing
 }
 
 func commandDispatchLabel(command string) string {

--- a/internal/coordinator/dispatch/human_test.go
+++ b/internal/coordinator/dispatch/human_test.go
@@ -37,6 +37,17 @@ func TestHumanGatedPlanFromNonAllowedUserDoesNothing(t *testing.T) {
 	}
 }
 
+func TestHumanGatedSkipsNewerUnauthorizedCommandAttempt(t *testing.T) {
+	t.Parallel()
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{
+		{ID: 44, Author: "octo", HasWriteAccess: true, Body: "/plan"},
+		{ID: 45, Author: "outsider", Body: "/implement"},
+	}}, testConfig(), time.Now())
+	if action.TriggerLabel != "looper:plan" || action.AssignTo != "octocat" || action.ReactionCommentID != 44 || action.ReactionContent != ReactionSuccess {
+		t.Fatalf("action = %#v, want latest authorized command to dispatch", action)
+	}
+}
+
 func TestHumanGatedTriggerAlreadyPresentIsIdempotent(t *testing.T) {
 	t.Parallel()
 	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan, "looper:plan"}, Comments: []Comment{{ID: 45, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())

--- a/internal/coordinator/dispatch/human_test.go
+++ b/internal/coordinator/dispatch/human_test.go
@@ -1,0 +1,75 @@
+package dispatch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHumanGatedPlanByAllowedUserAppliesPlannerTrigger(t *testing.T) {
+	t.Parallel()
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 41, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
+	if action.TriggerLabel != "looper:plan" || action.AssignTo != "octocat" || action.ReactionCommentID != 41 || action.ReactionContent != ReactionSuccess {
+		t.Fatalf("action = %#v, want planner dispatch with success reaction", action)
+	}
+}
+
+func TestHumanGatedImplementAppliesWorkerTrigger(t *testing.T) {
+	t.Parallel()
+	action := Decide(Issue{Labels: []string{"triaged", DispatchImplement}, Comments: []Comment{{ID: 42, Author: "octo", HasWriteAccess: true, Body: "/implement"}}}, testConfig(), time.Now())
+	if action.TriggerLabel != "looper:worker-ready" || action.ReactionContent != ReactionSuccess {
+		t.Fatalf("action = %#v, want worker dispatch with success reaction", action)
+	}
+}
+
+func TestHumanGatedPlanMidLineDoesNothing(t *testing.T) {
+	t.Parallel()
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 43, Author: "octo", HasWriteAccess: true, Body: "please /plan this"}}}, testConfig(), time.Now())
+	if !action.NoOp || action.ReactionCommentID != 0 || action.TriggerLabel != "" {
+		t.Fatalf("action = %#v, want no-op", action)
+	}
+}
+
+func TestHumanGatedPlanFromNonAllowedUserDoesNothing(t *testing.T) {
+	t.Parallel()
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 44, Author: "outsider", Body: "/plan"}}}, testConfig(), time.Now())
+	if !action.NoOp || action.ReactionCommentID != 0 {
+		t.Fatalf("action = %#v, want no-op", action)
+	}
+}
+
+func TestHumanGatedTriggerAlreadyPresentIsIdempotent(t *testing.T) {
+	t.Parallel()
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan, "looper:plan"}, Comments: []Comment{{ID: 45, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
+	if !action.NoOp || action.TriggerLabel != "" || action.ReactionContent != ReactionSuccess || action.ReactionCommentID != 45 {
+		t.Fatalf("action = %#v, want idempotent success ack", action)
+	}
+}
+
+func TestHumanGatedMissingTriagedFails(t *testing.T) {
+	t.Parallel()
+	action := Decide(Issue{Labels: []string{DispatchPlan}, Comments: []Comment{{ID: 46, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
+	if action.ReactionContent != ReactionFailure || action.FailureCommentBody == "" || action.TriggerLabel != "" {
+		t.Fatalf("action = %#v, want failure reaction with comment", action)
+	}
+}
+
+func TestHumanGatedMissingDispatchFails(t *testing.T) {
+	t.Parallel()
+	action := Decide(Issue{Labels: []string{"triaged"}, Comments: []Comment{{ID: 47, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
+	if action.ReactionContent != ReactionFailure || action.FailureCommentBody == "" {
+		t.Fatalf("action = %#v, want failure reaction with comment", action)
+	}
+}
+
+func testConfig() Config {
+	return Config{
+		Mode:                ModeHumanGated,
+		TriagedLabel:        "triaged",
+		HoldLabel:           "looper:hold",
+		AutonomousDelay:     30 * time.Minute,
+		SlashCommands:       []string{"/plan", "/implement"},
+		AssignTo:            "octocat",
+		PlannerTriggerLabel: "looper:plan",
+		WorkerTriggerLabel:  "looper:worker-ready",
+	}
+}

--- a/internal/coordinator/dispatch/human_test.go
+++ b/internal/coordinator/dispatch/human_test.go
@@ -8,7 +8,7 @@ import (
 func TestHumanGatedPlanByAllowedUserAppliesPlannerTrigger(t *testing.T) {
 	t.Parallel()
 	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 41, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
-	if action.TriggerLabel != "looper:plan" || action.AssignTo != "octocat" || action.ReactionCommentID != 41 || action.ReactionContent != ReactionSuccess {
+	if len(action.TriggerLabels) != 1 || action.TriggerLabels[0] != "looper:plan" || action.AssignTo != "octocat" || action.ReactionCommentID != 41 || action.ReactionContent != ReactionSuccess {
 		t.Fatalf("action = %#v, want planner dispatch with success reaction", action)
 	}
 }
@@ -16,7 +16,7 @@ func TestHumanGatedPlanByAllowedUserAppliesPlannerTrigger(t *testing.T) {
 func TestHumanGatedImplementAppliesWorkerTrigger(t *testing.T) {
 	t.Parallel()
 	action := Decide(Issue{Labels: []string{"triaged", DispatchImplement}, Comments: []Comment{{ID: 42, Author: "octo", HasWriteAccess: true, Body: "/implement"}}}, testConfig(), time.Now())
-	if action.TriggerLabel != "looper:worker-ready" || action.ReactionContent != ReactionSuccess {
+	if len(action.TriggerLabels) != 1 || action.TriggerLabels[0] != "looper:worker-ready" || action.ReactionContent != ReactionSuccess {
 		t.Fatalf("action = %#v, want worker dispatch with success reaction", action)
 	}
 }
@@ -24,7 +24,7 @@ func TestHumanGatedImplementAppliesWorkerTrigger(t *testing.T) {
 func TestHumanGatedPlanMidLineDoesNothing(t *testing.T) {
 	t.Parallel()
 	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 43, Author: "octo", HasWriteAccess: true, Body: "please /plan this"}}}, testConfig(), time.Now())
-	if !action.NoOp || action.ReactionCommentID != 0 || action.TriggerLabel != "" {
+	if !action.NoOp || action.ReactionCommentID != 0 || len(action.TriggerLabels) != 0 {
 		t.Fatalf("action = %#v, want no-op", action)
 	}
 }
@@ -43,7 +43,7 @@ func TestHumanGatedSkipsNewerUnauthorizedCommandAttempt(t *testing.T) {
 		{ID: 44, Author: "octo", HasWriteAccess: true, Body: "/plan"},
 		{ID: 45, Author: "outsider", Body: "/implement"},
 	}}, testConfig(), time.Now())
-	if action.TriggerLabel != "looper:plan" || action.AssignTo != "octocat" || action.ReactionCommentID != 44 || action.ReactionContent != ReactionSuccess {
+	if len(action.TriggerLabels) != 1 || action.TriggerLabels[0] != "looper:plan" || action.AssignTo != "octocat" || action.ReactionCommentID != 44 || action.ReactionContent != ReactionSuccess {
 		t.Fatalf("action = %#v, want latest authorized command to dispatch", action)
 	}
 }
@@ -51,7 +51,7 @@ func TestHumanGatedSkipsNewerUnauthorizedCommandAttempt(t *testing.T) {
 func TestHumanGatedTriggerAlreadyPresentIsIdempotent(t *testing.T) {
 	t.Parallel()
 	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan, "looper:plan"}, Comments: []Comment{{ID: 45, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
-	if !action.NoOp || action.TriggerLabel != "" || action.ReactionContent != ReactionSuccess || action.ReactionCommentID != 45 {
+	if !action.NoOp || len(action.TriggerLabels) != 0 || action.ReactionContent != ReactionSuccess || action.ReactionCommentID != 45 {
 		t.Fatalf("action = %#v, want idempotent success ack", action)
 	}
 }
@@ -59,8 +59,18 @@ func TestHumanGatedTriggerAlreadyPresentIsIdempotent(t *testing.T) {
 func TestHumanGatedMissingTriagedFails(t *testing.T) {
 	t.Parallel()
 	action := Decide(Issue{Labels: []string{DispatchPlan}, Comments: []Comment{{ID: 46, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
-	if action.ReactionContent != ReactionFailure || action.FailureCommentBody == "" || action.TriggerLabel != "" {
+	if action.ReactionContent != ReactionFailure || action.FailureCommentBody == "" || len(action.TriggerLabels) != 0 {
 		t.Fatalf("action = %#v, want failure reaction with comment", action)
+	}
+}
+
+func TestHumanGatedPlanAppliesAllPlannerTriggersWhenConfigured(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.PlannerTriggerLabels = []string{"looper:plan", "team:planner"}
+	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 48, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, cfg, time.Now())
+	if len(action.TriggerLabels) != 2 || action.TriggerLabels[0] != "looper:plan" || action.TriggerLabels[1] != "team:planner" {
+		t.Fatalf("action = %#v, want all planner triggers", action)
 	}
 }
 
@@ -74,13 +84,13 @@ func TestHumanGatedMissingDispatchFails(t *testing.T) {
 
 func testConfig() Config {
 	return Config{
-		Mode:                ModeHumanGated,
-		TriagedLabel:        "triaged",
-		HoldLabel:           "looper:hold",
-		AutonomousDelay:     30 * time.Minute,
-		SlashCommands:       []string{"/plan", "/implement"},
-		AssignTo:            "octocat",
-		PlannerTriggerLabel: "looper:plan",
-		WorkerTriggerLabel:  "looper:worker-ready",
+		Mode:                 ModeHumanGated,
+		TriagedLabel:         "triaged",
+		HoldLabel:            "looper:hold",
+		AutonomousDelay:      30 * time.Minute,
+		SlashCommands:        []string{"/plan", "/implement"},
+		AssignTo:             "octocat",
+		PlannerTriggerLabels: []string{"looper:plan"},
+		WorkerTriggerLabels:  []string{"looper:worker-ready"},
 	}
 }

--- a/internal/coordinator/runner.go
+++ b/internal/coordinator/runner.go
@@ -2,12 +2,25 @@ package coordinator
 
 import (
 	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/nexu-io/looper/internal/bootstrap"
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/coordinator/triage"
+	"github.com/nexu-io/looper/internal/disclosure"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/storage"
 )
+
+const jsISOStringLayout = "2006-01-02T15:04:05.000Z"
+
+const triageCommentMarker = "<!-- looper:coordinator:triage -->"
 
 type DiscoveryInput struct {
 	ProjectID string
@@ -20,17 +33,45 @@ type DiscoveryResult struct {
 }
 
 type IssueSummary struct {
+	Number int64
 	Labels []string
 }
 
+type GitHubGateway interface {
+	ListOpenIssues(context.Context, githubinfra.ListOpenIssuesInput) ([]githubinfra.IssueSummary, error)
+	ViewIssue(context.Context, githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error)
+	ListIssueComments(context.Context, githubinfra.ViewIssueInput) ([]githubinfra.CommentInfo, error)
+	ListIssueTimeline(context.Context, githubinfra.IssueTimelineInput) ([]map[string]any, error)
+	AddIssueLabels(context.Context, githubinfra.IssueLabelsInput) error
+	RemoveIssueLabels(context.Context, githubinfra.IssueLabelsInput) error
+	CreateIssueComment(context.Context, githubinfra.IssueCommentInput) (githubinfra.IssueCommentResult, error)
+	UpdateIssueComment(context.Context, githubinfra.UpdateIssueCommentInput) error
+}
+
+type RepositoryInspector interface {
+	Inspect(context.Context, string, triage.Issue) (triage.RepoContext, error)
+}
+
 type Options struct {
-	Config *config.Config
-	Now    func() time.Time
+	Repos      *storage.Repositories
+	GitHub     GitHubGateway
+	Config     *config.Config
+	Logger     bootstrap.Logger
+	Now        func() time.Time
+	TriageLLM  triage.LLM
+	Inspector  RepositoryInspector
+	Disclosure *config.DisclosureConfig
 }
 
 type Runner struct {
-	config *config.Config
-	now    func() time.Time
+	repos      *storage.Repositories
+	github     GitHubGateway
+	config     *config.Config
+	logger     bootstrap.Logger
+	now        func() time.Time
+	triageLLM  triage.LLM
+	inspector  RepositoryInspector
+	disclosure *config.DisclosureConfig
 
 	mu                sync.Mutex
 	lastTickByProject map[string]time.Time
@@ -41,12 +82,75 @@ func New(options Options) *Runner {
 	if now == nil {
 		now = time.Now
 	}
-	return &Runner{config: options.Config, now: now, lastTickByProject: map[string]time.Time{}}
+	inspector := options.Inspector
+	if inspector == nil {
+		inspector = localRepositoryInspector{}
+	}
+	return &Runner{
+		repos:             options.Repos,
+		github:            options.GitHub,
+		config:            options.Config,
+		logger:            options.Logger,
+		now:               now,
+		triageLLM:         options.TriageLLM,
+		inspector:         inspector,
+		disclosure:        options.Disclosure,
+		lastTickByProject: map[string]time.Time{},
+	}
 }
 
-func (r *Runner) DiscoverIssues(_ context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
 	if !r.shouldRunTick(input.ProjectID) {
 		return DiscoveryResult{Skipped: true}, nil
+	}
+	if r.github == nil {
+		return DiscoveryResult{Ticked: true}, nil
+	}
+	if r.repos == nil || r.repos.Projects == nil {
+		return DiscoveryResult{}, fmt.Errorf("coordinator repositories are not configured")
+	}
+	project, roleCfg, sweeperCfg, err := r.projectConfig(ctx, input.ProjectID)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if project.Archived || !roleCfg.Enabled {
+		return DiscoveryResult{Skipped: true}, nil
+	}
+	issues, err := r.github.ListOpenIssues(ctx, githubinfra.ListOpenIssuesInput{Repo: input.Repo, CWD: project.RepoPath, Limit: 100})
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	triageCfg := roleConfigToTriageConfig(roleCfg)
+	processed := 0
+	for _, summary := range issues {
+		if processed >= triageCfg.MaxPerTick {
+			break
+		}
+		if ShouldSkipIssue(IssueSummary{Number: summary.Number, Labels: summary.Labels}, roleCfg, sweeperCfg) {
+			continue
+		}
+		if !mightNeedCoordinatorAction(summary, triageCfg) {
+			continue
+		}
+		issue, err := r.loadIssue(ctx, input.Repo, project.RepoPath, summary.Number)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		if !triage.ShouldReTriage(issue, triageCfg, r.now().UTC()) && !triage.ShouldTriage(issue, triageCfg, r.now().UTC()) {
+			continue
+		}
+		analysisStartedAt := r.now().UTC()
+		processed++
+		decision, err := r.decide(ctx, project.RepoPath, input.Repo, issue, triageCfg)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		if decision.NoOp {
+			continue
+		}
+		if err := r.applyDecision(ctx, input.Repo, project.RepoPath, issue, triageCfg, analysisStartedAt, decision); err != nil {
+			return DiscoveryResult{}, err
+		}
 	}
 	return DiscoveryResult{Ticked: true}, nil
 }
@@ -56,9 +160,124 @@ func (r *Runner) DiscoverIssues(_ context.Context, input DiscoveryInput) (Discov
 // retired, or quarantined so the two roles never fight over authority.
 func ShouldSkipIssue(issue IssueSummary, roleCfg config.CoordinatorRoleConfig, sweeperCfg config.SweeperRoleConfig) bool {
 	_ = roleCfg
-	return hasLabel(issue.Labels, sweeperCfg.Lifecycle.PendingLabel) ||
-		hasLabel(issue.Labels, sweeperCfg.Lifecycle.ClosedLabel) ||
-		hasLabel(issue.Labels, sweeperCfg.Security.QuarantineLabel)
+	return hasExactLabel(issue.Labels, sweeperCfg.Lifecycle.PendingLabel) ||
+		hasExactLabel(issue.Labels, sweeperCfg.Lifecycle.ClosedLabel) ||
+		hasExactLabel(issue.Labels, sweeperCfg.Security.QuarantineLabel)
+}
+
+func (r *Runner) decide(ctx context.Context, repoPath string, repo string, issue triage.Issue, cfg triage.Config) (triage.Decision, error) {
+	if triage.ShouldReTriage(issue, cfg, r.now().UTC()) {
+		return triage.ReTriageDecision(cfg), nil
+	}
+	if !triage.ShouldTriage(issue, cfg, r.now().UTC()) {
+		return triage.NoOpDecision(), nil
+	}
+	repoCtx, err := r.inspector.Inspect(ctx, repoPath, issue)
+	if err != nil {
+		return triage.Decision{}, err
+	}
+	repoCtx.Repo = repo
+	repoCtx.WorkingDirectory = repoPath
+	return triage.Decide(ctx, r.triageLLM, triage.Input{Issue: issue, RepoContext: repoCtx, Config: cfg, Now: r.now().UTC()}), nil
+}
+
+func (r *Runner) applyDecision(ctx context.Context, repo string, cwd string, issue triage.Issue, cfg triage.Config, analysisStartedAt time.Time, decision triage.Decision) error {
+	if err := r.removeIssueLabels(ctx, repo, cwd, issue.Number, issue.Labels, decision.ClearLabelPatterns); err != nil {
+		return err
+	}
+	if err := r.removeIssueLabels(ctx, repo, cwd, issue.Number, issue.Labels, decision.RemoveLabels); err != nil {
+		return err
+	}
+	applyNow := removeExactLabels(decision.ApplyLabels, cfg.TriagedLabel)
+	if len(applyNow) > 0 {
+		if err := r.github.AddIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: repo, IssueNumber: issue.Number, Labels: applyNow, CWD: cwd}); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(decision.CommentBody) != "" {
+		if err := r.postOrEditComment(ctx, repo, cwd, issue, analysisStartedAt, decision.CommentBody); err != nil {
+			return err
+		}
+	}
+	if decision.MarkTriaged && !hasExactLabel(issue.Labels, cfg.TriagedLabel) {
+		if err := r.github.AddIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: repo, IssueNumber: issue.Number, Labels: []string{cfg.TriagedLabel}, CWD: cwd}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Runner) postOrEditComment(ctx context.Context, repo, cwd string, issue triage.Issue, analysisStartedAt time.Time, body string) error {
+	comments, err := r.github.ListIssueComments(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: issue.Number, CWD: cwd})
+	if err != nil {
+		return err
+	}
+	existing := findMarkerComment(comments)
+	if hasNewHumanComment(comments, analysisStartedAt) {
+		return nil
+	}
+	commentBody := triageCommentMarker + "\n\n" + body
+	stamper := disclosure.FromConfig(*r.config)
+	commentBody = stamper.Markdown(commentBody, "coordinator", disclosure.ChannelIssueComment)
+	if existing != nil {
+		return r.github.UpdateIssueComment(ctx, githubinfra.UpdateIssueCommentInput{Repo: repo, CommentID: existing.ID, Body: commentBody, CWD: cwd})
+	}
+	_, err = r.github.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: repo, IssueNumber: issue.Number, Body: commentBody, CWD: cwd})
+	return err
+}
+
+func (r *Runner) removeIssueLabels(ctx context.Context, repo, cwd string, issueNumber int64, existing []string, patterns []string) error {
+	labels := matchingLabels(existing, patterns)
+	if len(labels) == 0 {
+		return nil
+	}
+	return r.github.RemoveIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: repo, IssueNumber: issueNumber, Labels: labels, CWD: cwd})
+}
+
+func (r *Runner) loadIssue(ctx context.Context, repo, cwd string, issueNumber int64) (triage.Issue, error) {
+	detail, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: issueNumber, CWD: cwd})
+	if err != nil {
+		return triage.Issue{}, err
+	}
+	comments, err := r.github.ListIssueComments(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: issueNumber, CWD: cwd})
+	if err != nil {
+		return triage.Issue{}, err
+	}
+	timeline, err := r.github.ListIssueTimeline(ctx, githubinfra.IssueTimelineInput{Repo: repo, IssueNumber: issueNumber, CWD: cwd})
+	if err != nil {
+		return triage.Issue{}, err
+	}
+	issue := triage.Issue{
+		Number:    detail.Number,
+		Title:     detail.Title,
+		Body:      detail.Body,
+		URL:       detail.URL,
+		Author:    detail.Author,
+		CreatedAt: detail.CreatedAt,
+		UpdatedAt: detail.UpdatedAt,
+		Labels:    append([]string(nil), detail.Labels...),
+		Comments:  make([]triage.Comment, 0, len(comments)),
+		Timeline:  make([]triage.TimelineEvent, 0, len(timeline)),
+	}
+	for _, comment := range comments {
+		issue.Comments = append(issue.Comments, triage.Comment{ID: comment.ID, Author: comment.Author, Body: comment.Body, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt})
+	}
+	for _, event := range timeline {
+		issue.Timeline = append(issue.Timeline, triage.TimelineEvent{Event: strings.TrimSpace(asString(event["event"])), CreatedAt: firstNonEmpty(asString(event["created_at"]), asString(event["createdAt"])), Label: timelineLabelName(event)})
+	}
+	return issue, nil
+}
+
+func (r *Runner) projectConfig(ctx context.Context, projectID string) (*storage.ProjectRecord, config.CoordinatorRoleConfig, config.SweeperRoleConfig, error) {
+	project, err := r.repos.Projects.GetByID(ctx, projectID)
+	if err != nil {
+		return nil, config.CoordinatorRoleConfig{}, config.SweeperRoleConfig{}, err
+	}
+	if project == nil {
+		return nil, config.CoordinatorRoleConfig{}, config.SweeperRoleConfig{}, fmt.Errorf("project %q not found", projectID)
+	}
+	roles := config.ProjectRoleConfigs(*r.config, projectID)
+	return project, roles.Coordinator, roles.Sweeper, nil
 }
 
 func (r *Runner) shouldRunTick(projectID string) bool {
@@ -89,11 +308,180 @@ func (r *Runner) pollInterval(projectID string) time.Duration {
 	return interval
 }
 
-func hasLabel(labels []string, want string) bool {
+func roleConfigToTriageConfig(roleCfg config.CoordinatorRoleConfig) triage.Config {
+	return triage.Config{
+		TriagedLabel:          roleCfg.Triage.TriagedLabel,
+		MaxIssueAgeDays:       roleCfg.Triage.MaxIssueAgeDays,
+		MaxPerTick:            roleCfg.Triage.MaxPerTick,
+		OutOfScopeLabel:       roleCfg.Triage.Disposition.OutOfScopeLabel,
+		UnclearLabel:          roleCfg.Triage.Disposition.UnclearLabel,
+		ReTriageOnAuthorReply: roleCfg.Triage.Disposition.ReTriageOnAuthorReply,
+	}
+}
+
+func mightNeedCoordinatorAction(issue githubinfra.IssueSummary, cfg triage.Config) bool {
+	return !hasExactLabel(issue.Labels, cfg.TriagedLabel) || hasExactLabel(issue.Labels, cfg.UnclearLabel)
+}
+
+func matchingLabels(existing []string, patterns []string) []string {
+	matched := []string{}
+	for _, label := range existing {
+		for _, pattern := range patterns {
+			if labelMatchesPattern(label, pattern) {
+				matched = append(matched, label)
+				break
+			}
+		}
+	}
+	return matched
+}
+
+func removeExactLabels(labels []string, target string) []string {
+	result := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if label != target {
+			result = append(result, label)
+		}
+	}
+	return result
+}
+
+func labelMatchesPattern(label string, pattern string) bool {
+	if strings.HasSuffix(pattern, "/*") {
+		return strings.HasPrefix(label, strings.TrimSuffix(pattern, "*"))
+	}
+	return label == pattern
+}
+
+func hasExactLabel(labels []string, want string) bool {
 	for _, label := range labels {
 		if label == want {
 			return true
 		}
 	}
 	return false
+}
+
+func findMarkerComment(comments []githubinfra.CommentInfo) *githubinfra.CommentInfo {
+	for index := range comments {
+		if strings.Contains(comments[index].Body, triageCommentMarker) {
+			return &comments[index]
+		}
+	}
+	return nil
+}
+
+func hasNewHumanComment(comments []githubinfra.CommentInfo, since time.Time) bool {
+	for _, comment := range comments {
+		if strings.Contains(comment.Body, triageCommentMarker) || disclosure.HasMarkdownStamp(comment.Body) {
+			continue
+		}
+		when, ok := parseCoordinatorTime(comment.CreatedAt)
+		if ok && when.After(since) {
+			return true
+		}
+	}
+	return false
+}
+
+func timelineLabelName(event map[string]any) string {
+	label, _ := event["label"].(map[string]any)
+	return strings.TrimSpace(asString(label["name"]))
+}
+
+func parseCoordinatorTime(raw string) (time.Time, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, jsISOStringLayout} {
+		parsed, err := time.Parse(layout, raw)
+		if err == nil {
+			return parsed.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func asString(value any) string {
+	if value == nil {
+		return ""
+	}
+	if s, ok := value.(string); ok {
+		return s
+	}
+	return fmt.Sprint(value)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+type localRepositoryInspector struct{}
+
+func (localRepositoryInspector) Inspect(_ context.Context, repoPath string, issue triage.Issue) (triage.RepoContext, error) {
+	ctx := triage.RepoContext{WorkingDirectory: repoPath}
+	tokens := triage.SearchTokens(issue)
+	if repoPath == "" {
+		return ctx, nil
+	}
+	_ = filepath.WalkDir(repoPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || len(ctx.Paths) >= 12 && len(ctx.Symbols) >= 12 {
+			return nil
+		}
+		if d.IsDir() {
+			base := d.Name()
+			if base == ".git" || base == "node_modules" || base == "dist" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if ext := strings.ToLower(filepath.Ext(path)); ext != ".go" && ext != ".md" && ext != ".txt" && ext != ".json" && ext != ".yaml" && ext != ".yml" && ext != ".toml" {
+			return nil
+		}
+		rel, relErr := filepath.Rel(repoPath, path)
+		if relErr != nil {
+			rel = path
+		}
+		lowerRel := strings.ToLower(rel)
+		for _, token := range tokens {
+			if strings.Contains(lowerRel, token) {
+				if len(ctx.Paths) < 12 {
+					ctx.Paths = append(ctx.Paths, rel)
+				}
+				break
+			}
+		}
+		if len(ctx.Symbols) >= 12 {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr == nil && info.Size() > 256*1024 {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		for _, line := range strings.Split(string(content), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if !strings.HasPrefix(trimmed, "func ") && !strings.HasPrefix(trimmed, "type ") && !strings.HasPrefix(trimmed, "const ") && !strings.HasPrefix(trimmed, "var ") {
+				continue
+			}
+			lowerLine := strings.ToLower(trimmed)
+			for _, token := range tokens {
+				if strings.Contains(lowerLine, token) {
+					ctx.Symbols = append(ctx.Symbols, rel+": "+trimmed)
+					return nil
+				}
+			}
+		}
+		return nil
+	})
+	return ctx, nil
 }

--- a/internal/coordinator/runner.go
+++ b/internal/coordinator/runner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nexu-io/looper/internal/bootstrap"
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/coordinator/dispatch"
 	"github.com/nexu-io/looper/internal/coordinator/triage"
 	"github.com/nexu-io/looper/internal/disclosure"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
@@ -21,6 +22,7 @@ import (
 const jsISOStringLayout = "2006-01-02T15:04:05.000Z"
 
 const triageCommentMarker = "<!-- looper:coordinator:triage -->"
+const dispatchFailureCommentMarker = "<!-- looper:coordinator:dispatch-failure -->"
 
 type DiscoveryInput struct {
 	ProjectID string
@@ -42,7 +44,12 @@ type GitHubGateway interface {
 	ViewIssue(context.Context, githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error)
 	ListIssueComments(context.Context, githubinfra.ViewIssueInput) ([]githubinfra.CommentInfo, error)
 	ListIssueTimeline(context.Context, githubinfra.IssueTimelineInput) ([]map[string]any, error)
+	GetCurrentUserLogin(context.Context, string) (string, error)
+	GetCurrentUserLoginForRepo(context.Context, string, string) (string, error)
+	GetRepositoryPermission(context.Context, githubinfra.RepositoryPermissionInput) (string, error)
+	AddIssueAssignees(context.Context, githubinfra.IssueAssigneesInput) error
 	AddIssueLabels(context.Context, githubinfra.IssueLabelsInput) error
+	AddIssueReaction(context.Context, githubinfra.CreateIssueReactionInput) error
 	RemoveIssueLabels(context.Context, githubinfra.IssueLabelsInput) error
 	CreateIssueComment(context.Context, githubinfra.IssueCommentInput) (githubinfra.IssueCommentResult, error)
 	UpdateIssueComment(context.Context, githubinfra.UpdateIssueCommentInput) error
@@ -121,20 +128,34 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 		return DiscoveryResult{}, err
 	}
 	triageCfg := roleConfigToTriageConfig(roleCfg)
+	dispatchCfg := roleConfigToDispatchConfig(roleCfg, config.ProjectRoleConfigs(*r.config, input.ProjectID))
 	processed := 0
 	for _, summary := range issues {
-		if processed >= triageCfg.MaxPerTick {
-			break
-		}
 		if ShouldSkipIssue(IssueSummary{Number: summary.Number, Labels: summary.Labels}, roleCfg, sweeperCfg) {
-			continue
-		}
-		if !mightNeedCoordinatorAction(summary, triageCfg) {
 			continue
 		}
 		issue, err := r.loadIssue(ctx, input.Repo, project.RepoPath, summary.Number)
 		if err != nil {
 			return DiscoveryResult{}, err
+		}
+		dispatchIssue, err := r.dispatchIssue(ctx, input.Repo, project.RepoPath, issue, triageCfg.TriagedLabel, dispatchCfg)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		dispatchAction := dispatch.Decide(dispatchIssue, dispatchCfg, r.now().UTC())
+		if r.hasDispatchWork(dispatchAction) {
+			if err := r.applyDispatchAction(ctx, input.Repo, project.RepoPath, issue, dispatchAction); err != nil {
+				return DiscoveryResult{}, err
+			}
+			if strings.TrimSpace(dispatchAction.FailureCommentBody) == "" {
+				continue
+			}
+		}
+		if processed >= triageCfg.MaxPerTick {
+			continue
+		}
+		if !mightNeedCoordinatorAction(summary, triageCfg) {
+			continue
 		}
 		if !triage.ShouldReTriage(issue, triageCfg, r.now().UTC()) && !triage.ShouldTriage(issue, triageCfg, r.now().UTC()) {
 			continue
@@ -153,6 +174,10 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 		}
 	}
 	return DiscoveryResult{Ticked: true}, nil
+}
+
+func (r *Runner) hasDispatchWork(action dispatch.Action) bool {
+	return action.ReactionCommentID != 0 || action.TriggerLabel != "" || action.FailureCommentBody != ""
 }
 
 // ShouldSkipIssue reserves the structural cross-role boundary with Sweeper.
@@ -207,12 +232,45 @@ func (r *Runner) applyDecision(ctx context.Context, repo string, cwd string, iss
 	return nil
 }
 
+func (r *Runner) applyDispatchAction(ctx context.Context, repo string, cwd string, issue triage.Issue, action dispatch.Action) error {
+	if strings.TrimSpace(action.FailureCommentBody) != "" {
+		if err := r.postOrEditDispatchFailureComment(ctx, repo, cwd, issue.Number, action.FailureCommentBody); err != nil {
+			return err
+		}
+		if action.ReactionCommentID != 0 && strings.TrimSpace(action.ReactionContent) != "" {
+			return r.github.AddIssueReaction(ctx, githubinfra.CreateIssueReactionInput{Repo: repo, CommentID: action.ReactionCommentID, Content: action.ReactionContent, CWD: cwd})
+		}
+		return nil
+	}
+	if strings.TrimSpace(action.AssignTo) != "" {
+		if err := r.github.AddIssueAssignees(ctx, githubinfra.IssueAssigneesInput{Repo: repo, IssueNumber: issue.Number, Assignees: []string{action.AssignTo}, CWD: cwd}); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(action.TriggerLabel) != "" && !hasExactLabel(issue.Labels, action.TriggerLabel) {
+		if err := r.github.AddIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: repo, IssueNumber: issue.Number, Labels: []string{action.TriggerLabel}, CWD: cwd}); err != nil {
+			return err
+		}
+	}
+	if action.ReactionCommentID != 0 && strings.TrimSpace(action.ReactionContent) != "" {
+		if err := r.github.AddIssueReaction(ctx, githubinfra.CreateIssueReactionInput{Repo: repo, CommentID: action.ReactionCommentID, Content: action.ReactionContent, CWD: cwd}); err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
 func (r *Runner) postOrEditComment(ctx context.Context, repo, cwd string, issue triage.Issue, analysisStartedAt time.Time, body string) error {
 	comments, err := r.github.ListIssueComments(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: issue.Number, CWD: cwd})
 	if err != nil {
 		return err
 	}
-	existing := findMarkerComment(comments)
+	currentLogin, err := r.github.GetCurrentUserLoginForRepo(ctx, repo, cwd)
+	if err != nil {
+		return err
+	}
+	existing := findMarkerComment(comments, currentLogin)
 	if hasNewHumanComment(comments, analysisStartedAt) {
 		return nil
 	}
@@ -223,6 +281,26 @@ func (r *Runner) postOrEditComment(ctx context.Context, repo, cwd string, issue 
 		return r.github.UpdateIssueComment(ctx, githubinfra.UpdateIssueCommentInput{Repo: repo, CommentID: existing.ID, Body: commentBody, CWD: cwd})
 	}
 	_, err = r.github.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: repo, IssueNumber: issue.Number, Body: commentBody, CWD: cwd})
+	return err
+}
+
+func (r *Runner) postOrEditDispatchFailureComment(ctx context.Context, repo, cwd string, issueNumber int64, body string) error {
+	comments, err := r.github.ListIssueComments(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: issueNumber, CWD: cwd})
+	if err != nil {
+		return err
+	}
+	currentLogin, err := r.github.GetCurrentUserLoginForRepo(ctx, repo, cwd)
+	if err != nil {
+		return err
+	}
+	existing := findDispatchFailureComment(comments, currentLogin)
+	commentBody := dispatchFailureCommentMarker + "\n\n" + strings.TrimSpace(body)
+	stamper := disclosure.FromConfig(*r.config)
+	commentBody = stamper.Markdown(commentBody, "coordinator", disclosure.ChannelIssueComment)
+	if existing != nil {
+		return r.github.UpdateIssueComment(ctx, githubinfra.UpdateIssueCommentInput{Repo: repo, CommentID: existing.ID, Body: commentBody, CWD: cwd})
+	}
+	_, err = r.github.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: repo, IssueNumber: issueNumber, Body: commentBody, CWD: cwd})
 	return err
 }
 
@@ -239,10 +317,6 @@ func (r *Runner) loadIssue(ctx context.Context, repo, cwd string, issueNumber in
 	if err != nil {
 		return triage.Issue{}, err
 	}
-	comments, err := r.github.ListIssueComments(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: issueNumber, CWD: cwd})
-	if err != nil {
-		return triage.Issue{}, err
-	}
 	timeline, err := r.github.ListIssueTimeline(ctx, githubinfra.IssueTimelineInput{Repo: repo, IssueNumber: issueNumber, CWD: cwd})
 	if err != nil {
 		return triage.Issue{}, err
@@ -256,16 +330,88 @@ func (r *Runner) loadIssue(ctx context.Context, repo, cwd string, issueNumber in
 		CreatedAt: detail.CreatedAt,
 		UpdatedAt: detail.UpdatedAt,
 		Labels:    append([]string(nil), detail.Labels...),
-		Comments:  make([]triage.Comment, 0, len(comments)),
+		Comments:  make([]triage.Comment, 0, len(detail.Comments)),
 		Timeline:  make([]triage.TimelineEvent, 0, len(timeline)),
 	}
-	for _, comment := range comments {
-		issue.Comments = append(issue.Comments, triage.Comment{ID: comment.ID, Author: comment.Author, Body: comment.Body, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt})
+	for _, comment := range detail.Comments {
+		issue.Comments = append(issue.Comments, triage.Comment{ID: comment.ID, Author: comment.Author, AuthorAssociation: comment.AuthorAssociation, Body: comment.Body, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt})
 	}
 	for _, event := range timeline {
 		issue.Timeline = append(issue.Timeline, triage.TimelineEvent{Event: strings.TrimSpace(asString(event["event"])), CreatedAt: firstNonEmpty(asString(event["created_at"]), asString(event["createdAt"])), Label: timelineLabelName(event)})
 	}
 	return issue, nil
+}
+
+func roleConfigToDispatchConfig(roleCfg config.CoordinatorRoleConfig, roles config.RoleConfigs) dispatch.Config {
+	return dispatch.Config{
+		Mode:                roleCfg.Dispatch.Mode,
+		TriagedLabel:        roleCfg.Triage.TriagedLabel,
+		HoldLabel:           roleCfg.Dispatch.Autonomous.HoldLabel,
+		AutonomousDelay:     time.Duration(roleCfg.Dispatch.Autonomous.DelayMinutes) * time.Minute,
+		AllowedUsers:        append([]string(nil), roleCfg.Dispatch.HumanGate.AllowedUsers...),
+		SlashCommands:       append([]string(nil), roleCfg.Dispatch.HumanGate.SlashCommands...),
+		AssignTo:            roleCfg.Dispatch.AssignTo,
+		PlannerTriggerLabel: firstRoleTrigger(roles.Planner.Triggers.Labels),
+		WorkerTriggerLabel:  firstRoleTrigger(roles.Worker.Triggers.Labels),
+	}
+}
+
+func firstRoleTrigger(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	return labels[0]
+}
+
+func (r *Runner) dispatchIssue(ctx context.Context, repo, cwd string, issue triage.Issue, triagedLabel string, cfg dispatch.Config) (dispatch.Issue, error) {
+	out := dispatch.Issue{Number: issue.Number, Labels: append([]string(nil), issue.Labels...), Comments: make([]dispatch.Comment, 0, len(issue.Comments))}
+	permissionCache := map[string]bool{}
+	for _, comment := range issue.Comments {
+		createdAt, _ := parseCoordinatorTime(comment.CreatedAt)
+		hasWriteAccess := false
+		if cfg.Mode == dispatch.ModeHumanGated {
+			if _, ok := dispatch.ParseSlashCommand(comment.Body, cfg.SlashCommands); ok {
+				allowed, err := r.commentHasWriteAccess(ctx, repo, cwd, comment.Author, permissionCache, cfg)
+				if err != nil {
+					return dispatch.Issue{}, err
+				}
+				hasWriteAccess = allowed
+			}
+		}
+		out.Comments = append(out.Comments, dispatch.Comment{ID: comment.ID, Author: comment.Author, AuthorAssociation: comment.AuthorAssociation, HasWriteAccess: hasWriteAccess, Body: comment.Body, CreatedAt: createdAt})
+	}
+	for _, event := range issue.Timeline {
+		if event.Event != "labeled" || event.Label != triagedLabel {
+			continue
+		}
+		when, ok := parseCoordinatorTime(event.CreatedAt)
+		if ok && (out.TriagedAt.IsZero() || when.After(out.TriagedAt)) {
+			out.TriagedAt = when
+		}
+	}
+	return out, nil
+}
+
+func (r *Runner) commentHasWriteAccess(ctx context.Context, repo, cwd, author string, cache map[string]bool, cfg dispatch.Config) (bool, error) {
+	author = strings.TrimSpace(author)
+	if author == "" {
+		return false, nil
+	}
+	for _, allowed := range cfg.AllowedUsers {
+		if strings.EqualFold(strings.TrimSpace(allowed), author) {
+			return true, nil
+		}
+	}
+	if allowed, ok := cache[strings.ToLower(author)]; ok {
+		return allowed, nil
+	}
+	permission, err := r.github.GetRepositoryPermission(ctx, githubinfra.RepositoryPermissionInput{Repo: repo, User: author, CWD: cwd})
+	if err != nil {
+		return false, nil
+	}
+	allowed := permission == "admin" || permission == "maintain" || permission == "write"
+	cache[strings.ToLower(author)] = allowed
+	return allowed, nil
 }
 
 func (r *Runner) projectConfig(ctx context.Context, projectID string) (*storage.ProjectRecord, config.CoordinatorRoleConfig, config.SweeperRoleConfig, error) {
@@ -362,9 +508,24 @@ func hasExactLabel(labels []string, want string) bool {
 	return false
 }
 
-func findMarkerComment(comments []githubinfra.CommentInfo) *githubinfra.CommentInfo {
+func findMarkerComment(comments []githubinfra.CommentInfo, currentLogin string) *githubinfra.CommentInfo {
 	for index := range comments {
-		if strings.Contains(comments[index].Body, triageCommentMarker) {
+		if !strings.Contains(comments[index].Body, triageCommentMarker) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(comments[index].Author), strings.TrimSpace(currentLogin)) {
+			return &comments[index]
+		}
+	}
+	return nil
+}
+
+func findDispatchFailureComment(comments []githubinfra.CommentInfo, currentLogin string) *githubinfra.CommentInfo {
+	for index := range comments {
+		if !strings.Contains(comments[index].Body, dispatchFailureCommentMarker) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(comments[index].Author), strings.TrimSpace(currentLogin)) {
 			return &comments[index]
 		}
 	}

--- a/internal/coordinator/runner.go
+++ b/internal/coordinator/runner.go
@@ -177,7 +177,7 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 }
 
 func (r *Runner) hasDispatchWork(action dispatch.Action) bool {
-	return action.ReactionCommentID != 0 || action.TriggerLabel != "" || action.FailureCommentBody != ""
+	return action.ReactionCommentID != 0 || len(action.TriggerLabels) != 0 || action.FailureCommentBody != ""
 }
 
 // ShouldSkipIssue reserves the structural cross-role boundary with Sweeper.
@@ -247,8 +247,9 @@ func (r *Runner) applyDispatchAction(ctx context.Context, repo string, cwd strin
 			return err
 		}
 	}
-	if strings.TrimSpace(action.TriggerLabel) != "" && !hasExactLabel(issue.Labels, action.TriggerLabel) {
-		if err := r.github.AddIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: repo, IssueNumber: issue.Number, Labels: []string{action.TriggerLabel}, CWD: cwd}); err != nil {
+	labelsToAdd := removeExistingLabels(action.TriggerLabels, issue.Labels)
+	if len(labelsToAdd) > 0 {
+		if err := r.github.AddIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: repo, IssueNumber: issue.Number, Labels: labelsToAdd, CWD: cwd}); err != nil {
 			return err
 		}
 	}
@@ -344,23 +345,26 @@ func (r *Runner) loadIssue(ctx context.Context, repo, cwd string, issueNumber in
 
 func roleConfigToDispatchConfig(roleCfg config.CoordinatorRoleConfig, roles config.RoleConfigs) dispatch.Config {
 	return dispatch.Config{
-		Mode:                roleCfg.Dispatch.Mode,
-		TriagedLabel:        roleCfg.Triage.TriagedLabel,
-		HoldLabel:           roleCfg.Dispatch.Autonomous.HoldLabel,
-		AutonomousDelay:     time.Duration(roleCfg.Dispatch.Autonomous.DelayMinutes) * time.Minute,
-		AllowedUsers:        append([]string(nil), roleCfg.Dispatch.HumanGate.AllowedUsers...),
-		SlashCommands:       append([]string(nil), roleCfg.Dispatch.HumanGate.SlashCommands...),
-		AssignTo:            roleCfg.Dispatch.AssignTo,
-		PlannerTriggerLabel: firstRoleTrigger(roles.Planner.Triggers.Labels),
-		WorkerTriggerLabel:  firstRoleTrigger(roles.Worker.Triggers.Labels),
+		Mode:                 roleCfg.Dispatch.Mode,
+		TriagedLabel:         roleCfg.Triage.TriagedLabel,
+		HoldLabel:            roleCfg.Dispatch.Autonomous.HoldLabel,
+		AutonomousDelay:      time.Duration(roleCfg.Dispatch.Autonomous.DelayMinutes) * time.Minute,
+		AllowedUsers:         append([]string(nil), roleCfg.Dispatch.HumanGate.AllowedUsers...),
+		SlashCommands:        append([]string(nil), roleCfg.Dispatch.HumanGate.SlashCommands...),
+		AssignTo:             roleCfg.Dispatch.AssignTo,
+		PlannerTriggerLabels: requiredTriggerLabels(roles.Planner.Triggers),
+		WorkerTriggerLabels:  requiredTriggerLabels(roles.Worker.Triggers),
 	}
 }
 
-func firstRoleTrigger(labels []string) string {
-	if len(labels) == 0 {
-		return ""
+func requiredTriggerLabels(cfg config.IssueRoleTriggersConfig) []string {
+	if cfg.LabelMode == config.LabelModeAll {
+		return append([]string(nil), cfg.Labels...)
 	}
-	return labels[0]
+	if len(cfg.Labels) == 0 {
+		return nil
+	}
+	return []string{cfg.Labels[0]}
 }
 
 func (r *Runner) dispatchIssue(ctx context.Context, repo, cwd string, issue triage.Issue, triagedLabel string, cfg dispatch.Config) (dispatch.Issue, error) {
@@ -407,7 +411,7 @@ func (r *Runner) commentHasWriteAccess(ctx context.Context, repo, cwd, author st
 	}
 	permission, err := r.github.GetRepositoryPermission(ctx, githubinfra.RepositoryPermissionInput{Repo: repo, User: author, CWD: cwd})
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	allowed := permission == "admin" || permission == "maintain" || permission == "write"
 	cache[strings.ToLower(author)] = allowed
@@ -490,6 +494,16 @@ func removeExactLabels(labels []string, target string) []string {
 		}
 	}
 	return result
+}
+
+func removeExistingLabels(labels []string, existing []string) []string {
+	out := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if !hasExactLabel(existing, label) {
+			out = append(out, label)
+		}
+	}
+	return out
 }
 
 func labelMatchesPattern(label string, pattern string) bool {

--- a/internal/coordinator/runner_actions_test.go
+++ b/internal/coordinator/runner_actions_test.go
@@ -1,0 +1,222 @@
+package coordinator
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/coordinator/triage"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestDiscoverIssuesRespectsMaxPerTick(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Coordinator.Triage.MaxPerTick = 5
+	for i := 1; i <= 50; i++ {
+		fixture.github.issues = append(fixture.github.issues, githubinfra.IssueSummary{Number: int64(i), Labels: nil})
+		fixture.github.details[int64(i)] = githubinfra.IssueDetail{Number: int64(i), Title: "Issue", Author: "octo", CreatedAt: fixture.now.Format(time.RFC3339)}
+	}
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if got := countOperations(fixture.github.ops, "add:"); got != 10 {
+		t.Fatalf("label add operations = %d, want 10 (two per issue for five issues)", got)
+	}
+	if got := countOperations(fixture.github.ops, "create-comment"); got != 5 {
+		t.Fatalf("comment creates = %d, want 5", got)
+	}
+}
+
+func TestRunnerAppliesLabelsThenCommentThenTriaged(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Format(time.RFC3339)}
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	want := []string{"add:kind/bug,area/coordinator,complexity/m,dispatch/plan", "create-comment", "add:triaged"}
+	assertOrderedOps(t, fixture.github.ops, want)
+	if body := fixture.github.createdBodies[0]; !containsAll(body, triageCommentMarker, "<!-- looper:stamp v=1 -->", "runner=coordinator") {
+		t.Fatalf("comment body = %q, want coordinator marker and disclosure stamp", body)
+	}
+}
+
+func TestRunnerEditsExistingMarkerComment(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Format(time.RFC3339)}
+	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{{ID: 91, Body: triageCommentMarker + "\n\nOld"}}}
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(fixture.github.updatedBodies) != 1 || len(fixture.github.createdBodies) != 0 {
+		t.Fatalf("updated=%d created=%d, want edit-in-place only", len(fixture.github.updatedBodies), len(fixture.github.createdBodies))
+	}
+}
+
+func TestRunnerStaysSilentWhenHumanCommentsBeforePost(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Format(time.RFC3339)}
+	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{}, {{ID: 77, Author: "human", Body: "I triaged this", CreatedAt: fixture.now.Add(time.Second).Format(time.RFC3339)}}}
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(fixture.github.createdBodies) != 0 || len(fixture.github.updatedBodies) != 0 {
+		t.Fatal("runner posted or edited a comment after concurrent human triage")
+	}
+	assertOrderedOps(t, fixture.github.ops, []string{"add:kind/bug,area/coordinator,complexity/m,dispatch/plan", "add:triaged"})
+	if countOperations(fixture.github.ops, "add:triaged") != 1 {
+		t.Fatal("triaged label not applied")
+	}
+}
+
+type coordinatorFixture struct {
+	runner    *Runner
+	github    *stubCoordinatorGitHub
+	cfg       *config.Config
+	projectID string
+	now       time.Time
+	coord     *storage.SQLiteCoordinator
+}
+
+func newCoordinatorFixture(t *testing.T) coordinatorFixture {
+	t.Helper()
+	now := time.Date(2026, time.May, 14, 12, 0, 0, 0, time.UTC)
+	coord, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(t.TempDir(), "coordinator.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coord.Close() })
+	if _, err := coord.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coord.DB())
+	projectID := "demo"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Demo", RepoPath: t.TempDir(), CreatedAt: now.Format(time.RFC3339), UpdatedAt: now.Format(time.RFC3339)}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Disclosure.Enabled = true
+	cfg.Disclosure.Channels.IssueComment = true
+	github := &stubCoordinatorGitHub{details: map[int64]githubinfra.IssueDetail{}, comments: map[int64][][]githubinfra.CommentInfo{}, timeline: map[int64][]map[string]any{}}
+	runner := New(Options{Repos: repos, GitHub: github, Config: &cfg, Now: func() time.Time { return now }, TriageLLM: stubCoordinatorLLM{}, Inspector: stubCoordinatorInspector{}})
+	return coordinatorFixture{runner: runner, github: github, cfg: &cfg, projectID: projectID, now: now, coord: coord}
+}
+
+type stubCoordinatorLLM struct{}
+
+func (stubCoordinatorLLM) Complete(context.Context, triage.Request) (string, error) {
+	return `{"disposition":"valid","comment":"Looks actionable.","labels":{"kind":["kind/bug"],"area":["area/coordinator"],"complexity":["complexity/m"],"dispatch":["dispatch/plan"]}}`, nil
+}
+
+type stubCoordinatorInspector struct{}
+
+func (stubCoordinatorInspector) Inspect(context.Context, string, triage.Issue) (triage.RepoContext, error) {
+	return triage.RepoContext{Paths: []string{"internal/coordinator/runner.go"}, Symbols: []string{"internal/coordinator/runner.go: func DiscoverIssues"}}, nil
+}
+
+type stubCoordinatorGitHub struct {
+	issues        []githubinfra.IssueSummary
+	details       map[int64]githubinfra.IssueDetail
+	comments      map[int64][][]githubinfra.CommentInfo
+	timeline      map[int64][]map[string]any
+	ops           []string
+	createdBodies []string
+	updatedBodies []string
+	commentReads  map[int64]int
+}
+
+func (s *stubCoordinatorGitHub) ListOpenIssues(context.Context, githubinfra.ListOpenIssuesInput) ([]githubinfra.IssueSummary, error) {
+	return append([]githubinfra.IssueSummary(nil), s.issues...), nil
+}
+func (s *stubCoordinatorGitHub) ViewIssue(_ context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
+	return s.details[input.IssueNumber], nil
+}
+func (s *stubCoordinatorGitHub) ListIssueComments(_ context.Context, input githubinfra.ViewIssueInput) ([]githubinfra.CommentInfo, error) {
+	if s.commentReads == nil {
+		s.commentReads = map[int64]int{}
+	}
+	reads := s.commentReads[input.IssueNumber]
+	batches := s.comments[input.IssueNumber]
+	if len(batches) == 0 {
+		return nil, nil
+	}
+	if reads >= len(batches) {
+		reads = len(batches) - 1
+	}
+	s.commentReads[input.IssueNumber]++
+	return append([]githubinfra.CommentInfo(nil), batches[reads]...), nil
+}
+func (s *stubCoordinatorGitHub) ListIssueTimeline(_ context.Context, input githubinfra.IssueTimelineInput) ([]map[string]any, error) {
+	return s.timeline[input.IssueNumber], nil
+}
+func (s *stubCoordinatorGitHub) AddIssueLabels(_ context.Context, input githubinfra.IssueLabelsInput) error {
+	s.ops = append(s.ops, "add:"+joinLabels(input.Labels))
+	return nil
+}
+func (s *stubCoordinatorGitHub) RemoveIssueLabels(_ context.Context, input githubinfra.IssueLabelsInput) error {
+	s.ops = append(s.ops, "remove:"+joinLabels(input.Labels))
+	return nil
+}
+func (s *stubCoordinatorGitHub) CreateIssueComment(_ context.Context, input githubinfra.IssueCommentInput) (githubinfra.IssueCommentResult, error) {
+	s.ops = append(s.ops, "create-comment")
+	s.createdBodies = append(s.createdBodies, input.Body)
+	return githubinfra.IssueCommentResult{ID: 1}, nil
+}
+func (s *stubCoordinatorGitHub) UpdateIssueComment(_ context.Context, input githubinfra.UpdateIssueCommentInput) error {
+	s.ops = append(s.ops, "update-comment")
+	s.updatedBodies = append(s.updatedBodies, input.Body)
+	return nil
+}
+
+func joinLabels(labels []string) string {
+	return strings.Join(labels, ",")
+}
+
+func countOperations(ops []string, prefix string) int {
+	count := 0
+	for _, op := range ops {
+		if strings.HasPrefix(op, prefix) {
+			count++
+		}
+	}
+	return count
+}
+
+func assertOrderedOps(t *testing.T, ops []string, want []string) {
+	t.Helper()
+	index := 0
+	for _, op := range ops {
+		if index < len(want) && op == want[index] {
+			index++
+		}
+	}
+	if index != len(want) {
+		t.Fatalf("ops = %v, want ordered subsequence %v", ops, want)
+	}
+}
+
+func containsAll(body string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(body, part) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/coordinator/runner_actions_test.go
+++ b/internal/coordinator/runner_actions_test.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -133,6 +134,42 @@ func TestRunnerAutonomousDispatchAppliesConfiguredPlannerTrigger(t *testing.T) {
 	assertOrderedOps(t, fixture.github.ops, []string{"assign:octocat", "add:my-custom-plan"})
 }
 
+func TestRunnerAutonomousDispatchAppliesAllConfiguredPlannerTriggersWhenLabelModeAll(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Coordinator.Dispatch.Mode = "autonomous"
+	fixture.runner.config.Roles.Coordinator.Dispatch.AssignTo = "octocat"
+	fixture.runner.config.Roles.Planner.Triggers.Labels = []string{"my-custom-plan", "team:planner"}
+	fixture.runner.config.Roles.Planner.Triggers.LabelMode = config.LabelModeAll
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged", "dispatch/plan"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Add(-2 * time.Hour).Format(time.RFC3339), Labels: []string{"triaged", "dispatch/plan"}}
+	fixture.github.timeline[1] = []map[string]any{{"event": "labeled", "created_at": fixture.now.Add(-time.Hour).Format(time.RFC3339), "label": map[string]any{"name": "triaged"}}}
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	assertOrderedOps(t, fixture.github.ops, []string{"assign:octocat", "add:my-custom-plan,team:planner"})
+}
+
+func TestRunnerDiscoverIssuesPropagatesRepositoryPermissionFailures(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.github.permissionErr = errors.New("permission lookup failed")
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged", "dispatch/plan"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339), Labels: []string{"triaged", "dispatch/plan"}, Comments: []githubinfra.CommentInfo{{ID: 11, Author: "octo", AuthorAssociation: "MEMBER", Body: "/plan", CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{{ID: 11, Author: "octo", AuthorAssociation: "MEMBER", Body: "/plan", CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	fixture.github.timeline[1] = []map[string]any{{"event": "labeled", "created_at": fixture.now.Add(-time.Hour).Format(time.RFC3339), "label": map[string]any{"name": "triaged"}}}
+
+	_, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"})
+	if err == nil || !strings.Contains(err.Error(), "permission lookup failed") {
+		t.Fatalf("DiscoverIssues() error = %v, want propagated repository permission failure", err)
+	}
+	if len(fixture.github.ops) != 0 {
+		t.Fatalf("ops = %v, want no dispatch side effects after permission failure", fixture.github.ops)
+	}
+}
+
 type coordinatorFixture struct {
 	runner    *Runner
 	github    *stubCoordinatorGitHub
@@ -186,6 +223,7 @@ type stubCoordinatorGitHub struct {
 	details       map[int64]githubinfra.IssueDetail
 	comments      map[int64][][]githubinfra.CommentInfo
 	timeline      map[int64][]map[string]any
+	permissionErr error
 	ops           []string
 	createdBodies []string
 	updatedBodies []string
@@ -223,6 +261,9 @@ func (s *stubCoordinatorGitHub) ListIssueTimeline(_ context.Context, input githu
 	return s.timeline[input.IssueNumber], nil
 }
 func (s *stubCoordinatorGitHub) GetRepositoryPermission(_ context.Context, input githubinfra.RepositoryPermissionInput) (string, error) {
+	if s.permissionErr != nil {
+		return "", s.permissionErr
+	}
 	if input.User == "octo" {
 		return "write", nil
 	}

--- a/internal/coordinator/runner_actions_test.go
+++ b/internal/coordinator/runner_actions_test.go
@@ -3,12 +3,14 @@ package coordinator
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/coordinator/triage"
+	"github.com/nexu-io/looper/internal/disclosure"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/storage"
 )
@@ -55,7 +57,8 @@ func TestRunnerEditsExistingMarkerComment(t *testing.T) {
 	fixture.runner.config.Roles.Coordinator.Enabled = true
 	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1}}
 	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Format(time.RFC3339)}
-	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{{ID: 91, Body: triageCommentMarker + "\n\nOld"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Format(time.RFC3339), Comments: []githubinfra.CommentInfo{{ID: 91, Author: "looper", Body: triageCommentMarker + "\n\nOld", CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{{ID: 91, Author: "looper", Body: stampedCoordinatorBody(fixture.cfg, triageCommentMarker+"\n\nOld"), CreatedAt: fixture.now.Format(time.RFC3339)}}}
 	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
 		t.Fatalf("DiscoverIssues() error = %v", err)
 	}
@@ -69,8 +72,8 @@ func TestRunnerStaysSilentWhenHumanCommentsBeforePost(t *testing.T) {
 	fixture := newCoordinatorFixture(t)
 	fixture.runner.config.Roles.Coordinator.Enabled = true
 	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1}}
-	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Format(time.RFC3339)}
-	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{}, {{ID: 77, Author: "human", Body: "I triaged this", CreatedAt: fixture.now.Add(time.Second).Format(time.RFC3339)}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Format(time.RFC3339), Comments: []githubinfra.CommentInfo{{ID: 77, Author: "human", Body: "I triaged this", CreatedAt: fixture.now.Add(time.Second).Format(time.RFC3339)}}}
+	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{{ID: 77, Author: "human", Body: "I triaged this", CreatedAt: fixture.now.Add(time.Second).Format(time.RFC3339)}}}
 	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
 		t.Fatalf("DiscoverIssues() error = %v", err)
 	}
@@ -81,6 +84,53 @@ func TestRunnerStaysSilentWhenHumanCommentsBeforePost(t *testing.T) {
 	if countOperations(fixture.github.ops, "add:triaged") != 1 {
 		t.Fatal("triaged label not applied")
 	}
+}
+
+func TestRunnerHumanDispatchOrdersAssignLabelReact(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Coordinator.Dispatch.AssignTo = "octocat"
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged", "dispatch/plan"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339), Labels: []string{"triaged", "dispatch/plan"}, Comments: []githubinfra.CommentInfo{{ID: 11, Author: "octo", AuthorAssociation: "MEMBER", Body: "/plan", CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{{ID: 11, Author: "octo", AuthorAssociation: "MEMBER", Body: "/plan", CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	fixture.github.timeline[1] = []map[string]any{{"event": "labeled", "created_at": fixture.now.Add(-time.Hour).Format(time.RFC3339), "label": map[string]any{"name": "triaged"}}}
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	assertOrderedOps(t, fixture.github.ops, []string{"assign:octocat", "add:looper:plan", "react:+1:11"})
+}
+
+func TestRunnerDispatchFailureDedupesMarkedComment(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Add(-10 * 24 * time.Hour).Format(time.RFC3339), Comments: []githubinfra.CommentInfo{{ID: 12, Author: "octo", AuthorAssociation: "MEMBER", Body: "/plan", CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{{ID: 12, Author: "octo", AuthorAssociation: "MEMBER", Body: "/plan", CreatedAt: fixture.now.Format(time.RFC3339)}, {ID: 99, Author: "looper", Body: stampedCoordinatorBody(fixture.cfg, dispatchFailureCommentMarker+"\n\nOld failure"), CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(fixture.github.createdBodies) != 0 || len(fixture.github.updatedBodies) != 1 {
+		t.Fatalf("created=%d updated=%d, want updated failure comment only", len(fixture.github.createdBodies), len(fixture.github.updatedBodies))
+	}
+	assertOrderedOps(t, fixture.github.ops, []string{"update-comment", "react:confused:12"})
+}
+
+func TestRunnerAutonomousDispatchAppliesConfiguredPlannerTrigger(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Coordinator.Dispatch.Mode = "autonomous"
+	fixture.runner.config.Roles.Coordinator.Dispatch.AssignTo = "octocat"
+	fixture.runner.config.Roles.Planner.Triggers.Labels = []string{"my-custom-plan"}
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged", "dispatch/plan"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Add(-2 * time.Hour).Format(time.RFC3339), Labels: []string{"triaged", "dispatch/plan"}}
+	fixture.github.timeline[1] = []map[string]any{{"event": "labeled", "created_at": fixture.now.Add(-time.Hour).Format(time.RFC3339), "label": map[string]any{"name": "triaged"}}}
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	assertOrderedOps(t, fixture.github.ops, []string{"assign:octocat", "add:my-custom-plan"})
 }
 
 type coordinatorFixture struct {
@@ -163,11 +213,31 @@ func (s *stubCoordinatorGitHub) ListIssueComments(_ context.Context, input githu
 	s.commentReads[input.IssueNumber]++
 	return append([]githubinfra.CommentInfo(nil), batches[reads]...), nil
 }
+func (s *stubCoordinatorGitHub) GetCurrentUserLogin(context.Context, string) (string, error) {
+	return "looper", nil
+}
+func (s *stubCoordinatorGitHub) GetCurrentUserLoginForRepo(context.Context, string, string) (string, error) {
+	return "looper", nil
+}
 func (s *stubCoordinatorGitHub) ListIssueTimeline(_ context.Context, input githubinfra.IssueTimelineInput) ([]map[string]any, error) {
 	return s.timeline[input.IssueNumber], nil
 }
+func (s *stubCoordinatorGitHub) GetRepositoryPermission(_ context.Context, input githubinfra.RepositoryPermissionInput) (string, error) {
+	if input.User == "octo" {
+		return "write", nil
+	}
+	return "read", nil
+}
+func (s *stubCoordinatorGitHub) AddIssueAssignees(_ context.Context, input githubinfra.IssueAssigneesInput) error {
+	s.ops = append(s.ops, "assign:"+joinLabels(input.Assignees))
+	return nil
+}
 func (s *stubCoordinatorGitHub) AddIssueLabels(_ context.Context, input githubinfra.IssueLabelsInput) error {
 	s.ops = append(s.ops, "add:"+joinLabels(input.Labels))
+	return nil
+}
+func (s *stubCoordinatorGitHub) AddIssueReaction(_ context.Context, input githubinfra.CreateIssueReactionInput) error {
+	s.ops = append(s.ops, "react:"+input.Content+":"+intToString(input.CommentID))
 	return nil
 }
 func (s *stubCoordinatorGitHub) RemoveIssueLabels(_ context.Context, input githubinfra.IssueLabelsInput) error {
@@ -219,4 +289,12 @@ func containsAll(body string, parts ...string) bool {
 		}
 	}
 	return true
+}
+
+func intToString(value int64) string {
+	return strconv.FormatInt(value, 10)
+}
+
+func stampedCoordinatorBody(cfg *config.Config, body string) string {
+	return disclosure.FromConfig(*cfg).Markdown(body, "coordinator", disclosure.ChannelIssueComment)
 }

--- a/internal/coordinator/runner_integration_test.go
+++ b/internal/coordinator/runner_integration_test.go
@@ -76,6 +76,109 @@ func TestCoordinatorHappyPathWithFakeGH(t *testing.T) {
 	}
 }
 
+func TestCoordinatorHumanDispatchWithFakeGH(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	fakeGH := harness.NewFakeGH(t, bins, harness.GHSchema{JSONFieldAllowlist: map[string][]string{"issue list": {"number", "title", "body", "url", "state", "updatedAt", "author", "assignees", "labels"}}})
+	for key, value := range fakeGH.EnvMap() {
+		t.Setenv(key, value)
+	}
+	fakeGH.WriteState(t, harness.GHState{Commands: map[string]any{"issue list": map[string]any{"stdout": json.RawMessage(`[{"number":2,"title":"Coordinator bug","body":"dispatch me","url":"https://example.test/issues/2","state":"open","updatedAt":"2026-05-14T12:00:00Z","author":{"login":"octo"},"assignees":[],"labels":[{"name":"triaged"},{"name":"dispatch/plan"}]}]`)}, "label create": map[string]any{"stdout": json.RawMessage(`{}`)}}, Routes: map[string]any{
+		"repos/acme/looper/issues/2":                      json.RawMessage(`{"number":2,"title":"Coordinator bug","body":"dispatch me","html_url":"https://example.test/issues/2","state":"open","created_at":"2026-05-14T11:00:00Z","updated_at":"2026-05-14T12:00:00Z","user":{"login":"octo"},"labels":[{"name":"triaged"},{"name":"dispatch/plan"}]}`),
+		"repos/acme/looper/issues/2/comments":             json.RawMessage(`[[{"id":17,"body":"/plan","created_at":"2026-05-14T12:00:00Z","user":{"login":"octo"},"author_association":"MEMBER"}]]`),
+		"repos/acme/looper/issues/2/timeline":             json.RawMessage(`[[{"event":"labeled","created_at":"2026-05-14T11:30:00Z","label":{"name":"triaged"}}]]`),
+		"repos/acme/looper/collaborators/octo/permission": json.RawMessage(`{"permission":"write"}`),
+	}})
+
+	coord, repos, cfg, repoPath, now := coordinatorFakeGHFixture(t)
+	_ = coord
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.Dispatch.AssignTo = "octocat"
+	gateway := githubinfra.New(githubinfra.Options{GHPath: fakeGH.Path, CWD: repoPath, Now: func() time.Time { return now }})
+	runner := New(Options{Repos: repos, GitHub: gateway, Config: &cfg, Now: func() time.Time { return now }, TriageLLM: stubCoordinatorLLM{}, Inspector: stubCoordinatorInspector{}})
+
+	if _, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "demo", Repo: "acme/looper"}); err != nil {
+		logBytes, _ := os.ReadFile(fakeGH.InvocationLog)
+		t.Fatalf("DiscoverIssues() error = %v\ninvocations:\n%s", err, string(logBytes))
+	}
+	logBytes, err := os.ReadFile(fakeGH.InvocationLog)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation log) error = %v", err)
+	}
+	assertOrderedText(t, string(logBytes),
+		`"argv":["api","repos/acme/looper/issues/2/assignees","--method","POST","-f","assignees[]=octocat"]`,
+		`"argv":["label","create","looper:plan"`,
+		`"argv":["api","repos/acme/looper/issues/2/labels","--method","POST","-f","labels[]=looper:plan"]`,
+		`"argv":["api","repos/acme/looper/issues/comments/17/reactions","--method","POST","-H","Accept: application/vnd.github+json","-f","content=+1"]`,
+	)
+	if strings.Contains(string(logBytes), dispatchFailureCommentMarker) {
+		t.Fatal("dispatch happy path unexpectedly posted failure comment")
+	}
+}
+
+func TestCoordinatorAutonomousDispatchWithFakeGH(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	fakeGH := harness.NewFakeGH(t, bins, harness.GHSchema{JSONFieldAllowlist: map[string][]string{"issue list": {"number", "title", "body", "url", "state", "updatedAt", "author", "assignees", "labels"}}})
+	for key, value := range fakeGH.EnvMap() {
+		t.Setenv(key, value)
+	}
+	fakeGH.WriteState(t, harness.GHState{Commands: map[string]any{"issue list": map[string]any{"stdout": json.RawMessage(`[{"number":3,"title":"Coordinator bug","body":"dispatch me","url":"https://example.test/issues/3","state":"open","updatedAt":"2026-05-14T12:00:00Z","author":{"login":"octo"},"assignees":[],"labels":[{"name":"triaged"},{"name":"dispatch/plan"}]}]`)}, "label create": map[string]any{"stdout": json.RawMessage(`{}`)}}, Routes: map[string]any{
+		"repos/acme/looper/issues/3":                      json.RawMessage(`{"number":3,"title":"Coordinator bug","body":"dispatch me","html_url":"https://example.test/issues/3","state":"open","created_at":"2026-05-14T09:00:00Z","updated_at":"2026-05-14T12:00:00Z","user":{"login":"octo"},"labels":[{"name":"triaged"},{"name":"dispatch/plan"}]}`),
+		"repos/acme/looper/issues/3/comments":             json.RawMessage(`[[]]`),
+		"repos/acme/looper/issues/3/timeline":             json.RawMessage(`[[{"event":"labeled","created_at":"2026-05-14T10:00:00Z","label":{"name":"triaged"}}]]`),
+		"repos/acme/looper/collaborators/octo/permission": json.RawMessage(`{"permission":"write"}`),
+	}})
+
+	coord, repos, cfg, repoPath, now := coordinatorFakeGHFixture(t)
+	_ = coord
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.Dispatch.Mode = "autonomous"
+	cfg.Roles.Coordinator.Dispatch.AssignTo = "octocat"
+	gateway := githubinfra.New(githubinfra.Options{GHPath: fakeGH.Path, CWD: repoPath, Now: func() time.Time { return now }})
+	runner := New(Options{Repos: repos, GitHub: gateway, Config: &cfg, Now: func() time.Time { return now }, TriageLLM: stubCoordinatorLLM{}, Inspector: stubCoordinatorInspector{}})
+
+	if _, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "demo", Repo: "acme/looper"}); err != nil {
+		logBytes, _ := os.ReadFile(fakeGH.InvocationLog)
+		t.Fatalf("DiscoverIssues() error = %v\ninvocations:\n%s", err, string(logBytes))
+	}
+	logBytes, err := os.ReadFile(fakeGH.InvocationLog)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation log) error = %v", err)
+	}
+	assertOrderedText(t, string(logBytes),
+		`"argv":["api","repos/acme/looper/issues/3/assignees","--method","POST","-f","assignees[]=octocat"]`,
+		`"argv":["label","create","looper:plan"`,
+		`"argv":["api","repos/acme/looper/issues/3/labels","--method","POST","-f","labels[]=looper:plan"]`,
+	)
+	if strings.Contains(string(logBytes), "/reactions") {
+		t.Fatal("autonomous dispatch unexpectedly reacted to a comment")
+	}
+}
+
+func coordinatorFakeGHFixture(t *testing.T) (*storage.SQLiteCoordinator, *storage.Repositories, config.Config, string, time.Time) {
+	t.Helper()
+	coord, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(t.TempDir(), "coordinator.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coord.Close() })
+	if _, err := coord.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coord.DB())
+	repoPath := t.TempDir()
+	now := time.Date(2026, time.May, 14, 12, 0, 0, 0, time.UTC)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "demo", Name: "Demo", RepoPath: repoPath, CreatedAt: now.Format(time.RFC3339), UpdatedAt: now.Format(time.RFC3339)}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Disclosure.Enabled = true
+	cfg.Disclosure.Channels.IssueComment = true
+	return coord, repos, cfg, repoPath, now
+}
+
 func assertOrderedText(t *testing.T, text string, parts ...string) {
 	t.Helper()
 	index := 0

--- a/internal/coordinator/runner_integration_test.go
+++ b/internal/coordinator/runner_integration_test.go
@@ -1,0 +1,91 @@
+package coordinator
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/coordinator/triage"
+	"github.com/nexu-io/looper/internal/e2e/harness"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestCoordinatorHappyPathWithFakeGH(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	fakeGH := harness.NewFakeGH(t, bins, harness.GHSchema{JSONFieldAllowlist: map[string][]string{"issue list": {"number", "title", "body", "url", "state", "updatedAt", "author", "assignees", "labels"}}})
+	for key, value := range fakeGH.EnvMap() {
+		t.Setenv(key, value)
+	}
+	fakeGH.WriteState(t, harness.GHState{
+		Commands: map[string]any{"label create": map[string]any{"stdout": json.RawMessage(`{}`)}},
+		Routes: map[string]any{
+			"repos/acme/looper/issues/1":          json.RawMessage(`{"number":1,"title":"Coordinator bug","body":"triage me","html_url":"https://example.test/issues/1","state":"open","created_at":"2026-05-14T12:00:00Z","updated_at":"2026-05-14T12:00:00Z","user":{"login":"octo"},"labels":[]}`),
+			"repos/acme/looper/issues/1/comments": json.RawMessage(`[[]]`),
+			"repos/acme/looper/issues/1/timeline": json.RawMessage(`[[]]`),
+		},
+	})
+
+	coord, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(t.TempDir(), "coordinator.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coord.Close() })
+	if _, err := coord.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coord.DB())
+	repoPath := t.TempDir()
+	now := time.Date(2026, time.May, 14, 12, 0, 0, 0, time.UTC)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "demo", Name: "Demo", RepoPath: repoPath, CreatedAt: now.Format(time.RFC3339), UpdatedAt: now.Format(time.RFC3339)}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Disclosure.Enabled = true
+	cfg.Disclosure.Channels.IssueComment = true
+	gateway := githubinfra.New(githubinfra.Options{GHPath: fakeGH.Path, CWD: repoPath, Now: func() time.Time { return now }})
+	runner := New(Options{Repos: repos, GitHub: gateway, Config: &cfg, Now: func() time.Time { return now }, TriageLLM: stubCoordinatorLLM{}, Inspector: stubCoordinatorInspector{}})
+
+	if _, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "demo", Repo: "acme/looper"}); err != nil {
+		logBytes, _ := os.ReadFile(fakeGH.InvocationLog)
+		t.Fatalf("DiscoverIssues() error = %v\ninvocations:\n%s", err, string(logBytes))
+	}
+	logBytes, err := os.ReadFile(fakeGH.InvocationLog)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation log) error = %v", err)
+	}
+	logText := string(logBytes)
+	assertOrderedText(t, logText,
+		`"argv":["issue","list"`,
+		`"argv":["label","create","kind/bug"`,
+		`"argv":["api","repos/acme/looper/issues/1/labels","--method","POST","-f","labels[]=kind/bug","-f","labels[]=area/coordinator","-f","labels[]=complexity/m","-f","labels[]=dispatch/plan"`,
+		`"argv":["api","repos/acme/looper/issues/1/comments","--method","POST"`,
+		`"argv":["api","repos/acme/looper/issues/1/labels","--method","POST","-f","labels[]=triaged"`,
+	)
+	if !(strings.Contains(logText, `<!-- looper:stamp v=1 -->`) || strings.Contains(logText, `\u003c!-- looper:stamp v=1 --\u003e`)) || !strings.Contains(logText, `runner=coordinator`) {
+		t.Fatal("invocation log missing stamped coordinator comment body")
+	}
+}
+
+func assertOrderedText(t *testing.T, text string, parts ...string) {
+	t.Helper()
+	index := 0
+	for _, part := range parts {
+		next := strings.Index(text[index:], part)
+		if next < 0 {
+			t.Fatalf("text missing ordered part %q\n%s", part, text)
+		}
+		index += next + len(part)
+	}
+}
+
+var _ triage.LLM = stubCoordinatorLLM{}

--- a/internal/coordinator/triage/triage.go
+++ b/internal/coordinator/triage/triage.go
@@ -23,11 +23,12 @@ const (
 )
 
 type Comment struct {
-	ID        int64
-	Author    string
-	Body      string
-	CreatedAt string
-	UpdatedAt string
+	ID                int64
+	Author            string
+	AuthorAssociation string
+	Body              string
+	CreatedAt         string
+	UpdatedAt         string
 }
 
 type TimelineEvent struct {

--- a/internal/coordinator/triage/triage.go
+++ b/internal/coordinator/triage/triage.go
@@ -1,0 +1,339 @@
+package triage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const jsISOStringLayout = "2006-01-02T15:04:05.000Z"
+
+var tokenPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9_./-]{2,}`)
+
+type Disposition string
+
+const (
+	DispositionValid      Disposition = "valid"
+	DispositionOutOfScope Disposition = "out-of-scope"
+	DispositionUnclear    Disposition = "unclear"
+)
+
+type Comment struct {
+	ID        int64
+	Author    string
+	Body      string
+	CreatedAt string
+	UpdatedAt string
+}
+
+type TimelineEvent struct {
+	Event     string
+	CreatedAt string
+	Label     string
+}
+
+type Issue struct {
+	Number    int64
+	Title     string
+	Body      string
+	URL       string
+	Author    string
+	CreatedAt string
+	UpdatedAt string
+	Labels    []string
+	Comments  []Comment
+	Timeline  []TimelineEvent
+}
+
+type RepoContext struct {
+	Repo             string
+	WorkingDirectory string
+	Paths            []string
+	Symbols          []string
+}
+
+type Config struct {
+	TriagedLabel          string
+	MaxIssueAgeDays       int
+	MaxPerTick            int
+	OutOfScopeLabel       string
+	UnclearLabel          string
+	ReTriageOnAuthorReply bool
+}
+
+type Input struct {
+	Issue       Issue
+	RepoContext RepoContext
+	Config      Config
+	Now         time.Time
+}
+
+type Request struct {
+	Prompt           string
+	WorkingDirectory string
+}
+
+type LLM interface {
+	Complete(context.Context, Request) (string, error)
+}
+
+type Decision struct {
+	NoOp               bool
+	Disposition        Disposition
+	ClearLabelPatterns []string
+	RemoveLabels       []string
+	ApplyLabels        []string
+	CommentBody        string
+	MarkTriaged        bool
+}
+
+type llmOutput struct {
+	Disposition string `json:"disposition"`
+	Comment     string `json:"comment"`
+	Labels      struct {
+		Kind       []string `json:"kind"`
+		Area       []string `json:"area"`
+		Complexity []string `json:"complexity"`
+		Dispatch   []string `json:"dispatch"`
+	} `json:"labels"`
+}
+
+func Decide(ctx context.Context, llm LLM, input Input) Decision {
+	if llm == nil {
+		return NoOpDecision()
+	}
+	raw, err := llm.Complete(ctx, Request{Prompt: BuildPrompt(input), WorkingDirectory: input.RepoContext.WorkingDirectory})
+	if err != nil {
+		return NoOpDecision()
+	}
+	decision, err := parseDecision(raw, input.Config)
+	if err != nil {
+		return NoOpDecision()
+	}
+	return decision
+}
+
+func NoOpDecision() Decision {
+	return Decision{NoOp: true}
+}
+
+func ReTriageDecision(cfg Config) Decision {
+	return Decision{Disposition: DispositionUnclear, RemoveLabels: []string{cfg.UnclearLabel, cfg.TriagedLabel}}
+}
+
+func ShouldTriage(issue Issue, cfg Config, now time.Time) bool {
+	if hasLabel(issue.Labels, cfg.TriagedLabel) {
+		return false
+	}
+	createdAt, ok := parseTime(issue.CreatedAt)
+	if !ok {
+		return false
+	}
+	return now.UTC().Sub(createdAt) <= time.Duration(cfg.MaxIssueAgeDays)*24*time.Hour
+}
+
+func ShouldReTriage(issue Issue, cfg Config, _ time.Time) bool {
+	if !cfg.ReTriageOnAuthorReply || !hasLabel(issue.Labels, cfg.UnclearLabel) {
+		return false
+	}
+	needsInfoAt, ok := needsInfoAppliedAt(issue, cfg.UnclearLabel)
+	if !ok {
+		return false
+	}
+	for _, comment := range issue.Comments {
+		when, parsed := parseTime(comment.CreatedAt)
+		if parsed && comment.Author == issue.Author && !when.Before(needsInfoAt) {
+			return true
+		}
+	}
+	return false
+}
+
+func LimitPerTick[T any](items []T, max int) []T {
+	if max <= 0 || len(items) <= max {
+		return append([]T(nil), items...)
+	}
+	return append([]T(nil), items[:max]...)
+}
+
+func BuildPrompt(input Input) string {
+	var b strings.Builder
+	b.WriteString("You are Looper Coordinator triage. Return strict JSON only.\n")
+	b.WriteString("Allowed dispositions: valid, out-of-scope, unclear.\n")
+	b.WriteString("Allowed kind labels: ")
+	b.WriteString(strings.Join(AllowedKinds(), ", "))
+	b.WriteString("\nAllowed area labels: ")
+	b.WriteString(strings.Join(AllowedAreas(), ", "))
+	b.WriteString("\nAllowed complexity labels: ")
+	b.WriteString(strings.Join(AllowedComplexities(), ", "))
+	b.WriteString("\nAllowed dispatch labels: ")
+	b.WriteString(strings.Join(AllowedDispatches(), ", "))
+	b.WriteString("\nOutput schema:\n")
+	b.WriteString(`{"disposition":"valid|out-of-scope|unclear","comment":"string","labels":{"kind":["kind/..."],"area":["area/..."],"complexity":["complexity/..."],"dispatch":["dispatch/..."]}}`)
+	b.WriteString("\n\nIssue:\n")
+	b.WriteString(input.Issue.Title)
+	b.WriteString("\n\n")
+	b.WriteString(strings.TrimSpace(input.Issue.Body))
+	if len(input.RepoContext.Paths) > 0 {
+		b.WriteString("\n\nRelevant paths:\n- ")
+		b.WriteString(strings.Join(input.RepoContext.Paths, "\n- "))
+	}
+	if len(input.RepoContext.Symbols) > 0 {
+		b.WriteString("\n\nRelevant symbols:\n- ")
+		b.WriteString(strings.Join(input.RepoContext.Symbols, "\n- "))
+	}
+	return b.String()
+}
+
+func SearchTokens(issue Issue) []string {
+	text := issue.Title + "\n" + issue.Body
+	matches := tokenPattern.FindAllString(text, -1)
+	seen := map[string]struct{}{}
+	tokens := make([]string, 0, len(matches))
+	for _, match := range matches {
+		match = strings.ToLower(strings.Trim(match, " ./-"))
+		if len(match) < 3 {
+			continue
+		}
+		if _, ok := seen[match]; ok {
+			continue
+		}
+		seen[match] = struct{}{}
+		tokens = append(tokens, match)
+		if len(tokens) == 12 {
+			break
+		}
+	}
+	return tokens
+}
+
+func AllowedKinds() []string {
+	return []string{"kind/bug", "kind/feature", "kind/docs", "kind/refactor"}
+}
+
+func AllowedAreas() []string {
+	return []string{"area/api", "area/config", "area/coordinator", "area/docs", "area/github", "area/runtime", "area/testing", "area/planner", "area/worker", "area/reviewer", "area/sweeper"}
+}
+
+func AllowedComplexities() []string {
+	return []string{"complexity/s", "complexity/m", "complexity/l"}
+}
+
+func AllowedDispatches() []string {
+	return []string{"dispatch/plan", "dispatch/implement"}
+}
+
+func parseDecision(raw string, cfg Config) (Decision, error) {
+	var output llmOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &output); err != nil {
+		return Decision{}, err
+	}
+	comment := strings.TrimSpace(output.Comment)
+	if comment == "" {
+		return Decision{}, fmt.Errorf("comment is required")
+	}
+	clear := []string{"kind/*", "area/*", "complexity/*", "dispatch/*", cfg.OutOfScopeLabel, cfg.UnclearLabel}
+	switch Disposition(strings.TrimSpace(output.Disposition)) {
+	case DispositionValid:
+		kind, err := requireExactlyOne(output.Labels.Kind, AllowedKinds())
+		if err != nil {
+			return Decision{}, err
+		}
+		area, err := requireExactlyOne(output.Labels.Area, AllowedAreas())
+		if err != nil {
+			return Decision{}, err
+		}
+		complexity, err := requireExactlyOne(output.Labels.Complexity, AllowedComplexities())
+		if err != nil {
+			return Decision{}, err
+		}
+		dispatch, err := requireExactlyOne(output.Labels.Dispatch, AllowedDispatches())
+		if err != nil {
+			return Decision{}, err
+		}
+		return Decision{Disposition: DispositionValid, ClearLabelPatterns: clear, ApplyLabels: []string{kind, area, complexity, dispatch, cfg.TriagedLabel}, CommentBody: comment, MarkTriaged: true}, nil
+	case DispositionOutOfScope:
+		if hasAnyLabels(output.Labels) {
+			return Decision{}, fmt.Errorf("unexpected labels for out-of-scope disposition")
+		}
+		return Decision{Disposition: DispositionOutOfScope, ClearLabelPatterns: clear, ApplyLabels: []string{cfg.OutOfScopeLabel, cfg.TriagedLabel}, CommentBody: comment, MarkTriaged: true}, nil
+	case DispositionUnclear:
+		if hasAnyLabels(output.Labels) {
+			return Decision{}, fmt.Errorf("unexpected labels for unclear disposition")
+		}
+		return Decision{Disposition: DispositionUnclear, ClearLabelPatterns: clear, ApplyLabels: []string{cfg.UnclearLabel, cfg.TriagedLabel}, CommentBody: comment, MarkTriaged: true}, nil
+	default:
+		return Decision{}, fmt.Errorf("unknown disposition")
+	}
+}
+
+func requireExactlyOne(values []string, allowed []string) (string, error) {
+	if len(values) != 1 {
+		return "", fmt.Errorf("expected exactly one value")
+	}
+	value := strings.TrimSpace(values[0])
+	allowedSet := map[string]struct{}{}
+	for _, item := range allowed {
+		allowedSet[item] = struct{}{}
+	}
+	if _, ok := allowedSet[value]; !ok {
+		return "", fmt.Errorf("unknown value %q", value)
+	}
+	return value, nil
+}
+
+func hasAnyLabels(labels struct {
+	Kind       []string `json:"kind"`
+	Area       []string `json:"area"`
+	Complexity []string `json:"complexity"`
+	Dispatch   []string `json:"dispatch"`
+}) bool {
+	return len(labels.Kind) > 0 || len(labels.Area) > 0 || len(labels.Complexity) > 0 || len(labels.Dispatch) > 0
+}
+
+func needsInfoAppliedAt(issue Issue, unclearLabel string) (time.Time, bool) {
+	for index := len(issue.Timeline) - 1; index >= 0; index-- {
+		event := issue.Timeline[index]
+		if event.Event != "labeled" || event.Label != unclearLabel {
+			continue
+		}
+		return parseTime(event.CreatedAt)
+	}
+	return time.Time{}, false
+}
+
+func parseTime(raw string) (time.Time, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, jsISOStringLayout} {
+		parsed, err := time.Parse(layout, raw)
+		if err == nil {
+			return parsed.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func hasLabel(labels []string, want string) bool {
+	for _, label := range labels {
+		if label == want {
+			return true
+		}
+	}
+	return false
+}
+
+func AllowedLabelUniverse() []string {
+	labels := append([]string{}, AllowedKinds()...)
+	labels = append(labels, AllowedAreas()...)
+	labels = append(labels, AllowedComplexities()...)
+	labels = append(labels, AllowedDispatches()...)
+	sort.Strings(labels)
+	return labels
+}

--- a/internal/coordinator/triage/triage_decisions_test.go
+++ b/internal/coordinator/triage/triage_decisions_test.go
@@ -1,0 +1,51 @@
+package triage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type fixtureLLM struct{ raw string }
+
+func (f fixtureLLM) Complete(context.Context, Request) (string, error) { return f.raw, nil }
+
+func TestDecideValidDisposition(t *testing.T) {
+	t.Parallel()
+	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"valid","comment":"Looks actionable.","labels":{"kind":["kind/bug"],"area":["area/coordinator"],"complexity":["complexity/m"],"dispatch":["dispatch/plan"]}}`}, Input{Issue: Issue{Title: "Coordinator bug", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for valid output")
+	}
+	if got, want := decision.ApplyLabels, []string{"kind/bug", "area/coordinator", "complexity/m", "dispatch/plan", "triaged"}; len(got) != len(want) {
+		t.Fatalf("ApplyLabels len = %d, want %d", len(got), len(want))
+	}
+	if !decision.MarkTriaged {
+		t.Fatal("MarkTriaged = false, want true")
+	}
+}
+
+func TestDecideOutOfScopeDisposition(t *testing.T) {
+	t.Parallel()
+	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"out-of-scope","comment":"Not aligned.","labels":{}}`}, Input{Issue: Issue{Title: "Unfit", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for out-of-scope output")
+	}
+	if len(decision.ApplyLabels) != 2 || decision.ApplyLabels[0] != "wontfix" || decision.ApplyLabels[1] != "triaged" {
+		t.Fatalf("ApplyLabels = %v, want [wontfix triaged]", decision.ApplyLabels)
+	}
+}
+
+func TestDecideUnclearDisposition(t *testing.T) {
+	t.Parallel()
+	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"unclear","comment":"Need repro steps.","labels":{}}`}, Input{Issue: Issue{Title: "Need info", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for unclear output")
+	}
+	if len(decision.ApplyLabels) != 2 || decision.ApplyLabels[0] != "needs-info" || decision.ApplyLabels[1] != "triaged" {
+		t.Fatalf("ApplyLabels = %v, want [needs-info triaged]", decision.ApplyLabels)
+	}
+}
+
+func testConfig() Config {
+	return Config{TriagedLabel: "triaged", MaxIssueAgeDays: 7, MaxPerTick: 5, OutOfScopeLabel: "wontfix", UnclearLabel: "needs-info", ReTriageOnAuthorReply: true}
+}

--- a/internal/coordinator/triage/triage_guards_test.go
+++ b/internal/coordinator/triage/triage_guards_test.go
@@ -1,0 +1,56 @@
+package triage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDecideFailsClosedOnMalformedOutput(t *testing.T) {
+	t.Parallel()
+	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"valid","comment":"bad","labels":{"dispatch":["dispatch/plan","dispatch/implement"]}}`}, Input{Issue: Issue{Title: "Bad", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if !decision.NoOp {
+		t.Fatalf("Decide() = %#v, want no-op on strict parse failure", decision)
+	}
+
+	decision = Decide(context.Background(), fixtureLLM{raw: `{"disposition":"valid","comment":"bad","labels":{"kind":["kind/unknown"],"area":["area/coordinator"],"complexity":["complexity/m"],"dispatch":["dispatch/plan"]}}`}, Input{Issue: Issue{Title: "Bad", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if !decision.NoOp {
+		t.Fatal("Decide() should fail closed on unknown label kind")
+	}
+}
+
+func TestShouldTriageHonorsMaxIssueAgeDays(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 14, 12, 0, 0, 0, time.UTC)
+	if ShouldTriage(Issue{CreatedAt: now.Add(-8 * 24 * time.Hour).Format(time.RFC3339)}, testConfig(), now) {
+		t.Fatal("ShouldTriage() = true, want false for issue older than maxIssueAgeDays")
+	}
+	if !ShouldTriage(Issue{CreatedAt: now.Add(-6 * 24 * time.Hour).Format(time.RFC3339)}, testConfig(), now) {
+		t.Fatal("ShouldTriage() = false, want true for fresh issue")
+	}
+}
+
+func TestLimitPerTick(t *testing.T) {
+	t.Parallel()
+	limited := LimitPerTick([]int{1, 2, 3, 4, 5, 6}, 5)
+	if len(limited) != 5 {
+		t.Fatalf("len(LimitPerTick()) = %d, want 5", len(limited))
+	}
+}
+
+func TestShouldReTriageOnAuthorReply(t *testing.T) {
+	t.Parallel()
+	issue := Issue{
+		Author:   "octo",
+		Labels:   []string{"needs-info", "triaged"},
+		Comments: []Comment{{Author: "octo", CreatedAt: "2026-05-14T12:05:00Z", Body: "Added details"}},
+		Timeline: []TimelineEvent{{Event: "labeled", Label: "needs-info", CreatedAt: "2026-05-14T12:00:00Z"}},
+	}
+	if !ShouldReTriage(issue, testConfig(), time.Now().UTC()) {
+		t.Fatal("ShouldReTriage() = false, want true after author clarification")
+	}
+	decision := ReTriageDecision(testConfig())
+	if len(decision.RemoveLabels) != 2 || decision.RemoveLabels[0] != "needs-info" || decision.RemoveLabels[1] != "triaged" {
+		t.Fatalf("RemoveLabels = %v, want [needs-info triaged]", decision.RemoveLabels)
+	}
+}

--- a/internal/e2e/harness/cmd/fake-gh/main.go
+++ b/internal/e2e/harness/cmd/fake-gh/main.go
@@ -198,6 +198,10 @@ func handleAPI(mode string, st state, stdin string) error {
 		_, _ = fmt.Fprintln(os.Stdout, `{"data":{}}`)
 		return nil
 	}
+	if strings.HasSuffix(route, "/comments") && strings.EqualFold(flagValue(args, "--method"), "POST") {
+		_, _ = fmt.Fprintln(os.Stdout, `{"id":1,"html_url":"https://example.test/issues/comments/1"}`)
+		return nil
+	}
 	if payload, ok := st.Routes[route]; ok {
 		_, _ = os.Stdout.Write(payload)
 		if len(payload) == 0 || payload[len(payload)-1] != '\n' {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -1901,11 +1901,11 @@ func (g *Gateway) getViewerLogin(ctx context.Context, cwd string, hostname strin
 	}
 	result, err := g.runGh(ctx, cwd, "", args...)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	row, err := decodeJSONObject(result.Stdout)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	data, _ := row["data"].(map[string]any)
 	viewer, _ := data["viewer"].(map[string]any)

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -116,6 +116,18 @@ type IssueReactionInput struct {
 	CommentID   int64
 	CWD         string
 }
+type CreateIssueReactionInput struct {
+	Repo        string
+	IssueNumber int64
+	CommentID   int64
+	Content     string
+	CWD         string
+}
+type RepositoryPermissionInput struct {
+	Repo string
+	User string
+	CWD  string
+}
 type LinkedPullRequestsInput struct {
 	Repo        string
 	IssueNumber int64
@@ -756,8 +768,31 @@ func (g *Gateway) ListIssueReactions(ctx context.Context, input IssueReactionInp
 	return out, nil
 }
 
+func (g *Gateway) AddIssueReaction(ctx context.Context, input CreateIssueReactionInput) error {
+	content := strings.TrimSpace(input.Content)
+	if content == "" {
+		return nil
+	}
+	hostname, repo := splitRepoHostname(input.Repo)
+	endpoint := fmt.Sprintf("repos/%s/issues/%d/reactions", repo, input.IssueNumber)
+	if input.CommentID > 0 {
+		endpoint = fmt.Sprintf("repos/%s/issues/comments/%d/reactions", repo, input.CommentID)
+	}
+	args := []string{"api", endpoint, "--method", "POST", "-H", "Accept: application/vnd.github+json", "-f", "content=" + content}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	_, err := g.runGh(ctx, input.CWD, "", args...)
+	return err
+}
+
 func (g *Gateway) CreateIssueComment(ctx context.Context, input IssueCommentInput) (IssueCommentResult, error) {
-	result, err := g.runGh(ctx, input.CWD, "", "api", fmt.Sprintf("repos/%s/issues/%d/comments", input.Repo, input.IssueNumber), "--method", "POST", "-f", "body="+input.Body)
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/issues/%d/comments", repo, input.IssueNumber), "--method", "POST", "-f", "body=" + input.Body}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
 	if err != nil {
 		return IssueCommentResult{}, err
 	}
@@ -769,7 +804,12 @@ func (g *Gateway) CreateIssueComment(ctx context.Context, input IssueCommentInpu
 }
 
 func (g *Gateway) UpdateIssueComment(ctx context.Context, input UpdateIssueCommentInput) error {
-	_, err := g.runGh(ctx, input.CWD, "", "api", fmt.Sprintf("repos/%s/issues/comments/%d", input.Repo, input.CommentID), "--method", "PATCH", "-f", "body="+input.Body)
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/issues/comments/%d", repo, input.CommentID), "--method", "PATCH", "-f", "body=" + input.Body}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	_, err := g.runGh(ctx, input.CWD, "", args...)
 	return err
 }
 
@@ -801,9 +841,13 @@ func (g *Gateway) AddIssueAssignees(ctx context.Context, input IssueAssigneesInp
 	if len(assignees) == 0 {
 		return nil
 	}
-	args := []string{"api", fmt.Sprintf("repos/%s/issues/%d/assignees", input.Repo, input.IssueNumber), "--method", "POST"}
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/issues/%d/assignees", repo, input.IssueNumber), "--method", "POST"}
 	for _, assignee := range assignees {
 		args = append(args, "-f", "assignees[]="+assignee)
+	}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
 	}
 	_, err := g.runGh(ctx, input.CWD, "", args...)
 	return err
@@ -816,9 +860,13 @@ func (g *Gateway) AddIssueLabels(ctx context.Context, input IssueLabelsInput) er
 	if err := g.ensureLabelsExist(ctx, input.Repo, input.Labels, input.CWD); err != nil {
 		return err
 	}
-	args := []string{"api", fmt.Sprintf("repos/%s/issues/%d/labels", input.Repo, input.IssueNumber), "--method", "POST"}
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/issues/%d/labels", repo, input.IssueNumber), "--method", "POST"}
 	for _, label := range input.Labels {
 		args = append(args, "-f", "labels[]="+label)
+	}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
 	}
 	_, err := g.runGh(ctx, input.CWD, "", args...)
 	return err
@@ -828,8 +876,13 @@ func (g *Gateway) RemoveIssueLabels(ctx context.Context, input IssueLabelsInput)
 	if len(input.Labels) == 0 {
 		return nil
 	}
+	hostname, repo := splitRepoHostname(input.Repo)
 	for _, label := range input.Labels {
-		_, err := g.runGh(ctx, input.CWD, "", "api", fmt.Sprintf("repos/%s/issues/%d/labels/%s", input.Repo, input.IssueNumber, encodeURIComponent(label)), "--method", "DELETE")
+		args := []string{"api", fmt.Sprintf("repos/%s/issues/%d/labels/%s", repo, input.IssueNumber, encodeURIComponent(label)), "--method", "DELETE"}
+		if hostname != "" {
+			args = append(args, "--hostname", hostname)
+		}
+		_, err := g.runGh(ctx, input.CWD, "", args...)
 		if err == nil {
 			continue
 		}
@@ -839,6 +892,26 @@ func (g *Gateway) RemoveIssueLabels(ctx context.Context, input IssueLabelsInput)
 		return err
 	}
 	return nil
+}
+
+func (g *Gateway) GetRepositoryPermission(ctx context.Context, input RepositoryPermissionInput) (string, error) {
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/collaborators/%s/permission", repo, input.User)}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
+	if err != nil {
+		if shellErr, ok := err.(*shell.CommandExecutionError); ok && strings.Contains(strings.ToLower(shellErr.Result.Stderr), "404") {
+			return "", nil
+		}
+		return "", err
+	}
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(strings.TrimSpace(asString(row["permission"]))), nil
 }
 
 func compactIssueAssignees(values []string) []string {
@@ -1803,6 +1876,40 @@ func (g *Gateway) GetCurrentUserLogin(ctx context.Context, cwd string) (string, 
 		return "", err
 	}
 	return strings.TrimSpace(result.Stdout), nil
+}
+
+func (g *Gateway) GetCurrentUserLoginForRepo(ctx context.Context, repo string, cwd string) (string, error) {
+	hostname, _ := splitRepoHostname(repo)
+	args := []string{"api", "user", "--jq", ".login"}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, cwd, "", args...)
+	if err != nil {
+		if isUserLoginUnsupportedForCurrentToken(err) {
+			return g.getViewerLogin(ctx, cwd, hostname)
+		}
+		return "", err
+	}
+	return strings.TrimSpace(result.Stdout), nil
+}
+
+func (g *Gateway) getViewerLogin(ctx context.Context, cwd string, hostname string) (string, error) {
+	args := []string{"api", "graphql", "-f", `query=query { viewer { login } }`}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, cwd, "", args...)
+	if err != nil {
+		return "", nil
+	}
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return "", nil
+	}
+	data, _ := row["data"].(map[string]any)
+	viewer, _ := data["viewer"].(map[string]any)
+	return strings.TrimSpace(asString(viewer["login"])), nil
 }
 
 func isUserLoginUnsupportedForCurrentToken(err error) bool {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1122,6 +1122,59 @@ func TestGatewayGetCurrentUserLoginReturnsEmptyForIntegrationTokens(t *testing.T
 	}
 }
 
+func TestGatewayGetCurrentUserLoginForRepoPropagatesViewerLookupFailure(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		switch strings.Join(options.Args, " ") {
+		case "api user --jq .login":
+			result := shell.Result{ExitCode: 1, Stderr: "HTTP 403: Resource not accessible by integration"}
+			return result, &shell.CommandExecutionError{Message: "Command exited with code 1", Result: result}
+		case "api graphql -f query=query { viewer { login } }":
+			result := shell.Result{ExitCode: 1, Stderr: "gh: GraphQL request failed"}
+			return result, &shell.CommandExecutionError{Message: "Command exited with code 1", Result: result}
+		default:
+			t.Fatalf("unexpected gh args: %q", strings.Join(options.Args, " "))
+			return shell.Result{}, nil
+		}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	login, err := gateway.GetCurrentUserLoginForRepo(context.Background(), "acme/looper", "")
+	if err == nil {
+		t.Fatal("GetCurrentUserLoginForRepo() error = nil, want propagated viewer lookup failure")
+	}
+	if login != "" {
+		t.Fatalf("GetCurrentUserLoginForRepo() login = %q, want empty login on failure", login)
+	}
+}
+
+func TestGatewayGetCurrentUserLoginForRepoPropagatesViewerLookupDecodeFailure(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		switch strings.Join(options.Args, " ") {
+		case "api user --jq .login":
+			result := shell.Result{ExitCode: 1, Stderr: "HTTP 403: Resource not accessible by integration"}
+			return result, &shell.CommandExecutionError{Message: "Command exited with code 1", Result: result}
+		case "api graphql -f query=query { viewer { login } }":
+			return shell.Result{Stdout: "{"}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", strings.Join(options.Args, " "))
+			return shell.Result{}, nil
+		}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	login, err := gateway.GetCurrentUserLoginForRepo(context.Background(), "acme/looper", "")
+	if err == nil {
+		t.Fatal("GetCurrentUserLoginForRepo() error = nil, want propagated viewer decode failure")
+	}
+	if login != "" {
+		t.Fatalf("GetCurrentUserLoginForRepo() login = %q, want empty login on failure", login)
+	}
+}
+
 func TestGatewayIsAuthenticatedScopesStatusToHostname(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1274,6 +1274,22 @@ func TestGatewayListIssueReactionsScopesAPIToHostname(t *testing.T) {
 	}
 }
 
+func TestGatewayAddIssueReactionScopesAPIToHostname(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		if args != "api repos/acme/looper/issues/comments/91/reactions --method POST -H Accept: application/vnd.github+json -f content=+1 --hostname github.example.com" {
+			t.Fatalf("unexpected gh args: %q", args)
+		}
+		return shell.Result{Stdout: `{}`}, nil
+	}
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	if err := gateway.AddIssueReaction(context.Background(), CreateIssueReactionInput{Repo: "github.example.com/acme/looper", CommentID: 91, Content: "+1"}); err != nil {
+		t.Fatalf("AddIssueReaction() error = %v", err)
+	}
+}
+
 func TestGatewayIgnoresPlainPullRequestCommentsAsReviewThreads(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -952,7 +952,17 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Planner", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
 		},
 	})
-	coordinatorRunner = coordinatorrole.New(coordinatorrole.Options{Config: &cfg, Now: now})
+	coordinatorRunner = coordinatorrole.New(coordinatorrole.Options{
+		Repos:  repos,
+		GitHub: githubGateway,
+		Config: &cfg,
+		Logger: logger,
+		Now:    now,
+		TriageLLM: coordinatorrole.NewAgentLLM(agentExecutor, now,
+			time.Duration(cfg.Agent.Timeouts.PlannerMaxRuntimeSeconds)*time.Second,
+			time.Duration(cfg.Agent.Timeouts.PlannerIdleTimeoutSeconds)*time.Second,
+		),
+	})
 	reviewerRunner = reviewer.New(reviewer.Options{
 		DB:               coordinator.DB(),
 		Repos:            repos,


### PR DESCRIPTION
## Summary
- add the pure `internal/coordinator/dispatch` module and wire coordinator dispatch through the runner for human-gated slash commands and autonomous handoff, with trigger labels derived from planner/worker config
- use GitHub issue comment reactions, deduped failure comments, collaborator-permission checks, and timeline-based grace/veto handling so dispatch stays stateless per ADR-0001 and follows the ADR-0002 authority chain
- cover the decision matrix with unit and fake-gh integration tests, and finish the coordinator dispatch docs/config reference

## Why
- finish coordinator slice 3/3 so triaged issues can move into planner or worker without private coordinator state
- keep trigger authority on GitHub labels/comments/timeline events while making retries durable and idempotent

## Validation
- gofmt -l .
- go vet ./...
- go test ./...

## Review notes
- @oracle review required per `AGENTS.md` because this PR adds the autonomous dispatch authority path
- authority chain: ADR-0002 explicit `dispatch/*` labels decide planner vs worker dispatch; ADR-0001 keeps coordinator stateless and reads the triaged grace window from GitHub timeline; ADR-0003 remains the planner/worker trigger-label source of truth via existing role config

## References
- PRD #334
- Slice #335
- Slice #336
- Closes #337