### PR TITLE
feat: add single-PR targeted reviewer and fixer discovery

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -450,6 +450,13 @@ type DiscoveryInput struct {
 	Snapshot  *githubinfra.DiscoverySnapshot
 }
 
+type TargetedDiscoveryInput struct {
+	ProjectID string
+	Repo      string
+	PRNumber  int64
+	Snapshot  *githubinfra.DiscoverySnapshot
+}
+
 type DiscoveryResult struct {
 	QueueItems     []storage.QueueItemRecord
 	CreatedLoopIDs []string
@@ -1039,15 +1046,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		appendDiscoveryQueueItem(&result.QueueItems, item)
 	}
 	for _, pr := range openPRs {
-		if (!policy.IncludeDrafts && pr.IsDraft) || normalizePRState(pr.State) != "open" || r.hasActivePRLock(ctx, input.Repo, pr.Number) {
-			result.Skipped++
-			continue
-		}
-		if policy.AuthorFilter != config.FixerAuthorFilterAny && !sameGitHubLogin(pr.Author, currentUser) {
-			result.Skipped++
-			continue
-		}
-		if !labelsMatch(pr.Labels, policy.Labels, policy.LabelMode) {
+		if !r.pullRequestEligibleForDiscovery(ctx, pr, input.Repo, currentUser, policy) {
 			result.Skipped++
 			continue
 		}
@@ -1055,59 +1054,49 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
-		allFixItems := collectFixItems(detail)
-		if len(allFixItems) == 0 {
-			if err := r.clearFixerFollowupStateForPR(ctx, project.ID, input.Repo, pr.Number); err != nil {
-				return DiscoveryResult{}, err
-			}
-			result.Skipped++
-			continue
+		if err := r.discoverPullRequestFromDetail(ctx, *project, input.Repo, detail, &result); err != nil {
+			return DiscoveryResult{}, err
 		}
-		allFixItemsStateHash := hashFixItemsState(allFixItems)
-		fixItems := suppressDeclinedFixItems(loopMetadataForPR(ctx, r, project.ID, input.Repo, pr.Number), detail.HeadSHA, allFixItems)
-		if len(fixItems) == 0 {
-			if err := r.resumePausedZeroProgressLoopIfStateChanged(ctx, project.ID, input.Repo, pr.Number, detail.HeadSHA, allFixItemsStateHash); err != nil {
-				return DiscoveryResult{}, err
-			}
-			result.Skipped++
-			continue
-		}
-		fixItemsHash := hashFixItems(fixItems)
-		fixItemsStateHash := allFixItemsStateHash
-		unresolvedThreadIDs := unresolvedThreadIDs(fixItems)
-		if len(unresolvedThreadIDs) == 0 {
-			if err := r.clearFixerFollowupMetadataForPR(ctx, project.ID, input.Repo, pr.Number); err != nil {
-				return DiscoveryResult{}, err
-			}
-		}
-		loopResult, err := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, detail.HeadSHA, fixItemsHash, fixItemsStateHash, fixItems, unresolvedThreadIDs)
+	}
+	return result, nil
+}
+
+func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscoveryInput) (DiscoveryResult, error) {
+	ctx = githubinfra.ContextWithDiscoverySnapshot(ctx, input.Snapshot)
+	if r.repos == nil || r.repos.Projects == nil || r.repos.Loops == nil || r.repos.Queue == nil || r.repos.Runs == nil || r.repos.Locks == nil {
+		return DiscoveryResult{}, fmt.Errorf("fixer repositories are not configured")
+	}
+	project, err := r.repos.Projects.GetByID(ctx, input.ProjectID)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if project == nil {
+		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
+	}
+	policy := r.discoveryPolicyForProject(project.ID)
+	if !policy.AutoDiscovery {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	currentUser := ""
+	if policy.AuthorFilter != config.FixerAuthorFilterAny {
+		currentUser, err = r.github.GetCurrentUserLogin(ctx, project.RepoPath)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
-		if loopResult.record.Status == "paused" || loopResult.record.Status == "failed" || loopResult.skipped {
-			result.Skipped++
-			continue
-		}
-		if loopResult.created {
-			result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
-		}
-		headSHA := detail.HeadSHA
-		if headSHA == "" {
-			headSHA = "unknown"
-		}
-		queueItem, err := r.enqueue(ctx, enqueueInput{
-			ProjectID:    project.ID,
-			LoopID:       loopResult.record.ID,
-			Repo:         input.Repo,
-			PRNumber:     pr.Number,
-			HeadSHA:      headSHA,
-			FixItemsHash: fixItemsStateHash,
-			AvailableAt:  loopResult.availableAt,
-		})
-		if err != nil {
-			return DiscoveryResult{}, err
-		}
-		appendDiscoveryQueueItem(&result.QueueItems, queueItem)
+		currentUser = strings.TrimSpace(currentUser)
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: project.RepoPath})
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	pr := PullRequestSummary{Number: detail.Number, State: detail.State, IsDraft: detail.IsDraft, Labels: append([]string(nil), detail.Labels...), HeadSHA: detail.HeadSHA, Author: detail.Author}
+	result := DiscoveryResult{}
+	if !r.pullRequestEligibleForDiscovery(ctx, pr, input.Repo, currentUser, policy) {
+		result.Skipped++
+		return result, nil
+	}
+	if err := r.discoverPullRequestFromDetail(ctx, *project, input.Repo, detail, &result); err != nil {
+		return DiscoveryResult{}, err
 	}
 	return result, nil
 }
