### PR TITLE
feat: make merge-conflict fixer discovery responsive to base-branch changes

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -135,12 +135,13 @@ type FixItem struct {
 }
 
 type PullRequestSummary struct {
-	Number  int64
-	State   string
-	IsDraft bool
-	Labels  []string
-	HeadSHA string
-	Author  string
+	Number      int64
+	State       string
+	IsDraft     bool
+	Labels      []string
+	BaseRefName string
+	HeadSHA     string
+	Author      string
 }
 
 type PullRequestDetail struct {
@@ -161,12 +162,13 @@ type PullRequestDetail struct {
 }
 
 type ListOpenPullRequestsInput struct {
-	Repo   string
-	CWD    string
-	Limit  int
-	Author string
-	Label  string
-	Labels []string
+	Repo        string
+	CWD         string
+	Limit       int
+	Author      string
+	Label       string
+	Labels      []string
+	BaseRefName string
 }
 
 type ViewPullRequestInput struct {
@@ -498,6 +500,13 @@ type TargetedDiscoveryInput struct {
 	Repo      string
 	PRNumber  int64
 	Snapshot  *githubinfra.DiscoverySnapshot
+}
+
+type BaseBranchDiscoveryInput struct {
+	ProjectID   string
+	Repo        string
+	BaseRefName string
+	Snapshot    *githubinfra.DiscoverySnapshot
 }
 
 type DiscoveryResult struct {
@@ -1080,7 +1089,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
-	openPRs, err := r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, input.Repo, project.RepoPath, input.Limit, currentUser, policy)
+	openPRs, err := r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, input.Repo, project.RepoPath, input.Limit, currentUser, policy, "")
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
@@ -1148,6 +1157,55 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 	return result, nil
 }
 
