### PR TITLE
fix: preserve pending fixer rediscovery during active runs

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -577,6 +577,13 @@ type rediscoveryDecision struct {
 	NextEligibleAt string
 }
 
+type pendingFixerRediscoveryState struct {
+	HeadSHA             string   `json:"headSha,omitempty"`
+	FixItemsStateHash   string   `json:"fixItemsStateHash,omitempty"`
+	UnresolvedThreadIDs []string `json:"unresolvedThreadIds,omitempty"`
+	RecordedAt          string   `json:"recordedAt,omitempty"`
+}
+
 type fixerCheckpoint struct {
 	ResumePolicy     string                      `json:"resumePolicy,omitempty"`
 	RunStartedAt     string                      `json:"runStartedAt,omitempty"`
@@ -1090,7 +1097,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 	}
 	for _, pr := range openPRs {
 
-		if !r.pullRequestEligibleForDiscovery(ctx, pr, input.Repo, currentUser, policy) {
+		if !r.pullRequestEligibleForDiscovery(ctx, input.ProjectID, pr, input.Repo, currentUser, policy) {
 			result.Skipped++
 			continue
 		}
@@ -1138,7 +1145,7 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 	}
 	pr := PullRequestSummary{Number: detail.Number, State: detail.State, IsDraft: detail.IsDraft, Labels: append([]string(nil), detail.Labels...), HeadSHA: detail.HeadSHA, Author: detail.Author}
 	result := DiscoveryResult{}
-	if !r.pullRequestEligibleForDiscovery(ctx, pr, input.Repo, currentUser, policy) {
+	if !r.pullRequestEligibleForDiscovery(ctx, input.ProjectID, pr, input.Repo, currentUser, policy) {
 		result.Skipped++
 		return result, nil
 	}
@@ -1214,9 +1221,19 @@ func defaultDiscoveryLimit(limit int) int {
 	return limit
 }
 
-func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, pr PullRequestSummary, repo, currentUser string, policy DiscoveryPolicy) bool {
-	if (!policy.IncludeDrafts && pr.IsDraft) || normalizePRState(pr.State) != "open" || r.hasActivePRLock(ctx, repo, pr.Number) {
+func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID string, pr PullRequestSummary, repo, currentUser string, policy DiscoveryPolicy) bool {
+	if (!policy.IncludeDrafts && pr.IsDraft) || normalizePRState(pr.State) != "open" {
 		return false
+	}
+	if r.hasActivePRLock(ctx, repo, pr.Number) {
+		loop, err := r.findFixerLoopByPR(ctx, projectID, repo, pr.Number)
+		if err != nil || loop == nil {
+			return false
+		}
+		activeRun, err := r.latestActiveRunningRun(ctx, loop.ID)
+		if err != nil || activeRun == nil {
+			return false
+		}
 	}
 	if policy.AuthorFilter != config.FixerAuthorFilterAny && !sameGitHubLogin(pr.Author, currentUser) {
 		return false
@@ -1249,7 +1266,7 @@ func (r *Runner) discoverPullRequestFromDetail(ctx context.Context, project stor
 	fixItemsStateHash := allFixItemsStateHash
 	unresolvedThreadIDs := unresolvedThreadIDs(fixItems)
 	if len(unresolvedThreadIDs) == 0 {
-		if err := r.clearFixerFollowupMetadataForPR(ctx, project.ID, repo, detail.Number); err != nil {
+		if err := r.clearFixerRetryMetadataForPR(ctx, project.ID, repo, detail.Number); err != nil {
 			return err
 		}
 	}
@@ -1263,6 +1280,9 @@ func (r *Runner) discoverPullRequestFromDetail(ctx context.Context, project stor
 	}
 	if loopResult.created {
 		result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
+	}
+	if loopResult.pending {
+		return nil
 	}
 	headSHA := detail.HeadSHA
 	if headSHA == "" {
@@ -1321,6 +1341,17 @@ func (r *Runner) recoverClaimedItem(ctx context.Context, queueItem storage.Queue
 	}
 	if err := r.reconcileRecoveredLoop(ctx, queueItem, failedQueue, failure.kind); err != nil {
 		return nil, err
+	}
+	if queueItem.LoopID != nil && queueItem.Repo != nil && queueItem.PRNumber != nil && (failedQueue == nil || failedQueue.Status != "queued") {
+		loop, err := r.repos.Loops.GetByID(ctx, *queueItem.LoopID)
+		if err != nil {
+			return nil, err
+		}
+		if loop != nil {
+			if _, err := r.schedulePendingRediscoveryAfterRun(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber); err != nil {
+				return nil, err
+			}
+		}
 	}
 	return &ProcessResult{LoopID: derefString(queueItem.LoopID), QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 }
@@ -1466,6 +1497,14 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			return ProcessResult{}, err
 		}
 		if failedQueue == nil || failedQueue.Status != "queued" {
+			if scheduled, err := r.schedulePendingRediscoveryAfterRun(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber); err != nil {
+				return ProcessResult{}, err
+			} else if scheduled {
+				r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &latest)
+				return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
+			}
+		}
+		if failedQueue == nil || failedQueue.Status != "queued" {
 			r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &latest)
 		}
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
@@ -1493,6 +1532,12 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		r.appendEvent(ctx, eventInput{eventType: "run.completed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"summary": reason}})
 		if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
 			return ProcessResult{}, err
+		}
+		if scheduled, err := r.schedulePendingRediscoveryAfterRun(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber); err != nil {
+			return ProcessResult{}, err
+		} else if scheduled {
+			r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
+			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: reason}, nil
 		}
 		if _, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
 			updated.Status = "completed"
@@ -1563,6 +1608,14 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 				return ProcessResult{}, err
 			}
 			if failedQueue == nil || failedQueue.Status != "queued" {
+				if scheduled, err := r.schedulePendingRediscoveryAfterRun(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber); err != nil {
+					return ProcessResult{}, err
+				} else if scheduled {
+					r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &latest)
+					return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
+				}
+			}
+			if failedQueue == nil || failedQueue.Status != "queued" {
 				r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &latest)
 			}
 			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
@@ -1597,6 +1650,13 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			return ProcessResult{}, err
 		}
 	} else {
+		if scheduled, err := r.schedulePendingRediscoveryAfterRun(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber); err != nil {
+			return ProcessResult{}, err
+		} else if scheduled {
+			r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
+			status := statusForSkip(checkpoint.SkipReason)
+			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
+		}
 		paused, err := r.recordZeroProgressSuccess(ctx, *loop, checkpoint)
 		if err != nil {
 			return ProcessResult{}, err
@@ -1605,6 +1665,13 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
 			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: statusForSkip(checkpoint.SkipReason), Summary: summary}, nil
 		}
