### PR TITLE
fix: accept loopback webhook forward headers

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -539,6 +539,17 @@ func isLoopbackRequest(r *http.Request) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+func hasForwardingProxyHeaders(headers http.Header) bool {
+	for _, name := range []string{"Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Real-Ip", "X-Real-IP"} {
+		for _, value := range headers.Values(name) {
+			if strings.TrimSpace(value) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type apiError struct {
 	code    pkgapi.ErrorCode
 	status  int
@@ -599,7 +610,9 @@ func assertMethod(method, allowed, path string, w http.ResponseWriter, requestID
 
 func authorizeRequest(r *http.Request, path string, cfg config.Config) error {
 	if path == webhookForwardPath && cfg.Webhook.Enabled && isLoopbackRemoteAddr(r.RemoteAddr) {
-		return nil
+		if !hasForwardingProxyHeaders(r.Header) {
+			return nil
+		}
 	}
 	if cfg.Server.AuthMode != config.AuthModeLocalToken {
 		return nil

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -539,17 +539,6 @@ func isLoopbackRequest(r *http.Request) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func hasForwardingProxyHeaders(headers http.Header) bool {
-	for _, name := range []string{"Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Real-Ip", "X-Real-IP"} {
-		for _, value := range headers.Values(name) {
-			if strings.TrimSpace(value) != "" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 type apiError struct {
 	code    pkgapi.ErrorCode
 	status  int
@@ -609,13 +598,6 @@ func assertMethod(method, allowed, path string, w http.ResponseWriter, requestID
 }
 
 func authorizeRequest(r *http.Request, path string, cfg config.Config) error {
-	if path == webhookForwardPath && hasForwardingProxyHeaders(r.Header) {
-		return apiError{
-			code:    pkgapi.ErrorCodeUnauthorized,
-			status:  http.StatusForbidden,
-			message: "Webhook forwarding does not accept proxied loopback requests",
-		}
-	}
 	if path == webhookForwardPath && cfg.Webhook.Enabled && isLoopbackRemoteAddr(r.RemoteAddr) {
 		return nil
 	}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -441,7 +441,7 @@ func TestHandlerWebhookForwardRejectsNonLoopbackEvenWithBearerToken(t *testing.T
 	}
 }
 
-func TestHandlerWebhookForwardAcceptsLoopbackWithForwardedHeaders(t *testing.T) {
+func TestHandlerWebhookForwardAcceptsLoopbackWithForwardedHeadersAndBearerToken(t *testing.T) {
 	fixture := newTestFixture(t)
 	token := "secret-token"
 	fixture.config.Server.AuthMode = config.AuthModeLocalToken
@@ -472,6 +472,38 @@ func TestHandlerWebhookForwardAcceptsLoopbackWithForwardedHeaders(t *testing.T) 
 	}
 	body := parseJSONMap(t, recorder.Body.Bytes())
 	assertEqual(t, body["ok"], true)
+}
+
+func TestHandlerWebhookForwardRejectsLoopbackWithForwardedHeadersWithoutBearerToken(t *testing.T) {
+	fixture := newTestFixture(t)
+	token := "secret-token"
+	fixture.config.Server.AuthMode = config.AuthModeLocalToken
+	fixture.config.Server.LocalToken = &token
+	fixture.config.Webhook.Enabled = true
+	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
+	runtime := webhookForwardRuntime{Runtime: fixture.runtime, status: func() looperdruntime.WebhookStatus {
+		return looperdruntime.WebhookStatus{Enabled: true}
+	}}
+	h := NewHandler(Context{Config: fixture.config, Runtime: runtime, WebhookForwarder: forwarder})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", bytes.NewReader([]byte(`{"action":"review_requested"}`)))
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Add("X-Forwarded-For", "203.0.113.5")
+	req.Header.Set("X-GitHub-Delivery", "delivery-4")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	recorder := httptest.NewRecorder()
+
+	h.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 body=%s", recorder.Code, recorder.Body.String())
+	}
+	if forwarder.calls != 0 {
+		t.Fatalf("forwarder calls = %d, want 0", forwarder.calls)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	errMap := body["error"].(map[string]any)
+	assertEqual(t, errMap["message"], "Authorization token is required")
 }
 
 func TestHandlerRouteAndMethodErrors(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -441,7 +441,7 @@ func TestHandlerWebhookForwardRejectsNonLoopbackEvenWithBearerToken(t *testing.T
 	}
 }
 
-func TestHandlerWebhookForwardRejectsLoopbackWithForwardedHeaders(t *testing.T) {
+func TestHandlerWebhookForwardAcceptsLoopbackWithForwardedHeaders(t *testing.T) {
 	fixture := newTestFixture(t)
 	token := "secret-token"
 	fixture.config.Server.AuthMode = config.AuthModeLocalToken
@@ -464,15 +464,14 @@ func TestHandlerWebhookForwardRejectsLoopbackWithForwardedHeaders(t *testing.T) 
 
 	h.ServeHTTP(recorder, req)
 
-	if recorder.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403 body=%s", recorder.Code, recorder.Body.String())
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", recorder.Code, recorder.Body.String())
 	}
-	if forwarder.calls != 0 {
-		t.Fatalf("forwarder calls = %d, want 0", forwarder.calls)
+	if forwarder.calls != 1 {
+		t.Fatalf("forwarder calls = %d, want 1", forwarder.calls)
 	}
 	body := parseJSONMap(t, recorder.Body.Bytes())
-	errMap := body["error"].(map[string]any)
-	assertEqual(t, errMap["message"], "Webhook forwarding does not accept proxied loopback requests")
+	assertEqual(t, body["ok"], true)
 }
 
 func TestHandlerRouteAndMethodErrors(t *testing.T) {


### PR DESCRIPTION
## Summary
- stop rejecting loopback `/webhook/forward` requests just because the GitHub CLI forwarder preserves forwarded headers
- keep the loopback-only guard in place so local webhook forwarding still requires a local caller
- add a regression test covering `gh webhook forward` style loopback deliveries with `X-Forwarded-For`

## Validation
- go test ./internal/api
- go test ./...
- go vet ./... && go build ./...