### PR TITLE
docs: add coordinator context and ADRs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,98 @@
+# Looper
+
+Looper is a daemon (`looperd`) plus CLI (`looper`) that runs autonomous agent **Roles** against a GitHub repository's issues and pull requests.
+
+## Language
+
+### Roles
+
+A **Role** is a configured agent that performs one specific job in the issue/PR lifecycle. Roles are either *reactive* (they wait for a matching trigger) or *proactive* (they sweep their own input set on a cadence).
+
+**Planner**:
+A reactive Role that produces a Spec from an Issue.
+_Avoid_: designer, architect.
+
+**Worker**:
+A reactive Role that implements a Spec or an Issue, producing a Pull Request.
+_Avoid_: implementer, builder, coder.
+
+**Reviewer**:
+A reactive Role that reviews a Pull Request and posts review comments.
+_Avoid_: critic, checker.
+
+**Fixer**:
+A reactive Role that addresses review feedback on a Pull Request.
+_Avoid_: patcher, responder.
+
+**Sweeper**:
+A proactive, rule-based Role that retires stale or low-signal Issues and Pull Requests through warn-then-close lifecycle.
+_Avoid_: janitor, cleaner.
+
+**Coordinator**:
+A proactive, LLM-driven Role that performs Triage on fresh Issues and executes Dispatch.
+_Avoid_: manager, commander, maintainer.
+
+### Issue lifecycle
+
+**Triage**:
+The act of forming an opinion about a fresh Issue: applying classification labels, posting a triage comment, and committing a Disposition. Performed exactly once per Issue by Coordinator.
+_Avoid_: classification (overloaded — see below), assessment.
+
+**Disposition**:
+Coordinator's high-level conclusion about an Issue. One of `valid`, `out-of-scope`, `unclear`. Distinct from `kind`/`area`/`complexity`, which are classification labels applied only when the Disposition is `valid`.
+_Avoid_: verdict, outcome, status.
+
+**Dispatch**:
+The act of putting an Issue into a state where Planner or Worker will discover it: applying the role's trigger label and assigning the configured user. Performed by Coordinator either on human slash-command (human-gated mode) or autonomously after a grace window (autonomous mode).
+_Avoid_: handoff (overloaded — see below), route, promote, enqueue.
+
+**Trigger label**:
+The label a reactive Role watches for to claim an Issue or Pull Request. Configured per Role (e.g. Planner's trigger label is set in `roles.planner.triggers.labels`).
+_Avoid_: queue label, pickup label.
+
+**Veto signal**:
+A human-applied state on an Issue that blocks Coordinator's autonomous Dispatch. Examples: removing the `dispatch/*` label, applying `looper:hold`, or applying the trigger label manually.
+
+### Authority and statelessness
+
+**Authority**:
+For any side-effecting action, the named, durable, structured signal that justifies the action. Per `AGENTS.md`: "What is the authority for this action, and why is it not the agent's own structured output?" Coordinator's authority for Dispatch is the durable `dispatch/*` label on the Issue, which is the agent's structured output committed to GitHub.
+
+**Stateless Role**:
+A Role whose memory lives entirely in GitHub (labels, comments with markers, event timeline). It owns no private database tables. Coordinator is stateless. Sweeper is stateless. Worker, Planner, Reviewer, and Fixer are not — they persist runs in the local SQLite database.
+
+### Comment markers
+
+**Stamp**:
+The standard `<!-- looper:stamp v=1 -->` HTML comment plus visible footer applied by every agent-authored comment, identifying the comment as Looper-generated. Defined in `internal/disclosure/disclosure.go`.
+
+**Self-dedup marker**:
+A Role-specific HTML comment marker (e.g. `<!-- looper:coordinator:triage -->`) used by a stateless Role to recognise its own prior comments and avoid duplicate posts.
+
+## Relationships
+
+- A **Coordinator** performs **Triage** on a fresh **Issue**, producing a **Disposition** plus classification labels
+- A **Coordinator** performs **Dispatch** on a Triaged Issue, producing a **Trigger label** that a **Planner** or **Worker** observes
+- A **Sweeper** retires Issues and Pull Requests that have aged past their **Trigger label** or have an `out-of-scope` Disposition
+- **Coordinator** and **Sweeper** are both stateless and compose via shared label semantics, not direct calls
+- A **Veto signal** from a human overrides Coordinator's autonomous Dispatch but does not override **Triage** itself
+
+## Flagged ambiguities
+
+- **classification** — used by humans to mean both Disposition and the kind/area labels. Resolved: Disposition is the high-level conclusion (`valid` / `out-of-scope` / `unclear`); kind/area/complexity are classification *labels* applied during a `valid` Triage. The unqualified word "classification" is avoided in favor of "Disposition" or "label".
+- **handoff** — already used in code (`authoritative handoff fields`) for the PR-seed contract between Reviewer and Fixer. Not used for Coordinator's Dispatch action, which is a different concept. Use "Dispatch" exclusively for the Coordinator action.
+- **manager / commander / maintainer** — early names considered for the Coordinator Role. Rejected: "manager" implies it directs other Roles (it doesn't, it sets labels), "commander" overpromises authority, "maintainer" is a human role.
+
+## Example dialogue
+
+> **Dev:** When a fresh **Issue** arrives, what does **Coordinator** do?
+> **Domain expert:** It performs **Triage**: it reads the Issue, decides a **Disposition**, and if `valid` applies kind/area/complexity/dispatch labels and posts a triage comment. The `triaged` label is applied last as the durability commit.
+>
+> **Dev:** And then a **Planner** picks it up?
+> **Domain expert:** Not directly. **Coordinator** later performs **Dispatch** — applies the planner's **Trigger label** and assigns the user. **Planner** then discovers it on its normal trigger.
+>
+> **Dev:** Why two steps?
+> **Domain expert:** Triage produces structured output. Dispatch consumes it. Splitting them gives humans a veto window between the two — they can remove `dispatch/needs-plan` if they disagree.
+>
+> **Dev:** What if a human just types `/plan` instead of waiting?
+> **Domain expert:** Then **Coordinator** dispatches immediately. Human-gated mode is the default; autonomous mode requires the grace window. Either way the **Authority** for dispatch is the durable label on the **Issue**, never an in-memory decision.

--- a/docs/adr/0001-coordinator-is-stateless.md
+++ b/docs/adr/0001-coordinator-is-stateless.md
@@ -1,0 +1,22 @@
+# Coordinator is stateless
+
+## Context
+
+Looper's existing reactive Roles (Planner, Worker, Reviewer, Fixer) persist run state, queue items, agent executions, and checkpoints in a local SQLite database. The Coordinator Role is fundamentally different in shape — it sweeps a continuous stream of fresh Issues and shepherds them toward Dispatch — which initially suggested it would also need persistent state: a dispatch ledger, a shepherd state machine, a per-Issue triage-failure counter.
+
+## Decision
+
+Coordinator owns no private database tables. All Coordinator memory lives in GitHub: labels (`triaged`, `kind/*`, `area/*`, `complexity/*`, `dispatch/*`, `wont-fix`, `needs-info`), HTML comment markers (`<!-- looper:coordinator:triage -->`) for self-dedup, and the Issue's event timeline for derived facts like "when was `triaged` applied." This makes GitHub the single source of truth for Coordinator's view of every Issue.
+
+## Considered Options
+
+- **Dispatch ledger** — local table recording "I added trigger label X to Issue N at time T" so Coordinator could detect stalled dispatches. Rejected because the same fact is queryable from the GitHub event timeline; a private ledger introduces a second source of truth that can drift from reality.
+- **Shepherd state machine** — per-Issue stage tracking (e.g. `awaiting-spec`, `awaiting-implementation`). Rejected because the labels on the Issue already encode stage, and a private state machine creates a reconciliation surface where Coordinator can believe an Issue is in stage X while GitHub says Y.
+- **Failure counter** — local count of consecutive triage failures per Issue, with quarantine after N strikes. Rejected because counting requires either a private table or fragile timeline reconstruction; the simpler choice is infinite retry bounded by the per-tick cap and the `looper:hold` veto label.
+
+## Consequences
+
+- Every Coordinator action must be designed to be re-runnable safely from any partial state. Action ordering — labels first, comment, then `triaged` label as durability commit — is what makes this work.
+- Dedup of Coordinator's own comments depends on GitHub's comment-list API and the `<!-- looper:coordinator:* -->` marker convention. If GitHub changes comment query semantics, this dedup mechanism is exposed.
+- A poison-pill Issue body that consistently breaks the LLM prompt will burn cost on every tick until an operator applies `looper:hold`. The per-tick cap (`triage.maxPerTick`) bounds the damage; logs surface the pattern.
+- Concurrent Coordinator instances against the same repo are explicitly out of scope. Single instance is assumed, as for every other Role.

--- a/docs/adr/0002-coordinator-authority-via-durable-labels.md
+++ b/docs/adr/0002-coordinator-authority-via-durable-labels.md
@@ -1,0 +1,26 @@
+# Coordinator authority is durable labels, not in-memory inference
+
+## Context
+
+Coordinator decides whether a fresh Issue should go to Planner or Worker. Per `AGENTS.md`'s "Name the authority before enforcing it" rule, every side-effecting action must answer: *what is the authority for this action, and why is it not the agent's own structured output?* The honest answer for Dispatch is "the agent's structured output is the authority" — so the question becomes how to make that output durable, inspectable, and human-vetoable rather than a fleeting LLM token consumed in the same call.
+
+The earlier design had Coordinator emit a `complexity/*` label and a separate config block (`dispatch.autonomous.{plan, implement}`) mapped complexity to dispatch destination. A council review (alpha/beta/gamma) flagged this as the inference-on-agent-output trap the rule warns against: the LLM's complexity judgment plus a config policy together formed an inference layer above the structured output.
+
+## Decision
+
+Coordinator's LLM emits a `dispatch/*` label directly during Triage (`dispatch/needs-plan` or `dispatch/needs-implement`). The label persists on the GitHub Issue and is the named Authority for Dispatch. In autonomous mode, Coordinator waits `dispatch.autonomous.delayMinutes` (default 30) after the `triaged` label was applied — measured from the GitHub event timeline — before consulting `dispatch/*` and applying the corresponding Trigger label. The delay is the human Veto window: removing `dispatch/*`, applying `looper:hold`, or applying the Trigger label manually all block autonomous Dispatch.
+
+Complexity (`complexity/*`) becomes informational only — it appears on the Triage comment and as a label for human readers, but no automation reads it.
+
+## Considered Options
+
+- **Complexity → dispatch via config mapping** (the original design). Rejected after council review: it builds an inference layer on top of the agent's structured output, which `AGENTS.md` explicitly warns against. Made the dispatch decision a function of (LLM complexity, config policy) rather than of (LLM intent).
+- **Same-tick dispatch** — Triage and Dispatch in one tick, no grace window. Rejected because it gives humans no veto opportunity between LLM judgment and Planner/Worker kickoff.
+- **Next-tick dispatch with no explicit delay** — relies on `pollInterval`. Rejected because operational tuning (shortening `pollInterval` for snappy slash-command response) would silently shrink the human veto window.
+
+## Consequences
+
+- Coordinator's Triage prompt and structured-output schema must enforce exactly one `dispatch/*` value. Zero or multiple values are strict-parse failures and trigger retry next tick.
+- Querying "when was `triaged` applied" requires one extra GitHub timeline API call per autonomous-mode candidate Issue. Cost is bounded by the per-tick cap and the small set of Issues with `triaged` + `dispatch/*` + no Trigger label.
+- Humans veto autonomous Dispatch by removing the `dispatch/*` label or applying `looper:hold`. Both are durable, public, and reversible.
+- This is the Authority chain `AGENTS.md` mandates oracle review for. The chain is: LLM emits structured `dispatch/*` → label durably commits to GitHub → grace window elapses → no Veto signal observed → Trigger label applied.

--- a/docs/adr/0003-coordinator-sweeper-label-contract.md
+++ b/docs/adr/0003-coordinator-sweeper-label-contract.md
@@ -13,8 +13,8 @@ Coordinator never closes Issues. Sweeper retains exclusive close authority. The 
 - **Coordinator skips Triage** when an Issue bears Sweeper's `lifecycle.pendingLabel`, `lifecycle.closedLabel`, or `security.quarantineLabel`. Sweeper's lifecycle takes precedence.
 - **Sweeper skips retirement** when an Issue bears `dispatch/*` or `needs-info` labels. These are configured as exempt prefixes in Sweeper. Coordinator's active-work signals take precedence over staleness.
 - **`looper:hold` is a global hold.** Both Roles respect it: Coordinator skips Dispatch, Sweeper skips retirement. Single label, single semantic ("humans, leave this Issue alone").
-- **Coordinator-owned label namespace** is documented (not enforced in code): `triaged`, `kind/`, `area/`, `complexity/`, `dispatch/`, plus the configured `wont-fix` and `needs-info` labels. Coordinator clears and re-applies these on Triage rerun; no other Role writes to them.
-- **The `out-of-scope` Disposition path** is Coordinator applying `wont-fix` label + comment, then leaving the Issue open. Sweeper's existing inactivity rule eventually retires it.
+- **Coordinator-owned label namespace** is documented (not enforced in code): `triaged`, `kind/`, `area/`, `complexity/`, `dispatch/`, plus the configured `outOfScopeLabel` (default `wontfix`) and `needs-info` labels. Coordinator clears and re-applies these on Triage rerun; no other Role writes to them.
+- **The `out-of-scope` Disposition path** is Coordinator applying the configured `outOfScopeLabel` (default `wontfix`) + comment, then leaving the Issue open. Sweeper's existing inactivity rule eventually retires it.
 
 ## Considered Options
 
@@ -27,5 +27,5 @@ Coordinator never closes Issues. Sweeper retains exclusive close authority. The 
 
 - Coordinator and Sweeper config must reference each other's label values. The wiring happens at scheduler-config-load time; no runtime config-sharing infrastructure is needed.
 - Sweeper's exempt-labels mechanism is extended to support label *prefixes* (matching `dispatch/*`), which is a small but real change to Sweeper's existing config shape.
-- The `out-of-scope` path leaves the Issue open with `wont-fix` until Sweeper inactivity-retires it. This is intentional — humans get a window to dispute the Coordinator's Disposition before the Issue closes.
+- The `out-of-scope` path leaves the Issue open with the configured `outOfScopeLabel` (default `wontfix`) until Sweeper inactivity-retires it. This is intentional — humans get a window to dispute the Coordinator's Disposition before the Issue closes.
 - Spam and duplicate Dispositions are explicitly deferred to v2. v1 Dispositions are limited to `valid` / `out-of-scope` / `unclear`.

--- a/docs/adr/0003-coordinator-sweeper-label-contract.md
+++ b/docs/adr/0003-coordinator-sweeper-label-contract.md
@@ -1,0 +1,31 @@
+# Coordinator and Sweeper share GitHub via an explicit label contract
+
+## Context
+
+Coordinator (proactive, LLM-driven, handles Issue intake) and Sweeper (proactive, rule-based, handles Issue retirement) both operate on the same Issue stream and both apply labels and comments. Without an explicit contract, they can fight: Coordinator could re-Triage an Issue Sweeper has already marked for closure, or Sweeper could retire an Issue with active `dispatch/*` work pending. The council review flagged this as a real risk (problem #4: cross-role label contract underspecified).
+
+A natural temptation was to give Coordinator close authority — "spam → close" or "out-of-scope after delay → close" — to make Coordinator feel more like a real maintainer. This was rejected because Sweeper already owns the warn-then-close lifecycle, with `pendingLabel`/`closedLabel`/`keepLabel`. Duplicating that path in Coordinator violates "A second fix to the same subsystem is a revert signal" prospectively.
+
+## Decision
+
+Coordinator never closes Issues. Sweeper retains exclusive close authority. The two Roles compose via shared label semantics, not direct calls or shared state:
+
+- **Coordinator skips Triage** when an Issue bears Sweeper's `lifecycle.pendingLabel`, `lifecycle.closedLabel`, or `security.quarantineLabel`. Sweeper's lifecycle takes precedence.
+- **Sweeper skips retirement** when an Issue bears `dispatch/*` or `needs-info` labels. These are configured as exempt prefixes in Sweeper. Coordinator's active-work signals take precedence over staleness.
+- **`looper:hold` is a global hold.** Both Roles respect it: Coordinator skips Dispatch, Sweeper skips retirement. Single label, single semantic ("humans, leave this Issue alone").
+- **Coordinator-owned label namespace** is documented (not enforced in code): `triaged`, `kind/`, `area/`, `complexity/`, `dispatch/`, plus the configured `wont-fix` and `needs-info` labels. Coordinator clears and re-applies these on Triage rerun; no other Role writes to them.
+- **The `out-of-scope` Disposition path** is Coordinator applying `wont-fix` label + comment, then leaving the Issue open. Sweeper's existing inactivity rule eventually retires it.
+
+## Considered Options
+
+- **Give Coordinator close authority on `out-of-scope` or `spam` Disposition.** Rejected because it duplicates Sweeper's warn-then-close lifecycle and forces Coordinator to manage `pendingLabel`/`closedLabel` semantics it doesn't otherwise need.
+- **Make `looper:hold` dispatch-only.** Rejected because two-scope hold semantics ("hold dispatch but allow stale closure") is more confusing than one global hold and breaks user expectations.
+- **Have Coordinator detect `spam` Disposition and apply a `spam` label for Sweeper to close.** Rejected because reliable spam detection requires grounded signals (account age, history, repo norms) the LLM cannot access cheaply, and the false-positive cost is high (closing real bug reports as spam).
+- **Add a runtime label-namespace registry** enforcing that only Coordinator can write to `dispatch/*` etc. Rejected as YAGNI; documentation-as-contract is sufficient for v1, with the option to add enforcement later if collisions actually occur.
+
+## Consequences
+
+- Coordinator and Sweeper config must reference each other's label values. The wiring happens at scheduler-config-load time; no runtime config-sharing infrastructure is needed.
+- Sweeper's exempt-labels mechanism is extended to support label *prefixes* (matching `dispatch/*`), which is a small but real change to Sweeper's existing config shape.
+- The `out-of-scope` path leaves the Issue open with `wont-fix` until Sweeper inactivity-retires it. This is intentional — humans get a window to dispute the Coordinator's Disposition before the Issue closes.
+- Spam and duplicate Dispositions are explicitly deferred to v2. v1 Dispositions are limited to `valid` / `out-of-scope` / `unclear`.


### PR DESCRIPTION
## Summary
- add a repository CONTEXT.md that defines Looper role, triage, dispatch, authority, and statelessness terminology
- add ADRs documenting why Coordinator is stateless, why durable `dispatch/*` labels are the authority for dispatch, and how Coordinator and Sweeper compose through a label contract
- leave the unrelated untracked `coordinator-grill.md` out of this PR