### PR TITLE
feat: gate reviewer auto-merge on issue acceptance criteria

### DIFF
--- a/docs/adr/0005-auto-merge-via-github-native-and-coordinator-watch.md
+++ b/docs/adr/0005-auto-merge-via-github-native-and-coordinator-watch.md
@@ -1,0 +1,71 @@
+# ADR-0005: Auto-merge via GitHub-native auto-merge and Coordinator watch
+
+- Status: Accepted
+- Date: 2026-05-18
+- Related: ADR-0002, PRD #352, slice #357, issue #358
+
+## Context
+
+Reviewer is extending an agent-driven authority path. AGENTS.md requires naming the authority before enforcing it and avoiding inference layers that override the agent's structured output with unrelated infrastructure guesses.
+
+This slice adds two authority-bearing behaviors:
+
+1. Reviewer raises the APPROVE bar for implementation PRs when reviewer auto-merge is enabled.
+2. Reviewer can opt an eligible PR into GitHub-native auto-merge.
+
+The watch that observes opted-in PRs belongs to Coordinator, but the concrete poll implementation lands in slice 3. This ADR establishes the authority boundaries now so slice 2 and slice 3 share the same contract.
+
+## Decision
+
+### Authority chain 1: “Is it safe to merge?”
+
+Authority: GitHub branch protection.
+
+Looper opts in with `gh pr merge --auto --{strategy}` and GitHub decides when the PR is mergeable. Looper does not re-check CI, count reviews, or resolve conversations before merging. Those are GitHub's merge gates, not Reviewer's authority.
+
+### Authority chain 2: “Is this Looper's PR?”
+
+Authority: the durable conjunction of:
+
+- a `looper:` label on the PR, and
+- a PR→Issue link to a Coordinator-tracked issue.
+
+Either signal alone is too weak. The label alone is broad, and the issue link alone would let unrelated PRs on tracked issues enter Looper's auto-merge scope.
+
+### Authority chain 3: “Did the work satisfy the issue?”
+
+Authority: the linked issue's `## Acceptance criteria` section plus Reviewer's per-criterion satisfying evidence pointers.
+
+Reviewer persists that evidence in the APPROVE review body under `### Acceptance criteria verification` so future readers can audit why the PR qualified.
+
+## Consequences
+
+### Positive
+
+- GitHub remains the merge authority for branch protection and timing.
+- Reviewer's APPROVE becomes auditable against the implementing issue instead of being a generic clean signal.
+- The Coordinator watch can consume GitHub state later without redefining merge safety or PR ownership.
+
+### Costs
+
+- Reviewer now depends on a linked issue with explicit acceptance criteria before engaging the stricter auto-merge path.
+- The system must preserve the PR→Issue link and per-criterion evidence text across retries.
+- Slice 3 must watch GitHub auto-merge state without treating that watch as the merge authority itself.
+
+## Rejected alternatives
+
+### Custom Looper merge endpoint (`PUT /pulls/.../merge`)
+
+Rejected because it would make Looper the merge gate authority. That duplicates GitHub's branch-protection logic and violates the “Name the authority before enforcing it” rule.
+
+### Multi-strategy fall-through
+
+Rejected because silently switching merge strategies changes the authority contract. The configured strategy is part of the operator's intent; if GitHub repo settings disallow it, Reviewer refuses auto-merge instead of guessing another merge mode.
+
+### Scope = any PR on a tracked issue
+
+Rejected because an issue link alone is insufficient to prove the PR is Looper-managed. Auto-merge scope requires both the Looper label and the tracked-issue link.
+
+## Coordinator watch boundary
+
+Coordinator owns the merge-watch poll in slice 3. It will observe GitHub-native auto-merge progress and merged/closed outcomes, but that watch is drift detection and orchestration state, not merge authority. The merge authority remains GitHub branch protection and merge execution.

--- a/internal/e2e/harness/cmd/fake-gh/main.go
+++ b/internal/e2e/harness/cmd/fake-gh/main.go
@@ -152,6 +152,9 @@ func dispatch(mode string, schemaDoc schema, st state, stdin string) error {
 			return nil
 		}
 		return emitDefaultJSON(key, fields)
+	case "pr merge":
+		_, _ = fmt.Fprintln(os.Stdout, "{}")
+		return nil
 	case "issue list", "pr list":
 		fields := requestedJSONFields(os.Args[1:])
 		allowed := schemaDoc.JSONFieldAllowlist[key]
@@ -198,6 +201,16 @@ func handleAPI(mode string, st state, stdin string) error {
 		_, _ = fmt.Fprintln(os.Stdout, `{"data":{}}`)
 		return nil
 	}
