### PR TITLE
test: validate Network Coordinator E2E and migration hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,23 @@ Each role runs in its own worktree, coordinated by `looperd` and gated by labels
 
 Looper is poll-driven, not webhook-driven: keep `looperd` running and `gh` authenticated for the loop to fire. Everything runs locally — no hosted control plane required.
 
+## Networked operation
+
+Looper supports two project modes:
+
+- `network.mode=off` — local-only behavior. Worker still claims `looper:worker-ready` Issues assigned to the local GitHub user, Reviewer still claims review requests for the local GitHub user, and any `looper:target:*` labels are ignored.
+- `network.mode=routed` — multi-Node behavior. `loopernet` centralizes webhook ingress and event fan-out, but GitHub remains the authority for work intent.
+
+In Routed mode:
+
+- Coordinator, not `loopernet`, mutates GitHub for Issue admission and PR review assignment.
+- `looper:worker-ready` and GitHub review requests express work intent.
+- exactly one `looper:target:<node_name>` label is the exact-Node authority, and Coordinator writes it last.
+- the `loopernet` Coordinator lease is only a fencing gate for mutation rights; if the lease is stale, Coordinator must stop mutating GitHub.
+- polling stays enabled as drift recovery if webhook ingress or SSE wakeups are missed; it is not the primary wakeup path.
+
+For setup, identity strategy, and recovery steps, see **[docs/users-guide.md](docs/users-guide.md)** and **[docs/configuration.md](docs/configuration.md)**. The formal authority rules live in ADRs **[0007](docs/adr/0007-coordinator-admission-assignment-authority.md)** through **[0011](docs/adr/0011-coordinator-control-plane-for-routed-projects-v1.md)**.
+
 ## Command cheatsheet
 
 **Setup & health**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,28 @@ The daemon lookup order used by the CLI is `~/.looper/bin/looperd`, then `$PATH`
 
 Keep the runtime directory (`~/.looper` by default, or the directory containing `storage.dbPath`) on a local filesystem. The webhook forwarder lock uses OS file locking and is not designed for NFS-style shared filesystems. Tunnel-mode webhook secrets live under the same runtime directory in `secrets/` and must be mode `0600`.
 
+## Network mode summary
+
+Looper has two project-level network modes:
+
+- `projects[].network.mode = "off"` — local-only operation. `looper:target:*` labels are ignored and the classic single-Node assignee/review-request behavior stays unchanged.
+- `projects[].network.mode = "routed"` — multi-Node operation coordinated through `loopernet`.
+
+Authority stays split on purpose:
+
+- GitHub work intent stays on GitHub: `looper:worker-ready` for Worker and GitHub review requests for Reviewer.
+- exactly one `looper:target:<node_name>` label is the exact-Node authority in Routed mode.
+- the `loopernet` lease is a mutation fence for Coordinator only; it does not become the source of truth for work intent.
+
+Operational notes:
+
+- `loopernet` centralizes webhook ingress and Node wakeups, but it must not mutate GitHub on its own.
+- Coordinator writes coarse GitHub authority first, then writes the exact target label last.
+- polling remains enabled as fallback and drift recovery when webhook delivery or SSE wakeups are missed.
+- if you use `looper network join` without `--no-enroll-projects`, Looper rejects enrollment when Planner or Fixer auto-discovery is still enabled for those projects; disable those settings first or opt projects into Routed mode manually.
+
+The formal contract is documented in ADRs [0007](adr/0007-coordinator-admission-assignment-authority.md) through [0011](adr/0011-coordinator-control-plane-for-routed-projects-v1.md).
+
 ## Webhook delivery modes
 
 `webhook.enabled=true` supports two delivery modes:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -34,6 +34,37 @@ Also make sure:
 - `gh` is authenticated with the target GitHub account
 - `config.agent.vendor` is set (for example via `looper bootstrap --agent-vendor opencode`)
 
