### PR TITLE
feat: gate coordinator dispatch on blocked_by dependencies

### DIFF
--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -257,6 +257,11 @@
                   "reTriageOnAuthorReply": true
                 }
               },
+              "dependencies": {
+                "enabled": false,
+                "apiTimeoutSeconds": 10,
+                "apiRetryAttempts": 3
+              },
               "dispatch": {
                 "mode": "human-gated",
                 "humanGate": {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3338,6 +3338,28 @@ func sha256Hex(value string) string {
 	return fmt.Sprintf("%x", sum)
 }
 
+func TestValidateCoordinatorDependenciesRequiresPositiveBoundsWhenEnabled(t *testing.T) {
+	cwd := t.TempDir()
+	cfg, err := DefaultConfig(cwd)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Coordinator.Dependencies.Enabled = true
+	cfg.Roles.Coordinator.Dependencies.APITimeoutSeconds = 0
+	cfg.Roles.Coordinator.Dependencies.APIRetryAttempts = 0
+
+	err = ValidateWithOptions(cfg, ValidateOptions{DefaultWorktreeRoot: t.TempDir()})
+	if err == nil {
+		t.Fatal("ValidateWithOptions() error = nil, want validation error")
+	}
+	validationErr, ok := err.(*ConfigValidationError)
+	if !ok {
+		t.Fatalf("ValidateWithOptions() error = %T, want *ConfigValidationError", err)
+	}
+	assertValidationIssue(t, validationErr, "roles.coordinator.dependencies.apiTimeoutSeconds", "must be a positive integer when dependencies are enabled")
+	assertValidationIssue(t, validationErr, "roles.coordinator.dependencies.apiRetryAttempts", "must be a positive integer when dependencies are enabled")
+}
+
 func mapEnvLookup(values map[string]string) EnvLookupFunc {
 	return func(key string) (string, bool) {
 		value, ok := values[key]

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -162,6 +162,11 @@ func DefaultConfig(cwd string) (Config, error) {
 					},
 					AssignTo: "",
 				},
+				Dependencies: CoordinatorDependenciesConfig{
+					Enabled:           false,
+					APITimeoutSeconds: 10,
+					APIRetryAttempts:  3,
+				},
 			},
 			Planner: PlannerRoleConfig{
 				AutoDiscovery: true,

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -710,6 +710,9 @@ func mergeCoordinatorRoleConfig(config *CoordinatorRoleConfig, partial PartialCo
 	if partial.Dispatch != nil {
 		mergeCoordinatorDispatchConfig(&config.Dispatch, *partial.Dispatch)
 	}
+	if partial.Dependencies != nil {
+		mergeCoordinatorDependenciesConfig(&config.Dependencies, *partial.Dependencies)
+	}
 }
 
 func mergeCoordinatorTriageConfig(config *CoordinatorTriageConfig, partial PartialCoordinatorTriageConfig) {
@@ -769,6 +772,18 @@ func mergeCoordinatorDispatchAutonomousConfig(config *CoordinatorDispatchAutonom
 	}
 	if partial.HoldLabel != nil {
 		config.HoldLabel = *partial.HoldLabel
+	}
+}
+
+func mergeCoordinatorDependenciesConfig(config *CoordinatorDependenciesConfig, partial PartialCoordinatorDependenciesConfig) {
+	if partial.Enabled != nil {
+		config.Enabled = *partial.Enabled
+	}
+	if partial.APITimeoutSeconds != nil {
+		config.APITimeoutSeconds = *partial.APITimeoutSeconds
+	}
+	if partial.APIRetryAttempts != nil {
+		config.APIRetryAttempts = *partial.APIRetryAttempts
 	}
 }
 

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -197,6 +197,11 @@
               "reTriageOnAuthorReply": true
             }
           },
+          "dependencies": {
+            "enabled": false,
+            "apiTimeoutSeconds": 10,
+            "apiRetryAttempts": 3
+          },
           "dispatch": {
             "mode": "human-gated",
             "humanGate": {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -134,6 +134,11 @@
               "reTriageOnAuthorReply": true
             }
           },
+          "dependencies": {
+            "enabled": false,
+            "apiTimeoutSeconds": 10,
+            "apiRetryAttempts": 3
+          },
           "dispatch": {
             "mode": "human-gated",
             "humanGate": {

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -217,6 +217,11 @@
               "reTriageOnAuthorReply": true
             }
           },
+          "dependencies": {
+            "enabled": false,
+            "apiTimeoutSeconds": 10,
+            "apiRetryAttempts": 3
+          },
           "dispatch": {
             "mode": "human-gated",
             "humanGate": {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -482,11 +482,18 @@ type CoordinatorDispatchConfig struct {
 	AssignTo   string                              `json:"assignTo"`
 }
 
+type CoordinatorDependenciesConfig struct {
+	Enabled           bool `json:"enabled"`
+	APITimeoutSeconds int  `json:"apiTimeoutSeconds"`
+	APIRetryAttempts  int  `json:"apiRetryAttempts"`
+}
+
 type CoordinatorRoleConfig struct {
-	Enabled      bool                      `json:"enabled"`
-	PollInterval string                    `json:"pollInterval"`
-	Triage       CoordinatorTriageConfig   `json:"triage"`
-	Dispatch     CoordinatorDispatchConfig `json:"dispatch"`
+	Enabled      bool                          `json:"enabled"`
+	PollInterval string                        `json:"pollInterval"`
+	Triage       CoordinatorTriageConfig       `json:"triage"`
+	Dispatch     CoordinatorDispatchConfig     `json:"dispatch"`
+	Dependencies CoordinatorDependenciesConfig `json:"dependencies"`
 }
 
 type RoleConfigs struct {
@@ -879,10 +886,17 @@ type PartialCoordinatorDispatchConfig struct {
 }
 
 type PartialCoordinatorRoleConfig struct {
-	Enabled      *bool                             `json:"enabled,omitempty"`
-	PollInterval *string                           `json:"pollInterval,omitempty"`
-	Triage       *PartialCoordinatorTriageConfig   `json:"triage,omitempty"`
-	Dispatch     *PartialCoordinatorDispatchConfig `json:"dispatch,omitempty"`
+	Enabled      *bool                                 `json:"enabled,omitempty"`
+	PollInterval *string                               `json:"pollInterval,omitempty"`
+	Triage       *PartialCoordinatorTriageConfig       `json:"triage,omitempty"`
+	Dispatch     *PartialCoordinatorDispatchConfig     `json:"dispatch,omitempty"`
+	Dependencies *PartialCoordinatorDependenciesConfig `json:"dependencies,omitempty"`
+}
+
+type PartialCoordinatorDependenciesConfig struct {
+	Enabled           *bool `json:"enabled,omitempty"`
+	APITimeoutSeconds *int  `json:"apiTimeoutSeconds,omitempty"`
+	APIRetryAttempts  *int  `json:"apiRetryAttempts,omitempty"`
 }
 
 type PartialRoleConfigs struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -692,6 +692,14 @@ func validateCoordinatorRoleConfig(config CoordinatorRoleConfig, path string, is
 	if config.Dispatch.AssignTo != strings.TrimSpace(config.Dispatch.AssignTo) {
 		*issues = append(*issues, ValidationIssue{Path: path + ".dispatch.assignTo", Message: "must not contain leading or trailing whitespace"})
 	}
+	if config.Dependencies.Enabled {
+		if config.Dependencies.APITimeoutSeconds <= 0 {
+			*issues = append(*issues, ValidationIssue{Path: path + ".dependencies.apiTimeoutSeconds", Message: "must be a positive integer when dependencies are enabled"})
+		}
+		if config.Dependencies.APIRetryAttempts <= 0 {
+			*issues = append(*issues, ValidationIssue{Path: path + ".dependencies.apiRetryAttempts", Message: "must be a positive integer when dependencies are enabled"})
+		}
+	}
 	validateDistinctLabels([]labelPathValue{
 		{Path: path + ".triage.triagedLabel", Value: config.Triage.TriagedLabel},
 		{Path: path + ".triage.disposition.outOfScopeLabel", Value: config.Triage.Disposition.OutOfScopeLabel},

--- a/internal/coordinator/depgraph/depgraph.go
+++ b/internal/coordinator/depgraph/depgraph.go
@@ -1,0 +1,74 @@
+package depgraph
+
+import "sort"
+
+type Snapshot struct {
+	Issues map[int64]IssueSnapshot
+}
+
+type IssueSnapshot struct {
+	Number    int64
+	BlockedBy []BlockerSnapshot
+}
+
+type BlockerSnapshot struct {
+	Number      int64
+	Repo        string
+	State       string
+	StateReason string
+	Reachable   bool
+}
+
+type DependencyGraph struct {
+	issues map[int64][]Blocker
+}
+
+type Blocker struct {
+	Number      int64
+	Repo        string
+	State       string
+	StateReason string
+	Reachable   bool
+}
+
+func Build(snapshot Snapshot) *DependencyGraph {
+	graph := &DependencyGraph{issues: map[int64][]Blocker{}}
+	for issueNumber, issue := range snapshot.Issues {
+		unsatisfied := make([]Blocker, 0, len(issue.BlockedBy))
+		for _, blocker := range issue.BlockedBy {
+			if blockerSatisfied(blocker) {
+				continue
+			}
+			unsatisfied = append(unsatisfied, Blocker{
+				Number:      blocker.Number,
+				Repo:        blocker.Repo,
+				State:       blocker.State,
+				StateReason: blocker.StateReason,
+				Reachable:   blocker.Reachable,
+			})
+		}
+		sort.Slice(unsatisfied, func(i, j int) bool {
+			if unsatisfied[i].Number == unsatisfied[j].Number {
+				return unsatisfied[i].Repo < unsatisfied[j].Repo
+			}
+			return unsatisfied[i].Number < unsatisfied[j].Number
+		})
+		graph.issues[issueNumber] = unsatisfied
+	}
+	return graph
+}
+
+func (g *DependencyGraph) Unsatisfied(issueNumber int64) []Blocker {
+	if g == nil {
+		return nil
+	}
+	blockers := g.issues[issueNumber]
+	if len(blockers) == 0 {
+		return nil
+	}
+	return append([]Blocker(nil), blockers...)
+}
+
+func blockerSatisfied(blocker BlockerSnapshot) bool {
+	return blocker.Reachable && blocker.State == "closed" && blocker.StateReason == "completed"
+}

--- a/internal/coordinator/dispatch/autonomous_test.go
+++ b/internal/coordinator/dispatch/autonomous_test.go
@@ -3,12 +3,14 @@ package dispatch
 import (
 	"testing"
 	"time"
+
+	"github.com/nexu-io/looper/internal/coordinator/depgraph"
 )
 
 func TestAutonomousGraceNotElapsedDoesNothing(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-29 * time.Minute)}, autonomousConfig(), now)
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-29 * time.Minute)}, autonomousConfig(), now, nil)
 	if !action.NoOp || len(action.TriggerLabels) != 0 {
 		t.Fatalf("action = %#v, want no-op", action)
 	}
@@ -17,9 +19,19 @@ func TestAutonomousGraceNotElapsedDoesNothing(t *testing.T) {
 func TestAutonomousGraceElapsedAppliesTrigger(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now)
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now, nil)
 	if len(action.TriggerLabels) != 1 || action.TriggerLabels[0] != "looper:plan" || action.AssignTo != "octocat" {
 		t.Fatalf("action = %#v, want autonomous planner dispatch", action)
+	}
+}
+
+func TestAutonomousGraceElapsedAppliesTriggerWithSatisfiedBlockedByGraph(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
+	graph := depgraph.Build(depgraph.Snapshot{Issues: map[int64]depgraph.IssueSnapshot{1: {Number: 1, BlockedBy: []depgraph.BlockerSnapshot{{Number: 9, State: "closed", StateReason: "completed", Reachable: true}}}}})
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now, graph)
+	if len(action.TriggerLabels) != 1 || action.TriggerLabels[0] != "looper:plan" || action.AssignTo != "octocat" {
+		t.Fatalf("action = %#v, want autonomous planner dispatch with satisfied graph", action)
 	}
 }
 
