### PR TITLE
fix: requeue recoverable fixer pauses

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -3572,7 +3572,7 @@ func (r *Runner) resumePausedNoopResolveLoop(ctx context.Context, loop storage.L
 	if len(checkpoint.FixItems) == 0 {
 		previousStateHash = strings.TrimSpace(checkpoint.FixItemsHash)
 	}
-	previousThreadIDs := unresolvedThreadIDsFromCheckpoint(checkpoint)
+	previousThreadIDs := unresolvedThreadIDsFromCheckpoint(checkpoint, loop.MetadataJSON, previousHeadSHA)
 	if previousHeadSHA == strings.TrimSpace(headSHA) && previousStateHash == strings.TrimSpace(fixItemsStateHash) && sameStringSlices(previousThreadIDs, unresolvedThreadIDs) {
 		return false, loop, nil
 	}
@@ -3621,14 +3621,14 @@ func (r *Runner) resumePausedRiskyConflictLoop(ctx context.Context, loop storage
 	return true, updated, nil
 }
 
-func unresolvedThreadIDsFromCheckpoint(checkpoint fixerCheckpoint) []string {
+func unresolvedThreadIDsFromCheckpoint(checkpoint fixerCheckpoint, loopMetadataJSON *string, headSHA string) []string {
 	if checkpoint.Recheck != nil {
-		ids := unresolvedThreadIDs(checkpoint.Recheck.RemainingFixItems)
+		ids := unresolvedThreadIDs(suppressDeclinedFixItems(loopMetadataJSON, headSHA, checkpoint.Recheck.RemainingFixItems))
 		if len(ids) > 0 {
 			return ids
 		}
 	}
-	return unresolvedThreadIDs(checkpoint.FixItems)
+	return unresolvedThreadIDs(suppressDeclinedFixItems(loopMetadataJSON, headSHA, checkpoint.FixItems))
 }
 
 func (r *Runner) recoverLegacyNoopFollowupLoops(ctx context.Context, project storage.ProjectRecord, repo string, policy DiscoveryPolicy, currentUser string) ([]storage.QueueItemRecord, error) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -67,6 +67,9 @@ const (
 	FailureNonRetryable         QueueFailureKind = "non_retryable"
 	FailureManualIntervention   QueueFailureKind = "manual_intervention"
 
+	noopResolveManualIntervention = "resolve-comments left review threads unresolved because fixer produced no new commits to push"
+	riskyConflictManualHold       = "risky conflict fixes require manual intervention"
+
 	defaultAgentTimeout = 30 * time.Minute
 	defaultClaimTTL     = 5 * time.Minute
 	// defaultLegacyMarkerlessRunGrace protects running fixer runs that predate
@@ -3185,6 +3188,9 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	resumeFromPrepare := false
 	if latestRun != nil {
 		failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage))
+		if strings.TrimSpace(derefString(latestRun.ErrorMessage)) == noopResolveManualIntervention {
+			failureSummary = noopResolveManualIntervention
+		}
 		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, failureSummary) || loops.ShouldRestartFromDiscover(latestRun.Status, checkpoint.ResumePolicy)
 		resumeFromPrepare = shouldResumeFromPrepare(latestRun.Status, failedStep, checkpoint)
 	}
