### PR TITLE
feat: trigger fixer from CI check webhook events

### DIFF
--- a/internal/runtime/webhook_forwarder.go
+++ b/internal/runtime/webhook_forwarder.go
@@ -27,6 +27,7 @@ var webhookForwarderEvents = []string{
 	"issue_comment",
 	"pull_request_review",
 	"pull_request_review_comment",
+	"check_run",
 }
 
 type WebhookRuntimeStatus struct {

--- a/internal/runtime/webhook_forwarder_test.go
+++ b/internal/runtime/webhook_forwarder_test.go
@@ -136,8 +136,9 @@ func TestWebhookForwarderManagerStartsUniqueReposAndRetainsTail(t *testing.T) {
 		if item.command.Path != ghPath {
 			t.Fatalf("forwarder gh path = %q, want %q", item.command.Path, ghPath)
 		}
-		if got := strings.Join(item.command.Events, ","); got != strings.Join(webhookForwarderEvents, ",") {
-			t.Fatalf("forwarder events = %q, want %q", got, strings.Join(webhookForwarderEvents, ","))
+		wantEvents := []string{"pull_request", "issue_comment", "pull_request_review", "pull_request_review_comment", "check_run"}
+		if got := strings.Join(item.command.Events, ","); got != strings.Join(wantEvents, ",") {
+			t.Fatalf("forwarder events = %q, want %q", got, strings.Join(wantEvents, ","))
 		}
 		if item.command.URL != "http://127.0.0.1:17310/webhook/forward" {
 			t.Fatalf("forwarder URL = %q, want loopback webhook URL", item.command.URL)

--- a/internal/webhookforward/forwarder.go
+++ b/internal/webhookforward/forwarder.go
@@ -135,7 +135,7 @@ type workItem struct {
 type routedDelivery struct {
 	repo       string
 	objectType string
-	number     int64
+	numbers    []int64
 	action     string
 	lanes      map[Lane]struct{}
 }
@@ -161,6 +161,24 @@ type issueCommentEnvelope struct {
 			URL string `json:"url"`
 		} `json:"pull_request"`
 	} `json:"issue"`
+}
+
+type pullRequestRef struct {
+	Number int64 `json:"number"`
+}
+
+type checkRunEnvelope struct {
+	Action     string `json:"action"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	CheckRun struct {
+		Conclusion   string           `json:"conclusion"`
+		PullRequests []pullRequestRef `json:"pull_requests"`
+		CheckSuite   struct {
+			PullRequests []pullRequestRef `json:"pull_requests"`
+		} `json:"check_suite"`
+	} `json:"check_run"`
 }
 
 type forwarder struct {
@@ -331,15 +349,20 @@ func (f *forwarder) enqueueLocked(projects []storage.ProjectRecord, routed route
 		if len(lanes) == 0 {
 			continue
 		}
-		matched++
-		key := workKey{ProjectID: project.ID, Repo: repo, ObjectType: routed.objectType, Number: routed.number}
-		candidates = append(candidates, candidate{key: key, lanes: lanes})
-		itemKey := workKeyString(key)
-		item, exists := f.works[itemKey]
-		if exists && (item.running || item.enqueued) {
-			continue
+		for _, number := range routed.numbers {
+			if number <= 0 {
+				continue
+			}
+			matched++
+			key := workKey{ProjectID: project.ID, Repo: repo, ObjectType: routed.objectType, Number: number}
+			candidates = append(candidates, candidate{key: key, lanes: lanes})
+			itemKey := workKeyString(key)
+			item, exists := f.works[itemKey]
+			if exists && (item.running || item.enqueued) {
+				continue
+			}
+			newQueueEntries++
 		}
-		newQueueEntries++
 	}
 	if newQueueEntries > f.queueCapacity-len(f.queue) {
 		f.stats.QueueRejected++
@@ -555,7 +578,7 @@ func routeDelivery(eventType string, payload []byte) (routedDelivery, bool, erro
 		if strings.TrimSpace(envelope.Repository.FullName) == "" || envelope.PullRequest.Number <= 0 {
 			return routedDelivery{}, false, errors.New("pull_request webhook missing repository or number")
 		}
-		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", number: envelope.PullRequest.Number, action: strings.TrimSpace(envelope.Action), lanes: lanes}, true, nil
+		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", numbers: []int64{envelope.PullRequest.Number}, action: strings.TrimSpace(envelope.Action), lanes: lanes}, true, nil
 	case "issue_comment":
 		var envelope issueCommentEnvelope
 		if err := json.Unmarshal(payload, &envelope); err != nil {
@@ -567,7 +590,7 @@ func routeDelivery(eventType string, payload []byte) (routedDelivery, bool, erro
 		if strings.TrimSpace(envelope.Repository.FullName) == "" || envelope.Issue.Number <= 0 {
 			return routedDelivery{}, false, errors.New("issue_comment webhook missing repository or number")
 		}
-		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", number: envelope.Issue.Number, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneFixer: {}}}, true, nil
+		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", numbers: []int64{envelope.Issue.Number}, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneFixer: {}}}, true, nil
 	case "pull_request_review", "pull_request_review_comment":
 		var envelope pullRequestEnvelope
 		if err := json.Unmarshal(payload, &envelope); err != nil {
@@ -576,9 +599,53 @@ func routeDelivery(eventType string, payload []byte) (routedDelivery, bool, erro
 		if strings.TrimSpace(envelope.Repository.FullName) == "" || envelope.PullRequest.Number <= 0 {
 			return routedDelivery{}, false, fmt.Errorf("%s webhook missing repository or number", eventType)
 		}
-		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", number: envelope.PullRequest.Number, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneFixer: {}}}, true, nil
+		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", numbers: []int64{envelope.PullRequest.Number}, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneFixer: {}}}, true, nil
+	case "check_run":
+		var envelope checkRunEnvelope
+		if err := json.Unmarshal(payload, &envelope); err != nil {
+			return routedDelivery{}, false, fmt.Errorf("decode check_run webhook: %w", err)
+		}
+		if strings.TrimSpace(envelope.Action) != "completed" || !isFailingCheckConclusion(envelope.CheckRun.Conclusion) {
+			return routedDelivery{}, false, nil
+		}
+		numbers := pullRequestNumbers(envelope.CheckRun.PullRequests)
+		if len(numbers) == 0 {
+			numbers = pullRequestNumbers(envelope.CheckRun.CheckSuite.PullRequests)
+		}
+		if strings.TrimSpace(envelope.Repository.FullName) == "" {
+			return routedDelivery{}, false, errors.New("check_run webhook missing repository")
+		}
+		if len(numbers) == 0 {
+			return routedDelivery{}, false, nil
+		}
+		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", numbers: numbers, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneFixer: {}}}, true, nil
 	default:
 		return routedDelivery{}, false, nil
+	}
+}
+
+func pullRequestNumbers(items []pullRequestRef) []int64 {
+	seen := make(map[int64]struct{}, len(items))
+	numbers := make([]int64, 0, len(items))
+	for _, item := range items {
+		if item.Number <= 0 {
+			continue
+		}
+		if _, ok := seen[item.Number]; ok {
+			continue
+		}
+		seen[item.Number] = struct{}{}
+		numbers = append(numbers, item.Number)
+	}
+	return numbers
+}
+
+func isFailingCheckConclusion(conclusion string) bool {
+	switch strings.ToUpper(strings.TrimSpace(conclusion)) {
+	case "FAILURE", "FAILED", "ERROR", "TIMED_OUT", "ACTION_REQUIRED":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/webhookforward/forwarder_test.go
+++ b/internal/webhookforward/forwarder_test.go
@@ -81,6 +81,62 @@ func TestForwardIgnoresUnsupportedAndNonPullRequestIssueComments(t *testing.T) {
 	fixerRunner.assertCallCount(t, 0)
 }
 
+func TestForwardTriggersFixerForFailedCheckWebhookEvents(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(nil)
+	fixerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: fixerRunner}, MaxConcurrent: 1, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	requests := []DeliveryRequest{
+		{DeliveryID: "check-run-1", EventType: "check_run", Payload: checkRunPayload("completed", "failure", "acme/looper", 42)},
+		{DeliveryID: "check-run-2", EventType: "check_run", Payload: checkRunFallbackPayload("completed", "timed_out", "acme/looper", 43)},
+	}
+
+	for _, request := range requests {
+		result, err := forwarder.Forward(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Forward(%s) error = %v", request.EventType, err)
+		}
+		if result.Status != "accepted" {
+			t.Fatalf("Forward(%s) status = %q, want accepted", request.EventType, result.Status)
+		}
+	}
+
+	fixerRunner.waitForCalls(t, 2)
+	fixerRunner.assertPRCount(t, 42, 1)
+	fixerRunner.assertPRCount(t, 43, 1)
+	reviewerRunner.assertCallCount(t, 0)
+}
+
+func TestForwardIgnoresNonPRAndNonFailedCheckWebhookEvents(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(nil)
+	fixerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: fixerRunner}, MaxConcurrent: 1, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	for _, request := range []DeliveryRequest{
+		{DeliveryID: "check-run-no-pr", EventType: "check_run", Payload: []byte(`{"action":"completed","repository":{"full_name":"acme/looper"},"check_run":{"conclusion":"failure","pull_requests":[]}}`)},
+		{DeliveryID: "check-run-success", EventType: "check_run", Payload: checkRunPayload("completed", "success", "acme/looper", 42)},
+		{DeliveryID: "check-run-pending", EventType: "check_run", Payload: checkRunPayload("requested", "", "acme/looper", 42)},
+	} {
+		result, err := forwarder.Forward(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Forward(%s) error = %v", request.DeliveryID, err)
+		}
+		if result.Status != "ignored" {
+			t.Fatalf("Forward(%s) status = %q, want ignored", request.DeliveryID, result.Status)
+		}
+	}
+
+	shortSleep()
+	reviewerRunner.assertCallCount(t, 0)
+	fixerRunner.assertCallCount(t, 0)
+}
+
 func TestForwardFansOutToMultipleProjectsForSameRepo(t *testing.T) {
 	repos := newTestRepositories(t)
 	seedProject(t, repos, "project_1", "acme/looper")
@@ -433,6 +489,14 @@ func seedProject(t *testing.T, repos *storage.Repositories, projectID, repo stri
 
 func pullRequestPayload(action, repo string, prNumber int64) []byte {
 	return []byte(`{"action":"` + action + `","repository":{"full_name":"` + repo + `"},"pull_request":{"number":` + itoa(prNumber) + `}}`)
+}
+
+func checkRunPayload(action, conclusion, repo string, prNumber int64) []byte {
+	return []byte(`{"action":"` + action + `","repository":{"full_name":"` + repo + `"},"check_run":{"conclusion":"` + conclusion + `","pull_requests":[{"number":` + itoa(prNumber) + `}]}}`)
+}
+
+func checkRunFallbackPayload(action, conclusion, repo string, prNumber int64) []byte {
+	return []byte(`{"action":"` + action + `","repository":{"full_name":"` + repo + `"},"check_run":{"conclusion":"` + conclusion + `","pull_requests":[],"check_suite":{"pull_requests":[{"number":` + itoa(prNumber) + `}]}}}`)
 }
 
 func itoa(value int64) string {


### PR DESCRIPTION
## Summary
- subscribe webhook forwarding to `check_run` events so failed PR checks reach looper immediately
- route failed PR-associated check webhook deliveries into targeted fixer discovery without waiting for fallback polling
- cover the new webhook subscription and fixer wake-up path with runtime and forwarder tests

## Testing
- go test ./internal/webhookforward
- go test ./internal/runtime
- go vet ./...
- go test ./...
- go build ./...

Closes #384

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>