@@ -28,7 +40,7 @@ func TestAutonomousGraceElapsedAppliesAllPlannerTriggersWhenConfigured(t *testin
 	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
 	cfg := autonomousConfig()
 	cfg.PlannerTriggerLabels = []string{"looper:plan", "team:planner"}
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-31 * time.Minute)}, cfg, now)
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-31 * time.Minute)}, cfg, now, nil)
 	if len(action.TriggerLabels) != 2 || action.TriggerLabels[0] != "looper:plan" || action.TriggerLabels[1] != "team:planner" {
 		t.Fatalf("action = %#v, want all planner triggers", action)
 	}
@@ -37,7 +49,7 @@ func TestAutonomousGraceElapsedAppliesAllPlannerTriggersWhenConfigured(t *testin
 func TestAutonomousDispatchRemovedDoesNothing(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
-	action := Decide(Issue{Labels: []string{"triaged"}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now)
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged"}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now, nil)
 	if !action.NoOp {
 		t.Fatalf("action = %#v, want no-op", action)
 	}
@@ -46,7 +58,7 @@ func TestAutonomousDispatchRemovedDoesNothing(t *testing.T) {
 func TestAutonomousHoldLabelVetoesDispatch(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan, "looper:hold"}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now)
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan, "looper:hold"}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now, nil)
 	if !action.NoOp {
 		t.Fatalf("action = %#v, want no-op", action)
 	}
@@ -55,9 +67,29 @@ func TestAutonomousHoldLabelVetoesDispatch(t *testing.T) {
 func TestAutonomousTriggerAlreadyPresentVetoesDispatch(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan, "looper:plan"}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now)
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan, "looper:plan"}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now, nil)
 	if !action.NoOp {
 		t.Fatalf("action = %#v, want no-op", action)
+	}
+}
+
+func TestAutonomousUnsatisfiedBlockedByVetoesDispatch(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
+	graph := depgraph.Build(depgraph.Snapshot{Issues: map[int64]depgraph.IssueSnapshot{1: {Number: 1, BlockedBy: []depgraph.BlockerSnapshot{{Number: 9, State: "open", Reachable: true}}}}})
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now, graph)
+	if !action.NoOp || len(action.TriggerLabels) != 0 {
+		t.Fatalf("action = %#v, want blocked_by veto", action)
+	}
+}
+
+func TestAutonomousUnreachableBlockedByVetoesDispatch(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
+	graph := depgraph.Build(depgraph.Snapshot{Issues: map[int64]depgraph.IssueSnapshot{1: {Number: 1, BlockedBy: []depgraph.BlockerSnapshot{{Number: 9, Reachable: false}}}}})
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, TriagedAt: now.Add(-31 * time.Minute)}, autonomousConfig(), now, graph)
+	if !action.NoOp || len(action.TriggerLabels) != 0 {
+		t.Fatalf("action = %#v, want unreachable blocked_by veto", action)
 	}
 }
 