@@ -3450,6 +3456,14 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 			if existing.Status == "paused" {
 				if resumed, updated, err := r.resumePausedZeroProgressLoop(ctx, existing, headSHA, fixItemsStateHash); err != nil {
 					return loopUpsertResult{}, err
+				} else if resumed {
+					existing = updated
+				} else if resumed, updated, err := r.resumePausedNoopResolveLoop(ctx, existing, headSHA, fixItemsStateHash, unresolvedThreadIDs); err != nil {
+					return loopUpsertResult{}, err
+				} else if resumed {
+					existing = updated
+				} else if resumed, updated, err := r.resumePausedRiskyConflictLoop(ctx, existing, headSHA, fixItemsStateHash); err != nil {
+					return loopUpsertResult{}, err
 				} else if !resumed {
 					return loopUpsertResult{record: existing, created: false}, nil
 				} else {
@@ -3536,6 +3550,85 @@ func (r *Runner) resumePausedZeroProgressLoop(ctx context.Context, loop storage.
 		return false, storage.LoopRecord{}, err
 	}
 	return true, updated, nil
+}
+
+func (r *Runner) resumePausedNoopResolveLoop(ctx context.Context, loop storage.LoopRecord, headSHA, fixItemsStateHash string, unresolvedThreadIDs []string) (bool, storage.LoopRecord, error) {
+	if loop.Status != "paused" || r.repos == nil || r.repos.Runs == nil {
+		return false, loop, nil
+	}
+	latestRun, err := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return false, storage.LoopRecord{}, err
+	}
+	if latestRun == nil || latestRun.Status != "failed" || strings.TrimSpace(derefString(latestRun.ErrorMessage)) != noopResolveManualIntervention {
+		return false, loop, nil
+	}
+	checkpoint := parseCheckpoint(latestRun.CheckpointJSON)
+	previousHeadSHA := ""
+	if checkpoint.Detail != nil {
+		previousHeadSHA = strings.TrimSpace(checkpoint.Detail.HeadSHA)
+	}
+	previousStateHash := hashFixItemsState(checkpoint.FixItems)
+	if len(checkpoint.FixItems) == 0 {
+		previousStateHash = strings.TrimSpace(checkpoint.FixItemsHash)
+	}
+	previousThreadIDs := unresolvedThreadIDsFromCheckpoint(checkpoint)
+	if previousHeadSHA == strings.TrimSpace(headSHA) && previousStateHash == strings.TrimSpace(fixItemsStateHash) && sameStringSlices(previousThreadIDs, unresolvedThreadIDs) {
+		return false, loop, nil
+	}
+	updated, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+		updated.Status = "queued"
+		nextRunAt := r.nowISO()
+		updated.NextRunAt = &nextRunAt
+	})
+	if err != nil {
+		return false, storage.LoopRecord{}, err
+	}
+	return true, updated, nil
+}
+
+func (r *Runner) resumePausedRiskyConflictLoop(ctx context.Context, loop storage.LoopRecord, headSHA, fixItemsStateHash string) (bool, storage.LoopRecord, error) {
+	if loop.Status != "paused" || r.repos == nil || r.repos.Runs == nil {
+		return false, loop, nil
+	}
+	latestRun, err := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return false, storage.LoopRecord{}, err
+	}
+	if latestRun == nil || latestRun.Status != "failed" || !strings.Contains(strings.TrimSpace(derefString(latestRun.ErrorMessage)), riskyConflictManualHold) {
+		return false, loop, nil
+	}
+	checkpoint := parseCheckpoint(latestRun.CheckpointJSON)
+	previousHeadSHA := ""
+	if checkpoint.Detail != nil {
+		previousHeadSHA = strings.TrimSpace(checkpoint.Detail.HeadSHA)
+	}
+	previousStateHash := hashFixItemsState(checkpoint.FixItems)
+	if len(checkpoint.FixItems) == 0 {
+		previousStateHash = strings.TrimSpace(checkpoint.FixItemsHash)
+	}
+	if previousHeadSHA == strings.TrimSpace(headSHA) && previousStateHash == strings.TrimSpace(fixItemsStateHash) {
+		return false, loop, nil
+	}
+	updated, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+		updated.Status = "queued"
+		nextRunAt := r.nowISO()
+		updated.NextRunAt = &nextRunAt
+	})
+	if err != nil {
+		return false, storage.LoopRecord{}, err
+	}
+	return true, updated, nil
+}
+
+func unresolvedThreadIDsFromCheckpoint(checkpoint fixerCheckpoint) []string {
+	if checkpoint.Recheck != nil {
+		ids := unresolvedThreadIDs(checkpoint.Recheck.RemainingFixItems)
+		if len(ids) > 0 {
+			return ids
+		}
+	}
+	return unresolvedThreadIDs(checkpoint.FixItems)
 }
 
 func (r *Runner) recoverLegacyNoopFollowupLoops(ctx context.Context, project storage.ProjectRecord, repo string, policy DiscoveryPolicy, currentUser string) ([]storage.QueueItemRecord, error) {
@@ -4830,6 +4923,12 @@ func shouldRestartFromDiscover(status string, failedStep FixerStep, failureSumma
 	}
 	if failedStep == stepPush {
 		return strings.Contains(strings.ToLower(failureSummary), "remote head changed")
+	}
+	if failedStep == stepRepair && strings.Contains(failureSummary, riskyConflictManualHold) {
+		return true
+	}
+	if failedStep == stepRecheck && strings.TrimSpace(failureSummary) == noopResolveManualIntervention {
+		return true
 	}
 	if failedStep != stepResolveComments {
 		return false

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -565,6 +565,57 @@ func TestDiscoverPullRequestsKeepsPausedNoopResolveLoopForSameFixItems(t *testin
 	}
 }
 
+func TestDiscoverPullRequestsKeepsPausedNoopResolveLoopWhenOnlyDeclinedThreadRemains(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	activeFixItem := FixItem{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "c1@active", Summary: "same blocker"}
+	declinedFixItem := FixItem{Type: "comment", ID: "c2", ThreadID: "t2", ThreadFingerprint: "c2@declined", Summary: "declined blocker"}
+	allFixItems := []FixItem{activeFixItem, declinedFixItem}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
+		ResumePolicy: loops.ResumePolicyManualIntervention,
+		Detail:       &checkpointDetail{State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "threadFingerprint": "c1@active", "body": "same blocker"}, {"id": "c2", "threadId": "t2", "threadFingerprint": "c2@declined", "body": "declined blocker"}}},
+		FixItems:     allFixItems,
+		FixItemsHash: hashFixItemsState(allFixItems),
+		Push:         &checkpointPush{Pushed: false, SkippedReason: "No new commits to push"},
+		Recheck:      &checkpointRecheck{RemainingFixItems: allFixItems},
+	})
+	metadataJSON := mustMarshalJSON(map[string]any{
+		"declinedThreads": map[string]any{
+			buildDeclinedThreadFingerprint(declinedFixItem, "head-42"): map[string]any{"threadId": declinedFixItem.ThreadID},
+		},
+	})
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_noop_declined", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &metadataJSON, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_paused_noop_declined", LoopID: "loop_paused_noop_declined", Status: "failed", CurrentStep: stringPtr(string(stepRecheck)), LastCompletedStep: stringPtr(string(stepResolveComments)), CheckpointJSON: &checkpointJSON, Summary: stringPtr(noopResolveManualIntervention), ErrorMessage: stringPtr(noopResolveManualIntervention), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{
+		listOpen:      []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: "head-42"}},
+		viewResponses: []PullRequestDetail{{Number: prNumber, State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "threadFingerprint": "c1@active", "body": "same blocker"}, {"id": "c2", "threadId": "t2", "threadFingerprint": "c2@declined", "body": "declined blocker"}}}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want declined-only delta suppressed", result.QueueItems)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), "loop_paused_noop_declined")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "paused" || persisted.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want unchanged paused loop", persisted)
+	}
+}
+
 func TestDiscoverPullRequestsResumesPausedRiskyConflictLoopWhenFixItemsChange(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -467,6 +467,213 @@ func TestDiscoverPullRequestsPreservesPausedLoop(t *testing.T) {
 	}
 }
 
