### PR TITLE
feat: route loopback webhook events into targeted PR discovery

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -29,6 +30,7 @@ import (
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/sweeper"
 	"github.com/nexu-io/looper/internal/version"
+	"github.com/nexu-io/looper/internal/webhookforward"
 	pkgapi "github.com/nexu-io/looper/pkg/api"
 )
 
@@ -121,6 +123,7 @@ type sweeperReplayResponse struct {
 type Context struct {
 	Config               config.Config
 	Runtime              RuntimeState
+	WebhookForwarder     webhookforward.Forwarder
 	ProjectsService      projectService
 	Now                  func() time.Time
 	RecoverySummary      func() any
@@ -130,9 +133,10 @@ type Context struct {
 }
 
 type Handler struct {
-	context         Context
-	now             func() time.Time
-	recoverySummary func() any
+	context          Context
+	now              func() time.Time
+	recoverySummary  func() any
+	webhookForwarder webhookforward.Forwarder
 }
 
 func NewHandler(context Context) *Handler {
@@ -155,18 +159,41 @@ func NewHandler(context Context) *Handler {
 			}
 		}
 	}
+	forwarder := context.WebhookForwarder
+	if forwarder == nil {
+		if runtimeWithForwarder, ok := any(context.Runtime).(interface {
+			WebhookForwarder() looperdruntime.WebhookForwarder
+		}); ok {
+			forwarder = runtimeWithForwarder.WebhookForwarder()
+		}
+	}
 
 	return &Handler{
-		context:         context,
-		now:             now,
-		recoverySummary: recoverySummary,
+		context:          context,
+		now:              now,
+		recoverySummary:  recoverySummary,
+		webhookForwarder: forwarder,
 	}
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := normalizePath(r.URL.Path)
 	requestID := strings.TrimSpace(r.Header.Get(requestIDHeaderName))
 	if requestID == "" {
 		requestID = generateRequestID()
+	}
+	if path == "/webhook/forward" {
+		payload, err := h.buildWebhookForwardResponse(r)
+		if err != nil {
+			var typed apiError
+			if !asAPIError(err, &typed) {
+				typed = internalServerError(err)
+			}
+			h.writeError(w, requestID, typed)
+			return
+		}
+		h.writeSuccess(w, requestID, payload)
+		return
 	}
 
 	if err := authorizeRequest(r, h.context.Config); err != nil {
@@ -177,8 +204,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, requestID, typed)
 		return
 	}
-
-	path := normalizePath(r.URL.Path)
 
 	switch path {
 	case apiBasePath + "/healthz":
@@ -448,6 +473,58 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		status:  http.StatusNotFound,
 		message: fmt.Sprintf("Unknown route: %s", path),
 	})
+}
+
+func (h *Handler) buildWebhookForwardResponse(r *http.Request) (webhookforward.ForwardResult, error) {
+	if r.Method != http.MethodPost {
+		return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: "Unsupported method for /webhook/forward"}
+	}
+	if !isLoopbackRequest(r) {
+		return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeUnauthorized, status: http.StatusForbidden, message: "Webhook forwarding is limited to loopback callers"}
+	}
+	if hasForwardingProxyHeaders(r.Header) {
+		return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeUnauthorized, status: http.StatusForbidden, message: "Webhook forwarding does not accept proxied loopback requests"}
+	}
+	if h.webhookForwarder == nil {
+		return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Webhook forwarding is not configured"}
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	result, err := h.webhookForwarder.Forward(r.Context(), webhookforward.DeliveryRequest{DeliveryID: r.Header.Get("X-GitHub-Delivery"), EventType: r.Header.Get("X-GitHub-Event"), Payload: body})
+	if err != nil {
+		status := http.StatusBadRequest
+		code := pkgapi.ErrorCodeValidationFailed
+		message := err.Error()
+		lower := strings.ToLower(message)
+		if strings.Contains(lower, "not configured") {
+			status = http.StatusInternalServerError
+			code = pkgapi.ErrorCodeInternalError
+		} else if strings.Contains(lower, "queue is full") {
+			status = http.StatusServiceUnavailable
+		}
+		return webhookforward.ForwardResult{}, apiError{code: code, status: status, message: message}
+	}
+	return result, nil
+}
+
+func isLoopbackRequest(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+	if err != nil {
+		host = strings.TrimSpace(r.RemoteAddr)
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func hasForwardingProxyHeaders(headers http.Header) bool {
+	for _, name := range []string{"Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Real-Ip", "X-Real-IP"} {
+		if strings.TrimSpace(headers.Get(name)) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 type apiError struct {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nexu-io/looper/internal/projects"
 	looperdruntime "github.com/nexu-io/looper/internal/runtime"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/webhookforward"
 )
 
 func TestHandlerHealthzSuccessAndRequestIDEcho(t *testing.T) {
@@ -349,6 +350,56 @@ func TestHandlerUnauthorized(t *testing.T) {
 	errMap := body["error"].(map[string]any)
 	assertEqual(t, errMap["code"], "UNAUTHORIZED")
 	assertEqual(t, errMap["message"], "Authorization token is required")
+}
+
+func TestHandlerWebhookForwardAllowsLoopbackWithoutBearerToken(t *testing.T) {
+	fixture := newTestFixture(t)
+	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, WebhookForwarder: forwarder})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", bytes.NewReader([]byte(`{"action":"review_requested"}`)))
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("X-GitHub-Delivery", "delivery-1")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	recorder := httptest.NewRecorder()
+
+	h.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	if forwarder.calls != 1 {
+		t.Fatalf("forwarder calls = %d, want 1", forwarder.calls)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	assertEqual(t, data["status"], "accepted")
+	assertEqual(t, data["workItems"], float64(1))
+}
+
+func TestHandlerWebhookForwardRejectsNonLoopbackEvenWithBearerToken(t *testing.T) {
+	fixture := newTestFixture(t)
+	token := "secret-token"
+	fixture.config.Server.AuthMode = config.AuthModeLocalToken
+	fixture.config.Server.LocalToken = &token
+	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, WebhookForwarder: forwarder})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", bytes.NewReader([]byte(`{"action":"review_requested"}`)))
+	req.RemoteAddr = "192.168.1.24:1234"
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-GitHub-Delivery", "delivery-2")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	recorder := httptest.NewRecorder()
+
+	h.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", recorder.Code)
+	}
+	if forwarder.calls != 0 {
+		t.Fatalf("forwarder calls = %d, want 0", forwarder.calls)
+	}
 }
 
 func TestHandlerRouteAndMethodErrors(t *testing.T) {
@@ -4846,6 +4897,21 @@ func seedStatusLoopCounts(t *testing.T, rt *looperdruntime.Runtime) {
 		}
 	}
 }
+
+type fakeWebhookForwarder struct {
+	result webhookforward.ForwardResult
+	err    error
+	calls  int
+}
+
+func (f *fakeWebhookForwarder) Forward(context.Context, webhookforward.DeliveryRequest) (webhookforward.ForwardResult, error) {
+	f.calls++
+	return f.result, f.err
+}
+
+func (f *fakeWebhookForwarder) Stats() webhookforward.Stats { return webhookforward.Stats{} }
+
+func (f *fakeWebhookForwarder) Close() {}
 
 func seedLoopRouteData(t *testing.T, rt *looperdruntime.Runtime) {
 	t.Helper()

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nexu-io/looper/internal/agent"
@@ -76,6 +77,45 @@ const (
 	defaultRetryDelay               = 5 * time.Second
 	defaultRetryMax                 = 3
 )
+
+var fixerDiscoveryLocks = newFixerDiscoveryLockSet()
+
+type fixerDiscoveryLockSet struct {
+	mu    sync.Mutex
+	locks map[string]*fixerDiscoveryLockRef
+}
+
+type fixerDiscoveryLockRef struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func newFixerDiscoveryLockSet() *fixerDiscoveryLockSet {
+	return &fixerDiscoveryLockSet{locks: map[string]*fixerDiscoveryLockRef{}}
+}
+
+func (s *fixerDiscoveryLockSet) With(key string, fn func() error) error {
+	s.mu.Lock()
+	ref := s.locks[key]
+	if ref == nil {
+		ref = &fixerDiscoveryLockRef{}
+		s.locks[key] = ref
+	}
+	ref.refs++
+	s.mu.Unlock()
+
+	ref.mu.Lock()
+	defer ref.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		ref.refs--
+		if ref.refs == 0 {
+			delete(s.locks, key)
+		}
+		s.mu.Unlock()
+	}()
+	return fn()
+}
 
 type FixItem struct {
 	Type              string   `json:"type"`
@@ -448,6 +488,12 @@ type DiscoveryInput struct {
 	Repo      string
 	Limit     int
 	Snapshot  *githubinfra.DiscoverySnapshot
+}
+
+type TargetedDiscoveryInput struct {
+	ProjectID string
+	Repo      string
+	PRNumber  int64
 }
 
 type DiscoveryResult struct {
@@ -1039,54 +1085,152 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		appendDiscoveryQueueItem(&result.QueueItems, item)
 	}
 	for _, pr := range openPRs {
-		if (!policy.IncludeDrafts && pr.IsDraft) || normalizePRState(pr.State) != "open" || r.hasActivePRLock(ctx, input.Repo, pr.Number) {
-			result.Skipped++
-			continue
+		if err := fixerDiscoveryLocks.With(fixerDiscoveryLockKey(project.ID, input.Repo, pr.Number), func() error {
+			if (!policy.IncludeDrafts && pr.IsDraft) || normalizePRState(pr.State) != "open" || r.hasActivePRLock(ctx, input.Repo, pr.Number) {
+				result.Skipped++
+				return nil
+			}
+			if policy.AuthorFilter != config.FixerAuthorFilterAny && !sameGitHubLogin(pr.Author, currentUser) {
+				result.Skipped++
+				return nil
+			}
+			if !labelsMatch(pr.Labels, policy.Labels, policy.LabelMode) {
+				result.Skipped++
+				return nil
+			}
+			detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: pr.Number, CWD: project.RepoPath})
+			if err != nil {
+				return err
+			}
+			allFixItems := collectFixItems(detail)
+			if len(allFixItems) == 0 {
+				if err := r.clearFixerFollowupStateForPR(ctx, project.ID, input.Repo, pr.Number); err != nil {
+					return err
+				}
+				result.Skipped++
+				return nil
+			}
+			allFixItemsStateHash := hashFixItemsState(allFixItems)
+			fixItems := suppressDeclinedFixItems(loopMetadataForPR(ctx, r, project.ID, input.Repo, pr.Number), detail.HeadSHA, allFixItems)
+			if len(fixItems) == 0 {
+				if err := r.resumePausedZeroProgressLoopIfStateChanged(ctx, project.ID, input.Repo, pr.Number, detail.HeadSHA, allFixItemsStateHash); err != nil {
+					return err
+				}
+				result.Skipped++
+				return nil
+			}
+			fixItemsHash := hashFixItems(fixItems)
+			fixItemsStateHash := allFixItemsStateHash
+			unresolvedThreadIDs := unresolvedThreadIDs(fixItems)
+			if len(unresolvedThreadIDs) == 0 {
+				if err := r.clearFixerFollowupMetadataForPR(ctx, project.ID, input.Repo, pr.Number); err != nil {
+					return err
+				}
+			}
+			loopResult, err := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, detail.HeadSHA, fixItemsHash, fixItemsStateHash, fixItems, unresolvedThreadIDs)
+			if err != nil {
+				return err
+			}
+			if loopResult.record.Status == "paused" || loopResult.record.Status == "failed" || loopResult.skipped {
+				result.Skipped++
+				return nil
+			}
+			if loopResult.created {
+				result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
+			}
+			headSHA := detail.HeadSHA
+			if headSHA == "" {
+				headSHA = "unknown"
+			}
+			queueItem, err := r.enqueue(ctx, enqueueInput{ProjectID: project.ID, LoopID: loopResult.record.ID, Repo: input.Repo, PRNumber: pr.Number, HeadSHA: headSHA, FixItemsHash: fixItemsStateHash, AvailableAt: loopResult.availableAt})
+			if err != nil {
+				return err
+			}
+			appendDiscoveryQueueItem(&result.QueueItems, queueItem)
+			return nil
+		}); err != nil {
+			return DiscoveryResult{}, err
 		}
