### PR TITLE
feat: make reviewer transient retries configurable

### DIFF
--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -365,6 +365,13 @@
                   "stopOnReadyLabel": true,
                   "stopOnIdenticalOutput": true
                 },
+                "retry": {
+                  "enhancedTransientClassification": false,
+                  "extraTransientErrorPatterns": [],
+                  "recoverExistingMatchedFailures": false,
+                  "autoRecoveryMaxAttempts": 3,
+                  "maxDelayMs": 60000
+                },
                 "scope": "changed_ranges",
                 "publishMode": "single_review",
                 "reviewEvents": {

--- a/internal/cliapp/config_commands.go
+++ b/internal/cliapp/config_commands.go
@@ -52,6 +52,31 @@ var configFieldRegistry = map[string]configField{
 	"reviewer.reviewEvents.blocking": reviewerReviewEventField("reviewer.reviewEvents.blocking", "LOOPER_REVIEWER_REVIEW_EVENTS_BLOCKING", "LOOPER_ROLES_REVIEWER_BEHAVIOR_REVIEW_EVENTS_BLOCKING", "reviewer-blocking-review-event", "roles-reviewer-behavior-review-events-blocking", func(c config.Config) any { return c.Roles.Reviewer.Behavior.ReviewEvents.Blocking }, func(p *config.PartialConfig) **config.ReviewerReviewEvent {
 		return &ensurePartialReviewerReviewEvents(p).Blocking
 	}),
+	"roles.reviewer.behavior.retry.enhancedTransientClassification": boolField("roles.reviewer.behavior.retry.enhancedTransientClassification", "", "", func(c config.Config) any {
+		return c.Roles.Reviewer.Behavior.Retry.EnhancedTransientClassification
+	}, func(p *config.PartialConfig) **bool {
+		return &ensurePartialReviewerRetry(p).EnhancedTransientClassification
+	}),
+	"roles.reviewer.behavior.retry.extraTransientErrorPatterns": stringListField("roles.reviewer.behavior.retry.extraTransientErrorPatterns", "", func(c config.Config) any {
+		return c.Roles.Reviewer.Behavior.Retry.ExtraTransientErrorPatterns
+	}, func(p *config.PartialConfig) **[]string {
+		return &ensurePartialReviewerRetry(p).ExtraTransientErrorPatterns
+	}),
+	"roles.reviewer.behavior.retry.recoverExistingMatchedFailures": boolField("roles.reviewer.behavior.retry.recoverExistingMatchedFailures", "", "", func(c config.Config) any {
+		return c.Roles.Reviewer.Behavior.Retry.RecoverExistingMatchedFailures
+	}, func(p *config.PartialConfig) **bool {
+		return &ensurePartialReviewerRetry(p).RecoverExistingMatchedFailures
+	}),
+	"roles.reviewer.behavior.retry.autoRecoveryMaxAttempts": positiveIntField("roles.reviewer.behavior.retry.autoRecoveryMaxAttempts", "", "", func(c config.Config) any {
+		return c.Roles.Reviewer.Behavior.Retry.AutoRecoveryMaxAttempts
+	}, func(p *config.PartialConfig) **int {
+		return &ensurePartialReviewerRetry(p).AutoRecoveryMaxAttempts
+	}),
+	"roles.reviewer.behavior.retry.maxDelayMs": positiveIntField("roles.reviewer.behavior.retry.maxDelayMs", "", "", func(c config.Config) any {
+		return c.Roles.Reviewer.Behavior.Retry.MaxDelayMS
+	}, func(p *config.PartialConfig) **int {
+		return &ensurePartialReviewerRetry(p).MaxDelayMS
+	}),
 	"roles.planner.autoDiscovery":      boolField("roles.planner.autoDiscovery", "LOOPER_ROLES_PLANNER_AUTO_DISCOVERY", "", func(c config.Config) any { return c.Roles.Planner.AutoDiscovery }, func(p *config.PartialConfig) **bool { return &ensurePartialPlannerRole(p).AutoDiscovery }),
 	"roles.planner.instructions":       stringField("roles.planner.instructions", "", "", func(c config.Config) any { return c.Roles.Planner.Instructions }, func(p *config.PartialConfig) **string { return &ensurePartialPlannerRole(p).Instructions }),
 	"roles.planner.triggers.labels":    stringListField("roles.planner.triggers.labels", "LOOPER_ROLES_PLANNER_TRIGGERS_LABELS", func(c config.Config) any { return c.Roles.Planner.Triggers.Labels }, func(p *config.PartialConfig) **[]string { return &ensurePartialPlannerTriggers(p).Labels }),
@@ -1375,6 +1400,17 @@ func ensurePartialReviewerReviewEvents(partial *config.PartialConfig) *config.Pa
 	return reviewer.Behavior.ReviewEvents
 }
 
+func ensurePartialReviewerRetry(partial *config.PartialConfig) *config.PartialReviewerRetryConfig {
+	reviewer := ensurePartialReviewerRole(partial)
+	if reviewer.Behavior == nil {
+		reviewer.Behavior = &config.PartialReviewerConfig{}
+	}
+	if reviewer.Behavior.Retry == nil {
+		reviewer.Behavior.Retry = &config.PartialReviewerRetryConfig{}
+	}
+	return reviewer.Behavior.Retry
+}
+
 func ensurePartialInstructions(partial *config.PartialConfig) *config.PartialInstructionsConfig {
 	if partial.Instructions == nil {
 		partial.Instructions = &config.PartialInstructionsConfig{}
@@ -1554,6 +1590,16 @@ func configFieldSet(partial config.PartialConfig, key string) bool {
 	case "roles.reviewer.behavior.reviewEvents.blocking", "reviewer.reviewEvents.blocking":
 		return (partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.Behavior != nil && partial.Roles.Reviewer.Behavior.ReviewEvents != nil && partial.Roles.Reviewer.Behavior.ReviewEvents.Blocking != nil) ||
 			(partial.LegacyReviewer != nil && partial.LegacyReviewer.ReviewEvents != nil && partial.LegacyReviewer.ReviewEvents.Blocking != nil)
+	case "roles.reviewer.behavior.retry.enhancedTransientClassification":
+		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.Behavior != nil && partial.Roles.Reviewer.Behavior.Retry != nil && partial.Roles.Reviewer.Behavior.Retry.EnhancedTransientClassification != nil
+	case "roles.reviewer.behavior.retry.extraTransientErrorPatterns":
+		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.Behavior != nil && partial.Roles.Reviewer.Behavior.Retry != nil && partial.Roles.Reviewer.Behavior.Retry.ExtraTransientErrorPatterns != nil
+	case "roles.reviewer.behavior.retry.recoverExistingMatchedFailures":
+		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.Behavior != nil && partial.Roles.Reviewer.Behavior.Retry != nil && partial.Roles.Reviewer.Behavior.Retry.RecoverExistingMatchedFailures != nil
+	case "roles.reviewer.behavior.retry.autoRecoveryMaxAttempts":
+		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.Behavior != nil && partial.Roles.Reviewer.Behavior.Retry != nil && partial.Roles.Reviewer.Behavior.Retry.AutoRecoveryMaxAttempts != nil
+	case "roles.reviewer.behavior.retry.maxDelayMs":
+		return partial.Roles != nil && partial.Roles.Reviewer != nil && partial.Roles.Reviewer.Behavior != nil && partial.Roles.Reviewer.Behavior.Retry != nil && partial.Roles.Reviewer.Behavior.Retry.MaxDelayMS != nil
 	case "roles.planner.autoDiscovery":
 		return partial.Roles != nil && partial.Roles.Planner != nil && partial.Roles.Planner.AutoDiscovery != nil
 	case "roles.planner.instructions":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -244,6 +244,9 @@ func TestRoleDefaultsMirrorCurrentDiscoveryPolicy(t *testing.T) {
 	if got := cfg.Roles.Reviewer.Behavior.ReviewEvents.Blocking; got != ReviewerReviewEventRequestChanges {
 		t.Fatalf("reviewer blocking review event default = %q, want %q", got, ReviewerReviewEventRequestChanges)
 	}
+	if got := cfg.Roles.Reviewer.Behavior.Retry; got.EnhancedTransientClassification || got.RecoverExistingMatchedFailures || len(got.ExtraTransientErrorPatterns) != 0 || got.AutoRecoveryMaxAttempts != DefaultReviewerAutoRecoveryMaxAttempts || got.MaxDelayMS != DefaultReviewerRetryMaxDelayMS {
+		t.Fatalf("reviewer retry defaults = %#v", got)
+	}
 	if got := reviewerEnableSelfReviewValue(t, cfg.Roles.Reviewer.Discovery.Triggers); got {
 		t.Fatalf("reviewer enableSelfReview default = %v, want false", got)
 	}
@@ -284,6 +287,71 @@ func TestAgentTimeoutConfigOverrides(t *testing.T) {
 	got := loaded.Config.Agent.Timeouts
 	if got.PlannerSeconds != 1200 || got.PlannerMaxRuntimeSeconds != 1200 || got.WorkerSeconds != 4200 || got.WorkerMaxRuntimeSeconds != 4200 || got.ReviewerSeconds != 2100 || got.ReviewerMaxRuntimeSeconds != 2100 || got.FixerSeconds != 1800 || got.FixerMaxRuntimeSeconds != 1800 {
 		t.Fatalf("agent timeouts = %#v", got)
+	}
+}
+
+func TestNormalizeMergesReviewerRetryConfig(t *testing.T) {
+	patterns := []string{"  custom EOF  ", "custom EOF", "Connection closed by"}
+	cfg, err := Normalize(t.TempDir(), PartialConfig{Roles: &PartialRoleConfigs{Reviewer: &PartialReviewerRoleConfig{Behavior: &PartialReviewerConfig{Retry: &PartialReviewerRetryConfig{
+		EnhancedTransientClassification: boolPtr(true),
+		ExtraTransientErrorPatterns:     &patterns,
+		RecoverExistingMatchedFailures:  boolPtr(true),
+		AutoRecoveryMaxAttempts:         intPtr(7),
+		MaxDelayMS:                      intPtr(15000),
+	}}}}})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	got := cfg.Roles.Reviewer.Behavior.Retry
+	if !got.EnhancedTransientClassification || !got.RecoverExistingMatchedFailures || got.AutoRecoveryMaxAttempts != 7 || got.MaxDelayMS != 15000 {
+		t.Fatalf("reviewer retry config = %#v", got)
+	}
+	if !reflectStringSlicesEqual(got.ExtraTransientErrorPatterns, []string{"custom EOF", "Connection closed by"}) {
+		t.Fatalf("extra transient patterns = %#v", got.ExtraTransientErrorPatterns)
+	}
+}
+
+func TestReviewerRetryMessageMatchesOnlyWhenEnhancedClassificationEnabled(t *testing.T) {
+	policy := ReviewerRetryConfig{EnhancedTransientClassification: false}
+	message := `Post "https://api.github.com/graphql": EOF`
+	if ReviewerRetryMessageMatches(policy, message) {
+		t.Fatal("ReviewerRetryMessageMatches(default) = true, want false")
+	}
+	policy.EnhancedTransientClassification = true
+	if !ReviewerRetryMessageMatches(policy, message) {
+		t.Fatal("ReviewerRetryMessageMatches(enabled GraphQL EOF) = false, want true")
+	}
+	custom := ReviewerRetryConfig{EnhancedTransientClassification: true, ExtraTransientErrorPatterns: []string{"provider temporarily unavailable"}}
+	if !ReviewerRetryMessageMatches(custom, "custom provider temporarily unavailable") {
+		t.Fatal("ReviewerRetryMessageMatches(extra pattern) = false, want true")
+	}
+}
+
+func TestValidateRejectsInvalidReviewerRetryConfig(t *testing.T) {
+	cfg, err := Normalize(t.TempDir())
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Retry.AutoRecoveryMaxAttempts = 0
+	cfg.Roles.Reviewer.Behavior.Retry.MaxDelayMS = 0
+	cfg.Roles.Reviewer.Behavior.Retry.ExtraTransientErrorPatterns = []string{" "}
+
+	err = ValidateWithOptions(cfg, ValidateOptions{DefaultWorktreeRoot: t.TempDir()})
+	if err == nil {
+		t.Fatal("ValidateWithOptions() error = nil, want ConfigValidationError")
+	}
+	validationErr := &ConfigValidationError{}
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("ValidateWithOptions() error = %T, want ConfigValidationError", err)
+	}
+	for _, path := range []string{
+		"roles.reviewer.behavior.retry.autoRecoveryMaxAttempts",
+		"roles.reviewer.behavior.retry.maxDelayMs",
+		"roles.reviewer.behavior.retry.extraTransientErrorPatterns[0]",
+	} {
+		if !validationIssuesContainPath(validationErr.Issues, path) {
+			t.Fatalf("validation issues = %#v, missing %s", validationErr.Issues, path)
+		}
 	}
 }
 
@@ -3647,4 +3715,13 @@ func intPtr(value int) *int {
 
 func labelModePtr(value LabelMode) *LabelMode {
 	return &value
+}
+
+func validationIssuesContainPath(issues []ValidationIssue, path string) bool {
+	for _, issue := range issues {
+		if issue.Path == path {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -8,6 +8,11 @@ import (
 
 const DefaultServerPort = 17310
 
+const (
+	DefaultReviewerAutoRecoveryMaxAttempts = 3
+	DefaultReviewerRetryMaxDelayMS         = 60000
+)
+
 func DefaultLooperHome() (string, error) {
 	homeDir := os.Getenv("HOME")
 	if homeDir == "" {
@@ -229,6 +234,7 @@ func DefaultConfig(cwd string) (Config, error) {
 						StopOnReadyLabel:          true,
 						StopOnIdenticalOutput:     true,
 					},
+					Retry:                   DefaultReviewerRetryConfig(),
 					Scope:                   ReviewerScopeChangedRanges,
 					PublishMode:             ReviewerPublishModeSingleReview,
 					ReviewEvents:            ReviewerReviewEventsConfig{Clean: ReviewerReviewEventApprove, Blocking: ReviewerReviewEventRequestChanges},
@@ -319,6 +325,16 @@ func DefaultConfig(cwd string) (Config, error) {
 		},
 		Projects: []ProjectRefConfig{},
 	}, nil
+}
+
+func DefaultReviewerRetryConfig() ReviewerRetryConfig {
+	return ReviewerRetryConfig{
+		EnhancedTransientClassification: false,
+		ExtraTransientErrorPatterns:     []string{},
+		RecoverExistingMatchedFailures:  false,
+		AutoRecoveryMaxAttempts:         DefaultReviewerAutoRecoveryMaxAttempts,
+		MaxDelayMS:                      DefaultReviewerRetryMaxDelayMS,
+	}
 }
 
 func DefaultDisclosureConfig() DisclosureConfig {

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -140,6 +140,9 @@ func mergePartialReviewerConfigWithCanonicalPriority(canonical *PartialReviewerC
 	if canonical.Loop == nil {
 		canonical.Loop = legacy.Loop
 	}
+	if canonical.Retry == nil {
+		canonical.Retry = legacy.Retry
+	}
 	if canonical.Scope == nil {
 		canonical.Scope = legacy.Scope
 	}
@@ -669,6 +672,9 @@ func mergeReviewerConfig(config *ReviewerConfig, partial PartialReviewerConfig) 
 	if partial.Loop != nil {
 		mergeReviewerLoopConfig(&config.Loop, *partial.Loop)
 	}
+	if partial.Retry != nil {
+		mergeReviewerRetryConfig(&config.Retry, *partial.Retry)
+	}
 	if partial.Scope != nil {
 		config.Scope = *partial.Scope
 	}
@@ -689,6 +695,25 @@ func mergeReviewerConfig(config *ReviewerConfig, partial PartialReviewerConfig) 
 	if partial.ThreadResolution != nil {
 		mergeReviewerThreadResolutionConfig(&config.ThreadResolution, *partial.ThreadResolution)
 	}
+}
+
+func mergeReviewerRetryConfig(config *ReviewerRetryConfig, partial PartialReviewerRetryConfig) {
+	if partial.EnhancedTransientClassification != nil {
+		config.EnhancedTransientClassification = *partial.EnhancedTransientClassification
+	}
+	if partial.ExtraTransientErrorPatterns != nil {
+		config.ExtraTransientErrorPatterns = append([]string(nil), (*partial.ExtraTransientErrorPatterns)...)
+	}
+	if partial.RecoverExistingMatchedFailures != nil {
+		config.RecoverExistingMatchedFailures = *partial.RecoverExistingMatchedFailures
+	}
+	if partial.AutoRecoveryMaxAttempts != nil {
+		config.AutoRecoveryMaxAttempts = *partial.AutoRecoveryMaxAttempts
+	}
+	if partial.MaxDelayMS != nil {
+		config.MaxDelayMS = *partial.MaxDelayMS
+	}
+	*config = NormalizeReviewerRetryConfig(*config)
 }
 
 func mergeReviewerNativeResumeConfig(config *ReviewerNativeResumeConfig, partial PartialReviewerNativeResumeConfig) {
@@ -1369,6 +1394,14 @@ func clonePartialReviewerConfig(config *PartialReviewerConfig) *PartialReviewerC
 		loop := *config.Loop
 		cloned.Loop = &loop
 	}
+	if config.Retry != nil {
+		retry := *config.Retry
+		if config.Retry.ExtraTransientErrorPatterns != nil {
+			patterns := append([]string(nil), (*config.Retry.ExtraTransientErrorPatterns)...)
+			retry.ExtraTransientErrorPatterns = &patterns
+		}
+		cloned.Retry = &retry
+	}
 	if config.ReviewEvents != nil {
 		reviewEvents := *config.ReviewEvents
 		cloned.ReviewEvents = &reviewEvents
@@ -1574,6 +1607,14 @@ func clonePartialRoleConfigs(configs *PartialRoleConfigs) *PartialRoleConfigs {
 			if configs.Reviewer.Behavior.Loop != nil {
 				loop := *configs.Reviewer.Behavior.Loop
 				behavior.Loop = &loop
+			}
+			if configs.Reviewer.Behavior.Retry != nil {
+				retry := *configs.Reviewer.Behavior.Retry
+				if configs.Reviewer.Behavior.Retry.ExtraTransientErrorPatterns != nil {
+					patterns := append([]string(nil), (*configs.Reviewer.Behavior.Retry.ExtraTransientErrorPatterns)...)
+					retry.ExtraTransientErrorPatterns = &patterns
+				}
+				behavior.Retry = &retry
 			}
 			if configs.Reviewer.Behavior.ReviewEvents != nil {
 				reviewEvents := *configs.Reviewer.Behavior.ReviewEvents

--- a/internal/config/reviewer_retry.go
+++ b/internal/config/reviewer_retry.go
@@ -1,0 +1,96 @@
+package config
+
+import "strings"
+
+var enhancedReviewerTransientPatterns = []string{
+	": eof",
+	"connection closed by",
+	"closed by remote host",
+	"connection reset by peer",
+	"remote end hung up unexpectedly",
+	"early eof",
+	"rpc failed",
+	"curl 56",
+	"curl 92",
+	"tls handshake timeout",
+	"i/o timeout",
+	"context deadline exceeded",
+	"server closed idle connection",
+	"http2: client connection lost",
+	"stream error",
+}
+
+var enhancedReviewerRemoteDependencyMarkers = []string{
+	"github.com",
+	"api.github.com",
+	"/graphql",
+	"git fetch",
+	"git ls-remote",
+	"git pull",
+	"git remote",
+	"refs/pull/",
+	"origin/",
+	"remote repository",
+}
+
+func NormalizeReviewerRetryConfig(policy ReviewerRetryConfig) ReviewerRetryConfig {
+	defaults := DefaultReviewerRetryConfig()
+	if policy.AutoRecoveryMaxAttempts <= 0 {
+		policy.AutoRecoveryMaxAttempts = defaults.AutoRecoveryMaxAttempts
+	}
+	if policy.MaxDelayMS <= 0 {
+		policy.MaxDelayMS = defaults.MaxDelayMS
+	}
+	if policy.ExtraTransientErrorPatterns == nil {
+		policy.ExtraTransientErrorPatterns = []string{}
+		return policy
+	}
+	trimmed := make([]string, 0, len(policy.ExtraTransientErrorPatterns))
+	seen := make(map[string]struct{}, len(policy.ExtraTransientErrorPatterns))
+	for _, pattern := range policy.ExtraTransientErrorPatterns {
+		pattern = strings.TrimSpace(pattern)
+		key := strings.ToLower(pattern)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		trimmed = append(trimmed, pattern)
+	}
+	policy.ExtraTransientErrorPatterns = trimmed
+	return policy
+}
+
+func ReviewerRetryMessageMatches(policy ReviewerRetryConfig, message string) bool {
+	policy = NormalizeReviewerRetryConfig(policy)
+	if !policy.EnhancedTransientClassification {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(message))
+	if lower == "" {
+		return false
+	}
+	for _, pattern := range policy.ExtraTransientErrorPatterns {
+		pattern = strings.ToLower(strings.TrimSpace(pattern))
+		if pattern != "" && strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	if !looksLikeReviewerRemoteDependencyFailure(lower) {
+		return false
+	}
+	for _, pattern := range enhancedReviewerTransientPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeReviewerRemoteDependencyFailure(message string) bool {
+	for _, marker := range enhancedReviewerRemoteDependencyMarkers {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -275,6 +275,13 @@
               "stopOnReadyLabel": true,
               "stopOnIdenticalOutput": true
             },
+            "retry": {
+              "enhancedTransientClassification": false,
+              "extraTransientErrorPatterns": [],
+              "recoverExistingMatchedFailures": false,
+              "autoRecoveryMaxAttempts": 3,
+              "maxDelayMs": 60000
+            },
             "scope": "changed_ranges",
             "publishMode": "single_review",
             "reviewEvents": {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -212,6 +212,13 @@
               "stopOnReadyLabel": true,
               "stopOnIdenticalOutput": true
             },
+            "retry": {
+              "enhancedTransientClassification": false,
+              "extraTransientErrorPatterns": [],
+              "recoverExistingMatchedFailures": false,
+              "autoRecoveryMaxAttempts": 3,
+              "maxDelayMs": 60000
+            },
             "scope": "changed_ranges",
             "publishMode": "single_review",
             "reviewEvents": {

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -295,6 +295,13 @@
               "stopOnReadyLabel": true,
               "stopOnIdenticalOutput": true
             },
+            "retry": {
+              "enhancedTransientClassification": false,
+              "extraTransientErrorPatterns": [],
+              "recoverExistingMatchedFailures": false,
+              "autoRecoveryMaxAttempts": 3,
+              "maxDelayMs": 60000
+            },
             "scope": "changed_ranges",
             "publishMode": "single_review",
             "reviewEvents": {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -338,12 +338,21 @@ type ReviewerLoopConfig struct {
 
 type ReviewerConfig struct {
 	Loop                    ReviewerLoopConfig             `json:"loop"`
+	Retry                   ReviewerRetryConfig            `json:"retry"`
 	Scope                   ReviewerScope                  `json:"scope"`
 	PublishMode             ReviewerPublishMode            `json:"publishMode"`
 	ReviewEvents            ReviewerReviewEventsConfig     `json:"reviewEvents"`
 	DetectDuplicateFindings bool                           `json:"detectDuplicateFindings"`
 	NativeResume            ReviewerNativeResumeConfig     `json:"nativeResume"`
 	ThreadResolution        ReviewerThreadResolutionConfig `json:"threadResolution"`
+}
+
+type ReviewerRetryConfig struct {
+	EnhancedTransientClassification bool     `json:"enhancedTransientClassification"`
+	ExtraTransientErrorPatterns     []string `json:"extraTransientErrorPatterns"`
+	RecoverExistingMatchedFailures  bool     `json:"recoverExistingMatchedFailures"`
+	AutoRecoveryMaxAttempts         int      `json:"autoRecoveryMaxAttempts"`
+	MaxDelayMS                      int      `json:"maxDelayMs"`
 }
 
 type ReviewerReviewEventsConfig struct {
@@ -803,6 +812,7 @@ type PartialReviewerLoopConfig struct {
 
 type PartialReviewerConfig struct {
 	Loop                    *PartialReviewerLoopConfig             `json:"loop,omitempty"`
+	Retry                   *PartialReviewerRetryConfig            `json:"retry,omitempty"`
 	Scope                   *ReviewerScope                         `json:"scope,omitempty"`
 	PublishMode             *ReviewerPublishMode                   `json:"publishMode,omitempty"`
 	ReviewEvents            *PartialReviewerReviewEventsConfig     `json:"reviewEvents,omitempty"`
@@ -810,6 +820,14 @@ type PartialReviewerConfig struct {
 	DedupeFindings          *bool                                  `json:"dedupeFindings,omitempty"`
 	NativeResume            *PartialReviewerNativeResumeConfig     `json:"nativeResume,omitempty"`
 	ThreadResolution        *PartialReviewerThreadResolutionConfig `json:"threadResolution,omitempty"`
+}
+
+type PartialReviewerRetryConfig struct {
+	EnhancedTransientClassification *bool     `json:"enhancedTransientClassification,omitempty"`
+	ExtraTransientErrorPatterns     *[]string `json:"extraTransientErrorPatterns,omitempty"`
+	RecoverExistingMatchedFailures  *bool     `json:"recoverExistingMatchedFailures,omitempty"`
+	AutoRecoveryMaxAttempts         *int      `json:"autoRecoveryMaxAttempts,omitempty"`
+	MaxDelayMS                      *int      `json:"maxDelayMs,omitempty"`
 }
 
 type PartialReviewerReviewEventsConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -175,6 +175,17 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 	if config.Roles.Reviewer.Behavior.Loop.MinPublishIntervalSeconds < 0 {
 		issues = append(issues, ValidationIssue{Path: "roles.reviewer.behavior.loop.minPublishIntervalSeconds", Message: "must be an integer >= 0"})
 	}
+	if config.Roles.Reviewer.Behavior.Retry.AutoRecoveryMaxAttempts < 1 {
+		issues = append(issues, ValidationIssue{Path: "roles.reviewer.behavior.retry.autoRecoveryMaxAttempts", Message: "must be a positive integer"})
+	}
+	if config.Roles.Reviewer.Behavior.Retry.MaxDelayMS < 1 {
+		issues = append(issues, ValidationIssue{Path: "roles.reviewer.behavior.retry.maxDelayMs", Message: "must be a positive integer"})
+	}
+	for index, pattern := range config.Roles.Reviewer.Behavior.Retry.ExtraTransientErrorPatterns {
+		if strings.TrimSpace(pattern) == "" {
+			issues = append(issues, ValidationIssue{Path: fmt.Sprintf("roles.reviewer.behavior.retry.extraTransientErrorPatterns[%d]", index), Message: "must be a non-empty string"})
+		}
+	}
 	if !isValidReviewerScope(config.Roles.Reviewer.Behavior.Scope) {
 		issues = append(issues, ValidationIssue{Path: "roles.reviewer.behavior.scope", Message: fmt.Sprintf("must be one of: %s, %s, %s", ReviewerScopeFullPR, ReviewerScopeChangedFiles, ReviewerScopeChangedRanges)})
 	}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1090,6 +1090,55 @@ func (r *Runner) reviewerAutoMergeConfigForProject(projectID string) config.Revi
 	return roles.Reviewer.AutoMerge
 }
 
+func (r *Runner) retryPolicyForProject(projectID string) config.ReviewerRetryConfig {
+	policy := config.NormalizeReviewerRetryConfig(r.retryPolicy)
+	if r.projectRoleConfig == nil {
+		return policy
+	}
+	projectID = strings.TrimSpace(projectID)
+	for _, project := range r.projectRoleConfig.Projects {
+		if strings.TrimSpace(project.ID) != projectID {
+			continue
+		}
+		if project.Roles == nil || project.Roles.Reviewer == nil || project.Roles.Reviewer.Behavior == nil || project.Roles.Reviewer.Behavior.Retry == nil {
+			return policy
+		}
+		return mergeProjectReviewerRetryPolicy(policy, *project.Roles.Reviewer.Behavior.Retry)
+	}
+	return policy
+}
+
+func mergeProjectReviewerRetryPolicy(policy config.ReviewerRetryConfig, partial config.PartialReviewerRetryConfig) config.ReviewerRetryConfig {
+	if partial.EnhancedTransientClassification != nil {
+		policy.EnhancedTransientClassification = *partial.EnhancedTransientClassification
+	}
+	if partial.ExtraTransientErrorPatterns != nil {
+		policy.ExtraTransientErrorPatterns = append([]string(nil), (*partial.ExtraTransientErrorPatterns)...)
+	}
+	if partial.RecoverExistingMatchedFailures != nil {
+		policy.RecoverExistingMatchedFailures = *partial.RecoverExistingMatchedFailures
+	}
+	if partial.AutoRecoveryMaxAttempts != nil {
+		policy.AutoRecoveryMaxAttempts = *partial.AutoRecoveryMaxAttempts
+	}
+	if partial.MaxDelayMS != nil {
+		policy.MaxDelayMS = *partial.MaxDelayMS
+	}
+	return config.NormalizeReviewerRetryConfig(policy)
+}
+
+func (r *Runner) retryMaxDelayForProject(projectID string) time.Duration {
+	if r.projectRoleConfig == nil && r.retryMaxDelay > 0 {
+		return r.retryMaxDelay
+	}
+	policy := r.retryPolicyForProject(projectID)
+	delay := time.Duration(policy.MaxDelayMS) * time.Millisecond
+	if delay <= 0 {
+		return maxRetryDelay
+	}
+	return delay
+}
+
 func isSelfAuthoredPR(author string, currentLogin string, policy DiscoveryPolicy) bool {
 	if policy.EnableSelfReview {
 		return false
@@ -1161,7 +1210,7 @@ func (r *Runner) ProcessClaimedQueueItem(ctx context.Context, queueItem storage.
 }
 
 func (r *Runner) finalizeClaimSetupFailure(ctx context.Context, queueItem storage.QueueItemRecord, cause error) error {
-	failure := r.classifyFailure(cause)
+	failure := r.classifyFailureForProject(derefString(queueItem.ProjectID), cause)
 	failedQueue, err := r.failQueueItem(ctx, queueItem, failure.kind, failure.message)
 	if err != nil {
 		return err
@@ -1287,7 +1336,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		checkpoint, err = r.executeStep(ctx, step, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem, Repo: *queueItem.Repo, PRNumber: *queueItem.PRNumber, Checkpoint: checkpoint})
 		if err != nil {
 			stepElapsedSeconds := durationSeconds(r.now().Sub(stepStartedAt))
-			failure := r.classifyFailure(err)
+			failure := r.classifyFailureForProject(project.ID, err)
 			latest := r.getLatestCheckpoint(ctx, run, checkpoint)
 			if checkpoint.ResumePolicy == "rerun_review" || hasPendingReviewMarkerMiss(checkpoint) {
 				latest = checkpoint
@@ -1489,6 +1538,7 @@ func (r *Runner) executeStepWithTransientExternalRetry(ctx context.Context, step
 	if maxAttempts <= 0 {
 		maxAttempts = defaultRetryMax
 	}
+	retryMaxDelay := r.retryMaxDelayForProject(input.Project.ID)
 	checkpoint := input.Checkpoint
 	var err error
 	for attempt := int64(1); attempt <= maxAttempts; attempt++ {
@@ -1500,10 +1550,10 @@ func (r *Runner) executeStepWithTransientExternalRetry(ctx context.Context, step
 			}
 			return checkpoint, nil
 		}
-		if attempt >= maxAttempts || !r.isTransientExternalFailure(err) {
+		if attempt >= maxAttempts || !r.isTransientExternalFailureForProject(input.Project.ID, err) {
 			break
 		}
-		delay := retryDelay(r.retryBaseDelay, attempt, err, r.retryMaxDelay)
+		delay := retryDelay(r.retryBaseDelay, attempt, err, retryMaxDelay)
 		if r.shouldSkipTransientRetryDelayForNativeResume(ctx, input.Loop.ID, err) {
 			delay = 0
 		}
@@ -3811,6 +3861,7 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if loop.Type != "reviewer" || loop.Status != "failed" || isManualReviewerLoop(loop) {
 		return false, "", "not_failed_reviewer_loop", nil
 	}
+	retryPolicy := r.retryPolicyForProject(loop.ProjectID)
 	if normalizePRState(pr.State) != "open" {
 		return false, "", "pr_not_open", nil
 	}
@@ -3828,7 +3879,7 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if reason, _ := stringFromAny(loopMeta["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
 		return false, "", reason, nil
 	}
-	if intFromAny(loopMeta["autoRecoveryAttempts"]) >= r.retryPolicy.AutoRecoveryMaxAttempts {
+	if intFromAny(loopMeta["autoRecoveryAttempts"]) >= retryPolicy.AutoRecoveryMaxAttempts {
 		return false, "", "auto_recovery_attempt_cap", nil
 	}
 	latestRun, err := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID)
@@ -3889,7 +3940,7 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if latestMessage == "" {
 		latestMessage = derefString(latestQueue.LastError)
 	}
-	if r.retryPolicy.RecoverExistingMatchedFailures && queueHasRemainingAttempts(*latestQueue) && r.isEnhancedTransientMessage(latestMessage) {
+	if retryPolicy.RecoverExistingMatchedFailures && queueHasRemainingAttempts(*latestQueue) && r.isEnhancedTransientMessageForPolicy(retryPolicy, latestMessage) {
 		approved, err := approvedByCurrentUser()
 		if err != nil {
 			return false, "", "", err
@@ -4111,7 +4162,8 @@ func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemR
 	nextAttempts := queueItem.Attempts + 1
 	nowISO := r.nowISO()
 	if isRetryableFailure(kind) && nextAttempts < queueItem.MaxAttempts {
-		retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, nextAttempts, r.retryMaxDelay)))
+		delay := backoffDelay(r.retryBaseDelay, nextAttempts, r.retryMaxDelayForProject(derefString(queueItem.ProjectID)))
+		retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(delay))
 		if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
 			return nil, err
 		}
@@ -4145,6 +4197,10 @@ func (r *Runner) updateLoop(ctx context.Context, loop storage.LoopRecord, mutate
 }
 
 func (r *Runner) classifyFailure(err error) *loopError {
+	return r.classifyFailureForProject("", err)
+}
+
+func (r *Runner) classifyFailureForProject(projectID string, err error) *loopError {
 	var typed *loopError
 	if errors.As(err, &typed) {
 		return typed
@@ -4163,38 +4219,51 @@ func (r *Runner) classifyFailure(err error) *loopError {
 	if isTransientModelProviderError(err) {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
-	if r.isEnhancedTransientFailure(err) {
+	if r.isEnhancedTransientFailureForPolicy(r.retryPolicyForProject(projectID), err) {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
 	return &loopError{message: err.Error(), kind: FailureNonRetryable}
 }
 
 func (r *Runner) isTransientExternalFailure(err error) bool {
+	return r.isTransientExternalFailureForProject("", err)
+}
+
+func (r *Runner) isTransientExternalFailureForProject(projectID string, err error) bool {
 	if err == nil {
 		return false
 	}
+	retryPolicy := r.retryPolicyForProject(projectID)
 	if githubinfra.IsTransientError(err) || isTransientModelProviderError(err) {
 		return true
 	}
-	if r.isEnhancedTransientFailure(err) {
+	if r.isEnhancedTransientFailureForPolicy(retryPolicy, err) {
 		return true
 	}
 	var loopErr *loopError
 	if errors.As(err, &loopErr) {
-		return loopErr.kind == FailureRetryableTransient && (isTransientModelProviderMessage(loopErr.message) || r.isEnhancedTransientMessage(loopErr.message))
+		return loopErr.kind == FailureRetryableTransient && (isTransientModelProviderMessage(loopErr.message) || r.isEnhancedTransientMessageForPolicy(retryPolicy, loopErr.message))
 	}
 	return false
 }
 
 func (r *Runner) isEnhancedTransientFailure(err error) bool {
+	return r.isEnhancedTransientFailureForPolicy(r.retryPolicyForProject(""), err)
+}
+
+func (r *Runner) isEnhancedTransientFailureForPolicy(policy config.ReviewerRetryConfig, err error) bool {
 	if err == nil {
 		return false
 	}
-	return r.isEnhancedTransientMessage(err.Error()) || config.ReviewerRetryMessageMatches(r.retryPolicy, githubinfra.ErrorMessage(err))
+	return r.isEnhancedTransientMessageForPolicy(policy, err.Error()) || config.ReviewerRetryMessageMatches(policy, githubinfra.ErrorMessage(err))
 }
 
 func (r *Runner) isEnhancedTransientMessage(message string) bool {
-	return config.ReviewerRetryMessageMatches(r.retryPolicy, message)
+	return r.isEnhancedTransientMessageForPolicy(r.retryPolicyForProject(""), message)
+}
+
+func (r *Runner) isEnhancedTransientMessageForPolicy(policy config.ReviewerRetryConfig, message string) bool {
+	return config.ReviewerRetryMessageMatches(policy, message)
 }
 
 func (r *Runner) markAgentExecutionNativeResumePendingForTransientProvider(ctx context.Context, executionID string, message string) bool {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4220,7 +4220,7 @@ func (r *Runner) classifyFailureForProject(projectID string, err error) *loopErr
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
 	if r.isEnhancedTransientFailureForPolicy(r.retryPolicyForProject(projectID), err) {
-		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
+		return &loopError{message: githubinfra.ErrorMessage(err), kind: FailureRetryableTransient}
 	}
 	return &loopError{message: err.Error(), kind: FailureNonRetryable}
 }

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -442,6 +442,7 @@ type Options struct {
 	LooperCLIPath           string
 	RetryBaseDelay          time.Duration
 	RetryMaxAttempts        int64
+	RetryPolicy             config.ReviewerRetryConfig
 	HeadChangePollInterval  time.Duration
 	OnAgentExecutionStarted AgentExecutionStartedFunc
 	OnQueueItemEnqueued     func()
@@ -487,6 +488,8 @@ type Runner struct {
 	looperCLIPath           string
 	retryBaseDelay          time.Duration
 	retryMaxAttempts        int64
+	retryPolicy             config.ReviewerRetryConfig
+	retryMaxDelay           time.Duration
 	headChangePollInterval  time.Duration
 	onAgentExecutionStarted AgentExecutionStartedFunc
 	onQueueItemEnqueued     func()
@@ -512,8 +515,6 @@ type DiscoveryResult struct {
 	CreatedLoopIDs []string
 	Skipped        int
 }
-
-const maxReviewerAutoRecoveryAttempts = 3
 
 type ProcessResult struct {
 	LoopID      string
@@ -638,6 +639,11 @@ func New(options Options) *Runner {
 	if retryMax <= 0 {
 		retryMax = defaultRetryMax
 	}
+	retryPolicy := config.NormalizeReviewerRetryConfig(options.RetryPolicy)
+	retryMaxDelay := time.Duration(retryPolicy.MaxDelayMS) * time.Millisecond
+	if retryMaxDelay <= 0 {
+		retryMaxDelay = maxRetryDelay
+	}
 	headChangePollInterval := options.HeadChangePollInterval
 	if headChangePollInterval <= 0 {
 		headChangePollInterval = defaultHeadChangePollInterval
@@ -700,6 +706,8 @@ func New(options Options) *Runner {
 		looperCLIPath:           normalizeLooperCLIPath(options.LooperCLIPath),
 		retryBaseDelay:          retryBaseDelay,
 		retryMaxAttempts:        retryMax,
+		retryPolicy:             retryPolicy,
+		retryMaxDelay:           retryMaxDelay,
 		headChangePollInterval:  headChangePollInterval,
 		onAgentExecutionStarted: options.OnAgentExecutionStarted,
 		onQueueItemEnqueued:     options.OnQueueItemEnqueued,
@@ -1495,7 +1503,7 @@ func (r *Runner) executeStepWithTransientExternalRetry(ctx context.Context, step
 		if attempt >= maxAttempts || !r.isTransientExternalFailure(err) {
 			break
 		}
-		delay := retryDelay(r.retryBaseDelay, attempt, err)
+		delay := retryDelay(r.retryBaseDelay, attempt, err, r.retryMaxDelay)
 		if r.shouldSkipTransientRetryDelayForNativeResume(ctx, input.Loop.ID, err) {
 			delay = 0
 		}
@@ -3754,7 +3762,7 @@ func (r *Runner) recoverFailedReviewerLoop(ctx context.Context, loop storage.Loo
 	if err != nil {
 		return nil, err
 	}
-	requeued, err := r.requeueFailedReviewerQueueItem(ctx, loop.ID, queueID, nowISO, latestQueue)
+	requeued, err := r.requeueFailedReviewerQueueItem(ctx, loop.ID, queueID, nowISO, latestQueue, reason)
 	if err != nil {
 		return nil, err
 	}
@@ -3792,8 +3800,8 @@ func (r *Runner) recoverFailedReviewerLoop(ctx context.Context, loop storage.Loo
 	return &updated, nil
 }
 
-func (r *Runner) requeueFailedReviewerQueueItem(ctx context.Context, loopID, queueID, queuedAt string, queue *storage.QueueItemRecord) (int64, error) {
-	if queue != nil && isRetryableTransientWithRemainingAttempts(*queue) {
+func (r *Runner) requeueFailedReviewerQueueItem(ctx context.Context, loopID, queueID, queuedAt string, queue *storage.QueueItemRecord, reason string) (int64, error) {
+	if queue != nil && (isRetryableTransientWithRemainingAttempts(*queue) || reason == "enhanced_transient_match_attempts_remaining") {
 		return r.repos.Queue.RequeueFailedByIDWithAttempts(ctx, loopID, queueID, queuedAt, queue.Attempts)
 	}
 	return r.repos.Queue.RequeueFailedByID(ctx, loopID, queueID, queuedAt)
@@ -3820,7 +3828,7 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if reason, _ := stringFromAny(loopMeta["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
 		return false, "", reason, nil
 	}
-	if intFromAny(loopMeta["autoRecoveryAttempts"]) >= maxReviewerAutoRecoveryAttempts {
+	if intFromAny(loopMeta["autoRecoveryAttempts"]) >= r.retryPolicy.AutoRecoveryMaxAttempts {
 		return false, "", "auto_recovery_attempt_cap", nil
 	}
 	latestRun, err := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID)
@@ -3881,6 +3889,16 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 	if latestMessage == "" {
 		latestMessage = derefString(latestQueue.LastError)
 	}
+	if r.retryPolicy.RecoverExistingMatchedFailures && queueHasRemainingAttempts(*latestQueue) && r.isEnhancedTransientMessage(latestMessage) {
+		approved, err := approvedByCurrentUser()
+		if err != nil {
+			return false, "", "", err
+		}
+		if approved {
+			return false, "", "approved", nil
+		}
+		return true, latestQueue.ID, "enhanced_transient_match_attempts_remaining", nil
+	}
 	if isKnownReviewerRediscoveryGuardrail(latestMessage) && isReviewerRediscoveryRunStep(latestRun) {
 		approved, err := approvedByCurrentUser()
 		if err != nil {
@@ -3898,6 +3916,10 @@ func isRetryableTransientWithRemainingAttempts(queue storage.QueueItemRecord) bo
 	if derefString(queue.LastErrorKind) != string(FailureRetryableTransient) {
 		return false
 	}
+	return queueHasRemainingAttempts(queue)
+}
+
+func queueHasRemainingAttempts(queue storage.QueueItemRecord) bool {
 	nextAttempts := queue.Attempts + 1
 	return queue.MaxAttempts > 0 && nextAttempts < queue.MaxAttempts
 }
@@ -4089,7 +4111,7 @@ func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemR
 	nextAttempts := queueItem.Attempts + 1
 	nowISO := r.nowISO()
 	if isRetryableFailure(kind) && nextAttempts < queueItem.MaxAttempts {
-		retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, nextAttempts)))
+		retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, nextAttempts, r.retryMaxDelay)))
 		if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
 			return nil, err
 		}
@@ -4141,6 +4163,9 @@ func (r *Runner) classifyFailure(err error) *loopError {
 	if isTransientModelProviderError(err) {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
+	if r.isEnhancedTransientFailure(err) {
+		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	}
 	return &loopError{message: err.Error(), kind: FailureNonRetryable}
 }
 
@@ -4151,11 +4176,25 @@ func (r *Runner) isTransientExternalFailure(err error) bool {
 	if githubinfra.IsTransientError(err) || isTransientModelProviderError(err) {
 		return true
 	}
+	if r.isEnhancedTransientFailure(err) {
+		return true
+	}
 	var loopErr *loopError
 	if errors.As(err, &loopErr) {
-		return loopErr.kind == FailureRetryableTransient && isTransientModelProviderMessage(loopErr.message)
+		return loopErr.kind == FailureRetryableTransient && (isTransientModelProviderMessage(loopErr.message) || r.isEnhancedTransientMessage(loopErr.message))
 	}
 	return false
+}
+
+func (r *Runner) isEnhancedTransientFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	return r.isEnhancedTransientMessage(err.Error()) || config.ReviewerRetryMessageMatches(r.retryPolicy, githubinfra.ErrorMessage(err))
+}
+
+func (r *Runner) isEnhancedTransientMessage(message string) bool {
+	return config.ReviewerRetryMessageMatches(r.retryPolicy, message)
 }
 
 func (r *Runner) markAgentExecutionNativeResumePendingForTransientProvider(ctx context.Context, executionID string, message string) bool {
@@ -5527,29 +5566,38 @@ func (p pendingReviewCheckpoint) clone() *pendingReviewCheckpoint {
 	return &copyValue
 }
 
-func backoffDelay(base time.Duration, attempts int64) time.Duration {
+func backoffDelay(base time.Duration, attempts int64, maxDelay time.Duration) time.Duration {
+	if maxDelay <= 0 {
+		maxDelay = maxRetryDelay
+	}
 	delay := base
 	for i := int64(1); i < attempts; i++ {
 		delay *= 2
 	}
-	if delay > maxRetryDelay {
-		return maxRetryDelay
+	if delay > maxDelay {
+		return maxDelay
 	}
 	return delay
 }
 
-func retryDelay(base time.Duration, attempts int64, err error) time.Duration {
+func retryDelay(base time.Duration, attempts int64, err error, maxDelay time.Duration) time.Duration {
+	if maxDelay <= 0 {
+		maxDelay = maxRetryDelay
+	}
 	if delay, ok := retryAfterDelay(err); ok {
-		if delay > maxRetryDelay {
-			return maxRetryDelay
+		if delay > maxDelay {
+			return maxDelay
 		}
 		return delay
 	}
-	return jitterDelay(backoffDelay(base, attempts))
+	return jitterDelay(backoffDelay(base, attempts, maxDelay), maxDelay)
 }
 
-func jitterDelay(delay time.Duration) time.Duration {
-	if delay <= 0 || delay >= maxRetryDelay {
+func jitterDelay(delay time.Duration, maxDelay time.Duration) time.Duration {
+	if maxDelay <= 0 {
+		maxDelay = maxRetryDelay
+	}
+	if delay <= 0 || delay >= maxDelay {
 		return delay
 	}
 	maxJitter := delay / retryJitterDivisor
@@ -5561,8 +5609,8 @@ func jitterDelay(delay time.Duration) time.Duration {
 		return delay
 	}
 	delay += time.Duration(n.Int64())
-	if delay > maxRetryDelay {
-		return maxRetryDelay
+	if delay > maxDelay {
+		return maxDelay
 	}
 	return delay
 }

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -218,7 +218,7 @@ func TestReviewerFailedLoopRecoveryEligibilityWhitelist(t *testing.T) {
 		{name: "follow updates disabled", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", FollowUpdates: boolPtr(false)}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 		{name: "loop disabled", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", LoopEnabled: boolPtr(false)}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 		{name: "legacy budget termination metadata", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", TerminationReason: "max_wall_clock"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
-		{name: "attempt cap", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", AutoRecoveryAttempts: maxReviewerAutoRecoveryAttempts}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
+		{name: "attempt cap", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", AutoRecoveryAttempts: config.DefaultReviewerAutoRecoveryMaxAttempts}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -237,6 +237,65 @@ func TestReviewerFailedLoopRecoveryEligibilityWhitelist(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReviewerFailedLoopRecoveryEnhancedTransientIsOptIn(t *testing.T) {
+	t.Parallel()
+	message := `Post "https://api.github.com/graphql": EOF`
+	pr := PullRequestSummary{Number: 42, State: "OPEN"}
+
+	t.Run("default remains non recoverable", func(t *testing.T) {
+		t.Parallel()
+		fixture := newRunnerFixture(t)
+		loopID, _ := seedFailedReviewerRecoveryLoop(t, fixture, failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureNonRetryable), ErrorMessage: message, QueueAttempts: 1, QueueMaxAttempts: 5})
+		runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25}})
+		loop, _ := fixture.repos.Loops.GetByID(context.Background(), loopID)
+		eligible, _, reason, err := runner.failedReviewerLoopRecoveryEligibility(context.Background(), *loop, pr)
+		if err != nil {
+			t.Fatalf("failedReviewerLoopRecoveryEligibility() error = %v", err)
+		}
+		if eligible || reason != "not_whitelisted" {
+			t.Fatalf("eligible=%v reason=%q, want not_whitelisted", eligible, reason)
+		}
+	})
+
+	t.Run("enabled recovers and preserves attempt count", func(t *testing.T) {
+		t.Parallel()
+		fixture := newRunnerFixture(t)
+		loopID, queueID := seedFailedReviewerRecoveryLoop(t, fixture, failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureNonRetryable), ErrorMessage: message, QueueAttempts: 1, QueueMaxAttempts: 5})
+		runner := New(Options{
+			DB:            fixture.coordinator.DB(),
+			Repos:         fixture.repos,
+			GitHub:        &fakeGitHubGateway{},
+			Git:           &fakeGitGateway{},
+			AgentExecutor: &fakeAgentExecutor{},
+			Logger:        fixture.logger,
+			Now:           fixture.now,
+			LoopConfig:    config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25},
+			RetryPolicy: config.ReviewerRetryConfig{
+				EnhancedTransientClassification: true,
+				RecoverExistingMatchedFailures:  true,
+			},
+		})
+		loop, _ := fixture.repos.Loops.GetByID(context.Background(), loopID)
+		eligible, _, reason, err := runner.failedReviewerLoopRecoveryEligibility(context.Background(), *loop, pr)
+		if err != nil {
+			t.Fatalf("failedReviewerLoopRecoveryEligibility() error = %v", err)
+		}
+		if !eligible || reason != "enhanced_transient_match_attempts_remaining" {
+			t.Fatalf("eligible=%v reason=%q, want enhanced transient recovery", eligible, reason)
+		}
+		if _, err := runner.recoverFailedReviewerLoop(context.Background(), *loop, pr); err != nil {
+			t.Fatalf("recoverFailedReviewerLoop() error = %v", err)
+		}
+		queue, err := fixture.repos.Queue.GetByID(context.Background(), queueID)
+		if err != nil || queue == nil {
+			t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queue, err)
+		}
+		if queue.Status != "queued" || queue.Attempts != 1 || queue.LastError != nil || queue.LastErrorKind != nil {
+			t.Fatalf("queue = %#v, want requeued with original attempts and cleared error", queue)
+		}
+	})
 }
 
 func TestReviewerFailedLoopRecoveryEligibilityHonorsStopOnConfig(t *testing.T) {
@@ -276,7 +335,7 @@ func TestReviewerFailedLoopRecoveryEligibilitySkipsCurrentLoginForLocalBlockers(
 		wantReason string
 	}{
 		{name: "loop disabled", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", LoopEnabled: boolPtr(false)}, wantReason: "loop_disabled"},
-		{name: "attempt cap", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", AutoRecoveryAttempts: maxReviewerAutoRecoveryAttempts}, wantReason: "auto_recovery_attempt_cap"},
+		{name: "attempt cap", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish", AutoRecoveryAttempts: config.DefaultReviewerAutoRecoveryMaxAttempts}, wantReason: "auto_recovery_attempt_cap"},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -5509,6 +5568,37 @@ func TestIsTransientExternalFailureDetectsWrappedGitHubStatus(t *testing.T) {
 	}
 }
 
+func TestEnhancedTransientClassificationIsOptIn(t *testing.T) {
+	err := &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: `Post "https://api.github.com/graphql": EOF`}}
+
+	defaultRunner := New(Options{})
+	if got := defaultRunner.classifyFailure(err); got.kind != FailureNonRetryable {
+		t.Fatalf("default classifyFailure() kind = %s, want %s", got.kind, FailureNonRetryable)
+	}
+	if defaultRunner.isTransientExternalFailure(err) {
+		t.Fatal("default isTransientExternalFailure() = true, want false")
+	}
+
+	enabledRunner := New(Options{RetryPolicy: config.ReviewerRetryConfig{EnhancedTransientClassification: true}})
+	if got := enabledRunner.classifyFailure(err); got.kind != FailureRetryableTransient {
+		t.Fatalf("enabled classifyFailure() kind = %s, want %s", got.kind, FailureRetryableTransient)
+	}
+	if !enabledRunner.isTransientExternalFailure(err) {
+		t.Fatal("enabled isTransientExternalFailure() = false, want true")
+	}
+}
+
+func TestEnhancedTransientClassificationHonorsExtraPatterns(t *testing.T) {
+	err := fmt.Errorf("custom provider temporarily unavailable")
+	runner := New(Options{RetryPolicy: config.ReviewerRetryConfig{
+		EnhancedTransientClassification: true,
+		ExtraTransientErrorPatterns:     []string{"temporarily unavailable"},
+	}})
+	if got := runner.classifyFailure(err); got.kind != FailureRetryableTransient {
+		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureRetryableTransient)
+	}
+}
+
 func TestIsTransientExternalFailureDetectsModelProviderHTTPAndNetworkFailures(t *testing.T) {
 	runner := New(Options{})
 	for _, message := range []string{
@@ -5526,14 +5616,17 @@ func TestIsTransientExternalFailureDetectsModelProviderHTTPAndNetworkFailures(t 
 }
 
 func TestRetryDelayHonorsRetryAfterAndCapsBackoff(t *testing.T) {
-	if got := retryDelay(time.Second, 1, fmt.Errorf("anthropic overloaded; retry-after: 7")); got != 7*time.Second {
+	if got := retryDelay(time.Second, 1, fmt.Errorf("anthropic overloaded; retry-after: 7"), maxRetryDelay); got != 7*time.Second {
 		t.Fatalf("retryDelay(retry-after) = %v, want 7s", got)
 	}
-	if got := retryDelay(time.Minute, 3, fmt.Errorf("anthropic overloaded; retry-after: 120")); got != maxRetryDelay {
+	if got := retryDelay(time.Minute, 3, fmt.Errorf("anthropic overloaded; retry-after: 120"), maxRetryDelay); got != maxRetryDelay {
 		t.Fatalf("retryDelay(capped retry-after) = %v, want %v", got, maxRetryDelay)
 	}
-	if got := retryDelay(time.Minute, 3, fmt.Errorf("anthropic overloaded")); got != maxRetryDelay {
+	if got := retryDelay(time.Minute, 3, fmt.Errorf("anthropic overloaded"), maxRetryDelay); got != maxRetryDelay {
 		t.Fatalf("retryDelay(capped exponential) = %v, want %v", got, maxRetryDelay)
+	}
+	if got := retryDelay(time.Minute, 3, fmt.Errorf("anthropic overloaded; retry-after: 120"), 10*time.Second); got != 10*time.Second {
+		t.Fatalf("retryDelay(custom capped retry-after) = %v, want 10s", got)
 	}
 }
 
@@ -5542,7 +5635,7 @@ func TestRetryDelayAddsBoundedJitter(t *testing.T) {
 	wantMin := 2 * base
 	wantMax := wantMin + wantMin/retryJitterDivisor
 	for i := 0; i < 20; i++ {
-		got := retryDelay(base, 2, fmt.Errorf("anthropic overloaded"))
+		got := retryDelay(base, 2, fmt.Errorf("anthropic overloaded"), maxRetryDelay)
 		if got < wantMin || got > wantMax {
 			t.Fatalf("retryDelay(jittered) = %v, want between %v and %v", got, wantMin, wantMax)
 		}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -298,6 +298,49 @@ func TestReviewerFailedLoopRecoveryEnhancedTransientIsOptIn(t *testing.T) {
 	})
 }
 
+func TestReviewerFailedLoopRecoveryUsesProjectRetryOverride(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	message := "project-only transient transport failure"
+	loopID, _ := seedFailedReviewerRecoveryLoop(t, fixture, failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureNonRetryable), ErrorMessage: message, QueueAttempts: 1, QueueMaxAttempts: 5})
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	enhanced := true
+	recoverExisting := true
+	patterns := []string{"project-only transient transport"}
+	cfg.Projects = []config.ProjectRefConfig{{
+		ID: "project_1",
+		Roles: &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Behavior: &config.PartialReviewerConfig{Retry: &config.PartialReviewerRetryConfig{
+			EnhancedTransientClassification: &enhanced,
+			RecoverExistingMatchedFailures:  &recoverExisting,
+			ExtraTransientErrorPatterns:     &patterns,
+		}}}},
+	}}
+	runner := New(Options{
+		DB:                 fixture.coordinator.DB(),
+		Repos:              fixture.repos,
+		GitHub:             &fakeGitHubGateway{},
+		Git:                &fakeGitGateway{},
+		AgentExecutor:      &fakeAgentExecutor{},
+		Logger:             fixture.logger,
+		Now:                fixture.now,
+		LoopConfig:         config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25},
+		RetryPolicy:        cfg.Roles.Reviewer.Behavior.Retry,
+		CustomInstructions: &cfg,
+	})
+	loop, _ := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	eligible, _, reason, err := runner.failedReviewerLoopRecoveryEligibility(context.Background(), *loop, PullRequestSummary{Number: 42, State: "OPEN"})
+	if err != nil {
+		t.Fatalf("failedReviewerLoopRecoveryEligibility() error = %v", err)
+	}
+	if !eligible || reason != "enhanced_transient_match_attempts_remaining" {
+		t.Fatalf("eligible=%v reason=%q, want project retry override recovery", eligible, reason)
+	}
+}
+
 func TestReviewerFailedLoopRecoveryEligibilityHonorsStopOnConfig(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -298,6 +298,69 @@ func TestReviewerFailedLoopRecoveryEnhancedTransientIsOptIn(t *testing.T) {
 	})
 }
 
+func TestReviewerEnhancedTransientPersistsExtractedShellStderr(t *testing.T) {
+	t.Parallel()
+
+	// Wrapped shell error whose generic exit-code Message hides the EOF text
+	// living in Stderr — exactly the shape `gh api ...` produces on a flaky
+	// network. Pre-fix, classifyFailureForProject persisted err.Error() ("Command
+	// exited with code 1") and failedReviewerLoopRecoveryEligibility could no
+	// longer match the persisted message against the enhanced-transient pattern.
+	cause := &shell.CommandExecutionError{
+		Message: "Command exited with code 1",
+		Result: shell.Result{
+			ExitCode: 1,
+			Stderr:   `Post "https://api.github.com/graphql": EOF`,
+		},
+	}
+
+	fixture := newRunnerFixture(t)
+	runner := New(Options{
+		DB:            fixture.coordinator.DB(),
+		Repos:         fixture.repos,
+		GitHub:        &fakeGitHubGateway{},
+		Git:           &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{},
+		Logger:        fixture.logger,
+		Now:           fixture.now,
+		LoopConfig:    config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25},
+		RetryPolicy: config.ReviewerRetryConfig{
+			EnhancedTransientClassification: true,
+			RecoverExistingMatchedFailures:  true,
+		},
+	})
+
+	classified := runner.classifyFailureForProject("", cause)
+	if classified == nil || classified.kind != FailureRetryableTransient {
+		t.Fatalf("classifyFailureForProject() = %#v, want retryable transient", classified)
+	}
+	if !strings.Contains(classified.message, "EOF") || !strings.Contains(classified.message, "/graphql") {
+		t.Fatalf("classified.message = %q, want extracted stderr containing graphql EOF", classified.message)
+	}
+	if !runner.isEnhancedTransientMessageForPolicy(runner.retryPolicyForProject(""), classified.message) {
+		t.Fatalf("persisted message %q should re-match enhanced transient pattern", classified.message)
+	}
+
+	loopID, queueID := seedFailedReviewerRecoveryLoop(t, fixture, failedReviewerRecoverySeed{
+		ResumePolicy:     "replay_step",
+		QueueErrorKind:   string(FailureNonRetryable),
+		ErrorMessage:     classified.message,
+		QueueAttempts:    1,
+		QueueMaxAttempts: 5,
+	})
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+	eligible, recoveredQueueID, reason, err := runner.failedReviewerLoopRecoveryEligibility(context.Background(), *loop, PullRequestSummary{Number: 42, State: "OPEN"})
+	if err != nil {
+		t.Fatalf("failedReviewerLoopRecoveryEligibility() error = %v", err)
+	}
+	if !eligible || reason != "enhanced_transient_match_attempts_remaining" || recoveredQueueID != queueID {
+		t.Fatalf("eligible=%v queueID=%q reason=%q, want enhanced transient recovery on queue %q", eligible, recoveredQueueID, reason, queueID)
+	}
+}
+
 func TestReviewerFailedLoopRecoveryUsesProjectRetryOverride(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1268,12 +1268,7 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 		if err != nil {
 			return RecoverySummary{}, err
 		}
-		policy := runtimeReviewerRecoveryPolicy{
-			includeDrafts:    r.config.Roles.Reviewer.Discovery.Triggers.IncludeDrafts,
-			stopOnApproved:   r.config.Roles.Reviewer.Behavior.Loop.StopOnApproved,
-			stopOnReadyLabel: r.config.Roles.Reviewer.Behavior.Loop.StopOnReadyLabel,
-			retry:            config.NormalizeReviewerRetryConfig(r.config.Roles.Reviewer.Behavior.Retry),
-		}
+		policy := r.reviewerRecoveryPolicyForProject(loop.ProjectID)
 		if reviewerRecoveryNeedsFreshLogin(loop, latestRun, policy) {
 			continue
 		}
@@ -1473,12 +1468,7 @@ func (r *Runtime) runDeferredReviewerRecovery(ctx context.Context, repositories 
 		if err != nil {
 			return requeued, err
 		}
-		policy := runtimeReviewerRecoveryPolicy{
-			includeDrafts:    r.config.Roles.Reviewer.Discovery.Triggers.IncludeDrafts,
-			stopOnApproved:   r.config.Roles.Reviewer.Behavior.Loop.StopOnApproved,
-			stopOnReadyLabel: r.config.Roles.Reviewer.Behavior.Loop.StopOnReadyLabel,
-			retry:            config.NormalizeReviewerRetryConfig(r.config.Roles.Reviewer.Behavior.Retry),
-		}
+		policy := r.reviewerRecoveryPolicyForProject(loop.ProjectID)
 		if !reviewerRecoveryNeedsFreshLogin(loop, latestRun, policy) {
 			continue
 		}
@@ -2015,6 +2005,16 @@ type runtimeReviewerRecoveryPolicy struct {
 	stopOnReadyLabel bool
 	currentLogin     string
 	retry            config.ReviewerRetryConfig
+}
+
+func (r *Runtime) reviewerRecoveryPolicyForProject(projectID string) runtimeReviewerRecoveryPolicy {
+	roles := config.ProjectRoleConfigs(r.config, projectID)
+	return runtimeReviewerRecoveryPolicy{
+		includeDrafts:    roles.Reviewer.Discovery.Triggers.IncludeDrafts,
+		stopOnApproved:   roles.Reviewer.Behavior.Loop.StopOnApproved,
+		stopOnReadyLabel: roles.Reviewer.Behavior.Loop.StopOnReadyLabel,
+		retry:            config.NormalizeReviewerRetryConfig(roles.Reviewer.Behavior.Retry),
+	}
 }
 
 func (r *Runtime) currentReviewerLoginForRecovery(ctx context.Context, repositories *storage.Repositories, githubGateway *githubinfra.Gateway, loop storage.LoopRecord, latestRun *storage.RunRecord, policy runtimeReviewerRecoveryPolicy) (string, bool) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1272,12 +1272,14 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 			includeDrafts:    r.config.Roles.Reviewer.Discovery.Triggers.IncludeDrafts,
 			stopOnApproved:   r.config.Roles.Reviewer.Behavior.Loop.StopOnApproved,
 			stopOnReadyLabel: r.config.Roles.Reviewer.Behavior.Loop.StopOnReadyLabel,
+			retry:            config.NormalizeReviewerRetryConfig(r.config.Roles.Reviewer.Behavior.Retry),
 		}
 		if reviewerRecoveryNeedsFreshLogin(loop, latestRun, policy) {
 			continue
 		}
 		if shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, policy) {
-			recoveredQueueItems, err := requeueFailedReviewerQueueItemForRecovery(ctx, repositories, loop.ID, latestQueue, nowISO)
+			failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage), derefString(latestQueue.LastError))
+			recoveredQueueItems, err := requeueFailedReviewerQueueItemForRecovery(ctx, repositories, loop.ID, latestQueue, nowISO, policy, failureSummary)
 			if err != nil {
 				return RecoverySummary{}, err
 			}
@@ -1475,6 +1477,7 @@ func (r *Runtime) runDeferredReviewerRecovery(ctx context.Context, repositories 
 			includeDrafts:    r.config.Roles.Reviewer.Discovery.Triggers.IncludeDrafts,
 			stopOnApproved:   r.config.Roles.Reviewer.Behavior.Loop.StopOnApproved,
 			stopOnReadyLabel: r.config.Roles.Reviewer.Behavior.Loop.StopOnReadyLabel,
+			retry:            config.NormalizeReviewerRetryConfig(r.config.Roles.Reviewer.Behavior.Retry),
 		}
 		if !reviewerRecoveryNeedsFreshLogin(loop, latestRun, policy) {
 			continue
@@ -1499,7 +1502,8 @@ func (r *Runtime) runDeferredReviewerRecovery(ctx context.Context, repositories 
 		if currentLoop == nil || !shouldAutoRecoverFailedReviewerLoop(*currentLoop, latestRun, latestQueue, policy) {
 			continue
 		}
-		recoveredQueueItems, err := requeueFailedReviewerQueueItemForRecovery(ctx, repositories, loop.ID, latestQueue, nowISO)
+		failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage), derefString(latestQueue.LastError))
+		recoveredQueueItems, err := requeueFailedReviewerQueueItemForRecovery(ctx, repositories, loop.ID, latestQueue, nowISO, policy, failureSummary)
 		if err != nil {
 			return requeued, err
 		}
@@ -1992,8 +1996,6 @@ func createEmptyRecoverySummary() RecoverySummary {
 	}
 }
 
-const maxReviewerAutoRecoveryAttempts = 3
-
 type runtimeReviewerCheckpoint struct {
 	ResumePolicy string `json:"resumePolicy,omitempty"`
 	Detail       *struct {
@@ -2012,6 +2014,7 @@ type runtimeReviewerRecoveryPolicy struct {
 	stopOnApproved   bool
 	stopOnReadyLabel bool
 	currentLogin     string
+	retry            config.ReviewerRetryConfig
 }
 
 func (r *Runtime) currentReviewerLoginForRecovery(ctx context.Context, repositories *storage.Repositories, githubGateway *githubinfra.Gateway, loop storage.LoopRecord, latestRun *storage.RunRecord, policy runtimeReviewerRecoveryPolicy) (string, bool) {
@@ -2075,7 +2078,8 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 	if reason, _ := runtimeStringFromAny(loopMeta["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
 		return false
 	}
-	if runtimeIntFromAny(loopMeta["autoRecoveryAttempts"]) >= maxReviewerAutoRecoveryAttempts {
+	policy.retry = config.NormalizeReviewerRetryConfig(policy.retry)
+	if runtimeIntFromAny(loopMeta["autoRecoveryAttempts"]) >= policy.retry.AutoRecoveryMaxAttempts {
 		return false
 	}
 	checkpoint := parseRuntimeReviewerCheckpoint(latestRun.CheckpointJSON)
@@ -2105,11 +2109,11 @@ func shouldAutoRecoverFailedReviewerLoop(loop storage.LoopRecord, latestRun *sto
 		return false
 	}
 	failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage), queueMessage)
-	return (queueKind == loops.FailureKindRetryableAfterResume && (resumePolicy == loops.ResumePolicyRestartFromDiscover || resumePolicy == "rerun_review")) || isRuntimeRetryableTransientWithRemainingAttempts(*latestQueue) || (isKnownReviewerRediscoveryGuardrail(failureSummary) && isRuntimeReviewerRediscoveryRunStep(latestRun))
+	return (queueKind == loops.FailureKindRetryableAfterResume && (resumePolicy == loops.ResumePolicyRestartFromDiscover || resumePolicy == "rerun_review")) || isRuntimeRetryableTransientWithRemainingAttempts(*latestQueue) || runtimeRecoverableEnhancedTransient(policy.retry, *latestQueue, failureSummary) || (isKnownReviewerRediscoveryGuardrail(failureSummary) && isRuntimeReviewerRediscoveryRunStep(latestRun))
 }
 
-func requeueFailedReviewerQueueItemForRecovery(ctx context.Context, repositories *storage.Repositories, loopID string, latestQueue *storage.QueueItemRecord, queuedAt string) (int64, error) {
-	if latestQueue != nil && isRuntimeRetryableTransientWithRemainingAttempts(*latestQueue) {
+func requeueFailedReviewerQueueItemForRecovery(ctx context.Context, repositories *storage.Repositories, loopID string, latestQueue *storage.QueueItemRecord, queuedAt string, policy runtimeReviewerRecoveryPolicy, matchedMessage string) (int64, error) {
+	if latestQueue != nil && (isRuntimeRetryableTransientWithRemainingAttempts(*latestQueue) || runtimeRecoverableEnhancedTransient(policy.retry, *latestQueue, matchedMessage)) {
 		return repositories.Queue.RequeueFailedByIDWithAttempts(ctx, loopID, latestQueue.ID, queuedAt, latestQueue.Attempts)
 	}
 	if latestQueue == nil {
@@ -2122,6 +2126,15 @@ func isRuntimeRetryableTransientWithRemainingAttempts(queue storage.QueueItemRec
 	if derefString(queue.LastErrorKind) != "retryable_transient" {
 		return false
 	}
+	return runtimeQueueHasRemainingAttempts(queue)
+}
+
+func runtimeRecoverableEnhancedTransient(policy config.ReviewerRetryConfig, queue storage.QueueItemRecord, message string) bool {
+	policy = config.NormalizeReviewerRetryConfig(policy)
+	return policy.RecoverExistingMatchedFailures && runtimeQueueHasRemainingAttempts(queue) && config.ReviewerRetryMessageMatches(policy, message)
+}
+
+func runtimeQueueHasRemainingAttempts(queue storage.QueueItemRecord) bool {
 	nextAttempts := queue.Attempts + 1
 	return queue.MaxAttempts > 0 && nextAttempts < queue.MaxAttempts
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2304,6 +2304,34 @@ func TestShouldAutoRecoverFailedReviewerLoopAllowsRetryableTransientWithAttempts
 	}
 }
 
+func TestShouldAutoRecoverFailedReviewerLoopAllowsEnhancedMatchedTransientWhenConfigured(t *testing.T) {
+	t.Parallel()
+	errorKind := "non_retryable"
+	errorMessage := `git fetch origin refs/pull/42/head:refs/remotes/origin/pr-42-head: Connection closed by 198.18.0.96 port 443`
+	step := "review"
+	checkpoint := `{"resumePolicy":"replay_step","detail":{"state":"OPEN","reviewDecision":"","labels":[]}}`
+	loop := storage.LoopRecord{ID: "loop_recover", Type: "reviewer", Status: "failed", MetadataJSON: stringPtr(`{"loop":{"enabled":true,"consecutiveFailures":1}}`)}
+	run := storage.RunRecord{ID: "run_recover", LoopID: "loop_recover", Status: "failed", CurrentStep: &step, CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage}
+	queue := storage.QueueItemRecord{ID: "queue_recover", LoopID: stringPtr("loop_recover"), Status: "failed", Attempts: 1, MaxAttempts: 5, LastError: &errorMessage, LastErrorKind: &errorKind}
+
+	defaultPolicy := runtimeReviewerRecoveryPolicy{stopOnApproved: true, stopOnReadyLabel: true}
+	if shouldAutoRecoverFailedReviewerLoop(loop, &run, &queue, defaultPolicy) {
+		t.Fatal("shouldAutoRecoverFailedReviewerLoop(default) = true, want false")
+	}
+
+	enabledPolicy := runtimeReviewerRecoveryPolicy{stopOnApproved: true, stopOnReadyLabel: true, retry: config.ReviewerRetryConfig{
+		EnhancedTransientClassification: true,
+		RecoverExistingMatchedFailures:  true,
+	}}
+	if !shouldAutoRecoverFailedReviewerLoop(loop, &run, &queue, enabledPolicy) {
+		t.Fatal("shouldAutoRecoverFailedReviewerLoop(enabled) = false, want true")
+	}
+	queue.Attempts = 4
+	if shouldAutoRecoverFailedReviewerLoop(loop, &run, &queue, enabledPolicy) {
+		t.Fatal("shouldAutoRecoverFailedReviewerLoop(enabled final attempt) = true, want false")
+	}
+}
+
 func TestShouldAutoRecoverFailedReviewerLoopIgnoresApprovalByAnotherUser(t *testing.T) {
 	t.Parallel()
 	errorKind := "retryable_after_resume"

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2025,6 +2025,75 @@ func TestRunRecoveryPipelineAutoRecoversFailedReviewerGuardrailLoop(t *testing.T
 	}
 }
 
+func TestRunRecoveryPipelineUsesProjectReviewerRetryOverride(t *testing.T) {
+	t.Parallel()
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	enhanced := true
+	recoverExisting := true
+	patterns := []string{"project-only transient transport"}
+	cfg.Projects = []config.ProjectRefConfig{{
+		ID:       "project_1",
+		Name:     "Looper",
+		RepoPath: filepath.Join(workingDir, "repo"),
+		Roles: &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Behavior: &config.PartialReviewerConfig{Retry: &config.PartialReviewerRetryConfig{
+			EnhancedTransientClassification: &enhanced,
+			RecoverExistingMatchedFailures:  &recoverExisting,
+			ExtraTransientErrorPatterns:     &patterns,
+		}}}},
+	}}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), cfg.Storage.DBPath, storage.SQLiteCoordinatorOptions{})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	defer coordinator.Close()
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 0, 0, 0, time.UTC)
+	nowISO := "2026-04-17T12:00:00.000Z"
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	loopID := "loop_project_retry_recover"
+	queueID := "queue_project_retry_recover"
+	metadata := mustMarshalJSON(map[string]any{"loop": map[string]any{"enabled": true, "failureCount": 1, "consecutiveFailures": 1, "lastFailure": "project-only transient transport failure"}})
+	if err := repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 166, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpoint := `{"resumePolicy":"replay_step","detail":{"state":"OPEN","reviewDecision":"","labels":[]}}`
+	errorMessage := "project-only transient transport failure"
+	if err := repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_project_retry_recover", LoopID: loopID, Status: "failed", CurrentStep: stringPtr("snapshot"), CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	queueKind := "non_retryable"
+	if err := repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:project_1:loop_project_retry_recover:acme/looper:42", Priority: storage.QueuePriorityReviewer, Status: "failed", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 5, FinishedAt: &nowISO, LastError: &errorMessage, LastErrorKind: &queueKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+
+	summary, err := rt.runRecoveryPipeline(context.Background(), repositories, nil, now)
+	if err != nil {
+		t.Fatalf("runRecoveryPipeline() error = %v", err)
+	}
+	if summary.LoopsRequeued != 1 {
+		t.Fatalf("LoopsRequeued = %d, want 1", summary.LoopsRequeued)
+	}
+	loop, _ := repositories.Loops.GetByID(context.Background(), loopID)
+	queue, _ := repositories.Queue.GetByID(context.Background(), queueID)
+	if loop == nil || loop.Status != "queued" || queue == nil || queue.Status != "queued" || queue.Attempts != 1 {
+		t.Fatalf("loop=%#v queue=%#v, want recovered queued loop and preserved attempts", loop, queue)
+	}
+}
+
 func TestRecoveryInterruptsOlderRunningRunWhenLatestCompleted(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1081,6 +1081,7 @@ func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, c
 		AgentIdleTimeout:        time.Duration(cfg.Agent.Timeouts.ReviewerIdleTimeoutSeconds) * time.Second,
 		RetryBaseDelay:          retryBaseDelay,
 		RetryMaxAttempts:        int64(cfg.Scheduler.RetryMaxAttempts),
+		RetryPolicy:             cfg.Roles.Reviewer.Behavior.Retry,
 		OnQueueItemEnqueued:     requestWake,
 		OnAgentExecutionStarted: func(ctx context.Context, input reviewer.AgentExecutionStartedInput) error {
 			return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Reviewer", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})


### PR DESCRIPTION
## What changed

- Added `roles.reviewer.behavior.retry` with opt-in controls for enhanced transient classification, extra transient error patterns, historical matched-failure recovery, auto-recovery max attempts, and retry max delay.
- Wired the reviewer runner and runtime startup/deferred recovery to use the new retry policy while preserving existing defaults.
- Added CLI config keys plus config/API parity fixtures.
- Added regression coverage for default-off behavior, enhanced EOF/connection-closed classification, historical matched-failure recovery, retry delay capping, validation, and runtime recovery.

## Why

Reviewer loops can currently fail permanently when GitHub/Git transport failures such as bare `EOF` or `Connection closed by ...` are classified as `non_retryable`. That leaves live review-requested PRs stuck until manual local repair. This PR makes that behavior configurable so operators can opt into broader transient matching and historical recovery without changing the default behavior for existing installations.

## Default behavior

Defaults preserve the previous behavior:

- `enhancedTransientClassification = false`
- `recoverExistingMatchedFailures = false`
- `extraTransientErrorPatterns = []`
- `autoRecoveryMaxAttempts = 3`
- `maxDelayMs = 60000`

## Trade-off for the new config concept

Concrete failure prevented: transient GitHub/Git transport failures that were persisted as `non_retryable` can be retried and, when explicitly enabled, already-failed matching reviewer loops can be recovered without manual SQLite repair.

Cost introduced: more reviewer retry configuration, more classification branches, and an opt-in path that can requeue historical reviewer loops. Operators need to understand that `recoverExistingMatchedFailures` can cause real reviewer work to run again.

Why not delete a layer instead: the failure is at the boundary between external transport errors and local persisted queue classification. Removing persistence or retry gates would make recovery less controlled. The smaller change is to keep existing gates and make the broader classification explicitly configured.

## Authority

The authority for recovering an existing failed queue item is the persisted queue/run failure message plus an explicit operator configuration match, not the agent's structured output.

Infra signals are used only to classify external transport failure and preserve queue attempt accounting; they do not authorize publishing a review. Existing publish-time PR head and review-request validation remain in force.

## Review note

This change adds config-controlled recovery behavior on an agent-driven reviewer path. Please get `@oracle` review before merging.

## Validation

- `git diff --check`
- `go test ./internal/config ./internal/reviewer ./internal/runtime ./internal/cliapp ./internal/api`
- `go test ./...`
- `go build ./...`

## Local dogfood

Built and deployed local `0.8.1-retry` binaries, enabled the new config locally, and restarted launchd `looperd`. The local daemon recovered historical reviewer failures and is running with the new binary; that deployment is intentionally local dogfooding and not part of this PR's committed state.