+func TestDiscoverPullRequestsResumesPausedNoopResolveLoopWhenFixItemsChange(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	previousFixItem := FixItem{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "c1@old"}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
+		ResumePolicy: loops.ResumePolicyManualIntervention,
+		Detail:       &checkpointDetail{State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "old blocker"}}},
+		FixItems:     []FixItem{previousFixItem},
+		FixItemsHash: hashFixItemsState([]FixItem{previousFixItem}),
+		Push:         &checkpointPush{Pushed: false, SkippedReason: "No new commits to push"},
+		Recheck:      &checkpointRecheck{RemainingFixItems: []FixItem{previousFixItem}},
+	})
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_noop_resolve", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_paused_noop_resolve", LoopID: "loop_paused_noop_resolve", Status: "failed", CurrentStep: stringPtr(string(stepRecheck)), LastCompletedStep: stringPtr(string(stepResolveComments)), CheckpointJSON: &checkpointJSON, Summary: stringPtr(noopResolveManualIntervention), ErrorMessage: stringPtr(noopResolveManualIntervention), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{
+		listOpen:      []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: "head-42"}},
+		viewResponses: []PullRequestDetail{{Number: prNumber, State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c2", "threadId": "t2", "body": "new blocker"}}}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want one requeued fixer item for changed fix items", result.QueueItems)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), "loop_paused_noop_resolve")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "queued" || persisted.NextRunAt == nil {
+		t.Fatalf("loop = %#v, want queued loop after changed fix items", persisted)
+	}
+	resumed, err := runner.createRunContext(context.Background(), *persisted)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if resumed.Resumed || resumed.StartStep != stepDiscoverPR {
+		t.Fatalf("resumed = %#v, want fresh discover run after changed fix items", resumed)
+	}
+	if resumed.Checkpoint.Detail != nil || len(resumed.Checkpoint.FixItems) != 0 || resumed.Checkpoint.Push != nil || resumed.Checkpoint.Recheck != nil {
+		t.Fatalf("checkpoint = %#v, want stale no-op resolve checkpoint cleared", resumed.Checkpoint)
+	}
+}
+
+func TestDiscoverPullRequestsKeepsPausedNoopResolveLoopForSameFixItems(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	fixItem := FixItem{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "legacy:t1:c1", Summary: "same blocker"}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
+		ResumePolicy: loops.ResumePolicyManualIntervention,
+		Detail:       &checkpointDetail{State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "same blocker"}}},
+		FixItems:     []FixItem{fixItem},
+		FixItemsHash: hashFixItemsState([]FixItem{fixItem}),
+		Push:         &checkpointPush{Pushed: false, SkippedReason: "No new commits to push"},
+		Recheck:      &checkpointRecheck{RemainingFixItems: []FixItem{fixItem}},
+	})
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_noop_same", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_paused_noop_same", LoopID: "loop_paused_noop_same", Status: "failed", CurrentStep: stringPtr(string(stepRecheck)), LastCompletedStep: stringPtr(string(stepResolveComments)), CheckpointJSON: &checkpointJSON, Summary: stringPtr(noopResolveManualIntervention), ErrorMessage: stringPtr(noopResolveManualIntervention), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{
+		listOpen:      []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: "head-42"}},
+		viewResponses: []PullRequestDetail{{Number: prNumber, State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "same blocker"}}}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want same no-op fingerprint suppressed", result.QueueItems)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), "loop_paused_noop_same")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "paused" || persisted.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want unchanged paused loop", persisted)
+	}
+}
+
+func TestDiscoverPullRequestsResumesPausedRiskyConflictLoopWhenFixItemsChange(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	previousFixItem := FixItem{Type: "conflict", Files: []string{}}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
+		ResumePolicy: loops.ResumePolicyManualIntervention,
+		Detail:       &checkpointDetail{State: "OPEN", HeadSHA: "head-42", HasConflicts: true},
+		FixItems:     []FixItem{previousFixItem},
+		FixItemsHash: hashFixItemsState([]FixItem{previousFixItem}),
+	})
+	message := "Skipped acme/looper#42 because risky conflict fixes require manual intervention"
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_risky_conflict", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_paused_risky_conflict", LoopID: "loop_paused_risky_conflict", Status: "failed", CurrentStep: stringPtr(string(stepRepair)), LastCompletedStep: stringPtr(string(stepPrepareWorktree)), CheckpointJSON: &checkpointJSON, Summary: stringPtr(message), ErrorMessage: stringPtr(message), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{
+		listOpen:      []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: "head-42"}},
+		viewResponses: []PullRequestDetail{{Number: prNumber, State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "now fix this comment"}}}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want one requeued fixer item after conflict signal changed", result.QueueItems)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), "loop_paused_risky_conflict")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	resumed, err := runner.createRunContext(context.Background(), *persisted)
+	if err != nil {
+		t.Fatalf("createRunContext() error = %v", err)
+	}
+	if resumed.Resumed || resumed.StartStep != stepDiscoverPR {
+		t.Fatalf("resumed = %#v, want fresh discover run after risky-conflict signal changed", resumed)
+	}
+}
+
+func TestDiscoverPullRequestsKeepsPausedRiskyConflictLoopForSameConflict(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	fixItem := FixItem{Type: "conflict", Files: []string{}}
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: loops.ResumePolicyManualIntervention, Detail: &checkpointDetail{State: "OPEN", HeadSHA: "head-42", HasConflicts: true}, FixItems: []FixItem{fixItem}, FixItemsHash: hashFixItemsState([]FixItem{fixItem})})
+	message := "Skipped acme/looper#42 because risky conflict fixes require manual intervention"
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_risky_same", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_paused_risky_same", LoopID: "loop_paused_risky_same", Status: "failed", CurrentStep: stringPtr(string(stepRepair)), LastCompletedStep: stringPtr(string(stepPrepareWorktree)), CheckpointJSON: &checkpointJSON, Summary: stringPtr(message), ErrorMessage: stringPtr(message), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: "head-42"}}, viewResponses: []PullRequestDetail{{Number: prNumber, State: "OPEN", HeadSHA: "head-42", HasConflicts: true}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want same risky-conflict fingerprint suppressed", result.QueueItems)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), "loop_paused_risky_same")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "paused" || persisted.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want unchanged paused loop", persisted)
+	}
+}
+
+func TestDiscoverPullRequestsKeepsOtherManualInterventionPausedOnNewSignal(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: loops.ResumePolicyManualIntervention, Detail: &checkpointDetail{State: "OPEN", HeadSHA: "old-head"}})
+	message := "Auto push disabled; manual fix push required for branch feature/fix-42"
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_auto_push", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_paused_auto_push", LoopID: "loop_paused_auto_push", Status: "failed", CurrentStep: stringPtr(string(stepPush)), LastCompletedStep: stringPtr(string(stepValidate)), CheckpointJSON: &checkpointJSON, Summary: stringPtr(message), ErrorMessage: stringPtr(message), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: "new-head"}}, viewResponses: []PullRequestDetail{{Number: prNumber, State: "OPEN", HeadSHA: "new-head", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "new blocker"}}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want auto-push hard hold to remain paused", result.QueueItems)
+	}
+}
+
 func TestEnqueueScopesFixerDedupeKeyToLoop(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/runtime/webhook_runtime_test.go
+++ b/internal/runtime/webhook_runtime_test.go
@@ -419,15 +419,30 @@ func TestWebhookRuntimeReconcileLaunchesNewForwarderDespiteExistingForwarderDegr
 		t.Fatal("new forwarder did not launch while only existing forwarder degradation remained")
 	}
 
