### PR TITLE
feat: add explicit webhook cleanup remediation

### DIFF
--- a/docs/adr/0005-forwarder-local-lifecycle-no-remote-authority.md
+++ b/docs/adr/0005-forwarder-local-lifecycle-no-remote-authority.md
@@ -2,11 +2,13 @@
 
 `looperd` may persist and reconcile records for `gh webhook forward` subprocesses that it spawned. The persisted row identifies a local process by repo, PID, process start time, executable path, endpoint, events, and daemon instance.
 
-The authority for adopting or signalling a process is the local identity gate: PID plus process start time plus executable and command shape. Looper does not infer ownership from GitHub hook state and does not call the GitHub hooks API.
+The authority for adopting or signalling a process is the local identity gate: PID plus process start time plus executable and command shape. `looperd` does not infer ownership from GitHub hook state and does not call the GitHub hooks API as part of startup, reconcile, retry, or latch handling.
+
+An explicit user-invoked CLI cleanup command may inspect and delete GitHub CLI `cli` hooks that point at `https://webhook-forwarder.github.com/hook`, but that command is a manual remediation path, not daemon authority. It must stay dry-run by default, require an explicit target repo, and require explicit user confirmation before deletion.
 
 Rejected alternatives:
 
-- deleting or adopting remote GitHub hooks directly, because `gh webhook forward` owns that lifecycle;
+- automatic daemon deletion or adoption of remote GitHub hooks, because `gh webhook forward` owns that lifecycle and Looper should not mutate remote hook state on inference alone;
 - enumerating unrelated `gh` processes on first upgrade boot, because Looper has no prior local record proving it spawned them;
 - keeping forwarders alive during a graceful restart, because stop and restart are indistinguishable without a future re-exec design.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -18,6 +18,15 @@ If the project is not registered in Looper yet:
 looper project add /path/to/repo --id myproj --repo owner/repo
 ```
 
+If webhook mode reports `degraded`, inspect stale GitHub CLI forwarder hooks first:
+
+```bash
+looper webhook status
+looper webhook cleanup owner/repo
+# if the dry run shows stale GitHub CLI hooks:
+looper webhook cleanup owner/repo --confirm
+```
+
 Also make sure:
 
 - `looperd` is running

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -114,12 +114,13 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 			newCommand(commandSpec{
 				use:             "webhook",
 				short:           "Webhook configuration and status",
-				helpSubcommands: []helpSubcommand{{name: "enable", description: "Enable webhook mode"}, {name: "disable", description: "Disable webhook mode"}, {name: "status", description: "Show webhook status"}},
+				helpSubcommands: []helpSubcommand{{name: "enable", description: "Enable webhook mode"}, {name: "disable", description: "Disable webhook mode"}, {name: "status", description: "Show webhook status"}, {name: "cleanup", description: "Inspect or delete stale GitHub CLI webhook hooks"}},
 				helpWhenNoArgs:  true,
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "enable", short: "Enable webhook mode", runE: runtime.webhookEnable, localFlags: []flagSpec{boolFlag("install-gh-webhook", "Install the GitHub CLI webhook extension if gh webhook is unavailable")}}),
 					newCommand(commandSpec{use: "disable", short: "Disable webhook mode", runE: runtime.webhookDisable}),
 					newCommand(commandSpec{use: "status", short: "Show webhook status", runE: runtime.webhookStatus, localFlags: []flagSpec{boolFlag("verbose", "Show per-repo forwarder details and log tails")}}),
+					newCommand(commandSpec{use: "cleanup <owner/repo>", short: "Inspect or delete stale GitHub CLI webhook hooks", args: cobra.ExactArgs(1), runE: runtime.webhookCleanup, localFlags: []flagSpec{boolFlag("confirm", "Delete matching stale GitHub CLI webhook hooks instead of showing a dry run")}, exampleLines: []string{"$ looper webhook cleanup owner/repo", "$ looper webhook cleanup owner/repo --confirm"}}),
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/webhook_commands.go
+++ b/internal/cliapp/webhook_commands.go
@@ -280,21 +280,12 @@ func (r *commandRuntime) webhookCleanup(cmd *cobra.Command, args []string) error
 		_, err := fmt.Fprintf(cmd.OutOrStdout(), "Dry run only. Rerun with: looper webhook cleanup %s --confirm\n", repo)
 		return err
 	}
-	freshHooks, err := r.listWebhookHooks(cmd.Context(), ghPath, repo)
-	if err != nil {
-		return err
-	}
-	freshCandidates := webhookCleanupCandidates(freshHooks)
-	if len(freshCandidates) == 0 {
-		_, err := fmt.Fprintf(cmd.OutOrStdout(), "No stale GitHub CLI webhook hooks remain for %s.\n", repo)
-		return err
-	}
-	for _, candidate := range freshCandidates {
+	for _, candidate := range candidates {
 		if err := r.deleteWebhookHook(cmd.Context(), ghPath, repo, candidate.ID); err != nil {
 			return err
 		}
 	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Deleted %d GitHub CLI webhook hook(s) for %s.\n", len(freshCandidates), repo)
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Deleted %d GitHub CLI webhook hook(s) for %s.\n", len(candidates), repo)
 	return err
 }
 

--- a/internal/cliapp/webhook_commands.go
+++ b/internal/cliapp/webhook_commands.go
@@ -485,10 +485,18 @@ func sortedLowercase(values []string) []string {
 func normalizeWebhookRepo(value string) (string, error) {
 	repo := strings.TrimSpace(value)
 	parts := strings.Split(repo, "/")
-	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
-		return "", errors.New("repo must be in owner/repo form")
+	if len(parts) != 2 && len(parts) != 3 {
+		return "", errors.New("repo must be in owner/repo or host/owner/repo form")
 	}
-	return strings.TrimSpace(parts[0]) + "/" + strings.TrimSpace(parts[1]), nil
+	trimmed := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return "", errors.New("repo must be in owner/repo or host/owner/repo form")
+		}
+		trimmed = append(trimmed, part)
+	}
+	return strings.Join(trimmed, "/"), nil
 }
 
 func webhookGHPath(cfg config.Config) string {

--- a/internal/cliapp/webhook_commands.go
+++ b/internal/cliapp/webhook_commands.go
@@ -392,7 +392,7 @@ func (r *commandRuntime) resolveGHPath(cfg config.Config) (string, error) {
 }
 
 func (r *commandRuntime) listWebhookHooks(ctx context.Context, ghPath, repo string) ([]webhookHook, error) {
-	result, err := r.runCommand(ctx, ghPath, []string{"api", "--paginate", fmt.Sprintf("repos/%s/hooks", repo)}, 15*time.Second)
+	result, err := r.runCommand(ctx, ghPath, []string{"api", "--paginate", "--slurp", fmt.Sprintf("repos/%s/hooks", repo)}, 15*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("list webhook hooks for %s: %w", repo, err)
 	}
@@ -403,9 +403,13 @@ func (r *commandRuntime) listWebhookHooks(ctx context.Context, ghPath, repo stri
 		}
 		return nil, fmt.Errorf("list webhook hooks for %s: %s", repo, output)
 	}
-	var hooks []webhookHook
-	if err := json.Unmarshal([]byte(result.Stdout), &hooks); err != nil {
+	var pages [][]webhookHook
+	if err := json.Unmarshal([]byte(result.Stdout), &pages); err != nil {
 		return nil, fmt.Errorf("decode webhook hooks for %s: %w", repo, err)
+	}
+	hooks := make([]webhookHook, 0)
+	for _, page := range pages {
+		hooks = append(hooks, page...)
 	}
 	return hooks, nil
 }

--- a/internal/cliapp/webhook_commands.go
+++ b/internal/cliapp/webhook_commands.go
@@ -392,7 +392,7 @@ func (r *commandRuntime) resolveGHPath(cfg config.Config) (string, error) {
 }
 
 func (r *commandRuntime) listWebhookHooks(ctx context.Context, ghPath, repo string) ([]webhookHook, error) {
-	result, err := r.runCommand(ctx, ghPath, []string{"api", fmt.Sprintf("repos/%s/hooks", repo)}, 15*time.Second)
+	result, err := r.runCommand(ctx, ghPath, []string{"api", "--paginate", fmt.Sprintf("repos/%s/hooks", repo)}, 15*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("list webhook hooks for %s: %w", repo, err)
 	}

--- a/internal/cliapp/webhook_commands.go
+++ b/internal/cliapp/webhook_commands.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,6 +17,8 @@ import (
 )
 
 const ghWebhookExtension = "cli/gh-webhook"
+
+const ghWebhookForwarderHookURL = "https://webhook-forwarder.github.com/hook"
 
 type webhookStatusOutput struct {
 	ConfigPath       string              `json:"configPath"`
@@ -69,6 +72,23 @@ type webhookRuntimeView struct {
 		StdoutTail    []string `json:"stdoutTail,omitempty"`
 		StderrTail    []string `json:"stderrTail,omitempty"`
 	} `json:"forwarders"`
+}
+
+type webhookHook struct {
+	ID     int64    `json:"id"`
+	Name   string   `json:"name"`
+	Type   string   `json:"type"`
+	Active bool     `json:"active"`
+	Events []string `json:"events"`
+	Config struct {
+		URL string `json:"url"`
+	} `json:"config"`
+}
+
+type webhookCleanupCandidate struct {
+	ID     int64
+	Events string
+	Active bool
 }
 
 func (r *commandRuntime) webhookEnable(cmd *cobra.Command, args []string) error {
@@ -226,6 +246,58 @@ func (r *commandRuntime) webhookStatus(cmd *cobra.Command, args []string) error 
 	return writeHumanWebhookStatus(cmd.OutOrStdout(), output, getBoolFlag(cmd, "verbose"))
 }
 
+func (r *commandRuntime) webhookCleanup(cmd *cobra.Command, args []string) error {
+	repo, err := normalizeWebhookRepo(args[0])
+	if err != nil {
+		return err
+	}
+	loaded, err := r.loadConfig()
+	if err != nil {
+		return err
+	}
+	ghPath, err := r.resolveGHPath(loaded.Config)
+	if err != nil {
+		return err
+	}
+	hooks, err := r.listWebhookHooks(cmd.Context(), ghPath, repo)
+	if err != nil {
+		return err
+	}
+	candidates := webhookCleanupCandidates(hooks)
+	if len(candidates) == 0 {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "No stale GitHub CLI webhook hooks found for %s.\n", repo)
+		return err
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Found %d GitHub CLI webhook hook(s) for %s:\n", len(candidates), repo); err != nil {
+		return err
+	}
+	for _, candidate := range candidates {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "- id=%d active=%t events=%s\n", candidate.ID, candidate.Active, candidate.Events); err != nil {
+			return err
+		}
+	}
+	if !getBoolFlag(cmd, "confirm") {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "Dry run only. Rerun with: looper webhook cleanup %s --confirm\n", repo)
+		return err
+	}
+	freshHooks, err := r.listWebhookHooks(cmd.Context(), ghPath, repo)
+	if err != nil {
+		return err
+	}
+	freshCandidates := webhookCleanupCandidates(freshHooks)
+	if len(freshCandidates) == 0 {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "No stale GitHub CLI webhook hooks remain for %s.\n", repo)
+		return err
+	}
+	for _, candidate := range freshCandidates {
+		if err := r.deleteWebhookHook(cmd.Context(), ghPath, repo, candidate.ID); err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Deleted %d GitHub CLI webhook hook(s) for %s.\n", len(freshCandidates), repo)
+	return err
+}
+
 func webhookRuntimeRestartRequired(output webhookStatusOutput) bool {
 	if output.Runtime == nil {
 		return false
@@ -257,6 +329,15 @@ func writeHumanWebhookStatus(w io.Writer, data webhookStatusOutput, verbose bool
 		return err
 	}
 	printSection(w, "Counters", [][2]any{{"deliveriesReceived", data.Runtime.Counters.DeliveriesReceived}, {"coalesced", data.Runtime.Counters.Coalesced}, {"dropped", data.Runtime.Counters.Dropped}, {"queued", data.Runtime.Counters.Queued}, {"processed", data.Runtime.Counters.Processed}, {"failed", data.Runtime.Counters.Failed}})
+	if data.Runtime.Degraded {
+		commands := webhookCleanupSuggestions(data.Runtime)
+		if len(commands) > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+			printSection(w, "Cleanup hint", [][2]any{{"staleCliWebhookCleanup", strings.Join(commands, "\n")}, {"note", "Run the dry-run command first; add --confirm to delete matching GitHub CLI webhook hooks."}})
+		}
+	}
 	if !verbose {
 		return nil
 	}
@@ -292,6 +373,119 @@ func webhookWarnings(cfg config.Config) []string {
 		warnings = append(warnings, "gh could not be resolved; looperd will degrade webhook mode to poll fallback")
 	}
 	return warnings
+}
+
+func (r *commandRuntime) resolveGHPath(cfg config.Config) (string, error) {
+	ghPath := webhookGHPath(cfg)
+	if ghPath != "" {
+		return ghPath, nil
+	}
+	resolved, err := r.lookPath()("gh")
+	if err != nil {
+		return "", errors.New("gh is not configured or could not be resolved")
+	}
+	resolved = strings.TrimSpace(resolved)
+	if resolved == "" {
+		return "", errors.New("gh is not configured or could not be resolved")
+	}
+	return resolved, nil
+}
+
+func (r *commandRuntime) listWebhookHooks(ctx context.Context, ghPath, repo string) ([]webhookHook, error) {
+	result, err := r.runCommand(ctx, ghPath, []string{"api", fmt.Sprintf("repos/%s/hooks", repo)}, 15*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("list webhook hooks for %s: %w", repo, err)
+	}
+	if result.ExitCode != 0 {
+		output := strings.TrimSpace(strings.Join([]string{result.Stderr, result.Stdout}, "\n"))
+		if output == "" {
+			output = fmt.Sprintf("exit code %d", result.ExitCode)
+		}
+		return nil, fmt.Errorf("list webhook hooks for %s: %s", repo, output)
+	}
+	var hooks []webhookHook
+	if err := json.Unmarshal([]byte(result.Stdout), &hooks); err != nil {
+		return nil, fmt.Errorf("decode webhook hooks for %s: %w", repo, err)
+	}
+	return hooks, nil
+}
+
+func (r *commandRuntime) deleteWebhookHook(ctx context.Context, ghPath, repo string, id int64) error {
+	result, err := r.runCommand(ctx, ghPath, []string{"api", "-X", "DELETE", fmt.Sprintf("repos/%s/hooks/%d", repo, id)}, 15*time.Second)
+	if err != nil {
+		return fmt.Errorf("delete webhook hook %d for %s: %w", id, repo, err)
+	}
+	if result.ExitCode != 0 {
+		output := strings.TrimSpace(strings.Join([]string{result.Stderr, result.Stdout}, "\n"))
+		if output == "" {
+			output = fmt.Sprintf("exit code %d", result.ExitCode)
+		}
+		return fmt.Errorf("delete webhook hook %d for %s: %s", id, repo, output)
+	}
+	return nil
+}
+
+func webhookCleanupCandidates(hooks []webhookHook) []webhookCleanupCandidate {
+	candidates := make([]webhookCleanupCandidate, 0, len(hooks))
+	for _, hook := range hooks {
+		if !strings.EqualFold(strings.TrimSpace(hook.Name), "cli") {
+			continue
+		}
+		if strings.TrimSpace(hook.Config.URL) != ghWebhookForwarderHookURL {
+			continue
+		}
+		candidates = append(candidates, webhookCleanupCandidate{ID: hook.ID, Active: hook.Active, Events: strings.Join(sortedLowercase(hook.Events), ",")})
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].ID < candidates[j].ID })
+	return candidates
+}
+
+func webhookCleanupSuggestions(runtime *webhookRuntimeView) []string {
+	if runtime == nil {
+		return nil
+	}
+	repos := map[string]struct{}{}
+	for _, forwarder := range runtime.Forwarders {
+		repo := strings.TrimSpace(forwarder.Repo)
+		if repo == "" {
+			continue
+		}
+		if forwarder.Running && !forwarder.Latched && strings.TrimSpace(forwarder.LastError) == "" {
+			continue
+		}
+		repos[repo] = struct{}{}
+	}
+	if len(repos) == 0 {
+		return []string{"looper webhook cleanup <owner/repo>"}
+	}
+	commands := make([]string, 0, len(repos))
+	for repo := range repos {
+		commands = append(commands, fmt.Sprintf("looper webhook cleanup %s", repo))
+	}
+	sort.Strings(commands)
+	return commands
+}
+
+func sortedLowercase(values []string) []string {
+	canon := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.ToLower(strings.TrimSpace(value))
+		if trimmed == "" {
+			continue
+		}
+		canon = append(canon, trimmed)
+	}
+	sort.Strings(canon)
+	return canon
+}
+
+func normalizeWebhookRepo(value string) (string, error) {
+	repo := strings.TrimSpace(value)
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", errors.New("repo must be in owner/repo form")
+	}
+	return strings.TrimSpace(parts[0]) + "/" + strings.TrimSpace(parts[1]), nil
 }
 
 func webhookGHPath(cfg config.Config) string {

--- a/internal/cliapp/webhook_commands.go
+++ b/internal/cliapp/webhook_commands.go
@@ -412,12 +412,20 @@ func (r *commandRuntime) deleteWebhookHook(ctx context.Context, ghPath, repo str
 	}
 	if result.ExitCode != 0 {
 		output := strings.TrimSpace(strings.Join([]string{result.Stderr, result.Stdout}, "\n"))
+		if webhookHookDeleteNotFound(output) {
+			return nil
+		}
 		if output == "" {
 			output = fmt.Sprintf("exit code %d", result.ExitCode)
 		}
 		return fmt.Errorf("delete webhook hook %d for %s: %s", id, repo, output)
 	}
 	return nil
+}
+
+func webhookHookDeleteNotFound(output string) bool {
+	lower := strings.ToLower(strings.TrimSpace(output))
+	return strings.Contains(lower, "404") && strings.Contains(lower, "not found")
 }
 
 func webhookCleanupCandidates(hooks []webhookHook) []webhookCleanupCandidate {

--- a/internal/cliapp/webhook_commands.go
+++ b/internal/cliapp/webhook_commands.go
@@ -383,7 +383,12 @@ func (r *commandRuntime) resolveGHPath(cfg config.Config) (string, error) {
 }
 
 func (r *commandRuntime) listWebhookHooks(ctx context.Context, ghPath, repo string) ([]webhookHook, error) {
-	result, err := r.runCommand(ctx, ghPath, []string{"api", "--paginate", "--slurp", fmt.Sprintf("repos/%s/hooks", repo)}, 15*time.Second)
+	hostname, repoPath := splitWebhookRepoHostname(repo)
+	args := []string{"api", "--paginate", "--slurp", fmt.Sprintf("repos/%s/hooks", repoPath)}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := r.runCommand(ctx, ghPath, args, 15*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("list webhook hooks for %s: %w", repo, err)
 	}
@@ -406,7 +411,12 @@ func (r *commandRuntime) listWebhookHooks(ctx context.Context, ghPath, repo stri
 }
 
 func (r *commandRuntime) deleteWebhookHook(ctx context.Context, ghPath, repo string, id int64) error {
-	result, err := r.runCommand(ctx, ghPath, []string{"api", "-X", "DELETE", fmt.Sprintf("repos/%s/hooks/%d", repo, id)}, 15*time.Second)
+	hostname, repoPath := splitWebhookRepoHostname(repo)
+	args := []string{"api", "-X", "DELETE", fmt.Sprintf("repos/%s/hooks/%d", repoPath, id)}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := r.runCommand(ctx, ghPath, args, 15*time.Second)
 	if err != nil {
 		return fmt.Errorf("delete webhook hook %d for %s: %w", id, repo, err)
 	}
@@ -497,6 +507,14 @@ func normalizeWebhookRepo(value string) (string, error) {
 		trimmed = append(trimmed, part)
 	}
 	return strings.Join(trimmed, "/"), nil
+}
+
+func splitWebhookRepoHostname(repo string) (string, string) {
+	parts := strings.Split(strings.TrimSpace(repo), "/")
+	if len(parts) == 3 {
+		return parts[0], parts[1] + "/" + parts[2]
+	}
+	return "", strings.TrimSpace(repo)
 }
 
 func webhookGHPath(cfg config.Config) string {

--- a/internal/cliapp/webhook_commands_test.go
+++ b/internal/cliapp/webhook_commands_test.go
@@ -459,11 +459,57 @@ func TestWebhookCleanupDryRunAcceptsHostQualifiedRepo(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run(webhook cleanup host-qualified) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if len(commands) != 1 || !strings.HasSuffix(commands[0], " api --paginate --slurp repos/github.example.com/acme/looper/hooks") {
-		t.Fatalf("commands = %q, want a paginated+slurped gh api list call using the host-qualified repo slug", commands)
+	if len(commands) != 1 || !strings.HasSuffix(commands[0], " api --paginate --slurp repos/acme/looper/hooks --hostname github.example.com") {
+		t.Fatalf("commands = %q, want a paginated+slurped gh api list call using owner/repo plus --hostname", commands)
 	}
 	if !strings.Contains(stdout.String(), "looper webhook cleanup github.example.com/acme/looper --confirm") {
 		t.Fatalf("stdout = %q, want host-qualified cleanup rerun hint", stdout.String())
+	}
+}
+
+func TestWebhookCleanupConfirmUsesHostnameForHostQualifiedRepo(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": false},
+		},
+	})
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	commands := []string{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		LookPath: func(command string) (string, error) {
+			if command == "gh" {
+				return "/usr/bin/gh", nil
+			}
+			return command, nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			commands = append(commands, command+" "+strings.Join(args, " "))
+			switch len(commands) {
+			case 1:
+				return commandExecutionResult{Stdout: `[[{"id":101,"name":"cli","type":"Repository","active":true,"events":["push","pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}]]`, ExitCode: 0}, nil
+			case 2:
+				return commandExecutionResult{ExitCode: 0}, nil
+			default:
+				t.Fatalf("unexpected RunCommand call %d: %s %q", len(commands), command, args)
+				return commandExecutionResult{}, nil
+			}
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"webhook", "cleanup", "github.example.com/acme/looper", "--confirm", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run(webhook cleanup --confirm host-qualified) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if len(commands) != 2 || !strings.HasSuffix(commands[0], " api --paginate --slurp repos/acme/looper/hooks --hostname github.example.com") || !strings.HasSuffix(commands[1], " api -X DELETE repos/acme/looper/hooks/101 --hostname github.example.com") {
+		t.Fatalf("commands = %q, want host-qualified cleanup to split owner/repo from --hostname for list and delete", commands)
+	}
+	if !strings.Contains(stdout.String(), "Deleted 1 GitHub CLI webhook hook(s) for github.example.com/acme/looper.") {
+		t.Fatalf("stdout = %q, want delete confirmation for host-qualified repo", stdout.String())
 	}
 }
 

--- a/internal/cliapp/webhook_commands_test.go
+++ b/internal/cliapp/webhook_commands_test.go
@@ -415,8 +415,8 @@ func TestWebhookCleanupDryRunListsMatchingCLIHooks(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run(webhook cleanup) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if len(commands) != 1 || !strings.HasSuffix(commands[0], " api repos/acme/looper/hooks") {
-		t.Fatalf("commands = %q, want a single gh api list call", commands)
+	if len(commands) != 1 || !strings.HasSuffix(commands[0], " api --paginate repos/acme/looper/hooks") {
+		t.Fatalf("commands = %q, want a single paginated gh api list call", commands)
 	}
 	for _, needle := range []string{"Found 1 GitHub CLI webhook hook(s)", "id=101", "Dry run only.", "looper webhook cleanup acme/looper --confirm"} {
 		if !strings.Contains(stdout.String(), needle) {
@@ -465,8 +465,8 @@ func TestWebhookCleanupConfirmDeletesMatchingCLIHooks(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run(webhook cleanup --confirm) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if len(commands) != 3 || !strings.HasSuffix(commands[0], " api repos/acme/looper/hooks") || !strings.HasSuffix(commands[1], " api repos/acme/looper/hooks") || !strings.HasSuffix(commands[2], " api -X DELETE repos/acme/looper/hooks/101") {
-		t.Fatalf("commands = %q, want gh api list, relist, then delete call", commands)
+	if len(commands) != 3 || !strings.HasSuffix(commands[0], " api --paginate repos/acme/looper/hooks") || !strings.HasSuffix(commands[1], " api --paginate repos/acme/looper/hooks") || !strings.HasSuffix(commands[2], " api -X DELETE repos/acme/looper/hooks/101") {
+		t.Fatalf("commands = %q, want paginated gh api list, relist, then delete call", commands)
 	}
 	if !strings.Contains(stdout.String(), "Deleted 1 GitHub CLI webhook hook(s) for acme/looper.") {
 		t.Fatalf("stdout = %q, want delete confirmation", stdout.String())

--- a/internal/cliapp/webhook_commands_test.go
+++ b/internal/cliapp/webhook_commands_test.go
@@ -429,6 +429,44 @@ func TestWebhookCleanupDryRunListsMatchingCLIHooks(t *testing.T) {
 	}
 }
 
+func TestWebhookCleanupDryRunAcceptsHostQualifiedRepo(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": false},
+		},
+	})
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	commands := []string{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		LookPath: func(command string) (string, error) {
+			if command == "gh" {
+				return "/usr/bin/gh", nil
+			}
+			return command, nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			commands = append(commands, command+" "+strings.Join(args, " "))
+			return commandExecutionResult{Stdout: `[[{"id":101,"name":"cli","type":"Repository","active":true,"events":["pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}]]`, ExitCode: 0}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"webhook", "cleanup", " github.example.com/acme/looper ", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run(webhook cleanup host-qualified) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if len(commands) != 1 || !strings.HasSuffix(commands[0], " api --paginate --slurp repos/github.example.com/acme/looper/hooks") {
+		t.Fatalf("commands = %q, want a paginated+slurped gh api list call using the host-qualified repo slug", commands)
+	}
+	if !strings.Contains(stdout.String(), "looper webhook cleanup github.example.com/acme/looper --confirm") {
+		t.Fatalf("stdout = %q, want host-qualified cleanup rerun hint", stdout.String())
+	}
+}
+
 func TestWebhookCleanupConfirmDeletesMatchingCLIHooks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/webhook_commands_test.go
+++ b/internal/cliapp/webhook_commands_test.go
@@ -60,6 +60,7 @@ func TestWebhookEnableWarnsWhenGHWebhookCommandIsUnavailable(t *testing.T) {
 	t.Parallel()
 
 	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"tools": map[string]any{"ghPath": "/usr/bin/gh"},
 		"notifications": map[string]any{
 			"osascript": map[string]any{"enabled": false},
 		},
@@ -96,6 +97,7 @@ func TestWebhookEnableCanInstallGHWebhookExtension(t *testing.T) {
 	t.Parallel()
 
 	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"tools": map[string]any{"ghPath": "/usr/bin/gh"},
 		"notifications": map[string]any{
 			"osascript": map[string]any{"enabled": false},
 		},
@@ -337,5 +339,136 @@ func TestWebhookStatusVerboseShowsRuntimeDetails(t *testing.T) {
 	}
 	if strings.Contains(stdout, "0x") {
 		t.Fatalf("stdout = %q, want pid value instead of pointer address", stdout)
+	}
+}
+
+func TestWebhookStatusShowsCleanupHintWhenDegraded(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/webhook/status" {
+			t.Fatalf("request path = %q, want %q", r.URL.Path, "/api/v1/webhook/status")
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_webhook", map[string]any{
+			"enabled":                     true,
+			"listenerPath":                "/webhook/forward",
+			"endpointUrl":                 "http://127.0.0.1:17310/webhook/forward",
+			"fallbackPollIntervalSeconds": 300,
+			"degraded":                    true,
+			"degradedReasons":             []string{"forwarder for acme/looper exited: exit status 1"},
+			"queue":                       map[string]any{"pending": 0, "capacity": 8, "activeWorkers": 0},
+			"counters":                    map[string]any{"deliveriesReceived": 0, "coalesced": 0, "dropped": 0, "queued": 0, "processed": 0, "failed": 0},
+			"recentOutcomes":              []map[string]any{},
+			"forwarders":                  []map[string]any{{"repo": "acme/looper", "running": false, "restartCount": 2, "lastError": "exit status 1"}},
+		}))
+	}))
+	defer server.Close()
+
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"webhook": map[string]any{"enabled": true, "fallbackPollIntervalSeconds": 300},
+		"server":  map[string]any{"baseUrl": server.URL, "authMode": "none"},
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": false},
+		},
+	})
+	exitCode, stdout, stderr := runApp(t, "webhook", "status", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run(webhook status) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	for _, needle := range []string{"Cleanup hint", "looper webhook cleanup acme/looper", "--confirm"} {
+		if !strings.Contains(stdout, needle) {
+			t.Fatalf("stdout = %q, want to contain %q", stdout, needle)
+		}
+	}
+}
+
+func TestWebhookCleanupDryRunListsMatchingCLIHooks(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": false},
+		},
+	})
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	commands := []string{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		LookPath: func(command string) (string, error) {
+			if command == "gh" {
+				return "/usr/bin/gh", nil
+			}
+			return command, nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			commands = append(commands, command+" "+strings.Join(args, " "))
+			return commandExecutionResult{Stdout: `[
+				{"id":101,"name":"cli","type":"Repository","active":true,"events":["pull_request","issue_comment"],"config":{"url":"https://webhook-forwarder.github.com/hook"}},
+				{"id":202,"name":"web","type":"Repository","active":true,"events":["push"],"config":{"url":"https://example.com/webhook"}}
+			]`, ExitCode: 0}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"webhook", "cleanup", "acme/looper", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run(webhook cleanup) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if len(commands) != 1 || !strings.HasSuffix(commands[0], " api repos/acme/looper/hooks") {
+		t.Fatalf("commands = %q, want a single gh api list call", commands)
+	}
+	for _, needle := range []string{"Found 1 GitHub CLI webhook hook(s)", "id=101", "Dry run only.", "looper webhook cleanup acme/looper --confirm"} {
+		if !strings.Contains(stdout.String(), needle) {
+			t.Fatalf("stdout = %q, want to contain %q", stdout.String(), needle)
+		}
+	}
+}
+
+func TestWebhookCleanupConfirmDeletesMatchingCLIHooks(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": false},
+		},
+	})
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	commands := []string{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		LookPath: func(command string) (string, error) {
+			if command == "gh" {
+				return "/usr/bin/gh", nil
+			}
+			return command, nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			commands = append(commands, command+" "+strings.Join(args, " "))
+			switch len(commands) {
+			case 1:
+				return commandExecutionResult{Stdout: `[{"id":101,"name":"cli","type":"Repository","active":true,"events":["push","pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}]`, ExitCode: 0}, nil
+			case 2:
+				return commandExecutionResult{Stdout: `[{"id":101,"name":"cli","type":"Repository","active":true,"events":["push","pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}]`, ExitCode: 0}, nil
+			case 3:
+				return commandExecutionResult{ExitCode: 0}, nil
+			default:
+				t.Fatalf("unexpected RunCommand call %d: %s %q", len(commands), command, args)
+				return commandExecutionResult{}, nil
+			}
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"webhook", "cleanup", "acme/looper", "--confirm", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run(webhook cleanup --confirm) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if len(commands) != 3 || !strings.HasSuffix(commands[0], " api repos/acme/looper/hooks") || !strings.HasSuffix(commands[1], " api repos/acme/looper/hooks") || !strings.HasSuffix(commands[2], " api -X DELETE repos/acme/looper/hooks/101") {
+		t.Fatalf("commands = %q, want gh api list, relist, then delete call", commands)
+	}
+	if !strings.Contains(stdout.String(), "Deleted 1 GitHub CLI webhook hook(s) for acme/looper.") {
+		t.Fatalf("stdout = %q, want delete confirmation", stdout.String())
 	}
 }

--- a/internal/cliapp/webhook_commands_test.go
+++ b/internal/cliapp/webhook_commands_test.go
@@ -405,8 +405,12 @@ func TestWebhookCleanupDryRunListsMatchingCLIHooks(t *testing.T) {
 		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
 			commands = append(commands, command+" "+strings.Join(args, " "))
 			return commandExecutionResult{Stdout: `[
-				{"id":101,"name":"cli","type":"Repository","active":true,"events":["pull_request","issue_comment"],"config":{"url":"https://webhook-forwarder.github.com/hook"}},
-				{"id":202,"name":"web","type":"Repository","active":true,"events":["push"],"config":{"url":"https://example.com/webhook"}}
+				[
+					{"id":101,"name":"cli","type":"Repository","active":true,"events":["pull_request","issue_comment"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}
+				],
+				[
+					{"id":202,"name":"web","type":"Repository","active":true,"events":["push"],"config":{"url":"https://example.com/webhook"}}
+				]
 			]`, ExitCode: 0}, nil
 		},
 	})
