### PR TITLE
feat: add network members CLI

### DIFF
--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -114,12 +114,13 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 			newCommand(commandSpec{
 				use:             "network",
 				short:           "Network membership commands",
-				helpSubcommands: []helpSubcommand{{name: "join", description: "Join a loopernet network"}, {name: "leave", description: "Leave the current network"}, {name: "status", description: "Show network membership status"}},
+				helpSubcommands: []helpSubcommand{{name: "join", description: "Join a loopernet network"}, {name: "leave", description: "Leave the current network"}, {name: "status", description: "Show network membership status"}, {name: "members", description: "List joined network nodes"}},
 				helpWhenNoArgs:  true,
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "join <url>", short: "Join a loopernet network", args: cobra.ExactArgs(1), runE: runtime.networkJoin, localFlags: []flagSpec{stringFlag("key", "key", "One-time join key"), stringFlag("name", "name", "Node name"), boolFlag("no-enroll-projects", "Skip setting all local projects to network.mode=routed")}}),
 					newCommand(commandSpec{use: "leave", short: "Leave the current network", runE: runtime.networkLeave}),
 					newCommand(commandSpec{use: "status", short: "Show network membership status", runE: runtime.networkStatus, localFlags: []flagSpec{boolFlag("verbose", "Show extended membership details")}}),
