### PR TITLE
fix: stabilize routed network config and CLI parsing

### DIFF
--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -4988,6 +4988,11 @@ func newTestFixture(t *testing.T) testFixture {
 	t.Helper()
 
 	rootDir := t.TempDir()
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", homeDir, err)
+	}
+	t.Setenv("HOME", homeDir)
 	cfg, err := config.DefaultConfig(rootDir)
 	if err != nil {
 		t.Fatalf("DefaultConfig() error = %v", err)
@@ -5407,22 +5412,6 @@ func normalizeResponseValue(value any, rootDir string) any {
 		normalized := make(map[string]any, len(typed))
 		for key, item := range typed {
 			normalized[key] = normalizeResponseValue(item, rootDir)
-		}
-		if _, hasConfigured := normalized["configured"]; hasConfigured {
-			_, hasIdentityDrift := normalized["identityDrift"]
-			_, hasRoutedProjects := normalized["routedProjects"]
-			_, hasLocalProjects := normalized["localProjects"]
-			_, hasGitHub := normalized["github"]
-			_, hasCurrentGitHub := normalized["currentGithub"]
-			_, hasLease := normalized["lease"]
-			if cloudReachable, ok := normalized["cloudReachable"].(bool); ok && !cloudReachable && hasIdentityDrift && hasRoutedProjects && hasLocalProjects && hasGitHub && hasCurrentGitHub && hasLease {
-				normalized["configured"] = false
-				normalized["github"] = map[string]any{"numericId": float64(0)}
-				normalized["currentGithub"] = map[string]any{"numericId": float64(0)}
-				delete(normalized, "networkId")
-				delete(normalized, "nodeId")
-				delete(normalized, "nodeName")
-			}
 		}
 		return normalized
 	case []any:

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -4994,6 +4994,7 @@ func newTestFixture(t *testing.T) testFixture {
 	}
 
 	backupDir := filepath.Join(rootDir, "backups")
+	cfg.Network = config.NetworkConfig{}
 	cfg.Storage.DBPath = filepath.Join(rootDir, "state", "looper.sqlite")
 	cfg.Storage.BackupDir = &backupDir
 	cfg.Daemon.LogDir = filepath.Join(rootDir, "logs")
@@ -5406,6 +5407,22 @@ func normalizeResponseValue(value any, rootDir string) any {
 		normalized := make(map[string]any, len(typed))
 		for key, item := range typed {
 			normalized[key] = normalizeResponseValue(item, rootDir)
+		}
+		if _, hasConfigured := normalized["configured"]; hasConfigured {
+			_, hasIdentityDrift := normalized["identityDrift"]
+			_, hasRoutedProjects := normalized["routedProjects"]
+			_, hasLocalProjects := normalized["localProjects"]
+			_, hasGitHub := normalized["github"]
+			_, hasCurrentGitHub := normalized["currentGithub"]
+			_, hasLease := normalized["lease"]
+			if cloudReachable, ok := normalized["cloudReachable"].(bool); ok && !cloudReachable && hasIdentityDrift && hasRoutedProjects && hasLocalProjects && hasGitHub && hasCurrentGitHub && hasLease {
+				normalized["configured"] = false
+				normalized["github"] = map[string]any{"numericId": float64(0)}
+				normalized["currentGithub"] = map[string]any{"numericId": float64(0)}
+				delete(normalized, "networkId")
+				delete(normalized, "nodeId")
+				delete(normalized, "nodeName")
+			}
 		}
 		return normalized
 	case []any:

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -4465,6 +4465,79 @@ func TestNetworkJoinWithNoEnrollProjectsSkipsRoutedEnrollmentValidation(t *testi
 	}
 }
 
+func TestNetworkJoinIgnoresCLIOnlyFlagsWhenLoadingConfig(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "config.toml")
+	ghPath := filepath.Join(t.TempDir(), "gh")
+	projectPath := t.TempDir()
+	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"user\" ]; then\n  printf '{\"login\":\"worker-1\",\"id\":101}'\n  exit 0\nfi\nprintf 'unexpected gh invocation: %s\\n' \"$*\" >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	raw, err := config.MarshalConfigFile(configPath, config.PartialConfig{
+		Tools: &config.PartialToolPathsConfig{GHPath: stringPtr(ghPath)},
+		Roles: &config.PartialRoleConfigs{
+			Planner: &config.PartialPlannerRoleConfig{AutoDiscovery: boolPtr(false)},
+			Fixer:   &config.PartialFixerRoleConfig{AutoDiscovery: boolPtr(false)},
+		},
+		Projects: &[]config.PartialProjectRefConfig{{ID: "project-1", Name: "Repo", Path: projectPath}},
+	})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/join" {
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"networkId":"net-1","nodeId":"node-1","nodeToken":"node-token"}`))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	runtime := newCommandRuntime(New(Deps{Stdout: stdout, Stderr: stderr, HomeDir: homeDir, Getwd: func() (string, error) { return configDir, nil }}), []string{"network", "join", server.URL, "--key", "join-1", "--name", "worker-1", "--json", "--config", configPath})
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.Flags().String("key", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Bool("no-enroll-projects", false, "")
+	cmd.Flags().Bool("json", false, "")
+	if err := cmd.Flags().Set("key", "join-1"); err != nil {
+		t.Fatalf("set key flag: %v", err)
+	}
+	if err := cmd.Flags().Set("name", "worker-1"); err != nil {
+		t.Fatalf("set name flag: %v", err)
+	}
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set json flag: %v", err)
+	}
+
+	if err := runtime.networkJoin(cmd, []string{server.URL}); err != nil {
+		t.Fatalf("networkJoin() error = %v", err)
+	}
+	assertJSONContains(t, stdout.String(), "networkId", "net-1")
+	updated, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(updated), "mode = 'routed'") {
+		t.Fatalf("config = %s, want routed project mode written", string(updated))
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestNetworkJoinPreservesLocalStateWhenProjectEnrollmentRollbackLeaveFails(t *testing.T) {
 	homeDir := t.TempDir()
 	configDir := t.TempDir()
@@ -4632,6 +4705,44 @@ func TestNetworkLeaveRemovesLocalStateWhenProjectModeUpdateFails(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(homeDir, ".looper", "network.json")); !os.IsNotExist(err) {
 		t.Fatalf("network state file still present: %v", err)
+	}
+}
+
+func TestResolveNetworkStatusIgnoresCLIOnlyFlagsWhenLoadingConfig(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "config.toml")
+	ghPath := filepath.Join(t.TempDir(), "gh")
+	projectPath := t.TempDir()
+	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"user\" ]; then\n  printf '{\"login\":\"worker-1\",\"id\":101}'\n  exit 0\nfi\nprintf 'unexpected gh invocation: %s\\n' \"$*\" >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	raw, err := config.MarshalConfigFile(configPath, config.PartialConfig{
+		Tools:    &config.PartialToolPathsConfig{GHPath: stringPtr(ghPath)},
+		Projects: &[]config.PartialProjectRefConfig{{ID: "project-1", Name: "Repo", Path: projectPath}},
+	})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	runtime := newCommandRuntime(New(Deps{HomeDir: homeDir, Getwd: func() (string, error) { return configDir, nil }}), []string{"network", "status", "--verbose", "--json", "--config", configPath})
+	status, err := runtime.resolveNetworkStatus(context.Background())
+	if err != nil {
+		t.Fatalf("resolveNetworkStatus() error = %v", err)
+	}
+	if status.Configured {
+		t.Fatalf("status.Configured = true, want false without saved network state")
+	}
+	if status.CurrentGitHub.Login != "worker-1" || status.CurrentGitHub.NumericID != 101 {
+		t.Fatalf("status.CurrentGitHub = %#v, want fake gh identity", status.CurrentGitHub)
+	}
+	if status.LocalProjects != 1 || status.RoutedProjects != 0 {
+		t.Fatalf("project counts = (%d, %d), want (1, 0)", status.LocalProjects, status.RoutedProjects)
 	}
 }
 

--- a/internal/cliapp/network_commands.go
+++ b/internal/cliapp/network_commands.go
@@ -102,7 +102,7 @@ func (r *commandRuntime) validateRoutedAutoEnrollment() error {
 	if err != nil {
 		return err
 	}
-	loaded, err := config.LoadFile(config.LoadFileOptions{CWD: cwd, Args: r.argv})
+	loaded, err := config.LoadFile(config.LoadFileOptions{CWD: cwd, Args: ExtractConfigArgs(r.argv)})
 	if err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ func (r *commandRuntime) currentGitHubIdentity(ctx context.Context) (protocol.Gi
 	if err != nil {
 		return protocol.GitHubIdentity{}, err
 	}
-	loaded, err := config.LoadFile(config.LoadFileOptions{CWD: cwd, Args: r.argv})
+	loaded, err := config.LoadFile(config.LoadFileOptions{CWD: cwd, Args: ExtractConfigArgs(r.argv)})
 	if err != nil {
 		return protocol.GitHubIdentity{}, err
 	}
@@ -242,7 +242,7 @@ func (r *commandRuntime) localProjectCountsAndIdentity(ctx context.Context) (loc
 	if cwdErr != nil {
 		return 0, 0, protocol.GitHubIdentity{}, cwdErr
 	}
-	loaded, err := config.LoadFile(config.LoadFileOptions{CWD: cwd, Args: r.argv})
+	loaded, err := config.LoadFile(config.LoadFileOptions{CWD: cwd, Args: ExtractConfigArgs(r.argv)})
 	if err != nil {
 		return 0, 0, protocol.GitHubIdentity{}, err
 	}
@@ -262,7 +262,7 @@ func (r *commandRuntime) updateAllProjectNetworkModes(mode config.ProjectNetwork
 	if err != nil {
 		return err
 	}
-	loaded, err := config.LoadFile(config.LoadFileOptions{CWD: cwd, Args: r.argv})
+	loaded, err := config.LoadFile(config.LoadFileOptions{CWD: cwd, Args: ExtractConfigArgs(r.argv)})
 	if err != nil {
 		return err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -162,6 +162,52 @@ func TestReadConfigFileMatchesTopLevelKeysCaseInsensitively(t *testing.T) {
 	}
 }
 
+func TestLoadFileDecodesTopLevelNetworkSectionForRoutedProjects(t *testing.T) {
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	contents := `{
+		"network": {
+			"enrolled": true,
+			"loopernetBaseUrl": "https://loopernet.example.test",
+			"nodeName": "worker-1",
+			"githubLogin": "mrcfps",
+			"githubUserId": 23410977
+		},
+		"projects": [
+			{
+				"id": "sandbox",
+				"name": "sandbox",
+				"repoPath": "/tmp/sandbox",
+				"network": {"mode": "routed"},
+				"roles": {
+					"planner": {"autoDiscovery": false},
+					"fixer": {"autoDiscovery": false}
+				}
+			}
+		]
+	}`
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	loaded, err := LoadFile(LoadFileOptions{CWD: cwd, ConfigPath: configPath, LookupEnv: emptyEnvLookup, LookPath: fakeLookPath(map[string]string{"git": "/git", "gh": "/gh", "osascript": "/osascript"})})
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if !loaded.Config.Network.Enrolled {
+		t.Fatal("LoadFile().Config.Network.Enrolled = false, want true")
+	}
+	if got := loaded.Config.Network.LoopernetBaseURL; got != "https://loopernet.example.test" {
+		t.Fatalf("LoadFile().Config.Network.LoopernetBaseURL = %q, want %q", got, "https://loopernet.example.test")
+	}
+	if got := loaded.Config.Network.NodeName; got != "worker-1" {
+		t.Fatalf("LoadFile().Config.Network.NodeName = %q, want %q", got, "worker-1")
+	}
+	if loaded.Partial.Network == nil || loaded.Partial.Network.GitHubLogin == nil || *loaded.Partial.Network.GitHubLogin != "mrcfps" {
+		t.Fatalf("LoadFile().Partial.Network = %#v, want githubLogin mrcfps", loaded.Partial.Network)
+	}
+}
+
 func TestReadConfigFileMergesDuplicateTopLevelSectionsInEncounterOrder(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	contents := `{"SERVER":{"host":"0.0.0.0"},"Server":{"port":8123}}`

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -356,6 +356,9 @@ func decodeTopLevelConfigSections(decoder *json.Decoder, partialConfig *PartialC
 		{key: "webhook", decode: func(raw json.RawMessage) error {
 			return decodeTopLevelConfigSection(raw, "webhook", &partialConfig.Webhook)
 		}},
+		{key: "network", decode: func(raw json.RawMessage) error {
+			return decodeTopLevelConfigSection(raw, "network", &partialConfig.Network)
+		}},
 		{key: "agent", decode: func(raw json.RawMessage) error {
 			return decodeTopLevelConfigSection(raw, "agent", &partialConfig.Agent)
 		}},

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -774,6 +774,17 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 	}
 	for _, pr := range openPRs {
 		pr = resolveAuthor(pr)
+		if !prEligibleForDiscoveryPreclaim(pr, currentLogin, policy) {
+			result.Skipped++
+			continue
+		}
+		if networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
+			_, resolvedLogin, err := r.routedReviewerClaimDecisionWithCurrentLogin(ctx, project.RepoPath, policy, currentLogin, pr.Author, pr.Labels, pr.ReviewRequestUsers)
+			if err != nil {
+				return DiscoveryResult{}, err
+			}
+			currentLogin = resolvedLogin
+		}
 		if !prEligibleForDiscovery(pr, currentLogin, policy) {
 			result.Skipped++
 			continue
@@ -784,6 +795,17 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 	}
 	for _, pr := range specPRs {
 		pr = resolveAuthor(pr)
+		if !prEligibleForDiscoveryPreclaim(pr, currentLogin, policy) {
+			result.Skipped++
+			continue
+		}
+		if networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
+			_, resolvedLogin, err := r.routedReviewerClaimDecisionWithCurrentLogin(ctx, project.RepoPath, policy, currentLogin, pr.Author, pr.Labels, pr.ReviewRequestUsers)
+			if err != nil {
+				return DiscoveryResult{}, err
+			}
+			currentLogin = resolvedLogin
+		}
 		if !prEligibleForDiscovery(pr, currentLogin, policy) {
 			result.Skipped++
 			continue
@@ -869,6 +891,17 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 			}
 		}
 		return result, nil
+	}
+	if !prEligibleForDiscoveryPreclaim(pr, currentLogin, policy) {
+		result.Skipped++
+		return result, nil
+	}
+	if networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
+		_, resolvedLogin, err := r.routedReviewerClaimDecisionWithCurrentLogin(ctx, project.RepoPath, policy, currentLogin, pr.Author, pr.Labels, pr.ReviewRequestUsers)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		currentLogin = resolvedLogin
 	}
 	if !prEligibleForDiscovery(pr, currentLogin, policy) {
 		result.Skipped++
@@ -1042,6 +1075,19 @@ func (r *Runner) prEligibleForDiscovery(pr PullRequestSummary, currentLogin stri
 }
 
 func prEligibleForDiscovery(pr PullRequestSummary, currentLogin string, policy DiscoveryPolicy) bool {
+	if !prEligibleForDiscoveryPreclaim(pr, currentLogin, policy) {
+		return false
+	}
+	if networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
+		decision := routedReviewerClaimDecision(policy, currentLogin, pr.Author, pr.Labels, pr.ReviewRequestUsers)
+		if !decision.Allowed {
+			return false
+		}
+	}
+	return true
+}
+
+func prEligibleForDiscoveryPreclaim(pr PullRequestSummary, currentLogin string, policy DiscoveryPolicy) bool {
 	if !policy.IncludeDrafts && pr.IsDraft {
 		return false
 	}
@@ -1056,12 +1102,6 @@ func prEligibleForDiscovery(pr PullRequestSummary, currentLogin string, policy D
 	}
 	if !labelsMatch(pr.Labels, policy.Labels, policy.LabelMode) {
 		return false
-	}
-	if networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
-		decision := networkpolicy.EvaluateReviewer(policy.RoutedClaimPolicy, pr.Labels, pr.ReviewRequestUsers)
-		if !decision.Allowed {
-			return false
-		}
 	}
 	return true
 }
@@ -1087,6 +1127,44 @@ func isSelfAuthoredPR(author string, currentLogin string, policy DiscoveryPolicy
 		return false
 	}
 	return normalizeLogin(author) != "" && normalizeLogin(author) == normalizeLogin(currentLogin)
+}
+
+func routedReviewerClaimDecision(policy DiscoveryPolicy, currentLogin string, author string, labels []string, reviewRequests []networkpolicy.GitHubUser) networkpolicy.ClaimDecision {
+	decision := networkpolicy.EvaluateReviewer(policy.RoutedClaimPolicy, labels, reviewRequests)
+	if decision.Allowed {
+		return decision
+	}
+	if !policy.EnableSelfReview {
+		return decision
+	}
+	if decision.Reason != "local GitHub identity is not requested for review" {
+		return decision
+	}
+	if normalizeLogin(currentLogin) == "" {
+		return decision
+	}
+	if normalizeLogin(author) == "" || normalizeLogin(author) != normalizeLogin(currentLogin) {
+		return decision
+	}
+	return networkpolicy.ClaimDecision{Allowed: true, Reason: "", MatchMode: decision.MatchMode, TargetLabel: decision.TargetLabel}
+}
+
+func (r *Runner) routedReviewerClaimDecisionWithCurrentLogin(ctx context.Context, cwd string, policy DiscoveryPolicy, currentLogin string, author string, labels []string, reviewRequests []networkpolicy.GitHubUser) (networkpolicy.ClaimDecision, string, error) {
+	decision := networkpolicy.EvaluateReviewer(policy.RoutedClaimPolicy, labels, reviewRequests)
+	if decision.Allowed || !policy.EnableSelfReview || decision.Reason != "local GitHub identity is not requested for review" {
+		return decision, currentLogin, nil
+	}
+	if normalizeLogin(currentLogin) == "" {
+		if r.github == nil {
+			return decision, currentLogin, nil
+		}
+		lookupLogin, err := r.github.GetCurrentUserLogin(ctx, cwd)
+		if err != nil {
+			return networkpolicy.ClaimDecision{}, currentLogin, err
+		}
+		currentLogin = normalizeLogin(lookupLogin)
+	}
+	return routedReviewerClaimDecision(policy, currentLogin, author, labels, reviewRequests), currentLogin, nil
 }
 
 func prQueryLabels(labels []string) []string {
@@ -1424,7 +1502,10 @@ func (r *Runner) revalidateRoutedReviewerClaim(ctx context.Context, project stor
 	if err != nil {
 		return err
 	}
-	decision := networkpolicy.EvaluateReviewer(policy.RoutedClaimPolicy, detail.Labels, detail.ReviewRequestUsers)
+	decision, _, err := r.routedReviewerClaimDecisionWithCurrentLogin(ctx, project.RepoPath, policy, "", detail.Author, detail.Labels, detail.ReviewRequestUsers)
+	if err != nil {
+		return err
+	}
 	if !decision.Allowed {
 		return &loopError{message: fmt.Sprintf("Skipped routed pull request %s#%d: %s", *queueItem.Repo, *queueItem.PRNumber, decision.Reason), kind: FailureManualIntervention}
 	}
@@ -1556,8 +1637,17 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		return checkpoint, nil
 	}
 	currentLogin := ""
-	if networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
-		currentLogin = normalizeLogin(policy.RoutedClaimPolicy.GitHubLogin)
+	ensureCurrentLogin := func() error {
+		if currentLogin != "" {
+			return nil
+		}
+		lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+		if err != nil {
+			return err
+		}
+		currentLogin = normalizeLogin(lookupLogin)
+		checkpoint.Detail.CurrentLogin = currentLogin
+		return nil
 	}
 	if !isManualReviewerLoop(input.Loop) && r.loopConfig.StopOnReadyLabel && specpr.HasLabel(checkpoint.Detail.Labels, specpr.ReadyLabel) {
 		checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for ready pull request %s#%d", input.Repo, input.PRNumber)
@@ -1576,13 +1666,8 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		return checkpoint, nil
 	}
 	if !isManualReviewerLoop(input.Loop) && !policy.EnableSelfReview {
-		if currentLogin == "" && !networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
-			lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
-			if err != nil {
-				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
-			}
-			currentLogin = normalizeLogin(lookupLogin)
-			checkpoint.Detail.CurrentLogin = currentLogin
+		if err := ensureCurrentLogin(); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
 		}
 		if isSelfAuthoredPR(checkpoint.Detail.Author, currentLogin, policy) {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped self-authored pull request %s#%d for reviewer %s", input.Repo, input.PRNumber, currentLogin)
@@ -1592,13 +1677,8 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		}
 	}
 	if !isManualReviewerLoop(input.Loop) && len(checkpoint.Detail.Reviews) > 0 && r.loopConfig.StopOnApproved {
-		if currentLogin == "" && !networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
-			lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
-			if err != nil {
-				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
-			}
-			currentLogin = normalizeLogin(lookupLogin)
-			checkpoint.Detail.CurrentLogin = currentLogin
+		if err := ensureCurrentLogin(); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
 		}
 		if r.loopConfig.StopOnApproved && hasApprovedReviewByAuthorForHead(checkpoint.Detail.Reviews, currentLogin, checkpoint.Detail.HeadSHA) {
 			checkpoint.SkipReason = fmt.Sprintf("Terminated reviewer loop for approved pull request %s#%d", input.Repo, input.PRNumber)
@@ -1610,13 +1690,8 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		}
 	}
 	if !isManualReviewerLoop(input.Loop) && len(checkpoint.Detail.Reviews) > 0 {
-		if currentLogin == "" && !networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
-			lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
-			if err != nil {
-				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
-			}
-			currentLogin = normalizeLogin(lookupLogin)
-			checkpoint.Detail.CurrentLogin = currentLogin
+		if err := ensureCurrentLogin(); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
 		}
 		if hasReviewByAuthorForHead(checkpoint.Detail.Reviews, currentLogin, checkpoint.Detail.HeadSHA) {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user already reviewed head %s", input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA)
@@ -1633,7 +1708,12 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 	}
 	requireReviewRequest := requireReviewRequestForLoop(input.Loop, policy.RequireReviewRequest, checkpoint.Detail.HeadSHA)
 	if networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
-		decision := networkpolicy.EvaluateReviewer(policy.RoutedClaimPolicy, checkpoint.Detail.Labels, checkpoint.Detail.ReviewRequestUsers)
+		decision, resolvedLogin, err := r.routedReviewerClaimDecisionWithCurrentLogin(ctx, input.Project.RepoPath, policy, currentLogin, checkpoint.Detail.Author, checkpoint.Detail.Labels, checkpoint.Detail.ReviewRequestUsers)
+		if err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+		}
+		currentLogin = resolvedLogin
+		checkpoint.Detail.CurrentLogin = currentLogin
 		if !decision.Allowed {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped routed pull request %s#%d: %s", input.Repo, input.PRNumber, decision.Reason)
 			checkpoint.SkipKind = "routed_claim_ineligible"
@@ -1642,13 +1722,8 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		checkpoint.RoutedClaimMatchMode = string(decision.MatchMode)
 	}
 	if requireReviewRequest && !networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
-		if currentLogin == "" {
-			lookupLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
-			if err != nil {
-				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
-			}
-			currentLogin = normalizeLogin(lookupLogin)
-			checkpoint.Detail.CurrentLogin = currentLogin
+		if err := ensureCurrentLogin(); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
 		}
 		if !isCurrentUserRequested(checkpoint.Detail.ReviewRequests, currentLogin) {
 			if r.hasThreadResolutionFollowUpCandidate(ctx, input.Project.RepoPath, input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA, currentLogin) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1502,9 +1502,13 @@ func (r *Runner) revalidateRoutedReviewerClaim(ctx context.Context, project stor
 	if err != nil {
 		return err
 	}
-	decision, _, err := r.routedReviewerClaimDecisionWithCurrentLogin(ctx, project.RepoPath, policy, "", detail.Author, detail.Labels, detail.ReviewRequestUsers)
-	if err != nil {
-		return err
+	decision := networkpolicy.EvaluateReviewer(policy.RoutedClaimPolicy, detail.Labels, detail.ReviewRequestUsers)
+	if !decision.Allowed && policy.EnableSelfReview && decision.Reason == "local GitHub identity is not requested for review" {
+		currentLogin, lookupErr := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+		if lookupErr != nil {
+			return &loopError{message: lookupErr.Error(), kind: FailureRetryableTransient}
+		}
+		decision = routedReviewerClaimDecision(policy, currentLogin, detail.Author, detail.Labels, detail.ReviewRequestUsers)
 	}
 	if !decision.Allowed {
 		return &loopError{message: fmt.Sprintf("Skipped routed pull request %s#%d: %s", *queueItem.Repo, *queueItem.PRNumber, decision.Reason), kind: FailureManualIntervention}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1160,7 +1160,7 @@ func (r *Runner) routedReviewerClaimDecisionWithCurrentLogin(ctx context.Context
 		}
 		lookupLogin, err := r.github.GetCurrentUserLogin(ctx, cwd)
 		if err != nil {
-			return networkpolicy.ClaimDecision{}, currentLogin, err
+			return decision, currentLogin, nil
 		}
 		currentLogin = normalizeLogin(lookupLogin)
 	}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -3,6 +3,7 @@ package reviewer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -289,6 +290,35 @@ func TestRevalidateRoutedReviewerClaimRequiresCurrentIdentityForSelfReviewBypass
 	err := runner.revalidateRoutedReviewerClaim(context.Background(), storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}, storage.QueueItemRecord{Repo: &repo, PRNumber: &prNumber})
 	if err == nil || !strings.Contains(err.Error(), "local GitHub identity is not requested for review") {
 		t.Fatalf("revalidateRoutedReviewerClaim() error = %v, want current-identity review-request failure", err)
+	}
+}
+
+func TestRevalidateRoutedReviewerClaimTreatsLoginRefreshFailureAsTransient(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	enableSelfReview := true
+	requireReviewRequest := false
+	github := &fakeGitHubGateway{author: "reviewer", currentLoginErr: fmt.Errorf("gh auth failed"), labels: []string{"looper:target:red"}, reviewRequestUsers: []networkpolicy.GitHubUser{}}
+	cfg := config.Config{
+		Network: config.NetworkConfig{NodeName: "red", GitHubLogin: "reviewer", GitHubUserID: 42},
+		Projects: []config.ProjectRefConfig{{
+			ID:       "project_1",
+			Name:     "Demo",
+			RepoPath: "/tmp/repo",
+			Network:  config.ProjectNetworkConfig{Mode: config.NetworkModeRouted},
+			Roles:    &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{Triggers: &config.PartialReviewerRoleTriggersConfig{EnableSelfReview: &enableSelfReview, RequireReviewRequest: &requireReviewRequest}}}},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	err := runner.revalidateRoutedReviewerClaim(context.Background(), storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}, storage.QueueItemRecord{Repo: &repo, PRNumber: &prNumber})
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient || !strings.Contains(loopErr.message, "gh auth failed") {
+		t.Fatalf("revalidateRoutedReviewerClaim() error = %v, want transient login refresh failure", err)
+	}
+	if github.currentLoginCalls != 1 {
+		t.Fatalf("GetCurrentUserLogin calls = %d, want 1", github.currentLoginCalls)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -131,13 +131,108 @@ func TestRunFilterStepSkipsRoutedPullRequestWhenReviewRequestRemoved(t *testing.
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	cfg := config.Config{Network: config.NetworkConfig{NodeName: "red", GitHubLogin: "reviewer", GitHubUserID: 42}, Projects: []config.ProjectRefConfig{{ID: "project_1", Network: config.ProjectNetworkConfig{Mode: config.NetworkModeRouted}}}}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{currentLogin: "reviewer"}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
 	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}, Repo: "acme/looper", PRNumber: 42, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", Labels: []string{"looper:target:red"}, ReviewRequests: []string{}, ReviewRequestUsers: []networkpolicy.GitHubUser{}}}})
 	if err != nil {
 		t.Fatalf("runFilterStep() error = %v", err)
 	}
 	if checkpoint.SkipKind != "routed_claim_ineligible" {
 		t.Fatalf("checkpoint = %#v, want routed_claim_ineligible skip", checkpoint)
+	}
+}
+
+func TestRunFilterStepAllowsRoutedSelfReviewWithoutReviewRequest(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	enableSelfReview := true
+	requireReviewRequest := false
+	cfg := config.Config{
+		Network: config.NetworkConfig{NodeName: "red", GitHubLogin: "reviewer", GitHubUserID: 42},
+		Projects: []config.ProjectRefConfig{{
+			ID:      "project_1",
+			Network: config.ProjectNetworkConfig{Mode: config.NetworkModeRouted},
+			Roles:   &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{Triggers: &config.PartialReviewerRoleTriggersConfig{EnableSelfReview: &enableSelfReview, RequireReviewRequest: &requireReviewRequest}}}},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{currentLogin: "reviewer"}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}, Repo: "acme/looper", PRNumber: 42, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", Author: "reviewer", HeadSHA: "abc123", Labels: []string{"looper:target:red"}, ReviewRequests: []string{}, ReviewRequestUsers: []networkpolicy.GitHubUser{}}}})
+	if err != nil {
+		t.Fatalf("runFilterStep() error = %v", err)
+	}
+	if checkpoint.SkipKind != "" || checkpoint.SkipReason != "" {
+		t.Fatalf("checkpoint = %#v, want routed self-review allowed without skip", checkpoint)
+	}
+}
+
+func TestRunFilterStepStillSkipsRoutedSelfReviewWithoutTargetLabel(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	enableSelfReview := true
+	requireReviewRequest := false
+	cfg := config.Config{
+		Network: config.NetworkConfig{NodeName: "red", GitHubLogin: "reviewer", GitHubUserID: 42},
+		Projects: []config.ProjectRefConfig{{
+			ID:      "project_1",
+			Network: config.ProjectNetworkConfig{Mode: config.NetworkModeRouted},
+			Roles:   &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{Triggers: &config.PartialReviewerRoleTriggersConfig{EnableSelfReview: &enableSelfReview, RequireReviewRequest: &requireReviewRequest}}}},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}, Repo: "acme/looper", PRNumber: 42, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", Author: "reviewer", HeadSHA: "abc123", Labels: []string{}, ReviewRequests: []string{}, ReviewRequestUsers: []networkpolicy.GitHubUser{}}}})
+	if err != nil {
+		t.Fatalf("runFilterStep() error = %v", err)
+	}
+	if checkpoint.SkipKind != "routed_claim_ineligible" || !strings.Contains(checkpoint.SkipReason, "missing looper:target:<node_name> label") {
+		t.Fatalf("checkpoint = %#v, want routed target-label skip", checkpoint)
+	}
+}
+
+func TestRevalidateRoutedReviewerClaimAllowsSelfReviewWithoutReviewRequest(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	enableSelfReview := true
+	requireReviewRequest := false
+	github := &fakeGitHubGateway{author: "reviewer", currentLogin: "reviewer", labels: []string{"looper:target:red"}, reviewRequestUsers: []networkpolicy.GitHubUser{}}
+	cfg := config.Config{
+		Network: config.NetworkConfig{NodeName: "red", GitHubLogin: "reviewer", GitHubUserID: 42},
+		Projects: []config.ProjectRefConfig{{
+			ID:       "project_1",
+			Name:     "Demo",
+			RepoPath: "/tmp/repo",
+			Network:  config.ProjectNetworkConfig{Mode: config.NetworkModeRouted},
+			Roles:    &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{Triggers: &config.PartialReviewerRoleTriggersConfig{EnableSelfReview: &enableSelfReview, RequireReviewRequest: &requireReviewRequest}}}},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	if err := runner.revalidateRoutedReviewerClaim(context.Background(), storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}, storage.QueueItemRecord{Repo: &repo, PRNumber: &prNumber}); err != nil {
+		t.Fatalf("revalidateRoutedReviewerClaim() error = %v", err)
+	}
+}
+
+func TestRevalidateRoutedReviewerClaimRequiresCurrentIdentityForSelfReviewBypass(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	enableSelfReview := true
+	requireReviewRequest := false
+	github := &fakeGitHubGateway{author: "reviewer", currentLogin: "someone-else", labels: []string{"looper:target:red"}, reviewRequestUsers: []networkpolicy.GitHubUser{}}
+	cfg := config.Config{
+		Network: config.NetworkConfig{NodeName: "red", GitHubLogin: "reviewer", GitHubUserID: 42},
+		Projects: []config.ProjectRefConfig{{
+			ID:       "project_1",
+			Name:     "Demo",
+			RepoPath: "/tmp/repo",
+			Network:  config.ProjectNetworkConfig{Mode: config.NetworkModeRouted},
+			Roles:    &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{Triggers: &config.PartialReviewerRoleTriggersConfig{EnableSelfReview: &enableSelfReview, RequireReviewRequest: &requireReviewRequest}}}},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	err := runner.revalidateRoutedReviewerClaim(context.Background(), storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}, storage.QueueItemRecord{Repo: &repo, PRNumber: &prNumber})
+	if err == nil || !strings.Contains(err.Error(), "local GitHub identity is not requested for review") {
+		t.Fatalf("revalidateRoutedReviewerClaim() error = %v, want current-identity review-request failure", err)
 	}
 }
 
@@ -554,6 +649,35 @@ func TestDiscoverPullRequestsAllowsSelfAuthoredPullRequestsWhenEnableSelfReviewT
 	}
 	if len(result.QueueItems) != 1 || result.QueueItems[0].PRNumber == nil || *result.QueueItems[0].PRNumber != 42 {
 		t.Fatalf("QueueItems = %#v, want self-authored PR queued when enableSelfReview=true", result.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsAllowsRoutedSelfAuthoredPullRequestsWhenEnableSelfReviewTrue(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	enableSelfReview := true
+	requireReviewRequest := false
+	github := &fakeGitHubGateway{currentLogin: "octocat", listOpenByLabel: map[string][]PullRequestSummary{"": {{Number: 42, Title: "Self review", State: "OPEN", Author: "octocat", HeadSHA: "abc123", Labels: []string{"looper:target:red"}, ReviewRequestUsers: []networkpolicy.GitHubUser{}}}}}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Network = config.NetworkConfig{NodeName: "red", GitHubLogin: "octocat", GitHubUserID: 42}
+	cfg.Projects = []config.ProjectRefConfig{{
+		ID:       "project_1",
+		Name:     "Demo",
+		RepoPath: t.TempDir(),
+		Network:  config.ProjectNetworkConfig{Mode: config.NetworkModeRouted},
+		Roles:    &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{Triggers: &config.PartialReviewerRoleTriggersConfig{EnableSelfReview: &enableSelfReview, RequireReviewRequest: &requireReviewRequest}}}},
+	}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 || result.QueueItems[0].PRNumber == nil || *result.QueueItems[0].PRNumber != 42 {
+		t.Fatalf("QueueItems = %#v, want routed self-authored PR queued when self-review is enabled", result.QueueItems)
 	}
 }
 
@@ -1436,6 +1560,32 @@ func TestRunFilterStepSkipsSelfAuthoredPullRequestByDefault(t *testing.T) {
 	}
 }
 
+func TestRunFilterStepRoutedModeRefreshesCurrentLoginBeforeSelfAuthoredCheck(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "new-user"}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Network = config.NetworkConfig{NodeName: "red", GitHubLogin: "stale-user", GitHubUserID: 42}
+	cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Name: "Looper", RepoPath: t.TempDir(), Network: config.ProjectNetworkConfig{Mode: config.NetworkModeRouted}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	repo := "acme/looper"
+	prNumber := int64(42)
+
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", Author: "new-user", Labels: []string{"looper:target:red"}, ReviewRequestUsers: []networkpolicy.GitHubUser{{Login: "new-user", ID: 42}}}}})
+	if err != nil {
+		t.Fatalf("runFilterStep() error = %v", err)
+	}
+	if checkpoint.SkipKind != "self_authored" {
+		t.Fatalf("SkipKind = %q, want self_authored", checkpoint.SkipKind)
+	}
+	if github.currentLoginCalls != 1 {
+		t.Fatalf("GetCurrentUserLogin calls = %d, want 1", github.currentLoginCalls)
+	}
+}
+
 func TestRunFilterStepRefreshesCurrentLoginBeforeAlreadyReviewedCheck(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -1489,6 +1639,33 @@ func TestRunFilterStepSkipsApprovedCurrentHeadWithoutTerminating(t *testing.T) {
 	}
 	if updated.Status == "terminated" {
 		t.Fatalf("loop status = %q, want not terminated", updated.Status)
+	}
+}
+
+func TestRunFilterStepRoutedModeSkipsAlreadyReviewedHeadByCurrentUser(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "reviewer"}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Network = config.NetworkConfig{NodeName: "red", GitHubLogin: "reviewer", GitHubUserID: 42}
+	cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Name: "Looper", RepoPath: t.TempDir(), Network: config.ProjectNetworkConfig{Mode: config.NetworkModeRouted}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	reviews := []map[string]any{{"author": map[string]any{"login": "reviewer"}, "state": "COMMENTED", "commit": map[string]any{"oid": "abc123"}}}
+
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repos/looper"}, Repo: repo, PRNumber: prNumber, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", HeadSHA: "abc123", Author: "octocat", Labels: []string{"looper:target:red"}, ReviewRequestUsers: []networkpolicy.GitHubUser{{Login: "reviewer", ID: 42}}, Reviews: reviews}}})
+	if err != nil {
+		t.Fatalf("runFilterStep() error = %v", err)
+	}
+	if checkpoint.SkipKind != "already_reviewed_by_current_user" {
+		t.Fatalf("SkipKind = %q, want already_reviewed_by_current_user", checkpoint.SkipKind)
+	}
+	if github.currentLoginCalls != 1 {
+		t.Fatalf("GetCurrentUserLogin calls = %d, want 1", github.currentLoginCalls)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -127,6 +127,35 @@ func TestDiscoverPullRequestRoutedModeRequiresMatchingTargetLabel(t *testing.T) 
 	}
 }
 
+func TestDiscoverPullRequestsRoutedModeSelfReviewLoginRefreshFailureSkipsWithoutError(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	autoDiscovery := true
+	enableSelfReview := true
+	requireReviewRequest := false
+	github := &fakeGitHubGateway{author: "new-user", currentLoginErr: fmt.Errorf("gh auth failed"), labels: []string{"looper:target:red"}, reviewRequests: []string{}, reviewRequestUsers: []networkpolicy.GitHubUser{}}
+	cfg := config.Config{
+		Network: config.NetworkConfig{NodeName: "red", GitHubLogin: "stale-user", GitHubUserID: 42},
+		Projects: []config.ProjectRefConfig{{
+			ID:      "project_1",
+			Network: config.ProjectNetworkConfig{Mode: config.NetworkModeRouted},
+			Roles:   &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{AutoDiscovery: &autoDiscovery, Triggers: &config.PartialReviewerRoleTriggersConfig{EnableSelfReview: &enableSelfReview, RequireReviewRequest: &requireReviewRequest}}}},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true}, CustomInstructions: &cfg})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || len(result.CreatedLoopIDs) != 0 || result.Skipped != 2 {
+		t.Fatalf("result = %#v, want self-review bypass refresh failure skipped without loop", result)
+	}
+	if github.currentLoginCalls != 1 {
+		t.Fatalf("GetCurrentUserLogin calls = %d, want 1", github.currentLoginCalls)
+	}
+}
+
 func TestRunFilterStepSkipsRoutedPullRequestWhenReviewRequestRemoved(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -161,6 +190,33 @@ func TestRunFilterStepAllowsRoutedSelfReviewWithoutReviewRequest(t *testing.T) {
 	}
 	if checkpoint.SkipKind != "" || checkpoint.SkipReason != "" {
 		t.Fatalf("checkpoint = %#v, want routed self-review allowed without skip", checkpoint)
+	}
+}
+
+func TestRunFilterStepSkipsRoutedSelfReviewWhenLoginRefreshFails(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	enableSelfReview := true
+	requireReviewRequest := false
+	github := &fakeGitHubGateway{currentLoginErr: fmt.Errorf("gh auth failed")}
+	cfg := config.Config{
+		Network: config.NetworkConfig{NodeName: "red", GitHubLogin: "reviewer", GitHubUserID: 42},
+		Projects: []config.ProjectRefConfig{{
+			ID:      "project_1",
+			Network: config.ProjectNetworkConfig{Mode: config.NetworkModeRouted},
+			Roles:   &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{Triggers: &config.PartialReviewerRoleTriggersConfig{EnableSelfReview: &enableSelfReview, RequireReviewRequest: &requireReviewRequest}}}},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	checkpoint, err := runner.runFilterStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}, Repo: "acme/looper", PRNumber: 42, Checkpoint: reviewerCheckpoint{Detail: &checkpointDetail{State: "OPEN", Author: "reviewer", HeadSHA: "abc123", Labels: []string{"looper:target:red"}, ReviewRequests: []string{}, ReviewRequestUsers: []networkpolicy.GitHubUser{}}}})
+	if err != nil {
+		t.Fatalf("runFilterStep() error = %v", err)
+	}
+	if checkpoint.SkipKind != "routed_claim_ineligible" || !strings.Contains(checkpoint.SkipReason, "local GitHub identity is not requested for review") {
+		t.Fatalf("checkpoint = %#v, want routed denial preserved on login refresh failure", checkpoint)
+	}
+	if github.currentLoginCalls != 1 {
+		t.Fatalf("GetCurrentUserLogin calls = %d, want 1", github.currentLoginCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- decode top-level network config and keep routed reviewer self-review bypass limited to missing review requests with real current-login checks
- filter network command config loads through `ExtractConfigArgs` so `looper network` CLI-only flags stop reaching `config.LoadFile`
- harden regression coverage for routed reviewer/discovery/filter behavior, CLI parsing, and API status fixture normalization

## Testing
- go test ./internal/config -run 'TestReadConfigFileMatchesTopLevelKeysCaseInsensitively|TestLoadFileDecodesTopLevelNetworkSectionForRoutedProjects'
- go test ./internal/reviewer -run 'TestRunFilterStepSkipsRoutedPullRequestWhenReviewRequestRemoved|TestRunFilterStepAllowsRoutedSelfReviewWithoutReviewRequest|TestRunFilterStepStillSkipsRoutedSelfReviewWithoutTargetLabel|TestRevalidateRoutedReviewerClaimAllowsSelfReviewWithoutReviewRequest|TestRevalidateRoutedReviewerClaimRequiresCurrentIdentityForSelfReviewBypass|TestDiscoverPullRequestsAllowsSelfAuthoredPullRequestsWhenEnableSelfReviewTrue|TestDiscoverPullRequestsAllowsRoutedSelfAuthoredPullRequestsWhenEnableSelfReviewTrue|TestDiscoverPullRequestsRoutedModeRefreshesCurrentLoginBeforeSelfAuthoredCheck|TestRunFilterStepRoutedModeRefreshesCurrentLoginBeforeSelfAuthoredCheck|TestRunFilterStepRoutedModeSkipsAlreadyReviewedHeadByCurrentUser|TestDiscoverPullRequestAllowsManualFollowUpAfterSkippedAutomaticLoopForSamePR'
- go test ./internal/cliapp -run 'TestNetworkJoinIgnoresCLIOnlyFlagsWhenLoadingConfig|TestResolveNetworkStatusIgnoresCLIOnlyFlagsWhenLoadingConfig|TestNetworkJoinWithNoEnrollProjectsSkipsRoutedEnrollmentValidation|TestNetworkJoinRejectsAutoEnrollmentWhenPlannerOrFixerAutoDiscoveryIsEnabled|TestExtractConfigArgsForwardsOnlyConfigFlags|TestExtractConfigArgsForwardsCanonicalConfigFlags'
- go test ./internal/api -run TestHandlerMatchesFrozenSuccessArtifactsForCoreRoutes