### PR TITLE
fix: recover worker from non-fast-forward push

### DIFF
--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -237,7 +237,11 @@ func (g *Gateway) CreateWorktree(ctx context.Context, input CreateWorktreeInput)
 		if branchExists {
 			args = append(args, worktreePath, input.Branch)
 		} else {
-			args = append(args, "-b", input.Branch, worktreePath, input.BaseBranch)
+			startPoint, err := g.resolveAttachedStartPoint(ctx, input.RepoPath, input.Branch, input.BaseBranch)
+			if err != nil {
+				return storage.WorktreeRecord{}, err
+			}
+			args = append(args, "-b", input.Branch, worktreePath, startPoint)
 		}
 		if err := g.runGit(ctx, input.RepoPath, nil, args...); err != nil {
 			return storage.WorktreeRecord{}, err
@@ -282,6 +286,29 @@ func (g *Gateway) CreateWorktree(ctx context.Context, input CreateWorktreeInput)
 
 	return record, nil
 
+}
+
+func (g *Gateway) resolveAttachedStartPoint(ctx context.Context, repoPath, branch, baseBranch string) (string, error) {
+	hasRemote, err := g.hasRemote(ctx, repoPath, "origin")
+	if err != nil {
+		return "", err
+	}
+	if !hasRemote {
+		return baseBranch, nil
+	}
+
+	remoteBranchExists, err := g.remoteBranchExists(ctx, repoPath, "origin", branch)
+	if err != nil {
+		return "", err
+	}
+	if !remoteBranchExists {
+		return baseBranch, nil
+	}
+	remoteRef := "refs/remotes/origin/" + branch
+	if err := g.runGit(ctx, repoPath, nil, "fetch", "origin", fmt.Sprintf("refs/heads/%s:%s", branch, remoteRef)); err != nil {
+		return "", err
+	}
+	return "origin/" + branch, nil
 }
 
 func (g *Gateway) ListWorktrees(ctx context.Context, repoPath string) ([]WorktreeListEntry, error) {
@@ -680,15 +707,15 @@ func (g *Gateway) branchExists(ctx context.Context, repoPath, branch string) (bo
 }
 
 func (g *Gateway) remoteBranchExists(ctx context.Context, repoPath, remote, branch string) (bool, error) {
-	_, err := g.runGitResult(ctx, repoPath, nil, "show-ref", "--quiet", "--verify", "refs/remotes/"+remote+"/"+branch)
-	if err == nil {
-		return true, nil
+	result, err := g.runGitResult(ctx, repoPath, nil, "ls-remote", "--heads", remote, "refs/heads/"+branch)
+	if err != nil {
+		var commandErr *shell.CommandExecutionError
+		if errors.As(err, &commandErr) && commandErr.Result.ExitCode == 2 {
+			return false, nil
+		}
+		return false, err
 	}
-	var commandErr *shell.CommandExecutionError
-	if errors.As(err, &commandErr) && commandErr.Result.ExitCode == 1 {
-		return false, nil
-	}
-	return false, err
+	return strings.TrimSpace(result.Stdout) != "", nil
 }
 
 func (g *Gateway) resolveDetachedStartPoint(ctx context.Context, input CreateWorktreeInput) (string, error) {

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -717,7 +717,10 @@ func (g *Gateway) resolveDetachedStartPoint(ctx context.Context, input CreateWor
 
 func (g *Gateway) resolveAttachedStartPoint(ctx context.Context, repoPath, branch, baseBranch string) (string, error) {
 	startPoint, ok, err := g.resolveDetachedStartPointRef(ctx, repoPath, branch)
-	if err == nil && ok {
+	if err != nil {
+		return "", err
+	}
+	if ok {
 		return startPoint, nil
 	}
 

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -305,7 +305,7 @@ func (g *Gateway) resolveAttachedStartPoint(ctx context.Context, repoPath, branc
 		return baseBranch, nil
 	}
 	remoteRef := "refs/remotes/origin/" + branch
-	if err := g.runGit(ctx, repoPath, nil, "fetch", "origin", fmt.Sprintf("refs/heads/%s:%s", branch, remoteRef)); err != nil {
+	if err := g.runGit(ctx, repoPath, nil, "fetch", "origin", fmt.Sprintf("+refs/heads/%s:%s", branch, remoteRef)); err != nil {
 		return "", err
 	}
 	return "origin/" + branch, nil

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -684,15 +684,15 @@ func (g *Gateway) branchExists(ctx context.Context, repoPath, branch string) (bo
 }
 
 func (g *Gateway) remoteBranchExists(ctx context.Context, repoPath, remote, branch string) (bool, error) {
-	result, err := g.runGitResult(ctx, repoPath, nil, "ls-remote", "--heads", remote, "refs/heads/"+branch)
-	if err != nil {
-		var commandErr *shell.CommandExecutionError
-		if errors.As(err, &commandErr) && commandErr.Result.ExitCode == 2 {
-			return false, nil
-		}
-		return false, err
+	_, err := g.runGitResult(ctx, repoPath, nil, "show-ref", "--quiet", "--verify", "refs/remotes/"+remote+"/"+branch)
+	if err == nil {
+		return true, nil
 	}
-	return strings.TrimSpace(result.Stdout) != "", nil
+	var commandErr *shell.CommandExecutionError
+	if errors.As(err, &commandErr) && commandErr.Result.ExitCode == 1 {
+		return false, nil
+	}
+	return false, err
 }
 
 func (g *Gateway) resolveDetachedStartPoint(ctx context.Context, input CreateWorktreeInput) (string, error) {

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -321,6 +321,38 @@ func TestGatewayCreatesAttachedWorktreeFromRemoteOnlyBranch(t *testing.T) {
 	}
 }
 
+func TestGatewayCreatesAttachedWorktreeAfterRemoteBranchForcePush(t *testing.T) {
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createMainOnlyRepo(t)
+	branch := "looper/force-pushed-worker-branch"
+	fixture.createUnfetchedRemoteBranch(t, branch)
+	runGit(t, fixture.repoPath, "fetch", "origin", fmt.Sprintf("refs/heads/%s:refs/remotes/origin/%s", branch, branch))
+	fixture.forcePushRemoteBranch(t, branch, sanitizeBranchName(branch)+"-force.txt", "force-pushed remote change\n")
+	gateway := fixture.gateway()
+
+	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       branch,
+		BaseBranch:   "main",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	remoteHeadSHA := stringsTrimSpace(runGit(t, fixture.remotePath, "rev-parse", "refs/heads/"+branch))
+	worktreeHeadSHA := stringsTrimSpace(runGit(t, worktree.WorktreePath, "rev-parse", "HEAD"))
+	if worktreeHeadSHA != remoteHeadSHA {
+		t.Fatalf("worktree HEAD = %q, want force-pushed remote branch head %q", worktreeHeadSHA, remoteHeadSHA)
+	}
+	trackingSHA := stringsTrimSpace(runGit(t, fixture.repoPath, "rev-parse", "refs/remotes/origin/"+branch))
+	if trackingSHA != remoteHeadSHA {
+		t.Fatalf("remote tracking HEAD = %q, want %q", trackingSHA, remoteHeadSHA)
+	}
+}
+
 func TestGatewayCreatesSeparateDetachedWorktreeForAttachedBranch(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixture(t)
@@ -950,6 +982,19 @@ func (f *fixture) advanceRemoteBranch(t *testing.T, branch, fileName, contents s
 	runGit(t, clonePath, "add", fileName)
 	runGit(t, clonePath, "commit", "-m", "remote update")
 	runGit(t, clonePath, "push", "origin", branch)
+}
+
+func (f *fixture) forcePushRemoteBranch(t *testing.T, branch, fileName, contents string) {
+	t.Helper()
+	clonePath := filepath.Join(f.rootDir, "remote-force-clone-"+sanitizeBranchName(branch))
+	runGit(t, f.rootDir, "clone", f.remotePath, clonePath)
+	configureRepo(t, clonePath)
+	runGit(t, clonePath, "checkout", branch)
+	runGit(t, clonePath, "reset", "--hard", "origin/main")
+	writeFile(t, filepath.Join(clonePath, fileName), contents)
+	runGit(t, clonePath, "add", fileName)
+	runGit(t, clonePath, "commit", "-m", "remote force update")
+	runGit(t, clonePath, "push", "--force", "origin", branch)
 }
 
 func configureRepo(t *testing.T, repoPath string) {

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -885,6 +885,26 @@ func TestGatewayRemoteBranchExistsTreatsOnlyExitCode1AsMissing(t *testing.T) {
 	}
 }
 
+func TestGatewayRemoteBranchExistsUsesFetchedTrackingRef(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fixture := newFixture(t)
+	branch := "feature/fixer"
+	fixture.createRemoteRepo(t, branch)
+	runGit(t, fixture.repoPath, "fetch", "origin", fmt.Sprintf("refs/heads/%s:refs/remotes/origin/%s", branch, branch))
+	runGit(t, fixture.repoPath, "remote", "set-url", "origin", filepath.Join(fixture.rootDir, "missing-remote.git"))
+	gateway := fixture.gateway()
+
+	exists, err := gateway.remoteBranchExists(ctx, fixture.repoPath, "origin", branch)
+	if err != nil {
+		t.Fatalf("remoteBranchExists(fetched tracking ref) error = %v", err)
+	}
+	if !exists {
+		t.Fatal("remoteBranchExists(fetched tracking ref) = false, want true")
+	}
+}
+
 func TestGatewayRestoreWorktreePropagatesHealthCheckFailureForStoredWorktree(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -290,6 +290,37 @@ func TestGatewayPushesHeadToRequestedRemoteBranch(t *testing.T) {
 	}
 }
 
+func TestGatewayCreatesAttachedWorktreeFromRemoteOnlyBranch(t *testing.T) {
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createMainOnlyRepo(t)
+	fixture.createUnfetchedRemoteBranch(t, "looper/715-error-exporting-apresentations-f1db7b9a10e512af")
+	gateway := fixture.gateway()
+
+	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       "looper/715-error-exporting-apresentations-f1db7b9a10e512af",
+		BaseBranch:   "main",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	remoteHeadSHA := stringsTrimSpace(runGit(t, fixture.remotePath, "rev-parse", "refs/heads/looper/715-error-exporting-apresentations-f1db7b9a10e512af"))
+	worktreeHeadSHA := stringsTrimSpace(runGit(t, worktree.WorktreePath, "rev-parse", "HEAD"))
+	if worktreeHeadSHA != remoteHeadSHA {
+		t.Fatalf("worktree HEAD = %q, want remote branch head %q", worktreeHeadSHA, remoteHeadSHA)
+	}
+	if got := stringsTrimSpace(runGit(t, worktree.WorktreePath, "branch", "--show-current")); got != "looper/715-error-exporting-apresentations-f1db7b9a10e512af" {
+		t.Fatalf("branch = %q, want remote-only branch checkout", got)
+	}
+	if got := stringsTrimSpace(runGitMaybe(t, fixture.repoPath, "show-ref", "--verify", "refs/remotes/origin/looper/715-error-exporting-apresentations-f1db7b9a10e512af")); got == "" {
+		t.Fatal("origin remote-tracking branch missing after CreateWorktree()")
+	}
+}
+
 func TestGatewayCreatesSeparateDetachedWorktreeForAttachedBranch(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixture(t)

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -287,32 +287,27 @@ func TestGatewayAttachedWorktreeFallsBackToRemoteOnlyBaseBranch(t *testing.T) {
 	}
 }
 
-func TestGatewayAttachedWorktreeFallsBackToLocalBaseBranchWhenRemoteProbeFails(t *testing.T) {
+func TestGatewayAttachedWorktreeFailsWhenWorkerBranchLookupErrors(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixture(t)
 	fixture.createMainOnlyRepo(t)
+	branch := "worker/offline-main-fallback"
+	fixture.createUnfetchedRemoteBranch(t, branch)
 	runGit(t, fixture.repoPath, "remote", "set-url", "origin", filepath.Join(fixture.rootDir, "missing-remote.git"))
 	gateway := fixture.gateway()
 
-	localBaseSHA := stringsTrimSpace(runGit(t, fixture.repoPath, "rev-parse", "main"))
-	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+	_, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
 		ProjectID:    fixture.projectID,
 		RepoPath:     fixture.repoPath,
 		WorktreeRoot: fixture.worktreeRoot,
-		Branch:       "worker/offline-main-fallback",
+		Branch:       branch,
 		BaseBranch:   "main",
 	})
-	if err != nil {
-		t.Fatalf("CreateWorktree() error = %v", err)
+	if err == nil {
+		t.Fatal("CreateWorktree() error = nil, want branch lookup failure")
 	}
-
-	if got := stringsTrimSpace(runGit(t, worktree.WorktreePath, "branch", "--show-current")); got != "worker/offline-main-fallback" {
-		t.Fatalf("attached branch name = %q, want worker/offline-main-fallback", got)
-	}
-
-	worktreeHeadSHA := stringsTrimSpace(runGit(t, worktree.WorktreePath, "rev-parse", "HEAD"))
-	if worktreeHeadSHA != localBaseSHA {
-		t.Fatalf("attached HEAD = %q, want %q", worktreeHeadSHA, localBaseSHA)
+	if !strings.Contains(err.Error(), "git ls-remote --heads origin "+branch) {
+		t.Fatalf("CreateWorktree() error = %v, want worker branch lookup failure", err)
 	}
 }
 

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -3252,7 +3252,7 @@ func shouldRestartWorkerFromDiscoverAfterPushFailure(err error) bool {
 		return false
 	}
 	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "non-fast-forward") || strings.Contains(message, "remote head changed")
+	return strings.Contains(message, "non-fast-forward") || strings.Contains(message, "remote head changed") || strings.Contains(message, "fetch first")
 }
 
 func buildWorkerLoopHash(loopID string) string {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1806,6 +1806,9 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 	}
 	if existing, err := r.findOpenPullRequestForBranch(ctx, work.Repo, aliases, work.BaseBranch, input.Project.RepoPath); err == nil && existing != nil {
 		if err := r.git.Push(ctx, PushInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Branch: firstNonEmpty(existing.HeadRefName, worktree.Branch), ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
+			if shouldRestartWorkerFromDiscoverAfterPushFailure(err) {
+				checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
+			}
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}
 		_ = r.assignReviewersIfNeeded(ctx, work, existing.Number, input.Project.RepoPath)
@@ -1822,6 +1825,9 @@ func (r *Runner) runOpenPRStep(ctx context.Context, input stepInput) (workerChec
 		return checkpoint, nil
 	}
 	if err := r.git.Push(ctx, PushInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: worktree.Path, Branch: worktree.Branch, ProtectedBranches: compactStrings([]string{work.BaseBranch})}); err != nil {
+		if shouldRestartWorkerFromDiscoverAfterPushFailure(err) {
+			checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
+		}
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
 	ahead, err := r.workerBranchAheadOfBase(ctx, input.Project, work, worktree)
@@ -3239,6 +3245,14 @@ func buildWorkerSlug(title string) string {
 		return "update"
 	}
 	return value
+}
+
+func shouldRestartWorkerFromDiscoverAfterPushFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "non-fast-forward") || strings.Contains(message, "remote head changed")
 }
 
 func buildWorkerLoopHash(loopID string) string {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -2654,10 +2654,10 @@ func TestProcessClaimedItemFindsExistingPRAfterPushAndStampsWorkerDisclosure(t *
 	}
 }
 
-func TestProcessClaimedItemRestartsFromDiscoverAfterNonFastForwardPush(t *testing.T) {
+func TestProcessClaimedItemRestartsFromDiscoverAfterFetchFirstPushReject(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
-	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/715-error-exporting-apresentations-f1db7b9a10e512af", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}, pushErrors: []error{errors.New("git push rejected (non-fast-forward)")}}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/715-error-exporting-apresentations-f1db7b9a10e512af", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}, pushErrors: []error{errors.New("! [rejected] HEAD -> refs/heads/looper/worker (fetch first)\nerror: failed to push some refs")}}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}, {Status: "completed", Summary: "done again", Stdout: "ok", ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
 
@@ -2667,7 +2667,7 @@ func TestProcessClaimedItemRestartsFromDiscoverAfterNonFastForwardPush(t *testin
 		t.Fatalf("ProcessClaimedItem(first) error = %v", err)
 	}
 	if first.Status != "failed" || first.FailureKind != FailureRetryableAfterResume {
-		t.Fatalf("first = %#v, want retryable non-fast-forward failure", first)
+		t.Fatalf("first = %#v, want retryable fetch-first push failure", first)
 	}
 	run, err := fixture.repos.Runs.GetByID(context.Background(), first.RunID)
 	if err != nil {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/lifecycle"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/network/protocol"
 	"github.com/nexu-io/looper/internal/networkpolicy"
 	"github.com/nexu-io/looper/internal/storage"
@@ -2650,6 +2651,47 @@ func TestProcessClaimedItemFindsExistingPRAfterPushAndStampsWorkerDisclosure(t *
 	}
 	if !strings.Contains(github.updatePRBodyCalls[0].Body, "runner=worker") {
 		t.Fatalf("updated body = %q, want worker disclosure footer", github.updatePRBodyCalls[0].Body)
+	}
+}
+
+func TestProcessClaimedItemRestartsFromDiscoverAfterNonFastForwardPush(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/715-error-exporting-apresentations-f1db7b9a10e512af", BaseBranch: "main", HeadSHA: "abc123", WorktreeID: "worktree_1"}, pushErrors: []error{errors.New("git push rejected (non-fast-forward)")}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", Stdout: "ok", ParseStatus: "parsed"}, {Status: "completed", Summary: "done again", Stdout: "ok", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"}}, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true, AllowAutoPush: true, OpenPRStrategy: config.OpenPRStrategyAllDone})
+
+	firstClaim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	first, err := runner.ProcessClaimedItem(context.Background(), *firstClaim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(first) error = %v", err)
+	}
+	if first.Status != "failed" || first.FailureKind != FailureRetryableAfterResume {
+		t.Fatalf("first = %#v, want retryable non-fast-forward failure", first)
+	}
+	run, err := fixture.repos.Runs.GetByID(context.Background(), first.RunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID(first) error = %v", err)
+	}
+	checkpoint, err := parseCheckpoint(run.CheckpointJSON)
+	if err != nil {
+		t.Fatalf("parseCheckpoint(first) error = %v", err)
+	}
+	if checkpoint.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+		t.Fatalf("checkpoint.ResumePolicy = %q, want restart_from_discover", checkpoint.ResumePolicy)
+	}
+
+	fixture.advance(5 * time.Second)
+	secondClaim, _ := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "worker-1", "worker")
+	second, err := runner.ProcessClaimedItem(context.Background(), *secondClaim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem(second) error = %v", err)
+	}
+	if second.Status != "success" || second.PullRequestNumber != 101 {
+		t.Fatalf("second = %#v, want success after restart from discover", second)
+	}
+	if len(git.createCalls) != 2 {
+		t.Fatalf("len(git.createCalls) = %d, want 2 after restarting from discover", len(git.createCalls))
 	}
 }
 


### PR DESCRIPTION
## Summary
- recover attached worker worktrees from an existing remote branch instead of recreating them from base
- restart worker runs from discover when push fails with non-fast-forward or remote-head-changed errors
- add regression coverage for remote-only branch recovery and worker retry behavior

## Testing
- go test ./internal/infra/git ./internal/worker
- go test ./internal/cliapp ./internal/e2e
- go test ./...