### PR TITLE
fix: prevent duplicate worker PR rediscovery

### DIFF
--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -718,6 +718,10 @@ func (g *Gateway) resolveDetachedStartPoint(ctx context.Context, input CreateWor
 func (g *Gateway) resolveAttachedStartPoint(ctx context.Context, repoPath, baseBranch string) (string, error) {
 	startPoint, ok, err := g.resolveDetachedStartPointRef(ctx, repoPath, baseBranch)
 	if err != nil {
+		branchExists, branchErr := g.branchExists(ctx, repoPath, baseBranch)
+		if branchErr == nil && branchExists {
+			return baseBranch, nil
+		}
 		return "", err
 	}
 	if ok {

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -237,7 +237,11 @@ func (g *Gateway) CreateWorktree(ctx context.Context, input CreateWorktreeInput)
 		if branchExists {
 			args = append(args, worktreePath, input.Branch)
 		} else {
-			args = append(args, "-b", input.Branch, worktreePath, input.BaseBranch)
+			startPoint, err := g.resolveAttachedStartPoint(ctx, input.RepoPath, input.BaseBranch)
+			if err != nil {
+				return storage.WorktreeRecord{}, err
+			}
+			args = append(args, "-b", input.Branch, worktreePath, startPoint)
 		}
 		if err := g.runGit(ctx, input.RepoPath, nil, args...); err != nil {
 			return storage.WorktreeRecord{}, err
@@ -709,6 +713,17 @@ func (g *Gateway) resolveDetachedStartPoint(ctx context.Context, input CreateWor
 	}
 
 	return "", fmt.Errorf("resolve detached start point: no local or remote ref found for branch %q or base branch %q", input.Branch, input.BaseBranch)
+}
+
+func (g *Gateway) resolveAttachedStartPoint(ctx context.Context, repoPath, baseBranch string) (string, error) {
+	startPoint, ok, err := g.resolveDetachedStartPointRef(ctx, repoPath, baseBranch)
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		return startPoint, nil
+	}
+	return "", fmt.Errorf("resolve attached start point: no local or remote ref found for base branch %q", baseBranch)
 }
 
 func (g *Gateway) resolveDetachedStartPointRef(ctx context.Context, repoPath, branch string) (string, bool, error) {

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -258,6 +258,35 @@ func TestGatewayDetachedWorktreeFallsBackToRemoteOnlyBaseBranch(t *testing.T) {
 	}
 }
 
+func TestGatewayAttachedWorktreeFallsBackToRemoteOnlyBaseBranch(t *testing.T) {
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createMainOnlyRepo(t)
+	fixture.createUnfetchedRemoteBranch(t, "release/base")
+	gateway := fixture.gateway()
+
+	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       "worker/release-base-sync",
+		BaseBranch:   "release/base",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	if got := stringsTrimSpace(runGit(t, worktree.WorktreePath, "branch", "--show-current")); got != "worker/release-base-sync" {
+		t.Fatalf("attached branch name = %q, want worker/release-base-sync", got)
+	}
+
+	remoteBaseSHA := stringsTrimSpace(runGit(t, fixture.remotePath, "rev-parse", "refs/heads/release/base"))
+	worktreeHeadSHA := stringsTrimSpace(runGit(t, worktree.WorktreePath, "rev-parse", "HEAD"))
+	if worktreeHeadSHA != remoteBaseSHA {
+		t.Fatalf("attached HEAD = %q, want %q", worktreeHeadSHA, remoteBaseSHA)
+	}
+}
+
 func TestGatewayPushesHeadToRequestedRemoteBranch(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixture(t)

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -287,6 +287,35 @@ func TestGatewayAttachedWorktreeFallsBackToRemoteOnlyBaseBranch(t *testing.T) {
 	}
 }
 
+func TestGatewayAttachedWorktreeFallsBackToLocalBaseBranchWhenRemoteProbeFails(t *testing.T) {
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createMainOnlyRepo(t)
+	runGit(t, fixture.repoPath, "remote", "set-url", "origin", filepath.Join(fixture.rootDir, "missing-remote.git"))
+	gateway := fixture.gateway()
+
+	localBaseSHA := stringsTrimSpace(runGit(t, fixture.repoPath, "rev-parse", "main"))
+	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       "worker/offline-main-fallback",
+		BaseBranch:   "main",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	if got := stringsTrimSpace(runGit(t, worktree.WorktreePath, "branch", "--show-current")); got != "worker/offline-main-fallback" {
+		t.Fatalf("attached branch name = %q, want worker/offline-main-fallback", got)
+	}
+
+	worktreeHeadSHA := stringsTrimSpace(runGit(t, worktree.WorktreePath, "rev-parse", "HEAD"))
+	if worktreeHeadSHA != localBaseSHA {
+		t.Fatalf("attached HEAD = %q, want %q", worktreeHeadSHA, localBaseSHA)
+	}
+}
+
 func TestGatewayPushesHeadToRequestedRemoteBranch(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixture(t)

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -602,8 +602,9 @@ type loopError struct {
 }
 
 type loopUpsertResult struct {
-	record  storage.LoopRecord
-	created bool
+	record      storage.LoopRecord
+	created     bool
+	skipEnqueue bool
 }
 
 func validateCompletedExecutionCheckpoint(execution *checkpointExecution) error {
@@ -774,7 +775,7 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 		if loopResult.created {
 			result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
 		}
-		if loopResult.record.Status == "paused" || loopResult.record.Status == "completed" || loopResult.record.Status == "failed" {
+		if loopResult.skipEnqueue || loopResult.record.Status == "paused" || loopResult.record.Status == "completed" || loopResult.record.Status == "failed" {
 			result.Skipped++
 			continue
 		}
@@ -2324,8 +2325,12 @@ func (r *Runner) ensureLoopForDiscoveredIssue(ctx context.Context, project stora
 		return loopUpsertResult{}, err
 	}
 	for _, existing := range existingLoops {
-		if existing.Type == "worker" && existing.ProjectID == project.ID && existing.TargetType == "issue" && derefString(existing.TargetID) == targetID {
+		if workerLoopTracksIssue(existing, project.ID, repo, issue.Number) {
 			pausedOrCompleted := existing.Status == "paused" || existing.Status == "completed"
+			prLinked := existing.TargetType == "pull_request" || derefInt64(existing.PRNumber) > 0
+			if prLinked {
+				return loopUpsertResult{record: existing, skipEnqueue: true}, nil
+			}
 			updated := existing
 			updated.Repo = &repo
 			suppressFailedRevival := loops.ShouldSuppressFailedRediscovery(existing.Status, loops.LastFailedDiscoveryFingerprint(existing.MetadataJSON), currentFingerprint)
@@ -3263,6 +3268,21 @@ func buildIssueTargetID(repo string, issueNumber int64) string {
 
 func buildWorkerIssueDedupeKey(projectID, repo string, issueNumber int64) string {
 	return fmt.Sprintf("worker:%s:%s:%d", projectID, repo, issueNumber)
+}
+
+func workerLoopTracksIssue(loop storage.LoopRecord, projectID, repo string, issueNumber int64) bool {
+	if loop.Type != "worker" || loop.ProjectID != projectID {
+		return false
+	}
+	if loop.TargetType == "issue" && derefString(loop.TargetID) == buildIssueTargetID(repo, issueNumber) {
+		return true
+	}
+	workerMeta, _ := parseJSONObject(loop.MetadataJSON)["worker"].(map[string]any)
+	if int64FromAny(workerMeta["issueNumber"]) != issueNumber {
+		return false
+	}
+	trackedRepo := firstNonEmpty(stringFromAnyDefault(workerMeta["issueRepo"]), stringFromAnyDefault(workerMeta["repo"]), derefString(loop.Repo))
+	return strings.EqualFold(trackedRepo, repo)
 }
 
 func buildWorkerDiscoveryFingerprint(repo, baseBranch string, issue IssueSummary) string {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -179,6 +179,41 @@ func TestDiscoverIssuesDedupesWorkerReadyIssue(t *testing.T) {
 	}
 }
 
+func TestDiscoverIssuesSkipsIssueWhenExistingWorkerLoopAlreadyLinkedPR(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "octocat", issues: []IssueSummary{{Number: 46, Title: "Implement worker-ready", URL: "https://github.com/acme/looper/issues/46", Assignees: []string{"octocat"}, Labels: []string{"looper:worker-ready"}}}}
+	nowISO := fixture.nowISO()
+	metadataJSON := `{"worker":{"title":"Implement worker-ready","repo":"acme/looper","baseBranch":"main","executionMode":"create-pr","issueNumber":46,"issueUrl":"https://github.com/acme/looper/issues/46","autoDiscovered":true}}`
+	prTargetID := "pr:acme/looper:101"
+	prNumber := int64(101)
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_pr_linked", Seq: 99, ProjectID: "project_1", Type: "worker", TargetType: "pull_request", TargetID: &prTargetID, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "running", MetadataJSON: &metadataJSON, NextRunAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || len(result.CreatedLoopIDs) != 0 || result.Skipped != 1 {
+		t.Fatalf("result = %#v, want existing PR-linked worker loop to suppress rediscovery", result)
+	}
+	loopsList, err := fixture.repos.Loops.List(context.Background())
+	if err != nil {
+		t.Fatalf("Loops.List() error = %v", err)
+	}
+	count := 0
+	for _, loop := range loopsList {
+		if workerLoopTracksIssue(loop, "project_1", "acme/looper", 46) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("worker loop count for issue 46 = %d, want 1", count)
+	}
+}
+
 func TestDiscoverIssuesUsesSingleServerSideLabelFilterWhenConfiguredWithMultipleLabels(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)


### PR DESCRIPTION
## Summary
- stop rediscovered worker issues from re-enqueueing when an existing worker loop is already linked to a PR
- create attached worker worktrees from the freshest resolvable base ref instead of a stale local base branch
- add regression coverage for duplicate issue rediscovery and remote-only base branch worktree creation

## Validation
- go test ./internal/worker ./internal/infra/git
- go test ./...