### PR TITLE
feat: add dependency graph foundation for dependency gate

### DIFF
--- a/docs/adr/0004-dependency-gate-via-github-native-blocked-by.md
+++ b/docs/adr/0004-dependency-gate-via-github-native-blocked-by.md
@@ -1,0 +1,31 @@
+# Dependency gate authority is GitHub-native blocked_by plus close state
+
+## Context
+
+Coordinator already performs Triage and Dispatch using durable, public GitHub state. ADR-0002 established that Dispatch must read an explicit Authority rather than infer intent from ephemeral agent output. The dependency-aware Dispatch PRD extends that rule: before Coordinator may Dispatch a Triaged Issue, it must have a named Authority for whether upstream work is complete.
+
+Per `AGENTS.md`'s "Name the authority before enforcing it" rule, the question is: *what is the Authority for "Issue may be Dispatched," and why is it not the agent's own structured output?* For this slice, the Authority is GitHub-native issue dependencies (`blocked_by`) plus the blocker Issue's durable close state (`state` + `state_reason`). That state is public, inspectable, human-vetoable, and already lives on the Issue record Coordinator reads.
+
+## Decision
+
+Coordinator's dependency gate will treat GitHub-native `blocked_by` as the source of dependency structure, and blocker close state as the source of dependency satisfaction.
+
+- `state==closed` and `state_reason==completed` is the only satisfied blocker state.
+- `state==closed` with `state_reason==not_planned` or `state_reason==duplicate` is not satisfied and requires re-triage.
+- `state==open` remains blocking.
+- Missing blocker reads are treated as unreachable dependencies, not as satisfied work.
+
+This keeps the Authority chain durable and human-visible: a human or agent links dependencies in GitHub, a human or agent closes blocker Issues with a durable reason, and Coordinator later reads those public records before Dispatch.
+
+## Considered Options
+
+- **`blocked-by:` label convention** — encode dependencies in labels. Rejected because labels do not express ordered dependency relationships well, become noisy on multi-blocker Issues, and would create a parallel Authority separate from GitHub's native dependency model.
+- **Markdown regex in the Issue body** — parse dependency references from prose or checklists. Rejected because it turns Dispatch into inference over unstructured text rather than reading a durable structured Authority.
+- **Private dependency cache** — mirror dependency edges and blocker state into Looper-managed storage. Rejected because it adds a second source of truth, drift risk, and recovery logic for data GitHub already persists publicly.
+
+## Consequences
+
+- Later Dispatch slices must read `blocked_by`, `state`, and `state_reason` directly from GitHub before applying a Trigger label.
+- `not_planned` and `duplicate` do not silently unblock Dispatch; they become explicit re-triage cases so humans can revisit Disposition and dependency structure.
+- Coordinator remains stateless with respect to dependency Authority. The graph used for Dispatch can be rebuilt from current GitHub state each tick.
+- This follows the same pattern as ADR-0002: the agent may propose structure, but Dispatch acts only on durable GitHub Authority that humans can inspect and veto.

