### PR TITLE
fix: avoid cross-mode worktree deletion

### DIFF
--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -337,7 +337,7 @@ func (g *Gateway) RestoreWorktree(ctx context.Context, input RestoreWorktreeInpu
 					}
 					return &restored, nil
 				}
-				shouldReplace, err := g.shouldReplaceStoredWorktreeOnRestoreMismatch(ctx, stored.WorktreePath, checkoutMode, input.Branch)
+				shouldReplace, err := g.shouldReplaceStoredWorktreeOnRestoreMismatch(ctx, stored.WorktreePath, checkoutMode, input.Branch, input.ExpectedWorktreePath)
 				if err != nil {
 					return nil, err
 				}
@@ -834,7 +834,7 @@ func (g *Gateway) matchesRestoreCheckoutMode(ctx context.Context, worktreePath s
 	return currentBranch == branch, nil
 }
 
-func (g *Gateway) shouldReplaceStoredWorktreeOnRestoreMismatch(ctx context.Context, worktreePath string, checkoutMode CheckoutMode, branch string) (bool, error) {
+func (g *Gateway) shouldReplaceStoredWorktreeOnRestoreMismatch(ctx context.Context, worktreePath string, checkoutMode CheckoutMode, branch, expectedWorktreePath string) (bool, error) {
 	if checkoutMode == CheckoutModeDetached {
 		return false, nil
 	}
@@ -844,7 +844,7 @@ func (g *Gateway) shouldReplaceStoredWorktreeOnRestoreMismatch(ctx context.Conte
 		return false, err
 	}
 	if currentBranch == "" {
-		return false, nil
+		return normalizeComparablePath(worktreePath) == normalizeComparablePath(expectedWorktreePath), nil
 	}
 	return currentBranch != branch, nil
 }

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -337,8 +337,13 @@ func (g *Gateway) RestoreWorktree(ctx context.Context, input RestoreWorktreeInpu
 					}
 					return &restored, nil
 				}
-
-				g.tryRemoveWorktree(ctx, input.RepoPath, stored.WorktreePath)
+				shouldReplace, err := g.shouldReplaceStoredWorktreeOnRestoreMismatch(ctx, stored.WorktreePath, checkoutMode, input.Branch)
+				if err != nil {
+					return nil, err
+				}
+				if shouldReplace {
+					g.tryRemoveWorktree(ctx, input.RepoPath, stored.WorktreePath)
+				}
 			}
 		}
 	}
@@ -387,7 +392,6 @@ func (g *Gateway) RestoreWorktree(ctx context.Context, input RestoreWorktreeInpu
 		return nil, err
 	}
 	if !checkoutMatches {
-		g.tryRemoveWorktree(ctx, input.RepoPath, match.Path)
 		return nil, nil
 	}
 
@@ -830,6 +834,21 @@ func (g *Gateway) matchesRestoreCheckoutMode(ctx context.Context, worktreePath s
 	return currentBranch == branch, nil
 }
 