+## 1a. Local-only vs Routed projects
+
+Looper supports two project modes:
+
+- `network.mode=off` — local-only. Worker claims `looper:worker-ready` Issues assigned to the local GitHub user, Reviewer claims PRs with a review request for the local GitHub user, and `looper:target:*` labels do nothing.
+- `network.mode=routed` — multi-Node. `loopernet` receives centralized webhook ingress, fans out wakeups to Nodes, and exposes the Coordinator lease used for fencing.
+
+Routed mode keeps authorities separate:
+
+- GitHub remains the work-intent authority.
+- `looper:target:<node_name>` is only the exact-Node authority.
+- the lease only decides which Coordinator may mutate GitHub.
+
+That means `loopernet` never becomes the source of truth for Issue admission or PR review assignment, and it must not mutate GitHub directly.
+
+## 1b. Routed setup and recovery
+
+Typical Routed rollout:
+
+1. join each Node to `loopernet` with `looper network join <url> --key ... --name <node>`
+2. disable unsupported routed auto-discovery (`planner` and `fixer`) before opting projects into `network.mode=routed`
+3. keep Worker and Reviewer identities stable per Node; duplicate GitHub identities are safe only because the exact target label disambiguates which Node may claim
+4. restart `looperd` and confirm `looper network status --verbose` shows membership, identity, and lease state
+
+Operator recovery rules:
+
+- if the target label is removed, duplicated, changed, or stale before work starts, Worker/Reviewer will not claim it
+- if `looper:worker-ready`, the GitHub assignee, or the review request disappears before processing starts, the queued item becomes unclaimable
+- if webhook ingress or SSE wakeups degrade, polling continues as a fallback so Coordinator can repair drift
+- if a stale target label remains after lease loss or a partial GitHub mutation, let Coordinator reconciliation repair or remove it before retrying
+
 ## 2. Project auto-detection from the current directory
 
 Looper can often infer the target project from your current working directory.

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -4248,6 +4248,7 @@ func TestNetworkJoinRemovesLocalStateWhenProjectEnrollmentRollbackFails(t *testi
 	}
 	configPayload := map[string]any{
 		"tools":    map[string]any{"ghPath": ghPath},
+		"roles":    map[string]any{"planner": map[string]any{"autoDiscovery": false}, "fixer": map[string]any{"autoDiscovery": false}},
 		"projects": []map[string]any{{"id": "project-1", "name": "Repo", "path": t.TempDir()}},
 	}
 	raw, err := json.Marshal(configPayload)
@@ -4325,6 +4326,145 @@ func TestNetworkJoinRemovesLocalStateWhenProjectEnrollmentRollbackFails(t *testi
 	}
 }
 