--- a/internal/coordinator/depgraph/depgraph.go
+++ b/internal/coordinator/depgraph/depgraph.go
@@ -1,0 +1,318 @@
+package depgraph
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type IssueRef struct {
+	Repo   string
+	Number int64
+}
+
+func (r IssueRef) String() string {
+	r = normalizeRef(r)
+	if r.Number <= 0 {
+		return ""
+	}
+	if r.Repo == "" {
+		return fmt.Sprintf("#%d", r.Number)
+	}
+	return fmt.Sprintf("%s#%d", r.Repo, r.Number)
+}
+
+type IssueState struct {
+	State       string
+	StateReason string
+}
+
+type Snapshot struct {
+	BlockedBy   map[IssueRef][]IssueRef
+	Issues      map[IssueRef]IssueState
+	Unreachable []IssueRef
+}
+
+type Blocker struct {
+	Issue            IssueRef
+	State            string
+	StateReason      string
+	Satisfied        bool
+	RequiresReTriage bool
+	Unreachable      bool
+}
+
+type Cycle []IssueRef
+
+type DependencyGraph struct {
+	readySet    []IssueRef
+	cycles      []Cycle
+	unreachable []IssueRef
+	blockers    map[IssueRef][]Blocker
+}
+
+func Build(tracked []IssueRef, snapshot Snapshot) DependencyGraph {
+	tracked = uniqueSortedRefs(tracked)
+	trackedSet := make(map[IssueRef]struct{}, len(tracked))
+	for _, ref := range tracked {
+		trackedSet[ref] = struct{}{}
+	}
+
+	blockedBy := normalizeBlockedBy(snapshot.BlockedBy)
+	issueStates := normalizeIssueStates(snapshot.Issues)
+	unreachableSet := make(map[IssueRef]struct{}, len(snapshot.Unreachable))
+	for _, ref := range snapshot.Unreachable {
+		ref = normalizeRef(ref)
+		if ref.Number > 0 {
+			unreachableSet[ref] = struct{}{}
+		}
+	}
+
+	readySet := make([]IssueRef, 0, len(tracked))
+	blockers := make(map[IssueRef][]Blocker, len(tracked))
+	edges := make(map[IssueRef][]IssueRef, len(tracked))
+
+	for _, issue := range tracked {
+		deps := uniqueSortedRefs(blockedBy[issue])
+		unsatisfied := make([]Blocker, 0, len(deps))
+		trackedDeps := make([]IssueRef, 0, len(deps))
+		for _, dep := range deps {
+			blocker := newBlocker(dep, issueStates)
+			if blocker.Satisfied {
+				continue
+			}
+			unsatisfied = append(unsatisfied, blocker)
+			if blocker.Unreachable {
+				unreachableSet[blocker.Issue] = struct{}{}
+				continue
+			}
+			if _, ok := trackedSet[blocker.Issue]; ok {
+				trackedDeps = append(trackedDeps, blocker.Issue)
+			}
+		}
+		if len(unsatisfied) == 0 {
+			readySet = append(readySet, issue)
+			continue
+		}
+		blockers[issue] = unsatisfied
+		if len(trackedDeps) > 0 {
+			edges[issue] = trackedDeps
+		}
+	}
+
+	return DependencyGraph{
+		readySet:    append([]IssueRef(nil), readySet...),
+		cycles:      detectCycles(tracked, edges),
+		unreachable: refsFromSet(unreachableSet),
+		blockers:    blockers,
+	}
+}
+
+func (g DependencyGraph) ReadySet() []IssueRef {
+	return append([]IssueRef(nil), g.readySet...)
+}
+
+func (g DependencyGraph) Cycles() []Cycle {
+	out := make([]Cycle, 0, len(g.cycles))
+	for _, cycle := range g.cycles {
+		out = append(out, append(Cycle(nil), cycle...))
+	}
+	return out
+}
+
+func (g DependencyGraph) UnreachableDeps() []IssueRef {
+	return append([]IssueRef(nil), g.unreachable...)
+}
+
+func (g DependencyGraph) BlockersOf(issue IssueRef) []Blocker {
+	rows := g.blockers[normalizeRef(issue)]
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make([]Blocker, len(rows))
+	copy(out, rows)
+	return out
+}
+
+type blockerDisposition struct {
+	Satisfied        bool
+	RequiresReTriage bool
+}
+
+func classifyBlockerState(state IssueState) blockerDisposition {
+	normalizedState := strings.ToLower(strings.TrimSpace(state.State))
+	normalizedReason := strings.ToLower(strings.TrimSpace(state.StateReason))
+	if normalizedState == "closed" && normalizedReason == "completed" {
+		return blockerDisposition{Satisfied: true}
+	}
+	if normalizedState == "closed" && (normalizedReason == "not_planned" || normalizedReason == "duplicate") {
+		return blockerDisposition{RequiresReTriage: true}
+	}
+	return blockerDisposition{}
+}
+
+func newBlocker(dep IssueRef, issues map[IssueRef]IssueState) Blocker {
+	dep = normalizeRef(dep)
+	state, ok := issues[dep]
+	if !ok {
+		return Blocker{Issue: dep, Unreachable: true}
+	}
+	state.State = strings.ToLower(strings.TrimSpace(state.State))
+	state.StateReason = strings.ToLower(strings.TrimSpace(state.StateReason))
+	classification := classifyBlockerState(state)
+	return Blocker{
+		Issue:            dep,
+		State:            state.State,
+		StateReason:      state.StateReason,
+		Satisfied:        classification.Satisfied,
+		RequiresReTriage: classification.RequiresReTriage,
+	}
+}
+
+func detectCycles(tracked []IssueRef, edges map[IssueRef][]IssueRef) []Cycle {
+	state := make(map[IssueRef]int, len(tracked))
+	stack := make([]IssueRef, 0, len(tracked))
+	stackIndex := map[IssueRef]int{}
+	seen := map[string]Cycle{}
+
+	var visit func(IssueRef)
+	visit = func(node IssueRef) {
+		state[node] = 1
+		stackIndex[node] = len(stack)
+		stack = append(stack, node)
+		for _, next := range edges[node] {
+			if idx, ok := stackIndex[next]; ok {
+				cycle := append(append([]IssueRef(nil), stack[idx:]...), next)
+				normalized := canonicalizeCycle(cycle)
+				seen[cycleKey(normalized)] = normalized
+				continue
+			}
+			if state[next] == 0 {
+				visit(next)
+			}
+		}
+		stack = stack[:len(stack)-1]
+		delete(stackIndex, node)
+		state[node] = 2
+	}
+
+	for _, node := range tracked {
+		if state[node] == 0 {
+			visit(node)
+		}
+	}
+
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]Cycle, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, append(Cycle(nil), seen[key]...))
+	}
+	return out
+}
+
+func canonicalizeCycle(cycle []IssueRef) Cycle {
+	if len(cycle) < 2 {
+		return nil
+	}
+	nodes := append([]IssueRef(nil), cycle[:len(cycle)-1]...)
+	best := nodes
+	for index := 1; index < len(nodes); index++ {
+		candidate := append(append([]IssueRef(nil), nodes[index:]...), nodes[:index]...)
+		if refsSliceLess(candidate, best) {
+			best = candidate
+		}
+	}
+	best = append(best, best[0])
+	return Cycle(best)
+}
+
+func refsSliceLess(left []IssueRef, right []IssueRef) bool {
+	for index := 0; index < len(left) && index < len(right); index++ {
+		if refLess(left[index], right[index]) {
+			return true
+		}
+		if refLess(right[index], left[index]) {
+			return false
+		}
+	}
+	return len(left) < len(right)
+}
+
+func cycleKey(cycle Cycle) string {
+	parts := make([]string, 0, len(cycle))
+	for _, ref := range cycle {
+		parts = append(parts, ref.String())
+	}
+	return strings.Join(parts, "->")
+}
+
+func normalizeBlockedBy(input map[IssueRef][]IssueRef) map[IssueRef][]IssueRef {
+	out := make(map[IssueRef][]IssueRef, len(input))
+	for issue, deps := range input {
+		issue = normalizeRef(issue)
+		if issue.Number <= 0 {
+			continue
+		}
+		for _, dep := range deps {
+			dep = normalizeRef(dep)
+			if dep.Number <= 0 {
+				continue
+			}
+			out[issue] = append(out[issue], dep)
+		}
+	}
+	return out
+}
+
+func normalizeIssueStates(input map[IssueRef]IssueState) map[IssueRef]IssueState {
+	out := make(map[IssueRef]IssueState, len(input))
+	for ref, state := range input {
+		ref = normalizeRef(ref)
+		if ref.Number <= 0 {
+			continue
+		}
+		out[ref] = IssueState{State: strings.TrimSpace(state.State), StateReason: strings.TrimSpace(state.StateReason)}
+	}
+	return out
+}
+
+func normalizeRef(ref IssueRef) IssueRef {
+	ref.Repo = strings.ToLower(strings.TrimSpace(ref.Repo))
+	return ref
+}
+
+func uniqueSortedRefs(input []IssueRef) []IssueRef {
+	set := make(map[IssueRef]struct{}, len(input))
+	for _, ref := range input {
+		ref = normalizeRef(ref)
+		if ref.Number <= 0 {
+			continue
+		}
+		set[ref] = struct{}{}
+	}
+	return refsFromSet(set)
+}
+
+func refsFromSet(set map[IssueRef]struct{}) []IssueRef {
+	out := make([]IssueRef, 0, len(set))
+	for ref := range set {
+		out = append(out, ref)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return refLess(out[i], out[j])
+	})
+	return out
+}
+
+func refLess(left IssueRef, right IssueRef) bool {
+	left = normalizeRef(left)
+	right = normalizeRef(right)
+	if left.Repo != right.Repo {
+		return left.Repo < right.Repo
+	}
+	return left.Number < right.Number
+}

