### PR TITLE
fix: decouple scheduler claiming from discovery

### DIFF
--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -172,7 +172,8 @@
             "pollIntervalSeconds": 30,
             "maxConcurrentRuns": 3,
             "retryMaxAttempts": 5,
-            "retryBaseDelayMs": 5000
+            "retryBaseDelayMs": 5000,
+            "slowLaneWarnThresholdMs": 5000
           },
           "agent": {
             "env": {},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2900,6 +2900,9 @@ func TestDefaultConfigMatchesDaemonDefaults(t *testing.T) {
 	if config.Scheduler.MaxConcurrentRuns != 3 {
 		t.Fatalf("DefaultConfig().Scheduler.MaxConcurrentRuns = %d, want %d", config.Scheduler.MaxConcurrentRuns, 3)
 	}
+	if config.Scheduler.SlowLaneWarnThresholdMS != 5000 {
+		t.Fatalf("DefaultConfig().Scheduler.SlowLaneWarnThresholdMS = %d, want %d", config.Scheduler.SlowLaneWarnThresholdMS, 5000)
+	}
 
 	if config.Logging.Level != LogLevelInfo {
 		t.Fatalf("DefaultConfig().Logging.Level = %q, want %q", config.Logging.Level, LogLevelInfo)
@@ -3056,6 +3059,10 @@ func TestNormalizeAppliesOverridesWithoutDroppingDefaults(t *testing.T) {
 
 	if config.Scheduler.MaxConcurrentRuns != 3 {
 		t.Fatalf("Normalize().Scheduler.MaxConcurrentRuns = %d, want default %d", config.Scheduler.MaxConcurrentRuns, 3)
+	}
+
+	if config.Scheduler.SlowLaneWarnThresholdMS != 5000 {
+		t.Fatalf("Normalize().Scheduler.SlowLaneWarnThresholdMS = %d, want default %d", config.Scheduler.SlowLaneWarnThresholdMS, 5000)
 	}
 
 	if config.Agent.Vendor == nil || *config.Agent.Vendor != AgentVendorOpenCode {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -65,10 +65,11 @@ func DefaultConfig(cwd string) (Config, error) {
 			BackupDir: stringPtr(backupDir),
 		},
 		Scheduler: SchedulerConfig{
-			PollIntervalSeconds: 30,
-			MaxConcurrentRuns:   3,
-			RetryMaxAttempts:    5,
-			RetryBaseDelayMS:    5000,
+			PollIntervalSeconds:     30,
+			MaxConcurrentRuns:       3,
+			RetryMaxAttempts:        5,
+			RetryBaseDelayMS:        5000,
+			SlowLaneWarnThresholdMS: 5000,
 		},
 		Agent: AgentConfig{
 			Params:       map[string]any{},

--- a/internal/config/format_roundtrip_test.go
+++ b/internal/config/format_roundtrip_test.go
@@ -55,7 +55,7 @@ func canonicalRoundTripFixtureConfig() Config {
 		Server:        ServerConfig{Host: "0.0.0.0", Port: 18443, BaseURL: &baseURL, AuthMode: AuthModeLocalToken, LocalToken: &localToken},
 		Daemon:        DaemonConfig{Mode: DaemonModeLaunchd, RestartPolicy: DaemonRestartAlways, RestartThrottleSeconds: 30, LogDir: "/tmp/looper/logs", ShutdownTimeoutMS: 2500, WorkingDirectory: "/tmp/looper/workdir", Environment: map[string]string{"LAUNCHD": "1"}},
 		Storage:       StorageConfig{Mode: "sqlite", DBPath: "/tmp/looper/state.sqlite", BackupDir: &backupDir},
-		Scheduler:     SchedulerConfig{PollIntervalSeconds: 45, MaxConcurrentRuns: 7, RetryMaxAttempts: 9, RetryBaseDelayMS: 1500},
+		Scheduler:     SchedulerConfig{PollIntervalSeconds: 45, MaxConcurrentRuns: 7, RetryMaxAttempts: 9, RetryBaseDelayMS: 1500, SlowLaneWarnThresholdMS: 2500},
 		Agent:         AgentConfig{Vendor: fixtureVendorPtr(AgentVendorCodex), Model: stringPtr("gpt-5"), Params: map[string]any{"reasoning": map[string]any{"effort": "high"}}, Env: map[string]string{"OPENAI_API_KEY": "test"}, Timeouts: AgentTimeoutConfig{PlannerSeconds: 360, WorkerSeconds: 720, ReviewerSeconds: 540, FixerSeconds: 480, PlannerIdleTimeoutSeconds: 120, PlannerMaxRuntimeSeconds: 360, WorkerIdleTimeoutSeconds: 180, WorkerMaxRuntimeSeconds: 720, ReviewerIdleTimeoutSeconds: 150, ReviewerMaxRuntimeSeconds: 540, FixerIdleTimeoutSeconds: 90, FixerMaxRuntimeSeconds: 480}, NativeResume: AgentNativeResumeConfig{Enabled: true}},
 		Logging:       LoggingConfig{Level: LogLevelDebug, MaxSizeMB: 25, MaxFiles: 9},
 		Notifications: NotificationConfig{InApp: false, Osascript: OsascriptNotificationConfig{Enabled: true, SoundForLevels: []NotificationSoundLevel{NotificationSoundLevelFailure}, ThrottleWindowSeconds: 120}},

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -298,6 +298,10 @@ func mergeSchedulerConfig(config *SchedulerConfig, partial PartialSchedulerConfi
 	if partial.RetryBaseDelayMS != nil {
 		config.RetryBaseDelayMS = *partial.RetryBaseDelayMS
 	}
+
+	if partial.SlowLaneWarnThresholdMS != nil {
+		config.SlowLaneWarnThresholdMS = *partial.SlowLaneWarnThresholdMS
+	}
 }
 
 func mergeAgentConfig(config *AgentConfig, partial PartialAgentConfig) {

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -93,7 +93,8 @@
         "pollIntervalSeconds": 30,
         "maxConcurrentRuns": 3,
         "retryMaxAttempts": 5,
-        "retryBaseDelayMs": 5000
+        "retryBaseDelayMs": 5000,
+        "slowLaneWarnThresholdMs": 5000
       },
       "agent": {
         "vendor": "opencode",

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -33,7 +33,8 @@
         "pollIntervalSeconds": 30,
         "maxConcurrentRuns": 3,
         "retryMaxAttempts": 5,
-        "retryBaseDelayMs": 5000
+        "retryBaseDelayMs": 5000,
+        "slowLaneWarnThresholdMs": 5000
       },
       "agent": {
         "params": {},

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -20,7 +20,8 @@
           "pollIntervalSeconds": 45,
           "maxConcurrentRuns": 4,
           "retryMaxAttempts": 7,
-          "retryBaseDelayMs": 1500
+          "retryBaseDelayMs": 1500,
+          "slowLaneWarnThresholdMs": 5000
         },
         "agent": {
           "vendor": "codex",
@@ -110,7 +111,8 @@
         "pollIntervalSeconds": 45,
         "maxConcurrentRuns": 4,
         "retryMaxAttempts": 7,
-        "retryBaseDelayMs": 1500
+        "retryBaseDelayMs": 1500,
+        "slowLaneWarnThresholdMs": 5000
       },
       "agent": {
         "vendor": "codex",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -135,10 +135,11 @@ type StorageConfig struct {
 }
 
 type SchedulerConfig struct {
-	PollIntervalSeconds int `json:"pollIntervalSeconds"`
-	MaxConcurrentRuns   int `json:"maxConcurrentRuns"`
-	RetryMaxAttempts    int `json:"retryMaxAttempts"`
-	RetryBaseDelayMS    int `json:"retryBaseDelayMs"`
+	PollIntervalSeconds     int `json:"pollIntervalSeconds"`
+	MaxConcurrentRuns       int `json:"maxConcurrentRuns"`
+	RetryMaxAttempts        int `json:"retryMaxAttempts"`
+	RetryBaseDelayMS        int `json:"retryBaseDelayMs"`
+	SlowLaneWarnThresholdMS int `json:"slowLaneWarnThresholdMs"`
 }
 
 type AgentConfig struct {
@@ -550,10 +551,11 @@ type PartialStorageConfig struct {
 }
 
 type PartialSchedulerConfig struct {
-	PollIntervalSeconds *int `json:"pollIntervalSeconds,omitempty"`
-	MaxConcurrentRuns   *int `json:"maxConcurrentRuns,omitempty"`
-	RetryMaxAttempts    *int `json:"retryMaxAttempts,omitempty"`
-	RetryBaseDelayMS    *int `json:"retryBaseDelayMs,omitempty"`
+	PollIntervalSeconds     *int `json:"pollIntervalSeconds,omitempty"`
+	MaxConcurrentRuns       *int `json:"maxConcurrentRuns,omitempty"`
+	RetryMaxAttempts        *int `json:"retryMaxAttempts,omitempty"`
+	RetryBaseDelayMS        *int `json:"retryBaseDelayMs,omitempty"`
+	SlowLaneWarnThresholdMS *int `json:"slowLaneWarnThresholdMs,omitempty"`
 }
 
 type PartialAgentConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -83,6 +83,10 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 		issues = append(issues, ValidationIssue{Path: "scheduler.retryBaseDelayMs", Message: "must be a positive integer"})
 	}
 
+	if config.Scheduler.SlowLaneWarnThresholdMS < 1 {
+		issues = append(issues, ValidationIssue{Path: "scheduler.slowLaneWarnThresholdMs", Message: "must be a positive integer"})
+	}
+
 	if config.Agent.Vendor != nil && !isValidAgentVendor(*config.Agent.Vendor) {
 		issues = append(issues, ValidationIssue{Path: "agent.vendor", Message: fmt.Sprintf("must be one of: %s, %s, %s, %s", AgentVendorClaudeCode, AgentVendorCodex, AgentVendorOpenCode, AgentVendorCursorCLI)})
 	}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -402,6 +402,7 @@ type Options struct {
 	RetryBaseDelay          time.Duration
 	RetryMaxAttempts        int64
 	OnAgentExecutionStarted AgentExecutionStartedFunc
+	OnQueueItemEnqueued     func()
 }
 
 type DiscoveryPolicy struct {
@@ -439,6 +440,7 @@ type Runner struct {
 	retryBaseDelay          time.Duration
 	retryMaxAttempts        int64
 	onAgentExecutionStarted AgentExecutionStartedFunc
+	onQueueItemEnqueued     func()
 }
 
 type DiscoveryInput struct {
@@ -994,6 +996,7 @@ func New(options Options) *Runner {
 		retryBaseDelay:          retryBaseDelay,
 		retryMaxAttempts:        retryMax,
 		onAgentExecutionStarted: options.OnAgentExecutionStarted,
+		onQueueItemEnqueued:     options.OnQueueItemEnqueued,
 	}
 }
 
@@ -3602,6 +3605,7 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 			if err := r.repos.Queue.Upsert(ctx, updated); err != nil {
 				return storage.QueueItemRecord{}, err
 			}
+			r.wakeSchedulerAfterEnqueue()
 			return updated, nil
 		}
 		return *existing, nil
@@ -3621,6 +3625,7 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 			if err := r.repos.Queue.Upsert(ctx, updated); err != nil {
 				return storage.QueueItemRecord{}, err
 			}
+			r.wakeSchedulerAfterEnqueue()
 			return updated, nil
 		}
 		return *activeForLoop, nil
@@ -3634,7 +3639,14 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 	if err := r.repos.Queue.Upsert(ctx, queueItem); err != nil {
 		return storage.QueueItemRecord{}, err
 	}
+	r.wakeSchedulerAfterEnqueue()
 	return queueItem, nil
+}
+
+func (r *Runner) wakeSchedulerAfterEnqueue() {
+	if r.onQueueItemEnqueued != nil {
+		r.onQueueItemEnqueued()
+	}
 }
 
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -294,6 +294,7 @@ type Options struct {
 	RetryBaseDelay          time.Duration
 	RetryMaxAttempts        int64
 	OnAgentExecutionStarted AgentExecutionStartedFunc
+	OnQueueItemEnqueued     func()
 	DiscoveryPolicy         DiscoveryPolicy
 }
 
@@ -324,6 +325,7 @@ type Runner struct {
 	retryBaseDelay          time.Duration
 	retryMaxAttempts        int64
 	onAgentExecutionStarted AgentExecutionStartedFunc
+	onQueueItemEnqueued     func()
 	discoveryPolicy         DiscoveryPolicy
 }
 
@@ -479,7 +481,7 @@ func New(options Options) *Runner {
 	if policy.LabelMode == "" {
 		policy = DiscoveryPolicy{AutoDiscovery: true, Labels: []string{discoveryLabel}, LabelMode: config.LabelModeAll, RequireAssigneeCurrentUser: true}
 	}
-	return &Runner{db: options.DB, repos: options.Repos, github: options.GitHub, git: options.Git, agentExecutor: options.AgentExecutor, logger: options.Logger, now: now, agentTimeout: agentTimeout, agentIdleTimeout: agentIdleTimeout, claimTTL: claimTTL, allowAutoPush: allowAutoPush, disclosure: disclosureCfg, agentRuntime: strings.TrimSpace(options.AgentRuntime), customInstructions: customInstructionConfig(options.CustomInstructions), projectRoleConfig: options.CustomInstructions, agentModel: derefString(options.AgentModel), retryBaseDelay: retryBaseDelay, retryMaxAttempts: retryMax, onAgentExecutionStarted: options.OnAgentExecutionStarted, discoveryPolicy: policy}
+	return &Runner{db: options.DB, repos: options.Repos, github: options.GitHub, git: options.Git, agentExecutor: options.AgentExecutor, logger: options.Logger, now: now, agentTimeout: agentTimeout, agentIdleTimeout: agentIdleTimeout, claimTTL: claimTTL, allowAutoPush: allowAutoPush, disclosure: disclosureCfg, agentRuntime: strings.TrimSpace(options.AgentRuntime), customInstructions: customInstructionConfig(options.CustomInstructions), projectRoleConfig: options.CustomInstructions, agentModel: derefString(options.AgentModel), retryBaseDelay: retryBaseDelay, retryMaxAttempts: retryMax, onAgentExecutionStarted: options.OnAgentExecutionStarted, onQueueItemEnqueued: options.OnQueueItemEnqueued, discoveryPolicy: policy}
 }
 
 func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
@@ -1488,7 +1490,14 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 	if err := r.repos.Queue.Upsert(ctx, queueItem); err != nil {
 		return storage.QueueItemRecord{}, err
 	}
+	r.wakeSchedulerAfterEnqueue()
 	return queueItem, nil
+}
+
+func (r *Runner) wakeSchedulerAfterEnqueue() {
+	if r.onQueueItemEnqueued != nil {
+		r.onQueueItemEnqueued()
+	}
 }
 
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -390,6 +390,7 @@ type Options struct {
 	RetryMaxAttempts        int64
 	HeadChangePollInterval  time.Duration
 	OnAgentExecutionStarted AgentExecutionStartedFunc
+	OnQueueItemEnqueued     func()
 }
 
 type DiscoveryPolicy struct {
@@ -432,6 +433,7 @@ type Runner struct {
 	retryMaxAttempts        int64
 	headChangePollInterval  time.Duration
 	onAgentExecutionStarted AgentExecutionStartedFunc
+	onQueueItemEnqueued     func()
 }
 
 type DiscoveryInput struct {
@@ -632,6 +634,7 @@ func New(options Options) *Runner {
 		retryMaxAttempts:        retryMax,
 		headChangePollInterval:  headChangePollInterval,
 		onAgentExecutionStarted: options.OnAgentExecutionStarted,
+		onQueueItemEnqueued:     options.OnQueueItemEnqueued,
 	}
 }
 
@@ -3356,6 +3359,7 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 				if err := r.repos.Queue.Upsert(ctx, updated); err != nil {
 					return storage.QueueItemRecord{}, err
 				}
+				r.wakeSchedulerAfterEnqueue()
 				return updated, nil
 			}
 		}
@@ -3373,7 +3377,14 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 	if err := r.repos.Queue.Upsert(ctx, queueItem); err != nil {
 		return storage.QueueItemRecord{}, err
 	}
+	r.wakeSchedulerAfterEnqueue()
 	return queueItem, nil
+}
+
+func (r *Runner) wakeSchedulerAfterEnqueue() {
+	if r.onQueueItemEnqueued != nil {
+		r.onQueueItemEnqueued()
+	}
 }
 
 func isoTimeAfter(candidate, current string) bool {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -83,34 +83,36 @@ type Runtime struct {
 	syncConfiguredProjects SyncConfiguredProjectsFunc
 	runSchedulerTick       RunSchedulerTickFunc
 	defaultSchedulerTick   RunSchedulerTickFunc
+	defaultSchedulerClaim  RunSchedulerTickFunc
 	customSchedulerTick    bool
 	readProcessCommand     ReadProcessCommandFunc
 	signalProcess          SignalProcessFunc
 	shutdownTimeout        time.Duration
 	deferRecovery          bool
 
-	mu                sync.RWMutex
-	startedAt         *time.Time
-	recovery          RecoverySummary
-	stopped           bool
-	services          Services
-	startErr          error
-	startOnce         sync.Once
-	shutdownOnce      sync.Once
-	shutdownCh        chan struct{}
-	schedulerStop     chan struct{}
-	schedulerDone     chan struct{}
-	schedulerWake     chan struct{}
-	schedulerCancel   context.CancelFunc
-	schedulerTasks    *schedulerTaskTracker
-	recoveryCancel    context.CancelFunc
-	recoveryDone      chan struct{}
-	activeExecutions  *ActiveExecutionRegistry
-	githubGateway     *githubinfra.Gateway
-	schedulerDisabled bool
-	startupReadyOnce  sync.Once
-	startupReadyErr   error
-	ownershipAcquired bool
+	mu                 sync.RWMutex
+	startedAt          *time.Time
+	recovery           RecoverySummary
+	stopped            bool
+	services           Services
+	startErr           error
+	startOnce          sync.Once
+	shutdownOnce       sync.Once
+	shutdownCh         chan struct{}
+	schedulerStop      chan struct{}
+	schedulerDone      chan struct{}
+	schedulerWake      chan struct{}
+	schedulerClaimWake chan struct{}
+	schedulerCancel    context.CancelFunc
+	schedulerTasks     *schedulerTaskTracker
+	recoveryCancel     context.CancelFunc
+	recoveryDone       chan struct{}
+	activeExecutions   *ActiveExecutionRegistry
+	githubGateway      *githubinfra.Gateway
+	schedulerDisabled  bool
+	startupReadyOnce   sync.Once
+	startupReadyErr    error
+	ownershipAcquired  bool
 }
 
 const reviewerRecoveryLoginTimeout = 3 * time.Second
@@ -376,11 +378,13 @@ func (r *Runtime) start(ctx context.Context) error {
 	}
 	schedulerDisabled := false
 	if !r.customSchedulerTick {
-		r.defaultSchedulerTick = buildDefaultSchedulerTick(r.config, r.logger, coordinator, repositories, gitGateway, githubGateway, r.activeExecutions, func() schedulerAsyncRunner {
+		handlers := buildDefaultSchedulerHandlers(r.config, r.logger, coordinator, repositories, gitGateway, githubGateway, r.activeExecutions, func() schedulerAsyncRunner {
 			r.mu.RLock()
 			defer r.mu.RUnlock()
 			return r.schedulerTasks
-		}, r.TriggerSchedulerTick, r.now)
+		}, r.TriggerSchedulerClaim, r.now)
+		r.defaultSchedulerTick = handlers.tick
+		r.defaultSchedulerClaim = handlers.claim
 		schedulerDisabled = r.config.Agent.Vendor == nil
 	}
 	r.githubGateway = githubGateway
@@ -464,6 +468,7 @@ func (r *Runtime) startSchedulerLoop() {
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
 	wakeCh := make(chan struct{}, 1)
+	claimWakeCh := make(chan struct{}, 1)
 	schedulerCtx, schedulerCancel := context.WithCancel(context.Background())
 	taskTracker := &schedulerTaskTracker{}
 
@@ -471,9 +476,16 @@ func (r *Runtime) startSchedulerLoop() {
 	r.schedulerStop = stopCh
 	r.schedulerDone = doneCh
 	r.schedulerWake = wakeCh
+	r.schedulerClaimWake = claimWakeCh
 	r.schedulerCancel = schedulerCancel
 	r.schedulerTasks = taskTracker
 	r.mu.Unlock()
+
+	if r.defaultSchedulerClaim != nil {
+		taskTracker.Go(func() {
+			r.runSchedulerClaimLoop(schedulerCtx, stopCh, claimWakeCh)
+		})
+	}
 
 	go func() {
 		defer close(doneCh)
@@ -516,6 +528,7 @@ func (r *Runtime) stopSchedulerLoop() {
 	r.schedulerStop = nil
 	r.schedulerDone = nil
 	r.schedulerWake = nil
+	r.schedulerClaimWake = nil
 	r.schedulerCancel = nil
 	r.mu.Unlock()
 
@@ -613,15 +626,36 @@ func (r *Runtime) TriggerSchedulerTick() {
 		return
 	}
 	wakeCh := r.schedulerWake
+	claimWakeCh := r.schedulerClaimWake
 	r.mu.RUnlock()
 
-	if wakeCh == nil {
+	if wakeCh != nil {
+		select {
+		case wakeCh <- struct{}{}:
+		default:
+		}
+	}
+	if claimWakeCh != nil {
+		select {
+		case claimWakeCh <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (r *Runtime) TriggerSchedulerClaim() {
+	r.mu.RLock()
+	if r.stopped {
+		r.mu.RUnlock()
 		return
 	}
-
-	select {
-	case wakeCh <- struct{}{}:
-	default:
+	claimWakeCh := r.schedulerClaimWake
+	r.mu.RUnlock()
+	if claimWakeCh != nil {
+		select {
+		case claimWakeCh <- struct{}{}:
+		default:
+		}
 	}
 }
 
@@ -650,6 +684,36 @@ func (r *Runtime) executeDefaultSchedulerTick(ctx context.Context, services Serv
 		return fmt.Errorf("default scheduler tick is not configured")
 	}
 	return tick(ctx, services)
+}
+
+func (r *Runtime) executeSchedulerClaimPass(ctx context.Context) {
+	r.mu.RLock()
+	services := r.services
+	claim := r.defaultSchedulerClaim
+	r.mu.RUnlock()
+	if services.Repositories == nil || claim == nil {
+		return
+	}
+	if err := claim(ctx, services); err != nil && r.logger != nil {
+		r.logger.Warn("looperd scheduler claim pump failed", map[string]any{"error": err.Error()})
+	}
+}
+
+func (r *Runtime) runSchedulerClaimLoop(ctx context.Context, stopCh <-chan struct{}, wakeCh <-chan struct{}) {
+	const claimPumpInterval = time.Second
+	r.executeSchedulerClaimPass(ctx)
+	ticker := time.NewTicker(claimPumpInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-wakeCh:
+			r.executeSchedulerClaimPass(ctx)
+		case <-ticker.C:
+			r.executeSchedulerClaimPass(ctx)
+		}
+	}
 }
 
 func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage.Repositories, githubGateway *githubinfra.Gateway, now time.Time) (RecoverySummary, error) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1465,6 +1465,44 @@ func TestRuntimeTriggerSchedulerTickCoalescesWhileTickIsRunning(t *testing.T) {
 	}
 }
 
+func TestRuntimeTriggerSchedulerClaimRunsImmediatelyWithoutWaitingForPolling(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Scheduler.PollIntervalSeconds = 3600
+
+	var tickCount int32
+	var claimCount int32
+	rt := &Runtime{
+		config:                cfg,
+		logger:                &testLogger{},
+		runSchedulerTick:      func(context.Context, Services) error { atomic.AddInt32(&tickCount, 1); return nil },
+		defaultSchedulerClaim: func(context.Context, Services) error { atomic.AddInt32(&claimCount, 1); return nil },
+		services:              Services{Repositories: &storage.Repositories{}},
+		shutdownTimeout:       time.Second,
+	}
+
+	rt.startSchedulerLoop()
+	t.Cleanup(func() { rt.stopSchedulerLoop() })
+
+	waitForCondition(t, time.Second, func() bool {
+		return atomic.LoadInt32(&claimCount) >= 1 && atomic.LoadInt32(&tickCount) >= 1
+	})
+
+	rt.TriggerSchedulerClaim()
+
+	waitForCondition(t, time.Second, func() bool {
+		return atomic.LoadInt32(&claimCount) >= 2
+	})
+	if got := atomic.LoadInt32(&tickCount); got != 1 {
+		t.Fatalf("scheduler tick count = %d, want claim wake without extra discovery tick", got)
+	}
+}
+
 func TestRuntimeStopClosesCoordinatorAndUnblocksWaitForShutdown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -82,6 +82,7 @@ type defaultSchedulerTickInput struct {
 	Logger                   bootstrap.Logger
 	Now                      func() time.Time
 	MaxConcurrentRuns        int
+	ClaimMu                  *sync.Mutex
 	AsyncRunner              schedulerAsyncRunner
 	RequestSchedulerWake     func()
 	Planner                  plannerScheduler
@@ -98,6 +99,11 @@ type defaultSchedulerTickInput struct {
 	FixerDiscoveryEnabled    *bool
 	WorkerDiscoveryEnabled   *bool
 	SweeperDiscoveryEnabled  *bool
+}
+
+type defaultSchedulerHandlers struct {
+	tick  RunSchedulerTickFunc
+	claim RunSchedulerTickFunc
 }
 
 type schedulerTaskTracker struct{ wg sync.WaitGroup }
@@ -808,17 +814,19 @@ func (a workerAgentExecutionAdapter) Kill(reason string) error {
 	return a.execution.Kill(reason)
 }
 
-func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time) RunSchedulerTickFunc {
+func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time) defaultSchedulerHandlers {
 	if now == nil {
 		now = time.Now
 	}
 	if repos == nil || coordinator == nil {
-		return func(context.Context, Services) error {
+		fail := func(context.Context, Services) error {
 			return fmt.Errorf("default scheduler dependencies are not configured")
 		}
+		return defaultSchedulerHandlers{tick: fail, claim: fail}
 	}
 	if cfg.Agent.Vendor == nil {
-		return func(context.Context, Services) error { return nil }
+		noop := func(context.Context, Services) error { return nil }
+		return defaultSchedulerHandlers{tick: noop, claim: noop}
 	}
 	notificationGateway := notify.NewGateway(notify.Options{
 		Config:        cfg.Notifications,
@@ -946,8 +954,9 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			LabelMode:                  cfg.Roles.Planner.Triggers.LabelMode,
 			RequireAssigneeCurrentUser: cfg.Roles.Planner.Triggers.RequireAssigneeCurrentUser,
 		},
-		RetryBaseDelay:   retryBaseDelay,
-		RetryMaxAttempts: int64(cfg.Scheduler.RetryMaxAttempts),
+		RetryBaseDelay:      retryBaseDelay,
+		RetryMaxAttempts:    int64(cfg.Scheduler.RetryMaxAttempts),
+		OnQueueItemEnqueued: requestWake,
 		OnAgentExecutionStarted: func(ctx context.Context, input planner.AgentExecutionStartedInput) error {
 			return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Planner", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
 		},
@@ -997,6 +1006,7 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 		AgentIdleTimeout:        time.Duration(cfg.Agent.Timeouts.ReviewerIdleTimeoutSeconds) * time.Second,
 		RetryBaseDelay:          retryBaseDelay,
 		RetryMaxAttempts:        int64(cfg.Scheduler.RetryMaxAttempts),
+		OnQueueItemEnqueued:     requestWake,
 		OnAgentExecutionStarted: func(ctx context.Context, input reviewer.AgentExecutionStartedInput) error {
 			return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Reviewer", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
 		},
@@ -1020,14 +1030,15 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			Labels:        append([]string(nil), cfg.Roles.Fixer.Triggers.Labels...),
 			LabelMode:     cfg.Roles.Fixer.Triggers.LabelMode,
 		},
-		Disclosure:         &cfg.Disclosure,
-		AgentRuntime:       agentRuntime,
-		CustomInstructions: &cfg,
-		AgentModel:         cfg.Agent.Model,
-		AgentTimeout:       time.Duration(cfg.Agent.Timeouts.FixerMaxRuntimeSeconds) * time.Second,
-		AgentIdleTimeout:   time.Duration(cfg.Agent.Timeouts.FixerIdleTimeoutSeconds) * time.Second,
-		RetryBaseDelay:     retryBaseDelay,
-		RetryMaxAttempts:   int64(cfg.Scheduler.RetryMaxAttempts),
+		Disclosure:          &cfg.Disclosure,
+		AgentRuntime:        agentRuntime,
+		CustomInstructions:  &cfg,
+		AgentModel:          cfg.Agent.Model,
+		AgentTimeout:        time.Duration(cfg.Agent.Timeouts.FixerMaxRuntimeSeconds) * time.Second,
+		AgentIdleTimeout:    time.Duration(cfg.Agent.Timeouts.FixerIdleTimeoutSeconds) * time.Second,
+		RetryBaseDelay:      retryBaseDelay,
+		RetryMaxAttempts:    int64(cfg.Scheduler.RetryMaxAttempts),
+		OnQueueItemEnqueued: requestWake,
 		OnAgentExecutionStarted: func(ctx context.Context, input fixer.AgentExecutionStartedInput) error {
 			return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Fixer", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
 		},
@@ -1052,30 +1063,33 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			LabelMode:                  cfg.Roles.Worker.Triggers.LabelMode,
 			RequireAssigneeCurrentUser: cfg.Roles.Worker.Triggers.RequireAssigneeCurrentUser,
 		},
-		Disclosure:         &cfg.Disclosure,
-		AgentRuntime:       agentRuntime,
-		CustomInstructions: &cfg,
-		AgentModel:         cfg.Agent.Model,
-		AgentTimeout:       time.Duration(cfg.Agent.Timeouts.WorkerMaxRuntimeSeconds) * time.Second,
-		AgentIdleTimeout:   time.Duration(cfg.Agent.Timeouts.WorkerIdleTimeoutSeconds) * time.Second,
-		RetryBaseDelay:     retryBaseDelay,
-		RetryMaxAttempts:   int64(cfg.Scheduler.RetryMaxAttempts),
+		Disclosure:          &cfg.Disclosure,
+		AgentRuntime:        agentRuntime,
+		CustomInstructions:  &cfg,
+		AgentModel:          cfg.Agent.Model,
+		AgentTimeout:        time.Duration(cfg.Agent.Timeouts.WorkerMaxRuntimeSeconds) * time.Second,
+		AgentIdleTimeout:    time.Duration(cfg.Agent.Timeouts.WorkerIdleTimeoutSeconds) * time.Second,
+		RetryBaseDelay:      retryBaseDelay,
+		RetryMaxAttempts:    int64(cfg.Scheduler.RetryMaxAttempts),
+		OnQueueItemEnqueued: requestWake,
 		OnRunCompleted: func(ctx context.Context, input worker.RunCompletedInput) error {
 			return notifyWorkerRunCompleted(ctx, workerRunCompletedNotificationInput{ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Subtitle: input.Subtitle, Status: input.Status, Summary: input.Summary, FailureKind: input.FailureKind, PullRequestNumber: input.PullRequestNumber, PullRequestURL: input.PullRequestURL})
 		},
 	})
-	sweeperRunner = sweeper.New(sweeper.Options{Repos: repos, GitHub: githubGateway, Agent: sweeperAgentExecutorAdapter{executor: sweeperAgentExecutor}, Logger: logger, Now: now, Config: &cfg, AgentRuntime: agentRuntime, AgentModel: sweeperAgentModel})
+	sweeperRunner = sweeper.New(sweeper.Options{Repos: repos, GitHub: githubGateway, Agent: sweeperAgentExecutorAdapter{executor: sweeperAgentExecutor}, Logger: logger, Now: now, Config: &cfg, AgentRuntime: agentRuntime, AgentModel: sweeperAgentModel, OnQueueItemEnqueued: requestWake})
+	claimMu := &sync.Mutex{}
 
-	return func(ctx context.Context, services Services) error {
+	inputForServices := func(services Services) defaultSchedulerTickInput {
 		var runner schedulerAsyncRunner
 		if asyncRunner != nil {
 			runner = asyncRunner()
 		}
-		return runDefaultSchedulerTick(ctx, defaultSchedulerTickInput{
+		return defaultSchedulerTickInput{
 			Repos:                    services.Repositories,
 			Logger:                   logger,
 			Now:                      now,
 			MaxConcurrentRuns:        cfg.Scheduler.MaxConcurrentRuns,
+			ClaimMu:                  claimMu,
 			AsyncRunner:              runner,
 			RequestSchedulerWake:     requestWake,
 			Planner:                  plannerRunner,
@@ -1092,7 +1106,16 @@ func buildDefaultSchedulerTick(cfg config.Config, logger bootstrap.Logger, coord
 			FixerDiscoveryEnabled:    boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "fixer")),
 			WorkerDiscoveryEnabled:   boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "worker")),
 			SweeperDiscoveryEnabled:  boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "sweeper")),
-		})
+		}
+	}
+
+	return defaultSchedulerHandlers{
+		tick: func(ctx context.Context, services Services) error {
+			return runDefaultSchedulerTick(ctx, inputForServices(services))
+		},
+		claim: func(ctx context.Context, services Services) error {
+			return runIndependentClaimPass(ctx, inputForServices(services))
+		},
 	}
 }
 
@@ -1136,10 +1159,27 @@ func githubAuthHostname(repo string) string {
 	return defaultHost
 }
 
-func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInput) error {
+func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInput) (retErr error) {
 	if input.Repos == nil || input.Repos.Projects == nil {
 		return nil
 	}
+
+	startedAt := time.Now()
+	claimStats := schedulerClaimStats{}
+	if input.Logger != nil {
+		input.Logger.Debug("scheduler tick start", nil)
+	}
+	defer func() {
+		if input.Logger == nil {
+			return
+		}
+		fields := map[string]any{"durationMs": time.Since(startedAt).Milliseconds(), "claimedCount": claimStats.claimedCount, "availableSlots": claimStats.availableSlots}
+		if retErr != nil {
+			fields["error"] = retErr.Error()
+		}
+		input.Logger.Debug("scheduler tick end", fields)
+		input.Logger.Info("scheduler tick summary", fields)
+	}()
 
 	now := input.Now
 	if now == nil {
@@ -1158,25 +1198,24 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 			discoveredRunnableIDs[id] = struct{}{}
 		}
 	}
+	recordClaim := func(claimedCount, availableSlots int, err error) {
+		claimStats.record(claimedCount, availableSlots)
+		appendErr(err)
+	}
 
-	availableSlots, err := schedulerAvailableSlots(ctx, input.Repos, input.MaxConcurrentRuns)
-	if err != nil {
-		appendErr(err)
-		availableSlots = 0
-	}
-	if availableSlots > 0 && input.Repos.Queue != nil {
-		_, err := claimAndRunScheduledQueueItems(ctx, availableSlots, input)
-		appendErr(err)
-	}
+	claimedCount, availableSlots, err := executeClaimPhase(ctx, "pre_discovery", input, discoveredRunnableIDs, true)
+	recordClaim(claimedCount, availableSlots, err)
 
 	projectsList, err := input.Repos.Projects.List(ctx)
 	if err != nil {
 		appendErr(err)
-		return errors.Join(errs...)
+		retErr = errors.Join(errs...)
+		return retErr
 	}
 	for _, project := range projectsList {
 		if err := ctx.Err(); err != nil {
-			return errors.Join(append(errs, err)...)
+			retErr = errors.Join(append(errs, err)...)
+			return retErr
 		}
 		if project.Archived {
 			continue
@@ -1189,53 +1228,66 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 			continue
 		}
 		if input.Planner != nil && discoveryEnabled(input.PlannerDiscoveryEnabled) {
-			result, err := input.Planner.DiscoverIssues(ctx, planner.DiscoveryInput{ProjectID: project.ID, Repo: repo})
-			trackRunnableDiscovery(result.QueueItems)
-			appendErr(wrapSchedulerError("planner discovery", project.ID, repo, err))
+			appendErr(runSchedulerLane(input, "planner discovery", project.ID, repo, func() error {
+				result, err := input.Planner.DiscoverIssues(ctx, planner.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				trackRunnableDiscovery(result.QueueItems)
+				return wrapSchedulerError("planner discovery", project.ID, repo, err)
+			}))
+			claimedCount, availableSlots, err = executeClaimPhase(ctx, "post_planner_discovery", input, discoveredRunnableIDs, true)
+			recordClaim(claimedCount, availableSlots, err)
 		} else if input.Planner != nil && input.Logger != nil {
 			input.Logger.Debug("planner auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
 		}
 		if input.Coordinator != nil && coordinatorEnabledForProject(input, project.ID) {
-			_, err := input.Coordinator.DiscoverIssues(ctx, coordinatorrole.DiscoveryInput{ProjectID: project.ID, Repo: repo})
-			appendErr(wrapSchedulerError("coordinator discovery", project.ID, repo, err))
+			appendErr(runSchedulerLane(input, "coordinator discovery", project.ID, repo, func() error {
+				_, err := input.Coordinator.DiscoverIssues(ctx, coordinatorrole.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				return wrapSchedulerError("coordinator discovery", project.ID, repo, err)
+			}))
+			claimedCount, availableSlots, err = executeClaimPhase(ctx, "post_coordinator_discovery", input, discoveredRunnableIDs, true)
+			recordClaim(claimedCount, availableSlots, err)
 		}
 		if input.Reviewer != nil && discoveryEnabled(input.ReviewerDiscoveryEnabled) {
-			result, err := input.Reviewer.DiscoverPullRequests(ctx, reviewer.DiscoveryInput{ProjectID: project.ID, Repo: repo})
-			trackRunnableDiscovery(result.QueueItems)
-			appendErr(wrapSchedulerError("reviewer discovery", project.ID, repo, err))
+			appendErr(runSchedulerLane(input, "reviewer discovery", project.ID, repo, func() error {
+				result, err := input.Reviewer.DiscoverPullRequests(ctx, reviewer.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				trackRunnableDiscovery(result.QueueItems)
+				return wrapSchedulerError("reviewer discovery", project.ID, repo, err)
+			}))
+			claimedCount, availableSlots, err = executeClaimPhase(ctx, "post_reviewer_discovery", input, discoveredRunnableIDs, true)
+			recordClaim(claimedCount, availableSlots, err)
 		} else if input.Reviewer != nil && input.Logger != nil {
 			input.Logger.Debug("reviewer auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
 		}
 		if input.Fixer != nil && discoveryEnabled(input.FixerDiscoveryEnabled) {
-			result, err := input.Fixer.DiscoverPullRequests(ctx, fixer.DiscoveryInput{ProjectID: project.ID, Repo: repo})
-			trackRunnableDiscovery(result.QueueItems)
-			appendErr(wrapSchedulerError("fixer discovery", project.ID, repo, err))
+			appendErr(runSchedulerLane(input, "fixer discovery", project.ID, repo, func() error {
+				result, err := input.Fixer.DiscoverPullRequests(ctx, fixer.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				trackRunnableDiscovery(result.QueueItems)
+				return wrapSchedulerError("fixer discovery", project.ID, repo, err)
+			}))
+			claimedCount, availableSlots, err = executeClaimPhase(ctx, "post_fixer_discovery", input, discoveredRunnableIDs, true)
+			recordClaim(claimedCount, availableSlots, err)
 		} else if input.Fixer != nil && input.Logger != nil {
 			input.Logger.Debug("fixer auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
 		}
 		if discoverer, ok := input.Worker.(workerIssueDiscoveryScheduler); ok && discoveryEnabled(input.WorkerDiscoveryEnabled) {
-			result, err := discoverer.DiscoverIssues(ctx, worker.DiscoveryInput{ProjectID: project.ID, Repo: repo})
-			trackRunnableDiscovery(result.QueueItems)
-			appendErr(wrapSchedulerError("worker issue discovery", project.ID, repo, err))
+			appendErr(runSchedulerLane(input, "worker issue discovery", project.ID, repo, func() error {
+				result, err := discoverer.DiscoverIssues(ctx, worker.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				trackRunnableDiscovery(result.QueueItems)
+				return wrapSchedulerError("worker issue discovery", project.ID, repo, err)
+			}))
+			claimedCount, availableSlots, err = executeClaimPhase(ctx, "post_worker_discovery", input, discoveredRunnableIDs, true)
+			recordClaim(claimedCount, availableSlots, err)
 		} else if input.Worker != nil && input.Logger != nil && !discoveryEnabled(input.WorkerDiscoveryEnabled) {
 			input.Logger.Debug("worker auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
 		}
 	}
 
-	availableSlots, err = schedulerAvailableSlots(ctx, input.Repos, input.MaxConcurrentRuns)
-	if err != nil {
-		appendErr(err)
-		availableSlots = 0
-	}
-	if availableSlots > 0 && input.Repos.Queue != nil {
-		claimedItems, err := claimAndRunScheduledQueueItems(ctx, availableSlots, input)
-		appendErr(err)
-		requestWakeForClaimedDiscovery(claimedItems, discoveredRunnableIDs, input.RequestSchedulerWake)
-	}
+	claimedCount, availableSlots, err = executeClaimPhase(ctx, "post_discovery", input, discoveredRunnableIDs, true)
+	recordClaim(claimedCount, availableSlots, err)
 
 	for _, project := range projectsList {
 		if err := ctx.Err(); err != nil {
-			return errors.Join(append(errs, err)...)
+			retErr = errors.Join(append(errs, err)...)
+			return retErr
 		}
 		if project.Archived {
 			continue
@@ -1246,12 +1298,20 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		}
 		if input.Sweeper != nil && discoveryEnabled(input.SweeperDiscoveryEnabled) {
 			appendErr(applySweeperBackpressure(ctx, input, project, repo))
-			_, err := input.Sweeper.DiscoverIssues(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
-			appendErr(wrapSchedulerError("sweeper issue discovery", project.ID, repo, err))
-			_, err = input.Sweeper.DiscoverPullRequests(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
-			appendErr(wrapSchedulerError("sweeper pull request discovery", project.ID, repo, err))
-			_, err = input.Sweeper.DiscoverReconcile(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
-			appendErr(wrapSchedulerError("sweeper reconciliation discovery", project.ID, repo, err))
+			appendErr(runSchedulerLane(input, "sweeper issue discovery", project.ID, repo, func() error {
+				_, err := input.Sweeper.DiscoverIssues(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				return wrapSchedulerError("sweeper issue discovery", project.ID, repo, err)
+			}))
+			appendErr(runSchedulerLane(input, "sweeper pull request discovery", project.ID, repo, func() error {
+				_, err := input.Sweeper.DiscoverPullRequests(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				return wrapSchedulerError("sweeper pull request discovery", project.ID, repo, err)
+			}))
+			appendErr(runSchedulerLane(input, "sweeper reconciliation discovery", project.ID, repo, func() error {
+				_, err := input.Sweeper.DiscoverReconcile(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				return wrapSchedulerError("sweeper reconciliation discovery", project.ID, repo, err)
+			}))
+			claimedCount, availableSlots, err = executeClaimPhase(ctx, "post_sweeper_discovery", input, discoveredRunnableIDs, true)
+			recordClaim(claimedCount, availableSlots, err)
 		} else if input.Sweeper != nil && input.Logger != nil {
 			input.Logger.Debug("sweeper auto-discovery disabled", map[string]any{"projectId": project.ID, "repo": repo})
 		}
@@ -1260,7 +1320,8 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 	if len(errs) == 0 {
 		return nil
 	}
-	return errors.Join(errs...)
+	retErr = errors.Join(errs...)
+	return retErr
 }
 
 func discoveryEnabled(value *bool) bool {
@@ -1301,6 +1362,83 @@ func requestWakeForClaimedDiscovery(claimedItems []storage.QueueItemRecord, disc
 			return
 		}
 	}
+}
+
+type schedulerClaimStats struct {
+	claimedCount   int
+	availableSlots int
+}
+
+func (s *schedulerClaimStats) record(claimedCount, availableSlots int) {
+	s.claimedCount += claimedCount
+	s.availableSlots = availableSlots
+}
+
+func runIndependentClaimPass(ctx context.Context, input defaultSchedulerTickInput) error {
+	_, _, err := executeClaimPhase(ctx, "claim_pump", input, nil, false)
+	return err
+}
+
+func executeClaimPhase(ctx context.Context, phase string, input defaultSchedulerTickInput, discoveredRunnableIDs map[string]struct{}, alwaysLog bool) (int, int, error) {
+	if input.ClaimMu != nil {
+		input.ClaimMu.Lock()
+		defer input.ClaimMu.Unlock()
+	}
+	start := time.Now()
+	availableSlots, err := schedulerAvailableSlots(ctx, input.Repos, input.MaxConcurrentRuns)
+	if err != nil {
+		logClaimPhase(input.Logger, phase, 0, 0, time.Since(start), err)
+		return 0, 0, err
+	}
+	claimedItems := make([]storage.QueueItemRecord, 0)
+	if availableSlots > 0 && input.Repos != nil && input.Repos.Queue != nil {
+		claimedItems, err = claimAndRunScheduledQueueItems(ctx, availableSlots, input)
+		if err == nil {
+			requestWakeForClaimedDiscovery(claimedItems, discoveredRunnableIDs, input.RequestSchedulerWake)
+		}
+	}
+	claimedCount := len(claimedItems)
+	if alwaysLog || availableSlots > 0 || claimedCount > 0 || err != nil {
+		logClaimPhase(input.Logger, phase, availableSlots, claimedCount, time.Since(start), err)
+	}
+	return claimedCount, availableSlots, err
+}
+
+func logClaimPhase(logger bootstrap.Logger, phase string, availableSlots, claimedCount int, duration time.Duration, err error) {
+	if logger == nil {
+		return
+	}
+	fields := map[string]any{"phase": phase, "availableSlots": availableSlots, "claimedCount": claimedCount, "durationMs": duration.Milliseconds()}
+	if err != nil {
+		fields["error"] = err.Error()
+	}
+	logger.Debug("scheduler claim phase", fields)
+}
+
+func runSchedulerLane(input defaultSchedulerTickInput, laneName, projectID, repo string, fn func() error) error {
+	start := time.Now()
+	if input.Logger != nil {
+		input.Logger.Debug("scheduler lane start", map[string]any{"lane": laneName, "projectId": projectID, "repo": repo})
+	}
+	err := fn()
+	if input.Logger != nil {
+		fields := map[string]any{"lane": laneName, "projectId": projectID, "repo": repo, "durationMs": time.Since(start).Milliseconds()}
+		if err != nil {
+			fields["error"] = err.Error()
+		}
+		input.Logger.Debug("scheduler lane end", fields)
+		if threshold := schedulerSlowLaneWarnThreshold(input); threshold > 0 && time.Since(start) >= threshold {
+			input.Logger.Warn("scheduler lane slow", fields)
+		}
+	}
+	return err
+}
+
+func schedulerSlowLaneWarnThreshold(input defaultSchedulerTickInput) time.Duration {
+	if input.Config == nil || input.Config.Scheduler.SlowLaneWarnThresholdMS <= 0 {
+		return 5 * time.Second
+	}
+	return time.Duration(input.Config.Scheduler.SlowLaneWarnThresholdMS) * time.Millisecond
 }
 
 func schedulerAvailableSlots(ctx context.Context, repos *storage.Repositories, maxConcurrentRuns int) (int, error) {

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -387,9 +387,126 @@ func TestRunDefaultSchedulerTickDiscoveryWakeIsBounded(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("runDefaultSchedulerTick() error = %v", err)
 	}
-	if got := atomic.LoadInt32(&wakes); got != 1 {
-		t.Fatalf("scheduler wake requests = %d, want one coalesced wake for repeated enqueue events", got)
+	if got := atomic.LoadInt32(&wakes); got != 3 {
+		t.Fatalf("scheduler wake requests = %d, want one wake per claim phase that picked up discovered work", got)
 	}
+}
+
+func TestIndependentClaimPassClaimsQueuedWorkWhileDiscoveryIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "scheduler-claim-pump.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	insertSchedulerProject(t, repos, workingDir, nowISO)
+
+	plannerRunner := &blockingPlannerDiscoveryScheduler{started: make(chan struct{}), release: make(chan struct{})}
+	workerRunner := &stubWorkerScheduler{}
+	input := defaultSchedulerTickInput{
+		Repos:                   repos,
+		Now:                     func() time.Time { return now },
+		MaxConcurrentRuns:       5,
+		ClaimMu:                 &sync.Mutex{},
+		AsyncRunner:             immediateSchedulerRunner{},
+		Planner:                 plannerRunner,
+		Worker:                  workerRunner,
+		SweeperDiscoveryEnabled: boolPtr(false),
+	}
+
+	tickDone := make(chan error, 1)
+	go func() {
+		tickDone <- runDefaultSchedulerTick(context.Background(), input)
+	}()
+
+	select {
+	case <-plannerRunner.started:
+	case <-time.After(time.Second):
+		t.Fatal("planner discovery did not block")
+	}
+
+	for i := 0; i < 5; i++ {
+		item := schedulerTestQueueItem(fmt.Sprintf("queue_worker_claim_pump_%d", i), "worker", nowISO)
+		if err := repos.Queue.Upsert(context.Background(), item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+
+	claimDone := make(chan error, 1)
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if err := runIndependentClaimPass(context.Background(), input); err != nil {
+				claimDone <- err
+				return
+			}
+			if workerRunner.processItemCount() == 5 {
+				claimDone <- nil
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		claimDone <- fmt.Errorf("timed out waiting for independent claim pass to process all items")
+	}()
+
+	select {
+	case err := <-claimDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2500 * time.Millisecond):
+		t.Fatal("independent claim pass did not finish before timeout")
+	}
+
+	close(plannerRunner.release)
+	if err := <-tickDone; err != nil {
+		t.Fatalf("runDefaultSchedulerTick() error = %v", err)
+	}
+}
+
+func TestRunDefaultSchedulerTickLogsClaimPhasesAndSlowLanes(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "scheduler-logs.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	insertSchedulerProject(t, repos, workingDir, nowISO)
+	logger := &capturingSchedulerLogger{}
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Scheduler.SlowLaneWarnThresholdMS = 1
+
+	plannerRunner := &sleepingPlannerScheduler{delay: 5 * time.Millisecond}
+	if err := runDefaultSchedulerTick(context.Background(), defaultSchedulerTickInput{
+		Repos:                    repos,
+		Logger:                   logger,
+		Now:                      func() time.Time { return now },
+		MaxConcurrentRuns:        1,
+		Config:                   &cfg,
+		Planner:                  plannerRunner,
+		ReviewerDiscoveryEnabled: boolPtr(false),
+		FixerDiscoveryEnabled:    boolPtr(false),
+		WorkerDiscoveryEnabled:   boolPtr(false),
+		SweeperDiscoveryEnabled:  boolPtr(false),
+	}); err != nil {
+		t.Fatalf("runDefaultSchedulerTick() error = %v", err)
+	}
+
+	logger.requireMessage(t, "scheduler tick start")
+	logger.requireMessage(t, "scheduler tick end")
+	logger.requireMessage(t, "scheduler tick summary")
+	logger.requireContextValue(t, "scheduler claim phase", "phase", "pre_discovery")
+	logger.requireContextValue(t, "scheduler claim phase", "phase", "post_planner_discovery")
+	logger.requireContextValue(t, "scheduler lane start", "lane", "planner discovery")
+	logger.requireContextValue(t, "scheduler lane end", "lane", "planner discovery")
+	logger.requireContextValue(t, "scheduler lane slow", "lane", "planner discovery")
 }
 
 func TestRunScheduledQueueItemsDispatchesEachSupportedType(t *testing.T) {
@@ -1076,6 +1193,88 @@ type queueStatusCheckingPlannerScheduler struct {
 	repos                *storage.Repositories
 	queueItemID          string
 	checkedClaimedStatus bool
+}
+
+type blockingPlannerDiscoveryScheduler struct {
+	stubPlannerScheduler
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingPlannerDiscoveryScheduler) DiscoverIssues(ctx context.Context, input planner.DiscoveryInput) (planner.DiscoveryResult, error) {
+	s.stubPlannerScheduler.DiscoverIssues(ctx, input)
+	s.once.Do(func() { close(s.started) })
+	<-s.release
+	return planner.DiscoveryResult{}, nil
+}
+
+type sleepingPlannerScheduler struct {
+	stubPlannerScheduler
+	delay time.Duration
+}
+
+func (s *sleepingPlannerScheduler) DiscoverIssues(ctx context.Context, input planner.DiscoveryInput) (planner.DiscoveryResult, error) {
+	s.stubPlannerScheduler.DiscoverIssues(ctx, input)
+	time.Sleep(s.delay)
+	return planner.DiscoveryResult{}, nil
+}
+
+type capturingSchedulerLogger struct {
+	mu      sync.Mutex
+	entries []schedulerLogEntry
+}
+
+type schedulerLogEntry struct {
+	message string
+	context map[string]any
+}
+
+func (l *capturingSchedulerLogger) Debug(message string, context map[string]any) {
+	l.append(message, context)
+}
+func (l *capturingSchedulerLogger) Info(message string, context map[string]any) {
+	l.append(message, context)
+}
+func (l *capturingSchedulerLogger) Warn(message string, context map[string]any) {
+	l.append(message, context)
+}
+func (l *capturingSchedulerLogger) Error(message string, context map[string]any) {
+	l.append(message, context)
+}
+
+func (l *capturingSchedulerLogger) append(message string, context map[string]any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	copyContext := map[string]any{}
+	for key, value := range context {
+		copyContext[key] = value
+	}
+	l.entries = append(l.entries, schedulerLogEntry{message: message, context: copyContext})
+}
+
+func (l *capturingSchedulerLogger) requireMessage(t *testing.T, message string) {
+	t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, entry := range l.entries {
+		if entry.message == message {
+			return
+		}
+	}
+	t.Fatalf("logger messages = %#v, want %q", l.entries, message)
+}
+
+func (l *capturingSchedulerLogger) requireContextValue(t *testing.T, message, key string, want any) {
+	t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, entry := range l.entries {
+		if entry.message == message && entry.context[key] == want {
+			return
+		}
+	}
+	t.Fatalf("logger entries = %#v, want %q with %s=%v", l.entries, message, key, want)
 }
 
 func (s *queueStatusCheckingPlannerScheduler) DiscoverIssues(ctx context.Context, _ planner.DiscoveryInput) (planner.DiscoveryResult, error) {

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -82,28 +82,30 @@ type GitHubGateway interface {
 }
 
 type Options struct {
-	Repos        *storage.Repositories
-	GitHub       GitHubGateway
-	Agent        AgentExecutor
-	Logger       bootstrap.Logger
-	Now          func() time.Time
-	Config       *config.Config
-	AgentRuntime string
-	AgentModel   *string
+	Repos               *storage.Repositories
+	GitHub              GitHubGateway
+	Agent               AgentExecutor
+	Logger              bootstrap.Logger
+	Now                 func() time.Time
+	Config              *config.Config
+	AgentRuntime        string
+	AgentModel          *string
+	OnQueueItemEnqueued func()
 }
 
 type Runner struct {
-	repos        *storage.Repositories
-	github       GitHubGateway
-	agent        AgentExecutor
-	logger       bootstrap.Logger
-	now          func() time.Time
-	config       *config.Config
-	agentRuntime string
-	agentModel   *string
-	claimer      string
-	maxTry       int64
-	retryDelay   time.Duration
+	repos               *storage.Repositories
+	github              GitHubGateway
+	agent               AgentExecutor
+	logger              bootstrap.Logger
+	now                 func() time.Time
+	config              *config.Config
+	agentRuntime        string
+	agentModel          *string
+	claimer             string
+	maxTry              int64
+	retryDelay          time.Duration
+	onQueueItemEnqueued func()
 }
 
 type payloadEnvelope struct {
@@ -193,7 +195,7 @@ func New(options Options) *Runner {
 	if now == nil {
 		now = time.Now
 	}
-	return &Runner{repos: options.Repos, github: options.GitHub, agent: options.Agent, logger: options.Logger, now: now, config: options.Config, agentRuntime: options.AgentRuntime, agentModel: options.AgentModel, claimer: defaultClaimedBy, maxTry: defaultRetryMax, retryDelay: defaultRetryDelay}
+	return &Runner{repos: options.Repos, github: options.GitHub, agent: options.Agent, logger: options.Logger, now: now, config: options.Config, agentRuntime: options.AgentRuntime, agentModel: options.AgentModel, claimer: defaultClaimedBy, maxTry: defaultRetryMax, retryDelay: defaultRetryDelay, onQueueItemEnqueued: options.OnQueueItemEnqueued}
 }
 
 func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
@@ -612,7 +614,14 @@ func (r *Runner) buildQueueItem(ctx context.Context, seed queueSeed) (storage.Qu
 	if err := r.repos.Queue.Upsert(ctx, item); err != nil {
 		return storage.QueueItemRecord{}, false, err
 	}
+	r.wakeSchedulerAfterEnqueue()
 	return item, true, nil
+}
+
+func (r *Runner) wakeSchedulerAfterEnqueue() {
+	if r.onQueueItemEnqueued != nil {
+		r.onQueueItemEnqueued()
+	}
 }
 
 func (r *Runner) processWarn(ctx context.Context, queueItem storage.QueueItemRecord, payload sweeperPayload) (sweeperPayload, string, string, error) {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -428,6 +428,7 @@ type Options struct {
 	OnAgentExecutionStarted         AgentExecutionStartedFunc
 	OnRunCompleted                  RunCompletedFunc
 	DiscoveryPolicy                 DiscoveryPolicy
+	OnQueueItemEnqueued             func()
 }
 
 type DiscoveryPolicy struct {
@@ -465,6 +466,7 @@ type Runner struct {
 	onAgentExecutionStarted AgentExecutionStartedFunc
 	onRunCompleted          RunCompletedFunc
 	discoveryPolicy         DiscoveryPolicy
+	onQueueItemEnqueued     func()
 }
 
 type ProcessResult struct {
@@ -682,6 +684,7 @@ func New(options Options) *Runner {
 		onAgentExecutionStarted: options.OnAgentExecutionStarted,
 		onRunCompleted:          options.OnRunCompleted,
 		discoveryPolicy:         policy,
+		onQueueItemEnqueued:     options.OnQueueItemEnqueued,
 	}
 }
 
@@ -2268,7 +2271,14 @@ func (r *Runner) enqueueDiscoveredIssue(ctx context.Context, project storage.Pro
 	if err := r.repos.Queue.Upsert(ctx, queueItem); err != nil {
 		return storage.QueueItemRecord{}, err
 	}
+	r.wakeSchedulerAfterEnqueue()
 	return queueItem, nil
+}
+
+func (r *Runner) wakeSchedulerAfterEnqueue() {
+	if r.onQueueItemEnqueued != nil {
+		r.onQueueItemEnqueued()
+	}
 }
 
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {


### PR DESCRIPTION
## Summary
- add scheduler tick, lane, and claim-phase timing logs plus slow-lane warnings so discovery latency is diagnosable from daemon logs
- add an independent claim pump, claim-only wake path, and per-lane claim backstops so eligible queue items are claimed while discovery is still running
- wake planner/reviewer/fixer/worker/sweeper enqueue paths after commit and add regression coverage for claim latency, wake behavior, and scheduler observability

## Validation
- go test ./...
- go vet ./...
- go build ./...

## Trade-offs
- New runtime component: an in-memory claim pump plus a process-local claim mutex to serialize capacity checks and claims. This prevents queued work from waiting behind long discovery ticks; the cost is one extra goroutine, one extra wake path, and more scheduler lifecycle paths to keep aligned.
- Simpler alternative considered: only claim after each discovery lane. Rejected because items enqueued after the last lane in a long-running tick would still wait for the next poll; the claim pump keeps claim latency near the wake interval even while discovery is blocked.
- Deleted or simplified layer: internal discovery enqueue paths now wake only the lightweight claim pump instead of scheduling a full discovery rerun.

## Authority
Claim authority remains the existing queue eligibility query in `scheduledQueueBaseQuery`; the claim pump only wakes and invokes the existing `ClaimNext` path, and does not add new persisted gates or new agent-output inference.

Closes #346

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>