### PR TITLE
feat: manage gh webhook forwarders for configured repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
           if-no-files-found: ignore
 
   github-contract-e2e:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    if: (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)) && needs.detect-e2e-changes.outputs.github_contract == 'true'
     name: GitHub contract E2E
     needs: detect-e2e-changes
     runs-on: ubuntu-latest

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -587,6 +587,13 @@ func assertMethod(method, allowed, path string, w http.ResponseWriter, requestID
 }
 
 func authorizeRequest(r *http.Request, path string, cfg config.Config) error {
+	if path == webhookForwardPath && hasForwardingProxyHeaders(r.Header) {
+		return apiError{
+			code:    pkgapi.ErrorCodeUnauthorized,
+			status:  http.StatusForbidden,
+			message: "Webhook forwarding does not accept proxied loopback requests",
+		}
+	}
 	if path == webhookForwardPath && cfg.Webhook.Enabled && isLoopbackRemoteAddr(r.RemoteAddr) {
 		return nil
 	}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -183,19 +183,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if requestID == "" {
 		requestID = generateRequestID()
 	}
-	if path == "/webhook/forward" {
-		payload, err := h.buildWebhookForwardResponse(r)
-		if err != nil {
-			var typed apiError
-			if !asAPIError(err, &typed) {
-				typed = internalServerError(err)
-			}
-			h.writeError(w, requestID, typed)
-			return
-		}
-		h.writeSuccess(w, requestID, payload)
-		return
-	}
 
 	if err := authorizeRequest(r, path, h.context.Config); err != nil {
 		var typed apiError

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -523,7 +523,7 @@ func assertMethod(method, allowed, path string, w http.ResponseWriter, requestID
 }
 
 func authorizeRequest(r *http.Request, path string, cfg config.Config) error {
-	if path == webhookForwardPath && isLoopbackRemoteAddr(r.RemoteAddr) {
+	if path == webhookForwardPath && cfg.Webhook.Enabled && isLoopbackRemoteAddr(r.RemoteAddr) {
 		return nil
 	}
 	if cfg.Server.AuthMode != config.AuthModeLocalToken {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -35,6 +36,7 @@ import (
 const (
 	requestIDHeaderName        = "x-request-id"
 	apiBasePath                = "/api/v1"
+	webhookForwardPath         = "/webhook/forward"
 	javaScriptISOString        = "2006-01-02T15:04:05.000Z"
 	loopLogsFollowPollInterval = 200 * time.Millisecond
 	activeRunHeartbeatTTL      = 30 * time.Minute
@@ -168,8 +170,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if requestID == "" {
 		requestID = generateRequestID()
 	}
+	path := normalizePath(r.URL.Path)
 
-	if err := authorizeRequest(r, h.context.Config); err != nil {
+	if err := authorizeRequest(r, path, h.context.Config); err != nil {
 		var typed apiError
 		if !asAPIError(err, &typed) {
 			typed = internalServerError(err)
@@ -178,9 +181,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	path := normalizePath(r.URL.Path)
-
 	switch path {
+	case webhookForwardPath:
+		if !assertMethod(r.Method, http.MethodPost, path, w, requestID, h.writeError) {
+			return
+		}
+		if !isLoopbackRemoteAddr(r.RemoteAddr) {
+			h.writeError(w, requestID, apiError{code: pkgapi.ErrorCodeUnauthorized, status: http.StatusForbidden, message: "webhook forwarding requires a loopback caller"})
+			return
+		}
+		if h.context.TriggerSchedulerTick != nil {
+			h.context.TriggerSchedulerTick()
+		}
+		h.writeJSON(w, http.StatusAccepted, pkgapi.Success(requestID, map[string]any{"accepted": true}))
+		return
 	case apiBasePath + "/healthz":
 		if !assertMethod(r.Method, http.MethodGet, path, w, requestID, h.writeError) {
 			return
@@ -508,7 +522,10 @@ func assertMethod(method, allowed, path string, w http.ResponseWriter, requestID
 	return false
 }
 
-func authorizeRequest(r *http.Request, cfg config.Config) error {
+func authorizeRequest(r *http.Request, path string, cfg config.Config) error {
+	if path == webhookForwardPath && isLoopbackRemoteAddr(r.RemoteAddr) {
+		return nil
+	}
 	if cfg.Server.AuthMode != config.AuthModeLocalToken {
 		return nil
 	}
@@ -530,6 +547,23 @@ func authorizeRequest(r *http.Request, cfg config.Config) error {
 	}
 
 	return nil
+}
+
+func isLoopbackRemoteAddr(remoteAddr string) bool {
+	remoteAddr = strings.TrimSpace(remoteAddr)
+	if remoteAddr == "" {
+		return false
+	}
+	host := remoteAddr
+	if parsedHost, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = parsedHost
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func normalizePath(path string) string {
@@ -612,6 +646,7 @@ type statusResponse struct {
 	Service       statusService       `json:"service"`
 	Storage       statusStorage       `json:"storage"`
 	Scheduler     statusScheduler     `json:"scheduler"`
+	Webhook       statusWebhook       `json:"webhook"`
 	Loops         statusLoops         `json:"loops"`
 	Safety        statusSafety        `json:"safety"`
 	Notifications statusNotifications `json:"notifications"`
@@ -678,6 +713,15 @@ type statusScheduler struct {
 	ActiveRuns     int  `json:"activeRuns"`
 }
 
+type statusWebhook struct {
+	Enabled         bool                                    `json:"enabled"`
+	Healthy         bool                                    `json:"healthy"`
+	Degraded        bool                                    `json:"degraded"`
+	Endpoint        *string                                 `json:"endpoint,omitempty"`
+	DegradedReasons []string                                `json:"degradedReasons,omitempty"`
+	Forwarders      []looperdruntime.WebhookForwarderStatus `json:"forwarders"`
+}
+
 type statusLoopType struct {
 	Queued     int `json:"queued"`
 	Running    int `json:"running"`
@@ -719,6 +763,7 @@ type configResponse struct {
 	Server        configServerResponse      `json:"server"`
 	Storage       config.StorageConfig      `json:"storage"`
 	Scheduler     config.SchedulerConfig    `json:"scheduler"`
+	Webhook       config.WebhookConfig      `json:"webhook"`
 	Agent         config.AgentConfig        `json:"agent"`
 	Logging       config.LoggingConfig      `json:"logging"`
 	Notifications config.NotificationConfig `json:"notifications"`
@@ -761,6 +806,7 @@ func (h *Handler) buildConfigResponse() configResponse {
 		},
 		Storage:       cfg.Storage,
 		Scheduler:     cfg.Scheduler,
+		Webhook:       cfg.Webhook,
 		Agent:         cfg.Agent,
 		Logging:       cfg.Logging,
 		Notifications: cfg.Notifications,
@@ -810,6 +856,20 @@ func (h *Handler) buildStatusResponse(ctx context.Context) (statusResponse, erro
 	currentTarget := currentLooperdTarget()
 	installDir := filepath.Join(homeDirOrEmpty(), ".looper", "bin")
 	artifactName := looperdArtifactName(currentTarget)
+	webhookStatus := statusWebhook{Forwarders: []looperdruntime.WebhookForwarderStatus{}}
+	if runtimeWithWebhooks, ok := any(h.context.Runtime).(interface {
+		WebhookStatus() looperdruntime.WebhookRuntimeStatus
+	}); ok {
+		runtimeStatus := runtimeWithWebhooks.WebhookStatus()
+		webhookStatus = statusWebhook{
+			Enabled:         runtimeStatus.Enabled,
+			Healthy:         runtimeStatus.Healthy,
+			Degraded:        runtimeStatus.Degraded,
+			Endpoint:        runtimeStatus.Endpoint,
+			DegradedReasons: append([]string{}, runtimeStatus.DegradedReasons...),
+			Forwarders:      append([]looperdruntime.WebhookForwarderStatus{}, runtimeStatus.Forwarders...),
+		}
+	}
 
 	return statusResponse{
 		Service: statusService{
@@ -844,7 +904,8 @@ func (h *Handler) buildStatusResponse(ctx context.Context) (statusResponse, erro
 			TotalRuns:      len(runs),
 			ActiveRuns:     runCounts["running"],
 		},
-		Loops: loopCounts,
+		Webhook: webhookStatus,
+		Loops:   loopCounts,
 		Safety: statusSafety{
 			AllowAutoCommit:    h.context.Config.Defaults.AllowAutoCommit,
 			AllowAutoPush:      h.context.Config.Defaults.AllowAutoPush,
@@ -1356,6 +1417,9 @@ func (h *Handler) buildProjectRouteResponse(r *http.Request, path string) (any, 
 		default:
 			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
+	}
+	if err := h.refreshWebhookForwarders(); err != nil {
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
 
 	return serializeProject(removed, h.context.Config.Defaults.BaseBranch), nil
@@ -4787,6 +4851,9 @@ func (h *Handler) buildCreateProjectResponse(r *http.Request, service projectSer
 			return createProjectResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 	}
+	if err := h.refreshWebhookForwarders(); err != nil {
+		return createProjectResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
 
 	return createProjectResponse{
 		projectResponse:        serializeProject(result.Project, h.context.Config.Defaults.BaseBranch),
@@ -4796,6 +4863,14 @@ func (h *Handler) buildCreateProjectResponse(r *http.Request, service projectSer
 		CapturedSnapshots:      result.CapturedSnapshots,
 		Warnings:               append([]string{}, result.Warnings...),
 	}, nil
+}
+
+func (h *Handler) refreshWebhookForwarders() error {
+	refresher, ok := any(h.context.Runtime).(interface{ RefreshWebhookForwarders() error })
+	if !ok {
+		return nil
+	}
+	return refresher.RefreshWebhookForwarders()
 }
 
 func serializeProject(project storage.ProjectRecord, defaultBaseBranch string) projectResponse {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -4849,9 +4849,7 @@ func (h *Handler) buildCreateProjectResponse(r *http.Request, service projectSer
 			return createProjectResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 	}
-	if err := h.refreshWebhookForwarders(); err != nil {
-		return createProjectResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-	}
+	_ = h.refreshWebhookForwarders()
 
 	return createProjectResponse{
 		projectResponse:        serializeProject(result.Project, h.context.Config.Defaults.BaseBranch),

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1418,9 +1418,7 @@ func (h *Handler) buildProjectRouteResponse(r *http.Request, path string) (any, 
 			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 	}
-	if err := h.refreshWebhookForwarders(); err != nil {
-		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-	}
+	_ = h.refreshWebhookForwarders()
 
 	return serializeProject(removed, h.context.Config.Defaults.BaseBranch), nil
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -860,6 +860,47 @@ func TestHandlerProjectsCreateRouteReturnsDiscoveryDetails(t *testing.T) {
 	}
 }
 
+func TestHandlerProjectsCreateRouteReturnsSuccessWhenWebhookRefreshFails(t *testing.T) {
+	t.Parallel()
+
+	nowISO := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC).Format(javaScriptISOString)
+	h := NewHandler(Context{
+		Config: config.Config{Defaults: config.DefaultsConfig{BaseBranch: "main"}},
+		ProjectsService: fakeProjectService{
+			addProject: func(context.Context, projects.AddInput) (projects.AddResult, error) {
+				metadataJSON := `{"repo":null,"worktreeRoot":null,"source":"api"}`
+				return projects.AddResult{
+					Project: storage.ProjectRecord{ID: "looper", Name: "Looper", RepoPath: "/tmp/repos/looper", BaseBranch: stringPtr("main"), MetadataJSON: &metadataJSON, CreatedAt: nowISO, UpdatedAt: nowISO},
+				}, nil
+			},
+		},
+		Runtime: fixedRuntimeState{
+			refreshWebhookForwarders: func() error { return errors.New("refresh failed") },
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects", bytes.NewReader([]byte(`{"repoPath":"/tmp/repos/looper","name":"Looper"}`)))
+	recorder := httptest.NewRecorder()
+
+	h.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	assertEqual(t, data["id"], "looper")
+	assertEqual(t, data["name"], "Looper")
+	assertEqual(t, data["repoPath"], "/tmp/repos/looper")
+	assertEqual(t, data["baseBranch"], "main")
+	assertEqual(t, data["archived"], false)
+	assertEqual(t, data["discoveredPullRequests"], float64(0))
+	assertEqual(t, data["discoveredWorktrees"], float64(0))
+	warnings, ok := data["warnings"].([]any)
+	if !ok || len(warnings) != 0 {
+		t.Fatalf("warnings = %#v, want empty array", data["warnings"])
+	}
+}
+
 func TestHandlerProjectsRemoveRouteDeletesProject(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -352,10 +352,12 @@ func TestHandlerUnauthorized(t *testing.T) {
 	assertEqual(t, errMap["message"], "Authorization token is required")
 }
 
-func TestHandlerWebhookForwardAllowsLoopbackWithoutBearerToken(t *testing.T) {
+func TestHandlerWebhookForwardAcceptsLoopbackAndTriggersSchedulerTick(t *testing.T) {
 	fixture := newTestFixture(t)
 	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
-	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, WebhookForwarder: forwarder})
+	fixture.config.Webhook.Enabled = true
+	triggered := 0
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, WebhookForwarder: forwarder, TriggerSchedulerTick: func() { triggered++ }})
 
 	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", bytes.NewReader([]byte(`{"action":"review_requested"}`)))
 	req.RemoteAddr = "127.0.0.1:1234"
@@ -365,16 +367,16 @@ func TestHandlerWebhookForwardAllowsLoopbackWithoutBearerToken(t *testing.T) {
 
 	h.ServeHTTP(recorder, req)
 
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", recorder.Code)
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", recorder.Code)
 	}
-	if forwarder.calls != 1 {
-		t.Fatalf("forwarder calls = %d, want 1", forwarder.calls)
+	if forwarder.calls != 0 {
+		t.Fatalf("forwarder calls = %d, want 0", forwarder.calls)
 	}
 	body := parseJSONMap(t, recorder.Body.Bytes())
 	data := body["data"].(map[string]any)
-	assertEqual(t, data["status"], "accepted")
-	assertEqual(t, data["workItems"], float64(1))
+	assertEqual(t, data["accepted"], true)
+	assertEqual(t, triggered, 1)
 }
 
 func TestHandlerWebhookForwardRejectsNonLoopbackEvenWithBearerToken(t *testing.T) {
@@ -382,6 +384,7 @@ func TestHandlerWebhookForwardRejectsNonLoopbackEvenWithBearerToken(t *testing.T
 	token := "secret-token"
 	fixture.config.Server.AuthMode = config.AuthModeLocalToken
 	fixture.config.Server.LocalToken = &token
+	fixture.config.Webhook.Enabled = true
 	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
 	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, WebhookForwarder: forwarder})
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -351,6 +351,51 @@ func TestHandlerUnauthorized(t *testing.T) {
 	assertEqual(t, errMap["message"], "Authorization token is required")
 }
 
+func TestHandlerWebhookForwardRouteRequiresTokenWhenWebhookDisabled(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	token := "secret-token"
+	cfg.Server.AuthMode = config.AuthModeLocalToken
+	cfg.Server.LocalToken = &token
+
+	triggered := 0
+	req := httptest.NewRequest(http.MethodPost, webhookForwardPath, nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	recorder := httptest.NewRecorder()
+
+	NewHandler(Context{Config: cfg, Runtime: rt, TriggerSchedulerTick: func() { triggered++ }}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	errMap := body["error"].(map[string]any)
+	assertEqual(t, errMap["code"], "UNAUTHORIZED")
+	assertEqual(t, errMap["message"], "Authorization token is required")
+	assertEqual(t, triggered, 0)
+}
+
+func TestHandlerWebhookForwardRouteAllowsLoopbackWithoutTokenWhenWebhookEnabled(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	token := "secret-token"
+	cfg.Server.AuthMode = config.AuthModeLocalToken
+	cfg.Server.LocalToken = &token
+	cfg.Webhook.Enabled = true
+
+	triggered := 0
+	req := httptest.NewRequest(http.MethodPost, webhookForwardPath, nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	recorder := httptest.NewRecorder()
+
+	NewHandler(Context{Config: cfg, Runtime: rt, TriggerSchedulerTick: func() { triggered++ }}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	assertEqual(t, body["ok"], true)
+	assertEqual(t, triggered, 1)
+}
+
 func TestHandlerRouteAndMethodErrors(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -405,6 +405,37 @@ func TestHandlerWebhookForwardRejectsNonLoopbackEvenWithBearerToken(t *testing.T
 	}
 }
 
+func TestHandlerWebhookForwardRejectsProxiedLoopbackRequests(t *testing.T) {
+	fixture := newTestFixture(t)
+	token := "secret-token"
+	fixture.config.Server.AuthMode = config.AuthModeLocalToken
+	fixture.config.Server.LocalToken = &token
+	fixture.config.Webhook.Enabled = true
+	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, WebhookForwarder: forwarder})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", bytes.NewReader([]byte(`{"action":"review_requested"}`)))
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-Forwarded-For", "203.0.113.5")
+	req.Header.Set("X-GitHub-Delivery", "delivery-3")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	recorder := httptest.NewRecorder()
+
+	h.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 body=%s", recorder.Code, recorder.Body.String())
+	}
+	if forwarder.calls != 0 {
+		t.Fatalf("forwarder calls = %d, want 0", forwarder.calls)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	errMap := body["error"].(map[string]any)
+	assertEqual(t, errMap["code"], "UNAUTHORIZED")
+	assertEqual(t, errMap["message"], "Webhook forwarding does not accept proxied loopback requests")
+}
+
 func TestHandlerRouteAndMethodErrors(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -932,6 +932,35 @@ func TestHandlerProjectsRemoveRouteReturnsNotFound(t *testing.T) {
 	assertEqual(t, errorMap["message"], "Project not found: missing")
 }
 
+func TestHandlerProjectsRemoveRouteReturnsSuccessWhenWebhookRefreshFails(t *testing.T) {
+	t.Parallel()
+
+	removed := storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/looper"}
+	h := NewHandler(Context{
+		Config: config.Config{Defaults: config.DefaultsConfig{BaseBranch: "main"}},
+		ProjectsService: fakeProjectService{
+			removeProject: func(context.Context, string) (storage.ProjectRecord, error) {
+				return removed, nil
+			},
+		},
+		Runtime: fixedRuntimeState{
+			refreshWebhookForwarders: func() error { return errors.New("refresh failed") },
+		},
+	})
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/projects/project_1", nil)
+	recorder := httptest.NewRecorder()
+
+	h.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	assertEqual(t, data["id"], "project_1")
+	assertEqual(t, data["name"], "Looper")
+}
+
 func TestHandlerProjectsRouteErrorsMatchArtifactCases(t *testing.T) {
 	fixture := newTestFixture(t)
 
@@ -5221,7 +5250,8 @@ func (noopLogger) Error(string, map[string]any) {}
 var _ bootstrap.Logger = noopLogger{}
 
 type fixedRuntimeState struct {
-	services looperdruntime.Services
+	services                 looperdruntime.Services
+	refreshWebhookForwarders func() error
 }
 
 type errorInjectingQuerier struct {
@@ -5252,6 +5282,13 @@ func (s fixedRuntimeState) Services() looperdruntime.Services {
 
 func (s fixedRuntimeState) StartedAt() (time.Time, bool) {
 	return time.Time{}, false
+}
+
+func (s fixedRuntimeState) RefreshWebhookForwarders() error {
+	if s.refreshWebhookForwarders != nil {
+		return s.refreshWebhookForwarders()
+	}
+	return nil
 }
 
 func seedConflictProject(t *testing.T, service *projects.Service) {

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -92,6 +92,12 @@
             "totalRuns": 1,
             "activeRuns": 1
           },
+          "webhook": {
+            "enabled": false,
+            "healthy": true,
+            "degraded": false,
+            "forwarders": []
+          },
           "loops": {
             "planner": {
               "queued": 0,
@@ -174,6 +180,10 @@
             "retryMaxAttempts": 5,
             "retryBaseDelayMs": 5000,
             "slowLaneWarnThresholdMs": 5000
+          },
+          "webhook": {
+            "enabled": false,
+            "fallbackPollIntervalSeconds": 300
           },
           "agent": {
             "env": {},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3333,6 +3333,38 @@ func TestRepoWorktreeDirectoryNameCanonicalizesSymlinks(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigSetsWebhookDefaults(t *testing.T) {
+	t.Parallel()
+
+	config, err := DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	if config.Webhook.Enabled {
+		t.Fatal("DefaultConfig().Webhook.Enabled = true, want false")
+	}
+	if config.Webhook.FallbackPollIntervalSeconds != 300 {
+		t.Fatalf("DefaultConfig().Webhook.FallbackPollIntervalSeconds = %d, want 300", config.Webhook.FallbackPollIntervalSeconds)
+	}
+}
+
+func TestValidateRejectsShortWebhookFallbackPollInterval(t *testing.T) {
+	t.Parallel()
+
+	config, err := DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	config.Webhook.FallbackPollIntervalSeconds = 59
+
+	validation := Validate(config)
+	validationErr, ok := validation.(*ConfigValidationError)
+	if !ok || validationErr == nil {
+		t.Fatalf("Validate() error = %T %v, want *ConfigValidationError", validation, validation)
+	}
+	assertValidationIssue(t, validationErr, "webhook.fallbackPollIntervalSeconds", "must be an integer >= 60")
+}
+
 func sha256Hex(value string) string {
 	sum := sha256.Sum256([]byte(value))
 	return fmt.Sprintf("%x", sum)

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -71,6 +71,10 @@ func DefaultConfig(cwd string) (Config, error) {
 			RetryBaseDelayMS:        5000,
 			SlowLaneWarnThresholdMS: 5000,
 		},
+		Webhook: WebhookConfig{
+			Enabled:                     false,
+			FallbackPollIntervalSeconds: 300,
+		},
 		Agent: AgentConfig{
 			Params:       map[string]any{},
 			Env:          map[string]string{},

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -197,6 +197,10 @@ func mergeConfig(config *Config, partial PartialConfig) {
 		mergeSchedulerConfig(&config.Scheduler, *partial.Scheduler)
 	}
 
+	if partial.Webhook != nil {
+		mergeWebhookConfig(&config.Webhook, *partial.Webhook)
+	}
+
 	if partial.Agent != nil {
 		mergeAgentConfig(&config.Agent, *partial.Agent)
 	}
@@ -301,6 +305,16 @@ func mergeSchedulerConfig(config *SchedulerConfig, partial PartialSchedulerConfi
 
 	if partial.SlowLaneWarnThresholdMS != nil {
 		config.SlowLaneWarnThresholdMS = *partial.SlowLaneWarnThresholdMS
+	}
+}
+
+func mergeWebhookConfig(config *WebhookConfig, partial PartialWebhookConfig) {
+	if partial.Enabled != nil {
+		config.Enabled = *partial.Enabled
+	}
+
+	if partial.FallbackPollIntervalSeconds != nil {
+		config.FallbackPollIntervalSeconds = *partial.FallbackPollIntervalSeconds
 	}
 }
 

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -96,6 +96,10 @@
         "retryBaseDelayMs": 5000,
         "slowLaneWarnThresholdMs": 5000
       },
+      "webhook": {
+        "enabled": false,
+        "fallbackPollIntervalSeconds": 300
+      },
       "agent": {
         "vendor": "opencode",
         "params": {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -36,6 +36,10 @@
         "retryBaseDelayMs": 5000,
         "slowLaneWarnThresholdMs": 5000
       },
+      "webhook": {
+        "enabled": false,
+        "fallbackPollIntervalSeconds": 300
+      },
       "agent": {
         "params": {},
         "env": {},

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -114,6 +114,10 @@
         "retryBaseDelayMs": 1500,
         "slowLaneWarnThresholdMs": 5000
       },
+      "webhook": {
+        "enabled": false,
+        "fallbackPollIntervalSeconds": 300
+      },
       "agent": {
         "vendor": "codex",
         "model": "gpt-5",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -142,6 +142,11 @@ type SchedulerConfig struct {
 	SlowLaneWarnThresholdMS int `json:"slowLaneWarnThresholdMs"`
 }
 
+type WebhookConfig struct {
+	Enabled                     bool `json:"enabled"`
+	FallbackPollIntervalSeconds int  `json:"fallbackPollIntervalSeconds"`
+}
+
 type AgentConfig struct {
 	Vendor       *AgentVendor            `json:"vendor,omitempty"`
 	Model        *string                 `json:"model,omitempty"`
@@ -523,6 +528,7 @@ type Config struct {
 	Server        ServerConfig       `json:"server"`
 	Storage       StorageConfig      `json:"storage"`
 	Scheduler     SchedulerConfig    `json:"scheduler"`
+	Webhook       WebhookConfig      `json:"webhook"`
 	Agent         AgentConfig        `json:"agent"`
 	Logging       LoggingConfig      `json:"logging"`
 	Notifications NotificationConfig `json:"notifications"`
@@ -556,6 +562,11 @@ type PartialSchedulerConfig struct {
 	RetryMaxAttempts        *int `json:"retryMaxAttempts,omitempty"`
 	RetryBaseDelayMS        *int `json:"retryBaseDelayMs,omitempty"`
 	SlowLaneWarnThresholdMS *int `json:"slowLaneWarnThresholdMs,omitempty"`
+}
+
+type PartialWebhookConfig struct {
+	Enabled                     *bool `json:"enabled,omitempty"`
+	FallbackPollIntervalSeconds *int  `json:"fallbackPollIntervalSeconds,omitempty"`
 }
 
 type PartialAgentConfig struct {
@@ -898,6 +909,7 @@ type PartialConfig struct {
 	Server         *PartialServerConfig       `json:"server,omitempty"`
 	Storage        *PartialStorageConfig      `json:"storage,omitempty"`
 	Scheduler      *PartialSchedulerConfig    `json:"scheduler,omitempty"`
+	Webhook        *PartialWebhookConfig      `json:"webhook,omitempty"`
 	Agent          *PartialAgentConfig        `json:"agent,omitempty"`
 	Logging        *PartialLoggingConfig      `json:"logging,omitempty"`
 	Notifications  *PartialNotificationConfig `json:"notifications,omitempty"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -87,6 +87,10 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 		issues = append(issues, ValidationIssue{Path: "scheduler.slowLaneWarnThresholdMs", Message: "must be a positive integer"})
 	}
 
+	if config.Webhook.FallbackPollIntervalSeconds < 60 {
+		issues = append(issues, ValidationIssue{Path: "webhook.fallbackPollIntervalSeconds", Message: "must be an integer >= 60"})
+	}
+
 	if config.Agent.Vendor != nil && !isValidAgentVendor(*config.Agent.Vendor) {
 		issues = append(issues, ValidationIssue{Path: "agent.vendor", Message: fmt.Sprintf("must be one of: %s, %s, %s, %s", AgentVendorClaudeCode, AgentVendorCodex, AgentVendorOpenCode, AgentVendorCursorCLI)})
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -109,6 +109,9 @@ type Runtime struct {
 	recoveryDone       chan struct{}
 	activeExecutions   *ActiveExecutionRegistry
 	githubGateway      *githubinfra.Gateway
+	webhookForwarders  *webhookForwarderManager
+	webhookContext     context.Context
+	webhookCancel      context.CancelFunc
 	schedulerDisabled  bool
 	startupReadyOnce   sync.Once
 	startupReadyErr    error
@@ -203,6 +206,16 @@ func (r *Runtime) Stop(reason string) {
 		}
 
 		r.stopDeferredReviewerRecovery()
+		r.mu.RLock()
+		webhookCancel := r.webhookCancel
+		webhookForwarders := r.webhookForwarders
+		r.mu.RUnlock()
+		if webhookCancel != nil {
+			webhookCancel()
+		}
+		if webhookForwarders != nil {
+			webhookForwarders.Stop()
+		}
 		r.stopSchedulerLoop()
 
 		r.mu.Lock()
@@ -277,6 +290,37 @@ func (r *Runtime) RecoverySummary() RecoverySummary {
 	defer r.mu.RUnlock()
 
 	return r.recovery
+}
+
+func (r *Runtime) WebhookStatus() WebhookRuntimeStatus {
+	r.mu.RLock()
+	manager := r.webhookForwarders
+	r.mu.RUnlock()
+	if manager == nil {
+		return WebhookRuntimeStatus{}
+	}
+	return manager.Status()
+}
+
+func (r *Runtime) RefreshWebhookForwarders() error {
+	r.mu.RLock()
+	manager := r.webhookForwarders
+	repositories := r.services.Repositories
+	webhookCtx := r.webhookContext
+	stopped := r.stopped
+	r.mu.RUnlock()
+	if stopped || manager == nil || repositories == nil || repositories.Projects == nil || webhookCtx == nil {
+		return nil
+	}
+	projectsList, err := repositories.Projects.List(context.Background())
+	if err != nil {
+		return err
+	}
+	if err := webhookCtx.Err(); err != nil {
+		return nil
+	}
+	manager.Sync(webhookCtx, projectsList)
+	return nil
 }
 
 func (r *Runtime) start(ctx context.Context) error {
@@ -358,10 +402,22 @@ func (r *Runtime) start(ctx context.Context) error {
 	}
 	loopService := &loops.Service{DB: coordinator.DB(), Repos: repositories, Now: r.now}
 	runService := &runs.Service{DB: coordinator.DB(), Repos: repositories, Loops: loopService, Now: r.now}
+	webhookForwarderCtx, webhookCancel := context.WithCancel(context.Background())
+	defer func() {
+		if !started {
+			webhookCancel()
+		}
+	}()
+	webhookForwarders := newWebhookForwarderManager(webhookForwarderManagerOptions{Config: r.config, Logger: r.logger, Now: r.now, StopTimeout: r.shutdownTimeout})
 	startedAt := r.now().UTC()
 	if err := r.syncConfiguredProjects(ctx, projectService, r.config, startedAt); err != nil {
 		return err
 	}
+	projectsList, err := repositories.Projects.List(context.Background())
+	if err != nil {
+		return err
+	}
+	webhookForwarders.Sync(webhookForwarderCtx, projectsList)
 	r.mu.Lock()
 	if r.stopped {
 		r.mu.Unlock()
@@ -388,6 +444,9 @@ func (r *Runtime) start(ctx context.Context) error {
 		schedulerDisabled = r.config.Agent.Vendor == nil
 	}
 	r.githubGateway = githubGateway
+	r.webhookForwarders = webhookForwarders
+	r.webhookContext = webhookForwarderCtx
+	r.webhookCancel = webhookCancel
 	r.schedulerDisabled = schedulerDisabled
 	r.mu.Unlock()
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -523,7 +523,7 @@ func (r *Runtime) CompleteStartup(ctx context.Context) error {
 }
 
 func (r *Runtime) startSchedulerLoop() {
-	pollInterval := time.Duration(r.config.Scheduler.PollIntervalSeconds) * time.Second
+	pollInterval := r.schedulerPollInterval()
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
 	wakeCh := make(chan struct{}, 1)
@@ -576,6 +576,14 @@ func (r *Runtime) startSchedulerLoop() {
 			}
 		}
 	}()
+}
+
+func (r *Runtime) schedulerPollInterval() time.Duration {
+	pollIntervalSeconds := r.config.Scheduler.PollIntervalSeconds
+	if r.config.Webhook.Enabled {
+		pollIntervalSeconds = r.config.Webhook.FallbackPollIntervalSeconds
+	}
+	return time.Duration(pollIntervalSeconds) * time.Second
 }
 
 func (r *Runtime) stopSchedulerLoop() {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1503,6 +1503,28 @@ func TestRuntimeTriggerSchedulerClaimRunsImmediatelyWithoutWaitingForPolling(t *
 	}
 }
 
+func TestRuntimeSchedulerPollIntervalUsesWebhookFallbackWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Scheduler.PollIntervalSeconds = 30
+	cfg.Webhook.Enabled = true
+	cfg.Webhook.FallbackPollIntervalSeconds = 90
+
+	rt := &Runtime{config: cfg}
+	if got := rt.schedulerPollInterval(); got != 90*time.Second {
+		t.Fatalf("schedulerPollInterval() = %s, want 90s", got)
+	}
+
+	rt.config.Webhook.Enabled = false
+	if got := rt.schedulerPollInterval(); got != 30*time.Second {
+		t.Fatalf("schedulerPollInterval() = %s, want 30s when webhook disabled", got)
+	}
+}
+
 func TestRuntimeStopClosesCoordinatorAndUnblocksWaitForShutdown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/webhook_forwarder.go
+++ b/internal/runtime/webhook_forwarder.go
@@ -668,9 +668,11 @@ func startWebhookForwarderProcess(ctx context.Context, command webhookForwarderC
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
+		closeWebhookForwarderPipes(stdout, nil)
 		return webhookForwarderStartResult{}, err
 	}
 	if err := cmd.Start(); err != nil {
+		closeWebhookForwarderPipes(stdout, stderr)
 		return webhookForwarderStartResult{}, err
 	}
 	return webhookForwarderStartResult{
@@ -678,4 +680,12 @@ func startWebhookForwarderProcess(ctx context.Context, command webhookForwarderC
 		stdout:  stdout,
 		stderr:  stderr,
 	}, nil
+}
+
+func closeWebhookForwarderPipes(closers ...io.Closer) {
+	for _, closer := range closers {
+		if closer != nil {
+			_ = closer.Close()
+		}
+	}
 }

--- a/internal/runtime/webhook_forwarder.go
+++ b/internal/runtime/webhook_forwarder.go
@@ -286,6 +286,7 @@ func (m *webhookForwarderManager) commandForRepo(repo string) []string {
 func (m *webhookForwarderManager) superviseForwarder(ctx context.Context, forwarder *managedWebhookForwarder) {
 	defer close(forwarder.doneCh)
 	backoff := m.backoffBase
+	resetBackoffAfterStart := false
 	for {
 		select {
 		case <-ctx.Done():
@@ -311,6 +312,7 @@ func (m *webhookForwarderManager) superviseForwarder(ctx context.Context, forwar
 				return
 			}
 			backoff = boundedWebhookBackoff(backoff, m.backoffBase, m.backoffMax)
+			resetBackoffAfterStart = true
 			continue
 		}
 		select {
@@ -346,6 +348,10 @@ func (m *webhookForwarderManager) superviseForwarder(ctx context.Context, forwar
 		m.mu.Unlock()
 		if m.logger != nil {
 			m.logger.Info("gh webhook forwarder started", map[string]any{"repo": forwarder.repo, "endpoint": endpoint})
+		}
+		if resetBackoffAfterStart {
+			backoff = m.backoffBase
+			resetBackoffAfterStart = false
 		}
 
 		var readers sync.WaitGroup

--- a/internal/runtime/webhook_forwarder.go
+++ b/internal/runtime/webhook_forwarder.go
@@ -1,0 +1,681 @@
+package runtime
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/nexu-io/looper/internal/bootstrap"
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+const webhookForwardPath = "/webhook/forward"
+const webhookForwarderTailLimit = 20
+
+var webhookForwarderEvents = []string{
+	"pull_request",
+	"issue_comment",
+	"pull_request_review",
+	"pull_request_review_comment",
+}
+
+type WebhookRuntimeStatus struct {
+	Enabled         bool                     `json:"enabled"`
+	Healthy         bool                     `json:"healthy"`
+	Degraded        bool                     `json:"degraded"`
+	Endpoint        *string                  `json:"endpoint,omitempty"`
+	DegradedReasons []string                 `json:"degradedReasons,omitempty"`
+	Forwarders      []WebhookForwarderStatus `json:"forwarders"`
+}
+
+type WebhookForwarderStatus struct {
+	Repo         string   `json:"repo"`
+	Events       []string `json:"events"`
+	Command      []string `json:"command"`
+	Running      bool     `json:"running"`
+	RespawnCount int      `json:"respawnCount"`
+	LastStartAt  *string  `json:"lastStartAt,omitempty"`
+	LastExitAt   *string  `json:"lastExitAt,omitempty"`
+	LastError    *string  `json:"lastError,omitempty"`
+	Tail         []string `json:"tail"`
+}
+
+type webhookForwarderProcess interface {
+	Wait() error
+	Stop() error
+	Kill() error
+}
+
+type webhookForwarderStartResult struct {
+	process webhookForwarderProcess
+	stdout  io.ReadCloser
+	stderr  io.ReadCloser
+}
+
+type webhookForwarderStarter func(context.Context, webhookForwarderCommand) (webhookForwarderStartResult, error)
+
+type webhookForwarderCommand struct {
+	Path   string
+	Repo   string
+	URL    string
+	Events []string
+}
+
+type webhookForwarderManagerOptions struct {
+	Config       config.Config
+	Logger       bootstrap.Logger
+	Now          func() time.Time
+	StartProcess webhookForwarderStarter
+	BackoffBase  time.Duration
+	BackoffMax   time.Duration
+	TailLimit    int
+	Sleep        func(context.Context, time.Duration) error
+	StopTimeout  time.Duration
+}
+
+type webhookForwarderManager struct {
+	config       config.Config
+	logger       bootstrap.Logger
+	now          func() time.Time
+	startProcess webhookForwarderStarter
+	backoffBase  time.Duration
+	backoffMax   time.Duration
+	tailLimit    int
+	sleep        func(context.Context, time.Duration) error
+	stopTimeout  time.Duration
+
+	syncMu         sync.Mutex
+	mu             sync.RWMutex
+	endpoint       *string
+	initialReasons []string
+	forwarders     map[string]*managedWebhookForwarder
+}
+
+type managedWebhookForwarder struct {
+	mu      sync.Mutex
+	repo    string
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+	status  WebhookForwarderStatus
+	process webhookForwarderProcess
+}
+
+func newWebhookForwarderManager(options webhookForwarderManagerOptions) *webhookForwarderManager {
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	startProcess := options.StartProcess
+	if startProcess == nil {
+		startProcess = startWebhookForwarderProcess
+	}
+	backoffBase := options.BackoffBase
+	if backoffBase <= 0 {
+		backoffBase = time.Second
+	}
+	backoffMax := options.BackoffMax
+	if backoffMax <= 0 {
+		backoffMax = 30 * time.Second
+	}
+	tailLimit := options.TailLimit
+	if tailLimit <= 0 {
+		tailLimit = webhookForwarderTailLimit
+	}
+	sleep := options.Sleep
+	if sleep == nil {
+		sleep = sleepWithContext
+	}
+	stopTimeout := options.StopTimeout
+	if stopTimeout <= 0 {
+		stopTimeout = 5 * time.Second
+	}
+
+	manager := &webhookForwarderManager{
+		config:       options.Config,
+		logger:       options.Logger,
+		now:          now,
+		startProcess: startProcess,
+		backoffBase:  backoffBase,
+		backoffMax:   backoffMax,
+		tailLimit:    tailLimit,
+		sleep:        sleep,
+		stopTimeout:  stopTimeout,
+		forwarders:   map[string]*managedWebhookForwarder{},
+	}
+	manager.endpoint, manager.initialReasons = webhookForwardEndpoint(options.Config)
+	return manager
+}
+
+func (m *webhookForwarderManager) Enabled() bool {
+	return m != nil && m.config.Webhook.Enabled
+}
+
+func (m *webhookForwarderManager) Sync(ctx context.Context, projects []storage.ProjectRecord) {
+	if m == nil {
+		return
+	}
+	m.syncMu.Lock()
+	defer m.syncMu.Unlock()
+	desiredRepos := uniqueConfiguredWebhookRepos(projects)
+	if !m.canRun() {
+		m.stopAllForwarders()
+		return
+	}
+
+	desired := make(map[string]struct{}, len(desiredRepos))
+	for _, repo := range desiredRepos {
+		desired[repo] = struct{}{}
+	}
+
+	removed := make([]*managedWebhookForwarder, 0)
+	m.mu.Lock()
+	for repo, forwarder := range m.forwarders {
+		if _, ok := desired[repo]; ok {
+			continue
+		}
+		delete(m.forwarders, repo)
+		removed = append(removed, forwarder)
+	}
+	m.mu.Unlock()
+	for _, forwarder := range removed {
+		m.stopForwarder(forwarder)
+	}
+	m.mu.Lock()
+	for _, repo := range desiredRepos {
+		if _, ok := m.forwarders[repo]; ok {
+			continue
+		}
+		forwarder := &managedWebhookForwarder{
+			repo:   repo,
+			stopCh: make(chan struct{}),
+			doneCh: make(chan struct{}),
+			status: WebhookForwarderStatus{
+				Repo:    repo,
+				Events:  append([]string{}, webhookForwarderEvents...),
+				Command: m.commandForRepo(repo),
+				Tail:    []string{},
+			},
+		}
+		m.forwarders[repo] = forwarder
+		go m.superviseForwarder(ctx, forwarder)
+	}
+	m.mu.Unlock()
+}
+
+func (m *webhookForwarderManager) Stop() {
+	if m == nil {
+		return
+	}
+	m.syncMu.Lock()
+	defer m.syncMu.Unlock()
+	m.stopAllForwarders()
+}
+
+func (m *webhookForwarderManager) Status() WebhookRuntimeStatus {
+	if m == nil {
+		return WebhookRuntimeStatus{}
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	status := WebhookRuntimeStatus{
+		Enabled:         m.config.Webhook.Enabled,
+		Healthy:         true,
+		Forwarders:      make([]WebhookForwarderStatus, 0, len(m.forwarders)),
+		DegradedReasons: append([]string{}, m.initialReasons...),
+	}
+	if m.endpoint != nil {
+		endpoint := *m.endpoint
+		status.Endpoint = &endpoint
+	}
+	for _, repo := range sortedManagedForwarderRepos(m.forwarders) {
+		forwarder := m.forwarders[repo]
+		copied := forwarder.status
+		copied.Events = append([]string{}, copied.Events...)
+		copied.Command = append([]string{}, copied.Command...)
+		copied.Tail = append([]string{}, copied.Tail...)
+		status.Forwarders = append(status.Forwarders, copied)
+		if copied.LastError != nil && strings.TrimSpace(*copied.LastError) != "" {
+			status.DegradedReasons = append(status.DegradedReasons, fmt.Sprintf("repo %s: %s", copied.Repo, *copied.LastError))
+		}
+	}
+	if len(status.DegradedReasons) > 0 {
+		status.Degraded = true
+		status.Healthy = false
+	}
+	if !status.Enabled {
+		status.Healthy = true
+		status.Degraded = false
+		status.DegradedReasons = nil
+	}
+	return status
+}
+
+func (m *webhookForwarderManager) canRun() bool {
+	return m != nil && m.config.Webhook.Enabled && m.endpoint != nil && len(m.initialReasons) == 0
+}
+
+func (m *webhookForwarderManager) commandForRepo(repo string) []string {
+	if m == nil {
+		return nil
+	}
+	endpoint := ""
+	if m.endpoint != nil {
+		endpoint = *m.endpoint
+	}
+	return []string{
+		strings.TrimSpace(derefString(m.config.Tools.GHPath)),
+		"webhook",
+		"forward",
+		"--repo=" + repo,
+		"--events=" + strings.Join(webhookForwarderEvents, ","),
+		"--url=" + endpoint,
+	}
+}
+
+func (m *webhookForwarderManager) superviseForwarder(ctx context.Context, forwarder *managedWebhookForwarder) {
+	defer close(forwarder.doneCh)
+	backoff := m.backoffBase
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-forwarder.stopCh:
+			return
+		default:
+		}
+
+		endpoint := ""
+		if m.endpoint != nil {
+			endpoint = *m.endpoint
+		}
+		startResult, err := m.startProcess(ctx, webhookForwarderCommand{
+			Path:   strings.TrimSpace(derefString(m.config.Tools.GHPath)),
+			Repo:   forwarder.repo,
+			URL:    endpoint,
+			Events: webhookForwarderEvents,
+		})
+		if err != nil {
+			m.markForwarderError(forwarder, fmt.Sprintf("start failed: %s", err.Error()), false)
+			if sleepErr := m.sleepUntilNextAttempt(ctx, forwarder, backoff); sleepErr != nil {
+				return
+			}
+			backoff = boundedWebhookBackoff(backoff, m.backoffBase, m.backoffMax)
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			_ = startResult.process.Kill()
+			if startResult.stdout != nil {
+				_ = startResult.stdout.Close()
+			}
+			if startResult.stderr != nil {
+				_ = startResult.stderr.Close()
+			}
+			_ = startResult.process.Wait()
+			return
+		case <-forwarder.stopCh:
+			_ = startResult.process.Kill()
+			if startResult.stdout != nil {
+				_ = startResult.stdout.Close()
+			}
+			if startResult.stderr != nil {
+				_ = startResult.stderr.Close()
+			}
+			_ = startResult.process.Wait()
+			return
+		default:
+		}
+
+		startedAt := formatJavaScriptISOString(m.now().UTC())
+		m.mu.Lock()
+		forwarder.setProcess(startResult.process)
+		forwarder.status.Running = true
+		forwarder.status.LastStartAt = &startedAt
+		forwarder.status.LastError = nil
+		m.mu.Unlock()
+		if m.logger != nil {
+			m.logger.Info("gh webhook forwarder started", map[string]any{"repo": forwarder.repo, "endpoint": endpoint})
+		}
+
+		var readers sync.WaitGroup
+		readers.Add(2)
+		go m.captureForwarderOutput(forwarder, "stdout", startResult.stdout, &readers)
+		go m.captureForwarderOutput(forwarder, "stderr", startResult.stderr, &readers)
+		waitErr := startResult.process.Wait()
+		readers.Wait()
+
+		m.mu.Lock()
+		forwarder.setProcess(nil)
+		forwarder.status.Running = false
+		exitedAt := formatJavaScriptISOString(m.now().UTC())
+		forwarder.status.LastExitAt = &exitedAt
+		m.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-forwarder.stopCh:
+			return
+		default:
+		}
+
+		errText := "process exited"
+		if waitErr != nil {
+			errText = waitErr.Error()
+		}
+		m.markForwarderError(forwarder, errText, true)
+		if sleepErr := m.sleepUntilNextAttempt(ctx, forwarder, backoff); sleepErr != nil {
+			return
+		}
+		backoff = boundedWebhookBackoff(backoff, m.backoffBase, m.backoffMax)
+	}
+}
+
+func (m *webhookForwarderManager) sleepUntilNextAttempt(ctx context.Context, forwarder *managedWebhookForwarder, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	select {
+	case <-forwarder.stopCh:
+		return context.Canceled
+	default:
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- m.sleep(ctx, delay)
+	}()
+	select {
+	case <-forwarder.stopCh:
+		return context.Canceled
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-done:
+		return err
+	}
+}
+
+func (m *webhookForwarderManager) captureForwarderOutput(forwarder *managedWebhookForwarder, stream string, reader io.ReadCloser, readers *sync.WaitGroup) {
+	defer readers.Done()
+	if reader == nil {
+		return
+	}
+	defer reader.Close()
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		m.recordForwarderOutput(forwarder, stream, line)
+	}
+	if err := scanner.Err(); err != nil && m.logger != nil {
+		m.logger.Warn("gh webhook forwarder output read failed", map[string]any{"repo": forwarder.repo, "stream": stream, "error": err.Error()})
+	}
+}
+
+func (m *webhookForwarderManager) recordForwarderOutput(forwarder *managedWebhookForwarder, stream string, line string) {
+	entry := stream + ": " + line
+	m.mu.Lock()
+	forwarder.status.Tail = appendTail(forwarder.status.Tail, entry, m.tailLimit)
+	m.mu.Unlock()
+	if m.logger == nil {
+		return
+	}
+	context := map[string]any{"repo": forwarder.repo, "stream": stream, "line": line}
+	if stream == "stderr" {
+		m.logger.Warn("gh webhook forwarder output", context)
+		return
+	}
+	m.logger.Info("gh webhook forwarder output", context)
+}
+
+func (m *webhookForwarderManager) markForwarderError(forwarder *managedWebhookForwarder, message string, respawn bool) {
+	errText := strings.TrimSpace(message)
+	if errText == "" {
+		errText = "forwarder failed"
+	}
+	m.mu.Lock()
+	forwarder.status.Running = false
+	forwarder.status.LastError = &errText
+	if respawn {
+		forwarder.status.RespawnCount++
+	}
+	m.mu.Unlock()
+	if m.logger != nil {
+		m.logger.Warn("gh webhook forwarder degraded", map[string]any{"repo": forwarder.repo, "error": errText, "respawn": respawn})
+	}
+}
+
+func (m *webhookForwarderManager) stopAllForwarders() {
+	m.mu.Lock()
+	forwarders := make([]*managedWebhookForwarder, 0, len(m.forwarders))
+	for repo, forwarder := range m.forwarders {
+		delete(m.forwarders, repo)
+		forwarders = append(forwarders, forwarder)
+	}
+	m.mu.Unlock()
+	for _, forwarder := range forwarders {
+		m.stopForwarder(forwarder)
+	}
+}
+
+func (m *webhookForwarderManager) stopForwarder(forwarder *managedWebhookForwarder) {
+	if forwarder == nil {
+		return
+	}
+	select {
+	case <-forwarder.stopCh:
+	default:
+		close(forwarder.stopCh)
+	}
+	if process := forwarder.currentProcess(); process != nil {
+		_ = process.Stop()
+	}
+	if m.waitForForwarderDone(forwarder, m.stopTimeout) {
+		return
+	}
+	if process := forwarder.currentProcess(); process != nil {
+		_ = process.Kill()
+	}
+	_ = m.waitForForwarderDone(forwarder, m.stopTimeout)
+}
+
+func (m *webhookForwarderManager) waitForForwarderDone(forwarder *managedWebhookForwarder, timeout time.Duration) bool {
+	if timeout <= 0 {
+		<-forwarder.doneCh
+		return true
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-forwarder.doneCh:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+func uniqueConfiguredWebhookRepos(projects []storage.ProjectRecord) []string {
+	seen := map[string]struct{}{}
+	repos := make([]string, 0, len(projects))
+	for _, project := range projects {
+		if project.Archived {
+			continue
+		}
+		repo := repoFromProjectMetadata(project.MetadataJSON)
+		if repo == "" {
+			continue
+		}
+		if _, ok := seen[repo]; ok {
+			continue
+		}
+		seen[repo] = struct{}{}
+		repos = append(repos, repo)
+	}
+	sort.Strings(repos)
+	return repos
+}
+
+func webhookForwardEndpoint(cfg config.Config) (*string, []string) {
+	if !cfg.Webhook.Enabled {
+		return nil, nil
+	}
+	reasons := make([]string, 0)
+	ghPath := strings.TrimSpace(derefString(cfg.Tools.GHPath))
+	if ghPath == "" {
+		reasons = append(reasons, "configured/resolved gh executable is missing")
+	}
+	if !isLoopbackHost(cfg.Server.Host) {
+		reasons = append(reasons, fmt.Sprintf("server host %q is not loopback", cfg.Server.Host))
+	}
+	if len(reasons) > 0 {
+		return nil, reasons
+	}
+	if cfg.Server.BaseURL != nil && strings.TrimSpace(*cfg.Server.BaseURL) != "" {
+		base, err := url.Parse(strings.TrimSpace(*cfg.Server.BaseURL))
+		if err != nil {
+			return nil, []string{fmt.Sprintf("server.baseUrl is invalid: %s", err.Error())}
+		}
+		if !isLoopbackHost(base.Hostname()) {
+			return nil, []string{fmt.Sprintf("server.baseUrl host %q is not loopback", base.Hostname())}
+		}
+		resolved := base.ResolveReference(&url.URL{Path: webhookForwardPath})
+		endpoint := resolved.String()
+		return &endpoint, nil
+	}
+	endpoint := (&url.URL{Scheme: "http", Host: net.JoinHostPort(cfg.Server.Host, fmt.Sprintf("%d", cfg.Server.Port)), Path: webhookForwardPath}).String()
+	return &endpoint, nil
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	host = strings.Trim(host, "[]")
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func appendTail(lines []string, line string, limit int) []string {
+	lines = append(lines, line)
+	if limit > 0 && len(lines) > limit {
+		return append([]string{}, lines[len(lines)-limit:]...)
+	}
+	return lines
+}
+
+func boundedWebhookBackoff(current, base, max time.Duration) time.Duration {
+	if current <= 0 {
+		current = base
+	}
+	next := current * 2
+	if next < base {
+		next = base
+	}
+	if next > max {
+		return max
+	}
+	return next
+}
+
+func sortedManagedForwarderRepos(forwarders map[string]*managedWebhookForwarder) []string {
+	repos := make([]string, 0, len(forwarders))
+	for repo := range forwarders {
+		repos = append(repos, repo)
+	}
+	sort.Strings(repos)
+	return repos
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+type execWebhookForwarderProcess struct {
+	cmd *exec.Cmd
+}
+
+func (p *execWebhookForwarderProcess) Wait() error {
+	return p.cmd.Wait()
+}
+
+func (p *execWebhookForwarderProcess) Stop() error {
+	if p == nil || p.cmd == nil || p.cmd.Process == nil {
+		return nil
+	}
+	if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *execWebhookForwarderProcess) Kill() error {
+	if p == nil || p.cmd == nil || p.cmd.Process == nil {
+		return nil
+	}
+	if err := p.cmd.Process.Kill(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *managedWebhookForwarder) currentProcess() webhookForwarderProcess {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.process
+}
+
+func (f *managedWebhookForwarder) setProcess(process webhookForwarderProcess) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.process = process
+}
+
+func startWebhookForwarderProcess(ctx context.Context, command webhookForwarderCommand) (webhookForwarderStartResult, error) {
+	args := []string{
+		"webhook",
+		"forward",
+		"--repo=" + command.Repo,
+		"--events=" + strings.Join(command.Events, ","),
+		"--url=" + command.URL,
+	}
+	cmd := exec.CommandContext(ctx, command.Path, args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return webhookForwarderStartResult{}, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return webhookForwarderStartResult{}, err
+	}
+	if err := cmd.Start(); err != nil {
+		return webhookForwarderStartResult{}, err
+	}
+	return webhookForwarderStartResult{
+		process: &execWebhookForwarderProcess{cmd: cmd},
+		stdout:  stdout,
+		stderr:  stderr,
+	}, nil
+}

--- a/internal/runtime/webhook_forwarder_test.go
+++ b/internal/runtime/webhook_forwarder_test.go
@@ -1,0 +1,378 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestUniqueConfiguredWebhookRepos(t *testing.T) {
+	t.Parallel()
+
+	projects := []storage.ProjectRecord{
+		{ID: "a", MetadataJSON: stringPtr(`{"repo":"acme/alpha"}`)},
+		{ID: "b", MetadataJSON: stringPtr(`{"repo":"acme/alpha"}`)},
+		{ID: "c", MetadataJSON: stringPtr(`{"repo":"acme/beta"}`)},
+		{ID: "d", Archived: true, MetadataJSON: stringPtr(`{"repo":"acme/ignored"}`)},
+		{ID: "e", MetadataJSON: stringPtr(`{"repo":null}`)},
+	}
+
+	got := uniqueConfiguredWebhookRepos(projects)
+	want := []string{"acme/alpha", "acme/beta"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("uniqueConfiguredWebhookRepos() = %v, want %v", got, want)
+	}
+}
+
+func TestWebhookForwardEndpointDegradedCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing gh", func(t *testing.T) {
+		cfg, err := config.DefaultConfig(t.TempDir())
+		if err != nil {
+			t.Fatalf("DefaultConfig() error = %v", err)
+		}
+		cfg.Webhook.Enabled = true
+
+		endpoint, reasons := webhookForwardEndpoint(cfg)
+		if endpoint != nil {
+			t.Fatalf("webhookForwardEndpoint() endpoint = %v, want nil", *endpoint)
+		}
+		if len(reasons) != 1 || reasons[0] != "configured/resolved gh executable is missing" {
+			t.Fatalf("webhookForwardEndpoint() reasons = %v", reasons)
+		}
+	})
+
+	t.Run("non loopback host", func(t *testing.T) {
+		cfg, err := config.DefaultConfig(t.TempDir())
+		if err != nil {
+			t.Fatalf("DefaultConfig() error = %v", err)
+		}
+		cfg.Webhook.Enabled = true
+		cfg.Server.Host = "0.0.0.0"
+		ghPath := "/usr/bin/gh"
+		cfg.Tools.GHPath = &ghPath
+
+		endpoint, reasons := webhookForwardEndpoint(cfg)
+		if endpoint != nil {
+			t.Fatalf("webhookForwardEndpoint() endpoint = %v, want nil", *endpoint)
+		}
+		if len(reasons) != 1 || !strings.Contains(reasons[0], "not loopback") {
+			t.Fatalf("webhookForwardEndpoint() reasons = %v, want non-loopback reason", reasons)
+		}
+	})
+
+	t.Run("loopback endpoint", func(t *testing.T) {
+		cfg, err := config.DefaultConfig(t.TempDir())
+		if err != nil {
+			t.Fatalf("DefaultConfig() error = %v", err)
+		}
+		cfg.Webhook.Enabled = true
+		ghPath := "/usr/bin/gh"
+		cfg.Tools.GHPath = &ghPath
+
+		endpoint, reasons := webhookForwardEndpoint(cfg)
+		if len(reasons) != 0 {
+			t.Fatalf("webhookForwardEndpoint() reasons = %v, want none", reasons)
+		}
+		if endpoint == nil || *endpoint != "http://127.0.0.1:17310/webhook/forward" {
+			t.Fatalf("webhookForwardEndpoint() endpoint = %v, want loopback webhook URL", endpoint)
+		}
+	})
+}
+
+func TestWebhookForwarderManagerStartsUniqueReposAndRetainsTail(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Webhook.Enabled = true
+	ghPath := "/resolved/gh"
+	cfg.Tools.GHPath = &ghPath
+
+	startedCh := make(chan *testStartedForwarder, 4)
+	manager := newWebhookForwarderManager(webhookForwarderManagerOptions{
+		Config:      cfg,
+		Logger:      &testLogger{},
+		Now:         func() time.Time { return time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC) },
+		BackoffBase: time.Millisecond,
+		BackoffMax:  2 * time.Millisecond,
+		StartProcess: func(ctx context.Context, command webhookForwarderCommand) (webhookForwarderStartResult, error) {
+			started := newTestStartedForwarder(command)
+			result := started.result()
+			startedCh <- started
+			return result, nil
+		},
+	})
+
+	projects := []storage.ProjectRecord{
+		{ID: "one", MetadataJSON: stringPtr(`{"repo":"acme/alpha"}`)},
+		{ID: "two", MetadataJSON: stringPtr(`{"repo":"acme/alpha"}`)},
+		{ID: "three", MetadataJSON: stringPtr(`{"repo":"acme/beta"}`)},
+	}
+	manager.Sync(context.Background(), projects)
+	t.Cleanup(manager.Stop)
+
+	started := []*testStartedForwarder{<-startedCh, <-startedCh}
+	sort.Slice(started, func(i, j int) bool { return started[i].command.Repo < started[j].command.Repo })
+	if got := started[0].command.Repo; got != "acme/alpha" {
+		t.Fatalf("first forwarder repo = %q, want acme/alpha", got)
+	}
+	if got := started[1].command.Repo; got != "acme/beta" {
+		t.Fatalf("second forwarder repo = %q, want acme/beta", got)
+	}
+	for _, item := range started {
+		if item.command.Path != ghPath {
+			t.Fatalf("forwarder gh path = %q, want %q", item.command.Path, ghPath)
+		}
+		if got := strings.Join(item.command.Events, ","); got != strings.Join(webhookForwarderEvents, ",") {
+			t.Fatalf("forwarder events = %q, want %q", got, strings.Join(webhookForwarderEvents, ","))
+		}
+		if item.command.URL != "http://127.0.0.1:17310/webhook/forward" {
+			t.Fatalf("forwarder URL = %q, want loopback webhook URL", item.command.URL)
+		}
+	}
+
+	started[0].writeStdout("hello from stdout\n")
+	started[0].writeStderr("warning from stderr\n")
+	waitForWebhookCondition(t, time.Second, func() bool {
+		status := manager.Status()
+		for _, forwarder := range status.Forwarders {
+			if forwarder.Repo == "acme/alpha" && len(forwarder.Tail) == 2 {
+				return true
+			}
+		}
+		return false
+	})
+
+	status := manager.Status()
+	if !status.Enabled || !status.Healthy || status.Degraded {
+		t.Fatalf("manager.Status() = %#v, want enabled healthy non-degraded", status)
+	}
+	if len(status.Forwarders) != 2 {
+		t.Fatalf("forwarder count = %d, want 2", len(status.Forwarders))
+	}
+	alpha := status.Forwarders[0]
+	if alpha.Repo != "acme/alpha" {
+		alpha = status.Forwarders[1]
+	}
+	if !alpha.Running {
+		t.Fatal("alpha forwarder Running = false, want true")
+	}
+	if got := strings.Join(alpha.Tail, "\n"); !strings.Contains(got, "stdout: hello from stdout") || !strings.Contains(got, "stderr: warning from stderr") {
+		t.Fatalf("alpha tail = %q, want stdout/stderr lines retained", got)
+	}
+}
+
+func TestWebhookForwarderManagerRespawnsAndStopsRemovedRepo(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Webhook.Enabled = true
+	ghPath := "/resolved/gh"
+	cfg.Tools.GHPath = &ghPath
+
+	var mu sync.Mutex
+	started := []*testStartedForwarder{}
+	sleepCalls := 0
+	manager := newWebhookForwarderManager(webhookForwarderManagerOptions{
+		Config:      cfg,
+		Logger:      &testLogger{},
+		Now:         func() time.Time { return time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC) },
+		BackoffBase: time.Millisecond,
+		BackoffMax:  2 * time.Millisecond,
+		Sleep: func(ctx context.Context, delay time.Duration) error {
+			mu.Lock()
+			sleepCalls++
+			mu.Unlock()
+			return nil
+		},
+		StartProcess: func(ctx context.Context, command webhookForwarderCommand) (webhookForwarderStartResult, error) {
+			startedForwarder := newTestStartedForwarder(command)
+			result := startedForwarder.result()
+			mu.Lock()
+			started = append(started, startedForwarder)
+			count := len(started)
+			mu.Unlock()
+			if count == 1 {
+				startedForwarder.exit(errors.New("boom"))
+			}
+			return result, nil
+		},
+	})
+
+	manager.Sync(context.Background(), []storage.ProjectRecord{{ID: "one", MetadataJSON: stringPtr(`{"repo":"acme/alpha"}`)}})
+	waitForWebhookCondition(t, time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(started) >= 2 && sleepCalls >= 1
+	})
+
+	status := manager.Status()
+	if len(status.Forwarders) != 1 {
+		t.Fatalf("forwarder count = %d, want 1", len(status.Forwarders))
+	}
+	if status.Forwarders[0].RespawnCount != 1 {
+		t.Fatalf("respawn count = %d, want 1", status.Forwarders[0].RespawnCount)
+	}
+
+	manager.Sync(context.Background(), nil)
+	waitForWebhookCondition(t, time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(started) >= 2 && started[1].process.stopCalls() == 1
+	})
+	status = manager.Status()
+	if len(status.Forwarders) != 0 {
+		t.Fatalf("forwarder count after removal = %d, want 0", len(status.Forwarders))
+	}
+	manager.Stop()
+	mu.Lock()
+	defer mu.Unlock()
+	if len(started) != 2 {
+		t.Fatalf("start count = %d, want 2 without respawn after removal", len(started))
+	}
+}
+
+func TestRuntimeStartDegradesWebhookWithoutFailingStartup(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	cfg.Webhook.Enabled = true
+	cfg.Server.Host = "0.0.0.0"
+	ghPath := "/resolved/gh"
+	cfg.Tools.GHPath = &ghPath
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v, want nil despite degraded webhook runtime", err)
+	}
+	defer rt.Stop("test cleanup")
+
+	status := rt.WebhookStatus()
+	if !status.Enabled || !status.Degraded || status.Healthy {
+		t.Fatalf("WebhookStatus() = %#v, want enabled degraded unhealthy status", status)
+	}
+	if len(status.Forwarders) != 0 {
+		t.Fatalf("WebhookStatus().Forwarders = %v, want none when host is non-loopback", status.Forwarders)
+	}
+	if len(status.DegradedReasons) == 0 || !strings.Contains(status.DegradedReasons[0], "not loopback") {
+		t.Fatalf("WebhookStatus().DegradedReasons = %v, want non-loopback reason", status.DegradedReasons)
+	}
+}
+
+type testStartedForwarder struct {
+	command webhookForwarderCommand
+	process *testWebhookForwarderProcess
+	stdoutW *io.PipeWriter
+	stderrW *io.PipeWriter
+}
+
+func newTestStartedForwarder(command webhookForwarderCommand) *testStartedForwarder {
+	return &testStartedForwarder{
+		command: command,
+		process: newTestWebhookForwarderProcess(),
+	}
+}
+
+func (t *testStartedForwarder) result() webhookForwarderStartResult {
+	stdoutR, stdoutW := io.Pipe()
+	stderrR, stderrW := io.Pipe()
+	t.stdoutW = stdoutW
+	t.stderrW = stderrW
+	t.process.onStop = func() {
+		_ = stdoutW.Close()
+		_ = stderrW.Close()
+	}
+	return webhookForwarderStartResult{process: t.process, stdout: stdoutR, stderr: stderrR}
+}
+
+func (t *testStartedForwarder) writeStdout(line string) {
+	_, _ = io.WriteString(t.stdoutW, line)
+}
+
+func (t *testStartedForwarder) writeStderr(line string) {
+	_, _ = io.WriteString(t.stderrW, line)
+}
+
+func (t *testStartedForwarder) exit(err error) {
+	t.process.exit(err)
+	_ = t.stdoutW.Close()
+	_ = t.stderrW.Close()
+}
+
+type testWebhookForwarderProcess struct {
+	mu        sync.Mutex
+	waitCh    chan error
+	stopCount int
+	onStop    func()
+}
+
+func newTestWebhookForwarderProcess() *testWebhookForwarderProcess {
+	return &testWebhookForwarderProcess{waitCh: make(chan error, 1)}
+}
+
+func (p *testWebhookForwarderProcess) Wait() error {
+	return <-p.waitCh
+}
+
+func (p *testWebhookForwarderProcess) Stop() error {
+	p.mu.Lock()
+	p.stopCount++
+	onStop := p.onStop
+	p.mu.Unlock()
+	if onStop != nil {
+		onStop()
+	}
+	p.exit(nil)
+	return nil
+}
+
+func (p *testWebhookForwarderProcess) Kill() error {
+	p.exit(nil)
+	return nil
+}
+
+func (p *testWebhookForwarderProcess) exit(err error) {
+	select {
+	case p.waitCh <- err:
+	default:
+	}
+}
+
+func (p *testWebhookForwarderProcess) stopCalls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.stopCount
+}
+
+func waitForWebhookCondition(t *testing.T, timeout time.Duration, predicate func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if predicate() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for condition")
+}

--- a/internal/runtime/webhook_forwarder_test.go
+++ b/internal/runtime/webhook_forwarder_test.go
@@ -280,11 +280,33 @@ func TestRuntimeStartDegradesWebhookWithoutFailingStartup(t *testing.T) {
 	}
 }
 
+func TestCloseWebhookForwarderPipesClosesAllNonNilClosers(t *testing.T) {
+	t.Parallel()
+	stdout := &testCloser{}
+	stderr := &testCloser{}
+
+	closeWebhookForwarderPipes(stdout, nil, stderr)
+
+	if stdout.closeCalls != 1 {
+		t.Fatalf("stdout close calls = %d, want 1", stdout.closeCalls)
+	}
+	if stderr.closeCalls != 1 {
+		t.Fatalf("stderr close calls = %d, want 1", stderr.closeCalls)
+	}
+}
+
 type testStartedForwarder struct {
 	command webhookForwarderCommand
 	process *testWebhookForwarderProcess
 	stdoutW *io.PipeWriter
 	stderrW *io.PipeWriter
+}
+
+type testCloser struct{ closeCalls int }
+
+func (c *testCloser) Close() error {
+	c.closeCalls++
+	return nil
 }
 
 func newTestStartedForwarder(command webhookForwarderCommand) *testStartedForwarder {

--- a/internal/runtime/webhook_forwarder_test.go
+++ b/internal/runtime/webhook_forwarder_test.go
@@ -248,6 +248,65 @@ func TestWebhookForwarderManagerRespawnsAndStopsRemovedRepo(t *testing.T) {
 	}
 }
 
+func TestWebhookForwarderManagerResetsBackoffAfterSuccessfulStart(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Webhook.Enabled = true
+	ghPath := "/resolved/gh"
+	cfg.Tools.GHPath = &ghPath
+
+	var mu sync.Mutex
+	started := []*testStartedForwarder{}
+	startCalls := 0
+	sleepCalls := []time.Duration{}
+	manager := newWebhookForwarderManager(webhookForwarderManagerOptions{
+		Config:      cfg,
+		Logger:      &testLogger{},
+		Now:         func() time.Time { return time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC) },
+		BackoffBase: time.Millisecond,
+		BackoffMax:  4 * time.Millisecond,
+		Sleep: func(ctx context.Context, delay time.Duration) error {
+			mu.Lock()
+			sleepCalls = append(sleepCalls, delay)
+			mu.Unlock()
+			return nil
+		},
+		StartProcess: func(ctx context.Context, command webhookForwarderCommand) (webhookForwarderStartResult, error) {
+			mu.Lock()
+			attempt := startCalls
+			startCalls++
+			mu.Unlock()
+			if attempt < 3 {
+				return webhookForwarderStartResult{}, errors.New("gh unavailable")
+			}
+			startedForwarder := newTestStartedForwarder(command)
+			result := startedForwarder.result()
+			mu.Lock()
+			started = append(started, startedForwarder)
+			mu.Unlock()
+			if attempt == 3 || attempt == 4 {
+				go startedForwarder.exit(errors.New("boom"))
+			}
+			return result, nil
+		},
+	})
+
+	manager.Sync(context.Background(), []storage.ProjectRecord{{ID: "one", MetadataJSON: stringPtr(`{"repo":"acme/alpha"}`)}})
+	waitForWebhookCondition(t, time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(sleepCalls) < 5 {
+			return false
+		}
+		return sleepCalls[0] == time.Millisecond && sleepCalls[1] == 2*time.Millisecond && sleepCalls[2] == 4*time.Millisecond && sleepCalls[3] == time.Millisecond && sleepCalls[4] == 2*time.Millisecond
+	})
+	manager.Stop()
+}
+
 func TestRuntimeStartDegradesWebhookWithoutFailingStartup(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- start and supervise one `gh webhook forward` process per unique configured repo when webhook mode is enabled, using Looper's resolved `gh` path and bounded respawn backoff
- degrade cleanly to poll fallback when forwarding cannot run, surface per-repo forwarder health and output tails in runtime status, and refresh forwarders when configured projects change
- add loopback-only webhook forwarding ACK handling plus config/runtime/API coverage for webhook status, command construction, repo removal, and degraded startup cases

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #370

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>