### PR TITLE
feat: show PR merge blockers in list

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1086,6 +1086,10 @@ type pullRequestResponse struct {
 	ChecksSummary         *string `json:"checksSummary"`
 	UnresolvedThreadCount int64   `json:"unresolvedThreadCount"`
 	ReviewState           *string `json:"reviewState"`
+	Mergeability          *string `json:"mergeability"`
+	BlockingReason        *string `json:"blockingReason"`
+	IsDraft               *bool   `json:"isDraft"`
+	HasConflicts          *bool   `json:"hasConflicts"`
 	CapturedAt            *string `json:"capturedAt"`
 	Reviewer              *string `json:"reviewer"`
 	Fixer                 *string `json:"fixer"`
@@ -1865,6 +1869,7 @@ func (h *Handler) serializePullRequestListItem(repo string, prNumber int64, snap
 	if snapshot != nil && snapshot.UnresolvedThreadCount != nil {
 		unresolvedThreadCount = *snapshot.UnresolvedThreadCount
 	}
+	actionability := derivePullRequestActionability(snapshot)
 
 	return pullRequestResponse{
 		Repo:                  repo,
@@ -1879,10 +1884,115 @@ func (h *Handler) serializePullRequestListItem(repo string, prNumber int64, snap
 		ChecksSummary:         snapshotString(snapshot, func(s storage.PullRequestSnapshotRecord) *string { return s.ChecksSummary }),
 		UnresolvedThreadCount: unresolvedThreadCount,
 		ReviewState:           snapshotString(snapshot, func(s storage.PullRequestSnapshotRecord) *string { return s.ReviewState }),
+		Mergeability:          stringPtrOrNil(actionability.mergeability),
+		BlockingReason:        stringPtrOrNil(actionability.blockingReason),
+		IsDraft:               actionability.isDraft,
+		HasConflicts:          actionability.hasConflicts,
 		CapturedAt:            snapshotString(snapshot, func(s storage.PullRequestSnapshotRecord) *string { return &s.CapturedAt }),
 		Reviewer:              findLatestLoopStatus(loopMatches, string(domain.LoopTypeReviewer)),
 		Fixer:                 findLatestLoopStatus(loopMatches, string(domain.LoopTypeFixer)),
 	}
+}
+
+type pullRequestActionability struct {
+	mergeability   string
+	blockingReason string
+	isDraft        *bool
+	hasConflicts   *bool
+}
+
+func derivePullRequestActionability(snapshot *storage.PullRequestSnapshotRecord) pullRequestActionability {
+	if snapshot == nil {
+		return pullRequestActionability{mergeability: "unknown", blockingReason: "no snapshot"}
+	}
+
+	detail := pullRequestSnapshotDetail(snapshot.PayloadJSON)
+	isDraft := boolPtrIfPresent(detail, "isDraft")
+	hasConflicts := boolPtrIfPresent(detail, "hasConflicts")
+	if hasConflicts == nil && strings.EqualFold(stringFromMap(detail, "mergeStateStatus"), "DIRTY") {
+		hasConflicts = boolPtr(true)
+	}
+
+	if isDraft != nil && *isDraft {
+		return pullRequestActionability{mergeability: "draft", blockingReason: "draft", isDraft: isDraft, hasConflicts: hasConflicts}
+	}
+	if hasConflicts != nil && *hasConflicts {
+		return pullRequestActionability{mergeability: "blocked", blockingReason: "conflicts", isDraft: isDraft, hasConflicts: hasConflicts}
+	}
+	if checksBlockMerge(snapshot.ChecksSummary) {
+		return pullRequestActionability{mergeability: "blocked", blockingReason: "checks", isDraft: isDraft, hasConflicts: hasConflicts}
+	}
+	if checksPending(snapshot.ChecksSummary) {
+		return pullRequestActionability{mergeability: "waiting", blockingReason: "checks pending", isDraft: isDraft, hasConflicts: hasConflicts}
+	}
+	if reviewBlocksMerge(snapshot.ReviewState) {
+		return pullRequestActionability{mergeability: "blocked", blockingReason: "review", isDraft: isDraft, hasConflicts: hasConflicts}
+	}
+	if reviewPending(snapshot.ReviewState) {
+		return pullRequestActionability{mergeability: "waiting", blockingReason: "review pending", isDraft: isDraft, hasConflicts: hasConflicts}
+	}
+	return pullRequestActionability{mergeability: "ready", blockingReason: "", isDraft: isDraft, hasConflicts: hasConflicts}
+}
+
+func pullRequestSnapshotDetail(payload *string) map[string]any {
+	if payload == nil || strings.TrimSpace(*payload) == "" {
+		return nil
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(*payload), &parsed); err != nil {
+		return nil
+	}
+	detail, _ := parsed["detail"].(map[string]any)
+	return detail
+}
+
+func checksBlockMerge(summary *string) bool {
+	if summary == nil {
+		return false
+	}
+	lower := strings.ToLower(*summary)
+	return strings.Contains(lower, "failure") || strings.Contains(lower, "failed") || strings.Contains(lower, "error") || strings.Contains(lower, "cancel")
+}
+
+func checksPending(summary *string) bool {
+	if summary == nil {
+		return false
+	}
+	lower := strings.ToLower(*summary)
+	return strings.Contains(lower, "pending") || strings.Contains(lower, "queued") || strings.Contains(lower, "in_progress") || strings.Contains(lower, "unknown")
+}
+
+func reviewBlocksMerge(state *string) bool {
+	return state != nil && strings.EqualFold(strings.TrimSpace(*state), "CHANGES_REQUESTED")
+}
+
+func reviewPending(state *string) bool {
+	if state == nil {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(*state)) {
+	case "", "APPROVED":
+		return false
+	default:
+		return true
+	}
+}
+
+func boolPtrIfPresent(values map[string]any, key string) *bool {
+	value, ok := values[key].(bool)
+	if !ok {
+		return nil
+	}
+	return boolPtr(value)
+}
+
+func stringFromMap(values map[string]any, key string) string {
+	value, _ := values[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 func snapshotString(snapshot *storage.PullRequestSnapshotRecord, getter func(storage.PullRequestSnapshotRecord) *string) *string {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1907,8 +1907,8 @@ func derivePullRequestActionability(snapshot *storage.PullRequestSnapshotRecord)
 	}
 
 	detail := pullRequestSnapshotDetail(snapshot.PayloadJSON)
-	isDraft := boolPtrIfPresent(detail, "isDraft")
-	hasConflicts := boolPtrIfPresent(detail, "hasConflicts")
+	isDraft := boolPtrIfPresent(detail, "isDraft", "IsDraft")
+	hasConflicts := boolPtrIfPresent(detail, "hasConflicts", "HasConflicts")
 	if hasConflicts == nil && strings.EqualFold(stringFromMap(detail, "mergeStateStatus"), "DIRTY") {
 		hasConflicts = boolPtr(true)
 	}
@@ -1978,12 +1978,14 @@ func reviewPending(state *string) bool {
 	}
 }
 
-func boolPtrIfPresent(values map[string]any, key string) *bool {
-	value, ok := values[key].(bool)
-	if !ok {
-		return nil
+func boolPtrIfPresent(values map[string]any, keys ...string) *bool {
+	for _, key := range keys {
+		value, ok := values[key].(bool)
+		if ok {
+			return boolPtr(value)
+		}
 	}
-	return boolPtr(value)
+	return nil
 }
 
 func stringFromMap(values map[string]any, key string) string {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2961,6 +2961,36 @@ func TestSerializePullRequestListItemUsesProvidedLoopMatches(t *testing.T) {
 	}
 }
 
+func TestSerializePullRequestListItemIncludesMergeabilityBlocker(t *testing.T) {
+	h := NewHandler(Context{})
+	payload := `{"detail":{"isDraft":false,"hasConflicts":true}}`
+	checks := "SUCCESS"
+	review := "APPROVED"
+
+	item := h.serializePullRequestListItem("acme/looper", 42, &storage.PullRequestSnapshotRecord{
+		ID:            "snapshot_1",
+		ProjectID:     "project_1",
+		Repo:          "acme/looper",
+		PRNumber:      42,
+		HeadSHA:       "head-1",
+		PayloadJSON:   &payload,
+		ChecksSummary: &checks,
+		ReviewState:   &review,
+		CapturedAt:    "2026-04-11T12:00:00.000Z",
+		CreatedAt:     "2026-04-11T12:00:00.000Z",
+	}, nil)
+
+	if item.Mergeability == nil || *item.Mergeability != "blocked" {
+		t.Fatalf("Mergeability = %v, want blocked", item.Mergeability)
+	}
+	if item.BlockingReason == nil || *item.BlockingReason != "conflicts" {
+		t.Fatalf("BlockingReason = %v, want conflicts", item.BlockingReason)
+	}
+	if item.HasConflicts == nil || !*item.HasConflicts {
+		t.Fatalf("HasConflicts = %v, want true", item.HasConflicts)
+	}
+}
+
 func TestIsPlannerPullRequestOpenReadsStructMarshaledStateKey(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nexu-io/looper/internal/bootstrap"
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/domain"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/projects"
 	looperdruntime "github.com/nexu-io/looper/internal/runtime"
 	"github.com/nexu-io/looper/internal/storage"
@@ -2963,7 +2964,11 @@ func TestSerializePullRequestListItemUsesProvidedLoopMatches(t *testing.T) {
 
 func TestSerializePullRequestListItemIncludesMergeabilityBlocker(t *testing.T) {
 	h := NewHandler(Context{})
-	payload := `{"detail":{"isDraft":false,"hasConflicts":true}}`
+	detail, err := json.Marshal(githubinfra.PullRequestDetail{IsDraft: false, HasConflicts: true})
+	if err != nil {
+		t.Fatalf("Marshal(PullRequestDetail) error = %v", err)
+	}
+	payload := fmt.Sprintf(`{"detail":%s}`, detail)
 	checks := "SUCCESS"
 	review := "APPROVED"
 

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -531,6 +531,10 @@
               "checksSummary": "green",
               "unresolvedThreadCount": 1,
               "reviewState": "changes_requested",
+              "mergeability": "blocked",
+              "blockingReason": "review",
+              "isDraft": null,
+              "hasConflicts": null,
               "capturedAt": "2026-04-11T12:00:00.000Z",
               "reviewer": "running",
               "fixer": null
@@ -558,6 +562,10 @@
           "checksSummary": "green",
           "unresolvedThreadCount": 1,
           "reviewState": "changes_requested",
+          "mergeability": "blocked",
+          "blockingReason": "review",
+          "isDraft": null,
+          "hasConflicts": null,
           "capturedAt": "2026-04-11T12:00:00.000Z",
           "reviewer": "running",
           "fixer": null

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -157,6 +157,38 @@ func TestFixCreateAcceptsNumericPRRefFromCurrentProject(t *testing.T) {
 	}
 }
 
+func TestPullRequestListShowsMergeabilityAndBlocker(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/pull-requests"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_prs", map[string]any{"items": []map[string]any{{
+			"repo":           "acme/looper",
+			"prNumber":       42,
+			"title":          "Fix queue visibility",
+			"mergeability":   "blocked",
+			"blockingReason": "checks",
+			"reviewState":    "APPROVED",
+			"checksSummary":  "FAILURE",
+			"reviewer":       "completed",
+		}}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "pr", "list", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([pr list]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	for _, want := range []string{"mergeability", "blocker", "blocked", "checks"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
 func TestFixCreateRequiresExplicitProjectWhenCurrentProjectIsAmbiguous(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -99,6 +99,8 @@ type pullRequestOutput struct {
 	ChecksSummary         *string `json:"checksSummary"`
 	UnresolvedThreadCount int64   `json:"unresolvedThreadCount"`
 	ReviewState           *string `json:"reviewState"`
+	Mergeability          *string `json:"mergeability"`
+	BlockingReason        *string `json:"blockingReason"`
 	Reviewer              *string `json:"reviewer"`
 	Fixer                 *string `json:"fixer"`
 	ProjectID             *string `json:"projectId"`
@@ -291,9 +293,9 @@ func writeHumanPullRequestList(w io.Writer, payload json.RawMessage) error {
 
 	rows := make([]tableRow, 0, len(data.Items))
 	for _, item := range data.Items {
-		rows = append(rows, tableRow{"pr": fmt.Sprintf("%s#%d", item.Repo, item.PRNumber), "title": item.Title, "reviewState": item.ReviewState, "checks": item.ChecksSummary, "reviewer": item.Reviewer, "fixer": item.Fixer})
+		rows = append(rows, tableRow{"pr": fmt.Sprintf("%s#%d", item.Repo, item.PRNumber), "title": item.Title, "mergeability": item.Mergeability, "blocker": item.BlockingReason, "reviewState": item.ReviewState, "checks": item.ChecksSummary, "reviewer": item.Reviewer, "fixer": item.Fixer})
 	}
-	printTable(w, []string{"pr", "title", "reviewState", "checks", "reviewer", "fixer"}, rows)
+	printTable(w, []string{"pr", "title", "mergeability", "blocker", "reviewState", "checks", "reviewer", "fixer"}, rows)
 	return nil
 }
 


### PR DESCRIPTION
# Summary

- Refs #48
- Add mergeability and blocker fields to PR list/detail responses from existing snapshots
- Show mergeability/blocker columns in `looper pr list`

# Testing

- [x] `go test ./...`
- [x] Additional targeted checks: `go test ./internal/api ./internal/cliapp`

# E2E / Invariant Risk

- [x] No Looper E2E / invariant risk
- [ ] Daemon boot / config / runtime path risk
- [ ] Worktree / repo isolation / lifecycle risk
- [ ] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [ ] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- PR / issue links for regression coverage:
  - #48: PR list now surfaces ready/blocked/waiting/draft plus the primary blocker reason

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied
