### PR TITLE
fix: retry transient git fetch ref lock races

### DIFF
--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -24,6 +24,8 @@ var (
 	pushConflictErrorPattern    = regexp.MustCompile(`(?i)stale info|non-fast-forward|failed to push|rejected`)
 )
 
+var fetchRefLockRetryDelays = []time.Duration{50 * time.Millisecond, 100 * time.Millisecond}
+
 type CheckoutMode string
 
 const (
@@ -903,6 +905,25 @@ func (g *Gateway) runGit(ctx context.Context, cwd string, env map[string]string,
 }
 
 func (g *Gateway) runGitResult(ctx context.Context, cwd string, env map[string]string, args ...string) (shell.Result, error) {
+	var result shell.Result
+	var err error
+	for attempt := 0; ; attempt++ {
+		result, err = g.runGitResultOnce(ctx, cwd, env, args...)
+		if err == nil || !isRetryableFetchRefLockRace(args, err) || attempt >= len(fetchRefLockRetryDelays) {
+			return result, err
+		}
+
+		timer := time.NewTimer(fetchRefLockRetryDelays[attempt])
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return result, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (g *Gateway) runGitResultOnce(ctx context.Context, cwd string, env map[string]string, args ...string) (shell.Result, error) {
 	result, err := shell.Run(ctx, shell.Options{Command: g.gitPath, Args: args, CWD: cwd, Env: env})
 	if err == nil {
 		return result, nil
@@ -923,6 +944,14 @@ func (g *Gateway) runGitResult(ctx context.Context, cwd string, env map[string]s
 	}
 
 	return result, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+}
+
+func isRetryableFetchRefLockRace(args []string, err error) bool {
+	if len(args) == 0 || args[0] != "fetch" || err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "cannot lock ref") && strings.Contains(message, " but expected ")
 }
 
 func buildWorktreeDirectoryName(input CreateWorktreeInput) string {

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -649,6 +649,41 @@ func TestGatewayResolveDetachedStartPointPropagatesFetchFailure(t *testing.T) {
 	}
 }
 
+func TestGatewayRetriesFetchWhenRemoteTrackingRefWasUpdatedConcurrently(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	gitPath := writeFakeGit(t, `#!/bin/sh
+count_file="$FAKE_GIT_COUNT"
+count=0
+if [ -f "$count_file" ]; then
+	count=$(cat "$count_file")
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+if [ "$count" -eq 1 ]; then
+	cat >&2 <<'EOF'
+From github.com:nexu-io/open-design
+ * branch                main       -> FETCH_HEAD
+error: cannot lock ref 'refs/remotes/origin/main': is at e64f1d8497409e76387cce3afcd5c51406a4174d but expected 6bf865a43beb8149c8f64a0af297c09c313f9a4a
+ ! 6bf865a43..e64f1d849  main       -> origin/main  (unable to update local ref)
+EOF
+	exit 1
+fi
+exit 0
+`)
+	countPath := filepath.Join(t.TempDir(), "git-count")
+	gateway := New(Options{GitPath: gitPath})
+
+	err := gateway.runGit(ctx, t.TempDir(), map[string]string{"FAKE_GIT_COUNT": countPath}, "fetch", "origin", "main")
+	if err != nil {
+		t.Fatalf("runGit(fetch) error = %v, want retry success", err)
+	}
+	if got := stringsTrimSpace(readFile(t, countPath)); got != "2" {
+		t.Fatalf("git attempts = %s, want 2", got)
+	}
+}
+
 func TestGatewayRemoteBranchExistsTreatsOnlyExitCode1AsMissing(t *testing.T) {
 	t.Parallel()
 
@@ -897,6 +932,15 @@ func runGitCommand(cwd string, args ...string) (string, error) {
 		return "", fmt.Errorf("%s", message)
 	}
 	return stdout.String(), nil
+}
+
+func writeFakeGit(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "git")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+	return path
 }
 
 func stringsTrimSpace(value string) string {


### PR DESCRIPTION
## Summary
- Retry transient `git fetch` ref-lock races caused by concurrent updates to shared remote-tracking refs.
- Keep retry behavior narrowly scoped to `fetch` errors matching `cannot lock ref ... but expected ...`.
- Add regression coverage for the observed `origin/main` race.

## Validation
- `go test ./internal/infra/git`
- `go test ./internal/reviewer -run TestRunPrepareWorktreeStep -count=1`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- @oracle review: no actionable issues found