-	status := rt.Status()
+	var status WebhookStatus
+	var launched *WebhookForwarderState
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		status = rt.Status()
+		for i := range status.Forwarders {
+			if status.Forwarders[i].Repo == "nexu-io/other" {
+				launched = &status.Forwarders[i]
+				break
+			}
+		}
+		if launched != nil && launched.Running {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if len(status.Forwarders) != 2 {
 		t.Fatalf("len(Status().Forwarders) = %d, want 2", len(status.Forwarders))
 	}
-	if status.Forwarders[1].Repo != "nexu-io/other" {
-		t.Fatalf("Status().Forwarders[1].Repo = %q, want nexu-io/other", status.Forwarders[1].Repo)
+	if launched == nil {
+		t.Fatalf("Status().Forwarders = %v, want launched forwarder for nexu-io/other", status.Forwarders)
 	}
-	if !status.Forwarders[1].Running {
-		t.Fatal("Status().Forwarders[1].Running = false, want true after launching new repo forwarder")
+	if !launched.Running {
+		t.Fatal("Status().Forwarders[nexu-io/other].Running = false, want true after launching new repo forwarder")
 	}
 	if !status.Degraded {
 		t.Fatal("Status().Degraded = false, want true while existing forwarder degradation remains")


### PR DESCRIPTION
## Summary
- requeue fixer loops paused by no-op resolve or risky-conflict holds when the PR head or fix-item fingerprint changes
- keep identical fingerprints suppressed so fixer does not loop on the same unresolved signal
- force recovered pauses to restart from discovery, while preserving true hard holds like disabled auto-push/auto-commit and dirty worktrees

## Validation
- go test ./internal/fixer
- go test ./internal/fixer ./internal/loops ./internal/runtime
- go test ./...

## Notes
- The PR live state and fix-item fingerprint are the authority for requeueing; paused run checkpoints are only used to scope whether an existing hold still matches the current signal.