+func (r *Runner) DiscoverPullRequestsForBaseBranchUpdate(ctx context.Context, input BaseBranchDiscoveryInput) (DiscoveryResult, error) {
+	baseRefName := strings.TrimSpace(input.BaseRefName)
+	if baseRefName == "" {
+		return DiscoveryResult{}, fmt.Errorf("baseRefName is required")
+	}
+	ctx = githubinfra.ContextWithDiscoverySnapshot(ctx, input.Snapshot)
+	if r.repos == nil || r.repos.Projects == nil || r.repos.Loops == nil || r.repos.Queue == nil || r.repos.Runs == nil || r.repos.Locks == nil {
+		return DiscoveryResult{}, fmt.Errorf("fixer repositories are not configured")
+	}
+	project, err := r.repos.Projects.GetByID(ctx, input.ProjectID)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if project == nil {
+		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
+	}
+	policy := r.discoveryPolicyForProject(project.ID)
+	if !policy.AutoDiscovery {
+		return DiscoveryResult{Skipped: 1}, nil
+	}
+	currentUser := ""
+	if policy.AuthorFilter != config.FixerAuthorFilterAny {
+		currentUser, err = r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		currentUser = strings.TrimSpace(currentUser)
+	}
+	openPRs, err := r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, input.Repo, project.RepoPath, 0, currentUser, policy, baseRefName)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	result := DiscoveryResult{}
+	for _, pr := range openPRs {
+		if !r.pullRequestEligibleForDiscovery(ctx, pr, input.Repo, currentUser, policy) {
+			result.Skipped++
+			continue
+		}
+		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: pr.Number, CWD: project.RepoPath})
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		if err := r.discoverPullRequestFromDetail(ctx, *project, input.Repo, detail, &result); err != nil {
+			return DiscoveryResult{}, err
+		}
+	}
+	return result, nil
+}
+
 func appendDiscoveryQueueItem(items *[]storage.QueueItemRecord, item storage.QueueItemRecord) {
 	for i, existing := range *items {
 		if existing.ID == item.ID {
@@ -1159,20 +1217,20 @@ func appendDiscoveryQueueItem(items *[]storage.QueueItemRecord, item storage.Que
 }
 
 func (r *Runner) listOpenPullRequestsForDiscovery(ctx context.Context, repo, cwd string, limit int, author string) ([]PullRequestSummary, error) {
-	return r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, repo, cwd, limit, author, r.discoveryPolicy)
+	return r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, repo, cwd, limit, author, r.discoveryPolicy, "")
 }
 
-func (r *Runner) listOpenPullRequestsForDiscoveryWithPolicy(ctx context.Context, repo, cwd string, limit int, author string, policy DiscoveryPolicy) ([]PullRequestSummary, error) {
+func (r *Runner) listOpenPullRequestsForDiscoveryWithPolicy(ctx context.Context, repo, cwd string, limit int, author string, policy DiscoveryPolicy, baseRefName string) ([]PullRequestSummary, error) {
 	labels := prQueryLabels(policy.Labels)
 	effectiveLimit := defaultDiscoveryLimit(limit)
 	if len(labels) == 0 {
-		return r.github.ListOpenPullRequests(ctx, ListOpenPullRequestsInput{Repo: repo, CWD: cwd, Limit: limit, Author: author})
+		return r.github.ListOpenPullRequests(ctx, ListOpenPullRequestsInput{Repo: repo, CWD: cwd, Limit: limit, Author: author, BaseRefName: baseRefName})
 	}
 	if len(labels) == 1 {
-		return r.github.ListOpenPullRequests(ctx, ListOpenPullRequestsInput{Repo: repo, CWD: cwd, Limit: limit, Author: author, Label: labels[0]})
+		return r.github.ListOpenPullRequests(ctx, ListOpenPullRequestsInput{Repo: repo, CWD: cwd, Limit: limit, Author: author, Label: labels[0], BaseRefName: baseRefName})
 	}
 	if policy.LabelMode == config.LabelModeAll {
-		return r.github.ListOpenPullRequests(ctx, ListOpenPullRequestsInput{Repo: repo, CWD: cwd, Limit: limit, Author: author, Labels: labels})
+		return r.github.ListOpenPullRequests(ctx, ListOpenPullRequestsInput{Repo: repo, CWD: cwd, Limit: limit, Author: author, Labels: labels, BaseRefName: baseRefName})
 	}
 
 	result := []PullRequestSummary{}
@@ -1181,7 +1239,7 @@ func (r *Runner) listOpenPullRequestsForDiscoveryWithPolicy(ctx context.Context,
 		if len(result) >= effectiveLimit {
 			break
 		}
-		prs, err := r.github.ListOpenPullRequests(ctx, ListOpenPullRequestsInput{Repo: repo, CWD: cwd, Limit: effectiveLimit, Author: author, Label: label})
+		prs, err := r.github.ListOpenPullRequests(ctx, ListOpenPullRequestsInput{Repo: repo, CWD: cwd, Limit: effectiveLimit, Author: author, Label: label, BaseRefName: baseRefName})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -256,6 +256,68 @@ func TestDiscoverPullRequestSkipsIneligiblePullRequest(t *testing.T) {
 	}
 }
 
+func TestDiscoverPullRequestsForBaseBranchUpdateTargetsMatchingBaseBranch(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		listOpen: []PullRequestSummary{
+			{Number: 42, State: "OPEN", BaseRefName: "main", HeadSHA: "head-42"},
+			{Number: 43, State: "OPEN", BaseRefName: "release", HeadSHA: "head-43"},
+		},
+		viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "head-42", BaseRefName: "main", HasConflicts: true}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequestsForBaseBranchUpdate(context.Background(), BaseBranchDiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", BaseRefName: "main"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequestsForBaseBranchUpdate() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 || *result.QueueItems[0].PRNumber != 42 {
+		t.Fatalf("QueueItems = %#v, want only PR #42", result.QueueItems)
+	}
+	if len(github.listCalls) != 1 || github.listCalls[0].BaseRefName != "main" {
+		t.Fatalf("list calls = %#v, want base branch filtered discovery", github.listCalls)
+	}
+}
+
+func TestDiscoverPullRequestsForBaseBranchUpdateAppliesLabelFilters(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		listOpenByLabel: map[string][]PullRequestSummary{
+			"bug":    {{Number: 42, State: "OPEN", BaseRefName: "main", HeadSHA: "head-42", Labels: []string{"bug"}}},
+			"urgent": {{Number: 43, State: "OPEN", BaseRefName: "main", HeadSHA: "head-43", Labels: []string{"urgent"}}},
+		},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-42", BaseRefName: "main", HasConflicts: true, Labels: []string{"bug"}},
+			{Number: 43, State: "OPEN", HeadSHA: "head-43", BaseRefName: "main", HasConflicts: true, Labels: []string{"urgent"}},
+		},
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	labels := []string{"bug", "urgent"}
+	labelMode := config.LabelModeAny
+	autoDiscovery := true
+	authorFilter := config.FixerAuthorFilterAny
+	cfg.Projects = append(cfg.Projects, config.ProjectRefConfig{ID: "project_1", RepoPath: t.TempDir(), Roles: &config.PartialRoleConfigs{Fixer: &config.PartialFixerRoleConfig{AutoDiscovery: &autoDiscovery, Triggers: &config.PartialFixerRoleTriggersConfig{AuthorFilter: &authorFilter, Labels: &labels, LabelMode: &labelMode}}}})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, FixAllPullRequests: true})
+
+	result, err := runner.DiscoverPullRequestsForBaseBranchUpdate(context.Background(), BaseBranchDiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", BaseRefName: "main"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequestsForBaseBranchUpdate() error = %v", err)
+	}
+	if len(result.QueueItems) != 2 {
+		t.Fatalf("len(QueueItems) = %d, want 2", len(result.QueueItems))
+	}
+	for _, call := range github.listCalls {
+		if call.BaseRefName != "main" {
+			t.Fatalf("list call = %#v, want base branch filter on every query", call)
+		}
+	}
+}
+
 func TestDiscoverPullRequestReusesExistingActiveQueueItem(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -4546,6 +4608,15 @@ func (f *fakeGitHubGateway) ListOpenPullRequests(_ context.Context, input ListOp
 		return append([]PullRequestSummary(nil), f.listOpenByLabel[input.Label]...), nil
 	}
 	result := append([]PullRequestSummary(nil), f.listOpen...)
+	if strings.TrimSpace(input.BaseRefName) != "" {
+		filtered := result[:0]
+		for _, pr := range result {
+			if strings.EqualFold(strings.TrimSpace(pr.BaseRefName), strings.TrimSpace(input.BaseRefName)) {
+				filtered = append(filtered, pr)
+			}
+		}
+		result = filtered
+	}
 	for index := range result {
 		if result[index].Author == "" {
 			result[index].Author = firstNonEmpty(f.currentUser, "looper")

--- a/internal/infra/github/discovery_snapshot.go
+++ b/internal/infra/github/discovery_snapshot.go
@@ -219,9 +219,13 @@ func (s *DiscoverySnapshot) getCurrentUserLogin(ctx context.Context, cwd string)
 func filterPullRequests(prs []PullRequestSummary, input ListOpenPullRequestsInput) []PullRequestSummary {
 	labels := prListLabels(input)
 	author := strings.TrimSpace(input.Author)
+	baseRefName := strings.TrimSpace(input.BaseRefName)
 	filtered := prs[:0]
 	for _, pr := range prs {
 		if author != "" && !strings.EqualFold(strings.TrimSpace(pr.Author), author) {
+			continue
+		}
+		if baseRefName != "" && !strings.EqualFold(strings.TrimSpace(pr.BaseRefName), baseRefName) {
 			continue
 		}
 		if len(labels) > 0 && !hasAllLabels(pr.Labels, labels) {
@@ -295,7 +299,7 @@ func snapshotPullRequestDetailKey(input ViewPullRequestInput) string {
 }
 
 func hasPullRequestFilters(input ListOpenPullRequestsInput) bool {
-	return strings.TrimSpace(input.Author) != "" || len(prListLabels(input)) > 0
+	return strings.TrimSpace(input.Author) != "" || strings.TrimSpace(input.BaseRefName) != "" || len(prListLabels(input)) > 0
 }
 
 func hasIssueFilters(input ListOpenIssuesInput) bool {

--- a/internal/infra/github/discovery_snapshot.go
+++ b/internal/infra/github/discovery_snapshot.go
@@ -225,7 +225,7 @@ func filterPullRequests(prs []PullRequestSummary, input ListOpenPullRequestsInpu
 		if author != "" && !strings.EqualFold(strings.TrimSpace(pr.Author), author) {
 			continue
 		}
-		if baseRefName != "" && !strings.EqualFold(strings.TrimSpace(pr.BaseRefName), baseRefName) {
+		if baseRefName != "" && strings.TrimSpace(pr.BaseRefName) != baseRefName {
 			continue
 		}
 		if len(labels) > 0 && !hasAllLabels(pr.Labels, labels) {

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -20,7 +20,8 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLoginByCWD(t *testing.T) {
 			counts["pr_list"]++
 			return shell.Result{Stdout: `[
 				{"number":1,"title":"PR 1","state":"OPEN","labels":[{"name":"bug"}],"baseRefName":"main","headRefOid":"sha-1","author":{"login":"octo"}},
-				{"number":2,"title":"PR 2","state":"OPEN","labels":[{"name":"feature"}],"baseRefName":"release","headRefOid":"sha-2","author":{"login":"other"}}
+				{"number":2,"title":"PR 2","state":"OPEN","labels":[{"name":"feature"}],"baseRefName":"release","headRefOid":"sha-2","author":{"login":"other"}},
+				{"number":3,"title":"PR 3","state":"OPEN","labels":[{"name":"feature"}],"baseRefName":"Release","headRefOid":"sha-3","author":{"login":"other"}}
 			]`}, nil
 		case strings.Contains(cmd, "issue list"):
 			counts["issue_list"]++
@@ -73,6 +74,13 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLoginByCWD(t *testing.T) {
 	}
 	if len(prs) != 1 || prs[0].Number != 1 {
 		t.Fatalf("ListOpenPullRequests(base) = %#v, want only PR 1", prs)
+	}
+	prs, err = gateway.ListOpenPullRequests(projectOneCtx, ListOpenPullRequestsInput{Repo: "acme/looper", CWD: "/repo-one", Limit: 10, BaseRefName: "release"})
+	if err != nil {
+		t.Fatalf("ListOpenPullRequests(base case) error = %v", err)
+	}
+	if len(prs) != 1 || prs[0].Number != 2 {
+		t.Fatalf("ListOpenPullRequests(base case) = %#v, want only PR 2", prs)
 	}
 	issues, err := gateway.ListOpenIssues(projectOneCtx, ListOpenIssuesInput{Repo: "acme/looper", CWD: "/repo-one", Limit: 10, Assignee: "octo", Label: "ready"})
 	if err != nil {

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -19,8 +19,8 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLoginByCWD(t *testing.T) {
 		case strings.Contains(cmd, "pr list"):
 			counts["pr_list"]++
 			return shell.Result{Stdout: `[
-				{"number":1,"title":"PR 1","state":"OPEN","labels":[{"name":"bug"}],"headRefOid":"sha-1","author":{"login":"octo"}},
-				{"number":2,"title":"PR 2","state":"OPEN","labels":[{"name":"feature"}],"headRefOid":"sha-2","author":{"login":"other"}}
+				{"number":1,"title":"PR 1","state":"OPEN","labels":[{"name":"bug"}],"baseRefName":"main","headRefOid":"sha-1","author":{"login":"octo"}},
+				{"number":2,"title":"PR 2","state":"OPEN","labels":[{"name":"feature"}],"baseRefName":"release","headRefOid":"sha-2","author":{"login":"other"}}
 			]`}, nil
 		case strings.Contains(cmd, "issue list"):
 			counts["issue_list"]++
@@ -66,6 +66,13 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLoginByCWD(t *testing.T) {
 	}
 	if len(prs) != 1 || prs[0].Number != 1 {
 		t.Fatalf("ListOpenPullRequests(author) = %#v, want only PR 1", prs)
+	}
+	prs, err = gateway.ListOpenPullRequests(projectOneCtx, ListOpenPullRequestsInput{Repo: "acme/looper", CWD: "/repo-one", Limit: 10, BaseRefName: "main"})
+	if err != nil {
+		t.Fatalf("ListOpenPullRequests(base) error = %v", err)
+	}
+	if len(prs) != 1 || prs[0].Number != 1 {
+		t.Fatalf("ListOpenPullRequests(base) = %#v, want only PR 1", prs)
 	}
 	issues, err := gateway.ListOpenIssues(projectOneCtx, ListOpenIssuesInput{Repo: "acme/looper", CWD: "/repo-one", Limit: 10, Assignee: "octo", Label: "ready"})
 	if err != nil {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -386,13 +386,14 @@ type UpdatePullRequestBodyInput struct {
 }
 
 type ListOpenPullRequestsInput struct {
-	Repo    string
-	CWD     string
-	Limit   int
-	Label   string
-	Labels  []string
-	Author  string
-	Timeout time.Duration
+	Repo        string
+	CWD         string
+	Limit       int
+	Label       string
+	Labels      []string
+	Author      string
+	BaseRefName string
+	Timeout     time.Duration
 }
 
 type ListOpenIssuesInput struct {
@@ -562,6 +563,9 @@ func (g *Gateway) listOpenPullRequestsRaw(ctx context.Context, input ListOpenPul
 	}
 	if strings.TrimSpace(input.Author) != "" {
 		args = append(args, "--author", strings.TrimSpace(input.Author))
+	}
+	if strings.TrimSpace(input.BaseRefName) != "" {
+		args = append(args, "--base", strings.TrimSpace(input.BaseRefName))
 	}
 	args = append(args, "--json", strings.Join([]string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "mergeStateStatus"}, ","))
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1901,6 +1901,23 @@ func TestListOpenPullRequestsPassesAllLabelsToGH(t *testing.T) {
 	}
 }
 
+func TestListOpenPullRequestsPassesBaseRefToGH(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		if args != "pr list --repo acme/looper --state open --limit 30 --base main --json number,title,url,state,updatedAt,isDraft,reviewDecision,labels,headRefName,baseRefName,headRefOid,baseRefOid,author,reviewRequests,reviews,mergeStateStatus" {
+			t.Fatalf("gh args = %q, want base filter", args)
+		}
+		return shell.Result{Stdout: `[]`}, nil
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	if _, err := gateway.ListOpenPullRequests(context.Background(), ListOpenPullRequestsInput{Repo: "acme/looper", BaseRefName: "main"}); err != nil {
+		t.Fatalf("ListOpenPullRequests() error = %v", err)
+	}
+}
+
 func TestListOpenIssuesPassesAllLabelsToGH(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -48,6 +48,7 @@ type reviewerScheduler interface {
 type fixerScheduler interface {
 	DiscoverPullRequests(context.Context, fixer.DiscoveryInput) (fixer.DiscoveryResult, error)
 	DiscoverPullRequest(context.Context, fixer.TargetedDiscoveryInput) (fixer.DiscoveryResult, error)
+	DiscoverPullRequestsForBaseBranchUpdate(context.Context, fixer.BaseBranchDiscoveryInput) (fixer.DiscoveryResult, error)
 	ProcessNext(context.Context, string) (*fixer.ProcessResult, error)
 	ProcessClaimedQueueItem(context.Context, storage.QueueItemRecord) (*fixer.ProcessResult, error)
 }
@@ -449,13 +450,13 @@ type fixerGitHubAdapter struct {
 }
 
 func (a fixerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input fixer.ListOpenPullRequestsInput) ([]fixer.PullRequestSummary, error) {
-	pullRequests, err := a.gateway.ListOpenPullRequests(ctx, githubinfra.ListOpenPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: input.Limit, Author: input.Author, Label: input.Label, Labels: input.Labels})
+	pullRequests, err := a.gateway.ListOpenPullRequests(ctx, githubinfra.ListOpenPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: input.Limit, Author: input.Author, Label: input.Label, Labels: input.Labels, BaseRefName: input.BaseRefName})
 	if err != nil {
 		return nil, err
 	}
 	result := make([]fixer.PullRequestSummary, 0, len(pullRequests))
 	for _, pr := range pullRequests {
-		result = append(result, fixer.PullRequestSummary{Number: pr.Number, State: pr.State, IsDraft: pr.IsDraft, Labels: pr.Labels, HeadSHA: pr.HeadSHA, Author: pr.Author})
+		result = append(result, fixer.PullRequestSummary{Number: pr.Number, State: pr.State, IsDraft: pr.IsDraft, Labels: pr.Labels, BaseRefName: pr.BaseRefName, HeadSHA: pr.HeadSHA, Author: pr.Author})
 	}
 	return result, nil
 }

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -1166,6 +1166,10 @@ func (s *enqueueingFixerScheduler) DiscoverPullRequest(ctx context.Context, inpu
 	return fixer.DiscoveryResult{}, nil
 }
 
+func (s *enqueueingFixerScheduler) DiscoverPullRequestsForBaseBranchUpdate(_ context.Context, _ fixer.BaseBranchDiscoveryInput) (fixer.DiscoveryResult, error) {
+	return fixer.DiscoveryResult{}, nil
+}
+
 type discoveringWorkerScheduler struct {
 	stubWorkerScheduler
 	repos  *storage.Repositories
@@ -1416,6 +1420,10 @@ func (s *stubFixerScheduler) DiscoverPullRequests(_ context.Context, input fixer
 }
 
 func (s *stubFixerScheduler) DiscoverPullRequest(_ context.Context, _ fixer.TargetedDiscoveryInput) (fixer.DiscoveryResult, error) {
+	return fixer.DiscoveryResult{}, s.discoverErr
+}
+
+func (s *stubFixerScheduler) DiscoverPullRequestsForBaseBranchUpdate(_ context.Context, _ fixer.BaseBranchDiscoveryInput) (fixer.DiscoveryResult, error) {
 	return fixer.DiscoveryResult{}, s.discoverErr
 }
 

--- a/internal/runtime/webhook_forwarder.go
+++ b/internal/runtime/webhook_forwarder.go
@@ -27,6 +27,7 @@ var webhookForwarderEvents = []string{
 	"issue_comment",
 	"pull_request_review",
 	"pull_request_review_comment",
+	"push",
 }
 
 type WebhookRuntimeStatus struct {

--- a/internal/runtime/webhook_forwarder_test.go
+++ b/internal/runtime/webhook_forwarder_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -172,6 +173,13 @@ func TestWebhookForwarderManagerStartsUniqueReposAndRetainsTail(t *testing.T) {
 	}
 	if got := strings.Join(alpha.Tail, "\n"); !strings.Contains(got, "stdout: hello from stdout") || !strings.Contains(got, "stderr: warning from stderr") {
 		t.Fatalf("alpha tail = %q, want stdout/stderr lines retained", got)
+	}
+}
+
+func TestWebhookForwarderEventsIncludePush(t *testing.T) {
+	t.Parallel()
+	if !slices.Contains(webhookForwarderEvents, "push") {
+		t.Fatalf("webhookForwarderEvents = %v, want push subscription", webhookForwarderEvents)
 	}
 }
 

--- a/internal/webhookforward/forwarder.go
+++ b/internal/webhookforward/forwarder.go
@@ -91,6 +91,7 @@ type TargetedReviewer interface {
 
 type TargetedFixer interface {
 	DiscoverPullRequest(context.Context, fixer.TargetedDiscoveryInput) (fixer.DiscoveryResult, error)
+	DiscoverPullRequestsForBaseBranchUpdate(context.Context, fixer.BaseBranchDiscoveryInput) (fixer.DiscoveryResult, error)
 }
 
 type Options struct {
@@ -116,6 +117,7 @@ type workKey struct {
 	Repo       string
 	ObjectType string
 	Number     int64
+	Branch     string
 }
 
 type workMetadata struct {
@@ -136,8 +138,17 @@ type routedDelivery struct {
 	repo       string
 	objectType string
 	number     int64
+	branch     string
 	action     string
 	lanes      map[Lane]struct{}
+}
+
+type pushEnvelope struct {
+	Ref        string `json:"ref"`
+	Deleted    bool   `json:"deleted"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
 }
 
 type pullRequestEnvelope struct {
@@ -333,6 +344,7 @@ func (f *forwarder) enqueueLocked(projects []storage.ProjectRecord, routed route
 		}
 		matched++
 		key := workKey{ProjectID: project.ID, Repo: repo, ObjectType: routed.objectType, Number: routed.number}
+		key.Branch = routed.branch
 		candidates = append(candidates, candidate{key: key, lanes: lanes})
 		itemKey := workKeyString(key)
 		item, exists := f.works[itemKey]
@@ -491,6 +503,10 @@ func (f *forwarder) executeOnce(ctx context.Context, key workKey, item workItem)
 		if f.fixer == nil {
 			return fmt.Errorf("fixer targeted discovery is not configured")
 		}
+		if key.ObjectType == "base_branch" {
+			_, err := f.fixer.DiscoverPullRequestsForBaseBranchUpdate(ctx, fixer.BaseBranchDiscoveryInput{ProjectID: key.ProjectID, Repo: key.Repo, BaseRefName: key.Branch})
+			return err
+		}
 		if _, err := f.fixer.DiscoverPullRequest(ctx, fixer.TargetedDiscoveryInput{ProjectID: key.ProjectID, Repo: key.Repo, PRNumber: key.Number}); err != nil {
 			return err
 		}
@@ -577,6 +593,22 @@ func routeDelivery(eventType string, payload []byte) (routedDelivery, bool, erro
 			return routedDelivery{}, false, fmt.Errorf("%s webhook missing repository or number", eventType)
 		}
 		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", number: envelope.PullRequest.Number, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneFixer: {}}}, true, nil
+	case "push":
+		var envelope pushEnvelope
+		if err := json.Unmarshal(payload, &envelope); err != nil {
+			return routedDelivery{}, false, fmt.Errorf("decode push webhook: %w", err)
+		}
+		if envelope.Deleted {
+			return routedDelivery{}, false, nil
+		}
+		if strings.TrimSpace(envelope.Repository.FullName) == "" {
+			return routedDelivery{}, false, errors.New("push webhook missing repository")
+		}
+		branch := strings.TrimPrefix(strings.TrimSpace(envelope.Ref), "refs/heads/")
+		if branch == "" || branch == strings.TrimSpace(envelope.Ref) {
+			return routedDelivery{}, false, nil
+		}
+		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "base_branch", branch: branch, action: "push", lanes: map[Lane]struct{}{LaneFixer: {}}}, true, nil
 	default:
 		return routedDelivery{}, false, nil
 	}
@@ -607,7 +639,7 @@ func repoFromProjectMetadata(metadataJSON *string) string {
 }
 
 func workKeyString(key workKey) string {
-	return fmt.Sprintf("%s|%s|%s|%d", key.ProjectID, strings.ToLower(key.Repo), key.ObjectType, key.Number)
+	return fmt.Sprintf("%s|%s|%s|%d|%s", key.ProjectID, strings.ToLower(key.Repo), key.ObjectType, key.Number, strings.ToLower(key.Branch))
 }
 
 func copyLanes(lanes map[Lane]struct{}) map[Lane]struct{} {

--- a/internal/webhookforward/forwarder.go
+++ b/internal/webhookforward/forwarder.go
@@ -717,7 +717,7 @@ func repoFromProjectMetadata(metadataJSON *string) string {
 }
 
 func workKeyString(key workKey) string {
-	return fmt.Sprintf("%s|%s|%s|%d|%s", key.ProjectID, strings.ToLower(key.Repo), key.ObjectType, key.Number, strings.ToLower(key.Branch))
+	return fmt.Sprintf("%s|%s|%s|%d|%s", key.ProjectID, strings.ToLower(key.Repo), key.ObjectType, key.Number, key.Branch)
 }
 
 func copyLanes(lanes map[Lane]struct{}) map[Lane]struct{} {

--- a/internal/webhookforward/forwarder_test.go
+++ b/internal/webhookforward/forwarder_test.go
@@ -321,6 +321,31 @@ func TestForwardRoutesPushToBaseBranchFixerDiscovery(t *testing.T) {
 	fixerRunner.assertBaseBranchCount(t, "project_1", "acme/looper", "main", 1)
 }
 
+func TestForwardPreservesBranchCaseInBaseBranchWorkKeys(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	fixerRunner := newFakeTargetedRunner(make(chan struct{}))
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: newFakeTargetedRunner(nil), Fixer: targetedFixerAdapter{runner: fixerRunner}, MaxConcurrent: 1, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	if _, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "push-case-1", EventType: "push", Payload: []byte(`{"ref":"refs/heads/Release","repository":{"full_name":"acme/looper"}}`)}); err != nil {
+		t.Fatalf("Forward(Release) error = %v", err)
+	}
+	fixerRunner.waitForCall(t, 1)
+	if _, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "push-case-2", EventType: "push", Payload: []byte(`{"ref":"refs/heads/release","repository":{"full_name":"acme/looper"}}`)}); err != nil {
+		t.Fatalf("Forward(release) error = %v", err)
+	}
+
+	close(fixerRunner.block)
+	fixerRunner.waitForCalls(t, 2)
+	fixerRunner.assertBaseBranchCount(t, "project_1", "acme/looper", "Release", 1)
+	fixerRunner.assertBaseBranchCount(t, "project_1", "acme/looper", "release", 1)
+	stats := forwarder.Stats()
+	if stats.QueueCoalesced != 0 {
+		t.Fatalf("QueueCoalesced = %d, want 0", stats.QueueCoalesced)
+	}
+}
+
 type fakeTargetedRunner struct {
 	mu                   sync.Mutex
 	block                chan struct{}
@@ -387,7 +412,11 @@ func (f *fakeTargetedRunner) run(projectID, repo string, prNumber int64) (review
 func (f *fakeTargetedRunner) runBaseBranch(projectID, repo, baseBranch string) error {
 	f.mu.Lock()
 	f.calls = append(f.calls, targetedCall{ProjectID: projectID, Repo: repo, BaseBranch: baseBranch})
+	block := f.block
 	f.mu.Unlock()
+	if block != nil {
+		<-block
+	}
 	return nil
 }
 

--- a/internal/webhookforward/forwarder_test.go
+++ b/internal/webhookforward/forwarder_test.go
@@ -247,6 +247,24 @@ func TestForwardKeepsFixedSizeRecentOutcomes(t *testing.T) {
 	}
 }
 
+func TestForwardRoutesPushToBaseBranchFixerDiscovery(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	fixerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: newFakeTargetedRunner(nil), Fixer: targetedFixerAdapter{runner: fixerRunner}, MaxConcurrent: 1, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	result, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "push-1", EventType: "push", Payload: []byte(`{"ref":"refs/heads/main","repository":{"full_name":"acme/looper"}}`)})
+	if err != nil {
+		t.Fatalf("Forward() error = %v", err)
+	}
+	if result.Status != "accepted" || result.WorkItems != 1 {
+		t.Fatalf("result = %#v, want accepted one work item", result)
+	}
+	fixerRunner.waitForCalls(t, 1)
+	fixerRunner.assertBaseBranchCount(t, "project_1", "acme/looper", "main", 1)
+}
+
 type fakeTargetedRunner struct {
 	mu                   sync.Mutex
 	block                chan struct{}
@@ -260,9 +278,10 @@ type fakeTargetedRunner struct {
 }
 
 type targetedCall struct {
-	ProjectID string
-	Repo      string
-	PRNumber  int64
+	ProjectID  string
+	Repo       string
+	PRNumber   int64
+	BaseBranch string
 }
 
 type temporaryError struct{ message string }
@@ -307,6 +326,13 @@ func (f *fakeTargetedRunner) run(projectID, repo string, prNumber int64) (review
 		return reviewer.DiscoveryResult{}, temporaryError{message: "temporary github failure"}
 	}
 	return reviewer.DiscoveryResult{}, nil
+}
+
+func (f *fakeTargetedRunner) runBaseBranch(projectID, repo, baseBranch string) error {
+	f.mu.Lock()
+	f.calls = append(f.calls, targetedCall{ProjectID: projectID, Repo: repo, BaseBranch: baseBranch})
+	f.mu.Unlock()
+	return nil
 }
 
 func (f *fakeTargetedRunner) failOnce(key string) {
@@ -377,6 +403,21 @@ func (f *fakeTargetedRunner) assertPRCount(t *testing.T, prNumber int64, want in
 	}
 	if count != want {
 		t.Fatalf("PR %d call count = %d, want %d", prNumber, count, want)
+	}
+}
+
+func (f *fakeTargetedRunner) assertBaseBranchCount(t *testing.T, projectID, repo, baseBranch string, want int) {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	count := 0
+	for _, call := range f.calls {
+		if call.ProjectID == projectID && call.Repo == repo && call.BaseBranch == baseBranch {
+			count++
+		}
+	}
+	if count != want {
+		t.Fatalf("base branch %s/%s@%s call count = %d, want %d", projectID, repo, baseBranch, count, want)
 	}
 }
 
@@ -473,4 +514,8 @@ type targetedFixerAdapter struct{ runner *fakeTargetedRunner }
 func (a targetedFixerAdapter) DiscoverPullRequest(_ context.Context, input fixer.TargetedDiscoveryInput) (fixer.DiscoveryResult, error) {
 	_, err := a.runner.run(input.ProjectID, input.Repo, input.PRNumber)
 	return fixer.DiscoveryResult{}, err
+}
+
+func (a targetedFixerAdapter) DiscoverPullRequestsForBaseBranchUpdate(_ context.Context, input fixer.BaseBranchDiscoveryInput) (fixer.DiscoveryResult, error) {
+	return fixer.DiscoveryResult{}, a.runner.runBaseBranch(input.ProjectID, input.Repo, input.BaseRefName)
 }


### PR DESCRIPTION
## Summary
- route GitHub `push` webhooks for branch refs into fixer-only targeted discovery so base-branch movement can trigger prompt merge-conflict discovery
- add branch-scoped fixer discovery and propagate base-branch filtering through `gh pr list` and discovery snapshot paths, including label-aware queries
- cover base-branch webhook routing, GitHub base filtering, snapshot filtering, and conflict discovery regressions with tests

## Validation
- go test ./...
- go build ./...
- go vet ./...

Closes #385

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>