### PR TITLE
fix: reconcile stale running runs after sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ looper ps                   # list active loops
 looper logs <id> --follow   # stream logs
 looper jump <id>            # jump into a loop's worktree
 looper stop <id>
+looper run reconcile-stale  # recover stale running loops after sleep/wake
 ```
 
 **Daemon control**
@@ -195,6 +196,8 @@ looper stop <id>
 ```bash
 looper daemon install|start|stop|restart|status
 ```
+
+If `looper ps` shows stale `running` work with no live agent after sleep/wake, run `looper run reconcile-stale` first. `looper daemon restart` remains a reasonable fallback when you want a full daemon restart.
 
 ## Configuration
 

--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -113,6 +113,9 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 	handler := looperdapi.NewHandler(looperdapi.Context{
 		Config:  deps.Config,
 		Runtime: rt,
+		ReconcileStaleRuns: func(ctx context.Context) (looperdruntime.StaleRunReconcileSummary, error) {
+			return rt.ReconcileStaleRunningRuns(ctx)
+		},
 		StopLoop: func(ctx context.Context, loopID, reason string) (any, error) {
 			return stopLoop(ctx, rt.Services(), loopID, reason, time.Now, syscall.Kill, rt.ExecutionMatchesProcess)
 		},

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -440,6 +440,7 @@ looper ps
 looper logs 12 --follow
 looper jump 12
 looper stop 12
+looper run reconcile-stale
 ```
 
 Typical usage:
@@ -449,6 +450,7 @@ Typical usage:
 - `looper jump <id>`: print the shell command for the loop's worktree; use `eval "$(looper jump 12)"` to actually change directories, or pass `--print-path` to print just the path
 - `looper worktree cleanup`: inspect Looper-managed worktree cleanup candidates without deleting anything; add `--confirm` for one immediate cleanup pass or `--json` for structured output
 - `looper stop <id>`: stop an active loop
+- `looper run reconcile-stale`: interrupt stale running runs, repair blocked queue state, and requeue eligible loops after sleep/wake or other local process loss; `looper daemon restart` is still a reasonable fallback if you want a full daemon restart
 
 ## 13. Minimal end-to-end example
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -53,6 +53,10 @@ type RuntimeState interface {
 	StartedAt() (time.Time, bool)
 }
 
+type activeRunExecutionVerifier interface {
+	ExecutionMatchesProcess(context.Context, storage.AgentExecutionRecord, int) (bool, bool, error)
+}
+
 type sweeperCaseView struct {
 	ID                     string  `json:"id"`
 	ProjectID              string  `json:"projectId"`
@@ -130,6 +134,7 @@ type Context struct {
 	ProjectsService      projectService
 	Now                  func() time.Time
 	RecoverySummary      func() any
+	ReconcileStaleRuns   func(context.Context) (looperdruntime.StaleRunReconcileSummary, error)
 	StopLoop             func(context.Context, string, string) (any, error)
 	StopAll              func(context.Context, string) (any, error)
 	TriggerSchedulerTick func()
@@ -328,6 +333,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case apiBasePath + "/runs":
 		payload, err := h.buildRunsRouteResponse(r)
+		if err != nil {
+			var typed apiError
+			if !asAPIError(err, &typed) {
+				typed = internalServerError(err)
+			}
+			h.writeError(w, requestID, typed)
+			return
+		}
+
+		h.writeSuccess(w, requestID, payload)
+		return
+	case apiBasePath + "/runs/reconcile-stale":
+		payload, err := h.buildReconcileStaleRunsResponse(r)
 		if err != nil {
 			var typed apiError
 			if !asAPIError(err, &typed) {
@@ -1626,6 +1644,23 @@ func (h *Handler) buildRunsRouteResponse(r *http.Request) (runsListResponse, err
 	return runsListResponse{Items: items}, nil
 }
 
+func (h *Handler) buildReconcileStaleRunsResponse(r *http.Request) (looperdruntime.StaleRunReconcileSummary, error) {
+	if r.Method != http.MethodPost {
+		return looperdruntime.StaleRunReconcileSummary{}, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", apiBasePath+"/runs/reconcile-stale")}
+	}
+	if h.context.ReconcileStaleRuns == nil {
+		return looperdruntime.StaleRunReconcileSummary{}, apiError{code: pkgapi.ErrorCodeRuntimeControlUnavailable, status: http.StatusNotImplemented, message: "Runtime control is not available in this process"}
+	}
+	summary, err := h.context.ReconcileStaleRuns(r.Context())
+	if err != nil {
+		return looperdruntime.StaleRunReconcileSummary{}, err
+	}
+	if h.context.TriggerSchedulerTick != nil && summary.LoopsRequeued > 0 {
+		h.context.TriggerSchedulerTick()
+	}
+	return summary, nil
+}
+
 func (h *Handler) buildEventsRouteResponse(r *http.Request) (eventsListResponse, error) {
 	services := h.context.Runtime.Services()
 	if services.Repositories == nil || services.Repositories.Events == nil {
@@ -2470,11 +2505,9 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 	}
 
 	queuedLoopIDs := make(map[string]struct{})
-	activeQueueByLoopID := make(map[string]struct{})
 	for _, item := range queueItems {
 		if item.LoopID != nil && (item.Status == "queued" || item.Status == "running") {
 			queuedLoopIDs[*item.LoopID] = struct{}{}
-			activeQueueByLoopID[*item.LoopID] = struct{}{}
 		}
 	}
 
@@ -2487,7 +2520,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 		}
 	}
 
-	activeAgentByRunID := buildActiveAgentByRunID(activeExecutions)
+	activeAgentByRunID := buildVerifiedActiveAgentByRunID(ctx, h.context.Runtime, activeExecutions)
 	plausiblyLiveRunningLoopIDs := make(map[string]struct{}, len(activeRuns))
 	runningViews := make([]activeRunView, 0, len(activeRuns))
 	for _, run := range activeRuns {
@@ -2499,9 +2532,8 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 		if err != nil {
 			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
-		_, hasActiveQueue := activeQueueByLoopID[run.LoopID]
 		hasActiveAgent := activeAgentByRunID[run.ID] != nil
-		if !isPlausiblyLiveActiveRun(run, loop, latestRun, hasActiveQueue, hasActiveAgent, h.now().UTC()) {
+		if !isPlausiblyLiveActiveRun(run, loop, latestRun, hasActiveAgent, h.now().UTC()) {
 			continue
 		}
 		plausiblyLiveRunningLoopIDs[run.LoopID] = struct{}{}
@@ -2535,6 +2567,9 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 				continue
 			}
 			if _, ok := plausiblyLiveRunningLoopIDs[loop.ID]; ok {
+				continue
+			}
+			if !includeInactiveLoops && !runningLoopWithoutRunIsFresh(loop, h.now().UTC(), activeRunHeartbeatTTL) {
 				continue
 			}
 			runningLoopsWithoutRuns = append(runningLoopsWithoutRuns, loop)
@@ -2677,10 +2712,21 @@ func excludeActiveRunViewsByLoopID(items []activeRunView, excluded []activeRunVi
 	return filtered
 }
 
-func buildActiveAgentByRunID(executions []storage.AgentExecutionRecord) map[string]*activeRunAgent {
+func buildVerifiedActiveAgentByRunID(ctx context.Context, runtime RuntimeState, executions []storage.AgentExecutionRecord) map[string]*activeRunAgent {
+	verifier, _ := runtime.(activeRunExecutionVerifier)
+	if verifier == nil {
+		return map[string]*activeRunAgent{}
+	}
 	grouped := make(map[string][]storage.AgentExecutionRecord)
 	for _, execution := range executions {
 		if execution.RunID == nil || strings.TrimSpace(*execution.RunID) == "" {
+			continue
+		}
+		if execution.PID == nil || *execution.PID <= 0 {
+			continue
+		}
+		matches, running, err := verifier.ExecutionMatchesProcess(ctx, execution, int(*execution.PID))
+		if err != nil || !running || !matches {
 			continue
 		}
 		runID := *execution.RunID
@@ -2712,14 +2758,14 @@ func buildActiveAgentByRunID(executions []storage.AgentExecutionRecord) map[stri
 	return result
 }
 
-func isPlausiblyLiveActiveRun(run storage.RunRecord, loop storage.LoopRecord, latestRun *storage.RunRecord, hasActiveQueue bool, hasActiveAgent bool, now time.Time) bool {
+func isPlausiblyLiveActiveRun(run storage.RunRecord, loop storage.LoopRecord, latestRun *storage.RunRecord, hasActiveAgent bool, now time.Time) bool {
 	if latestRun == nil || latestRun.ID != run.ID {
 		return false
 	}
 	if !domain.IsActiveLoopStatus(domain.LoopStatus(loop.Status)) {
 		return false
 	}
-	if hasActiveQueue || hasActiveAgent {
+	if hasActiveAgent {
 		return true
 	}
 	return runHeartbeatIsRecent(run, now, activeRunHeartbeatTTL)
@@ -2734,6 +2780,21 @@ func runHeartbeatIsRecent(run storage.RunRecord, now time.Time, ttl time.Duratio
 		return false
 	}
 	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(*heartbeatAt))
+	if err != nil {
+		return false
+	}
+	return !parsed.UTC().Before(now.UTC().Add(-ttl))
+}
+
+func runningLoopWithoutRunIsFresh(loop storage.LoopRecord, now time.Time, ttl time.Duration) bool {
+	if ttl <= 0 {
+		return true
+	}
+	activityAt := firstNonEmptyString(loop.LastRunAt, loop.NextRunAt, stringPtrOrNil(loop.UpdatedAt), stringPtrOrNil(loop.CreatedAt))
+	if activityAt == nil || strings.TrimSpace(*activityAt) == "" {
+		return false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(*activityAt))
 	if err != nil {
 		return false
 	}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -534,6 +534,58 @@ func TestHandlerRouteAndMethodErrors(t *testing.T) {
 	}
 }
 
+func TestHandlerReconcileStaleRunsRoute(t *testing.T) {
+	fixture := newTestFixture(t)
+	triggered := 0
+	h := NewHandler(Context{
+		Config:  fixture.config,
+		Runtime: fixture.runtime,
+		ReconcileStaleRuns: func(context.Context) (looperdruntime.StaleRunReconcileSummary, error) {
+			return looperdruntime.StaleRunReconcileSummary{Mode: "manual", CandidateRuns: 2, InterruptedRuns: 1, LoopsRequeued: 1, RunIDs: []string{"run_1"}, LoopIDs: []string{"loop_1"}}, nil
+		},
+		TriggerSchedulerTick: func() { triggered++ },
+	})
+
+	t.Run("success", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/reconcile-stale", nil)
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 body=%s", recorder.Code, recorder.Body.String())
+		}
+		body := parseJSONMap(t, recorder.Body.Bytes())
+		data := body["data"].(map[string]any)
+		assertEqual(t, data["mode"], "manual")
+		assertEqual(t, data["candidateRuns"], float64(2))
+		assertEqual(t, data["interruptedRuns"], float64(1))
+		assertEqual(t, data["loopsRequeued"], float64(1))
+		assertEqual(t, triggered, 1)
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/reconcile-stale", nil)
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		if recorder.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("status = %d, want 405", recorder.Code)
+		}
+		body := parseJSONMap(t, recorder.Body.Bytes())
+		assertEqual(t, body["error"].(map[string]any)["code"], "METHOD_NOT_ALLOWED")
+	})
+
+	t.Run("runtime control unavailable", func(t *testing.T) {
+		unavailable := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/reconcile-stale", nil)
+		recorder := httptest.NewRecorder()
+		unavailable.ServeHTTP(recorder, req)
+		if recorder.Code != http.StatusNotImplemented {
+			t.Fatalf("status = %d, want 501", recorder.Code)
+		}
+		body := parseJSONMap(t, recorder.Body.Bytes())
+		assertEqual(t, body["error"].(map[string]any)["code"], "RUNTIME_CONTROL_UNAVAILABLE")
+	})
+}
+
 func TestHandlerPullRequestRouteReturnsInternalErrorWhenLoopLookupFails(t *testing.T) {
 	fixture := newTestFixture(t)
 	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: fixture.now.UTC().Format(javaScriptISOString), UpdatedAt: fixture.now.UTC().Format(javaScriptISOString)}); err != nil {
@@ -865,7 +917,7 @@ func TestHandlerEventAndPullRequestRouteErrorsMatchArtifactCases(t *testing.T) {
 		{caseID: "pr-not-found", method: http.MethodGet, path: "/api/v1/pull-requests/acme%2Flooper/999"},
 	}
 
-	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now }})
 	for _, tt := range tests {
 		t.Run(tt.caseID, func(t *testing.T) {
 			req := httptest.NewRequest(tt.method, tt.path, nil)
@@ -1283,7 +1335,7 @@ func TestHandlerProjectsRouteErrorsMatchArtifactCases(t *testing.T) {
 
 func TestHandlerProjectsCreateRouteMapsProjectIDConflict(t *testing.T) {
 	fixture := newTestFixture(t)
-	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now }})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects", bytes.NewReader([]byte(`{"repoPath":"/tmp/repos/looper","id":"looper"}`)))
 
 	_, err := h.buildCreateProjectResponse(req, fakeProjectService{
@@ -3307,7 +3359,7 @@ func TestIsPlannerPullRequestOpenReadsStructMarshaledStateKey(t *testing.T) {
 		t.Fatalf("PullRequestSnapshots.Upsert() error = %v", err)
 	}
 
-	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now }})
 	if !h.isPlannerPullRequestOpen(context.Background(), "project_1", "acme/looper", 42) {
 		t.Fatal("isPlannerPullRequestOpen() = false, want true")
 	}
@@ -4274,9 +4326,7 @@ func TestHandlerActiveRunsSupportFiltersAgentsAndWorktrees(t *testing.T) {
 	assertEqual(t, first["type"], "worker")
 	target := first["target"].(map[string]any)
 	assertEqual(t, target["label"], "Looper")
-	agent := first["agent"].(map[string]any)
-	assertEqual(t, agent["executionId"], "agent_exec_worker_new")
-	assertEqual(t, agent["activeCount"], float64(2))
+	assertEqual(t, first["agent"], nil)
 
 	detailReq := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active/1", nil)
 	detailRecorder := httptest.NewRecorder()
@@ -4510,7 +4560,7 @@ func TestActiveRunsDefaultExcludesOlderRunningRunWhenLatestCompleted(t *testing.
 	assertEqual(t, item["status"], "completed")
 }
 
-func TestActiveRunsDefaultFallsBackToRunningLoopWhenRunIsStale(t *testing.T) {
+func TestActiveRunsDefaultHidesRunningLoopFallbackWhenRunIsStale(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)
 	oldHeartbeat := fixture.now.Add(-2 * time.Hour).UTC().Format(javaScriptISOString)
@@ -4534,13 +4584,9 @@ func TestActiveRunsDefaultFallsBackToRunningLoopWhenRunIsStale(t *testing.T) {
 	}
 	body := parseJSONMap(t, recorder.Body.Bytes())
 	items := body["data"].(map[string]any)["items"].([]any)
-	if len(items) != 1 {
-		t.Fatalf("len(items) = %d, want 1: %#v", len(items), items)
+	if len(items) != 0 {
+		t.Fatalf("len(items) = %d, want 0: %#v", len(items), items)
 	}
-	item := items[0].(map[string]any)
-	assertEqual(t, item["loopId"], "loop_stale_no_activity")
-	assertEqual(t, item["runId"], nil)
-	assertEqual(t, item["status"], "running")
 }
 
 func TestActiveRunsDefaultExcludesPausedLoopWithStaleRunningRun(t *testing.T) {
@@ -4641,7 +4687,7 @@ func TestActiveRunsDedupesQueuedLoopWhenRunIsRunning(t *testing.T) {
 		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
 
-	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now }})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -4734,11 +4780,9 @@ func TestActiveRunsStatusAndTypeFiltersIncludeInactiveCompletedWorkerLoops(t *te
 	}
 	defaultBody := parseJSONMap(t, defaultRecorder.Body.Bytes())
 	defaultItems := defaultBody["data"].(map[string]any)["items"].([]any)
-	if len(defaultItems) != 1 {
-		t.Fatalf("len(default items) = %d, want 1", len(defaultItems))
+	if len(defaultItems) != 0 {
+		t.Fatalf("len(default items) = %d, want 0", len(defaultItems))
 	}
-	defaultItem := defaultItems[0].(map[string]any)
-	assertEqual(t, defaultItem["loopId"], "loop_worker_running")
 
 	filteredReq := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active?status=completed&type=worker", nil)
 	filteredRecorder := httptest.NewRecorder()
@@ -4923,7 +4967,7 @@ func TestActiveRunDetailIncludesRunningLoopWithoutRun(t *testing.T) {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 
-	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now }})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active/loop_reviewer_running_only", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -477,17 +477,19 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 			newCommand(commandSpec{
 				use:             "run",
 				short:           "Run commands",
-				helpSubcommands: []helpSubcommand{{name: "list", description: "List runs"}, {name: "stats", description: "Show recent run stats"}},
+				helpSubcommands: []helpSubcommand{{name: "list", description: "List runs"}, {name: "stats", description: "Show recent run stats"}, {name: "reconcile-stale", description: "Reconcile stale running runs"}},
 				helpWhenNoArgs:  true,
 				persistentFlags: []flagSpec{stringFlag("loop", "loopId", "Filter by loop id")},
 				exampleLines: []string{
 					"$ looper run list",
 					"$ looper run stats --since 24h",
+					"$ looper run reconcile-stale",
 					"$ looper run list --loop loop_1",
 				},
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "list", short: "List runs", runE: runtime.runList}),
 					newCommand(commandSpec{use: "stats", short: "Show recent run stats", args: cobra.NoArgs, runE: runtime.runStats, localFlags: []flagSpec{stringFlag("since", "duration", "Time window to aggregate (default 24h; supports h and d, for example 1h, 24h, 7d)"), stringFlag("role", "role", "Filter by role: planner, reviewer, worker, or fixer")}}),
+					newCommand(commandSpec{use: "reconcile-stale", short: "Reconcile stale running runs", args: cobra.NoArgs, runE: runtime.runReconcileStale}),
 				},
 			}),
 		},

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -71,7 +71,7 @@ func TestCommandGroupHelpListsExpectedSubcommands(t *testing.T) {
 		{args: []string{"labels", "--help"}, subcommands: []string{"init  Initialize standard Looper GitHub labels"}},
 		{args: []string{"loop", "--help"}, subcommands: []string{"list   List loops", "start  Start a loop", "pause  Pause a loop"}},
 		{args: []string{"pr", "--help"}, subcommands: []string{"list    List pull requests", "show    Show a pull request", "status  Show pull request status"}},
-		{args: []string{"run", "--help"}, subcommands: []string{"list   List runs", "stats  Show recent run stats"}},
+		{args: []string{"run", "--help"}, subcommands: []string{"list             List runs", "stats            Show recent run stats", "reconcile-stale  Reconcile stale running runs"}},
 	}
 
 	for _, testCase := range tests {
@@ -190,6 +190,65 @@ func TestPullRequestListShowsMergeabilityAndBlocker(t *testing.T) {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout = %q, want to contain %q", stdout, want)
 		}
+	}
+}
+
+func TestRunReconcileStaleOutputsHumanAndJSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/runs/reconcile-stale"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		if got, want := r.Method, http.MethodPost; got != want {
+			t.Fatalf("request method = %q, want %q", got, want)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_reconcile", map[string]any{
+			"mode":                 "manual",
+			"candidateRuns":        2,
+			"interruptedRuns":      1,
+			"loopsRequeued":        1,
+			"queueItemsRequeued":   1,
+			"queueItemsCancelled":  0,
+			"cleanedExecutions":    1,
+			"skippedUncertainRuns": 0,
+			"runIds":               []string{"run_1"},
+			"loopIds":              []string{"loop_1"},
+			"executionIds":         []string{"exec_1"},
+		}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "run", "reconcile-stale", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([run reconcile-stale]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([run reconcile-stale]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Stale runs reconciled", "mode", "manual", "interruptedRuns", "run_1", "exec_1"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+
+	exitCode, stdout, stderr = runApp(t, "run", "reconcile-stale", "--json", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([run reconcile-stale --json]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([run reconcile-stale --json]) stderr = %q, want empty string", stderr)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal(stdout) error = %v", err)
+	}
+	if got := payload["mode"]; got != "manual" {
+		t.Fatalf("payload.mode = %#v, want manual", got)
+	}
+	if got := payload["loopsRequeued"]; got != float64(1) {
+		t.Fatalf("payload.loopsRequeued = %#v, want 1", got)
 	}
 }
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -197,6 +197,20 @@ type runsListOutput struct {
 	Items []runOutput `json:"items"`
 }
 
+type runReconcileStaleOutput struct {
+	Mode                 string   `json:"mode"`
+	CandidateRuns        int64    `json:"candidateRuns"`
+	InterruptedRuns      int64    `json:"interruptedRuns"`
+	LoopsRequeued        int64    `json:"loopsRequeued"`
+	QueueItemsRequeued   int64    `json:"queueItemsRequeued"`
+	QueueItemsCancelled  int64    `json:"queueItemsCancelled"`
+	CleanedExecutions    int64    `json:"cleanedExecutions"`
+	SkippedUncertainRuns int64    `json:"skippedUncertainRuns"`
+	RunIDs               []string `json:"runIds"`
+	LoopIDs              []string `json:"loopIds"`
+	ExecutionIDs         []string `json:"executionIds"`
+}
+
 type runOutput struct {
 	ID          string  `json:"id"`
 	LoopID      string  `json:"loopId"`
@@ -371,6 +385,15 @@ func writeHumanActiveRuns(w io.Writer, payload json.RawMessage) error {
 		rows = append(rows, tableRow{"#": item.Seq, "type": item.Type, "target": item.Target.Label, "step": item.CurrentStep, "agent": agentVendor(item.Agent), "pid": agentPID(item.Agent), "status": item.Status, "age": formatRelativeAge(firstNonEmptyCLIString(item.EndedAt, item.StartedAt))})
 	}
 	printTable(w, []string{"#", "type", "target", "step", "agent", "pid", "status", "age"}, rows)
+	return nil
+}
+
+func writeHumanRunReconcileStale(w io.Writer, payload json.RawMessage) error {
+	var data runReconcileStaleOutput
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return fmt.Errorf("decode reconcile stale response: %w", err)
+	}
+	printSection(w, "Stale runs reconciled", [][2]any{{"mode", data.Mode}, {"candidates", data.CandidateRuns}, {"interruptedRuns", data.InterruptedRuns}, {"loopsRequeued", data.LoopsRequeued}, {"queueItemsRequeued", data.QueueItemsRequeued}, {"queueItemsCancelled", data.QueueItemsCancelled}, {"cleanedExecutions", data.CleanedExecutions}, {"skippedUncertainRuns", data.SkippedUncertainRuns}, {"runIds", joinOrNone(data.RunIDs)}, {"loopIds", joinOrNone(data.LoopIDs)}, {"executionIds", joinOrNone(data.ExecutionIDs)}})
 	return nil
 }
 

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -447,6 +447,12 @@ func (r *commandRuntime) runList(cmd *cobra.Command, args []string) error {
 	}, writeHumanRunList)
 }
 
