### PR TITLE
fix: resolve detached reviewer/fixer base branch fallback

### DIFF
--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -685,40 +685,60 @@ func (g *Gateway) remoteBranchExists(ctx context.Context, repoPath, remote, bran
 }
 
 func (g *Gateway) resolveDetachedStartPoint(ctx context.Context, input CreateWorktreeInput) (string, error) {
-	remote := "origin"
-	hasRemote, err := g.hasRemote(ctx, input.RepoPath, remote)
+	startPoint, ok, err := g.resolveDetachedStartPointRef(ctx, input.RepoPath, input.Branch)
 	if err != nil {
 		return "", err
+	}
+	if ok {
+		return startPoint, nil
+	}
+
+	startPoint, ok, err = g.resolveDetachedStartPointRef(ctx, input.RepoPath, input.BaseBranch)
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		return startPoint, nil
+	}
+
+	return "", fmt.Errorf("resolve detached start point: no local or remote ref found for branch %q or base branch %q", input.Branch, input.BaseBranch)
+}
+
+func (g *Gateway) resolveDetachedStartPointRef(ctx context.Context, repoPath, branch string) (string, bool, error) {
+	remote := "origin"
+	hasRemote, err := g.hasRemote(ctx, repoPath, remote)
+	if err != nil {
+		return "", false, err
 	}
 	if hasRemote {
-		remoteHeadSHA, err := g.getRemoteHeadSHA(ctx, input.RepoPath, remote, input.Branch)
+		remoteHeadSHA, err := g.getRemoteHeadSHA(ctx, repoPath, remote, branch)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
 		if remoteHeadSHA != "" {
-			if err := g.runGit(ctx, input.RepoPath, nil, "fetch", remote, input.Branch); err != nil {
-				return "", err
+			if err := g.runGit(ctx, repoPath, nil, "fetch", remote, branch); err != nil {
+				return "", false, err
 			}
 
-			remoteBranchExists, err := g.remoteBranchExists(ctx, input.RepoPath, remote, input.Branch)
+			remoteBranchExists, err := g.remoteBranchExists(ctx, repoPath, remote, branch)
 			if err != nil {
-				return "", err
+				return "", false, err
 			}
 			if remoteBranchExists {
-				return remote + "/" + input.Branch, nil
+				return remote + "/" + branch, true, nil
 			}
 		}
 	}
 
-	branchExists, err := g.branchExists(ctx, input.RepoPath, input.Branch)
+	branchExists, err := g.branchExists(ctx, repoPath, branch)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	if branchExists {
-		return input.Branch, nil
+		return branch, true, nil
 	}
 
-	return input.BaseBranch, nil
+	return "", false, nil
 }
 
 func (g *Gateway) hasRemote(ctx context.Context, repoPath, remote string) (bool, error) {

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -227,6 +227,37 @@ func TestGatewayKeepsPrimaryCheckoutCleanForDetachedFixerWorktree(t *testing.T) 
 	}
 }
 
+func TestGatewayDetachedWorktreeFallsBackToRemoteOnlyBaseBranch(t *testing.T) {
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createMainOnlyRepo(t)
+	fixture.createUnfetchedRemoteBranch(t, "release/base")
+	gateway := fixture.gateway()
+
+	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       "reviewer/pr-42",
+		BaseBranch:   "release/base",
+		PRNumber:     42,
+		CheckoutMode: CheckoutModeDetached,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	if got := stringsTrimSpace(runGit(t, worktree.WorktreePath, "branch", "--show-current")); got != "" {
+		t.Fatalf("detached branch name = %q, want empty", got)
+	}
+
+	remoteBaseSHA := stringsTrimSpace(runGit(t, fixture.remotePath, "rev-parse", "refs/heads/release/base"))
+	worktreeHeadSHA := stringsTrimSpace(runGit(t, worktree.WorktreePath, "rev-parse", "HEAD"))
+	if worktreeHeadSHA != remoteBaseSHA {
+		t.Fatalf("detached HEAD = %q, want %q", worktreeHeadSHA, remoteBaseSHA)
+	}
+}
+
 func TestGatewayPushesHeadToRequestedRemoteBranch(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixture(t)
@@ -744,6 +775,24 @@ func (f *fixture) createRemoteRepo(t *testing.T, branch string) {
 	runGit(t, f.repoPath, "commit", "-m", "feature")
 	runGit(t, f.repoPath, "push", "-u", "origin", branch)
 	runGit(t, f.repoPath, "checkout", "main")
+}
+
+func (f *fixture) createUnfetchedRemoteBranch(t *testing.T, branch string) {
+	t.Helper()
+	clonePath := filepath.Join(f.rootDir, "remote-clone-"+sanitizeBranchName(branch))
+	runGit(t, f.rootDir, "clone", f.remotePath, clonePath)
+	configureRepo(t, clonePath)
+	runGit(t, clonePath, "checkout", "-b", branch)
+	writeFile(t, filepath.Join(clonePath, sanitizeBranchName(branch)+".txt"), "remote change\n")
+	runGit(t, clonePath, "add", ".")
+	runGit(t, clonePath, "commit", "-m", "remote branch")
+	runGit(t, clonePath, "push", "-u", "origin", branch)
+	if got := stringsTrimSpace(runGitMaybe(t, f.repoPath, "show-ref", "--verify", "refs/remotes/origin/"+branch)); got != "" {
+		t.Fatalf("remote tracking ref for %q already exists locally: %q", branch, got)
+	}
+	if got := stringsTrimSpace(runGitMaybe(t, f.repoPath, "show-ref", "--verify", "refs/heads/"+branch)); got != "" {
+		t.Fatalf("local branch %q already exists: %q", branch, got)
+	}
 }
 
 func (f *fixture) createLocalFeatureRepo(t *testing.T) {


### PR DESCRIPTION
## Summary
- resolve detached worktree start points by trying the requested branch first, then resolving and fetching the PR base branch when the requested branch is only a synthetic local name
- return a usable remote-tracking ref for remote-only base branches instead of passing an unfetched base branch name to `git worktree add --detach`
- add regression coverage for detached reviewer/fixer-style worktrees whose base branch exists only on `origin`

## Testing
- go test ./internal/infra/git
- go test ./...
- go vet ./...
- go build ./...

Closes #345

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>