--- a/internal/coordinator/dispatch/dispatch.go
+++ b/internal/coordinator/dispatch/dispatch.go
@@ -1,8 +1,11 @@
 package dispatch
 
 import (
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/nexu-io/looper/internal/coordinator/depgraph"
 )
 
 const (
@@ -53,14 +56,55 @@ type Action struct {
 	FailureCommentBody string
 }
 
-func Decide(issue Issue, cfg Config, now time.Time) Action {
+func Decide(issue Issue, cfg Config, now time.Time, graph *depgraph.DependencyGraph) Action {
 	if cfg.Mode == ModeAutonomous {
-		return decideAutonomous(issue, cfg, now)
+		return decideAutonomous(issue, cfg, now, graph)
 	}
-	return decideHumanGated(issue, cfg)
+	return decideHumanGated(issue, cfg, graph)
 }
 
-func decideHumanGated(issue Issue, cfg Config) Action {
+func NeedsDependencyGate(issue Issue, cfg Config, now time.Time) bool {
+	if cfg.Mode == ModeAutonomous {
+		return autonomousNeedsDependencyGate(issue, cfg, now)
+	}
+	return humanNeedsDependencyGate(issue, cfg)
+}
+
+func humanNeedsDependencyGate(issue Issue, cfg Config) bool {
+	_, command, ok := latestCommandAttempt(issue.Comments, cfg.SlashCommands, cfg.AllowedUsers)
+	if !ok || !hasLabel(issue.Labels, cfg.TriagedLabel) {
+		return false
+	}
+	dispatchLabel, ok := singleDispatchLabel(issue.Labels)
+	if !ok || dispatchLabel != commandDispatchLabel(command) {
+		return false
+	}
+	triggerLabels := triggerLabelsForDispatch(dispatchLabel, cfg)
+	if len(triggerLabels) == 0 {
+		return false
+	}
+	return len(missingLabels(issue.Labels, triggerLabels)) > 0
+}
+
+func autonomousNeedsDependencyGate(issue Issue, cfg Config, now time.Time) bool {
+	if !hasLabel(issue.Labels, cfg.TriagedLabel) {
+		return false
+	}
+	dispatchLabel, ok := singleDispatchLabel(issue.Labels)
+	if !ok {
+		return false
+	}
+	triggerLabels := triggerLabelsForDispatch(dispatchLabel, cfg)
+	if len(triggerLabels) == 0 || hasLabel(issue.Labels, strings.TrimSpace(cfg.HoldLabel)) || len(missingLabels(issue.Labels, triggerLabels)) == 0 {
+		return false
+	}
+	if issue.TriagedAt.IsZero() || now.UTC().Before(issue.TriagedAt.UTC().Add(cfg.AutonomousDelay)) {
+		return false
+	}
+	return true
+}
+
+func decideHumanGated(issue Issue, cfg Config, graph *depgraph.DependencyGraph) Action {
 	comment, command, ok := latestCommandAttempt(issue.Comments, cfg.SlashCommands, cfg.AllowedUsers)
 	if !ok {
 		return Action{NoOp: true}
@@ -89,6 +133,9 @@ func decideHumanGated(issue Issue, cfg Config) Action {
 		action.ReactionContent = ReactionSuccess
 		return action
 	}
+	if blockers := graph.Unsatisfied(issue.Number); len(blockers) > 0 {
+		return fail(action, dependencyFailureBody(blockers))
+	}
 
 	action.AssignTo = strings.TrimSpace(cfg.AssignTo)
 	action.TriggerLabels = missingLabels
@@ -96,7 +143,7 @@ func decideHumanGated(issue Issue, cfg Config) Action {
 	return action
 }
 
-func decideAutonomous(issue Issue, cfg Config, now time.Time) Action {
+func decideAutonomous(issue Issue, cfg Config, now time.Time, graph *depgraph.DependencyGraph) Action {
 	if !hasLabel(issue.Labels, cfg.TriagedLabel) {
 		return Action{NoOp: true}
 	}
@@ -112,6 +159,9 @@ func decideAutonomous(issue Issue, cfg Config, now time.Time) Action {
 		return Action{NoOp: true}
 	}
 	if issue.TriagedAt.IsZero() || now.UTC().Before(issue.TriagedAt.UTC().Add(cfg.AutonomousDelay)) {
+		return Action{NoOp: true}
+	}
+	if len(graph.Unsatisfied(issue.Number)) > 0 {
 		return Action{NoOp: true}
 	}
 	return Action{AssignTo: strings.TrimSpace(cfg.AssignTo), TriggerLabels: missingLabels(issue.Labels, triggerLabels)}
@@ -260,4 +310,33 @@ func hasLabel(labels []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func dependencyFailureBody(blockers []depgraph.Blocker) string {
+	lines := []string{"Coordinator can't dispatch because blocked_by is still unsatisfied:"}
+	for _, blocker := range blockers {
+		lines = append(lines, fmt.Sprintf("- %s (%s)", blockerReference(blocker), blockerStateReason(blocker)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func blockerReference(blocker depgraph.Blocker) string {
+	repo := strings.TrimSpace(blocker.Repo)
+	if repo != "" {
+		return fmt.Sprintf("%s#%d", repo, blocker.Number)
+	}
+	return fmt.Sprintf("#%d", blocker.Number)
+}
+
+func blockerStateReason(blocker depgraph.Blocker) string {
+	if !blocker.Reachable {
+		return "unreachable"
+	}
+	if reason := strings.TrimSpace(blocker.StateReason); reason != "" {
+		return reason
+	}
+	if state := strings.TrimSpace(blocker.State); state != "" {
+		return state
+	}
+	return "unknown"
 }

--- a/internal/coordinator/dispatch/human_test.go
+++ b/internal/coordinator/dispatch/human_test.go
@@ -1,13 +1,16 @@
 package dispatch
 
 import (
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/nexu-io/looper/internal/coordinator/depgraph"
 )
 
 func TestHumanGatedPlanByAllowedUserAppliesPlannerTrigger(t *testing.T) {
 	t.Parallel()
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 41, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 41, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now(), nil)
 	if len(action.TriggerLabels) != 1 || action.TriggerLabels[0] != "looper:plan" || action.AssignTo != "octocat" || action.ReactionCommentID != 41 || action.ReactionContent != ReactionSuccess {
 		t.Fatalf("action = %#v, want planner dispatch with success reaction", action)
 	}
@@ -15,7 +18,7 @@ func TestHumanGatedPlanByAllowedUserAppliesPlannerTrigger(t *testing.T) {
 
 func TestHumanGatedImplementAppliesWorkerTrigger(t *testing.T) {
 	t.Parallel()
-	action := Decide(Issue{Labels: []string{"triaged", DispatchImplement}, Comments: []Comment{{ID: 42, Author: "octo", HasWriteAccess: true, Body: "/implement"}}}, testConfig(), time.Now())
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchImplement}, Comments: []Comment{{ID: 42, Author: "octo", HasWriteAccess: true, Body: "/implement"}}}, testConfig(), time.Now(), nil)
 	if len(action.TriggerLabels) != 1 || action.TriggerLabels[0] != "looper:worker-ready" || action.ReactionContent != ReactionSuccess {
 		t.Fatalf("action = %#v, want worker dispatch with success reaction", action)
 	}
@@ -23,7 +26,7 @@ func TestHumanGatedImplementAppliesWorkerTrigger(t *testing.T) {
 
 func TestHumanGatedPlanMidLineDoesNothing(t *testing.T) {
 	t.Parallel()
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 43, Author: "octo", HasWriteAccess: true, Body: "please /plan this"}}}, testConfig(), time.Now())
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 43, Author: "octo", HasWriteAccess: true, Body: "please /plan this"}}}, testConfig(), time.Now(), nil)
 	if !action.NoOp || action.ReactionCommentID != 0 || len(action.TriggerLabels) != 0 {
 		t.Fatalf("action = %#v, want no-op", action)
 	}
@@ -31,7 +34,7 @@ func TestHumanGatedPlanMidLineDoesNothing(t *testing.T) {
 
 func TestHumanGatedPlanFromNonAllowedUserDoesNothing(t *testing.T) {
 	t.Parallel()
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 44, Author: "outsider", Body: "/plan"}}}, testConfig(), time.Now())
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 44, Author: "outsider", Body: "/plan"}}}, testConfig(), time.Now(), nil)
 	if !action.NoOp || action.ReactionCommentID != 0 {
 		t.Fatalf("action = %#v, want no-op", action)
 	}
@@ -39,10 +42,10 @@ func TestHumanGatedPlanFromNonAllowedUserDoesNothing(t *testing.T) {
 
 func TestHumanGatedSkipsNewerUnauthorizedCommandAttempt(t *testing.T) {
 	t.Parallel()
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{
 		{ID: 44, Author: "octo", HasWriteAccess: true, Body: "/plan"},
 		{ID: 45, Author: "outsider", Body: "/implement"},
-	}}, testConfig(), time.Now())
+	}}, testConfig(), time.Now(), nil)
 	if len(action.TriggerLabels) != 1 || action.TriggerLabels[0] != "looper:plan" || action.AssignTo != "octocat" || action.ReactionCommentID != 44 || action.ReactionContent != ReactionSuccess {
 		t.Fatalf("action = %#v, want latest authorized command to dispatch", action)
 	}
