### PR TITLE
fix: preserve integer config values in TOML

### DIFF
--- a/internal/cliapp/config_migrate_preview_test.go
+++ b/internal/cliapp/config_migrate_preview_test.go
@@ -22,6 +22,7 @@ func TestConfigMigrateDryRunPreviewsCanonicalTOMLWithoutWritingDestination(t *te
 	}
 	legacy := `{
 		"defaults": {"allowAutoApprove": true, "fixAllPullRequests": true},
+		"webhook": {"enabled": true, "mode": "tunnel", "listenPort": 17311, "publicBaseUrl": "https://looper.example.test", "fallbackPollIntervalSeconds": 300},
 		"reviewer": {"reviewEvents": {"blocking": "REQUEST_CHANGES"}},
 		"roles": {"reviewer": {"autoDiscovery": true, "triggers": {"requireReviewRequest": true}, "specReview": {"includeReviewingLabel": true}}},
 		"projects": [{"id": "project_1", "name": "Repo", "path": "/tmp/repo", "instructions": {"reviewer": "be careful"}, "roles": {"reviewer": {"autoDiscovery": true, "triggers": {"requireReviewRequest": true}}}}],
@@ -46,9 +47,14 @@ func TestConfigMigrateDryRunPreviewsCanonicalTOMLWithoutWritingDestination(t *te
 			t.Fatalf("dry-run preview unexpectedly contained %q:\n%s", notWant, stdout)
 		}
 	}
-	for _, want := range []string{"Preview migration:", "[roles.reviewer.behavior.reviewEvents]", "clean = 'APPROVE'", "authorFilter = 'any'", "repoPath = '/tmp/repo'", "[projects.roles.reviewer.discovery]"} {
+	for _, want := range []string{"Preview migration:", "fallbackPollIntervalSeconds = 300", "listenPort = 17311", "[roles.reviewer.behavior.reviewEvents]", "clean = 'APPROVE'", "authorFilter = 'any'", "repoPath = '/tmp/repo'", "[projects.roles.reviewer.discovery]"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("dry-run preview missing %q:\n%s", want, stdout)
+		}
+	}
+	for _, notWant := range []string{"fallbackPollIntervalSeconds = 300.0", "listenPort = 17311.0"} {
+		if strings.Contains(stdout, notWant) {
+			t.Fatalf("dry-run preview unexpectedly contained %q:\n%s", notWant, stdout)
 		}
 	}
 

--- a/internal/config/file_format.go
+++ b/internal/config/file_format.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
@@ -49,8 +51,35 @@ func normalizeConfigEncodingValue(value any) (any, error) {
 		return nil, fmt.Errorf("normalize config for encoding: %w", err)
 	}
 	var normalized any
-	if err := json.Unmarshal(raw, &normalized); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&normalized); err != nil {
 		return nil, fmt.Errorf("normalize config for encoding: %w", err)
 	}
-	return normalized, nil
+	return normalizeJSONNumbers(normalized), nil
+}
+
+func normalizeJSONNumbers(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			typed[key] = normalizeJSONNumbers(child)
+		}
+		return typed
+	case []any:
+		for index, child := range typed {
+			typed[index] = normalizeJSONNumbers(child)
+		}
+		return typed
+	case json.Number:
+		if integer, err := strconv.ParseInt(typed.String(), 10, 64); err == nil {
+			return integer
+		}
+		if floating, err := strconv.ParseFloat(typed.String(), 64); err == nil {
+			return floating
+		}
+		return typed.String()
+	default:
+		return value
+	}
 }

--- a/internal/config/format_roundtrip_test.go
+++ b/internal/config/format_roundtrip_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	toml "github.com/pelletier/go-toml/v2"
@@ -36,6 +37,30 @@ func TestCanonicalDomainsRoundTripAcrossStructuredFormats(t *testing.T) {
 					t.Fatalf("%s domain mismatch after %s round trip\nactual: %#v\nwant: %#v", name, format, extract(roundTripped), extract(original))
 				}
 			})
+		}
+	}
+}
+
+func TestMarshalConfigFilePreservesIntegerTOMLNumbers(t *testing.T) {
+	mode := WebhookModeTunnel
+	listenPort := 17311
+	publicBaseURL := "https://looper.example.test"
+	fallback := 300
+	partial := PartialConfig{Webhook: &PartialWebhookConfig{Enabled: fixtureBoolPtr(true), Mode: &mode, ListenPort: &listenPort, PublicBaseURL: &publicBaseURL, FallbackPollIntervalSeconds: &fallback}}
+
+	raw, err := MarshalConfigFile("config.toml", partial)
+	if err != nil {
+		t.Fatalf("MarshalConfigFile() error = %v", err)
+	}
+	text := string(raw)
+	for _, want := range []string{"fallbackPollIntervalSeconds = 300", "listenPort = 17311"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("MarshalConfigFile() missing %q:\n%s", want, text)
+		}
+	}
+	for _, notWant := range []string{"fallbackPollIntervalSeconds = 300.0", "listenPort = 17311.0"} {
+		if strings.Contains(text, notWant) {
+			t.Fatalf("MarshalConfigFile() contained %q:\n%s", notWant, text)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Preserve JSON integer values when normalizing config before TOML/YAML/JSON encoding.
- Add regression coverage for webhook integer fields in `MarshalConfigFile` and `config migrate` previews.

## Tests
- `go test ./internal/config ./internal/cliapp`
- `go test ./...`