### PR TITLE
test: relax timing-sensitive fixtures

### DIFF
--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -835,7 +835,7 @@ func TestExecutorCapturesConcurrentStdoutAndStderr(t *testing.T) {
 	t.Parallel()
 
 	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", `for i in 1 2 3; do printf "out$i\n"; printf "err$i\n" >&2; sleep 0.02; done`}}}})
-	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_streams", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: time.Second})
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_streams", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: 3 * time.Second})
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
@@ -1043,7 +1043,7 @@ func TestExecutorHeartbeatTimeoutPreservesOriginalTimeoutTypeDuringGracefulShutd
 
 	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", `printf 'beat\n'; trap '' TERM; while true; do sleep 0.05; done`}}}})
 
-	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_heartbeat_timeout_grace", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: 120 * time.Millisecond, HeartbeatTimeout: 50 * time.Millisecond, GracefulShutdown: 200 * time.Millisecond})
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_heartbeat_timeout_grace", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: 600 * time.Millisecond, HeartbeatTimeout: 100 * time.Millisecond, GracefulShutdown: 200 * time.Millisecond})
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
@@ -1065,9 +1065,9 @@ func TestExecutorMaxRuntimeTimeoutIgnoresProgressResets(t *testing.T) {
 
 	coordinator := openAgentCoordinator(t)
 	repos := storage.NewRepositories(coordinator.DB())
-	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", "while true; do printf 'beat\n'; sleep 0.02; done"}}}, Repos: repos})
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", "while true; do printf 'beat\n'; sleep 0.03; done"}}}, Repos: repos})
 
-	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_max_runtime_timeout", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: 80 * time.Millisecond, HeartbeatTimeout: time.Second, GracefulShutdown: 10 * time.Millisecond})
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_max_runtime_timeout", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: 300 * time.Millisecond, HeartbeatTimeout: time.Second, GracefulShutdown: 10 * time.Millisecond})
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -1043,7 +1043,7 @@ func TestExecutorHeartbeatTimeoutPreservesOriginalTimeoutTypeDuringGracefulShutd
 
 	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", `printf 'beat\n'; trap '' TERM; while true; do sleep 0.05; done`}}}})
 
-	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_heartbeat_timeout_grace", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: 600 * time.Millisecond, HeartbeatTimeout: 100 * time.Millisecond, GracefulShutdown: 200 * time.Millisecond})
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_heartbeat_timeout_grace", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: 250 * time.Millisecond, HeartbeatTimeout: 100 * time.Millisecond, GracefulShutdown: 200 * time.Millisecond})
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2794,6 +2795,8 @@ func TestLogsFollowRejectsJSON(t *testing.T) {
 func TestLogsFollowStopsOnContextCancellation(t *testing.T) {
 	t.Parallel()
 
+	snapshotFlushed := make(chan struct{})
+	var flushOnce sync.Once
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = io.WriteString(w, "event: snapshot\n")
@@ -2801,6 +2804,7 @@ func TestLogsFollowStopsOnContextCancellation(t *testing.T) {
 		if flusher, ok := w.(http.Flusher); ok {
 			flusher.Flush()
 		}
+		flushOnce.Do(func() { close(snapshotFlushed) })
 		<-r.Context().Done()
 	}))
 	defer server.Close()
@@ -2808,6 +2812,10 @@ func TestLogsFollowStopsOnContextCancellation(t *testing.T) {
 	configPath := writeCLIConfig(t, server.URL, "")
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
+		select {
+		case <-snapshotFlushed:
+		case <-time.After(2 * time.Second):
+		}
 		time.Sleep(100 * time.Millisecond)
 		cancel()
 	}()

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -2811,10 +2812,12 @@ func TestLogsFollowStopsOnContextCancellation(t *testing.T) {
 
 	configPath := writeCLIConfig(t, server.URL, "")
 	ctx, cancel := context.WithCancel(context.Background())
+	cancelErr := make(chan error, 1)
 	go func() {
 		select {
 		case <-snapshotFlushed:
 		case <-time.After(2 * time.Second):
+			cancelErr <- errors.New("timed out waiting for snapshot flush")
 		}
 		time.Sleep(100 * time.Millisecond)
 		cancel()
@@ -2829,6 +2832,11 @@ func TestLogsFollowStopsOnContextCancellation(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "Waiting for log output...") {
 		t.Fatalf("Run([logs loop_1 --follow]) stdout = %q, want waiting message", stdout)
+	}
+	select {
+	case err := <-cancelErr:
+		t.Fatal(err)
+	default:
 	}
 }
 

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -72,8 +72,8 @@ func TestRunTimesOutAndPreservesCapturedOutput(t *testing.T) {
 	result, err := Run(context.Background(), Options{
 		Command:          "/bin/sh",
 		Args:             []string{"-c", `printf 'start'; sleep 1`},
-		Timeout:          50 * time.Millisecond,
-		GracefulShutdown: 10 * time.Millisecond,
+		Timeout:          500 * time.Millisecond,
+		GracefulShutdown: 50 * time.Millisecond,
 	})
 	var commandErr *CommandExecutionError
 	if !errors.As(err, &commandErr) {


### PR DESCRIPTION
## Summary
- Relax timing-sensitive test fixtures that can fail on slower local or CI runners.
- Synchronize the log-follow cancellation fixture with the snapshot flush so assertions observe the final state deterministically.

Fixes test flakiness observed while validating follow-up looper changes.

## Testing
- [x] go test ./internal/cliapp ./internal/agent ./internal/infra/shell
- [x] go test ./...

## E2E / Invariant Risk
Test-only change. No runtime behavior, command output, or storage invariants are changed.

## Regression Policy
Keeps existing coverage while widening timing tolerances and removing a race in a test fixture.

## Regression Mapping
- internal/agent/executor_test.go: relaxes timeout-sensitive executor assertions.
- internal/cliapp/app_test.go: waits for log snapshot flush after cancellation.
- internal/infra/shell/runner_test.go: relaxes shell runner timeout fixture.

## Reviewer Checklist
- [x] Test-only surface
- [x] No production code paths touched
- [x] Full Go test suite passes