@@ -50,7 +53,7 @@ func TestHumanGatedSkipsNewerUnauthorizedCommandAttempt(t *testing.T) {
 
 func TestHumanGatedTriggerAlreadyPresentIsIdempotent(t *testing.T) {
 	t.Parallel()
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan, "looper:plan"}, Comments: []Comment{{ID: 45, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan, "looper:plan"}, Comments: []Comment{{ID: 45, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now(), nil)
 	if !action.NoOp || len(action.TriggerLabels) != 0 || action.ReactionContent != ReactionSuccess || action.ReactionCommentID != 45 {
 		t.Fatalf("action = %#v, want idempotent success ack", action)
 	}
@@ -58,7 +61,7 @@ func TestHumanGatedTriggerAlreadyPresentIsIdempotent(t *testing.T) {
 
 func TestHumanGatedMissingTriagedFails(t *testing.T) {
 	t.Parallel()
-	action := Decide(Issue{Labels: []string{DispatchPlan}, Comments: []Comment{{ID: 46, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
+	action := Decide(Issue{Number: 1, Labels: []string{DispatchPlan}, Comments: []Comment{{ID: 46, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now(), nil)
 	if action.ReactionContent != ReactionFailure || action.FailureCommentBody == "" || len(action.TriggerLabels) != 0 {
 		t.Fatalf("action = %#v, want failure reaction with comment", action)
 	}
@@ -68,7 +71,7 @@ func TestHumanGatedPlanAppliesAllPlannerTriggersWhenConfigured(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig()
 	cfg.PlannerTriggerLabels = []string{"looper:plan", "team:planner"}
-	action := Decide(Issue{Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 48, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, cfg, time.Now())
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 48, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, cfg, time.Now(), nil)
 	if len(action.TriggerLabels) != 2 || action.TriggerLabels[0] != "looper:plan" || action.TriggerLabels[1] != "team:planner" {
 		t.Fatalf("action = %#v, want all planner triggers", action)
 	}
@@ -76,10 +79,37 @@ func TestHumanGatedPlanAppliesAllPlannerTriggersWhenConfigured(t *testing.T) {
 
 func TestHumanGatedMissingDispatchFails(t *testing.T) {
 	t.Parallel()
-	action := Decide(Issue{Labels: []string{"triaged"}, Comments: []Comment{{ID: 47, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now())
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged"}, Comments: []Comment{{ID: 47, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now(), nil)
 	if action.ReactionContent != ReactionFailure || action.FailureCommentBody == "" {
 		t.Fatalf("action = %#v, want failure reaction with comment", action)
 	}
+}
+
+func TestHumanGatedBlockedByUnsatisfiedFails(t *testing.T) {
+	t.Parallel()
+	graph := depgraph.Build(depgraph.Snapshot{Issues: map[int64]depgraph.IssueSnapshot{1: {Number: 1, BlockedBy: []depgraph.BlockerSnapshot{{Number: 9, State: "open", Reachable: true}}}}})
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 49, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now(), graph)
+	if action.ReactionContent != ReactionFailure || action.FailureCommentBody == "" || !containsAllText(action.FailureCommentBody, "#9", "open") {
+		t.Fatalf("action = %#v, want blocked_by failure comment", action)
+	}
+}
+
+func TestHumanGatedBlockedBySatisfiedStillDispatches(t *testing.T) {
+	t.Parallel()
+	graph := depgraph.Build(depgraph.Snapshot{Issues: map[int64]depgraph.IssueSnapshot{1: {Number: 1, BlockedBy: []depgraph.BlockerSnapshot{{Number: 9, State: "closed", StateReason: "completed", Reachable: true}}}}})
+	action := Decide(Issue{Number: 1, Labels: []string{"triaged", DispatchPlan}, Comments: []Comment{{ID: 50, Author: "octo", HasWriteAccess: true, Body: "/plan"}}}, testConfig(), time.Now(), graph)
+	if len(action.TriggerLabels) != 1 || action.TriggerLabels[0] != "looper:plan" || action.ReactionContent != ReactionSuccess {
+		t.Fatalf("action = %#v, want successful dispatch", action)
+	}
+}
+
+func containsAllText(value string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(value, part) {
+			return false
+		}
+	}
+	return true
 }
 
 func testConfig() Config {

--- a/internal/coordinator/runner.go
+++ b/internal/coordinator/runner.go
@@ -6,12 +6,14 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/nexu-io/looper/internal/bootstrap"
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/coordinator/depgraph"
 	"github.com/nexu-io/looper/internal/coordinator/dispatch"
 	"github.com/nexu-io/looper/internal/coordinator/triage"
 	"github.com/nexu-io/looper/internal/disclosure"
@@ -40,11 +42,19 @@ type IssueSummary struct {
 	Labels []string
 }
 
+type loadedCoordinatorIssue struct {
+	summary       githubinfra.IssueSummary
+	issue         triage.Issue
+	dispatchIssue dispatch.Issue
+}
+
 type GitHubGateway interface {
 	ListOpenIssues(context.Context, githubinfra.ListOpenIssuesInput) ([]githubinfra.IssueSummary, error)
 	ViewIssue(context.Context, githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error)
 	ListIssueComments(context.Context, githubinfra.ViewIssueInput) ([]githubinfra.CommentInfo, error)
 	ListIssueTimeline(context.Context, githubinfra.IssueTimelineInput) ([]map[string]any, error)
+	ListIssueBlockedBy(context.Context, githubinfra.ListIssueBlockedByInput) ([]githubinfra.IssueDependency, error)
+	GetIssueState(context.Context, githubinfra.ViewIssueInput) (githubinfra.IssueState, error)
 	GetCurrentUserLogin(context.Context, string) (string, error)
 	GetCurrentUserLoginForRepo(context.Context, string, string) (string, error)
 	GetRepositoryPermission(context.Context, githubinfra.RepositoryPermissionInput) (string, error)
@@ -131,7 +141,55 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 	}
 	triageCfg := roleConfigToTriageConfig(roleCfg)
 	dispatchCfg := roleConfigToDispatchConfig(roleCfg, config.ProjectRoleConfigs(*r.config, input.ProjectID))
-	processed := 0
+	if !roleCfg.Dependencies.Enabled {
+		processed := 0
+		for _, summary := range issues {
+			if ShouldSkipIssue(IssueSummary{Number: summary.Number, Labels: summary.Labels}, roleCfg, sweeperCfg) {
+				continue
+			}
+			issue, err := r.loadIssue(ctx, input.Repo, project.RepoPath, summary.Number)
+			if err != nil {
+				return DiscoveryResult{}, err
+			}
+			dispatchIssue, err := r.dispatchIssue(ctx, input.Repo, project.RepoPath, issue, triageCfg.TriagedLabel, dispatchCfg)
+			if err != nil {
+				return DiscoveryResult{}, err
+			}
+			dispatchAction := dispatch.Decide(dispatchIssue, dispatchCfg, r.now().UTC(), nil)
+			if r.hasDispatchWork(dispatchAction) {
+				if err := r.applyDispatchAction(ctx, input.Repo, project.RepoPath, issue, dispatchAction); err != nil {
+					return DiscoveryResult{}, err
+				}
+				if strings.TrimSpace(dispatchAction.FailureCommentBody) == "" {
+					continue
+				}
+			}
+			if processed >= triageCfg.MaxPerTick {
+				continue
+			}
+			if !mightNeedCoordinatorAction(summary, triageCfg) {
+				continue
+			}
+			if !triage.ShouldReTriage(issue, triageCfg, r.now().UTC()) && !triage.ShouldTriage(issue, triageCfg, r.now().UTC()) {
+				continue
+			}
+			analysisStartedAt := r.now().UTC()
+			processed++
+			decision, err := r.decide(ctx, project.RepoPath, input.Repo, issue, triageCfg)
+			if err != nil {
+				return DiscoveryResult{}, err
+			}
+			if decision.NoOp {
+				continue
+			}
+			if err := r.applyDecision(ctx, input.Repo, project.RepoPath, issue, triageCfg, analysisStartedAt, decision); err != nil {
+				return DiscoveryResult{}, err
+			}
+		}
+		return DiscoveryResult{Ticked: true}, nil
+	}
+	tickNow := r.now().UTC()
+	loaded := make([]loadedCoordinatorIssue, 0, len(issues))
 	for _, summary := range issues {
 		if ShouldSkipIssue(IssueSummary{Number: summary.Number, Labels: summary.Labels}, roleCfg, sweeperCfg) {
 			continue
@@ -144,9 +202,17 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
-		dispatchAction := dispatch.Decide(dispatchIssue, dispatchCfg, r.now().UTC())
+		loaded = append(loaded, loadedCoordinatorIssue{summary: summary, issue: issue, dispatchIssue: dispatchIssue})
+	}
+	graph, err := r.buildDispatchDependencyGraph(ctx, input.Repo, project.RepoPath, roleCfg.Dependencies, dispatchCfg, loaded, tickNow)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	processed := 0
+	for _, loadedIssue := range loaded {
+		dispatchAction := dispatch.Decide(loadedIssue.dispatchIssue, dispatchCfg, tickNow, graph)
 		if r.hasDispatchWork(dispatchAction) {
-			if err := r.applyDispatchAction(ctx, input.Repo, project.RepoPath, issue, dispatchAction); err != nil {
+			if err := r.applyDispatchAction(ctx, input.Repo, project.RepoPath, loadedIssue.issue, dispatchAction); err != nil {
 				return DiscoveryResult{}, err
 			}
 			if strings.TrimSpace(dispatchAction.FailureCommentBody) == "" {
@@ -156,26 +222,123 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 		if processed >= triageCfg.MaxPerTick {
 			continue
 		}
-		if !mightNeedCoordinatorAction(summary, triageCfg) {
+		if !mightNeedCoordinatorAction(loadedIssue.summary, triageCfg) {
 			continue
 		}
-		if !triage.ShouldReTriage(issue, triageCfg, r.now().UTC()) && !triage.ShouldTriage(issue, triageCfg, r.now().UTC()) {
+		if !triage.ShouldReTriage(loadedIssue.issue, triageCfg, r.now().UTC()) && !triage.ShouldTriage(loadedIssue.issue, triageCfg, r.now().UTC()) {
 			continue
 		}
 		analysisStartedAt := r.now().UTC()
 		processed++
-		decision, err := r.decide(ctx, project.RepoPath, input.Repo, issue, triageCfg)
+		decision, err := r.decide(ctx, project.RepoPath, input.Repo, loadedIssue.issue, triageCfg)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
 		if decision.NoOp {
 			continue
 		}
-		if err := r.applyDecision(ctx, input.Repo, project.RepoPath, issue, triageCfg, analysisStartedAt, decision); err != nil {
+		if err := r.applyDecision(ctx, input.Repo, project.RepoPath, loadedIssue.issue, triageCfg, analysisStartedAt, decision); err != nil {
 			return DiscoveryResult{}, err
 		}
 	}
 	return DiscoveryResult{Ticked: true}, nil
+}
+
+func (r *Runner) buildDispatchDependencyGraph(ctx context.Context, repo, cwd string, depsCfg config.CoordinatorDependenciesConfig, dispatchCfg dispatch.Config, loaded []loadedCoordinatorIssue, now time.Time) (*depgraph.DependencyGraph, error) {
+	if !depsCfg.Enabled {
+		return nil, nil
+	}
+	candidates := dispatchDependencyCandidates(loaded, dispatchCfg, now)
+	if len(candidates) == 0 {
+		return depgraph.Build(depgraph.Snapshot{Issues: map[int64]depgraph.IssueSnapshot{}}), nil
+	}
+	snapshot := depgraph.Snapshot{Issues: make(map[int64]depgraph.IssueSnapshot, len(candidates))}
+	for _, issueNumber := range candidates {
+		blockedBy, err := r.listIssueBlockedByWithRetry(ctx, repo, cwd, issueNumber, depsCfg)
+		if err != nil {
+			return nil, err
+		}
+		issueSnapshot := depgraph.IssueSnapshot{Number: issueNumber, BlockedBy: make([]depgraph.BlockerSnapshot, 0, len(blockedBy))}
+		for _, blocker := range blockedBy {
+			issueSnapshot.BlockedBy = append(issueSnapshot.BlockedBy, r.loadBlockerSnapshot(ctx, cwd, blocker, depsCfg))
+		}
+		snapshot.Issues[issueNumber] = issueSnapshot
+	}
+	return depgraph.Build(snapshot), nil
+}
+
+func dispatchDependencyCandidates(loaded []loadedCoordinatorIssue, cfg dispatch.Config, now time.Time) []int64 {
+	set := map[int64]struct{}{}
+	for _, loadedIssue := range loaded {
+		if !dispatch.NeedsDependencyGate(loadedIssue.dispatchIssue, cfg, now) {
+			continue
+		}
+		set[loadedIssue.issue.Number] = struct{}{}
+	}
+	out := make([]int64, 0, len(set))
+	for issueNumber := range set {
+		out = append(out, issueNumber)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+func (r *Runner) listIssueBlockedByWithRetry(ctx context.Context, repo, cwd string, issueNumber int64, depsCfg config.CoordinatorDependenciesConfig) ([]githubinfra.IssueDependency, error) {
+	var lastErr error
+	attempts := maxDependencyAttempts(depsCfg.APIRetryAttempts)
+	for attempt := 0; attempt < attempts; attempt++ {
+		callCtx, cancel := context.WithTimeout(ctx, dependencyTimeout(depsCfg.APITimeoutSeconds))
+		blockedBy, err := r.github.ListIssueBlockedBy(callCtx, githubinfra.ListIssueBlockedByInput{Repo: repo, IssueNumber: issueNumber, CWD: cwd})
+		cancel()
+		if err == nil {
+			return blockedBy, nil
+		}
+		lastErr = err
+		if !shouldRetryDependencyError(err) {
+			return nil, err
+		}
+	}
+	return nil, lastErr
+}
+
+func (r *Runner) loadBlockerSnapshot(ctx context.Context, cwd string, blocker githubinfra.IssueDependency, depsCfg config.CoordinatorDependenciesConfig) depgraph.BlockerSnapshot {
+	var lastErr error
+	attempts := maxDependencyAttempts(depsCfg.APIRetryAttempts)
+	for attempt := 0; attempt < attempts; attempt++ {
+		callCtx, cancel := context.WithTimeout(ctx, dependencyTimeout(depsCfg.APITimeoutSeconds))
+		state, err := r.github.GetIssueState(callCtx, githubinfra.ViewIssueInput{Repo: blocker.Repo, IssueNumber: blocker.Number, CWD: cwd})
+		cancel()
+		if err == nil {
+			return depgraph.BlockerSnapshot{Number: blocker.Number, Repo: blocker.Repo, State: strings.ToLower(strings.TrimSpace(state.State)), StateReason: strings.ToLower(strings.TrimSpace(state.StateReason)), Reachable: true}
+		}
+		lastErr = err
+		if !shouldRetryDependencyError(err) {
+			break
+		}
+	}
+	_ = lastErr
+	return depgraph.BlockerSnapshot{Number: blocker.Number, Repo: blocker.Repo, Reachable: false}
+}
+
+func dependencyTimeout(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 10 * time.Second
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func maxDependencyAttempts(attempts int) int {
+	if attempts <= 0 {
+		return 1
+	}
+	return attempts
+}
+
+func shouldRetryDependencyError(err error) bool {
+	if githubinfra.IsTransientError(err) {
+		return true
+	}
+	message := strings.ToLower(githubinfra.ErrorMessage(err))
+	return strings.Contains(message, "timed out") || strings.Contains(message, "context deadline exceeded")
 }
 
 func (r *Runner) hasDispatchWork(action dispatch.Action) bool {

--- a/internal/coordinator/runner_actions_test.go
+++ b/internal/coordinator/runner_actions_test.go
@@ -436,6 +436,7 @@ func newCoordinatorFixture(t *testing.T) coordinatorFixture {
 	cfg.Disclosure.Enabled = true
 	cfg.Disclosure.Channels.IssueComment = true
 	github := &stubCoordinatorGitHub{details: map[int64]githubinfra.IssueDetail{}, comments: map[int64][][]githubinfra.CommentInfo{}, timeline: map[int64][]map[string]any{}}
+	github.blockedBy = map[int64][]githubinfra.IssueDependency{}
 	runner := New(Options{Repos: repos, GitHub: github, Config: &cfg, Now: func() time.Time { return now }, TriageLLM: stubCoordinatorLLM{}, Inspector: stubCoordinatorInspector{}})
 	return coordinatorFixture{runner: runner, github: github, cfg: &cfg, projectID: projectID, now: now, coord: coord}
 }
@@ -459,16 +460,18 @@ func (stubCoordinatorInspector) Inspect(context.Context, string, triage.Issue) (
 }
 
 type stubCoordinatorGitHub struct {
-	issues        []githubinfra.IssueSummary
-	details       map[int64]githubinfra.IssueDetail
-	comments      map[int64][][]githubinfra.CommentInfo
-	timeline      map[int64][]map[string]any
-	permissionErr error
-	ops           []string
-	createdBodies []string
-	updatedBodies []string
-	commentReads  map[int64]int
-	failAddLabels map[string]error
+	issues         []githubinfra.IssueSummary
+	details        map[int64]githubinfra.IssueDetail
+	comments       map[int64][][]githubinfra.CommentInfo
+	timeline       map[int64][]map[string]any
+	blockedBy      map[int64][]githubinfra.IssueDependency
+	blockedByReads int
+	permissionErr  error
+	ops            []string
+	createdBodies  []string
+	updatedBodies  []string
+	commentReads   map[int64]int
+	failAddLabels  map[string]error
 }
 
 func (s *stubCoordinatorGitHub) ListOpenIssues(context.Context, githubinfra.ListOpenIssuesInput) ([]githubinfra.IssueSummary, error) {
@@ -476,6 +479,10 @@ func (s *stubCoordinatorGitHub) ListOpenIssues(context.Context, githubinfra.List
 }
 func (s *stubCoordinatorGitHub) ViewIssue(_ context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
 	return s.details[input.IssueNumber], nil
+}
+func (s *stubCoordinatorGitHub) GetIssueState(_ context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueState, error) {
+	detail := s.details[input.IssueNumber]
+	return githubinfra.IssueState{State: detail.State, StateReason: detail.StateReason}, nil
 }
 func (s *stubCoordinatorGitHub) ListIssueComments(_ context.Context, input githubinfra.ViewIssueInput) ([]githubinfra.CommentInfo, error) {
 	if s.commentReads == nil {
@@ -491,6 +498,10 @@ func (s *stubCoordinatorGitHub) ListIssueComments(_ context.Context, input githu
 	}
 	s.commentReads[input.IssueNumber]++
 	return append([]githubinfra.CommentInfo(nil), batches[reads]...), nil
+}
+func (s *stubCoordinatorGitHub) ListIssueBlockedBy(_ context.Context, input githubinfra.ListIssueBlockedByInput) ([]githubinfra.IssueDependency, error) {
+	s.blockedByReads++
+	return append([]githubinfra.IssueDependency(nil), s.blockedBy[input.IssueNumber]...), nil
 }
 func (s *stubCoordinatorGitHub) GetCurrentUserLogin(context.Context, string) (string, error) {
 	return "looper", nil
@@ -540,6 +551,64 @@ func (s *stubCoordinatorGitHub) UpdateIssueComment(_ context.Context, input gith
 	s.ops = append(s.ops, "update-comment")
 	s.updatedBodies = append(s.updatedBodies, input.Body)
 	return nil
+}
+
+func TestRunnerHumanDispatchBlockedByPostsFailureComment(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Coordinator.Dependencies.Enabled = true
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged", "dispatch/plan"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339), Labels: []string{"triaged", "dispatch/plan"}, Comments: []githubinfra.CommentInfo{{ID: 11, Author: "octo", AuthorAssociation: "MEMBER", Body: "/plan", CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	fixture.github.details[9] = githubinfra.IssueDetail{Number: 9, State: "open"}
+	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{{ID: 11, Author: "octo", AuthorAssociation: "MEMBER", Body: "/plan", CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	fixture.github.timeline[1] = []map[string]any{{"event": "labeled", "created_at": fixture.now.Add(-time.Hour).Format(time.RFC3339), "label": map[string]any{"name": "triaged"}}}
+	fixture.github.blockedBy[1] = []githubinfra.IssueDependency{{Number: 9, Repo: "acme/looper"}}
+
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	assertOrderedOps(t, fixture.github.ops, []string{"create-comment", "react:confused:11"})
+	if len(fixture.github.createdBodies) != 1 || !containsAll(fixture.github.createdBodies[0], dispatchFailureCommentMarker, "#9", "open") {
+		t.Fatalf("createdBodies = %v, want blocked_by failure comment", fixture.github.createdBodies)
+	}
+}
+
+func TestRunnerAutonomousDispatchBlockedByVetoesSilently(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Coordinator.Dispatch.Mode = "autonomous"
+	fixture.runner.config.Roles.Coordinator.Dependencies.Enabled = true
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged", "dispatch/plan"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Add(-2 * time.Hour).Format(time.RFC3339), Labels: []string{"triaged", "dispatch/plan"}}
+	fixture.github.details[9] = githubinfra.IssueDetail{Number: 9, State: "open"}
+	fixture.github.timeline[1] = []map[string]any{{"event": "labeled", "created_at": fixture.now.Add(-time.Hour).Format(time.RFC3339), "label": map[string]any{"name": "triaged"}}}
+	fixture.github.blockedBy[1] = []githubinfra.IssueDependency{{Number: 9, Repo: "acme/looper"}}
+
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(fixture.github.ops) != 0 {
+		t.Fatalf("ops = %v, want no autonomous dispatch side effects", fixture.github.ops)
+	}
+}
+
+func TestRunnerDispatchSkipsDependencyAPIsWhenDisabled(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged", "dispatch/plan"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{Number: 1, Title: "Bug", Author: "octo", CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339), Labels: []string{"triaged", "dispatch/plan"}, Comments: []githubinfra.CommentInfo{{ID: 11, Author: "octo", AuthorAssociation: "MEMBER", Body: "/plan", CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	fixture.github.comments[1] = [][]githubinfra.CommentInfo{{{ID: 11, Author: "octo", AuthorAssociation: "MEMBER", Body: "/plan", CreatedAt: fixture.now.Format(time.RFC3339)}}}
+	fixture.github.timeline[1] = []map[string]any{{"event": "labeled", "created_at": fixture.now.Add(-time.Hour).Format(time.RFC3339), "label": map[string]any{"name": "triaged"}}}
+
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if fixture.github.blockedByReads != 0 {
+		t.Fatalf("blocked_by reads = %d, want 0 when dependencies are disabled", fixture.github.blockedByReads)
+	}
 }
 
 func joinLabels(labels []string) string {

--- a/internal/coordinator/runner_integration_test.go
+++ b/internal/coordinator/runner_integration_test.go
@@ -154,6 +154,67 @@ func TestCoordinatorAutonomousDispatchWithFakeGH(t *testing.T) {
 	}
 }
 
+func TestCoordinatorAutonomousDispatchWaitsForBlockedByCompletionWithFakeGH(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	fakeGH := harness.NewFakeGH(t, bins, harness.GHSchema{JSONFieldAllowlist: map[string][]string{"issue list": {"number", "title", "body", "url", "state", "updatedAt", "author", "assignees", "labels"}}})
+	for key, value := range fakeGH.EnvMap() {
+		t.Setenv(key, value)
+	}
+
+	writeBlockedByState := func(blockerState, blockerStateReason string) {
+		stateReasonField := `"state_reason":null`
+		if blockerStateReason != "" {
+			stateReasonField = `"state_reason":"` + blockerStateReason + `"`
+		}
+		fakeGH.WriteState(t, harness.GHState{Commands: map[string]any{"issue list": map[string]any{"stdout": json.RawMessage(`[{"number":1,"title":"A","body":"done first","url":"https://example.test/issues/1","state":"open","updatedAt":"2026-05-14T12:00:00Z","author":{"login":"octo"},"assignees":[],"labels":[{"name":"triaged"},{"name":"dispatch/plan"}]},{"number":2,"title":"B","body":"blocked","url":"https://example.test/issues/2","state":"open","updatedAt":"2026-05-14T12:00:00Z","author":{"login":"octo"},"assignees":[],"labels":[{"name":"triaged"},{"name":"dispatch/plan"}]}]`)}, "label create": map[string]any{"stdout": json.RawMessage(`{}`)}}, Routes: map[string]any{
+			"repos/acme/looper/issues/1":                         json.RawMessage(`{"number":1,"title":"A","body":"done first","html_url":"https://example.test/issues/1","state":"` + blockerState + `",` + stateReasonField + `,"created_at":"2026-05-14T09:00:00Z","updated_at":"2026-05-14T12:00:00Z","user":{"login":"octo"},"labels":[{"name":"triaged"},{"name":"dispatch/plan"}]}`),
+			"repos/acme/looper/issues/1/comments":                json.RawMessage(`[[]]`),
+			"repos/acme/looper/issues/1/timeline":                json.RawMessage(`[[{"event":"labeled","created_at":"2026-05-14T10:00:00Z","label":{"name":"triaged"}}]]`),
+			"repos/acme/looper/issues/1/dependencies/blocked_by": json.RawMessage(`[[]]`),
+			"repos/acme/looper/issues/2":                         json.RawMessage(`{"number":2,"title":"B","body":"blocked","html_url":"https://example.test/issues/2","state":"open","created_at":"2026-05-14T09:00:00Z","updated_at":"2026-05-14T12:00:00Z","user":{"login":"octo"},"labels":[{"name":"triaged"},{"name":"dispatch/plan"}]}`),
+			"repos/acme/looper/issues/2/comments":                json.RawMessage(`[[]]`),
+			"repos/acme/looper/issues/2/timeline":                json.RawMessage(`[[{"event":"labeled","created_at":"2026-05-14T10:00:00Z","label":{"name":"triaged"}}]]`),
+			"repos/acme/looper/issues/2/dependencies/blocked_by": json.RawMessage(`[[{"number":1,"repository":{"full_name":"acme/looper"}}]]`),
+		}})
+	}
+
+	coord, repos, cfg, repoPath, now := coordinatorFakeGHFixture(t)
+	_ = coord
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.Dispatch.Mode = "autonomous"
+	cfg.Roles.Coordinator.Dispatch.AssignTo = "octocat"
+	cfg.Roles.Coordinator.Dependencies.Enabled = true
+	gateway := githubinfra.New(githubinfra.Options{GHPath: fakeGH.Path, CWD: repoPath, Now: func() time.Time { return now }})
+	runner := New(Options{Repos: repos, GitHub: gateway, Config: &cfg, Now: func() time.Time { return now }, TriageLLM: stubCoordinatorLLM{}, Inspector: stubCoordinatorInspector{}})
+
+	writeBlockedByState("open", "")
+	if _, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "demo", Repo: "acme/looper"}); err != nil {
+		logBytes, _ := os.ReadFile(fakeGH.InvocationLog)
+		t.Fatalf("DiscoverIssues() tick1 error = %v\ninvocations:\n%s", err, string(logBytes))
+	}
+	logBytes, err := os.ReadFile(fakeGH.InvocationLog)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation log) error = %v", err)
+	}
+	if strings.Contains(string(logBytes), `"argv":["api","repos/acme/looper/issues/2/labels","--method","POST","-f","labels[]=looper:plan"]`) {
+		t.Fatal("blocked issue dispatched before blocker completed")
+	}
+
+	writeBlockedByState("closed", "completed")
+	runner.now = func() time.Time { return now.Add(10 * time.Minute) }
+	if _, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "demo", Repo: "acme/looper"}); err != nil {
+		logBytes, _ := os.ReadFile(fakeGH.InvocationLog)
+		t.Fatalf("DiscoverIssues() tick2 error = %v\ninvocations:\n%s", err, string(logBytes))
+	}
+	logBytes, err = os.ReadFile(fakeGH.InvocationLog)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation log) error = %v", err)
+	}
+	if !strings.Contains(string(logBytes), `"argv":["api","repos/acme/looper/issues/2/labels","--method","POST","-f","labels[]=looper:plan"]`) {
+		t.Fatal("blocked issue did not dispatch after blocker completed")
+	}
+}
+
 func coordinatorFakeGHFixture(t *testing.T) (*storage.SQLiteCoordinator, *storage.Repositories, config.Config, string, time.Time) {
 	t.Helper()
 	coord, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(t.TempDir(), "coordinator.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})

--- a/internal/infra/github/errors.go
+++ b/internal/infra/github/errors.go
@@ -71,6 +71,18 @@ func IsPullRequestNotFoundError(err error) bool {
 	return isPullRequestNotFoundMessage(err.Error())
 }
 
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var commandErr *shell.CommandExecutionError
+	if errors.As(err, &commandErr) {
+		message := strings.ToLower(strings.Join([]string{commandErr.Message, commandErr.Result.Stdout, commandErr.Result.Stderr}, "\n"))
+		return strings.Contains(message, "http 404") || strings.Contains(message, " 404")
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "404")
+}
+
 func nonEmptyStrings(values ...string) []string {
 	out := make([]string, 0, len(values))
 	for _, value := range values {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -784,7 +784,7 @@ func (g *Gateway) ListIssueBlockedBy(ctx context.Context, input ListIssueBlocked
 
 func (g *Gateway) FindAnyIssueNumber(ctx context.Context, repo string, cwd string) (int64, error) {
 	hostname, repoName := splitRepoHostname(repo)
-	for page := 1; page <= 5; page++ {
+	for page := 1; ; page++ {
 		args := []string{"api", fmt.Sprintf("repos/%s/issues?state=all&per_page=100&page=%d", repoName, page)}
 		if hostname != "" {
 			args = append(args, "--hostname", hostname)
@@ -2513,7 +2513,7 @@ func dependencyRepo(value any, repositoryURL string, fallback string) string {
 func hostQualifiedRepo(nameWithOwner string, repoURL string) string {
 	repo := strings.TrimSpace(nameWithOwner)
 	parsed, err := url.Parse(strings.TrimSpace(repoURL))
-	if err != nil || parsed.Hostname() == "" || parsed.Hostname() == "github.com" {
+	if err != nil || parsed.Hostname() == "" || parsed.Hostname() == "github.com" || parsed.Hostname() == "api.github.com" {
 		return repo
 	}
 	return parsed.Hostname() + "/" + repo

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -128,6 +128,19 @@ type RepositoryPermissionInput struct {
 	User string
 	CWD  string
 }
+type ListIssueBlockedByInput struct {
+	Repo        string
+	IssueNumber int64
+	CWD         string
+}
+type IssueDependency struct {
+	Number int64
+	Repo   string
+}
+type IssueState struct {
+	State       string
+	StateReason string
+}
 type LinkedPullRequestsInput struct {
 	Repo        string
 	IssueNumber int64
@@ -182,6 +195,7 @@ type IssueDetail struct {
 	Body              string
 	URL               string
 	State             string
+	StateReason       string
 	CreatedAt         string
 	UpdatedAt         string
 	ClosedAt          string
@@ -712,6 +726,7 @@ func (g *Gateway) ViewIssue(ctx context.Context, input ViewIssueInput) (IssueDet
 		Body:              asString(row["body"]),
 		URL:               firstNonEmpty(asString(row["html_url"]), asString(row["url"])),
 		State:             asString(row["state"]),
+		StateReason:       firstNonEmpty(asString(row["state_reason"]), asString(row["stateReason"])),
 		CreatedAt:         firstNonEmpty(asString(row["created_at"]), asString(row["createdAt"])),
 		UpdatedAt:         firstNonEmpty(asString(row["updated_at"]), asString(row["updatedAt"])),
 		ClosedAt:          firstNonEmpty(asString(row["closed_at"]), asString(row["closedAt"])),
@@ -723,6 +738,78 @@ func (g *Gateway) ViewIssue(ctx context.Context, input ViewIssueInput) (IssueDet
 		CommentCount:      len(commentRows),
 		Comments:          extractCommentInfos(commentRows),
 	}, nil
+}
+
+func (g *Gateway) GetIssueState(ctx context.Context, input ViewIssueInput) (IssueState, error) {
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/issues/%d", repo, input.IssueNumber)}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
+	if err != nil {
+		return IssueState{}, err
+	}
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return IssueState{}, err
+	}
+	return IssueState{State: asString(row["state"]), StateReason: firstNonEmpty(asString(row["state_reason"]), asString(row["stateReason"]))}, nil
+}
+
+func (g *Gateway) ListIssueBlockedBy(ctx context.Context, input ListIssueBlockedByInput) ([]IssueDependency, error) {
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", "--paginate", "--slurp", fmt.Sprintf("repos/%s/issues/%d/dependencies/blocked_by", repo, input.IssueNumber)}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := decodeJSONArrayOrPages(result.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]IssueDependency, 0, len(rows))
+	for _, row := range rows {
+		dependency := IssueDependency{Number: asInt64(row["number"]), Repo: dependencyRepo(firstNonNil(row["repository"], row["repo"]), asString(row["repository_url"]), input.Repo)}
+		if dependency.Number <= 0 {
+			continue
+		}
+		out = append(out, dependency)
+	}
+	return out, nil
+}
+
+func (g *Gateway) FindAnyIssueNumber(ctx context.Context, repo string, cwd string) (int64, error) {
+	hostname, repoName := splitRepoHostname(repo)
+	for page := 1; page <= 5; page++ {
+		args := []string{"api", fmt.Sprintf("repos/%s/issues?state=all&per_page=100&page=%d", repoName, page)}
+		if hostname != "" {
+			args = append(args, "--hostname", hostname)
+		}
+		result, err := g.runGh(ctx, cwd, "", args...)
+		if err != nil {
+			return 0, err
+		}
+		rows, err := decodeJSONArray(result.Stdout)
+		if err != nil {
+			return 0, err
+		}
+		if len(rows) == 0 {
+			return 0, nil
+		}
+		for _, row := range rows {
+			if row["pull_request"] != nil {
+				continue
+			}
+			if issueNumber := asInt64(row["number"]); issueNumber > 0 {
+				return issueNumber, nil
+			}
+		}
+	}
+	return 0, nil
 }
 
 func (g *Gateway) ListIssueComments(ctx context.Context, input ViewIssueInput) ([]CommentInfo, error) {
@@ -2401,6 +2488,26 @@ func validateGitHubRepoSlug(repo string) error {
 		return fmt.Errorf("invalid GitHub repo: %s", repo)
 	}
 	return nil
+}
+
+func dependencyRepo(value any, repositoryURL string, fallback string) string {
+	repository, _ := value.(map[string]any)
+	if fullName := strings.TrimSpace(asString(repository["full_name"])); fullName != "" {
+		return hostQualifiedRepo(fullName, firstNonEmpty(repositoryURL, asString(repository["url"])))
+	}
+	if apiURL := strings.TrimSpace(firstNonEmpty(repositoryURL, asString(repository["url"]))); apiURL != "" {
+		if parsed, err := url.Parse(apiURL); err == nil {
+			trimmed := strings.Trim(parsed.Path, "/")
+			if index := strings.Index(trimmed, "repos/"); index >= 0 {
+				nameWithOwner := strings.TrimPrefix(trimmed[index:], "repos/")
+				if parsed.Hostname() != "" && parsed.Hostname() != "api.github.com" && parsed.Hostname() != "github.com" {
+					return parsed.Hostname() + "/" + nameWithOwner
+				}
+				return nameWithOwner
+			}
+		}
+	}
+	return strings.TrimSpace(fallback)
 }
 
 func hostQualifiedRepo(nameWithOwner string, repoURL string) string {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1243,6 +1243,25 @@ func TestListIssueBlockedByUsesRepositoryURLForCrossRepoBlockers(t *testing.T) {
 	}
 }
 
+func TestListIssueBlockedByIgnoresPublicGitHubAPIHostname(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		if got := strings.Join(options.Args, " "); got != "api --paginate --slurp repos/acme/looper/issues/12/dependencies/blocked_by" {
+			t.Fatalf("unexpected gh args: %q", got)
+		}
+		return shell.Result{Stdout: `[[{"number":34,"repository":{"full_name":"other/repo","url":"https://api.github.com/repos/other/repo"}}]]`}, nil
+	}
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	blockedBy, err := gateway.ListIssueBlockedBy(context.Background(), ListIssueBlockedByInput{Repo: "acme/looper", IssueNumber: 12})
+	if err != nil {
+		t.Fatalf("ListIssueBlockedBy() error = %v", err)
+	}
+	if len(blockedBy) != 1 || blockedBy[0].Number != 34 || blockedBy[0].Repo != "other/repo" {
+		t.Fatalf("ListIssueBlockedBy() = %#v, want unqualified public GitHub repo", blockedBy)
+	}
+}
+
 func TestFindAnyIssueNumberSkipsPullRequests(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}
@@ -1259,6 +1278,34 @@ func TestFindAnyIssueNumberSkipsPullRequests(t *testing.T) {
 	}
 	if issueNumber != 7 {
 		t.Fatalf("FindAnyIssueNumber() = %d, want first non-PR issue", issueNumber)
+	}
+}
+
+func TestFindAnyIssueNumberContinuesPastFivePages(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch args {
+		case "api repos/acme/looper/issues?state=all&per_page=100&page=1", "api repos/acme/looper/issues?state=all&per_page=100&page=2", "api repos/acme/looper/issues?state=all&per_page=100&page=3", "api repos/acme/looper/issues?state=all&per_page=100&page=4", "api repos/acme/looper/issues?state=all&per_page=100&page=5":
+			return shell.Result{Stdout: `[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}}]`}, nil
+		case "api repos/acme/looper/issues?state=all&per_page=100&page=6":
+			return shell.Result{Stdout: `[{"number":7}]`}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	issueNumber, err := gateway.FindAnyIssueNumber(context.Background(), "acme/looper", "")
+	if err != nil {
+		t.Fatalf("FindAnyIssueNumber() error = %v", err)
+	}
+	if issueNumber != 7 {
+		t.Fatalf("FindAnyIssueNumber() = %d, want issue discovered after page five", issueNumber)
+	}
+	if len(runner.calls) != 6 {
+		t.Fatalf("FindAnyIssueNumber() calls = %d, want six pages probed", len(runner.calls))
 	}
 }
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1224,6 +1224,44 @@ func TestGatewayViewIssueScopesAPIToHostname(t *testing.T) {
 	}
 }
 
+func TestListIssueBlockedByUsesRepositoryURLForCrossRepoBlockers(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		if got := strings.Join(options.Args, " "); got != "api --paginate --slurp repos/acme/looper/issues/12/dependencies/blocked_by" {
+			t.Fatalf("unexpected gh args: %q", got)
+		}
+		return shell.Result{Stdout: `[[{"number":34,"repository_url":"https://github.example.com/api/v3/repos/other/repo"}]]`}, nil
+	}
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	blockedBy, err := gateway.ListIssueBlockedBy(context.Background(), ListIssueBlockedByInput{Repo: "acme/looper", IssueNumber: 12})
+	if err != nil {
+		t.Fatalf("ListIssueBlockedBy() error = %v", err)
+	}
+	if len(blockedBy) != 1 || blockedBy[0].Number != 34 || blockedBy[0].Repo != "github.example.com/other/repo" {
+		t.Fatalf("ListIssueBlockedBy() = %#v, want hosted cross-repo blocker", blockedBy)
+	}
+}
+
+func TestFindAnyIssueNumberSkipsPullRequests(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		if got := strings.Join(options.Args, " "); got != "api repos/acme/looper/issues?state=all&per_page=100&page=1" {
+			t.Fatalf("unexpected gh args: %q", got)
+		}
+		return shell.Result{Stdout: `[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}},{"number":7}]`}, nil
+	}
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	issueNumber, err := gateway.FindAnyIssueNumber(context.Background(), "acme/looper", "")
+	if err != nil {
+		t.Fatalf("FindAnyIssueNumber() error = %v", err)
+	}
+	if issueNumber != 7 {
+		t.Fatalf("FindAnyIssueNumber() = %d, want first non-PR issue", issueNumber)
+	}
+}
+
 func TestGatewayListLinkedPullRequestsHandlesHostQualifiedRepo(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -425,6 +425,10 @@ func (r *Runtime) CompleteStartup(ctx context.Context) error {
 			r.startupReadyErr = fmt.Errorf("runtime repositories are not configured")
 			return
 		}
+		if err := r.validateCoordinatorDependencyGates(ctx, repositories, githubGateway); err != nil {
+			r.startupReadyErr = err
+			return
+		}
 		recoverySummary, err := r.runRecoveryPipeline(ctx, repositories, githubGateway, *startedAt)
 		if err != nil {
 			r.startupReadyErr = err
@@ -461,6 +465,95 @@ func (r *Runtime) CompleteStartup(ctx context.Context) error {
 	})
 
 	return r.startupReadyErr
+}
+
+func (r *Runtime) validateCoordinatorDependencyGates(ctx context.Context, repositories *storage.Repositories, githubGateway *githubinfra.Gateway) error {
+	if repositories == nil || repositories.Projects == nil || githubGateway == nil {
+		return nil
+	}
+	projectsList, err := repositories.Projects.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, project := range projectsList {
+		roleCfg := config.ProjectRoleConfigs(r.config, project.ID).Coordinator
+		if !roleCfg.Enabled || !roleCfg.Dependencies.Enabled {
+			continue
+		}
+		repo := strings.TrimSpace(runtimeProjectRepo(project.MetadataJSON))
+		if repo == "" {
+			return fmt.Errorf("coordinator dependency gate enabled but repository metadata unavailable for project %s", project.ID)
+		}
+		issueNumber, err := r.firstDependencyProbeIssue(ctx, githubGateway, repo, project.RepoPath)
+		if err != nil {
+			return err
+		}
+		if issueNumber == 0 {
+			return fmt.Errorf("coordinator dependency gate enabled but no issue available to probe dependencies API on %s", repo)
+		}
+		if err := r.probeDependencyAPI(ctx, githubGateway, repo, project.RepoPath, issueNumber, roleCfg.Dependencies); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Runtime) firstDependencyProbeIssue(ctx context.Context, githubGateway *githubinfra.Gateway, repo, cwd string) (int64, error) {
+	return githubGateway.FindAnyIssueNumber(ctx, repo, cwd)
+}
+
+func (r *Runtime) probeDependencyAPI(ctx context.Context, githubGateway *githubinfra.Gateway, repo, cwd string, issueNumber int64, depsCfg config.CoordinatorDependenciesConfig) error {
+	var lastErr error
+	for attempt := 0; attempt < runtimeMaxDependencyAttempts(depsCfg.APIRetryAttempts); attempt++ {
+		callCtx, cancel := context.WithTimeout(ctx, runtimeDependencyTimeout(depsCfg.APITimeoutSeconds))
+		_, err := githubGateway.ListIssueBlockedBy(callCtx, githubinfra.ListIssueBlockedByInput{Repo: repo, IssueNumber: issueNumber, CWD: cwd})
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if githubinfra.IsNotFoundError(err) {
+			return fmt.Errorf("coordinator dependency gate enabled but dependencies API unavailable on %s; disable roles.coordinator.dependencies.enabled or upgrade GHES", repo)
+		}
+		if !runtimeShouldRetryDependencyError(err) {
+			return err
+		}
+	}
+	return lastErr
+}
+
+func runtimeProjectRepo(metadataJSON *string) string {
+	if metadataJSON == nil || strings.TrimSpace(*metadataJSON) == "" {
+		return ""
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(*metadataJSON), &metadata); err != nil {
+		return ""
+	}
+	value, _ := metadata["repo"].(string)
+	return strings.TrimSpace(value)
+}
+
+func runtimeDependencyTimeout(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 10 * time.Second
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func runtimeMaxDependencyAttempts(attempts int) int {
+	if attempts <= 0 {
+		return 1
+	}
+	return attempts
+}
+
+func runtimeShouldRetryDependencyError(err error) bool {
+	if githubinfra.IsTransientError(err) {
+		return true
+	}
+	message := strings.ToLower(githubinfra.ErrorMessage(err))
+	return strings.Contains(message, "timed out") || strings.Contains(message, "context deadline exceeded")
 }
 
 func (r *Runtime) startSchedulerLoop() {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -489,7 +489,7 @@ func (r *Runtime) validateCoordinatorDependencyGates(ctx context.Context, reposi
 			return err
 		}
 		if issueNumber == 0 {
-			return fmt.Errorf("coordinator dependency gate enabled but no issue available to probe dependencies API on %s", repo)
+			continue
 		}
 		if err := r.probeDependencyAPI(ctx, githubGateway, repo, project.RepoPath, issueNumber, roleCfg.Dependencies); err != nil {
 			return err

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -476,6 +476,9 @@ func (r *Runtime) validateCoordinatorDependencyGates(ctx context.Context, reposi
 		return err
 	}
 	for _, project := range projectsList {
+		if project.Archived {
+			continue
+		}
 		roleCfg := config.ProjectRoleConfigs(r.config, project.ID).Coordinator
 		if !roleCfg.Enabled || !roleCfg.Dependencies.Enabled {
 			continue

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2507,6 +2507,49 @@ func TestValidateCoordinatorDependencyGatesAllowsAvailableAPI(t *testing.T) {
 	}
 }
 
+func TestValidateCoordinatorDependencyGatesSkipsProbeWhenRepoHasNoIssues(t *testing.T) {
+	t.Parallel()
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.Dependencies.Enabled = true
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "runtime.sqlite"), filepath.Join(workingDir, "backups"))
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := formatJavaScriptISOString(time.Date(2026, time.May, 16, 12, 0, 0, 0, time.UTC))
+	metadata := `{"repo":"acme/looper","worktreeRoot":null,"source":"config"}`
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "demo", Name: "Demo", RepoPath: workingDir, MetadataJSON: &metadata, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	blockedByCalls := 0
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch {
+		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=1"):
+			return shell.Result{Stdout: `[{"number":12,"pull_request":{}}]`}, nil
+		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=2"):
+			return shell.Result{Stdout: `[]`}, nil
+		case strings.Contains(args, "dependencies/blocked_by"):
+			blockedByCalls++
+			return shell.Result{Stdout: `[]`}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}})
+	rt := New(Options{Config: cfg, Logger: &testLogger{}})
+
+	if err := rt.validateCoordinatorDependencyGates(context.Background(), repositories, githubGateway); err != nil {
+		t.Fatalf("validateCoordinatorDependencyGates() error = %v, want nil", err)
+	}
+	if blockedByCalls != 0 {
+		t.Fatalf("dependencies/blocked_by call count = %d, want 0", blockedByCalls)
+	}
+}
+
 func TestFormatJavaScriptISOStringPreservesMilliseconds(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -2429,6 +2430,80 @@ func TestRuntimeStartReturnsErrorAfterStop(t *testing.T) {
 	err = rt.Start(context.Background())
 	if err == nil || err.Error() != "runtime already stopped" {
 		t.Fatalf("Start() after Stop() error = %v, want runtime already stopped", err)
+	}
+}
+
+func TestValidateCoordinatorDependencyGatesFailsClosedWhenAPIUnavailable(t *testing.T) {
+	t.Parallel()
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.Dependencies.Enabled = true
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "runtime.sqlite"), filepath.Join(workingDir, "backups"))
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := formatJavaScriptISOString(time.Date(2026, time.May, 16, 12, 0, 0, 0, time.UTC))
+	metadata := `{"repo":"acme/looper","worktreeRoot":null,"source":"config"}`
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "demo", Name: "Demo", RepoPath: workingDir, MetadataJSON: &metadata, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch {
+		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=1"):
+			return shell.Result{Stdout: `[{"number":7}]`}, nil
+		case strings.Contains(args, "dependencies/blocked_by"):
+			result := shell.Result{ExitCode: 1, Stderr: "gh: HTTP 404: Not Found"}
+			return result, &shell.CommandExecutionError{Message: "Command exited with code 1", Result: result}
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}})
+	rt := New(Options{Config: cfg, Logger: &testLogger{}})
+
+	err = rt.validateCoordinatorDependencyGates(context.Background(), repositories, githubGateway)
+	if err == nil || !strings.Contains(err.Error(), "coordinator dependency gate enabled but dependencies API unavailable on acme/looper") {
+		t.Fatalf("validateCoordinatorDependencyGates() error = %v, want actionable unavailable error", err)
+	}
+}
+
+func TestValidateCoordinatorDependencyGatesAllowsAvailableAPI(t *testing.T) {
+	t.Parallel()
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.Dependencies.Enabled = true
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "runtime.sqlite"), filepath.Join(workingDir, "backups"))
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := formatJavaScriptISOString(time.Date(2026, time.May, 16, 12, 0, 0, 0, time.UTC))
+	metadata := `{"repo":"acme/looper","worktreeRoot":null,"source":"config"}`
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "demo", Name: "Demo", RepoPath: workingDir, MetadataJSON: &metadata, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch {
+		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=1"):
+			return shell.Result{Stdout: `[{"number":7}]`}, nil
+		case strings.Contains(args, "dependencies/blocked_by"):
+			return shell.Result{Stdout: `[]`}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}})
+	rt := New(Options{Config: cfg, Logger: &testLogger{}})
+
+	if err := rt.validateCoordinatorDependencyGates(context.Background(), repositories, githubGateway); err != nil {
+		t.Fatalf("validateCoordinatorDependencyGates() error = %v, want nil", err)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2550,6 +2550,47 @@ func TestValidateCoordinatorDependencyGatesSkipsProbeWhenRepoHasNoIssues(t *test
 	}
 }
 
+func TestValidateCoordinatorDependencyGatesSkipsArchivedProjects(t *testing.T) {
+	t.Parallel()
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.Dependencies.Enabled = true
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "runtime.sqlite"), filepath.Join(workingDir, "backups"))
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := formatJavaScriptISOString(time.Date(2026, time.May, 16, 12, 0, 0, 0, time.UTC))
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "archived", Name: "Archived", RepoPath: workingDir, Archived: true, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	blockedByCalls := 0
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch {
+		case strings.Contains(args, "issues?state=all"):
+			t.Fatalf("unexpected issue listing for archived project: %q", args)
+			return shell.Result{}, nil
+		case strings.Contains(args, "dependencies/blocked_by"):
+			blockedByCalls++
+			return shell.Result{Stdout: `[]`}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}})
+	rt := New(Options{Config: cfg, Logger: &testLogger{}})
+
+	if err := rt.validateCoordinatorDependencyGates(context.Background(), repositories, githubGateway); err != nil {
+		t.Fatalf("validateCoordinatorDependencyGates() error = %v, want nil", err)
+	}
+	if blockedByCalls != 0 {
+		t.Fatalf("dependencies/blocked_by call count = %d, want 0", blockedByCalls)
+	}
+}
+
 func TestFormatJavaScriptISOStringPreservesMilliseconds(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- gate coordinator Dispatch on the GitHub-native `blocked_by` graph while preserving slice #337 behavior when `roles.coordinator.dependencies.enabled` is off
- add coordinator dependency config, startup fail-closed validation for the dependencies API, and a pure `depgraph`/dispatch path for unsatisfied or unreachable blockers
- cover the happy path with dispatch matrix tests, runner regressions, fake-gh integration, and gateway/runtime validation tests

## Why
This extends the Coordinator Dispatch authority chain to honor dependency readiness without adding persisted state, so blocked work stays vetoed until blockers are completed.

## References
- PRD #351
- Slice foundation #354
- ADR-0001 stateless coordinator
- ADR-0002 authority pattern
- ADR-0004 dependency-gate authority chain

## Review
- @oracle review required per AGENTS.md because this PR extends Dispatch authority to consult the GitHub-native `blocked_by` relationship

Closes #355

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>