@@ -1176,6 +1165,76 @@ func defaultDiscoveryLimit(limit int) int {
 		return 30
 	}
 	return limit
+}
+
+func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, pr PullRequestSummary, repo, currentUser string, policy DiscoveryPolicy) bool {
+	if (!policy.IncludeDrafts && pr.IsDraft) || normalizePRState(pr.State) != "open" || r.hasActivePRLock(ctx, repo, pr.Number) {
+		return false
+	}
+	if policy.AuthorFilter != config.FixerAuthorFilterAny && !sameGitHubLogin(pr.Author, currentUser) {
+		return false
+	}
+	if !labelsMatch(pr.Labels, policy.Labels, policy.LabelMode) {
+		return false
+	}
+	return true
+}
+
+func (r *Runner) discoverPullRequestFromDetail(ctx context.Context, project storage.ProjectRecord, repo string, detail PullRequestDetail, result *DiscoveryResult) error {
+	allFixItems := collectFixItems(detail)
+	if len(allFixItems) == 0 {
+		if err := r.clearFixerFollowupStateForPR(ctx, project.ID, repo, detail.Number); err != nil {
+			return err
+		}
+		result.Skipped++
+		return nil
+	}
+	allFixItemsStateHash := hashFixItemsState(allFixItems)
+	fixItems := suppressDeclinedFixItems(loopMetadataForPR(ctx, r, project.ID, repo, detail.Number), detail.HeadSHA, allFixItems)
+	if len(fixItems) == 0 {
+		if err := r.resumePausedZeroProgressLoopIfStateChanged(ctx, project.ID, repo, detail.Number, detail.HeadSHA, allFixItemsStateHash); err != nil {
+			return err
+		}
+		result.Skipped++
+		return nil
+	}
+	fixItemsHash := hashFixItems(fixItems)
+	fixItemsStateHash := allFixItemsStateHash
+	unresolvedThreadIDs := unresolvedThreadIDs(fixItems)
+	if len(unresolvedThreadIDs) == 0 {
+		if err := r.clearFixerFollowupMetadataForPR(ctx, project.ID, repo, detail.Number); err != nil {
+			return err
+		}
+	}
+	loopResult, err := r.ensureLoopForPullRequest(ctx, project, repo, detail.Number, detail.HeadSHA, fixItemsHash, fixItemsStateHash, fixItems, unresolvedThreadIDs)
+	if err != nil {
+		return err
+	}
+	if loopResult.record.Status == "paused" || loopResult.record.Status == "failed" || loopResult.skipped {
+		result.Skipped++
+		return nil
+	}
+	if loopResult.created {
+		result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
+	}
+	headSHA := detail.HeadSHA
+	if headSHA == "" {
+		headSHA = "unknown"
+	}
+	queueItem, err := r.enqueue(ctx, enqueueInput{
+		ProjectID:    project.ID,
+		LoopID:       loopResult.record.ID,
+		Repo:         repo,
+		PRNumber:     detail.Number,
+		HeadSHA:      headSHA,
+		FixItemsHash: fixItemsStateHash,
+		AvailableAt:  loopResult.availableAt,
+	})
+	if err != nil {
+		return err
+	}
+	appendDiscoveryQueueItem(&result.QueueItems, queueItem)
+	return nil
 }
 
 func (r *Runner) ProcessNext(ctx context.Context, claimedBy string) (*ProcessResult, error) {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -223,6 +223,65 @@ func TestDiscoverPullRequestsCreatesLoopAndQueue(t *testing.T) {
 	}
 }
 
