### PR TITLE
fix: stabilize dependency gate startup validation

### DIFF
--- a/internal/e2e/dependency_gate_sandbox_test.go
+++ b/internal/e2e/dependency_gate_sandbox_test.go
@@ -1,0 +1,335 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/coordinator"
+	"github.com/nexu-io/looper/internal/e2e/harness"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+const (
+	depGateDispatchFailureMarker = "<!-- looper:coordinator:dispatch-failure -->"
+	depGateCycleMarker           = "<!-- looper:coordinator:cycle -->"
+)
+
+type depGateSandboxIssue struct {
+	ID     int64  `json:"id"`
+	Number int64  `json:"number"`
+	URL    string `json:"html_url"`
+	Title  string
+}
+
+type depGateSandboxComment struct {
+	ID   int64  `json:"id"`
+	Body string `json:"body"`
+	URL  string `json:"html_url"`
+}
+
+type depGateSandboxIssueView struct {
+	State  string `json:"state"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+}
+
+func TestGitHubSandboxDependencyGateScenarios(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	sb := requireSandboxConfig(t)
+	t.Setenv("GH_TOKEN", sb.Token)
+	t.Setenv("GITHUB_TOKEN", sb.Token)
+	t.Setenv("GH_PROMPT_DISABLED", "1")
+	repo := ensureSandboxProjectRepo(t, sb)
+	ensureSandboxCoordinatorLabel(t, sb, "triaged", "0e8a16")
+	ensureSandboxCoordinatorLabel(t, sb, "dispatch/plan", "1d76db")
+
+	t.Run("looperd startup validation succeeds against real dependency API", func(t *testing.T) {
+		home := harness.NewTempHome(t)
+		port := harness.MustFreePort(t)
+		cfg := coordinatorSandboxDaemonConfig(t, bins, home, repo, port)
+		harness.WriteConfig(t, home.ConfigPath, cfg, nil)
+		seedCoordinatorSandboxProjectMetadata(t, home, repo, sb.Repo)
+		proc := harness.StartLooperd(t, bins, home, home.ConfigPath, sandboxEnvMap(sb), cfg.Server.Host, cfg.Server.Port)
+		defer proc.Stop(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		if _, err := proc.WaitForReady(ctx); err != nil {
+			t.Fatalf("wait for ready: %v", err)
+		}
+	})
+
+	t.Run("human gated blocked_by fails then releases after completion", func(t *testing.T) {
+		home := harness.NewTempHome(t)
+		blocker := createDependencyGateIssue(t, sb, "dependency blocker")
+		dependent := createDependencyGateIssue(t, sb, "dependency dependent")
+		defer closeSandboxIssueIfOpen(t, sb, blocker.Number, "not_planned")
+		defer closeSandboxIssueIfOpen(t, sb, dependent.Number, "not_planned")
+		addSandboxIssueLabels(t, sb, dependent.Number, "triaged", "dispatch/plan")
+		linkSandboxBlockedBy(t, sb, dependent.Number, blocker.ID)
+		postSandboxIssueComment(t, sb, dependent.Number, "/plan")
+
+		runner := newCoordinatorSandboxRunner(t, home, repo, sb.Repo)
+		if _, err := runner.DiscoverIssues(context.Background(), coordinator.DiscoveryInput{ProjectID: "project_1", Repo: sb.Repo}); err != nil {
+			t.Fatalf("DiscoverIssues blocked path: %v", err)
+		}
+
+		waitForSandboxIssueComment(t, sb, dependent.Number, depGateDispatchFailureMarker)
+		waitForSandboxIssueLabelAbsent(t, sb, dependent.Number, "looper:plan")
+
+		setSandboxIssueState(t, sb, blocker.Number, "closed", "completed")
+		postSandboxIssueComment(t, sb, dependent.Number, "/plan")
+		if _, err := runner.DiscoverIssues(context.Background(), coordinator.DiscoveryInput{ProjectID: "project_1", Repo: sb.Repo}); err != nil {
+			t.Fatalf("DiscoverIssues release path: %v", err)
+		}
+		waitForSandboxIssueLabel(t, sb, dependent.Number, "looper:plan")
+	})
+
+	t.Run("cycle issues are returned to retriage with stamped comments", func(t *testing.T) {
+		left := createDependencyGateIssue(t, sb, "cycle left")
+		right := createDependencyGateIssue(t, sb, "cycle right")
+		defer closeSandboxIssueIfOpen(t, sb, left.Number, "not_planned")
+		defer closeSandboxIssueIfOpen(t, sb, right.Number, "not_planned")
+		linkSandboxBlockedBy(t, sb, left.Number, right.ID)
+		output, err := runSandboxCommand("", sb.CmdEnv, "gh", "api", fmt.Sprintf("repos/%s/issues/%d/dependencies/blocked_by", sb.Repo, right.Number), "--method", "POST", "-H", "X-GitHub-Api-Version: 2026-03-10", "-F", fmt.Sprintf("issue_id=%d", left.ID))
+		if err == nil {
+			t.Fatalf("expected GitHub to reject cycle creation, but request succeeded: %s", output)
+		}
+		if !strings.Contains(output, "would create a cycle") {
+			t.Fatalf("expected cycle validation error, got: %s", output)
+		}
+	})
+
+	t.Run("not planned blocker returns dependent to retriage without cycle comment", func(t *testing.T) {
+		home := harness.NewTempHome(t)
+		blocker := createDependencyGateIssue(t, sb, "not planned blocker")
+		dependent := createDependencyGateIssue(t, sb, "not planned dependent")
+		defer closeSandboxIssueIfOpen(t, sb, blocker.Number, "not_planned")
+		defer closeSandboxIssueIfOpen(t, sb, dependent.Number, "not_planned")
+		addSandboxIssueLabels(t, sb, dependent.Number, "triaged", "dispatch/plan")
+		linkSandboxBlockedBy(t, sb, dependent.Number, blocker.ID)
+		setSandboxIssueState(t, sb, blocker.Number, "closed", "not_planned")
+
+		runner := newCoordinatorSandboxRunner(t, home, repo, sb.Repo)
+		if _, err := runner.DiscoverIssues(context.Background(), coordinator.DiscoveryInput{ProjectID: "project_1", Repo: sb.Repo}); err != nil {
+			t.Fatalf("DiscoverIssues not_planned path: %v", err)
+		}
+
+		waitForSandboxIssueLabelsAbsent(t, sb, dependent.Number, "triaged", "dispatch/plan")
+		comments := listSandboxIssueComments(t, sb, dependent.Number)
+		for _, comment := range comments {
+			if strings.Contains(comment.Body, depGateCycleMarker) {
+				t.Fatalf("unexpected cycle comment on dependent %s: %s", dependent.URL, comment.URL)
+			}
+		}
+	})
+}
+
+func coordinatorSandboxConfig(tb testing.TB, home harness.TempHome, repo harness.SeededRepo) config.Config {
+	tb.Helper()
+	cfg := harness.DefaultConfig(tb, home, harness.ConfigOptions{
+		Projects:          writeProjectConfig(repo, home),
+		DisableDisclosure: true,
+	})
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.PollInterval = "0s"
+	cfg.Roles.Coordinator.Dependencies.Enabled = true
+	cfg.Roles.Planner.AutoDiscovery = false
+	cfg.Roles.Worker.AutoDiscovery = false
+	cfg.Roles.Fixer.AutoDiscovery = false
+	return cfg
+}
+
+func coordinatorSandboxDaemonConfig(tb testing.TB, bins harness.BuiltBinaries, home harness.TempHome, repo harness.SeededRepo, port int) config.Config {
+	tb.Helper()
+	cfg := harness.DefaultConfig(tb, home, harness.ConfigOptions{
+		Port:              port,
+		ToolPaths:         harness.TestToolPaths{Git: "git", GH: "gh", Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},
+		EnableOsascript:   true,
+		Projects:          writeProjectConfig(repo, home),
+		DisableDisclosure: true,
+	})
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.PollInterval = "2s"
+	cfg.Roles.Coordinator.Dependencies.Enabled = true
+	cfg.Roles.Planner.AutoDiscovery = false
+	cfg.Roles.Worker.AutoDiscovery = false
+	cfg.Roles.Fixer.AutoDiscovery = false
+	return cfg
+}
+
+func newCoordinatorSandboxRunner(tb testing.TB, home harness.TempHome, repo harness.SeededRepo, repoSlug string) *coordinator.Runner {
+	tb.Helper()
+	coord := seedCoordinatorSandboxProjectMetadata(tb, home, repo, repoSlug)
+	tb.Cleanup(func() { _ = coord.Close() })
+	cfg := coordinatorSandboxConfig(tb, home, repo)
+	gateway := githubinfra.New(githubinfra.Options{GHPath: "gh", CWD: repo.Path, Now: time.Now})
+	return coordinator.New(coordinator.Options{Repos: storage.NewRepositories(coord.DB()), GitHub: gateway, Config: &cfg, Now: time.Now})
+}
+
+func seedCoordinatorSandboxProjectMetadata(tb testing.TB, home harness.TempHome, repo harness.SeededRepo, repoSlug string) *storage.SQLiteCoordinator {
+	tb.Helper()
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), home.DBPath, storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: home.BackupDir})
+	if err != nil {
+		tb.Fatalf("open sqlite coordinator: %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		tb.Fatalf("run sqlite migrations: %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Now().UTC().Format(time.RFC3339)
+	metadata := fmt.Sprintf(`{"repo":%q}`, repoSlug)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID:           "project_1",
+		Name:         "Looper E2E",
+		RepoPath:     repo.Path,
+		BaseBranch:   stringPtr(repo.DefaultBranch),
+		Archived:     false,
+		MetadataJSON: &metadata,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}); err != nil {
+		tb.Fatalf("seed project metadata: %v", err)
+	}
+	return coordinator
+}
+
+func ensureSandboxCoordinatorLabel(tb testing.TB, sb sandboxConfig, name, color string) {
+	tb.Helper()
+	output, err := runSandboxCommand("", sb.CmdEnv, "gh", "label", "create", name, "--repo", sb.Repo, "--color", color, "--description", "Looper dependency gate sandbox label")
+	if err != nil && !strings.Contains(output, "already exists") {
+		tb.Fatalf("ensure label %s: %v\noutput=%s", name, err, output)
+	}
+}
+
+func createDependencyGateIssue(tb testing.TB, sb sandboxConfig, scenario string) depGateSandboxIssue {
+	tb.Helper()
+	title := fmt.Sprintf("%s %s", sb.TitlePrefix, scenario)
+	body := fmt.Sprintf("Dependency gate sandbox issue for %s (%s)", scenario, sb.RunID)
+	var issue depGateSandboxIssue
+	runSandboxJSON(tb, "", sb.CmdEnv, &issue, "gh", "api", "repos/"+sb.Repo+"/issues", "--method", "POST", "-f", "title="+title, "-f", "body="+body, "-f", "labels[]="+sandboxLabelName)
+	issue.Title = title
+	return issue
+}
+
+func addSandboxIssueLabels(tb testing.TB, sb sandboxConfig, issueNumber int64, labels ...string) {
+	tb.Helper()
+	args := []string{"gh", "api", fmt.Sprintf("repos/%s/issues/%d/labels", sb.Repo, issueNumber), "--method", "POST"}
+	for _, label := range labels {
+		args = append(args, "-f", "labels[]="+label)
+	}
+	runSandboxCommandMust(tb, "", sb.CmdEnv, args[0], args[1:]...)
+}
+
+func linkSandboxBlockedBy(tb testing.TB, sb sandboxConfig, issueNumber, blockerID int64) {
+	tb.Helper()
+	runSandboxCommandMust(tb, "", sb.CmdEnv, "gh", "api", fmt.Sprintf("repos/%s/issues/%d/dependencies/blocked_by", sb.Repo, issueNumber), "--method", "POST", "-H", "X-GitHub-Api-Version: 2026-03-10", "-F", fmt.Sprintf("issue_id=%d", blockerID))
+}
+
+func postSandboxIssueComment(tb testing.TB, sb sandboxConfig, issueNumber int64, body string) {
+	tb.Helper()
+	runSandboxCommandMust(tb, "", sb.CmdEnv, "gh", "api", fmt.Sprintf("repos/%s/issues/%d/comments", sb.Repo, issueNumber), "--method", "POST", "-f", "body="+body)
+}
+
+func setSandboxIssueState(tb testing.TB, sb sandboxConfig, issueNumber int64, state, reason string) {
+	tb.Helper()
+	args := []string{"gh", "api", fmt.Sprintf("repos/%s/issues/%d", sb.Repo, issueNumber), "--method", "PATCH", "-f", "state=" + state}
+	if strings.TrimSpace(reason) != "" {
+		args = append(args, "-f", "state_reason="+reason)
+	}
+	runSandboxCommandMust(tb, "", sb.CmdEnv, args[0], args[1:]...)
+}
+
+func closeSandboxIssueIfOpen(tb testing.TB, sb sandboxConfig, issueNumber int64, reason string) {
+	tb.Helper()
+	issue := getSandboxIssueView(tb, sb, issueNumber)
+	if issue.State == "closed" {
+		return
+	}
+	setSandboxIssueState(tb, sb, issueNumber, "closed", reason)
+}
+
+func waitForSandboxIssueLabel(tb testing.TB, sb sandboxConfig, issueNumber int64, want string) {
+	tb.Helper()
+	waitForCondition(tb, 90*time.Second, func() (bool, string) {
+		issue := getSandboxIssueView(tb, sb, issueNumber)
+		for _, label := range issue.Labels {
+			if label.Name == want {
+				return true, ""
+			}
+		}
+		return false, fmt.Sprintf("issue #%d labels=%v missing %s", issueNumber, sandboxLabelNames(issue.Labels), want)
+	})
+}
+
+func waitForSandboxIssueLabelAbsent(tb testing.TB, sb sandboxConfig, issueNumber int64, unwanted string) {
+	tb.Helper()
+	waitForCondition(tb, 45*time.Second, func() (bool, string) {
+		issue := getSandboxIssueView(tb, sb, issueNumber)
+		for _, label := range issue.Labels {
+			if label.Name == unwanted {
+				return false, fmt.Sprintf("issue #%d still has label %s", issueNumber, unwanted)
+			}
+		}
+		return true, ""
+	})
+}
+
+func waitForSandboxIssueLabelsAbsent(tb testing.TB, sb sandboxConfig, issueNumber int64, unwanted ...string) {
+	tb.Helper()
+	waitForCondition(tb, 90*time.Second, func() (bool, string) {
+		issue := getSandboxIssueView(tb, sb, issueNumber)
+		present := map[string]bool{}
+		for _, label := range issue.Labels {
+			present[label.Name] = true
+		}
+		for _, label := range unwanted {
+			if present[label] {
+				return false, fmt.Sprintf("issue #%d still has label %s; labels=%v", issueNumber, label, sandboxLabelNames(issue.Labels))
+			}
+		}
+		return true, ""
+	})
+}
+
+func waitForSandboxIssueComment(tb testing.TB, sb sandboxConfig, issueNumber int64, contains string) {
+	tb.Helper()
+	waitForCondition(tb, 90*time.Second, func() (bool, string) {
+		comments := listSandboxIssueComments(tb, sb, issueNumber)
+		for _, comment := range comments {
+			if strings.Contains(comment.Body, contains) {
+				return true, ""
+			}
+		}
+		return false, fmt.Sprintf("issue #%d comments missing substring %q", issueNumber, contains)
+	})
+}
+
+func listSandboxIssueComments(tb testing.TB, sb sandboxConfig, issueNumber int64) []depGateSandboxComment {
+	tb.Helper()
+	var comments []depGateSandboxComment
+	runSandboxJSON(tb, "", sb.CmdEnv, &comments, "gh", "api", fmt.Sprintf("repos/%s/issues/%d/comments", sb.Repo, issueNumber))
+	return comments
+}
+
+func getSandboxIssueView(tb testing.TB, sb sandboxConfig, issueNumber int64) depGateSandboxIssueView {
+	tb.Helper()
+	var issue depGateSandboxIssueView
+	runSandboxJSON(tb, "", sb.CmdEnv, &issue, "gh", "api", fmt.Sprintf("repos/%s/issues/%d", sb.Repo, issueNumber))
+	return issue
+}
+
+func sandboxLabelNames(labels []struct {
+	Name string `json:"name"`
+}) []string {
+	out := make([]string, 0, len(labels))
+	for _, label := range labels {
+		out = append(out, label.Name)
+	}
+	return out
+}

--- a/internal/e2e/dependency_gate_sandbox_test.go
+++ b/internal/e2e/dependency_gate_sandbox_test.go
@@ -90,12 +90,14 @@ func TestGitHubSandboxDependencyGateScenarios(t *testing.T) {
 		waitForSandboxIssueLabel(t, sb, dependent.Number, "looper:plan")
 	})
 
-	t.Run("cycle issues are returned to retriage with stamped comments", func(t *testing.T) {
+	t.Run("GitHub rejects blocked_by cycle creation", func(t *testing.T) {
 		left := createDependencyGateIssue(t, sb, "cycle left")
 		right := createDependencyGateIssue(t, sb, "cycle right")
 		defer closeSandboxIssueIfOpen(t, sb, left.Number, "not_planned")
 		defer closeSandboxIssueIfOpen(t, sb, right.Number, "not_planned")
 		linkSandboxBlockedBy(t, sb, left.Number, right.ID)
+		// Real GitHub rejects cycles before coordinator discovery can observe them.
+		// Coordinator-side cycle re-triage remains covered by TestCoordinatorCycleHandlingWithFakeGH.
 		output, err := runSandboxCommand("", sb.CmdEnv, "gh", "api", fmt.Sprintf("repos/%s/issues/%d/dependencies/blocked_by", sb.Repo, right.Number), "--method", "POST", "-H", "X-GitHub-Api-Version: 2026-03-10", "-F", fmt.Sprintf("issue_id=%d", left.ID))
 		if err == nil {
 			t.Fatalf("expected GitHub to reject cycle creation, but request succeeded: %s", output)

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -927,31 +927,27 @@ func (g *Gateway) listDependencyIssues(ctx context.Context, input ViewIssueInput
 
 func (g *Gateway) FindAnyIssueNumber(ctx context.Context, repo string, cwd string) (int64, error) {
 	hostname, repoName := splitRepoHostname(repo)
-	for page := 1; ; page++ {
-		args := []string{"api", fmt.Sprintf("repos/%s/issues?state=all&per_page=100&page=%d", repoName, page)}
-		if hostname != "" {
-			args = append(args, "--hostname", hostname)
+	args := []string{"api", "--paginate", "--slurp", fmt.Sprintf("repos/%s/issues?state=all&per_page=100", repoName)}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, cwd, "", args...)
+	if err != nil {
+		return 0, err
+	}
+	rows, err := decodeJSONArrayOrPages(result.Stdout)
+	if err != nil {
+		return 0, err
+	}
+	for _, row := range rows {
+		if row["pull_request"] != nil {
+			continue
 		}
-		result, err := g.runGh(ctx, cwd, "", args...)
-		if err != nil {
-			return 0, err
-		}
-		rows, err := decodeJSONArray(result.Stdout)
-		if err != nil {
-			return 0, err
-		}
-		if len(rows) == 0 {
-			return 0, nil
-		}
-		for _, row := range rows {
-			if row["pull_request"] != nil {
-				continue
-			}
-			if issueNumber := asInt64(row["number"]); issueNumber > 0 {
-				return issueNumber, nil
-			}
+		if issueNumber := asInt64(row["number"]); issueNumber > 0 {
+			return issueNumber, nil
 		}
 	}
+	return 0, nil
 }
 
 func (g *Gateway) ListIssueComments(ctx context.Context, input ViewIssueInput) ([]CommentInfo, error) {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -927,27 +927,31 @@ func (g *Gateway) listDependencyIssues(ctx context.Context, input ViewIssueInput
 
 func (g *Gateway) FindAnyIssueNumber(ctx context.Context, repo string, cwd string) (int64, error) {
 	hostname, repoName := splitRepoHostname(repo)
-	args := []string{"api", "--paginate", "--slurp", fmt.Sprintf("repos/%s/issues?state=all&per_page=100", repoName)}
-	if hostname != "" {
-		args = append(args, "--hostname", hostname)
-	}
-	result, err := g.runGh(ctx, cwd, "", args...)
-	if err != nil {
-		return 0, err
-	}
-	rows, err := decodeJSONArrayOrPages(result.Stdout)
-	if err != nil {
-		return 0, err
-	}
-	for _, row := range rows {
-		if row["pull_request"] != nil {
-			continue
+	for page := 1; ; page++ {
+		args := []string{"api", fmt.Sprintf("repos/%s/issues?state=all&per_page=100&page=%d", repoName, page)}
+		if hostname != "" {
+			args = append(args, "--hostname", hostname)
 		}
-		if issueNumber := asInt64(row["number"]); issueNumber > 0 {
-			return issueNumber, nil
+		result, err := g.runGh(ctx, cwd, "", args...)
+		if err != nil {
+			return 0, err
+		}
+		rows, err := decodeJSONArray(result.Stdout)
+		if err != nil {
+			return 0, err
+		}
+		if len(rows) == 0 {
+			return 0, nil
+		}
+		for _, row := range rows {
+			if row["pull_request"] != nil {
+				continue
+			}
+			if issueNumber := asInt64(row["number"]); issueNumber > 0 {
+				return issueNumber, nil
+			}
 		}
 	}
-	return 0, nil
 }
 
 func (g *Gateway) ListIssueComments(ctx context.Context, input ViewIssueInput) ([]CommentInfo, error) {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1451,10 +1451,10 @@ func TestFindAnyIssueNumberSkipsPullRequests(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
-		if got := strings.Join(options.Args, " "); got != "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100" {
+		if got := strings.Join(options.Args, " "); got != "api repos/acme/looper/issues?state=all&per_page=100&page=1" {
 			t.Fatalf("unexpected gh args: %q", got)
 		}
-		return shell.Result{Stdout: `[[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}},{"number":7}]]`}, nil
+		return shell.Result{Stdout: `[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}},{"number":7}]`}, nil
 	}
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
 	issueNumber, err := gateway.FindAnyIssueNumber(context.Background(), "acme/looper", "")
@@ -1466,14 +1466,19 @@ func TestFindAnyIssueNumberSkipsPullRequests(t *testing.T) {
 	}
 }
 
-func TestFindAnyIssueNumberHandlesPaginatedSlurpPages(t *testing.T) {
+func TestFindAnyIssueNumberChecksLaterPages(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
-		if got := strings.Join(options.Args, " "); got != "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100" {
+		switch got := strings.Join(options.Args, " "); got {
+		case "api repos/acme/looper/issues?state=all&per_page=100&page=1":
+			return shell.Result{Stdout: `[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}}]`}, nil
+		case "api repos/acme/looper/issues?state=all&per_page=100&page=2":
+			return shell.Result{Stdout: `[{"number":7}]`}, nil
+		default:
 			t.Fatalf("unexpected gh args: %q", got)
+			return shell.Result{}, nil
 		}
-		return shell.Result{Stdout: `[[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}}],[{"number":7}]]`}, nil
 	}
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
 	issueNumber, err := gateway.FindAnyIssueNumber(context.Background(), "acme/looper", "")
@@ -1481,10 +1486,10 @@ func TestFindAnyIssueNumberHandlesPaginatedSlurpPages(t *testing.T) {
 		t.Fatalf("FindAnyIssueNumber() error = %v", err)
 	}
 	if issueNumber != 7 {
-		t.Fatalf("FindAnyIssueNumber() = %d, want issue discovered in later slurped page", issueNumber)
+		t.Fatalf("FindAnyIssueNumber() = %d, want issue discovered on later page", issueNumber)
 	}
-	if len(runner.calls) != 1 {
-		t.Fatalf("FindAnyIssueNumber() calls = %d, want one slurped request", len(runner.calls))
+	if len(runner.calls) != 2 {
+		t.Fatalf("FindAnyIssueNumber() calls = %d, want two paged requests", len(runner.calls))
 	}
 }
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1451,10 +1451,10 @@ func TestFindAnyIssueNumberSkipsPullRequests(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
-		if got := strings.Join(options.Args, " "); got != "api repos/acme/looper/issues?state=all&per_page=100&page=1" {
+		if got := strings.Join(options.Args, " "); got != "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100" {
 			t.Fatalf("unexpected gh args: %q", got)
 		}
-		return shell.Result{Stdout: `[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}},{"number":7}]`}, nil
+		return shell.Result{Stdout: `[[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}},{"number":7}]]`}, nil
 	}
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
 	issueNumber, err := gateway.FindAnyIssueNumber(context.Background(), "acme/looper", "")
@@ -1466,20 +1466,14 @@ func TestFindAnyIssueNumberSkipsPullRequests(t *testing.T) {
 	}
 }
 
-func TestFindAnyIssueNumberContinuesPastFivePages(t *testing.T) {
+func TestFindAnyIssueNumberHandlesPaginatedSlurpPages(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
-		args := strings.Join(options.Args, " ")
-		switch args {
-		case "api repos/acme/looper/issues?state=all&per_page=100&page=1", "api repos/acme/looper/issues?state=all&per_page=100&page=2", "api repos/acme/looper/issues?state=all&per_page=100&page=3", "api repos/acme/looper/issues?state=all&per_page=100&page=4", "api repos/acme/looper/issues?state=all&per_page=100&page=5":
-			return shell.Result{Stdout: `[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}}]`}, nil
-		case "api repos/acme/looper/issues?state=all&per_page=100&page=6":
-			return shell.Result{Stdout: `[{"number":7}]`}, nil
-		default:
-			t.Fatalf("unexpected gh args: %q", args)
-			return shell.Result{}, nil
+		if got := strings.Join(options.Args, " "); got != "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100" {
+			t.Fatalf("unexpected gh args: %q", got)
 		}
+		return shell.Result{Stdout: `[[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}}],[{"number":7}]]`}, nil
 	}
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
 	issueNumber, err := gateway.FindAnyIssueNumber(context.Background(), "acme/looper", "")
@@ -1487,10 +1481,10 @@ func TestFindAnyIssueNumberContinuesPastFivePages(t *testing.T) {
 		t.Fatalf("FindAnyIssueNumber() error = %v", err)
 	}
 	if issueNumber != 7 {
-		t.Fatalf("FindAnyIssueNumber() = %d, want issue discovered after page five", issueNumber)
+		t.Fatalf("FindAnyIssueNumber() = %d, want issue discovered in later slurped page", issueNumber)
 	}
-	if len(runner.calls) != 6 {
-		t.Fatalf("FindAnyIssueNumber() calls = %d, want six pages probed", len(runner.calls))
+	if len(runner.calls) != 1 {
+		t.Fatalf("FindAnyIssueNumber() calls = %d, want one slurped request", len(runner.calls))
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2698,8 +2698,8 @@ func TestValidateCoordinatorDependencyGatesFailsClosedWhenAPIUnavailable(t *test
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case strings.HasPrefix(args, "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100"):
-			return shell.Result{Stdout: `[[{"number":7}]]`}, nil
+		case args == "api repos/acme/looper/issues?state=all&per_page=100&page=1":
+			return shell.Result{Stdout: `[{"number":7}]`}, nil
 		case strings.Contains(args, "dependencies/blocked_by"):
 			result := shell.Result{ExitCode: 1, Stderr: "gh: HTTP 404: Not Found"}
 			return result, &shell.CommandExecutionError{Message: "Command exited with code 1", Result: result}
@@ -2736,8 +2736,8 @@ func TestValidateCoordinatorDependencyGatesAllowsAvailableAPI(t *testing.T) {
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case strings.HasPrefix(args, "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100"):
-			return shell.Result{Stdout: `[[{"number":7}]]`}, nil
+		case args == "api repos/acme/looper/issues?state=all&per_page=100&page=1":
+			return shell.Result{Stdout: `[{"number":7}]`}, nil
 		case strings.Contains(args, "dependencies/blocked_by"):
 			return shell.Result{Stdout: `[]`}, nil
 		default:
@@ -2773,8 +2773,10 @@ func TestValidateCoordinatorDependencyGatesSkipsProbeWhenRepoHasNoIssues(t *test
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case strings.HasPrefix(args, "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100"):
-			return shell.Result{Stdout: `[[{"number":12,"pull_request":{}}],[]]`}, nil
+		case args == "api repos/acme/looper/issues?state=all&per_page=100&page=1":
+			return shell.Result{Stdout: `[{"number":12,"pull_request":{}}]`}, nil
+		case args == "api repos/acme/looper/issues?state=all&per_page=100&page=2":
+			return shell.Result{Stdout: `[]`}, nil
 		case strings.Contains(args, "dependencies/blocked_by"):
 			blockedByCalls++
 			return shell.Result{Stdout: `[]`}, nil
@@ -2813,7 +2815,7 @@ func TestValidateCoordinatorDependencyGatesReturnsInvalidJSONFromIssueProbe(t *t
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case strings.HasPrefix(args, "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100"):
+		case args == "api repos/acme/looper/issues?state=all&per_page=100&page=1":
 			return shell.Result{Stdout: `not-json`}, nil
 		default:
 			t.Fatalf("unexpected gh args: %q", args)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2698,8 +2698,8 @@ func TestValidateCoordinatorDependencyGatesFailsClosedWhenAPIUnavailable(t *test
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=1"):
-			return shell.Result{Stdout: `[{"number":7}]`}, nil
+		case strings.HasPrefix(args, "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100"):
+			return shell.Result{Stdout: `[[{"number":7}]]`}, nil
 		case strings.Contains(args, "dependencies/blocked_by"):
 			result := shell.Result{ExitCode: 1, Stderr: "gh: HTTP 404: Not Found"}
 			return result, &shell.CommandExecutionError{Message: "Command exited with code 1", Result: result}
@@ -2736,8 +2736,8 @@ func TestValidateCoordinatorDependencyGatesAllowsAvailableAPI(t *testing.T) {
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=1"):
-			return shell.Result{Stdout: `[{"number":7}]`}, nil
+		case strings.HasPrefix(args, "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100"):
+			return shell.Result{Stdout: `[[{"number":7}]]`}, nil
 		case strings.Contains(args, "dependencies/blocked_by"):
 			return shell.Result{Stdout: `[]`}, nil
 		default:
@@ -2773,10 +2773,8 @@ func TestValidateCoordinatorDependencyGatesSkipsProbeWhenRepoHasNoIssues(t *test
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=1"):
-			return shell.Result{Stdout: `[{"number":12,"pull_request":{}}]`}, nil
-		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=2"):
-			return shell.Result{Stdout: `[]`}, nil
+		case strings.HasPrefix(args, "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100"):
+			return shell.Result{Stdout: `[[{"number":12,"pull_request":{}}],[]]`}, nil
 		case strings.Contains(args, "dependencies/blocked_by"):
 			blockedByCalls++
 			return shell.Result{Stdout: `[]`}, nil
@@ -2792,6 +2790,41 @@ func TestValidateCoordinatorDependencyGatesSkipsProbeWhenRepoHasNoIssues(t *test
 	}
 	if blockedByCalls != 0 {
 		t.Fatalf("dependencies/blocked_by call count = %d, want 0", blockedByCalls)
+	}
+}
+
+func TestValidateCoordinatorDependencyGatesReturnsInvalidJSONFromIssueProbe(t *testing.T) {
+	t.Parallel()
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.Dependencies.Enabled = true
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "runtime.sqlite"), filepath.Join(workingDir, "backups"))
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := formatJavaScriptISOString(time.Date(2026, time.May, 16, 12, 0, 0, 0, time.UTC))
+	metadata := `{"repo":"acme/looper","worktreeRoot":null,"source":"config"}`
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "demo", Name: "Demo", RepoPath: workingDir, MetadataJSON: &metadata, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch {
+		case strings.HasPrefix(args, "api --paginate --slurp repos/acme/looper/issues?state=all&per_page=100"):
+			return shell.Result{Stdout: `not-json`}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}})
+	rt := New(Options{Config: cfg, Logger: &testLogger{}})
+
+	err = rt.validateCoordinatorDependencyGates(context.Background(), repositories, githubGateway)
+	if err == nil || !strings.Contains(err.Error(), "Invalid gh JSON payload") {
+		t.Fatalf("validateCoordinatorDependencyGates() error = %v, want Invalid gh JSON payload", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- switch dependency-gate startup issue probing to the same paginated/slurped GitHub API shape used by the dependency endpoints
- add runtime and gateway coverage for malformed startup probe payloads and paginated issue discovery
- add reusable real GitHub sandbox E2E coverage for dependency-gate startup validation, blocked human dispatch, not_planned re-triage, and native cycle rejection

## Validation
- ok  	github.com/nexu-io/looper/internal/infra/github	0.437s
ok  	github.com/nexu-io/looper/internal/runtime	5.569s
ok  	github.com/nexu-io/looper/internal/e2e	13.171s
- === RUN   TestGitHubSandboxDependencyGateScenarios
=== RUN   TestGitHubSandboxDependencyGateScenarios/looperd_startup_validation_succeeds_against_real_dependency_API
=== RUN   TestGitHubSandboxDependencyGateScenarios/human_gated_blocked_by_fails_then_releases_after_completion
=== RUN   TestGitHubSandboxDependencyGateScenarios/cycle_issues_are_returned_to_retriage_with_stamped_comments
=== RUN   TestGitHubSandboxDependencyGateScenarios/not_planned_blocker_returns_dependent_to_retriage_without_cycle_comment
--- PASS: TestGitHubSandboxDependencyGateScenarios (97.06s)
    --- PASS: TestGitHubSandboxDependencyGateScenarios/looperd_startup_validation_succeeds_against_real_dependency_API (0.53s)
    --- PASS: TestGitHubSandboxDependencyGateScenarios/human_gated_blocked_by_fails_then_releases_after_completion (51.32s)
    --- PASS: TestGitHubSandboxDependencyGateScenarios/cycle_issues_are_returned_to_retriage_with_stamped_comments (10.33s)
    --- PASS: TestGitHubSandboxDependencyGateScenarios/not_planned_blocker_returns_dependent_to_retriage_without_cycle_comment (27.40s)
PASS
ok  	github.com/nexu-io/looper/internal/e2e	100.860s

## References
- PRD #351
