### PR TITLE
fix: suppress config deprecation noise

### DIFF
--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -2230,6 +2230,38 @@ func TestConfigValidatePrintsLegacyDefaultConfigMigrationNote(t *testing.T) {
 	}
 }
 
+func TestConfigShowSourceSuppressesLegacyDefaultConfigMigrationNote(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	looperHome := filepath.Join(homeDir, ".looper")
+	if err := os.MkdirAll(looperHome, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+	legacyDefaultPath := filepath.Join(looperHome, "config.json")
+	if err := os.WriteFile(legacyDefaultPath, []byte(`{"server":{"port":7400}}`), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	exitCode, stdout, stderr := runApp(t, "config", "show", "--source")
+	if exitCode != 0 {
+		t.Fatalf("Run([config show --source]) exit code = %d, want 0; stdout=%q stderr=%q", exitCode, stdout, stderr)
+	}
+	if strings.Contains(stderr, "note: legacy default config file ") {
+		t.Fatalf("stderr = %q, want migration note suppressed", stderr)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("unmarshal source output: %v", err)
+	}
+	fields, ok := decoded["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("fields = %#v, want object", decoded["fields"])
+	}
+	if len(fields) == 0 {
+		t.Fatalf("fields = %#v, want non-empty source map", fields)
+	}
+}
+
 func TestConfigMigrateDryRunCanonicalizesLegacyJSONWithoutWritingDestination(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "legacy.json")
 	if err := os.WriteFile(configPath, []byte(`{"reviewer":{"reviewEvents":{"clean":"COMMENT"}},"defaults":{"allowAutoApprove":true},"projects":[{"id":"repo","name":"Repo","path":"/tmp/repo","instructions":{"reviewer":"check carefully"}}]}`), 0o644); err != nil {

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -2230,6 +2230,16 @@ func TestConfigValidatePrintsLegacyDefaultConfigMigrationNote(t *testing.T) {
 	}
 }
 
+func TestConfigCommandPathSkipsExplicitBoolLiteralForConfigFlag(t *testing.T) {
+	command, subcommand := configCommandPath([]string{"config", "--no-custom-instructions", "false", "validate"})
+	if got, want := command, "config"; got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+	if got, want := subcommand, "validate"; got != want {
+		t.Fatalf("subcommand = %q, want %q", got, want)
+	}
+}
+
 func TestConfigShowSourceSuppressesLegacyDefaultConfigMigrationNote(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -2705,6 +2705,39 @@ func TestPSWithoutJSONPrintsEmptyMessage(t *testing.T) {
 	}
 }
 
+func TestPSSuppressesConfigFileDeprecationNotices(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/runs/active"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_active_runs", map[string]any{"items": []map[string]any{}}))
+	}))
+	defer server.Close()
+
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"server": map[string]any{
+			"baseUrl":  server.URL,
+			"authMode": "none",
+		},
+		"reviewer": map[string]any{"reviewEvents": map[string]any{"clean": "COMMENT"}},
+		"defaults": map[string]any{"allowAutoApprove": true},
+		"roles":    map[string]any{"reviewer": map[string]any{"autoDiscovery": true}},
+	})
+
+	exitCode, stdout, stderr := runApp(t, "ps", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([ps]) exit code = %d, want 0; stdout=%q stderr=%q", exitCode, stdout, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([ps]) stderr = %q, want empty string", stderr)
+	}
+	if got, want := stdout, "No running or queued loops.\n"; got != want {
+		t.Fatalf("Run([ps]) stdout = %q, want %q", got, want)
+	}
+}
+
 func TestPSWithoutJSONShowsRunningLoopWithoutRunRow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/config_commands.go