-		if policy.AuthorFilter != config.FixerAuthorFilterAny && !sameGitHubLogin(pr.Author, currentUser) {
-			result.Skipped++
-			continue
-		}
-		if !labelsMatch(pr.Labels, policy.Labels, policy.LabelMode) {
-			result.Skipped++
-			continue
-		}
-		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: pr.Number, CWD: project.RepoPath})
+	}
+	return result, nil
+}
+
+func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscoveryInput) (DiscoveryResult, error) {
+	if input.PRNumber <= 0 {
+		return DiscoveryResult{}, fmt.Errorf("prNumber must be positive")
+	}
+	if r.repos == nil || r.repos.Projects == nil || r.repos.Loops == nil || r.repos.Queue == nil || r.repos.Runs == nil || r.repos.Locks == nil {
+		return DiscoveryResult{}, fmt.Errorf("fixer repositories are not configured")
+	}
+	project, err := r.repos.Projects.GetByID(ctx, input.ProjectID)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if project == nil {
+		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
+	}
+	policy := r.discoveryPolicyForProject(project.ID)
+	if !policy.AutoDiscovery {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	currentUser := ""
+	if policy.AuthorFilter != config.FixerAuthorFilterAny {
+		currentUser, err = r.github.GetCurrentUserLogin(ctx, project.RepoPath)
 		if err != nil {
 			return DiscoveryResult{}, err
+		}
+		currentUser = strings.TrimSpace(currentUser)
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: project.RepoPath})
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if (!policy.IncludeDrafts && detail.IsDraft) || normalizePRState(detail.State) != "open" {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	if policy.AuthorFilter != config.FixerAuthorFilterAny && !sameGitHubLogin(detail.Author, currentUser) {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	if !labelsMatch(detail.Labels, policy.Labels, policy.LabelMode) {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	result := DiscoveryResult{}
+	if err := fixerDiscoveryLocks.With(fixerDiscoveryLockKey(project.ID, input.Repo, input.PRNumber), func() error {
+		if r.hasActivePRLock(ctx, input.Repo, input.PRNumber) {
+			result.Skipped++
+			return nil
 		}
 		allFixItems := collectFixItems(detail)
 		if len(allFixItems) == 0 {
-			if err := r.clearFixerFollowupStateForPR(ctx, project.ID, input.Repo, pr.Number); err != nil {
-				return DiscoveryResult{}, err
+			if err := r.clearFixerFollowupStateForPR(ctx, project.ID, input.Repo, input.PRNumber); err != nil {
+				return err
 			}
 			result.Skipped++
-			continue
+			return nil
 		}
 		allFixItemsStateHash := hashFixItemsState(allFixItems)
-		fixItems := suppressDeclinedFixItems(loopMetadataForPR(ctx, r, project.ID, input.Repo, pr.Number), detail.HeadSHA, allFixItems)
+		fixItems := suppressDeclinedFixItems(loopMetadataForPR(ctx, r, project.ID, input.Repo, input.PRNumber), detail.HeadSHA, allFixItems)
 		if len(fixItems) == 0 {
-			if err := r.resumePausedZeroProgressLoopIfStateChanged(ctx, project.ID, input.Repo, pr.Number, detail.HeadSHA, allFixItemsStateHash); err != nil {
-				return DiscoveryResult{}, err
+			if err := r.resumePausedZeroProgressLoopIfStateChanged(ctx, project.ID, input.Repo, input.PRNumber, detail.HeadSHA, allFixItemsStateHash); err != nil {
+				return err
 			}
 			result.Skipped++
-			continue
+			return nil
 		}
-		fixItemsHash := hashFixItems(fixItems)
 		fixItemsStateHash := allFixItemsStateHash
 		unresolvedThreadIDs := unresolvedThreadIDs(fixItems)
 		if len(unresolvedThreadIDs) == 0 {
-			if err := r.clearFixerFollowupMetadataForPR(ctx, project.ID, input.Repo, pr.Number); err != nil {
-				return DiscoveryResult{}, err
+			if err := r.clearFixerFollowupMetadataForPR(ctx, project.ID, input.Repo, input.PRNumber); err != nil {
+				return err
 			}
 		}
-		loopResult, err := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, detail.HeadSHA, fixItemsHash, fixItemsStateHash, fixItems, unresolvedThreadIDs)
+		loopResult, err := r.ensureLoopForPullRequest(ctx, *project, input.Repo, input.PRNumber, detail.HeadSHA, hashFixItems(fixItems), fixItemsStateHash, fixItems, unresolvedThreadIDs)
 		if err != nil {
-			return DiscoveryResult{}, err
+			return err
 		}
 		if loopResult.record.Status == "paused" || loopResult.record.Status == "failed" || loopResult.skipped {
 			result.Skipped++
-			continue
+			return nil
 		}
 		if loopResult.created {
 			result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
@@ -1095,21 +1239,20 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		if headSHA == "" {
 			headSHA = "unknown"
 		}
-		queueItem, err := r.enqueue(ctx, enqueueInput{
-			ProjectID:    project.ID,
-			LoopID:       loopResult.record.ID,
-			Repo:         input.Repo,
-			PRNumber:     pr.Number,
-			HeadSHA:      headSHA,
-			FixItemsHash: fixItemsStateHash,
-			AvailableAt:  loopResult.availableAt,
-		})
+		queueItem, err := r.enqueue(ctx, enqueueInput{ProjectID: project.ID, LoopID: loopResult.record.ID, Repo: input.Repo, PRNumber: input.PRNumber, HeadSHA: headSHA, FixItemsHash: fixItemsStateHash, AvailableAt: loopResult.availableAt})
 		if err != nil {
-			return DiscoveryResult{}, err
+			return err
 		}
 		appendDiscoveryQueueItem(&result.QueueItems, queueItem)
+		return nil
+	}); err != nil {
+		return DiscoveryResult{}, err
 	}
 	return result, nil
+}
+
+func fixerDiscoveryLockKey(projectID, repo string, prNumber int64) string {
+	return fmt.Sprintf("%s|%s|%d", projectID, repo, prNumber)
 }
 
 func appendDiscoveryQueueItem(items *[]storage.QueueItemRecord, item storage.QueueItemRecord) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nexu-io/looper/internal/agent"
@@ -95,6 +96,45 @@ const (
 )
 
 var retryAfterPattern = regexp.MustCompile(`(?i)retry-after\s*[:=]\s*(\d+)`)
+
+var reviewerDiscoveryLocks = newDiscoveryLockSet()
+
+type discoveryLockSet struct {
+	mu    sync.Mutex
+	locks map[string]*discoveryLockRef
+}
+
+type discoveryLockRef struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func newDiscoveryLockSet() *discoveryLockSet {
+	return &discoveryLockSet{locks: map[string]*discoveryLockRef{}}
+}
+
+func (s *discoveryLockSet) With(key string, fn func() error) error {
+	s.mu.Lock()
+	ref := s.locks[key]
+	if ref == nil {
+		ref = &discoveryLockRef{}
+		s.locks[key] = ref
+	}
+	ref.refs++
+	s.mu.Unlock()
+
+	ref.mu.Lock()
+	defer ref.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		ref.refs--
+		if ref.refs == 0 {
+			delete(s.locks, key)
+		}
+		s.mu.Unlock()
+	}()
+	return fn()
+}
 
 type PullRequestSummary struct {
 	Number         int64
@@ -443,6 +483,12 @@ type DiscoveryInput struct {
 	Snapshot  *githubinfra.DiscoverySnapshot
 }
 
+type TargetedDiscoveryInput struct {
+	ProjectID string
+	Repo      string
+	PRNumber  int64
+}
+
 type DiscoveryResult struct {
 	QueueItems     []storage.QueueItemRecord
 	CreatedLoopIDs []string
@@ -693,68 +739,63 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		return pr
 	}
 	enqueue := func(pr PullRequestSummary, existing *storage.LoopRecord) error {
-		loopResult, loopErr := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, existing)
-		if loopErr != nil {
-			return loopErr
-		}
-		if terminalReviewerLoopReason(loopResult.record) == "failed" {
-			recovered, recoverErr := r.recoverFailedReviewerLoop(ctx, loopResult.record, pr)
-			if recoverErr != nil {
-				return recoverErr
+		return reviewerDiscoveryLocks.With(reviewerDiscoveryLockKey(project.ID, input.Repo, pr.Number), func() error {
+			loopResult, loopErr := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, existing)
+			if loopErr != nil {
+				return loopErr
 			}
-			if recovered != nil {
-				loopResult.record = *recovered
+			if terminalReviewerLoopReason(loopResult.record) == "failed" {
+				recovered, recoverErr := r.recoverFailedReviewerLoop(ctx, loopResult.record, pr)
+				if recoverErr != nil {
+					return recoverErr
+				}
+				if recovered != nil {
+					loopResult.record = *recovered
+				}
 			}
-		}
-		if terminalReviewerLoopReason(loopResult.record) != "" {
-			result.Skipped++
-			return nil
-		}
-		if loopResult.created {
-			result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
-		}
-		meta := parseJSONObject(loopResult.record.MetadataJSON)
-		_, hasPublishedHead := stringFromAny(meta["lastPublishedHeadSha"])
-		if !r.loopEnabled(meta) && (!loopResult.created || hasPublishedHead) {
-			result.Skipped++
-			return nil
-		}
-		if reviewerDiscoverySuppressedByLastSkip(meta, pr, currentLogin, policy) {
-			result.Skipped++
-			return nil
-		}
-		if reviewerLastSkipNeedsCurrentLogin(meta, pr) && currentLogin == "" {
-			lookupLogin, lookupErr := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
-			if lookupErr != nil {
-				lookupLogin = ""
+			if terminalReviewerLoopReason(loopResult.record) != "" {
+				result.Skipped++
+				return nil
 			}
-			currentLogin = normalizeLogin(lookupLogin)
-		}
-		if reviewerDiscoverySuppressedByLastSkip(meta, pr, currentLogin, policy) {
-			result.Skipped++
+			if loopResult.created {
+				result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
+			}
+			meta := parseJSONObject(loopResult.record.MetadataJSON)
+			_, hasPublishedHead := stringFromAny(meta["lastPublishedHeadSha"])
+			if !r.loopEnabled(meta) && (!loopResult.created || hasPublishedHead) {
+				result.Skipped++
+				return nil
+			}
+			if reviewerDiscoverySuppressedByLastSkip(meta, pr, currentLogin, policy) {
+				result.Skipped++
+				return nil
+			}
+			if reviewerLastSkipNeedsCurrentLogin(meta, pr) && currentLogin == "" {
+				lookupLogin, lookupErr := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+				if lookupErr != nil {
+					lookupLogin = ""
+				}
+				currentLogin = normalizeLogin(lookupLogin)
+			}
+			if reviewerDiscoverySuppressedByLastSkip(meta, pr, currentLogin, policy) {
+				result.Skipped++
+				return nil
+			}
+			if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && last == pr.HeadSHA && pr.HeadSHA != "" {
+				result.Skipped++
+				return nil
+			}
+			availableAt := r.nextReviewAvailableAt(meta)
+			queueItem, queueErr := r.enqueue(ctx, enqueueInput{ProjectID: project.ID, LoopID: loopResult.record.ID, Repo: input.Repo, PRNumber: pr.Number, HeadSHA: pr.HeadSHA, AvailableAt: availableAt})
+			if queueErr != nil {
+				return queueErr
+			}
+			if err := r.markLoopQueuedForReview(ctx, loopResult.record, queueItem.AvailableAt); err != nil {
+				return err
+			}
+			result.QueueItems = append(result.QueueItems, queueItem)
 			return nil
-		}
-		if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && last == pr.HeadSHA && pr.HeadSHA != "" {
-			result.Skipped++
-			return nil
-		}
-		availableAt := r.nextReviewAvailableAt(meta)
-		queueItem, queueErr := r.enqueue(ctx, enqueueInput{
-			ProjectID:   project.ID,
-			LoopID:      loopResult.record.ID,
-			Repo:        input.Repo,
-			PRNumber:    pr.Number,
-			HeadSHA:     pr.HeadSHA,
-			AvailableAt: availableAt,
 		})
-		if queueErr != nil {
-			return queueErr
-		}
-		if err := r.markLoopQueuedForReview(ctx, loopResult.record, queueItem.AvailableAt); err != nil {
-			return err
-		}
-		result.QueueItems = append(result.QueueItems, queueItem)
-		return nil
 	}
 	seenEnqueue := func(pr PullRequestSummary) error {
 		key := fmt.Sprintf("%s#%d", input.Repo, pr.Number)
@@ -831,6 +872,139 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		}
 	}
 	return result, nil
+}
+
+func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscoveryInput) (DiscoveryResult, error) {
+	if input.PRNumber <= 0 {
+		return DiscoveryResult{}, fmt.Errorf("prNumber must be positive")
+	}
+	if r.repos == nil || r.repos.Projects == nil || r.repos.Loops == nil || r.repos.Queue == nil || r.repos.Runs == nil {
+		return DiscoveryResult{}, fmt.Errorf("reviewer repositories are not configured")
+	}
+	project, err := r.repos.Projects.GetByID(ctx, input.ProjectID)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if project == nil {
+		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
+	}
+	policy := r.discoveryPolicyForProject(project.ID)
+	if !policy.AutoDiscovery {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	currentLogin := ""
+	if policy.RequireReviewRequest || !policy.EnableSelfReview {
+		current, err := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		currentLogin = normalizeLogin(current)
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: project.RepoPath})
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	pr := summaryFromDetail(detail)
+	existingLoop := (*storage.LoopRecord)(nil)
+	if loops, err := r.listFollowUpLoops(ctx, project.ID, input.Repo); err == nil {
+		for _, loop := range loops {
+			if loop.PRNumber != nil && *loop.PRNumber == input.PRNumber {
+				existingLoop = &loop
+				break
+			}
+		}
+	} else {
+		return DiscoveryResult{}, err
+	}
+	if !prEligibleForDiscovery(pr, currentLogin, policy) {
+		if existingLoop == nil {
+			return DiscoveryResult{Skipped: 1}, nil
+		}
+		if !policy.IncludeDrafts && detail.IsDraft {
+			return DiscoveryResult{Skipped: 1}, nil
+		}
+		if normalizePRState(detail.State) != "open" {
+			if err := r.terminateLoop(ctx, *existingLoop, "pr_closed_or_merged"); err != nil {
+				return DiscoveryResult{}, err
+			}
+			return DiscoveryResult{Skipped: 1}, nil
+		}
+		if !isManualReviewerLoop(*existingLoop) && isSelfAuthoredPR(detail.Author, currentLogin, policy) {
+			return DiscoveryResult{Skipped: 1}, nil
+		}
+		requireReviewRequest := requireReviewRequestForLoop(*existingLoop, policy.RequireReviewRequest, detail.HeadSHA)
+		if requireReviewRequest && !isCurrentUserRequested(detail.ReviewRequests, currentLogin) && !r.hasThreadResolutionFollowUpCandidate(ctx, project.RepoPath, input.Repo, input.PRNumber, detail.HeadSHA, currentLogin) {
+			return DiscoveryResult{Skipped: 1}, nil
+		}
+		if !isManualReviewerLoop(*existingLoop) && !labelsMatch(detail.Labels, policy.Labels, policy.LabelMode) {
+			return DiscoveryResult{Skipped: 1}, nil
+		}
+	}
+	result := DiscoveryResult{}
+	if err := reviewerDiscoveryLocks.With(reviewerDiscoveryLockKey(project.ID, input.Repo, pr.Number), func() error {
+		loopResult, err := r.ensureLoopForPullRequest(ctx, *project, input.Repo, pr.Number, existingLoop)
+		if err != nil {
+			return err
+		}
+		if terminalReviewerLoopReason(loopResult.record) == "failed" {
+			recovered, recoverErr := r.recoverFailedReviewerLoop(ctx, loopResult.record, pr)
+			if recoverErr != nil {
+				return recoverErr
+			}
+			if recovered != nil {
+				loopResult.record = *recovered
+			}
+		}
+		if terminalReviewerLoopReason(loopResult.record) != "" {
+			result.Skipped++
+			return nil
+		}
+		if loopResult.created {
+			result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
+		}
+		meta := parseJSONObject(loopResult.record.MetadataJSON)
+		_, hasPublishedHead := stringFromAny(meta["lastPublishedHeadSha"])
+		if !r.loopEnabled(meta) && (!loopResult.created || hasPublishedHead) {
+			result.Skipped++
+			return nil
+		}
+		if reviewerDiscoverySuppressedByLastSkip(meta, pr, currentLogin, policy) {
+			result.Skipped++
+			return nil
+		}
+		if reviewerLastSkipNeedsCurrentLogin(meta, pr) && currentLogin == "" {
+			lookupLogin, lookupErr := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+			if lookupErr != nil {
+				lookupLogin = ""
+			}
+			currentLogin = normalizeLogin(lookupLogin)
+		}
+		if reviewerDiscoverySuppressedByLastSkip(meta, pr, currentLogin, policy) {
+			result.Skipped++
+			return nil
+		}
+		if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && last == pr.HeadSHA && pr.HeadSHA != "" {
+			result.Skipped++
+			return nil
+		}
+		availableAt := r.nextReviewAvailableAt(meta)
+		queueItem, err := r.enqueue(ctx, enqueueInput{ProjectID: project.ID, LoopID: loopResult.record.ID, Repo: input.Repo, PRNumber: pr.Number, HeadSHA: pr.HeadSHA, AvailableAt: availableAt})
+		if err != nil {
+			return err
+		}
+		if err := r.markLoopQueuedForReview(ctx, loopResult.record, queueItem.AvailableAt); err != nil {
+			return err
+		}
+		result.QueueItems = append(result.QueueItems, queueItem)
+		return nil
+	}); err != nil {
+		return DiscoveryResult{}, err
+	}
+	return result, nil
+}
+
+func reviewerDiscoveryLockKey(projectID, repo string, prNumber int64) string {
+	return fmt.Sprintf("%s|%s|%d", projectID, repo, prNumber)
 }
 
 func (r *Runner) listOpenPullRequestsForDiscovery(ctx context.Context, repo, cwd string, limit int) ([]PullRequestSummary, error) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nexu-io/looper/internal/projects"
 	"github.com/nexu-io/looper/internal/runs"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/webhookforward"
 )
 
 type OpenSQLiteCoordinatorFunc func(context.Context, string, storage.SQLiteCoordinatorOptions) (*storage.SQLiteCoordinator, error)
@@ -74,6 +75,12 @@ type Services struct {
 	ActiveExecutions *ActiveExecutionRegistry
 }
 
+type WebhookForwarder interface {
+	Forward(context.Context, webhookforward.DeliveryRequest) (webhookforward.ForwardResult, error)
+	Stats() webhookforward.Stats
+	Close()
+}
+
 type Runtime struct {
 	config config.Config
 	logger bootstrap.Logger
@@ -109,6 +116,7 @@ type Runtime struct {
 	recoveryDone       chan struct{}
 	activeExecutions   *ActiveExecutionRegistry
 	githubGateway      *githubinfra.Gateway
+	webhookForwarder   WebhookForwarder
 	schedulerDisabled  bool
 	startupReadyOnce   sync.Once
 	startupReadyErr    error
@@ -207,6 +215,8 @@ func (r *Runtime) Stop(reason string) {
 
 		r.mu.Lock()
 		r.stopped = true
+		forwarder := r.webhookForwarder
+		r.webhookForwarder = nil
 		coordinator := r.services.Coordinator
 		repositories := r.services.Repositories
 		ownershipAcquired := r.ownershipAcquired
@@ -222,6 +232,9 @@ func (r *Runtime) Stop(reason string) {
 		r.services = Services{}
 		r.mu.Unlock()
 
+		if forwarder != nil {
+			forwarder.Close()
+		}
 		if coordinator != nil {
 			if err := coordinator.Close(); err != nil && r.logger != nil {
 				r.logger.Warn("looperd runtime close failed", map[string]any{"error": err.Error()})
@@ -265,6 +278,12 @@ func (r *Runtime) StartedAt() (time.Time, bool) {
 	return *r.startedAt, true
 }
 
+func (r *Runtime) WebhookForwarder() WebhookForwarder {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.webhookForwarder
+}
+
 func (r *Runtime) Config() config.Config {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -303,6 +322,13 @@ func (r *Runtime) start(ctx context.Context) error {
 	started := false
 	defer func() {
 		if !started {
+			r.mu.Lock()
+			forwarder := r.webhookForwarder
+			r.webhookForwarder = nil
+			r.mu.Unlock()
+			if forwarder != nil {
+				forwarder.Close()
+			}
 			_ = coordinator.Close()
 		}
 	}()
@@ -385,6 +411,7 @@ func (r *Runtime) start(ctx context.Context) error {
 		}, r.TriggerSchedulerClaim, r.now)
 		r.defaultSchedulerTick = handlers.tick
 		r.defaultSchedulerClaim = handlers.claim
+		r.webhookForwarder = handlers.webhook
 		schedulerDisabled = r.config.Agent.Vendor == nil
 	}
 	r.githubGateway = githubGateway

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nexu-io/looper/internal/reviewer"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/sweeper"
+	"github.com/nexu-io/looper/internal/webhookforward"
 	"github.com/nexu-io/looper/internal/worker"
 )
 
@@ -39,12 +40,14 @@ type coordinatorScheduler interface {
 
 type reviewerScheduler interface {
 	DiscoverPullRequests(context.Context, reviewer.DiscoveryInput) (reviewer.DiscoveryResult, error)
+	DiscoverPullRequest(context.Context, reviewer.TargetedDiscoveryInput) (reviewer.DiscoveryResult, error)
 	ProcessNext(context.Context, string) (*reviewer.ProcessResult, error)
 	ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) (*reviewer.ProcessResult, error)
 }
 
 type fixerScheduler interface {
 	DiscoverPullRequests(context.Context, fixer.DiscoveryInput) (fixer.DiscoveryResult, error)
+	DiscoverPullRequest(context.Context, fixer.TargetedDiscoveryInput) (fixer.DiscoveryResult, error)
 	ProcessNext(context.Context, string) (*fixer.ProcessResult, error)
 	ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) (*fixer.ProcessResult, error)
 }
@@ -103,8 +106,9 @@ type defaultSchedulerTickInput struct {
 }
 
 type defaultSchedulerHandlers struct {
-	tick  RunSchedulerTickFunc
-	claim RunSchedulerTickFunc
+	tick    RunSchedulerTickFunc
+	claim   RunSchedulerTickFunc
+	webhook WebhookForwarder
 }
 
 type schedulerTaskTracker struct{ wg sync.WaitGroup }
@@ -1118,6 +1122,14 @@ func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, c
 		claim: func(ctx context.Context, services Services) error {
 			return runIndependentClaimPass(ctx, inputForServices(services))
 		},
+		webhook: webhookforward.New(webhookforward.Options{
+			Repos:    repos,
+			Config:   cfg,
+			Reviewer: reviewerRunner,
+			Fixer:    fixerRunner,
+			Logger:   logger,
+			Now:      now,
+		}),
 	}
 }
 

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -1144,6 +1144,10 @@ func (s *enqueueingReviewerScheduler) DiscoverPullRequests(ctx context.Context, 
 	return reviewer.DiscoveryResult{QueueItems: []storage.QueueItemRecord{s.item}}, nil
 }
 
+func (s *enqueueingReviewerScheduler) DiscoverPullRequest(ctx context.Context, input reviewer.TargetedDiscoveryInput) (reviewer.DiscoveryResult, error) {
+	return reviewer.DiscoveryResult{}, nil
+}
+
 type enqueueingFixerScheduler struct {
 	stubFixerScheduler
 	repos *storage.Repositories
@@ -1156,6 +1160,10 @@ func (s *enqueueingFixerScheduler) DiscoverPullRequests(ctx context.Context, inp
 		return fixer.DiscoveryResult{}, err
 	}
 	return fixer.DiscoveryResult{QueueItems: []storage.QueueItemRecord{s.item}}, nil
+}
+
+func (s *enqueueingFixerScheduler) DiscoverPullRequest(ctx context.Context, input fixer.TargetedDiscoveryInput) (fixer.DiscoveryResult, error) {
+	return fixer.DiscoveryResult{}, nil
 }
 
 type discoveringWorkerScheduler struct {
@@ -1361,6 +1369,10 @@ func (s *stubReviewerScheduler) DiscoverPullRequests(_ context.Context, input re
 	return reviewer.DiscoveryResult{}, s.discoverErr
 }
 
+func (s *stubReviewerScheduler) DiscoverPullRequest(_ context.Context, _ reviewer.TargetedDiscoveryInput) (reviewer.DiscoveryResult, error) {
+	return reviewer.DiscoveryResult{}, s.discoverErr
+}
+
 func (s *stubReviewerScheduler) ProcessNext(_ context.Context, claimedBy string) (*reviewer.ProcessResult, error) {
 	s.mu.Lock()
 	s.processClaims = append(s.processClaims, claimedBy)
@@ -1400,6 +1412,10 @@ func (s *stubFixerScheduler) DiscoverPullRequests(_ context.Context, input fixer
 	s.mu.Lock()
 	s.discoverCalls = append(s.discoverCalls, input)
 	s.mu.Unlock()
+	return fixer.DiscoveryResult{}, s.discoverErr
+}
+
+func (s *stubFixerScheduler) DiscoverPullRequest(_ context.Context, _ fixer.TargetedDiscoveryInput) (fixer.DiscoveryResult, error) {
 	return fixer.DiscoveryResult{}, s.discoverErr
 }
 

--- a/internal/webhookforward/forwarder.go
+++ b/internal/webhookforward/forwarder.go
@@ -381,14 +381,17 @@ func (f *forwarder) worker() {
 func (f *forwarder) nextWork() (workKey, workItem, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.enqueuePendingLocked()
 	for len(f.queue) == 0 && !f.closed {
 		f.cond.Wait()
+		f.enqueuePendingLocked()
 	}
 	if f.closed && len(f.queue) == 0 {
 		return workKey{}, workItem{}, false
 	}
 	key := f.queue[0]
 	f.queue = f.queue[1:]
+	f.enqueuePendingLocked()
 	itemKey := workKeyString(key)
 	item := f.works[itemKey]
 	if item == nil {
@@ -422,8 +425,6 @@ func (f *forwarder) finishWork(key workKey, outcome Outcome) {
 				f.queue = append(f.queue, key)
 				f.stats.QueueEnqueued++
 				f.cond.Signal()
-			} else {
-				f.stats.QueueRejected++
 			}
 		}
 	}
@@ -507,6 +508,28 @@ func (f *forwarder) appendOutcomeLocked(outcome Outcome) {
 	f.recentOutcomes = append(f.recentOutcomes, outcome)
 	if len(f.recentOutcomes) > f.recentOutcomeLimit {
 		f.recentOutcomes = append([]Outcome(nil), f.recentOutcomes[len(f.recentOutcomes)-f.recentOutcomeLimit:]...)
+	}
+}
+
+func (f *forwarder) enqueuePendingLocked() {
+	if len(f.queue) >= f.queueCapacity {
+		return
+	}
+	added := 0
+	for _, item := range f.works {
+		if item == nil || item.running || item.enqueued || len(item.lanes) == 0 {
+			continue
+		}
+		item.enqueued = true
+		f.queue = append(f.queue, item.key)
+		f.stats.QueueEnqueued++
+		added++
+		if len(f.queue) >= f.queueCapacity {
+			break
+		}
+	}
+	if added > 0 {
+		f.cond.Signal()
 	}
 }
 

--- a/internal/webhookforward/forwarder.go
+++ b/internal/webhookforward/forwarder.go
@@ -1,0 +1,619 @@
+package webhookforward
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nexu-io/looper/internal/bootstrap"
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/fixer"
+	"github.com/nexu-io/looper/internal/reviewer"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+const (
+	defaultQueueCapacity     = 128
+	defaultMaxConcurrent     = 4
+	defaultDeliveryTTL       = time.Hour
+	defaultRetryDelay        = 2 * time.Second
+	defaultRecentOutcomeSize = 64
+	maxRetries               = 2
+)
+
+type Lane string
+
+const (
+	LaneReviewer Lane = "reviewer"
+	LaneFixer    Lane = "fixer"
+)
+
+type DeliveryRequest struct {
+	DeliveryID string
+	EventType  string
+	Payload    []byte
+}
+
+type ForwardResult struct {
+	Status    string `json:"status"`
+	Reason    string `json:"reason,omitempty"`
+	WorkItems int    `json:"workItems"`
+}
+
+type Outcome struct {
+	At         string   `json:"at"`
+	ProjectID  string   `json:"projectId"`
+	Repo       string   `json:"repo"`
+	ObjectType string   `json:"objectType"`
+	Number     int64    `json:"number"`
+	Lanes      []string `json:"lanes"`
+	Status     string   `json:"status"`
+	Attempts   int      `json:"attempts"`
+	Error      string   `json:"error,omitempty"`
+	EventType  string   `json:"eventType,omitempty"`
+	Action     string   `json:"action,omitempty"`
+	DeliveryID string   `json:"deliveryId,omitempty"`
+}
+
+type Stats struct {
+	DeliveriesReceived  int64     `json:"deliveriesReceived"`
+	DeliveriesDeduped   int64     `json:"deliveriesDeduped"`
+	DeliveriesIgnored   int64     `json:"deliveriesIgnored"`
+	DeliveriesAccepted  int64     `json:"deliveriesAccepted"`
+	QueueEnqueued       int64     `json:"queueEnqueued"`
+	QueueCoalesced      int64     `json:"queueCoalesced"`
+	QueueRejected       int64     `json:"queueRejected"`
+	ExecutionsStarted   int64     `json:"executionsStarted"`
+	ExecutionsRetried   int64     `json:"executionsRetried"`
+	ExecutionsSucceeded int64     `json:"executionsSucceeded"`
+	ExecutionsFailed    int64     `json:"executionsFailed"`
+	InFlight            int       `json:"inFlight"`
+	Queued              int       `json:"queued"`
+	KnownCoalescedKeys  int       `json:"knownCoalescedKeys"`
+	RecentOutcomes      []Outcome `json:"recentOutcomes"`
+}
+
+type Forwarder interface {
+	Forward(context.Context, DeliveryRequest) (ForwardResult, error)
+	Stats() Stats
+	Close()
+}
+
+type TargetedReviewer interface {
+	DiscoverPullRequest(context.Context, reviewer.TargetedDiscoveryInput) (reviewer.DiscoveryResult, error)
+}
+
+type TargetedFixer interface {
+	DiscoverPullRequest(context.Context, fixer.TargetedDiscoveryInput) (fixer.DiscoveryResult, error)
+}
+
+type Options struct {
+	Repos              *storage.Repositories
+	Config             config.Config
+	Reviewer           TargetedReviewer
+	Fixer              TargetedFixer
+	Logger             bootstrap.Logger
+	Now                func() time.Time
+	QueueCapacity      int
+	MaxConcurrent      int
+	DeliveryTTL        time.Duration
+	RetryDelay         time.Duration
+	RecentOutcomeLimit int
+}
+
+type deliveryRecord struct {
+	expiresAt time.Time
+}
+
+type workKey struct {
+	ProjectID  string
+	Repo       string
+	ObjectType string
+	Number     int64
+}
+
+type workMetadata struct {
+	EventType  string
+	Action     string
+	DeliveryID string
+}
+
+type workItem struct {
+	key      workKey
+	lanes    map[Lane]struct{}
+	metadata workMetadata
+	running  bool
+	enqueued bool
+}
+
+type routedDelivery struct {
+	repo       string
+	objectType string
+	number     int64
+	action     string
+	lanes      map[Lane]struct{}
+}
+
+type pullRequestEnvelope struct {
+	Action     string `json:"action"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	PullRequest struct {
+		Number int64 `json:"number"`
+	} `json:"pull_request"`
+}
+
+type issueCommentEnvelope struct {
+	Action     string `json:"action"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	Issue struct {
+		Number      int64 `json:"number"`
+		PullRequest *struct {
+			URL string `json:"url"`
+		} `json:"pull_request"`
+	} `json:"issue"`
+}
+
+type forwarder struct {
+	repos              *storage.Repositories
+	cfg                config.Config
+	reviewer           TargetedReviewer
+	fixer              TargetedFixer
+	logger             bootstrap.Logger
+	now                func() time.Time
+	queueCapacity      int
+	maxConcurrent      int
+	deliveryTTL        time.Duration
+	retryDelay         time.Duration
+	recentOutcomeLimit int
+
+	mu              sync.Mutex
+	cond            *sync.Cond
+	closed          bool
+	workersDone     sync.WaitGroup
+	queue           []workKey
+	works           map[string]*workItem
+	deliveries      map[string]deliveryRecord
+	stats           Stats
+	recentOutcomes  []Outcome
+	currentInFlight int
+}
+
+func New(options Options) Forwarder {
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	queueCapacity := options.QueueCapacity
+	if queueCapacity <= 0 {
+		queueCapacity = defaultQueueCapacity
+	}
+	maxConcurrent := options.MaxConcurrent
+	if maxConcurrent <= 0 {
+		maxConcurrent = defaultMaxConcurrent
+	}
+	deliveryTTL := options.DeliveryTTL
+	if deliveryTTL <= 0 {
+		deliveryTTL = defaultDeliveryTTL
+	}
+	retryDelay := options.RetryDelay
+	if retryDelay <= 0 {
+		retryDelay = defaultRetryDelay
+	}
+	recentOutcomeLimit := options.RecentOutcomeLimit
+	if recentOutcomeLimit <= 0 {
+		recentOutcomeLimit = defaultRecentOutcomeSize
+	}
+	f := &forwarder{
+		repos:              options.Repos,
+		cfg:                options.Config,
+		reviewer:           options.Reviewer,
+		fixer:              options.Fixer,
+		logger:             options.Logger,
+		now:                now,
+		queueCapacity:      queueCapacity,
+		maxConcurrent:      maxConcurrent,
+		deliveryTTL:        deliveryTTL,
+		retryDelay:         retryDelay,
+		recentOutcomeLimit: recentOutcomeLimit,
+		works:              map[string]*workItem{},
+		deliveries:         map[string]deliveryRecord{},
+	}
+	f.cond = sync.NewCond(&f.mu)
+	for i := 0; i < f.maxConcurrent; i++ {
+		f.workersDone.Add(1)
+		go f.worker()
+	}
+	return f
+}
+
+func (f *forwarder) Forward(ctx context.Context, request DeliveryRequest) (ForwardResult, error) {
+	if f.repos == nil || f.repos.Projects == nil {
+		return ForwardResult{}, fmt.Errorf("webhook forwarder repositories are not configured")
+	}
+	now := f.now().UTC()
+	deliveryID := strings.TrimSpace(request.DeliveryID)
+	eventType := strings.TrimSpace(request.EventType)
+	if deliveryID == "" {
+		return ForwardResult{}, fmt.Errorf("x-github-delivery header is required")
+	}
+	if eventType == "" {
+		return ForwardResult{}, fmt.Errorf("x-github-event header is required")
+	}
+	routed, ok, err := routeDelivery(eventType, request.Payload)
+	if err != nil {
+		return ForwardResult{}, err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return ForwardResult{}, fmt.Errorf("webhook forwarder is closed")
+	}
+	f.stats.DeliveriesReceived++
+	f.pruneExpiredDeliveriesLocked(now)
+	if _, exists := f.deliveries[deliveryID]; exists {
+		f.stats.DeliveriesDeduped++
+		return ForwardResult{Status: "duplicate", Reason: "delivery_deduped", WorkItems: 0}, nil
+	}
+	if !ok {
+		f.deliveries[deliveryID] = deliveryRecord{expiresAt: now.Add(f.deliveryTTL)}
+		f.stats.DeliveriesIgnored++
+		return ForwardResult{Status: "ignored", Reason: "unsupported_event", WorkItems: 0}, nil
+	}
+	projects, projectErr := f.repos.Projects.List(ctx)
+	if projectErr != nil {
+		return ForwardResult{}, projectErr
+	}
+	workItems, enqueueErr := f.enqueueLocked(projects, routed, workMetadata{EventType: eventType, Action: routed.action, DeliveryID: deliveryID})
+	if enqueueErr != nil {
+		return ForwardResult{}, enqueueErr
+	}
+	f.deliveries[deliveryID] = deliveryRecord{expiresAt: now.Add(f.deliveryTTL)}
+	if workItems == 0 {
+		f.stats.DeliveriesIgnored++
+		return ForwardResult{Status: "ignored", Reason: "no_matching_projects", WorkItems: 0}, nil
+	}
+	f.stats.DeliveriesAccepted++
+	return ForwardResult{Status: "accepted", WorkItems: workItems}, nil
+}
+
+func (f *forwarder) Stats() Stats {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	stats := f.stats
+	stats.InFlight = f.currentInFlight
+	stats.Queued = len(f.queue)
+	stats.KnownCoalescedKeys = len(f.works)
+	stats.RecentOutcomes = append([]Outcome(nil), f.recentOutcomes...)
+	return stats
+}
+
+func (f *forwarder) Close() {
+	f.mu.Lock()
+	if f.closed {
+		f.mu.Unlock()
+		return
+	}
+	f.closed = true
+	f.cond.Broadcast()
+	f.mu.Unlock()
+	f.workersDone.Wait()
+}
+
+func (f *forwarder) enqueueLocked(projects []storage.ProjectRecord, routed routedDelivery, metadata workMetadata) (int, error) {
+	type candidate struct {
+		key   workKey
+		lanes map[Lane]struct{}
+	}
+	candidates := make([]candidate, 0, len(projects))
+	newQueueEntries := 0
+	matched := 0
+	for _, project := range projects {
+		if project.Archived {
+			continue
+		}
+		repo := repoFromProjectMetadata(project.MetadataJSON)
+		if !strings.EqualFold(repo, routed.repo) {
+			continue
+		}
+		lanes := enabledLanesForProject(f.cfg, project.ID, routed.lanes)
+		if len(lanes) == 0 {
+			continue
+		}
+		matched++
+		key := workKey{ProjectID: project.ID, Repo: repo, ObjectType: routed.objectType, Number: routed.number}
+		candidates = append(candidates, candidate{key: key, lanes: lanes})
+		itemKey := workKeyString(key)
+		item, exists := f.works[itemKey]
+		if exists && (item.running || item.enqueued) {
+			continue
+		}
+		newQueueEntries++
+	}
+	if newQueueEntries > f.queueCapacity-len(f.queue) {
+		f.stats.QueueRejected++
+		return 0, fmt.Errorf("webhook forward queue is full")
+	}
+	for _, candidate := range candidates {
+		itemKey := workKeyString(candidate.key)
+		item, exists := f.works[itemKey]
+		if !exists {
+			item = &workItem{key: candidate.key, lanes: map[Lane]struct{}{}, metadata: metadata}
+			f.works[itemKey] = item
+		}
+		for lane := range candidate.lanes {
+			item.lanes[lane] = struct{}{}
+		}
+		item.metadata = metadata
+		if item.running || item.enqueued {
+			f.stats.QueueCoalesced++
+			continue
+		}
+		item.enqueued = true
+		f.queue = append(f.queue, candidate.key)
+		f.stats.QueueEnqueued++
+		f.cond.Signal()
+	}
+	return matched, nil
+}
+
+func (f *forwarder) worker() {
+	defer f.workersDone.Done()
+	for {
+		key, item, ok := f.nextWork()
+		if !ok {
+			return
+		}
+		outcome := f.executeWithRetry(context.Background(), key, item)
+		f.finishWork(key, outcome)
+	}
+}
+
+func (f *forwarder) nextWork() (workKey, workItem, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for len(f.queue) == 0 && !f.closed {
+		f.cond.Wait()
+	}
+	if f.closed && len(f.queue) == 0 {
+		return workKey{}, workItem{}, false
+	}
+	key := f.queue[0]
+	f.queue = f.queue[1:]
+	itemKey := workKeyString(key)
+	item := f.works[itemKey]
+	if item == nil {
+		return workKey{}, workItem{}, true
+	}
+	lanes := copyLanes(item.lanes)
+	metadata := item.metadata
+	item.lanes = map[Lane]struct{}{}
+	item.running = true
+	item.enqueued = false
+	f.currentInFlight++
+	f.stats.ExecutionsStarted++
+	return key, workItem{key: key, lanes: lanes, metadata: metadata}, true
+}
+
+func (f *forwarder) finishWork(key workKey, outcome Outcome) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.currentInFlight > 0 {
+		f.currentInFlight--
+	}
+	itemKey := workKeyString(key)
+	item := f.works[itemKey]
+	if item != nil {
+		item.running = false
+		if len(item.lanes) == 0 {
+			delete(f.works, itemKey)
+		} else if !item.enqueued {
+			if len(f.queue) < f.queueCapacity {
+				item.enqueued = true
+				f.queue = append(f.queue, key)
+				f.stats.QueueEnqueued++
+				f.cond.Signal()
+			} else {
+				f.stats.QueueRejected++
+			}
+		}
+	}
+	switch outcome.Status {
+	case "succeeded":
+		f.stats.ExecutionsSucceeded++
+	case "failed":
+		f.stats.ExecutionsFailed++
+	}
+	f.appendOutcomeLocked(outcome)
+	if f.logger != nil {
+		fields := map[string]any{"projectId": outcome.ProjectID, "repo": outcome.Repo, "objectType": outcome.ObjectType, "number": outcome.Number, "lanes": outcome.Lanes, "status": outcome.Status, "attempts": outcome.Attempts}
+		if outcome.Error != "" {
+			fields["error"] = outcome.Error
+		}
+		f.logger.Info("webhook targeted discovery completed", fields)
+	}
+}
+
+func (f *forwarder) executeWithRetry(ctx context.Context, key workKey, item workItem) Outcome {
+	lanes := sortedLaneStrings(item.lanes)
+	outcome := Outcome{At: f.now().UTC().Format(time.RFC3339Nano), ProjectID: key.ProjectID, Repo: key.Repo, ObjectType: key.ObjectType, Number: key.Number, Lanes: lanes, EventType: item.metadata.EventType, Action: item.metadata.Action, DeliveryID: item.metadata.DeliveryID}
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		outcome.Attempts = attempt
+		err := f.executeOnce(ctx, key, item)
+		if err == nil {
+			outcome.Status = "succeeded"
+			return outcome
+		}
+		if attempt < maxRetries && isTransient(err) {
+			f.mu.Lock()
+			f.stats.ExecutionsRetried++
+			f.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				outcome.Status = "failed"
+				outcome.Error = ctx.Err().Error()
+				return outcome
+			case <-time.After(f.retryDelay):
+			}
+			continue
+		}
+		outcome.Status = "failed"
+		outcome.Error = err.Error()
+		return outcome
+	}
+	outcome.Status = "failed"
+	outcome.Error = "targeted discovery exhausted retries"
+	return outcome
+}
+
+func (f *forwarder) executeOnce(ctx context.Context, key workKey, item workItem) error {
+	if _, ok := item.lanes[LaneReviewer]; ok {
+		if f.reviewer == nil {
+			return fmt.Errorf("reviewer targeted discovery is not configured")
+		}
+		if _, err := f.reviewer.DiscoverPullRequest(ctx, reviewer.TargetedDiscoveryInput{ProjectID: key.ProjectID, Repo: key.Repo, PRNumber: key.Number}); err != nil {
+			return err
+		}
+	}
+	if _, ok := item.lanes[LaneFixer]; ok {
+		if f.fixer == nil {
+			return fmt.Errorf("fixer targeted discovery is not configured")
+		}
+		if _, err := f.fixer.DiscoverPullRequest(ctx, fixer.TargetedDiscoveryInput{ProjectID: key.ProjectID, Repo: key.Repo, PRNumber: key.Number}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *forwarder) pruneExpiredDeliveriesLocked(now time.Time) {
+	for key, record := range f.deliveries {
+		if !record.expiresAt.After(now) {
+			delete(f.deliveries, key)
+		}
+	}
+}
+
+func (f *forwarder) appendOutcomeLocked(outcome Outcome) {
+	f.recentOutcomes = append(f.recentOutcomes, outcome)
+	if len(f.recentOutcomes) > f.recentOutcomeLimit {
+		f.recentOutcomes = append([]Outcome(nil), f.recentOutcomes[len(f.recentOutcomes)-f.recentOutcomeLimit:]...)
+	}
+}
+
+func routeDelivery(eventType string, payload []byte) (routedDelivery, bool, error) {
+	switch strings.TrimSpace(eventType) {
+	case "pull_request":
+		var envelope pullRequestEnvelope
+		if err := json.Unmarshal(payload, &envelope); err != nil {
+			return routedDelivery{}, false, fmt.Errorf("decode pull_request webhook: %w", err)
+		}
+		lanes := map[Lane]struct{}{}
+		switch strings.TrimSpace(envelope.Action) {
+		case "review_requested":
+			lanes[LaneReviewer] = struct{}{}
+		case "opened", "reopened", "ready_for_review", "synchronize":
+			lanes[LaneReviewer] = struct{}{}
+			lanes[LaneFixer] = struct{}{}
+		default:
+			return routedDelivery{}, false, nil
+		}
+		if strings.TrimSpace(envelope.Repository.FullName) == "" || envelope.PullRequest.Number <= 0 {
+			return routedDelivery{}, false, errors.New("pull_request webhook missing repository or number")
+		}
+		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", number: envelope.PullRequest.Number, action: strings.TrimSpace(envelope.Action), lanes: lanes}, true, nil
+	case "issue_comment":
+		var envelope issueCommentEnvelope
+		if err := json.Unmarshal(payload, &envelope); err != nil {
+			return routedDelivery{}, false, fmt.Errorf("decode issue_comment webhook: %w", err)
+		}
+		if envelope.Issue.PullRequest == nil {
+			return routedDelivery{}, false, nil
+		}
+		if strings.TrimSpace(envelope.Repository.FullName) == "" || envelope.Issue.Number <= 0 {
+			return routedDelivery{}, false, errors.New("issue_comment webhook missing repository or number")
+		}
+		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", number: envelope.Issue.Number, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneFixer: {}}}, true, nil
+	case "pull_request_review", "pull_request_review_comment":
+		var envelope pullRequestEnvelope
+		if err := json.Unmarshal(payload, &envelope); err != nil {
+			return routedDelivery{}, false, fmt.Errorf("decode %s webhook: %w", eventType, err)
+		}
+		if strings.TrimSpace(envelope.Repository.FullName) == "" || envelope.PullRequest.Number <= 0 {
+			return routedDelivery{}, false, fmt.Errorf("%s webhook missing repository or number", eventType)
+		}
+		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", number: envelope.PullRequest.Number, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneFixer: {}}}, true, nil
+	default:
+		return routedDelivery{}, false, nil
+	}
+}
+
+func enabledLanesForProject(cfg config.Config, projectID string, lanes map[Lane]struct{}) map[Lane]struct{} {
+	roles := config.ProjectRoleConfigs(cfg, projectID)
+	result := map[Lane]struct{}{}
+	if _, ok := lanes[LaneReviewer]; ok && roles.Reviewer.Discovery.AutoDiscovery {
+		result[LaneReviewer] = struct{}{}
+	}
+	if _, ok := lanes[LaneFixer]; ok && roles.Fixer.AutoDiscovery {
+		result[LaneFixer] = struct{}{}
+	}
+	return result
+}
+
+func repoFromProjectMetadata(metadataJSON *string) string {
+	if metadataJSON == nil || strings.TrimSpace(*metadataJSON) == "" {
+		return ""
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(*metadataJSON), &payload); err != nil {
+		return ""
+	}
+	value, _ := payload["repo"].(string)
+	return strings.TrimSpace(value)
+}
+
+func workKeyString(key workKey) string {
+	return fmt.Sprintf("%s|%s|%s|%d", key.ProjectID, strings.ToLower(key.Repo), key.ObjectType, key.Number)
+}
+
+func copyLanes(lanes map[Lane]struct{}) map[Lane]struct{} {
+	result := make(map[Lane]struct{}, len(lanes))
+	for lane := range lanes {
+		result[lane] = struct{}{}
+	}
+	return result
+}
+
+func sortedLaneStrings(lanes map[Lane]struct{}) []string {
+	items := make([]string, 0, len(lanes))
+	for lane := range lanes {
+		items = append(items, string(lane))
+	}
+	sort.Strings(items)
+	return items
+}
+
+func isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	type temporary interface{ Temporary() bool }
+	var temp temporary
+	if errors.As(err, &temp) && temp.Temporary() {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "timeout") || strings.Contains(message, "tempor") || strings.Contains(message, "rate limit") || strings.Contains(message, "retry after")
+}

--- a/internal/webhookforward/forwarder_test.go
+++ b/internal/webhookforward/forwarder_test.go
@@ -1,0 +1,440 @@
+package webhookforward
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/fixer"
+	"github.com/nexu-io/looper/internal/reviewer"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestForwardDedupesDeliveriesWithinTTLAndExpiresAfterAnHour(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	now := time.Date(2026, time.May, 16, 12, 0, 0, 0, time.UTC)
+	reviewerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: newFakeTargetedRunner(nil)}, Now: func() time.Time { return now }, MaxConcurrent: 1, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	first, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "delivery-1", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 42)})
+	if err != nil {
+		t.Fatalf("first Forward() error = %v", err)
+	}
+	if first.Status != "accepted" {
+		t.Fatalf("first status = %q, want accepted", first.Status)
+	}
+	reviewerRunner.waitForCalls(t, 1)
+
+	second, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "delivery-1", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 42)})
+	if err != nil {
+		t.Fatalf("second Forward() error = %v", err)
+	}
+	if second.Status != "duplicate" {
+		t.Fatalf("second status = %q, want duplicate", second.Status)
+	}
+	reviewerRunner.assertCallCount(t, 1)
+
+	now = now.Add(time.Hour + time.Second)
+	third, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "delivery-1", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 42)})
+	if err != nil {
+		t.Fatalf("third Forward() error = %v", err)
+	}
+	if third.Status != "accepted" {
+		t.Fatalf("third status = %q, want accepted", third.Status)
+	}
+	reviewerRunner.waitForCalls(t, 2)
+
+	stats := forwarder.Stats()
+	if stats.DeliveriesDeduped != 1 {
+		t.Fatalf("DeliveriesDeduped = %d, want 1", stats.DeliveriesDeduped)
+	}
+}
+
+func TestForwardIgnoresUnsupportedAndNonPullRequestIssueComments(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(nil)
+	fixerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: fixerRunner}, MaxConcurrent: 1, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	for _, request := range []DeliveryRequest{
+		{DeliveryID: "ignored-1", EventType: "issues", Payload: []byte(`{"action":"opened"}`)},
+		{DeliveryID: "ignored-2", EventType: "issue_comment", Payload: []byte(`{"action":"created","repository":{"full_name":"acme/looper"},"issue":{"number":42}}`)},
+	} {
+		result, err := forwarder.Forward(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Forward(%s) error = %v", request.EventType, err)
+		}
+		if result.Status != "ignored" {
+			t.Fatalf("Forward(%s) status = %q, want ignored", request.EventType, result.Status)
+		}
+	}
+	shortSleep()
+	reviewerRunner.assertCallCount(t, 0)
+	fixerRunner.assertCallCount(t, 0)
+}
+
+func TestForwardFansOutToMultipleProjectsForSameRepo(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	seedProject(t, repos, "project_2", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: newFakeTargetedRunner(nil)}, MaxConcurrent: 2, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	result, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "fanout-1", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "Acme/Looper", 55)})
+	if err != nil {
+		t.Fatalf("Forward() error = %v", err)
+	}
+	if result.WorkItems != 2 {
+		t.Fatalf("WorkItems = %d, want 2", result.WorkItems)
+	}
+	reviewerRunner.waitForCalls(t, 2)
+	reviewerRunner.assertProjects(t, []string{"project_1", "project_2"})
+	reviewerRunner.assertRepos(t, []string{"acme/looper", "acme/looper"})
+}
+
+func TestForwardCoalescesQueuedWorkAndUnionsLanes(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(make(chan struct{}))
+	fixerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: fixerRunner}, MaxConcurrent: 1, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	if _, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "busy-pr1", EventType: "pull_request", Payload: pullRequestPayload("opened", "acme/looper", 1)}); err != nil {
+		t.Fatalf("busy Forward() error = %v", err)
+	}
+	reviewerRunner.waitForCall(t, 1)
+
+	if _, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "queue-pr2-a", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 2)}); err != nil {
+		t.Fatalf("queue Forward(a) error = %v", err)
+	}
+	if _, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "queue-pr2-b", EventType: "pull_request_review_comment", Payload: pullRequestPayload("created", "acme/looper", 2)}); err != nil {
+		t.Fatalf("queue Forward(b) error = %v", err)
+	}
+
+	close(reviewerRunner.block)
+	reviewerRunner.waitForCalls(t, 2)
+	fixerRunner.waitForCalls(t, 2)
+
+	reviewerRunner.assertPRCount(t, 2, 1)
+	fixerRunner.assertPRCount(t, 2, 1)
+	stats := forwarder.Stats()
+	if stats.QueueCoalesced == 0 {
+		t.Fatalf("QueueCoalesced = %d, want > 0", stats.QueueCoalesced)
+	}
+}
+
+func TestForwardUsesBoundedConcurrencyAndPerWorkKeyLocking(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(make(chan struct{}))
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: newFakeTargetedRunner(nil)}, MaxConcurrent: 2, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	requests := []DeliveryRequest{
+		{DeliveryID: "lock-1", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 10)},
+		{DeliveryID: "lock-2", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 11)},
+		{DeliveryID: "lock-3", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 10)},
+	}
+	for _, request := range requests[:2] {
+		if _, err := forwarder.Forward(context.Background(), request); err != nil {
+			t.Fatalf("Forward(%s) error = %v", request.DeliveryID, err)
+		}
+	}
+	reviewerRunner.waitForCalls(t, 2)
+	if _, err := forwarder.Forward(context.Background(), requests[2]); err != nil {
+		t.Fatalf("Forward(lock-3) error = %v", err)
+	}
+	close(reviewerRunner.block)
+	reviewerRunner.waitForCalls(t, 3)
+
+	if reviewerRunner.maxActive() > 2 {
+		t.Fatalf("max active = %d, want <= 2", reviewerRunner.maxActive())
+	}
+	if reviewerRunner.maxActiveForKey("project_1|acme/looper|10") > 1 {
+		t.Fatalf("max active for same PR = %d, want 1", reviewerRunner.maxActiveForKey("project_1|acme/looper|10"))
+	}
+}
+
+func TestForwardRetriesTransientTargetedFailuresWithoutEscalation(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(nil)
+	reviewerRunner.failOnce("project_1|acme/looper|77")
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: newFakeTargetedRunner(nil)}, MaxConcurrent: 1, QueueCapacity: 8, RetryDelay: time.Millisecond})
+	defer forwarder.Close()
+
+	if _, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "retry-1", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 77)}); err != nil {
+		t.Fatalf("Forward() error = %v", err)
+	}
+	reviewerRunner.waitForCalls(t, 2)
+	if reviewerRunner.nonTargetedCalls() != 0 {
+		t.Fatalf("non-targeted calls = %d, want 0", reviewerRunner.nonTargetedCalls())
+	}
+	stats := forwarder.Stats()
+	if stats.ExecutionsRetried != 1 {
+		t.Fatalf("ExecutionsRetried = %d, want 1", stats.ExecutionsRetried)
+	}
+	if stats.ExecutionsSucceeded != 1 {
+		t.Fatalf("ExecutionsSucceeded = %d, want 1", stats.ExecutionsSucceeded)
+	}
+}
+
+func TestForwardKeepsFixedSizeRecentOutcomes(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: newFakeTargetedRunner(nil)}, MaxConcurrent: 1, QueueCapacity: 8, RecentOutcomeLimit: 2})
+	defer forwarder.Close()
+
+	for i, deliveryID := range []string{"recent-1", "recent-2", "recent-3"} {
+		if _, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: deliveryID, EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", int64(i+1))}); err != nil {
+			t.Fatalf("Forward(%s) error = %v", deliveryID, err)
+		}
+	}
+	reviewerRunner.waitForCalls(t, 3)
+	stats := forwarder.Stats()
+	if len(stats.RecentOutcomes) != 2 {
+		t.Fatalf("len(RecentOutcomes) = %d, want 2", len(stats.RecentOutcomes))
+	}
+	if stats.RecentOutcomes[0].Number != 2 || stats.RecentOutcomes[1].Number != 3 {
+		t.Fatalf("RecentOutcomes numbers = %#v, want [2 3]", []int64{stats.RecentOutcomes[0].Number, stats.RecentOutcomes[1].Number})
+	}
+}
+
+type fakeTargetedRunner struct {
+	mu                   sync.Mutex
+	block                chan struct{}
+	calls                []targetedCall
+	active               int
+	maxConcurrent        int
+	activeByKey          map[string]int
+	maxConcurrentByKey   map[string]int
+	failuresRemaining    map[string]int
+	nonTargetedCallCount int
+}
+
+type targetedCall struct {
+	ProjectID string
+	Repo      string
+	PRNumber  int64
+}
+
+type temporaryError struct{ message string }
+
+func (e temporaryError) Error() string   { return e.message }
+func (e temporaryError) Temporary() bool { return true }
+
+func newFakeTargetedRunner(block chan struct{}) *fakeTargetedRunner {
+	return &fakeTargetedRunner{block: block, activeByKey: map[string]int{}, maxConcurrentByKey: map[string]int{}, failuresRemaining: map[string]int{}}
+}
+
+func (f *fakeTargetedRunner) DiscoverPullRequest(_ context.Context, input reviewer.TargetedDiscoveryInput) (reviewer.DiscoveryResult, error) {
+	return f.run(input.ProjectID, input.Repo, input.PRNumber)
+}
+
+func (f *fakeTargetedRunner) run(projectID, repo string, prNumber int64) (reviewer.DiscoveryResult, error) {
+	key := runnerKey(projectID, repo, prNumber)
+	f.mu.Lock()
+	f.calls = append(f.calls, targetedCall{ProjectID: projectID, Repo: repo, PRNumber: prNumber})
+	f.active++
+	if f.active > f.maxConcurrent {
+		f.maxConcurrent = f.active
+	}
+	f.activeByKey[key]++
+	if f.activeByKey[key] > f.maxConcurrentByKey[key] {
+		f.maxConcurrentByKey[key] = f.activeByKey[key]
+	}
+	shouldFail := f.failuresRemaining[key] > 0
+	if shouldFail {
+		f.failuresRemaining[key]--
+	}
+	block := f.block
+	f.mu.Unlock()
+	if block != nil {
+		<-block
+	}
+	f.mu.Lock()
+	f.active--
+	f.activeByKey[key]--
+	f.mu.Unlock()
+	if shouldFail {
+		return reviewer.DiscoveryResult{}, temporaryError{message: "temporary github failure"}
+	}
+	return reviewer.DiscoveryResult{}, nil
+}
+
+func (f *fakeTargetedRunner) failOnce(key string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failuresRemaining[key] = 1
+}
+
+func (f *fakeTargetedRunner) waitForCall(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		got := len(f.calls)
+		f.mu.Unlock()
+		if got >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("call count did not reach %d", want)
+}
+
+func (f *fakeTargetedRunner) waitForCalls(t *testing.T, want int) {
+	f.waitForCall(t, want)
+}
+
+func (f *fakeTargetedRunner) assertCallCount(t *testing.T, want int) {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) != want {
+		t.Fatalf("call count = %d, want %d", len(f.calls), want)
+	}
+}
+
+func (f *fakeTargetedRunner) assertProjects(t *testing.T, want []string) {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	got := make([]string, 0, len(f.calls))
+	for _, call := range f.calls {
+		got = append(got, call.ProjectID)
+	}
+	assertStringMultiset(t, got, want, "projects")
+}
+
+func (f *fakeTargetedRunner) assertRepos(t *testing.T, want []string) {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	got := make([]string, 0, len(f.calls))
+	for _, call := range f.calls {
+		got = append(got, call.Repo)
+	}
+	assertStringMultiset(t, got, want, "repos")
+}
+
+func (f *fakeTargetedRunner) assertPRCount(t *testing.T, prNumber int64, want int) {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	count := 0
+	for _, call := range f.calls {
+		if call.PRNumber == prNumber {
+			count++
+		}
+	}
+	if count != want {
+		t.Fatalf("PR %d call count = %d, want %d", prNumber, count, want)
+	}
+}
+
+func (f *fakeTargetedRunner) maxActive() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.maxConcurrent
+}
+
+func (f *fakeTargetedRunner) maxActiveForKey(key string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.maxConcurrentByKey[key]
+}
+
+func (f *fakeTargetedRunner) nonTargetedCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.nonTargetedCallCount
+}
+
+func testConfig(t *testing.T) config.Config {
+	t.Helper()
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Discovery.AutoDiscovery = true
+	cfg.Roles.Fixer.AutoDiscovery = true
+	return cfg
+}
+
+func newTestRepositories(t *testing.T) *storage.Repositories {
+	t.Helper()
+	root := t.TempDir()
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: filepath.Join(root, "backups")})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	return storage.NewRepositories(coordinator.DB())
+}
+
+func seedProject(t *testing.T, repos *storage.Repositories, projectID, repo string) {
+	t.Helper()
+	metadata := `{"repo":"` + repo + `"}`
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: projectID, RepoPath: "/tmp/" + projectID, MetadataJSON: &metadata, CreatedAt: "2026-05-16T12:00:00.000Z", UpdatedAt: "2026-05-16T12:00:00.000Z"}); err != nil {
+		t.Fatalf("Projects.Upsert(%s) error = %v", projectID, err)
+	}
+}
+
+func pullRequestPayload(action, repo string, prNumber int64) []byte {
+	return []byte(`{"action":"` + action + `","repository":{"full_name":"` + repo + `"},"pull_request":{"number":` + itoa(prNumber) + `}}`)
+}
+
+func itoa(value int64) string {
+	return strconv.FormatInt(value, 10)
+}
+
+func runnerKey(projectID, repo string, prNumber int64) string {
+	return projectID + "|" + repo + "|" + itoa(prNumber)
+}
+
+func shortSleep() {
+	time.Sleep(50 * time.Millisecond)
+}
+
+func assertStringMultiset(t *testing.T, got, want []string, label string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %#v, want %#v", label, got, want)
+	}
+	counts := map[string]int{}
+	for _, item := range got {
+		counts[item]++
+	}
+	for _, item := range want {
+		counts[item]--
+	}
+	for _, count := range counts {
+		if count != 0 {
+			t.Fatalf("%s = %#v, want %#v", label, got, want)
+		}
+	}
+}
+
+var _ TargetedFixer = targetedFixerAdapter{}
+
+type targetedFixerAdapter struct{ runner *fakeTargetedRunner }
+
+func (a targetedFixerAdapter) DiscoverPullRequest(_ context.Context, input fixer.TargetedDiscoveryInput) (fixer.DiscoveryResult, error) {
+	_, err := a.runner.run(input.ProjectID, input.Repo, input.PRNumber)
+	return fixer.DiscoveryResult{}, err
+}