+					newCommand(commandSpec{use: "members", short: "List joined network nodes", runE: runtime.networkMembers, localFlags: []flagSpec{boolFlag("verbose", "Show extended membership details")}}),
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/network_commands.go
+++ b/internal/cliapp/network_commands.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -266,7 +268,10 @@ func (r *commandRuntime) resolveNetworkMembers(ctx context.Context) (networkMemb
 	}
 	remote, err := client.New(state.URL, state.NodeToken, r.httpClient()).Status(ctx)
 	if err != nil {
-		return networkMembersOutput{}, fmt.Errorf("network members requires a reachable loopernet status endpoint")
+		if isNetworkStatusReachabilityError(err) {
+			return networkMembersOutput{}, fmt.Errorf("network members requires a reachable loopernet status endpoint: %w", err)
+		}
+		return networkMembersOutput{}, err
 	}
 	leaseHolder := findMembershipByNodeID(remote.Memberships, remote.Lease.HolderNodeID)
 	output := networkMembersOutput{
@@ -305,6 +310,18 @@ func (r *commandRuntime) resolveNetworkMembers(ctx context.Context) (networkMemb
 		output.NetworkID = state.NetworkID
 	}
 	return output, nil
+}
+
+func isNetworkStatusReachabilityError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }
 
 func (r *commandRuntime) loadNetworkState() (client.LocalState, string, error) {

--- a/internal/cliapp/network_commands.go
+++ b/internal/cliapp/network_commands.go
@@ -270,13 +270,13 @@ func (r *commandRuntime) resolveNetworkMembers(ctx context.Context) (networkMemb
 	}
 	leaseHolder := findMembershipByNodeID(remote.Memberships, remote.Lease.HolderNodeID)
 	output := networkMembersOutput{
-		NetworkID:       remote.NetworkID,
-		CurrentNodeID:   remote.Membership.NodeID,
-		CurrentNodeName: remote.Membership.NodeName,
-		Warnings:        append([]string{}, remote.Warnings...),
+		NetworkID:         remote.NetworkID,
+		CurrentNodeID:     remote.Membership.NodeID,
+		CurrentNodeName:   remote.Membership.NodeName,
+		LeaseHolderNodeID: remote.Lease.HolderNodeID,
+		Warnings:          append([]string{}, remote.Warnings...),
 	}
 	if leaseHolder != nil {
-		output.LeaseHolderNodeID = leaseHolder.NodeID
 		output.LeaseHolderName = leaseHolder.NodeName
 	}
 	for _, member := range remote.Memberships {

--- a/internal/cliapp/network_commands.go
+++ b/internal/cliapp/network_commands.go
@@ -314,7 +314,7 @@ func (r *commandRuntime) resolveNetworkMembers(ctx context.Context) (networkMemb
 
 func isNetworkStatusReachabilityError(err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return true
+		return false
 	}
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {

--- a/internal/cliapp/network_commands.go
+++ b/internal/cliapp/network_commands.go
@@ -257,27 +257,29 @@ func (r *commandRuntime) resolveNetworkStatus(ctx context.Context) (networkStatu
 }
 
 func (r *commandRuntime) resolveNetworkMembers(ctx context.Context) (networkMembersOutput, error) {
-	status, err := r.resolveNetworkStatus(ctx)
+	state, _, err := r.loadNetworkState()
 	if err != nil {
+		if isNotExist(err) {
+			return networkMembersOutput{}, fmt.Errorf("network members requires a joined network")
+		}
 		return networkMembersOutput{}, err
 	}
-	if !status.Configured || status.Membership == nil {
-		return networkMembersOutput{}, fmt.Errorf("network members requires a joined network")
-	}
-	if !status.CloudReachable {
+	remote, err := client.New(state.URL, state.NodeToken, r.httpClient()).Status(ctx)
+	if err != nil {
 		return networkMembersOutput{}, fmt.Errorf("network members requires a reachable loopernet status endpoint")
 	}
+	leaseHolder := findMembershipByNodeID(remote.Memberships, remote.Lease.HolderNodeID)
 	output := networkMembersOutput{
-		NetworkID:       status.NetworkID,
-		CurrentNodeID:   status.Membership.NodeID,
-		CurrentNodeName: status.Membership.NodeName,
-		Warnings:        append([]string{}, status.Warnings...),
+		NetworkID:       remote.NetworkID,
+		CurrentNodeID:   remote.Membership.NodeID,
+		CurrentNodeName: remote.Membership.NodeName,
+		Warnings:        append([]string{}, remote.Warnings...),
 	}
-	if status.LeaseHolder != nil {
-		output.LeaseHolderNodeID = status.LeaseHolder.NodeID
-		output.LeaseHolderName = status.LeaseHolder.NodeName
+	if leaseHolder != nil {
+		output.LeaseHolderNodeID = leaseHolder.NodeID
+		output.LeaseHolderName = leaseHolder.NodeName
 	}
-	for _, member := range status.Memberships {
+	for _, member := range remote.Memberships {
 		summary := networkMemberSummary{
 			NodeID:                   member.NodeID,
 			NodeName:                 member.NodeName,
@@ -285,8 +287,8 @@ func (r *commandRuntime) resolveNetworkMembers(ctx context.Context) (networkMemb
 			Roles:                    append([]string{}, member.Capabilities.Roles...),
 			RoutedProjects:           member.Capabilities.RoutedProjects,
 			LocalProjects:            member.Capabilities.LocalProjects,
-			Current:                  member.NodeID == status.Membership.NodeID,
-			LeaseHolder:              status.LeaseHolder != nil && member.NodeID == status.LeaseHolder.NodeID,
+			Current:                  member.NodeID == remote.Membership.NodeID,
+			LeaseHolder:              leaseHolder != nil && member.NodeID == leaseHolder.NodeID,
 			TargetLabels:             append([]string{}, member.TargetLabels...),
 			CoordinatorEligible:      member.Capabilities.CoordinatorEligible,
 			DynamicLoad:              member.Capabilities.DynamicLoad,
@@ -300,7 +302,7 @@ func (r *commandRuntime) resolveNetworkMembers(ctx context.Context) (networkMemb
 		output.Members = append(output.Members, summary)
 	}
 	if strings.TrimSpace(output.NetworkID) == "" {
-		output.NetworkID = status.NetworkID
+		output.NetworkID = state.NetworkID
 	}
 	return output, nil
 }

--- a/internal/cliapp/network_commands.go
+++ b/internal/cliapp/network_commands.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/nexu-io/looper/internal/config"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
@@ -19,8 +20,10 @@ import (
 
 type networkStatusOutput struct {
 	Configured       bool                       `json:"configured"`
+	NetworkID        string                     `json:"networkId,omitempty"`
 	Membership       *protocol.Membership       `json:"membership,omitempty"`
 	LeaseHolder      *protocol.Membership       `json:"leaseHolder,omitempty"`
+	Memberships      []protocol.Membership      `json:"memberships,omitempty"`
 	NodeName         string                     `json:"nodeName,omitempty"`
 	GitHub           protocol.GitHubIdentity    `json:"github"`
 	CurrentGitHub    protocol.GitHubIdentity    `json:"currentGithub"`
@@ -34,6 +37,33 @@ type networkStatusOutput struct {
 	LeaseAction      string                     `json:"leaseAction,omitempty"`
 	LeaseError       string                     `json:"leaseError,omitempty"`
 	DriftReason      string                     `json:"driftReason,omitempty"`
+}
+
+type networkMembersOutput struct {
+	NetworkID         string                 `json:"networkId"`
+	CurrentNodeID     string                 `json:"currentNodeId,omitempty"`
+	CurrentNodeName   string                 `json:"currentNodeName,omitempty"`
+	LeaseHolderNodeID string                 `json:"leaseHolderNodeId,omitempty"`
+	LeaseHolderName   string                 `json:"leaseHolderNodeName,omitempty"`
+	Members           []networkMemberSummary `json:"members"`
+	Warnings          []string               `json:"warnings,omitempty"`
+}
+
+type networkMemberSummary struct {
+	NodeID                   string                  `json:"nodeId"`
+	NodeName                 string                  `json:"nodeName"`
+	GitHub                   protocol.GitHubIdentity `json:"github"`
+	Roles                    []string                `json:"roles,omitempty"`
+	RoutedProjects           int                     `json:"routedProjects"`
+	LocalProjects            int                     `json:"localProjects"`
+	LastHeartbeatAt          *string                 `json:"lastHeartbeatAt,omitempty"`
+	Current                  bool                    `json:"current,omitempty"`
+	LeaseHolder              bool                    `json:"leaseHolder,omitempty"`
+	TargetLabels             []string                `json:"targetLabels,omitempty"`
+	CoordinatorEligible      bool                    `json:"coordinatorEligible,omitempty"`
+	DynamicLoad              int                     `json:"dynamicLoad,omitempty"`
+	JoinedAt                 string                  `json:"joinedAt,omitempty"`
+	DuplicateIdentityWarning bool                    `json:"duplicateGithubIdentityWarning,omitempty"`
 }
 
 func (r *commandRuntime) networkJoin(cmd *cobra.Command, args []string) error {
@@ -168,6 +198,18 @@ func (r *commandRuntime) networkStatus(cmd *cobra.Command, args []string) error 
 	return writeHumanNetworkStatus(cmd.OutOrStdout(), status, getBoolFlag(cmd, "verbose"))
 }
 
+func (r *commandRuntime) networkMembers(cmd *cobra.Command, args []string) error {
+	_ = args
+	members, err := r.resolveNetworkMembers(cmd.Context())
+	if err != nil {
+		return err
+	}
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), members)
+	}
+	return writeHumanNetworkMembers(cmd.OutOrStdout(), members, getBoolFlag(cmd, "verbose"))
+}
+
 func (r *commandRuntime) resolveNetworkStatus(ctx context.Context) (networkStatusOutput, error) {
 	state, _, err := r.loadNetworkState()
 	if err != nil {
@@ -188,7 +230,7 @@ func (r *commandRuntime) resolveNetworkStatus(ctx context.Context) (networkStatu
 	if err != nil {
 		return networkStatusOutput{}, err
 	}
-	status := networkStatusOutput{Configured: true, NodeName: state.NodeName, GitHub: state.GitHub, CurrentGitHub: current, LocalProjects: local, RoutedProjects: routed}
+	status := networkStatusOutput{Configured: true, NetworkID: state.NetworkID, NodeName: state.NodeName, GitHub: state.GitHub, CurrentGitHub: current, LocalProjects: local, RoutedProjects: routed}
 	status.IdentityFallback = current.Login != "" && current.NumericID == 0
 	if drift, reason := githubIdentityDrift(state.GitHub, current); drift {
 		status.IdentityDrift = true
@@ -197,9 +239,13 @@ func (r *commandRuntime) resolveNetworkStatus(ctx context.Context) (networkStatu
 	remote, remoteErr := client.New(state.URL, state.NodeToken, r.httpClient()).Status(ctx)
 	if remoteErr == nil {
 		status.CloudReachable = true
+		if strings.TrimSpace(remote.NetworkID) != "" {
+			status.NetworkID = remote.NetworkID
+		}
 		status.Lease = &remote.Lease
 		membership := remote.Membership
 		status.Membership = &membership
+		status.Memberships = append([]protocol.Membership{}, remote.Memberships...)
 		status.LeaseHolder = findMembershipByNodeID(remote.Memberships, remote.Lease.HolderNodeID)
 		status.Warnings = append([]string{}, remote.Warnings...)
 		if remote.IdentityDrift {
@@ -208,6 +254,55 @@ func (r *commandRuntime) resolveNetworkStatus(ctx context.Context) (networkStatu
 		}
 	}
 	return status, nil
+}
+
+func (r *commandRuntime) resolveNetworkMembers(ctx context.Context) (networkMembersOutput, error) {
+	status, err := r.resolveNetworkStatus(ctx)
+	if err != nil {
+		return networkMembersOutput{}, err
+	}
+	if !status.Configured || status.Membership == nil {
+		return networkMembersOutput{}, fmt.Errorf("network members requires a joined network")
+	}
+	if !status.CloudReachable {
+		return networkMembersOutput{}, fmt.Errorf("network members requires a reachable loopernet status endpoint")
+	}
+	output := networkMembersOutput{
+		NetworkID:       status.NetworkID,
+		CurrentNodeID:   status.Membership.NodeID,
+		CurrentNodeName: status.Membership.NodeName,
+		Warnings:        append([]string{}, status.Warnings...),
+	}
+	if status.LeaseHolder != nil {
+		output.LeaseHolderNodeID = status.LeaseHolder.NodeID
+		output.LeaseHolderName = status.LeaseHolder.NodeName
+	}
+	for _, member := range status.Memberships {
+		summary := networkMemberSummary{
+			NodeID:                   member.NodeID,
+			NodeName:                 member.NodeName,
+			GitHub:                   member.GitHub,
+			Roles:                    append([]string{}, member.Capabilities.Roles...),
+			RoutedProjects:           member.Capabilities.RoutedProjects,
+			LocalProjects:            member.Capabilities.LocalProjects,
+			Current:                  member.NodeID == status.Membership.NodeID,
+			LeaseHolder:              status.LeaseHolder != nil && member.NodeID == status.LeaseHolder.NodeID,
+			TargetLabels:             append([]string{}, member.TargetLabels...),
+			CoordinatorEligible:      member.Capabilities.CoordinatorEligible,
+			DynamicLoad:              member.Capabilities.DynamicLoad,
+			JoinedAt:                 member.JoinedAt.Format(time.RFC3339),
+			DuplicateIdentityWarning: member.DuplicateWarning,
+		}
+		if member.LastHeartbeatAt != nil {
+			value := member.LastHeartbeatAt.Format(time.RFC3339)
+			summary.LastHeartbeatAt = &value
+		}
+		output.Members = append(output.Members, summary)
+	}
+	if strings.TrimSpace(output.NetworkID) == "" {
+		output.NetworkID = status.NetworkID
+	}
+	return output, nil
 }
 
 func (r *commandRuntime) loadNetworkState() (client.LocalState, string, error) {
@@ -334,7 +429,7 @@ func githubIdentityDrift(expected, current protocol.GitHubIdentity) (bool, strin
 }
 
 func writeHumanNetworkStatus(w io.Writer, status networkStatusOutput, verbose bool) error {
-	printSection(w, "Network", [][2]any{{"configured", status.Configured}, {"cloudReachable", status.CloudReachable}, {"nodeName", status.NodeName}, {"githubLogin", status.GitHub.Login}, {"githubNumericId", status.GitHub.NumericID}, {"currentGithubLogin", status.CurrentGitHub.Login}, {"currentGithubNumericId", status.CurrentGitHub.NumericID}, {"identityDrift", status.IdentityDrift}, {"routedProjects", status.RoutedProjects}, {"localProjects", status.LocalProjects}})
+	printSection(w, "Network", [][2]any{{"configured", status.Configured}, {"networkId", status.NetworkID}, {"cloudReachable", status.CloudReachable}, {"nodeName", status.NodeName}, {"githubLogin", status.GitHub.Login}, {"githubNumericId", status.GitHub.NumericID}, {"currentGithubLogin", status.CurrentGitHub.Login}, {"currentGithubNumericId", status.CurrentGitHub.NumericID}, {"identityDrift", status.IdentityDrift}, {"routedProjects", status.RoutedProjects}, {"localProjects", status.LocalProjects}})
 	if status.IdentityFallback {
 		fmt.Fprintln(w)
 		printSection(w, "Identity fallback", [][2]any{{"warning", "current GitHub identity is using login fallback because no numeric ID is available"}})
@@ -364,6 +459,51 @@ func writeHumanNetworkStatus(w io.Writer, status networkStatusOutput, verbose bo
 		printSection(w, "Warnings", entries)
 	}
 	return nil
+}
+
+func writeHumanNetworkMembers(w io.Writer, output networkMembersOutput, verbose bool) error {
+	printSection(w, "Network members", [][2]any{{"networkId", output.NetworkID}, {"currentNodeId", output.CurrentNodeID}, {"currentNodeName", output.CurrentNodeName}, {"leaseHolderNodeId", output.LeaseHolderNodeID}, {"leaseHolderNodeName", output.LeaseHolderName}, {"count", len(output.Members)}})
+	if len(output.Members) > 0 {
+		fmt.Fprintln(w)
+		rows := make([]tableRow, 0, len(output.Members))
+		for _, member := range output.Members {
+			rows = append(rows, tableRow{
+				"nodeId":        member.NodeID,
+				"node":          member.NodeName,
+				"github":        member.GitHub.Login,
+				"roles":         joinOrNone(member.Roles),
+				"routed":        member.RoutedProjects,
+				"local":         member.LocalProjects,
+				"lastHeartbeat": valueOrNone(member.LastHeartbeatAt),
+				"current":       member.Current,
+				"lease":         member.LeaseHolder,
+			})
+		}
+		printTable(w, []string{"nodeId", "node", "github", "roles", "routed", "local", "lastHeartbeat", "current", "lease"}, rows)
+	}
+	if verbose {
+		for index, member := range output.Members {
+			fmt.Fprintln(w)
+			rows := [][2]any{{"nodeId", member.NodeID}, {"nodeName", member.NodeName}, {"githubLogin", member.GitHub.Login}, {"githubNumericId", member.GitHub.NumericID}, {"current", member.Current}, {"leaseHolder", member.LeaseHolder}, {"roles", joinOrNone(member.Roles)}, {"routedProjects", member.RoutedProjects}, {"localProjects", member.LocalProjects}, {"lastHeartbeatAt", valueOrNone(member.LastHeartbeatAt)}, {"targetLabels", joinOrNone(member.TargetLabels)}, {"coordinatorEligible", member.CoordinatorEligible}, {"dynamicLoad", member.DynamicLoad}, {"joinedAt", member.JoinedAt}, {"duplicateGithubIdentityWarning", member.DuplicateIdentityWarning}}
+			printSection(w, fmt.Sprintf("Member %d", index+1), rows)
+		}
+	}
+	if len(output.Warnings) > 0 {
+		fmt.Fprintln(w)
+		entries := make([][2]any, 0, len(output.Warnings))
+		for index, warning := range output.Warnings {
+			entries = append(entries, [2]any{fmt.Sprintf("warning[%d]", index), warning})
+		}
+		printSection(w, "Warnings", entries)
+	}
+	return nil
+}
+
+func valueOrNone(value *string) string {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return "none"
+	}
+	return *value
 }
 
 func networkStringValue(value *string) string {

--- a/internal/cliapp/network_members_test.go
+++ b/internal/cliapp/network_members_test.go
@@ -1,6 +1,7 @@
 package cliapp
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -322,6 +323,25 @@ func TestNetworkMembersIncludesLeaseHolderNodeIDWithoutActiveMembership(t *testi
 	}
 	if payload.LeaseHolderName != nil {
 		t.Fatalf("payload.LeaseHolderName = %q, want nil", *payload.LeaseHolderName)
+	}
+}
+
+func TestIsNetworkStatusReachabilityErrorIgnoresContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "canceled", err: context.Canceled},
+		{name: "deadline exceeded", err: context.DeadlineExceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if isNetworkStatusReachabilityError(tc.err) {
+				t.Fatalf("isNetworkStatusReachabilityError(%v) = true, want false", tc.err)
+			}
+		})
 	}
 }
 

--- a/internal/cliapp/network_members_test.go
+++ b/internal/cliapp/network_members_test.go
@@ -197,6 +197,38 @@ func TestNetworkMembersRequiresJoinedNetwork(t *testing.T) {
 	}
 }
 
+func TestNetworkMembersRequiresReachableStatusEndpoint(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	serverURL := server.URL
+	server.Close()
+
+	if err := client.SaveState(filepath.Join(homeDir, ".looper", "network.json"), client.LocalState{
+		URL:       serverURL,
+		NetworkID: "net-1",
+		NodeID:    "node-1",
+		NodeName:  "worker-1",
+		NodeToken: "node-token",
+		GitHub:    protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+	}); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	app := New(Deps{HomeDir: homeDir})
+	exitCode, stdout, stderr := runAppWithDeps(t, app, []string{"network", "members"})
+	if exitCode == 0 {
+		t.Fatalf("Run(network members) exit code = 0, want non-zero")
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if got := stderr; got == "" || !strings.Contains(got, "network members requires a reachable loopernet status endpoint") {
+		t.Fatalf("stderr = %q, want reachable-endpoint error", got)
+	}
+}
+
 func ptrTime(value time.Time) *time.Time {
 	return &value
 }

--- a/internal/cliapp/network_members_test.go
+++ b/internal/cliapp/network_members_test.go
@@ -1,0 +1,202 @@
+package cliapp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/network/client"
+	"github.com/nexu-io/looper/internal/network/protocol"
+)
+
+func TestNetworkMembersListsJoinedNodesAsJSON(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	now := time.Date(2026, time.May, 22, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/v1/status"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		if got, want := r.Header.Get("Authorization"), "Bearer node-token"; got != want {
+			t.Fatalf("Authorization = %q, want %q", got, want)
+		}
+		response := protocol.NodeStatusResponse{
+			NetworkID: "net-1",
+			Membership: protocol.Membership{
+				NodeID:   "node-1",
+				NodeName: "worker-1",
+				GitHub:   protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+			},
+			Memberships: []protocol.Membership{
+				{
+					NodeID:   "node-1",
+					NodeName: "worker-1",
+					GitHub:   protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+					Capabilities: protocol.NodeCapabilities{
+						Roles:               []string{"worker", "reviewer"},
+						CoordinatorEligible: true,
+						RoutedProjects:      1,
+						LocalProjects:       0,
+						DynamicLoad:         2,
+					},
+					TargetLabels:    []string{"looper:target:worker-1"},
+					JoinedAt:        now.Add(-2 * time.Hour),
+					LastHeartbeatAt: ptrTime(now),
+				},
+				{
+					NodeID:   "node-2",
+					NodeName: "worker-2",
+					GitHub:   protocol.GitHubIdentity{Login: "alice", NumericID: 42},
+					Capabilities: protocol.NodeCapabilities{
+						Roles:          []string{"reviewer"},
+						RoutedProjects: 0,
+						LocalProjects:  2,
+					},
+					JoinedAt: now.Add(-1 * time.Hour),
+				},
+			},
+			Lease:    protocol.CoordinatorLease{HolderNodeID: "node-2"},
+			Warnings: []string{"duplicate GitHub identity detected elsewhere"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	if err := client.SaveState(filepath.Join(homeDir, ".looper", "network.json"), client.LocalState{
+		URL:       server.URL,
+		NetworkID: "net-1",
+		NodeID:    "node-1",
+		NodeName:  "worker-1",
+		NodeToken: "node-token",
+		GitHub:    protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+	}); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	app := New(Deps{HomeDir: homeDir})
+	exitCode, stdout, stderr := runAppWithDeps(t, app, []string{"network", "members", "--json"})
+	if exitCode != 0 {
+		t.Fatalf("Run(network members --json) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var payload struct {
+		NetworkID         string                 `json:"networkId"`
+		CurrentNodeID     string                 `json:"currentNodeId"`
+		LeaseHolderNodeID string                 `json:"leaseHolderNodeId"`
+		Members           []networkMemberSummary `json:"members"`
+		Warnings          []string               `json:"warnings"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("Unmarshal(stdout) error = %v\nstdout=%q", err, stdout)
+	}
+	if payload.NetworkID != "net-1" {
+		t.Fatalf("payload.NetworkID = %q, want %q", payload.NetworkID, "net-1")
+	}
+	if payload.CurrentNodeID != "node-1" {
+		t.Fatalf("payload.CurrentNodeID = %q, want %q", payload.CurrentNodeID, "node-1")
+	}
+	if payload.LeaseHolderNodeID != "node-2" {
+		t.Fatalf("payload.LeaseHolderNodeID = %q, want %q", payload.LeaseHolderNodeID, "node-2")
+	}
+	if len(payload.Members) != 2 {
+		t.Fatalf("len(payload.Members) = %d, want 2", len(payload.Members))
+	}
+	if !payload.Members[0].Current || payload.Members[0].LeaseHolder {
+		t.Fatalf("first member flags = %#v, want current=true leaseHolder=false", payload.Members[0])
+	}
+	if payload.Members[1].Current || !payload.Members[1].LeaseHolder {
+		t.Fatalf("second member flags = %#v, want current=false leaseHolder=true", payload.Members[1])
+	}
+	if len(payload.Warnings) != 1 || payload.Warnings[0] == "" {
+		t.Fatalf("payload.Warnings = %#v, want one warning", payload.Warnings)
+	}
+}
+
+func TestNetworkMembersHumanOutputUsesTable(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	now := time.Date(2026, time.May, 22, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := protocol.NodeStatusResponse{
+			NetworkID: "net-1",
+			Membership: protocol.Membership{
+				NodeID:   "node-1",
+				NodeName: "worker-1",
+				GitHub:   protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+			},
+			Memberships: []protocol.Membership{{
+				NodeID:   "node-1",
+				NodeName: "worker-1",
+				GitHub:   protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+				Capabilities: protocol.NodeCapabilities{
+					Roles:          []string{"worker", "reviewer"},
+					RoutedProjects: 1,
+					LocalProjects:  2,
+				},
+				LastHeartbeatAt: ptrTime(now),
+			}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	if err := client.SaveState(filepath.Join(homeDir, ".looper", "network.json"), client.LocalState{
+		URL:       server.URL,
+		NetworkID: "net-1",
+		NodeID:    "node-1",
+		NodeName:  "worker-1",
+		NodeToken: "node-token",
+		GitHub:    protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+	}); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	app := New(Deps{HomeDir: homeDir})
+	exitCode, stdout, stderr := runAppWithDeps(t, app, []string{"network", "members"})
+	if exitCode != 0 {
+		t.Fatalf("Run(network members) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{"Network members", "nodeId", "node", "github", "roles", "routed", "local", "lastHeartbeat", "current", "lease", "node-1", "worker-1", "mrcfps"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
+func TestNetworkMembersRequiresJoinedNetwork(t *testing.T) {
+	t.Parallel()
+
+	app := New(Deps{HomeDir: t.TempDir()})
+	exitCode, stdout, stderr := runAppWithDeps(t, app, []string{"network", "members"})
+	if exitCode == 0 {
+		t.Fatalf("Run(network members) exit code = 0, want non-zero")
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if got := stderr; got == "" || !strings.Contains(got, "network members requires a joined network") {
+		t.Fatalf("stderr = %q, want joined-network error", got)
+	}
+}
+
+func ptrTime(value time.Time) *time.Time {
+	return &value
+}

--- a/internal/cliapp/network_members_test.go
+++ b/internal/cliapp/network_members_test.go
@@ -224,8 +224,43 @@ func TestNetworkMembersRequiresReachableStatusEndpoint(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("stdout = %q, want empty", stdout)
 	}
-	if got := stderr; got == "" || !strings.Contains(got, "network members requires a reachable loopernet status endpoint") {
-		t.Fatalf("stderr = %q, want reachable-endpoint error", got)
+	if got := stderr; got == "" || !strings.Contains(got, "network members requires a reachable loopernet status endpoint") || !strings.Contains(got, "connection refused") {
+		t.Fatalf("stderr = %q, want reachable-endpoint error with underlying cause", got)
+	}
+}
+
+func TestNetworkMembersPreservesStatusEndpointAuthErrors(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"node token revoked"}`))
+	}))
+	defer server.Close()
+
+	if err := client.SaveState(filepath.Join(homeDir, ".looper", "network.json"), client.LocalState{
+		URL:       server.URL,
+		NetworkID: "net-1",
+		NodeID:    "node-1",
+		NodeName:  "worker-1",
+		NodeToken: "node-token",
+		GitHub:    protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+	}); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	app := New(Deps{HomeDir: homeDir})
+	exitCode, stdout, stderr := runAppWithDeps(t, app, []string{"network", "members"})
+	if exitCode == 0 {
+		t.Fatalf("Run(network members) exit code = 0, want non-zero")
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if got := stderr; got == "" || !strings.Contains(got, "node token revoked") || strings.Contains(got, "requires a reachable loopernet status endpoint") {
+		t.Fatalf("stderr = %q, want preserved auth error without reachability wrapper", got)
 	}
 }
 

--- a/internal/cliapp/network_members_test.go
+++ b/internal/cliapp/network_members_test.go
@@ -229,6 +229,67 @@ func TestNetworkMembersRequiresReachableStatusEndpoint(t *testing.T) {
 	}
 }
 
+func TestNetworkMembersIncludesLeaseHolderNodeIDWithoutActiveMembership(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := protocol.NodeStatusResponse{
+			NetworkID: "net-1",
+			Membership: protocol.Membership{
+				NodeID:   "node-1",
+				NodeName: "worker-1",
+				GitHub:   protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+			},
+			Memberships: []protocol.Membership{{
+				NodeID:   "node-1",
+				NodeName: "worker-1",
+				GitHub:   protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+			}},
+			Lease: protocol.CoordinatorLease{HolderNodeID: "node-2"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	if err := client.SaveState(filepath.Join(homeDir, ".looper", "network.json"), client.LocalState{
+		URL:       server.URL,
+		NetworkID: "net-1",
+		NodeID:    "node-1",
+		NodeName:  "worker-1",
+		NodeToken: "node-token",
+		GitHub:    protocol.GitHubIdentity{Login: "mrcfps", NumericID: 23410977},
+	}); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	app := New(Deps{HomeDir: homeDir})
+	exitCode, stdout, stderr := runAppWithDeps(t, app, []string{"network", "members", "--json"})
+	if exitCode != 0 {
+		t.Fatalf("Run(network members --json) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var payload struct {
+		LeaseHolderNodeID string  `json:"leaseHolderNodeId"`
+		LeaseHolderName   *string `json:"leaseHolderName"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("Unmarshal(stdout) error = %v\nstdout=%q", err, stdout)
+	}
+	if payload.LeaseHolderNodeID != "node-2" {
+		t.Fatalf("payload.LeaseHolderNodeID = %q, want %q", payload.LeaseHolderNodeID, "node-2")
+	}
+	if payload.LeaseHolderName != nil {
+		t.Fatalf("payload.LeaseHolderName = %q, want nil", *payload.LeaseHolderName)
+	}
+}
+
 func ptrTime(value time.Time) *time.Time {
 	return &value
 }


### PR DESCRIPTION
## Summary
- add `looper network members` for listing joined loopernet nodes
- reuse the joined node `/v1/status` response for JSON and human output
- render human output as a table and cover JSON/human/error cases with CLI tests

## Testing
- go test ./internal/cliapp -run 'TestNetworkMembers'
- go run ./cmd/looper network members