+func TestDiscoverPullRequestCreatesLoopAndQueue(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequest() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 || len(result.CreatedLoopIDs) != 1 {
+		t.Fatalf("result = %#v, want one queue item and one created loop", result)
+	}
+	if len(github.listCalls) != 0 {
+		t.Fatalf("list calls = %#v, want targeted discovery to avoid repo scan", github.listCalls)
+	}
+}
+
+func TestDiscoverPullRequestSkipsIneligiblePullRequest(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", IsDraft: true, HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequest() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || len(result.CreatedLoopIDs) != 0 || result.Skipped != 1 {
+		t.Fatalf("result = %#v, want skipped targeted discovery with no loop", result)
+	}
+}
+
+func TestDiscoverPullRequestReusesExistingActiveQueueItem(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}, {Number: 42, State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	first, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("first DiscoverPullRequest() error = %v", err)
+	}
+	second, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("second DiscoverPullRequest() error = %v", err)
+	}
+	if len(first.QueueItems) != 1 || len(second.QueueItems) != 1 || first.QueueItems[0].ID != second.QueueItems[0].ID {
+		t.Fatalf("first=%#v second=%#v, want same active queue item reused", first, second)
+	}
+	queues, err := fixture.repos.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(queues) != 1 {
+		t.Fatalf("len(Queue.List()) = %d, want one active queue item", len(queues))
+	}
+}
+
 func TestDiscoverPullRequestsSkipsPRsNotOwnedByCurrentUser(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -747,9 +747,12 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			result.Skipped++
 			continue
 		}
-		seen[key] = struct{}{}
+		queuedBefore := len(result.QueueItems)
 		if err := r.discoverExistingReviewerLoop(ctx, *project, input.Repo, policy, &currentLogin, loop, detail, &result); err != nil {
 			return DiscoveryResult{}, err
+		}
+		if len(result.QueueItems) > queuedBefore {
+			seen[key] = struct{}{}
 		}
 	}
 	return result, nil
@@ -785,13 +788,19 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 	}
 	pr := summaryFromDetail(detail)
 	result := DiscoveryResult{}