+func TestNetworkJoinRejectsAutoEnrollmentWhenPlannerOrFixerAutoDiscoveryIsEnabled(t *testing.T) {
+	homeDir := t.TempDir()
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "config.toml")
+	projectPath := t.TempDir()
+	raw, err := config.MarshalConfigFile(configPath, config.PartialConfig{
+		Roles: &config.PartialRoleConfigs{
+			Planner: &config.PartialPlannerRoleConfig{AutoDiscovery: boolPtr(true)},
+			Fixer:   &config.PartialFixerRoleConfig{AutoDiscovery: boolPtr(true)},
+		},
+		Projects: &[]config.PartialProjectRefConfig{{ID: "project-1", Name: "Repo", Path: projectPath}},
+	})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	joinCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		joinCalls++
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"networkId":"net-1","nodeId":"node-1","nodeToken":"node-token"}`))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	runtime := newCommandRuntime(New(Deps{Stdout: stdout, Stderr: stderr, HomeDir: homeDir, Getwd: func() (string, error) { return configDir, nil }}), []string{"--config", configPath})
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.Flags().String("key", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Bool("no-enroll-projects", false, "")
+	cmd.Flags().Bool("json", false, "")
+	if err := cmd.Flags().Set("key", "join-1"); err != nil {
+		t.Fatalf("set key flag: %v", err)
+	}
+	if err := cmd.Flags().Set("name", "worker-1"); err != nil {
+		t.Fatalf("set name flag: %v", err)
+	}
+
+	err = runtime.networkJoin(cmd, []string{server.URL})
+	if err == nil {
+		t.Fatal("networkJoin() error = nil, want auto-enrollment validation failure")
+	}
+	if !strings.Contains(err.Error(), "cannot auto-enroll projects in network.mode=routed") || !strings.Contains(err.Error(), "--no-enroll-projects") {
+		t.Fatalf("error = %q, want actionable routed enrollment remediation", err)
+	}
+	if joinCalls != 0 {
+		t.Fatalf("join calls = %d, want no remote join attempt", joinCalls)
+	}
+	if _, err := os.Stat(filepath.Join(homeDir, ".looper", "network.json")); !os.IsNotExist(err) {
+		t.Fatalf("network state file present after validation failure: %v", err)
+	}
+}
+
+func TestNetworkJoinWithNoEnrollProjectsSkipsRoutedEnrollmentValidation(t *testing.T) {
+	homeDir := t.TempDir()
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "config.toml")
+	ghPath := filepath.Join(t.TempDir(), "gh")
+	projectPath := t.TempDir()
+	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"user\" ]; then\n  printf '{\"login\":\"worker-1\",\"id\":101}'\n  exit 0\nfi\nprintf 'unexpected gh invocation: %s\\n' \"$*\" >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	raw, err := config.MarshalConfigFile(configPath, config.PartialConfig{
+		Tools: &config.PartialToolPathsConfig{GHPath: stringPtr(ghPath)},
+		Roles: &config.PartialRoleConfigs{
+			Planner: &config.PartialPlannerRoleConfig{AutoDiscovery: boolPtr(true)},
+			Fixer:   &config.PartialFixerRoleConfig{AutoDiscovery: boolPtr(true)},
+		},
+		Projects: &[]config.PartialProjectRefConfig{{ID: "project-1", Name: "Repo", Path: projectPath}},
+	})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	joinCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/join" {
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+		joinCalls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"networkId":"net-1","nodeId":"node-1","nodeToken":"node-token"}`))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	runtime := newCommandRuntime(New(Deps{Stdout: stdout, Stderr: stderr, HomeDir: homeDir, Getwd: func() (string, error) { return configDir, nil }}), []string{"--config", configPath})
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.Flags().String("key", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Bool("no-enroll-projects", false, "")
+	cmd.Flags().Bool("json", false, "")
+	if err := cmd.Flags().Set("key", "join-1"); err != nil {
+		t.Fatalf("set key flag: %v", err)
+	}
+	if err := cmd.Flags().Set("name", "worker-1"); err != nil {
+		t.Fatalf("set name flag: %v", err)
+	}
+	if err := cmd.Flags().Set("no-enroll-projects", "true"); err != nil {
+		t.Fatalf("set no-enroll-projects flag: %v", err)
+	}
+
+	if err := runtime.networkJoin(cmd, []string{server.URL}); err != nil {
+		t.Fatalf("networkJoin() error = %v", err)
+	}
+	if joinCalls != 1 {
+		t.Fatalf("join calls = %d, want 1", joinCalls)
+	}
+	state, err := client.LoadState(filepath.Join(homeDir, ".looper", "network.json"))
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.URL != server.URL || state.NodeName != "worker-1" {
+		t.Fatalf("state = %#v, want saved routed membership", state)
+	}
+	updated, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(updated), "network") {
+		t.Fatalf("config = %s, want project network mode unchanged when --no-enroll-projects is used", string(updated))
+	}
+}
+
 func TestNetworkJoinPreservesLocalStateWhenProjectEnrollmentRollbackLeaveFails(t *testing.T) {
 	homeDir := t.TempDir()
 	configDir := t.TempDir()
@@ -4335,6 +4475,7 @@ func TestNetworkJoinPreservesLocalStateWhenProjectEnrollmentRollbackLeaveFails(t
 	}
 	configPayload := map[string]any{
 		"tools":    map[string]any{"ghPath": ghPath},
+		"roles":    map[string]any{"planner": map[string]any{"autoDiscovery": false}, "fixer": map[string]any{"autoDiscovery": false}},
 		"projects": []map[string]any{{"id": "project-1", "name": "Repo", "path": t.TempDir()}},
 	}
 	raw, err := json.Marshal(configPayload)

--- a/internal/cliapp/network_commands.go
+++ b/internal/cliapp/network_commands.go
@@ -36,6 +36,7 @@ func (r *commandRuntime) networkJoin(cmd *cobra.Command, args []string) error {
 	url := strings.TrimSpace(args[0])
 	joinKey := strings.TrimSpace(getStringFlag(cmd, "key"))
 	nodeName := strings.TrimSpace(getStringFlag(cmd, "name"))
+	autoEnrollProjects := !getBoolFlag(cmd, "no-enroll-projects")
 	if joinKey == "" {
 		return fmt.Errorf("network join requires --key <key>")
 	}
@@ -44,6 +45,11 @@ func (r *commandRuntime) networkJoin(cmd *cobra.Command, args []string) error {
 	}
 	if err := protocol.ValidateNodeName(nodeName); err != nil {
 		return err
+	}
+	if autoEnrollProjects {
+		if err := r.validateRoutedAutoEnrollment(); err != nil {
+			return err
+		}
 	}
 	homeDir, err := r.homeDir()
 	if err != nil {
@@ -69,7 +75,7 @@ func (r *commandRuntime) networkJoin(cmd *cobra.Command, args []string) error {
 	if err := client.SaveState(client.DefaultStatePath(homeDir), state); err != nil {
 		return err
 	}
-	if !getBoolFlag(cmd, "no-enroll-projects") {
+	if autoEnrollProjects {
 		if err := r.updateAllProjectNetworkModes(config.ProjectNetworkModeRouted); err != nil {
 			if leaveErr := client.New(state.URL, state.NodeToken, r.httpClient()).Leave(cmd.Context()); leaveErr != nil {
 				return errors.Join(err, leaveErr)
@@ -78,13 +84,43 @@ func (r *commandRuntime) networkJoin(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	output := map[string]any{"networkId": joinResp.NetworkID, "nodeId": joinResp.NodeID, "nodeName": nodeName, "github": identity, "warnings": joinResp.Warnings, "enrolledProjects": !getBoolFlag(cmd, "no-enroll-projects")}
+	output := map[string]any{"networkId": joinResp.NetworkID, "nodeId": joinResp.NodeID, "nodeName": nodeName, "github": identity, "warnings": joinResp.Warnings, "enrolledProjects": autoEnrollProjects}
 	if getBoolFlag(cmd, "json") {
 		return writeJSON(cmd.OutOrStdout(), output)
 	}
-	printSection(cmd.OutOrStdout(), "Network joined", [][2]any{{"networkId", joinResp.NetworkID}, {"nodeId", joinResp.NodeID}, {"nodeName", nodeName}, {"githubLogin", identity.Login}, {"githubNumericId", identity.NumericID}, {"enrolledProjects", !getBoolFlag(cmd, "no-enroll-projects")}, {"warnings", joinOrNone(joinResp.Warnings)}})
+	printSection(cmd.OutOrStdout(), "Network joined", [][2]any{{"networkId", joinResp.NetworkID}, {"nodeId", joinResp.NodeID}, {"nodeName", nodeName}, {"githubLogin", identity.Login}, {"githubNumericId", identity.NumericID}, {"enrolledProjects", autoEnrollProjects}, {"warnings", joinOrNone(joinResp.Warnings)}})
 	return nil
 
+}
+
+func (r *commandRuntime) validateRoutedAutoEnrollment() error {
+	cwd, err := r.getwd()
+	if err != nil {
+		return err
+	}
+	loaded, err := config.LoadFile(config.LoadFileOptions{CWD: cwd, Args: r.argv})
+	if err != nil {
+		return err
+	}
+	var affected []string
+	for _, project := range loaded.Config.Projects {
+		roles := config.ProjectRoleConfigs(loaded.Config, project.ID)
+		var unsupported []string
+		if roles.Planner.AutoDiscovery {
+			unsupported = append(unsupported, "roles.planner.autoDiscovery")
+		}
+		if roles.Fixer.AutoDiscovery {
+			unsupported = append(unsupported, "roles.fixer.autoDiscovery")
+		}
+		if len(unsupported) == 0 {
+			continue
+		}
+		affected = append(affected, fmt.Sprintf("%s (%s)", networkProjectDisplayName(project), strings.Join(unsupported, ", ")))
+	}
+	if len(affected) == 0 {
+		return nil
+	}
+	return fmt.Errorf("cannot auto-enroll projects in network.mode=routed while planner/fixer auto-discovery is enabled: %s; disable those settings globally or per-project, or rerun network join with --no-enroll-projects and opt projects into routed mode manually", strings.Join(affected, "; "))
 }
 
 func (r *commandRuntime) networkLeave(cmd *cobra.Command, args []string) error {
@@ -266,6 +302,19 @@ func (r *commandRuntime) updateAllProjectNetworkModes(mode config.ProjectNetwork
 		return err
 	}
 	return renameFile(tmp, loaded.Metadata.ConfigPath)
+}
+
+func networkProjectDisplayName(project config.ProjectRefConfig) string {
+	if trimmed := strings.TrimSpace(project.ID); trimmed != "" {
+		return trimmed
+	}
+	if trimmed := strings.TrimSpace(project.Name); trimmed != "" {
+		return trimmed
+	}
+	if trimmed := strings.TrimSpace(project.RepoPath); trimmed != "" {
+		return trimmed
+	}
+	return "<unnamed project>"
 }
 
 func githubIdentityDrift(expected, current protocol.GitHubIdentity) (bool, string) {


### PR DESCRIPTION
## Summary
- add CLI coverage for routed auto-enrollment validation, including actionable remediation and `--no-enroll-projects` behavior
- fail `looper network join` before remote enrollment when Planner/Fixer auto-discovery would make routed projects invalid
- document local-only vs Routed operation, exact target-label authority, loopernet ingress, lease fencing, and polling-based recovery

## Validation
- go test ./internal/cliapp ./internal/config ./internal/coordinator ./internal/worker ./internal/reviewer ./internal/networkpolicy
- go test ./...
- go build ./...

Closes #414

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>