--- a/internal/webhookforward/forwarder_test.go
+++ b/internal/webhookforward/forwarder_test.go
@@ -189,6 +189,42 @@ func TestForwardRetriesTransientTargetedFailuresWithoutEscalation(t *testing.T) 
 	}
 }
 
+func TestForwardPreservesCoalescedWorkWhenRequeueHitsCapacity(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(make(chan struct{}))
+	fixerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: fixerRunner}, MaxConcurrent: 1, QueueCapacity: 1})
+	defer forwarder.Close()
+
+	if _, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "running-pr1", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 1)}); err != nil {
+		t.Fatalf("Forward(running-pr1) error = %v", err)
+	}
+	reviewerRunner.waitForCall(t, 1)
+
+	if _, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "queued-pr2", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 2)}); err != nil {
+		t.Fatalf("Forward(queued-pr2) error = %v", err)
+	}
+	if _, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "coalesced-pr1", EventType: "issue_comment", Payload: []byte(`{"action":"created","repository":{"full_name":"acme/looper"},"issue":{"number":1,"pull_request":{"url":"https://api.github.com/repos/acme/looper/pulls/1"}}}`)}); err != nil {
+		t.Fatalf("Forward(coalesced-pr1) error = %v", err)
+	}
+
+	close(reviewerRunner.block)
+	reviewerRunner.waitForCalls(t, 2)
+	fixerRunner.waitForCalls(t, 1)
+
+	reviewerRunner.assertPRCount(t, 1, 1)
+	reviewerRunner.assertPRCount(t, 2, 1)
+	fixerRunner.assertPRCount(t, 1, 1)
+	stats := forwarder.Stats()
+	if stats.QueueRejected != 0 {
+		t.Fatalf("QueueRejected = %d, want 0", stats.QueueRejected)
+	}
+	if stats.QueueCoalesced == 0 {
+		t.Fatalf("QueueCoalesced = %d, want > 0", stats.QueueCoalesced)
+	}
+}
+
 func TestForwardKeepsFixedSizeRecentOutcomes(t *testing.T) {
 	repos := newTestRepositories(t)
 	seedProject(t, repos, "project_1", "acme/looper")


### PR DESCRIPTION
## Summary
- add a loopback-only `POST /webhook/forward` ingress that fast-acks forwarded GitHub deliveries, rejects proxied/non-loopback callers, and hands supported PR events to an in-memory targeted work pipeline
- coalesce per-project PR work with delivery dedupe, bounded concurrency, short transient retries, and direct targeted reviewer/fixer discovery instead of escalating to repo-wide discovery
- cover webhook security, routing, fanout, coalescing, locking, retries, and recent outcome bookkeeping with focused API and forwarder tests

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #369

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>