-	existingLoop, err := r.findReviewerLoopByPR(ctx, project.ID, input.Repo, input.PRNumber)
+	existingLoops, err := r.findReviewerLoopsByPR(ctx, project.ID, input.Repo, input.PRNumber)
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
-	if existingLoop != nil {
-		if err := r.discoverExistingReviewerLoop(ctx, *project, input.Repo, policy, &currentLogin, *existingLoop, detail, &result); err != nil {
-			return DiscoveryResult{}, err
+	if len(existingLoops) > 0 {
+		for _, loop := range existingLoops {
+			queuedBefore := len(result.QueueItems)
+			if err := r.discoverExistingReviewerLoop(ctx, *project, input.Repo, policy, &currentLogin, loop, detail, &result); err != nil {
+				return DiscoveryResult{}, err
+			}
+			if len(result.QueueItems) > queuedBefore {
+				return result, nil
+			}
 		}
 		return result, nil
 	}
@@ -898,18 +907,18 @@ func (r *Runner) discoverExistingReviewerLoop(ctx context.Context, project stora
 	return r.enqueueReviewerDiscoveryCandidate(ctx, project, repo, policy, currentLogin, summaryFromDetail(detail), &loop, result)
 }
 
-func (r *Runner) findReviewerLoopByPR(ctx context.Context, projectID, repo string, prNumber int64) (*storage.LoopRecord, error) {
+func (r *Runner) findReviewerLoopsByPR(ctx context.Context, projectID, repo string, prNumber int64) ([]storage.LoopRecord, error) {
 	loops, err := r.repos.Loops.List(ctx)
 	if err != nil {
 		return nil, err
 	}
+	matched := []storage.LoopRecord{}
 	for _, loop := range loops {
 		if loop.Type == "reviewer" && loop.ProjectID == projectID && derefString(loop.Repo) == repo && derefInt64(loop.PRNumber) == prNumber {
-			loop := loop
-			return &loop, nil
+			matched = append(matched, loop)
 		}
 	}
-	return nil, nil
+	return matched, nil
 }
 
 func (r *Runner) listOpenPullRequestsForDiscovery(ctx context.Context, repo, cwd string, limit int) ([]PullRequestSummary, error) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -443,6 +443,13 @@ type DiscoveryInput struct {
 	Snapshot  *githubinfra.DiscoverySnapshot
 }
 
+type TargetedDiscoveryInput struct {
+	ProjectID string
+	Repo      string
+	PRNumber  int64
+	Snapshot  *githubinfra.DiscoverySnapshot
+}
+
 type DiscoveryResult struct {
 	QueueItems     []storage.QueueItemRecord
 	CreatedLoopIDs []string
@@ -693,68 +700,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		return pr
 	}
 	enqueue := func(pr PullRequestSummary, existing *storage.LoopRecord) error {
-		loopResult, loopErr := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, existing)
-		if loopErr != nil {
-			return loopErr
-		}
-		if terminalReviewerLoopReason(loopResult.record) == "failed" {
-			recovered, recoverErr := r.recoverFailedReviewerLoop(ctx, loopResult.record, pr)
-			if recoverErr != nil {
-				return recoverErr
-			}
-			if recovered != nil {
-				loopResult.record = *recovered
-			}
-		}
-		if terminalReviewerLoopReason(loopResult.record) != "" {
-			result.Skipped++
-			return nil
-		}
-		if loopResult.created {
-			result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
-		}
-		meta := parseJSONObject(loopResult.record.MetadataJSON)
-		_, hasPublishedHead := stringFromAny(meta["lastPublishedHeadSha"])
-		if !r.loopEnabled(meta) && (!loopResult.created || hasPublishedHead) {
-			result.Skipped++
-			return nil
-		}
-		if reviewerDiscoverySuppressedByLastSkip(meta, pr, currentLogin, policy) {
-			result.Skipped++
-			return nil
-		}
-		if reviewerLastSkipNeedsCurrentLogin(meta, pr) && currentLogin == "" {
-			lookupLogin, lookupErr := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
-			if lookupErr != nil {
-				lookupLogin = ""
-			}
-			currentLogin = normalizeLogin(lookupLogin)
-		}
-		if reviewerDiscoverySuppressedByLastSkip(meta, pr, currentLogin, policy) {
-			result.Skipped++
-			return nil
-		}
-		if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && last == pr.HeadSHA && pr.HeadSHA != "" {
-			result.Skipped++
-			return nil
-		}
-		availableAt := r.nextReviewAvailableAt(meta)
-		queueItem, queueErr := r.enqueue(ctx, enqueueInput{
-			ProjectID:   project.ID,
-			LoopID:      loopResult.record.ID,
-			Repo:        input.Repo,
-			PRNumber:    pr.Number,
-			HeadSHA:     pr.HeadSHA,
-			AvailableAt: availableAt,
-		})
-		if queueErr != nil {
-			return queueErr
-		}
-		if err := r.markLoopQueuedForReview(ctx, loopResult.record, queueItem.AvailableAt); err != nil {
-			return err
-		}
-		result.QueueItems = append(result.QueueItems, queueItem)
-		return nil
+		return r.enqueueReviewerDiscoveryCandidate(ctx, *project, input.Repo, policy, &currentLogin, pr, existing, &result)
 	}
 	seenEnqueue := func(pr PullRequestSummary) error {
 		key := fmt.Sprintf("%s#%d", input.Repo, pr.Number)
@@ -801,36 +747,169 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			result.Skipped++
 			continue
 		}
-		if !policy.IncludeDrafts && detail.IsDraft {
-			result.Skipped++
-			continue
-		}
-		if normalizePRState(detail.State) != "open" {
-			if err := r.terminateLoop(ctx, loop, "pr_closed_or_merged"); err != nil {
-				return DiscoveryResult{}, err
-			}
-			result.Skipped++
-			continue
-		}
-		if !isManualReviewerLoop(loop) && isSelfAuthoredPR(detail.Author, currentLogin, policy) {
-			result.Skipped++
-			continue
-		}
-		requireReviewRequest := requireReviewRequestForLoop(loop, policy.RequireReviewRequest, detail.HeadSHA)
-		if requireReviewRequest && !isCurrentUserRequested(detail.ReviewRequests, currentLogin) && !r.hasThreadResolutionFollowUpCandidate(ctx, project.RepoPath, input.Repo, *loop.PRNumber, detail.HeadSHA, currentLogin) {
-			result.Skipped++
-			continue
-		}
-		if !isManualReviewerLoop(loop) && !labelsMatch(detail.Labels, policy.Labels, policy.LabelMode) {
-			result.Skipped++
-			continue
-		}
 		seen[key] = struct{}{}
-		if err := enqueue(summaryFromDetail(detail), &loop); err != nil {
+		if err := r.discoverExistingReviewerLoop(ctx, *project, input.Repo, policy, &currentLogin, loop, detail, &result); err != nil {
 			return DiscoveryResult{}, err
 		}
 	}
 	return result, nil
+}
+
+func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscoveryInput) (DiscoveryResult, error) {
+	ctx = githubinfra.ContextWithDiscoverySnapshot(ctx, input.Snapshot)
+	if r.repos == nil || r.repos.Projects == nil || r.repos.Loops == nil || r.repos.Queue == nil || r.repos.Runs == nil {
+		return DiscoveryResult{}, fmt.Errorf("reviewer repositories are not configured")
+	}
+	project, err := r.repos.Projects.GetByID(ctx, input.ProjectID)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if project == nil {
+		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
+	}
+	policy := r.discoveryPolicyForProject(project.ID)
+	if !policy.AutoDiscovery {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: project.RepoPath})
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	currentLogin := ""
+	if policy.RequireReviewRequest || !policy.EnableSelfReview {
+		currentLogin, err = r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		currentLogin = normalizeLogin(currentLogin)
+	}
+	pr := summaryFromDetail(detail)
+	result := DiscoveryResult{}
+	existingLoop, err := r.findReviewerLoopByPR(ctx, project.ID, input.Repo, input.PRNumber)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if existingLoop != nil {
+		if err := r.discoverExistingReviewerLoop(ctx, *project, input.Repo, policy, &currentLogin, *existingLoop, detail, &result); err != nil {
+			return DiscoveryResult{}, err
+		}
+		return result, nil
+	}
+	if !prEligibleForDiscovery(pr, currentLogin, policy) {
+		result.Skipped++
+		return result, nil
+	}
+	if err := r.enqueueReviewerDiscoveryCandidate(ctx, *project, input.Repo, policy, &currentLogin, pr, nil, &result); err != nil {
+		return DiscoveryResult{}, err
+	}
+	return result, nil
+}
+
+func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project storage.ProjectRecord, repo string, policy DiscoveryPolicy, currentLogin *string, pr PullRequestSummary, existing *storage.LoopRecord, result *DiscoveryResult) error {
+	loopResult, loopErr := r.ensureLoopForPullRequest(ctx, project, repo, pr.Number, existing)
+	if loopErr != nil {
+		return loopErr
+	}
+	if terminalReviewerLoopReason(loopResult.record) == "failed" {
+		recovered, recoverErr := r.recoverFailedReviewerLoop(ctx, loopResult.record, pr)
+		if recoverErr != nil {
+			return recoverErr
+		}
+		if recovered != nil {
+			loopResult.record = *recovered
+		}
+	}
+	if terminalReviewerLoopReason(loopResult.record) != "" {
+		result.Skipped++
+		return nil
+	}
+	if loopResult.created {
+		result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
+	}
+	meta := parseJSONObject(loopResult.record.MetadataJSON)
+	_, hasPublishedHead := stringFromAny(meta["lastPublishedHeadSha"])
+	if !r.loopEnabled(meta) && (!loopResult.created || hasPublishedHead) {
+		result.Skipped++
+		return nil
+	}
+	if reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) {
+		result.Skipped++
+		return nil
+	}
+	if reviewerLastSkipNeedsCurrentLogin(meta, pr) && *currentLogin == "" {
+		lookupLogin, lookupErr := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+		if lookupErr != nil {
+			lookupLogin = ""
+		}
+		*currentLogin = normalizeLogin(lookupLogin)
+	}
+	if reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) {
+		result.Skipped++
+		return nil
+	}
+	if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && last == pr.HeadSHA && pr.HeadSHA != "" {
+		result.Skipped++
+		return nil
+	}
+	availableAt := r.nextReviewAvailableAt(meta)
+	queueItem, queueErr := r.enqueue(ctx, enqueueInput{
+		ProjectID:   project.ID,
+		LoopID:      loopResult.record.ID,
+		Repo:        repo,
+		PRNumber:    pr.Number,
+		HeadSHA:     pr.HeadSHA,
+		AvailableAt: availableAt,
+	})
+	if queueErr != nil {
+		return queueErr
+	}
+	if err := r.markLoopQueuedForReview(ctx, loopResult.record, queueItem.AvailableAt); err != nil {
+		return err
+	}
+	result.QueueItems = append(result.QueueItems, queueItem)
+	return nil
+}
+
+func (r *Runner) discoverExistingReviewerLoop(ctx context.Context, project storage.ProjectRecord, repo string, policy DiscoveryPolicy, currentLogin *string, loop storage.LoopRecord, detail PullRequestDetail, result *DiscoveryResult) error {
+	if !policy.IncludeDrafts && detail.IsDraft {
+		result.Skipped++
+		return nil
+	}
+	if normalizePRState(detail.State) != "open" {
+		if err := r.terminateLoop(ctx, loop, "pr_closed_or_merged"); err != nil {
+			return err
+		}
+		result.Skipped++
+		return nil
+	}
+	if !isManualReviewerLoop(loop) && isSelfAuthoredPR(detail.Author, *currentLogin, policy) {
+		result.Skipped++
+		return nil
+	}
+	requireReviewRequest := requireReviewRequestForLoop(loop, policy.RequireReviewRequest, detail.HeadSHA)
+	if requireReviewRequest && !isCurrentUserRequested(detail.ReviewRequests, *currentLogin) && !r.hasThreadResolutionFollowUpCandidate(ctx, project.RepoPath, repo, detail.Number, detail.HeadSHA, *currentLogin) {
+		result.Skipped++
+		return nil
+	}
+	if !isManualReviewerLoop(loop) && !labelsMatch(detail.Labels, policy.Labels, policy.LabelMode) {
+		result.Skipped++
+		return nil
+	}
+	return r.enqueueReviewerDiscoveryCandidate(ctx, project, repo, policy, currentLogin, summaryFromDetail(detail), &loop, result)
+}
+
+func (r *Runner) findReviewerLoopByPR(ctx context.Context, projectID, repo string, prNumber int64) (*storage.LoopRecord, error) {
+	loops, err := r.repos.Loops.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, loop := range loops {
+		if loop.Type == "reviewer" && loop.ProjectID == projectID && derefString(loop.Repo) == repo && derefInt64(loop.PRNumber) == prNumber {
+			loop := loop
+			return &loop, nil
+		}
+	}
+	return nil, nil
 }
 
 func (r *Runner) listOpenPullRequestsForDiscovery(ctx context.Context, repo, cwd string, limit int) ([]PullRequestSummary, error) {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -51,6 +51,65 @@ func TestDiscoverPullRequestsCreatesLoopAndQueue(t *testing.T) {
 	}
 }
 
