### PR TITLE
feat: add loop diagnostics CLI

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -477,6 +477,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if strings.HasPrefix(path, apiBasePath+"/runs/") {
+		payload, err := h.buildRunRouteResponse(r, path)
+		if err != nil {
+			var typed apiError
+			if !asAPIError(err, &typed) {
+				typed = internalServerError(err)
+			}
+			h.writeError(w, requestID, typed)
+			return
+		}
+
+		h.writeSuccess(w, requestID, payload)
+		return
+	}
+
 	h.writeError(w, requestID, apiError{
 		code:    pkgapi.ErrorCodeRouteNotFound,
 		status:  http.StatusNotFound,
@@ -2428,6 +2443,22 @@ func (h *Handler) buildActiveRunRouteResponse(r *http.Request, path string) (any
 	}
 }
 
+func (h *Handler) buildRunRouteResponse(r *http.Request, path string) (any, error) {
+	parts := strings.Split(strings.TrimPrefix(path, apiBasePath+"/runs/"), "/")
+	runID, err := urlPathSegment(parts, 0)
+	if err != nil {
+		return nil, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "run id is required"}
+	}
+	if len(parts) != 2 || strings.TrimSpace(parts[1]) != "logs" {
+		return nil, apiError{code: pkgapi.ErrorCodeRouteNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Unknown route: %s", path)}
+	}
+	if r.Method != http.MethodGet {
+		return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
+	}
+
+	return h.buildRunLogsResponse(r.Context(), runID)
+}
+
 func (h *Handler) buildActiveRunDetailResponse(ctx context.Context, loopID string) (activeRunView, error) {
 	items, err := h.buildActiveRunViews(ctx, true, false)
 	if err != nil {
@@ -4220,20 +4251,46 @@ func (h *Handler) buildLoopLogsResponse(ctx context.Context, loop storage.LoopRe
 		return loopLogsResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
 
+	return h.buildLogsResponseForRun(ctx, loop, latestRun)
+}
+
+func (h *Handler) buildRunLogsResponse(ctx context.Context, runID string) (loopLogsResponse, error) {
+	services := h.context.Runtime.Services()
+	run, err := services.Repositories.Runs.GetByID(ctx, runID)
+	if err != nil {
+		return loopLogsResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	if run == nil {
+		return loopLogsResponse{}, apiError{code: pkgapi.ErrorCodeRunNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Run not found: %s", runID)}
+	}
+
+	loop, err := services.Repositories.Loops.GetByID(ctx, run.LoopID)
+	if err != nil {
+		return loopLogsResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	if loop == nil {
+		return loopLogsResponse{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found for run: %s", runID)}
+	}
+
+	return h.buildLogsResponseForRun(ctx, *loop, run)
+}
+
+func (h *Handler) buildLogsResponseForRun(ctx context.Context, loop storage.LoopRecord, run *storage.RunRecord) (loopLogsResponse, error) {
+	services := h.context.Runtime.Services()
 	var runPayload *loopLogsRunResponse
 	var agentPayload *loopLogsAgentPayload
-	if latestRun != nil {
+	if run != nil {
 		runPayload = &loopLogsRunResponse{
-			RunID:        latestRun.ID,
-			Status:       latestRun.Status,
-			CurrentStep:  latestRun.CurrentStep,
-			StartedAt:    latestRun.StartedAt,
-			EndedAt:      latestRun.EndedAt,
-			Summary:      latestRun.Summary,
-			ErrorMessage: latestRun.ErrorMessage,
+			RunID:        run.ID,
+			Status:       run.Status,
+			CurrentStep:  run.CurrentStep,
+			StartedAt:    run.StartedAt,
+			EndedAt:      run.EndedAt,
+			Summary:      run.Summary,
+			ErrorMessage: run.ErrorMessage,
 		}
 
-		latestAgent, agentErr := services.Repositories.AgentExecutions.GetLatestByRunID(ctx, latestRun.ID)
+		latestAgent, agentErr := services.Repositories.AgentExecutions.GetLatestByRunID(ctx, run.ID)
 		if agentErr != nil {
 			return loopLogsResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: agentErr.Error()}
 		}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -3556,6 +3556,7 @@ func TestHandlerRunRoutesMatchFrozenSuccessArtifacts(t *testing.T) {
 		setup   func(testFixture) Context
 	}{
 		{routeID: "runs.list", method: http.MethodGet, path: "/api/v1/runs?loopId=loop_1"},
+		{routeID: "run.logs", method: http.MethodGet, path: "/api/v1/runs/run_1/logs"},
 		{routeID: "runs.active.list", method: http.MethodGet, path: "/api/v1/runs/active"},
 		{routeID: "runs.active.detail", method: http.MethodGet, path: "/api/v1/runs/active/1"},
 		{routeID: "runs.active.stop", method: http.MethodPost, path: "/api/v1/runs/active/1/stop", setup: func(fixture testFixture) Context {
@@ -3776,6 +3777,73 @@ func TestHandlerLoopLogsReturnsPersistedHistoricalAgentOutput(t *testing.T) {
 	agent := data["agent"].(map[string]any)
 	assertEqual(t, agent["stdout"], fullStdout)
 	assertEqual(t, agent["stderr"], fullStderr)
+}
+
+func TestHandlerRunLogsUsesSelectedRunInsteadOfLatest(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedRunRouteData(t, fixture.runtime)
+
+	oldStartedAt := fixture.now.Add(-time.Hour).UTC().Format(javaScriptISOString)
+	if err := fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID:          "run_old",
+		LoopID:      "loop_1",
+		Status:      "failed",
+		CurrentStep: stringPtr("snapshot"),
+		StartedAt:   oldStartedAt,
+		EndedAt:     stringPtr(oldStartedAt),
+		CreatedAt:   oldStartedAt,
+		UpdatedAt:   oldStartedAt,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(run_old) error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
+		ID:         "agent_old",
+		ProjectID:  stringPtr("project_1"),
+		LoopID:     stringPtr("loop_1"),
+		RunID:      stringPtr("run_old"),
+		Vendor:     "opencode",
+		Status:     "failed",
+		StartedAt:  oldStartedAt,
+		EndedAt:    stringPtr(oldStartedAt),
+		OutputJSON: stringPtr(`{"stdout":"old run output","stderr":"old run stderr"}`),
+		CreatedAt:  oldStartedAt,
+		UpdatedAt:  oldStartedAt,
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(agent_old) error = %v", err)
+	}
+
+	latestStartedAt := fixture.now.UTC().Format(javaScriptISOString)
+	if err := fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
+		ID:         "agent_latest",
+		ProjectID:  stringPtr("project_1"),
+		LoopID:     stringPtr("loop_1"),
+		RunID:      stringPtr("run_1"),
+		Vendor:     "opencode",
+		Status:     "running",
+		StartedAt:  latestStartedAt,
+		OutputJSON: stringPtr(`{"stdout":"latest run output","stderr":"latest run stderr"}`),
+		CreatedAt:  latestStartedAt,
+		UpdatedAt:  latestStartedAt,
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(agent_latest) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/run_old/logs", nil)
+	recorder := httptest.NewRecorder()
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	run := data["run"].(map[string]any)
+	agent := data["agent"].(map[string]any)
+	assertEqual(t, run["runId"], "run_old")
+	assertEqual(t, run["status"], "failed")
+	assertEqual(t, agent["executionId"], "agent_old")
+	assertEqual(t, agent["stdout"], "old run output")
+	assertEqual(t, agent["stderr"], "old run stderr")
 }
 
 func TestHandlerLoopLogsFollowDefaultsToStderrWhenStdoutEmpty(t *testing.T) {

--- a/internal/api/testdata/contracts/daemon-http.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.compat.json
@@ -244,6 +244,14 @@
       "routeSpecificStatuses": []
     },
     {
+      "id": "run.logs",
+      "method": "GET",
+      "path": "/api/v1/runs/run_1/logs",
+      "fixture": "default",
+      "expectedStatus": 200,
+      "routeSpecificStatuses": [404]
+    },
+    {
       "id": "runs.active.list",
       "method": "GET",
       "path": "/api/v1/runs/active",

--- a/internal/api/testdata/contracts/daemon-http.errors.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.errors.compat.json
@@ -94,6 +94,10 @@
       "status": 404
     },
     {
+      "code": "RUN_NOT_FOUND",
+      "status": 404
+    },
+    {
       "code": "RUNTIME_CONTROL_UNAVAILABLE",
       "status": 501
     },

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -948,6 +948,30 @@
       }
     },
     {
+      "id": "run.logs",
+      "status": 200,
+      "body": {
+        "ok": true,
+        "data": {
+          "seq": 1,
+          "loopId": "loop_1",
+          "loopType": "reviewer",
+          "loopStatus": "running",
+          "run": {
+            "runId": "run_1",
+            "status": "running",
+            "currentStep": "review",
+            "startedAt": "2026-04-11T12:00:00.000Z",
+            "endedAt": null,
+            "summary": null,
+            "errorMessage": null
+          },
+          "agent": null
+        },
+        "requestId": "fixture-request-id"
+      }
+    },
+    {
       "id": "runs.active.list",
       "status": 200,
       "body": {

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -293,16 +293,18 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 			newCommand(commandSpec{
 				use:             "queue",
 				short:           "Queue inspection and maintenance commands",
-				helpSubcommands: []helpSubcommand{{name: "stats", description: "Show queue eligibility stats"}, {name: "list", description: "List queue items"}, {name: "cleanup", description: "Clean stale queue items"}},
+				helpSubcommands: []helpSubcommand{{name: "stats", description: "Show queue eligibility stats"}, {name: "list", description: "List queue items"}, {name: "failed", description: "List failed queue items"}, {name: "cleanup", description: "Clean stale queue items"}},
 				helpWhenNoArgs:  true,
 				exampleLines: []string{
 					"$ looper queue stats",
 					"$ looper queue list --eligible",
+					"$ looper queue failed --type reviewer",
 					"$ looper queue cleanup --stale",
 				},
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "stats", short: "Show queue eligibility stats", runE: runtime.queueStats}),
 					newCommand(commandSpec{use: "list", short: "List queue items", runE: runtime.queueList, localFlags: []flagSpec{boolFlag("eligible", "Only list currently eligible queued items")}}),
+					newCommand(commandSpec{use: "failed", short: "List failed queue items", runE: runtime.queueFailed, localFlags: []flagSpec{stringFlag("type", "type", "Filter by queue item type"), stringFlag("project", "projectId", "Filter by project id"), stringFlag("limit", "count", "Maximum number of failed queue items to list")}}),
 					newCommand(commandSpec{use: "cleanup", short: "Clean stale queue items", runE: runtime.queueCleanup, localFlags: []flagSpec{boolFlag("stale", "Cancel queued items blocked by terminal loops")}}),
 				},
 			}),
@@ -318,14 +320,18 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 			newCommand(commandSpec{
 				use:             "loop",
 				short:           "Loop commands",
-				helpSubcommands: []helpSubcommand{{name: "list", description: "List loops"}, {name: "start", description: "Start a loop"}, {name: "pause", description: "Pause a loop"}},
+				helpSubcommands: []helpSubcommand{{name: "list", description: "List loops"}, {name: "inspect", description: "Inspect loop diagnostics"}, {name: "failures", description: "List failed loop diagnostics"}, {name: "start", description: "Start a loop"}, {name: "pause", description: "Pause a loop"}},
 				helpWhenNoArgs:  true,
 				exampleLines: []string{
 					"$ looper loop list",
+					"$ looper loop inspect 42",
+					"$ looper loop failures --type reviewer",
 					"$ looper loop start --type reviewer --pr acme/looper#42",
 				},
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "list", short: "List loops", runE: runtime.loopList}),
+					newCommand(commandSpec{use: "inspect <seq|loopId|runId>", short: "Inspect loop diagnostics", args: cobra.ExactArgs(1), runE: runtime.loopInspect}),
+					newCommand(commandSpec{use: "failures", short: "List failed loop diagnostics", runE: runtime.loopFailures, localFlags: []flagSpec{stringFlag("type", "type", "Filter by loop type"), stringFlag("project", "projectId", "Filter by project id"), stringFlag("limit", "count", "Maximum number of failed loops to list")}}),
 					newCommand(commandSpec{use: "start", short: "Start a loop", runE: runtime.loopStart, localFlags: []flagSpec{stringFlag("type", "type", "Loop type"), stringFlag("pr", "repo#number", "Pull request reference"), stringFlag("project", "projectId", "Project id")}}),
 					newCommand(commandSpec{use: "pause [id]", short: "Pause a loop", args: cobra.MaximumNArgs(1), runE: runtime.loopPause, localFlags: []flagSpec{stringFlag("id", "id", "Loop id")}}),
 				},

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -69,7 +69,7 @@ func TestCommandGroupHelpListsExpectedSubcommands(t *testing.T) {
 		{args: []string{"config", "--help"}, subcommands: []string{"get       Get a config value", "set       Set a config value", "unset     Unset a config value", "validate  Validate the active config file", "show      Show active config", "edit      Edit the active config file", "migrate   Migrate a config file to canonical format"}},
 		{args: []string{"daemon", "--help"}, subcommands: []string{"install  Install the managed daemon binary", "status   Show daemon status", "start    Start the daemon", "stop     Stop the daemon", "restart  Restart the daemon", "logs     Show daemon logs"}},
 		{args: []string{"labels", "--help"}, subcommands: []string{"init  Initialize standard Looper GitHub labels"}},
-		{args: []string{"loop", "--help"}, subcommands: []string{"list   List loops", "start  Start a loop", "pause  Pause a loop"}},
+		{args: []string{"loop", "--help"}, subcommands: []string{"list      List loops", "inspect   Inspect loop diagnostics", "failures  List failed loop diagnostics", "start     Start a loop", "pause     Pause a loop"}},
 		{args: []string{"pr", "--help"}, subcommands: []string{"list    List pull requests", "show    Show a pull request", "status  Show pull request status"}},
 		{args: []string{"run", "--help"}, subcommands: []string{"list   List runs", "stats  Show recent run stats"}},
 	}

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -381,15 +381,19 @@ func (r *commandRuntime) activeRuns(cmd *cobra.Command, args []string) error {
 }
 
 func (r *commandRuntime) loopLogs(cmd *cobra.Command, args []string) error {
+	selector, err := r.resolveLogLoopSelector(cmd.Context(), strings.TrimSpace(args[0]))
+	if err != nil {
+		return err
+	}
 	if getBoolFlag(cmd, "follow") {
 		if getBoolFlag(cmd, "json") {
 			return fmt.Errorf("--json cannot be combined with --follow")
 		}
-		return r.followLoopLogs(cmd, strings.TrimSpace(args[0]))
+		return r.followLoopLogs(cmd, selector)
 	}
 
 	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
-		return r.getJSON(ctx, "/api/v1/loops/"+url.PathEscape(strings.TrimSpace(args[0]))+"/logs")
+		return r.getJSON(ctx, "/api/v1/loops/"+url.PathEscape(selector)+"/logs")
 	}, func(w io.Writer, payload json.RawMessage) error {
 		return writeHumanLoopLogs(w, payload, getBoolFlag(cmd, "stderr"), getBoolFlag(cmd, "full"), getStringFlag(cmd, "tail"))
 	})

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -381,19 +381,24 @@ func (r *commandRuntime) activeRuns(cmd *cobra.Command, args []string) error {
 }
 
 func (r *commandRuntime) loopLogs(cmd *cobra.Command, args []string) error {
-	selector, err := r.resolveLogLoopSelector(cmd.Context(), strings.TrimSpace(args[0]))
-	if err != nil {
-		return err
-	}
+	selector := strings.TrimSpace(args[0])
 	if getBoolFlag(cmd, "follow") {
 		if getBoolFlag(cmd, "json") {
 			return fmt.Errorf("--json cannot be combined with --follow")
 		}
+		if strings.HasPrefix(selector, "run_") {
+			return fmt.Errorf("run-scoped logs cannot be followed; use the owning loop id to follow current loop logs")
+		}
 		return r.followLoopLogs(cmd, selector)
 	}
 
+	logsPath := "/api/v1/loops/" + url.PathEscape(selector) + "/logs"
+	if strings.HasPrefix(selector, "run_") {
+		logsPath = "/api/v1/runs/" + url.PathEscape(selector) + "/logs"
+	}
+
 	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
-		return r.getJSON(ctx, "/api/v1/loops/"+url.PathEscape(selector)+"/logs")
+		return r.getJSON(ctx, logsPath)
 	}, func(w io.Writer, payload json.RawMessage) error {
 		return writeHumanLoopLogs(w, payload, getBoolFlag(cmd, "stderr"), getBoolFlag(cmd, "full"), getStringFlag(cmd, "tail"))
 	})

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -1,0 +1,760 @@
+package cliapp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+const defaultDiagnosticsLimit int64 = 100
+
+type loopInspectOutput struct {
+	NowISO          string                  `json:"nowIso"`
+	Selector        string                  `json:"selector"`
+	SelectorKind    string                  `json:"selectorKind"`
+	Loop            loopDiagnosticLoop      `json:"loop"`
+	Metadata        loopDiagnosticMetadata  `json:"metadata"`
+	Run             *loopDiagnosticRun      `json:"run,omitempty"`
+	LatestQueueItem *queueItemCommandOutput `json:"latestQueueItem,omitempty"`
+	Agent           *loopDiagnosticAgent    `json:"agent,omitempty"`
+	Diagnosis       loopDiagnosis           `json:"diagnosis"`
+}
+
+type loopFailuresOutput struct {
+	NowISO    string              `json:"nowIso"`
+	Type      string              `json:"type,omitempty"`
+	ProjectID string              `json:"projectId,omitempty"`
+	Limit     int64               `json:"limit"`
+	Count     int                 `json:"count"`
+	Items     []loopInspectOutput `json:"items"`
+}
+
+type queueFailedOutput struct {
+	NowISO    string                  `json:"nowIso"`
+	Type      string                  `json:"type,omitempty"`
+	ProjectID string                  `json:"projectId,omitempty"`
+	Limit     int64                   `json:"limit"`
+	Count     int                     `json:"count"`
+	Items     []queueFailedItemOutput `json:"items"`
+}
+
+type queueFailedItemOutput struct {
+	QueueItem queueItemCommandOutput `json:"queueItem"`
+	Diagnosis loopDiagnosis          `json:"diagnosis"`
+}
+
+type loopDiagnosticLoop struct {
+	ID        string               `json:"id"`
+	Seq       int64                `json:"seq"`
+	ProjectID string               `json:"projectId"`
+	Type      string               `json:"type"`
+	Status    string               `json:"status"`
+	Target    loopDiagnosticTarget `json:"target"`
+	LastRunAt *string              `json:"lastRunAt,omitempty"`
+	NextRunAt *string              `json:"nextRunAt,omitempty"`
+	CreatedAt string               `json:"createdAt"`
+	UpdatedAt string               `json:"updatedAt"`
+}
+
+type loopDiagnosticTarget struct {
+	Type     string  `json:"type"`
+	ID       *string `json:"id,omitempty"`
+	Repo     *string `json:"repo,omitempty"`
+	PRNumber *int64  `json:"prNumber,omitempty"`
+	Label    string  `json:"label"`
+}
+
+type loopDiagnosticMetadata struct {
+	DecodeError          *string                     `json:"decodeError,omitempty"`
+	FollowUpdates        *bool                       `json:"followUpdates,omitempty"`
+	LastPublishedAt      *string                     `json:"lastPublishedAt,omitempty"`
+	LastPublishedHeadSHA *string                     `json:"lastPublishedHeadSha,omitempty"`
+	LastReviewEvent      *string                     `json:"lastReviewEvent,omitempty"`
+	LastReviewSummary    *string                     `json:"lastReviewSummary,omitempty"`
+	LastFilterSkip       map[string]any              `json:"lastFilterSkip,omitempty"`
+	Loop                 *loopDiagnosticLoopMetadata `json:"loop,omitempty"`
+}
+
+type loopDiagnosticLoopMetadata struct {
+	Status                 *string `json:"status,omitempty"`
+	LastStatus             *string `json:"lastStatus,omitempty"`
+	ConsecutiveFailures    *int64  `json:"consecutiveFailures,omitempty"`
+	FailureCount           *int64  `json:"failureCount,omitempty"`
+	AutoRecoveryAttempts   *int64  `json:"autoRecoveryAttempts,omitempty"`
+	LastAutoRecoveryReason *string `json:"lastAutoRecoveryReason,omitempty"`
+	LastFailure            *string `json:"lastFailure,omitempty"`
+	LastReviewedHeadSHA    *string `json:"lastReviewedHeadSha,omitempty"`
+	LastOutputFingerprint  *string `json:"lastOutputFingerprint,omitempty"`
+	IterationCount         *int64  `json:"iterationCount,omitempty"`
+	AgentExecutionCount    *int64  `json:"agentExecutionCount,omitempty"`
+	TerminationReason      *string `json:"terminationReason,omitempty"`
+	MinPublishIntervalSecs *int64  `json:"minPublishIntervalSeconds,omitempty"`
+	QuietPeriodSeconds     *int64  `json:"quietPeriodSeconds,omitempty"`
+}
+
+type loopDiagnosticRun struct {
+	ID                  string  `json:"id"`
+	LoopID              string  `json:"loopId"`
+	Status              string  `json:"status"`
+	CurrentStep         *string `json:"currentStep,omitempty"`
+	LastCompletedStep   *string `json:"lastCompletedStep,omitempty"`
+	Summary             *string `json:"summary,omitempty"`
+	ErrorMessage        *string `json:"errorMessage,omitempty"`
+	StartedAt           string  `json:"startedAt"`
+	LastHeartbeatAt     *string `json:"lastHeartbeatAt,omitempty"`
+	EndedAt             *string `json:"endedAt,omitempty"`
+	ElapsedSeconds      *int64  `json:"elapsedSeconds,omitempty"`
+	HeartbeatAgeSeconds *int64  `json:"heartbeatAgeSeconds,omitempty"`
+	CreatedAt           string  `json:"createdAt"`
+	UpdatedAt           string  `json:"updatedAt"`
+}
+
+type loopDiagnosticAgent struct {
+	ID                  string  `json:"id"`
+	Vendor              string  `json:"vendor"`
+	Status              string  `json:"status"`
+	PID                 *int64  `json:"pid,omitempty"`
+	Summary             *string `json:"summary,omitempty"`
+	ParseStatus         *string `json:"parseStatus,omitempty"`
+	CompletionSignal    *string `json:"completionSignal,omitempty"`
+	HeartbeatCount      int64   `json:"heartbeatCount"`
+	LastHeartbeatAt     *string `json:"lastHeartbeatAt,omitempty"`
+	HeartbeatAgeSeconds *int64  `json:"heartbeatAgeSeconds,omitempty"`
+	ErrorMessage        *string `json:"errorMessage,omitempty"`
+	NativeSessionID     *string `json:"nativeSessionId,omitempty"`
+	NativeResumeMode    *string `json:"nativeResumeMode,omitempty"`
+	NativeResumeStatus  *string `json:"nativeResumeStatus,omitempty"`
+	NativeResumeError   *string `json:"nativeResumeError,omitempty"`
+	StartedAt           string  `json:"startedAt"`
+	EndedAt             *string `json:"endedAt,omitempty"`
+	CreatedAt           string  `json:"createdAt"`
+	UpdatedAt           string  `json:"updatedAt"`
+}
+
+type loopDiagnosis struct {
+	State             string `json:"state"`
+	Source            string `json:"source,omitempty"`
+	FailureClass      string `json:"failureClass,omitempty"`
+	Retryable         *bool  `json:"retryable,omitempty"`
+	Message           string `json:"message,omitempty"`
+	RecommendedAction string `json:"recommendedAction,omitempty"`
+}
+
+type loopSelectorResult struct {
+	Loop         storage.LoopRecord
+	Run          *storage.RunRecord
+	SelectorKind string
+}
+
+func (r *commandRuntime) queueFailed(cmd *cobra.Command, args []string) error {
+	_ = args
+	limit, err := diagnosticsLimit(cmd)
+	if err != nil {
+		return err
+	}
+	typeFilter := strings.TrimSpace(getStringFlag(cmd, "type"))
+	projectFilter := strings.TrimSpace(getStringFlag(cmd, "project"))
+	return r.withLocalRepositories(cmd.Context(), func(repos *storage.Repositories) error {
+		items, err := repos.Queue.List(cmd.Context())
+		if err != nil {
+			return err
+		}
+		output := queueFailedOutput{NowISO: eventlog.FormatJavaScriptISOString(time.Now().UTC()), Type: typeFilter, ProjectID: projectFilter, Limit: limit}
+		for _, item := range items {
+			if item.Status != "failed" {
+				continue
+			}
+			if typeFilter != "" && item.Type != typeFilter {
+				continue
+			}
+			if projectFilter != "" && (item.ProjectID == nil || *item.ProjectID != projectFilter) {
+				continue
+			}
+			output.Items = append(output.Items, queueFailedItemOutput{QueueItem: queueItemOutput(item), Diagnosis: diagnoseQueueItem(item)})
+			if int64(len(output.Items)) >= limit {
+				break
+			}
+		}
+		output.Count = len(output.Items)
+		if getBoolFlag(cmd, "json") {
+			return writeJSON(cmd.OutOrStdout(), output)
+		}
+		return writeHumanQueueFailed(cmd.OutOrStdout(), output)
+	})
+}
+
+func (r *commandRuntime) loopInspect(cmd *cobra.Command, args []string) error {
+	selector := strings.TrimSpace(args[0])
+	return r.withLocalRepositories(cmd.Context(), func(repos *storage.Repositories) error {
+		resolved, err := resolveLoopSelector(cmd.Context(), repos, selector)
+		if err != nil {
+			return err
+		}
+		output, err := buildLoopInspectOutput(cmd.Context(), repos, selector, resolved, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		if getBoolFlag(cmd, "json") {
+			return writeJSON(cmd.OutOrStdout(), output)
+		}
+		return writeHumanLoopInspect(cmd.OutOrStdout(), output)
+	})
+}
+
+func (r *commandRuntime) loopFailures(cmd *cobra.Command, args []string) error {
+	_ = args
+	limit, err := diagnosticsLimit(cmd)
+	if err != nil {
+		return err
+	}
+	typeFilter := strings.TrimSpace(getStringFlag(cmd, "type"))
+	projectFilter := strings.TrimSpace(getStringFlag(cmd, "project"))
+	return r.withLocalRepositories(cmd.Context(), func(repos *storage.Repositories) error {
+		loops, err := repos.Loops.List(cmd.Context())
+		if err != nil {
+			return err
+		}
+		now := time.Now().UTC()
+		output := loopFailuresOutput{NowISO: eventlog.FormatJavaScriptISOString(now), Type: typeFilter, ProjectID: projectFilter, Limit: limit}
+		for _, loop := range loops {
+			if loop.Status != "failed" {
+				continue
+			}
+			if typeFilter != "" && loop.Type != typeFilter {
+				continue
+			}
+			if projectFilter != "" && loop.ProjectID != projectFilter {
+				continue
+			}
+			run, err := repos.Runs.GetLatestByLoopID(cmd.Context(), loop.ID)
+			if err != nil {
+				return err
+			}
+			item, err := buildLoopInspectOutput(cmd.Context(), repos, fmt.Sprintf("%d", loop.Seq), loopSelectorResult{Loop: loop, Run: run, SelectorKind: "loop"}, now)
+			if err != nil {
+				return err
+			}
+			output.Items = append(output.Items, item)
+			if int64(len(output.Items)) >= limit {
+				break
+			}
+		}
+		output.Count = len(output.Items)
+		if getBoolFlag(cmd, "json") {
+			return writeJSON(cmd.OutOrStdout(), output)
+		}
+		return writeHumanLoopFailures(cmd.OutOrStdout(), output)
+	})
+}
+
+func diagnosticsLimit(cmd *cobra.Command) (int64, error) {
+	raw := strings.TrimSpace(getStringFlag(cmd, "limit"))
+	if raw == "" {
+		return defaultDiagnosticsLimit, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("--limit must be a positive integer")
+	}
+	return value, nil
+}
+
+func resolveLoopSelector(ctx context.Context, repos *storage.Repositories, selector string) (loopSelectorResult, error) {
+	if selector == "" {
+		return loopSelectorResult{}, fmt.Errorf("loop selector is required")
+	}
+	if seq, err := strconv.ParseInt(selector, 10, 64); err == nil {
+		loop, err := repos.Loops.GetBySeq(ctx, seq)
+		if err != nil {
+			return loopSelectorResult{}, err
+		}
+		if loop == nil {
+			return loopSelectorResult{}, fmt.Errorf("loop not found: %s", selector)
+		}
+		run, err := repos.Runs.GetLatestByLoopID(ctx, loop.ID)
+		if err != nil {
+			return loopSelectorResult{}, err
+		}
+		return loopSelectorResult{Loop: *loop, Run: run, SelectorKind: "seq"}, nil
+	}
+	if strings.HasPrefix(selector, "run_") {
+		run, err := repos.Runs.GetByID(ctx, selector)
+		if err != nil {
+			return loopSelectorResult{}, err
+		}
+		if run == nil {
+			return loopSelectorResult{}, fmt.Errorf("run not found: %s", selector)
+		}
+		loop, err := repos.Loops.GetByID(ctx, run.LoopID)
+		if err != nil {
+			return loopSelectorResult{}, err
+		}
+		if loop == nil {
+			return loopSelectorResult{}, fmt.Errorf("loop not found for run: %s", selector)
+		}
+		return loopSelectorResult{Loop: *loop, Run: run, SelectorKind: "runId"}, nil
+	}
+	loop, err := repos.Loops.GetByID(ctx, selector)
+	if err != nil {
+		return loopSelectorResult{}, err
+	}
+	if loop == nil {
+		return loopSelectorResult{}, fmt.Errorf("loop not found: %s", selector)
+	}
+	run, err := repos.Runs.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return loopSelectorResult{}, err
+	}
+	return loopSelectorResult{Loop: *loop, Run: run, SelectorKind: "loopId"}, nil
+}
+
+func (r *commandRuntime) resolveLogLoopSelector(ctx context.Context, selector string) (string, error) {
+	if !strings.HasPrefix(selector, "run_") {
+		return selector, nil
+	}
+	var loopID string
+	err := r.withLocalRepositories(ctx, func(repos *storage.Repositories) error {
+		run, err := repos.Runs.GetByID(ctx, selector)
+		if err != nil {
+			return err
+		}
+		if run == nil {
+			return fmt.Errorf("run not found: %s", selector)
+		}
+		loopID = run.LoopID
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return loopID, nil
+}
+
+func buildLoopInspectOutput(ctx context.Context, repos *storage.Repositories, selector string, resolved loopSelectorResult, now time.Time) (loopInspectOutput, error) {
+	metadata := parseLoopDiagnosticMetadata(resolved.Loop.MetadataJSON)
+	queueItem, err := repos.Queue.GetLatestByLoopID(ctx, resolved.Loop.ID)
+	if err != nil {
+		return loopInspectOutput{}, err
+	}
+	var queueOutput *queueItemCommandOutput
+	if queueItem != nil {
+		item := queueItemOutput(*queueItem)
+		queueOutput = &item
+	}
+
+	var agent *storage.AgentExecutionRecord
+	if resolved.Run != nil {
+		agent, err = repos.AgentExecutions.GetLatestByRunID(ctx, resolved.Run.ID)
+	} else {
+		agent, err = repos.AgentExecutions.GetLatestByLoopID(ctx, resolved.Loop.ID)
+	}
+	if err != nil {
+		return loopInspectOutput{}, err
+	}
+
+	output := loopInspectOutput{
+		NowISO:          eventlog.FormatJavaScriptISOString(now),
+		Selector:        selector,
+		SelectorKind:    resolved.SelectorKind,
+		Loop:            diagnosticLoopOutput(resolved.Loop),
+		Metadata:        metadata,
+		LatestQueueItem: queueOutput,
+		Diagnosis:       diagnoseLoop(resolved.Loop, resolved.Run, queueItem, metadata),
+	}
+	if resolved.Run != nil {
+		run := diagnosticRunOutput(*resolved.Run, now)
+		output.Run = &run
+	}
+	if agent != nil {
+		agentOutput := diagnosticAgentOutput(*agent, now)
+		output.Agent = &agentOutput
+	}
+	return output, nil
+}
+
+func parseLoopDiagnosticMetadata(raw *string) loopDiagnosticMetadata {
+	if raw == nil || strings.TrimSpace(*raw) == "" {
+		return loopDiagnosticMetadata{}
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(*raw), &doc); err != nil {
+		msg := err.Error()
+		return loopDiagnosticMetadata{DecodeError: &msg}
+	}
+	output := loopDiagnosticMetadata{
+		FollowUpdates:        boolPtrFromMap(doc, "followUpdates"),
+		LastPublishedAt:      stringPtrFromMap(doc, "lastPublishedAt"),
+		LastPublishedHeadSHA: stringPtrFromMap(doc, "lastPublishedHeadSha"),
+		LastReviewEvent:      stringPtrFromMap(doc, "lastReviewEvent"),
+		LastReviewSummary:    stringPtrFromMap(doc, "lastReviewSummary"),
+	}
+	if skip, ok := doc["lastFilterSkip"].(map[string]any); ok {
+		output.LastFilterSkip = skip
+	}
+	if loopDoc, ok := doc["loop"].(map[string]any); ok {
+		output.Loop = &loopDiagnosticLoopMetadata{
+			Status:                 stringPtrFromMap(loopDoc, "status"),
+			LastStatus:             stringPtrFromMap(loopDoc, "lastStatus"),
+			ConsecutiveFailures:    int64PtrFromMap(loopDoc, "consecutiveFailures"),
+			FailureCount:           int64PtrFromMap(loopDoc, "failureCount"),
+			AutoRecoveryAttempts:   int64PtrFromMap(loopDoc, "autoRecoveryAttempts"),
+			LastAutoRecoveryReason: stringPtrFromMap(loopDoc, "lastAutoRecoveryReason"),
+			LastFailure:            stringPtrFromMap(loopDoc, "lastFailure"),
+			LastReviewedHeadSHA:    stringPtrFromMap(loopDoc, "lastReviewedHeadSha"),
+			LastOutputFingerprint:  stringPtrFromMap(loopDoc, "lastOutputFingerprint"),
+			IterationCount:         int64PtrFromMap(loopDoc, "iterationCount"),
+			AgentExecutionCount:    int64PtrFromMap(loopDoc, "agentExecutionCount"),
+			TerminationReason:      stringPtrFromMap(loopDoc, "terminationReason"),
+			MinPublishIntervalSecs: int64PtrFromMap(loopDoc, "minPublishIntervalSeconds"),
+			QuietPeriodSeconds:     int64PtrFromMap(loopDoc, "quietPeriodSeconds"),
+		}
+	}
+	return output
+}
+
+func diagnosticLoopOutput(loop storage.LoopRecord) loopDiagnosticLoop {
+	return loopDiagnosticLoop{
+		ID:        loop.ID,
+		Seq:       loop.Seq,
+		ProjectID: loop.ProjectID,
+		Type:      loop.Type,
+		Status:    loop.Status,
+		Target:    diagnosticTargetOutput(loop),
+		LastRunAt: loop.LastRunAt,
+		NextRunAt: loop.NextRunAt,
+		CreatedAt: loop.CreatedAt,
+		UpdatedAt: loop.UpdatedAt,
+	}
+}
+
+func diagnosticTargetOutput(loop storage.LoopRecord) loopDiagnosticTarget {
+	label := strings.TrimSpace(diagnosticString(loop.TargetID))
+	if loop.Repo != nil && loop.PRNumber != nil {
+		label = fmt.Sprintf("%s#%d", *loop.Repo, *loop.PRNumber)
+	}
+	return loopDiagnosticTarget{Type: loop.TargetType, ID: loop.TargetID, Repo: loop.Repo, PRNumber: loop.PRNumber, Label: label}
+}
+
+func diagnosticRunOutput(run storage.RunRecord, now time.Time) loopDiagnosticRun {
+	output := loopDiagnosticRun{
+		ID:                run.ID,
+		LoopID:            run.LoopID,
+		Status:            run.Status,
+		CurrentStep:       run.CurrentStep,
+		LastCompletedStep: run.LastCompletedStep,
+		Summary:           run.Summary,
+		ErrorMessage:      run.ErrorMessage,
+		StartedAt:         run.StartedAt,
+		LastHeartbeatAt:   run.LastHeartbeatAt,
+		EndedAt:           run.EndedAt,
+		CreatedAt:         run.CreatedAt,
+		UpdatedAt:         run.UpdatedAt,
+	}
+	endISO := eventlog.FormatJavaScriptISOString(now)
+	if run.EndedAt != nil && strings.TrimSpace(*run.EndedAt) != "" {
+		endISO = *run.EndedAt
+	}
+	output.ElapsedSeconds = elapsedSecondsPtr(run.StartedAt, endISO)
+	if run.LastHeartbeatAt != nil && run.EndedAt == nil {
+		output.HeartbeatAgeSeconds = elapsedSecondsPtr(*run.LastHeartbeatAt, eventlog.FormatJavaScriptISOString(now))
+	}
+	return output
+}
+
+func diagnosticAgentOutput(agent storage.AgentExecutionRecord, now time.Time) loopDiagnosticAgent {
+	output := loopDiagnosticAgent{
+		ID:                 agent.ID,
+		Vendor:             agent.Vendor,
+		Status:             agent.Status,
+		PID:                agent.PID,
+		Summary:            agent.Summary,
+		ParseStatus:        agent.ParseStatus,
+		CompletionSignal:   agent.CompletionSignal,
+		HeartbeatCount:     agent.HeartbeatCount,
+		LastHeartbeatAt:    agent.LastHeartbeatAt,
+		ErrorMessage:       agent.ErrorMessage,
+		NativeSessionID:    agent.NativeSessionID,
+		NativeResumeMode:   agent.NativeResumeMode,
+		NativeResumeStatus: agent.NativeResumeStatus,
+		NativeResumeError:  agent.NativeResumeError,
+		StartedAt:          agent.StartedAt,
+		EndedAt:            agent.EndedAt,
+		CreatedAt:          agent.CreatedAt,
+		UpdatedAt:          agent.UpdatedAt,
+	}
+	if agent.LastHeartbeatAt != nil && agent.EndedAt == nil {
+		output.HeartbeatAgeSeconds = elapsedSecondsPtr(*agent.LastHeartbeatAt, eventlog.FormatJavaScriptISOString(now))
+	}
+	return output
+}
+
+func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storage.QueueItemRecord, metadata loopDiagnosticMetadata) loopDiagnosis {
+	state := loop.Status
+	message, source := loopDiagnosticMessage(run, queue, metadata)
+	diagnosis := classifyDiagnosticMessage(message, queueErrorKind(queue))
+	diagnosis.State = state
+	diagnosis.Source = source
+	if diagnosis.Message == "" {
+		diagnosis.Message = message
+	}
+	if diagnosis.RecommendedAction == "" {
+		diagnosis.RecommendedAction = recommendedActionForState(state)
+	}
+	return diagnosis
+}
+
+func diagnoseQueueItem(item storage.QueueItemRecord) loopDiagnosis {
+	diagnosis := classifyDiagnosticMessage(diagnosticString(item.LastError), diagnosticString(item.LastErrorKind))
+	diagnosis.State = item.Status
+	diagnosis.Source = "queueItem"
+	if diagnosis.RecommendedAction == "" {
+		diagnosis.RecommendedAction = "inspect the owning loop before requeueing"
+	}
+	return diagnosis
+}
+
+func loopDiagnosticMessage(run *storage.RunRecord, queue *storage.QueueItemRecord, metadata loopDiagnosticMetadata) (string, string) {
+	if run != nil && (run.Status == "failed" || run.Status == "interrupted") {
+		if msg := firstNonEmpty(diagnosticString(run.ErrorMessage), diagnosticString(run.Summary)); msg != "" {
+			return msg, "run"
+		}
+	}
+	if queue != nil && strings.TrimSpace(diagnosticString(queue.LastError)) != "" {
+		return strings.TrimSpace(diagnosticString(queue.LastError)), "queueItem"
+	}
+	if metadata.Loop != nil && metadata.Loop.LastFailure != nil && strings.TrimSpace(*metadata.Loop.LastFailure) != "" {
+		return strings.TrimSpace(*metadata.Loop.LastFailure), "loopMetadata"
+	}
+	if run != nil {
+		if msg := firstNonEmpty(diagnosticString(run.ErrorMessage), diagnosticString(run.Summary)); msg != "" {
+			return msg, "run"
+		}
+	}
+	return "", ""
+}
+
+func classifyDiagnosticMessage(message string, errorKind string) loopDiagnosis {
+	msg := strings.TrimSpace(message)
+	lower := strings.ToLower(msg)
+	kind := strings.ToLower(strings.TrimSpace(errorKind))
+	if msg == "" && kind == "" {
+		return loopDiagnosis{}
+	}
+	if strings.Contains(lower, "could not resolve to a pullrequest") {
+		retryable := false
+		return loopDiagnosis{FailureClass: "pull_request_unresolved", Retryable: &retryable, Message: msg, RecommendedAction: "confirm the PR still exists or terminate the stale loop"}
+	}
+	if strings.Contains(lower, "pull request lock is already held") {
+		retryable := false
+		return loopDiagnosis{FailureClass: "lock_held", Retryable: &retryable, Message: msg, RecommendedAction: "inspect the active run or lock holder before retrying"}
+	}
+	if strings.Contains(lower, "no matching github review marker") {
+		retryable := true
+		return loopDiagnosis{FailureClass: "review_marker_missing", Retryable: &retryable, Message: msg, RecommendedAction: "rerun publish verification or re-review after checking GitHub state"}
+	}
+	if strings.Contains(lower, "timed out (idle)") || strings.Contains(lower, "idle timed out") {
+		retryable := true
+		return loopDiagnosis{FailureClass: "agent_idle_timeout", Retryable: &retryable, Message: msg, RecommendedAction: "retry the loop; inspect agent output if the timeout repeats"}
+	}
+	if strings.Contains(lower, "api.github.com") || strings.Contains(lower, "http 502") || strings.Contains(lower, "http 504") || strings.Contains(lower, "gateway timeout") || strings.Contains(lower, "eof") {
+		retryable := true
+		return loopDiagnosis{FailureClass: "github_transient", Retryable: &retryable, Message: msg, RecommendedAction: "retry or allow auto-recovery after GitHub transport stabilizes"}
+	}
+	if strings.Contains(lower, "connection closed") || strings.Contains(lower, "could not read from remote repository") || strings.Contains(lower, "git ") {
+		retryable := true
+		return loopDiagnosis{FailureClass: "git_transient", Retryable: &retryable, Message: msg, RecommendedAction: "retry after checking network access to the remote"}
+	}
+	if kind == "retryable" || strings.HasPrefix(kind, "retryable_") {
+		retryable := true
+		return loopDiagnosis{FailureClass: kind, Retryable: &retryable, Message: msg, RecommendedAction: "retry according to queue policy"}
+	}
+	if kind == "non_retryable" {
+		retryable := false
+		return loopDiagnosis{FailureClass: kind, Retryable: &retryable, Message: msg, RecommendedAction: "inspect before manual recovery"}
+	}
+	return loopDiagnosis{FailureClass: "unknown", Message: msg, RecommendedAction: "inspect the loop, run, and queue item details"}
+}
+
+func recommendedActionForState(state string) string {
+	switch state {
+	case "running":
+		return "monitor active run progress"
+	case "waiting":
+		return "no immediate action; loop is waiting for follow-up work"
+	case "failed":
+		return "inspect failure fields before requeueing"
+	case "terminated", "completed", "stopped":
+		return "no action expected for terminal loop"
+	default:
+		return "inspect loop details"
+	}
+}
+
+func queueErrorKind(queue *storage.QueueItemRecord) string {
+	if queue == nil {
+		return ""
+	}
+	return diagnosticString(queue.LastErrorKind)
+}
+
+func writeHumanQueueFailed(w io.Writer, output queueFailedOutput) error {
+	if len(output.Items) == 0 {
+		_, err := fmt.Fprintln(w, "No failed queue items.")
+		return err
+	}
+	for _, item := range output.Items {
+		target := strings.TrimSpace(item.QueueItem.TargetID)
+		if item.QueueItem.Repo != nil && item.QueueItem.PRNumber != nil {
+			target = fmt.Sprintf("%s#%d", *item.QueueItem.Repo, *item.QueueItem.PRNumber)
+		}
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\tattempts=%d/%d\tclass=%s\ttarget=%s\n", item.QueueItem.ID, item.QueueItem.Type, item.QueueItem.Status, item.QueueItem.Attempts, item.QueueItem.MaxAttempts, item.Diagnosis.FailureClass, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeHumanLoopInspect(w io.Writer, output loopInspectOutput) error {
+	if _, err := fmt.Fprintf(w, "Loop #%d · %s · %s · %s\n", output.Loop.Seq, output.Loop.Type, output.Loop.Status, output.Loop.Target.Label); err != nil {
+		return err
+	}
+	if output.Run != nil {
+		if _, err := fmt.Fprintf(w, "Run %s · %s", output.Run.ID, output.Run.Status); err != nil {
+			return err
+		}
+		if output.Run.CurrentStep != nil {
+			if _, err := fmt.Fprintf(w, " · step: %s", *output.Run.CurrentStep); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	if output.Agent != nil {
+		if _, err := fmt.Fprintf(w, "Agent %s · %s · %s", output.Agent.ID, output.Agent.Vendor, output.Agent.Status); err != nil {
+			return err
+		}
+		if output.Agent.PID != nil {
+			if _, err := fmt.Fprintf(w, " · pid %d", *output.Agent.PID); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	if output.Diagnosis.FailureClass != "" || output.Diagnosis.Message != "" {
+		if _, err := fmt.Fprintf(w, "Diagnosis: state=%s class=%s retryable=%s source=%s\n", output.Diagnosis.State, output.Diagnosis.FailureClass, humanBoolPtr(output.Diagnosis.Retryable), output.Diagnosis.Source); err != nil {
+			return err
+		}
+		if output.Diagnosis.Message != "" {
+			if _, err := fmt.Fprintf(w, "Message: %s\n", output.Diagnosis.Message); err != nil {
+				return err
+			}
+		}
+	}
+	if output.Diagnosis.RecommendedAction != "" {
+		if _, err := fmt.Fprintf(w, "Action: %s\n", output.Diagnosis.RecommendedAction); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeHumanLoopFailures(w io.Writer, output loopFailuresOutput) error {
+	if len(output.Items) == 0 {
+		_, err := fmt.Fprintln(w, "No failed loops.")
+		return err
+	}
+	for _, item := range output.Items {
+		if _, err := fmt.Fprintf(w, "#%d\t%s\t%s\tclass=%s\tretryable=%s\t%s\n", item.Loop.Seq, item.Loop.Type, item.Loop.Target.Label, item.Diagnosis.FailureClass, humanBoolPtr(item.Diagnosis.Retryable), item.Diagnosis.RecommendedAction); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func humanBoolPtr(value *bool) string {
+	if value == nil {
+		return "unknown"
+	}
+	if *value {
+		return "true"
+	}
+	return "false"
+}
+
+func stringPtrFromMap(values map[string]any, key string) *string {
+	value, ok := values[key]
+	if !ok {
+		return nil
+	}
+	text, ok := value.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return nil
+	}
+	return &text
+}
+
+func boolPtrFromMap(values map[string]any, key string) *bool {
+	value, ok := values[key]
+	if !ok {
+		return nil
+	}
+	typed, ok := value.(bool)
+	if !ok {
+		return nil
+	}
+	return &typed
+}
+
+func int64PtrFromMap(values map[string]any, key string) *int64 {
+	value, ok := values[key]
+	if !ok {
+		return nil
+	}
+	switch typed := value.(type) {
+	case float64:
+		next := int64(typed)
+		return &next
+	case int64:
+		return &typed
+	case int:
+		next := int64(typed)
+		return &next
+	default:
+		return nil
+	}
+}
+
+func elapsedSecondsPtr(startISO string, endISO string) *int64 {
+	start, err := time.Parse(time.RFC3339Nano, startISO)
+	if err != nil {
+		return nil
+	}
+	end, err := time.Parse(time.RFC3339Nano, endISO)
+	if err != nil {
+		return nil
+	}
+	elapsed := int64(end.Sub(start).Seconds())
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	return &elapsed
+}
+
+func diagnosticString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nexu-io/looper/internal/storage"
@@ -92,13 +93,12 @@ func TestLogsAcceptsRunIDFromPSOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestedPath = r.URL.Path
 		writeEnvelope(t, w, pkgapi.Success("req_logs", map[string]any{
-			"seq":    7,
-			"loopId": "loop_failed",
-			"runId":  "run_reviewer_failed",
-			"type":   "reviewer",
-			"status": "failed",
-			"stdout": "review output",
-			"stderr": "",
+			"seq":        7,
+			"loopId":     "loop_failed",
+			"loopType":   "reviewer",
+			"loopStatus": "failed",
+			"run":        map[string]any{"runId": "run_reviewer_failed", "status": "failed", "currentStep": "snapshot"},
+			"agent":      map[string]any{"executionId": "agent_failed", "vendor": "claude-code", "status": "failed", "stdout": "review output", "stderr": ""},
 		}))
 	}))
 	defer server.Close()
@@ -108,11 +108,26 @@ func TestLogsAcceptsRunIDFromPSOutput(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([logs run_reviewer_failed]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
 	}
-	if requestedPath != "/api/v1/loops/loop_failed/logs" {
-		t.Fatalf("requested path = %q, want loop logs path resolved from run id", requestedPath)
+	if requestedPath != "/api/v1/runs/run_reviewer_failed/logs" {
+		t.Fatalf("requested path = %q, want run-scoped logs path", requestedPath)
 	}
-	if stdout == "" {
-		t.Fatal("stdout is empty, want logs output")
+	for _, want := range []string{"Loop #7 · reviewer · failed", "Run run_reviewer_failed · step: snapshot", "review output"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
+func TestLogsRejectsRunIDFollow(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeLoopDiagnosticsFixture(t, "")
+	exitCode, _, stderr := runApp(t, "logs", "run_reviewer_failed", "--follow", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatal("Run([logs run_reviewer_failed --follow]) exit code = 0, want non-zero")
+	}
+	if !strings.Contains(stderr, "run-scoped logs cannot be followed") {
+		t.Fatalf("stderr = %q, want run-scoped follow error", stderr)
 	}
 }
 

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -1,0 +1,170 @@
+package cliapp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/storage"
+	pkgapi "github.com/nexu-io/looper/pkg/api"
+)
+
+func TestLoopInspectAcceptsRunIDAndClassifiesFailure(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeLoopDiagnosticsFixture(t, "")
+	exitCode, stdout, stderr := runApp(t, "loop", "inspect", "run_reviewer_failed", "--json", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([loop inspect]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	var decoded struct {
+		SelectorKind string `json:"selectorKind"`
+		Loop         struct {
+			Seq    int64  `json:"seq"`
+			Status string `json:"status"`
+			Target struct {
+				Label string `json:"label"`
+			} `json:"target"`
+		} `json:"loop"`
+		Run struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"run"`
+		LatestQueueItem struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"latestQueueItem"`
+		Diagnosis struct {
+			FailureClass      string `json:"failureClass"`
+			Retryable         *bool  `json:"retryable"`
+			RecommendedAction string `json:"recommendedAction"`
+		} `json:"diagnosis"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\noutput=%q", err, stdout)
+	}
+	if decoded.SelectorKind != "runId" || decoded.Loop.Seq != 7 || decoded.Loop.Target.Label != "acme/looper#42" || decoded.Run.ID != "run_reviewer_failed" {
+		t.Fatalf("inspect output = %#v, want run selector resolved to loop #7", decoded)
+	}
+	if decoded.LatestQueueItem.ID != "queue_failed" || decoded.LatestQueueItem.Status != "failed" {
+		t.Fatalf("latest queue item = %#v, want failed queue", decoded.LatestQueueItem)
+	}
+	if decoded.Diagnosis.FailureClass != "github_transient" || decoded.Diagnosis.Retryable == nil || !*decoded.Diagnosis.Retryable || decoded.Diagnosis.RecommendedAction == "" {
+		t.Fatalf("diagnosis = %#v, want retryable github_transient with action", decoded.Diagnosis)
+	}
+}
+
+func TestLoopFailuresListsFailedLoops(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeLoopDiagnosticsFixture(t, "")
+	exitCode, stdout, stderr := runApp(t, "loop", "failures", "--type", "reviewer", "--json", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([loop failures]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	var decoded struct {
+		Count int `json:"count"`
+		Items []struct {
+			Loop struct {
+				Seq int64 `json:"seq"`
+			} `json:"loop"`
+			Diagnosis struct {
+				FailureClass string `json:"failureClass"`
+			} `json:"diagnosis"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\noutput=%q", err, stdout)
+	}
+	if decoded.Count != 1 || len(decoded.Items) != 1 || decoded.Items[0].Loop.Seq != 7 || decoded.Items[0].Diagnosis.FailureClass != "github_transient" {
+		t.Fatalf("loop failures output = %#v, want one failed reviewer loop", decoded)
+	}
+}
+
+func TestLogsAcceptsRunIDFromPSOutput(t *testing.T) {
+	t.Parallel()
+
+	var requestedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		writeEnvelope(t, w, pkgapi.Success("req_logs", map[string]any{
+			"seq":    7,
+			"loopId": "loop_failed",
+			"runId":  "run_reviewer_failed",
+			"type":   "reviewer",
+			"status": "failed",
+			"stdout": "review output",
+			"stderr": "",
+		}))
+	}))
+	defer server.Close()
+
+	configPath := writeLoopDiagnosticsFixture(t, server.URL)
+	exitCode, stdout, stderr := runApp(t, "logs", "run_reviewer_failed", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([logs run_reviewer_failed]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if requestedPath != "/api/v1/loops/loop_failed/logs" {
+		t.Fatalf("requested path = %q, want loop logs path resolved from run id", requestedPath)
+	}
+	if stdout == "" {
+		t.Fatal("stdout is empty, want logs output")
+	}
+}
+
+func writeLoopDiagnosticsFixture(t *testing.T, serverURL string) string {
+	t.Helper()
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "looper.sqlite")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), dbPath, storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: filepath.Join(root, "backups")})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+
+	repos := storage.NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	projectID := "project_loop_diagnostics"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	metadata := `{"followUpdates":true,"lastPublishedAt":"2026-04-11T11:00:00.000Z","lastReviewSummary":"previous review","loop":{"status":"active","lastStatus":"failed","consecutiveFailures":2,"failureCount":2,"lastFailure":"Command exited with code 1: Post \"https://api.github.com/graphql\": EOF"}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_failed", Seq: 7, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, LastRunAt: &now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	errorMessage := `Command exited with code 1: Post "https://api.github.com/graphql": EOF`
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_reviewer_failed", LoopID: "loop_failed", Status: "failed", CurrentStep: stringPtr("snapshot"), ErrorMessage: &errorMessage, StartedAt: now, LastHeartbeatAt: &now, EndedAt: &now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	lastErrorKind := "retryable_transient"
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_failed", ProjectID: &projectID, LoopID: stringPtr("loop_failed"), Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "reviewer:failed", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 2, MaxAttempts: 5, LastError: &errorMessage, LastErrorKind: &lastErrorKind, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	pid := int64(1234)
+	if err := repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_failed", ProjectID: &projectID, LoopID: stringPtr("loop_failed"), RunID: stringPtr("run_reviewer_failed"), Vendor: "claude-code", Status: "failed", PID: &pid, ErrorMessage: &errorMessage, StartedAt: now, EndedAt: &now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	configPayload := map[string]any{"storage": map[string]any{"dbPath": dbPath}}
+	if serverURL != "" {
+		configPayload["server"] = map[string]any{"baseUrl": serverURL, "authMode": "none"}
+	}
+	configPath := filepath.Join(root, "config.json")
+	raw, err := json.Marshal(configPayload)
+	if err != nil {
+		t.Fatalf("json.Marshal(config) error = %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+	return configPath
+}

--- a/internal/cliapp/queue_commands.go
+++ b/internal/cliapp/queue_commands.go
@@ -124,6 +124,10 @@ func (r *commandRuntime) queueCleanup(cmd *cobra.Command, args []string) error {
 }
 
 func (r *commandRuntime) withQueueRepositories(ctx context.Context, fn func(*storage.Repositories) error) error {
+	return r.withLocalRepositories(ctx, fn)
+}
+
+func (r *commandRuntime) withLocalRepositories(ctx context.Context, fn func(*storage.Repositories) error) error {
 	loaded, err := r.loadConfig()
 	if err != nil {
 		return err
@@ -139,28 +143,32 @@ func (r *commandRuntime) withQueueRepositories(ctx context.Context, fn func(*sto
 func queueItemOutputs(items []storage.QueueItemRecord) []queueItemCommandOutput {
 	outputs := make([]queueItemCommandOutput, 0, len(items))
 	for _, item := range items {
-		outputs = append(outputs, queueItemCommandOutput{
-			ID:            item.ID,
-			ProjectID:     item.ProjectID,
-			LoopID:        item.LoopID,
-			Type:          item.Type,
-			TargetType:    item.TargetType,
-			TargetID:      item.TargetID,
-			Repo:          item.Repo,
-			PRNumber:      item.PRNumber,
-			Priority:      item.Priority,
-			Status:        item.Status,
-			AvailableAt:   item.AvailableAt,
-			Attempts:      item.Attempts,
-			MaxAttempts:   item.MaxAttempts,
-			LockKey:       item.LockKey,
-			LastError:     item.LastError,
-			LastErrorKind: item.LastErrorKind,
-			CreatedAt:     item.CreatedAt,
-			UpdatedAt:     item.UpdatedAt,
-		})
+		outputs = append(outputs, queueItemOutput(item))
 	}
 	return outputs
+}
+
+func queueItemOutput(item storage.QueueItemRecord) queueItemCommandOutput {
+	return queueItemCommandOutput{
+		ID:            item.ID,
+		ProjectID:     item.ProjectID,
+		LoopID:        item.LoopID,
+		Type:          item.Type,
+		TargetType:    item.TargetType,
+		TargetID:      item.TargetID,
+		Repo:          item.Repo,
+		PRNumber:      item.PRNumber,
+		Priority:      item.Priority,
+		Status:        item.Status,
+		AvailableAt:   item.AvailableAt,
+		Attempts:      item.Attempts,
+		MaxAttempts:   item.MaxAttempts,
+		LockKey:       item.LockKey,
+		LastError:     item.LastError,
+		LastErrorKind: item.LastErrorKind,
+		CreatedAt:     item.CreatedAt,
+		UpdatedAt:     item.UpdatedAt,
+	}
 }
 
 func writeHumanQueueStats(w io.Writer, output queueStatsOutput) error {

--- a/internal/cliapp/queue_commands_test.go
+++ b/internal/cliapp/queue_commands_test.go
@@ -131,6 +131,39 @@ func TestQueueListCommandListsQueuedItemsAndFiltersEligible(t *testing.T) {
 	}
 }
 
+func TestQueueFailedCommandListsFailedItems(t *testing.T) {
+	t.Parallel()
+
+	configPath, _ := writeQueueCommandFixture(t)
+	exitCode, stdout, stderr := runApp(t, "queue", "failed", "--type", "reviewer", "--json", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([queue failed]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	var decoded struct {
+		Count int `json:"count"`
+		Items []struct {
+			QueueItem struct {
+				ID     string `json:"id"`
+				Status string `json:"status"`
+			} `json:"queueItem"`
+			Diagnosis struct {
+				FailureClass string `json:"failureClass"`
+				Retryable    *bool  `json:"retryable"`
+			} `json:"diagnosis"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\noutput=%q", err, stdout)
+	}
+	if decoded.Count != 1 || len(decoded.Items) != 1 {
+		t.Fatalf("queue failed output = %#v, want one item", decoded)
+	}
+	item := decoded.Items[0]
+	if item.QueueItem.ID != "qi_failed" || item.QueueItem.Status != "failed" || item.Diagnosis.FailureClass != "github_transient" || item.Diagnosis.Retryable == nil || !*item.Diagnosis.Retryable {
+		t.Fatalf("queue failed item = %#v, want retryable github_transient failed item", item)
+	}
+}
+
 func writeQueueCommandFixture(t *testing.T) (string, *storage.Repositories) {
 	t.Helper()
 	root := t.TempDir()
@@ -155,11 +188,20 @@ func writeQueueCommandFixture(t *testing.T) (string, *storage.Repositories) {
 	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_stale", Seq: 2, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "terminated", CreatedAt: now, UpdatedAt: now}); err != nil {
 		t.Fatalf("Loops.Upsert(loop_stale) error = %v", err)
 	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_failed", Seq: 3, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", Status: "failed", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_failed) error = %v", err)
+	}
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "qi_eligible", ProjectID: &projectID, LoopID: stringPtr("loop_eligible"), Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "eligible", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(qi_eligible) error = %v", err)
 	}
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "qi_stale", ProjectID: &projectID, LoopID: stringPtr("loop_stale"), Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "stale", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(qi_stale) error = %v", err)
+	}
+	lastError := `Command exited with code 1: Post "https://api.github.com/graphql": EOF`
+	lastErrorKind := "retryable_transient"
+	prNumber := int64(42)
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "qi_failed", ProjectID: &projectID, LoopID: stringPtr("loop_failed"), Type: "reviewer", TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "failed", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 2, MaxAttempts: 3, LastError: &lastError, LastErrorKind: &lastErrorKind, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(qi_failed) error = %v", err)
 	}
 	configPath := filepath.Join(root, "config.json")
 	raw, err := json.Marshal(map[string]any{"storage": map[string]any{"dbPath": dbPath}})

--- a/pkg/api/envelope.go
+++ b/pkg/api/envelope.go
@@ -18,6 +18,7 @@ const (
 	ErrorCodePullRequestNotFound        ErrorCode = "PULL_REQUEST_NOT_FOUND"
 	ErrorCodePullRequestProjectMismatch ErrorCode = "PULL_REQUEST_PROJECT_MISMATCH"
 	ErrorCodeRouteNotFound              ErrorCode = "ROUTE_NOT_FOUND"
+	ErrorCodeRunNotFound                ErrorCode = "RUN_NOT_FOUND"
 	ErrorCodeRuntimeControlUnavailable  ErrorCode = "RUNTIME_CONTROL_UNAVAILABLE"
 	ErrorCodeUnauthorized               ErrorCode = "UNAUTHORIZED"
 	ErrorCodeValidationFailed           ErrorCode = "VALIDATION_FAILED"
@@ -88,6 +89,8 @@ func (c ErrorCode) Status() int {
 		return 409
 	case ErrorCodeRouteNotFound:
 		return 404
+	case ErrorCodeRunNotFound:
+		return 404
 	case ErrorCodeRuntimeControlUnavailable:
 		return 501
 	case ErrorCodeUnauthorized:
@@ -116,6 +119,7 @@ func AllErrorCodes() []ErrorCode {
 		ErrorCodePullRequestNotFound,
 		ErrorCodePullRequestProjectMismatch,
 		ErrorCodeRouteNotFound,
+		ErrorCodeRunNotFound,
 		ErrorCodeRuntimeControlUnavailable,
 		ErrorCodeUnauthorized,
 		ErrorCodeValidationFailed,


### PR DESCRIPTION
## Summary

- Add `looper queue failed` for failed queue-item inspection with type/project/limit filters.
- Add `looper loop inspect <seq|loopId|runId>` and `looper loop failures` for structured loop diagnostics.
- Allow `looper logs <runId>` by resolving the run id to its owning loop before calling the existing logs API.

## Why

CLI-first巡检 showed that common reviewer failure questions required either raw SQLite queries or ad hoc parsing of `metadataJson` and daemon logs. The new commands expose the same persisted state through first-class CLI surfaces so operators can inspect failed work without depending on internal table shape.

## Design notes

Authority: the diagnostic view is read-only and is based on persisted loop, run, queue-item, and agent-execution records. The failure classification is an operator-facing label only; it is not authority for scheduler, retry, publish, or recovery side effects.

New concept trade-off: the CLI adds a small heuristic failure classifier (`github_transient`, `git_transient`, `agent_idle_timeout`, `pull_request_unresolved`, etc.) so humans can triage failures quickly. Cost is another place where diagnostic wording can drift from retry internals, so the output includes the source message and keeps the recommendation advisory. The simpler alternative, continuing to parse raw `metadataJson` or SQLite tables, was rejected because it normalizes internal storage as the observability API.

## Validation

- `HOME=/Users/zqxy123/.looper-test-home go test ./...`
- `HOME=/Users/zqxy123/.looper-test-home go vet ./...`
- `HOME=/Users/zqxy123/.looper-test-home go build ./...`
- `go run ./cmd/looper loop --help`
- `go run ./cmd/looper queue --help`