@@ -415,8 +419,8 @@ func TestWebhookCleanupDryRunListsMatchingCLIHooks(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run(webhook cleanup) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if len(commands) != 1 || !strings.HasSuffix(commands[0], " api --paginate repos/acme/looper/hooks") {
-		t.Fatalf("commands = %q, want a single paginated gh api list call", commands)
+	if len(commands) != 1 || !strings.HasSuffix(commands[0], " api --paginate --slurp repos/acme/looper/hooks") {
+		t.Fatalf("commands = %q, want a single paginated+slurped gh api list call", commands)
 	}
 	for _, needle := range []string{"Found 1 GitHub CLI webhook hook(s)", "id=101", "Dry run only.", "looper webhook cleanup acme/looper --confirm"} {
 		if !strings.Contains(stdout.String(), needle) {
@@ -449,9 +453,9 @@ func TestWebhookCleanupConfirmDeletesMatchingCLIHooks(t *testing.T) {
 			commands = append(commands, command+" "+strings.Join(args, " "))
 			switch len(commands) {
 			case 1:
-				return commandExecutionResult{Stdout: `[{"id":101,"name":"cli","type":"Repository","active":true,"events":["push","pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}]`, ExitCode: 0}, nil
+				return commandExecutionResult{Stdout: `[[{"id":101,"name":"cli","type":"Repository","active":true,"events":["push","pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}]]`, ExitCode: 0}, nil
 			case 2:
-				return commandExecutionResult{Stdout: `[{"id":101,"name":"cli","type":"Repository","active":true,"events":["push","pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}]`, ExitCode: 0}, nil
+				return commandExecutionResult{Stdout: `[[{"id":101,"name":"cli","type":"Repository","active":true,"events":["push","pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}]]`, ExitCode: 0}, nil
 			case 3:
 				return commandExecutionResult{ExitCode: 0}, nil
 			default:
@@ -465,8 +469,8 @@ func TestWebhookCleanupConfirmDeletesMatchingCLIHooks(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run(webhook cleanup --confirm) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if len(commands) != 3 || !strings.HasSuffix(commands[0], " api --paginate repos/acme/looper/hooks") || !strings.HasSuffix(commands[1], " api --paginate repos/acme/looper/hooks") || !strings.HasSuffix(commands[2], " api -X DELETE repos/acme/looper/hooks/101") {
-		t.Fatalf("commands = %q, want paginated gh api list, relist, then delete call", commands)
+	if len(commands) != 3 || !strings.HasSuffix(commands[0], " api --paginate --slurp repos/acme/looper/hooks") || !strings.HasSuffix(commands[1], " api --paginate --slurp repos/acme/looper/hooks") || !strings.HasSuffix(commands[2], " api -X DELETE repos/acme/looper/hooks/101") {
+		t.Fatalf("commands = %q, want paginated+slurped gh api list, relist, then delete call", commands)
 	}
 	if !strings.Contains(stdout.String(), "Deleted 1 GitHub CLI webhook hook(s) for acme/looper.") {
 		t.Fatalf("stdout = %q, want delete confirmation", stdout.String())

--- a/internal/cliapp/webhook_commands_test.go
+++ b/internal/cliapp/webhook_commands_test.go
@@ -455,8 +455,6 @@ func TestWebhookCleanupConfirmDeletesMatchingCLIHooks(t *testing.T) {
 			case 1:
 				return commandExecutionResult{Stdout: `[[{"id":101,"name":"cli","type":"Repository","active":true,"events":["push","pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}]]`, ExitCode: 0}, nil
 			case 2:
-				return commandExecutionResult{Stdout: `[[{"id":101,"name":"cli","type":"Repository","active":true,"events":["push","pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}]]`, ExitCode: 0}, nil
-			case 3:
 				return commandExecutionResult{ExitCode: 0}, nil
 			default:
 				t.Fatalf("unexpected RunCommand call %d: %s %q", len(commands), command, args)
@@ -469,8 +467,8 @@ func TestWebhookCleanupConfirmDeletesMatchingCLIHooks(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run(webhook cleanup --confirm) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
 	}
-	if len(commands) != 3 || !strings.HasSuffix(commands[0], " api --paginate --slurp repos/acme/looper/hooks") || !strings.HasSuffix(commands[1], " api --paginate --slurp repos/acme/looper/hooks") || !strings.HasSuffix(commands[2], " api -X DELETE repos/acme/looper/hooks/101") {
-		t.Fatalf("commands = %q, want paginated+slurped gh api list, relist, then delete call", commands)
+	if len(commands) != 2 || !strings.HasSuffix(commands[0], " api --paginate --slurp repos/acme/looper/hooks") || !strings.HasSuffix(commands[1], " api -X DELETE repos/acme/looper/hooks/101") {
+		t.Fatalf("commands = %q, want one paginated+slurped gh api list call followed by deleting the shown hook id", commands)
 	}
 	if !strings.Contains(stdout.String(), "Deleted 1 GitHub CLI webhook hook(s) for acme/looper.") {
 		t.Fatalf("stdout = %q, want delete confirmation", stdout.String())

--- a/internal/cliapp/webhook_commands_test.go
+++ b/internal/cliapp/webhook_commands_test.go
@@ -474,3 +474,54 @@ func TestWebhookCleanupConfirmDeletesMatchingCLIHooks(t *testing.T) {
 		t.Fatalf("stdout = %q, want delete confirmation", stdout.String())
 	}
 }
+
+func TestWebhookCleanupConfirmContinuesPastMissingShownHook(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"notifications": map[string]any{
+			"osascript": map[string]any{"enabled": false},
+		},
+	})
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	commands := []string{}
+	app := New(Deps{
+		Stdout: stdout,
+		Stderr: stderr,
+		LookPath: func(command string) (string, error) {
+			if command == "gh" {
+				return "/usr/bin/gh", nil
+			}
+			return command, nil
+		},
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			commands = append(commands, command+" "+strings.Join(args, " "))
+			switch len(commands) {
+			case 1:
+				return commandExecutionResult{Stdout: `[[
+					{"id":101,"name":"cli","type":"Repository","active":true,"events":["push"],"config":{"url":"https://webhook-forwarder.github.com/hook"}},
+					{"id":202,"name":"cli","type":"Repository","active":true,"events":["pull_request"],"config":{"url":"https://webhook-forwarder.github.com/hook"}}
+				]]`, ExitCode: 0}, nil
+			case 2:
+				return commandExecutionResult{ExitCode: 1, Stderr: "gh: HTTP 404: Not Found (https://api.github.com/repos/acme/looper/hooks/101)"}, nil
+			case 3:
+				return commandExecutionResult{ExitCode: 0}, nil
+			default:
+				t.Fatalf("unexpected RunCommand call %d: %s %q", len(commands), command, args)
+				return commandExecutionResult{}, nil
+			}
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"webhook", "cleanup", "acme/looper", "--confirm", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run(webhook cleanup --confirm) exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if len(commands) != 3 || !strings.HasSuffix(commands[1], " api -X DELETE repos/acme/looper/hooks/101") || !strings.HasSuffix(commands[2], " api -X DELETE repos/acme/looper/hooks/202") {
+		t.Fatalf("commands = %q, want cleanup to continue deleting the remaining shown hook ids after a 404", commands)
+	}
+	if !strings.Contains(stdout.String(), "Deleted 2 GitHub CLI webhook hook(s) for acme/looper.") {
+		t.Fatalf("stdout = %q, want delete confirmation after continuing past a missing hook", stdout.String())
+	}
+}

--- a/internal/runtime/webhook.go
+++ b/internal/runtime/webhook.go
@@ -27,6 +27,11 @@ var webhookReconcileRetryDelay = 5 * time.Second
 
 var webhookForwardEvents = []string{"pull_request", "issue_comment", "pull_request_review", "pull_request_review_comment", "push", "check_run"}
 
+const (
+	webhookForwarderStdoutTailLines = 20
+	webhookForwarderStderrTailLines = 40
+)
+
 type WebhookStatus struct {
 	Enabled                     bool                    `json:"enabled"`
 	FallbackPollIntervalSeconds int                     `json:"fallbackPollIntervalSeconds"`
@@ -882,9 +887,9 @@ func (w *webhookRuntime) captureTail(repo string, stopCh chan struct{}, pipe io.
 	for scanner.Scan() {
 		w.updateForwarder(repo, stopCh, func(state *WebhookForwarderState) {
 			if stdout {
-				state.StdoutTail = appendTail(state.StdoutTail, scanner.Text(), 20)
+				state.StdoutTail = appendTail(state.StdoutTail, scanner.Text(), webhookForwarderStdoutTailLines)
 			} else {
-				state.StderrTail = appendTail(state.StderrTail, scanner.Text(), 20)
+				state.StderrTail = appendTail(state.StderrTail, scanner.Text(), webhookForwarderStderrTailLines)
 			}
 		})
 	}

--- a/internal/runtime/webhook.go
+++ b/internal/runtime/webhook.go
@@ -833,10 +833,21 @@ func (w *webhookRuntime) runForwarder(repo string) {
 			w.logger.Info("webhook.forwarder.spawned", map[string]any{"repo": repo, "pid": pid, "fingerprint": fingerprint, "daemon_id": w.daemonID})
 		}
 
-		var pipes sync.WaitGroup
+		var (
+			pipes           sync.WaitGroup
+			stderrTailMu    sync.Mutex
+			localStderrTail []string
+		)
 		pipes.Add(2)
 		go func() { defer pipes.Done(); w.captureTail(repo, stopCh, stdout, true) }()
-		go func() { defer pipes.Done(); w.captureTail(repo, stopCh, stderr, false) }()
+		go func() {
+			defer pipes.Done()
+			w.captureTail(repo, stopCh, stderr, false, func(line string) {
+				stderrTailMu.Lock()
+				defer stderrTailMu.Unlock()
+				localStderrTail = appendTail(localStderrTail, line, webhookForwarderStderrTailLines)
+			})
+		}()
 		err = cmd.Wait()
 		close(stopKillDone)
 		pipes.Wait()
@@ -853,7 +864,9 @@ func (w *webhookRuntime) runForwarder(repo string) {
 			state.RestartCount++
 		})
 		w.deleteForwarderRecord(repo)
-		classification := classifyForwarderExit(w.stderrTail(repo, stopCh), err)
+		stderrTailMu.Lock()
+		classification := classifyForwarderExit(append([]string{}, localStderrTail...), err)
+		stderrTailMu.Unlock()
 		if w.logger != nil {
 			w.logger.Info("webhook.forwarder.exited", map[string]any{"repo": repo, "pid": pid, "exit_class": string(classification.Class), "matched_pattern": classification.MatchedPattern, "wait_err": message})
 		}
@@ -882,14 +895,22 @@ func (w *webhookRuntime) runForwarder(repo string) {
 	}
 }
 
-func (w *webhookRuntime) captureTail(repo string, stopCh chan struct{}, pipe io.ReadCloser, stdout bool) {
+func (w *webhookRuntime) captureTail(repo string, stopCh chan struct{}, pipe io.ReadCloser, stdout bool, onLine ...func(string)) {
+	var recordLine func(string)
+	if len(onLine) > 0 {
+		recordLine = onLine[0]
+	}
 	scanner := bufio.NewScanner(pipe)
 	for scanner.Scan() {
+		line := scanner.Text()
+		if recordLine != nil {
+			recordLine(line)
+		}
 		w.updateForwarder(repo, stopCh, func(state *WebhookForwarderState) {
 			if stdout {
-				state.StdoutTail = appendTail(state.StdoutTail, scanner.Text(), webhookForwarderStdoutTailLines)
+				state.StdoutTail = appendTail(state.StdoutTail, line, webhookForwarderStdoutTailLines)
 			} else {
-				state.StderrTail = appendTail(state.StderrTail, scanner.Text(), webhookForwarderStderrTailLines)
+				state.StderrTail = appendTail(state.StderrTail, line, webhookForwarderStderrTailLines)
 			}
 		})
 	}

--- a/internal/runtime/webhook_runtime_test.go
+++ b/internal/runtime/webhook_runtime_test.go
@@ -587,7 +587,27 @@ func TestWebhookRuntimeTerminalForwarderExitLatchesWithoutRespawn(t *testing.T) 
 		starts++
 		mu.Unlock()
 		cmd := exec.Command(testBin, "-test.run=TestWebhookRuntimeForwarderHelperProcess", "--")
-		cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1", "LOOPER_HELPER_STDERR_EXIT=Hook already exists on this repository")
+		cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1", `LOOPER_HELPER_STDERR_EXIT=Error: error creating webhook: HTTP 422: Validation Failed
+Hook already exists on this repository
+Usage:
+  forward --events=<types> [--url=<url>] [flags]
+
+Examples:
+# create a dev webhook for the 'issue_open' event in the monalisa/smile repo in GitHub running locally, and
+# forward payloads for the triggered event to http://localhost:9999/webhooks
+
+$ gh webhook forward --events=issues --repo=monalisa/smile --url="http://localhost:9999/webhooks"
+$ gh webhook forward --events=issues --org=github --url="http://localhost:9999/webhooks"
+
+
+Flags:
+  -E, --events types         Names of the event types to forward. Use * to forward all events.
+  -H, --github-host string   GitHub host name (default "github.com")
+  -h, --help                 help for forward
+  -O, --org string           Name of the org where the webhook is installed
+  -R, --repo string          Name of the repo where the webhook is installed
+  -S, --secret string        Webhook secret for incoming events
+  -U, --url string           Address of the local server to receive events. If omitted, events will be printed to stdout.`)
 		cmd.Args[0] = name
 		return cmd
 	}

--- a/skills/looper/SKILL.md
+++ b/skills/looper/SKILL.md
@@ -7,6 +7,8 @@ description: Use when installing, bootstrapping, configuring, starting, verifyin
 
 Use this skill when an agent needs to install, configure, start, check, operate, or troubleshoot Looper (`looper` CLI, `looperd` daemon, or files under `~/.looper`).
 
+This skill now includes the webhook-mode lifecycle: enabling `looper webhook`, installing or validating the GitHub CLI webhook extension, verifying healthy forwarders, diagnosing degraded webhook runtime, cleaning up stale GitHub CLI `cli` hooks with `looper webhook cleanup`, and deciding when a daemon restart is or is not necessary.
+
 **When NOT to use this skill:** developing on the Looper codebase itself (Go sources at `cmd/`, `internal/`, `pkg/`). For that, follow `AGENTS.md` and standard Go tooling.
 
 ## Looper in one paragraph
@@ -82,7 +84,7 @@ If none are installed, ask the user which one they want to install before contin
 
 After the user picks a vendor, verify it is authenticated (run the vendor's own status command, e.g. `claude --version` followed by a quick auth check, or `agent status`). If the vendor CLI exits with an auth error, surface it and ask the user to log in via the vendor's own flow before continuing.
 
-Looper inherits the vendor's own authentication (e.g. `claude login`, `agent login`, or env vars in the user's shell). **Do not** store agent credentials in `~/.looper/config.json`.
+Looper inherits the vendor's own authentication (e.g. `claude login`, `agent login`, or env vars in the user's shell). **Do not** store agent credentials in the Looper config file (commonly `~/.looper/config.toml`, with some existing installs still using `~/.looper/config.json`).
 
 ### Step 2 — Pick the first project to watch
 
@@ -111,9 +113,9 @@ If `looper --version` fails, do not guess a new install location. The installer 
 
 ### Step 4 — Bootstrap config, daemon, and first project
 
-`looper bootstrap` writes `~/.looper/config.json`, installs the managed daemon to `~/.looper/bin/looperd`, optionally registers a project, and starts `looperd`.
+`looper bootstrap` writes the active Looper config file (usually `~/.looper/config.toml`; some existing installs still use `~/.looper/config.json`), installs the managed daemon to `~/.looper/bin/looperd`, optionally registers a project, and starts `looperd`.
 
-**If `~/.looper/config.json` already exists, do NOT pass `--yes`.** Inspect first with `looper config show`, then triage by what is missing or wrong:
+**If a Looper config file already exists (commonly `~/.looper/config.toml` or legacy `~/.looper/config.json`), do NOT pass `--yes`.** Inspect first with `looper config show`, then triage by what is missing or wrong:
 
 | Existing-config state | Action |
 | --- | --- |
@@ -208,7 +210,7 @@ looper logs <id> --follow
 For deeper detail, consult these bundled docs before acting:
 
 - [`references/cli.md`](references/cli.md) — installed `looper` CLI commands, install/uninstall scripts, `looper bootstrap`, `looper project add`, daemon lifecycle, loop inspection.
-- [`references/config.md`](references/config.md) — full `~/.looper/config.json` shape, every field, validation rules, env var overrides, CLI flag overrides, role trigger customization, reviewer event mapping.
+- [`references/config.md`](references/config.md) — full Looper config shape, every field, validation rules, env var overrides, CLI flag overrides, role trigger customization, reviewer event mapping.
 - [`references/daemon.md`](references/daemon.md) — `looperd` startup, supervised vs detached mode, launchd integration, log locations, startup-failure triage.
 - [`scripts/check.sh`](scripts/check.sh) — read-only local diagnostic. Verifies `git`, `gh`, `gh auth status`, optional `osascript`, `looper --version`, config presence, and `~/.looper` writability. Invoke via absolute skill path.
 
@@ -236,7 +238,7 @@ looper webhook cleanup owner/repo --confirm
 
 ## Safety rules
 
-- Do not overwrite or rewrite `~/.looper/config.json` without explicit user confirmation. Prefer targeted edits.
+- Do not overwrite or rewrite the Looper config file (`~/.looper/config.toml` on new installs; `~/.looper/config.json` on some existing installs) without explicit user confirmation. Prefer targeted edits.
 - Do not delete runtime artifacts (`~/.looper/looper.sqlite`, `backups/`, `logs/`, `worktrees/`) unless the user explicitly asks and understands the impact.
 - Starting or restarting `looperd` can launch background automation against configured GitHub repositories — confirm intent before doing so.
 - Do not toggle `daemon.mode` (foreground ↔ launchd) without confirming; supervised mode persists across login/reboot.
@@ -247,7 +249,7 @@ looper webhook cleanup owner/repo --confirm
 
 ## Common mistakes
 
-- `cat ~/.looper/config.json` as a first move: use `looper config show` instead and redact secrets.
+- `cat ~/.looper/config.*` as a first move: use `looper config show` instead and redact secrets.
 - Restarting the daemon under pressure: check status/logs first; restart can re-trigger automation.
 - Disabling `notifications.osascript.enabled` silently: confirm the change or set an explicit `tools.osascriptPath`.
 - Rewriting the whole config for one fix: make targeted edits and preserve existing settings.

--- a/skills/looper/SKILL.md
+++ b/skills/looper/SKILL.md
@@ -219,6 +219,19 @@ looper status
 looper daemon status --json
 looper daemon logs --startup
 looper config show
+looper webhook status
+```
+
+When webhook mode is degraded, inspect stale GitHub CLI forwarder hooks before restarting the daemon:
+
+```bash
+looper webhook cleanup owner/repo
+```
+
+Only run deletion after the dry run shows stale `cli` hooks and the user confirms:
+
+```bash
+looper webhook cleanup owner/repo --confirm
 ```
 
 ## Safety rules

--- a/skills/looper/SKILL.md
+++ b/skills/looper/SKILL.md
@@ -7,7 +7,7 @@ description: Use when installing, bootstrapping, configuring, starting, verifyin
 
 Use this skill when an agent needs to install, configure, start, check, operate, or troubleshoot Looper (`looper` CLI, `looperd` daemon, or files under `~/.looper`).
 
-This skill now includes the webhook-mode lifecycle: enabling `looper webhook`, installing or validating the GitHub CLI webhook extension, verifying healthy forwarders, diagnosing degraded webhook runtime, cleaning up stale GitHub CLI `cli` hooks with `looper webhook cleanup`, and deciding when a daemon restart is or is not necessary.
+It also covers the full webhook-mode lifecycle — turning it on, installing or validating the `gh webhook` extension, confirming forwarders are healthy, diagnosing a degraded runtime, clearing stale GitHub CLI hooks with `looper webhook cleanup`, and judging when a daemon restart is actually needed.
 
 **When NOT to use this skill:** developing on the Looper codebase itself (Go sources at `cmd/`, `internal/`, `pkg/`). For that, follow `AGENTS.md` and standard Go tooling.
 

--- a/skills/looper/references/cli.md
+++ b/skills/looper/references/cli.md
@@ -67,6 +67,124 @@ looper daemon status
 looper daemon logs --startup
 ```
 
+## Webhook mode lifecycle
+
+Webhook mode is optional. It improves reaction latency by running local `gh webhook forward` subprocesses and keeping polling as a correctness fallback.
+
+### 1. Enable webhook mode
+
+Enable webhook mode in config:
+
+```bash
+looper webhook enable
+```
+
+If `gh webhook` is not available yet, either install it yourself:
+
+```bash
+gh extension install cli/gh-webhook
+```
+
+or let Looper do it during enable:
+
+```bash
+looper webhook enable --install-gh-webhook
+```
+
+After enabling, restart `looperd` only after confirming with the user because restart can trigger background automation:
+
+```bash
+looper daemon restart
+```
+
+### 2. Verify a healthy webhook runtime
+
+Use:
+
+```bash
+looper webhook status
+looper webhook status --verbose
+```
+
+A healthy runtime usually shows:
+
+- `enabled: yes`
+- `degraded: no`
+- one running forwarder per configured GitHub repo
+- `endpointUrl` pointing at the local daemon listener
+
+### 3. Understand the fallback contract
+
+Webhook mode does **not** replace polling. If webhook forwarders fail, Looper still falls back to `webhook.fallbackPollIntervalSeconds` polling. That means correctness should remain intact while latency worsens.
+
+### 4. Common degraded states
+
+Start with:
+
+```bash
+looper webhook status --verbose
+looper daemon status --json
+looper daemon logs
+gh auth status
+```
+
+Typical causes and first actions:
+
+- `gh could not be resolved` → set `tools.ghPath` explicitly or fix the daemon environment.
+- `server.host is not loopback` → webhook forwarders require a loopback daemon endpoint such as `127.0.0.1` or `localhost`.
+- `Hook already exists on this repository` / repeated forwarder exits → inspect stale GitHub CLI hooks with `looper webhook cleanup owner/repo`.
+- `HTTP 401`, `HTTP 403`, `authentication required`, `gh auth login` → fix GitHub auth first.
+- `HTTP 404` or other GitHub API failures → verify repo access and the authenticated account.
+
+### 5. Clean up stale GitHub CLI hooks
+
+If `gh webhook forward` left conflicting remote `cli` hooks behind, inspect them first:
+
+```bash
+looper webhook cleanup owner/repo
+```
+
+That command is dry-run by default. If the listed hooks are clearly stale GitHub CLI forwarder hooks, delete them explicitly:
+
+```bash
+looper webhook cleanup owner/repo --confirm
+```
+
+Notes:
+
+- This command only targets GitHub CLI `cli` hooks that point at `https://webhook-forwarder.github.com/hook`.
+- It does not run automatically from the daemon.
+- In multi-repo setups, run it once per affected `owner/repo`.
+- `--confirm` can delete another developer's active GitHub CLI forwarder hook on a shared repo; only use it when the user understands that risk.
+- Listing and deleting repo hooks requires sufficient GitHub permissions for that repository; if the command fails, verify `gh auth status` and repo access first.
+
+### 6. After cleanup: when restart is needed
+
+Cleanup alone may be enough if `looperd` is already healthy enough to retry and recreate forwarders on its own. Re-check first:
+
+```bash
+looper webhook status
+```
+
+If `looper webhook status --verbose` shows `latched: true`, cleanup first and then restart `looperd` after confirming with the user because a latched forwarder will not respawn on its own.
+
+If webhook mode is still degraded after cleanup, then restart `looperd` after confirming with the user:
+
+```bash
+looper daemon restart
+```
+
+### 7. Useful verbose fields
+
+`looper webhook status --verbose` may show these per-forwarder fields:
+
+- `adopted` — Looper adopted a still-running local forwarder from persisted local state.
+- `latched` — Looper saw a terminal forwarder failure and stopped respawning that forwarder until restart/reconfigure.
+- `latchReason` — remediation-oriented explanation for a latched forwarder.
+- `fingerprint` — normalized command identity for the local forwarder.
+- `spawnedAt` / `lastStartedAt` / `lastExitAt` — timing data for local process lifecycle.
+- `stdoutTail` / `stderrTail` — recent captured subprocess output; adopted processes may not have captured tails.
+
 ## Add an existing project/repo
 
 If Looper is already installed and the user has an existing local repository, register it explicitly instead of re-running first-time bootstrap:

--- a/skills/looper/references/cli.md
+++ b/skills/looper/references/cli.md
@@ -27,6 +27,19 @@ looper status
 looper daemon status
 looper daemon status --json
 looper daemon logs
+looper webhook status
+```
+
+If webhook mode is degraded because `gh webhook forward` left conflicting GitHub CLI hooks behind, inspect them with:
+
+```bash
+looper webhook cleanup owner/repo
+```
+
+That command is dry-run by default. Only after confirming the listed `cli` hooks are stale should you delete them:
+
+```bash
+looper webhook cleanup owner/repo --confirm
 ```
 
 ## Common operations

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -26,6 +26,8 @@ Canonical default path:
 ~/.looper/config.toml
 ```
 
+For webhook-mode troubleshooting in this repository, users may also have a JSON config at `~/.looper/config.json`. Respect whichever supported config file Looper is actually loading.
+
 Config source selection precedence is:
 
 1. `--config`
@@ -206,6 +208,10 @@ maxConcurrentRuns = 3
 retryMaxAttempts = 5
 retryBaseDelayMs = 5000
 
+[webhook]
+enabled = false
+fallbackPollIntervalSeconds = 300
+
 [agent]
 vendor = "opencode"
 
@@ -288,6 +294,22 @@ labels = ["needs-review"]
 labelMode = "any"
 requireReviewRequest = false
 ```
+
+## Webhook-related config guidance
+
+When diagnosing or editing webhook mode, pay attention to:
+
+- `webhook.enabled` — turns webhook mode on or off.
+- `webhook.fallbackPollIntervalSeconds` — polling fallback cadence when forwarders are unavailable.
+- `server.host` — must remain loopback for local forwarders.
+- `server.host` and `server.port` — webhook forwarders derive the local listener endpoint from these fields, so `server.host` must stay loopback and `server.port` must match the running daemon.
+- `tools.ghPath` — set explicitly when `looperd` cannot resolve `gh` from its runtime environment.
+
+Targeted checks:
+
+- If `looper webhook status` warns about loopback, inspect `server.host` first.
+- If it warns that `gh` could not be resolved, set `tools.ghPath` explicitly instead of rewriting unrelated config.
+- If webhook mode is degraded but config is correct, prefer `looper webhook cleanup owner/repo` or auth troubleshooting before editing config.
 
 ## Runtime paths
 

--- a/skills/looper/references/daemon.md
+++ b/skills/looper/references/daemon.md
@@ -73,3 +73,21 @@ looper daemon install --force
 ```
 
 After any repair, re-run read-only checks and only run repair or restart commands after confirming with the user.
+
+## Webhook-mode daemon checks
+
+When the user is troubleshooting webhook mode specifically, add these read-only checks before restarting anything:
+
+```bash
+looper webhook status
+looper webhook status --verbose
+looper daemon status --json
+looper daemon logs
+```
+
+Key daemon/runtime facts for webhook mode:
+
+- `looperd` runs local `gh webhook forward` subprocesses; it does not rely on webhook mode for correctness because polling remains the fallback.
+- Webhook forwarders require a loopback daemon endpoint. Non-loopback `server.host` will degrade webhook mode.
+- If webhook runtime becomes degraded because stale remote GitHub CLI hooks already exist, prefer `looper webhook cleanup owner/repo` before restarting the daemon.
+- Restart is only the next step if status still shows degraded after cleanup or after fixing auth/path/config problems.


### PR DESCRIPTION
## Summary
- add an explicit `looper webhook cleanup <owner/repo>` command that dry-runs by default and only deletes matching GitHub CLI forwarder hooks with `--confirm`
- surface degraded webhook cleanup guidance in `looper webhook status` and document the remediation flow in the user guide, ADR, and `skills/looper`
- harden terminal webhook-forwarder detection by retaining enough stderr to classify conflicting-hook failures correctly

## Validation
- `go test ./internal/cliapp`
- `go vet ./...`
- `go build ./...`
- `go test ./...`