### PR TITLE
refactor: replace string-based paused fixer recovery with structured reasons

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -579,6 +579,7 @@ type rediscoveryDecision struct {
 
 type fixerCheckpoint struct {
 	ResumePolicy     string                      `json:"resumePolicy,omitempty"`
+	Pause            *checkpointPause            `json:"pause,omitempty"`
 	RunStartedAt     string                      `json:"runStartedAt,omitempty"`
 	RunStartedRunID  string                      `json:"runStartedRunId,omitempty"`
 	RunPreStartAt    string                      `json:"runPreStartAt,omitempty"`
@@ -598,6 +599,24 @@ type fixerCheckpoint struct {
 	Recheck          *checkpointRecheck          `json:"recheck,omitempty"`
 	SkipReason       string                      `json:"skipReason,omitempty"`
 }
+
+type checkpointPause struct {
+	Reason              string   `json:"reason,omitempty"`
+	Recoverable         bool     `json:"recoverable,omitempty"`
+	HeadSHA             string   `json:"headSha,omitempty"`
+	FixItemsStateHash   string   `json:"fixItemsStateHash,omitempty"`
+	UnresolvedThreadIDs []string `json:"unresolvedThreadIds,omitempty"`
+}
+
+type checkpointPauseReason string
+
+const (
+	checkpointPauseReasonNoopResolveNoNewCommits checkpointPauseReason = "noop_resolve_no_new_commits"
+	checkpointPauseReasonRiskyConflict           checkpointPauseReason = "risky_conflict"
+	checkpointPauseReasonDirtyWorktree           checkpointPauseReason = "dirty_worktree"
+	checkpointPauseReasonAutoPushDisabled        checkpointPauseReason = "auto_push_disabled"
+	checkpointPauseReasonAutoCommitDisabled      checkpointPauseReason = "auto_commit_disabled"
+)
 
 type checkpointDetail struct {
 	State          string           `json:"state,omitempty"`
@@ -1805,6 +1824,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (f
 	}
 	if !prepared.Clean {
 		checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+		checkpoint.Pause = newCheckpointPause(checkpointPauseReasonDirtyWorktree, false, "", "", nil)
 		return checkpoint, &loopError{message: fmt.Sprintf("Fixer worktree is dirty for branch %s; manual intervention required", branch), kind: FailureManualIntervention}
 	}
 	preparedAt := r.nowISO()
@@ -1833,6 +1853,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		for _, item := range checkpoint.FixItems {
 			if item.Type == "conflict" {
 				checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+				checkpoint.Pause = newCheckpointPause(checkpointPauseReasonRiskyConflict, true, detailHeadSHA(checkpoint.Detail), currentFixItemsStateHash(checkpoint), nil)
 				return checkpoint, &loopError{message: fmt.Sprintf("Skipped %s#%d because risky conflict fixes require manual intervention", input.Repo, input.PRNumber), kind: FailureManualIntervention}
 			}
 		}
@@ -1998,6 +2019,7 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 		r.appendEvent(ctx, eventInput{eventType: "fixer.push.skipped", projectID: input.Project.ID, loopID: input.Loop.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"branch": branch, "reason": "auto_push_disabled"}})
 		checkpoint.Push = &checkpointPush{Pushed: false, Branch: branch, Remote: "origin", SkippedReason: "Auto push disabled"}
 		checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+		checkpoint.Pause = newCheckpointPause(checkpointPauseReasonAutoPushDisabled, false, "", "", nil)
 		return checkpoint, &loopError{message: fmt.Sprintf("Auto push disabled; manual fix push required for branch %s", branch), kind: FailureManualIntervention}
 	}
 	if checkpoint.ReconcileCommits == nil {
@@ -3154,6 +3176,7 @@ func (r *Runner) runRecheckStep(ctx context.Context, input stepInput) (fixerChec
 	hasVerifiedNoPushHead := verifiedNoPushHead != "" && strings.TrimSpace(detail.HeadSHA) == verifiedNoPushHead
 	if shouldBlockResolveWithoutFix(checkpoint, checkpoint.Recheck.RemainingFixItems, hasVerifiedNoPushHead) {
 		checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+		checkpoint.Pause = newCheckpointPause(checkpointPauseReasonNoopResolveNoNewCommits, true, strings.TrimSpace(detail.HeadSHA), currentRecheckFixItemsStateHash(checkpoint), unresolvedThreadIDs(suppressDeclinedFixItems(input.Loop.MetadataJSON, strings.TrimSpace(detail.HeadSHA), checkpoint.Recheck.RemainingFixItems)))
 		return checkpoint, &loopError{message: "resolve-comments left review threads unresolved because fixer produced no new commits to push", kind: FailureManualIntervention}
 	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
@@ -3188,10 +3211,8 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	resumeFromPrepare := false
 	if latestRun != nil {
 		failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage))
-		if strings.TrimSpace(derefString(latestRun.ErrorMessage)) == noopResolveManualIntervention {
-			failureSummary = noopResolveManualIntervention
-		}
-		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, failureSummary) || loops.ShouldRestartFromDiscover(latestRun.Status, checkpoint.ResumePolicy)
+		pause, _ := classifyFixerPause(latestRun, checkpoint, loop.MetadataJSON)
+		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, pause, failureSummary) || loops.ShouldRestartFromDiscover(latestRun.Status, checkpoint.ResumePolicy)
 		resumeFromPrepare = shouldResumeFromPrepare(latestRun.Status, failedStep, checkpoint)
 	}
 	startStep := stepDiscoverPR
