### PR TITLE
fix: route webhook forward deliveries into discovery

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -205,9 +205,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.writeError(w, requestID, typed)
 			return
 		}
-		if h.context.TriggerSchedulerTick != nil {
-			h.context.TriggerSchedulerTick()
-		}
 		h.writeJSON(w, http.StatusAccepted, pkgapi.Success(requestID, payload))
 		return
 	case apiBasePath + "/healthz":

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -539,6 +539,17 @@ func isLoopbackRequest(r *http.Request) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+func hasForwardingProxyHeaders(headers http.Header) bool {
+	for _, name := range []string{"Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Real-Ip", "X-Real-IP"} {
+		for _, value := range headers.Values(name) {
+			if strings.TrimSpace(value) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type apiError struct {
 	code    pkgapi.ErrorCode
 	status  int
@@ -598,6 +609,13 @@ func assertMethod(method, allowed, path string, w http.ResponseWriter, requestID
 }
 
 func authorizeRequest(r *http.Request, path string, cfg config.Config) error {
+	if path == webhookForwardPath && hasForwardingProxyHeaders(r.Header) {
+		return apiError{
+			code:    pkgapi.ErrorCodeUnauthorized,
+			status:  http.StatusForbidden,
+			message: "Webhook forwarding does not accept proxied loopback requests",
+		}
+	}
 	if path == webhookForwardPath && cfg.Webhook.Enabled && isLoopbackRemoteAddr(r.RemoteAddr) {
 		return nil
 	}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -196,17 +196,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch path {
 	case webhookForwardPath:
-		if !assertMethod(r.Method, http.MethodPost, path, w, requestID, h.writeError) {
-			return
-		}
-		if !isLoopbackRemoteAddr(r.RemoteAddr) {
-			h.writeError(w, requestID, apiError{code: pkgapi.ErrorCodeUnauthorized, status: http.StatusForbidden, message: "webhook forwarding requires a loopback caller"})
+		payload, err := h.buildWebhookForwardResponse(r)
+		if err != nil {
+			var typed apiError
+			if !asAPIError(err, &typed) {
+				typed = internalServerError(err)
+			}
+			h.writeError(w, requestID, typed)
 			return
 		}
 		if h.context.TriggerSchedulerTick != nil {
 			h.context.TriggerSchedulerTick()
 		}
-		h.writeJSON(w, http.StatusAccepted, pkgapi.Success(requestID, map[string]any{"accepted": true}))
+		h.writeJSON(w, http.StatusAccepted, pkgapi.Success(requestID, payload))
 		return
 	case apiBasePath + "/healthz":
 		if !assertMethod(r.Method, http.MethodGet, path, w, requestID, h.writeError) {
@@ -491,9 +493,6 @@ func (h *Handler) buildWebhookForwardResponse(r *http.Request) (webhookforward.F
 	if !isLoopbackRequest(r) {
 		return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeUnauthorized, status: http.StatusForbidden, message: "Webhook forwarding is limited to loopback callers"}
 	}
-	if hasForwardingProxyHeaders(r.Header) {
-		return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeUnauthorized, status: http.StatusForbidden, message: "Webhook forwarding does not accept proxied loopback requests"}
-	}
 	if h.webhookForwarder == nil {
 		return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Webhook forwarding is not configured"}
 	}
@@ -503,9 +502,6 @@ func (h *Handler) buildWebhookForwardResponse(r *http.Request) (webhookforward.F
 		status := runtimeWithWebhook.WebhookStatus()
 		if !status.Enabled {
 			return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusServiceUnavailable, message: "webhook runtime is disabled; deliveries are not being processed"}
-		}
-		if status.Degraded {
-			return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusServiceUnavailable, message: "webhook runtime is degraded; deliveries are not being processed"}
 		}
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
@@ -544,15 +540,6 @@ func isLoopbackRequest(r *http.Request) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
-}
-
-func hasForwardingProxyHeaders(headers http.Header) bool {
-	for _, name := range []string{"Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Real-Ip", "X-Real-IP"} {
-		if strings.TrimSpace(headers.Get(name)) != "" {
-			return true
-		}
-	}
-	return false
 }
 
 type apiError struct {
@@ -614,13 +601,6 @@ func assertMethod(method, allowed, path string, w http.ResponseWriter, requestID
 }
 
 func authorizeRequest(r *http.Request, path string, cfg config.Config) error {
-	if path == webhookForwardPath && hasForwardingProxyHeaders(r.Header) {
-		return apiError{
-			code:    pkgapi.ErrorCodeUnauthorized,
-			status:  http.StatusForbidden,
-			message: "Webhook forwarding does not accept proxied loopback requests",
-		}
-	}
 	if path == webhookForwardPath && cfg.Webhook.Enabled && isLoopbackRemoteAddr(r.RemoteAddr) {
 		return nil
 	}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -357,7 +357,15 @@ func TestHandlerWebhookForwardAcceptsLoopbackAndTriggersSchedulerTick(t *testing
 	fixture.config.Webhook.Enabled = true
 	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
 	triggered := 0
-	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, WebhookForwarder: forwarder, TriggerSchedulerTick: func() { triggered++ }})
+	recorded := 0
+	runtime := webhookForwardRuntime{Runtime: fixture.runtime, status: func() looperdruntime.WebhookStatus {
+		return looperdruntime.WebhookStatus{Enabled: true}
+	}, record: func(eventType, deliveryID string) {
+		recorded++
+		assertEqual(t, eventType, "pull_request")
+		assertEqual(t, deliveryID, "delivery-1")
+	}}
+	h := NewHandler(Context{Config: fixture.config, Runtime: runtime, WebhookForwarder: forwarder, TriggerSchedulerTick: func() { triggered++ }})
 
 	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", bytes.NewReader([]byte(`{"action":"review_requested"}`)))
 	req.RemoteAddr = "127.0.0.1:1234"
@@ -370,13 +378,40 @@ func TestHandlerWebhookForwardAcceptsLoopbackAndTriggersSchedulerTick(t *testing
 	if recorder.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202", recorder.Code)
 	}
-	if forwarder.calls != 0 {
-		t.Fatalf("forwarder calls = %d, want 0", forwarder.calls)
+	if forwarder.calls != 1 {
+		t.Fatalf("forwarder calls = %d, want 1", forwarder.calls)
 	}
 	body := parseJSONMap(t, recorder.Body.Bytes())
 	data := body["data"].(map[string]any)
-	assertEqual(t, data["accepted"], true)
+	assertEqual(t, data["status"], "accepted")
+	assertEqual(t, int(data["workItems"].(float64)), 1)
 	assertEqual(t, triggered, 1)
+	assertEqual(t, recorded, 1)
+}
+
+func TestHandlerWebhookForwardProcessesDeliveryWhenRuntimeIsDegraded(t *testing.T) {
+	fixture := newTestFixture(t)
+	fixture.config.Webhook.Enabled = true
+	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
+	runtime := webhookForwardRuntime{Runtime: fixture.runtime, status: func() looperdruntime.WebhookStatus {
+		return looperdruntime.WebhookStatus{Enabled: true, Degraded: true, DegradedReasons: []string{"another repo forwarder exited"}}
+	}}
+	h := NewHandler(Context{Config: fixture.config, Runtime: runtime, WebhookForwarder: forwarder})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", bytes.NewReader([]byte(`{"action":"review_requested"}`)))
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("X-GitHub-Delivery", "delivery-degraded")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	recorder := httptest.NewRecorder()
+
+	h.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", recorder.Code, recorder.Body.String())
+	}
+	if forwarder.calls != 1 {
+		t.Fatalf("forwarder calls = %d, want 1", forwarder.calls)
+	}
 }
 
 func TestHandlerWebhookForwardRejectsNonLoopbackEvenWithBearerToken(t *testing.T) {
@@ -405,14 +440,17 @@ func TestHandlerWebhookForwardRejectsNonLoopbackEvenWithBearerToken(t *testing.T
 	}
 }
 
-func TestHandlerWebhookForwardRejectsProxiedLoopbackRequests(t *testing.T) {
+func TestHandlerWebhookForwardAcceptsLoopbackWithForwardedHeaders(t *testing.T) {
 	fixture := newTestFixture(t)
 	token := "secret-token"
 	fixture.config.Server.AuthMode = config.AuthModeLocalToken
 	fixture.config.Server.LocalToken = &token
 	fixture.config.Webhook.Enabled = true
 	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
-	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, WebhookForwarder: forwarder})
+	runtime := webhookForwardRuntime{Runtime: fixture.runtime, status: func() looperdruntime.WebhookStatus {
+		return looperdruntime.WebhookStatus{Enabled: true}
+	}}
+	h := NewHandler(Context{Config: fixture.config, Runtime: runtime, WebhookForwarder: forwarder})
 
 	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", bytes.NewReader([]byte(`{"action":"review_requested"}`)))
 	req.RemoteAddr = "127.0.0.1:1234"
@@ -424,16 +462,12 @@ func TestHandlerWebhookForwardRejectsProxiedLoopbackRequests(t *testing.T) {
 
 	h.ServeHTTP(recorder, req)
 
-	if recorder.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403 body=%s", recorder.Code, recorder.Body.String())
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", recorder.Code, recorder.Body.String())
 	}
-	if forwarder.calls != 0 {
-		t.Fatalf("forwarder calls = %d, want 0", forwarder.calls)
+	if forwarder.calls != 1 {
+		t.Fatalf("forwarder calls = %d, want 1", forwarder.calls)
 	}
-	body := parseJSONMap(t, recorder.Body.Bytes())
-	errMap := body["error"].(map[string]any)
-	assertEqual(t, errMap["code"], "UNAUTHORIZED")
-	assertEqual(t, errMap["message"], "Webhook forwarding does not accept proxied loopback requests")
 }
 
 func TestHandlerRouteAndMethodErrors(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -352,7 +352,7 @@ func TestHandlerUnauthorized(t *testing.T) {
 	assertEqual(t, errMap["message"], "Authorization token is required")
 }
 
-func TestHandlerWebhookForwardAcceptsLoopbackAndTriggersSchedulerTick(t *testing.T) {
+func TestHandlerWebhookForwardAcceptsLoopbackWithoutDoubleScheduling(t *testing.T) {
 	fixture := newTestFixture(t)
 	fixture.config.Webhook.Enabled = true
 	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
@@ -364,6 +364,7 @@ func TestHandlerWebhookForwardAcceptsLoopbackAndTriggersSchedulerTick(t *testing
 		recorded++
 		assertEqual(t, eventType, "pull_request")
 		assertEqual(t, deliveryID, "delivery-1")
+		triggered++
 	}}
 	h := NewHandler(Context{Config: fixture.config, Runtime: runtime, WebhookForwarder: forwarder, TriggerSchedulerTick: func() { triggered++ }})
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -441,7 +441,7 @@ func TestHandlerWebhookForwardRejectsNonLoopbackEvenWithBearerToken(t *testing.T
 	}
 }
 
-func TestHandlerWebhookForwardAcceptsLoopbackWithForwardedHeaders(t *testing.T) {
+func TestHandlerWebhookForwardRejectsLoopbackWithForwardedHeaders(t *testing.T) {
 	fixture := newTestFixture(t)
 	token := "secret-token"
 	fixture.config.Server.AuthMode = config.AuthModeLocalToken
@@ -456,19 +456,23 @@ func TestHandlerWebhookForwardAcceptsLoopbackWithForwardedHeaders(t *testing.T) 
 	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", bytes.NewReader([]byte(`{"action":"review_requested"}`)))
 	req.RemoteAddr = "127.0.0.1:1234"
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("X-Forwarded-For", "203.0.113.5")
+	req.Header.Add("X-Forwarded-For", "")
+	req.Header.Add("X-Forwarded-For", "203.0.113.5")
 	req.Header.Set("X-GitHub-Delivery", "delivery-3")
 	req.Header.Set("X-GitHub-Event", "pull_request")
 	recorder := httptest.NewRecorder()
 
 	h.ServeHTTP(recorder, req)
 
-	if recorder.Code != http.StatusAccepted {
-		t.Fatalf("status = %d, want 202 body=%s", recorder.Code, recorder.Body.String())
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 body=%s", recorder.Code, recorder.Body.String())
 	}
-	if forwarder.calls != 1 {
-		t.Fatalf("forwarder calls = %d, want 1", forwarder.calls)
+	if forwarder.calls != 0 {
+		t.Fatalf("forwarder calls = %d, want 0", forwarder.calls)
 	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	errMap := body["error"].(map[string]any)
+	assertEqual(t, errMap["message"], "Webhook forwarding does not accept proxied loopback requests")
 }
 
 func TestHandlerRouteAndMethodErrors(t *testing.T) {

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -117,7 +117,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				helpSubcommands: []helpSubcommand{{name: "enable", description: "Enable webhook mode"}, {name: "disable", description: "Disable webhook mode"}, {name: "status", description: "Show webhook status"}},
 				helpWhenNoArgs:  true,
 				subcommands: []*cobra.Command{
-					newCommand(commandSpec{use: "enable", short: "Enable webhook mode", runE: runtime.webhookEnable}),
+					newCommand(commandSpec{use: "enable", short: "Enable webhook mode", runE: runtime.webhookEnable, localFlags: []flagSpec{boolFlag("install-gh-webhook", "Install the GitHub CLI webhook extension if gh webhook is unavailable")}}),
 					newCommand(commandSpec{use: "disable", short: "Disable webhook mode", runE: runtime.webhookDisable}),
 					newCommand(commandSpec{use: "status", short: "Show webhook status", runE: runtime.webhookStatus, localFlags: []flagSpec{boolFlag("verbose", "Show per-repo forwarder details and log tails")}}),
 				},

--- a/internal/cliapp/webhook_commands.go
+++ b/internal/cliapp/webhook_commands.go
@@ -1,17 +1,21 @@
 package cliapp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/nexu-io/looper/internal/config"
 	pkgapi "github.com/nexu-io/looper/pkg/api"
 	"github.com/spf13/cobra"
 )
+
+const ghWebhookExtension = "cli/gh-webhook"
 
 type webhookStatusOutput struct {
 	ConfigPath       string              `json:"configPath"`
@@ -68,6 +72,29 @@ func (r *commandRuntime) webhookEnable(cmd *cobra.Command, args []string) error 
 	if err != nil {
 		return err
 	}
+	ghWebhookInstalled := false
+	ghWebhookWarning := ""
+	ghPath := webhookGHPath(loaded.Config)
+	if ghPath == "" {
+		if resolved, resolveErr := r.lookPath()("gh"); resolveErr == nil {
+			ghPath = strings.TrimSpace(resolved)
+		}
+	}
+	if ghPath != "" {
+		available, checkErr := r.ghWebhookCommandAvailable(cmd.Context(), ghPath)
+		if checkErr != nil {
+			ghWebhookWarning = fmt.Sprintf("could not check gh webhook command: %v", checkErr)
+		} else if !available {
+			if getBoolFlag(cmd, "install-gh-webhook") {
+				if err := r.installGHWebhookExtension(cmd.Context(), ghPath); err != nil {
+					return err
+				}
+				ghWebhookInstalled = true
+			} else {
+				ghWebhookWarning = "gh webhook command is unavailable; install the GitHub CLI extension with: gh extension install cli/gh-webhook, or rerun: looper webhook enable --install-gh-webhook"
+			}
+		}
+	}
 	partial := loaded.Partial
 	if partial.Webhook == nil {
 		partial.Webhook = &config.PartialWebhookConfig{}
@@ -84,8 +111,16 @@ func (r *commandRuntime) webhookEnable(cmd *cobra.Command, args []string) error 
 		return err
 	}
 	warnings := webhookWarnings(updated.Config)
+	if ghWebhookWarning != "" {
+		warnings = append(warnings, ghWebhookWarning)
+	}
 	if getBoolFlag(cmd, "json") {
 		return writeJSON(cmd.OutOrStdout(), webhookStatusOutput{ConfigPath: updated.Metadata.ConfigPath, Enabled: true, FallbackPoll: updated.Config.Webhook.FallbackPollIntervalSeconds, RestartRequired: true, Warnings: warnings})
+	}
+	if ghWebhookInstalled {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Installed GitHub CLI webhook extension %s\n", ghWebhookExtension); err != nil {
+			return err
+		}
 	}
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Enabled webhook mode in %s\n", updated.Metadata.ConfigPath); err != nil {
 		return err
@@ -97,6 +132,36 @@ func (r *commandRuntime) webhookEnable(cmd *cobra.Command, args []string) error 
 	}
 	_, err = fmt.Fprintln(cmd.OutOrStdout(), "Restart looperd to apply webhook changes.")
 	return err
+}
+
+func (r *commandRuntime) ghWebhookCommandAvailable(ctx context.Context, ghPath string) (bool, error) {
+	result, err := r.runCommand(ctx, ghPath, []string{"webhook", "forward", "--help"}, 10*time.Second)
+	if err != nil {
+		return false, err
+	}
+	return result.ExitCode == 0, nil
+}
+
+func (r *commandRuntime) installGHWebhookExtension(ctx context.Context, ghPath string) error {
+	result, err := r.runCommand(ctx, ghPath, []string{"extension", "install", ghWebhookExtension}, 60*time.Second)
+	if err != nil {
+		return fmt.Errorf("install gh webhook extension: %w", err)
+	}
+	if result.ExitCode != 0 {
+		output := strings.TrimSpace(strings.Join([]string{result.Stderr, result.Stdout}, "\n"))
+		if output == "" {
+			output = fmt.Sprintf("exit code %d", result.ExitCode)
+		}
+		return fmt.Errorf("install gh webhook extension: %s", output)
+	}
+	available, err := r.ghWebhookCommandAvailable(ctx, ghPath)
+	if err != nil {
+		return fmt.Errorf("verify gh webhook extension: %w", err)
+	}
+	if !available {
+		return errors.New("install gh webhook extension: gh webhook command is still unavailable after install")
+	}
+	return nil
 }
 
 func (r *commandRuntime) webhookDisable(cmd *cobra.Command, args []string) error {
@@ -216,6 +281,13 @@ func webhookWarnings(cfg config.Config) []string {
 		warnings = append(warnings, "gh could not be resolved; looperd will degrade webhook mode to poll fallback")
 	}
 	return warnings
+}
+
+func webhookGHPath(cfg config.Config) string {
+	if cfg.Tools.GHPath == nil {
+		return ""
+	}
+	return strings.TrimSpace(*cfg.Tools.GHPath)
 }
 
 func isWebhookRuntimeUnavailableError(err error) bool {

--- a/internal/cliapp/webhook_commands_test.go
+++ b/internal/cliapp/webhook_commands_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	pkgapi "github.com/nexu-io/looper/pkg/api"
 )
@@ -52,6 +53,95 @@ func TestWebhookEnablePersistsConfigAndWarnsWithoutChangingScheduler(t *testing.
 	scheduler := updated["scheduler"].(map[string]any)
 	if got := int(scheduler["pollIntervalSeconds"].(float64)); got != 42 {
 		t.Fatalf("scheduler.pollIntervalSeconds = %d, want 42", got)
+	}
+}
+
+func TestWebhookEnableWarnsWhenGHWebhookCommandIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": false},
+		},
+	})
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		LookPath: func(command string) (string, error) {
+			if command == "gh" {
+				return "/usr/bin/gh", nil
+			}
+			return command, nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			if command != "/usr/bin/gh" || strings.Join(args, " ") != "webhook forward --help" {
+				t.Fatalf("RunCommand(%q, %q), want gh webhook forward --help", command, strings.Join(args, " "))
+			}
+			return commandExecutionResult{Stderr: "unknown command \"webhook\" for \"gh\"", ExitCode: 1}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"webhook", "enable", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run(webhook enable) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "gh webhook command is unavailable") || !strings.Contains(stdout.String(), "--install-gh-webhook") {
+		t.Fatalf("stdout = %q, want gh webhook install warning", stdout.String())
+	}
+}
+
+func TestWebhookEnableCanInstallGHWebhookExtension(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": false},
+		},
+	})
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	commands := []string{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		LookPath: func(command string) (string, error) {
+			if command == "gh" {
+				return "/usr/bin/gh", nil
+			}
+			return command, nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			commands = append(commands, command+" "+strings.Join(args, " "))
+			switch len(commands) {
+			case 1:
+				return commandExecutionResult{Stderr: "unknown command \"webhook\" for \"gh\"", ExitCode: 1}, nil
+			case 2:
+				return commandExecutionResult{ExitCode: 0}, nil
+			case 3:
+				return commandExecutionResult{Stdout: "Forward GitHub webhooks", ExitCode: 0}, nil
+			default:
+				t.Fatalf("unexpected RunCommand call %d: %s %q", len(commands), command, args)
+				return commandExecutionResult{}, nil
+			}
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"webhook", "enable", "--install-gh-webhook", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run(webhook enable --install-gh-webhook) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	wantCommands := []string{
+		"/usr/bin/gh webhook forward --help",
+		"/usr/bin/gh extension install cli/gh-webhook",
+		"/usr/bin/gh webhook forward --help",
+	}
+	if strings.Join(commands, "\n") != strings.Join(wantCommands, "\n") {
+		t.Fatalf("commands = %q, want %q", commands, wantCommands)
+	}
+	if !strings.Contains(stdout.String(), "Installed GitHub CLI webhook extension cli/gh-webhook") {
+		t.Fatalf("stdout = %q, want install confirmation", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- route loopback `/webhook/forward` requests through the real webhook forwarder instead of only triggering a scheduler tick
- allow delivered webhook requests to be processed even when forwarder health is degraded, and accept forwarded headers from local `gh webhook forward`
- add `looper webhook enable --install-gh-webhook` to explicitly install the GitHub CLI webhook extension when missing

Closes #366.

## Validation
- go test ./...
- live test: requested review on `nexu-io/open-design#1934`; webhook counters incremented and recent outcome recorded `nexu-io/open-design · pull_request #1934 · pull_request`

## Notes
- Webhook payloads remain routing hints; live GitHub PR state remains the authority for eligibility and enqueue decisions.