### PR TITLE
fix: tolerate nested lifecycle action sources

### DIFF
--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -680,6 +680,26 @@ func TestExecutorMalformedLifecycleDoesNotInvalidateCompletion(t *testing.T) {
 	}
 }
 
+func TestExecutorParsesNestedLifecycleActionSources(t *testing.T) {
+	t.Parallel()
+
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", `printf '__LOOPER_RESULT__={"summary":"done","git_pr_lifecycle":{"branch":"looper/test","baseBranch":"main","prNumber":84,"prUrl":"https://github.com/nexu-io/looper/pull/84","actions":{"commit":{"source":"agent"},"push":{"source":"agent"},"pr":{"source":"agent"}}}}\n'`}}}})
+	execHandle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_nested_lifecycle", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.ParseStatus != "parsed" || result.Lifecycle == nil {
+		t.Fatalf("result = %#v, want parsed lifecycle", result)
+	}
+	if result.Lifecycle.PRNumber != 84 || result.Lifecycle.Actions.Commit != "agent" || result.Lifecycle.Actions.Push != "agent" || result.Lifecycle.Actions.PR != "agent" {
+		t.Fatalf("result lifecycle = %#v, want nested action sources normalized", result.Lifecycle)
+	}
+}
+
 func TestExecutorFailedCommandIgnoresEchoedTemplateCompletion(t *testing.T) {
 	t.Parallel()
 

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -38,6 +38,53 @@ type Actions struct {
 	PR     string `json:"pr,omitempty"`
 }
 
+type actionSourceShape struct {
+	Source string `json:"source,omitempty"`
+}
+
+func (a *Actions) UnmarshalJSON(data []byte) error {
+	type rawActions struct {
+		Commit json.RawMessage `json:"commit,omitempty"`
+		Push   json.RawMessage `json:"push,omitempty"`
+		PR     json.RawMessage `json:"pr,omitempty"`
+	}
+	var raw rawActions
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	commit, err := parseActionSource(raw.Commit)
+	if err != nil {
+		return err
+	}
+	push, err := parseActionSource(raw.Push)
+	if err != nil {
+		return err
+	}
+	pr, err := parseActionSource(raw.PR)
+	if err != nil {
+		return err
+	}
+	a.Commit = commit
+	a.Push = push
+	a.PR = pr
+	return nil
+}
+
+func parseActionSource(data json.RawMessage) (string, error) {
+	if len(data) == 0 || string(data) == "null" {
+		return "", nil
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err == nil {
+		return value, nil
+	}
+	var shape actionSourceShape
+	if err := json.Unmarshal(data, &shape); err == nil {
+		return shape.Source, nil
+	}
+	return "", fmt.Errorf("invalid lifecycle action source: %s", string(data))
+}
+
 type State struct {
 	Policy            string   `json:"policy,omitempty"`
 	PolicyVersion     int      `json:"policy_version,omitempty"`
@@ -333,7 +380,7 @@ func PromptInstruction(runner, branch, baseBranch string, expectPush, expectPR b
 		"Before finishing: inspect git status, staged and unstaged diffs, untracked files, and recent commit style; " + gitStep + "; " + prStep + ".",
 		disclosurePromptInstruction(runner, disclosureCfg, agentRuntime, agentModel),
 		"If a branch PR already exists, reuse it and preserve human-edited title/body while adding only missing labels, reviewers, or closing references requested by the run.",
-		"Include a git_pr_lifecycle object in the final " + "__LOOPER_RESULT__" + " JSON with branch, baseBranch, commitShas, pushed, prNumber, prUrl, prAdopted, and actions {commit,push,pr}; use action source \"agent\" for actions you completed and \"none\" for actions still missing.",
+		"Include a git_pr_lifecycle object in the final " + "__LOOPER_RESULT__" + " JSON with branch, baseBranch, commitShas, pushed, prNumber, prUrl, prAdopted, and actions {commit,push,pr}; set each action to a plain string source like \"agent\" or \"none\", not a nested object.",
 		fmt.Sprintf("Expected lifecycle branch=%q baseBranch=%q expectPush=%t expectPR=%t fallbackAllowed=%t.", branch, baseBranch, expectPush, policy.ExpectPR, policy.AllowFallback),
 	}, "\n")
 }

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -31,6 +31,24 @@ func TestFromMapNormalizesAgentLifecycleState(t *testing.T) {
 	}
 }
 