+func TestDiscoverPullRequestCreatesLoopAndQueue(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequest() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 || len(result.CreatedLoopIDs) != 1 {
+		t.Fatalf("result = %#v, want one queue item and one created loop", result)
+	}
+	if len(github.listCalls) != 0 {
+		t.Fatalf("list calls = %#v, want targeted discovery to avoid repo scan", github.listCalls)
+	}
+}
+
+func TestDiscoverPullRequestSkipsIneligiblePullRequest(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"someone-else"}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequest() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || len(result.CreatedLoopIDs) != 0 || result.Skipped != 1 {
+		t.Fatalf("result = %#v, want skipped targeted discovery with no loop", result)
+	}
+}
+
+func TestDiscoverPullRequestReusesExistingActiveQueueItem(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	first, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("first DiscoverPullRequest() error = %v", err)
+	}
+	second, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("second DiscoverPullRequest() error = %v", err)
+	}
+	if len(first.QueueItems) != 1 || len(second.QueueItems) != 0 || second.Skipped != 1 {
+		t.Fatalf("first=%#v second=%#v, want duplicate targeted discovery skipped without new queue item", first, second)
+	}
+	queues, err := fixture.repos.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(queues) != 1 {
+		t.Fatalf("len(Queue.List()) = %d, want one active queue item", len(queues))
+	}
+}
+
 func TestDiscoverPullRequestsRecoversRetryableAfterResumeRestartFromDiscover(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1685,6 +1685,37 @@ func TestDiscoverPullRequestsAllowsManualFollowUpAfterSkippedAutomaticLoopForSam
 	}
 }
 
