### PR TITLE
feat: add coordinator merge-watch routing

### DIFF
--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -278,6 +278,10 @@
                 "apiTimeoutSeconds": 10,
                 "apiRetryAttempts": 3
               },
+              "mergeWatch": {
+                "maxIndeterminateDuration": "15m",
+                "transientRetries": 3
+              },
               "dispatch": {
                 "mode": "human-gated",
                 "humanGate": {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -174,6 +174,10 @@ func DefaultConfig(cwd string) (Config, error) {
 					APITimeoutSeconds: 10,
 					APIRetryAttempts:  3,
 				},
+				MergeWatch: CoordinatorMergeWatchConfig{
+					TransientRetries:         3,
+					MaxIndeterminateDuration: "15m",
+				},
 			},
 			Planner: PlannerRoleConfig{
 				AutoDiscovery: true,

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -771,6 +771,9 @@ func mergeCoordinatorRoleConfig(config *CoordinatorRoleConfig, partial PartialCo
 	if partial.Dependencies != nil {
 		mergeCoordinatorDependenciesConfig(&config.Dependencies, *partial.Dependencies)
 	}
+	if partial.MergeWatch != nil {
+		mergeCoordinatorMergeWatchConfig(&config.MergeWatch, *partial.MergeWatch)
+	}
 }
 
 func mergeCoordinatorTriageConfig(config *CoordinatorTriageConfig, partial PartialCoordinatorTriageConfig) {
@@ -842,6 +845,15 @@ func mergeCoordinatorDependenciesConfig(config *CoordinatorDependenciesConfig, p
 	}
 	if partial.APIRetryAttempts != nil {
 		config.APIRetryAttempts = *partial.APIRetryAttempts
+	}
+}
+
+func mergeCoordinatorMergeWatchConfig(config *CoordinatorMergeWatchConfig, partial PartialCoordinatorMergeWatchConfig) {
+	if partial.TransientRetries != nil {
+		config.TransientRetries = *partial.TransientRetries
+	}
+	if partial.MaxIndeterminateDuration != nil {
+		config.MaxIndeterminateDuration = *partial.MaxIndeterminateDuration
 	}
 }
 

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -209,6 +209,10 @@
             "apiTimeoutSeconds": 10,
             "apiRetryAttempts": 3
           },
+          "mergeWatch": {
+            "maxIndeterminateDuration": "15m",
+            "transientRetries": 3
+          },
           "dispatch": {
             "mode": "human-gated",
             "humanGate": {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -146,6 +146,10 @@
             "apiTimeoutSeconds": 10,
             "apiRetryAttempts": 3
           },
+          "mergeWatch": {
+            "maxIndeterminateDuration": "15m",
+            "transientRetries": 3
+          },
           "dispatch": {
             "mode": "human-gated",
             "humanGate": {

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -229,6 +229,10 @@
             "apiTimeoutSeconds": 10,
             "apiRetryAttempts": 3
           },
+          "mergeWatch": {
+            "maxIndeterminateDuration": "15m",
+            "transientRetries": 3
+          },
           "dispatch": {
             "mode": "human-gated",
             "humanGate": {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -526,12 +526,18 @@ type CoordinatorDependenciesConfig struct {
 	APIRetryAttempts  int  `json:"apiRetryAttempts"`
 }
 
+type CoordinatorMergeWatchConfig struct {
+	TransientRetries         int    `json:"transientRetries"`
+	MaxIndeterminateDuration string `json:"maxIndeterminateDuration"`
+}
+
 type CoordinatorRoleConfig struct {
 	Enabled      bool                          `json:"enabled"`
 	PollInterval string                        `json:"pollInterval"`
 	Triage       CoordinatorTriageConfig       `json:"triage"`
 	Dispatch     CoordinatorDispatchConfig     `json:"dispatch"`
 	Dependencies CoordinatorDependenciesConfig `json:"dependencies"`
+	MergeWatch   CoordinatorMergeWatchConfig   `json:"mergeWatch"`
 }
 
 type RoleConfigs struct {
@@ -957,12 +963,18 @@ type PartialCoordinatorDependenciesConfig struct {
 	APIRetryAttempts  *int  `json:"apiRetryAttempts,omitempty"`
 }
 
+type PartialCoordinatorMergeWatchConfig struct {
+	TransientRetries         *int    `json:"transientRetries,omitempty"`
+	MaxIndeterminateDuration *string `json:"maxIndeterminateDuration,omitempty"`
+}
+
 type PartialCoordinatorRoleConfig struct {
 	Enabled      *bool                                 `json:"enabled,omitempty"`
 	PollInterval *string                               `json:"pollInterval,omitempty"`
 	Triage       *PartialCoordinatorTriageConfig       `json:"triage,omitempty"`
 	Dispatch     *PartialCoordinatorDispatchConfig     `json:"dispatch,omitempty"`
 	Dependencies *PartialCoordinatorDependenciesConfig `json:"dependencies,omitempty"`
+	MergeWatch   *PartialCoordinatorMergeWatchConfig   `json:"mergeWatch,omitempty"`
 }
 
 type PartialRoleConfigs struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -781,6 +781,16 @@ func validateCoordinatorRoleConfig(config CoordinatorRoleConfig, path string, is
 			*issues = append(*issues, ValidationIssue{Path: path + ".dependencies.apiRetryAttempts", Message: "must be a positive integer when dependencies are enabled"})
 		}
 	}
+	if config.MergeWatch.TransientRetries <= 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".mergeWatch.transientRetries", Message: "must be a positive integer"})
+	}
+	if strings.TrimSpace(config.MergeWatch.MaxIndeterminateDuration) == "" {
+		*issues = append(*issues, ValidationIssue{Path: path + ".mergeWatch.maxIndeterminateDuration", Message: "must be a non-empty duration string"})
+	} else if duration, err := time.ParseDuration(strings.TrimSpace(config.MergeWatch.MaxIndeterminateDuration)); err != nil {
+		*issues = append(*issues, ValidationIssue{Path: path + ".mergeWatch.maxIndeterminateDuration", Message: "must be a valid time.Duration string"})
+	} else if duration <= 0 {
+		*issues = append(*issues, ValidationIssue{Path: path + ".mergeWatch.maxIndeterminateDuration", Message: "must be greater than 0"})
+	}
 	validateDistinctLabels([]labelPathValue{
 		{Path: path + ".triage.triagedLabel", Value: config.Triage.TriagedLabel},
 		{Path: path + ".triage.disposition.outOfScopeLabel", Value: config.Triage.Disposition.OutOfScopeLabel},

--- a/internal/coordinator/mergewatch/mergewatch.go
+++ b/internal/coordinator/mergewatch/mergewatch.go
@@ -1,0 +1,113 @@
+package mergewatch
+
+import "time"
+
+type WatchActionKind string
+
+const (
+	ActionMerged                  WatchActionKind = "Merged"
+	ActionStillPending            WatchActionKind = "StillPending"
+	ActionIndeterminate           WatchActionKind = "Indeterminate"
+	ActionConflict                WatchActionKind = "Conflict"
+	ActionRedCI                   WatchActionKind = "RedCI"
+	ActionBranchProtectionChanged WatchActionKind = "BranchProtectionChanged"
+	ActionHumanDisabledAutoMerge  WatchActionKind = "HumanDisabledAutoMerge"
+	ActionTransientError          WatchActionKind = "TransientError"
+)
+
+type PriorWatchMarker struct {
+	PRNumber       int64
+	HeadSHA        string
+	Retries        int
+	FirstUnknownAt *time.Time
+	NextRetryAt    *time.Time
+}
+
+type RetryBudget struct {
+	Now                      time.Time
+	TransientRetries         int
+	MaxIndeterminateDuration time.Duration
+}
+
+type RequiredCheckSummary struct {
+	Failed  []string
+	Pending []string
+	Missing []string
+}
+
+type TemporaryError struct {
+	SuggestedDelay time.Duration
+}
+
+type PRSnapshot struct {
+	Repo                   string
+	PRNumber               int64
+	IssueNumber            int64
+	HeadSHA                string
+	Merged                 bool
+	Open                   bool
+	AutoMergeEnabled       bool
+	AutoMergeOwnedByLooper bool
+	HasLooperLabel         bool
+	Mergeable              *bool
+	MergeableState         string
+	RequiredChecks         RequiredCheckSummary
+	TemporaryError         *TemporaryError
+}
+
+type WatchAction struct {
+	Kind             WatchActionKind
+	FirstUnknownAt   *time.Time
+	DeadlineExceeded bool
+	RetriesLeft      int
+	SuggestedDelay   time.Duration
+	Exhausted        bool
+}
+
+func Classify(snapshot PRSnapshot, prior *PriorWatchMarker, budget RetryBudget) WatchAction {
+	normalized := normalizePrior(prior, snapshot, budget.TransientRetries)
+	if snapshot.TemporaryError != nil {
+		retriesLeft := normalized.Retries
+		if prior != nil && prior.PRNumber == snapshot.PRNumber && prior.HeadSHA == snapshot.HeadSHA {
+			if retriesLeft > 0 {
+				retriesLeft--
+			}
+		}
+		return WatchAction{Kind: ActionTransientError, RetriesLeft: retriesLeft, SuggestedDelay: snapshot.TemporaryError.SuggestedDelay, Exhausted: retriesLeft == 0}
+	}
+	if snapshot.Merged {
+		return WatchAction{Kind: ActionMerged}
+	}
+	if prior != nil && prior.PRNumber == snapshot.PRNumber && !snapshot.AutoMergeEnabled {
+		return WatchAction{Kind: ActionHumanDisabledAutoMerge}
+	}
+	if snapshot.Mergeable == nil || snapshot.MergeableState == "unknown" {
+		firstUnknownAt := normalized.FirstUnknownAt
+		if firstUnknownAt == nil {
+			now := budget.Now.UTC()
+			firstUnknownAt = &now
+		}
+		deadlineExceeded := budget.MaxIndeterminateDuration > 0 && budget.Now.UTC().Sub(*firstUnknownAt) > budget.MaxIndeterminateDuration
+		if deadlineExceeded {
+			return WatchAction{Kind: ActionBranchProtectionChanged, FirstUnknownAt: firstUnknownAt, DeadlineExceeded: true}
+		}
+		return WatchAction{Kind: ActionIndeterminate, FirstUnknownAt: firstUnknownAt}
+	}
+	if snapshot.MergeableState == "dirty" {
+		return WatchAction{Kind: ActionConflict}
+	}
+	if len(snapshot.RequiredChecks.Failed) > 0 {
+		return WatchAction{Kind: ActionRedCI}
+	}
+	if len(snapshot.RequiredChecks.Missing) > 0 {
+		return WatchAction{Kind: ActionBranchProtectionChanged}
+	}
+	return WatchAction{Kind: ActionStillPending}
+}
+
+func normalizePrior(prior *PriorWatchMarker, snapshot PRSnapshot, fallbackRetries int) PriorWatchMarker {
+	if prior == nil || prior.PRNumber != snapshot.PRNumber || prior.HeadSHA != snapshot.HeadSHA {
+		return PriorWatchMarker{PRNumber: snapshot.PRNumber, HeadSHA: snapshot.HeadSHA, Retries: fallbackRetries}
+	}
+	return *prior
+}

--- a/internal/coordinator/mergewatch/mergewatch_test.go
+++ b/internal/coordinator/mergewatch/mergewatch_test.go
@@ -1,0 +1,53 @@
+package mergewatch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+	mergeable := true
+	conflicted := false
+	beforeDeadline := now.Add(-10 * time.Minute)
+	afterDeadline := now.Add(-16 * time.Minute)
+
+	for _, tc := range []struct {
+		name         string
+		snapshot     PRSnapshot
+		prior        *PriorWatchMarker
+		budget       RetryBudget
+		wantKind     WatchActionKind
+		wantUnknown  *time.Time
+		wantDeadline bool
+		wantRetries  int
+		wantDelay    time.Duration
+		wantExhaust  bool
+	}{
+		{name: "merged", snapshot: PRSnapshot{PRNumber: 42, Merged: true}, budget: RetryBudget{Now: now, TransientRetries: 3, MaxIndeterminateDuration: 15 * time.Minute}, wantKind: ActionMerged},
+		{name: "still pending", snapshot: PRSnapshot{PRNumber: 42, Mergeable: &mergeable, MergeableState: "blocked", RequiredChecks: RequiredCheckSummary{Pending: []string{"ci"}}}, budget: RetryBudget{Now: now, TransientRetries: 3, MaxIndeterminateDuration: 15 * time.Minute}, wantKind: ActionStillPending},
+		{name: "indeterminate before deadline", snapshot: PRSnapshot{PRNumber: 42, HeadSHA: "abc", AutoMergeEnabled: true, MergeableState: "unknown"}, prior: &PriorWatchMarker{PRNumber: 42, HeadSHA: "abc", FirstUnknownAt: &beforeDeadline}, budget: RetryBudget{Now: now, TransientRetries: 3, MaxIndeterminateDuration: 15 * time.Minute}, wantKind: ActionIndeterminate, wantUnknown: &beforeDeadline},
+		{name: "indeterminate after deadline", snapshot: PRSnapshot{PRNumber: 42, HeadSHA: "abc", AutoMergeEnabled: true, Mergeable: &conflicted, MergeableState: "unknown"}, prior: &PriorWatchMarker{PRNumber: 42, HeadSHA: "abc", FirstUnknownAt: &afterDeadline}, budget: RetryBudget{Now: now, TransientRetries: 3, MaxIndeterminateDuration: 15 * time.Minute}, wantKind: ActionBranchProtectionChanged, wantUnknown: &afterDeadline, wantDeadline: true},
+		{name: "conflict", snapshot: PRSnapshot{PRNumber: 42, Mergeable: &conflicted, MergeableState: "dirty"}, budget: RetryBudget{Now: now, TransientRetries: 3, MaxIndeterminateDuration: 15 * time.Minute}, wantKind: ActionConflict},
+		{name: "red ci", snapshot: PRSnapshot{PRNumber: 42, Mergeable: &mergeable, MergeableState: "unstable", RequiredChecks: RequiredCheckSummary{Failed: []string{"ci"}}}, budget: RetryBudget{Now: now, TransientRetries: 3, MaxIndeterminateDuration: 15 * time.Minute}, wantKind: ActionRedCI},
+		{name: "human disabled auto merge", snapshot: PRSnapshot{PRNumber: 42, AutoMergeEnabled: false, Mergeable: &mergeable, MergeableState: "clean"}, prior: &PriorWatchMarker{PRNumber: 42, HeadSHA: "abc"}, budget: RetryBudget{Now: now, TransientRetries: 3, MaxIndeterminateDuration: 15 * time.Minute}, wantKind: ActionHumanDisabledAutoMerge},
+		{name: "transient error first observation", snapshot: PRSnapshot{PRNumber: 42, HeadSHA: "abc", TemporaryError: &TemporaryError{SuggestedDelay: time.Minute}}, budget: RetryBudget{Now: now, TransientRetries: 3, MaxIndeterminateDuration: 15 * time.Minute}, wantKind: ActionTransientError, wantRetries: 3, wantDelay: time.Minute},
+		{name: "transient exhausted", snapshot: PRSnapshot{PRNumber: 42, HeadSHA: "abc", TemporaryError: &TemporaryError{SuggestedDelay: 2 * time.Minute}}, prior: &PriorWatchMarker{PRNumber: 42, HeadSHA: "abc", Retries: 1}, budget: RetryBudget{Now: now, TransientRetries: 3, MaxIndeterminateDuration: 15 * time.Minute}, wantKind: ActionTransientError, wantDelay: 2 * time.Minute, wantExhaust: true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Classify(tc.snapshot, tc.prior, tc.budget)
+			if got.Kind != tc.wantKind || got.DeadlineExceeded != tc.wantDeadline || got.RetriesLeft != tc.wantRetries || got.SuggestedDelay != tc.wantDelay || got.Exhausted != tc.wantExhaust {
+				t.Fatalf("Classify() = %#v", got)
+			}
+			switch {
+			case tc.wantUnknown == nil && got.FirstUnknownAt != nil:
+				t.Fatalf("FirstUnknownAt = %v, want nil", got.FirstUnknownAt)
+			case tc.wantUnknown != nil && (got.FirstUnknownAt == nil || !got.FirstUnknownAt.Equal(*tc.wantUnknown)):
+				t.Fatalf("FirstUnknownAt = %v, want %v", got.FirstUnknownAt, tc.wantUnknown)
+			}
+		})
+	}
+}

--- a/internal/coordinator/mergewatch_runner.go
+++ b/internal/coordinator/mergewatch_runner.go
@@ -182,6 +182,9 @@ func (r *Runner) mergeWatchSnapshot(ctx context.Context, repo, cwd string, issue
 	mergeableState := strings.ToLower(strings.TrimSpace(detail.MergeableState))
 	protection, err := r.github.GetBranchProtection(ctx, githubinfra.BranchProtectionInput{Repo: repo, Branch: detail.BaseRefName, CWD: cwd})
 	if err != nil {
+		if isTransientMergeWatchError(err) {
+			return mergeWatchPartialSnapshot(repo, issueNumber, prNumber, detail, currentLogin), &mergewatch.TemporaryError{SuggestedDelay: time.Minute}, nil
+		}
 		return mergewatch.PRSnapshot{}, nil, err
 	}
 	requiredChecks := map[string]struct{}{}
@@ -232,6 +235,21 @@ func (r *Runner) mergeWatchSnapshot(ctx context.Context, repo, cwd string, issue
 		MergeableState:         mergeableState,
 		RequiredChecks:         checks,
 	}, nil, nil
+}
+
+func mergeWatchPartialSnapshot(repo string, issueNumber, prNumber int64, detail githubinfra.PullRequestDetail, currentLogin string) mergewatch.PRSnapshot {
+	return mergewatch.PRSnapshot{
+		Repo:                   repo,
+		PRNumber:               prNumber,
+		IssueNumber:            issueNumber,
+		HeadSHA:                detail.HeadSHA,
+		Open:                   strings.EqualFold(detail.State, "open"),
+		AutoMergeEnabled:       detail.AutoMerge != nil,
+		AutoMergeOwnedByLooper: detail.AutoMerge != nil && strings.EqualFold(strings.TrimSpace(detail.AutoMerge.EnabledBy), strings.TrimSpace(currentLogin)),
+		HasLooperLabel:         hasLooperLabel(detail.Labels),
+		Mergeable:              detail.Mergeable,
+		MergeableState:         strings.ToLower(strings.TrimSpace(detail.MergeableState)),
+	}
 }
 
 func mergeWatchBaseMarker(marker *mergeWatchComment, snapshot mergewatch.PRSnapshot, fallbackRetries int) mergewatch.PriorWatchMarker {

--- a/internal/coordinator/mergewatch_runner.go
+++ b/internal/coordinator/mergewatch_runner.go
@@ -71,14 +71,14 @@ func (r *Runner) applyMergeWatchLocked(ctx context.Context, repo, cwd string, is
 	}
 	if tempErr != nil {
 		snapshot.TemporaryError = tempErr
-	}
-	if !snapshot.HasLooperLabel || (snapshot.AutoMergeEnabled && !snapshot.AutoMergeOwnedByLooper) {
-		return false, r.deleteMergeWatchComment(ctx, repo, cwd, marker)
+		if snapshot.HeadSHA == "" && marker != nil && marker.Marker.PRNumber == snapshot.PRNumber {
+			snapshot.HeadSHA = marker.Marker.HeadSHA
+		}
 	}
 	action := mergewatch.Classify(snapshot, markerState(marker), mergewatch.RetryBudget{Now: r.now().UTC(), TransientRetries: roles.Coordinator.MergeWatch.TransientRetries, MaxIndeterminateDuration: maxIndeterminateDuration})
-	baseMarker := mergewatch.PriorWatchMarker{PRNumber: snapshot.PRNumber, HeadSHA: snapshot.HeadSHA, Retries: roles.Coordinator.MergeWatch.TransientRetries}
-	if marker != nil && marker.Marker.PRNumber == snapshot.PRNumber && marker.Marker.HeadSHA == snapshot.HeadSHA {
-		baseMarker = marker.Marker
+	baseMarker := mergeWatchBaseMarker(marker, snapshot, roles.Coordinator.MergeWatch.TransientRetries)
+	if action.Kind != mergewatch.ActionTransientError && (!snapshot.HasLooperLabel || (snapshot.AutoMergeEnabled && !snapshot.AutoMergeOwnedByLooper)) {
+		return false, r.deleteMergeWatchComment(ctx, repo, cwd, marker)
 	}
 	switch action.Kind {
 	case mergewatch.ActionMerged, mergewatch.ActionHumanDisabledAutoMerge:
@@ -201,6 +201,17 @@ func (r *Runner) mergeWatchSnapshot(ctx context.Context, repo, cwd string, issue
 			checks.Failed = append(checks.Failed, checkRun.Name)
 		}
 	}
+	for _, status := range checkRuns.Statuses {
+		contextKey := strings.ToLower(strings.TrimSpace(status.Context))
+		state := strings.ToLower(strings.TrimSpace(status.State))
+		seenChecks[contextKey] = struct{}{}
+		switch {
+		case requiredCheck(requiredChecks, contextKey) && state == "pending":
+			checks.Pending = append(checks.Pending, status.Context)
+		case mergeableState == "unstable" && requiredCheck(requiredChecks, contextKey) && (state == "failure" || state == "error"):
+			checks.Failed = append(checks.Failed, status.Context)
+		}
+	}
 	for requiredName := range requiredChecks {
 		if _, ok := seenChecks[requiredName]; !ok {
 			checks.Missing = append(checks.Missing, requiredName)
@@ -221,6 +232,13 @@ func (r *Runner) mergeWatchSnapshot(ctx context.Context, repo, cwd string, issue
 		MergeableState:         mergeableState,
 		RequiredChecks:         checks,
 	}, nil, nil
+}
+
+func mergeWatchBaseMarker(marker *mergeWatchComment, snapshot mergewatch.PRSnapshot, fallbackRetries int) mergewatch.PriorWatchMarker {
+	if marker != nil && marker.Marker.PRNumber == snapshot.PRNumber && (snapshot.HeadSHA == "" || marker.Marker.HeadSHA == snapshot.HeadSHA) {
+		return marker.Marker
+	}
+	return mergewatch.PriorWatchMarker{PRNumber: snapshot.PRNumber, HeadSHA: snapshot.HeadSHA, Retries: fallbackRetries}
 }
 
 func markerState(marker *mergeWatchComment) *mergewatch.PriorWatchMarker {

--- a/internal/coordinator/mergewatch_runner.go
+++ b/internal/coordinator/mergewatch_runner.go
@@ -1,0 +1,467 @@
+package coordinator
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/coordinator/mergewatch"
+	"github.com/nexu-io/looper/internal/disclosure"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+)
+
+var mergeWatchPRURLPattern = regexp.MustCompile(`/pull/(\d+)(?:/|$)`)
+var mergeWatchClosingReferencePattern = regexp.MustCompile(`(?i)(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+([\w.-]+/[\w.-]+#\d+|#\d+)`)
+
+type mergeWatchComment struct {
+	ID      int64
+	Summary string
+	Marker  mergewatch.PriorWatchMarker
+	Body    string
+}
+
+func (r *Runner) applyMergeWatch(ctx context.Context, repo, cwd string, loaded []loadedIssue, roles config.RoleConfigs) (map[int64]struct{}, error) {
+	result := map[int64]struct{}{}
+	if r.github == nil {
+		return result, nil
+	}
+	currentLogin, err := r.github.GetCurrentUserLoginForRepo(ctx, repo, cwd)
+	if err != nil {
+		return nil, err
+	}
+	budget, err := time.ParseDuration(strings.TrimSpace(roles.Coordinator.MergeWatch.MaxIndeterminateDuration))
+	if err != nil {
+		return nil, err
+	}
+	for _, issue := range loaded {
+		if !issueHasCoordinatorTracking(issue.detail.Labels, roles.Coordinator.Triage.TriagedLabel) {
+			continue
+		}
+		lock := r.watchLock(repo, issue.detail.Number)
+		lock.Lock()
+		removed, applyErr := r.applyMergeWatchLocked(ctx, repo, cwd, issue, roles, currentLogin, budget)
+		lock.Unlock()
+		if applyErr != nil {
+			return nil, applyErr
+		}
+		if removed {
+			result[issue.detail.Number] = struct{}{}
+		}
+	}
+	return result, nil
+}
+
+func (r *Runner) applyMergeWatchLocked(ctx context.Context, repo, cwd string, issue loadedIssue, roles config.RoleConfigs, currentLogin string, maxIndeterminateDuration time.Duration) (bool, error) {
+	marker := findMergeWatchComment(issue.detail.Comments, currentLogin)
+	watchedPR, ok, err := r.resolveWatchedPR(ctx, repo, cwd, issue, marker, currentLogin)
+	if err != nil || !ok {
+		return false, err
+	}
+	if marker != nil && marker.Marker.NextRetryAt != nil && r.now().UTC().Before(marker.Marker.NextRetryAt.UTC()) {
+		return false, nil
+	}
+	snapshot, tempErr, err := r.mergeWatchSnapshot(ctx, repo, cwd, issue.detail.Number, watchedPR, currentLogin)
+	if err != nil {
+		return false, err
+	}
+	if tempErr != nil {
+		snapshot.TemporaryError = tempErr
+	}
+	if !snapshot.HasLooperLabel || (snapshot.AutoMergeEnabled && !snapshot.AutoMergeOwnedByLooper) {
+		return false, r.deleteMergeWatchComment(ctx, repo, cwd, marker)
+	}
+	action := mergewatch.Classify(snapshot, markerState(marker), mergewatch.RetryBudget{Now: r.now().UTC(), TransientRetries: roles.Coordinator.MergeWatch.TransientRetries, MaxIndeterminateDuration: maxIndeterminateDuration})
+	baseMarker := mergewatch.PriorWatchMarker{PRNumber: snapshot.PRNumber, HeadSHA: snapshot.HeadSHA, Retries: roles.Coordinator.MergeWatch.TransientRetries}
+	if marker != nil && marker.Marker.PRNumber == snapshot.PRNumber && marker.Marker.HeadSHA == snapshot.HeadSHA {
+		baseMarker = marker.Marker
+	}
+	switch action.Kind {
+	case mergewatch.ActionMerged, mergewatch.ActionHumanDisabledAutoMerge:
+		return false, r.deleteMergeWatchComment(ctx, repo, cwd, marker)
+	case mergewatch.ActionStillPending:
+		baseMarker.FirstUnknownAt = nil
+		baseMarker.NextRetryAt = nil
+		baseMarker.Retries = roles.Coordinator.MergeWatch.TransientRetries
+		if marker == nil || mergeWatchCommentNeedsUpdate(marker, baseMarker, "") {
+			return false, r.upsertMergeWatchComment(ctx, repo, cwd, issue.detail.Number, marker, baseMarker, "")
+		}
+		return false, nil
+	case mergewatch.ActionIndeterminate:
+		baseMarker.FirstUnknownAt = action.FirstUnknownAt
+		baseMarker.NextRetryAt = nil
+		return false, r.upsertMergeWatchComment(ctx, repo, cwd, issue.detail.Number, marker, baseMarker, "")
+	case mergewatch.ActionConflict, mergewatch.ActionRedCI:
+		labels := requiredPRTriggerLabels(roles.Fixer.Triggers)
+		if len(labels) > 0 {
+			if err := r.github.AddPullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: repo, PRNumber: snapshot.PRNumber, Labels: labels, CWD: cwd}); err != nil {
+				return false, err
+			}
+		}
+		baseMarker.FirstUnknownAt = nil
+		baseMarker.NextRetryAt = nil
+		baseMarker.Retries = roles.Coordinator.MergeWatch.TransientRetries
+		summary := fmt.Sprintf("Coordinator merge-watch routed PR #%d to Fixer for %s.", snapshot.PRNumber, strings.ToLower(string(action.Kind)))
+		return false, r.upsertMergeWatchComment(ctx, repo, cwd, issue.detail.Number, marker, baseMarker, summary)
+	case mergewatch.ActionTransientError:
+		if action.Exhausted {
+			if err := r.removeIssueLabels(ctx, repo, cwd, issue.detail.Number, issue.detail.Labels, retriageCleanupPatterns(roles, roles.Coordinator.Triage.TriagedLabel)); err != nil {
+				return false, err
+			}
+			return true, r.deleteMergeWatchComment(ctx, repo, cwd, marker)
+		}
+		baseMarker.FirstUnknownAt = nil
+		if action.SuggestedDelay > 0 {
+			next := r.now().UTC().Add(action.SuggestedDelay)
+			baseMarker.NextRetryAt = &next
+		}
+		baseMarker.Retries = action.RetriesLeft
+		return false, r.upsertMergeWatchComment(ctx, repo, cwd, issue.detail.Number, marker, baseMarker, "")
+	case mergewatch.ActionBranchProtectionChanged:
+		if err := r.removeIssueLabels(ctx, repo, cwd, issue.detail.Number, issue.detail.Labels, retriageCleanupPatterns(roles, roles.Coordinator.Triage.TriagedLabel)); err != nil {
+			return false, err
+		}
+		return true, r.deleteMergeWatchComment(ctx, repo, cwd, marker)
+	default:
+		return false, nil
+	}
+}
+
+func (r *Runner) resolveWatchedPR(ctx context.Context, repo, cwd string, issue loadedIssue, marker *mergeWatchComment, currentLogin string) (int64, bool, error) {
+	linked := linkedPullRequestNumbers(issue.rawTimeline)
+	if marker != nil && marker.Marker.PRNumber > 0 {
+		for _, linkedPR := range linked {
+			if linkedPR == marker.Marker.PRNumber {
+				detail, err := r.github.ViewPullRequestMergeWatch(ctx, githubinfra.ViewPullRequestInput{Repo: repo, PRNumber: linkedPR, CWD: cwd})
+				if err == nil && prLinksIssue(repo, issue.detail.Number, detail.Body) {
+					return marker.Marker.PRNumber, true, nil
+				}
+			}
+		}
+	}
+	eligible := []int64{}
+	for _, prNumber := range linked {
+		detail, err := r.github.ViewPullRequestMergeWatch(ctx, githubinfra.ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: cwd})
+		if err != nil {
+			continue
+		}
+		if detail.AutoMerge == nil || !strings.EqualFold(strings.TrimSpace(detail.AutoMerge.EnabledBy), strings.TrimSpace(currentLogin)) || !hasLooperLabel(detail.Labels) || !prLinksIssue(repo, issue.detail.Number, detail.Body) {
+			continue
+		}
+		eligible = append(eligible, prNumber)
+	}
+	if len(eligible) != 1 {
+		if len(eligible) > 1 && r.logger != nil {
+			r.logger.Warn("coordinator merge-watch skipped ambiguous linked PR set", map[string]any{"repo": repo, "issue": issue.detail.Number, "count": len(eligible)})
+		}
+		return 0, false, nil
+	}
+	return eligible[0], true, nil
+}
+
+func (r *Runner) mergeWatchSnapshot(ctx context.Context, repo, cwd string, issueNumber, prNumber int64, currentLogin string) (mergewatch.PRSnapshot, *mergewatch.TemporaryError, error) {
+	detail, err := r.github.ViewPullRequestMergeWatch(ctx, githubinfra.ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: cwd})
+	if err != nil {
+		if isTransientMergeWatchError(err) {
+			return mergewatch.PRSnapshot{Repo: repo, PRNumber: prNumber, IssueNumber: issueNumber}, &mergewatch.TemporaryError{SuggestedDelay: time.Minute}, nil
+		}
+		return mergewatch.PRSnapshot{}, nil, err
+	}
+	checkRuns, err := r.github.ListPullRequestCheckRuns(ctx, githubinfra.PullRequestCheckRunsInput{Repo: repo, Ref: detail.HeadSHA, CWD: cwd})
+	if err != nil {
+		if isTransientMergeWatchError(err) {
+			return mergewatch.PRSnapshot{Repo: repo, PRNumber: prNumber, IssueNumber: issueNumber, HeadSHA: detail.HeadSHA, AutoMergeEnabled: detail.AutoMerge != nil, AutoMergeOwnedByLooper: detail.AutoMerge != nil && strings.EqualFold(detail.AutoMerge.EnabledBy, currentLogin), Mergeable: detail.Mergeable, MergeableState: detail.MergeableState}, &mergewatch.TemporaryError{SuggestedDelay: time.Minute}, nil
+		}
+		return mergewatch.PRSnapshot{}, nil, err
+	}
+	checks := mergewatch.RequiredCheckSummary{}
+	mergeableState := strings.ToLower(strings.TrimSpace(detail.MergeableState))
+	protection, err := r.github.GetBranchProtection(ctx, githubinfra.BranchProtectionInput{Repo: repo, Branch: detail.BaseRefName, CWD: cwd})
+	if err != nil {
+		return mergewatch.PRSnapshot{}, nil, err
+	}
+	requiredChecks := map[string]struct{}{}
+	for _, name := range protection.RequiredChecks {
+		requiredChecks[strings.ToLower(strings.TrimSpace(name))] = struct{}{}
+	}
+	seenChecks := map[string]struct{}{}
+	for _, checkRun := range checkRuns.CheckRuns {
+		status := strings.ToLower(strings.TrimSpace(checkRun.Status))
+		conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
+		nameKey := strings.ToLower(strings.TrimSpace(checkRun.Name))
+		seenChecks[nameKey] = struct{}{}
+		switch {
+		case status != "completed" && requiredCheck(requiredChecks, nameKey):
+			checks.Pending = append(checks.Pending, checkRun.Name)
+		case mergeableState == "unstable" && requiredCheck(requiredChecks, nameKey) && (conclusion == "failure" || conclusion == "timed_out" || conclusion == "cancelled" || conclusion == "action_required" || conclusion == "startup_failure" || conclusion == "stale"):
+			checks.Failed = append(checks.Failed, checkRun.Name)
+		}
+	}
+	for requiredName := range requiredChecks {
+		if _, ok := seenChecks[requiredName]; !ok {
+			checks.Missing = append(checks.Missing, requiredName)
+		}
+	}
+	open := strings.EqualFold(detail.State, "open")
+	return mergewatch.PRSnapshot{
+		Repo:                   repo,
+		PRNumber:               prNumber,
+		IssueNumber:            issueNumber,
+		HeadSHA:                detail.HeadSHA,
+		Merged:                 detail.MergedAt != "" || strings.EqualFold(detail.State, "merged"),
+		Open:                   open,
+		AutoMergeEnabled:       detail.AutoMerge != nil,
+		AutoMergeOwnedByLooper: detail.AutoMerge != nil && strings.EqualFold(strings.TrimSpace(detail.AutoMerge.EnabledBy), strings.TrimSpace(currentLogin)),
+		HasLooperLabel:         hasLooperLabel(detail.Labels),
+		Mergeable:              detail.Mergeable,
+		MergeableState:         mergeableState,
+		RequiredChecks:         checks,
+	}, nil, nil
+}
+
+func markerState(marker *mergeWatchComment) *mergewatch.PriorWatchMarker {
+	if marker == nil {
+		return nil
+	}
+	copy := marker.Marker
+	return &copy
+}
+
+func requiredPRTriggerLabels(cfg config.FixerRoleTriggersConfig) []string {
+	if cfg.LabelMode == config.LabelModeAll {
+		return append([]string(nil), cfg.Labels...)
+	}
+	if len(cfg.Labels) == 0 {
+		return nil
+	}
+	return []string{cfg.Labels[0]}
+}
+
+func retriageCleanupPatterns(roles config.RoleConfigs, triagedLabel string) []string {
+	patterns := []string{triagedLabel, "dispatch/*"}
+	patterns = append(patterns, requiredTriggerLabels(roles.Planner.Triggers)...)
+	patterns = append(patterns, requiredTriggerLabels(roles.Worker.Triggers)...)
+	return patterns
+}
+
+func (r *Runner) watchLock(repo string, issueNumber int64) *sync.Mutex {
+	key := fmt.Sprintf("%s#%d", repo, issueNumber)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.watchLocks[key] == nil {
+		r.watchLocks[key] = &sync.Mutex{}
+	}
+	return r.watchLocks[key]
+}
+
+func linkedPullRequestNumbers(timeline []map[string]any) []int64 {
+	seen := map[int64]struct{}{}
+	out := []int64{}
+	for _, event := range timeline {
+		for _, candidate := range []any{event["source"], event["pull_request"], event["issue"]} {
+			if prNumber := pullRequestNumberFromTimelineCandidate(candidate); prNumber > 0 {
+				if _, ok := seen[prNumber]; !ok {
+					seen[prNumber] = struct{}{}
+					out = append(out, prNumber)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func pullRequestNumberFromTimelineCandidate(candidate any) int64 {
+	row, ok := candidate.(map[string]any)
+	if !ok {
+		return 0
+	}
+	if nested, ok := row["issue"].(map[string]any); ok {
+		row = nested
+	}
+	if pullRequest := row["pull_request"]; pullRequest != nil {
+		if prRow, ok := pullRequest.(map[string]any); ok {
+			if number := asInt64(prRow["number"]); number > 0 {
+				return number
+			}
+			if url := firstNonEmpty(asString(prRow["html_url"]), asString(prRow["url"])); url != "" {
+				return pullRequestNumberFromURL(url)
+			}
+		}
+	}
+	if number := asInt64(row["number"]); number > 0 && row["pull_request"] != nil {
+		return number
+	}
+	if url := firstNonEmpty(asString(row["html_url"]), asString(row["url"])); url != "" {
+		return pullRequestNumberFromURL(url)
+	}
+	return 0
+}
+
+func pullRequestNumberFromURL(raw string) int64 {
+	match := mergeWatchPRURLPattern.FindStringSubmatch(strings.TrimSpace(raw))
+	if len(match) != 2 {
+		return 0
+	}
+	value, _ := strconv.ParseInt(match[1], 10, 64)
+	return value
+}
+
+func findMergeWatchComment(comments []githubinfra.CommentInfo, currentLogin string) *mergeWatchComment {
+	for i := len(comments) - 1; i >= 0; i-- {
+		if !strings.EqualFold(strings.TrimSpace(comments[i].Author), strings.TrimSpace(currentLogin)) {
+			continue
+		}
+		marker, ok := parseMergeWatchComment(comments[i])
+		if ok {
+			return &marker
+		}
+	}
+	return nil
+}
+
+func parseMergeWatchComment(comment githubinfra.CommentInfo) (mergeWatchComment, bool) {
+	lines := strings.Split(strings.TrimSpace(comment.Body), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, mergeWatchCommentMarkerPrefix) {
+			continue
+		}
+		payload := strings.TrimSuffix(strings.TrimPrefix(line, mergeWatchCommentMarkerPrefix), "-->")
+		fields := strings.Fields(strings.TrimSpace(payload))
+		marker := mergewatch.PriorWatchMarker{Retries: 0}
+		for _, field := range fields {
+			parts := strings.SplitN(field, "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			switch parts[0] {
+			case "pr":
+				marker.PRNumber = asInt64(parts[1])
+			case "head_sha":
+				marker.HeadSHA = parts[1]
+			case "retries":
+				marker.Retries = int(asInt64(parts[1]))
+			case "first_unknown_at":
+				if when, err := time.Parse(time.RFC3339, parts[1]); err == nil {
+					marker.FirstUnknownAt = &when
+				}
+			case "next_retry_at":
+				if when, err := time.Parse(time.RFC3339, parts[1]); err == nil {
+					marker.NextRetryAt = &when
+				}
+			}
+		}
+		summary := ""
+		if idx := strings.Index(comment.Body, line); idx > 0 {
+			summary = strings.TrimSpace(comment.Body[:idx])
+		}
+		return mergeWatchComment{ID: comment.ID, Summary: summary, Marker: marker, Body: comment.Body}, true
+	}
+	return mergeWatchComment{}, false
+}
+
+func mergeWatchCommentNeedsUpdate(existing *mergeWatchComment, next mergewatch.PriorWatchMarker, summary string) bool {
+	line := fmt.Sprintf("<!-- looper:coordinator:merge-watch pr=%d head_sha=%s retries=%d first_unknown_at=%s next_retry_at=%s -->", next.PRNumber, next.HeadSHA, next.Retries, mergeWatchTime(next.FirstUnknownAt), mergeWatchTime(next.NextRetryAt))
+	return !strings.Contains(existing.Body, line) || strings.TrimSpace(existing.Summary) != strings.TrimSpace(summary)
+}
+
+func mergeWatchTime(value *time.Time) string {
+	if value == nil || value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func (r *Runner) upsertMergeWatchComment(ctx context.Context, repo, cwd string, issueNumber int64, existing *mergeWatchComment, marker mergewatch.PriorWatchMarker, summary string) error {
+	body := strings.TrimSpace(summary)
+	line := fmt.Sprintf("<!-- looper:coordinator:merge-watch pr=%d head_sha=%s retries=%d first_unknown_at=%s next_retry_at=%s -->", marker.PRNumber, marker.HeadSHA, marker.Retries, mergeWatchTime(marker.FirstUnknownAt), mergeWatchTime(marker.NextRetryAt))
+	if body != "" {
+		body += "\n\n" + line
+	} else {
+		body = line
+	}
+	body = disclosure.FromConfig(*r.config).Markdown(body, "coordinator", disclosure.ChannelIssueComment)
+	if existing != nil {
+		if strings.TrimSpace(existing.Body) == strings.TrimSpace(body) {
+			return nil
+		}
+		return r.github.UpdateIssueComment(ctx, githubinfra.UpdateIssueCommentInput{Repo: repo, CommentID: existing.ID, Body: body, CWD: cwd})
+	}
+	_, err := r.github.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: repo, IssueNumber: issueNumber, Body: body, CWD: cwd})
+	return err
+}
+
+func (r *Runner) deleteMergeWatchComment(ctx context.Context, repo, cwd string, existing *mergeWatchComment) error {
+	if existing == nil {
+		return nil
+	}
+	return r.github.DeleteIssueComment(ctx, githubinfra.DeleteIssueCommentInput{Repo: repo, CommentID: existing.ID, CWD: cwd})
+}
+
+func hasLooperLabel(labels []string) bool {
+	for _, label := range labels {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(label)), "looper:") {
+			return true
+		}
+	}
+	return false
+}
+
+func isTransientMergeWatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "timeout") || strings.Contains(text, "timed out") || strings.Contains(text, "secondary rate") || strings.Contains(text, "abuse") || strings.Contains(text, "429") || strings.Contains(text, "502") || strings.Contains(text, "503") || strings.Contains(text, "504") || strings.Contains(text, "500")
+}
+
+func prLinksIssue(repo string, issueNumber int64, body string) bool {
+	for _, match := range mergeWatchClosingReferencePattern.FindAllStringSubmatch(body, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		reference := strings.TrimSpace(match[1])
+		if strings.HasPrefix(reference, "#") && asInt64(reference[1:]) == issueNumber {
+			return true
+		}
+		parts := strings.Split(reference, "#")
+		if len(parts) == 2 && strings.EqualFold(strings.TrimSpace(parts[0]), strings.TrimSpace(repo)) && asInt64(parts[1]) == issueNumber {
+			return true
+		}
+	}
+	return false
+}
+
+func requiredCheck(required map[string]struct{}, name string) bool {
+	if len(required) == 0 {
+		return false
+	}
+	_, ok := required[name]
+	return ok
+}
+
+func issueHasCoordinatorTracking(labels []string, triagedLabel string) bool {
+	for _, label := range labels {
+		normalized := strings.ToLower(strings.TrimSpace(label))
+		if normalized == strings.ToLower(strings.TrimSpace(triagedLabel)) || strings.HasPrefix(normalized, "dispatch/") {
+			return true
+		}
+	}
+	return false
+}
+
+func asInt64(value any) int64 {
+	if text, ok := value.(string); ok {
+		out, _ := strconv.ParseInt(strings.TrimSpace(text), 10, 64)
+		return out
+	}
+	if number, ok := value.(float64); ok {
+		return int64(number)
+	}
+	out, _ := strconv.ParseInt(strings.TrimSpace(fmt.Sprint(value)), 10, 64)
+	return out
+}

