### PR TITLE
[codex] fix resilient coordinator triage output

### DIFF
--- a/internal/coordinator/triage/triage.go
+++ b/internal/coordinator/triage/triage.go
@@ -13,6 +13,7 @@ import (
 const jsISOStringLayout = "2006-01-02T15:04:05.000Z"
 
 var tokenPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9_./-]{2,}`)
+var fencedJSONPattern = regexp.MustCompile("(?s)^```(?:json)?\\s*(.*?)\\s*```$")
 
 type Disposition string
 
@@ -175,7 +176,19 @@ func BuildPrompt(input Input) string {
 	b.WriteString(strings.Join(AllowedDispatches(), ", "))
 	b.WriteString("\nOutput schema:\n")
 	b.WriteString(`{"disposition":"valid|out-of-scope|unclear","comment":"string","labels":{"kind":["kind/..."],"area":["area/..."],"complexity":["complexity/..."],"dispatch":["dispatch/..."]}}`)
+	b.WriteString("\n\nComment style:\n")
+	b.WriteString("- Write the comment in a warm maintainer voice.\n")
+	b.WriteString("- Briefly acknowledge the reporter and reference concrete details from the issue.\n")
+	b.WriteString("- For valid issues, name the selected label/status path and give one clear next step.\n")
+	b.WriteString("- For unclear issues, ask for the smallest missing detail needed to proceed.\n")
+	b.WriteString("- For out-of-scope issues, explain the boundary respectfully.\n")
+	b.WriteString("- Do not write generic bot boilerplate or repeat the entire issue.")
 	b.WriteString("\n\nIssue:\n")
+	if author := strings.TrimSpace(input.Issue.Author); author != "" {
+		b.WriteString("Reporter: @")
+		b.WriteString(strings.TrimPrefix(author, "@"))
+		b.WriteString("\n")
+	}
 	b.WriteString(input.Issue.Title)
 	b.WriteString("\n\n")
 	b.WriteString(strings.TrimSpace(input.Issue.Body))
@@ -230,7 +243,7 @@ func AllowedDispatches() []string {
 
 func parseDecision(raw string, cfg Config) (Decision, error) {
 	var output llmOutput
-	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &output); err != nil {
+	if err := json.Unmarshal([]byte(extractJSON(raw)), &output); err != nil {
 		return Decision{}, err
 	}
 	comment := strings.TrimSpace(output.Comment)
@@ -240,36 +253,76 @@ func parseDecision(raw string, cfg Config) (Decision, error) {
 	clear := []string{"kind/*", "area/*", "complexity/*", "dispatch/*", cfg.OutOfScopeLabel, cfg.UnclearLabel}
 	switch Disposition(strings.TrimSpace(output.Disposition)) {
 	case DispositionValid:
-		kind, err := requireExactlyOne(output.Labels.Kind, AllowedKinds())
+		if len(output.Labels.Kind) == 0 && len(output.Labels.Area) == 0 && len(output.Labels.Complexity) == 0 {
+			return Decision{}, fmt.Errorf("valid disposition requires at least one classification label")
+		}
+		kind, err := requireAllowedOrDefault(output.Labels.Kind, AllowedKinds(), "kind/feature")
 		if err != nil {
 			return Decision{}, err
 		}
-		area, err := requireExactlyOne(output.Labels.Area, AllowedAreas())
+		area, err := requireAllowedOrDefault(output.Labels.Area, AllowedAreas(), defaultAreaForKind(kind))
 		if err != nil {
 			return Decision{}, err
 		}
-		complexity, err := requireExactlyOne(output.Labels.Complexity, AllowedComplexities())
+		complexity, err := requireAllowedOrDefault(output.Labels.Complexity, AllowedComplexities(), "complexity/m")
 		if err != nil {
 			return Decision{}, err
 		}
-		dispatch, err := requireExactlyOne(output.Labels.Dispatch, AllowedDispatches())
+		dispatch, err := requireAllowedOrDefault(output.Labels.Dispatch, AllowedDispatches(), "dispatch/plan")
 		if err != nil {
 			return Decision{}, err
 		}
 		return Decision{Disposition: DispositionValid, ClearLabelPatterns: clear, ApplyLabels: []string{kind, area, complexity, dispatch, cfg.TriagedLabel}, CommentBody: comment, MarkTriaged: true}, nil
 	case DispositionOutOfScope:
-		if hasAnyLabels(output.Labels) {
-			return Decision{}, fmt.Errorf("unexpected labels for out-of-scope disposition")
-		}
 		return Decision{Disposition: DispositionOutOfScope, ClearLabelPatterns: clear, ApplyLabels: []string{cfg.OutOfScopeLabel, cfg.TriagedLabel}, CommentBody: comment, MarkTriaged: true}, nil
 	case DispositionUnclear:
-		if hasAnyLabels(output.Labels) {
-			return Decision{}, fmt.Errorf("unexpected labels for unclear disposition")
-		}
 		return Decision{Disposition: DispositionUnclear, ClearLabelPatterns: clear, ApplyLabels: []string{cfg.UnclearLabel, cfg.TriagedLabel}, CommentBody: comment, MarkTriaged: true}, nil
 	default:
 		return Decision{}, fmt.Errorf("unknown disposition")
 	}
+}
+
+func requireAllowedOrDefault(values []string, allowed []string, fallback string) (string, error) {
+	if len(values) == 0 {
+		values = []string{fallback}
+	}
+	allowedSet := map[string]struct{}{}
+	for _, item := range allowed {
+		allowedSet[item] = struct{}{}
+	}
+	for _, raw := range values {
+		value := strings.TrimSpace(raw)
+		if _, ok := allowedSet[value]; ok {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("no allowed value")
+}
+
+func defaultAreaForKind(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case "kind/docs":
+		return "area/docs"
+	case "kind/feature":
+		return "area/planner"
+	case "kind/bug":
+		return "area/runtime"
+	default:
+		return "area/runtime"
+	}
+}
+
+func extractJSON(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if matches := fencedJSONPattern.FindStringSubmatch(trimmed); len(matches) == 2 {
+		trimmed = strings.TrimSpace(matches[1])
+	}
+	start := strings.Index(trimmed, "{")
+	end := strings.LastIndex(trimmed, "}")
+	if start >= 0 && end > start {
+		return strings.TrimSpace(trimmed[start : end+1])
+	}
+	return trimmed
 }
 
 func requireExactlyOne(values []string, allowed []string) (string, error) {
@@ -285,15 +338,6 @@ func requireExactlyOne(values []string, allowed []string) (string, error) {
 		return "", fmt.Errorf("unknown value %q", value)
 	}
 	return value, nil
-}
-
-func hasAnyLabels(labels struct {
-	Kind       []string `json:"kind"`
-	Area       []string `json:"area"`
-	Complexity []string `json:"complexity"`
-	Dispatch   []string `json:"dispatch"`
-}) bool {
-	return len(labels.Kind) > 0 || len(labels.Area) > 0 || len(labels.Complexity) > 0 || len(labels.Dispatch) > 0
 }
 
 func needsInfoAppliedAt(issue Issue, unclearLabel string) (time.Time, bool) {

--- a/internal/coordinator/triage/triage_decisions_test.go
+++ b/internal/coordinator/triage/triage_decisions_test.go
@@ -2,6 +2,7 @@ package triage
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 )
@@ -24,11 +25,114 @@ func TestDecideValidDisposition(t *testing.T) {
 	}
 }
 
+func TestDecideValidDispositionFromFencedJSON(t *testing.T) {
+	t.Parallel()
+	raw := "```json\n" + `{"disposition":"valid","comment":"Looks actionable.","labels":{"kind":["kind/bug"],"area":["area/coordinator"],"complexity":["complexity/m"],"dispatch":["dispatch/plan"]}}` + "\n```"
+	decision := Decide(context.Background(), fixtureLLM{raw: raw}, Input{Issue: Issue{Title: "Coordinator bug", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for fenced JSON output")
+	}
+	if got, want := decision.ApplyLabels, []string{"kind/bug", "area/coordinator", "complexity/m", "dispatch/plan", "triaged"}; len(got) != len(want) {
+		t.Fatalf("ApplyLabels len = %d, want %d", len(got), len(want))
+	}
+}
+
+func TestDecideValidDispositionFromTextWrappedJSON(t *testing.T) {
+	t.Parallel()
+	raw := "Here is the triage decision:\n" + `{"disposition":"valid","comment":"Looks actionable.","labels":{"kind":["kind/docs"],"area":["area/docs"],"complexity":["complexity/s"],"dispatch":["dispatch/plan"]}}` + "\nThanks."
+	decision := Decide(context.Background(), fixtureLLM{raw: raw}, Input{Issue: Issue{Title: "Docs gap", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for text-wrapped JSON output")
+	}
+	if got, want := decision.ApplyLabels, []string{"kind/docs", "area/docs", "complexity/s", "dispatch/plan", "triaged"}; len(got) != len(want) {
+		t.Fatalf("ApplyLabels len = %d, want %d", len(got), len(want))
+	}
+}
+
+func TestDecideValidDispositionDefaultsMissingArea(t *testing.T) {
+	t.Parallel()
+	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"valid","comment":"Needs planning.","labels":{"kind":["kind/feature"],"area":[],"complexity":["complexity/l"],"dispatch":["dispatch/plan"]}}`}, Input{Issue: Issue{Title: "Spaced repetition", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for valid output with missing area")
+	}
+	if got, want := decision.ApplyLabels, []string{"kind/feature", "area/planner", "complexity/l", "dispatch/plan", "triaged"}; len(got) != len(want) {
+		t.Fatalf("ApplyLabels len = %d, want %d", len(got), len(want))
+	} else {
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("ApplyLabels = %v, want %v", got, want)
+			}
+		}
+	}
+}
+
+func TestDecideValidDispositionDefaultsMissingDispatch(t *testing.T) {
+	t.Parallel()
+	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"valid","comment":"Docs task.","labels":{"kind":["kind/docs"],"area":["area/docs"],"complexity":["complexity/s"],"dispatch":[]}}`}, Input{Issue: Issue{Title: "Gemini docs", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for valid output with missing dispatch")
+	}
+	if got, want := decision.ApplyLabels, []string{"kind/docs", "area/docs", "complexity/s", "dispatch/plan", "triaged"}; len(got) != len(want) {
+		t.Fatalf("ApplyLabels len = %d, want %d", len(got), len(want))
+	} else {
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("ApplyLabels = %v, want %v", got, want)
+			}
+		}
+	}
+}
+
+func TestDecideValidDispositionSelectsFirstAllowedExtraArea(t *testing.T) {
+	t.Parallel()
+	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"valid","comment":"Needs planning.","labels":{"kind":["kind/feature"],"area":["area/api","area/planner"],"complexity":["complexity/l"],"dispatch":["dispatch/plan"]}}`}, Input{Issue: Issue{Title: "Spaced repetition", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for valid output with multiple area labels")
+	}
+	if got, want := decision.ApplyLabels, []string{"kind/feature", "area/api", "complexity/l", "dispatch/plan", "triaged"}; len(got) != len(want) {
+		t.Fatalf("ApplyLabels len = %d, want %d", len(got), len(want))
+	} else {
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("ApplyLabels = %v, want %v", got, want)
+			}
+		}
+	}
+}
+
+func TestDecideValidDispositionSelectsFirstAllowedExtraDispatch(t *testing.T) {
+	t.Parallel()
+	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"valid","comment":"Parser bug.","labels":{"kind":["kind/bug"],"area":["area/runtime"],"complexity":["complexity/s"],"dispatch":["dispatch/plan","dispatch/implement"]}}`}, Input{Issue: Issue{Title: "Parser bug", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for valid output with multiple dispatch labels")
+	}
+	if got, want := decision.ApplyLabels, []string{"kind/bug", "area/runtime", "complexity/s", "dispatch/plan", "triaged"}; len(got) != len(want) {
+		t.Fatalf("ApplyLabels len = %d, want %d", len(got), len(want))
+	} else {
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("ApplyLabels = %v, want %v", got, want)
+			}
+		}
+	}
+}
+
 func TestDecideOutOfScopeDisposition(t *testing.T) {
 	t.Parallel()
 	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"out-of-scope","comment":"Not aligned.","labels":{}}`}, Input{Issue: Issue{Title: "Unfit", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
 	if decision.NoOp {
 		t.Fatal("Decide() returned no-op for out-of-scope output")
+	}
+	if len(decision.ApplyLabels) != 2 || decision.ApplyLabels[0] != "wontfix" || decision.ApplyLabels[1] != "triaged" {
+		t.Fatalf("ApplyLabels = %v, want [wontfix triaged]", decision.ApplyLabels)
+	}
+}
+
+func TestDecideOutOfScopeIgnoresExtraLabels(t *testing.T) {
+	t.Parallel()
+	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"out-of-scope","comment":"Not aligned.","labels":{"kind":["kind/feature"],"area":["area/docs"],"complexity":["complexity/s"],"dispatch":["dispatch/plan"]}}`}, Input{Issue: Issue{Title: "Unfit", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for out-of-scope output with extra labels")
 	}
 	if len(decision.ApplyLabels) != 2 || decision.ApplyLabels[0] != "wontfix" || decision.ApplyLabels[1] != "triaged" {
 		t.Fatalf("ApplyLabels = %v, want [wontfix triaged]", decision.ApplyLabels)
@@ -43,6 +147,35 @@ func TestDecideUnclearDisposition(t *testing.T) {
 	}
 	if len(decision.ApplyLabels) != 2 || decision.ApplyLabels[0] != "needs-info" || decision.ApplyLabels[1] != "triaged" {
 		t.Fatalf("ApplyLabels = %v, want [needs-info triaged]", decision.ApplyLabels)
+	}
+}
+
+func TestDecideUnclearIgnoresExtraLabels(t *testing.T) {
+	t.Parallel()
+	decision := Decide(context.Background(), fixtureLLM{raw: `{"disposition":"unclear","comment":"Need repro steps.","labels":{"kind":["kind/bug"],"area":["area/runtime"],"complexity":["complexity/m"],"dispatch":["dispatch/implement"]}}`}, Input{Issue: Issue{Title: "Need info", CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Config: testConfig(), Now: time.Now().UTC()})
+	if decision.NoOp {
+		t.Fatal("Decide() returned no-op for unclear output with extra labels")
+	}
+	if len(decision.ApplyLabels) != 2 || decision.ApplyLabels[0] != "needs-info" || decision.ApplyLabels[1] != "triaged" {
+		t.Fatalf("ApplyLabels = %v, want [needs-info triaged]", decision.ApplyLabels)
+	}
+}
+
+func TestBuildPromptAsksForMaintainerStyleComment(t *testing.T) {
+	t.Parallel()
+	prompt := BuildPrompt(Input{Issue: Issue{Title: "Mac install failed", Body: "DeepSeek V4 flash failed on my MacBook", Author: "VIVAAN-DHAWAN"}, Config: testConfig()})
+	for _, want := range []string{
+		"Reporter: @VIVAAN-DHAWAN",
+		"Write the comment in a warm maintainer voice",
+		"acknowledge the reporter",
+		"reference concrete details",
+		"name the selected label/status path",
+		"give one clear next step",
+		"Do not write generic bot boilerplate",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("BuildPrompt() missing %q in:\n%s", want, prompt)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #456

## Summary
- tolerate coordinator triage JSON wrapped in markdown fences or surrounding prose
- default missing single-label fields to safe coordinator choices and choose the first allowed label when a model returns extra allowed values, including multiple dispatch labels
- ignore irrelevant labels for unclear/out-of-scope decisions
- guide triage comments toward a warmer maintainer style modeled after recent lefarcen issue responses: acknowledge the reporter, reference concrete issue details, name routing/status, and give one next step

## Root cause
The coordinator treated the LLM response as exact raw JSON and rejected otherwise usable decisions when models returned fenced JSON, prose-wrapped JSON, missing label groups, extra labels on non-valid dispositions, or more than one dispatch label. That made triage silently no-op in common agent-output cases.

## Validation
- go test ./internal/coordinator/triage -count=10
- go test ./internal/coordinator ./cmd/looperd ./cmd/looper -count=1
- installed the rebuilt local looper/looperd binaries and restarted the daemon
- live coordinator verification triaged 5 new marked issues across 5 repos: https://github.com/VIVAAN-DHAWAN/ai-study-companion/issues/16, https://github.com/VIVAAN-DHAWAN/termux-math-practice/issues/3, https://github.com/VIVAAN-DHAWAN/readme-ai-generator/issues/1, https://github.com/VIVAAN-DHAWAN/usage-based-billing/issues/5, and https://github.com/VIVAAN-DHAWAN/github-roaster/issues/1
- live scenarios covered valid feature, valid bug, docs, unclear/needs-info, and out-of-scope/wontfix; each ended with one Looper coordinator comment and the expected routing labels

## Notes
I sampled recent lefarcen comments on nexu-io/open-design issues https://github.com/nexu-io/open-design/issues/2815, https://github.com/nexu-io/open-design/issues/2801, https://github.com/nexu-io/open-design/issues/2794, and https://github.com/nexu-io/open-design/issues/2785. The common pattern was warm acknowledgement, concrete issue recap, explicit routing/status, and a clear next step; this PR adds that guidance to the coordinator prompt without changing the comment stamping/disclosure path.