+func (r *commandRuntime) runReconcileStale(cmd *cobra.Command, args []string) error {
+	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
+		return r.postJSON(ctx, "/api/v1/runs/reconcile-stale", nil)
+	}, writeHumanRunReconcileStale)
+}
+
 func (r *commandRuntime) workCreate(cmd *cobra.Command, args []string) error {
 	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
 		issueNumberValue := strings.TrimSpace(getStringFlag(cmd, "issue"))

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1102,10 +1102,13 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				if _, ok := uncertainExecutionIDs[execution.ID]; !ok {
 					uncertainExecutionIDs[execution.ID] = struct{}{}
 				}
-				if err := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, "orphan_cleanup", nowISO); err != nil {
+				written, err := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, "orphan_cleanup", nowISO)
+				if err != nil {
 					return RecoverySummary{}, err
 				}
-				eventsWritten += 1
+				if written {
+					eventsWritten += 1
+				}
 				continue
 			}
 			if running {
@@ -1617,7 +1620,16 @@ func (r *Runtime) reconcileStaleRunningRunsWithMode(ctx context.Context, reposit
 			summary.ExecutionIDs = append(summary.ExecutionIDs, execution.ID)
 		}
 
-		queueRepair, err := r.repairStaleRunQueueState(ctx, repositories, *loop, latestRun, nowISO)
+		latestRunBlocksRequeue := false
+		if latestRun != nil && latestRun.ID != run.ID && latestRun.Status == string(domain.RunStatusRunning) {
+			verification, err := r.verifyRunExecutionLiveness(ctx, repositories, activeExecutionsByRunID[latestRun.ID], now, string(mode)+"_latest_run")
+			if err != nil {
+				return StaleRunReconcileSummary{}, err
+			}
+			summary.EventsWritten += verification.EventsWritten
+			latestRunBlocksRequeue = verification.Live || verification.Uncertain
+		}
+		queueRepair, err := r.repairStaleRunQueueState(ctx, repositories, *loop, latestRun, latestRunBlocksRequeue, nowISO)
 		if err != nil {
 			return StaleRunReconcileSummary{}, err
 		}
@@ -1770,20 +1782,26 @@ func (r *Runtime) verifyRunExecutionLiveness(ctx context.Context, repositories *
 				r.logger.Warn("failed to verify active agent execution identity", map[string]any{"executionId": execution.ID, "pid": *execution.PID, "error": err.Error(), "scope": scope})
 			}
 			nowISO := formatJavaScriptISOString(now)
-			if appendErr := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO); appendErr != nil {
+			written, appendErr := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO)
+			if appendErr != nil {
 				return executionLivenessResult{}, appendErr
 			}
 			result.Uncertain = true
-			result.EventsWritten += 1
+			if written {
+				result.EventsWritten += 1
+			}
 			continue
 		}
 		if running && !matches {
 			nowISO := formatJavaScriptISOString(now)
-			if err := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO); err != nil {
+			written, err := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO)
+			if err != nil {
 				return executionLivenessResult{}, err
 			}
 			result.Uncertain = true