+func (g *Gateway) shouldReplaceStoredWorktreeOnRestoreMismatch(ctx context.Context, worktreePath string, checkoutMode CheckoutMode, branch string) (bool, error) {
+	if checkoutMode == CheckoutModeDetached {
+		return false, nil
+	}
+
+	currentBranch, err := g.getCurrentBranch(ctx, worktreePath)
+	if err != nil {
+		return false, err
+	}
+	if currentBranch == "" {
+		return false, nil
+	}
+	return currentBranch != branch, nil
+}
+
 func (g *Gateway) tryRemoveWorktree(ctx context.Context, repoPath, worktreePath string) {
 	if err := g.runGit(ctx, repoPath, nil, "worktree", "remove", "--force", worktreePath); err != nil {
 		return
@@ -956,6 +975,9 @@ func isRetryableFetchRefLockRace(args []string, err error) bool {
 
 func buildWorktreeDirectoryName(input CreateWorktreeInput) string {
 	if input.PRNumber != 0 {
+		if normalizeCheckoutMode(input.CheckoutMode) == CheckoutModeDetached {
+			return fmt.Sprintf("looper-fix-%s-pr-%d-detached", sanitizeBranchName(input.ProjectID), input.PRNumber)
+		}
 		return fmt.Sprintf("looper-fix-%s-pr-%d", sanitizeBranchName(input.ProjectID), input.PRNumber)
 	}
 

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -392,6 +392,7 @@ func (g *Gateway) RestoreWorktree(ctx context.Context, input RestoreWorktreeInpu
 		return nil, err
 	}
 	if !checkoutMatches {
+		g.tryRemoveWorktree(ctx, input.RepoPath, match.Path)
 		return nil, nil
 	}
 

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -348,6 +348,29 @@ func TestGatewayCreatesSeparateAttachedWorktreeForDetachedBranch(t *testing.T) {
 	}
 }
 
+func TestGatewayRecreatesBranchNamedWorktreeAsDetachedAtSamePath(t *testing.T) {
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createLocalFeatureRepo(t)
+	gateway := fixture.gateway()
+
+	attached, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{ProjectID: fixture.projectID, RepoPath: fixture.repoPath, WorktreeRoot: fixture.worktreeRoot, Branch: "feature/fixer", BaseBranch: "main"})
+	if err != nil {
+		t.Fatalf("CreateWorktree(attached) error = %v", err)
+	}
+
+	detached, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{ProjectID: fixture.projectID, RepoPath: fixture.repoPath, WorktreeRoot: fixture.worktreeRoot, Branch: "feature/fixer", BaseBranch: "main", CheckoutMode: CheckoutModeDetached})
+	if err != nil {
+		t.Fatalf("CreateWorktree(detached) error = %v", err)
+	}
+	if detached.WorktreePath != attached.WorktreePath {
+		t.Fatalf("detached path = %q, want %q", detached.WorktreePath, attached.WorktreePath)
+	}
+	if got := stringsTrimSpace(runGit(t, detached.WorktreePath, "branch", "--show-current")); got != "" {
+		t.Fatalf("detached branch = %q, want empty", got)
+	}
+}
+
 func TestGatewayRecreatesStoredAttachedWorktreeWhenOnWrongBranch(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixture(t)

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -290,7 +290,7 @@ func TestGatewayPushesHeadToRequestedRemoteBranch(t *testing.T) {
 	}
 }
 
-func TestGatewayRecreatesAttachedBranchWorktreeForDetachedMode(t *testing.T) {
+func TestGatewayCreatesSeparateDetachedWorktreeForAttachedBranch(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixture(t)
 	fixture.createLocalFeatureRepo(t)
@@ -308,15 +308,18 @@ func TestGatewayRecreatesAttachedBranchWorktreeForDetachedMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateWorktree(detached) error = %v", err)
 	}
-	if detached.WorktreePath != attached.WorktreePath {
-		t.Fatalf("detached worktree path = %q, want %q", detached.WorktreePath, attached.WorktreePath)
+	if detached.WorktreePath == attached.WorktreePath {
+		t.Fatalf("detached worktree path = %q, want separate path from attached worktree", detached.WorktreePath)
 	}
 	if got := stringsTrimSpace(runGit(t, detached.WorktreePath, "branch", "--show-current")); got != "" {
 		t.Fatalf("detached branch = %q, want empty", got)
+	}
+	if _, err := os.Stat(attached.WorktreePath); err != nil {
+		t.Fatalf("attached worktree missing after detached create: %v", err)
 	}
 }
 
-func TestGatewayRecreatesDetachedWorktreeForBranchMode(t *testing.T) {
+func TestGatewayCreatesSeparateAttachedWorktreeForDetachedBranch(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixture(t)
 	fixture.createLocalFeatureRepo(t)
@@ -334,11 +337,14 @@ func TestGatewayRecreatesDetachedWorktreeForBranchMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateWorktree(attached) error = %v", err)
 	}
-	if attached.WorktreePath != detached.WorktreePath {
-		t.Fatalf("attached worktree path = %q, want %q", attached.WorktreePath, detached.WorktreePath)
+	if attached.WorktreePath == detached.WorktreePath {
+		t.Fatalf("attached worktree path = %q, want separate path from detached worktree", attached.WorktreePath)
 	}
 	if got := stringsTrimSpace(runGit(t, attached.WorktreePath, "branch", "--show-current")); got != "feature/fixer" {
 		t.Fatalf("attached branch = %q, want feature/fixer", got)
+	}
+	if _, err := os.Stat(detached.WorktreePath); err != nil {
+		t.Fatalf("detached worktree missing after attached create: %v", err)
 	}
 }
 
@@ -395,7 +401,7 @@ func TestGatewayRecreatesWorktreeWhenStoredRowPointsAtDeletedPath(t *testing.T) 
 	fixture.createMainOnlyRepo(t)
 	gateway := fixture.gateway()
 
-	missingWorktreePath := filepath.Join(fixture.worktreeRoot, "looper-fix-project_1-pr-42")
+	missingWorktreePath := filepath.Join(fixture.worktreeRoot, "looper-fix-project_1-pr-42-detached")
 	metadata := `{"recovered":false}`
 	baseBranch := "main"
 	if err := fixture.repos.Worktrees.Upsert(ctx, storage.WorktreeRecord{ID: "missing-record", ProjectID: fixture.projectID, RepoPath: fixture.repoPath, WorktreePath: missingWorktreePath, Branch: "feature/fixer", BaseBranch: &baseBranch, Status: "active", MetadataJSON: &metadata, CreatedAt: fixture.now().UTC().Format(javaScriptISOStringLayout), UpdatedAt: fixture.now().UTC().Format(javaScriptISOStringLayout)}); err != nil {

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -372,6 +372,30 @@ func TestGatewayRecreatesStoredAttachedWorktreeWhenOnWrongBranch(t *testing.T) {
 	}
 }
 
+func TestGatewayRecreatesStoredAttachedWorktreeWhenDetached(t *testing.T) {
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createLocalFeatureRepo(t)
+	gateway := fixture.gateway()
+
+	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{ProjectID: fixture.projectID, RepoPath: fixture.repoPath, WorktreeRoot: fixture.worktreeRoot, Branch: "feature/fixer", BaseBranch: "main", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+	runGit(t, worktree.WorktreePath, "checkout", "HEAD")
+
+	restored, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{ProjectID: fixture.projectID, RepoPath: fixture.repoPath, WorktreeRoot: fixture.worktreeRoot, Branch: "feature/fixer", BaseBranch: "main", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("CreateWorktree(recreated) error = %v", err)
+	}
+	if restored.WorktreePath != worktree.WorktreePath {
+		t.Fatalf("restored path = %q, want %q", restored.WorktreePath, worktree.WorktreePath)
+	}
+	if got := stringsTrimSpace(runGit(t, restored.WorktreePath, "branch", "--show-current")); got != "feature/fixer" {
+		t.Fatalf("restored branch = %q, want feature/fixer", got)
+	}
+}
+
 func TestGatewayRestoresDetachedWorktreeFromExpectedPathWithoutStoreRow(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixture(t)


### PR DESCRIPTION
## Summary
- stop deleting an existing worktree when restore sees a cross checkout-mode mismatch
- keep replacement only for attached worktrees that are on the wrong branch
- give detached PR fixer worktrees a distinct directory suffix to avoid path collisions

## Testing
- go test ./internal/infra/git
- go test ./internal/fixer ./internal/worker