--- a/internal/coordinator/runner.go
+++ b/internal/coordinator/runner.go
@@ -190,15 +190,16 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
+	activeLoaded := filterLoadedIssues(loaded, mergeWatchRetriggers)
 
-	deps, err := r.buildDependencyState(ctx, input.Repo, project.RepoPath, loaded, triageCfg, dispatchCfg, roleCfg.Dependencies)
+	deps, err := r.buildDependencyState(ctx, input.Repo, project.RepoPath, activeLoaded, triageCfg, dispatchCfg, roleCfg.Dependencies)
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
 	if err := r.applyDependencyActions(ctx, input.Repo, project.RepoPath, triageCfg, deps); err != nil {
 		return DiscoveryResult{}, err
 	}
-	if err := r.applyDispatches(ctx, input.Repo, project.RepoPath, loaded, triageCfg, dispatchCfg, deps); err != nil {
+	if err := r.applyDispatches(ctx, input.Repo, project.RepoPath, activeLoaded, triageCfg, dispatchCfg, deps); err != nil {
 		return DiscoveryResult{}, err
 	}
 
@@ -233,6 +234,20 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 		}
 	}
 	return DiscoveryResult{Ticked: true}, nil
+}
+
+func filterLoadedIssues(loaded []loadedIssue, skipped map[int64]struct{}) []loadedIssue {
+	if len(skipped) == 0 {
+		return loaded
+	}
+	filtered := make([]loadedIssue, 0, len(loaded))
+	for _, item := range loaded {
+		if _, skip := skipped[item.issue.Number]; skip {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
 }
 
 func (r *Runner) buildDispatchDependencyGraph(ctx context.Context, repo, cwd string, depsCfg config.CoordinatorDependenciesConfig, dispatchCfg dispatch.Config, loaded []loadedCoordinatorIssue, now time.Time) (*depgraph.DependencyGraph, error) {

--- a/internal/coordinator/runner.go
+++ b/internal/coordinator/runner.go
@@ -26,6 +26,7 @@ const jsISOStringLayout = "2006-01-02T15:04:05.000Z"
 const triageCommentMarker = "<!-- looper:coordinator:triage -->"
 const dispatchFailureCommentMarker = "<!-- looper:coordinator:dispatch-failure -->"
 const cycleCommentMarker = "<!-- looper:coordinator:cycle -->"
+const mergeWatchCommentMarkerPrefix = "<!-- looper:coordinator:merge-watch"
 
 type DiscoveryInput struct {
 	ProjectID string
@@ -67,6 +68,11 @@ type GitHubGateway interface {
 	RemoveIssueLabels(context.Context, githubinfra.IssueLabelsInput) error
 	CreateIssueComment(context.Context, githubinfra.IssueCommentInput) (githubinfra.IssueCommentResult, error)
 	UpdateIssueComment(context.Context, githubinfra.UpdateIssueCommentInput) error
+	DeleteIssueComment(context.Context, githubinfra.DeleteIssueCommentInput) error
+	AddPullRequestLabels(context.Context, githubinfra.PullRequestLabelsInput) error
+	ViewPullRequestMergeWatch(context.Context, githubinfra.ViewPullRequestInput) (githubinfra.PullRequestDetail, error)
+	ListPullRequestCheckRuns(context.Context, githubinfra.PullRequestCheckRunsInput) (githubinfra.PullRequestCheckRuns, error)
+	GetBranchProtection(context.Context, githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error)
 }
 
 type RepositoryInspector interface {
@@ -96,12 +102,14 @@ type Runner struct {
 
 	mu                sync.Mutex
 	lastTickByProject map[string]time.Time
+	watchLocks        map[string]*sync.Mutex
 }
 
 type loadedIssue struct {
-	summary githubinfra.IssueSummary
-	detail  githubinfra.IssueDetail
-	issue   triage.Issue
+	summary     githubinfra.IssueSummary
+	detail      githubinfra.IssueDetail
+	issue       triage.Issue
+	rawTimeline []map[string]any
 }
 
 type dependencyState struct {
@@ -139,6 +147,7 @@ func New(options Options) *Runner {
 		inspector:         inspector,
 		disclosure:        options.Disclosure,
 		lastTickByProject: map[string]time.Time{},
+		watchLocks:        map[string]*sync.Mutex{},
 	}
 }
 
@@ -177,6 +186,10 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 		}
 		loaded = append(loaded, issue)
 	}
+	mergeWatchRetriggers, err := r.applyMergeWatch(ctx, input.Repo, project.RepoPath, loaded, config.ProjectRoleConfigs(*r.config, input.ProjectID))
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
 
 	deps, err := r.buildDependencyState(ctx, input.Repo, project.RepoPath, loaded, triageCfg, dispatchCfg, roleCfg.Dependencies)
 	if err != nil {
@@ -191,6 +204,9 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 
 	processed := 0
 	for _, loadedIssue := range loaded {
+		if _, skip := mergeWatchRetriggers[loadedIssue.issue.Number]; skip {
+			continue
+		}
 		if _, skip := deps.retriageIssueNumbers[loadedIssue.issue.Number]; skip {
 			continue
 		}
@@ -843,7 +859,7 @@ func (r *Runner) loadIssue(ctx context.Context, repo, cwd string, summary github
 	for _, event := range timeline {
 		issue.Timeline = append(issue.Timeline, triage.TimelineEvent{Event: strings.TrimSpace(asString(event["event"])), CreatedAt: firstNonEmpty(asString(event["created_at"]), asString(event["createdAt"])), Label: timelineLabelName(event)})
 	}
-	return loadedIssue{summary: summary, detail: detail, issue: issue}, nil
+	return loadedIssue{summary: summary, detail: detail, issue: issue, rawTimeline: append([]map[string]any(nil), timeline...)}, nil
 }
 
 func roleConfigToDispatchConfig(roleCfg config.CoordinatorRoleConfig, roles config.RoleConfigs) dispatch.Config {

--- a/internal/coordinator/runner_actions_test.go
+++ b/internal/coordinator/runner_actions_test.go
@@ -688,7 +688,7 @@ func newCoordinatorFixture(t *testing.T) coordinatorFixture {
 	}
 	cfg.Disclosure.Enabled = true
 	cfg.Disclosure.Channels.IssueComment = true
-	github := &stubCoordinatorGitHub{details: map[int64]githubinfra.IssueDetail{}, comments: map[int64][][]githubinfra.CommentInfo{}, timeline: map[int64][]map[string]any{}, blockedBy: map[int64][]githubinfra.DependencyIssue{}, subIssues: map[int64][]githubinfra.DependencyIssue{}, subIssueErr: map[int64]error{}}
+	github := &stubCoordinatorGitHub{details: map[int64]githubinfra.IssueDetail{}, comments: map[int64][][]githubinfra.CommentInfo{}, timeline: map[int64][]map[string]any{}, blockedBy: map[int64][]githubinfra.DependencyIssue{}, subIssues: map[int64][]githubinfra.DependencyIssue{}, subIssueErr: map[int64]error{}, prDetails: map[int64]githubinfra.PullRequestDetail{}, prCheckRuns: map[string]githubinfra.PullRequestCheckRuns{}, branchProtection: map[string]githubinfra.BranchProtection{}}
 	runner := New(Options{Repos: repos, GitHub: github, Config: &cfg, Now: func() time.Time { return now }, TriageLLM: stubCoordinatorLLM{}, Inspector: stubCoordinatorInspector{}})
 	return coordinatorFixture{runner: runner, github: github, cfg: &cfg, projectID: projectID, now: now, coord: coord}
 }
@@ -731,6 +731,10 @@ type stubCoordinatorGitHub struct {
 	addedLabels         []githubinfra.IssueLabelsInput
 	removedLabels       []githubinfra.IssueLabelsInput
 	assigned            []githubinfra.IssueAssigneesInput
+	prDetails           map[int64]githubinfra.PullRequestDetail
+	prCheckRuns         map[string]githubinfra.PullRequestCheckRuns
+	branchProtection    map[string]githubinfra.BranchProtection
+	addedPRLabels       []githubinfra.PullRequestLabelsInput
 }
 
 func (s *stubCoordinatorGitHub) ListOpenIssues(context.Context, githubinfra.ListOpenIssuesInput) ([]githubinfra.IssueSummary, error) {
@@ -834,6 +838,33 @@ func (s *stubCoordinatorGitHub) UpdateIssueComment(_ context.Context, input gith
 	s.updatedBodies = append(s.updatedBodies, input.Body)
 	return nil
 }
+func (s *stubCoordinatorGitHub) DeleteIssueComment(_ context.Context, input githubinfra.DeleteIssueCommentInput) error {
+	s.ops = append(s.ops, "delete-comment")
+	return nil
+}
+func (s *stubCoordinatorGitHub) AddPullRequestLabels(_ context.Context, input githubinfra.PullRequestLabelsInput) error {
+	s.ops = append(s.ops, "add-pr:"+joinLabels(input.Labels))
+	s.addedPRLabels = append(s.addedPRLabels, input)
+	return nil
+}
+func (s *stubCoordinatorGitHub) ViewPullRequestMergeWatch(_ context.Context, input githubinfra.ViewPullRequestInput) (githubinfra.PullRequestDetail, error) {
+	if s.prDetails == nil {
+		return githubinfra.PullRequestDetail{}, nil
+	}
+	return s.prDetails[input.PRNumber], nil
+}
+func (s *stubCoordinatorGitHub) ListPullRequestCheckRuns(_ context.Context, input githubinfra.PullRequestCheckRunsInput) (githubinfra.PullRequestCheckRuns, error) {
+	if s.prCheckRuns == nil {
+		return githubinfra.PullRequestCheckRuns{}, nil
+	}
+	return s.prCheckRuns[input.Ref], nil
+}
+func (s *stubCoordinatorGitHub) GetBranchProtection(_ context.Context, input githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+	if s.branchProtection == nil {
+		return githubinfra.BranchProtection{}, nil
+	}
+	return s.branchProtection[input.Branch], nil
+}
 
 func TestRunnerHumanDispatchBlockedByPostsFailureComment(t *testing.T) {
 	t.Parallel()
@@ -853,6 +884,95 @@ func TestRunnerHumanDispatchBlockedByPostsFailureComment(t *testing.T) {
 	assertOrderedOps(t, fixture.github.ops, []string{"create-comment", "react:confused:11"})
 	if len(fixture.github.createdBodies) != 1 || !containsAll(fixture.github.createdBodies[0], dispatchFailureCommentMarker, "#9", "open") {
 		t.Fatalf("createdBodies = %v, want blocked_by failure comment", fixture.github.createdBodies)
+	}
+}
+
+func TestRunnerMergeWatchConflictRoutesToFixerAndUpdatesMarker(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Fixer.Triggers.Labels = []string{"looper:fix"}
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{
+		Number: 1,
+		Title:  "Bug",
+		Author: "octo",
+		Labels: []string{"triaged"},
+		Comments: []githubinfra.CommentInfo{{
+			ID:        44,
+			Author:    "looper",
+			Body:      mergeWatchCommentBody(fixture.cfg, 77, "abc123", 3, nil, nil, "old summary"),
+			CreatedAt: fixture.now.Format(time.RFC3339),
+		}},
+		CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339),
+	}
+	fixture.github.prDetails[77] = githubinfra.PullRequestDetail{
+		Number:         77,
+		Body:           "Closes #1",
+		State:          "open",
+		HeadSHA:        "abc123",
+		BaseRefName:    "main",
+		Labels:         []string{"looper:plan"},
+		Mergeable:      boolPtr(false),
+		MergeableState: "dirty",
+		AutoMerge:      &githubinfra.PullRequestAutoMerge{EnabledBy: "looper"},
+	}
+	fixture.github.timeline[1] = []map[string]any{{"source": map[string]any{"issue": map[string]any{"pull_request": map[string]any{"number": 77, "html_url": "https://github.com/acme/looper/pull/77"}}}}}
+
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	assertOrderedOps(t, fixture.github.ops, []string{"add-pr:looper:fix", "update-comment"})
+	if len(fixture.github.addedPRLabels) != 1 || fixture.github.addedPRLabels[0].PRNumber != 77 {
+		t.Fatalf("addedPRLabels = %#v, want PR #77 label add", fixture.github.addedPRLabels)
+	}
+	if len(fixture.github.updatedBodies) != 1 || !containsAll(fixture.github.updatedBodies[0], "Coordinator merge-watch routed PR #77 to Fixer for conflict.", mergeWatchCommentMarkerPrefix, "pr=77", "head_sha=abc123") {
+		t.Fatalf("updatedBodies = %v, want conflict summary marker update", fixture.github.updatedBodies)
+	}
+	if len(fixture.github.createdBodies) != 0 {
+		t.Fatalf("createdBodies = %v, want no new comments", fixture.github.createdBodies)
+	}
+}
+
+func TestRunnerMergeWatchHumanDisabledRemovesMarkerOnly(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Fixer.Triggers.Labels = []string{"looper:fix"}
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{
+		Number: 1,
+		Title:  "Bug",
+		Author: "octo",
+		Labels: []string{"triaged"},
+		Comments: []githubinfra.CommentInfo{{
+			ID:        45,
+			Author:    "looper",
+			Body:      mergeWatchCommentBody(fixture.cfg, 78, "def456", 3, nil, nil, "watching"),
+			CreatedAt: fixture.now.Format(time.RFC3339),
+		}},
+		CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339),
+	}
+	fixture.github.prDetails[78] = githubinfra.PullRequestDetail{
+		Number:         78,
+		Body:           "Closes #1",
+		State:          "open",
+		HeadSHA:        "def456",
+		BaseRefName:    "main",
+		Labels:         []string{"looper:plan"},
+		Mergeable:      boolPtr(true),
+		MergeableState: "clean",
+	}
+	fixture.github.timeline[1] = []map[string]any{{"source": map[string]any{"issue": map[string]any{"pull_request": map[string]any{"number": 78, "html_url": "https://github.com/acme/looper/pull/78"}}}}}
+
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(fixture.github.ops) != 1 || fixture.github.ops[0] != "delete-comment" {
+		t.Fatalf("ops = %v, want only delete-comment", fixture.github.ops)
+	}
+	if len(fixture.github.addedPRLabels) != 0 || len(fixture.github.updatedBodies) != 0 || len(fixture.github.createdBodies) != 0 || len(fixture.github.addedLabels) != 0 || len(fixture.github.removedLabels) != 0 {
+		t.Fatalf("unexpected mutations: addedPRLabels=%v updatedBodies=%v createdBodies=%v addedLabels=%v removedLabels=%v", fixture.github.addedPRLabels, fixture.github.updatedBodies, fixture.github.createdBodies, fixture.github.addedLabels, fixture.github.removedLabels)
 	}
 }
 
@@ -991,6 +1111,21 @@ func containsAll(body string, parts ...string) bool {
 
 func intToString(value int64) string {
 	return strconv.FormatInt(value, 10)
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func mergeWatchCommentBody(cfg *config.Config, prNumber int64, headSHA string, retries int, firstUnknownAt, nextRetryAt *time.Time, summary string) string {
+	body := strings.TrimSpace(summary)
+	line := "<!-- looper:coordinator:merge-watch pr=" + strconv.FormatInt(prNumber, 10) + " head_sha=" + headSHA + " retries=" + strconv.Itoa(retries) + " first_unknown_at=" + mergeWatchTime(firstUnknownAt) + " next_retry_at=" + mergeWatchTime(nextRetryAt) + " -->"
+	if body != "" {
+		body += "\n\n" + line
+	} else {
+		body = line
+	}
+	return stampedCoordinatorBody(cfg, body)
 }
 
 func stampedCoordinatorBody(cfg *config.Config, body string) string {

--- a/internal/coordinator/runner_actions_test.go
+++ b/internal/coordinator/runner_actions_test.go
@@ -712,31 +712,32 @@ func (stubCoordinatorInspector) Inspect(context.Context, string, triage.Issue) (
 }
 
 type stubCoordinatorGitHub struct {
-	issues              []githubinfra.IssueSummary
-	details             map[int64]githubinfra.IssueDetail
-	comments            map[int64][][]githubinfra.CommentInfo
-	timeline            map[int64][]map[string]any
-	blockedBy           map[int64][]githubinfra.DependencyIssue
-	subIssues           map[int64][]githubinfra.DependencyIssue
-	subIssueErr         map[int64]error
-	blockedByReads      int
-	blockedByIssueReads int
-	permissionErr       error
-	ops                 []string
-	createdBodies       []string
-	updatedBodies       []string
-	commentReads        map[int64]int
-	failAddLabels       map[string]error
-	failBlockedByIssues map[int64][]error
-	addedLabels         []githubinfra.IssueLabelsInput
-	removedLabels       []githubinfra.IssueLabelsInput
-	assigned            []githubinfra.IssueAssigneesInput
-	prDetails           map[int64]githubinfra.PullRequestDetail
-	failPRDetails       map[int64][]error
-	prCheckRuns         map[string]githubinfra.PullRequestCheckRuns
-	failPRCheckRuns     map[string]error
-	branchProtection    map[string]githubinfra.BranchProtection
-	addedPRLabels       []githubinfra.PullRequestLabelsInput
+	issues               []githubinfra.IssueSummary
+	details              map[int64]githubinfra.IssueDetail
+	comments             map[int64][][]githubinfra.CommentInfo
+	timeline             map[int64][]map[string]any
+	blockedBy            map[int64][]githubinfra.DependencyIssue
+	subIssues            map[int64][]githubinfra.DependencyIssue
+	subIssueErr          map[int64]error
+	blockedByReads       int
+	blockedByIssueReads  int
+	permissionErr        error
+	ops                  []string
+	createdBodies        []string
+	updatedBodies        []string
+	commentReads         map[int64]int
+	failAddLabels        map[string]error
+	failBlockedByIssues  map[int64][]error
+	addedLabels          []githubinfra.IssueLabelsInput
+	removedLabels        []githubinfra.IssueLabelsInput
+	assigned             []githubinfra.IssueAssigneesInput
+	prDetails            map[int64]githubinfra.PullRequestDetail
+	failPRDetails        map[int64][]error
+	prCheckRuns          map[string]githubinfra.PullRequestCheckRuns
+	failPRCheckRuns      map[string]error
+	branchProtection     map[string]githubinfra.BranchProtection
+	failBranchProtection map[string]error
+	addedPRLabels        []githubinfra.PullRequestLabelsInput
 }
 
 func (s *stubCoordinatorGitHub) ListOpenIssues(context.Context, githubinfra.ListOpenIssuesInput) ([]githubinfra.IssueSummary, error) {
@@ -872,6 +873,9 @@ func (s *stubCoordinatorGitHub) ListPullRequestCheckRuns(_ context.Context, inpu
 	return s.prCheckRuns[input.Ref], nil
 }
 func (s *stubCoordinatorGitHub) GetBranchProtection(_ context.Context, input githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+	if err := s.failBranchProtection[input.Branch]; err != nil {
+		return githubinfra.BranchProtection{}, err
+	}
 	if s.branchProtection == nil {
 		return githubinfra.BranchProtection{}, nil
 	}
@@ -1085,6 +1089,59 @@ func TestRunnerMergeWatchPRDetailTransientErrorConsumesRetryBudget(t *testing.T)
 	}
 }
 
+func TestRunnerMergeWatchBranchProtectionTransientErrorConsumesRetryBudget(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Coordinator.MergeWatch.TransientRetries = 3
+	fixture.github.failBranchProtection = map[string]error{"main": errors.New("HTTP 429 rate limit")}
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{
+		Number: 1,
+		Title:  "Bug",
+		Author: "octo",
+		Labels: []string{"triaged"},
+		Comments: []githubinfra.CommentInfo{{
+			ID:        49,
+			Author:    "looper",
+			Body:      mergeWatchCommentBody(fixture.cfg, 77, "abc123", 2, nil, nil, "watching"),
+			CreatedAt: fixture.now.Format(time.RFC3339),
+		}},
+		CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339),
+	}
+	fixture.github.prDetails[77] = githubinfra.PullRequestDetail{
+		Number:         77,
+		Body:           "Closes #1",
+		State:          "open",
+		HeadSHA:        "abc123",
+		BaseRefName:    "main",
+		Labels:         []string{"looper:plan"},
+		Mergeable:      boolPtr(true),
+		MergeableState: "blocked",
+		AutoMerge:      &githubinfra.PullRequestAutoMerge{EnabledBy: "looper"},
+	}
+	fixture.github.timeline[1] = []map[string]any{{"source": map[string]any{"issue": map[string]any{"pull_request": map[string]any{"number": 77, "html_url": "https://github.com/acme/looper/pull/77"}}}}}
+
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(fixture.github.ops) != 1 || fixture.github.ops[0] != "update-comment" {
+		t.Fatalf("ops = %v, want retry marker update only", fixture.github.ops)
+	}
+	if len(fixture.github.updatedBodies) != 1 || !containsAll(fixture.github.updatedBodies[0], "head_sha=abc123", "retries=1") {
+		t.Fatalf("updatedBodies = %v, want preserved head SHA and decremented retry budget", fixture.github.updatedBodies)
+	}
+	if len(fixture.github.removedLabels) != 0 {
+		t.Fatalf("removedLabels = %v, want no retriage cleanup on transient error", fixture.github.removedLabels)
+	}
+	if len(fixture.github.createdBodies) != 0 {
+		t.Fatalf("createdBodies = %v, want no new comments", fixture.github.createdBodies)
+	}
+	if len(fixture.github.addedPRLabels) != 0 {
+		t.Fatalf("addedPRLabels = %v, want no fixer routing on transient error", fixture.github.addedPRLabels)
+	}
+}
+
 func TestRunnerMergeWatchStatusContextsPreventMissingRequiredCheck(t *testing.T) {
 	t.Parallel()
 	fixture := newCoordinatorFixture(t)
@@ -1128,6 +1185,58 @@ func TestRunnerMergeWatchStatusContextsPreventMissingRequiredCheck(t *testing.T)
 	}
 	if len(fixture.github.removedLabels) != 0 || len(fixture.github.createdBodies) != 0 {
 		t.Fatalf("removedLabels=%v createdBodies=%v, want watch to stay pending without retriage", fixture.github.removedLabels, fixture.github.createdBodies)
+	}
+}
+
+func TestRunnerMergeWatchRetriggerSkipsSameTickDispatch(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Coordinator.Dispatch.AssignTo = "octocat"
+	fixture.runner.config.Roles.Coordinator.MergeWatch.MaxIndeterminateDuration = "15m"
+	firstUnknownAt := fixture.now.Add(-16 * time.Minute)
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged", "dispatch/plan"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{
+		Number: 1,
+		Title:  "Bug",
+		Author: "octo",
+		Labels: []string{"triaged", "dispatch/plan"},
+		Comments: []githubinfra.CommentInfo{{
+			ID:        50,
+			Author:    "looper",
+			Body:      mergeWatchCommentBody(fixture.cfg, 77, "abc123", 3, &firstUnknownAt, nil, "watching"),
+			CreatedAt: fixture.now.Format(time.RFC3339),
+		}},
+		CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339),
+	}
+	fixture.github.prDetails[77] = githubinfra.PullRequestDetail{
+		Number:         77,
+		Body:           "Closes #1",
+		State:          "open",
+		HeadSHA:        "abc123",
+		BaseRefName:    "main",
+		Labels:         []string{"looper:plan"},
+		Mergeable:      boolPtr(false),
+		MergeableState: "unknown",
+		AutoMerge:      &githubinfra.PullRequestAutoMerge{EnabledBy: "looper"},
+	}
+	fixture.github.timeline[1] = []map[string]any{{"source": map[string]any{"issue": map[string]any{"pull_request": map[string]any{"number": 77, "html_url": "https://github.com/acme/looper/pull/77"}}}}, {"event": "labeled", "created_at": fixture.now.Add(-time.Hour).Format(time.RFC3339), "label": map[string]any{"name": "triaged"}}}
+
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	assertOrderedOps(t, fixture.github.ops, []string{"remove:triaged,dispatch/plan", "delete-comment"})
+	if got := countRemovedIssueOperations(fixture.github.removedLabels, 1, "triaged", "dispatch/plan"); got != 1 {
+		t.Fatalf("issue 1 remove count = %d, want 1", got)
+	}
+	if hasAssignedIssue(fixture.github.assigned, 1) {
+		t.Fatalf("assigned = %#v, want no same-tick dispatch assignment after merge-watch cleanup", fixture.github.assigned)
+	}
+	if len(fixture.github.addedLabels) != 0 {
+		t.Fatalf("addedLabels = %#v, want no same-tick dispatch labels after merge-watch cleanup", fixture.github.addedLabels)
+	}
+	if len(fixture.github.createdBodies) != 0 || len(fixture.github.updatedBodies) != 0 {
+		t.Fatalf("createdBodies=%v updatedBodies=%v, want only cleanup mutations", fixture.github.createdBodies, fixture.github.updatedBodies)
 	}
 }
 

--- a/internal/coordinator/runner_actions_test.go
+++ b/internal/coordinator/runner_actions_test.go
@@ -732,7 +732,9 @@ type stubCoordinatorGitHub struct {
 	removedLabels       []githubinfra.IssueLabelsInput
 	assigned            []githubinfra.IssueAssigneesInput
 	prDetails           map[int64]githubinfra.PullRequestDetail
+	failPRDetails       map[int64][]error
 	prCheckRuns         map[string]githubinfra.PullRequestCheckRuns
+	failPRCheckRuns     map[string]error
 	branchProtection    map[string]githubinfra.BranchProtection
 	addedPRLabels       []githubinfra.PullRequestLabelsInput
 }
@@ -848,12 +850,22 @@ func (s *stubCoordinatorGitHub) AddPullRequestLabels(_ context.Context, input gi
 	return nil
 }
 func (s *stubCoordinatorGitHub) ViewPullRequestMergeWatch(_ context.Context, input githubinfra.ViewPullRequestInput) (githubinfra.PullRequestDetail, error) {
+	if failures := s.failPRDetails[input.PRNumber]; len(failures) > 0 {
+		err := failures[0]
+		s.failPRDetails[input.PRNumber] = failures[1:]
+		if err != nil {
+			return githubinfra.PullRequestDetail{}, err
+		}
+	}
 	if s.prDetails == nil {
 		return githubinfra.PullRequestDetail{}, nil
 	}
 	return s.prDetails[input.PRNumber], nil
 }
 func (s *stubCoordinatorGitHub) ListPullRequestCheckRuns(_ context.Context, input githubinfra.PullRequestCheckRunsInput) (githubinfra.PullRequestCheckRuns, error) {
+	if err := s.failPRCheckRuns[input.Ref]; err != nil {
+		return githubinfra.PullRequestCheckRuns{}, err
+	}
 	if s.prCheckRuns == nil {
 		return githubinfra.PullRequestCheckRuns{}, nil
 	}
@@ -973,6 +985,149 @@ func TestRunnerMergeWatchHumanDisabledRemovesMarkerOnly(t *testing.T) {
 	}
 	if len(fixture.github.addedPRLabels) != 0 || len(fixture.github.updatedBodies) != 0 || len(fixture.github.createdBodies) != 0 || len(fixture.github.addedLabels) != 0 || len(fixture.github.removedLabels) != 0 {
 		t.Fatalf("unexpected mutations: addedPRLabels=%v updatedBodies=%v createdBodies=%v addedLabels=%v removedLabels=%v", fixture.github.addedPRLabels, fixture.github.updatedBodies, fixture.github.createdBodies, fixture.github.addedLabels, fixture.github.removedLabels)
+	}
+}
+
+func TestRunnerMergeWatchTransientErrorKeepsMarkerAndSchedulesRetry(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Coordinator.MergeWatch.TransientRetries = 3
+	fixture.github.failPRCheckRuns = map[string]error{"abc123": errors.New("HTTP 504 gateway timeout")}
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{
+		Number: 1,
+		Title:  "Bug",
+		Author: "octo",
+		Labels: []string{"triaged"},
+		Comments: []githubinfra.CommentInfo{{
+			ID:        46,
+			Author:    "looper",
+			Body:      mergeWatchCommentBody(fixture.cfg, 77, "abc123", 2, nil, nil, "watching"),
+			CreatedAt: fixture.now.Format(time.RFC3339),
+		}},
+		CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339),
+	}
+	fixture.github.prDetails[77] = githubinfra.PullRequestDetail{
+		Number:         77,
+		Body:           "Closes #1",
+		State:          "open",
+		HeadSHA:        "abc123",
+		BaseRefName:    "main",
+		Labels:         []string{"looper:plan"},
+		Mergeable:      boolPtr(true),
+		MergeableState: "blocked",
+		AutoMerge:      &githubinfra.PullRequestAutoMerge{EnabledBy: "looper"},
+	}
+	fixture.github.timeline[1] = []map[string]any{{"source": map[string]any{"issue": map[string]any{"pull_request": map[string]any{"number": 77, "html_url": "https://github.com/acme/looper/pull/77"}}}}}
+
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(fixture.github.ops) != 1 || fixture.github.ops[0] != "update-comment" {
+		t.Fatalf("ops = %v, want retry marker update only", fixture.github.ops)
+	}
+	if len(fixture.github.updatedBodies) != 1 || len(fixture.github.createdBodies) != 0 {
+		t.Fatalf("updatedBodies=%v createdBodies=%v, want marker retry update without recreation", fixture.github.updatedBodies, fixture.github.createdBodies)
+	}
+	if len(fixture.github.removedLabels) != 0 {
+		t.Fatalf("removedLabels = %v, want no retriage cleanup on transient error", fixture.github.removedLabels)
+	}
+	if !containsAll(fixture.github.updatedBodies[0], "head_sha=abc123", "retries=1") || strings.Contains(fixture.github.updatedBodies[0], "pr=0") {
+		t.Fatalf("updatedBodies = %v, want preserved head SHA and decremented retry budget", fixture.github.updatedBodies)
+	}
+}
+
+func TestRunnerMergeWatchPRDetailTransientErrorConsumesRetryBudget(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.runner.config.Roles.Coordinator.MergeWatch.TransientRetries = 3
+	fixture.github.failPRDetails = map[int64][]error{77: {nil, errors.New("HTTP 504 gateway timeout")}}
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{
+		Number: 1,
+		Title:  "Bug",
+		Author: "octo",
+		Labels: []string{"triaged"},
+		Comments: []githubinfra.CommentInfo{{
+			ID:        48,
+			Author:    "looper",
+			Body:      mergeWatchCommentBody(fixture.cfg, 77, "abc123", 2, nil, nil, "watching"),
+			CreatedAt: fixture.now.Format(time.RFC3339),
+		}},
+		CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339),
+	}
+	fixture.github.prDetails[77] = githubinfra.PullRequestDetail{
+		Number:         77,
+		Body:           "Closes #1",
+		State:          "open",
+		HeadSHA:        "abc123",
+		BaseRefName:    "main",
+		Labels:         []string{"looper:plan"},
+		Mergeable:      boolPtr(true),
+		MergeableState: "blocked",
+		AutoMerge:      &githubinfra.PullRequestAutoMerge{EnabledBy: "looper"},
+	}
+	fixture.github.timeline[1] = []map[string]any{{"source": map[string]any{"issue": map[string]any{"pull_request": map[string]any{"number": 77, "html_url": "https://github.com/acme/looper/pull/77"}}}}}
+
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(fixture.github.ops) != 1 || fixture.github.ops[0] != "update-comment" {
+		t.Fatalf("ops = %v, want retry marker update only", fixture.github.ops)
+	}
+	if len(fixture.github.updatedBodies) != 1 || !containsAll(fixture.github.updatedBodies[0], "head_sha=abc123", "retries=1") {
+		t.Fatalf("updatedBodies = %v, want preserved head SHA and decremented retry budget", fixture.github.updatedBodies)
+	}
+	if len(fixture.github.removedLabels) != 0 {
+		t.Fatalf("removedLabels = %v, want no retriage cleanup on transient error", fixture.github.removedLabels)
+	}
+}
+
+func TestRunnerMergeWatchStatusContextsPreventMissingRequiredCheck(t *testing.T) {
+	t.Parallel()
+	fixture := newCoordinatorFixture(t)
+	fixture.runner.config.Roles.Coordinator.Enabled = true
+	fixture.github.issues = []githubinfra.IssueSummary{{Number: 1, Labels: []string{"triaged"}}}
+	fixture.github.details[1] = githubinfra.IssueDetail{
+		Number: 1,
+		Title:  "Bug",
+		Author: "octo",
+		Labels: []string{"triaged"},
+		Comments: []githubinfra.CommentInfo{{
+			ID:        47,
+			Author:    "looper",
+			Body:      mergeWatchCommentBody(fixture.cfg, 79, "ghi789", 3, nil, nil, "watching"),
+			CreatedAt: fixture.now.Add(-2 * time.Minute).Format(time.RFC3339),
+		}},
+		CreatedAt: fixture.now.Add(-time.Hour).Format(time.RFC3339),
+	}
+	fixture.github.prDetails[79] = githubinfra.PullRequestDetail{
+		Number:         79,
+		Body:           "Closes #1",
+		State:          "open",
+		HeadSHA:        "ghi789",
+		BaseRefName:    "main",
+		Labels:         []string{"looper:plan"},
+		Mergeable:      boolPtr(true),
+		MergeableState: "blocked",
+		AutoMerge:      &githubinfra.PullRequestAutoMerge{EnabledBy: "looper"},
+	}
+	fixture.github.prCheckRuns["ghi789"] = githubinfra.PullRequestCheckRuns{Statuses: []githubinfra.PullRequestStatus{{Context: "legacy-ci", State: "success"}}}
+	fixture.github.branchProtection["main"] = githubinfra.BranchProtection{Enabled: true, HasRequiredChecks: true, RequiredChecks: []string{"legacy-ci"}}
+	fixture.github.timeline[1] = []map[string]any{{"source": map[string]any{"issue": map[string]any{"pull_request": map[string]any{"number": 79, "html_url": "https://github.com/acme/looper/pull/79"}}}}}
+
+	if _, err := fixture.runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: fixture.projectID, Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	for _, op := range fixture.github.ops {
+		if op == "delete-comment" || strings.HasPrefix(op, "remove:") {
+			t.Fatalf("ops = %v, want no branch-protection cleanup when required status succeeded", fixture.github.ops)
+		}
+	}
+	if len(fixture.github.removedLabels) != 0 || len(fixture.github.createdBodies) != 0 {
+		t.Fatalf("removedLabels=%v createdBodies=%v, want watch to stay pending without retriage", fixture.github.removedLabels, fixture.github.createdBodies)
 	}
 }
 

--- a/internal/e2e/harness/cmd/fake-gh/main.go
+++ b/internal/e2e/harness/cmd/fake-gh/main.go
@@ -66,6 +66,11 @@ type pullRequestState struct {
 	Reviews           []map[string]any    `json:"reviews,omitempty"`
 	StatusCheckRollup []map[string]any    `json:"statusCheckRollup,omitempty"`
 	MergeStateStatus  string              `json:"mergeStateStatus,omitempty"`
+	Mergeable         *bool               `json:"mergeable,omitempty"`
+	MergeableState    string              `json:"mergeableState,omitempty"`
+	MergedAt          string              `json:"mergedAt,omitempty"`
+	AutoMerge         map[string]any      `json:"autoMerge,omitempty"`
+	CheckRuns         []map[string]any    `json:"checkRuns,omitempty"`
 	Threads           []reviewThreadState `json:"threads,omitempty"`
 }
 type reviewThreadState struct {
@@ -211,6 +216,12 @@ func handleAPI(mode string, st state, stdin string) error {
 			return err
 		}
 	}
+	if handled, err := handlePullRequestAPI(st, route); handled || err != nil {
+		return err
+	}
+	if handled, err := handleCheckRunsAPI(st, route); handled || err != nil {
+		return err
+	}
 	if strings.HasSuffix(route, "/comments") && strings.EqualFold(flagValue(args, "--method"), "POST") {
 		_, _ = fmt.Fprintln(os.Stdout, `{"id":1,"html_url":"https://example.test/issues/comments/1"}`)
 		return nil
@@ -238,6 +249,75 @@ func handleAPI(mode string, st state, stdin string) error {
 	_, _ = fmt.Fprintln(os.Stdout, `{"id":1,"number":1,"title":"fake issue"}`)
 	_ = stdin
 	return nil
+}
+
+func handlePullRequestAPI(st state, route string) (bool, error) {
+	const marker = "repos/"
+	if !strings.HasPrefix(route, marker) || !strings.Contains(route, "/pulls/") || strings.Contains(route, "/reviews") {
+		return false, nil
+	}
+	rest := strings.TrimPrefix(route, marker)
+	parts := strings.Split(rest, "/")
+	if len(parts) < 4 || parts[2] != "pulls" {
+		return false, nil
+	}
+	prNumber, err := strconv.ParseInt(parts[3], 10, 64)
+	if err != nil {
+		return false, nil
+	}
+	pr, ok := lookupPullRequest(st, parts[0]+"/"+parts[1], prNumber)
+	if !ok {
+		return false, nil
+	}
+	payload, err := json.Marshal(map[string]any{
+		"number":          pr.Number,
+		"title":           pr.Title,
+		"body":            pr.Body,
+		"url":             pr.URL,
+		"html_url":        pr.URL,
+		"state":           strings.ToLower(pr.State),
+		"created_at":      pr.CreatedAt,
+		"updated_at":      pr.UpdatedAt,
+		"closed_at":       pr.ClosedAt,
+		"merged_at":       pr.MergedAt,
+		"labels":          pullRequestFieldValue(pr, "labels"),
+		"head":            map[string]any{"ref": pr.HeadRefName, "sha": pr.HeadSHA},
+		"base":            map[string]any{"ref": pr.BaseRefName, "sha": pr.BaseSHA},
+		"mergeable":       pr.Mergeable,
+		"mergeable_state": firstNonEmpty(pr.MergeableState, pr.MergeStateStatus),
+		"auto_merge":      pr.AutoMerge,
+	})
+	if err != nil {
+		return true, err
+	}
+	_, _ = fmt.Fprintln(os.Stdout, string(payload))
+	return true, nil
+}
+
+func handleCheckRunsAPI(st state, route string) (bool, error) {
+	const marker = "repos/"
+	if !strings.HasPrefix(route, marker) || !strings.Contains(route, "/commits/") || !strings.HasSuffix(route, "/check-runs") {
+		return false, nil
+	}
+	rest := strings.TrimPrefix(route, marker)
+	parts := strings.Split(rest, "/")
+	if len(parts) < 5 || parts[2] != "commits" {
+		return false, nil
+	}
+	repo := parts[0] + "/" + parts[1]
+	ref := parts[3]
+	for _, pr := range st.PullRequests {
+		candidate := hydratePullRequest(pr)
+		if candidate.Repo == repo && candidate.HeadSHA == ref {
+			payload, err := json.Marshal(map[string]any{"total_count": len(candidate.CheckRuns), "check_runs": candidate.CheckRuns})
+			if err != nil {
+				return true, err
+			}
+			_, _ = fmt.Fprintln(os.Stdout, string(payload))
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func handlePullRequestReviews(st *state, args []string, stdin string, route string) (bool, error) {
@@ -635,6 +715,9 @@ func hydratePullRequest(pr pullRequestState) pullRequestState {
 	if pr.MergeStateStatus == "" {
 		pr.MergeStateStatus = "CLEAN"
 	}
+	if pr.MergeableState == "" {
+		pr.MergeableState = strings.ToLower(pr.MergeStateStatus)
+	}
 	if pr.UpdatedAt == "" {
 		pr.UpdatedAt = "2026-05-12T00:00:00Z"
 	}
@@ -698,6 +781,14 @@ func pullRequestFieldValue(pr pullRequestState, field string) any {
 		return pr.StatusCheckRollup
 	case "mergeStateStatus":
 		return pr.MergeStateStatus
+	case "mergeable":
+		return pr.Mergeable
+	case "mergeable_state":
+		return pr.MergeableState
+	case "merged_at":
+		return pr.MergedAt
+	case "auto_merge":
+		return pr.AutoMerge
 	default:
 		return defaultValue(field)
 	}

--- a/internal/e2e/harness/fake_gh.go
+++ b/internal/e2e/harness/fake_gh.go
@@ -79,6 +79,11 @@ type GHPullRequest struct {
 	Reviews           []map[string]any `json:"reviews,omitempty"`
 	StatusCheckRollup []map[string]any `json:"statusCheckRollup,omitempty"`
 	MergeStateStatus  string           `json:"mergeStateStatus,omitempty"`
+	Mergeable         *bool            `json:"mergeable,omitempty"`
+	MergeableState    string           `json:"mergeableState,omitempty"`
+	MergedAt          string           `json:"mergedAt,omitempty"`
+	AutoMerge         map[string]any   `json:"autoMerge,omitempty"`
+	CheckRuns         []map[string]any `json:"checkRuns,omitempty"`
 	Threads           []GHThread       `json:"threads,omitempty"`
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -107,12 +107,18 @@ type PullRequestAutoMerge struct {
 type PullRequestCheckRuns struct {
 	TotalCount int
 	CheckRuns  []PullRequestCheckRun
+	Statuses   []PullRequestStatus
 }
 
 type PullRequestCheckRun struct {
 	Name       string
 	Status     string
 	Conclusion string
+}
+
+type PullRequestStatus struct {
+	Context string
+	State   string
 }
 
 type CommentInfo struct {
@@ -1321,10 +1327,37 @@ func (g *Gateway) ListPullRequestCheckRuns(ctx context.Context, input PullReques
 	if err != nil {
 		return PullRequestCheckRuns{}, err
 	}
+	statusArgs := []string{"api", fmt.Sprintf("repos/%s/commits/%s/status", repo, encodeURIComponent(input.Ref)), "-H", "Accept: application/vnd.github+json"}
+	if hostname != "" {
+		statusArgs = append(statusArgs, "--hostname", hostname)
+	}
+	statusResult, err := g.runGh(ctx, input.CWD, "", statusArgs...)
+	if err != nil {
+		return PullRequestCheckRuns{}, err
+	}
+	statusRow, err := decodeJSONObject(statusResult.Stdout)
+	if err != nil {
+		return PullRequestCheckRuns{}, err
+	}
 	checkRuns := toObjectSlice(row["check_runs"])
 	out := PullRequestCheckRuns{TotalCount: int(asInt64(row["total_count"])), CheckRuns: make([]PullRequestCheckRun, 0, len(checkRuns))}
 	for _, checkRun := range checkRuns {
 		out.CheckRuns = append(out.CheckRuns, PullRequestCheckRun{Name: asString(checkRun["name"]), Status: asString(checkRun["status"]), Conclusion: asString(checkRun["conclusion"])})
+	}
+	statuses := toObjectSlice(statusRow["statuses"])
+	out.Statuses = make([]PullRequestStatus, 0, len(statuses))
+	seenContexts := map[string]struct{}{}
+	for _, status := range statuses {
+		contextName := asString(status["context"])
+		key := strings.ToLower(strings.TrimSpace(contextName))
+		if key == "" {
+			continue
+		}
+		if _, ok := seenContexts[key]; ok {
+			continue
+		}
+		seenContexts[key] = struct{}{}
+		out.Statuses = append(out.Statuses, PullRequestStatus{Context: contextName, State: asString(status["state"])})
 	}
 	return out, nil
 }

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -93,6 +93,26 @@ type PullRequestDetail struct {
 	IssueComments     []CommentInfo
 	Reviews           []map[string]any
 	Checks            []map[string]any
+	Mergeable         *bool
+	MergeableState    string
+	MergedAt          string
+	AutoMerge         *PullRequestAutoMerge
+}
+
+type PullRequestAutoMerge struct {
+	EnabledBy   string
+	MergeMethod string
+}
+
+type PullRequestCheckRuns struct {
+	TotalCount int
+	CheckRuns  []PullRequestCheckRun
+}
+
+type PullRequestCheckRun struct {
+	Name       string
+	Status     string
+	Conclusion string
 }
 
 type CommentInfo struct {
@@ -196,6 +216,7 @@ type BranchProtectionInput struct {
 type BranchProtection struct {
 	Enabled           bool
 	HasRequiredChecks bool
+	RequiredChecks    []string
 }
 
 type IssueSummary struct {
@@ -283,6 +304,12 @@ type UpdateIssueCommentInput struct {
 	CWD       string
 }
 
+type DeleteIssueCommentInput struct {
+	Repo      string
+	CommentID int64
+	CWD       string
+}
+
 type CloseIssueInput struct {
 	Repo        string
 	IssueNumber int64
@@ -302,6 +329,12 @@ type EnableAutoMergeInput struct {
 	Strategy config.ReviewerAutoMergeStrategy
 	HeadSHA  string
 	CWD      string
+}
+
+type PullRequestCheckRunsInput struct {
+	Repo string
+	Ref  string
+	CWD  string
 }
 
 type SubmitReviewInput struct {
@@ -1000,6 +1033,16 @@ func (g *Gateway) UpdateIssueComment(ctx context.Context, input UpdateIssueComme
 	return err
 }
 
+func (g *Gateway) DeleteIssueComment(ctx context.Context, input DeleteIssueCommentInput) error {
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/issues/comments/%d", repo, input.CommentID), "--method", "DELETE"}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	_, err := g.runGh(ctx, input.CWD, "", args...)
+	return err
+}
+
 func (g *Gateway) CloseIssue(ctx context.Context, input CloseIssueInput) error {
 	reason, err := validateCloseIssueStateReason(input.StateReason)
 	if err != nil {
@@ -1142,15 +1185,28 @@ func (g *Gateway) GetBranchProtection(ctx context.Context, input BranchProtectio
 	}
 	requiredStatusChecks, _ := row["required_status_checks"].(map[string]any)
 	hasRequiredChecks := false
+	requiredChecks := []string{}
 	if requiredStatusChecks != nil {
-		if len(toObjectSlice(requiredStatusChecks["checks"])) > 0 {
+		for _, check := range toObjectSlice(requiredStatusChecks["checks"]) {
+			name := firstNonEmpty(asString(check["context"]), asString(check["name"]))
+			if strings.TrimSpace(name) != "" {
+				requiredChecks = append(requiredChecks, name)
+			}
+		}
+		if len(requiredChecks) > 0 {
 			hasRequiredChecks = true
 		}
 		if contexts, ok := requiredStatusChecks["contexts"].([]any); ok && len(contexts) > 0 {
 			hasRequiredChecks = true
+			for _, context := range contexts {
+				name := asString(context)
+				if strings.TrimSpace(name) != "" {
+					requiredChecks = append(requiredChecks, name)
+				}
+			}
 		}
 	}
-	return BranchProtection{Enabled: true, HasRequiredChecks: hasRequiredChecks}, nil
+	return BranchProtection{Enabled: true, HasRequiredChecks: hasRequiredChecks, RequiredChecks: uniqueStrings(requiredChecks)}, nil
 }
 
 func compactIssueAssignees(values []string) []string {
@@ -1209,7 +1265,68 @@ func (g *Gateway) viewPullRequestRaw(ctx context.Context, input ViewPullRequestI
 		IssueComments:     extractCommentInfos(toObjectSlice(row["comments"])),
 		Reviews:           toObjectSlice(row["reviews"]),
 		Checks:            toObjectSlice(row["statusCheckRollup"]),
+		Mergeable:         boolPtrFromValue(row["mergeable"]),
+		MergeableState:    asString(row["mergeable_state"]),
+		MergedAt:          asString(row["merged_at"]),
+		AutoMerge:         extractAutoMerge(row["auto_merge"]),
 	}, nil
+}
+
+func (g *Gateway) ViewPullRequestMergeWatch(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/pulls/%d", repo, input.PRNumber), "-H", "Accept: application/vnd.github+json"}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
+	if err != nil {
+		return PullRequestDetail{}, err
+	}
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return PullRequestDetail{}, err
+	}
+	return PullRequestDetail{
+		Number:         asInt64(row["number"]),
+		Title:          asString(row["title"]),
+		Body:           asString(row["body"]),
+		URL:            firstNonEmpty(asString(row["html_url"]), asString(row["url"])),
+		State:          asString(row["state"]),
+		CreatedAt:      firstNonEmpty(asString(row["created_at"]), asString(row["createdAt"])),
+		UpdatedAt:      firstNonEmpty(asString(row["updated_at"]), asString(row["updatedAt"])),
+		ClosedAt:       firstNonEmpty(asString(row["closed_at"]), asString(row["closedAt"])),
+		MergedAt:       firstNonEmpty(asString(row["merged_at"]), asString(row["mergedAt"])),
+		Labels:         extractLabelNames(row["labels"]),
+		HeadRefName:    nestedString(row, "head", "ref"),
+		BaseRefName:    nestedString(row, "base", "ref"),
+		HeadSHA:        nestedString(row, "head", "sha"),
+		BaseSHA:        nestedString(row, "base", "sha"),
+		Mergeable:      boolPtrFromValue(row["mergeable"]),
+		MergeableState: firstNonEmpty(asString(row["mergeable_state"]), asString(row["mergeStateStatus"])),
+		AutoMerge:      extractAutoMerge(row["auto_merge"]),
+	}, nil
+}
+
+func (g *Gateway) ListPullRequestCheckRuns(ctx context.Context, input PullRequestCheckRunsInput) (PullRequestCheckRuns, error) {
+	hostname, repo := splitRepoHostname(input.Repo)
+	args := []string{"api", fmt.Sprintf("repos/%s/commits/%s/check-runs", repo, encodeURIComponent(input.Ref)), "-H", "Accept: application/vnd.github+json"}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
+	if err != nil {
+		return PullRequestCheckRuns{}, err
+	}
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return PullRequestCheckRuns{}, err
+	}
+	checkRuns := toObjectSlice(row["check_runs"])
+	out := PullRequestCheckRuns{TotalCount: int(asInt64(row["total_count"])), CheckRuns: make([]PullRequestCheckRun, 0, len(checkRuns))}
+	for _, checkRun := range checkRuns {
+		out.CheckRuns = append(out.CheckRuns, PullRequestCheckRun{Name: asString(checkRun["name"]), Status: asString(checkRun["status"]), Conclusion: asString(checkRun["conclusion"])})
+	}
+	return out, nil
 }
 
 func (g *Gateway) ListLinkedPullRequests(ctx context.Context, input LinkedPullRequestsInput) ([]LinkedPullRequest, error) {
@@ -3181,6 +3298,14 @@ func asBool(value any) bool {
 	return ok && typed
 }
 
+func boolPtrFromValue(value any) *bool {
+	typed, ok := value.(bool)
+	if !ok {
+		return nil
+	}
+	return &typed
+}
+
 func asInt64(value any) int64 {
 	switch typed := value.(type) {
 	case float64:
@@ -3236,6 +3361,46 @@ func valueOr(value, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func nestedString(value map[string]any, path ...string) string {
+	current := any(value)
+	for _, part := range path {
+		next, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = next[part]
+	}
+	return asString(current)
+}
+
+func extractAutoMerge(value any) *PullRequestAutoMerge {
+	row, ok := value.(map[string]any)
+	if !ok || row == nil {
+		return nil
+	}
+	return &PullRequestAutoMerge{
+		EnabledBy:   extractAuthor(firstNonNil(row["enabled_by"], row["enabledBy"])),
+		MergeMethod: firstNonEmpty(asString(row["merge_method"]), asString(row["mergeMethod"])),
+	}
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, strings.TrimSpace(value))
+	}
+	return out
 }
 
 func ternary[T any](condition bool, truthy, falsy T) T {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -397,6 +397,43 @@ func TestGetBranchProtectionReturnsEmptyOnMissingProtectionFromStdout(t *testing
 	}
 }
 
+func TestListPullRequestCheckRunsIncludesStatusContexts(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	call := 0
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		call++
+		args := strings.Join(options.Args, " ")
+		switch call {
+		case 1:
+			if args != "api repos/acme/looper/commits/abc123/check-runs -H Accept: application/vnd.github+json" {
+				t.Fatalf("unexpected gh args: %q", args)
+			}
+			return shell.Result{Stdout: `{"total_count":1,"check_runs":[{"name":"unit","status":"completed","conclusion":"success"}]}`}, nil
+		case 2:
+			if args != "api repos/acme/looper/commits/abc123/status -H Accept: application/vnd.github+json" {
+				t.Fatalf("unexpected gh args: %q", args)
+			}
+			return shell.Result{Stdout: `{"statuses":[{"context":"legacy-ci","state":"success"},{"context":"legacy-ci","state":"failure"},{"context":"lint","state":"pending"}]}`}, nil
+		default:
+			t.Fatalf("unexpected extra gh call: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	runs, err := gateway.ListPullRequestCheckRuns(context.Background(), PullRequestCheckRunsInput{Repo: "acme/looper", Ref: "abc123"})
+	if err != nil {
+		t.Fatalf("ListPullRequestCheckRuns() error = %v", err)
+	}
+	if len(runs.CheckRuns) != 1 || runs.CheckRuns[0].Name != "unit" {
+		t.Fatalf("CheckRuns = %#v, want decoded check run", runs.CheckRuns)
+	}
+	if len(runs.Statuses) != 2 || runs.Statuses[0].Context != "legacy-ci" || runs.Statuses[1].Context != "lint" {
+		t.Fatalf("Statuses = %#v, want deduped status contexts in API order", runs.Statuses)
+	}
+}
+
 func TestGetPullRequestHeadAndAuthorUsesNarrowPRView(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}


### PR DESCRIPTION
## Summary
- add a pure `internal/coordinator/mergewatch` classifier plus durable issue-marker handling for watched auto-merge PRs
- teach Coordinator to watch linked Looper-owned auto-merge PRs, route conflicts to Fixer, and send drift/exhausted watches back to re-triage
- extend GitHub/fake-gh support and add coordinator/config/API contract coverage for merge-watch state

## Why
Slice 3/4 for PRD #352 needs Coordinator to watch what happens after Reviewer opts a PR into GitHub-native auto-merge, while preserving ADR-0001 statelessness and ADR-0003 role boundaries.

## Authority / review request
This PR is authority-bearing. Please request `@oracle` review per AGENTS.md. The implementation preserves ADR-0001, ADR-0003, and ADR-0005 by rooting durable watch state on the linked Issue marker comment and limiting PR mutation to the configured Fixer trigger label.

## Links
- PRD #352
- Slice #357
- Slice #358
- Closes #359

## Validation
- `gofmt -l .`
- `LOOPER_CONFIG= go vet ./...`
- `LOOPER_CONFIG= go test ./...`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>