-			result.EventsWritten += 1
+			if written {
+				result.EventsWritten += 1
+			}
 			continue
 		}
 		if running && matches {
@@ -1795,12 +1813,12 @@ func (r *Runtime) verifyRunExecutionLiveness(ctx context.Context, repositories *
 	return result, nil
 }
 
-func (r *Runtime) repairStaleRunQueueState(ctx context.Context, repositories *storage.Repositories, loop storage.LoopRecord, latestRun *storage.RunRecord, nowISO string) (staleRunQueueRepairSummary, error) {
+func (r *Runtime) repairStaleRunQueueState(ctx context.Context, repositories *storage.Repositories, loop storage.LoopRecord, latestRun *storage.RunRecord, latestRunHasLiveAgent bool, nowISO string) (staleRunQueueRepairSummary, error) {
 	summary := staleRunQueueRepairSummary{}
 	if repositories == nil || repositories.Queue == nil {
 		return summary, nil
 	}
-	if shouldRequeueLoop(loop, latestRun, false) {
+	if shouldRequeueLoop(loop, latestRun, latestRunHasLiveAgent) {
 		requeuedLoop := loop
 		requeuedLoop.Status = "queued"
 		requeuedLoop.NextRunAt = stringPtr(nowISO)
@@ -1896,7 +1914,7 @@ func (r *Runtime) repairInterruptedLoopQueueIfNeeded(ctx context.Context, reposi
 	if activeCount == 0 && !shouldRequeueLoop(loop, latestRun, false) {
 		return staleRunQueueRepairSummary{}, nil
 	}
-	return r.repairStaleRunQueueState(ctx, repositories, loop, latestRun, nowISO)
+	return r.repairStaleRunQueueState(ctx, repositories, loop, latestRun, false, nowISO)
 }
 
 func isAgentBackedRunStep(loop storage.LoopRecord, run storage.RunRecord) bool {
@@ -1933,25 +1951,40 @@ func runHeartbeatIsRecent(run storage.RunRecord, now time.Time, ttl time.Duratio
 	return !parsed.UTC().Before(now.UTC().Add(-ttl))
 }
 
-func (r *Runtime) appendUncertainProcessIdentityEvent(ctx context.Context, repositories *storage.Repositories, execution storage.AgentExecutionRecord, pid int, scope string, nowISO string) error {
+func (r *Runtime) appendUncertainProcessIdentityEvent(ctx context.Context, repositories *storage.Repositories, execution storage.AgentExecutionRecord, pid int, scope string, nowISO string) (bool, error) {
 	if r.logger != nil {
 		r.logger.Warn("recovery skipped due to uncertain process identity", map[string]any{"executionId": execution.ID, "pid": pid, "scope": scope})
 	}
-	return appendSystemEvent(ctx, repositories, storage.EventLogRecord{
-		ID:         newRuntimeEventID(),
-		EventType:  "looperd.recovery.process_identity_uncertain",
-		ProjectID:  execution.ProjectID,
-		LoopID:     execution.LoopID,
-		RunID:      execution.RunID,
-		EntityType: stringPtr("agent_execution"),
-		EntityID:   stringPtr(execution.ID),
-		PayloadJSON: mustMarshalJSON(map[string]any{
-			"pid":    pid,
-			"reason": "command_mismatch",
-			"scope":  scope,
-		}),
-		CreatedAt: nowISO,
+	payloadJSON := mustMarshalJSON(map[string]any{
+		"pid":    pid,
+		"reason": "command_mismatch",
+		"scope":  scope,
 	})
+	if repositories != nil && repositories.Events != nil {
+		events, err := repositories.Events.ListByEntity(ctx, "agent_execution", execution.ID)
+		if err != nil {
+			return false, err
+		}
+		for _, event := range events {
+			if event.EventType == "looperd.recovery.process_identity_uncertain" && event.PayloadJSON == payloadJSON {
+				return false, nil
+			}
+		}
+	}
+	if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
+		ID:          newRuntimeEventID(),
+		EventType:   "looperd.recovery.process_identity_uncertain",
+		ProjectID:   execution.ProjectID,
+		LoopID:      execution.LoopID,
+		RunID:       execution.RunID,
+		EntityType:  stringPtr("agent_execution"),
+		EntityID:    stringPtr(execution.ID),
+		PayloadJSON: payloadJSON,
+		CreatedAt:   nowISO,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (r *Runtime) markRecoveredExecutionTerminal(ctx context.Context, repositories *storage.Repositories, execution storage.AgentExecutionRecord, pid int, nowISO string, message string) error {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -49,6 +49,31 @@ type RecoverySummary struct {
 	EventsWritten         int64                      `json:"eventsWritten"`
 }
 
+type StaleRunReconcileSummary struct {
+	Mode                 string   `json:"mode"`
+	StartedAt            string   `json:"startedAt,omitempty"`
+	CompletedAt          string   `json:"completedAt,omitempty"`
+	CandidateRuns        int64    `json:"candidateRuns"`
+	InterruptedRuns      int64    `json:"interruptedRuns"`
+	LoopsRequeued        int64    `json:"loopsRequeued"`
+	QueueItemsRequeued   int64    `json:"queueItemsRequeued"`
+	QueueItemsCancelled  int64    `json:"queueItemsCancelled"`
+	CleanedExecutions    int64    `json:"cleanedExecutions"`
+	SkippedUncertainRuns int64    `json:"skippedUncertainRuns"`
+	EventsWritten        int64    `json:"eventsWritten"`
+	RunIDs               []string `json:"runIds,omitempty"`
+	LoopIDs              []string `json:"loopIds,omitempty"`
+	ExecutionIDs         []string `json:"executionIds,omitempty"`
+}
+
+type staleRunReconcileMode string
+
+const (
+	staleRunReconcileModeStartup staleRunReconcileMode = "startup"
+	staleRunReconcileModeLive    staleRunReconcileMode = "live"
+	staleRunReconcileModeManual  staleRunReconcileMode = "manual"
+)
+
 type RecoveryOrphanAgentCleanup struct {
 	Attempted    bool   `json:"attempted"`
 	CleanedCount int64  `json:"cleanedCount"`
@@ -587,7 +612,7 @@ func (r *Runtime) start(ctx context.Context) error {
 			r.mu.RLock()
 			defer r.mu.RUnlock()
 			return r.schedulerTasks
-		}, r.TriggerSchedulerClaim, r.now)
+		}, r.TriggerSchedulerClaim, r.now, r.reconcileLiveStaleRunningRuns)
 		r.defaultSchedulerTick = handlers.tick
 		r.defaultSchedulerClaim = handlers.claim
 		r.webhookForwarder = handlers.webhook
@@ -1053,37 +1078,6 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 	summary.OrphanAgentCleanup.Attempted = true
 	uncertainAgentRunIDs := make(map[string]struct{})
 	uncertainExecutionIDs := make(map[string]struct{})
-	recordUncertainExecution := func(execution storage.AgentExecutionRecord, pid int, scope string) error {
-		if _, ok := uncertainExecutionIDs[execution.ID]; ok {
-			return nil
-		}
-		uncertainExecutionIDs[execution.ID] = struct{}{}
-		if execution.RunID != nil && strings.TrimSpace(*execution.RunID) != "" {
-			uncertainAgentRunIDs[*execution.RunID] = struct{}{}
-		}
-		if r.logger != nil {
-			r.logger.Warn("recovery skipped due to uncertain process identity", map[string]any{"executionId": execution.ID, "pid": pid, "scope": scope})
-		}
-		if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
-			ID:         newRuntimeEventID(),
-			EventType:  "looperd.recovery.process_identity_uncertain",
-			ProjectID:  execution.ProjectID,
-			LoopID:     execution.LoopID,
-			RunID:      execution.RunID,
-			EntityType: stringPtr("agent_execution"),
-			EntityID:   stringPtr(execution.ID),
-			PayloadJSON: mustMarshalJSON(map[string]any{
-				"pid":    pid,
-				"reason": "command_mismatch",
-				"scope":  scope,
-			}),
-			CreatedAt: nowISO,
-		}); err != nil {
-			return err
-		}
-		eventsWritten += 1
-		return nil
-	}
 	if repositories.AgentExecutions != nil {
 		activeExecutions, err := repositories.AgentExecutions.ListActive(ctx)
 		if err != nil {
@@ -1102,9 +1096,16 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				continue
 			}
 			if running && !matches {
-				if err := recordUncertainExecution(execution, pid, "orphan_cleanup"); err != nil {
+				if execution.RunID != nil && strings.TrimSpace(*execution.RunID) != "" {
+					uncertainAgentRunIDs[*execution.RunID] = struct{}{}
+				}
+				if _, ok := uncertainExecutionIDs[execution.ID]; !ok {
+					uncertainExecutionIDs[execution.ID] = struct{}{}
+				}
+				if err := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, "orphan_cleanup", nowISO); err != nil {
 					return RecoverySummary{}, err
 				}
+				eventsWritten += 1
 				continue
 			}
 			if running {
@@ -1127,43 +1128,10 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 					}(pid)
 				}
 			}
-
-			cleaned := execution
-			cleaned.Status = "killed"
-			if cleaned.ErrorMessage == nil {
-				cleaned.ErrorMessage = stringPtr("Killed during looperd recovery")
-			}
-			if r.config.Agent.NativeResume.Enabled && runtimeNativeResumeSupported(cleaned.Vendor) && cleaned.NativeSessionID != nil && strings.TrimSpace(*cleaned.NativeSessionID) != "" {
-				cleaned.NativeResumeMode = stringPtr("native_resume")
-				cleaned.NativeResumeStatus = stringPtr("pending")
-				if r.logger != nil {
-					r.logger.Info("agent execution eligible for native resume", map[string]any{"executionId": execution.ID, "runId": execution.RunID, "vendor": execution.Vendor})
-				}
-			} else if r.logger != nil {
-				r.logger.Info("agent execution will restart from checkpoint", map[string]any{"executionId": execution.ID, "runId": execution.RunID, "vendor": execution.Vendor})
-			}
-			cleaned.EndedAt = stringPtr(nowISO)
-			cleaned.UpdatedAt = nowISO
-			if err := repositories.AgentExecutions.Upsert(ctx, cleaned); err != nil {
+			if err := r.markRecoveredExecutionTerminal(ctx, repositories, execution, pid, nowISO, "Killed during looperd recovery"); err != nil {
 				return RecoverySummary{}, err
 			}
 			summary.OrphanAgentCleanup.CleanedCount += 1
-			if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
-				ID:         newRuntimeEventID(),
-				EventType:  "agent.killed",
-				ProjectID:  execution.ProjectID,
-				LoopID:     execution.LoopID,
-				RunID:      execution.RunID,
-				EntityType: stringPtr("agent_execution"),
-				EntityID:   stringPtr(execution.ID),
-				PayloadJSON: mustMarshalJSON(map[string]any{
-					"pid":         pid,
-					"recoveredAt": nowISO,
-				}),
-				CreatedAt: nowISO,
-			}); err != nil {
-				return RecoverySummary{}, err
-			}
 			eventsWritten += 1
 		}
 	}
@@ -1194,6 +1162,14 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 		eventsWritten += 1
 	}
 
+	staleSummary, err := r.reconcileStaleRunningRunsWithMode(ctx, repositories, now, staleRunReconcileModeStartup)
+	if err != nil {
+		return RecoverySummary{}, err
+	}
+	summary.InterruptedRunsMarked += staleSummary.InterruptedRuns
+	summary.LoopsRequeued += staleSummary.LoopsRequeued
+	eventsWritten += staleSummary.EventsWritten
+
 	loops, err := repositories.Loops.List(ctx)
 	if err != nil {
 		return RecoverySummary{}, err
@@ -1202,64 +1178,43 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 	for _, loop := range loops {
 		loopsByID[loop.ID] = loop
 	}
+	requeuedLoopIDs := make(map[string]struct{})
+	if staleSummary.LoopsRequeued > 0 {
+		for _, loopID := range staleSummary.LoopIDs {
+			loop, ok := loopsByID[loopID]
+			if ok && loop.Status == "queued" {
+				requeuedLoopIDs[loopID] = struct{}{}
+			}
+		}
+	}
 	activeAgentRunIDs := make(map[string]struct{})
-	if repositories.Runs != nil {
-		runningRuns, err := repositories.Runs.ListByStatus(ctx, string(domain.RunStatusRunning))
+	if repositories.AgentExecutions != nil {
+		activeExecutions, err := repositories.AgentExecutions.ListActive(ctx)
 		if err != nil {
 			return RecoverySummary{}, err
 		}
-		if repositories.AgentExecutions != nil {
-			activeExecutions, err := repositories.AgentExecutions.ListActive(ctx)
-			if err != nil {
-				return RecoverySummary{}, err
-			}
-			activeAgentRunIDs = make(map[string]struct{}, len(activeExecutions))
-			for _, execution := range activeExecutions {
-				if execution.RunID == nil || strings.TrimSpace(*execution.RunID) == "" || execution.PID == nil || *execution.PID <= 0 {
-					continue
-				}
-				pid := int(*execution.PID)
-				matches, running, err := r.executionMatchesProcess(ctx, execution, pid)
-				if err != nil {
-					if r.logger != nil {
-						r.logger.Warn("failed to verify active agent execution identity", map[string]any{"executionId": execution.ID, "pid": *execution.PID, "error": err.Error()})
-					}
-					continue
-				}
-				if running && !matches {
-					if err := recordUncertainExecution(execution, pid, "active_run_detection"); err != nil {
-						return RecoverySummary{}, err
-					}
-					continue
-				}
-				if running && matches {
-					activeAgentRunIDs[*execution.RunID] = struct{}{}
-				}
-			}
-		}
-		for _, run := range runningRuns {
-			loop, ok := loopsByID[run.LoopID]
-			if !ok {
+		activeAgentRunIDs = make(map[string]struct{}, len(activeExecutions))
+		for _, execution := range activeExecutions {
+			if execution.RunID == nil || strings.TrimSpace(*execution.RunID) == "" || execution.PID == nil || *execution.PID <= 0 {
 				continue
 			}
-			latestRun, err := repositories.Runs.GetLatestByLoopID(ctx, run.LoopID)
+			pid := int(*execution.PID)
+			matches, running, err := r.executionMatchesProcess(ctx, execution, pid)
 			if err != nil {
-				return RecoverySummary{}, err
-			}
-			_, hasActiveAgent := activeAgentRunIDs[run.ID]
-			_, hasUncertainAgent := uncertainAgentRunIDs[run.ID]
-			if !shouldInterruptStaleRunningRun(run, latestRun, hasActiveAgent, hasUncertainAgent) {
+				if r.logger != nil {
+					r.logger.Warn("failed to verify active agent execution identity", map[string]any{"executionId": execution.ID, "pid": *execution.PID, "error": err.Error()})
+				}
 				continue
 			}
-			if err := interruptRecoveryRun(ctx, repositories, run, loop, nowISO, "Interrupted stale/orphaned running run during looperd recovery"); err != nil {
-				return RecoverySummary{}, err
+			if running && matches {
+				activeAgentRunIDs[*execution.RunID] = struct{}{}
 			}
-			summary.InterruptedRunsMarked += 1
-			eventsWritten += 1
 		}
 	}
-	requeuedLoopIDs := make(map[string]struct{})
 	for _, loop := range loops {
+		if _, wasRequeued := requeuedLoopIDs[loop.ID]; wasRequeued {
+			continue
+		}
 		latestRun, err := repositories.Runs.GetLatestByLoopID(ctx, loop.ID)
 		if err != nil {
 			return RecoverySummary{}, err
@@ -1374,9 +1329,6 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 
 	for _, loop := range loops {
 		if loop.Status != "queued" {
-			continue
-		}
-		if _, wasRequeued := requeuedLoopIDs[loop.ID]; wasRequeued {
 			continue
 		}
 		if _, exists := queuedLoopIDs[loop.ID]; exists {
@@ -1562,6 +1514,138 @@ func (r *Runtime) ExecutionMatchesProcess(ctx context.Context, execution storage
 	return r.executionMatchesProcess(ctx, execution, pid)
 }
 
+func (r *Runtime) ReconcileStaleRunningRuns(ctx context.Context) (StaleRunReconcileSummary, error) {
+	r.mu.RLock()
+	repositories := r.services.Repositories
+	now := r.now
+	r.mu.RUnlock()
+	if repositories == nil {
+		return StaleRunReconcileSummary{}, fmt.Errorf("storage is not configured")
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return r.reconcileStaleRunningRunsWithMode(ctx, repositories, now().UTC(), staleRunReconcileModeManual)
+}
+
+func (r *Runtime) reconcileLiveStaleRunningRuns(ctx context.Context) (StaleRunReconcileSummary, error) {
+	r.mu.RLock()
+	repositories := r.services.Repositories
+	now := r.now
+	r.mu.RUnlock()
+	if repositories == nil {
+		return StaleRunReconcileSummary{}, fmt.Errorf("storage is not configured")
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return r.reconcileStaleRunningRunsWithMode(ctx, repositories, now().UTC(), staleRunReconcileModeLive)
+}
+
+func (r *Runtime) reconcileStaleRunningRunsWithMode(ctx context.Context, repositories *storage.Repositories, now time.Time, mode staleRunReconcileMode) (StaleRunReconcileSummary, error) {
+	summary := StaleRunReconcileSummary{Mode: string(mode), StartedAt: formatJavaScriptISOString(now)}
+	if repositories == nil || repositories.Runs == nil || repositories.Loops == nil {
+		return summary, nil
+	}
+	nowISO := summary.StartedAt
+	runningRuns, err := repositories.Runs.ListByStatus(ctx, string(domain.RunStatusRunning))
+	if err != nil {
+		return StaleRunReconcileSummary{}, err
+	}
+	activeExecutionsByRunID := make(map[string][]storage.AgentExecutionRecord)
+	if repositories.AgentExecutions != nil {
+		activeExecutions, err := repositories.AgentExecutions.ListActive(ctx)
+		if err != nil {
+			return StaleRunReconcileSummary{}, err
+		}
+		for _, execution := range activeExecutions {
+			if execution.RunID == nil || strings.TrimSpace(*execution.RunID) == "" {
+				continue
+			}
+			activeExecutionsByRunID[*execution.RunID] = append(activeExecutionsByRunID[*execution.RunID], execution)
+		}
+	}
+	for _, run := range runningRuns {
+		if err := ctx.Err(); err != nil {
+			return StaleRunReconcileSummary{}, err
+		}
+		loop, err := repositories.Loops.GetByID(ctx, run.LoopID)
+		if err != nil {
+			return StaleRunReconcileSummary{}, err
+		}
+		if loop == nil {
+			continue
+		}
+		latestRun, err := repositories.Runs.GetLatestByLoopID(ctx, run.LoopID)
+		if err != nil {
+			return StaleRunReconcileSummary{}, err
+		}
+		decision, err := r.evaluateStaleRunCandidate(ctx, repositories, run, *loop, latestRun, activeExecutionsByRunID[run.ID], now, mode)
+		if err != nil {
+			return StaleRunReconcileSummary{}, err
+		}
+		if !decision.Candidate {
+			continue
+		}
+		summary.CandidateRuns += 1
+		if decision.Uncertain {
+			summary.SkippedUncertainRuns += 1
+			summary.EventsWritten += decision.EventsWritten
+			continue
+		}
+		if !decision.Interrupt {
+			continue
+		}
+		if err := interruptRecoveryRun(ctx, repositories, run, *loop, nowISO, decision.Message); err != nil {
+			return StaleRunReconcileSummary{}, err
+		}
+		summary.InterruptedRuns += 1
+		summary.EventsWritten += 1
+		summary.RunIDs = append(summary.RunIDs, run.ID)
+		summary.LoopIDs = append(summary.LoopIDs, run.LoopID)
+
+		for _, execution := range decision.CleanupExecutions {
+			pid := 0
+			if execution.PID != nil && *execution.PID > 0 {
+				pid = int(*execution.PID)
+			}
+			if err := r.markRecoveredExecutionTerminal(ctx, repositories, execution, pid, nowISO, decision.ExecutionMessage); err != nil {
+				return StaleRunReconcileSummary{}, err
+			}
+			summary.CleanedExecutions += 1
+			summary.EventsWritten += 1
+			summary.ExecutionIDs = append(summary.ExecutionIDs, execution.ID)
+		}
+
+		queueRepair, err := r.repairStaleRunQueueState(ctx, repositories, *loop, latestRun, nowISO)
+		if err != nil {
+			return StaleRunReconcileSummary{}, err
+		}
+		summary.LoopsRequeued += queueRepair.LoopsRequeued
+		summary.QueueItemsRequeued += queueRepair.QueueItemsRequeued
+		summary.QueueItemsCancelled += queueRepair.QueueItemsCancelled
+		summary.EventsWritten += queueRepair.EventsWritten
+	}
+	if repositories.Queue != nil {
+		loops, err := repositories.Loops.List(ctx)
+		if err != nil {
+			return StaleRunReconcileSummary{}, err
+		}
+		for _, loop := range loops {
+			queueRepair, err := r.repairInterruptedLoopQueueIfNeeded(ctx, repositories, loop, nowISO)
+			if err != nil {
+				return StaleRunReconcileSummary{}, err
+			}
+			summary.LoopsRequeued += queueRepair.LoopsRequeued
+			summary.QueueItemsRequeued += queueRepair.QueueItemsRequeued
+			summary.QueueItemsCancelled += queueRepair.QueueItemsCancelled
+			summary.EventsWritten += queueRepair.EventsWritten
+		}
+	}
+	summary.CompletedAt = nowISO
+	return summary, nil
+}
+
 func (r *Runtime) appendStoppedEvent(ctx context.Context, repositories *storage.Repositories, reason string) error {
 	return appendSystemEvent(ctx, repositories, storage.EventLogRecord{
 		ID:         newRuntimeEventID(),
@@ -1580,6 +1664,331 @@ func defaultSyncConfiguredProjects(ctx context.Context, service *projects.Servic
 		return fmt.Errorf("projects service is not configured")
 	}
 	return service.SyncConfigured(ctx, cfg, now)
+}
+
+type staleRunCandidateDecision struct {
+	Candidate         bool
+	Interrupt         bool
+	Uncertain         bool
+	Message           string
+	ExecutionMessage  string
+	CleanupExecutions []storage.AgentExecutionRecord
+	EventsWritten     int64
+}
+
+type staleRunQueueRepairSummary struct {
+	LoopsRequeued       int64
+	QueueItemsRequeued  int64
+	QueueItemsCancelled int64
+	EventsWritten       int64
+}
+
+func (r *Runtime) evaluateStaleRunCandidate(ctx context.Context, repositories *storage.Repositories, run storage.RunRecord, loop storage.LoopRecord, latestRun *storage.RunRecord, activeExecutions []storage.AgentExecutionRecord, now time.Time, mode staleRunReconcileMode) (staleRunCandidateDecision, error) {
+	decision := staleRunCandidateDecision{}
+	if run.Status != string(domain.RunStatusRunning) {
+		return decision, nil
+	}
+	if mode == staleRunReconcileModeStartup {
+		decision.Candidate = true
+		if latestRun != nil && latestRun.ID == run.ID && len(activeExecutions) > 0 {
+			verification, err := r.verifyRunExecutionLiveness(ctx, repositories, activeExecutions, now, "startup_stale_run")
+			if err != nil {
+				return staleRunCandidateDecision{}, err
+			}
+			decision.EventsWritten += verification.EventsWritten
+			if verification.Uncertain {
+				decision.Uncertain = true
+				return decision, nil
+			}
+			if verification.Live {
+				return staleRunCandidateDecision{}, nil
+			}
+		}
+		decision.Interrupt = latestRun == nil || latestRun.ID != run.ID || len(activeExecutions) == 0
+		if latestRun != nil && latestRun.ID == run.ID && len(activeExecutions) > 0 {
+			decision.Interrupt = true
+			decision.CleanupExecutions = append(decision.CleanupExecutions, activeExecutions...)
+			decision.ExecutionMessage = "Killed during stale-run recovery"
+		}
+		decision.Message = "Interrupted stale/orphaned running run during looperd recovery"
+		return decision, nil
+	}
+
+	if latestRun == nil {
+		return decision, nil
+	}
+	if runHeartbeatIsRecent(run, now, 30*time.Minute) {
+		return decision, nil
+	}
+	if len(activeExecutions) == 0 && latestRun.ID == run.ID && !isAgentBackedRunStep(loop, run) {
+		return decision, nil
+	}
+	decision.Candidate = true
+	if len(activeExecutions) > 0 {
+		verification, err := r.verifyRunExecutionLiveness(ctx, repositories, activeExecutions, now, string(mode)+"_stale_run")
+		if err != nil {
+			return staleRunCandidateDecision{}, err
+		}
+		decision.EventsWritten += verification.EventsWritten
+		if verification.Uncertain {
+			decision.Uncertain = true
+			return decision, nil
+		}
+		if verification.Live {
+			return staleRunCandidateDecision{}, nil
+		}
+		decision.CleanupExecutions = append(decision.CleanupExecutions, verification.DeadExecutions...)
+		decision.ExecutionMessage = "Killed during stale-run reconciliation"
+	}
+	decision.Interrupt = true
+	if latestRun.ID != run.ID {
+		decision.Message = "Interrupted superseded stale running run during stale-run reconciliation"
+	} else {
+		decision.Message = "Interrupted stale running run during stale-run reconciliation"
+	}
+	return decision, nil
+}
+
+type executionLivenessResult struct {
+	Live           bool
+	Uncertain      bool
+	DeadExecutions []storage.AgentExecutionRecord
+	EventsWritten  int64
+}
+
+func (r *Runtime) verifyRunExecutionLiveness(ctx context.Context, repositories *storage.Repositories, executions []storage.AgentExecutionRecord, now time.Time, scope string) (executionLivenessResult, error) {
+	result := executionLivenessResult{}
+	for _, execution := range executions {
+		if execution.PID == nil || *execution.PID <= 0 {
+			result.DeadExecutions = append(result.DeadExecutions, execution)
+			continue
+		}
+		pid := int(*execution.PID)
+		matches, running, err := r.executionMatchesProcess(ctx, execution, pid)
+		if err != nil {
+			if r.logger != nil {
+				r.logger.Warn("failed to verify active agent execution identity", map[string]any{"executionId": execution.ID, "pid": *execution.PID, "error": err.Error(), "scope": scope})
+			}
+			nowISO := formatJavaScriptISOString(now)
+			if appendErr := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO); appendErr != nil {
+				return executionLivenessResult{}, appendErr
+			}
+			result.Uncertain = true
+			result.EventsWritten += 1
+			continue
+		}
+		if running && !matches {
+			nowISO := formatJavaScriptISOString(now)
+			if err := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO); err != nil {
+				return executionLivenessResult{}, err
+			}
+			result.Uncertain = true
+			result.EventsWritten += 1
+			continue
+		}
+		if running && matches {
+			result.Live = true
+			continue
+		}
+		result.DeadExecutions = append(result.DeadExecutions, execution)
+	}
+	return result, nil
+}
+
+func (r *Runtime) repairStaleRunQueueState(ctx context.Context, repositories *storage.Repositories, loop storage.LoopRecord, latestRun *storage.RunRecord, nowISO string) (staleRunQueueRepairSummary, error) {
+	summary := staleRunQueueRepairSummary{}
+	if repositories == nil || repositories.Queue == nil {
+		return summary, nil
+	}
+	if shouldRequeueLoop(loop, latestRun, false) {
+		requeuedLoop := loop
+		requeuedLoop.Status = "queued"
+		requeuedLoop.NextRunAt = stringPtr(nowISO)
+		if latestRun != nil {
+			requeuedLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
+		}
+		requeuedLoop.UpdatedAt = nowISO
+		if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
+			return staleRunQueueRepairSummary{}, err
+		}
+		activeQueue, err := repositories.Queue.FindActiveByLoopID(ctx, loop.ID)
+		if err != nil {
+			return staleRunQueueRepairSummary{}, err
+		}
+		keepQueueID := ""
+		if activeQueue != nil {
+			keepQueueID = activeQueue.ID
+		}
+		requeuedCount, err := repositories.Queue.RequeueRunningByLoop(ctx, loop.ID, nowISO)
+		if err != nil {
+			return staleRunQueueRepairSummary{}, err
+		}
+		createdQueue := int64(0)
+		if requeuedCount == 0 {
+			if err := ensureRecoveryQueueItem(ctx, repositories, requeuedLoop, nowISO, int64(r.config.Scheduler.RetryMaxAttempts)); err != nil {
+				return staleRunQueueRepairSummary{}, err
+			}
+			activeQueue, err = repositories.Queue.FindActiveByLoopID(ctx, loop.ID)
+			if err != nil {
+				return staleRunQueueRepairSummary{}, err
+			}
+			if activeQueue != nil {
+				keepQueueID = activeQueue.ID
+				createdQueue = 1
+			}
+		}
+		if keepQueueID != "" {
+			duplicateReason := "Cancelled duplicate active queue items during stale-run reconciliation"
+			cancelledDuplicates, err := repositories.Queue.CancelActiveByLoopExcept(ctx, loop.ID, keepQueueID, nowISO, &duplicateReason)
+			if err != nil {
+				return staleRunQueueRepairSummary{}, err
+			}
+			summary.QueueItemsCancelled += cancelledDuplicates
+		}
+		summary.LoopsRequeued = 1
+		summary.QueueItemsRequeued = requeuedCount + createdQueue
+		if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
+			ID:         newRuntimeEventID(),
+			EventType:  "looperd.recovery.loop_requeued",
+			LoopID:     stringPtr(loop.ID),
+			EntityType: stringPtr("loop"),
+			EntityID:   stringPtr(loop.ID),
+			PayloadJSON: mustMarshalJSON(map[string]any{
+				"previousStatus":      loop.Status,
+				"nextRunAt":           nowISO,
+				"recoveredQueueItems": requeuedCount + createdQueue,
+			}),
+			CreatedAt: nowISO,
+		}); err != nil {
+			return staleRunQueueRepairSummary{}, err
+		}
+		summary.EventsWritten = 1
+		return summary, nil
+	}
+	reason := "Cancelled stale queue items during stale-run reconciliation"
+	cancelledCount, err := repositories.Queue.CancelByLoop(ctx, loop.ID, nowISO, &reason)
+	if err != nil {
+		return staleRunQueueRepairSummary{}, err
+	}
+	summary.QueueItemsCancelled = cancelledCount
+	return summary, nil
+}
+
+func (r *Runtime) repairInterruptedLoopQueueIfNeeded(ctx context.Context, repositories *storage.Repositories, loop storage.LoopRecord, nowISO string) (staleRunQueueRepairSummary, error) {
+	if repositories == nil || repositories.Runs == nil || repositories.Queue == nil {
+		return staleRunQueueRepairSummary{}, nil
+	}
+	latestRun, err := repositories.Runs.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil || latestRun == nil || latestRun.Status != string(domain.RunStatusInterrupted) {
+		return staleRunQueueRepairSummary{}, err
+	}
+	activeCount, err := repositories.Queue.CountActiveByLoopID(ctx, loop.ID)
+	if err != nil {
+		return staleRunQueueRepairSummary{}, err
+	}
+	runningCount, err := repositories.Queue.CountByLoopIDAndStatus(ctx, loop.ID, "running")
+	if err != nil {
+		return staleRunQueueRepairSummary{}, err
+	}
+	if loop.Status == "queued" && runningCount == 0 && activeCount == 1 {
+		return staleRunQueueRepairSummary{}, nil
+	}
+	if activeCount == 0 && !shouldRequeueLoop(loop, latestRun, false) {
+		return staleRunQueueRepairSummary{}, nil
+	}
+	return r.repairStaleRunQueueState(ctx, repositories, loop, latestRun, nowISO)
+}
+
+func isAgentBackedRunStep(loop storage.LoopRecord, run storage.RunRecord) bool {
+	if run.CurrentStep == nil {
+		return false
+	}
+	step := strings.TrimSpace(*run.CurrentStep)
+	switch loop.Type {
+	case "planner":
+		return step == "write-spec"
+	case "reviewer":
+		return step == "thread_resolution" || step == "review"
+	case "fixer":
+		return step == "repair"
+	case "worker":
+		return step == "execute"
+	default:
+		return false
+	}
+}
+
+func runHeartbeatIsRecent(run storage.RunRecord, now time.Time, ttl time.Duration) bool {
+	if ttl <= 0 {
+		return true
+	}
+	heartbeatAt := firstNonEmpty(stringOrEmpty(run.LastHeartbeatAt), run.UpdatedAt, run.StartedAt)
+	if heartbeatAt == "" {
+		return false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(heartbeatAt))
+	if err != nil {
+		return false
+	}
+	return !parsed.UTC().Before(now.UTC().Add(-ttl))
+}
+
+func (r *Runtime) appendUncertainProcessIdentityEvent(ctx context.Context, repositories *storage.Repositories, execution storage.AgentExecutionRecord, pid int, scope string, nowISO string) error {
+	if r.logger != nil {
+		r.logger.Warn("recovery skipped due to uncertain process identity", map[string]any{"executionId": execution.ID, "pid": pid, "scope": scope})
+	}
+	return appendSystemEvent(ctx, repositories, storage.EventLogRecord{
+		ID:         newRuntimeEventID(),
+		EventType:  "looperd.recovery.process_identity_uncertain",
+		ProjectID:  execution.ProjectID,
+		LoopID:     execution.LoopID,
+		RunID:      execution.RunID,
+		EntityType: stringPtr("agent_execution"),
+		EntityID:   stringPtr(execution.ID),
+		PayloadJSON: mustMarshalJSON(map[string]any{
+			"pid":    pid,
+			"reason": "command_mismatch",
+			"scope":  scope,
+		}),
+		CreatedAt: nowISO,
+	})
+}
+
+func (r *Runtime) markRecoveredExecutionTerminal(ctx context.Context, repositories *storage.Repositories, execution storage.AgentExecutionRecord, pid int, nowISO string, message string) error {
+	cleaned := execution
+	cleaned.Status = "killed"
+	if cleaned.ErrorMessage == nil {
+		cleaned.ErrorMessage = stringPtr(message)
+	}
+	if r.config.Agent.NativeResume.Enabled && runtimeNativeResumeSupported(cleaned.Vendor) && cleaned.NativeSessionID != nil && strings.TrimSpace(*cleaned.NativeSessionID) != "" {
+		cleaned.NativeResumeMode = stringPtr("native_resume")
+		cleaned.NativeResumeStatus = stringPtr("pending")
+		if r.logger != nil {
+			r.logger.Info("agent execution eligible for native resume", map[string]any{"executionId": execution.ID, "runId": execution.RunID, "vendor": execution.Vendor})
+		}
+	} else if r.logger != nil {
+		r.logger.Info("agent execution will restart from checkpoint", map[string]any{"executionId": execution.ID, "runId": execution.RunID, "vendor": execution.Vendor})
+	}
+	cleaned.EndedAt = stringPtr(nowISO)
+	cleaned.UpdatedAt = nowISO
+	if err := repositories.AgentExecutions.Upsert(ctx, cleaned); err != nil {
+		return err
+	}
+	payload := map[string]any{"recoveredAt": nowISO}
+	if pid > 0 {
+		payload["pid"] = pid
+	}
+	return appendSystemEvent(ctx, repositories, storage.EventLogRecord{
+		ID:          newRuntimeEventID(),
+		EventType:   "agent.killed",
+		ProjectID:   execution.ProjectID,
+		LoopID:      execution.LoopID,
+		RunID:       execution.RunID,
+		EntityType:  stringPtr("agent_execution"),
+		EntityID:    stringPtr(execution.ID),
+		PayloadJSON: mustMarshalJSON(payload),
+		CreatedAt:   nowISO,
+	})
 }
 
 func ensureRecoveryQueueItem(ctx context.Context, repositories *storage.Repositories, loop storage.LoopRecord, nowISO string, maxAttempts int64) error {
@@ -2344,6 +2753,13 @@ func coalesceString(values ...*string) *string {
 		}
 	}
 	return nil
+}
+
+func stringOrEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }
 
 func newRuntimeEventID() string {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1400,6 +1400,636 @@ func TestRuntimeRecoveryPreservesLoopWithActiveAgentExecution(t *testing.T) {
 	}
 }
 
+func TestRuntimeReconcileLiveStaleRunningRunsInterruptsAgentBackedRunWithoutExecution(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer rt.Stop("test cleanup")
+	repos := rt.Services().Repositories
+	repo := "nexu-io/looper"
+	prNumber := int64(186)
+	targetID := "pr:nexu-io/looper:186"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_stale_live", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_stale_live", LoopID: "loop_stale_live", Status: "running", CurrentStep: stringPtr("review"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	summary, err := rt.reconcileLiveStaleRunningRuns(context.Background())
+	if err != nil {
+		t.Fatalf("reconcileLiveStaleRunningRuns() error = %v", err)
+	}
+	if summary.Mode != "live" || summary.CandidateRuns != 1 || summary.InterruptedRuns != 1 || summary.LoopsRequeued != 1 {
+		t.Fatalf("summary = %#v, want one interrupted live stale run and requeued loop", summary)
+	}
+	run, err := repos.Runs.GetByID(context.Background(), "run_stale_live")
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	if run == nil || run.Status != "interrupted" || run.EndedAt == nil {
+		t.Fatalf("run = %#v, want interrupted ended run", run)
+	}
+	loop, err := repos.Loops.GetByID(context.Background(), "loop_stale_live")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued loop", loop)
+	}
+}
+
+func TestRuntimeReconcileLiveStaleRunningRunsSkipsNonAgentRunWithoutExecution(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer rt.Stop("test cleanup")
+	repos := rt.Services().Repositories
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_non_agent_live", Seq: 1, ProjectID: "project_1", Type: "worker", TargetType: "project", Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_non_agent_live", LoopID: "loop_non_agent_live", Status: "running", CurrentStep: stringPtr("discover-pr"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	summary, err := rt.reconcileLiveStaleRunningRuns(context.Background())
+	if err != nil {
+		t.Fatalf("reconcileLiveStaleRunningRuns() error = %v", err)
+	}
+	if summary.CandidateRuns != 0 || summary.InterruptedRuns != 0 {
+		t.Fatalf("summary = %#v, want no live reconciliation for non-agent stale run", summary)
+	}
+}
+
+func TestRuntimeReconcileLiveStaleRunningRunsInterruptsWorkerExecuteRunWithoutExecution(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer rt.Stop("test cleanup")
+	repos := rt.Services().Repositories
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_worker_execute_stale", Seq: 2, ProjectID: "project_1", Type: "worker", TargetType: "project", Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_worker_execute_stale", LoopID: "loop_worker_execute_stale", Status: "running", CurrentStep: stringPtr("execute"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	summary, err := rt.reconcileLiveStaleRunningRuns(context.Background())
+	if err != nil {
+		t.Fatalf("reconcileLiveStaleRunningRuns() error = %v", err)
+	}
+	if summary.CandidateRuns != 1 || summary.InterruptedRuns != 1 || summary.LoopsRequeued != 1 {
+		t.Fatalf("summary = %#v, want interrupted stale worker execute run", summary)
+	}
+}
+
+func TestRuntimeReconcileStaleRunningRunsSkipsVerifiedLiveExecution(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		reconcile func(*Runtime, context.Context) (StaleRunReconcileSummary, error)
+	}{
+		{name: "live", reconcile: func(rt *Runtime, ctx context.Context) (StaleRunReconcileSummary, error) {
+			return rt.reconcileLiveStaleRunningRuns(ctx)
+		}},
+		{name: "manual", reconcile: func(rt *Runtime, ctx context.Context) (StaleRunReconcileSummary, error) {
+			return rt.ReconcileStaleRunningRuns(ctx)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workingDir := t.TempDir()
+			cfg, err := config.DefaultConfig(workingDir)
+			if err != nil {
+				t.Fatalf("DefaultConfig() error = %v", err)
+			}
+			cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+			backupDir := filepath.Join(workingDir, "backups")
+			cfg.Storage.BackupDir = &backupDir
+			now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+			nowISO := formatJavaScriptISOString(now)
+			oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+			pid := int64(5151)
+
+			rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }, ReadProcessCommand: func(context.Context, int) (string, error) { return "codex exec", nil }})
+			if err := rt.Start(context.Background()); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			defer rt.Stop("test cleanup")
+			repos := rt.Services().Repositories
+			repo := "nexu-io/looper"
+			prNumber := int64(188)
+			targetID := "pr:nexu-io/looper:188"
+			if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+				t.Fatalf("Projects.Upsert() error = %v", err)
+			}
+			if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_live_execution", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+				t.Fatalf("Loops.Upsert() error = %v", err)
+			}
+			if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_live_execution", LoopID: "loop_live_execution", Status: "running", CurrentStep: stringPtr("review"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+				t.Fatalf("Runs.Upsert() error = %v", err)
+			}
+			if err := repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "exec_live_execution", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_live_execution"), RunID: stringPtr("run_live_execution"), Vendor: "codex", Status: "running", PID: &pid, CommandJSON: stringPtr(`{"command":"codex","args":["exec"]}`), CWD: stringPtr(workingDir), StartedAt: oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+				t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+			}
+
+			summary, err := tc.reconcile(rt, context.Background())
+			if err != nil {
+				t.Fatalf("reconcile error = %v", err)
+			}
+			if summary.CandidateRuns != 0 || summary.InterruptedRuns != 0 {
+				t.Fatalf("summary = %#v, want verified live execution preserved", summary)
+			}
+			run, _ := repos.Runs.GetByID(context.Background(), "run_live_execution")
+			if run == nil || run.Status != "running" {
+				t.Fatalf("run = %#v, want still running", run)
+			}
+		})
+	}
+}
+
+func TestRuntimeReconcileStaleRunningRunsKeepsSupersededRunWithVerifiedLiveExecution(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		reconcile func(*Runtime, context.Context) (StaleRunReconcileSummary, error)
+	}{
+		{name: "live", reconcile: func(rt *Runtime, ctx context.Context) (StaleRunReconcileSummary, error) {
+			return rt.reconcileLiveStaleRunningRuns(ctx)
+		}},
+		{name: "manual", reconcile: func(rt *Runtime, ctx context.Context) (StaleRunReconcileSummary, error) {
+			return rt.ReconcileStaleRunningRuns(ctx)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workingDir := t.TempDir()
+			cfg, err := config.DefaultConfig(workingDir)
+			if err != nil {
+				t.Fatalf("DefaultConfig() error = %v", err)
+			}
+			cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+			backupDir := filepath.Join(workingDir, "backups")
+			cfg.Storage.BackupDir = &backupDir
+			now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+			nowISO := formatJavaScriptISOString(now)
+			oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+			completedISO := formatJavaScriptISOString(now.Add(-10 * time.Minute))
+			pid := int64(5252)
+
+			rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }, ReadProcessCommand: func(context.Context, int) (string, error) { return "codex exec", nil }})
+			if err := rt.Start(context.Background()); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			defer rt.Stop("test cleanup")
+			repos := rt.Services().Repositories
+			repo := "nexu-io/looper"
+			prNumber := int64(189)
+			targetID := "pr:nexu-io/looper:189"
+			if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+				t.Fatalf("Projects.Upsert() error = %v", err)
+			}
+			if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_superseded_live", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "completed", CreatedAt: oldISO, UpdatedAt: completedISO}); err != nil {
+				t.Fatalf("Loops.Upsert() error = %v", err)
+			}
+			if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_superseded_old", LoopID: "loop_superseded_live", Status: "running", CurrentStep: stringPtr("review"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+				t.Fatalf("Runs.Upsert(old) error = %v", err)
+			}
+			if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_superseded_latest", LoopID: "loop_superseded_live", Status: "success", StartedAt: completedISO, EndedAt: stringPtr(completedISO), CreatedAt: completedISO, UpdatedAt: completedISO}); err != nil {
+				t.Fatalf("Runs.Upsert(latest) error = %v", err)
+			}
+			if err := repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "exec_superseded_live", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_superseded_live"), RunID: stringPtr("run_superseded_old"), Vendor: "codex", Status: "running", PID: &pid, CommandJSON: stringPtr(`{"command":"codex","args":["exec"]}`), CWD: stringPtr(workingDir), StartedAt: oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+				t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+			}
+
+			summary, err := tc.reconcile(rt, context.Background())
+			if err != nil {
+				t.Fatalf("reconcile error = %v", err)
+			}
+			if summary.CandidateRuns != 0 || summary.InterruptedRuns != 0 {
+				t.Fatalf("summary = %#v, want superseded live run preserved", summary)
+			}
+			run, _ := repos.Runs.GetByID(context.Background(), "run_superseded_old")
+			if run == nil || run.Status != "running" {
+				t.Fatalf("run = %#v, want still running", run)
+			}
+		})
+	}
+}
+
+func TestRuntimeReconcileStaleRunningRunsWithMultipleActiveExecutions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("verified live execution wins", func(t *testing.T) {
+		workingDir := t.TempDir()
+		cfg, err := config.DefaultConfig(workingDir)
+		if err != nil {
+			t.Fatalf("DefaultConfig() error = %v", err)
+		}
+		cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+		backupDir := filepath.Join(workingDir, "backups")
+		cfg.Storage.BackupDir = &backupDir
+		now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+		nowISO := formatJavaScriptISOString(now)
+		oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+		livePID := int64(5353)
+		deadPID := int64(5354)
+
+		rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }, ReadProcessCommand: func(_ context.Context, pid int) (string, error) {
+			switch pid {
+			case int(livePID):
+				return "codex exec", nil
+			case int(deadPID):
+				return "", nil
+			default:
+				return "", nil
+			}
+		}})
+		if err := rt.Start(context.Background()); err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+		defer rt.Stop("test cleanup")
+		repos := rt.Services().Repositories
+		repo := "nexu-io/looper"
+		prNumber := int64(190)
+		targetID := "pr:nexu-io/looper:190"
+		if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+			t.Fatalf("Projects.Upsert() error = %v", err)
+		}
+		if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_multi_exec_live", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+			t.Fatalf("Loops.Upsert() error = %v", err)
+		}
+		if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_multi_exec_live", LoopID: "loop_multi_exec_live", Status: "running", CurrentStep: stringPtr("review"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+			t.Fatalf("Runs.Upsert() error = %v", err)
+		}
+		for _, exec := range []storage.AgentExecutionRecord{{ID: "exec_multi_live", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_multi_exec_live"), RunID: stringPtr("run_multi_exec_live"), Vendor: "codex", Status: "running", PID: &livePID, CommandJSON: stringPtr(`{"command":"codex","args":["exec"]}`), CWD: stringPtr(workingDir), StartedAt: oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}, {ID: "exec_multi_dead", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_multi_exec_live"), RunID: stringPtr("run_multi_exec_live"), Vendor: "codex", Status: "running", PID: &deadPID, CommandJSON: stringPtr(`{"command":"codex","args":["exec"]}`), CWD: stringPtr(workingDir), StartedAt: oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}} {
+			if err := repos.AgentExecutions.Upsert(context.Background(), exec); err != nil {
+				t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+			}
+		}
+
+		summary, err := rt.ReconcileStaleRunningRuns(context.Background())
+		if err != nil {
+			t.Fatalf("ReconcileStaleRunningRuns() error = %v", err)
+		}
+		if summary.CandidateRuns != 0 || summary.InterruptedRuns != 0 || summary.SkippedUncertainRuns != 0 {
+			t.Fatalf("summary = %#v, want live execution to keep run active", summary)
+		}
+	})
+
+	t.Run("ambiguous without verified live is uncertain", func(t *testing.T) {
+		workingDir := t.TempDir()
+		cfg, err := config.DefaultConfig(workingDir)
+		if err != nil {
+			t.Fatalf("DefaultConfig() error = %v", err)
+		}
+		cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+		backupDir := filepath.Join(workingDir, "backups")
+		cfg.Storage.BackupDir = &backupDir
+		now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+		nowISO := formatJavaScriptISOString(now)
+		oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+		ambiguousPID := int64(5453)
+		deadPID := int64(5454)
+
+		rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }, ReadProcessCommand: func(_ context.Context, pid int) (string, error) {
+			switch pid {
+			case int(ambiguousPID):
+				return "python unrelated.py", nil
+			case int(deadPID):
+				return "", nil
+			default:
+				return "", nil
+			}
+		}})
+		if err := rt.Start(context.Background()); err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+		defer rt.Stop("test cleanup")
+		repos := rt.Services().Repositories
+		repo := "nexu-io/looper"
+		prNumber := int64(191)
+		targetID := "pr:nexu-io/looper:191"
+		if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+			t.Fatalf("Projects.Upsert() error = %v", err)
+		}
+		if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_multi_exec_uncertain", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+			t.Fatalf("Loops.Upsert() error = %v", err)
+		}
+		if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_multi_exec_uncertain", LoopID: "loop_multi_exec_uncertain", Status: "running", CurrentStep: stringPtr("review"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+			t.Fatalf("Runs.Upsert() error = %v", err)
+		}
+		for _, exec := range []storage.AgentExecutionRecord{{ID: "exec_multi_ambiguous", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_multi_exec_uncertain"), RunID: stringPtr("run_multi_exec_uncertain"), Vendor: "codex", Status: "running", PID: &ambiguousPID, CommandJSON: stringPtr(`{"command":"codex","args":["exec"]}`), CWD: stringPtr(workingDir), StartedAt: oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}, {ID: "exec_multi_dead_2", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_multi_exec_uncertain"), RunID: stringPtr("run_multi_exec_uncertain"), Vendor: "codex", Status: "running", PID: &deadPID, CommandJSON: stringPtr(`{"command":"codex","args":["exec"]}`), CWD: stringPtr(workingDir), StartedAt: oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}} {
+			if err := repos.AgentExecutions.Upsert(context.Background(), exec); err != nil {
+				t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+			}
+		}
+
+		summary, err := rt.ReconcileStaleRunningRuns(context.Background())
+		if err != nil {
+			t.Fatalf("ReconcileStaleRunningRuns() error = %v", err)
+		}
+		if summary.CandidateRuns != 1 || summary.SkippedUncertainRuns != 1 || summary.InterruptedRuns != 0 {
+			t.Fatalf("summary = %#v, want uncertain candidate preserved", summary)
+		}
+	})
+}
+
+func TestRuntimeReconcileStaleRunningRunsCancelsDuplicateActiveQueueItems(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer rt.Stop("test cleanup")
+	repos := rt.Services().Repositories
+	repo := "nexu-io/looper"
+	prNumber := int64(192)
+	targetID := "pr:nexu-io/looper:192"
+	loopID := "loop_duplicate_active_queue"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_duplicate_active_queue", LoopID: loopID, Status: "running", CurrentStep: stringPtr("repair"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	for _, item := range []storage.QueueItemRecord{{ID: "queue_duplicate_1", ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:project_1:loop_duplicate_active_queue:nexu-io/looper:192:a", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: oldISO, StartedAt: stringPtr(oldISO), MaxAttempts: 3, CreatedAt: oldISO, UpdatedAt: oldISO}, {ID: "queue_duplicate_2", ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:project_1:loop_duplicate_active_queue:nexu-io/looper:192:b", Priority: storage.QueuePriorityFixer, Status: "queued", AvailableAt: oldISO, MaxAttempts: 3, CreatedAt: oldISO, UpdatedAt: oldISO}} {
+		if err := repos.Queue.Upsert(context.Background(), item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+
+	summary, err := rt.ReconcileStaleRunningRuns(context.Background())
+	if err != nil {
+		t.Fatalf("ReconcileStaleRunningRuns() error = %v", err)
+	}
+	if summary.InterruptedRuns != 1 || summary.LoopsRequeued != 1 {
+		t.Fatalf("summary = %#v, want stale run reconciled", summary)
+	}
+	activeCount, err := repos.Queue.CountActiveByLoopID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("CountActiveByLoopID() error = %v", err)
+	}
+	if activeCount > 1 {
+		t.Fatalf("active queue count = %d, want at most 1", activeCount)
+	}
+}
+
+func TestRuntimeReconcileStaleRunningRunsIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		reconcile func(*Runtime, context.Context) (StaleRunReconcileSummary, error)
+	}{
+		{name: "live", reconcile: func(rt *Runtime, ctx context.Context) (StaleRunReconcileSummary, error) {
+			return rt.reconcileLiveStaleRunningRuns(ctx)
+		}},
+		{name: "manual", reconcile: func(rt *Runtime, ctx context.Context) (StaleRunReconcileSummary, error) {
+			return rt.ReconcileStaleRunningRuns(ctx)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workingDir := t.TempDir()
+			cfg, err := config.DefaultConfig(workingDir)
+			if err != nil {
+				t.Fatalf("DefaultConfig() error = %v", err)
+			}
+			cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+			backupDir := filepath.Join(workingDir, "backups")
+			cfg.Storage.BackupDir = &backupDir
+			now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+			nowISO := formatJavaScriptISOString(now)
+			oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+
+			rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+			if err := rt.Start(context.Background()); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			defer rt.Stop("test cleanup")
+			repos := rt.Services().Repositories
+			repo := "nexu-io/looper"
+			prNumber := int64(193)
+			targetID := "pr:nexu-io/looper:193"
+			loopID := "loop_idempotent_reconcile"
+			if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+				t.Fatalf("Projects.Upsert() error = %v", err)
+			}
+			if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+				t.Fatalf("Loops.Upsert() error = %v", err)
+			}
+			if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_idempotent_reconcile", LoopID: loopID, Status: "running", CurrentStep: stringPtr("repair"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+				t.Fatalf("Runs.Upsert() error = %v", err)
+			}
+
+			first, err := tc.reconcile(rt, context.Background())
+			if err != nil {
+				t.Fatalf("first reconcile error = %v", err)
+			}
+			if first.InterruptedRuns != 1 || first.LoopsRequeued != 1 {
+				t.Fatalf("first summary = %#v, want first pass to reconcile stale run", first)
+			}
+			second, err := tc.reconcile(rt, context.Background())
+			if err != nil {
+				t.Fatalf("second reconcile error = %v", err)
+			}
+			if second.InterruptedRuns != 0 || second.LoopsRequeued != 0 || second.QueueItemsRequeued != 0 || second.QueueItemsCancelled != 0 {
+				t.Fatalf("second summary = %#v, want idempotent no-op", second)
+			}
+		})
+	}
+}
+
+func TestRuntimeReconcileStaleRunningRunsRepairsInterruptedLoopQueueOnLaterPass(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer rt.Stop("test cleanup")
+	repos := rt.Services().Repositories
+	repo := "nexu-io/looper"
+	prNumber := int64(194)
+	targetID := "pr:nexu-io/looper:194"
+	loopID := "loop_interrupted_queue_repair"
+	queueID := "queue_interrupted_queue_repair"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_interrupted_queue_repair", LoopID: loopID, Status: "interrupted", CurrentStep: stringPtr("repair"), StartedAt: oldISO, EndedAt: stringPtr(nowISO), CreatedAt: oldISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: queueID, ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:project_1:loop_interrupted_queue_repair:nexu-io/looper:194", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: oldISO, StartedAt: stringPtr(oldISO), MaxAttempts: 3, CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	summary, err := rt.ReconcileStaleRunningRuns(context.Background())
+	if err != nil {
+		t.Fatalf("ReconcileStaleRunningRuns() error = %v", err)
+	}
+	if summary.LoopsRequeued != 1 || summary.QueueItemsRequeued != 1 {
+		t.Fatalf("summary = %#v, want later pass to repair interrupted loop queue", summary)
+	}
+	loop, _ := repos.Loops.GetByID(context.Background(), loopID)
+	queue, _ := repos.Queue.GetByID(context.Background(), queueID)
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued", loop)
+	}
+	if queue == nil || queue.Status != "queued" {
+		t.Fatalf("queue = %#v, want queued", queue)
+	}
+}
+
+func TestRuntimeReconcileStaleRunningRunsRecreatesQueuedItemForInterruptedQueuedLoopWithoutActiveQueue(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer rt.Stop("test cleanup")
+	repos := rt.Services().Repositories
+	repo := "nexu-io/looper"
+	prNumber := int64(195)
+	targetID := "pr:nexu-io/looper:195"
+	loopID := "loop_interrupted_needs_queue_recreate"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_interrupted_needs_queue_recreate", LoopID: loopID, Status: "interrupted", CurrentStep: stringPtr("repair"), StartedAt: oldISO, EndedAt: stringPtr(nowISO), CreatedAt: oldISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	summary, err := rt.ReconcileStaleRunningRuns(context.Background())
+	if err != nil {
+		t.Fatalf("ReconcileStaleRunningRuns() error = %v", err)
+	}
+	if summary.LoopsRequeued != 1 || summary.QueueItemsRequeued != 1 {
+		t.Fatalf("summary = %#v, want one queued item recreated", summary)
+	}
+	activeCount, err := repos.Queue.CountActiveByLoopID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("CountActiveByLoopID() error = %v", err)
+	}
+	if activeCount != 1 {
+		t.Fatalf("active queue count = %d, want 1", activeCount)
+	}
+	items, err := repos.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	matched := 0
+	for _, item := range items {
+		if item.LoopID != nil && *item.LoopID == loopID && (item.Status == "queued" || item.Status == "running") {
+			matched++
+		}
+	}
+	if matched != 1 {
+		t.Fatalf("active queue items for loop = %d, want exactly 1: %#v", matched, items)
+	}
+}
+
 func TestRuntimeStartBeginsSchedulerPolling(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1671,6 +1671,67 @@ func TestRuntimeReconcileStaleRunningRunsKeepsSupersededRunWithVerifiedLiveExecu
 	}
 }
 
