### PR TITLE
fix: keep reviewer stamps in fixer drift hashes

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -595,7 +595,8 @@ type checkpointRepair struct {
 // checkpoint so resume/retry reuses the same explanation if it still maps to
 // the current fix items snapshot. Fixed decisions must include
 // ThreadCommentsObserved so resolve-comments can verify the live thread still
-// contains exactly the same non-Looper comment IDs before auto-resolving.
+// contains exactly the same target review comment IDs before auto-resolving,
+// excluding only prior Looper fixer replies.
 type replyExplanationEntry struct {
 	FixItemID              string `json:"fixItemId"`
 	ThreadID               string `json:"threadId,omitempty"`
@@ -2495,7 +2496,7 @@ func hashReviewThreadComments(thread ReviewThread) string {
 	}
 	comments := make([]observedThreadComment, 0, len(thread.Comments))
 	for _, comment := range thread.Comments {
-		if isLooperReviewThreadComment(comment) {
+		if isLooperFixerReplyComment(comment) {
 			continue
 		}
 		id := strings.TrimSpace(comment.ID)
@@ -2544,6 +2545,14 @@ func isLooperReviewThreadComment(comment ReviewThreadComment) bool {
 		return false
 	}
 	return disclosure.HasMarkdownStamp(body) || strings.Contains(body, "looper-fixer-reply") || strings.Contains(body, "looper:fixer-round")
+}
+
+func isLooperFixerReplyComment(comment ReviewThreadComment) bool {
+	body := strings.TrimSpace(comment.Body)
+	if body == "" {
+		return false
+	}
+	return strings.Contains(body, "looper-fixer-reply") || strings.Contains(body, "looper:fixer-round")
 }
 
 // isBotReviewThreadComment reports whether the comment was authored by a
@@ -4615,7 +4624,7 @@ func buildFixerReplyExplanationInstruction(fixItems []FixItem) string {
 		`  - "threadId": the exact "threadId" of the same fix item`,
 		`  - "action": "fixed" or "declined"`,
 		`  - "explanation": one or two sentences (max ~500 chars). If action is "fixed", say what you changed and where. If action is "declined", give a concrete reason why you are not acting. No greetings, no @mentions, no markdown headings, no HTML, no disclosure markers.`,
-		`  - "threadCommentsObserved": sha256 of the JSON array of non-Looper review-thread comments you observed in thread order, where each element is {"id","updatedAt"}. Exclude prior Looper-generated replies.`,
+		`  - "threadCommentsObserved": sha256 of the JSON array of review-thread comments you observed in thread order, where each element is {"id","updatedAt"}. Include target reviewer comments even when they contain a Looper stamp. Exclude only prior Looper fixer replies/round comments.`,
 		"Before including an entry, re-read the relevant review thread/comment context.",
 		"Use \"fixed\" only when you can confidently confirm the current branch state actually addresses the thread; in other words, only include items you can confidently confirm are actually addressed by the current branch state. Use \"declined\" if you deliberately are not acting, including cases such as: already implemented on this branch, out of scope for this PR, reviewer request is incorrect, or you cannot safely complete it.",
 		"Do not omit any comment-type fix item. Do not use vague explanations like \"looks fine\" or \"no change needed\".",

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1836,6 +1836,47 @@ func TestRunResolveCommentsStepSkipsThreadWhenObservedThreadSnapshotDriftsDuring
 	}
 }
 
+func TestRunResolveCommentsStepResolvesLooperReviewerStampedThread(t *testing.T) {
+	t.Parallel()
+
+	reviewerBody := "please fix\n\n<!-- looper:stamp v=1 -->\n<sub>🔁 Powered by <a href=\"https://github.com/nexu-io/looper\">Looper</a> · runner=reviewer · agent=opencode · model=openai/gpt-5.4 · An autonomous AI dev team for your GitHub repos.</sub>"
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "fix-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     reviewerBody,
+		}},
+	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: reviewerBody, Author: "nettee", CreatedAt: "2026-04-11T11:59:00Z", UpdatedAt: "2026-04-11T11:59:00Z"}}}}}
+	runner := New(Options{GitHub: github})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "please fix"}}
+	observedThread := ReviewThread{Comments: []ReviewThreadComment{{ID: "c1", UpdatedAt: "2026-04-11T11:59:00Z"}}}
+	checkPoint := fixerCheckpoint{
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "fix-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionFixed), Explanation: "Applied the requested fix.", ThreadCommentsObserved: hashReviewThreadComments(observedThread)}}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkPoint})
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v, want Looper reviewer thread resolved", err)
+	}
+	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t1" {
+		t.Fatalf("resolve calls = %#v, want Looper reviewer thread resolved", github.resolveCalls)
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "resolved" {
+		t.Fatalf("resolved comments = %#v, want resolved", updated.ResolvedComments)
+	}
+}
+
 func TestRunResolveCommentsStepRequiresObservedThreadSnapshotForFixedDecision(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- keep Looper reviewer inline comments in fixer thread drift hashes even when they carry the standard Looper stamp
- continue excluding prior Looper fixer replies/round comments from the hash
- update fixer agent instructions and add regression coverage for resolving Looper-stamped reviewer feedback

## Authority / trade-off
- Authority for resolving remains the agent's structured `review_thread_replies` plus the live GitHub review thread snapshot; the drift hash only verifies that the target reviewer comments are unchanged before Looper mutates the thread.
- Narrowing the exclusion avoids mistaking Looper reviewer feedback for a prior fixer reply while preserving protection against stale fixer replies/round comments affecting the snapshot.
- Simpler alternative considered: disable drift checking for Looper-stamped comments. Rejected because edited target comments should still block auto-resolution.

## Tests
- `go test ./internal/fixer`
- `go test ./...`

## Review
- @oracle reviewed this gate change; no blockers after follow-up fixes.