+	if strings.Contains(route, "/pulls/") && strings.HasSuffix(route, "/reviews") {
+		if handled, err := handlePullRequestReviews(&st, args, stdin, route); handled || err != nil {
+			return err
+		}
+	}
+	if strings.Contains(route, "/pulls/") && strings.Contains(route, "/reviews/") && strings.HasSuffix(route, "/comments") {
+		if handled, err := handlePullRequestReviewComments(st, route); handled || err != nil {
+			return err
+		}
+	}
 	if strings.HasSuffix(route, "/comments") && strings.EqualFold(flagValue(args, "--method"), "POST") {
 		_, _ = fmt.Fprintln(os.Stdout, `{"id":1,"html_url":"https://example.test/issues/comments/1"}`)
 		return nil
@@ -227,16 +240,145 @@ func handleAPI(mode string, st state, stdin string) error {
 	return nil
 }
 
+func handlePullRequestReviews(st *state, args []string, stdin string, route string) (bool, error) {
+	repo, prNumber, ok := parsePullRequestReviewRoute(route)
+	if !ok {
+		return false, nil
+	}
+	method := strings.ToUpper(strings.TrimSpace(flagValue(args, "--method")))
+	if method == "" {
+		method = "GET"
+	}
+	pr, ok := lookupPullRequest(*st, repo, prNumber)
+	if !ok {
+		return false, nil
+	}
+	if method == "POST" {
+		body, event, err := parseReviewCreatePayload(stdin)
+		if err != nil {
+			return true, err
+		}
+		reviewID := fmt.Sprintf("review-%d", len(pr.Reviews)+1)
+		pr.Reviews = append(pr.Reviews, map[string]any{"id": reviewID, "body": body, "state": reviewStateForEvent(event), "user": map[string]any{"login": firstNonEmpty(st.CurrentUserLogin, "looper")}})
+		st.PullRequests[fmt.Sprintf("%s#%d", repo, prNumber)] = pr
+		if err := saveState(strings.TrimSpace(os.Getenv(envFakeGHStatePath)), *st); err != nil {
+			return true, err
+		}
+		_, _ = fmt.Fprintf(os.Stdout, "{\"id\":%q}\n", reviewID)
+		return true, nil
+	}
+	payload, err := json.Marshal([][]map[string]any{pr.Reviews})
+	if err != nil {
+		return true, err
+	}
+	_, _ = fmt.Fprintln(os.Stdout, string(payload))
+	return true, nil
+}
+
+func handlePullRequestReviewComments(st state, route string) (bool, error) {
+	repo, prNumber, reviewID, ok := parsePullRequestReviewCommentsRoute(route)
+	if !ok {
+		return false, nil
+	}
+	pr, ok := lookupPullRequest(st, repo, prNumber)
+	if !ok {
+		return false, nil
+	}
+	for _, review := range pr.Reviews {
+		if asString(review["id"]) != reviewID {
+			continue
+		}
+		payload, err := json.Marshal([][]map[string]any{{}})
+		if err != nil {
+			return true, err
+		}
+		_, _ = fmt.Fprintln(os.Stdout, string(payload))
+		return true, nil
+	}
+	return false, nil
+}
+
+func parsePullRequestReviewRoute(route string) (string, int64, bool) {
+	const marker = "repos/"
+	if !strings.HasPrefix(route, marker) || !strings.HasSuffix(route, "/reviews") {
+		return "", 0, false
+	}
+	rest := strings.TrimSuffix(strings.TrimPrefix(route, marker), "/reviews")
+	parts := strings.Split(rest, "/")
+	if len(parts) < 4 || parts[2] != "pulls" {
+		return "", 0, false
+	}
+	prNumber, err := strconv.ParseInt(parts[3], 10, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return parts[0] + "/" + parts[1], prNumber, true
+}
+
+func parsePullRequestReviewCommentsRoute(route string) (string, int64, string, bool) {
+	const marker = "repos/"
+	if !strings.HasPrefix(route, marker) || !strings.Contains(route, "/reviews/") || !strings.HasSuffix(route, "/comments") {
+		return "", 0, "", false
+	}
+	rest := strings.TrimPrefix(route, marker)
+	parts := strings.Split(rest, "/")
+	if len(parts) < 7 || parts[2] != "pulls" || parts[4] != "reviews" {
+		return "", 0, "", false
+	}
+	prNumber, err := strconv.ParseInt(parts[3], 10, 64)
+	if err != nil {
+		return "", 0, "", false
+	}
+	return parts[0] + "/" + parts[1], prNumber, parts[5], true
+}
+
+func parseReviewCreatePayload(stdin string) (string, string, error) {
+	var payload struct {
+		Body  string `json:"body"`
+		Event string `json:"event"`
+	}
+	if err := json.Unmarshal([]byte(stdin), &payload); err != nil {
+		return "", "", err
+	}
+	return payload.Body, payload.Event, nil
+}
+
+func reviewStateForEvent(event string) string {
+	switch strings.ToUpper(strings.TrimSpace(event)) {
+	case "APPROVE":
+		return "APPROVED"
+	case "REQUEST_CHANGES":
+		return "CHANGES_REQUESTED"
+	default:
+		return "COMMENTED"
+	}
+}
+
+func asString(value any) string {
+	text, _ := value.(string)
+	return text
+}
+
 func emitResponse(resp response) error {
 	if resp.Stderr != "" {
 		_, _ = os.Stderr.WriteString(resp.Stderr)
 	}
 	if len(resp.Stdout) > 0 {
+		var text string
+		if err := json.Unmarshal(resp.Stdout, &text); err == nil {
+			_, _ = os.Stdout.WriteString(text)
+			if text == "" || text[len(text)-1] != '\n' {
+				_, _ = fmt.Fprintln(os.Stdout)
+			}
+			goto exitCode
+		}
 		_, _ = os.Stdout.Write(resp.Stdout)
 		if resp.Stdout[len(resp.Stdout)-1] != '\n' {
 			_, _ = fmt.Fprintln(os.Stdout)
 		}
 	}
+
+exitCode:
 	if resp.ExitCode != 0 {
 		os.Exit(resp.ExitCode)
 	}
@@ -545,7 +687,7 @@ func pullRequestFieldValue(pr pullRequestState, field string) any {
 	case "reviewRequests":
 		items := make([]map[string]any, 0, len(pr.ReviewRequests))
 		for _, login := range pr.ReviewRequests {
-			items = append(items, map[string]any{"login": login})
+			items = append(items, map[string]any{"__typename": "ReviewRequest", "requestedReviewer": map[string]any{"__typename": "User", "login": login}})
 		}
 		return items
 	case "comments":

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -300,6 +300,7 @@ type EnableAutoMergeInput struct {
 	Repo     string
 	PRNumber int64
 	Strategy config.ReviewerAutoMergeStrategy
+	HeadSHA  string
 	CWD      string
 }
 
@@ -1279,7 +1280,11 @@ func (g *Gateway) EnableAutoMerge(ctx context.Context, input EnableAutoMergeInpu
 	if strategy == "" {
 		return fmt.Errorf("auto-merge strategy is required")
 	}
-	_, err := g.runGh(ctx, input.CWD, "", "pr", "merge", strconv.FormatInt(input.PRNumber, 10), "--repo", input.Repo, "--auto", "--"+strategy)
+	headSHA := strings.TrimSpace(input.HeadSHA)
+	if headSHA == "" {
+		return fmt.Errorf("auto-merge head SHA is required")
+	}
+	_, err := g.runGh(ctx, input.CWD, "", "pr", "merge", strconv.FormatInt(input.PRNumber, 10), "--repo", input.Repo, "--auto", "--"+strategy, "--match-head-commit", headSHA)
 	return err
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -296,6 +296,13 @@ type ClosePullRequestInput struct {
 	CWD      string
 }
 
+type EnableAutoMergeInput struct {
+	Repo     string
+	PRNumber int64
+	Strategy config.ReviewerAutoMergeStrategy
+	CWD      string
+}
+
 type SubmitReviewInput struct {
 	Repo       string
 	PRNumber   int64
@@ -1264,6 +1271,15 @@ func (g *Gateway) ClosePullRequest(ctx context.Context, input ClosePullRequestIn
 	if stateErr == nil && (state == "closed" || state == "merged") {
 		return nil
 	}
+	return err
+}
+
+func (g *Gateway) EnableAutoMerge(ctx context.Context, input EnableAutoMergeInput) error {
+	strategy := strings.TrimSpace(string(input.Strategy))
+	if strategy == "" {
+		return fmt.Errorf("auto-merge strategy is required")
+	}
+	_, err := g.runGh(ctx, input.CWD, "", "pr", "merge", strconv.FormatInt(input.PRNumber, 10), "--repo", input.Repo, "--auto", "--"+strategy)
 	return err
 }
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1947,6 +1947,22 @@ func TestGatewayClosePullRequestIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestGatewayEnableAutoMerge(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		if args != "pr merge 42 --repo acme/looper --auto --squash" {
+			t.Fatalf("unexpected gh args: %q", args)
+		}
+		return shell.Result{}, nil
+	}
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	if err := gateway.EnableAutoMerge(context.Background(), EnableAutoMergeInput{Repo: "acme/looper", PRNumber: 42, Strategy: config.ReviewerAutoMergeStrategySquash}); err != nil {
+		t.Fatalf("EnableAutoMerge() error = %v", err)
+	}
+}
+
 func TestGatewayCloseIssueRejectsUnknownStateReason(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1952,14 +1952,28 @@ func TestGatewayEnableAutoMerge(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
-		if args != "pr merge 42 --repo acme/looper --auto --squash" {
+		if args != "pr merge 42 --repo acme/looper --auto --squash --match-head-commit abc123" {
 			t.Fatalf("unexpected gh args: %q", args)
 		}
 		return shell.Result{}, nil
 	}
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
-	if err := gateway.EnableAutoMerge(context.Background(), EnableAutoMergeInput{Repo: "acme/looper", PRNumber: 42, Strategy: config.ReviewerAutoMergeStrategySquash}); err != nil {
+	if err := gateway.EnableAutoMerge(context.Background(), EnableAutoMergeInput{Repo: "acme/looper", PRNumber: 42, Strategy: config.ReviewerAutoMergeStrategySquash, HeadSHA: "abc123"}); err != nil {
 		t.Fatalf("EnableAutoMerge() error = %v", err)
+	}
+}
+
+func TestGatewayEnableAutoMergeRequiresHeadSHA(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		t.Fatalf("unexpected gh args: %v", options.Args)
+		return shell.Result{}, nil
+	}
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	err := gateway.EnableAutoMerge(context.Background(), EnableAutoMergeInput{Repo: "acme/looper", PRNumber: 42, Strategy: config.ReviewerAutoMergeStrategySquash})
+	if err == nil || err.Error() != "auto-merge head SHA is required" {
+		t.Fatalf("EnableAutoMerge() error = %v, want missing head SHA error", err)
 	}
 }
 

--- a/internal/reviewer/criteria/default_verifier.go
+++ b/internal/reviewer/criteria/default_verifier.go
@@ -1,0 +1,129 @@
+package criteria
+
+import "strings"
+
+type DefaultVerifier struct{}
+
+func NewDefaultVerifier() Verifier { return DefaultVerifier{} }
+
+func (DefaultVerifier) VerifyCriterion(criterion AcceptanceCriterion, diff PRDiff) (CriterionAssessment, error) {
+	added := collectAddedLines(diff)
+	criterionText := strings.ToLower(strings.TrimSpace(string(criterion)))
+	tokens := criterionTokens(criterionText)
+	for _, line := range added {
+		lineLower := strings.ToLower(strings.TrimSpace(line.text))
+		if lineLower == "" {
+			continue
+		}
+		if strings.Contains(lineLower, criterionText) || tokenOverlap(tokens, criterionTokens(lineLower)) {
+			return CriterionAssessment{Verdict: VerdictPass, Justification: "diff contains matching implementation evidence", Evidence: []Evidence{{FilePath: lineFilePath(line), StartLine: lineStart(line), EndLine: lineEnd(line)}}}, nil
+		}
+	}
+	return CriterionAssessment{Verdict: VerdictUnverifiable, Justification: "diff does not contain deterministic evidence matching this criterion"}, nil
+}
+
+type addedLine struct {
+	filePath string
+	line     int
+	text     string
+}
+
+func lineFilePath(line addedLine) string { return line.filePath }
+func lineStart(line addedLine) int       { return line.line }
+func lineEnd(line addedLine) int         { return line.line }
+
+func collectAddedLines(diff PRDiff) []addedLine {
+	lines := []addedLine{}
+	for _, file := range diff.Files {
+		lineNo := 0
+		for _, raw := range strings.Split(file.Patch, "\n") {
+			if strings.HasPrefix(raw, "@@") {
+				lineNo = hunkStart(raw)
+				continue
+			}
+			if strings.HasPrefix(raw, "+") && !strings.HasPrefix(raw, "+++") {
+				lines = append(lines, addedLine{filePath: file.Path, line: max(lineNo, 1), text: raw[1:]})
+				lineNo++
+				continue
+			}
+			if strings.HasPrefix(raw, "-") && !strings.HasPrefix(raw, "---") {
+				continue
+			}
+			if raw != "" {
+				lineNo++
+			}
+		}
+	}
+	return lines
+}
+
+func hunkStart(raw string) int {
+	parts := strings.Split(raw, " ")
+	for _, part := range parts {
+		if !strings.HasPrefix(part, "+") {
+			continue
+		}
+		part = strings.TrimPrefix(part, "+")
+		part = strings.TrimSuffix(part, "@@")
+		if index := strings.Index(part, ","); index >= 0 {
+			part = part[:index]
+		}
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return 0
+		}
+		value := 0
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return value
+			}
+			value = value*10 + int(r-'0')
+		}
+		return value
+	}
+	return 0
+}
+
+func criterionTokens(value string) []string {
+	words := strings.FieldsFunc(value, func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	})
+	tokens := make([]string, 0, len(words))
+	for _, word := range words {
+		if len(word) >= 4 {
+			tokens = append(tokens, word)
+		}
+	}
+	return tokens
+}
+
+func tokenOverlap(a []string, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	set := map[string]struct{}{}
+	for _, token := range a {
+		set[token] = struct{}{}
+	}
+	matches := 0
+	for _, token := range b {
+		if _, ok := set[token]; ok {
+			matches++
+		}
+	}
+	return matches >= min(2, len(a))
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/reviewer/criteria/default_verifier.go
+++ b/internal/reviewer/criteria/default_verifier.go
@@ -98,7 +98,7 @@ func criterionTokens(value string) []string {
 }
 
 func tokenOverlap(a []string, b []string) bool {
-	if len(a) == 0 || len(b) == 0 {
+	if len(a) < 2 || len(b) == 0 {
 		return false
 	}
 	set := map[string]struct{}{}
@@ -109,6 +109,7 @@ func tokenOverlap(a []string, b []string) bool {
 	for _, token := range b {
 		if _, ok := set[token]; ok {
 			matches++
+			delete(set, token)
 		}
 	}
 	return matches >= min(2, len(a))

--- a/internal/reviewer/criteria/default_verifier_test.go
+++ b/internal/reviewer/criteria/default_verifier_test.go
@@ -1,0 +1,48 @@
+package criteria
+
+import "testing"
+
+func TestDefaultVerifierDoesNotPassSingleTokenCriterionOnOverlapAlone(t *testing.T) {
+	t.Parallel()
+
+	assessment, err := NewDefaultVerifier().VerifyCriterion(
+		AcceptanceCriterion("add tests"),
+		PRDiff{Files: []DiffFile{{Path: "app_test.go", Patch: "@@ -1,1 +1,1 @@\n-old\n+table driven tests cover another path\n"}}},
+	)
+	if err != nil {
+		t.Fatalf("VerifyCriterion() error = %v", err)
+	}
+	if assessment.Verdict != VerdictUnverifiable {
+		t.Fatalf("VerifyCriterion().Verdict = %q, want %q", assessment.Verdict, VerdictUnverifiable)
+	}
+}
+
+func TestDefaultVerifierStillPassesExactCriterionTextMatch(t *testing.T) {
+	t.Parallel()
+
+	assessment, err := NewDefaultVerifier().VerifyCriterion(
+		AcceptanceCriterion("add tests"),
+		PRDiff{Files: []DiffFile{{Path: "app_test.go", Patch: "@@ -1,1 +1,1 @@\n-old\n+add tests for reviewer auto-merge\n"}}},
+	)
+	if err != nil {
+		t.Fatalf("VerifyCriterion() error = %v", err)
+	}
+	if assessment.Verdict != VerdictPass {
+		t.Fatalf("VerifyCriterion().Verdict = %q, want %q", assessment.Verdict, VerdictPass)
+	}
+}
+
+func TestDefaultVerifierRequiresDistinctOverlapTokens(t *testing.T) {
+	t.Parallel()
+
+	assessment, err := NewDefaultVerifier().VerifyCriterion(
+		AcceptanceCriterion("update tests docs"),
+		PRDiff{Files: []DiffFile{{Path: "app_test.go", Patch: "@@ -1,1 +1,1 @@\n-old\n+tests tests cover another path\n"}}},
+	)
+	if err != nil {
+		t.Fatalf("VerifyCriterion() error = %v", err)
+	}
+	if assessment.Verdict != VerdictUnverifiable {
+		t.Fatalf("VerifyCriterion().Verdict = %q, want %q", assessment.Verdict, VerdictUnverifiable)
+	}
+}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2995,7 +2995,7 @@ func (r *Runner) publishCriteriaApprovedReview(ctx context.Context, input stepIn
 		return nil, err
 	}
 	if decision.Reason == "" {
-		if err := r.github.EnableAutoMerge(ctx, githubinfra.EnableAutoMergeInput{Repo: input.Repo, PRNumber: input.PRNumber, Strategy: decision.Strategy, CWD: input.Project.RepoPath}); err != nil && !isAlreadyEnabledAutoMergeError(err) {
+		if err := r.github.EnableAutoMerge(ctx, githubinfra.EnableAutoMergeInput{Repo: input.Repo, PRNumber: input.PRNumber, Strategy: decision.Strategy, HeadSHA: pending.HeadSHA, CWD: input.Project.RepoPath}); err != nil && !isAlreadyEnabledAutoMergeError(err) {
 			return nil, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		return &criteriaPublishResult{reviewEvent: marker.Event, marker: marker}, nil
@@ -3025,6 +3025,9 @@ func (r *Runner) resolveLinkedIssueForCriteria(ctx context.Context, input stepIn
 	if ref, ok := parseClosingReference(input.Repo, detail.Body); ok {
 		issue, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: ref.Repo, IssueNumber: ref.Number, CWD: input.Project.RepoPath})
 		if err != nil {
+			if linkedIssueLookupUnavailable(err) {
+				return linkedIssueReference{}, githubinfra.IssueDetail{}, false, nil
+			}
 			return linkedIssueReference{}, githubinfra.IssueDetail{}, false, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		if issue.IsPullRequest {
@@ -3034,6 +3037,17 @@ func (r *Runner) resolveLinkedIssueForCriteria(ctx context.Context, input stepIn
 		return ref, issue, true, nil
 	}
 	return linkedIssueReference{}, githubinfra.IssueDetail{}, false, nil
+}
+
+func linkedIssueLookupUnavailable(err error) bool {
+	if err == nil || githubinfra.IsTransientError(err) {
+		return false
+	}
+	if githubinfra.IsNotFoundError(err) {
+		return true
+	}
+	message := strings.ToLower(githubinfra.ErrorMessage(err))
+	return strings.Contains(message, "resource not accessible") || strings.Contains(message, "http 403") || strings.Contains(message, "http 410")
 }
 
 func (r *Runner) verifyAcceptanceCriteria(rawDiff string, extracted []criteria.AcceptanceCriterion) (criteria.VerificationResult, error) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -28,6 +29,8 @@ import (
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/reviewer/automerge"
+	"github.com/nexu-io/looper/internal/reviewer/criteria"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/version"
 	"github.com/nexu-io/looper/internal/worktreesafety"
@@ -58,6 +61,7 @@ var reviewerStepSequence = []ReviewerStep{
 var reviewMarkerCommentPattern = regexp.MustCompile(`(?is)<!--\s*looper:review\b.*?-->`)
 var reviewHumanHTMLCommentPattern = regexp.MustCompile(`(?s)<!--.*?-->`)
 var reviewHumanReferenceDefinitionPattern = regexp.MustCompile(`(?m)^\s{0,3}\[[^\]\n]+\]:[^\n]*(?:\n[ \t]+[^\n]*)*`)
+var reviewerIssueClosingReferencePattern = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+((?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#\d+)\b`)
 
 const (
 	reviewerNativeResumeMetadataKey      = "reviewerNativeResume"
@@ -335,14 +339,20 @@ type GitHubGateway interface {
 	ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error)
 	GetCurrentUserLogin(context.Context, string) (string, error)
 	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
+	ViewIssue(context.Context, githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error)
 	GetPullRequestHeadSHA(context.Context, ViewPullRequestInput) (string, error)
+	GetRepositorySettings(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error)
+	GetBranchProtection(context.Context, githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error)
 	CapturePullRequestSnapshot(context.Context, CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error)
 	FindReviewMarker(context.Context, VerifyReviewMarkerInput) (ReviewMarkerResult, error)
 	CreateIssueComment(context.Context, IssueCommentInput) (IssueCommentResult, error)
+	SubmitReview(context.Context, githubinfra.SubmitReviewInput) error
+	EnableAutoMerge(context.Context, githubinfra.EnableAutoMergeInput) error
 	AddPullRequestReaction(context.Context, PullRequestReactionInput) error
 	RemovePullRequestReaction(context.Context, PullRequestReactionInput) error
 	AddPullRequestLabels(context.Context, PullRequestLabelsInput) error
 	RemovePullRequestLabels(context.Context, PullRequestLabelsInput) error
+	RemoveIssueLabels(context.Context, githubinfra.IssueLabelsInput) error
 	ListReviewThreads(context.Context, ListReviewThreadsInput) ([]ReviewThread, error)
 	AddReviewThreadReply(context.Context, AddReviewThreadReplyInput) error
 	ResolveReviewThread(context.Context, ResolveReviewThreadInput) error
@@ -423,6 +433,7 @@ type Options struct {
 	ThreadResolution        config.ReviewerThreadResolutionConfig
 	Disclosure              *config.DisclosureConfig
 	CustomInstructions      *config.Config
+	CriteriaVerifier        criteria.Verifier
 	AgentRuntime            string
 	AgentModel              *string
 	LooperCLIPath           string
@@ -466,6 +477,7 @@ type Runner struct {
 	disclosure              config.DisclosureConfig
 	customInstructions      config.Config
 	projectRoleConfig       *config.Config
+	criteriaVerifier        criteria.Verifier
 	agentRuntime            string
 	agentModel              string
 	looperCLIPath           string
@@ -676,6 +688,7 @@ func New(options Options) *Runner {
 		disclosure:              disclosureCfg,
 		customInstructions:      customInstructionConfig(options.CustomInstructions),
 		projectRoleConfig:       options.CustomInstructions,
+		criteriaVerifier:        options.CriteriaVerifier,
 		agentRuntime:            strings.TrimSpace(options.AgentRuntime),
 		agentModel:              derefString(options.AgentModel),
 		looperCLIPath:           normalizeLooperCLIPath(options.LooperCLIPath),
@@ -1047,6 +1060,14 @@ func (r *Runner) discoveryPolicyForProject(projectID string) DiscoveryPolicy {
 	}
 	roles := config.ProjectRoleConfigs(*r.projectRoleConfig, projectID)
 	return DiscoveryPolicy{AutoDiscovery: roles.Reviewer.Discovery.AutoDiscovery, IncludeDrafts: roles.Reviewer.Discovery.Triggers.IncludeDrafts, RequireReviewRequest: roles.Reviewer.Discovery.Triggers.RequireReviewRequest, EnableSelfReview: roles.Reviewer.Discovery.Triggers.EnableSelfReview, Labels: append([]string(nil), roles.Reviewer.Discovery.Triggers.Labels...), LabelMode: roles.Reviewer.Discovery.Triggers.LabelMode, IncludeSpecReviewingLabel: roles.Reviewer.Discovery.SpecReview.IncludeReviewingLabel, SpecReviewingLabel: roles.Reviewer.Discovery.SpecReview.ReviewingLabel}
+}
+
+func (r *Runner) reviewerAutoMergeConfigForProject(projectID string) config.ReviewerAutoMergeConfig {
+	if r.projectRoleConfig == nil {
+		return config.ReviewerAutoMergeConfig{}
+	}
+	roles := config.ProjectRoleConfigs(*r.projectRoleConfig, projectID)
+	return roles.Reviewer.AutoMerge
 }
 
 func isSelfAuthoredPR(author string, currentLogin string, policy DiscoveryPolicy) bool {
@@ -2344,7 +2365,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	if !requireReviewRequest && policy.RequireReviewRequest && reviewerFollowUpHasNewHead(input.Loop, checkpoint.Snapshot.HeadSHA) {
 		reviewRequestBypassReason = "follow_up_new_head"
 	}
-	prompt, instructionBlock := buildReviewPromptWithInstructions(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint, input.Run.ID, idempotencyKey, r.effectiveReviewEvents(input.Loop.MetadataJSON), isManualReviewerLoop(input.Loop), requireReviewRequest, reviewRequestBypassReason, r.scope, r.disclosure, r.agentRuntime, r.agentModel, r.looperCLIPath)
+	prompt, instructionBlock := buildReviewPromptWithInstructions(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint, input.Run.ID, idempotencyKey, r.effectiveReviewEvents(input.Loop.MetadataJSON), isManualReviewerLoop(input.Loop), requireReviewRequest, reviewRequestBypassReason, r.scope, r.disclosure, r.agentRuntime, r.agentModel, r.looperCLIPath, r.reviewerAutoMergeConfigForProject(input.Project.ID).Enabled)
 	nativeResumePrompt := r.nativeResumePromptForReview(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey)
 	metadata := map[string]any{"loopType": "reviewer", "repo": input.Repo, "prNumber": input.PRNumber}
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
@@ -2433,6 +2454,11 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	}
 	if cleanReviewNoopSummary(result.Summary) {
 		policy := r.effectiveReviewEvents(input.Loop.MetadataJSON)
+		if policy.Clean == config.ReviewerReviewEventApprove && r.reviewerAutoMergeConfigForProject(input.Project.ID).Enabled && resolvePullRequestPhase(detailLabels(checkpoint.Detail)) != "spec" {
+			checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, CleanNoop: true}
+			checkpoint.ResumePolicy = "advance_from_checkpoint"
+			return checkpoint, nil
+		}
 		if policy.Clean == config.ReviewerReviewEventApprove {
 			if found, err := r.verifyAgentNativeReviewMarker(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey, cleanReviewAuthorLogin(checkpoint, PullRequestDetail{})); err != nil {
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
@@ -2491,6 +2517,14 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 				checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", input.Repo, input.PRNumber)
 				return checkpoint, nil
 			}
+		}
+		if criteriaResult, err := r.maybePublishCriteriaAnchoredCleanReview(ctx, input, checkpoint, pending, detail); err != nil {
+			return checkpoint, err
+		} else if criteriaResult != nil {
+			if err := r.recordPublishedReviewProgress(ctx, input, pending, criteriaResult.reviewEvent); err != nil {
+				return checkpoint, err
+			}
+			return checkpoint, nil
 		}
 		if r.effectiveReviewEvents(input.Loop.MetadataJSON).Clean == config.ReviewerReviewEventApprove {
 			found, err := r.verifyAgentNativeReviewMarker(ctx, input, pending.HeadSHA, pending.IdempotencyKey, cleanReviewAuthorLogin(checkpoint, detail))
@@ -2873,6 +2907,412 @@ func (r *Runner) applyCleanSpecLabelTransition(ctx context.Context, input stepIn
 		}
 	}
 	return nil
+}
+
+type linkedIssueReference struct {
+	Repo    string
+	Number  int64
+	Tracked bool
+}
+
+type criteriaPublishResult struct {
+	reviewEvent ReviewEvent
+	marker      ReviewMarkerResult
+	recordOnly  bool
+}
+
+const (
+	criteriaFailCommentMarker     = "<!-- looper:reviewer:criteria-fail -->"
+	autoMergeRefusedCommentMarker = "<!-- looper:reviewer:automerge-refused -->"
+	criteriaVerificationHeading   = "### Acceptance criteria verification"
+)
+
+func (r *Runner) maybePublishCriteriaAnchoredCleanReview(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, pending pendingReviewCheckpoint, detail PullRequestDetail) (*criteriaPublishResult, error) {
+	if resolvePullRequestPhase(detail.Labels) == "spec" {
+		return nil, nil
+	}
+	if r.effectiveReviewEvents(input.Loop.MetadataJSON).Clean != config.ReviewerReviewEventApprove {
+		return nil, nil
+	}
+	autoMergeCfg := r.reviewerAutoMergeConfigForProject(input.Project.ID)
+	if !autoMergeCfg.Enabled {
+		return nil, nil
+	}
+	issueRef, issue, ok, err := r.resolveLinkedIssueForCriteria(ctx, input, detail)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return r.publishCleanReviewWithoutCriteria(ctx, input, checkpoint, pending, detail)
+	}
+	extracted := criteria.Extract(issue.Body)
+	if len(extracted) == 0 {
+		return r.publishCleanReviewWithoutCriteria(ctx, input, checkpoint, pending, detail)
+	}
+	verification, err := r.verifyAcceptanceCriteria(criteriaVerificationDiff(checkpoint, detail), extracted)
+	if err != nil {
+		return nil, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if verification.Disposition != criteria.DispositionPass {
+		return r.publishCriteriaFailureReview(ctx, input, detail, pending, issueRef, issue, verification)
+	}
+	return r.publishCriteriaApprovedReview(ctx, input, checkpoint, pending, detail, autoMergeCfg, issueRef, verification)
+}
+
+func (r *Runner) publishCleanReviewWithoutCriteria(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, pending pendingReviewCheckpoint, detail PullRequestDetail) (*criteriaPublishResult, error) {
+	policy := r.effectiveReviewEvents(input.Loop.MetadataJSON)
+	if policy.Clean != config.ReviewerReviewEventApprove {
+		if err := r.applyCleanNoopReviewSideEffects(ctx, input, checkpoint, detail); err != nil {
+			return nil, err
+		}
+		return &criteriaPublishResult{reviewEvent: ReviewEventComment, recordOnly: true}, nil
+	}
+	body := stampReviewBody(r.disclosure, buildCleanApprovalBody(cleanReviewAuthorLogin(checkpoint, detail), criteriaVerificationHeading, nil, "No explicit acceptance criteria were stated on the linked issue, so this review follows the standard clean-review path."), "reviewer")
+	marker, err := r.submitOrReuseReview(ctx, input, detail, pending, ReviewEventApprove, "clean", body)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.applyVerifiedReviewSideEffects(ctx, input, checkpoint, detail, marker); err != nil {
+		return nil, err
+	}
+	return &criteriaPublishResult{reviewEvent: marker.Event, marker: marker}, nil
+}
+
+func (r *Runner) publishCriteriaApprovedReview(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, pending pendingReviewCheckpoint, detail PullRequestDetail, autoMergeCfg config.ReviewerAutoMergeConfig, issueRef linkedIssueReference, verification criteria.VerificationResult) (*criteriaPublishResult, error) {
+	body := stampReviewBody(r.disclosure, buildCleanApprovalBody(cleanReviewAuthorLogin(checkpoint, detail), criteriaVerificationHeading, verification.Criteria, "I verified each stated acceptance criterion against the current PR diff before approving."), "reviewer")
+	marker, err := r.submitOrReuseReview(ctx, input, detail, pending, ReviewEventApprove, "clean", body)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.applyVerifiedReviewSideEffects(ctx, input, checkpoint, detail, marker); err != nil {
+		return nil, err
+	}
+	if marker.Event != ReviewEventApprove {
+		return &criteriaPublishResult{reviewEvent: marker.Event, marker: marker}, nil
+	}
+	decision, err := r.decideAutoMerge(ctx, input, detail, autoMergeCfg, issueRef)
+	if err != nil {
+		return nil, err
+	}
+	if decision.Reason == "" {
+		if err := r.github.EnableAutoMerge(ctx, githubinfra.EnableAutoMergeInput{Repo: input.Repo, PRNumber: input.PRNumber, Strategy: decision.Strategy, CWD: input.Project.RepoPath}); err != nil && !isAlreadyEnabledAutoMergeError(err) {
+			return nil, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
+		return &criteriaPublishResult{reviewEvent: marker.Event, marker: marker}, nil
+	}
+	if err := r.postStampedPRCommentIfMissing(ctx, input, detail, autoMergeRefusedCommentMarker, fmt.Sprintf("Auto-merge opt-in was refused for this PR: %s.", decision.Reason)); err != nil {
+		return nil, err
+	}
+	return &criteriaPublishResult{reviewEvent: marker.Event, marker: marker}, nil
+}
+
+func (r *Runner) publishCriteriaFailureReview(ctx context.Context, input stepInput, detail PullRequestDetail, pending pendingReviewCheckpoint, issueRef linkedIssueReference, issue githubinfra.IssueDetail, verification criteria.VerificationResult) (*criteriaPublishResult, error) {
+	body := stampReviewBody(r.disclosure, buildCriteriaFailureBody(verification.Criteria), "reviewer")
+	marker, err := r.submitOrReuseReview(ctx, input, detail, pending, ReviewEventComment, "non_blocking", body)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.github.RemoveIssueLabels(ctx, githubinfra.IssueLabelsInput{Repo: issueRef.Repo, IssueNumber: issueRef.Number, Labels: criteriaFailureLabels(issue.Labels), CWD: input.Project.RepoPath}); err != nil {
+		return nil, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if err := r.github.RemovePullRequestReaction(ctx, PullRequestReactionInput{Repo: input.Repo, PRNumber: input.PRNumber, Content: "+1", CWD: input.Project.RepoPath}); err != nil {
+		return nil, &loopError{message: fmt.Sprintf("Failed to remove stale clean-review reaction before marking publish success: %v", err), kind: FailureRetryableAfterResume}
+	}
+	return &criteriaPublishResult{reviewEvent: ReviewEventComment, marker: marker}, nil
+}
+
+func (r *Runner) resolveLinkedIssueForCriteria(ctx context.Context, input stepInput, detail PullRequestDetail) (linkedIssueReference, githubinfra.IssueDetail, bool, error) {
+	if ref, ok := parseClosingReference(input.Repo, detail.Body); ok {
+		issue, err := r.github.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: ref.Repo, IssueNumber: ref.Number, CWD: input.Project.RepoPath})
+		if err != nil {
+			return linkedIssueReference{}, githubinfra.IssueDetail{}, false, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
+		if issue.IsPullRequest {
+			return linkedIssueReference{}, githubinfra.IssueDetail{}, false, nil
+		}
+		ref.Tracked = issueHasCoordinatorTracking(issue.Labels)
+		return ref, issue, true, nil
+	}
+	return linkedIssueReference{}, githubinfra.IssueDetail{}, false, nil
+}
+
+func (r *Runner) verifyAcceptanceCriteria(rawDiff string, extracted []criteria.AcceptanceCriterion) (criteria.VerificationResult, error) {
+	verifier := r.criteriaVerifier
+	if verifier == nil {
+		verifier = criteria.NewDefaultVerifier()
+	}
+	return criteria.Verify(extracted, parseCriteriaPRDiff(rawDiff), verifier)
+}
+
+func (r *Runner) decideAutoMerge(ctx context.Context, input stepInput, detail PullRequestDetail, autoMergeCfg config.ReviewerAutoMergeConfig, issueRef linkedIssueReference) (automerge.AutoMergeDecision, error) {
+	settings, err := r.github.GetRepositorySettings(ctx, githubinfra.RepositorySettingsInput{Repo: input.Repo, CWD: input.Project.RepoPath})
+	if err != nil {
+		return automerge.AutoMergeDecision{}, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	protection := githubinfra.BranchProtection{}
+	if autoMergeCfg.RequireBranchProtection {
+		protection, err = r.github.GetBranchProtection(ctx, githubinfra.BranchProtectionInput{Repo: input.Repo, Branch: firstNonEmpty(detail.BaseRefName, "main"), CWD: input.Project.RepoPath})
+		if err != nil {
+			return automerge.AutoMergeDecision{}, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
+	}
+	return automerge.Decide(
+		automerge.PRSnapshot{Labels: append([]string(nil), detail.Labels...), HasTrackedIssueLink: issueRef.Tracked},
+		autoMergeCfg,
+		automerge.BranchProtectionSnapshot{Exists: protection.Enabled, HasRequiredChecks: protection.HasRequiredChecks},
+		automerge.RepoSettingsSnapshot{AllowSquashMerge: settings.AllowSquashMerge, AllowMergeCommit: settings.AllowMergeCommit, AllowRebaseMerge: settings.AllowRebaseMerge, AllowAutoMerge: settings.AllowAutoMerge},
+	), nil
+}
+
+func (r *Runner) submitOrReuseReview(ctx context.Context, input stepInput, detail PullRequestDetail, pending pendingReviewCheckpoint, event ReviewEvent, outcome string, body string) (ReviewMarkerResult, error) {
+	body = appendReviewMarker(body, agentNativeReviewMarker(input.Loop.ID, pending.HeadSHA, pending.IdempotencyKey), outcome)
+	currentLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+	if err != nil {
+		return ReviewMarkerResult{}, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	selfApprovalFallback := event == ReviewEventApprove && sameReviewAuthorLogin(detail.Author, currentLogin)
+	found, err := r.verifyAgentNativeReviewMarker(ctx, input, pending.HeadSHA, pending.IdempotencyKey, cleanReviewAuthorLogin(reviewerCheckpoint{Detail: checkpointDetailFromDetail(detail)}, detail))
+	if err != nil {
+		return ReviewMarkerResult{}, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if found.Found && strings.EqualFold(strings.TrimSpace(found.Outcome), strings.TrimSpace(outcome)) && (found.Event == event || (selfApprovalFallback && found.Event == ReviewEventComment)) {
+		return found, nil
+	}
+	submitEvent := event
+	if selfApprovalFallback {
+		submitEvent = ReviewEventComment
+	}
+	if err := r.github.SubmitReview(ctx, githubinfra.SubmitReviewInput{Repo: input.Repo, PRNumber: input.PRNumber, Event: string(submitEvent), Body: body, CommitID: pending.HeadSHA, Disclosure: r.disclosure, CWD: input.Project.RepoPath}); err != nil {
+		return ReviewMarkerResult{}, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	marker, err := r.verifyAgentNativeReviewMarker(ctx, input, pending.HeadSHA, pending.IdempotencyKey, cleanReviewAuthorLogin(reviewerCheckpoint{Detail: checkpointDetailFromDetail(detail)}, detail))
+	if err != nil {
+		return ReviewMarkerResult{}, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if !marker.Found || !strings.EqualFold(strings.TrimSpace(marker.Outcome), strings.TrimSpace(outcome)) || (marker.Event != submitEvent && !(submitEvent == ReviewEventComment && event == ReviewEventApprove && sameReviewAuthorLogin(detail.Author, currentLogin))) {
+		return ReviewMarkerResult{}, &loopError{message: fmt.Sprintf("Reviewer submitted %s review for outcome=%s but could not verify the idempotency marker", submitEvent, outcome), kind: FailureRetryableAfterResume}
+	}
+	return marker, nil
+}
+
+func appendReviewMarker(body string, marker string, outcome string) string {
+	if strings.Contains(body, marker) {
+		return body
+	}
+	markerBody := fmt.Sprintf("<!-- %s outcome=%s -->", strings.TrimSpace(marker), strings.TrimSpace(outcome))
+	trimmed := strings.TrimRight(body, "\n")
+	if trimmed == "" {
+		return markerBody
+	}
+	return trimmed + "\n\n" + markerBody
+}
+
+func (r *Runner) postStampedPRCommentIfMissing(ctx context.Context, input stepInput, detail PullRequestDetail, marker string, visible string) error {
+	if stampedCommentAlreadyPosted(detail.IssueComments, marker) {
+		return nil
+	}
+	body := stampIssueComment(r.disclosure, visible+"\n\n"+marker, "reviewer")
+	if _, err := r.github.CreateIssueComment(ctx, IssueCommentInput{Repo: input.Repo, IssueNumber: input.PRNumber, Body: body, CWD: input.Project.RepoPath}); err != nil {
+		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	return nil
+}
+
+func stampedCommentAlreadyPosted(comments []map[string]any, marker string) bool {
+	if marker == "" {
+		return false
+	}
+	for _, comment := range comments {
+		body, _ := stringFromAny(comment["body"])
+		if strings.Contains(body, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCriteriaPRDiff(raw string) criteria.PRDiff {
+	files := []criteria.DiffFile{}
+	var current *criteria.DiffFile
+	for _, line := range strings.Split(raw, "\n") {
+		if strings.HasPrefix(line, "diff --git ") {
+			if current != nil {
+				files = append(files, *current)
+			}
+			path := parseDiffFilePath(line)
+			current = &criteria.DiffFile{Path: path}
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		if current.Patch == "" {
+			current.Patch = line
+		} else {
+			current.Patch += "\n" + line
+		}
+	}
+	if current != nil {
+		files = append(files, *current)
+	}
+	return criteria.PRDiff{Files: files}
+}
+
+func criteriaVerificationDiff(checkpoint reviewerCheckpoint, detail PullRequestDetail) string {
+	if strings.TrimSpace(detail.Diff) != "" {
+		return detail.Diff
+	}
+	if checkpoint.Snapshot == nil || strings.TrimSpace(checkpoint.Snapshot.PayloadJSON) == "" {
+		return ""
+	}
+	payload := parseJSONObject(&checkpoint.Snapshot.PayloadJSON)
+	if diff, ok := payload["diff"].(string); ok {
+		return diff
+	}
+	return ""
+}
+
+func parseDiffFilePath(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) < 4 {
+		return ""
+	}
+	path := strings.TrimPrefix(fields[3], "b/")
+	if path == fields[3] {
+		path = strings.TrimPrefix(fields[2], "a/")
+	}
+	return strings.Trim(path, `"`)
+}
+
+func parseClosingReference(defaultRepo, body string) (linkedIssueReference, bool) {
+	match := reviewerIssueClosingReferencePattern.FindStringSubmatch(body)
+	if len(match) != 2 {
+		return linkedIssueReference{}, false
+	}
+	reference := strings.TrimSpace(match[1])
+	repo, number, ok := splitIssueReference(defaultRepo, reference)
+	if !ok {
+		return linkedIssueReference{}, false
+	}
+	return linkedIssueReference{Repo: repo, Number: number}, true
+}
+
+func splitIssueReference(defaultRepo, reference string) (string, int64, bool) {
+	parts := strings.Split(reference, "#")
+	if len(parts) != 2 {
+		return "", 0, false
+	}
+	number, err := parseInt64(strings.TrimSpace(parts[1]))
+	if err != nil || number <= 0 {
+		return "", 0, false
+	}
+	repo := strings.TrimSpace(parts[0])
+	if repo == "" {
+		repo = strings.TrimSpace(defaultRepo)
+	}
+	if repo == "" {
+		return "", 0, false
+	}
+	return repo, number, true
+}
+
+func parseInt64(raw string) (int64, error) {
+	return strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+}
+
+func buildCleanApprovalBody(authorLogin string, heading string, results []criteria.CriterionResult, intro string) string {
+	parts := []string{fmt.Sprintf("%s Thanks for the update — I reviewed the current PR head and it's ready to move forward.", cleanReviewAuthorMention(authorLogin))}
+	if strings.TrimSpace(intro) != "" {
+		parts = append(parts, intro)
+	}
+	if heading != "" {
+		parts = append(parts, heading, formatCriteriaResults(results, true))
+	}
+	parts = append(parts, "Happy to see this tightened up — nice work.")
+	return strings.Join(parts, "\n\n")
+}
+
+func buildCriteriaFailureBody(results []criteria.CriterionResult) string {
+	return strings.Join([]string{"Acceptance criteria could not be fully verified for this PR head.", criteriaVerificationHeading, formatCriteriaResults(results, false), criteriaFailCommentMarker}, "\n\n")
+}
+
+func formatCriteriaResults(results []criteria.CriterionResult, includeOnlyPass bool) string {
+	if len(results) == 0 {
+		if includeOnlyPass {
+			return "- No explicit acceptance criteria were available to verify."
+		}
+		return "- No acceptance criteria results were recorded."
+	}
+	lines := make([]string, 0, len(results))
+	for _, result := range results {
+		if includeOnlyPass && result.Verdict != criteria.VerdictPass {
+			continue
+		}
+		line := fmt.Sprintf("- **%s** — %s", result.Criterion, strings.ToUpper(string(result.Verdict)))
+		if pointers := formatEvidencePointers(result.Evidence); pointers != "" {
+			line += " (" + pointers + ")"
+		}
+		if justification := strings.TrimSpace(result.Justification); justification != "" {
+			line += ": " + justification
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) == 0 && includeOnlyPass {
+		return "- No passing acceptance criteria were recorded."
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatEvidencePointers(evidence []criteria.Evidence) string {
+	parts := make([]string, 0, len(evidence))
+	for _, entry := range evidence {
+		if entry.FilePath == "" || entry.StartLine < 1 {
+			continue
+		}
+		if entry.EndLine > entry.StartLine {
+			parts = append(parts, fmt.Sprintf("%s:%d-%d", entry.FilePath, entry.StartLine, entry.EndLine))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s:%d", entry.FilePath, entry.StartLine))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func criteriaFailureLabels(labels []string) []string {
+	toRemove := []string{}
+	for _, label := range labels {
+		normalized := strings.ToLower(strings.TrimSpace(label))
+		if normalized == "triaged" || strings.HasPrefix(normalized, "dispatch/") {
+			toRemove = append(toRemove, label)
+		}
+	}
+	return toRemove
+}
+
+func issueHasCoordinatorTracking(labels []string) bool {
+	for _, label := range labels {
+		normalized := strings.ToLower(strings.TrimSpace(label))
+		if normalized == "triaged" || strings.HasPrefix(normalized, "dispatch/") {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlreadyEnabledAutoMergeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "auto-merge is already enabled") || strings.Contains(message, "already enabled for this pull request")
+}
+
+func stampReviewBody(cfg config.DisclosureConfig, body string, runner string) string {
+	return disclosure.Stamper{Config: cfg, Version: version.Current().Version}.Markdown(body, runner, disclosure.ChannelReviewComment)
+}
+
+func stampIssueComment(cfg config.DisclosureConfig, body string, runner string) string {
+	return disclosure.Stamper{Config: cfg, Version: version.Current().Version}.Markdown(body, runner, disclosure.ChannelIssueComment)
 }
 
 func cleanReviewNoopSummary(summary string) bool {
@@ -4672,7 +5112,7 @@ func buildPullRequestLockKey(item storage.QueueItemRecord) string {
 func buildReviewPrompt(repo string, prNumber int64, checkpoint reviewerCheckpoint, runID string, idempotencyKey string, reviewEvents config.ReviewerReviewEventsConfig, manual bool, scope config.ReviewerScope, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string, looperCLIPath string) string {
 	cfg, _ := config.Normalize("")
 	cfg.Instructions.Enabled = false
-	prompt, _ := buildReviewPromptWithInstructions("", cfg, repo, prNumber, checkpoint, runID, idempotencyKey, reviewEvents, manual, true, "", scope, disclosureCfg, agentRuntime, agentModel, looperCLIPath)
+	prompt, _ := buildReviewPromptWithInstructions("", cfg, repo, prNumber, checkpoint, runID, idempotencyKey, reviewEvents, manual, true, "", scope, disclosureCfg, agentRuntime, agentModel, looperCLIPath, false)
 	return prompt
 }
 
@@ -4744,7 +5184,7 @@ func reviewerAgentSideGitHubFetchContract() string {
 	}, "\n")
 }
 
-func buildReviewPromptWithInstructions(projectID string, instructionConfig config.Config, repo string, prNumber int64, checkpoint reviewerCheckpoint, runID string, idempotencyKey string, reviewEvents config.ReviewerReviewEventsConfig, manual bool, requireReviewRequest bool, reviewRequestBypassReason string, scope config.ReviewerScope, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string, looperCLIPath string) (string, config.CustomInstructionBlock) {
+func buildReviewPromptWithInstructions(projectID string, instructionConfig config.Config, repo string, prNumber int64, checkpoint reviewerCheckpoint, runID string, idempotencyKey string, reviewEvents config.ReviewerReviewEventsConfig, manual bool, requireReviewRequest bool, reviewRequestBypassReason string, scope config.ReviewerScope, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string, looperCLIPath string, autoMergeEnabled bool) (string, config.CustomInstructionBlock) {
 	looperCLIPath = normalizeLooperCLIPath(looperCLIPath)
 	looperCLICommand := shellQuote(looperCLIPath)
 	phase := resolvePullRequestPhase(detailLabels(checkpoint.Detail))
@@ -4785,6 +5225,9 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	cleanReviewAuthorMention := cleanReviewAuthorTarget(checkpoint)
 	cleanNoopInstruction := "For no-actionable-finding results when the clean review policy is COMMENT, do not submit a clean COMMENT or APPROVE review; finish successfully with the `No actionable findings` summary only. After Looper validates that no clean review marker was required for this run, the runner will reconcile the clean-signal +1 reaction."
 	cleanInstruction := cleanNoopInstruction
+	if autoMergeEnabled && phase != "spec" {
+		cleanInstruction = "For no-actionable-finding results on this implementation PR, do not submit a clean GitHub review yourself. Finish successfully with a summary beginning `No actionable findings`; the runner will verify the linked issue's acceptance criteria and decide whether to publish APPROVE, COMMENT, or no clean review."
+	}
 	if looperCLIPath == "" {
 		cleanInstruction = "For no-actionable-finding results, do not use the clean COMMENT no-op path and do not finish successfully because the trusted review-submit wrapper is unavailable; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
 	}
@@ -4792,7 +5235,7 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	specLabelInstruction := "Do not transition spec-review labels yourself. Looper may transition spec-review labels only after it validates a matching APPROVED clean review marker for the current head."
 	policyFlags := fmt.Sprintf("--clean-review-event %s --blocking-review-event %s", reviewEvents.Clean, reviewEvents.Blocking)
 	actionableReviewSubmitCommand := fmt.Sprintf("`%s review submit %s#%d --event COMMENT --commit-id %s %s`", looperCLICommand, repo, prNumber, snapshotHeadSHA(checkpoint), policyFlags)
-	if reviewEvents.Clean == config.ReviewerReviewEventApprove && looperCLIPath != "" {
+	if reviewEvents.Clean == config.ReviewerReviewEventApprove && looperCLIPath != "" && !(autoMergeEnabled && phase != "spec") {
 		cleanInstruction = fmt.Sprintf("For no-actionable-finding results when the clean review policy is APPROVE, submit exactly one APPROVE review through the trusted Looper CLI wrapper with `outcome=clean`, no inline `comments`, and no extra PR conversation comment: `%s review submit %s#%d --event APPROVE --commit-id %s %s`. The APPROVE review body must not be empty or disclosure-only: the visible body must start with `%s`, briefly summarize what changed or what you verified, and include a warm, friendly, encouraging acknowledgement of the author's work. Then include exactly one clean review marker and any required Looper disclosure. Do not use a bare LGTM or marker/disclosure-only body; the wrapper rejects clean APPROVE reviews that do not start with an @mention or lack enough human-written summary text. If the authenticated GitHub user authored the pull request, the wrapper will downgrade the submission to a COMMENT because GitHub rejects self-approval. After Looper validates the matching APPROVED clean review marker, or the self-authored clean COMMENT fallback, the runner will reconcile the clean-signal +1 reaction and any eligible spec label transition.", looperCLICommand, repo, prNumber, snapshotHeadSHA(checkpoint), policyFlags, cleanReviewAuthorMention)
 		specLabelInstruction = "Do not transition spec-review labels yourself. Looper may transition spec-review labels only after a new matching APPROVED clean review is validated for this head, or when idempotency finds an existing matching APPROVED clean review for this head."
 	}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3059,6 +3059,15 @@ func (r *Runner) verifyAcceptanceCriteria(rawDiff string, extracted []criteria.A
 }
 
 func (r *Runner) decideAutoMerge(ctx context.Context, input stepInput, detail PullRequestDetail, autoMergeCfg config.ReviewerAutoMergeConfig, issueRef linkedIssueReference) (automerge.AutoMergeDecision, error) {
+	decision := automerge.Decide(
+		automerge.PRSnapshot{Labels: append([]string(nil), detail.Labels...), HasTrackedIssueLink: issueRef.Tracked},
+		autoMergeCfg,
+		automerge.BranchProtectionSnapshot{},
+		automerge.RepoSettingsSnapshot{},
+	)
+	if decision.Reason == automerge.RefusalReasonDisabled || decision.Reason == automerge.RefusalReasonScope {
+		return decision, nil
+	}
 	settings, err := r.github.GetRepositorySettings(ctx, githubinfra.RepositorySettingsInput{Repo: input.Repo, CWD: input.Project.RepoPath})
 	if err != nil {
 		return automerge.AutoMergeDecision{}, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}

--- a/internal/reviewer/runner_integration_test.go
+++ b/internal/reviewer/runner_integration_test.go
@@ -1,0 +1,290 @@
+package reviewer
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/e2e/harness"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/reviewer/criteria"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestReviewerAutoMergeHappyPathWithFakeGH(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	fakeGH := harness.NewFakeGH(t, bins, harness.GHSchema{JSONFieldAllowlist: map[string][]string{"pr view": {"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "authorAssociation", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}}})
+	for key, value := range fakeGH.EnvMap() {
+		t.Setenv(key, value)
+	}
+	fakeGH.WriteState(t, harness.GHState{
+		Commands: map[string]any{"pr diff": map[string]any{"stdout": json.RawMessage(`"diff --git a/app.go b/app.go\n@@ -1,1 +1,2 @@\n-old\n+new\n+more\n"`)}},
+		Routes: map[string]any{
+			"repos/acme/looper/issues/358":               json.RawMessage(`{"number":358,"title":"Auto merge","body":"## Acceptance criteria\n- ship app change\n- add more\n","html_url":"https://example.test/issues/358","state":"open","created_at":"2026-05-14T12:00:00Z","updated_at":"2026-05-14T12:00:00Z","user":{"login":"octo"},"labels":[{"name":"triaged"},{"name":"dispatch/plan"}]}`),
+			"repos/acme/looper":                          json.RawMessage(`{"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"allow_auto_merge":true}`),
+			"repos/acme/looper/branches/main/protection": json.RawMessage(`{"required_status_checks":{"contexts":["ci"]}}`),
+		},
+		CurrentUserLogin: "reviewer",
+		PullRequests: map[string]harness.GHPullRequest{
+			"acme/looper#42": {Number: 42, Repo: "acme/looper", Title: "Review me", Body: "Implements feature.\n\nCloses #358", State: "OPEN", Labels: []string{"looper:worker-ready"}, HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", BaseSHA: "base123", Author: "octocat", ReviewRequests: []string{"reviewer"}},
+		},
+	})
+
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	repoPath := t.TempDir()
+	baseBranch := "main"
+	if err := fixture.repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: repoPath, BaseBranch: &baseBranch, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	github := reviewerIntegrationGatewayAdapter{Gateway: githubinfra.New(githubinfra.Options{GHPath: fakeGH.Path, CWD: repoPath, Now: fixture.now})}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings"}`, ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ReviewEvents: config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove}, LoopConfig: testReviewerLoopConfig(), CustomInstructions: reviewerAutoMergeTestConfig(t), CriteriaVerifier: stubCriteriaVerifier{responses: map[criteria.AcceptanceCriterion]criteria.CriterionAssessment{
+		"ship app change": {Verdict: criteria.VerdictPass, Justification: "present in diff", Evidence: []criteria.Evidence{{FilePath: "app.go", StartLine: 1, EndLine: 2}}},
+		"add more":        {Verdict: criteria.VerdictPass, Justification: "present in diff", Evidence: []criteria.Evidence{{FilePath: "app.go", StartLine: 2, EndLine: 2}}},
+	}}})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"followUpdates":true,"loop":{"enabled":true}}`
+	loop := storage.LoopRecord{ID: "loop_fakegh_auto_merge_pass", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue, err := runner.enqueue(ctx, enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queue item %s", claimed, err, queue.ID)
+	}
+	result, err := runner.ProcessClaimedItem(ctx, *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	logBytes, err := os.ReadFile(fakeGH.InvocationLog)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation log) error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v\ninvocations:\n%s", result, string(logBytes))
+	}
+	assertOrderedText(t, string(logBytes),
+		`"argv":["api","repos/acme/looper/pulls/42/reviews","--method","POST","--input","-","--include"]`,
+		`"argv":["pr","merge","42","--repo","acme/looper","--auto","--squash"]`,
+	)
+	if !strings.Contains(string(logBytes), criteriaVerificationHeading) {
+		t.Fatalf("invocation log missing criteria verification heading:\n%s", string(logBytes))
+	}
+}
+
+func TestReviewerAutoMergeCriteriaFailWithFakeGH(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	fakeGH := harness.NewFakeGH(t, bins, harness.GHSchema{JSONFieldAllowlist: map[string][]string{"pr view": {"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "authorAssociation", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}}})
+	for key, value := range fakeGH.EnvMap() {
+		t.Setenv(key, value)
+	}
+	fakeGH.WriteState(t, harness.GHState{
+		Commands: map[string]any{"pr diff": map[string]any{"stdout": json.RawMessage(`"diff --git a/app.go b/app.go\n@@ -1,1 +1,1 @@\n-old\n+new\n"`)}},
+		Routes: map[string]any{
+			"repos/acme/looper/issues/358": json.RawMessage(`{"number":358,"title":"Auto merge","body":"## Acceptance criteria\n- ship app change\n- add tests\n","html_url":"https://example.test/issues/358","state":"open","created_at":"2026-05-14T12:00:00Z","updated_at":"2026-05-14T12:00:00Z","user":{"login":"octo"},"labels":[{"name":"triaged"},{"name":"dispatch/plan"}]}`),
+		},
+		CurrentUserLogin: "reviewer",
+		PullRequests: map[string]harness.GHPullRequest{
+			"acme/looper#42": {Number: 42, Repo: "acme/looper", Title: "Review me", Body: "Implements feature.\n\nCloses #358", State: "OPEN", Labels: []string{"looper:worker-ready"}, HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", BaseSHA: "base123", Author: "octocat", ReviewRequests: []string{"reviewer"}},
+		},
+	})
+
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	repoPath := t.TempDir()
+	baseBranch := "main"
+	if err := fixture.repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: repoPath, BaseBranch: &baseBranch, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	github := reviewerIntegrationGatewayAdapter{Gateway: githubinfra.New(githubinfra.Options{GHPath: fakeGH.Path, CWD: repoPath, Now: fixture.now})}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings"}`, ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ReviewEvents: config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove}, LoopConfig: testReviewerLoopConfig(), CustomInstructions: reviewerAutoMergeTestConfig(t), CriteriaVerifier: stubCriteriaVerifier{responses: map[criteria.AcceptanceCriterion]criteria.CriterionAssessment{
+		"ship app change": {Verdict: criteria.VerdictPass, Justification: "present in diff", Evidence: []criteria.Evidence{{FilePath: "app.go", StartLine: 1, EndLine: 1}}},
+		"add tests":       {Verdict: criteria.VerdictFail, Justification: "no test change in diff"},
+	}}})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"followUpdates":true,"loop":{"enabled":true}}`
+	loop := storage.LoopRecord{ID: "loop_fakegh_auto_merge_fail", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue, err := runner.enqueue(ctx, enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queue item %s", claimed, err, queue.ID)
+	}
+	result, err := runner.ProcessClaimedItem(ctx, *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	logBytes, err := os.ReadFile(fakeGH.InvocationLog)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation log) error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v\ninvocations:\n%s", result, string(logBytes))
+	}
+	assertOrderedText(t, string(logBytes),
+		`"argv":["api","repos/acme/looper/pulls/42/reviews","--method","POST","--input","-","--include"]`,
+		`"argv":["api","repos/acme/looper/issues/358/labels/triaged","--method","DELETE"]`,
+		`"argv":["api","repos/acme/looper/issues/358/labels/dispatch%2Fplan","--method","DELETE"]`,
+	)
+	if strings.Contains(string(logBytes), `"argv":["pr","merge","42"`) {
+		t.Fatalf("criteria-fail path unexpectedly enabled auto-merge:\n%s", string(logBytes))
+	}
+	if !strings.Contains(string(logBytes), criteriaFailCommentMarker) && !strings.Contains(string(logBytes), "criteria-fail") {
+		t.Fatalf("invocation log missing criteria-fail marker:\n%s", string(logBytes))
+	}
+}
+
+func assertOrderedText(t *testing.T, text string, parts ...string) {
+	t.Helper()
+	index := 0
+	for _, part := range parts {
+		next := strings.Index(text[index:], part)
+		if next < 0 {
+			t.Fatalf("missing ordered text %q in:\n%s", part, text)
+		}
+		index += next + len(part)
+	}
+}
+
+type reviewerIntegrationGatewayAdapter struct{ *githubinfra.Gateway }
+
+func (a reviewerIntegrationGatewayAdapter) ListOpenPullRequests(ctx context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
+	prs, err := a.Gateway.ListOpenPullRequests(ctx, githubinfra.ListOpenPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: input.Limit, Label: input.Label, Labels: input.Labels})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PullRequestSummary, 0, len(prs))
+	for _, pr := range prs {
+		out = append(out, PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: pr.ReviewDecision, Labels: append([]string(nil), pr.Labels...), HeadSHA: pr.HeadSHA, BaseSHA: pr.BaseSHA, HasConflicts: pr.HasConflicts, Author: pr.Author, ReviewRequests: append([]string(nil), pr.ReviewRequests...), Reviews: pr.Reviews})
+	}
+	return out, nil
+}
+
+func (a reviewerIntegrationGatewayAdapter) GetCurrentUserLogin(ctx context.Context, cwd string) (string, error) {
+	return a.Gateway.GetCurrentUserLogin(ctx, cwd)
+}
+
+func (a reviewerIntegrationGatewayAdapter) ViewPullRequest(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
+	detail, err := a.Gateway.ViewPullRequest(ctx, githubinfra.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
+	if err != nil {
+		return PullRequestDetail{}, err
+	}
+	diff, _ := a.Gateway.GetPullRequestDiff(ctx, githubinfra.GetPullRequestDiffInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
+	issueComments := make([]map[string]any, 0, len(detail.IssueComments))
+	for _, comment := range detail.IssueComments {
+		issueComments = append(issueComments, map[string]any{"body": comment.Body})
+	}
+	return PullRequestDetail{Number: detail.Number, Title: detail.Title, Body: detail.Body, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: append([]string(nil), detail.Labels...), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, Author: detail.Author, ReviewRequests: append([]string(nil), detail.ReviewRequests...), HasConflicts: detail.HasConflicts, Diff: diff, Comments: detail.Comments, IssueComments: issueComments, Reviews: detail.Reviews}, nil
+}
+
+func (a reviewerIntegrationGatewayAdapter) GetPullRequestHeadSHA(ctx context.Context, input ViewPullRequestInput) (string, error) {
+	return a.Gateway.GetPullRequestHeadSHA(ctx, githubinfra.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
+}
+
+func (a reviewerIntegrationGatewayAdapter) ViewIssue(ctx context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
+	return a.Gateway.ViewIssue(ctx, input)
+}
+
+func (a reviewerIntegrationGatewayAdapter) GetRepositorySettings(ctx context.Context, input githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+	return a.Gateway.GetRepositorySettings(ctx, input)
+}
+
+func (a reviewerIntegrationGatewayAdapter) GetBranchProtection(ctx context.Context, input githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+	return a.Gateway.GetBranchProtection(ctx, input)
+}
+
+func (a reviewerIntegrationGatewayAdapter) CapturePullRequestSnapshot(ctx context.Context, input CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
+	return a.Gateway.CapturePullRequestSnapshot(ctx, githubinfra.CapturePullRequestSnapshotInput{ProjectID: input.ProjectID, Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, CapturedAt: input.CapturedAt})
+}
+
+func (a reviewerIntegrationGatewayAdapter) FindReviewMarker(ctx context.Context, input VerifyReviewMarkerInput) (ReviewMarkerResult, error) {
+	found, err := a.Gateway.FindReviewMarker(ctx, githubinfra.VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: input.Marker, AllowedReviewEvents: reviewEventsToStringsLocal(input.AllowedReviewEvents), AuthorLogin: input.AuthorLogin, AllowCleanComment: input.AllowCleanComment, CWD: input.CWD})
+	if err != nil {
+		return ReviewMarkerResult{}, err
+	}
+	return ReviewMarkerResult{Found: found.Found, Outcome: found.Outcome, Event: ReviewEvent(found.Event), AuthorLogin: found.AuthorLogin, Body: found.Body, InlineCommentBodies: append([]string(nil), found.InlineCommentBodies...)}, nil
+}
+
+func (a reviewerIntegrationGatewayAdapter) CreateIssueComment(ctx context.Context, input IssueCommentInput) (IssueCommentResult, error) {
+	comment, err := a.Gateway.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: input.Repo, IssueNumber: input.IssueNumber, Body: input.Body, CWD: input.CWD})
+	if err != nil {
+		return IssueCommentResult{}, err
+	}
+	return IssueCommentResult{ID: comment.ID, URL: comment.URL}, nil
+}
+
+func (a reviewerIntegrationGatewayAdapter) SubmitReview(ctx context.Context, input githubinfra.SubmitReviewInput) error {
+	return a.Gateway.SubmitReview(ctx, input)
+}
+
+func (a reviewerIntegrationGatewayAdapter) EnableAutoMerge(ctx context.Context, input githubinfra.EnableAutoMergeInput) error {
+	return a.Gateway.EnableAutoMerge(ctx, input)
+}
+
+func (a reviewerIntegrationGatewayAdapter) AddPullRequestReaction(ctx context.Context, input PullRequestReactionInput) error {
+	return a.Gateway.AddPullRequestReaction(ctx, githubinfra.PullRequestReactionInput{Repo: input.Repo, PRNumber: input.PRNumber, Content: input.Content, CWD: input.CWD})
+}
+
+func (a reviewerIntegrationGatewayAdapter) RemovePullRequestReaction(ctx context.Context, input PullRequestReactionInput) error {
+	return a.Gateway.RemovePullRequestReaction(ctx, githubinfra.PullRequestReactionInput{Repo: input.Repo, PRNumber: input.PRNumber, Content: input.Content, CWD: input.CWD})
+}
+
+func (a reviewerIntegrationGatewayAdapter) AddPullRequestLabels(ctx context.Context, input PullRequestLabelsInput) error {
+	return a.Gateway.AddPullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: input.Repo, PRNumber: input.PRNumber, Labels: input.Labels, CWD: input.CWD})
+}
+
+func (a reviewerIntegrationGatewayAdapter) RemovePullRequestLabels(ctx context.Context, input PullRequestLabelsInput) error {
+	return a.Gateway.RemovePullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: input.Repo, PRNumber: input.PRNumber, Labels: input.Labels, CWD: input.CWD})
+}
+
+func (a reviewerIntegrationGatewayAdapter) RemoveIssueLabels(ctx context.Context, input githubinfra.IssueLabelsInput) error {
+	return a.Gateway.RemoveIssueLabels(ctx, input)
+}
+
+func (a reviewerIntegrationGatewayAdapter) ListReviewThreads(ctx context.Context, input ListReviewThreadsInput) ([]ReviewThread, error) {
+	threads, err := a.Gateway.ListReviewThreads(ctx, githubinfra.ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, Limit: input.Limit})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ReviewThread, 0, len(threads))
+	for _, thread := range threads {
+		comments := make([]ReviewThreadComment, 0, len(thread.Comments))
+		for _, comment := range thread.Comments {
+			comments = append(comments, ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt, Path: comment.Path, Line: comment.Line, OriginalCommitOID: comment.OriginalCommitOID, CommitOID: comment.CommitOID, URL: comment.URL})
+		}
+		out = append(out, ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved, Path: thread.Path, Line: thread.Line, URL: thread.URL, Comments: comments})
+	}
+	return out, nil
+}
+
+func (a reviewerIntegrationGatewayAdapter) AddReviewThreadReply(ctx context.Context, input AddReviewThreadReplyInput) error {
+	return a.Gateway.AddReviewThreadReply(ctx, githubinfra.AddReviewThreadReplyInput{Repo: input.Repo, ThreadID: input.ThreadID, Body: input.Body, CWD: input.CWD})
+}
+
+func (a reviewerIntegrationGatewayAdapter) ResolveReviewThread(ctx context.Context, input ResolveReviewThreadInput) error {
+	return a.Gateway.ResolveReviewThread(ctx, githubinfra.ResolveReviewThreadInput{Repo: input.Repo, ThreadID: input.ThreadID, CWD: input.CWD})
+}
+
+func reviewEventsToStringsLocal(events []ReviewEvent) []string {
+	result := make([]string, 0, len(events))
+	for _, event := range events {
+		result = append(result, string(event))
+	}
+	return result
+}

--- a/internal/reviewer/runner_integration_test.go
+++ b/internal/reviewer/runner_integration_test.go
@@ -74,7 +74,7 @@ func TestReviewerAutoMergeHappyPathWithFakeGH(t *testing.T) {
 	}
 	assertOrderedText(t, string(logBytes),
 		`"argv":["api","repos/acme/looper/pulls/42/reviews","--method","POST","--input","-","--include"]`,
-		`"argv":["pr","merge","42","--repo","acme/looper","--auto","--squash"]`,
+		`"argv":["pr","merge","42","--repo","acme/looper","--auto","--squash","--match-head-commit","abc123"]`,
 	)
 	if !strings.Contains(string(logBytes), criteriaVerificationHeading) {
 		t.Fatalf("invocation log missing criteria verification heading:\n%s", string(logBytes))

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -16,6 +16,7 @@ import (
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/infra/specpr"
+	"github.com/nexu-io/looper/internal/reviewer/automerge"
 	"github.com/nexu-io/looper/internal/reviewer/criteria"
 	"github.com/nexu-io/looper/internal/storage"
 )
@@ -3289,6 +3290,53 @@ func TestProcessClaimedItemAutoMergeApprovesAndCommentsWhenAutoMergeRefused(t *t
 	}
 	if len(github.issueCommentCalls) != 1 || !strings.Contains(github.issueCommentCalls[0].Body, autoMergeRefusedCommentMarker) {
 		t.Fatalf("issueCommentCalls = %#v, want stamped refusal comment", github.issueCommentCalls)
+	}
+}
+
+func TestProcessClaimedItemAutoMergeApprovesWithoutRemoteProbeWhenOutOfScope(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		author:              "octocat",
+		currentLogin:        "reviewer",
+		labels:              []string{"team:backend"},
+		reviewMarkerMissing: true,
+		reviewRequests:      []string{"reviewer"},
+		viewBody:            "Implements feature.\n\nCloses #358",
+		viewDiff:            "diff --git a/app.go b/app.go\n@@ -1,1 +1,1 @@\n-old\n+new\n",
+		issueDetail:         githubinfra.IssueDetail{Number: 358, Body: "## Acceptance criteria\n- ship app change\n", Labels: []string{"triaged", "dispatch/plan"}},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings"}`, ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ReviewEvents: config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove}, LoopConfig: testReviewerLoopConfig(), CustomInstructions: reviewerAutoMergeTestConfig(t), CriteriaVerifier: stubCriteriaVerifier{responses: map[criteria.AcceptanceCriterion]criteria.CriterionAssessment{
+		"ship app change": {Verdict: criteria.VerdictPass, Justification: "present in diff", Evidence: []criteria.Evidence{{FilePath: "app.go", StartLine: 1, EndLine: 1}}},
+	}}})
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queue item", claim, err)
+	}
+	if _, err := runner.ProcessClaimedItem(context.Background(), *claim); err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if len(github.submitReviewCalls) != 1 || github.submitReviewCalls[0].Event != string(ReviewEventApprove) {
+		t.Fatalf("submitReviewCalls = %#v, want one APPROVE review", github.submitReviewCalls)
+	}
+	if github.repositorySettingsCalls != 0 {
+		t.Fatalf("repositorySettingsCalls = %d, want 0", github.repositorySettingsCalls)
+	}
+	if github.branchProtectionCalls != 0 {
+		t.Fatalf("branchProtectionCalls = %d, want 0", github.branchProtectionCalls)
+	}
+	if len(github.enableAutoMergeCalls) != 0 {
+		t.Fatalf("enableAutoMergeCalls = %#v, want none", github.enableAutoMergeCalls)
+	}
+	if len(github.issueCommentCalls) != 1 || !strings.Contains(github.issueCommentCalls[0].Body, autoMergeRefusedCommentMarker) {
+		t.Fatalf("issueCommentCalls = %#v, want stamped refusal comment", github.issueCommentCalls)
+	}
+	if !strings.Contains(github.issueCommentCalls[0].Body, string(automerge.RefusalReasonScope)) {
+		t.Fatalf("issueCommentCalls[0].Body = %q, want scope refusal reason", github.issueCommentCalls[0].Body)
 	}
 }
 
@@ -7184,7 +7232,9 @@ type fakeGitHubGateway struct {
 	reviewMarkerInputs              []VerifyReviewMarkerInput
 	issueDetail                     githubinfra.IssueDetail
 	repositorySettings              githubinfra.RepositorySettings
+	repositorySettingsCalls         int
 	branchProtection                githubinfra.BranchProtection
+	branchProtectionCalls           int
 	viewDraft                       bool
 	viewBody                        string
 	viewDiff                        string
@@ -7297,6 +7347,7 @@ func (g *fakeGitHubGateway) ViewIssue(_ context.Context, input githubinfra.ViewI
 }
 
 func (g *fakeGitHubGateway) GetRepositorySettings(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+	g.repositorySettingsCalls++
 	if g.repositorySettings.AllowSquashMerge || g.repositorySettings.AllowMergeCommit || g.repositorySettings.AllowRebaseMerge || g.repositorySettings.AllowAutoMerge {
 		return g.repositorySettings, nil
 	}
@@ -7304,6 +7355,7 @@ func (g *fakeGitHubGateway) GetRepositorySettings(context.Context, githubinfra.R
 }
 
 func (g *fakeGitHubGateway) GetBranchProtection(context.Context, githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+	g.branchProtectionCalls++
 	if g.branchProtection.Enabled || g.branchProtection.HasRequiredChecks {
 		return g.branchProtection, nil
 	}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -16,6 +16,7 @@ import (
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/infra/specpr"
+	"github.com/nexu-io/looper/internal/reviewer/criteria"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -3186,6 +3187,150 @@ func TestProcessClaimedItemDoesNotTransitionSpecLabelsForCleanNoopCommentPolicy(
 	}
 	if len(github.addLabelCalls) != 0 {
 		t.Fatalf("addLabelCalls = %#v, want no spec-ready add for COMMENT clean policy", github.addLabelCalls)
+	}
+}
+
+func TestProcessClaimedItemAutoMergeApprovesAndEnablesAutoMergeWhenCriteriaPass(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		author:              "octocat",
+		currentLogin:        "reviewer",
+		labels:              []string{"looper:worker-ready"},
+		reviewMarkerMissing: true,
+		reviewRequests:      []string{"reviewer"},
+		viewBody:            "Implements feature.\n\nCloses #358",
+		viewDiff:            "diff --git a/app.go b/app.go\n@@ -1,1 +1,2 @@\n-old\n+new\n+more\n",
+		issueDetail:         githubinfra.IssueDetail{Number: 358, Body: "## Acceptance criteria\n- ship app change\n- add more\n", Labels: []string{"triaged", "dispatch/plan"}},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings"}`, ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ReviewEvents: config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove}, LoopConfig: testReviewerLoopConfig(), CustomInstructions: reviewerAutoMergeTestConfig(t), CriteriaVerifier: stubCriteriaVerifier{responses: map[criteria.AcceptanceCriterion]criteria.CriterionAssessment{
+		"ship app change": {Verdict: criteria.VerdictPass, Justification: "present in diff", Evidence: []criteria.Evidence{{FilePath: "app.go", StartLine: 1, EndLine: 2}}},
+		"add more":        {Verdict: criteria.VerdictPass, Justification: "present in diff", Evidence: []criteria.Evidence{{FilePath: "app.go", StartLine: 2, EndLine: 2}}},
+	}}})
+	ctx := context.Background()
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"followUpdates":true,"loop":{"enabled":true}}`
+	loop := storage.LoopRecord{ID: "loop_auto_merge_pass", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue, err := runner.enqueue(ctx, enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+	}
+	result, err := runner.ProcessClaimedItem(ctx, *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success", result)
+	}
+	if len(github.submitReviewCalls) != 1 || github.submitReviewCalls[0].Event != string(ReviewEventApprove) {
+		t.Fatalf("submitReviewCalls = %#v, want one APPROVE review", github.submitReviewCalls)
+	}
+	if len(github.enableAutoMergeCalls) != 1 || github.enableAutoMergeCalls[0].Strategy != config.ReviewerAutoMergeStrategySquash {
+		t.Fatalf("enableAutoMergeCalls = %#v, want one squash auto-merge call", github.enableAutoMergeCalls)
+	}
+	if !strings.Contains(github.submitReviewCalls[0].Body, criteriaVerificationHeading) || !strings.Contains(github.submitReviewCalls[0].Body, "app.go:1-2") {
+		t.Fatalf("review body = %q, want acceptance criteria evidence", github.submitReviewCalls[0].Body)
+	}
+	if len(github.removeIssueLabelCalls) != 0 {
+		t.Fatalf("removeIssueLabelCalls = %#v, want none", github.removeIssueLabelCalls)
+	}
+	if len(github.issueCommentCalls) != 0 {
+		t.Fatalf("issueCommentCalls = %#v, want no refusal comment", github.issueCommentCalls)
+	}
+}
+
+func TestProcessClaimedItemAutoMergeApprovesAndCommentsWhenAutoMergeRefused(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	cfg := reviewerAutoMergeTestConfig(t)
+	github := &fakeGitHubGateway{
+		author:              "octocat",
+		currentLogin:        "reviewer",
+		labels:              []string{"looper:worker-ready"},
+		reviewMarkerMissing: true,
+		reviewRequests:      []string{"reviewer"},
+		viewBody:            "Implements feature.\n\nCloses #358",
+		viewDiff:            "diff --git a/app.go b/app.go\n@@ -1,1 +1,1 @@\n-old\n+new\n",
+		issueDetail:         githubinfra.IssueDetail{Number: 358, Body: "## Acceptance criteria\n- ship app change\n", Labels: []string{"triaged", "dispatch/plan"}},
+		repositorySettings:  githubinfra.RepositorySettings{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true, AllowAutoMerge: false},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings"}`, ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ReviewEvents: config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove}, LoopConfig: testReviewerLoopConfig(), CustomInstructions: cfg, CriteriaVerifier: stubCriteriaVerifier{responses: map[criteria.AcceptanceCriterion]criteria.CriterionAssessment{
+		"ship app change": {Verdict: criteria.VerdictPass, Justification: "present in diff", Evidence: []criteria.Evidence{{FilePath: "app.go", StartLine: 1, EndLine: 1}}},
+	}}})
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queue item", claim, err)
+	}
+	if _, err := runner.ProcessClaimedItem(context.Background(), *claim); err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if len(github.submitReviewCalls) != 1 || github.submitReviewCalls[0].Event != string(ReviewEventApprove) {
+		t.Fatalf("submitReviewCalls = %#v, want one APPROVE review", github.submitReviewCalls)
+	}
+	if len(github.enableAutoMergeCalls) != 0 {
+		t.Fatalf("enableAutoMergeCalls = %#v, want none", github.enableAutoMergeCalls)
+	}
+	if len(github.issueCommentCalls) != 1 || !strings.Contains(github.issueCommentCalls[0].Body, autoMergeRefusedCommentMarker) {
+		t.Fatalf("issueCommentCalls = %#v, want stamped refusal comment", github.issueCommentCalls)
+	}
+}
+
+func TestProcessClaimedItemAutoMergeCommentsAndRetriagesWhenCriteriaFail(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		author:              "octocat",
+		currentLogin:        "reviewer",
+		labels:              []string{"looper:worker-ready"},
+		reviewMarkerMissing: true,
+		reviewRequests:      []string{"reviewer"},
+		viewBody:            "Implements feature.\n\nCloses #358",
+		viewDiff:            "diff --git a/app.go b/app.go\n@@ -1,1 +1,1 @@\n-old\n+new\n",
+		issueDetail:         githubinfra.IssueDetail{Number: 358, Body: "## Acceptance criteria\n- ship app change\n- add tests\n", Labels: []string{"triaged", "dispatch/plan", "other"}},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings"}`, ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ReviewEvents: config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove}, LoopConfig: testReviewerLoopConfig(), CustomInstructions: reviewerAutoMergeTestConfig(t), CriteriaVerifier: stubCriteriaVerifier{responses: map[criteria.AcceptanceCriterion]criteria.CriterionAssessment{
+		"ship app change": {Verdict: criteria.VerdictPass, Justification: "present in diff", Evidence: []criteria.Evidence{{FilePath: "app.go", StartLine: 1, EndLine: 1}}},
+		"add tests":       {Verdict: criteria.VerdictFail, Justification: "no test change in diff"},
+	}}})
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queue item", claim, err)
+	}
+	if _, err := runner.ProcessClaimedItem(context.Background(), *claim); err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if len(github.submitReviewCalls) != 1 || github.submitReviewCalls[0].Event != string(ReviewEventComment) {
+		t.Fatalf("submitReviewCalls = %#v, want one COMMENT review", github.submitReviewCalls)
+	}
+	if !strings.Contains(github.submitReviewCalls[0].Body, criteriaFailCommentMarker) {
+		t.Fatalf("review body = %q, want criteria fail marker", github.submitReviewCalls[0].Body)
+	}
+	if len(github.removeIssueLabelCalls) != 1 {
+		t.Fatalf("removeIssueLabelCalls = %#v, want one issue label removal", github.removeIssueLabelCalls)
+	}
+	if got := github.removeIssueLabelCalls[0].Labels; len(got) != 2 || got[0] != "triaged" || got[1] != "dispatch/plan" {
+		t.Fatalf("removed labels = %#v, want triaged + dispatch/plan", got)
+	}
+	if len(github.enableAutoMergeCalls) != 0 {
+		t.Fatalf("enableAutoMergeCalls = %#v, want none", github.enableAutoMergeCalls)
 	}
 }
 
@@ -6530,7 +6675,7 @@ func TestBuildReviewPromptDoesNotTransitionSpecLabelsWithoutApprove(t *testing.T
 func TestBuildReviewPromptOmitsReviewRequestGuardrailWhenDisabled(t *testing.T) {
 	t.Parallel()
 
-	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper")
+	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false)
 
 	if strings.Contains(prompt, "review request removed before publish") {
 		t.Fatalf("prompt retained review-request guardrail while disabled:\n%s", prompt)
@@ -6543,7 +6688,7 @@ func TestBuildReviewPromptOmitsReviewRequestGuardrailWhenDisabled(t *testing.T) 
 func TestBuildReviewPromptNamesFollowUpReviewRequestBypass(t *testing.T) {
 	t.Parallel()
 
-	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "follow_up_new_head", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper")
+	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "follow_up_new_head", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false)
 
 	if strings.Contains(prompt, "review request removed before publish") {
 		t.Fatalf("prompt retained review-request guardrail for follow-up bypass:\n%s", prompt)
@@ -6842,6 +6987,28 @@ func (f *runnerFixture) nowISO() string {
 
 func boolPtr(value bool) *bool { return &value }
 
+type stubCriteriaVerifier struct {
+	responses map[criteria.AcceptanceCriterion]criteria.CriterionAssessment
+}
+
+func (s stubCriteriaVerifier) VerifyCriterion(criterion criteria.AcceptanceCriterion, _ criteria.PRDiff) (criteria.CriterionAssessment, error) {
+	if assessment, ok := s.responses[criterion]; ok {
+		return assessment, nil
+	}
+	return criteria.CriterionAssessment{Verdict: criteria.VerdictUnverifiable, Justification: "missing test verifier response"}, nil
+}
+
+func reviewerAutoMergeTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.AutoMerge.Enabled = true
+	cfg.Roles.Reviewer.AutoMerge.Strategy = config.ReviewerAutoMergeStrategySquash
+	return &cfg
+}
+
 type failedReviewerRecoverySeed struct {
 	ResumePolicy         string
 	QueueErrorKind       string
@@ -6932,7 +7099,12 @@ type fakeGitHubGateway struct {
 	reviewMarkerInlineCommentBodies []string
 	reviewMarkerCalls               int
 	reviewMarkerInputs              []VerifyReviewMarkerInput
+	issueDetail                     githubinfra.IssueDetail
+	repositorySettings              githubinfra.RepositorySettings
+	branchProtection                githubinfra.BranchProtection
 	viewDraft                       bool
+	viewBody                        string
+	viewDiff                        string
 	viewState                       string
 	viewStateAfterFirstView         string
 	viewErrs                        []error
@@ -6946,6 +7118,9 @@ type fakeGitHubGateway struct {
 	viewHeadSHA                     string
 	headSHACalls                    int
 	issueCommentCalls               []IssueCommentInput
+	submitReviewCalls               []githubinfra.SubmitReviewInput
+	enableAutoMergeCalls            []githubinfra.EnableAutoMergeInput
+	removeIssueLabelCalls           []githubinfra.IssueLabelsInput
 	captureSnapshotErrs             []error
 	captureSnapshotCalls            int
 	addThreadReplyCalls             []AddReviewThreadReplyInput
@@ -7016,7 +7191,36 @@ func (g *fakeGitHubGateway) ViewPullRequest(context.Context, ViewPullRequestInpu
 	if state == "" {
 		state = "OPEN"
 	}
-	return PullRequestDetail{Number: 42, Title: "Review me", Body: "PR body", State: state, IsDraft: g.viewDraft, ReviewDecision: reviewDecision, Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, BaseSHA: "base123", HeadRefName: "feature/review-me", BaseRefName: "main", Author: g.effectiveAuthor(), ReviewRequests: reviewRequests, HasConflicts: g.hasConflicts, ChecksSummary: "SUCCESS", Diff: "diff --git a/a.ts b/a.ts", Comments: cloneCommentMaps(comments), IssueComments: cloneCommentMaps(g.issueComments), Reviews: cloneCommentMaps(g.reviews)}, nil
+	body := g.viewBody
+	if body == "" {
+		body = "PR body"
+	}
+	diff := g.viewDiff
+	if diff == "" {
+		diff = "diff --git a/a.ts b/a.ts"
+	}
+	return PullRequestDetail{Number: 42, Title: "Review me", Body: body, State: state, IsDraft: g.viewDraft, ReviewDecision: reviewDecision, Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, BaseSHA: "base123", HeadRefName: "feature/review-me", BaseRefName: "main", Author: g.effectiveAuthor(), ReviewRequests: reviewRequests, HasConflicts: g.hasConflicts, ChecksSummary: "SUCCESS", Diff: diff, Comments: cloneCommentMaps(comments), IssueComments: cloneCommentMaps(g.issueComments), Reviews: cloneCommentMaps(g.reviews)}, nil
+}
+
+func (g *fakeGitHubGateway) ViewIssue(_ context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
+	if g.issueDetail.Number != 0 {
+		return g.issueDetail, nil
+	}
+	return githubinfra.IssueDetail{Number: input.IssueNumber, Title: "Issue", Body: "", State: "open", Labels: []string{"triaged", "dispatch/plan"}}, nil
+}
+
+func (g *fakeGitHubGateway) GetRepositorySettings(context.Context, githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+	if g.repositorySettings.AllowSquashMerge || g.repositorySettings.AllowMergeCommit || g.repositorySettings.AllowRebaseMerge || g.repositorySettings.AllowAutoMerge {
+		return g.repositorySettings, nil
+	}
+	return githubinfra.RepositorySettings{AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true, AllowAutoMerge: true}, nil
+}
+
+func (g *fakeGitHubGateway) GetBranchProtection(context.Context, githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+	if g.branchProtection.Enabled || g.branchProtection.HasRequiredChecks {
+		return g.branchProtection, nil
+	}
+	return githubinfra.BranchProtection{Enabled: true, HasRequiredChecks: true}, nil
 }
 
 func (g *fakeGitHubGateway) GetPullRequestHeadSHA(context.Context, ViewPullRequestInput) (string, error) {
@@ -7082,6 +7286,33 @@ func (g *fakeGitHubGateway) FindReviewMarker(_ context.Context, input VerifyRevi
 	if g.reviewMarkerErr != nil {
 		return ReviewMarkerResult{}, g.reviewMarkerErr
 	}
+	for i := len(g.reviews) - 1; i >= 0; i-- {
+		row := g.reviews[i]
+		body, _ := row["body"].(string)
+		if !strings.Contains(body, input.Marker) {
+			continue
+		}
+		state, _ := row["state"].(string)
+		event := ReviewEventComment
+		switch state {
+		case "APPROVED":
+			event = ReviewEventApprove
+		case "CHANGES_REQUESTED":
+			event = ReviewEventRequestChanges
+		}
+		if !reviewEventIn(input.AllowedReviewEvents, event) {
+			continue
+		}
+		outcome := "actionable"
+		if strings.Contains(body, "outcome=clean") {
+			outcome = "clean"
+		} else if strings.Contains(body, "outcome=blocking") {
+			outcome = "blocking"
+		} else if strings.Contains(body, "outcome=non_blocking") {
+			outcome = "non_blocking"
+		}
+		return ReviewMarkerResult{Found: true, Outcome: outcome, Event: event, Body: body, InlineCommentBodies: append([]string(nil), g.reviewMarkerInlineCommentBodies...)}, nil
+	}
 	if g.reviewMarkerExactMissing && strings.Contains(input.Marker, " id=") {
 		return ReviewMarkerResult{}, nil
 	}
@@ -7115,6 +7346,26 @@ func (g *fakeGitHubGateway) CreateIssueComment(_ context.Context, input IssueCom
 		return g.issueCommentResult, nil
 	}
 	return IssueCommentResult{ID: int64(len(g.issueCommentCalls)), URL: fmt.Sprintf("https://github.com/%s/pull/%d#issuecomment-%d", input.Repo, input.IssueNumber, len(g.issueCommentCalls))}, nil
+}
+
+func (g *fakeGitHubGateway) SubmitReview(_ context.Context, input githubinfra.SubmitReviewInput) error {
+	g.submitReviewCalls = append(g.submitReviewCalls, input)
+	state := "COMMENTED"
+	switch input.Event {
+	case string(ReviewEventApprove):
+		state = "APPROVED"
+	case string(ReviewEventRequestChanges):
+		state = "CHANGES_REQUESTED"
+	}
+	body := input.Body
+	g.reviews = append(g.reviews, map[string]any{"body": body, "state": state, "user": map[string]any{"login": firstNonEmpty(strings.TrimSpace(g.currentLogin), "octocat")}})
+	g.issueComments = append(g.issueComments, map[string]any{"body": body})
+	return nil
+}
+
+func (g *fakeGitHubGateway) EnableAutoMerge(_ context.Context, input githubinfra.EnableAutoMergeInput) error {
+	g.enableAutoMergeCalls = append(g.enableAutoMergeCalls, input)
+	return nil
 }
 
 func cleanApproveReviewBody(author string, outcome string) string {
@@ -7153,6 +7404,11 @@ func (g *fakeGitHubGateway) AddPullRequestLabels(_ context.Context, input PullRe
 func (g *fakeGitHubGateway) RemovePullRequestLabels(_ context.Context, input PullRequestLabelsInput) error {
 	g.removeLabelCalls = append(g.removeLabelCalls, input)
 	return g.removeLabelErr
+}
+
+func (g *fakeGitHubGateway) RemoveIssueLabels(_ context.Context, input githubinfra.IssueLabelsInput) error {
+	g.removeIssueLabelCalls = append(g.removeIssueLabelCalls, input)
+	return nil
 }
 
 func (g *fakeGitHubGateway) ListReviewThreads(context.Context, ListReviewThreadsInput) ([]ReviewThread, error) {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -3238,6 +3238,9 @@ func TestProcessClaimedItemAutoMergeApprovesAndEnablesAutoMergeWhenCriteriaPass(
 	if len(github.enableAutoMergeCalls) != 1 || github.enableAutoMergeCalls[0].Strategy != config.ReviewerAutoMergeStrategySquash {
 		t.Fatalf("enableAutoMergeCalls = %#v, want one squash auto-merge call", github.enableAutoMergeCalls)
 	}
+	if github.enableAutoMergeCalls[0].HeadSHA != "abc123" {
+		t.Fatalf("enableAutoMergeCalls[0].HeadSHA = %q, want abc123", github.enableAutoMergeCalls[0].HeadSHA)
+	}
 	if !strings.Contains(github.submitReviewCalls[0].Body, criteriaVerificationHeading) || !strings.Contains(github.submitReviewCalls[0].Body, "app.go:1-2") {
 		t.Fatalf("review body = %q, want acceptance criteria evidence", github.submitReviewCalls[0].Body)
 	}
@@ -3328,6 +3331,86 @@ func TestProcessClaimedItemAutoMergeCommentsAndRetriagesWhenCriteriaFail(t *test
 	}
 	if got := github.removeIssueLabelCalls[0].Labels; len(got) != 2 || got[0] != "triaged" || got[1] != "dispatch/plan" {
 		t.Fatalf("removed labels = %#v, want triaged + dispatch/plan", got)
+	}
+	if len(github.enableAutoMergeCalls) != 0 {
+		t.Fatalf("enableAutoMergeCalls = %#v, want none", github.enableAutoMergeCalls)
+	}
+}
+
+func TestProcessClaimedItemFallsBackWhenLinkedIssueLookupIsUnavailable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		author:              "octocat",
+		currentLogin:        "reviewer",
+		labels:              []string{"looper:worker-ready"},
+		reviewMarkerMissing: true,
+		reviewRequests:      []string{"reviewer"},
+		viewBody:            "Implements feature.\n\nCloses owner/private#358",
+		viewDiff:            "diff --git a/app.go b/app.go\n@@ -1,1 +1,1 @@\n-old\n+new\n",
+		issueDetailErr:      &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "HTTP 403: Resource not accessible by integration"}},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings"}`, ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ReviewEvents: config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove}, LoopConfig: testReviewerLoopConfig(), CustomInstructions: reviewerAutoMergeTestConfig(t)})
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queue item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success", result)
+	}
+	if len(github.submitReviewCalls) != 1 || github.submitReviewCalls[0].Event != string(ReviewEventApprove) {
+		t.Fatalf("submitReviewCalls = %#v, want one APPROVE review", github.submitReviewCalls)
+	}
+	if !strings.Contains(github.submitReviewCalls[0].Body, "No explicit acceptance criteria were stated on the linked issue") {
+		t.Fatalf("review body = %q, want non-criteria fallback explanation", github.submitReviewCalls[0].Body)
+	}
+	if len(github.enableAutoMergeCalls) != 0 {
+		t.Fatalf("enableAutoMergeCalls = %#v, want none", github.enableAutoMergeCalls)
+	}
+	if len(github.removeIssueLabelCalls) != 0 {
+		t.Fatalf("removeIssueLabelCalls = %#v, want none", github.removeIssueLabelCalls)
+	}
+}
+
+func TestProcessClaimedItemRetriesWhenLinkedIssueLookupIsTransient(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		author:              "octocat",
+		currentLogin:        "reviewer",
+		labels:              []string{"looper:worker-ready"},
+		reviewMarkerMissing: true,
+		reviewRequests:      []string{"reviewer"},
+		viewBody:            "Implements feature.\n\nCloses #358",
+		viewDiff:            "diff --git a/app.go b/app.go\n@@ -1,1 +1,1 @@\n-old\n+new\n",
+		issueDetailErr:      &githubinfra.TransientError{Err: &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: `Post "https://api.github.com/graphql": unexpected EOF`}}},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings"}`, ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ReviewEvents: config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove}, LoopConfig: testReviewerLoopConfig(), CustomInstructions: reviewerAutoMergeTestConfig(t)})
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queue item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume {
+		t.Fatalf("result = %#v, want retryable_after_resume failure", result)
+	}
+	if len(github.submitReviewCalls) != 0 {
+		t.Fatalf("submitReviewCalls = %#v, want none", github.submitReviewCalls)
 	}
 	if len(github.enableAutoMergeCalls) != 0 {
 		t.Fatalf("enableAutoMergeCalls = %#v, want none", github.enableAutoMergeCalls)
@@ -7108,6 +7191,7 @@ type fakeGitHubGateway struct {
 	viewState                       string
 	viewStateAfterFirstView         string
 	viewErrs                        []error
+	issueDetailErr                  error
 	addReactionErr                  error
 	removeReactionErr               error
 	addLabelErr                     error
@@ -7203,6 +7287,9 @@ func (g *fakeGitHubGateway) ViewPullRequest(context.Context, ViewPullRequestInpu
 }
 
 func (g *fakeGitHubGateway) ViewIssue(_ context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
+	if g.issueDetailErr != nil {
+		return githubinfra.IssueDetail{}, g.issueDetailErr
+	}
 	if g.issueDetail.Number != 0 {
 		return g.issueDetail, nil
 	}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -306,6 +306,18 @@ func (a reviewerGitHubAdapter) ViewPullRequest(ctx context.Context, input review
 	return reviewer.PullRequestDetail{Number: detail.Number, Title: detail.Title, Body: detail.Body, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: detail.Labels, HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, Author: detail.Author, ReviewRequests: detail.ReviewRequests, HasConflicts: detail.HasConflicts, ChecksSummary: summarizeCheckStates(detail.Checks), Comments: detail.Comments, IssueComments: commentInfosToObjects(detail.IssueComments), Reviews: detail.Reviews}, nil
 }
 
+func (a reviewerGitHubAdapter) ViewIssue(ctx context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
+	return a.gateway.ViewIssue(ctx, input)
+}
+
+func (a reviewerGitHubAdapter) GetRepositorySettings(ctx context.Context, input githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+	return a.gateway.GetRepositorySettings(ctx, input)
+}
+
+func (a reviewerGitHubAdapter) GetBranchProtection(ctx context.Context, input githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+	return a.gateway.GetBranchProtection(ctx, input)
+}
+
 func (a reviewerGitHubAdapter) GetPullRequestHeadSHA(ctx context.Context, input reviewer.ViewPullRequestInput) (string, error) {
 	return a.gateway.GetPullRequestHeadSHA(ctx, githubinfra.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 }
@@ -335,6 +347,14 @@ func (a reviewerGitHubAdapter) CreateIssueComment(ctx context.Context, input rev
 	return reviewer.IssueCommentResult{ID: comment.ID, URL: comment.URL}, nil
 }
 
+func (a reviewerGitHubAdapter) SubmitReview(ctx context.Context, input githubinfra.SubmitReviewInput) error {
+	return a.gateway.SubmitReview(ctx, input)
+}
+
+func (a reviewerGitHubAdapter) EnableAutoMerge(ctx context.Context, input githubinfra.EnableAutoMergeInput) error {
+	return a.gateway.EnableAutoMerge(ctx, input)
+}
+
 func (a reviewerGitHubAdapter) AddPullRequestReaction(ctx context.Context, input reviewer.PullRequestReactionInput) error {
 	return a.gateway.AddPullRequestReaction(ctx, githubinfra.PullRequestReactionInput{Repo: input.Repo, PRNumber: input.PRNumber, Content: input.Content, CWD: input.CWD})
 }
@@ -349,6 +369,10 @@ func (a reviewerGitHubAdapter) AddPullRequestLabels(ctx context.Context, input r
 
 func (a reviewerGitHubAdapter) RemovePullRequestLabels(ctx context.Context, input reviewer.PullRequestLabelsInput) error {
 	return a.gateway.RemovePullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: input.Repo, PRNumber: input.PRNumber, Labels: input.Labels, CWD: input.CWD})
+}
+
+func (a reviewerGitHubAdapter) RemoveIssueLabels(ctx context.Context, input githubinfra.IssueLabelsInput) error {
+	return a.gateway.RemoveIssueLabels(ctx, input)
 }
 
 func (a reviewerGitHubAdapter) ListReviewThreads(ctx context.Context, input reviewer.ListReviewThreadsInput) ([]reviewer.ReviewThread, error) {


### PR DESCRIPTION
## Summary
- wire reviewer auto-merge through linked-issue acceptance-criteria verification, GitHub-native auto-merge opt-in, and stamped retry-safe fallback comments
- add the GitHub gateway and fake-gh support needed to submit criteria-backed reviews, enable `gh pr merge --auto`, and exercise the reviewer happy-path and criteria-fail flows end to end
- document the authority model in ADR-0005 and keep the worker `Closes #N` contract unchanged after auditing the existing PR-body builder

## Validation
- `gofmt -w internal/reviewer/runner.go internal/reviewer/runner_test.go internal/reviewer/runner_integration_test.go internal/reviewer/criteria/default_verifier.go internal/runtime/scheduler.go internal/e2e/harness/cmd/fake-gh/main.go internal/infra/github/gateway.go internal/infra/github/gateway_test.go`
- `go test ./...`
- `go vet ./...`

## Notes
- @oracle review is required for this authority-bearing change per AGENTS.md.
- This PR cites ADR-0002 and adds ADR-0005 for the reviewer auto-merge authority boundaries.
- PRD: #352
- Previous slice: #357

Closes #358

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>