+func TestRepairStaleRunQueueStateDoesNotRequeueLoopWhileNewerRunIsLive(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer rt.Stop("test cleanup")
+	repos := rt.Services().Repositories
+	repo := "nexu-io/looper"
+	prNumber := int64(195)
+	targetID := "pr:nexu-io/looper:195"
+	loopID := "loop_superseded_latest_live"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loop := storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}
+	if err := repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	runningQueue := storage.QueueItemRecord{ID: "queue_superseded_running", ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:project_1:loop_superseded_latest_live:nexu-io/looper:195", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: oldISO, StartedAt: stringPtr(oldISO), MaxAttempts: 3, CreatedAt: oldISO, UpdatedAt: oldISO}
+	if err := repos.Queue.Upsert(context.Background(), runningQueue); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	latestRun := &storage.RunRecord{ID: "run_superseded_latest_live", LoopID: loopID, Status: "running", CurrentStep: stringPtr("review"), StartedAt: nowISO, LastHeartbeatAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}
+
+	summary, err := rt.repairStaleRunQueueState(context.Background(), repos, loop, latestRun, true, nowISO)
+	if err != nil {
+		t.Fatalf("repairStaleRunQueueState() error = %v", err)
+	}
+	if summary.LoopsRequeued != 0 || summary.QueueItemsRequeued != 0 || summary.QueueItemsCancelled != 1 {
+		t.Fatalf("summary = %#v, want no requeue and one stale queue cancellation", summary)
+	}
+	repairedLoop, err := repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if repairedLoop == nil || repairedLoop.Status != "running" {
+		t.Fatalf("loop = %#v, want loop to stay running under newer live run", repairedLoop)
+	}
+	repairedQueue, err := repos.Queue.GetByID(context.Background(), runningQueue.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if repairedQueue == nil || repairedQueue.Status != "cancelled" {
+		t.Fatalf("queue = %#v, want stale running queue item cancelled", repairedQueue)
+	}
+}
+
 func TestRuntimeReconcileStaleRunningRunsWithMultipleActiveExecutions(t *testing.T) {
 	t.Parallel()
 
@@ -1907,6 +1968,75 @@ func TestRuntimeReconcileStaleRunningRunsIsIdempotent(t *testing.T) {
 				t.Fatalf("second summary = %#v, want idempotent no-op", second)
 			}
 		})