+func TestFromMapAcceptsNestedActionSources(t *testing.T) {
+	state, err := FromMap(map[string]any{
+		"branch":    "looper/test",
+		"pr_number": float64(84),
+		"actions": map[string]any{
+			"commit": map[string]any{"source": "agent"},
+			"push":   map[string]any{"source": "fallback"},
+			"pr":     map[string]any{"source": "none"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("FromMap() error = %v", err)
+	}
+	if state.Actions.Commit != ActionSourceAgent || state.Actions.Push != ActionSourceFallback || state.Actions.PR != ActionSourceNone {
+		t.Fatalf("state.Actions = %#v, want nested action sources normalized", state.Actions)
+	}
+}
+
 func TestMergeAgentPreservesFallbackMetadata(t *testing.T) {
 	state := NewState(AgentManagedWithFallbackPolicy("worker", true), "looper/test", "main")
 	state.Actions.PR = ActionSourceFallback
@@ -62,7 +80,7 @@ func TestStateSetActiveBranchMarksAgentMigration(t *testing.T) {
 
 func TestPromptInstructionDocumentsLifecycleContract(t *testing.T) {
 	prompt := PromptInstruction("worker", "looper/test", "main", true, true, config.DefaultDisclosureConfig(), "opencode", "")
-	for _, want := range []string{PolicyAgentManagedWithFallback, "git_pr_lifecycle", "commitShas", "actions {commit,push,pr}", "fallbackAllowed=true"} {
+	for _, want := range []string{PolicyAgentManagedWithFallback, "git_pr_lifecycle", "commitShas", "actions {commit,push,pr}", "plain string source", "fallbackAllowed=true"} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("PromptInstruction missing %q in:\n%s", want, prompt)
 		}

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -3058,7 +3058,7 @@ func noRemoteLifecyclePromptInstruction(runner, branch, baseBranch string, discl
 		"Before finishing: inspect git status, staged and unstaged diffs, untracked files, and recent commit style; commit only relevant non-secret changes if needed; do not push branches, create pull requests, update pull request metadata, or otherwise change remote review state.",
 		lifecycle.DisclosurePromptInstruction(runner, disclosureCfg, agentRuntime, agentModel),
 		"Because remote PR actions are disabled for this run, do not create or update PR bodies; any PR disclosure stamping can only happen during a later Looper-managed remote reconciliation step.",
-		"Include a git_pr_lifecycle object in the final " + "__LOOPER_RESULT__" + " JSON with branch, baseBranch, commitShas, pushed, prNumber, prUrl, prAdopted, and actions {commit,push,pr}; use action source \"agent\" only for local commits you completed and \"none\" for disabled remote actions.",
+		"Include a git_pr_lifecycle object in the final " + "__LOOPER_RESULT__" + " JSON with branch, baseBranch, commitShas, pushed, prNumber, prUrl, prAdopted, and actions {commit,push,pr}; set each action to a plain string source like \"agent\" or \"none\", not a nested object.",
 		fmt.Sprintf("Expected lifecycle runner=%q branch=%q baseBranch=%q expectPush=%t expectPR=%t fallbackAllowed=%t.", runner, branch, baseBranch, false, false, true),
 	}, "\n")
 }


### PR DESCRIPTION
## Summary
- accept both flat and nested git_pr_lifecycle action source shapes during lifecycle parsing
- keep the canonical prompt contract on plain string action sources to reduce malformed agent output
- add regression coverage for nested lifecycle action parsing in lifecycle and agent executor tests

## Testing
- go test ./internal/lifecycle ./internal/agent
- go test ./internal/worker
- go test ./...