--- a/internal/coordinator/depgraph/depgraph_test.go
+++ b/internal/coordinator/depgraph/depgraph_test.go
@@ -1,0 +1,150 @@
+package depgraph
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReadySet(t *testing.T) {
+	t.Parallel()
+	repo := "acme/looper"
+	blocker := IssueRef{Repo: repo, Number: 2}
+	tests := []struct {
+		name     string
+		tracked  []IssueRef
+		snapshot Snapshot
+		want     []IssueRef
+	}{
+		{name: "empty input", want: nil},
+		{name: "single issue with no blockers", tracked: []IssueRef{{Repo: repo, Number: 1}}, want: []IssueRef{{Repo: repo, Number: 1}}},
+		{
+			name:     "open blocker is not ready",
+			tracked:  []IssueRef{{Repo: repo, Number: 1}},
+			snapshot: Snapshot{BlockedBy: map[IssueRef][]IssueRef{{Repo: repo, Number: 1}: {blocker}}, Issues: map[IssueRef]IssueState{blocker: {State: "open"}}},
+			want:     nil,
+		},
+		{
+			name:     "closed completed blocker is ready",
+			tracked:  []IssueRef{{Repo: repo, Number: 1}},
+			snapshot: Snapshot{BlockedBy: map[IssueRef][]IssueRef{{Repo: repo, Number: 1}: {blocker}}, Issues: map[IssueRef]IssueState{blocker: {State: "closed", StateReason: "completed"}}},
+			want:     []IssueRef{{Repo: repo, Number: 1}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			graph := Build(tt.tracked, tt.snapshot)
+			if got := graph.ReadySet(); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ReadySet() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCycles(t *testing.T) {
+	t.Parallel()
+	repo := "acme/looper"
+	tests := []struct {
+		name     string
+		tracked  []IssueRef
+		snapshot Snapshot
+		want     []Cycle
+	}{
+		{
+			name:     "two node cycle",
+			tracked:  []IssueRef{{Repo: repo, Number: 1}, {Repo: repo, Number: 2}},
+			snapshot: Snapshot{BlockedBy: map[IssueRef][]IssueRef{{Repo: repo, Number: 1}: {{Repo: repo, Number: 2}}, {Repo: repo, Number: 2}: {{Repo: repo, Number: 1}}}, Issues: map[IssueRef]IssueState{{Repo: repo, Number: 1}: {State: "open"}, {Repo: repo, Number: 2}: {State: "open"}}},
+			want:     []Cycle{{{Repo: repo, Number: 1}, {Repo: repo, Number: 2}, {Repo: repo, Number: 1}}},
+		},
+		{
+			name:     "three node cycle",
+			tracked:  []IssueRef{{Repo: repo, Number: 1}, {Repo: repo, Number: 2}, {Repo: repo, Number: 3}},
+			snapshot: Snapshot{BlockedBy: map[IssueRef][]IssueRef{{Repo: repo, Number: 1}: {{Repo: repo, Number: 2}}, {Repo: repo, Number: 2}: {{Repo: repo, Number: 3}}, {Repo: repo, Number: 3}: {{Repo: repo, Number: 1}}}, Issues: map[IssueRef]IssueState{{Repo: repo, Number: 1}: {State: "open"}, {Repo: repo, Number: 2}: {State: "open"}, {Repo: repo, Number: 3}: {State: "open"}}},
+			want:     []Cycle{{{Repo: repo, Number: 1}, {Repo: repo, Number: 2}, {Repo: repo, Number: 3}, {Repo: repo, Number: 1}}},
+		},
+		{
+			name:     "self loop",
+			tracked:  []IssueRef{{Repo: repo, Number: 1}},
+			snapshot: Snapshot{BlockedBy: map[IssueRef][]IssueRef{{Repo: repo, Number: 1}: {{Repo: repo, Number: 1}}}, Issues: map[IssueRef]IssueState{{Repo: repo, Number: 1}: {State: "open"}}},
+			want:     []Cycle{{{Repo: repo, Number: 1}, {Repo: repo, Number: 1}}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			graph := Build(tt.tracked, tt.snapshot)
+			if got := graph.Cycles(); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Cycles() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnreachableDeps(t *testing.T) {
+	t.Parallel()
+	repo := "acme/looper"
+	graph := Build(
+		[]IssueRef{{Repo: repo, Number: 1}},
+		Snapshot{
+			BlockedBy: map[IssueRef][]IssueRef{{Repo: repo, Number: 1}: {{Repo: repo, Number: 2}, {Repo: "other/repo", Number: 9}}},
+			Issues:    map[IssueRef]IssueState{},
+		},
+	)
+	want := []IssueRef{{Repo: repo, Number: 2}, {Repo: "other/repo", Number: 9}}
+	if got := graph.UnreachableDeps(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("UnreachableDeps() = %#v, want %#v", got, want)
+	}
+}
+
+func TestClassifyBlockerState(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		state             IssueState
+		wantSatisfied     bool
+		wantRequiresRetry bool
+	}{
+		{name: "completed", state: IssueState{State: "closed", StateReason: "completed"}, wantSatisfied: true},
+		{name: "not planned", state: IssueState{State: "closed", StateReason: "not_planned"}, wantRequiresRetry: true},
+		{name: "duplicate", state: IssueState{State: "closed", StateReason: "duplicate"}, wantRequiresRetry: true},
+		{name: "open", state: IssueState{State: "open"}},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyBlockerState(tt.state)
+			if got.Satisfied != tt.wantSatisfied || got.RequiresReTriage != tt.wantRequiresRetry {
+				t.Fatalf("classifyBlockerState(%#v) = %#v, want satisfied=%v requiresReTriage=%v", tt.state, got, tt.wantSatisfied, tt.wantRequiresRetry)
+			}
+		})
+	}
+}
+
+func TestBlockersOfReturnsOnlyUnsatisfiedBlockers(t *testing.T) {
+	t.Parallel()
+	repo := "acme/looper"
+	graph := Build(
+		[]IssueRef{{Repo: repo, Number: 1}},
+		Snapshot{
+			BlockedBy: map[IssueRef][]IssueRef{{Repo: repo, Number: 1}: {{Repo: repo, Number: 2}, {Repo: repo, Number: 3}, {Repo: repo, Number: 4}}},
+			Issues: map[IssueRef]IssueState{
+				{Repo: repo, Number: 2}: {State: "closed", StateReason: "completed"},
+				{Repo: repo, Number: 3}: {State: "open"},
+				{Repo: repo, Number: 4}: {State: "closed", StateReason: "not_planned"},
+			},
+		},
+	)
+	got := graph.BlockersOf(IssueRef{Repo: repo, Number: 1})
+	want := []Blocker{
+		{Issue: IssueRef{Repo: repo, Number: 3}, State: "open"},
+		{Issue: IssueRef{Repo: repo, Number: 4}, State: "closed", StateReason: "not_planned", RequiresReTriage: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BlockersOf() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/e2e/githubcontract/contract_test.go
+++ b/internal/e2e/githubcontract/contract_test.go
@@ -28,7 +28,7 @@ func TestInvariantGatewayUsesSupportedGHJSONFields(t *testing.T) {
 	fakeGH := harness.NewFakeGH(t, bins, schema)
 	writeFakeState(t, fakeGH.StatePath, fakeGHState{
 		Routes: map[string]json.RawMessage{
-			"repos/acme/looper/issues/7":          json.RawMessage(`{"number":7,"title":"Issue title","body":"body","html_url":"https://github.com/acme/looper/issues/7","state":"open","updated_at":"2026-05-12T00:00:00Z","user":{"login":"octocat"},"author_association":"COLLABORATOR","assignees":[{"login":"octocat"}],"labels":[{"name":"bug"}]}`),
+			"repos/acme/looper/issues/7":          json.RawMessage(`{"number":7,"title":"Issue title","body":"body","html_url":"https://github.com/acme/looper/issues/7","state":"open","state_reason":"completed","updated_at":"2026-05-12T00:00:00Z","user":{"login":"octocat"},"author_association":"COLLABORATOR","assignees":[{"login":"octocat"}],"labels":[{"name":"bug"}]}`),
 			"repos/acme/looper/issues/7/comments": json.RawMessage(`[]`),
 		},
 		GraphQL: map[string]json.RawMessage{
@@ -71,6 +71,9 @@ func TestInvariantGatewayUsesSupportedGHJSONFields(t *testing.T) {
 	if issue.AuthorAssociation != "COLLABORATOR" {
 		t.Fatalf("issue.AuthorAssociation = %q, want COLLABORATOR", issue.AuthorAssociation)
 	}
+	if issue.StateReason != "completed" {
+		t.Fatalf("issue.StateReason = %q, want completed", issue.StateReason)
+	}
 	if err := gateway.ResolveReviewThread(ctx, githubinfra.ResolveReviewThreadInput{Repo: "acme/looper", ThreadID: "thread-1", CWD: root}); err != nil {
 		t.Fatalf("ResolveReviewThread() error = %v", err)
 	}
@@ -81,6 +84,50 @@ func TestInvariantGatewayUsesSupportedGHJSONFields(t *testing.T) {
 	assertInvocationMissingJSONField(t, invocations, "pr", "list", "authorAssociation")
 	assertInvocationContains(t, invocations, []string{"api", "repos/acme/looper/issues/7"})
 	assertInvocationContains(t, invocations, []string{"api", "graphql"})
+}
+
+func TestInvariantGatewayDependencyWrappersUseSupportedRoutes(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	fakeGH := harness.NewFakeGH(t, bins, loadFixtureSchema(t))
+	writeFakeState(t, fakeGH.StatePath, fakeGHState{
+		Routes: map[string]json.RawMessage{
+			"repos/acme/looper/issues/22/dependencies/blocked_by": json.RawMessage(`[{"id":101,"number":101,"title":"blocked by","url":"https://api.example.test/issues/101","html_url":"https://example.test/issues/101","repository_url":"https://api.example.test/repos/acme/looper","state":"open","state_reason":"","repository":{"name":"looper","full_name":"acme/looper","url":"https://api.example.test/repos/acme/looper","html_url":"https://example.test/acme/looper"}}]`),
+			"repos/acme/looper/issues/22/dependencies/blocking":   json.RawMessage(`[{"id":102,"number":102,"title":"blocking","url":"https://api.example.test/issues/102","html_url":"https://example.test/issues/102","repository_url":"https://api.example.test/repos/acme/looper","state":"closed","state_reason":"completed","repository":{"name":"looper","full_name":"acme/looper","url":"https://api.example.test/repos/acme/looper","html_url":"https://example.test/acme/looper"}}]`),
+			"repos/acme/looper/issues/22/sub_issues":              json.RawMessage(`[{"id":103,"number":103,"title":"sub issue","url":"https://api.example.test/issues/103","html_url":"https://example.test/issues/103","repository_url":"https://api.example.test/repos/acme/looper","state":"open","state_reason":"","repository":{"name":"looper","full_name":"acme/looper","url":"https://api.example.test/repos/acme/looper","html_url":"https://example.test/acme/looper"}}]`),
+		},
+	})
+	root := t.TempDir()
+	for key, value := range fakeGH.EnvMap() {
+		t.Setenv(key, value)
+	}
+	t.Setenv("HOME", root)
+	gateway := githubinfra.New(githubinfra.Options{GHPath: fakeGH.Path, CWD: root})
+
+	blockedBy, err := gateway.ListBlockedByIssues(context.Background(), githubinfra.ViewIssueInput{Repo: "acme/looper", IssueNumber: 22, CWD: root})
+	if err != nil {
+		t.Fatalf("ListBlockedByIssues() error = %v", err)
+	}
+	blocking, err := gateway.ListBlockingIssues(context.Background(), githubinfra.ViewIssueInput{Repo: "acme/looper", IssueNumber: 22, CWD: root})
+	if err != nil {
+		t.Fatalf("ListBlockingIssues() error = %v", err)
+	}
+	subIssues, err := gateway.ListSubIssues(context.Background(), githubinfra.ViewIssueInput{Repo: "acme/looper", IssueNumber: 22, CWD: root})
+	if err != nil {
+		t.Fatalf("ListSubIssues() error = %v", err)
+	}
+	if len(blockedBy) != 1 || blockedBy[0].Number != 101 || blockedBy[0].Repository.FullName != "acme/looper" {
+		t.Fatalf("blockedBy = %#v, want parsed blocked-by route", blockedBy)
+	}
+	if len(blocking) != 1 || blocking[0].Number != 102 || blocking[0].StateReason != "completed" {
+		t.Fatalf("blocking = %#v, want parsed blocking route", blocking)
+	}
+	if len(subIssues) != 1 || subIssues[0].Number != 103 {
+		t.Fatalf("subIssues = %#v, want parsed sub-issue route", subIssues)
+	}
+	invocations := readInvocationsForContract(t, fakeGH.InvocationLog)
+	assertInvocationContains(t, invocations, []string{"api", "--paginate", "--slurp", "repos/acme/looper/issues/22/dependencies/blocked_by"})
+	assertInvocationContains(t, invocations, []string{"api", "--paginate", "--slurp", "repos/acme/looper/issues/22/dependencies/blocking"})
+	assertInvocationContains(t, invocations, []string{"api", "--paginate", "--slurp", "repos/acme/looper/issues/22/sub_issues"})
 }
 
 func TestRegressionPR261FallsBackToIssueDetailForPRAuthorAssociation(t *testing.T) {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -774,7 +774,7 @@ func (g *Gateway) listDependencyIssues(ctx context.Context, input ViewIssueInput
 	}
 	out := make([]DependencyIssue, 0, len(rows))
 	for _, row := range rows {
-		out = append(out, extractDependencyIssue(row, repo))
+		out = append(out, extractDependencyIssue(row, input.Repo))
 	}
 	return out, nil
 }
@@ -2642,9 +2642,9 @@ func extractDependencyIssue(value map[string]any, defaultRepo string) Dependency
 func completeIssueRepository(repo IssueRepository, repositoryURL string, defaultRepo string) IssueRepository {
 	fullName, name := parseRepositoryIdentity(repositoryURL)
 	if fullName == "" {
-		_, fallbackRepo := splitRepoHostname(defaultRepo)
-		fullName = strings.TrimSpace(fallbackRepo)
-		_, name = splitRepoOwnerName(fullName)
+		fullName = strings.TrimSpace(defaultRepo)
+		_, fallbackRepo := splitRepoHostname(fullName)
+		_, name = splitRepoOwnerName(fallbackRepo)
 	}
 	if repo.Name == "" {
 		repo.Name = name

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -2664,10 +2664,18 @@ func parseRepositoryIdentity(repositoryURL string) (fullName string, name string
 		return "", ""
 	}
 	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
-	if len(parts) < 3 || parts[0] != "repos" {
+	switch {
+	case len(parts) >= 3 && parts[0] == "repos":
+		parts = parts[:3]
+	case len(parts) >= 5 && parts[0] == "api" && parts[1] == "v3" && parts[2] == "repos":
+		parts = parts[2:5]
+	default:
 		return "", ""
 	}
 	fullName = parts[1] + "/" + parts[2]
+	if hostname := strings.TrimSpace(parsed.Hostname()); hostname != "" && hostname != "github.com" && hostname != "api.github.com" {
+		fullName = hostname + "/" + fullName
+	}
 	return fullName, parts[2]
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -182,6 +182,7 @@ type IssueDetail struct {
 	Body              string
 	URL               string
 	State             string
+	StateReason       string
 	CreatedAt         string
 	UpdatedAt         string
 	ClosedAt          string
@@ -192,6 +193,25 @@ type IssueDetail struct {
 	IsPullRequest     bool
 	CommentCount      int
 	Comments          []CommentInfo
+}
+
+type IssueRepository struct {
+	Name     string
+	FullName string
+	URL      string
+	HTMLURL  string
+}
+
+type DependencyIssue struct {
+	ID            int64
+	Number        int64
+	Title         string
+	URL           string
+	HTMLURL       string
+	RepositoryURL string
+	State         string
+	StateReason   string
+	Repository    IssueRepository
 }
 
 type IssueCommentInput struct {
@@ -712,6 +732,7 @@ func (g *Gateway) ViewIssue(ctx context.Context, input ViewIssueInput) (IssueDet
 		Body:              asString(row["body"]),
 		URL:               firstNonEmpty(asString(row["html_url"]), asString(row["url"])),
 		State:             asString(row["state"]),
+		StateReason:       asString(row["state_reason"]),
 		CreatedAt:         firstNonEmpty(asString(row["created_at"]), asString(row["createdAt"])),
 		UpdatedAt:         firstNonEmpty(asString(row["updated_at"]), asString(row["updatedAt"])),
 		ClosedAt:          firstNonEmpty(asString(row["closed_at"]), asString(row["closedAt"])),
@@ -723,6 +744,39 @@ func (g *Gateway) ViewIssue(ctx context.Context, input ViewIssueInput) (IssueDet
 		CommentCount:      len(commentRows),
 		Comments:          extractCommentInfos(commentRows),
 	}, nil
+}
+
+func (g *Gateway) ListBlockedByIssues(ctx context.Context, input ViewIssueInput) ([]DependencyIssue, error) {
+	return g.listDependencyIssues(ctx, input, "dependencies/blocked_by")
+}
+
+func (g *Gateway) ListBlockingIssues(ctx context.Context, input ViewIssueInput) ([]DependencyIssue, error) {
+	return g.listDependencyIssues(ctx, input, "dependencies/blocking")
+}
+
+func (g *Gateway) ListSubIssues(ctx context.Context, input ViewIssueInput) ([]DependencyIssue, error) {
+	return g.listDependencyIssues(ctx, input, "sub_issues")
+}
+
+func (g *Gateway) listDependencyIssues(ctx context.Context, input ViewIssueInput, suffix string) ([]DependencyIssue, error) {
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", "--paginate", "--slurp", fmt.Sprintf("repos/%s/issues/%d/%s", repo, input.IssueNumber, suffix), "-H", "Accept: application/vnd.github+json"}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := decodeJSONArrayOrPages(result.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]DependencyIssue, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, extractDependencyIssue(row))
+	}
+	return out, nil
 }
 
 func (g *Gateway) ListIssueComments(ctx context.Context, input ViewIssueInput) ([]CommentInfo, error) {
@@ -2566,6 +2620,34 @@ func normalizeReaction(value any) (githubReaction, bool) {
 		return githubReaction{}, false
 	}
 	return githubReaction{ID: id, Content: content, UserLogin: userLogin}, true
+}
+
+func extractDependencyIssue(value map[string]any) DependencyIssue {
+	repo := extractIssueRepository(value["repository"])
+	return DependencyIssue{
+		ID:            asInt64(value["id"]),
+		Number:        asInt64(value["number"]),
+		Title:         asString(value["title"]),
+		URL:           asString(value["url"]),
+		HTMLURL:       asString(value["html_url"]),
+		RepositoryURL: asString(value["repository_url"]),
+		State:         asString(value["state"]),
+		StateReason:   asString(value["state_reason"]),
+		Repository:    repo,
+	}
+}
+
+func extractIssueRepository(value any) IssueRepository {
+	row, _ := value.(map[string]any)
+	if row == nil {
+		return IssueRepository{}
+	}
+	return IssueRepository{
+		Name:     asString(row["name"]),
+		FullName: asString(row["full_name"]),
+		URL:      asString(row["url"]),
+		HTMLURL:  asString(row["html_url"]),
+	}
 }
 
 func resolveLabelColor(label string) string {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -774,7 +774,7 @@ func (g *Gateway) listDependencyIssues(ctx context.Context, input ViewIssueInput
 	}
 	out := make([]DependencyIssue, 0, len(rows))
 	for _, row := range rows {
-		out = append(out, extractDependencyIssue(row))
+		out = append(out, extractDependencyIssue(row, repo))
 	}
 	return out, nil
 }
@@ -2622,19 +2622,53 @@ func normalizeReaction(value any) (githubReaction, bool) {
 	return githubReaction{ID: id, Content: content, UserLogin: userLogin}, true
 }
 
-func extractDependencyIssue(value map[string]any) DependencyIssue {
+func extractDependencyIssue(value map[string]any, defaultRepo string) DependencyIssue {
+	repositoryURL := asString(value["repository_url"])
 	repo := extractIssueRepository(value["repository"])
+	repo = completeIssueRepository(repo, repositoryURL, defaultRepo)
 	return DependencyIssue{
 		ID:            asInt64(value["id"]),
 		Number:        asInt64(value["number"]),
 		Title:         asString(value["title"]),
 		URL:           asString(value["url"]),
 		HTMLURL:       asString(value["html_url"]),
-		RepositoryURL: asString(value["repository_url"]),
+		RepositoryURL: repositoryURL,
 		State:         asString(value["state"]),
 		StateReason:   asString(value["state_reason"]),
 		Repository:    repo,
 	}
+}
+
+func completeIssueRepository(repo IssueRepository, repositoryURL string, defaultRepo string) IssueRepository {
+	fullName, name := parseRepositoryIdentity(repositoryURL)
+	if fullName == "" {
+		_, fallbackRepo := splitRepoHostname(defaultRepo)
+		fullName = strings.TrimSpace(fallbackRepo)
+		_, name = splitRepoOwnerName(fullName)
+	}
+	if repo.Name == "" {
+		repo.Name = name
+	}
+	if repo.FullName == "" {
+		repo.FullName = fullName
+	}
+	if repo.URL == "" {
+		repo.URL = repositoryURL
+	}
+	return repo
+}
+
+func parseRepositoryIdentity(repositoryURL string) (fullName string, name string) {
+	parsed, err := url.Parse(strings.TrimSpace(repositoryURL))
+	if err != nil {
+		return "", ""
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) < 3 || parts[0] != "repos" {
+		return "", ""
+	}
+	fullName = parts[1] + "/" + parts[2]
+	return fullName, parts[2]
 }
 
 func extractIssueRepository(value any) IssueRepository {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -341,6 +341,31 @@ func TestGetPullRequestHeadAndAuthorUsesNarrowPRView(t *testing.T) {
 	}
 }
 
+func TestExtractDependencyIssueFallsBackToRepositoryURL(t *testing.T) {
+	t.Parallel()
+	issue := extractDependencyIssue(map[string]any{
+		"id":             int64(12),
+		"number":         int64(34),
+		"title":          "blocked by",
+		"repository_url": "https://api.github.com/repos/other/repo",
+	}, "acme/looper")
+	if issue.Repository.Name != "repo" || issue.Repository.FullName != "other/repo" || issue.Repository.URL != "https://api.github.com/repos/other/repo" {
+		t.Fatalf("issue.Repository = %#v, want repository identity parsed from repository_url", issue.Repository)
+	}
+}
+
+func TestExtractDependencyIssueFallsBackToRequestedRepo(t *testing.T) {
+	t.Parallel()
+	issue := extractDependencyIssue(map[string]any{
+		"id":     int64(12),
+		"number": int64(34),
+		"title":  "blocked by",
+	}, "github.example.com/acme/looper")
+	if issue.Repository.Name != "looper" || issue.Repository.FullName != "acme/looper" {
+		t.Fatalf("issue.Repository = %#v, want repository identity parsed from requested repo", issue.Repository)
+	}
+}
+
 func TestIsTransientErrorTreatsShellCommandNetworkFailuresAsRetryable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -354,6 +354,19 @@ func TestExtractDependencyIssueFallsBackToRepositoryURL(t *testing.T) {
 	}
 }
 
+func TestExtractDependencyIssueFallsBackToGHESRepositoryURL(t *testing.T) {
+	t.Parallel()
+	issue := extractDependencyIssue(map[string]any{
+		"id":             int64(12),
+		"number":         int64(34),
+		"title":          "blocked by",
+		"repository_url": "https://github.example.com/api/v3/repos/other/repo",
+	}, "github.example.com/acme/looper")
+	if issue.Repository.Name != "repo" || issue.Repository.FullName != "github.example.com/other/repo" || issue.Repository.URL != "https://github.example.com/api/v3/repos/other/repo" {
+		t.Fatalf("issue.Repository = %#v, want repository identity parsed from GHES repository_url", issue.Repository)
+	}
+}
+
 func TestExtractDependencyIssueFallsBackToRequestedRepo(t *testing.T) {
 	t.Parallel()
 	issue := extractDependencyIssue(map[string]any{

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -27,7 +27,13 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 		case strings.HasPrefix(args, "issue list"):
 			return shell.Result{Stdout: `[{"number":8,"title":"Fix gateway","body":"Issue body","url":"https://example.test/issues/8","state":"OPEN","updatedAt":"2026-05-02T12:00:00Z","author":{"login":"octocat"},"assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}]`}, nil
 		case args == "api repos/acme/looper/issues/8":
-			return shell.Result{Stdout: `{"number":8,"title":"Fix gateway","body":"Issue body","html_url":"https://example.test/issues/8","state":"open","updated_at":"2026-05-03T12:00:00Z","user":{"login":"octocat"},"author_association":"COLLABORATOR","assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}`}, nil
+			return shell.Result{Stdout: `{"number":8,"title":"Fix gateway","body":"Issue body","html_url":"https://example.test/issues/8","state":"open","state_reason":"completed","updated_at":"2026-05-03T12:00:00Z","user":{"login":"octocat"},"author_association":"COLLABORATOR","assignees":[{"login":"reviewer"}],"labels":[{"name":"phase-1"},{"name":"gateway"}]}`}, nil
+		case args == "api --paginate --slurp repos/acme/looper/issues/8/dependencies/blocked_by -H Accept: application/vnd.github+json":
+			return shell.Result{Stdout: `[[{"id":12,"number":12,"title":"blocked by","url":"https://api.example.test/issues/12","html_url":"https://example.test/issues/12","repository_url":"https://api.example.test/repos/acme/looper","state":"open","state_reason":"","repository":{"name":"looper","full_name":"acme/looper","url":"https://api.example.test/repos/acme/looper","html_url":"https://example.test/acme/looper"}}]]`}, nil
+		case args == "api --paginate --slurp repos/acme/looper/issues/8/dependencies/blocking -H Accept: application/vnd.github+json":
+			return shell.Result{Stdout: `[[{"id":13,"number":13,"title":"blocking","url":"https://api.example.test/issues/13","html_url":"https://example.test/issues/13","repository_url":"https://api.example.test/repos/acme/looper","state":"closed","state_reason":"completed","repository":{"name":"looper","full_name":"acme/looper","url":"https://api.example.test/repos/acme/looper","html_url":"https://example.test/acme/looper"}}]]`}, nil
+		case args == "api --paginate --slurp repos/acme/looper/issues/8/sub_issues -H Accept: application/vnd.github+json":
+			return shell.Result{Stdout: `[[{"id":14,"number":14,"title":"sub issue","url":"https://api.example.test/issues/14","html_url":"https://example.test/issues/14","repository_url":"https://api.example.test/repos/acme/looper","state":"open","state_reason":"","repository":{"name":"looper","full_name":"acme/looper","url":"https://api.example.test/repos/acme/looper","html_url":"https://example.test/acme/looper"}}]]`}, nil
 		case args == "api --paginate --slurp repos/acme/looper/issues/8/comments":
 			return shell.Result{Stdout: `[[{"id":91,"body":"First human follow-up","html_url":"https://example.test/issues/8#issuecomment-91","created_at":"2026-05-03T13:00:00Z","updated_at":"2026-05-03T13:00:00Z","user":{"login":"reviewer"},"author_association":"MEMBER"}]]`}, nil
 		case args == "api repos/acme/looper/issues/8/comments --method POST -f body=Looper started":
@@ -93,6 +99,18 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	issueDetail, err := gateway.ViewIssue(context.Background(), ViewIssueInput{Repo: "acme/looper", IssueNumber: 8})
 	if err != nil {
 		t.Fatalf("ViewIssue() error = %v", err)
+	}
+	blockedBy, err := gateway.ListBlockedByIssues(context.Background(), ViewIssueInput{Repo: "acme/looper", IssueNumber: 8})
+	if err != nil {
+		t.Fatalf("ListBlockedByIssues() error = %v", err)
+	}
+	blocking, err := gateway.ListBlockingIssues(context.Background(), ViewIssueInput{Repo: "acme/looper", IssueNumber: 8})
+	if err != nil {
+		t.Fatalf("ListBlockingIssues() error = %v", err)
+	}
+	subIssues, err := gateway.ListSubIssues(context.Background(), ViewIssueInput{Repo: "acme/looper", IssueNumber: 8})
+	if err != nil {
+		t.Fatalf("ListSubIssues() error = %v", err)
 	}
 	comment, err := gateway.CreateIssueComment(context.Background(), IssueCommentInput{Repo: "acme/looper", IssueNumber: 8, Body: "Looper started"})
 	if err != nil {
@@ -187,6 +205,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if issueDetail.State != "open" || issueDetail.IsPullRequest {
 		t.Fatalf("issueDetail = %#v, want open issue not pull request", issueDetail)
 	}
+	if issueDetail.StateReason != "completed" {
+		t.Fatalf("issueDetail.StateReason = %q, want completed", issueDetail.StateReason)
+	}
 	if issueDetail.AuthorAssociation != "COLLABORATOR" {
 		t.Fatalf("issueDetail.AuthorAssociation = %q, want COLLABORATOR", issueDetail.AuthorAssociation)
 	}
@@ -198,6 +219,15 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	}
 	if comment.ID != 91 || comment.URL != "https://example.test/issues/8#issuecomment-91" {
 		t.Fatalf("comment = %#v, want parsed issue comment metadata", comment)
+	}
+	if len(blockedBy) != 1 || blockedBy[0].Number != 12 || blockedBy[0].Repository.FullName != "acme/looper" {
+		t.Fatalf("blockedBy = %#v, want parsed blocked-by issue", blockedBy)
+	}
+	if len(blocking) != 1 || blocking[0].Number != 13 || blocking[0].StateReason != "completed" {
+		t.Fatalf("blocking = %#v, want parsed blocking issue", blocking)
+	}
+	if len(subIssues) != 1 || subIssues[0].Number != 14 {
+		t.Fatalf("subIssues = %#v, want parsed sub-issue", subIssues)
 	}
 	if snapshot.HeadSHA != "abc123" {
 		t.Fatalf("snapshot.HeadSHA = %q, want abc123", snapshot.HeadSHA)
@@ -244,6 +274,9 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 		"pr list --repo acme/looper --state open --limit 30 --label phase-1",
 		"issue list --repo acme/looper --state open --limit 30 --assignee reviewer --label phase-1",
 		"api repos/acme/looper/issues/8",
+		"api --paginate --slurp repos/acme/looper/issues/8/dependencies/blocked_by -H Accept: application/vnd.github+json",
+		"api --paginate --slurp repos/acme/looper/issues/8/dependencies/blocking -H Accept: application/vnd.github+json",
+		"api --paginate --slurp repos/acme/looper/issues/8/sub_issues -H Accept: application/vnd.github+json",
 		"api --paginate --slurp repos/acme/looper/issues/8/comments",
 		"api repos/acme/looper/issues/8/comments --method POST -f body=Looper started",
 		"api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished",

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -361,7 +361,7 @@ func TestExtractDependencyIssueFallsBackToRequestedRepo(t *testing.T) {
 		"number": int64(34),
 		"title":  "blocked by",
 	}, "github.example.com/acme/looper")
-	if issue.Repository.Name != "looper" || issue.Repository.FullName != "acme/looper" {
+	if issue.Repository.Name != "looper" || issue.Repository.FullName != "github.example.com/acme/looper" {
 		t.Fatalf("issue.Repository = %#v, want repository identity parsed from requested repo", issue.Repository)
 	}
 }


### PR DESCRIPTION
## Summary
- add the pure `internal/coordinator/depgraph` module with ready-set, cycle, unreachable-dependency, and blocker queries for later dependency-aware Dispatch slices
- add GitHub gateway wrappers for `dependencies/blocked_by`, `dependencies/blocking`, and `sub_issues`, and surface `state_reason` on issue reads with fake-gh-backed happy-path coverage
- add ADR-0004 to name GitHub-native dependency links plus `state`/`state_reason` as Dispatch Authority, following the ADR-0002 pattern from PRD #351

## Why
- slice 1/3 for PRD #351 needs the dependency graph foundation and GitHub I/O wrappers in place before Coordinator can enforce a dependency gate
- keeping this slice as dead code at runtime preserves current Coordinator Dispatch behavior while locking the Authority chain for later slices

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

References: ADR-0002, ADR-0004, PRD #351

Closes #354

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>