+++ b/internal/cliapp/config_commands.go
@@ -748,7 +748,7 @@ func (r *commandRuntime) loadConfigForEdit() (config.LoadedFileConfig, error) {
 	if err != nil {
 		return config.LoadedFileConfig{}, err
 	}
-	r.emitConfigLoadNotices(loaded)
+	r.emitConfigLoadNotices(r.filterConfigLoadNoticesForCommand(loaded))
 	return loaded, nil
 }
 

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -748,8 +748,74 @@ func (r *commandRuntime) loadConfig() (config.LoadedFileConfig, error) {
 	if err != nil {
 		return config.LoadedFileConfig{}, err
 	}
-	r.emitConfigLoadNotices(loaded)
+	r.emitConfigLoadNotices(r.filterConfigLoadNoticesForCommand(loaded))
 	return loaded, nil
+}
+
+func (r *commandRuntime) filterConfigLoadNoticesForCommand(loaded config.LoadedFileConfig) config.LoadedFileConfig {
+	if shouldEmitConfigFileNotices(r.argv) {
+		return loaded
+	}
+	filtered := loaded
+	filtered.Warnings = filterNonConfigPathWarnings(loaded.Warnings)
+	filtered.Notices = nil
+	return filtered
+}
+
+func filterNonConfigPathWarnings(warnings []string) []string {
+	if len(warnings) == 0 {
+		return nil
+	}
+	filtered := make([]string, 0, len(warnings))
+	for _, warning := range warnings {
+		if strings.HasPrefix(warning, "deprecated config path ") {
+			continue
+		}
+		filtered = append(filtered, warning)
+	}
+	return filtered
+}
+
+func shouldEmitConfigFileNotices(argv []string) bool {
+	command, subcommand := configCommandPath(argv)
+	return command == "config" && (subcommand == "validate" || subcommand == "lint")
+}
+
+func configCommandPath(argv []string) (string, string) {
+	skipNext := false
+	parts := make([]string, 0, 2)
+	for _, arg := range argv {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if arg == "--" {
+			break
+		}
+		if strings.HasPrefix(arg, "--") {
+			name := strings.TrimPrefix(arg, "--")
+			if index := strings.IndexByte(name, '='); index >= 0 {
+				name = name[:index]
+			}
+			_, isConfigFlag := configFlagNames[name]
+			_, isConfigBoolFlag := configBoolFlagNames[name]
+			if isConfigFlag && !isConfigBoolFlag && !strings.Contains(arg, "=") {
+				skipNext = true
+			}
+			continue
+		}
+		parts = append(parts, arg)
+		if len(parts) == 2 {
+			break
+		}
+	}
+	if len(parts) == 0 {
+		return "", ""
+	}
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return parts[0], parts[1]
 }
 
 func (r *commandRuntime) emitConfigLoadNotices(loaded config.LoadedFileConfig) {

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -784,7 +784,7 @@ func shouldEmitConfigFileNotices(argv []string) bool {
 func configCommandPath(argv []string) (string, string) {
 	skipNext := false
 	parts := make([]string, 0, 2)
-	for _, arg := range argv {
+	for index, arg := range argv {
 		if skipNext {
 			skipNext = false
 			continue
@@ -799,8 +799,10 @@ func configCommandPath(argv []string) (string, string) {
 			}
 			_, isConfigFlag := configFlagNames[name]
 			_, isConfigBoolFlag := configBoolFlagNames[name]
-			if isConfigFlag && !isConfigBoolFlag && !strings.Contains(arg, "=") {
-				skipNext = true
+			if isConfigFlag && !strings.Contains(arg, "=") {
+				if !isConfigBoolFlag || (index+1 < len(argv) && isConfigBoolLiteral(argv[index+1])) {
+					skipNext = true
+				}
 			}
 			continue
 		}


### PR DESCRIPTION
## Summary
- suppress legacy config-path warnings and default config migration notes during normal CLI commands
- keep config migration notices visible for `looper config validate` and `looper config lint`
- add regression coverage for `looper ps` with legacy config keys

## Testing
- `go test ./internal/cliapp`
- `go test ./internal/config`
- `go test ./...`
- `go run ./cmd/looper ps`
- `go run ./cmd/looper config validate`
- `go run ./cmd/looper config migrate --dry-run`
- temp-copy `looper config migrate --from ... --to ...` + `config validate`