@@ -3216,6 +3237,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		initialCheckpoint = resumedCheckpoint
 		initialCheckpoint.ResumePolicy = "advance_from_checkpoint"
 	}
+	initialCheckpoint.Pause = nil
 	initialCheckpoint.RunStartedAt = ""
 	initialCheckpoint.RunStartedRunID = ""
 	nowISO := r.nowISO()
@@ -3560,19 +3582,17 @@ func (r *Runner) resumePausedNoopResolveLoop(ctx context.Context, loop storage.L
 	if err != nil {
 		return false, storage.LoopRecord{}, err
 	}
-	if latestRun == nil || latestRun.Status != "failed" || strings.TrimSpace(derefString(latestRun.ErrorMessage)) != noopResolveManualIntervention {
+	if latestRun == nil {
 		return false, loop, nil
 	}
 	checkpoint := parseCheckpoint(latestRun.CheckpointJSON)
-	previousHeadSHA := ""
-	if checkpoint.Detail != nil {
-		previousHeadSHA = strings.TrimSpace(checkpoint.Detail.HeadSHA)
+	pause, ok := classifyFixerPause(latestRun, checkpoint, loop.MetadataJSON)
+	if !ok || strings.TrimSpace(pause.Reason) != string(checkpointPauseReasonNoopResolveNoNewCommits) || !pause.Recoverable {
+		return false, loop, nil
 	}
-	previousStateHash := hashFixItemsState(checkpoint.FixItems)
-	if len(checkpoint.FixItems) == 0 {
-		previousStateHash = strings.TrimSpace(checkpoint.FixItemsHash)
-	}
-	previousThreadIDs := unresolvedThreadIDsFromCheckpoint(checkpoint, loop.MetadataJSON, previousHeadSHA)
+	previousHeadSHA := strings.TrimSpace(pause.HeadSHA)
+	previousStateHash := strings.TrimSpace(pause.FixItemsStateHash)
+	previousThreadIDs := canonicalizeStringSlice(pause.UnresolvedThreadIDs)
 	if previousHeadSHA == strings.TrimSpace(headSHA) && previousStateHash == strings.TrimSpace(fixItemsStateHash) && sameStringSlices(previousThreadIDs, unresolvedThreadIDs) {
 		return false, loop, nil
 	}
@@ -3595,18 +3615,16 @@ func (r *Runner) resumePausedRiskyConflictLoop(ctx context.Context, loop storage
 	if err != nil {
 		return false, storage.LoopRecord{}, err
 	}
-	if latestRun == nil || latestRun.Status != "failed" || !strings.Contains(strings.TrimSpace(derefString(latestRun.ErrorMessage)), riskyConflictManualHold) {
+	if latestRun == nil {
 		return false, loop, nil
 	}
 	checkpoint := parseCheckpoint(latestRun.CheckpointJSON)
-	previousHeadSHA := ""
-	if checkpoint.Detail != nil {
-		previousHeadSHA = strings.TrimSpace(checkpoint.Detail.HeadSHA)
+	pause, ok := classifyFixerPause(latestRun, checkpoint, loop.MetadataJSON)
+	if !ok || strings.TrimSpace(pause.Reason) != string(checkpointPauseReasonRiskyConflict) || !pause.Recoverable {
+		return false, loop, nil
 	}
-	previousStateHash := hashFixItemsState(checkpoint.FixItems)
-	if len(checkpoint.FixItems) == 0 {
-		previousStateHash = strings.TrimSpace(checkpoint.FixItemsHash)
-	}
+	previousHeadSHA := strings.TrimSpace(pause.HeadSHA)
+	previousStateHash := strings.TrimSpace(pause.FixItemsStateHash)
 	if previousHeadSHA == strings.TrimSpace(headSHA) && previousStateHash == strings.TrimSpace(fixItemsStateHash) {
 		return false, loop, nil
 	}
@@ -4250,6 +4268,7 @@ func (r *Runner) reconcileCommits(ctx context.Context, project storage.ProjectRe
 	if initial.HasUncommittedChanges {
 		if !r.allowAutoCommit {
 			checkpoint.ResumePolicy = loops.ResumePolicyManualIntervention
+			checkpoint.Pause = newCheckpointPause(checkpointPauseReasonAutoCommitDisabled, false, "", "", nil)
 			return checkpoint, &loopError{message: fmt.Sprintf("Auto commit disabled but fixer worktree has uncommitted changes: %s", firstNonEmpty(strings.Join(initial.ChangedFiles, ", "), "unknown files")), kind: FailureManualIntervention}
 		}
 		if _, err := r.git.Commit(ctx, CommitInput{RepoPath: project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Message: commitMessage}); err != nil {
@@ -4914,7 +4933,7 @@ func shouldResumeFromPrepare(status string, failedStep FixerStep, checkpoint fix
 	}
 }
 
-func shouldRestartFromDiscover(status string, failedStep FixerStep, failureSummary string) bool {
+func shouldRestartFromDiscover(status string, failedStep FixerStep, pause *checkpointPause, failureSummary string) bool {
 	if status != "failed" && status != "interrupted" {
 		return false
 	}
@@ -4924,10 +4943,10 @@ func shouldRestartFromDiscover(status string, failedStep FixerStep, failureSumma
 	if failedStep == stepPush {
 		return strings.Contains(strings.ToLower(failureSummary), "remote head changed")
 	}
-	if failedStep == stepRepair && strings.Contains(failureSummary, riskyConflictManualHold) {
+	if failedStep == stepRepair && pauseReasonIs(pause, checkpointPauseReasonRiskyConflict) {
 		return true
 	}
-	if failedStep == stepRecheck && strings.TrimSpace(failureSummary) == noopResolveManualIntervention {
+	if failedStep == stepRecheck && pauseReasonIs(pause, checkpointPauseReasonNoopResolveNoNewCommits) {
 		return true
 	}
 	if failedStep != stepResolveComments {
@@ -5999,6 +6018,83 @@ func parseFixerFollowupState(metadata map[string]any) (fixerFollowupState, bool)
 	}
 	state.UnresolvedThreadIDs = canonicalizeStringSlice(state.UnresolvedThreadIDs)
 	return state, state.HeadSHA != "" && state.FixItemsStateHash != ""
+}
+
+func classifyFixerPause(run *storage.RunRecord, checkpoint fixerCheckpoint, loopMetadataJSON *string) (*checkpointPause, bool) {
+	if run == nil {
+		return nil, false
+	}
+	if pause, ok := normalizedCheckpointPause(checkpoint.Pause); ok {
+		return pause, true
+	}
+	if run.Status != "failed" {
+		return nil, false
+	}
+	failedStep := asFixerStep(derefString(run.CurrentStep))
+	summary := firstNonEmpty(derefString(run.Summary), derefString(run.ErrorMessage))
+	switch failedStep {
+	case stepRepair:
+		if strings.Contains(summary, riskyConflictManualHold) || strings.Contains(derefString(run.ErrorMessage), riskyConflictManualHold) {
+			return newCheckpointPause(checkpointPauseReasonRiskyConflict, true, detailHeadSHA(checkpoint.Detail), currentFixItemsStateHash(checkpoint), nil), true
+		}
+	case stepRecheck:
+		if strings.TrimSpace(derefString(run.ErrorMessage)) == noopResolveManualIntervention {
+			return newCheckpointPause(checkpointPauseReasonNoopResolveNoNewCommits, true, detailHeadSHA(checkpoint.Detail), legacyNoopResolveStateHash(checkpoint), unresolvedThreadIDsFromCheckpoint(checkpoint, loopMetadataJSON, detailHeadSHA(checkpoint.Detail))), true
+		}
+	}
+	return nil, false
+}
+
+func newCheckpointPause(reason checkpointPauseReason, recoverable bool, headSHA, fixItemsStateHash string, unresolvedThreadIDs []string) *checkpointPause {
+	return &checkpointPause{
+		Reason:              string(reason),
+		Recoverable:         recoverable,
+		HeadSHA:             strings.TrimSpace(headSHA),
+		FixItemsStateHash:   strings.TrimSpace(fixItemsStateHash),
+		UnresolvedThreadIDs: canonicalizeStringSlice(unresolvedThreadIDs),
+	}
+}
+
+func normalizedCheckpointPause(pause *checkpointPause) (*checkpointPause, bool) {
+	if pause == nil || strings.TrimSpace(pause.Reason) == "" {
+		return nil, false
+	}
+	normalized := *pause
+	normalized.Reason = strings.TrimSpace(normalized.Reason)
+	normalized.HeadSHA = strings.TrimSpace(normalized.HeadSHA)
+	normalized.FixItemsStateHash = strings.TrimSpace(normalized.FixItemsStateHash)
+	normalized.UnresolvedThreadIDs = canonicalizeStringSlice(normalized.UnresolvedThreadIDs)
+	return &normalized, true
+}
+
+func pauseReasonIs(pause *checkpointPause, reason checkpointPauseReason) bool {
+	return pause != nil && strings.TrimSpace(pause.Reason) == string(reason)
+}
+
+func currentFixItemsStateHash(checkpoint fixerCheckpoint) string {
+	if len(checkpoint.FixItems) > 0 {
+		return hashFixItemsState(checkpoint.FixItems)
+	}
+	if fixItemsHash := strings.TrimSpace(checkpoint.FixItemsHash); fixItemsHash != "" {
+		return fixItemsHash
+	}
+	return hashFixItemsState(checkpoint.FixItems)
+}
+
+func currentRecheckFixItemsStateHash(checkpoint fixerCheckpoint) string {
+	if checkpoint.Recheck != nil {
+		if hash := hashFixItemsState(checkpoint.Recheck.RemainingFixItems); hash != "" {
+			return hash
+		}
+	}
+	return currentFixItemsStateHash(checkpoint)
+}
+
+func legacyNoopResolveStateHash(checkpoint fixerCheckpoint) string {
+	if hash := currentFixItemsStateHash(checkpoint); hash != "" {
+		return hash
+	}
+	return currentRecheckFixItemsStateHash(checkpoint)
 }
 
 func unresolvedThreadIDs(fixItems []FixItem) []string {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -477,6 +477,7 @@ func TestDiscoverPullRequestsResumesPausedNoopResolveLoopWhenFixItemsChange(t *t
 	previousFixItem := FixItem{Type: "comment", ID: "c1", ThreadID: "t1", ThreadFingerprint: "c1@old"}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
 		ResumePolicy: loops.ResumePolicyManualIntervention,
+		Pause:        newCheckpointPause(checkpointPauseReasonNoopResolveNoNewCommits, true, "head-42", hashFixItemsState([]FixItem{previousFixItem}), []string{"t1"}),
 		Detail:       &checkpointDetail{State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "old blocker"}}},
 		FixItems:     []FixItem{previousFixItem},
 		FixItemsHash: hashFixItemsState([]FixItem{previousFixItem}),
@@ -486,7 +487,8 @@ func TestDiscoverPullRequestsResumesPausedNoopResolveLoopWhenFixItemsChange(t *t
 	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_noop_resolve", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
-	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_paused_noop_resolve", LoopID: "loop_paused_noop_resolve", Status: "failed", CurrentStep: stringPtr(string(stepRecheck)), LastCompletedStep: stringPtr(string(stepResolveComments)), CheckpointJSON: &checkpointJSON, Summary: stringPtr(noopResolveManualIntervention), ErrorMessage: stringPtr(noopResolveManualIntervention), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+	message := "manual hold recorded by structured pause reason"
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_paused_noop_resolve", LoopID: "loop_paused_noop_resolve", Status: "failed", CurrentStep: stringPtr(string(stepRecheck)), LastCompletedStep: stringPtr(string(stepResolveComments)), CheckpointJSON: &checkpointJSON, Summary: stringPtr(message), ErrorMessage: stringPtr(message), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
 	github := &fakeGitHubGateway{
@@ -577,6 +579,7 @@ func TestDiscoverPullRequestsKeepsPausedNoopResolveLoopWhenOnlyDeclinedThreadRem
 	allFixItems := []FixItem{activeFixItem, declinedFixItem}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
 		ResumePolicy: loops.ResumePolicyManualIntervention,
+		Pause:        newCheckpointPause(checkpointPauseReasonNoopResolveNoNewCommits, true, "head-42", hashFixItemsState(allFixItems), []string{"t1"}),
 		Detail:       &checkpointDetail{State: "OPEN", HeadSHA: "head-42", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "threadFingerprint": "c1@active", "body": "same blocker"}, {"id": "c2", "threadId": "t2", "threadFingerprint": "c2@declined", "body": "declined blocker"}}},
 		FixItems:     allFixItems,
 		FixItemsHash: hashFixItemsState(allFixItems),
@@ -591,7 +594,8 @@ func TestDiscoverPullRequestsKeepsPausedNoopResolveLoopWhenOnlyDeclinedThreadRem
 	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_noop_declined", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &metadataJSON, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
-	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_paused_noop_declined", LoopID: "loop_paused_noop_declined", Status: "failed", CurrentStep: stringPtr(string(stepRecheck)), LastCompletedStep: stringPtr(string(stepResolveComments)), CheckpointJSON: &checkpointJSON, Summary: stringPtr(noopResolveManualIntervention), ErrorMessage: stringPtr(noopResolveManualIntervention), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+	message := "structured pause with declined-thread suppression"
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_paused_noop_declined", LoopID: "loop_paused_noop_declined", Status: "failed", CurrentStep: stringPtr(string(stepRecheck)), LastCompletedStep: stringPtr(string(stepResolveComments)), CheckpointJSON: &checkpointJSON, Summary: stringPtr(message), ErrorMessage: stringPtr(message), StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
 	github := &fakeGitHubGateway{
@@ -626,11 +630,12 @@ func TestDiscoverPullRequestsResumesPausedRiskyConflictLoopWhenFixItemsChange(t 
 	previousFixItem := FixItem{Type: "conflict", Files: []string{}}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
 		ResumePolicy: loops.ResumePolicyManualIntervention,
+		Pause:        newCheckpointPause(checkpointPauseReasonRiskyConflict, true, "head-42", hashFixItemsState([]FixItem{previousFixItem}), nil),
 		Detail:       &checkpointDetail{State: "OPEN", HeadSHA: "head-42", HasConflicts: true},
 		FixItems:     []FixItem{previousFixItem},
 		FixItemsHash: hashFixItemsState([]FixItem{previousFixItem}),
 	})
-	message := "Skipped acme/looper#42 because risky conflict fixes require manual intervention"
+	message := "manual hold recorded by structured conflict reason"
 	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_risky_conflict", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
@@ -705,8 +710,8 @@ func TestDiscoverPullRequestsKeepsOtherManualInterventionPausedOnNewSignal(t *te
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
 	loopTarget := buildPullRequestTargetID(repo, prNumber)
-	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: loops.ResumePolicyManualIntervention, Detail: &checkpointDetail{State: "OPEN", HeadSHA: "old-head"}})
-	message := "Auto push disabled; manual fix push required for branch feature/fix-42"
+	checkpointJSON := mustMarshalJSON(fixerCheckpoint{ResumePolicy: loops.ResumePolicyManualIntervention, Pause: newCheckpointPause(checkpointPauseReasonAutoPushDisabled, false, "", "", nil), Detail: &checkpointDetail{State: "OPEN", HeadSHA: "old-head"}})
+	message := "human must inspect push state"
 	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_auto_push", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
@@ -722,6 +727,120 @@ func TestDiscoverPullRequestsKeepsOtherManualInterventionPausedOnNewSignal(t *te
 	}
 	if len(result.QueueItems) != 0 {
 		t.Fatalf("QueueItems = %#v, want auto-push hard hold to remain paused", result.QueueItems)
+	}
+}
+
+func TestClassifyFixerPauseUsesStructuredReason(t *testing.T) {
+	t.Parallel()
+
+	fixItem := FixItem{Type: "comment", ID: "c1", ThreadID: "t1"}
+	checkpoint := fixerCheckpoint{
+		Pause:    newCheckpointPause(checkpointPauseReasonNoopResolveNoNewCommits, true, "head-1", hashFixItemsState([]FixItem{fixItem}), []string{"t1"}),
+		FixItems: []FixItem{fixItem},
+	}
+	message := "totally unrelated human message"
+	run := &storage.RunRecord{Status: "failed", CurrentStep: stringPtr(string(stepRecheck)), Summary: &message, ErrorMessage: &message}
+
+	pause, ok := classifyFixerPause(run, checkpoint, nil)
+	if !ok {
+		t.Fatal("classifyFixerPause() = not found, want structured pause")
+	}
+	if pause.Reason != string(checkpointPauseReasonNoopResolveNoNewCommits) || !pause.Recoverable {
+		t.Fatalf("pause = %#v, want recoverable structured no-op reason", pause)
+	}
+	if pause.HeadSHA != "head-1" || pause.FixItemsStateHash != hashFixItemsState([]FixItem{fixItem}) || !sameStringSlices(pause.UnresolvedThreadIDs, []string{"t1"}) {
+		t.Fatalf("pause = %#v, want structured fingerprint preserved", pause)
+	}
+}
+
+func TestClassifyFixerPauseFallsBackToLegacyNoopMessage(t *testing.T) {
+	t.Parallel()
+
+	fixItem := FixItem{Type: "comment", ID: "c1", ThreadID: "t1"}
+	checkpoint := fixerCheckpoint{
+		Detail:       &checkpointDetail{HeadSHA: "head-1"},
+		FixItems:     []FixItem{fixItem},
+		FixItemsHash: hashFixItemsState([]FixItem{fixItem}),
+		Recheck:      &checkpointRecheck{RemainingFixItems: []FixItem{fixItem}},
+	}
+	run := &storage.RunRecord{Status: "failed", CurrentStep: stringPtr(string(stepRecheck)), ErrorMessage: stringPtr(noopResolveManualIntervention)}
+
+	pause, ok := classifyFixerPause(run, checkpoint, nil)
+	if !ok {
+		t.Fatal("classifyFixerPause() = not found, want legacy compatibility pause")
+	}
+	if pause.Reason != string(checkpointPauseReasonNoopResolveNoNewCommits) || !pause.Recoverable {
+		t.Fatalf("pause = %#v, want recoverable legacy no-op reason", pause)
+	}
+	if pause.HeadSHA != "head-1" || pause.FixItemsStateHash != hashFixItemsState([]FixItem{fixItem}) || !sameStringSlices(pause.UnresolvedThreadIDs, []string{"t1"}) {
+		t.Fatalf("pause = %#v, want legacy fingerprint derived from checkpoint", pause)
+	}
+}
+
+func TestClassifyFixerPauseUsesLegacyFixItemsHashWhenFixItemsMissing(t *testing.T) {
+	t.Parallel()
+
+	checkpoint := fixerCheckpoint{
+		Detail:       &checkpointDetail{HeadSHA: "head-1"},
+		FixItemsHash: "legacy-fix-items-hash",
+		Recheck:      &checkpointRecheck{RemainingFixItems: []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}},
+	}
+	run := &storage.RunRecord{Status: "failed", CurrentStep: stringPtr(string(stepRecheck)), ErrorMessage: stringPtr(noopResolveManualIntervention)}
+
+	pause, ok := classifyFixerPause(run, checkpoint, nil)
+	if !ok {
+		t.Fatal("classifyFixerPause() = not found, want legacy compatibility pause")
+	}
+	if pause.FixItemsStateHash != "legacy-fix-items-hash" {
+		t.Fatalf("pause.FixItemsStateHash = %q, want legacy-fix-items-hash", pause.FixItemsStateHash)
+	}
+}
+
+func TestClassifyFixerPauseFallsBackToLegacyRiskyConflictErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	fixItem := FixItem{Type: "conflict", Files: []string{"a.go"}}
+	checkpoint := fixerCheckpoint{
+		Detail:       &checkpointDetail{HeadSHA: "head-1"},
+		FixItems:     []FixItem{fixItem},
+		FixItemsHash: hashFixItemsState([]FixItem{fixItem}),
+	}
+	summary := "generic manual hold"
+	errorMessage := "Skipped acme/looper#42 because risky conflict fixes require manual intervention"
+	run := &storage.RunRecord{Status: "failed", CurrentStep: stringPtr(string(stepRepair)), Summary: &summary, ErrorMessage: &errorMessage}
+
+	pause, ok := classifyFixerPause(run, checkpoint, nil)
+	if !ok {
+		t.Fatal("classifyFixerPause() = not found, want legacy risky-conflict compatibility pause")
+	}
+	if pause.Reason != string(checkpointPauseReasonRiskyConflict) || !pause.Recoverable {
+		t.Fatalf("pause = %#v, want recoverable risky-conflict pause", pause)
+	}
+}
+
+func TestRunRecheckStepRecordsPauseWithLiveHead(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "still blocked"}}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+	checkpoint := fixerCheckpoint{
+		Detail:           &checkpointDetail{State: "OPEN", HeadSHA: "old-head"},
+		FixItems:         []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}},
+		FixItemsHash:     hashFixItemsState([]FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}),
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
+	}
+	updated, err := runner.runRecheckStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()}, Loop: storage.LoopRecord{ID: "loop_1", ProjectID: "project_1"}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err == nil {
+		t.Fatal("runRecheckStep() error = nil, want manual intervention hold")
+	}
+	loopErr, ok := err.(*loopError)
+	if !ok || loopErr.kind != FailureManualIntervention {
+		t.Fatalf("runRecheckStep() error = %#v, want manual_intervention loopError", err)
+	}
+	if updated.Pause == nil || updated.Pause.HeadSHA != "new-head" {
+		t.Fatalf("Pause = %#v, want live recheck head recorded", updated.Pause)
 	}
 }
 
@@ -3844,7 +3963,8 @@ func TestCreateRunContextRestartsFromDiscoverForRediscoverableCheckpoint(t *test
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	checkpointJSON := mustMarshalJSON(fixerCheckpoint{
-		ResumePolicy: "restart_from_discover",
+		ResumePolicy: loops.ResumePolicyManualIntervention,
+		Pause:        newCheckpointPause(checkpointPauseReasonNoopResolveNoNewCommits, true, "head-1", hashFixItemsState([]FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}), []string{"t1"}),
 		Detail: &checkpointDetail{
 			State:       "OPEN",
 			HeadSHA:     "head-1",
@@ -3857,14 +3977,15 @@ func TestCreateRunContextRestartsFromDiscoverForRediscoverableCheckpoint(t *test
 		Repair:     &checkpointRepair{Status: "completed", Summary: "nothing to change", CompletedAt: nowISO},
 		Validation: &ValidationResult{Passed: true, Summary: "passed"},
 		Push:       &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Recheck:    &checkpointRecheck{RemainingFixItems: []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}},
 	})
-	manualReason := "resolve-comments refused because fixer produced no new commits to push; leaving review threads unresolved"
+	manualReason := "manual hold captured by structured pause"
 	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
 		ID:                "run_manual_intervention",
 		LoopID:            "loop_fixer_manual_restart",
 		Status:            "failed",
-		CurrentStep:       stringPtr(string(stepResolveComments)),
-		LastCompletedStep: stringPtr(string(stepPush)),
+		CurrentStep:       stringPtr(string(stepRecheck)),
+		LastCompletedStep: stringPtr(string(stepResolveComments)),
 		CheckpointJSON:    &checkpointJSON,
 		Summary:           &manualReason,
 		ErrorMessage:      &manualReason,


### PR DESCRIPTION
## Summary
- persist structured fixer pause reasons and fingerprints on failed checkpoints so no-op resolve and risky-conflict recovery no longer depend on human-readable error text
- keep legacy compatibility by deriving recoverable pause state from older persisted runs while preserving hard manual holds and declined-thread suppression
- add regression coverage for structured pause classification, live-head fingerprinting, and legacy fixer recovery fallbacks

## Validation
- go test ./...
- go vet ./...
- go build ./...

Closes #388

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>