+	}
+}
+
+func TestRuntimeReconcileStaleRunningRunsDedupesUncertainIdentityEvents(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	now := time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+	ambiguousPID := int64(5651)
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }, ReadProcessCommand: func(context.Context, int) (string, error) { return "python unrelated.py", nil }})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer rt.Stop("test cleanup")
+	repos := rt.Services().Repositories
+	repo := "nexu-io/looper"
+	prNumber := int64(196)
+	targetID := "pr:nexu-io/looper:196"
+	loopID := "loop_uncertain_event_dedupe"
+	runID := "run_uncertain_event_dedupe"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: runID, LoopID: loopID, Status: "running", CurrentStep: stringPtr("review"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "exec_uncertain_event_dedupe", ProjectID: stringPtr("project_1"), LoopID: stringPtr(loopID), RunID: stringPtr(runID), Vendor: "codex", Status: "running", PID: &ambiguousPID, CommandJSON: stringPtr(`{"command":"codex","args":["exec"]}`), CWD: stringPtr(workingDir), StartedAt: oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	first, err := rt.reconcileLiveStaleRunningRuns(context.Background())
+	if err != nil {
+		t.Fatalf("first reconcile error = %v", err)
+	}
+	second, err := rt.reconcileLiveStaleRunningRuns(context.Background())
+	if err != nil {
+		t.Fatalf("second reconcile error = %v", err)
+	}
+	if first.SkippedUncertainRuns != 1 || first.EventsWritten != 1 {
+		t.Fatalf("first summary = %#v, want one uncertain event written", first)
+	}
+	if second.SkippedUncertainRuns != 1 || second.EventsWritten != 0 {
+		t.Fatalf("second summary = %#v, want deduped uncertain event without new writes", second)
+	}
+	events, err := repos.Events.ListByEntity(context.Background(), "agent_execution", "exec_uncertain_event_dedupe")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	count := 0
+	for _, event := range events {
+		if event.EventType == "looperd.recovery.process_identity_uncertain" {
+			count += 1
+		}
+	}
+	if count != 1 {
+		t.Fatalf("uncertain event count = %d, want 1; events = %#v", count, events)
 	}
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -92,6 +92,7 @@ type defaultSchedulerTickInput struct {
 	Now                      func() time.Time
 	MaxConcurrentRuns        int
 	ClaimMu                  *sync.Mutex
+	ReconcileStaleRuns       func(context.Context) (StaleRunReconcileSummary, error)
 	AsyncRunner              schedulerAsyncRunner
 	RequestSchedulerWake     func()
 	Planner                  plannerScheduler
@@ -888,7 +889,7 @@ func (a workerAgentExecutionAdapter) Kill(reason string) error {
 	return a.execution.Kill(reason)
 }
 
-func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time) defaultSchedulerHandlers {
+func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time, reconcileStaleRuns func(context.Context) (StaleRunReconcileSummary, error)) defaultSchedulerHandlers {
 	if now == nil {
 		now = time.Now
 	}
@@ -1167,6 +1168,7 @@ func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, c
 			Now:                      now,
 			MaxConcurrentRuns:        cfg.Scheduler.MaxConcurrentRuns,
 			ClaimMu:                  claimMu,
+			ReconcileStaleRuns:       reconcileStaleRuns,
 			AsyncRunner:              runner,
 			RequestSchedulerWake:     requestWake,
 			Planner:                  plannerRunner,
@@ -1511,6 +1513,17 @@ func executeClaimPhase(ctx context.Context, phase string, input defaultScheduler
 	if err != nil {
 		logClaimPhase(input.Logger, phase, 0, 0, time.Since(start), err)
 		return 0, 0, err
+	}
+	if availableSlots == 0 && input.ReconcileStaleRuns != nil {
+		if _, err := input.ReconcileStaleRuns(ctx); err != nil {
+			logClaimPhase(input.Logger, phase, 0, 0, time.Since(start), err)
+			return 0, 0, err
+		}
+		availableSlots, err = schedulerAvailableSlots(ctx, input.Repos, input.MaxConcurrentRuns)
+		if err != nil {
+			logClaimPhase(input.Logger, phase, 0, 0, time.Since(start), err)
+			return 0, 0, err
+		}
 	}
 	claimedItems := make([]storage.QueueItemRecord, 0)
 	if availableSlots > 0 && input.Repos != nil && input.Repos.Queue != nil {

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -466,6 +466,61 @@ func TestIndependentClaimPassClaimsQueuedWorkWhileDiscoveryIsBlocked(t *testing.
 	}
 }
 
+func TestRunDefaultSchedulerTickReconcilesLiveStaleRunsWhenCapacityIsFull(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "scheduler-live-reconcile.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+	insertSchedulerProject(t, repos, workingDir, nowISO)
+	projectID := "looper"
+	staleLoopID := "loop_reconcile_stale"
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: staleLoopID, Seq: 2, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: stringPtr("pr:nexu-io/looper:42"), Repo: stringPtr("nexu-io/looper"), PRNumber: int64Ptr(42), Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert(stale) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_reconcile_stale", LoopID: staleLoopID, Status: "running", CurrentStep: stringPtr("review"), StartedAt: oldISO, LastHeartbeatAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Runs.Upsert(stale) error = %v", err)
+	}
+	queuedLoopID := "loop_worker_queued"
+	loopTarget := "project:project_1"
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: queuedLoopID, Seq: 3, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &loopTarget, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert(queued) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_after_reconcile", ProjectID: &projectID, LoopID: &queuedLoopID, Type: "worker", TargetType: "project", TargetID: loopTarget, DedupeKey: "worker:loop_worker_queued", Priority: 1, Status: "queued", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	workerRunner := &stubWorkerScheduler{}
+	reconcileCalls := 0
+	if err := runDefaultSchedulerTick(context.Background(), defaultSchedulerTickInput{
+		Repos:             repos,
+		Now:               func() time.Time { return now },
+		MaxConcurrentRuns: 1,
+		AsyncRunner:       immediateSchedulerRunner{},
+		ReconcileStaleRuns: func(context.Context) (StaleRunReconcileSummary, error) {
+			reconcileCalls++
+			if err := interruptRecoveryRun(context.Background(), repos, storage.RunRecord{ID: "run_reconcile_stale", LoopID: staleLoopID}, storage.LoopRecord{ID: staleLoopID, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", Status: "running"}, nowISO, "Interrupted stale running run during stale-run reconciliation"); err != nil {
+				return StaleRunReconcileSummary{}, err
+			}
+			return StaleRunReconcileSummary{Mode: "live", CandidateRuns: 1, InterruptedRuns: 1, LoopsRequeued: 1, RunIDs: []string{"run_reconcile_stale"}, LoopIDs: []string{staleLoopID}}, nil
+		},
+		Worker: workerRunner,
+	}); err != nil {
+		t.Fatalf("runDefaultSchedulerTick() error = %v", err)
+	}
+	if reconcileCalls == 0 {
+		t.Fatal("reconcile calls = 0, want at least one live reconcile attempt")
+	}
+	waitForSchedulerCondition(t, func() bool { return workerRunner.processItemCount() == 1 })
+	if workerRunner.processItemCount() != 1 || workerRunner.processedItems[0] != "queue_worker_after_reconcile" {
+		t.Fatalf("worker processed items = %#v, want queued item claimed after live reconcile", workerRunner.processedItems)
+	}
+}
+
 func TestRunDefaultSchedulerTickLogsClaimPhasesAndSlowLanes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -1418,6 +1419,24 @@ func (r *QueueRepository) CountByStatus(ctx context.Context, status string) (int
 	return count, nil
 }
 
+func (r *QueueRepository) CountActiveByLoopID(ctx context.Context, loopID string) (int64, error) {
+	row := r.q.QueryRowContext(ctx, `SELECT COUNT(*) FROM queue_items WHERE loop_id = ? AND status IN ('queued', 'running')`, loopID)
+	var count int64
+	if err := row.Scan(&count); err != nil {
+		return 0, fmt.Errorf("count active queue items by loop: %w", err)
+	}
+	return count, nil
+}
+
+func (r *QueueRepository) CountByLoopIDAndStatus(ctx context.Context, loopID, status string) (int64, error) {
+	row := r.q.QueryRowContext(ctx, `SELECT COUNT(*) FROM queue_items WHERE loop_id = ? AND status = ?`, loopID, status)
+	var count int64
+	if err := row.Scan(&count); err != nil {
+		return 0, fmt.Errorf("count queue items by loop and status: %w", err)
+	}
+	return count, nil
+}
+
 func (r *QueueRepository) FindActiveByDedupe(ctx context.Context, dedupeKey string) (*QueueItemRecord, error) {
 	row := r.q.QueryRowContext(ctx, `
 		SELECT * FROM queue_items
@@ -1892,6 +1911,28 @@ func (r *QueueRepository) CancelByLoop(ctx context.Context, loopID, finishedAt s
 		return 0, fmt.Errorf("read cancel queue items rows affected: %w", err)
 	}
 
+	return affected, nil
+}
+
+func (r *QueueRepository) CancelActiveByLoopExcept(ctx context.Context, loopID, keepID, finishedAt string, reason *string) (int64, error) {
+	if strings.TrimSpace(loopID) == "" || strings.TrimSpace(keepID) == "" {
+		return 0, nil
+	}
+	result, err := r.q.ExecContext(ctx, `
+		UPDATE queue_items
+		SET status = 'cancelled',
+			finished_at = ?,
+			last_error = COALESCE(?, last_error),
+			updated_at = ?
+		WHERE loop_id = ? AND status IN ('queued', 'running') AND id != ?
+	`, finishedAt, reason, finishedAt, loopID, keepID)
+	if err != nil {
+		return 0, fmt.Errorf("cancel active queue items by loop except %s: %w", keepID, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read cancel active queue items rows affected: %w", err)
+	}
 	return affected, nil
 }
 

--- a/specs/2026-05-23-issue-364-stale-run-reconcile/spec.md
+++ b/specs/2026-05-23-issue-364-stale-run-reconcile/spec.md
@@ -1,0 +1,425 @@
+# Issue #364 — Recover Stale Running Tasks After Sleep/Wake
+
+## 1. Background
+
+Looper already has startup recovery that can interrupt stale or orphaned `running` runs when `looperd` starts. That helps after a daemon restart, but it does not fully solve the user-visible failure from issue #364:
+
+- the machine sleeps,
+- the child agent process disappears,
+- the daemon later appears healthy again,
+- one or more runs remain `status=running`,
+- scheduler capacity stays consumed,
+- queued work remains blocked indefinitely.
+
+The problem is not merely presentation. The underlying run and queue bookkeeping remain in a blocking state while there is no real live agent execution behind them.
+
+Today Looper also lacks a clear product surface for this situation. Operators can use `looper daemon restart` or try `looper stop`, but there is no explicit “reconcile stale running runs” workflow documented or exposed as a dedicated API/CLI.
+
+---
+
+## 2. Goals
+
+### 2.1 Primary goals
+
+1. Automatically release scheduler capacity held by stale `running` runs after sleep/wake without requiring a daemon restart.
+2. Add a supported manual recovery command/API for operators.
+3. Reuse the existing startup stale-run recovery logic instead of introducing a second lifecycle system.
+4. Prevent stale runs from appearing as normal active work in default active-run views.
+
+### 2.2 Non-goals
+
+1. Do not introduce a new persisted run state such as `stale` or `recovered`.
+2. Do not add a new background watchdog or a large new state machine.
+3. Do not use GitHub state as the authority for local process liveness.
+4. Do not solve this by only hiding stale rows in the UI while leaving scheduler state blocked.
+
+---
+
+## 3. Problem summary
+
+The issue is caused by a mismatch between:
+
+- **DB state**: run row says `running`, queue row may say `running`, loop may say `running`
+- **real runtime state**: the underlying agent process is gone
+
+The scheduler trusts the persisted `running` bookkeeping enough to count those items against capacity. That is correct when the bookkeeping is fresh, but wrong after machine sleep/wake if the child process has disappeared and no online reconciliation happens.
+
+Existing startup recovery already proves that Looper has the right basic primitive:
+
+- identify stale/orphaned running runs
+- interrupt them safely
+- repair queue state so work can continue
+
+The missing piece is to reuse that primitive while the daemon is still alive.
+
+---
+
+## 4. Design principles
+
+### 4.1 Reuse one reconciliation primitive everywhere
+
+Looper should have one stale-run reconciliation primitive reused by:
+
+1. startup recovery,
+2. live scheduler recovery,
+3. manual operator recovery.
+
+This avoids split logic and prevents startup and live recovery from drifting apart.
+
+### 4.2 Name the authority clearly
+
+The authority for whether a run is still alive is **verified local execution identity**, not the persisted `running` status by itself.
+
+A run should be treated as live only when Looper can verify a matching active agent execution with a real process behind it.
+
+In live daemon mode, that authority must stay narrow. The absence of a verified agent process is **not** by itself authority to interrupt every `running` run, because some steps may still be executing inside the daemon without an agent process.
+
+### 4.3 Repair state, do not mask symptoms
+
+The fix must repair the run/queue state that blocks scheduler capacity. Merely filtering stale items out of `/api/v1/runs/active` is insufficient.
+
+### 4.4 Be conservative before interrupting live work
+
+Live reconciliation must use a grace period and identity checks so a fresh run is not interrupted just because its PID or first heartbeat has not propagated yet.
+
+---
+
+## 5. Recommended approach
+
+## 5.1 Extract a shared stale-run reconciler
+
+Extract the stale/orphaned running-run logic from startup recovery into a shared helper, for example:
+
+```go
+ReconcileStaleRunningRuns(ctx, repositories, now, mode) (summary, error)
+```
+
+Where `mode` is one of:
+
+- `startup`
+- `live`
+- `manual`
+
+The helper should:
+
+1. list candidate `running` runs,
+2. inspect the latest run/loop/queue/execution state,
+3. verify whether a live agent execution still exists,
+4. interrupt truly stale runs,
+5. repair queue state,
+6. emit a structured summary and recovery events.
+
+### 5.1.1 Why this is the right level of abstraction
+
+This adds one reusable behavior, not a new concept. The concrete failure it prevents is duplicated or inconsistent stale-run handling between startup recovery, live scheduler operation, and manual recovery. The cost is limited to one shared helper and mode-specific guards. A simpler alternative — continuing to keep startup-only logic and adding ad hoc live fixes elsewhere — would create divergence and more failure modes over time.
+
+---
+
+## 5.2 Add automatic live reconciliation at the scheduler boundary
+
+When the scheduler is about to skip claiming work because running capacity is full, it should first attempt stale-run reconciliation.
+
+Recommended flow:
+
+1. scheduler computes running capacity,
+2. if capacity is available, continue normally,
+3. if capacity is exhausted, call live stale-run reconcile,
+4. recompute capacity,
+5. if stale work was released, continue claiming queued work.
+
+This keeps the extra process inspection work focused on the exact scenario where stale runs are causing damage.
+
+### 5.2.1 Why not a polling watchdog
+
+A periodic watchdog would add more moving parts and repeated `ps` inspection even when the system is healthy. Scheduler-bound reconciliation is simpler and directly tied to the blocking symptom.
+
+---
+
+## 5.3 Add an explicit manual recovery API and CLI
+
+Add a dedicated product surface, for example:
+
+```bash
+looper run reconcile-stale
+```
+
+Back it with a route such as:
+
+```http
+POST /api/v1/runs/reconcile-stale
+```
+
+The command should return a structured summary, for example:
+
+- interrupted runs
+- repaired queue items
+- cleaned agent executions
+- skipped uncertain candidates
+
+This gives operators a safe, supported recovery path without needing to restart the daemon.
+
+Initial manual recovery behavior should be narrow and explicit:
+
+1. it is mutating,
+2. it uses the same safety rules as live reconciliation,
+3. it scans all stale running candidates rather than only capacity-full cases,
+4. it does not provide `--force` in the initial version,
+5. it reports uncertain candidates rather than killing or signalling them blindly.
+
+`looper daemon restart` remains a fallback, not the primary workflow.
+
+---
+
+## 6. Authority and stale-run decision rules
+
+## 6.1 Positive liveness authority
+
+For agent-backed work, a run is live only if Looper can verify all of the following:
+
+1. there is an active agent execution associated with the run,
+2. the execution has a PID,
+3. the process still exists locally,
+4. the running process command matches the persisted command identity.
+
+This should reuse the existing process identity helpers already used by startup recovery.
+
+## 6.2 Live stale-run rule
+
+In `live` mode, a running run can be interrupted only when all of the following hold:
+
+1. the run is still persisted as `running`,
+2. the run is in an agent-backed or agent-waiting phase, or it has an associated active execution row whose PID is missing or dead,
+3. there is no verified live execution behind it,
+4. its heartbeat / activity timestamp is older than the stale threshold,
+5. it is still occupying scheduler capacity directly or indirectly.
+
+In live mode, absence of a verified agent execution is not universal authority to interrupt every running run. It is authority only for runs whose state indicates they are agent-backed candidates for reconciliation.
+
+Initial stale threshold: reuse the existing active-run heartbeat TTL of **30 minutes**. Do not add a new config knob in this change.
+
+## 6.3 Queue state is not authority
+
+`queue.status = running` is not proof of liveness. It is scheduler bookkeeping and must be repaired after a stale run is interrupted.
+
+## 6.4 Uncertain cases
+
+If PID inspection fails, command identity cannot be validated, or the state is otherwise ambiguous, automatic live reconciliation should skip the candidate and report it as uncertain.
+
+Manual recovery may support an explicit force mode later, but the initial version should avoid force semantics unless clearly needed.
+
+## 6.5 Process identity limits
+
+Command matching reduces accidental signalling risk, but it does not fully eliminate same-command PID reuse risk.
+
+This change accepts that residual risk rather than introducing a new persisted process-start identity field.
+
+---
+
+## 7. Product behavior changes
+
+## 7.1 Automatic behavior
+
+After sleep/wake, stale `running` runs should stop blocking queued work once the scheduler next reaches the “capacity full” path and reconciles stale entries.
+
+## 7.2 Manual behavior
+
+Operators should be able to run a dedicated command that reconciles stale running tasks immediately and prints a clear summary.
+
+## 7.3 Active-run presentation
+
+Default active-run views should no longer treat “loop is running but the run is stale” as normal active work.
+
+If Looper wants to keep stale historical visibility, that should live behind an explicit expanded or diagnostic view rather than the default active view.
+
+---
+
+## 8. Implementation plan
+
+## 8.1 Runtime recovery extraction
+
+Update `internal/runtime/runtime.go` to:
+
+1. extract the stale-running-run portion of startup recovery into a shared helper,
+2. preserve the existing startup behavior by calling that helper in `startup` mode,
+3. return a reusable summary struct suitable for startup, live, and manual flows.
+
+The helper should continue reusing the current interruption path instead of introducing a new terminal transition mechanism.
+
+## 8.2 Scheduler integration
+
+Update the scheduler path under `internal/runtime/` so that when running capacity is exhausted, it performs one live stale-run reconciliation pass before giving up on claiming new work.
+
+This must run inside the existing scheduler claim serialization so concurrent claim passes do not duplicate repair or claim decisions.
+
+The flow should be:
+
+1. compute available slots,
+2. if slots are available, continue normally,
+3. if slots are exhausted, run one live reconcile pass inside the claim path,
+4. recompute available slots in the same claim pass,
+5. continue claiming only if capacity was truly released.
+
+This must be idempotent and safe to run repeatedly.
+
+## 8.3 Queue repair
+
+Ensure that interrupting a stale run also repairs its queue consequences:
+
+- stale `running` queue rows should no longer hold capacity,
+- loops that should continue should become claimable again,
+- paused or terminal loops should not be spuriously requeued.
+
+Required semantics:
+
+1. if a stale run is interrupted and the loop should continue, requeue the running queue item for that loop or ensure exactly one queued item exists,
+2. if the loop is paused, stopped, or terminal, cancel stale running queue items and do not requeue them,
+3. queue repair must be idempotent,
+4. run interruption and queue repair should happen in the same consistency boundary where practical so capacity is not left half-repaired.
+
+## 8.4 API and CLI
+
+Add:
+
+- a manual reconcile API endpoint in `internal/api/handler.go`,
+- runtime wiring in `cmd/looperd/main.go`,
+- a CLI command and human/JSON output under `internal/cliapp/`.
+
+The response should expose counts and IDs where practical, but the product surface should stay simple.
+
+Live/manual cleanup should stay narrow: only executions tied to stale candidate runs should be marked dead or killed. This command should not become a broad orphan-agent sweeper.
+
+When a dead execution is marked terminal, it should preserve the same native-resume metadata behavior already used by startup recovery.
+
+## 8.5 Active-runs behavior cleanup
+
+Update the active-runs view logic so stale fallback behavior is no longer the default interpretation of active work.
+
+Default active view should:
+
+1. show verified live running runs,
+2. show queued loops with active queued work,
+3. optionally show very fresh running loops without runs only within the same freshness window,
+4. hide stale running-loop fallback by default,
+5. keep stale or historical visibility behind `all=true` or another explicit diagnostic surface.
+
+This should include replacing the current test expectation that stale running loops still appear as active.
+
+## 8.6 Documentation
+
+Update user-facing docs to explain:
+
+1. what stale running tasks after sleep/wake look like,
+2. the automatic recovery behavior,
+3. the new manual recovery command,
+4. when `looper daemon restart` is still a reasonable fallback.
+
+---
+
+## 9. Files likely to change
+
+Primary areas:
+
+- `internal/runtime/runtime.go`
+- `internal/runtime/runtime_test.go`
+- `internal/runtime/scheduler.go`
+- `internal/api/handler.go`
+- `internal/api/handler_test.go`
+- `cmd/looperd/main.go`
+- `internal/cliapp/app.go`
+- `internal/cliapp/json_output.go`
+- `internal/cliapp/human_output.go`
+- relevant docs under `docs/`
+
+Additional test files may be needed if queue/rerun behavior is owned elsewhere.
+
+---
+
+## 10. Required regression coverage
+
+At minimum, add or update tests for:
+
+1. **live stale-run interruption**
+   - agent-backed or agent-waiting running run + stale heartbeat + no verified live execution → interrupted.
+
+2. **scheduler capacity unblock**
+   - stale running work consumes the last slot,
+   - queued work exists,
+   - reconcile releases capacity,
+   - queued work becomes claimable.
+
+3. **queue repair semantics**
+   - stale running queue item no longer blocks capacity after reconcile,
+   - loop is requeued only when appropriate.
+
+4. **do not interrupt live work**
+   - stale-looking heartbeat but matching live PID/command → leave running.
+
+5. **fresh-start grace period**
+   - run has not yet established full execution metadata, but timestamps are fresh → do not interrupt in live mode.
+
+6. **non-agent live-mode safety**
+   - running run in a non-agent or in-process phase + stale heartbeat + no agent execution → skipped in live mode, because absence of an agent is not authority for that phase.
+
+7. **dead PID execution cleanup**
+   - execution row exists but process is gone → cleanup is reflected in run/execution state.
+
+8. **uncertain process identity**
+   - process inspection is ambiguous → auto-reconcile skips rather than killing blindly.
+
+9. **manual API/CLI flow**
+   - API returns a stable summary,
+   - CLI renders both human and JSON output.
+
+10. **active-runs default behavior**
+   - stale running loops no longer appear as normal active work by default.
+
+11. **idempotent repeated reconcile**
+   - running reconcile twice does not create duplicate queue rows, duplicate repair state, or unstable summary counts on the second pass.
+
+---
+
+## 11. Risks and edge cases
+
+1. **False interruption of real work**
+   - mitigated by TTL + verified process identity.
+
+2. **PID reuse**
+   - reduced, but not fully eliminated, by command identity matching before trusting or signalling a process.
+
+3. **Fresh-start race**
+   - mitigated by live-mode grace period.
+
+4. **Repeated reconcile churn**
+   - mitigated by idempotent interruption and queue-repair behavior.
+
+5. **Presentation vs state divergence**
+   - mitigated by fixing state first, then tightening active-run presentation.
+
+6. **Manual recovery expectations**
+   - documentation must explain whether the command interrupts stale work, requeues work, or only reports it.
+
+---
+
+## 12. Rollout order
+
+Recommended order:
+
+1. extract shared reconciler from startup recovery together with helper-level regression coverage,
+2. add live scheduler integration together with the capacity-unblock regression test,
+3. add manual API/CLI,
+4. tighten active-runs presentation,
+5. update docs.
+
+This order keeps the core correctness change first and the product surface changes second.
+
+---
+
+## 13. Success criteria
+
+This work is done when all of the following are true:
+
+1. a stale post-sleep `running` run no longer blocks queued work indefinitely while the daemon remains alive,
+2. operators have a documented, supported manual reconcile command,
+3. startup and live stale-run recovery share one implementation path,
+4. default active-run views no longer present stale work as healthy active work,
+5. regression tests cover both safety and unblock behavior.


### PR DESCRIPTION
## Summary
- add shared stale-run reconciliation reused by startup, live scheduler, and manual operator flows
- add manual stale-run recovery via API and `looper run reconcile-stale`, and tighten active-run liveness authority
- repair blocked queue state idempotently, dedupe active queue items, and document the new recovery workflow

## Testing
- go test ./internal/runtime ./internal/api ./internal/cliapp ./cmd/looperd
- go test ./...
- go vet ./...
- go build ./...

Closes #364