### PR TITLE
feat: add reviewer auto-merge scaffolding and validators

### DIFF
--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -329,7 +329,7 @@ func TestExecutorResumesPersistedNativeSession(t *testing.T) {
 		},
 	})
 
-	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_resumed", LoopID: "loop_1", WorkingDirectory: t.TempDir(), Prompt: "continue work", Timeout: 5 * time.Second, Env: map[string]string{"ARGS_PATH": argsPath}})
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_resumed", LoopID: "loop_1", WorkingDirectory: t.TempDir(), Prompt: "continue work", Timeout: 15 * time.Second, Env: map[string]string{"ARGS_PATH": argsPath}})
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -302,6 +302,13 @@
               }
             },
             "reviewer": {
+              "autoMerge": {
+                "enabled": false,
+                "requireBranchProtection": true,
+                "scope": "looper-only",
+                "strategy": "squash",
+                "transientRetries": 3
+              },
               "behavior": {
                 "loop": {
                   "enabledByDefault": true,

--- a/internal/cliapp/config_commands.go
+++ b/internal/cliapp/config_commands.go
@@ -71,6 +71,17 @@ var configFieldRegistry = map[string]configField{
 	}, func(p *config.PartialConfig) **bool {
 		return &ensurePartialReviewerRole(p).AutoDiscovery
 	}),
+	"roles.reviewer.autoMerge.enabled": boolFieldWithAlias("roles.reviewer.autoMerge.enabled", "", "", "roles-reviewer-auto-merge-enabled", "reviewer-auto-merge-enabled", func(c config.Config) any { return c.Roles.Reviewer.AutoMerge.Enabled }, func(p *config.PartialConfig) **bool {
+		return &ensurePartialReviewerAutoMerge(p).Enabled
+	}),
+	"roles.reviewer.autoMerge.strategy": reviewerAutoMergeStrategyField(),
+	"roles.reviewer.autoMerge.requireBranchProtection": boolFieldWithAlias("roles.reviewer.autoMerge.requireBranchProtection", "", "", "roles-reviewer-auto-merge-require-branch-protection", "reviewer-auto-merge-require-branch-protection", func(c config.Config) any { return c.Roles.Reviewer.AutoMerge.RequireBranchProtection }, func(p *config.PartialConfig) **bool {
+		return &ensurePartialReviewerAutoMerge(p).RequireBranchProtection
+	}),
+	"roles.reviewer.autoMerge.transientRetries": positiveIntField("roles.reviewer.autoMerge.transientRetries", "", "roles-reviewer-auto-merge-transient-retries", func(c config.Config) any { return c.Roles.Reviewer.AutoMerge.TransientRetries }, func(p *config.PartialConfig) **int {
+		return &ensurePartialReviewerAutoMerge(p).TransientRetries
+	}),
+	"roles.reviewer.autoMerge.scope": reviewerAutoMergeScopeField(),
 	"roles.reviewer.autoDiscovery": reviewerDiscoveryBoolFieldWithAlias("roles.reviewer.autoDiscovery", "LOOPER_ROLES_REVIEWER_AUTO_DISCOVERY", "LOOPER_ROLES_REVIEWER_DISCOVERY_AUTO_DISCOVERY", "", "", func(c config.Config) any { return c.Roles.Reviewer.Discovery.AutoDiscovery }, func(p *config.PartialConfig) **bool {
 		return &ensurePartialReviewerRoleDiscovery(p).AutoDiscovery
 	}, func(p *config.PartialConfig) **bool {
@@ -1252,6 +1263,30 @@ func openPRStrategyField() configField {
 	}}
 }
 
+func reviewerAutoMergeStrategyField() configField {
+	return configField{key: "roles.reviewer.autoMerge.strategy", valueType: "string", flag: "roles-reviewer-auto-merge-strategy", flagAlias: "reviewer-auto-merge-strategy", get: func(c config.Config) any { return c.Roles.Reviewer.AutoMerge.Strategy }, set: func(p *config.PartialConfig, raw string) error {
+		value := config.ReviewerAutoMergeStrategy(strings.TrimSpace(raw))
+		switch value {
+		case config.ReviewerAutoMergeStrategySquash, config.ReviewerAutoMergeStrategyMerge, config.ReviewerAutoMergeStrategyRebase:
+			ensurePartialReviewerAutoMerge(p).Strategy = &value
+			return nil
+		default:
+			return fmt.Errorf("invalid value for roles.reviewer.autoMerge.strategy: must be one of: %s, %s, %s", config.ReviewerAutoMergeStrategySquash, config.ReviewerAutoMergeStrategyMerge, config.ReviewerAutoMergeStrategyRebase)
+		}
+	}, unset: func(p *config.PartialConfig) { ensurePartialReviewerAutoMerge(p).Strategy = nil }}
+}
+
+func reviewerAutoMergeScopeField() configField {
+	return configField{key: "roles.reviewer.autoMerge.scope", valueType: "string", flag: "roles-reviewer-auto-merge-scope", flagAlias: "reviewer-auto-merge-scope", get: func(c config.Config) any { return c.Roles.Reviewer.AutoMerge.Scope }, set: func(p *config.PartialConfig, raw string) error {
+		value := config.ReviewerAutoMergeScope(strings.TrimSpace(raw))
+		if value != config.ReviewerAutoMergeScopeLooperOnly {
+			return fmt.Errorf("invalid value for roles.reviewer.autoMerge.scope: must be %s", config.ReviewerAutoMergeScopeLooperOnly)
+		}
+		ensurePartialReviewerAutoMerge(p).Scope = &value
+		return nil
+	}, unset: func(p *config.PartialConfig) { ensurePartialReviewerAutoMerge(p).Scope = nil }}
+}
+
 func reviewerReviewEventField(key, env, envAlias, flag, flagAlias string, get func(config.Config) any, target func(*config.PartialConfig) **config.ReviewerReviewEvent) configField {
 	return configField{key: key, valueType: "string", env: env, envAlias: envAlias, flag: flag, flagAlias: flagAlias, get: get, set: func(p *config.PartialConfig, raw string) error {
 		value := config.ReviewerReviewEvent(strings.ToUpper(strings.TrimSpace(raw)))
@@ -1409,6 +1444,14 @@ func ensurePartialReviewerRoleDiscovery(partial *config.PartialConfig) *config.P
 	return reviewer.Discovery
 }
 
+func ensurePartialReviewerAutoMerge(partial *config.PartialConfig) *config.PartialReviewerAutoMergeConfig {
+	reviewer := ensurePartialReviewerRole(partial)
+	if reviewer.AutoMerge == nil {
+		reviewer.AutoMerge = &config.PartialReviewerAutoMergeConfig{}
+	}
+	return reviewer.AutoMerge
+}
+
 func ensurePartialReviewerRoleTriggers(partial *config.PartialConfig) *config.PartialReviewerRoleTriggersConfig {
 	reviewer := ensurePartialReviewerRole(partial)
 	if reviewer.Triggers == nil {
@@ -1533,6 +1576,16 @@ func configFieldSet(partial config.PartialConfig, key string) bool {
 		return partial.Roles != nil && partial.Roles.Worker != nil && partial.Roles.Worker.Triggers != nil && partial.Roles.Worker.Triggers.RequireAssigneeCurrentUser != nil
 	case "roles.reviewer.discovery.autoDiscovery", "roles.reviewer.autoDiscovery":
 		return partial.Roles != nil && partial.Roles.Reviewer != nil && ((partial.Roles.Reviewer.Discovery != nil && partial.Roles.Reviewer.Discovery.AutoDiscovery != nil) || partial.Roles.Reviewer.AutoDiscovery != nil)
+	case "roles.reviewer.autoMerge.enabled":
+		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.AutoMerge != nil && partial.Roles.Reviewer.AutoMerge.Enabled != nil
+	case "roles.reviewer.autoMerge.strategy":
+		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.AutoMerge != nil && partial.Roles.Reviewer.AutoMerge.Strategy != nil
+	case "roles.reviewer.autoMerge.requireBranchProtection":
+		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.AutoMerge != nil && partial.Roles.Reviewer.AutoMerge.RequireBranchProtection != nil
+	case "roles.reviewer.autoMerge.transientRetries":
+		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.AutoMerge != nil && partial.Roles.Reviewer.AutoMerge.TransientRetries != nil
+	case "roles.reviewer.autoMerge.scope":
+		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.AutoMerge != nil && partial.Roles.Reviewer.AutoMerge.Scope != nil
 	case "roles.reviewer.instructions":
 		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.Instructions != nil
 	case "roles.reviewer.discovery.triggers.includeDrafts", "roles.reviewer.triggers.includeDrafts":

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -225,6 +225,13 @@ func DefaultConfig(cwd string) (Config, error) {
 						MaxThreadsPerRun:            10,
 					},
 				},
+				AutoMerge: ReviewerAutoMergeConfig{
+					Enabled:                 false,
+					Strategy:                ReviewerAutoMergeStrategySquash,
+					RequireBranchProtection: true,
+					TransientRetries:        3,
+					Scope:                   ReviewerAutoMergeScopeLooperOnly,
+				},
 			},
 			Fixer: FixerRoleConfig{
 				AutoDiscovery: true,

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -871,8 +871,29 @@ func mergeReviewerRoleConfig(config *ReviewerRoleConfig, partial PartialReviewer
 	if partial.Behavior != nil {
 		mergeReviewerConfig(&config.Behavior, *partial.Behavior)
 	}
+	if partial.AutoMerge != nil {
+		mergeReviewerAutoMergeConfig(&config.AutoMerge, *partial.AutoMerge)
+	}
 	if partial.Instructions != nil {
 		config.Instructions = *partial.Instructions
+	}
+}
+
+func mergeReviewerAutoMergeConfig(config *ReviewerAutoMergeConfig, partial PartialReviewerAutoMergeConfig) {
+	if partial.Enabled != nil {
+		config.Enabled = *partial.Enabled
+	}
+	if partial.Strategy != nil {
+		config.Strategy = *partial.Strategy
+	}
+	if partial.RequireBranchProtection != nil {
+		config.RequireBranchProtection = *partial.RequireBranchProtection
+	}
+	if partial.TransientRetries != nil {
+		config.TransientRetries = *partial.TransientRetries
+	}
+	if partial.Scope != nil {
+		config.Scope = *partial.Scope
 	}
 }
 

--- a/internal/config/reviewer_automerge_test.go
+++ b/internal/config/reviewer_automerge_test.go
@@ -1,0 +1,61 @@
+package config
+
+import "testing"
+
+func TestDefaultConfigReviewerAutoMergeDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	autoMerge := cfg.Roles.Reviewer.AutoMerge
+	if autoMerge.Enabled {
+		t.Fatal("DefaultConfig().Roles.Reviewer.AutoMerge.Enabled = true, want false")
+	}
+	if autoMerge.Strategy != ReviewerAutoMergeStrategySquash {
+		t.Fatalf("DefaultConfig().Roles.Reviewer.AutoMerge.Strategy = %q, want %q", autoMerge.Strategy, ReviewerAutoMergeStrategySquash)
+	}
+	if !autoMerge.RequireBranchProtection {
+		t.Fatal("DefaultConfig().Roles.Reviewer.AutoMerge.RequireBranchProtection = false, want true")
+	}
+	if autoMerge.TransientRetries != 3 {
+		t.Fatalf("DefaultConfig().Roles.Reviewer.AutoMerge.TransientRetries = %d, want 3", autoMerge.TransientRetries)
+	}
+	if autoMerge.Scope != ReviewerAutoMergeScopeLooperOnly {
+		t.Fatalf("DefaultConfig().Roles.Reviewer.AutoMerge.Scope = %q, want %q", autoMerge.Scope, ReviewerAutoMergeScopeLooperOnly)
+	}
+}
+
+func TestProjectRoleConfigsMergesReviewerAutoMergeOverrides(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Projects = []ProjectRefConfig{{
+		ID:       "demo",
+		Name:     "Demo",
+		RepoPath: "/tmp/demo",
+		Roles: &PartialRoleConfigs{Reviewer: &PartialReviewerRoleConfig{AutoMerge: &PartialReviewerAutoMergeConfig{
+			Enabled:                 reviewerAutoMergeBoolPtr(true),
+			Strategy:                reviewerAutoMergeStrategyPtr(ReviewerAutoMergeStrategyMerge),
+			RequireBranchProtection: reviewerAutoMergeBoolPtr(false),
+			TransientRetries:        reviewerAutoMergeIntPtr(5),
+			Scope:                   reviewerAutoMergeScopePtr(ReviewerAutoMergeScopeLooperOnly),
+		}}},
+	}}
+
+	roles := ProjectRoleConfigs(cfg, "demo")
+	if !roles.Reviewer.AutoMerge.Enabled || roles.Reviewer.AutoMerge.Strategy != ReviewerAutoMergeStrategyMerge || roles.Reviewer.AutoMerge.RequireBranchProtection || roles.Reviewer.AutoMerge.TransientRetries != 5 || roles.Reviewer.AutoMerge.Scope != ReviewerAutoMergeScopeLooperOnly {
+		t.Fatalf("ProjectRoleConfigs() reviewer auto-merge = %#v, want project override applied", roles.Reviewer.AutoMerge)
+	}
+}
+
+func reviewerAutoMergeStrategyPtr(value ReviewerAutoMergeStrategy) *ReviewerAutoMergeStrategy {
+	return &value
+}
+func reviewerAutoMergeScopePtr(value ReviewerAutoMergeScope) *ReviewerAutoMergeScope { return &value }
+func reviewerAutoMergeBoolPtr(value bool) *bool                                      { return &value }
+func reviewerAutoMergeIntPtr(value int) *int                                         { return &value }

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -233,6 +233,13 @@
           }
         },
         "reviewer": {
+          "autoMerge": {
+            "enabled": false,
+            "requireBranchProtection": true,
+            "scope": "looper-only",
+            "strategy": "squash",
+            "transientRetries": 3
+          },
           "behavior": {
             "loop": {
               "enabledByDefault": true,

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -170,6 +170,13 @@
           }
         },
         "reviewer": {
+          "autoMerge": {
+            "enabled": false,
+            "requireBranchProtection": true,
+            "scope": "looper-only",
+            "strategy": "squash",
+            "transientRetries": 3
+          },
           "behavior": {
             "loop": {
               "enabledByDefault": true,

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -253,6 +253,13 @@
           }
         },
         "reviewer": {
+          "autoMerge": {
+            "enabled": false,
+            "requireBranchProtection": true,
+            "scope": "looper-only",
+            "strategy": "squash",
+            "transientRetries": 3
+          },
           "behavior": {
             "loop": {
               "enabledByDefault": true,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -113,6 +113,20 @@ const (
 	ReviewerReviewEventRequestChanges ReviewerReviewEvent = "REQUEST_CHANGES"
 )
 
+type ReviewerAutoMergeStrategy string
+
+const (
+	ReviewerAutoMergeStrategySquash ReviewerAutoMergeStrategy = "squash"
+	ReviewerAutoMergeStrategyMerge  ReviewerAutoMergeStrategy = "merge"
+	ReviewerAutoMergeStrategyRebase ReviewerAutoMergeStrategy = "rebase"
+)
+
+type ReviewerAutoMergeScope string
+
+const (
+	ReviewerAutoMergeScopeLooperOnly ReviewerAutoMergeScope = "looper-only"
+)
+
 type NotificationSoundLevel string
 
 const (
@@ -307,6 +321,14 @@ type ReviewerThreadResolutionConfig struct {
 	MaxThreadsPerRun            int                                 `json:"maxThreadsPerRun"`
 }
 
+type ReviewerAutoMergeConfig struct {
+	Enabled                 bool                      `json:"enabled"`
+	Strategy                ReviewerAutoMergeStrategy `json:"strategy"`
+	RequireBranchProtection bool                      `json:"requireBranchProtection"`
+	TransientRetries        int                       `json:"transientRetries"`
+	Scope                   ReviewerAutoMergeScope    `json:"scope"`
+}
+
 type IssueRoleTriggersConfig struct {
 	Labels                     []string  `json:"labels"`
 	LabelMode                  LabelMode `json:"labelMode"`
@@ -359,6 +381,7 @@ type WorkerRoleConfig struct {
 type ReviewerRoleConfig struct {
 	Discovery    ReviewerRoleDiscoveryConfig `json:"discovery"`
 	Behavior     ReviewerConfig              `json:"behavior"`
+	AutoMerge    ReviewerAutoMergeConfig     `json:"autoMerge"`
 	Instructions string                      `json:"instructions,omitempty"`
 }
 
@@ -720,6 +743,14 @@ type PartialReviewerThreadResolutionConfig struct {
 	MaxThreadsPerRun            *int                                 `json:"maxThreadsPerRun,omitempty"`
 }
 
+type PartialReviewerAutoMergeConfig struct {
+	Enabled                 *bool                      `json:"enabled,omitempty"`
+	Strategy                *ReviewerAutoMergeStrategy `json:"strategy,omitempty"`
+	RequireBranchProtection *bool                      `json:"requireBranchProtection,omitempty"`
+	TransientRetries        *int                       `json:"transientRetries,omitempty"`
+	Scope                   *ReviewerAutoMergeScope    `json:"scope,omitempty"`
+}
+
 type PartialInstructionsConfig struct {
 	Enabled  *bool `json:"enabled,omitempty"`
 	MaxBytes *int  `json:"maxBytes,omitempty"`
@@ -839,6 +870,7 @@ type PartialWorkerRoleConfig struct {
 type PartialReviewerRoleConfig struct {
 	Discovery    *PartialReviewerRoleDiscoveryConfig `json:"discovery,omitempty"`
 	Behavior     *PartialReviewerConfig              `json:"behavior,omitempty"`
+	AutoMerge    *PartialReviewerAutoMergeConfig     `json:"autoMerge,omitempty"`
 	Instructions *string                             `json:"instructions,omitempty"`
 
 	AutoDiscovery *bool                              `json:"autoDiscovery,omitempty"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -185,6 +185,15 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 	if config.Roles.Reviewer.Behavior.ThreadResolution.Mode == ReviewerThreadResolutionModeResolveObjective && !config.Roles.Reviewer.Behavior.ThreadResolution.RequireAuditComment {
 		issues = append(issues, ValidationIssue{Path: "roles.reviewer.behavior.threadResolution.requireAuditComment", Message: "must be true when mode is resolve_objective"})
 	}
+	if !isValidReviewerAutoMergeStrategy(config.Roles.Reviewer.AutoMerge.Strategy) {
+		issues = append(issues, ValidationIssue{Path: "roles.reviewer.autoMerge.strategy", Message: fmt.Sprintf("must be one of: %s, %s, %s", ReviewerAutoMergeStrategySquash, ReviewerAutoMergeStrategyMerge, ReviewerAutoMergeStrategyRebase)})
+	}
+	if config.Roles.Reviewer.AutoMerge.TransientRetries < 1 {
+		issues = append(issues, ValidationIssue{Path: "roles.reviewer.autoMerge.transientRetries", Message: "must be a positive integer"})
+	}
+	if config.Roles.Reviewer.AutoMerge.Scope != ReviewerAutoMergeScopeLooperOnly {
+		issues = append(issues, ValidationIssue{Path: "roles.reviewer.autoMerge.scope", Message: fmt.Sprintf("must be %s", ReviewerAutoMergeScopeLooperOnly)})
+	}
 	if config.Roles.Reviewer.Behavior.ReviewEvents.Clean != ReviewerReviewEventComment && config.Roles.Reviewer.Behavior.ReviewEvents.Clean != ReviewerReviewEventApprove {
 		issues = append(issues, ValidationIssue{Path: "roles.reviewer.behavior.reviewEvents.clean", Message: fmt.Sprintf("must be one of: %s, %s", ReviewerReviewEventComment, ReviewerReviewEventApprove)})
 	}
@@ -343,6 +352,9 @@ func validateProjectRoleOverrides(roles *PartialRoleConfigs, prefix string, maxI
 			if label != "" && label != strings.TrimSpace(label) {
 				*issues = append(*issues, ValidationIssue{Path: prefix + ".reviewer.specReview.reviewingLabel", Message: "must not contain leading or trailing whitespace"})
 			}
+		}
+		if roles.Reviewer.AutoMerge != nil {
+			validatePartialReviewerAutoMerge(*roles.Reviewer.AutoMerge, prefix+".reviewer.autoMerge", issues)
 		}
 	}
 	if roles.Fixer != nil {
@@ -633,6 +645,27 @@ func isValidFixerAuthorFilter(filter FixerAuthorFilter) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func isValidReviewerAutoMergeStrategy(strategy ReviewerAutoMergeStrategy) bool {
+	switch strategy {
+	case ReviewerAutoMergeStrategySquash, ReviewerAutoMergeStrategyMerge, ReviewerAutoMergeStrategyRebase:
+		return true
+	default:
+		return false
+	}
+}
+
+func validatePartialReviewerAutoMerge(partial PartialReviewerAutoMergeConfig, path string, issues *[]ValidationIssue) {
+	if partial.Strategy != nil && !isValidReviewerAutoMergeStrategy(*partial.Strategy) {
+		*issues = append(*issues, ValidationIssue{Path: path + ".strategy", Message: fmt.Sprintf("must be one of: %s, %s, %s", ReviewerAutoMergeStrategySquash, ReviewerAutoMergeStrategyMerge, ReviewerAutoMergeStrategyRebase)})
+	}
+	if partial.TransientRetries != nil && *partial.TransientRetries < 1 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".transientRetries", Message: "must be a positive integer"})
+	}
+	if partial.Scope != nil && *partial.Scope != ReviewerAutoMergeScopeLooperOnly {
+		*issues = append(*issues, ValidationIssue{Path: path + ".scope", Message: fmt.Sprintf("must be %s", ReviewerAutoMergeScopeLooperOnly)})
 	}
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -175,6 +175,29 @@ type PullRequestHeadAndAuthor struct {
 	Author  string
 }
 
+type RepositorySettingsInput struct {
+	Repo string
+	CWD  string
+}
+
+type RepositorySettings struct {
+	AllowSquashMerge bool
+	AllowMergeCommit bool
+	AllowRebaseMerge bool
+	AllowAutoMerge   bool
+}
+
+type BranchProtectionInput struct {
+	Repo   string
+	Branch string
+	CWD    string
+}
+
+type BranchProtection struct {
+	Enabled           bool
+	HasRequiredChecks bool
+}
+
 type IssueSummary struct {
 	Number            int64
 	Title             string
@@ -1064,6 +1087,58 @@ func (g *Gateway) GetRepositoryPermission(ctx context.Context, input RepositoryP
 		return "", err
 	}
 	return strings.ToLower(strings.TrimSpace(asString(row["permission"]))), nil
+}
+
+func (g *Gateway) GetRepositorySettings(ctx context.Context, input RepositorySettingsInput) (RepositorySettings, error) {
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s", repo)}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
+	if err != nil {
+		return RepositorySettings{}, err
+	}
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return RepositorySettings{}, err
+	}
+	return RepositorySettings{
+		AllowSquashMerge: asBool(row["allow_squash_merge"]),
+		AllowMergeCommit: asBool(row["allow_merge_commit"]),
+		AllowRebaseMerge: asBool(row["allow_rebase_merge"]),
+		AllowAutoMerge:   asBool(row["allow_auto_merge"]),
+	}, nil
+}
+
+func (g *Gateway) GetBranchProtection(ctx context.Context, input BranchProtectionInput) (BranchProtection, error) {
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/branches/%s/protection", repo, encodeURIComponent(input.Branch))}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
+	if err != nil {
+		if shellErr, ok := err.(*shell.CommandExecutionError); ok && strings.Contains(strings.ToLower(shellErr.Result.Stderr), "404") {
+			return BranchProtection{}, nil
+		}
+		return BranchProtection{}, err
+	}
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return BranchProtection{}, err
+	}
+	requiredStatusChecks, _ := row["required_status_checks"].(map[string]any)
+	hasRequiredChecks := false
+	if requiredStatusChecks != nil {
+		if len(toObjectSlice(requiredStatusChecks["checks"])) > 0 {
+			hasRequiredChecks = true
+		}
+		if contexts, ok := requiredStatusChecks["contexts"].([]any); ok && len(contexts) > 0 {
+			hasRequiredChecks = true
+		}
+	}
+	return BranchProtection{Enabled: true, HasRequiredChecks: hasRequiredChecks}, nil
 }
 
 func compactIssueAssignees(values []string) []string {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -1119,7 +1119,7 @@ func (g *Gateway) GetBranchProtection(ctx context.Context, input BranchProtectio
 	}
 	result, err := g.runGh(ctx, input.CWD, "", args...)
 	if err != nil {
-		if shellErr, ok := err.(*shell.CommandExecutionError); ok && strings.Contains(strings.ToLower(shellErr.Result.Stderr), "404") {
+		if IsNotFoundError(err) {
 			return BranchProtection{}, nil
 		}
 		return BranchProtection{}, err

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -320,6 +320,65 @@ func TestGetPullRequestHeadSHA(t *testing.T) {
 	}
 }
 
+func TestGetRepositorySettings(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		if args != "api repos/acme/looper" {
+			t.Fatalf("unexpected gh args: %q", args)
+		}
+		return shell.Result{Stdout: `{"allow_squash_merge":true,"allow_merge_commit":false,"allow_rebase_merge":true,"allow_auto_merge":true}`}, nil
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	settings, err := gateway.GetRepositorySettings(context.Background(), RepositorySettingsInput{Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("GetRepositorySettings() error = %v", err)
+	}
+	if !settings.AllowSquashMerge || settings.AllowMergeCommit || !settings.AllowRebaseMerge || !settings.AllowAutoMerge {
+		t.Fatalf("GetRepositorySettings() = %#v, want decoded repo settings", settings)
+	}
+}
+
+func TestGetBranchProtection(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		if args != "api repos/acme/looper/branches/main/protection" {
+			t.Fatalf("unexpected gh args: %q", args)
+		}
+		return shell.Result{Stdout: `{"required_status_checks":{"checks":[{"context":"ci"}]}}`}, nil
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	protection, err := gateway.GetBranchProtection(context.Background(), BranchProtectionInput{Repo: "acme/looper", Branch: "main"})
+	if err != nil {
+		t.Fatalf("GetBranchProtection() error = %v", err)
+	}
+	if !protection.Enabled || !protection.HasRequiredChecks {
+		t.Fatalf("GetBranchProtection() = %#v, want enabled protection with required checks", protection)
+	}
+}
+
+func TestGetBranchProtectionReturnsEmptyOnMissingProtection(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		return shell.Result{Stderr: "HTTP 404: Not Found"}, &shell.CommandExecutionError{Result: shell.Result{Stderr: "HTTP 404: Not Found"}}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	protection, err := gateway.GetBranchProtection(context.Background(), BranchProtectionInput{Repo: "acme/looper", Branch: "main"})
+	if err != nil {
+		t.Fatalf("GetBranchProtection() error = %v", err)
+	}
+	if protection.Enabled || protection.HasRequiredChecks {
+		t.Fatalf("GetBranchProtection() = %#v, want no protection", protection)
+	}
+}
+
 func TestGetPullRequestHeadAndAuthorUsesNarrowPRView(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -379,6 +379,24 @@ func TestGetBranchProtectionReturnsEmptyOnMissingProtection(t *testing.T) {
 	}
 }
 
+func TestGetBranchProtectionReturnsEmptyOnMissingProtectionFromStdout(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		result := shell.Result{Stdout: `{"message":"Branch not protected","documentation_url":"https://docs.github.com/rest/branches/branch-protection#get-branch-protection","status":"404"}`}
+		return result, &shell.CommandExecutionError{Message: "Command exited with code 1: stdout: HTTP 404: Not Found", Result: result}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	protection, err := gateway.GetBranchProtection(context.Background(), BranchProtectionInput{Repo: "acme/looper", Branch: "main"})
+	if err != nil {
+		t.Fatalf("GetBranchProtection() error = %v", err)
+	}
+	if protection.Enabled || protection.HasRequiredChecks {
+		t.Fatalf("GetBranchProtection() = %#v, want no protection", protection)
+	}
+}
+
 func TestGetPullRequestHeadAndAuthorUsesNarrowPRView(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/projects/reviewer_automerge_validation.go
+++ b/internal/projects/reviewer_automerge_validation.go
@@ -29,13 +29,6 @@ func (s *Service) validateReviewerAutoMergeForProject(ctx context.Context, proje
 	if repoName == "" {
 		return reviewerAutoMergeValidationError(projectID, "GitHub repo is unknown")
 	}
-	branch := strings.TrimSpace(baseBranch)
-	if branch == "" {
-		branch = strings.TrimSpace(cfg.Defaults.BaseBranch)
-	}
-	if branch == "" {
-		return reviewerAutoMergeValidationError(repoName, "default branch is unknown")
-	}
 	settings, err := s.GetRepositorySettings(ctx, githubinfra.RepositorySettingsInput{Repo: repoName})
 	if err != nil {
 		return fmt.Errorf("read repo settings for %s: %w", repoName, err)
@@ -52,6 +45,13 @@ func (s *Service) validateReviewerAutoMergeForProject(ctx context.Context, proje
 		return reviewerAutoMergeValidationError(repoName, "GitHub repo auto-merge is disabled")
 	}
 	if autoMergeCfg.RequireBranchProtection {
+		branch := strings.TrimSpace(baseBranch)
+		if branch == "" {
+			branch = strings.TrimSpace(cfg.Defaults.BaseBranch)
+		}
+		if branch == "" {
+			return reviewerAutoMergeValidationError(repoName, "default branch is unknown")
+		}
 		protection, err := s.GetBranchProtection(ctx, githubinfra.BranchProtectionInput{Repo: repoName, Branch: branch})
 		if err != nil {
 			return fmt.Errorf("read branch protection for %s@%s: %w", repoName, branch, err)

--- a/internal/projects/reviewer_automerge_validation.go
+++ b/internal/projects/reviewer_automerge_validation.go
@@ -22,7 +22,7 @@ func (s *Service) validateReviewerAutoMergeForProject(ctx context.Context, proje
 	if autoMergeCfg.Scope != config.ReviewerAutoMergeScopeLooperOnly {
 		return reviewerAutoMergeValidationError(projectRepoLabel(repo, projectID), fmt.Sprintf("scope %q is unsupported in v1", autoMergeCfg.Scope))
 	}
-	if s.GetRepositorySettings == nil || s.GetBranchProtection == nil {
+	if s.GetRepositorySettings == nil || (autoMergeCfg.RequireBranchProtection && s.GetBranchProtection == nil) {
 		return reviewerAutoMergeValidationError(projectRepoLabel(repo, projectID), "GitHub auto-merge validation is not configured")
 	}
 	repoName := strings.TrimSpace(stringValue(repo))

--- a/internal/projects/reviewer_automerge_validation.go
+++ b/internal/projects/reviewer_automerge_validation.go
@@ -1,0 +1,82 @@
+package projects
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/config"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/reviewer/automerge"
+)
+
+type GetRepositorySettingsFunc func(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error)
+type GetBranchProtectionFunc func(context.Context, githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error)
+
+func (s *Service) validateReviewerAutoMergeForProject(ctx context.Context, projectID string, repo *string, baseBranch string, cfg config.Config) error {
+	roles := config.ProjectRoleConfigs(cfg, projectID)
+	autoMergeCfg := roles.Reviewer.AutoMerge
+	if !autoMergeCfg.Enabled {
+		return nil
+	}
+	if autoMergeCfg.Scope != config.ReviewerAutoMergeScopeLooperOnly {
+		return reviewerAutoMergeValidationError(projectRepoLabel(repo, projectID), fmt.Sprintf("scope %q is unsupported in v1", autoMergeCfg.Scope))
+	}
+	if s.GetRepositorySettings == nil || s.GetBranchProtection == nil {
+		return reviewerAutoMergeValidationError(projectRepoLabel(repo, projectID), "GitHub auto-merge validation is not configured")
+	}
+	repoName := strings.TrimSpace(stringValue(repo))
+	if repoName == "" {
+		return reviewerAutoMergeValidationError(projectID, "GitHub repo is unknown")
+	}
+	branch := strings.TrimSpace(baseBranch)
+	if branch == "" {
+		branch = strings.TrimSpace(cfg.Defaults.BaseBranch)
+	}
+	if branch == "" {
+		return reviewerAutoMergeValidationError(repoName, "default branch is unknown")
+	}
+	settings, err := s.GetRepositorySettings(ctx, githubinfra.RepositorySettingsInput{Repo: repoName})
+	if err != nil {
+		return fmt.Errorf("read repo settings for %s: %w", repoName, err)
+	}
+	if !automerge.StrategyAllowed(autoMergeCfg.Strategy, automerge.RepoSettingsSnapshot{
+		AllowSquashMerge: settings.AllowSquashMerge,
+		AllowMergeCommit: settings.AllowMergeCommit,
+		AllowRebaseMerge: settings.AllowRebaseMerge,
+		AllowAutoMerge:   settings.AllowAutoMerge,
+	}) {
+		return reviewerAutoMergeValidationError(repoName, fmt.Sprintf("configured strategy %q is not allowed by repo settings", autoMergeCfg.Strategy))
+	}
+	if !settings.AllowAutoMerge {
+		return reviewerAutoMergeValidationError(repoName, "GitHub repo auto-merge is disabled")
+	}
+	if autoMergeCfg.RequireBranchProtection {
+		protection, err := s.GetBranchProtection(ctx, githubinfra.BranchProtectionInput{Repo: repoName, Branch: branch})
+		if err != nil {
+			return fmt.Errorf("read branch protection for %s@%s: %w", repoName, branch, err)
+		}
+		if !protection.Enabled || !protection.HasRequiredChecks {
+			return reviewerAutoMergeValidationError(repoName, "default branch protection is missing or has no required checks")
+		}
+	}
+	return nil
+}
+
+func reviewerAutoMergeValidationError(repo, failure string) error {
+	return ProjectValidationError{Message: fmt.Sprintf("reviewer auto-merge enabled on %s but %s; disable roles.reviewer.autoMerge.enabled or fix repo settings", repo, failure)}
+}
+
+func projectRepoLabel(repo *string, projectID string) string {
+	if trimmed := strings.TrimSpace(stringValue(repo)); trimmed != "" {
+		return trimmed
+	}
+	return projectID
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/projects/reviewer_automerge_validation_test.go
+++ b/internal/projects/reviewer_automerge_validation_test.go
@@ -48,6 +48,9 @@ func TestValidateReviewerAutoMergeForProjectFailureModes(t *testing.T) {
 		{name: "missing branch protection", mutate: func(cfg *config.Config) {}, service: &Service{GetRepositorySettings: service.GetRepositorySettings, GetBranchProtection: func(context.Context, githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
 			return githubinfra.BranchProtection{}, nil
 		}}, want: "default branch protection is missing or has no required checks"},
+		{name: "missing branch protection gateway only matters when protection required", mutate: func(cfg *config.Config) {
+			cfg.Roles.Reviewer.AutoMerge.RequireBranchProtection = false
+		}, service: &Service{GetRepositorySettings: service.GetRepositorySettings}, want: ""},
 	}
 
 	for _, tt := range tests {
@@ -56,6 +59,12 @@ func TestValidateReviewerAutoMergeForProjectFailureModes(t *testing.T) {
 			cfg := baseConfig
 			tt.mutate(&cfg)
 			err := tt.service.validateReviewerAutoMergeForProject(context.Background(), "project_1", &repo, "main", cfg)
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("validateReviewerAutoMergeForProject() error = %v, want nil", err)
+				}
+				return
+			}
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("validateReviewerAutoMergeForProject() error = %v, want substring %q", err, tt.want)
 			}

--- a/internal/projects/reviewer_automerge_validation_test.go
+++ b/internal/projects/reviewer_automerge_validation_test.go
@@ -103,6 +103,39 @@ func TestServiceAddProjectValidatesReviewerAutoMerge(t *testing.T) {
 	}
 }
 
+func TestServiceAddProjectAllowsUnknownBaseBranchWithoutProtectionRequirement(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	repo := "acme/looper"
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.AutoMerge.Enabled = true
+	cfg.Roles.Reviewer.AutoMerge.RequireBranchProtection = false
+	cfg.Defaults.BaseBranch = ""
+
+	service := &Service{
+		DB:     coordinator.DB(),
+		Repos:  repos,
+		Config: cfg,
+		Now:    func() time.Time { return time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC) },
+		GetRepositorySettings: func(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+			return githubinfra.RepositorySettings{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true, AllowAutoMerge: true}, nil
+		},
+	}
+
+	result, err := service.AddProject(context.Background(), AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", Repo: &repo})
+	if err != nil {
+		t.Fatalf("AddProject() error = %v, want nil", err)
+	}
+	if result.Project.BaseBranch != nil && *result.Project.BaseBranch != "" {
+		t.Fatalf("AddProject() base branch = %q, want empty", *result.Project.BaseBranch)
+	}
+}
+
 func TestServiceSyncConfiguredValidatesReviewerAutoMerge(t *testing.T) {
 	t.Parallel()
 
@@ -132,5 +165,45 @@ func TestServiceSyncConfiguredValidatesReviewerAutoMerge(t *testing.T) {
 	err = service.SyncConfigured(context.Background(), cfg, time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC))
 	if err == nil || !strings.Contains(err.Error(), "default branch protection is missing or has no required checks") {
 		t.Fatalf("SyncConfigured() error = %v, want branch protection validation failure", err)
+	}
+}
+
+func TestServiceSyncConfiguredAllowsUnknownBaseBranchWithoutProtectionRequirement(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	service := &Service{
+		DB:    coordinator.DB(),
+		Repos: repos,
+		Now:   func() time.Time { return time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC) },
+		GetRepositorySettings: func(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+			return githubinfra.RepositorySettings{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true, AllowAutoMerge: true}, nil
+		},
+	}
+	repoName := "acme/looper"
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.AutoMerge.Enabled = true
+	cfg.Roles.Reviewer.AutoMerge.RequireBranchProtection = false
+	cfg.Defaults.BaseBranch = ""
+	cfg.Projects = []config.ProjectRefConfig{{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper"}}
+
+	service.DetectRepo = func(context.Context, string) (string, error) { return repoName, nil }
+	err = service.SyncConfigured(context.Background(), cfg, time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("SyncConfigured() error = %v, want nil", err)
+	}
+	project, err := repos.Projects.GetByID(context.Background(), "looper")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	if project == nil {
+		t.Fatalf("Projects.GetByID() = nil, want stored project")
+	}
+	if project.BaseBranch != nil && *project.BaseBranch != "" {
+		t.Fatalf("SyncConfigured() base branch = %q, want empty", *project.BaseBranch)
 	}
 }

--- a/internal/projects/reviewer_automerge_validation_test.go
+++ b/internal/projects/reviewer_automerge_validation_test.go
@@ -1,0 +1,127 @@
+package projects
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestValidateReviewerAutoMergeForProjectFailureModes(t *testing.T) {
+	t.Parallel()
+
+	baseConfig, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	baseConfig.Roles.Reviewer.AutoMerge.Enabled = true
+	baseConfig.Defaults.BaseBranch = "main"
+	service := &Service{
+		GetRepositorySettings: func(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+			return githubinfra.RepositorySettings{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true, AllowAutoMerge: true}, nil
+		},
+		GetBranchProtection: func(context.Context, githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+			return githubinfra.BranchProtection{Enabled: true, HasRequiredChecks: true}, nil
+		},
+	}
+	repo := "acme/looper"
+
+	tests := []struct {
+		name    string
+		mutate  func(*config.Config)
+		service *Service
+		want    string
+	}{
+		{name: "unsupported scope", mutate: func(cfg *config.Config) { cfg.Roles.Reviewer.AutoMerge.Scope = "future-scope" }, service: service, want: `scope "future-scope" is unsupported in v1`},
+		{name: "strategy disallowed", mutate: func(cfg *config.Config) {
+			cfg.Roles.Reviewer.AutoMerge.Strategy = config.ReviewerAutoMergeStrategyRebase
+		}, service: &Service{GetRepositorySettings: func(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+			return githubinfra.RepositorySettings{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: false, AllowAutoMerge: true}, nil
+		}, GetBranchProtection: service.GetBranchProtection}, want: `configured strategy "rebase" is not allowed by repo settings`},
+		{name: "auto merge disabled", mutate: func(cfg *config.Config) {}, service: &Service{GetRepositorySettings: func(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+			return githubinfra.RepositorySettings{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true, AllowAutoMerge: false}, nil
+		}, GetBranchProtection: service.GetBranchProtection}, want: "GitHub repo auto-merge is disabled"},
+		{name: "missing branch protection", mutate: func(cfg *config.Config) {}, service: &Service{GetRepositorySettings: service.GetRepositorySettings, GetBranchProtection: func(context.Context, githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+			return githubinfra.BranchProtection{}, nil
+		}}, want: "default branch protection is missing or has no required checks"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := baseConfig
+			tt.mutate(&cfg)
+			err := tt.service.validateReviewerAutoMergeForProject(context.Background(), "project_1", &repo, "main", cfg)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validateReviewerAutoMergeForProject() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceAddProjectValidatesReviewerAutoMerge(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	repo := "acme/looper"
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.AutoMerge.Enabled = true
+
+	service := &Service{
+		DB:     coordinator.DB(),
+		Repos:  repos,
+		Config: cfg,
+		Now:    func() time.Time { return time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC) },
+		GetRepositorySettings: func(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+			return githubinfra.RepositorySettings{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true, AllowAutoMerge: true}, nil
+		},
+		GetBranchProtection: func(context.Context, githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+			return githubinfra.BranchProtection{}, nil
+		},
+	}
+
+	_, err = service.AddProject(context.Background(), AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main", Repo: &repo})
+	if err == nil || !strings.Contains(err.Error(), "default branch protection is missing or has no required checks") {
+		t.Fatalf("AddProject() error = %v, want branch protection validation failure", err)
+	}
+}
+
+func TestServiceSyncConfiguredValidatesReviewerAutoMerge(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	service := &Service{
+		DB:    coordinator.DB(),
+		Repos: repos,
+		Now:   func() time.Time { return time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC) },
+		GetRepositorySettings: func(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+			return githubinfra.RepositorySettings{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true, AllowAutoMerge: true}, nil
+		},
+		GetBranchProtection: func(context.Context, githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+			return githubinfra.BranchProtection{}, nil
+		},
+	}
+	repoName := "acme/looper"
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.AutoMerge.Enabled = true
+	baseBranch := "main"
+	cfg.Projects = []config.ProjectRefConfig{{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: &baseBranch}}
+
+	service.DetectRepo = func(context.Context, string) (string, error) { return repoName, nil }
+	err = service.SyncConfigured(context.Background(), cfg, time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC))
+	if err == nil || !strings.Contains(err.Error(), "default branch protection is missing or has no required checks") {
+		t.Fatalf("SyncConfigured() error = %v, want branch protection validation failure", err)
+	}
+}

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -74,8 +74,11 @@ type Service struct {
 	DB                         *sql.DB
 	Repos                      *storage.Repositories
 	Logger                     bootstrap.Logger
+	Config                     config.Config
 	Now                        func() time.Time
 	DetectRepo                 DetectRepoFunc
+	GetRepositorySettings      GetRepositorySettingsFunc
+	GetBranchProtection        GetBranchProtectionFunc
 	ListWorktrees              ListWorktreesFunc
 	ListOpenPullRequests       ListOpenPullRequestsFunc
 	CapturePullRequestSnapshot CapturePullRequestSnapshotFunc
@@ -170,6 +173,10 @@ func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, er
 		} else if detected != "" {
 			repo = &detected
 		}
+	}
+
+	if err := s.validateReviewerAutoMergeForProject(ctx, projectID, repo, input.BaseBranch, s.Config); err != nil {
+		return AddResult{}, err
 	}
 
 	nowISO := currentISO(s.Now)
@@ -332,6 +339,9 @@ func (s *Service) SyncConfigured(ctx context.Context, cfg config.Config, now tim
 		baseBranch := cfg.Defaults.BaseBranch
 		if project.BaseBranch != nil {
 			baseBranch = *project.BaseBranch
+		}
+		if err := s.validateReviewerAutoMergeForProject(ctx, project.ID, repo, baseBranch, cfg); err != nil {
+			return err
 		}
 
 		createdAt := nowISO

--- a/internal/reviewer/automerge/automerge.go
+++ b/internal/reviewer/automerge/automerge.go
@@ -67,7 +67,7 @@ func Decide(pr PRSnapshot, autoMergeConfig config.ReviewerAutoMergeConfig, prote
 
 func hasLooperLabel(labels []string) bool {
 	for _, label := range labels {
-		if strings.HasPrefix(strings.TrimSpace(label), "looper:") {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(label)), "looper:") {
 			return true
 		}
 	}

--- a/internal/reviewer/automerge/automerge.go
+++ b/internal/reviewer/automerge/automerge.go
@@ -1,0 +1,88 @@
+package automerge
+
+import (
+	"strings"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+type RefusalReason string
+
+const (
+	RefusalReasonDisabled           RefusalReason = "disabled"
+	RefusalReasonScope              RefusalReason = "scope"
+	RefusalReasonNoBranchProtection RefusalReason = "no-branch-protection"
+	RefusalReasonStrategyDisallowed RefusalReason = "strategy-disallowed"
+	RefusalReasonAutoMergeDisabled  RefusalReason = "auto-merge-disabled"
+)
+
+type PRSnapshot struct {
+	Labels              []string
+	HasTrackedIssueLink bool
+}
+
+type BranchProtectionSnapshot struct {
+	Exists            bool
+	HasRequiredChecks bool
+}
+
+type RepoSettingsSnapshot struct {
+	AllowSquashMerge bool
+	AllowMergeCommit bool
+	AllowRebaseMerge bool
+	AllowAutoMerge   bool
+}
+
+type AutoMergeDecision struct {
+	Strategy config.ReviewerAutoMergeStrategy
+	Reason   RefusalReason
+}
+
+func OptInWithStrategy(strategy config.ReviewerAutoMergeStrategy) AutoMergeDecision {
+	return AutoMergeDecision{Strategy: strategy}
+}
+
+func RefuseWithReason(reason RefusalReason) AutoMergeDecision {
+	return AutoMergeDecision{Reason: reason}
+}
+
+func Decide(pr PRSnapshot, autoMergeConfig config.ReviewerAutoMergeConfig, protection BranchProtectionSnapshot, settings RepoSettingsSnapshot) AutoMergeDecision {
+	if !autoMergeConfig.Enabled {
+		return RefuseWithReason(RefusalReasonDisabled)
+	}
+	if !hasLooperLabel(pr.Labels) || !pr.HasTrackedIssueLink {
+		return RefuseWithReason(RefusalReasonScope)
+	}
+	if autoMergeConfig.RequireBranchProtection && (!protection.Exists || !protection.HasRequiredChecks) {
+		return RefuseWithReason(RefusalReasonNoBranchProtection)
+	}
+	if !StrategyAllowed(autoMergeConfig.Strategy, settings) {
+		return RefuseWithReason(RefusalReasonStrategyDisallowed)
+	}
+	if !settings.AllowAutoMerge {
+		return RefuseWithReason(RefusalReasonAutoMergeDisabled)
+	}
+	return OptInWithStrategy(autoMergeConfig.Strategy)
+}
+
+func hasLooperLabel(labels []string) bool {
+	for _, label := range labels {
+		if strings.HasPrefix(strings.TrimSpace(label), "looper:") {
+			return true
+		}
+	}
+	return false
+}
+
+func StrategyAllowed(strategy config.ReviewerAutoMergeStrategy, settings RepoSettingsSnapshot) bool {
+	switch strategy {
+	case config.ReviewerAutoMergeStrategySquash:
+		return settings.AllowSquashMerge
+	case config.ReviewerAutoMergeStrategyMerge:
+		return settings.AllowMergeCommit
+	case config.ReviewerAutoMergeStrategyRebase:
+		return settings.AllowRebaseMerge
+	default:
+		return false
+	}
+}

--- a/internal/reviewer/automerge/automerge_test.go
+++ b/internal/reviewer/automerge/automerge_test.go
@@ -1,0 +1,50 @@
+package automerge
+
+import (
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestDecide(t *testing.T) {
+	t.Parallel()
+
+	baseConfig := config.ReviewerAutoMergeConfig{
+		Enabled:                 true,
+		Strategy:                config.ReviewerAutoMergeStrategySquash,
+		RequireBranchProtection: true,
+		TransientRetries:        3,
+		Scope:                   config.ReviewerAutoMergeScopeLooperOnly,
+	}
+	basePR := PRSnapshot{Labels: []string{"looper:worker-ready"}, HasTrackedIssueLink: true}
+	baseProtection := BranchProtectionSnapshot{Exists: true, HasRequiredChecks: true}
+	baseSettings := RepoSettingsSnapshot{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true, AllowAutoMerge: true}
+
+	tests := []struct {
+		name         string
+		pr           PRSnapshot
+		cfg          config.ReviewerAutoMergeConfig
+		protection   BranchProtectionSnapshot
+		settings     RepoSettingsSnapshot
+		wantDecision AutoMergeDecision
+	}{
+		{name: "full pass", pr: basePR, cfg: baseConfig, protection: baseProtection, settings: baseSettings, wantDecision: OptInWithStrategy(config.ReviewerAutoMergeStrategySquash)},
+		{name: "label only", pr: PRSnapshot{Labels: []string{"looper:worker-ready"}}, cfg: baseConfig, protection: baseProtection, settings: baseSettings, wantDecision: RefuseWithReason(RefusalReasonScope)},
+		{name: "tracked issue only", pr: PRSnapshot{HasTrackedIssueLink: true}, cfg: baseConfig, protection: baseProtection, settings: baseSettings, wantDecision: RefuseWithReason(RefusalReasonScope)},
+		{name: "no branch protection", pr: basePR, cfg: baseConfig, protection: BranchProtectionSnapshot{}, settings: baseSettings, wantDecision: RefuseWithReason(RefusalReasonNoBranchProtection)},
+		{name: "strategy disallowed", pr: basePR, cfg: config.ReviewerAutoMergeConfig{Enabled: true, Strategy: config.ReviewerAutoMergeStrategyRebase, RequireBranchProtection: true, TransientRetries: 3, Scope: config.ReviewerAutoMergeScopeLooperOnly}, protection: baseProtection, settings: RepoSettingsSnapshot{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: false, AllowAutoMerge: true}, wantDecision: RefuseWithReason(RefusalReasonStrategyDisallowed)},
+		{name: "auto merge disabled", pr: basePR, cfg: baseConfig, protection: baseProtection, settings: RepoSettingsSnapshot{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true, AllowAutoMerge: false}, wantDecision: RefuseWithReason(RefusalReasonAutoMergeDisabled)},
+		{name: "feature disabled", pr: basePR, cfg: config.ReviewerAutoMergeConfig{Enabled: false, Strategy: config.ReviewerAutoMergeStrategySquash, RequireBranchProtection: true, TransientRetries: 3, Scope: config.ReviewerAutoMergeScopeLooperOnly}, protection: baseProtection, settings: baseSettings, wantDecision: RefuseWithReason(RefusalReasonDisabled)},
+		{name: "branch protection waived", pr: basePR, cfg: config.ReviewerAutoMergeConfig{Enabled: true, Strategy: config.ReviewerAutoMergeStrategySquash, RequireBranchProtection: false, TransientRetries: 3, Scope: config.ReviewerAutoMergeScopeLooperOnly}, protection: BranchProtectionSnapshot{}, settings: baseSettings, wantDecision: OptInWithStrategy(config.ReviewerAutoMergeStrategySquash)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Decide(tt.pr, tt.cfg, tt.protection, tt.settings)
+			if got != tt.wantDecision {
+				t.Fatalf("Decide() = %#v, want %#v", got, tt.wantDecision)
+			}
+		})
+	}
+}

--- a/internal/reviewer/automerge/automerge_test.go
+++ b/internal/reviewer/automerge/automerge_test.go
@@ -29,6 +29,7 @@ func TestDecide(t *testing.T) {
 		wantDecision AutoMergeDecision
 	}{
 		{name: "full pass", pr: basePR, cfg: baseConfig, protection: baseProtection, settings: baseSettings, wantDecision: OptInWithStrategy(config.ReviewerAutoMergeStrategySquash)},
+		{name: "mixed case looper label", pr: PRSnapshot{Labels: []string{"Looper:worker-ready"}, HasTrackedIssueLink: true}, cfg: baseConfig, protection: baseProtection, settings: baseSettings, wantDecision: OptInWithStrategy(config.ReviewerAutoMergeStrategySquash)},
 		{name: "label only", pr: PRSnapshot{Labels: []string{"looper:worker-ready"}}, cfg: baseConfig, protection: baseProtection, settings: baseSettings, wantDecision: RefuseWithReason(RefusalReasonScope)},
 		{name: "tracked issue only", pr: PRSnapshot{HasTrackedIssueLink: true}, cfg: baseConfig, protection: baseProtection, settings: baseSettings, wantDecision: RefuseWithReason(RefusalReasonScope)},
 		{name: "no branch protection", pr: basePR, cfg: baseConfig, protection: BranchProtectionSnapshot{}, settings: baseSettings, wantDecision: RefuseWithReason(RefusalReasonNoBranchProtection)},

--- a/internal/reviewer/criteria/criteria.go
+++ b/internal/reviewer/criteria/criteria.go
@@ -164,9 +164,10 @@ func parseCriterionLine(line string) (string, bool) {
 	if trimmed == "" {
 		return "", false
 	}
-	if strings.HasPrefix(trimmed, "-") || strings.HasPrefix(trimmed, "*") {
-		trimmed = strings.TrimSpace(trimmed[1:])
+	if !strings.HasPrefix(trimmed, "-") && !strings.HasPrefix(trimmed, "*") {
+		return "", false
 	}
+	trimmed = strings.TrimSpace(trimmed[1:])
 	trimmed = trimCheckboxPrefix(trimmed)
 	if trimmed == "" {
 		return "", false

--- a/internal/reviewer/criteria/criteria.go
+++ b/internal/reviewer/criteria/criteria.go
@@ -1,0 +1,181 @@
+package criteria
+
+import (
+	"fmt"
+	"strings"
+)
+
+type AcceptanceCriterion string
+
+type Verdict string
+
+const (
+	VerdictPass         Verdict = "pass"
+	VerdictFail         Verdict = "fail"
+	VerdictUnverifiable Verdict = "unverifiable"
+)
+
+type AggregateDisposition string
+
+const (
+	DispositionPass         AggregateDisposition = "pass"
+	DispositionFail         AggregateDisposition = "fail"
+	DispositionUnverifiable AggregateDisposition = "unverifiable"
+)
+
+type Evidence struct {
+	FilePath  string
+	StartLine int
+	EndLine   int
+}
+
+type PRDiff struct {
+	Files []DiffFile
+}
+
+type DiffFile struct {
+	Path  string
+	Patch string
+}
+
+type CriterionAssessment struct {
+	Verdict       Verdict
+	Justification string
+	Evidence      []Evidence
+}
+
+type CriterionResult struct {
+	Criterion     AcceptanceCriterion
+	Verdict       Verdict
+	Justification string
+	Evidence      []Evidence
+}
+
+type VerificationResult struct {
+	Disposition AggregateDisposition
+	Criteria    []CriterionResult
+}
+
+type Verifier interface {
+	VerifyCriterion(criterion AcceptanceCriterion, diff PRDiff) (CriterionAssessment, error)
+}
+
+func Extract(issueBody string) []AcceptanceCriterion {
+	lines := strings.Split(issueBody, "\n")
+	inSection := false
+	criteria := make([]AcceptanceCriterion, 0)
+
+	for _, rawLine := range lines {
+		trimmed := strings.TrimSpace(rawLine)
+		lower := strings.ToLower(trimmed)
+
+		if strings.HasPrefix(trimmed, "## ") {
+			if lower == "## acceptance criteria" {
+				inSection = true
+				continue
+			}
+			if inSection {
+				break
+			}
+		}
+		if !inSection || trimmed == "" {
+			continue
+		}
+		if criterion, ok := parseCriterionLine(trimmed); ok {
+			criteria = append(criteria, AcceptanceCriterion(criterion))
+		}
+	}
+
+	return criteria
+}
+
+func Verify(criteria []AcceptanceCriterion, diff PRDiff, verifier Verifier) (VerificationResult, error) {
+	if verifier == nil && len(criteria) > 0 {
+		return VerificationResult{}, fmt.Errorf("criteria verifier is required")
+	}
+
+	results := make([]CriterionResult, 0, len(criteria))
+	disposition := DispositionPass
+
+	for _, criterion := range criteria {
+		assessment, err := verifier.VerifyCriterion(criterion, diff)
+		if err != nil {
+			return VerificationResult{}, err
+		}
+		if err := validateAssessment(criterion, assessment, diff); err != nil {
+			return VerificationResult{}, err
+		}
+		results = append(results, CriterionResult{
+			Criterion:     criterion,
+			Verdict:       assessment.Verdict,
+			Justification: assessment.Justification,
+			Evidence:      append([]Evidence(nil), assessment.Evidence...),
+		})
+		switch assessment.Verdict {
+		case VerdictFail:
+			disposition = DispositionFail
+		case VerdictUnverifiable:
+			if disposition != DispositionFail {
+				disposition = DispositionUnverifiable
+			}
+		}
+	}
+
+	return VerificationResult{Disposition: disposition, Criteria: results}, nil
+}
+
+func validateAssessment(criterion AcceptanceCriterion, assessment CriterionAssessment, diff PRDiff) error {
+	if assessment.Verdict != VerdictPass && assessment.Verdict != VerdictFail && assessment.Verdict != VerdictUnverifiable {
+		return fmt.Errorf("criterion %q returned unsupported verdict %q", criterion, assessment.Verdict)
+	}
+	if strings.TrimSpace(assessment.Justification) == "" {
+		return fmt.Errorf("criterion %q returned empty justification", criterion)
+	}
+	if assessment.Verdict != VerdictPass {
+		return nil
+	}
+	if len(assessment.Evidence) == 0 {
+		return fmt.Errorf("criterion %q returned pass without evidence", criterion)
+	}
+	for _, evidence := range assessment.Evidence {
+		if strings.TrimSpace(evidence.FilePath) == "" || evidence.StartLine < 1 || evidence.EndLine < evidence.StartLine {
+			return fmt.Errorf("criterion %q returned invalid evidence", criterion)
+		}
+		if !diffContainsFile(diff, evidence.FilePath) {
+			return fmt.Errorf("criterion %q returned pass evidence outside the diff", criterion)
+		}
+	}
+	return nil
+}
+
+func diffContainsFile(diff PRDiff, filePath string) bool {
+	for _, file := range diff.Files {
+		if file.Path == filePath {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCriterionLine(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return "", false
+	}
+	if strings.HasPrefix(trimmed, "-") || strings.HasPrefix(trimmed, "*") {
+		trimmed = strings.TrimSpace(trimmed[1:])
+	}
+	trimmed = strings.TrimPrefix(trimmed, "[ ]")
+	trimmed = strings.TrimPrefix(trimmed, "[x]")
+	trimmed = strings.TrimPrefix(trimmed, "[X]")
+	trimmed = strings.TrimSpace(trimmed)
+	if strings.HasPrefix(trimmed, "[") {
+		if idx := strings.Index(trimmed, "]"); idx >= 0 && idx+1 < len(trimmed) {
+			trimmed = strings.TrimSpace(trimmed[idx+1:])
+		}
+	}
+	if trimmed == "" {
+		return "", false
+	}
+	return trimmed, true
+}

--- a/internal/reviewer/criteria/criteria.go
+++ b/internal/reviewer/criteria/criteria.go
@@ -3,6 +3,8 @@ package criteria
 import (
 	"fmt"
 	"strings"
+
+	"github.com/nexu-io/looper/internal/diffanchor"
 )
 
 type AcceptanceCriterion string
@@ -143,16 +145,32 @@ func validateAssessment(criterion AcceptanceCriterion, assessment CriterionAsses
 		if strings.TrimSpace(evidence.FilePath) == "" || evidence.StartLine < 1 || evidence.EndLine < evidence.StartLine {
 			return fmt.Errorf("criterion %q returned invalid evidence", criterion)
 		}
-		if !diffContainsFile(diff, evidence.FilePath) {
+		if !diffContainsEvidence(diff, evidence) {
 			return fmt.Errorf("criterion %q returned pass evidence outside the diff", criterion)
 		}
 	}
 	return nil
 }
 
-func diffContainsFile(diff PRDiff, filePath string) bool {
+func diffContainsEvidence(diff PRDiff, evidence Evidence) bool {
 	for _, file := range diff.Files {
-		if file.Path == filePath {
+		if file.Path != evidence.FilePath {
+			continue
+		}
+
+		parsed := diffanchor.Parse(strings.Join([]string{
+			fmt.Sprintf("diff --git a/%s b/%s", file.Path, file.Path),
+			fmt.Sprintf("--- a/%s", file.Path),
+			fmt.Sprintf("+++ b/%s", file.Path),
+			file.Patch,
+		}, "\n"))
+		if parsed.Validate(diffanchor.Anchor{
+			Path:      evidence.FilePath,
+			StartLine: int64(evidence.StartLine),
+			StartSide: diffanchor.SideRight,
+			Line:      int64(evidence.EndLine),
+			Side:      diffanchor.SideRight,
+		}).Valid {
 			return true
 		}
 	}

--- a/internal/reviewer/criteria/criteria.go
+++ b/internal/reviewer/criteria/criteria.go
@@ -68,11 +68,11 @@ func Extract(issueBody string) []AcceptanceCriterion {
 	for _, rawLine := range lines {
 		trimmed := strings.TrimSpace(rawLine)
 
-		if strings.HasPrefix(trimmed, "## ") {
-			if isAcceptanceCriteriaHeading(trimmed) {
-				inSection = true
-				continue
-			}
+		if isAcceptanceCriteriaHeading(trimmed) {
+			inSection = true
+			continue
+		}
+		if isMarkdownHeading(trimmed) {
 			if inSection {
 				break
 			}
@@ -164,15 +164,7 @@ func parseCriterionLine(line string) (string, bool) {
 	if strings.HasPrefix(trimmed, "-") || strings.HasPrefix(trimmed, "*") {
 		trimmed = strings.TrimSpace(trimmed[1:])
 	}
-	trimmed = strings.TrimPrefix(trimmed, "[ ]")
-	trimmed = strings.TrimPrefix(trimmed, "[x]")
-	trimmed = strings.TrimPrefix(trimmed, "[X]")
-	trimmed = strings.TrimSpace(trimmed)
-	if strings.HasPrefix(trimmed, "[") {
-		if idx := strings.Index(trimmed, "]"); idx >= 0 && idx+1 < len(trimmed) {
-			trimmed = strings.TrimSpace(trimmed[idx+1:])
-		}
-	}
+	trimmed = trimCheckboxPrefix(trimmed)
 	if trimmed == "" {
 		return "", false
 	}
@@ -180,7 +172,38 @@ func parseCriterionLine(line string) (string, bool) {
 }
 
 func isAcceptanceCriteriaHeading(line string) bool {
-	heading := strings.TrimSpace(strings.TrimPrefix(line, "## "))
+	heading, ok := markdownHeadingText(line)
+	if !ok {
+		return false
+	}
 	heading = strings.TrimSpace(strings.TrimRight(heading, ":;.!?"))
 	return strings.EqualFold(heading, "acceptance criteria")
+}
+
+func isMarkdownHeading(line string) bool {
+	_, ok := markdownHeadingText(line)
+	return ok
+}
+
+func markdownHeadingText(line string) (string, bool) {
+	if line == "" || line[0] != '#' {
+		return "", false
+	}
+	level := 0
+	for level < len(line) && line[level] == '#' {
+		level++
+	}
+	if level == 0 || level > 6 || level >= len(line) || line[level] != ' ' {
+		return "", false
+	}
+	return strings.TrimSpace(line[level+1:]), true
+}
+
+func trimCheckboxPrefix(line string) string {
+	for _, prefix := range []string{"[ ]", "[x]", "[X]", "[]"} {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(line[len(prefix):])
+		}
+	}
+	return strings.TrimSpace(line)
 }

--- a/internal/reviewer/criteria/criteria.go
+++ b/internal/reviewer/criteria/criteria.go
@@ -67,10 +67,9 @@ func Extract(issueBody string) []AcceptanceCriterion {
 
 	for _, rawLine := range lines {
 		trimmed := strings.TrimSpace(rawLine)
-		lower := strings.ToLower(trimmed)
 
 		if strings.HasPrefix(trimmed, "## ") {
-			if lower == "## acceptance criteria" {
+			if isAcceptanceCriteriaHeading(trimmed) {
 				inSection = true
 				continue
 			}
@@ -178,4 +177,10 @@ func parseCriterionLine(line string) (string, bool) {
 		return "", false
 	}
 	return trimmed, true
+}
+
+func isAcceptanceCriteriaHeading(line string) bool {
+	heading := strings.TrimSpace(strings.TrimPrefix(line, "## "))
+	heading = strings.TrimSpace(strings.TrimRight(heading, ":;.!?"))
+	return strings.EqualFold(heading, "acceptance criteria")
 }

--- a/internal/reviewer/criteria/criteria.go
+++ b/internal/reviewer/criteria/criteria.go
@@ -180,6 +180,7 @@ func isAcceptanceCriteriaHeading(line string) bool {
 	if !ok {
 		return false
 	}
+	heading = strings.TrimSpace(strings.TrimRight(heading, "#"))
 	heading = strings.TrimSpace(strings.TrimRight(heading, ":;.!?"))
 	return strings.EqualFold(heading, "acceptance criteria")
 }

--- a/internal/reviewer/criteria/criteria.go
+++ b/internal/reviewer/criteria/criteria.go
@@ -63,19 +63,22 @@ type Verifier interface {
 func Extract(issueBody string) []AcceptanceCriterion {
 	lines := strings.Split(issueBody, "\n")
 	inSection := false
+	sectionLevel := 0
 	criteria := make([]AcceptanceCriterion, 0)
 
 	for _, rawLine := range lines {
 		trimmed := strings.TrimSpace(rawLine)
 
-		if isAcceptanceCriteriaHeading(trimmed) {
+		if level, _, ok := markdownHeading(trimmed); ok && isAcceptanceCriteriaHeading(trimmed) {
 			inSection = true
+			sectionLevel = level
 			continue
 		}
-		if isMarkdownHeading(trimmed) {
-			if inSection {
+		if level, _, ok := markdownHeading(trimmed); ok {
+			if inSection && level <= sectionLevel {
 				break
 			}
+			continue
 		}
 		if !inSection || trimmed == "" {
 			continue
@@ -172,7 +175,7 @@ func parseCriterionLine(line string) (string, bool) {
 }
 
 func isAcceptanceCriteriaHeading(line string) bool {
-	heading, ok := markdownHeadingText(line)
+	_, heading, ok := markdownHeading(line)
 	if !ok {
 		return false
 	}
@@ -180,23 +183,18 @@ func isAcceptanceCriteriaHeading(line string) bool {
 	return strings.EqualFold(heading, "acceptance criteria")
 }
 
-func isMarkdownHeading(line string) bool {
-	_, ok := markdownHeadingText(line)
-	return ok
-}
-
-func markdownHeadingText(line string) (string, bool) {
+func markdownHeading(line string) (int, string, bool) {
 	if line == "" || line[0] != '#' {
-		return "", false
+		return 0, "", false
 	}
 	level := 0
 	for level < len(line) && line[level] == '#' {
 		level++
 	}
 	if level == 0 || level > 6 || level >= len(line) || line[level] != ' ' {
-		return "", false
+		return 0, "", false
 	}
-	return strings.TrimSpace(line[level+1:]), true
+	return level, strings.TrimSpace(line[level+1:]), true
 }
 
 func trimCheckboxPrefix(line string) string {

--- a/internal/reviewer/criteria/criteria_test.go
+++ b/internal/reviewer/criteria/criteria_test.go
@@ -26,6 +26,11 @@ func TestExtract(t *testing.T) {
 			want:      []AcceptanceCriterion{"first criterion"},
 		},
 		{
+			name:      "nested headings inside acceptance criteria do not end parsing",
+			issueBody: "## Acceptance Criteria\n- [ ] api returns ok\n\n### Backend\n- [ ] background worker retries\n\n## Notes\nignored",
+			want:      []AcceptanceCriterion{"api returns ok", "background worker retries"},
+		},
+		{
 			name:      "missing section returns empty list",
 			issueBody: "## Summary\n- [ ] not here",
 			want:      []AcceptanceCriterion{},

--- a/internal/reviewer/criteria/criteria_test.go
+++ b/internal/reviewer/criteria/criteria_test.go
@@ -1,0 +1,145 @@
+package criteria
+
+import "testing"
+
+func TestExtract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		issueBody string
+		want      []AcceptanceCriterion
+	}{
+		{
+			name:      "standard acceptance criteria section",
+			issueBody: "## Acceptance criteria\n- [ ] first criterion\n- [x] second criterion\n\n## Notes\nignored",
+			want:      []AcceptanceCriterion{"first criterion", "second criterion"},
+		},
+		{
+			name:      "missing section returns empty list",
+			issueBody: "## Summary\n- [ ] not here",
+			want:      []AcceptanceCriterion{},
+		},
+		{
+			name:      "malformed lines are tolerated",
+			issueBody: "## Acceptance criteria\n- [] missing space\n* [x] valid\n- criterion without checkbox",
+			want:      []AcceptanceCriterion{"missing space", "valid", "criterion without checkbox"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Extract(tt.issueBody)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(Extract()) = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("Extract()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestVerify(t *testing.T) {
+	t.Parallel()
+
+	diff := PRDiff{Files: []DiffFile{{Path: "internal/reviewer/automerge/decision.go", Patch: "@@"}}}
+	passEvidence := []Evidence{{FilePath: "internal/reviewer/automerge/decision.go", StartLine: 10, EndLine: 20}}
+
+	tests := []struct {
+		name         string
+		criteria     []AcceptanceCriterion
+		responses    map[AcceptanceCriterion]CriterionAssessment
+		wantVerdicts []Verdict
+		wantOverall  AggregateDisposition
+	}{
+		{
+			name:         "all pass",
+			criteria:     []AcceptanceCriterion{"criterion 1", "criterion 2"},
+			wantVerdicts: []Verdict{VerdictPass, VerdictPass},
+			wantOverall:  DispositionPass,
+			responses: map[AcceptanceCriterion]CriterionAssessment{
+				"criterion 1": {Verdict: VerdictPass, Justification: "matched diff", Evidence: passEvidence},
+				"criterion 2": {Verdict: VerdictPass, Justification: "matched diff", Evidence: passEvidence},
+			},
+		},
+		{
+			name:         "missing evidence fails",
+			criteria:     []AcceptanceCriterion{"criterion 1", "criterion 2"},
+			wantVerdicts: []Verdict{VerdictPass, VerdictFail},
+			wantOverall:  DispositionFail,
+			responses: map[AcceptanceCriterion]CriterionAssessment{
+				"criterion 1": {Verdict: VerdictPass, Justification: "matched diff", Evidence: passEvidence},
+				"criterion 2": {Verdict: VerdictFail, Justification: "no evidence in diff"},
+			},
+		},
+		{
+			name:         "unverifiable distinguished from fail",
+			criteria:     []AcceptanceCriterion{"criterion 1", "criterion 2"},
+			wantVerdicts: []Verdict{VerdictPass, VerdictUnverifiable},
+			wantOverall:  DispositionUnverifiable,
+			responses: map[AcceptanceCriterion]CriterionAssessment{
+				"criterion 1": {Verdict: VerdictPass, Justification: "matched diff", Evidence: passEvidence},
+				"criterion 2": {Verdict: VerdictUnverifiable, Justification: "non-functional criterion"},
+			},
+		},
+		{
+			name:         "fail dominates unverifiable",
+			criteria:     []AcceptanceCriterion{"criterion 1", "criterion 2", "criterion 3"},
+			wantVerdicts: []Verdict{VerdictPass, VerdictUnverifiable, VerdictFail},
+			wantOverall:  DispositionFail,
+			responses: map[AcceptanceCriterion]CriterionAssessment{
+				"criterion 1": {Verdict: VerdictPass, Justification: "matched diff", Evidence: passEvidence},
+				"criterion 2": {Verdict: VerdictUnverifiable, Justification: "non-functional criterion"},
+				"criterion 3": {Verdict: VerdictFail, Justification: "contradicted by diff"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := Verify(tt.criteria, diff, fixtureVerifier{responses: tt.responses})
+			if err != nil {
+				t.Fatalf("Verify() error = %v", err)
+			}
+			if result.Disposition != tt.wantOverall {
+				t.Fatalf("Verify().Disposition = %q, want %q", result.Disposition, tt.wantOverall)
+			}
+			for i, want := range tt.wantVerdicts {
+				if result.Criteria[i].Verdict != want {
+					t.Fatalf("Verify().Criteria[%d].Verdict = %q, want %q", i, result.Criteria[i].Verdict, want)
+				}
+			}
+		})
+	}
+}
+
+func TestVerifyRejectsInvalidVerifierOutput(t *testing.T) {
+	t.Parallel()
+
+	_, err := Verify([]AcceptanceCriterion{"criterion 1"}, PRDiff{}, fixtureVerifier{responses: map[AcceptanceCriterion]CriterionAssessment{
+		"criterion 1": {Verdict: VerdictPass, Justification: "matched diff"},
+	}})
+	if err == nil || err.Error() != `criterion "criterion 1" returned pass without evidence` {
+		t.Fatalf("Verify() error = %v, want pass-without-evidence failure", err)
+	}
+
+	_, err = Verify([]AcceptanceCriterion{"criterion 2"}, PRDiff{Files: []DiffFile{{Path: "changed.go", Patch: "@@"}}}, fixtureVerifier{responses: map[AcceptanceCriterion]CriterionAssessment{
+		"criterion 2": {Verdict: VerdictPass, Justification: "matched diff", Evidence: []Evidence{{FilePath: "other.go", StartLine: 1, EndLine: 2}}},
+	}})
+	if err == nil || err.Error() != `criterion "criterion 2" returned pass evidence outside the diff` {
+		t.Fatalf("Verify() error = %v, want evidence-outside-diff failure", err)
+	}
+}
+
+type fixtureVerifier struct {
+	responses map[AcceptanceCriterion]CriterionAssessment
+}
+
+func (f fixtureVerifier) VerifyCriterion(criterion AcceptanceCriterion, _ PRDiff) (CriterionAssessment, error) {
+	return f.responses[criterion], nil
+}

--- a/internal/reviewer/criteria/criteria_test.go
+++ b/internal/reviewer/criteria/criteria_test.go
@@ -71,8 +71,11 @@ func TestExtract(t *testing.T) {
 func TestVerify(t *testing.T) {
 	t.Parallel()
 
-	diff := PRDiff{Files: []DiffFile{{Path: "internal/reviewer/automerge/decision.go", Patch: "@@"}}}
-	passEvidence := []Evidence{{FilePath: "internal/reviewer/automerge/decision.go", StartLine: 10, EndLine: 20}}
+	diff := PRDiff{Files: []DiffFile{{
+		Path:  "internal/reviewer/automerge/decision.go",
+		Patch: "@@ -10,2 +10,3 @@\n context\n-old decision\n+new decision\n+follow up\n",
+	}}}
+	passEvidence := []Evidence{{FilePath: "internal/reviewer/automerge/decision.go", StartLine: 10, EndLine: 12}}
 
 	tests := []struct {
 		name         string
@@ -158,6 +161,16 @@ func TestVerifyRejectsInvalidVerifierOutput(t *testing.T) {
 	}})
 	if err == nil || err.Error() != `criterion "criterion 2" returned pass evidence outside the diff` {
 		t.Fatalf("Verify() error = %v, want evidence-outside-diff failure", err)
+	}
+
+	_, err = Verify([]AcceptanceCriterion{"criterion 3"}, PRDiff{Files: []DiffFile{{
+		Path:  "changed.go",
+		Patch: "@@ -10,2 +10,2 @@\n-old\n+new\n keep\n",
+	}}}, fixtureVerifier{responses: map[AcceptanceCriterion]CriterionAssessment{
+		"criterion 3": {Verdict: VerdictPass, Justification: "matched diff", Evidence: []Evidence{{FilePath: "changed.go", StartLine: 50, EndLine: 51}}},
+	}})
+	if err == nil || err.Error() != `criterion "criterion 3" returned pass evidence outside the diff` {
+		t.Fatalf("Verify() error = %v, want evidence-outside-hunks failure", err)
 	}
 }
 

--- a/internal/reviewer/criteria/criteria_test.go
+++ b/internal/reviewer/criteria/criteria_test.go
@@ -21,6 +21,11 @@ func TestExtract(t *testing.T) {
 			want:      []AcceptanceCriterion{"first criterion"},
 		},
 		{
+			name:      "acceptance criteria heading allows nested heading levels",
+			issueBody: "### Acceptance Criteria\n- [ ] first criterion\n\n### Notes\nignored",
+			want:      []AcceptanceCriterion{"first criterion"},
+		},
+		{
 			name:      "missing section returns empty list",
 			issueBody: "## Summary\n- [ ] not here",
 			want:      []AcceptanceCriterion{},
@@ -29,6 +34,11 @@ func TestExtract(t *testing.T) {
 			name:      "malformed lines are tolerated",
 			issueBody: "## Acceptance criteria\n- [] missing space\n* [x] valid\n- criterion without checkbox",
 			want:      []AcceptanceCriterion{"missing space", "valid", "criterion without checkbox"},
+		},
+		{
+			name:      "preserves leading markdown links in criteria",
+			issueBody: "## Acceptance criteria\n- [ ] [Spec](https://example.com) is updated",
+			want:      []AcceptanceCriterion{"[Spec](https://example.com) is updated"},
 		},
 	}
 

--- a/internal/reviewer/criteria/criteria_test.go
+++ b/internal/reviewer/criteria/criteria_test.go
@@ -26,6 +26,11 @@ func TestExtract(t *testing.T) {
 			want:      []AcceptanceCriterion{"first criterion"},
 		},
 		{
+			name:      "acceptance criteria heading allows closing atx markers",
+			issueBody: "## Acceptance Criteria ##\n- [ ] first criterion\n\n## Notes\nignored",
+			want:      []AcceptanceCriterion{"first criterion"},
+		},
+		{
 			name:      "nested headings inside acceptance criteria do not end parsing",
 			issueBody: "## Acceptance Criteria\n- [ ] api returns ok\n\n### Backend\n- [ ] background worker retries\n\n## Notes\nignored",
 			want:      []AcceptanceCriterion{"api returns ok", "background worker retries"},

--- a/internal/reviewer/criteria/criteria_test.go
+++ b/internal/reviewer/criteria/criteria_test.go
@@ -16,6 +16,11 @@ func TestExtract(t *testing.T) {
 			want:      []AcceptanceCriterion{"first criterion", "second criterion"},
 		},
 		{
+			name:      "acceptance criteria heading allows trailing punctuation",
+			issueBody: "## Acceptance Criteria:\n- [ ] first criterion\n\n## Notes\nignored",
+			want:      []AcceptanceCriterion{"first criterion"},
+		},
+		{
 			name:      "missing section returns empty list",
 			issueBody: "## Summary\n- [ ] not here",
 			want:      []AcceptanceCriterion{},

--- a/internal/reviewer/criteria/criteria_test.go
+++ b/internal/reviewer/criteria/criteria_test.go
@@ -37,7 +37,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:      "malformed lines are tolerated",
-			issueBody: "## Acceptance criteria\n- [] missing space\n* [x] valid\n- criterion without checkbox",
+			issueBody: "## Acceptance criteria\nPlease convert this list before merging.\n- [] missing space\n* [x] valid\n- criterion without checkbox",
 			want:      []AcceptanceCriterion{"missing space", "valid", "criterion without checkbox"},
 		},
 		{

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -448,9 +448,16 @@ func (r *Runtime) start(ctx context.Context) error {
 		DB:     coordinator.DB(),
 		Repos:  repositories,
 		Logger: r.logger,
+		Config: r.config,
 		Now:    r.now,
 		DetectRepo: func(ctx context.Context, repoPath string) (string, error) {
 			return gitGateway.DetectGitHubRepo(ctx, repoPath)
+		},
+		GetRepositorySettings: func(ctx context.Context, input githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+			return githubGateway.GetRepositorySettings(ctx, input)
+		},
+		GetBranchProtection: func(ctx context.Context, input githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+			return githubGateway.GetBranchProtection(ctx, input)
 		},
 		ListWorktrees: func(ctx context.Context, repoPath string) ([]projects.WorktreeListEntry, error) {
 			worktrees, err := gitGateway.ListWorktrees(ctx, repoPath)


### PR DESCRIPTION
## Summary
- add pure `internal/reviewer/criteria` and `internal/reviewer/automerge` modules with table-driven coverage so slice 2 can wire Reviewer behavior onto tested value objects later
- add `roles.reviewer.autoMerge.*` config defaults, project override support, CLI config knobs, and parity/contract fixture updates for the new scaffold
- add read-only GitHub gateway wrappers plus shared startup/project-add validation so unsupported auto-merge opt-ins fail fast before any Reviewer behavior changes

## Validation
- go test ./...
- go vet ./...
- gofmt -l .

## Links
- PRD #352

Closes #357

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>