+func TestDiscoverPullRequestAllowsManualFollowUpAfterSkippedAutomaticLoopForSamePR(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"alice"}, currentLogin: "bob"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	automaticMetadata := `{"followUpdates":true}`
+	manualMetadata := `{"followUpdates":true,"manual":true}`
+	for _, loop := range []storage.LoopRecord{
+		{ID: "loop_auto_targeted_follow", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &automaticMetadata, CreatedAt: nowISO, UpdatedAt: nowISO},
+		{ID: "loop_manual_targeted_follow", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &manualMetadata, CreatedAt: nowISO, UpdatedAt: nowISO},
+	} {
+		if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+
+	result, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequest() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("len(QueueItems) = %d, want 1", len(result.QueueItems))
+	}
+	if result.QueueItems[0].LoopID == nil || *result.QueueItems[0].LoopID != "loop_manual_targeted_follow" {
+		t.Fatalf("queue loopID = %#v, want manual follow-up loop", result.QueueItems[0].LoopID)
+	}
+}
+
 func TestDiscoverPullRequestsSkipsSelfAuthoredFollowUpLoopByDefault(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)


### PR DESCRIPTION
## Summary
- add targeted single-PR discovery entrypoints for reviewer and fixer that evaluate one live PR without scanning the repo
- refactor poll discovery to reuse shared per-PR processing helpers so targeted and poll paths keep the same loop, dedupe, and guardrail behavior
- add reviewer and fixer tests for eligible, skipped, and duplicate-active targeted discovery cases

## Validation
- go test ./...
- go build ./...

Closes #368

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>