+	}
+	if scheduled, err := r.schedulePendingRediscoveryAfterRun(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber); err != nil {
+		return ProcessResult{}, err
+	} else if scheduled {
+		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
+		status := statusForSkip(checkpoint.SkipReason)
+		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
 	}
 	if scheduled, err := r.scheduleFollowupRetryAfterSuccess(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber, checkpoint.SkipReason == ""); err != nil {
 		return ProcessResult{}, err
@@ -1627,6 +1694,49 @@ func statusForSkip(skipReason string) string {
 		return "skipped"
 	}
 	return "success"
+}
+
+func (r *Runner) schedulePendingRediscoveryAfterRun(ctx context.Context, loop storage.LoopRecord, repo string, prNumber int64) (bool, error) {
+	current, err := r.repos.Loops.GetByID(ctx, loop.ID)
+	if err != nil {
+		return false, err
+	}
+	if current == nil {
+		return false, nil
+	}
+	pending, ok := parsePendingFixerRediscoveryState(parseJSONObject(current.MetadataJSON))
+	if !ok {
+		return false, nil
+	}
+	availableAt := r.now()
+	availableAtISO := eventlog.FormatJavaScriptISOString(availableAt.UTC())
+	queueItem, err := r.enqueue(ctx, enqueueInput{ProjectID: current.ProjectID, LoopID: current.ID, Repo: repo, PRNumber: prNumber, HeadSHA: pending.HeadSHA, FixItemsHash: pending.FixItemsStateHash, AvailableAt: availableAt})
+	if err != nil {
+		return false, err
+	}
+	if queueItem.Status != "queued" {
+		return false, nil
+	}
+	current, err = r.repos.Loops.GetByID(ctx, loop.ID)
+	if err != nil {
+		return false, err
+	}
+	if current == nil {
+		return false, nil
+	}
+	updatedLoop, err := r.clearPendingFixerRediscoveryIfMatch(ctx, *current, pending)
+	if err != nil {
+		return false, err
+	}
+	updatedLoop, err = r.updateLoop(ctx, updatedLoop, func(updated *storage.LoopRecord) {
+		updated.Status = "queued"
+		updated.LastRunAt = stringPtr(r.nowISO())
+		updated.NextRunAt = &availableAtISO
+	})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (r *Runner) scheduleFollowupRetryAfterSuccess(ctx context.Context, loop storage.LoopRecord, repo string, prNumber int64, allow bool) (bool, error) {
@@ -3442,6 +3552,7 @@ type loopUpsertResult struct {
 	created     bool
 	skipped     bool
 	availableAt time.Time
+	pending     bool
 }
 
 func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64, headSHA, fixItemsHash, fixItemsStateHash string, fixItems []FixItem, unresolvedThreadIDs []string) (loopUpsertResult, error) {
@@ -3486,9 +3597,22 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 			}
 			availableAtISO := eventlog.FormatJavaScriptISOString(availableAt.UTC())
 			updated := existing
-			if active, err := r.hasActiveRunningRun(ctx, updated.ID); err == nil && active {
+			activeRun, err := r.latestActiveRunningRun(ctx, updated.ID)
+			if err != nil {
+				return loopUpsertResult{}, err
+			}
+			if activeRun != nil {
 				updated.Status = "running"
 				updated.NextRunAt = nil
+				updated, err = r.recordPendingFixerRediscovery(ctx, updated, headSHA, fixItemsStateHash, unresolvedThreadIDs)
+				if err != nil {
+					return loopUpsertResult{}, err
+				}
+				updated.UpdatedAt = nowISO
+				if err := r.repos.Loops.Upsert(ctx, updated); err != nil {
+					return loopUpsertResult{}, err
+				}
+				return loopUpsertResult{record: updated, created: false, pending: true}, nil
 			} else {
 				updated.Status = "queued"
 				updated.NextRunAt = &availableAtISO
@@ -3789,16 +3913,24 @@ func (r *Runner) legacyRecoveryTargetBusy(ctx context.Context, loopsList []stora
 }
 
 func (r *Runner) hasActiveRunningRun(ctx context.Context, loopID string) (bool, error) {
-	runs, err := r.repos.Runs.ListByLoop(ctx, loopID)
+	activeRun, err := r.latestActiveRunningRun(ctx, loopID)
 	if err != nil {
 		return false, err
 	}
+	return activeRun != nil, nil
+}
+
+func (r *Runner) latestActiveRunningRun(ctx context.Context, loopID string) (*storage.RunRecord, error) {
+	runs, err := r.repos.Runs.ListByLoop(ctx, loopID)
+	if err != nil {
+		return nil, err
+	}
 	for _, run := range runs {
 		if run.Status == "running" {
-			return true, nil
+			return &run, nil
 		}
 	}
-	return false, nil
+	return nil, nil
 }
 
 type enqueueInput struct {
@@ -3960,10 +4092,22 @@ func (r *Runner) clearFixerFollowupStateForPR(ctx context.Context, projectID, re
 	if err != nil {
 		return err
 	}
+	if cleared, err = r.clearPendingFixerRediscovery(ctx, cleared); err != nil {
+		return err
+	}
 	return r.cancelQueuedFixerItemsForLoop(ctx, cleared.ID)
 }
 
 func (r *Runner) clearFixerFollowupMetadataForPR(ctx context.Context, projectID, repo string, prNumber int64) error {
+	loop, err := r.findFixerLoopByPR(ctx, projectID, repo, prNumber)
+	if err != nil || loop == nil {
+		return err
+	}
+	_, err = r.clearFixerFollowupMetadata(ctx, *loop)
+	return err
+}
+
+func (r *Runner) clearFixerRetryMetadataForPR(ctx context.Context, projectID, repo string, prNumber int64) error {
 	loop, err := r.findFixerLoopByPR(ctx, projectID, repo, prNumber)
 	if err != nil || loop == nil {
 		return err
@@ -4101,6 +4245,65 @@ func (r *Runner) recordFixerFollowupState(ctx context.Context, loop storage.Loop
 		state.NextEligibleAt = eventlog.FormatJavaScriptISOString(now.Add(fixerFollowupBackoffSchedule[attempts-1]).UTC())
 	}
 	return r.persistFixerFollowupState(ctx, loop, state)
+}
+
+func (r *Runner) recordPendingFixerRediscovery(ctx context.Context, loop storage.LoopRecord, headSHA, fixItemsStateHash string, unresolvedThreadIDs []string) (storage.LoopRecord, error) {
+	state := pendingFixerRediscoveryState{
+		HeadSHA:             strings.TrimSpace(headSHA),
+		FixItemsStateHash:   strings.TrimSpace(fixItemsStateHash),
+		UnresolvedThreadIDs: canonicalizeStringSlice(unresolvedThreadIDs),
+		RecordedAt:          r.nowISO(),
+	}
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if current, err := r.repos.Loops.GetByID(ctx, loop.ID); err != nil {
+			return storage.LoopRecord{}, err
+		} else if current != nil {
+			loop = *current
+		}
+	}
+	if pending, ok := parsePendingFixerRediscoveryState(parseJSONObject(loop.MetadataJSON)); ok && pending.HeadSHA == state.HeadSHA && pending.FixItemsStateHash == state.FixItemsStateHash && sameStringSlices(pending.UnresolvedThreadIDs, state.UnresolvedThreadIDs) {
+		return loop, nil
+	}
+	return r.mergeLoopMetadata(ctx, loop, map[string]any{"pendingFixerRediscovery": state})
+}
+
+func (r *Runner) clearPendingFixerRediscovery(ctx context.Context, loop storage.LoopRecord) (storage.LoopRecord, error) {
+	return r.clearPendingFixerRediscoveryIfMatch(ctx, loop, pendingFixerRediscoveryState{})
+}
+
+func (r *Runner) clearPendingFixerRediscoveryIfMatch(ctx context.Context, loop storage.LoopRecord, expected pendingFixerRediscoveryState) (storage.LoopRecord, error) {
+	apply := func(updated *storage.LoopRecord) error {
+		meta := parseJSONObject(updated.MetadataJSON)
+		if expected.HeadSHA != "" || expected.FixItemsStateHash != "" || len(expected.UnresolvedThreadIDs) > 0 {
+			current, ok := parsePendingFixerRediscoveryState(meta)
+			if !ok || current.HeadSHA != expected.HeadSHA || current.FixItemsStateHash != expected.FixItemsStateHash || !sameStringSlices(current.UnresolvedThreadIDs, expected.UnresolvedThreadIDs) {
+				return nil
+			}
+		}
+		delete(meta, "pendingFixerRediscovery")
+		encoded, err := json.Marshal(meta)
+		if err != nil {
+			return err
+		}
+		metadataJSON := string(encoded)
+		updated.MetadataJSON = &metadataJSON
+		return nil
+	}
+	if r.repos == nil || r.repos.Loops == nil || strings.TrimSpace(loop.ID) == "" {
+		updated := loop
+		if err := apply(&updated); err != nil {
+			return storage.LoopRecord{}, err
+		}
+		return updated, nil
+	}
+	var mutateErr error
+	updated, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+		mutateErr = apply(updated)
+	})
+	if mutateErr != nil {
+		return storage.LoopRecord{}, mutateErr
+	}
+	return updated, err
 }
 
 func (r *Runner) mergeLoopMetadata(ctx context.Context, loop storage.LoopRecord, updates map[string]any) (storage.LoopRecord, error) {
@@ -5996,6 +6199,23 @@ func parseFixerFollowupState(metadata map[string]any) (fixerFollowupState, bool)
 	var state fixerFollowupState
 	if err := json.Unmarshal(encoded, &state); err != nil {
 		return fixerFollowupState{}, false
+	}
+	state.UnresolvedThreadIDs = canonicalizeStringSlice(state.UnresolvedThreadIDs)
+	return state, state.HeadSHA != "" && state.FixItemsStateHash != ""
+}
+
+func parsePendingFixerRediscoveryState(metadata map[string]any) (pendingFixerRediscoveryState, bool) {
+	raw, ok := metadata["pendingFixerRediscovery"]
+	if !ok {
+		return pendingFixerRediscoveryState{}, false
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return pendingFixerRediscoveryState{}, false
+	}
+	var state pendingFixerRediscoveryState
+	if err := json.Unmarshal(encoded, &state); err != nil {
+		return pendingFixerRediscoveryState{}, false
 	}
 	state.UnresolvedThreadIDs = canonicalizeStringSlice(state.UnresolvedThreadIDs)
 	return state, state.HeadSHA != "" && state.FixItemsStateHash != ""

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1785,6 +1785,9 @@ func (r *Runner) schedulePendingRediscoveryAfterRun(ctx context.Context, loop st
 	if !ok {
 		return false, nil
 	}
+	if current.Status == "paused" {
+		return false, nil
+	}
 	availableAt := r.now()
 	availableAtISO := eventlog.FormatJavaScriptISOString(availableAt.UTC())
 	queueItem, err := r.enqueue(ctx, enqueueInput{ProjectID: current.ProjectID, LoopID: current.ID, Repo: repo, PRNumber: prNumber, HeadSHA: pending.HeadSHA, FixItemsHash: pending.FixItemsStateHash, AvailableAt: availableAt})

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1564,6 +1564,52 @@ func TestDiscoverPullRequestsPreservesPendingRediscoveryForMidRunReviewComment(t
 	}
 }
 
+func TestSchedulePendingRediscoveryAfterRunPreservesPausedHardHold(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(84)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	projectID := "project_1"
+	metadata := mustMarshalJSON(map[string]any{"pendingFixerRediscovery": map[string]any{"headSha": "head-84", "fixItemsStateHash": "state-84", "unresolvedThreadIds": []string{"t1"}, "recordedAt": nowISO}})
+	loop := storage.LoopRecord{ID: "loop_paused_pending_rediscovery", Seq: 98, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+
+	scheduled, err := runner.schedulePendingRediscoveryAfterRun(context.Background(), loop, repo, prNumber)
+	if err != nil {
+		t.Fatalf("schedulePendingRediscoveryAfterRun() error = %v", err)
+	}
+	if scheduled {
+		t.Fatal("schedulePendingRediscoveryAfterRun() = true, want paused hard hold to stay pending")
+	}
+	activeQueue, err := fixture.repos.Queue.FindActiveByLoopID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Queue.FindActiveByLoopID() error = %v", err)
+	}
+	if activeQueue != nil {
+		t.Fatalf("activeQueue = %#v, want no queued rediscovery while paused", activeQueue)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "paused" || persisted.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want unchanged paused loop", persisted)
+	}
+	pending, ok := parsePendingFixerRediscoveryState(parseJSONObject(persisted.MetadataJSON))
+	if !ok {
+		t.Fatalf("parsePendingFixerRediscoveryState() = false, want pending rediscovery metadata")
+	}
+	if pending.HeadSHA != "head-84" || pending.FixItemsStateHash != "state-84" || !sameStringSlices(pending.UnresolvedThreadIDs, []string{"t1"}) || pending.RecordedAt != nowISO {
+		t.Fatalf("pending = %#v, want unchanged pending rediscovery metadata", pending)
+	}
+}
+
 func TestDiscoverPullRequestsPreservesPendingRediscoveryForMidRunCIFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1302,6 +1302,214 @@ func TestDecideRediscoveryAfterNoopResolveDefersLegacyMetadataDuringCooldown(t *
 	}
 }
 
+func TestDiscoverPullRequestsPreservesPendingRediscoveryForMidRunReviewComment(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(81)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	loopID := "loop_fixer_midrun_comment"
+	projectID := "project_1"
+	loop := storage.LoopRecord{ID: loopID, Seq: 95, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_fixer_midrun_comment", LoopID: loopID, Status: "running", CurrentStep: stringPtr(string(stepClaimPR)), LastCompletedStep: stringPtr(string(stepDiscoverPR)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	lockKey := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+	if acquired, err := fixture.repos.Locks.Acquire(context.Background(), storage.LockRecord{Key: lockKey, Owner: loopID, ExpiresAt: eventlog.FormatJavaScriptISOString(fixture.now().Add(time.Minute).UTC()), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Locks.Acquire() error = %v", err)
+	} else if !acquired {
+		t.Fatal("Locks.Acquire() = false, want active fixer PR lock")
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_midrun_comment", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: loopTarget, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:midrun-comment:active", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, LockKey: &lockKey, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-81", HeadRefName: "feature/fix-81", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}, {"id": "c2", "threadId": "t2", "body": "also fix this"}}}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: detail.HeadSHA}}, viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: projectID, Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want no parallel queue item while active run continues", result.QueueItems)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	pending, ok := parsePendingFixerRediscoveryState(parseJSONObject(persisted.MetadataJSON))
+	if !ok {
+		t.Fatalf("parsePendingFixerRediscoveryState() = false, want pending rediscovery metadata")
+	}
+	if pending.HeadSHA != detail.HeadSHA || pending.FixItemsStateHash == "" || !sameStringSlices(pending.UnresolvedThreadIDs, []string{"t1", "t2"}) {
+		t.Fatalf("pending = %#v, want persisted pending rediscovery state", pending)
+	}
+	activeQueue, err := fixture.repos.Queue.FindActiveByLoopID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Queue.FindActiveByLoopID() error = %v", err)
+	}
+	if activeQueue == nil || activeQueue.ID != "queue_fixer_midrun_comment" || activeQueue.Status != "running" {
+		t.Fatalf("activeQueue = %#v, want original running queue item only", activeQueue)
+	}
+	if err := fixture.repos.Queue.Complete(context.Background(), activeQueue.ID, fixture.nowISO()); err != nil {
+		t.Fatalf("Queue.Complete() error = %v", err)
+	}
+	scheduled, err := runner.schedulePendingRediscoveryAfterRun(context.Background(), *persisted, repo, prNumber)
+	if err != nil {
+		t.Fatalf("schedulePendingRediscoveryAfterRun() error = %v", err)
+	}
+	if !scheduled {
+		t.Fatal("schedulePendingRediscoveryAfterRun() = false, want queued follow-up rediscovery")
+	}
+	followupQueue, err := fixture.repos.Queue.FindActiveByLoopID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Queue.FindActiveByLoopID() after schedule error = %v", err)
+	}
+	if followupQueue == nil || followupQueue.ID == activeQueue.ID || followupQueue.Status != "queued" {
+		t.Fatalf("followupQueue = %#v, want new queued follow-up item", followupQueue)
+	}
+	persisted, err = fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() after schedule error = %v", err)
+	}
+	if _, ok := parsePendingFixerRediscoveryState(parseJSONObject(persisted.MetadataJSON)); ok {
+		t.Fatalf("pending rediscovery still present in %#v", parseJSONObject(persisted.MetadataJSON))
+	}
+}
+
+func TestDiscoverPullRequestsPreservesPendingRediscoveryForMidRunCIFailure(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(82)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	loopID := "loop_fixer_midrun_ci"
+	projectID := "project_1"
+	loop := storage.LoopRecord{ID: loopID, Seq: 96, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_fixer_midrun_ci", LoopID: loopID, Status: "running", CurrentStep: stringPtr(string(stepRepair)), LastCompletedStep: stringPtr(string(stepCollectFixes)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	lockKey := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+	if acquired, err := fixture.repos.Locks.Acquire(context.Background(), storage.LockRecord{Key: lockKey, Owner: loopID, ExpiresAt: eventlog.FormatJavaScriptISOString(fixture.now().Add(time.Minute).UTC()), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Locks.Acquire() error = %v", err)
+	} else if !acquired {
+		t.Fatal("Locks.Acquire() = false, want active fixer PR lock")
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_midrun_ci", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: loopTarget, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:midrun-ci:active", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, LockKey: &lockKey, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-82", HeadRefName: "feature/fix-82", BaseRefName: "main", BaseSHA: "base-1", Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: detail.HeadSHA}}, viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: projectID, Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want no parallel queue item while active CI run continues", result.QueueItems)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	pending, ok := parsePendingFixerRediscoveryState(parseJSONObject(persisted.MetadataJSON))
+	if !ok {
+		t.Fatalf("parsePendingFixerRediscoveryState() = false, want pending rediscovery metadata")
+	}
+	if pending.HeadSHA != detail.HeadSHA || pending.FixItemsStateHash == "" || len(pending.UnresolvedThreadIDs) != 0 {
+		t.Fatalf("pending = %#v, want pending CI rediscovery without thread IDs", pending)
+	}
+	fixture.advance(time.Minute)
+	result, err = runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: projectID, Repo: repo})
+	if err != nil {
+		t.Fatalf("second DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("second QueueItems = %#v, want no new queue item for duplicate CI signal", result.QueueItems)
+	}
+	persisted, err = fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() after duplicate error = %v", err)
+	}
+	pending, ok = parsePendingFixerRediscoveryState(parseJSONObject(persisted.MetadataJSON))
+	if !ok {
+		t.Fatalf("parsePendingFixerRediscoveryState() after duplicate = false, want pending rediscovery metadata")
+	}
+	if pending.RecordedAt != nowISO {
+		t.Fatalf("pending.RecordedAt = %q, want unchanged %q for duplicate CI signal", pending.RecordedAt, nowISO)
+	}
+}
+
+func TestDiscoverPullRequestsLeavesPendingRediscoveryUnchangedForDuplicateSignal(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(83)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	loopID := "loop_fixer_midrun_duplicate"
+	projectID := "project_1"
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-83", HeadRefName: "feature/fix-83", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}, {"id": "c2", "threadId": "t2", "body": "also fix this"}}}
+	pendingMeta := mustMarshalJSON(map[string]any{"pendingFixerRediscovery": map[string]any{"headSha": detail.HeadSHA, "fixItemsStateHash": hashFixItemsState(collectFixItems(detail)), "unresolvedThreadIds": []string{"t1", "t2"}, "recordedAt": nowISO}})
+	loop := storage.LoopRecord{ID: loopID, Seq: 97, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &pendingMeta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_fixer_midrun_duplicate", LoopID: loopID, Status: "running", CurrentStep: stringPtr(string(stepValidate)), LastCompletedStep: stringPtr(string(stepCollectFixes)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	lockKey := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+	if acquired, err := fixture.repos.Locks.Acquire(context.Background(), storage.LockRecord{Key: lockKey, Owner: loopID, ExpiresAt: eventlog.FormatJavaScriptISOString(fixture.now().Add(time.Minute).UTC()), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Locks.Acquire() error = %v", err)
+	} else if !acquired {
+		t.Fatal("Locks.Acquire() = false, want active fixer PR lock")
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_midrun_duplicate", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: loopTarget, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:midrun-duplicate:active", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, LockKey: &lockKey, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: detail.HeadSHA}}, viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: projectID, Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want no new queue item for duplicate signal", result.QueueItems)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	pending, ok := parsePendingFixerRediscoveryState(parseJSONObject(persisted.MetadataJSON))
+	if !ok {
+		t.Fatalf("parsePendingFixerRediscoveryState() = false, want pending rediscovery metadata")
+	}
+	if pending.RecordedAt != nowISO {
+		t.Fatalf("pending.RecordedAt = %q, want unchanged %q for duplicate signal", pending.RecordedAt, nowISO)
+	}
+	queueItems, err := fixture.repos.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(queueItems) != 1 {
+		t.Fatalf("queue item count = %d, want original active item only", len(queueItems))
+	}
+}
+
 func TestDiscoverPullRequestsRecoversLegacyNoopLoopWithoutOpenPRListing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- preserve a durable pending fixer rediscovery marker when new PR signals arrive while a fixer run is already active
- schedule that pending rediscovery after success, failure, ownership-skip, and recovery completion paths without creating parallel fixer runs
- add regression coverage for mid-run review comments, CI failures, and unchanged duplicate pending signals under the normal PR lock path

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #386

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>