### PR TITLE
fix: share per-tick GitHub discovery snapshots (#348)

### DIFF
--- a/internal/coordinator/runner.go
+++ b/internal/coordinator/runner.go
@@ -27,6 +27,7 @@ const dispatchFailureCommentMarker = "<!-- looper:coordinator:dispatch-failure -
 type DiscoveryInput struct {
 	ProjectID string
 	Repo      string
+	Snapshot  *githubinfra.DiscoverySnapshot
 }
 
 type DiscoveryResult struct {
@@ -107,6 +108,7 @@ func New(options Options) *Runner {
 }
 
 func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	ctx = githubinfra.ContextWithDiscoverySnapshot(ctx, input.Snapshot)
 	if !r.shouldRunTick(input.ProjectID) {
 		return DiscoveryResult{Skipped: true}, nil
 	}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -447,6 +447,7 @@ type DiscoveryInput struct {
 	ProjectID string
 	Repo      string
 	Limit     int
+	Snapshot  *githubinfra.DiscoverySnapshot
 }
 
 type DiscoveryResult struct {
@@ -1001,6 +1002,7 @@ func New(options Options) *Runner {
 }
 
 func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	ctx = githubinfra.ContextWithDiscoverySnapshot(ctx, input.Snapshot)
 	if r.repos == nil || r.repos.Projects == nil || r.repos.Loops == nil || r.repos.Queue == nil || r.repos.Runs == nil || r.repos.Locks == nil {
 		return DiscoveryResult{}, fmt.Errorf("fixer repositories are not configured")
 	}

--- a/internal/infra/github/discovery_snapshot.go
+++ b/internal/infra/github/discovery_snapshot.go
@@ -16,9 +16,8 @@ type DiscoverySnapshotOptions struct {
 type discoverySnapshotContextKey struct{}
 
 type DiscoveryTickState struct {
-	mu           sync.Mutex
-	userLogin    string
-	userLoginSet bool
+	mu         sync.Mutex
+	userLogins map[string]string
 }
 
 type DiscoverySnapshot struct {
@@ -44,7 +43,7 @@ type DiscoverySnapshot struct {
 }
 
 func NewDiscoveryTickState() *DiscoveryTickState {
-	return &DiscoveryTickState{}
+	return &DiscoveryTickState{userLogins: map[string]string{}}
 }
 
 func NewDiscoverySnapshot(gateway *Gateway, tick *DiscoveryTickState, options DiscoverySnapshotOptions) *DiscoverySnapshot {
@@ -200,9 +199,9 @@ func (s *DiscoverySnapshot) getCurrentUserLogin(ctx context.Context, cwd string)
 	if s.tick == nil {
 		return s.gateway.getCurrentUserLoginRaw(ctx, cwd)
 	}
+	cacheKey := strings.TrimSpace(cwd)
 	s.tick.mu.Lock()
-	if s.tick.userLoginSet {
-		login := s.tick.userLogin
+	if login, ok := s.tick.userLogins[cacheKey]; ok {
 		s.tick.mu.Unlock()
 		return login, nil
 	}
@@ -212,8 +211,7 @@ func (s *DiscoverySnapshot) getCurrentUserLogin(ctx context.Context, cwd string)
 		return "", err
 	}
 	s.tick.mu.Lock()
-	s.tick.userLogin = login
-	s.tick.userLoginSet = true
+	s.tick.userLogins[cacheKey] = login
 	s.tick.mu.Unlock()
 	return login, nil
 }

--- a/internal/infra/github/discovery_snapshot.go
+++ b/internal/infra/github/discovery_snapshot.go
@@ -1,0 +1,312 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+)
+
+type DiscoverySnapshotOptions struct {
+	PullRequestLimit int
+	IssueLimit       int
+}
+
+type discoverySnapshotContextKey struct{}
+
+type DiscoveryTickState struct {
+	mu           sync.Mutex
+	userLogin    string
+	userLoginSet bool
+}
+
+type DiscoverySnapshot struct {
+	gateway    *Gateway
+	tick       *DiscoveryTickState
+	prLimit    int
+	issueLimit int
+
+	mu               sync.Mutex
+	openPRs          []PullRequestSummary
+	openPRsFetched   bool
+	openPRsFetchRepo string
+	openPRsFetchCWD  string
+	openPRsLimit     int
+
+	openIssues          []IssueSummary
+	openIssuesFetched   bool
+	openIssuesFetchRepo string
+	openIssuesFetchCWD  string
+	openIssuesLimit     int
+
+	prDetails map[string]PullRequestDetail
+}
+
+func NewDiscoveryTickState() *DiscoveryTickState {
+	return &DiscoveryTickState{}
+}
+
+func NewDiscoverySnapshot(gateway *Gateway, tick *DiscoveryTickState, options DiscoverySnapshotOptions) *DiscoverySnapshot {
+	if gateway == nil {
+		return nil
+	}
+	if tick == nil {
+		tick = NewDiscoveryTickState()
+	}
+	return &DiscoverySnapshot{gateway: gateway, tick: tick, prLimit: max(defaultLimit(options.PullRequestLimit), 30), issueLimit: max(defaultLimit(options.IssueLimit), 30), prDetails: map[string]PullRequestDetail{}}
+}
+
+func ContextWithDiscoverySnapshot(ctx context.Context, snapshot *DiscoverySnapshot) context.Context {
+	if snapshot == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, discoverySnapshotContextKey{}, snapshot)
+}
+
+func discoverySnapshotFromContext(ctx context.Context) *DiscoverySnapshot {
+	if ctx == nil {
+		return nil
+	}
+	snapshot, _ := ctx.Value(discoverySnapshotContextKey{}).(*DiscoverySnapshot)
+	return snapshot
+}
+
+func (s *DiscoverySnapshot) listOpenPullRequests(ctx context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
+	if err := s.ensureOpenPullRequests(ctx, input); err != nil {
+		return nil, err
+	}
+	prs := s.filteredPullRequests(input)
+	if s.shouldFallbackToFilteredPullRequestQuery(input, len(prs)) {
+		return s.gateway.listOpenPullRequestsRaw(ctx, input)
+	}
+	return limitPullRequests(prs, input.Limit), nil
+}
+
+func (s *DiscoverySnapshot) ensureOpenPullRequests(ctx context.Context, input ListOpenPullRequestsInput) error {
+	s.mu.Lock()
+	ready := s.openPRsFetched && s.openPRsFetchRepo == input.Repo && s.openPRsFetchCWD == input.CWD
+	s.mu.Unlock()
+	if ready {
+		return nil
+	}
+	requiredLimit := s.prLimit
+	prs, err := s.gateway.listOpenPullRequestsRaw(ctx, ListOpenPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: requiredLimit, Timeout: input.Timeout})
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.openPRs = prs
+	s.openPRsFetched = true
+	s.openPRsFetchRepo = input.Repo
+	s.openPRsFetchCWD = input.CWD
+	s.openPRsLimit = requiredLimit
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *DiscoverySnapshot) listOpenIssues(ctx context.Context, input ListOpenIssuesInput) ([]IssueSummary, error) {
+	if err := s.ensureOpenIssues(ctx, input); err != nil {
+		return nil, err
+	}
+	issues := s.filteredIssues(input)
+	if s.shouldFallbackToFilteredIssueQuery(input, len(issues)) {
+		return s.gateway.listOpenIssuesRaw(ctx, input)
+	}
+	return limitIssues(issues, input.Limit), nil
+}
+
+func (s *DiscoverySnapshot) ensureOpenIssues(ctx context.Context, input ListOpenIssuesInput) error {
+	s.mu.Lock()
+	ready := s.openIssuesFetched && s.openIssuesFetchRepo == input.Repo && s.openIssuesFetchCWD == input.CWD
+	s.mu.Unlock()
+	if ready {
+		return nil
+	}
+	requiredLimit := s.issueLimit
+	issues, err := s.gateway.listOpenIssuesRaw(ctx, ListOpenIssuesInput{Repo: input.Repo, CWD: input.CWD, Limit: requiredLimit})
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.openIssues = issues
+	s.openIssuesFetched = true
+	s.openIssuesFetchRepo = input.Repo
+	s.openIssuesFetchCWD = input.CWD
+	s.openIssuesLimit = requiredLimit
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *DiscoverySnapshot) viewPullRequest(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
+	key := snapshotPullRequestDetailKey(input)
+	s.mu.Lock()
+	if detail, ok := s.prDetails[key]; ok {
+		s.mu.Unlock()
+		return detail, nil
+	}
+	s.mu.Unlock()
+	detail, err := s.gateway.viewPullRequestRaw(ctx, input)
+	if err != nil {
+		return PullRequestDetail{}, err
+	}
+	s.mu.Lock()
+	s.prDetails[key] = detail
+	s.mu.Unlock()
+	return detail, nil
+}
+
+func (s *DiscoverySnapshot) filteredPullRequests(input ListOpenPullRequestsInput) []PullRequestSummary {
+	s.mu.Lock()
+	prs := append([]PullRequestSummary(nil), s.openPRs...)
+	s.mu.Unlock()
+	return filterPullRequests(prs, input)
+}
+
+func (s *DiscoverySnapshot) filteredIssues(input ListOpenIssuesInput) []IssueSummary {
+	s.mu.Lock()
+	issues := append([]IssueSummary(nil), s.openIssues...)
+	s.mu.Unlock()
+	return filterIssues(issues, input)
+}
+
+func (s *DiscoverySnapshot) shouldFallbackToFilteredPullRequestQuery(input ListOpenPullRequestsInput, filteredCount int) bool {
+	if !hasPullRequestFilters(input) {
+		return defaultLimit(input.Limit) > s.prLimit
+	}
+	if filteredCount >= defaultLimit(input.Limit) {
+		return false
+	}
+	s.mu.Lock()
+	truncated := len(s.openPRs) >= s.openPRsLimit
+	s.mu.Unlock()
+	return truncated
+}
+
+func (s *DiscoverySnapshot) shouldFallbackToFilteredIssueQuery(input ListOpenIssuesInput, filteredCount int) bool {
+	if !hasIssueFilters(input) {
+		return defaultLimit(input.Limit) > s.issueLimit
+	}
+	if filteredCount >= defaultLimit(input.Limit) {
+		return false
+	}
+	s.mu.Lock()
+	truncated := len(s.openIssues) >= s.openIssuesLimit
+	s.mu.Unlock()
+	return truncated
+}
+
+func (s *DiscoverySnapshot) getCurrentUserLogin(ctx context.Context, cwd string) (string, error) {
+	if s.tick == nil {
+		return s.gateway.getCurrentUserLoginRaw(ctx, cwd)
+	}
+	s.tick.mu.Lock()
+	if s.tick.userLoginSet {
+		login := s.tick.userLogin
+		s.tick.mu.Unlock()
+		return login, nil
+	}
+	s.tick.mu.Unlock()
+	login, err := s.gateway.getCurrentUserLoginRaw(ctx, cwd)
+	if err != nil {
+		return "", err
+	}
+	s.tick.mu.Lock()
+	s.tick.userLogin = login
+	s.tick.userLoginSet = true
+	s.tick.mu.Unlock()
+	return login, nil
+}
+
+func filterPullRequests(prs []PullRequestSummary, input ListOpenPullRequestsInput) []PullRequestSummary {
+	labels := prListLabels(input)
+	author := strings.TrimSpace(input.Author)
+	filtered := prs[:0]
+	for _, pr := range prs {
+		if author != "" && !strings.EqualFold(strings.TrimSpace(pr.Author), author) {
+			continue
+		}
+		if len(labels) > 0 && !hasAllLabels(pr.Labels, labels) {
+			continue
+		}
+		filtered = append(filtered, pr)
+	}
+	return filtered
+}
+
+func filterIssues(issues []IssueSummary, input ListOpenIssuesInput) []IssueSummary {
+	labels := issueListLabels(input)
+	assignee := strings.TrimSpace(input.Assignee)
+	filtered := issues[:0]
+	for _, issue := range issues {
+		if assignee != "" && !includesLogin(issue.Assignees, assignee) {
+			continue
+		}
+		if len(labels) > 0 && !hasAllLabels(issue.Labels, labels) {
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+	return filtered
+}
+
+func hasAllLabels(labels []string, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	normalized := make([]string, 0, len(labels))
+	for _, label := range labels {
+		normalized = append(normalized, strings.ToLower(strings.TrimSpace(label)))
+	}
+	for _, requiredLabel := range required {
+		if !slices.Contains(normalized, strings.ToLower(strings.TrimSpace(requiredLabel))) {
+			return false
+		}
+	}
+	return true
+}
+
+func includesLogin(logins []string, required string) bool {
+	required = strings.TrimSpace(required)
+	for _, login := range logins {
+		if strings.EqualFold(strings.TrimSpace(login), required) {
+			return true
+		}
+	}
+	return false
+}
+
+func limitPullRequests(prs []PullRequestSummary, limit int) []PullRequestSummary {
+	effective := defaultLimit(limit)
+	if len(prs) <= effective {
+		return prs
+	}
+	return prs[:effective]
+}
+
+func limitIssues(issues []IssueSummary, limit int) []IssueSummary {
+	effective := defaultLimit(limit)
+	if len(issues) <= effective {
+		return issues
+	}
+	return issues[:effective]
+}
+
+func snapshotPullRequestDetailKey(input ViewPullRequestInput) string {
+	return fmt.Sprintf("%s|%s|%d", input.Repo, input.CWD, input.PRNumber)
+}
+
+func hasPullRequestFilters(input ListOpenPullRequestsInput) bool {
+	return strings.TrimSpace(input.Author) != "" || len(prListLabels(input)) > 0
+}
+
+func hasIssueFilters(input ListOpenIssuesInput) bool {
+	return strings.TrimSpace(input.Assignee) != "" || len(issueListLabels(input)) > 0
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nexu-io/looper/internal/infra/shell"
 )
 
-func TestDiscoverySnapshotCachesPerProjectDataAndTickLogin(t *testing.T) {
+func TestDiscoverySnapshotCachesPerProjectDataAndTickLoginByCWD(t *testing.T) {
 	t.Parallel()
 
 	counts := map[string]int{}
@@ -35,7 +35,14 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLogin(t *testing.T) {
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
 		case strings.Contains(cmd, "api user --jq .login"):
 			counts["user_login"]++
-			return shell.Result{Stdout: "octo\n"}, nil
+			switch options.CWD {
+			case "/repo-one":
+				return shell.Result{Stdout: "octo\n"}, nil
+			case "/repo-two":
+				return shell.Result{Stdout: "other\n"}, nil
+			default:
+				return shell.Result{}, errors.New("unexpected cwd for user login: " + options.CWD)
+			}
 		default:
 			return shell.Result{}, errors.New("unexpected command: " + cmd)
 		}
@@ -73,11 +80,19 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLogin(t *testing.T) {
 	if _, err := gateway.ViewPullRequest(projectOneCtx, ViewPullRequestInput{Repo: "acme/looper", PRNumber: 1, CWD: "/repo-one"}); err != nil {
 		t.Fatalf("ViewPullRequest(second) error = %v", err)
 	}
-	if _, err := gateway.GetCurrentUserLogin(projectOneCtx, "/repo-one"); err != nil {
+	login, err := gateway.GetCurrentUserLogin(projectOneCtx, "/repo-one")
+	if err != nil {
 		t.Fatalf("GetCurrentUserLogin(project one) error = %v", err)
 	}
-	if _, err := gateway.GetCurrentUserLogin(projectTwoCtx, "/repo-two"); err != nil {
+	if login != "octo" {
+		t.Fatalf("GetCurrentUserLogin(project one) = %q, want octo", login)
+	}
+	login, err = gateway.GetCurrentUserLogin(projectTwoCtx, "/repo-two")
+	if err != nil {
 		t.Fatalf("GetCurrentUserLogin(project two) error = %v", err)
+	}
+	if login != "other" {
+		t.Fatalf("GetCurrentUserLogin(project two) = %q, want other", login)
 	}
 
 	if got := counts["pr_list"]; got != 1 {
@@ -89,8 +104,8 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLogin(t *testing.T) {
 	if got := counts["pr_view"]; got != 1 {
 		t.Fatalf("pr view calls = %d, want 1", got)
 	}
-	if got := counts["user_login"]; got != 1 {
-		t.Fatalf("user login calls = %d, want 1", got)
+	if got := counts["user_login"]; got != 2 {
+		t.Fatalf("user login calls = %d, want 2", got)
 	}
 }
 

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -1,0 +1,127 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/infra/shell"
+)
+
+func TestDiscoverySnapshotCachesPerProjectDataAndTickLogin(t *testing.T) {
+	t.Parallel()
+
+	counts := map[string]int{}
+	gateway := New(Options{GHRun: func(_ context.Context, options shell.Options) (shell.Result, error) {
+		cmd := strings.Join(options.Args, " ")
+		switch {
+		case strings.Contains(cmd, "pr list"):
+			counts["pr_list"]++
+			return shell.Result{Stdout: `[
+				{"number":1,"title":"PR 1","state":"OPEN","labels":[{"name":"bug"}],"headRefOid":"sha-1","author":{"login":"octo"}},
+				{"number":2,"title":"PR 2","state":"OPEN","labels":[{"name":"feature"}],"headRefOid":"sha-2","author":{"login":"other"}}
+			]`}, nil
+		case strings.Contains(cmd, "issue list"):
+			counts["issue_list"]++
+			return shell.Result{Stdout: `[
+				{"number":11,"title":"Issue 11","body":"body","url":"https://example.com/issues/11","state":"OPEN","assignees":[{"login":"octo"}],"labels":[{"name":"ready"}]},
+				{"number":12,"title":"Issue 12","body":"body","url":"https://example.com/issues/12","state":"OPEN","assignees":[{"login":"other"}],"labels":[{"name":"other"}]}
+			]`}, nil
+		case strings.Contains(cmd, "pr view 1") && strings.Contains(cmd, "statusCheckRollup"):
+			counts["pr_view"]++
+			return shell.Result{Stdout: `{"number":1,"title":"PR 1","body":"body","url":"https://example.com/pulls/1","state":"OPEN","labels":[{"name":"bug"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-1","baseRefOid":"base-1","author":{"login":"octo"},"comments":[],"reviewRequests":[],"reviews":[],"statusCheckRollup":[]}`}, nil
+		case strings.Contains(cmd, "api graphql") && strings.Contains(cmd, "reviewThreads"):
+			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
+		case strings.Contains(cmd, "api user --jq .login"):
+			counts["user_login"]++
+			return shell.Result{Stdout: "octo\n"}, nil
+		default:
+			return shell.Result{}, errors.New("unexpected command: " + cmd)
+		}
+	}})
+
+	tick := NewDiscoveryTickState()
+	options := DiscoverySnapshotOptions{PullRequestLimit: 100, IssueLimit: 100}
+	projectOneCtx := ContextWithDiscoverySnapshot(context.Background(), NewDiscoverySnapshot(gateway, tick, options))
+	projectTwoCtx := ContextWithDiscoverySnapshot(context.Background(), NewDiscoverySnapshot(gateway, tick, options))
+
+	prs, err := gateway.ListOpenPullRequests(projectOneCtx, ListOpenPullRequestsInput{Repo: "acme/looper", CWD: "/repo-one", Limit: 10, Label: "bug"})
+	if err != nil {
+		t.Fatalf("ListOpenPullRequests(label) error = %v", err)
+	}
+	if len(prs) != 1 || prs[0].Number != 1 {
+		t.Fatalf("ListOpenPullRequests(label) = %#v, want only PR 1", prs)
+	}
+	prs, err = gateway.ListOpenPullRequests(projectOneCtx, ListOpenPullRequestsInput{Repo: "acme/looper", CWD: "/repo-one", Limit: 10, Author: "octo"})
+	if err != nil {
+		t.Fatalf("ListOpenPullRequests(author) error = %v", err)
+	}
+	if len(prs) != 1 || prs[0].Number != 1 {
+		t.Fatalf("ListOpenPullRequests(author) = %#v, want only PR 1", prs)
+	}
+	issues, err := gateway.ListOpenIssues(projectOneCtx, ListOpenIssuesInput{Repo: "acme/looper", CWD: "/repo-one", Limit: 10, Assignee: "octo", Label: "ready"})
+	if err != nil {
+		t.Fatalf("ListOpenIssues() error = %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 11 {
+		t.Fatalf("ListOpenIssues() = %#v, want only issue 11", issues)
+	}
+	if _, err := gateway.ViewPullRequest(projectOneCtx, ViewPullRequestInput{Repo: "acme/looper", PRNumber: 1, CWD: "/repo-one"}); err != nil {
+		t.Fatalf("ViewPullRequest(first) error = %v", err)
+	}
+	if _, err := gateway.ViewPullRequest(projectOneCtx, ViewPullRequestInput{Repo: "acme/looper", PRNumber: 1, CWD: "/repo-one"}); err != nil {
+		t.Fatalf("ViewPullRequest(second) error = %v", err)
+	}
+	if _, err := gateway.GetCurrentUserLogin(projectOneCtx, "/repo-one"); err != nil {
+		t.Fatalf("GetCurrentUserLogin(project one) error = %v", err)
+	}
+	if _, err := gateway.GetCurrentUserLogin(projectTwoCtx, "/repo-two"); err != nil {
+		t.Fatalf("GetCurrentUserLogin(project two) error = %v", err)
+	}
+
+	if got := counts["pr_list"]; got != 1 {
+		t.Fatalf("pr list calls = %d, want 1", got)
+	}
+	if got := counts["issue_list"]; got != 1 {
+		t.Fatalf("issue list calls = %d, want 1", got)
+	}
+	if got := counts["pr_view"]; got != 1 {
+		t.Fatalf("pr view calls = %d, want 1", got)
+	}
+	if got := counts["user_login"]; got != 1 {
+		t.Fatalf("user login calls = %d, want 1", got)
+	}
+}
+
+func TestDiscoverySnapshotDoesNotCacheFailedPullRequestDetailFetch(t *testing.T) {
+	t.Parallel()
+
+	viewCalls := 0
+	gateway := New(Options{GHRun: func(_ context.Context, options shell.Options) (shell.Result, error) {
+		cmd := strings.Join(options.Args, " ")
+		switch {
+		case strings.Contains(cmd, "pr view 7") && strings.Contains(cmd, "statusCheckRollup"):
+			viewCalls++
+			if viewCalls == 1 {
+				return shell.Result{}, errors.New("temporary gh failure")
+			}
+			return shell.Result{Stdout: `{"number":7,"title":"PR 7","body":"body","url":"https://example.com/pulls/7","state":"OPEN","labels":[],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-7","baseRefOid":"base-7","author":{"login":"octo"},"comments":[],"reviewRequests":[],"reviews":[],"statusCheckRollup":[]}`}, nil
+		case strings.Contains(cmd, "api graphql") && strings.Contains(cmd, "reviewThreads"):
+			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
+		default:
+			return shell.Result{}, errors.New("unexpected command: " + cmd)
+		}
+	}})
+
+	ctx := ContextWithDiscoverySnapshot(context.Background(), NewDiscoverySnapshot(gateway, NewDiscoveryTickState(), DiscoverySnapshotOptions{PullRequestLimit: 100, IssueLimit: 100}))
+	if _, err := gateway.ViewPullRequest(ctx, ViewPullRequestInput{Repo: "acme/looper", PRNumber: 7, CWD: "/repo"}); err == nil {
+		t.Fatal("ViewPullRequest(first) error = nil, want error")
+	}
+	if _, err := gateway.ViewPullRequest(ctx, ViewPullRequestInput{Repo: "acme/looper", PRNumber: 7, CWD: "/repo"}); err != nil {
+		t.Fatalf("ViewPullRequest(second) error = %v", err)
+	}
+	if viewCalls != 2 {
+		t.Fatalf("pr view calls = %d, want 2 after retry", viewCalls)
+	}
+}

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -515,6 +515,13 @@ func New(options Options) *Gateway {
 }
 
 func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
+	if snapshot := discoverySnapshotFromContext(ctx); snapshot != nil {
+		return snapshot.listOpenPullRequests(ctx, input)
+	}
+	return g.listOpenPullRequestsRaw(ctx, input)
+}
+
+func (g *Gateway) listOpenPullRequestsRaw(ctx context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
 	args := []string{"pr", "list", "--repo", input.Repo, "--state", "open", "--limit", fmt.Sprintf("%d", defaultLimit(input.Limit))}
 	labels := prListLabels(input)
 	for _, label := range labels {
@@ -609,6 +616,13 @@ func (g *Gateway) GetPullRequestHeadAndAuthor(ctx context.Context, input ViewPul
 }
 
 func (g *Gateway) ListOpenIssues(ctx context.Context, input ListOpenIssuesInput) ([]IssueSummary, error) {
+	if snapshot := discoverySnapshotFromContext(ctx); snapshot != nil {
+		return snapshot.listOpenIssues(ctx, input)
+	}
+	return g.listOpenIssuesRaw(ctx, input)
+}
+
+func (g *Gateway) listOpenIssuesRaw(ctx context.Context, input ListOpenIssuesInput) ([]IssueSummary, error) {
 	args := []string{"issue", "list", "--repo", input.Repo, "--state", "open", "--limit", fmt.Sprintf("%d", defaultLimit(input.Limit))}
 	if strings.TrimSpace(input.Assignee) != "" {
 		args = append(args, "--assignee", input.Assignee)
@@ -926,6 +940,13 @@ func compactIssueAssignees(values []string) []string {
 }
 
 func (g *Gateway) ViewPullRequest(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
+	if snapshot := discoverySnapshotFromContext(ctx); snapshot != nil {
+		return snapshot.viewPullRequest(ctx, input)
+	}
+	return g.viewPullRequestRaw(ctx, input)
+}
+
+func (g *Gateway) viewPullRequestRaw(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
 	result, err := g.runGh(ctx, input.CWD, "", "pr", "view", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo, "--json", strings.Join([]string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}, ","))
 	if err != nil {
 		return PullRequestDetail{}, err
@@ -1868,6 +1889,13 @@ func (g *Gateway) IsAuthenticated(ctx context.Context, cwd, hostname string) (bo
 }
 
 func (g *Gateway) GetCurrentUserLogin(ctx context.Context, cwd string) (string, error) {
+	if snapshot := discoverySnapshotFromContext(ctx); snapshot != nil {
+		return snapshot.getCurrentUserLogin(ctx, cwd)
+	}
+	return g.getCurrentUserLoginRaw(ctx, cwd)
+}
+
+func (g *Gateway) getCurrentUserLoginRaw(ctx context.Context, cwd string) (string, error) {
 	result, err := g.runGh(ctx, cwd, "", "api", "user", "--jq", ".login")
 	if err != nil {
 		if isUserLoginUnsupportedForCurrentToken(err) {

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -333,6 +333,7 @@ type DiscoveryInput struct {
 	ProjectID string
 	Repo      string
 	Limit     int
+	Snapshot  *githubinfra.DiscoverySnapshot
 }
 
 type DiscoveryResult struct {
@@ -485,6 +486,7 @@ func New(options Options) *Runner {
 }
 
 func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	ctx = githubinfra.ContextWithDiscoverySnapshot(ctx, input.Snapshot)
 	if r.repos == nil || r.repos.Projects == nil || r.repos.Loops == nil || r.repos.Queue == nil || r.repos.Runs == nil {
 		return DiscoveryResult{}, fmt.Errorf("planner repositories are not configured")
 	}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -440,6 +440,7 @@ type DiscoveryInput struct {
 	ProjectID string
 	Repo      string
 	Limit     int
+	Snapshot  *githubinfra.DiscoverySnapshot
 }
 
 type DiscoveryResult struct {
@@ -639,6 +640,7 @@ func New(options Options) *Runner {
 }
 
 func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	ctx = githubinfra.ContextWithDiscoverySnapshot(ctx, input.Snapshot)
 	if r.repos == nil || r.repos.Projects == nil || r.repos.Loops == nil || r.repos.Queue == nil || r.repos.Runs == nil {
 		return DiscoveryResult{}, fmt.Errorf("reviewer repositories are not configured")
 	}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -79,6 +79,7 @@ type schedulerAsyncRunner interface {
 
 type defaultSchedulerTickInput struct {
 	Repos                    *storage.Repositories
+	GitHubGateway            *githubinfra.Gateway
 	Logger                   bootstrap.Logger
 	Now                      func() time.Time
 	MaxConcurrentRuns        int
@@ -1086,6 +1087,7 @@ func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, c
 		}
 		return defaultSchedulerTickInput{
 			Repos:                    services.Repositories,
+			GitHubGateway:            githubGateway,
 			Logger:                   logger,
 			Now:                      now,
 			MaxConcurrentRuns:        cfg.Scheduler.MaxConcurrentRuns,
@@ -1212,6 +1214,19 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		retErr = errors.Join(errs...)
 		return retErr
 	}
+	tickDiscoveryState := githubinfra.NewDiscoveryTickState()
+	projectSnapshots := map[string]*githubinfra.DiscoverySnapshot{}
+	projectSnapshot := func(projectID string) *githubinfra.DiscoverySnapshot {
+		if input.GitHubGateway == nil {
+			return nil
+		}
+		if snapshot, ok := projectSnapshots[projectID]; ok {
+			return snapshot
+		}
+		snapshot := githubinfra.NewDiscoverySnapshot(input.GitHubGateway, tickDiscoveryState, projectDiscoverySnapshotOptions(input, projectID))
+		projectSnapshots[projectID] = snapshot
+		return snapshot
+	}
 	for _, project := range projectsList {
 		if err := ctx.Err(); err != nil {
 			retErr = errors.Join(append(errs, err)...)
@@ -1221,6 +1236,7 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 			continue
 		}
 		repo := repoFromProjectMetadata(project.MetadataJSON)
+		snapshot := projectSnapshot(project.ID)
 		if repo == "" {
 			if input.Logger != nil {
 				input.Logger.Warn("scheduler skipped project without repo metadata", map[string]any{"projectId": project.ID})
@@ -1229,7 +1245,7 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		}
 		if input.Planner != nil && discoveryEnabled(input.PlannerDiscoveryEnabled) {
 			appendErr(runSchedulerLane(input, "planner discovery", project.ID, repo, func() error {
-				result, err := input.Planner.DiscoverIssues(ctx, planner.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				result, err := input.Planner.DiscoverIssues(ctx, planner.DiscoveryInput{ProjectID: project.ID, Repo: repo, Snapshot: snapshot})
 				trackRunnableDiscovery(result.QueueItems)
 				return wrapSchedulerError("planner discovery", project.ID, repo, err)
 			}))
@@ -1240,7 +1256,7 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		}
 		if input.Coordinator != nil && coordinatorEnabledForProject(input, project.ID) {
 			appendErr(runSchedulerLane(input, "coordinator discovery", project.ID, repo, func() error {
-				_, err := input.Coordinator.DiscoverIssues(ctx, coordinatorrole.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				_, err := input.Coordinator.DiscoverIssues(ctx, coordinatorrole.DiscoveryInput{ProjectID: project.ID, Repo: repo, Snapshot: snapshot})
 				return wrapSchedulerError("coordinator discovery", project.ID, repo, err)
 			}))
 			claimedCount, availableSlots, err = executeClaimPhase(ctx, "post_coordinator_discovery", input, discoveredRunnableIDs, true)
@@ -1248,7 +1264,7 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		}
 		if input.Reviewer != nil && discoveryEnabled(input.ReviewerDiscoveryEnabled) {
 			appendErr(runSchedulerLane(input, "reviewer discovery", project.ID, repo, func() error {
-				result, err := input.Reviewer.DiscoverPullRequests(ctx, reviewer.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				result, err := input.Reviewer.DiscoverPullRequests(ctx, reviewer.DiscoveryInput{ProjectID: project.ID, Repo: repo, Snapshot: snapshot})
 				trackRunnableDiscovery(result.QueueItems)
 				return wrapSchedulerError("reviewer discovery", project.ID, repo, err)
 			}))
@@ -1259,7 +1275,7 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		}
 		if input.Fixer != nil && discoveryEnabled(input.FixerDiscoveryEnabled) {
 			appendErr(runSchedulerLane(input, "fixer discovery", project.ID, repo, func() error {
-				result, err := input.Fixer.DiscoverPullRequests(ctx, fixer.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				result, err := input.Fixer.DiscoverPullRequests(ctx, fixer.DiscoveryInput{ProjectID: project.ID, Repo: repo, Snapshot: snapshot})
 				trackRunnableDiscovery(result.QueueItems)
 				return wrapSchedulerError("fixer discovery", project.ID, repo, err)
 			}))
@@ -1270,7 +1286,7 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 		}
 		if discoverer, ok := input.Worker.(workerIssueDiscoveryScheduler); ok && discoveryEnabled(input.WorkerDiscoveryEnabled) {
 			appendErr(runSchedulerLane(input, "worker issue discovery", project.ID, repo, func() error {
-				result, err := discoverer.DiscoverIssues(ctx, worker.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				result, err := discoverer.DiscoverIssues(ctx, worker.DiscoveryInput{ProjectID: project.ID, Repo: repo, Snapshot: snapshot})
 				trackRunnableDiscovery(result.QueueItems)
 				return wrapSchedulerError("worker issue discovery", project.ID, repo, err)
 			}))
@@ -1293,17 +1309,18 @@ func runDefaultSchedulerTick(ctx context.Context, input defaultSchedulerTickInpu
 			continue
 		}
 		repo := repoFromProjectMetadata(project.MetadataJSON)
+		snapshot := projectSnapshot(project.ID)
 		if repo == "" {
 			continue
 		}
 		if input.Sweeper != nil && discoveryEnabled(input.SweeperDiscoveryEnabled) {
 			appendErr(applySweeperBackpressure(ctx, input, project, repo))
 			appendErr(runSchedulerLane(input, "sweeper issue discovery", project.ID, repo, func() error {
-				_, err := input.Sweeper.DiscoverIssues(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				_, err := input.Sweeper.DiscoverIssues(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo, Snapshot: snapshot})
 				return wrapSchedulerError("sweeper issue discovery", project.ID, repo, err)
 			}))
 			appendErr(runSchedulerLane(input, "sweeper pull request discovery", project.ID, repo, func() error {
-				_, err := input.Sweeper.DiscoverPullRequests(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo})
+				_, err := input.Sweeper.DiscoverPullRequests(ctx, sweeper.DiscoveryInput{ProjectID: project.ID, Repo: repo, Snapshot: snapshot})
 				return wrapSchedulerError("sweeper pull request discovery", project.ID, repo, err)
 			}))
 			appendErr(runSchedulerLane(input, "sweeper reconciliation discovery", project.ID, repo, func() error {
@@ -1333,6 +1350,28 @@ func coordinatorEnabledForProject(input defaultSchedulerTickInput, projectID str
 		return false
 	}
 	return input.CoordinatorEnabled(projectID)
+}
+
+func projectDiscoverySnapshotOptions(input defaultSchedulerTickInput, projectID string) githubinfra.DiscoverySnapshotOptions {
+	prLimit := 30
+	issueLimit := 30
+	if input.Coordinator != nil && coordinatorEnabledForProject(input, projectID) {
+		issueLimit = maxInt(issueLimit, 100)
+	}
+	if input.Config != nil && input.Sweeper != nil && discoveryEnabled(input.SweeperDiscoveryEnabled) {
+		roles := config.ProjectRoleConfigs(*input.Config, projectID)
+		sweeperLimit := maxInt(roles.Sweeper.Triggers.MaxPerTick*6, 30)
+		prLimit = maxInt(prLimit, sweeperLimit)
+		issueLimit = maxInt(issueLimit, sweeperLimit)
+	}
+	return githubinfra.DiscoverySnapshotOptions{PullRequestLimit: prLimit, IssueLimit: issueLimit}
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func runnableSchedulerQueueItemIDs(queueItems []storage.QueueItemRecord, now func() time.Time) []string {

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -49,6 +49,7 @@ type DiscoveryInput struct {
 	ProjectID string
 	Repo      string
 	Limit     int
+	Snapshot  *githubinfra.DiscoverySnapshot
 }
 
 type DiscoveryResult struct {
@@ -376,6 +377,7 @@ func (r *Runner) recoverClaimedQueueItem(ctx context.Context, queueItem storage.
 }
 
 func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	ctx = githubinfra.ContextWithDiscoverySnapshot(ctx, input.Snapshot)
 	project, roleCfg, err := r.projectConfig(ctx, input.ProjectID)
 	if err != nil {
 		return DiscoveryResult{}, err
@@ -471,6 +473,7 @@ func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryI
 }
 
 func (r *Runner) discoverPullRequestsAndClosures(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	ctx = githubinfra.ContextWithDiscoverySnapshot(ctx, input.Snapshot)
 	project, roleCfg, err := r.projectConfig(ctx, input.ProjectID)
 	if err != nil {
 		return DiscoveryResult{}, err

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -483,6 +483,7 @@ type DiscoveryInput struct {
 	ProjectID string
 	Repo      string
 	Limit     int
+	Snapshot  *githubinfra.DiscoverySnapshot
 }
 
 type DiscoveryResult struct {
@@ -689,6 +690,7 @@ func New(options Options) *Runner {
 }
 
 func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {
+	ctx = githubinfra.ContextWithDiscoverySnapshot(ctx, input.Snapshot)
 	if r.repos == nil || r.repos.Projects == nil || r.repos.Loops == nil || r.repos.Queue == nil || r.github == nil {
 		return DiscoveryResult{}, fmt.Errorf("worker discovery is not configured")
 	}


### PR DESCRIPTION
## Summary
- add a per-tick discovery snapshot that is created once per project in the scheduler and threaded through planner, coordinator, reviewer, fixer, worker, and sweeper discovery lanes
- reuse cached open PRs, open issues, PR detail payloads, and the current GitHub login during discovery so overlapping scheduler roles stop shelling out for the same data in the same tick
- add focused snapshot tests plus full Go validation coverage for the threaded discovery path

## Why
- this removes redundant GitHub discovery fetches inside a single scheduler tick without introducing cross-tick state
- authority for side effects is unchanged: the snapshot is only used for discovery reuse, while action-time mutations still re-read GitHub live state when they execute
- the trade-off is one in-memory snapshot type plus scheduler threading instead of repeated role-local GitHub list/detail/login fetches every tick

## Validation
- go vet ./...
- go test ./...
- go build ./...

Closes #348

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>