### PR TITLE
fix: support manual fixer runs on foreign PRs

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3324,14 +3324,14 @@ func (h *Handler) buildCreateLoopResponse(r *http.Request) (loopResponse, error)
 			return loopResponse{}, err
 		}
 	}
+	now := h.now().UTC()
+	nowISO := eventlog.FormatJavaScriptISOString(now)
 	if domain.LoopType(loopType) == domain.LoopTypeFixer {
-		metadataJSON, err = manualFixerMetadataJSON(metadataJSON)
+		metadataJSON, err = manualFixerMetadataJSON(metadataJSON, nowISO)
 		if err != nil {
 			return loopResponse{}, err
 		}
 	}
-	now := h.now().UTC()
-	nowISO := eventlog.FormatJavaScriptISOString(now)
 	if domain.LoopType(loopType) == domain.LoopTypeReviewer {
 		metadataJSON, err = reviewerLoopMetadataJSON(metadataJSON, h.context.Config.Roles.Reviewer.Behavior, target, nowISO)
 		if err != nil {
@@ -4495,7 +4495,7 @@ func manualPlannerMetadataJSON(existing *string, issueNumber int64) (*string, er
 	return &text, nil
 }
 
-func manualFixerMetadataJSON(existing *string) (*string, error) {
+func manualFixerMetadataJSON(existing *string, nowISO string) (*string, error) {
 	metadata := map[string]any{}
 	if existing != nil && strings.TrimSpace(*existing) != "" {
 		if err := json.Unmarshal([]byte(*existing), &metadata); err != nil {
@@ -4503,6 +4503,20 @@ func manualFixerMetadataJSON(existing *string) (*string, error) {
 		}
 	}
 	metadata["manual"] = true
+	followUpdates, _ := metadata["followUpdates"].(bool)
+	loopMeta, _ := metadata["loop"].(map[string]any)
+	if loopMeta == nil {
+		loopMeta = map[string]any{}
+	}
+	metadata["followUpdates"] = followUpdates
+	loopMeta["enabled"] = followUpdates
+	if _, ok := loopMeta["status"].(string); !ok {
+		loopMeta["status"] = "active"
+	}
+	if _, ok := loopMeta["startTime"].(string); !ok && strings.TrimSpace(nowISO) != "" {
+		loopMeta["startTime"] = nowISO
+	}
+	metadata["loop"] = loopMeta
 	encoded, err := json.Marshal(metadata)
 	if err != nil {
 		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3324,6 +3324,12 @@ func (h *Handler) buildCreateLoopResponse(r *http.Request) (loopResponse, error)
 			return loopResponse{}, err
 		}
 	}
+	if domain.LoopType(loopType) == domain.LoopTypeFixer {
+		metadataJSON, err = manualFixerMetadataJSON(metadataJSON)
+		if err != nil {
+			return loopResponse{}, err
+		}
+	}
 	now := h.now().UTC()
 	nowISO := eventlog.FormatJavaScriptISOString(now)
 	if domain.LoopType(loopType) == domain.LoopTypeReviewer {
@@ -4480,6 +4486,22 @@ func manualPlannerMetadataJSON(existing *string, issueNumber int64) (*string, er
 		}
 	}
 	metadata["issueNumber"] = issueNumber
+	metadata["manual"] = true
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	text := string(encoded)
+	return &text, nil
+}
+
+func manualFixerMetadataJSON(existing *string) (*string, error) {
+	metadata := map[string]any{}
+	if existing != nil && strings.TrimSpace(*existing) != "" {
+		if err := json.Unmarshal([]byte(*existing), &metadata); err != nil {
+			return nil, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "metadata must be a JSON object"}
+		}
+	}
 	metadata["manual"] = true
 	encoded, err := json.Marshal(metadata)
 	if err != nil {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2893,6 +2893,10 @@ func TestHandlerCreateLoopFixerEnqueuesSchedulableManualLoop(t *testing.T) {
 	}
 	metadata := parseJSONObject(loop.MetadataJSON)
 	assertEqual(t, metadata["manual"], true)
+	assertEqual(t, metadata["followUpdates"], false)
+	loopMeta := metadata["loop"].(map[string]any)
+	assertEqual(t, loopMeta["enabled"], false)
+	assertEqual(t, loopMeta["startTime"], fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString))
 
 	queueItems, err := fixture.runtime.Services().Repositories.Queue.List(context.Background())
 	if err != nil {
@@ -2914,6 +2918,33 @@ func TestHandlerCreateLoopFixerEnqueuesSchedulableManualLoop(t *testing.T) {
 	assertEqual(t, queue.TargetID, "pr:acme/looper:99")
 	assertEqual(t, queue.DedupeKey, "fixer:"+loopID)
 	assertEqual(t, triggered, 1)
+}
+
+func TestHandlerCreateLoopFixerPersistsFollowUpdatesWhenLoopEnabled(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops", bytes.NewReader([]byte(`{"projectId":"project_1","type":"fixer","targetType":"pull_request","repo":"acme/looper","prNumber":99,"metadata":{"followUpdates":true}}`)))
+	req.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now }}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	loopID := data["id"].(string)
+	loop, err := fixture.runtime.Services().Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+	metadata := parseJSONObject(loop.MetadataJSON)
+	assertEqual(t, metadata["manual"], true)
+	assertEqual(t, metadata["followUpdates"], true)
+	loopMeta := metadata["loop"].(map[string]any)
+	assertEqual(t, loopMeta["enabled"], true)
+	assertEqual(t, loopMeta["startTime"], fixture.now.UTC().Format(javaScriptISOString))
 }
 
 func TestHandlerCreateLoopWorkerEnqueuesSchedulableManualLoop(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2884,6 +2884,15 @@ func TestHandlerCreateLoopFixerEnqueuesSchedulableManualLoop(t *testing.T) {
 	data := resp["data"].(map[string]any)
 	loopID := data["id"].(string)
 	assertEqual(t, data["status"], "queued")
+	loop, err := fixture.runtime.Services().Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.MetadataJSON == nil {
+		t.Fatalf("loop = %#v, want stored manual metadata", loop)
+	}
+	metadata := parseJSONObject(loop.MetadataJSON)
+	assertEqual(t, metadata["manual"], true)
 
 	queueItems, err := fixture.runtime.Services().Repositories.Queue.List(context.Background())
 	if err != nil {

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -387,10 +387,13 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				runE:  runtime.fixCreate,
 				localFlags: []flagSpec{
 					stringFlag("project", "projectId", "Project id"),
+					boolFlag("loop", "Keep fixing when new PR comments arrive"),
+					boolFlag("no-loop", "Run only one fixer pass"),
 				},
 				exampleLines: []string{
 					"$ looper fix 42",
 					"$ looper fix acme/looper#42",
+					"$ looper fix acme/looper#42 --loop",
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -131,6 +131,13 @@ func TestFixCreateAcceptsNumericPRRefFromCurrentProject(t *testing.T) {
 			if got, want := body["prNumber"], float64(123); got != want {
 				t.Fatalf("body.prNumber = %#v, want %#v", got, want)
 			}
+			metadata, ok := body["metadata"].(map[string]any)
+			if !ok {
+				t.Fatalf("body.metadata = %#v, want object", body["metadata"])
+			}
+			if got, want := metadata["manual"], true; got != want {
+				t.Fatalf("body.metadata.manual = %#v, want %#v", got, want)
+			}
 			writeEnvelope(t, w, pkgapi.Success("req_loop", map[string]any{"id": "loop_fix_1", "projectId": "project_1", "repo": "acme/looper", "prNumber": 123, "status": "queued"}))
 		default:
 			t.Fatalf("unexpected request path: %s", r.URL.Path)

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -138,6 +138,9 @@ func TestFixCreateAcceptsNumericPRRefFromCurrentProject(t *testing.T) {
 			if got, want := metadata["manual"], true; got != want {
 				t.Fatalf("body.metadata.manual = %#v, want %#v", got, want)
 			}
+			if got, want := metadata["followUpdates"], false; got != want {
+				t.Fatalf("body.metadata.followUpdates = %#v, want %#v", got, want)
+			}
 			writeEnvelope(t, w, pkgapi.Success("req_loop", map[string]any{"id": "loop_fix_1", "projectId": "project_1", "repo": "acme/looper", "prNumber": 123, "status": "queued"}))
 		default:
 			t.Fatalf("unexpected request path: %s", r.URL.Path)
@@ -165,6 +168,48 @@ func TestFixCreateAcceptsNumericPRRefFromCurrentProject(t *testing.T) {
 	}
 	if got := stdout.String(); !strings.Contains(got, "Fixer started") || !strings.Contains(got, "acme/looper#123") {
 		t.Fatalf("Run([fix 123]) stdout = %q, want fixer summary for %q", got, "acme/looper#123")
+	}
+}
+
+func TestFixCreateAcceptsLoopFlag(t *testing.T) {
+	t.Parallel()
+
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", repoPath, err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			writeEnvelope(t, w, pkgapi.Success("req_projects", map[string]any{"items": []map[string]any{{"id": "project_1", "name": "Looper", "repoPath": repoPath, "repo": "acme/looper", "updatedAt": "2026-04-20T10:00:00.000Z"}}}))
+		case "/api/v1/loops":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			metadata, ok := body["metadata"].(map[string]any)
+			if !ok {
+				t.Fatalf("body.metadata = %#v, want object", body["metadata"])
+			}
+			if got, want := metadata["followUpdates"], true; got != want {
+				t.Fatalf("body.metadata.followUpdates = %#v, want %#v", got, want)
+			}
+			writeEnvelope(t, w, pkgapi.Success("req_loop", map[string]any{"id": "loop_fix_1", "projectId": "project_1", "repo": "acme/looper", "prNumber": 123, "status": "queued"}))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, Getwd: func() (string, error) { return repoPath, nil }})
+
+	exitCode := app.Run(context.Background(), []string{"fix", "123", "--loop", "--config", configPath})
+	if exitCode != 0 {
+		t.Fatalf("Run([fix 123 --loop]) exit code = %d, want 0", exitCode)
 	}
 }
 

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -346,6 +346,15 @@ func (r *commandRuntime) reviewCreate(cmd *cobra.Command, args []string) error {
 }
 
 func (r *commandRuntime) fixCreate(cmd *cobra.Command, args []string) error {
+	loopFlagChanged := cmd.Flags().Changed("loop")
+	noLoop := getBoolFlag(cmd, "no-loop")
+	if loopFlagChanged && noLoop {
+		return fmt.Errorf("--loop and --no-loop are mutually exclusive")
+	}
+	loopEnabled := false
+	if !noLoop && loopFlagChanged {
+		loopEnabled = getBoolFlag(cmd, "loop")
+	}
 	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
 		projectID, repo, prNumber, err := r.resolveReviewTarget(ctx, strings.TrimSpace(args[0]), strings.TrimSpace(getStringFlag(cmd, "project")))
 		if err != nil {
@@ -360,7 +369,8 @@ func (r *commandRuntime) fixCreate(cmd *cobra.Command, args []string) error {
 			"prNumber":   prNumber,
 			"status":     "running",
 			"metadata": map[string]any{
-				"manual": true,
+				"manual":        true,
+				"followUpdates": loopEnabled,
 			},
 		}
 

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -359,6 +359,9 @@ func (r *commandRuntime) fixCreate(cmd *cobra.Command, args []string) error {
 			"repo":       repo,
 			"prNumber":   prNumber,
 			"status":     "running",
+			"metadata": map[string]any{
+				"manual": true,
+			},
 		}
 
 		return r.postJSON(ctx, "/api/v1/loops", body)

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1101,24 +1101,29 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
 	}
 	policy := r.discoveryPolicyForProject(project.ID)
-	if !policy.AutoDiscovery {
-		return DiscoveryResult{Skipped: 1}, nil
-	}
 	currentUser := ""
-	if policy.AuthorFilter != config.FixerAuthorFilterAny {
+	if policy.AutoDiscovery && policy.AuthorFilter != config.FixerAuthorFilterAny {
 		currentUser, err = r.github.GetCurrentUserLogin(ctx, project.RepoPath)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
 		currentUser = strings.TrimSpace(currentUser)
 	}
-	recoveredQueueItems, err := r.recoverLegacyNoopFollowupLoops(ctx, *project, input.Repo, policy, currentUser)
-	if err != nil {
-		return DiscoveryResult{}, err
+	recoveredQueueItems := []storage.QueueItemRecord{}
+	openPRs := []PullRequestSummary{}
+	if policy.AutoDiscovery {
+		recoveredQueueItems, err = r.recoverLegacyNoopFollowupLoops(ctx, *project, input.Repo, policy, currentUser)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		openPRs, err = r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, input.Repo, project.RepoPath, input.Limit, currentUser, policy, "")
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
 	}
-	openPRs, err := r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, input.Repo, project.RepoPath, input.Limit, currentUser, policy, "")
-	if err != nil {
-		return DiscoveryResult{}, err
+	openPRs = appendManualFixerFollowupCandidates(ctx, r, input.ProjectID, input.Repo, openPRs)
+	if !policy.AutoDiscovery && len(openPRs) == 0 {
+		return DiscoveryResult{Skipped: 1}, nil
 	}
 	result := DiscoveryResult{}
 	for _, item := range recoveredQueueItems {
@@ -1133,6 +1138,10 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: pr.Number, CWD: project.RepoPath})
 		if err != nil {
 			return DiscoveryResult{}, err
+		}
+		if normalizePRState(detail.State) != "open" {
+			result.Skipped++
+			continue
 		}
 		if err := r.discoverPullRequestFromDetail(ctx, *project, input.Repo, detail, &result); err != nil {
 			return DiscoveryResult{}, err
@@ -1158,10 +1167,16 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 	}
 	policy := r.discoveryPolicyForProject(project.ID)
 	if !policy.AutoDiscovery {
-		return DiscoveryResult{Skipped: 1}, nil
+		manualFollowupLoop, err := r.findManualFixerFollowupLoopByPR(ctx, input.ProjectID, input.Repo, input.PRNumber)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		if manualFollowupLoop == nil {
+			return DiscoveryResult{Skipped: 1}, nil
+		}
 	}
 	currentUser := ""
-	if policy.AuthorFilter != config.FixerAuthorFilterAny {
+	if policy.AutoDiscovery && policy.AuthorFilter != config.FixerAuthorFilterAny {
 		currentUser, err = r.github.GetCurrentUserLogin(ctx, project.RepoPath)
 		if err != nil {
 			return DiscoveryResult{}, err
@@ -1171,6 +1186,9 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: project.RepoPath})
 	if err != nil {
 		return DiscoveryResult{}, err
+	}
+	if normalizePRState(detail.State) != "open" {
+		return DiscoveryResult{Skipped: 1}, nil
 	}
 	pr := PullRequestSummary{Number: detail.Number, State: detail.State, IsDraft: detail.IsDraft, Labels: append([]string(nil), detail.Labels...), HeadSHA: detail.HeadSHA, Author: detail.Author}
 	result := DiscoveryResult{}
@@ -1206,20 +1224,24 @@ func (r *Runner) DiscoverPullRequestsForBaseBranchUpdate(ctx context.Context, in
 		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
 	}
 	policy := r.discoveryPolicyForProject(project.ID)
-	if !policy.AutoDiscovery {
-		return DiscoveryResult{Skipped: 1}, nil
-	}
 	currentUser := ""
-	if policy.AuthorFilter != config.FixerAuthorFilterAny {
+	if policy.AutoDiscovery && policy.AuthorFilter != config.FixerAuthorFilterAny {
 		currentUser, err = r.github.GetCurrentUserLogin(ctx, project.RepoPath)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
 		currentUser = strings.TrimSpace(currentUser)
 	}
-	openPRs, err := r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, input.Repo, project.RepoPath, 0, currentUser, policy, baseRefName)
-	if err != nil {
-		return DiscoveryResult{}, err
+	openPRs := []PullRequestSummary{}
+	if policy.AutoDiscovery {
+		openPRs, err = r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, input.Repo, project.RepoPath, 0, currentUser, policy, baseRefName)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+	}
+	openPRs = appendManualFixerFollowupCandidates(ctx, r, input.ProjectID, input.Repo, openPRs)
+	if !policy.AutoDiscovery && len(openPRs) == 0 {
+		return DiscoveryResult{Skipped: 1}, nil
 	}
 	result := DiscoveryResult{}
 	for _, pr := range openPRs {
@@ -1230,6 +1252,10 @@ func (r *Runner) DiscoverPullRequestsForBaseBranchUpdate(ctx context.Context, in
 		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: pr.Number, CWD: project.RepoPath})
 		if err != nil {
 			return DiscoveryResult{}, err
+		}
+		if normalizePRState(detail.State) != "open" || !strings.EqualFold(strings.TrimSpace(detail.BaseRefName), baseRefName) {
+			result.Skipped++
+			continue
 		}
 		if err := r.discoverPullRequestFromDetail(ctx, *project, input.Repo, detail, &result); err != nil {
 			return DiscoveryResult{}, err
@@ -1305,7 +1331,11 @@ func defaultDiscoveryLimit(limit int) int {
 }
 
 func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID string, pr PullRequestSummary, repo, currentUser string, policy DiscoveryPolicy) bool {
-	if (!policy.IncludeDrafts && pr.IsDraft) || normalizePRState(pr.State) != "open" {
+	manualFollowupLoop, _ := r.findManualFixerFollowupLoopByPR(ctx, projectID, repo, pr.Number)
+	if normalizePRState(pr.State) != "open" {
+		return false
+	}
+	if manualFollowupLoop == nil && !policy.IncludeDrafts && pr.IsDraft {
 		return false
 	}
 	if r.hasActivePRLock(ctx, repo, pr.Number) {
@@ -1318,6 +1348,9 @@ func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID 
 			return false
 		}
 	}
+	if manualFollowupLoop != nil {
+		return true
+	}
 	if policy.AuthorFilter != config.FixerAuthorFilterAny && !sameGitHubLogin(pr.Author, currentUser) {
 		return false
 	}
@@ -1328,6 +1361,14 @@ func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID 
 }
 
 func (r *Runner) discoverPullRequestFromDetail(ctx context.Context, project storage.ProjectRecord, repo string, detail PullRequestDetail, result *DiscoveryResult) error {
+	loop, err := r.findFixerLoopByPR(ctx, project.ID, repo, detail.Number)
+	if err != nil {
+		return err
+	}
+	if loop != nil && isManualFixerLoop(*loop) && !fixerFollowUpdatesEnabled(*loop) {
+		result.Skipped++
+		return nil
+	}
 	allFixItems := collectFixItems(detail)
 	if len(allFixItems) == 0 {
 		if err := r.clearFixerFollowupStateForPR(ctx, project.ID, repo, detail.Number); err != nil {
@@ -1812,6 +1853,12 @@ func (r *Runner) schedulePendingRediscoveryAfterRun(ctx context.Context, loop st
 	if current == nil {
 		return false, nil
 	}
+	if !fixerFollowUpdatesEnabled(*current) {
+		if _, err := r.clearPendingFixerRediscovery(ctx, *current); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
 	pending, ok := parsePendingFixerRediscoveryState(parseJSONObject(current.MetadataJSON))
 	if !ok {
 		return false, nil
@@ -1859,6 +1906,9 @@ func (r *Runner) scheduleFollowupRetryAfterSuccess(ctx context.Context, loop sto
 		return false, err
 	}
 	if current == nil {
+		return false, nil
+	}
+	if !fixerFollowUpdatesEnabled(*current) {
 		return false, nil
 	}
 	followup, ok := parseFixerFollowupState(parseJSONObject(current.MetadataJSON))
@@ -3708,6 +3758,9 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 	}
 	for _, existing := range existingLoops {
 		if existing.Type == "fixer" && existing.ProjectID == project.ID && derefString(existing.Repo) == repo && derefInt64(existing.PRNumber) == prNumber {
+			if isManualFixerLoop(existing) && !isManualFixerFollowupCandidate(existing) {
+				continue
+			}
 			if existing.Status == "paused" {
 				if resumed, updated, err := r.resumePausedZeroProgressLoop(ctx, existing, headSHA, fixItemsStateHash); err != nil {
 					return loopUpsertResult{}, err
@@ -3930,10 +3983,18 @@ func (r *Runner) recoverLegacyNoopFollowupLoops(ctx context.Context, project sto
 		if loop.Status == "paused" || loop.Status == "running" {
 			continue
 		}
+		if isManualFixerLoop(loop) && !isManualFixerFollowupCandidate(loop) {
+			seenTargets[targetKey] = struct{}{}
+			continue
+		}
 		if r.hasActivePRLock(ctx, repo, *loop.PRNumber) {
 			continue
 		}
 		metadata := parseJSONObject(loop.MetadataJSON)
+		if isManualFixerLoop(loop) && !fixerFollowUpdatesEnabled(loop) {
+			seenTargets[targetKey] = struct{}{}
+			continue
+		}
 		if _, ok := parseFixerFollowupState(metadata); ok {
 			continue
 		}
@@ -4210,13 +4271,91 @@ func (r *Runner) findFixerLoopByPR(ctx context.Context, projectID, repo string, 
 	if err != nil {
 		return nil, err
 	}
+	var firstMatch *storage.LoopRecord
+	var firstAutomatic *storage.LoopRecord
+	var manualFollowup *storage.LoopRecord
 	for _, loop := range loops {
 		if loop.Type == "fixer" && loop.ProjectID == projectID && derefString(loop.Repo) == repo && derefInt64(loop.PRNumber) == prNumber {
+			matched := loop
+			if manualFollowup == nil && isManualFixerFollowupCandidate(matched) {
+				manualFollowup = &matched
+			}
+			if firstAutomatic == nil && !isManualFixerLoop(matched) {
+				firstAutomatic = &matched
+			}
+			if firstMatch == nil && (!isManualFixerLoop(matched) || isManualFixerFollowupCandidate(matched)) {
+				firstMatch = &matched
+			}
+		}
+	}
+	if manualFollowup != nil {
+		return manualFollowup, nil
+	}
+	if firstAutomatic != nil {
+		return firstAutomatic, nil
+	}
+	return firstMatch, nil
+}
+
+func (r *Runner) findManualFixerFollowupLoopByPR(ctx context.Context, projectID, repo string, prNumber int64) (*storage.LoopRecord, error) {
+	loops, err := r.repos.Loops.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, loop := range loops {
+		if loop.Type != "fixer" || loop.ProjectID != projectID || derefString(loop.Repo) != repo || derefInt64(loop.PRNumber) != prNumber {
+			continue
+		}
+		if isManualFixerFollowupCandidate(loop) {
 			matched := loop
 			return &matched, nil
 		}
 	}
 	return nil, nil
+}
+
+func appendManualFixerFollowupCandidates(ctx context.Context, runner *Runner, projectID, repo string, prs []PullRequestSummary) []PullRequestSummary {
+	if runner == nil || runner.repos == nil || runner.repos.Loops == nil {
+		return prs
+	}
+	loops, err := runner.repos.Loops.List(ctx)
+	if err != nil {
+		return prs
+	}
+	seen := make(map[int64]struct{}, len(prs))
+	for _, pr := range prs {
+		seen[pr.Number] = struct{}{}
+	}
+	for _, loop := range loops {
+		if loop.Type != "fixer" || loop.ProjectID != projectID || derefString(loop.Repo) != repo || loop.PRNumber == nil {
+			continue
+		}
+		if !isManualFixerFollowupCandidate(loop) {
+			continue
+		}
+		if _, ok := seen[*loop.PRNumber]; ok {
+			continue
+		}
+		prs = append(prs, PullRequestSummary{Number: *loop.PRNumber, State: "OPEN"})
+		seen[*loop.PRNumber] = struct{}{}
+	}
+	return prs
+}
+
+func fixerFollowUpdatesEnabled(loop storage.LoopRecord) bool {
+	meta := parseJSONObject(loop.MetadataJSON)
+	if enabled, ok := meta["followUpdates"].(bool); ok {
+		return enabled
+	}
+	return !isManualFixerLoop(loop)
+}
+
+func isManualFixerFollowupCandidate(loop storage.LoopRecord) bool {
+	if !isManualFixerLoop(loop) || !fixerFollowUpdatesEnabled(loop) {
+		return false
+	}
+	status := strings.TrimSpace(loop.Status)
+	return status != "stopped" && status != "terminated"
 }
 
 func loopMetadataForPR(ctx context.Context, runner *Runner, projectID, repo string, prNumber int64) *string {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1632,7 +1632,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: reason}, nil
 	}
-	if reason, err := r.pullRequestLabelAuthoritySkipReason(ctx, project.ID, project.RepoPath, queueItem, *queueItem.Repo, *queueItem.PRNumber); err != nil {
+	if reason, err := r.pullRequestLabelAuthoritySkipReason(ctx, *loop, project.ID, project.RepoPath, queueItem, *queueItem.Repo, *queueItem.PRNumber); err != nil {
 		return ProcessResult{}, err
 	} else if reason != "" {
 		checkpoint.SkipReason = reason
@@ -1950,7 +1950,10 @@ func (r *Runner) pullRequestOwnershipSkipReason(ctx context.Context, loop storag
 	return fmt.Sprintf("Skipped fixer run for %s#%d because PR author %q does not match fixer owner %q", repo, prNumber, strings.TrimSpace(author), strings.TrimSpace(currentUser)), nil
 }
 
-func (r *Runner) pullRequestLabelAuthoritySkipReason(ctx context.Context, projectID, cwd string, queueItem storage.QueueItemRecord, repo string, prNumber int64) (string, error) {
+func (r *Runner) pullRequestLabelAuthoritySkipReason(ctx context.Context, loop storage.LoopRecord, projectID, cwd string, queueItem storage.QueueItemRecord, repo string, prNumber int64) (string, error) {
+	if isManualFixerLoop(loop) {
+		return "", nil
+	}
 	policy := r.discoveryPolicyForProject(projectID)
 	if !queueItemRequiresLabelAuthority(queueItem) {
 		return "", nil

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1170,11 +1170,12 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 		return DiscoveryResult{}, fmt.Errorf("project not found: %s", input.ProjectID)
 	}
 	policy := r.discoveryPolicyForProject(project.ID)
+	loopsByPR, _, err := r.listFixerLoopsByPR(ctx, input.ProjectID, input.Repo)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
 	if !policy.AutoDiscovery {
-		manualFollowupLoop, err := r.findManualFixerFollowupLoopByPR(ctx, input.ProjectID, input.Repo, input.PRNumber)
-		if err != nil {
-			return DiscoveryResult{}, err
-		}
+		manualFollowupLoop := manualFixerFollowupLoopFromCandidates(loopsByPR[input.PRNumber])
 		if manualFollowupLoop == nil {
 			return DiscoveryResult{Skipped: 1}, nil
 		}
@@ -1196,7 +1197,7 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 	}
 	pr := PullRequestSummary{Number: detail.Number, State: detail.State, IsDraft: detail.IsDraft, Labels: append([]string(nil), detail.Labels...), HeadSHA: detail.HeadSHA, Author: detail.Author}
 	result := DiscoveryResult{}
-	if !r.pullRequestEligibleForDiscovery(ctx, input.ProjectID, pr, input.Repo, currentUser, policy, nil) {
+	if !r.pullRequestEligibleForDiscovery(ctx, input.ProjectID, pr, input.Repo, currentUser, policy, loopsByPR) {
 		if !labelsMatch(detail.Labels, policy.Labels, policy.LabelMode) {
 			if err := r.pauseFixerLoopForLabelMismatch(ctx, project.ID, input.Repo, input.PRNumber); err != nil {
 				return DiscoveryResult{}, err
@@ -1339,8 +1340,12 @@ func defaultDiscoveryLimit(limit int) int {
 }
 
 func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID string, pr PullRequestSummary, repo, currentUser string, policy DiscoveryPolicy, loopsByPR map[int64][]storage.LoopRecord) bool {
-	manualFollowupLoop := manualFixerFollowupLoopFromCandidates(loopsByPR[pr.Number])
-	if manualFollowupLoop == nil {
+	candidates := []storage.LoopRecord(nil)
+	if loopsByPR != nil {
+		candidates = loopsByPR[pr.Number]
+	}
+	manualFollowupLoop := manualFixerFollowupLoopFromCandidates(candidates)
+	if manualFollowupLoop == nil && loopsByPR == nil {
 		manualFollowupLoop, _ = r.findManualFixerFollowupLoopByPR(ctx, projectID, repo, pr.Number)
 	}
 	if normalizePRState(pr.State) != "open" {
@@ -1350,8 +1355,19 @@ func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID 
 		return false
 	}
 	if r.hasActivePRLock(ctx, repo, pr.Number) {
-		loop, err := r.findRunningFixerLoopByPR(ctx, projectID, repo, pr.Number, loopsByPR[pr.Number])
+		var (
+			loop *storage.LoopRecord
+			err  error
+		)
+		if loopsByPR != nil {
+			loop, err = r.runningFixerLoopFromCandidates(ctx, candidates)
+		} else {
+			loop, err = r.findRunningFixerLoopByPR(ctx, projectID, repo, pr.Number, nil)
+		}
 		if err != nil || loop == nil {
+			return false
+		}
+		if isManualFixerLoop(*loop) && !fixerFollowUpdatesEnabled(*loop) {
 			return false
 		}
 	}
@@ -3998,7 +4014,6 @@ func (r *Runner) recoverLegacyNoopFollowupLoops(ctx context.Context, project sto
 			continue
 		}
 		if isManualFixerLoop(loop) && !isManualFixerFollowupCandidate(loop) {
-			seenTargets[targetKey] = struct{}{}
 			continue
 		}
 		if r.hasActivePRLock(ctx, repo, *loop.PRNumber) {
@@ -4376,7 +4391,11 @@ func (r *Runner) findRunningFixerLoopByPR(ctx context.Context, projectID, repo s
 		}
 		loops = filtered
 	}
-	for _, loop := range loops {
+	return r.runningFixerLoopFromCandidates(ctx, loops)
+}
+
+func (r *Runner) runningFixerLoopFromCandidates(ctx context.Context, candidates []storage.LoopRecord) (*storage.LoopRecord, error) {
+	for _, loop := range candidates {
 		activeRun, err := r.latestActiveRunningRun(ctx, loop.ID)
 		if err != nil {
 			return nil, err

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1605,7 +1605,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		return ProcessResult{}, fmt.Errorf("run not found after start checkpoint: %s", resumedRun.Run.ID)
 	}
 	run = *persistedRun
-	if reason, err := r.pullRequestOwnershipSkipReason(ctx, project.ID, project.RepoPath, *queueItem.Repo, *queueItem.PRNumber); err != nil {
+	if reason, err := r.pullRequestOwnershipSkipReason(ctx, *loop, project.ID, project.RepoPath, *queueItem.Repo, *queueItem.PRNumber); err != nil {
 		return ProcessResult{}, err
 	} else if reason != "" {
 		checkpoint.SkipReason = reason
@@ -1923,7 +1923,16 @@ func (r *Runner) runDiscoverPRStep(ctx context.Context, input stepInput) (fixerC
 	return checkpoint, nil
 }
 
-func (r *Runner) pullRequestOwnershipSkipReason(ctx context.Context, projectID, cwd, repo string, prNumber int64) (string, error) {
+func isManualFixerLoop(loop storage.LoopRecord) bool {
+	meta := parseJSONObject(loop.MetadataJSON)
+	manual, _ := meta["manual"].(bool)
+	return manual
+}
+
+func (r *Runner) pullRequestOwnershipSkipReason(ctx context.Context, loop storage.LoopRecord, projectID, cwd, repo string, prNumber int64) (string, error) {
+	if isManualFixerLoop(loop) {
+		return "", nil
+	}
 	if r.discoveryPolicyForProject(projectID).AuthorFilter == config.FixerAuthorFilterAny {
 		return "", nil
 	}
@@ -3954,15 +3963,15 @@ func (r *Runner) recoverLegacyNoopFollowupLoops(ctx context.Context, project sto
 			}
 			continue
 		}
-		if (!policy.IncludeDrafts && detail.IsDraft) || normalizePRState(detail.State) != "open" {
+		if (!isManualFixerLoop(loop) && !policy.IncludeDrafts && detail.IsDraft) || normalizePRState(detail.State) != "open" {
 			seenTargets[targetKey] = struct{}{}
 			continue
 		}
-		if policy.AuthorFilter != config.FixerAuthorFilterAny && !sameGitHubLogin(detail.Author, currentUser) {
+		if !isManualFixerLoop(loop) && policy.AuthorFilter != config.FixerAuthorFilterAny && !sameGitHubLogin(detail.Author, currentUser) {
 			seenTargets[targetKey] = struct{}{}
 			continue
 		}
-		if !labelsMatch(detail.Labels, policy.Labels, policy.LabelMode) {
+		if !isManualFixerLoop(loop) && !labelsMatch(detail.Labels, policy.Labels, policy.LabelMode) {
 			seenTargets[targetKey] = struct{}{}
 			continue
 		}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1111,6 +1111,10 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 	}
 	recoveredQueueItems := []storage.QueueItemRecord{}
 	openPRs := []PullRequestSummary{}
+	loopsByPR, manualFollowupPRNumbers, err := r.listFixerLoopsByPR(ctx, input.ProjectID, input.Repo)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
 	if policy.AutoDiscovery {
 		recoveredQueueItems, err = r.recoverLegacyNoopFollowupLoops(ctx, *project, input.Repo, policy, currentUser)
 		if err != nil {
@@ -1121,7 +1125,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 			return DiscoveryResult{}, err
 		}
 	}
-	openPRs = appendManualFixerFollowupCandidates(ctx, r, input.ProjectID, input.Repo, openPRs)
+	openPRs = appendManualFixerFollowupCandidates(openPRs, manualFollowupPRNumbers)
 	if !policy.AutoDiscovery && len(openPRs) == 0 {
 		return DiscoveryResult{Skipped: 1}, nil
 	}
@@ -1131,7 +1135,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 	}
 	for _, pr := range openPRs {
 
-		if !r.pullRequestEligibleForDiscovery(ctx, input.ProjectID, pr, input.Repo, currentUser, policy) {
+		if !r.pullRequestEligibleForDiscovery(ctx, input.ProjectID, pr, input.Repo, currentUser, policy, loopsByPR) {
 			result.Skipped++
 			continue
 		}
@@ -1192,7 +1196,7 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 	}
 	pr := PullRequestSummary{Number: detail.Number, State: detail.State, IsDraft: detail.IsDraft, Labels: append([]string(nil), detail.Labels...), HeadSHA: detail.HeadSHA, Author: detail.Author}
 	result := DiscoveryResult{}
-	if !r.pullRequestEligibleForDiscovery(ctx, input.ProjectID, pr, input.Repo, currentUser, policy) {
+	if !r.pullRequestEligibleForDiscovery(ctx, input.ProjectID, pr, input.Repo, currentUser, policy, nil) {
 		if !labelsMatch(detail.Labels, policy.Labels, policy.LabelMode) {
 			if err := r.pauseFixerLoopForLabelMismatch(ctx, project.ID, input.Repo, input.PRNumber); err != nil {
 				return DiscoveryResult{}, err
@@ -1233,19 +1237,23 @@ func (r *Runner) DiscoverPullRequestsForBaseBranchUpdate(ctx context.Context, in
 		currentUser = strings.TrimSpace(currentUser)
 	}
 	openPRs := []PullRequestSummary{}
+	loopsByPR, manualFollowupPRNumbers, err := r.listFixerLoopsByPR(ctx, input.ProjectID, input.Repo)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
 	if policy.AutoDiscovery {
 		openPRs, err = r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, input.Repo, project.RepoPath, 0, currentUser, policy, baseRefName)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
 	}
-	openPRs = appendManualFixerFollowupCandidates(ctx, r, input.ProjectID, input.Repo, openPRs)
+	openPRs = appendManualFixerFollowupCandidates(openPRs, manualFollowupPRNumbers)
 	if !policy.AutoDiscovery && len(openPRs) == 0 {
 		return DiscoveryResult{Skipped: 1}, nil
 	}
 	result := DiscoveryResult{}
 	for _, pr := range openPRs {
-		if !r.pullRequestEligibleForDiscovery(ctx, input.ProjectID, pr, input.Repo, currentUser, policy) {
+		if !r.pullRequestEligibleForDiscovery(ctx, input.ProjectID, pr, input.Repo, currentUser, policy, loopsByPR) {
 			result.Skipped++
 			continue
 		}
@@ -1330,8 +1338,11 @@ func defaultDiscoveryLimit(limit int) int {
 	return limit
 }
 
-func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID string, pr PullRequestSummary, repo, currentUser string, policy DiscoveryPolicy) bool {
-	manualFollowupLoop, _ := r.findManualFixerFollowupLoopByPR(ctx, projectID, repo, pr.Number)
+func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID string, pr PullRequestSummary, repo, currentUser string, policy DiscoveryPolicy, loopsByPR map[int64][]storage.LoopRecord) bool {
+	manualFollowupLoop := manualFixerFollowupLoopFromCandidates(loopsByPR[pr.Number])
+	if manualFollowupLoop == nil {
+		manualFollowupLoop, _ = r.findManualFixerFollowupLoopByPR(ctx, projectID, repo, pr.Number)
+	}
 	if normalizePRState(pr.State) != "open" {
 		return false
 	}
@@ -1339,12 +1350,8 @@ func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID 
 		return false
 	}
 	if r.hasActivePRLock(ctx, repo, pr.Number) {
-		loop, err := r.findFixerLoopByPR(ctx, projectID, repo, pr.Number)
+		loop, err := r.findRunningFixerLoopByPR(ctx, projectID, repo, pr.Number, loopsByPR[pr.Number])
 		if err != nil || loop == nil {
-			return false
-		}
-		activeRun, err := r.latestActiveRunningRun(ctx, loop.ID)
-		if err != nil || activeRun == nil {
 			return false
 		}
 	}
@@ -3756,74 +3763,81 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 	if err != nil {
 		return loopUpsertResult{}, err
 	}
+	matchingLoops := make([]storage.LoopRecord, 0)
 	for _, existing := range existingLoops {
 		if existing.Type == "fixer" && existing.ProjectID == project.ID && derefString(existing.Repo) == repo && derefInt64(existing.PRNumber) == prNumber {
 			if isManualFixerLoop(existing) && !isManualFixerFollowupCandidate(existing) {
 				continue
 			}
-			if existing.Status == "paused" {
-				if resumed, updated, err := r.resumePausedZeroProgressLoop(ctx, existing, headSHA, fixItemsStateHash); err != nil {
-					return loopUpsertResult{}, err
-				} else if resumed {
-					existing = updated
-				} else if resumed, updated, err := r.resumePausedLabelMismatchLoop(ctx, existing); err != nil {
-					return loopUpsertResult{}, err
-				} else if resumed {
-					existing = updated
-				} else if resumed, updated, err := r.resumePausedNoopResolveLoop(ctx, existing, headSHA, fixItemsStateHash, unresolvedThreadIDs); err != nil {
-					return loopUpsertResult{}, err
-				} else if resumed {
-					existing = updated
-				} else if resumed, updated, err := r.resumePausedRiskyConflictLoop(ctx, existing, headSHA, fixItemsStateHash); err != nil {
-					return loopUpsertResult{}, err
-				} else if !resumed {
-					return loopUpsertResult{record: existing, created: false}, nil
-				} else {
-					existing = updated
-				}
+			matchingLoops = append(matchingLoops, existing)
+		}
+	}
+	existing, err := r.preferredFixerLoopCandidate(ctx, matchingLoops)
+	if err != nil {
+		return loopUpsertResult{}, err
+	}
+	if existing != nil {
+		updatedLoop := *existing
+		if updatedLoop.Status == "paused" {
+			if resumed, updated, err := r.resumePausedZeroProgressLoop(ctx, updatedLoop, headSHA, fixItemsStateHash); err != nil {
+				return loopUpsertResult{}, err
+			} else if resumed {
+				updatedLoop = updated
+			} else if resumed, updated, err := r.resumePausedLabelMismatchLoop(ctx, updatedLoop); err != nil {
+				return loopUpsertResult{}, err
+			} else if resumed {
+				updatedLoop = updated
+			} else if resumed, updated, err := r.resumePausedNoopResolveLoop(ctx, updatedLoop, headSHA, fixItemsStateHash, unresolvedThreadIDs); err != nil {
+				return loopUpsertResult{}, err
+			} else if resumed {
+				updatedLoop = updated
+			} else if resumed, updated, err := r.resumePausedRiskyConflictLoop(ctx, updatedLoop, headSHA, fixItemsStateHash); err != nil {
+				return loopUpsertResult{}, err
+			} else if !resumed {
+				return loopUpsertResult{record: updatedLoop, created: false}, nil
+			} else {
+				updatedLoop = updated
 			}
-			if loops.ShouldSuppressFailedRediscovery(existing.Status, loops.LastFailedDiscoveryFingerprint(existing.MetadataJSON), buildFixerDiscoveryFingerprint(repo, prNumber, headSHA, fixItemsStateHash)) {
-				return loopUpsertResult{record: existing, created: false, skipped: true}, nil
+		}
+		if loops.ShouldSuppressFailedRediscovery(updatedLoop.Status, loops.LastFailedDiscoveryFingerprint(updatedLoop.MetadataJSON), buildFixerDiscoveryFingerprint(repo, prNumber, headSHA, fixItemsStateHash)) {
+			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
+		}
+		decision := decideRediscoveryAfterNoopResolve(updatedLoop, headSHA, fixItemsHash, fixItemsStateHash, fixItems, unresolvedThreadIDs, now)
+		if decision.Action == rediscoveryActionSuppress {
+			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
+		}
+		availableAt := now
+		if decision.Action == rediscoveryActionDefer {
+			availableAt = parseRFC3339OrZero(decision.NextEligibleAt)
+			if availableAt.IsZero() {
+				availableAt = now
 			}
-			decision := decideRediscoveryAfterNoopResolve(existing, headSHA, fixItemsHash, fixItemsStateHash, fixItems, unresolvedThreadIDs, now)
-			if decision.Action == rediscoveryActionSuppress {
-				return loopUpsertResult{record: existing, created: false, skipped: true}, nil
-			}
-			availableAt := now
-			if decision.Action == rediscoveryActionDefer {
-				availableAt = parseRFC3339OrZero(decision.NextEligibleAt)
-				if availableAt.IsZero() {
-					availableAt = now
-				}
-			}
-			availableAtISO := eventlog.FormatJavaScriptISOString(availableAt.UTC())
-			updated := existing
-			activeRun, err := r.latestActiveRunningRun(ctx, updated.ID)
+		}
+		availableAtISO := eventlog.FormatJavaScriptISOString(availableAt.UTC())
+		activeRun, err := r.latestActiveRunningRun(ctx, updatedLoop.ID)
+		if err != nil {
+			return loopUpsertResult{}, err
+		}
+		if activeRun != nil {
+			updatedLoop.Status = "running"
+			updatedLoop.NextRunAt = nil
+			updatedLoop, err = r.recordPendingFixerRediscovery(ctx, updatedLoop, headSHA, fixItemsStateHash, unresolvedThreadIDs)
 			if err != nil {
 				return loopUpsertResult{}, err
 			}
-			if activeRun != nil {
-				updated.Status = "running"
-				updated.NextRunAt = nil
-				updated, err = r.recordPendingFixerRediscovery(ctx, updated, headSHA, fixItemsStateHash, unresolvedThreadIDs)
-				if err != nil {
-					return loopUpsertResult{}, err
-				}
-				updated.UpdatedAt = nowISO
-				if err := r.repos.Loops.Upsert(ctx, updated); err != nil {
-					return loopUpsertResult{}, err
-				}
-				return loopUpsertResult{record: updated, created: false, pending: true}, nil
-			} else {
-				updated.Status = "queued"
-				updated.NextRunAt = &availableAtISO
-			}
-			updated.UpdatedAt = nowISO
-			if err := r.repos.Loops.Upsert(ctx, updated); err != nil {
+			updatedLoop.UpdatedAt = nowISO
+			if err := r.repos.Loops.Upsert(ctx, updatedLoop); err != nil {
 				return loopUpsertResult{}, err
 			}
-			return loopUpsertResult{record: updated, created: false, availableAt: availableAt}, nil
+			return loopUpsertResult{record: updatedLoop, created: false, pending: true}, nil
 		}
+		updatedLoop.Status = "queued"
+		updatedLoop.NextRunAt = &availableAtISO
+		updatedLoop.UpdatedAt = nowISO
+		if err := r.repos.Loops.Upsert(ctx, updatedLoop); err != nil {
+			return loopUpsertResult{}, err
+		}
+		return loopUpsertResult{record: updatedLoop, created: false, availableAt: availableAt}, nil
 	}
 	seq, err := r.repos.Loops.AllocateSeq(ctx)
 	if err != nil {
@@ -4271,30 +4285,13 @@ func (r *Runner) findFixerLoopByPR(ctx context.Context, projectID, repo string, 
 	if err != nil {
 		return nil, err
 	}
-	var firstMatch *storage.LoopRecord
-	var firstAutomatic *storage.LoopRecord
-	var manualFollowup *storage.LoopRecord
+	matchingLoops := make([]storage.LoopRecord, 0)
 	for _, loop := range loops {
 		if loop.Type == "fixer" && loop.ProjectID == projectID && derefString(loop.Repo) == repo && derefInt64(loop.PRNumber) == prNumber {
-			matched := loop
-			if manualFollowup == nil && isManualFixerFollowupCandidate(matched) {
-				manualFollowup = &matched
-			}
-			if firstAutomatic == nil && !isManualFixerLoop(matched) {
-				firstAutomatic = &matched
-			}
-			if firstMatch == nil && (!isManualFixerLoop(matched) || isManualFixerFollowupCandidate(matched)) {
-				firstMatch = &matched
-			}
+			matchingLoops = append(matchingLoops, loop)
 		}
 	}
-	if manualFollowup != nil {
-		return manualFollowup, nil
-	}
-	if firstAutomatic != nil {
-		return firstAutomatic, nil
-	}
-	return firstMatch, nil
+	return r.preferredFixerLoopCandidate(ctx, matchingLoops)
 }
 
 func (r *Runner) findManualFixerFollowupLoopByPR(ctx context.Context, projectID, repo string, prNumber int64) (*storage.LoopRecord, error) {
@@ -4314,32 +4311,114 @@ func (r *Runner) findManualFixerFollowupLoopByPR(ctx context.Context, projectID,
 	return nil, nil
 }
 
-func appendManualFixerFollowupCandidates(ctx context.Context, runner *Runner, projectID, repo string, prs []PullRequestSummary) []PullRequestSummary {
-	if runner == nil || runner.repos == nil || runner.repos.Loops == nil {
-		return prs
-	}
-	loops, err := runner.repos.Loops.List(ctx)
-	if err != nil {
-		return prs
-	}
+func appendManualFixerFollowupCandidates(prs []PullRequestSummary, manualFollowupPRNumbers []int64) []PullRequestSummary {
 	seen := make(map[int64]struct{}, len(prs))
 	for _, pr := range prs {
 		seen[pr.Number] = struct{}{}
 	}
+	for _, prNumber := range manualFollowupPRNumbers {
+		if _, ok := seen[prNumber]; ok {
+			continue
+		}
+		prs = append(prs, PullRequestSummary{Number: prNumber, State: "OPEN"})
+		seen[prNumber] = struct{}{}
+	}
+	return prs
+}
+
+func (r *Runner) listFixerLoopsByPR(ctx context.Context, projectID, repo string) (map[int64][]storage.LoopRecord, []int64, error) {
+	loops, err := r.repos.Loops.List(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	loopsByPR := make(map[int64][]storage.LoopRecord)
+	manualFollowupPRNumbers := make([]int64, 0)
+	manualSeen := make(map[int64]struct{})
 	for _, loop := range loops {
 		if loop.Type != "fixer" || loop.ProjectID != projectID || derefString(loop.Repo) != repo || loop.PRNumber == nil {
 			continue
 		}
-		if !isManualFixerFollowupCandidate(loop) {
-			continue
+		prNumber := *loop.PRNumber
+		loopsByPR[prNumber] = append(loopsByPR[prNumber], loop)
+		if isManualFixerFollowupCandidate(loop) {
+			if _, ok := manualSeen[prNumber]; !ok {
+				manualFollowupPRNumbers = append(manualFollowupPRNumbers, prNumber)
+				manualSeen[prNumber] = struct{}{}
+			}
 		}
-		if _, ok := seen[*loop.PRNumber]; ok {
-			continue
-		}
-		prs = append(prs, PullRequestSummary{Number: *loop.PRNumber, State: "OPEN"})
-		seen[*loop.PRNumber] = struct{}{}
 	}
-	return prs
+	return loopsByPR, manualFollowupPRNumbers, nil
+}
+
+func manualFixerFollowupLoopFromCandidates(loops []storage.LoopRecord) *storage.LoopRecord {
+	for _, loop := range loops {
+		if isManualFixerFollowupCandidate(loop) {
+			matched := loop
+			return &matched
+		}
+	}
+	return nil
+}
+
+func (r *Runner) findRunningFixerLoopByPR(ctx context.Context, projectID, repo string, prNumber int64, candidates []storage.LoopRecord) (*storage.LoopRecord, error) {
+	loops := candidates
+	if len(loops) == 0 {
+		var err error
+		loops, err = r.repos.Loops.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+		filtered := make([]storage.LoopRecord, 0, len(loops))
+		for _, loop := range loops {
+			if loop.Type == "fixer" && loop.ProjectID == projectID && derefString(loop.Repo) == repo && derefInt64(loop.PRNumber) == prNumber {
+				filtered = append(filtered, loop)
+			}
+		}
+		loops = filtered
+	}
+	for _, loop := range loops {
+		activeRun, err := r.latestActiveRunningRun(ctx, loop.ID)
+		if err != nil {
+			return nil, err
+		}
+		if activeRun != nil {
+			matched := loop
+			return &matched, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *Runner) preferredFixerLoopCandidate(ctx context.Context, candidates []storage.LoopRecord) (*storage.LoopRecord, error) {
+	var firstMatch *storage.LoopRecord
+	var firstAutomatic *storage.LoopRecord
+	var manualFollowup *storage.LoopRecord
+	for _, candidate := range candidates {
+		matched := candidate
+		activeRun, err := r.latestActiveRunningRun(ctx, matched.ID)
+		if err != nil {
+			return nil, err
+		}
+		if activeRun != nil && !isManualFixerLoop(matched) {
+			return &matched, nil
+		}
+		if manualFollowup == nil && isManualFixerFollowupCandidate(matched) {
+			manualFollowup = &matched
+		}
+		if firstAutomatic == nil && !isManualFixerLoop(matched) {
+			firstAutomatic = &matched
+		}
+		if firstMatch == nil && (!isManualFixerLoop(matched) || isManualFixerFollowupCandidate(matched)) {
+			firstMatch = &matched
+		}
+	}
+	if manualFollowup != nil {
+		return manualFollowup, nil
+	}
+	if firstAutomatic != nil {
+		return firstAutomatic, nil
+	}
+	return firstMatch, nil
 }
 
 func fixerFollowUpdatesEnabled(loop storage.LoopRecord) bool {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1969,7 +1969,7 @@ func TestDiscoverPullRequestsRecoversManualForeignLegacyNoopLoop(t *testing.T) {
 	legacyAt := fixture.nowISO()
 	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
 	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{comment}}
-	metadata := mustMarshalJSON(map[string]any{"manual": true, "lastNoopResolveHeadSha": "head-1", "lastNoopResolveStateHash": hashFixItemsState(collectFixItems(detail)), "lastNoopResolveAt": legacyAt})
+	metadata := mustMarshalJSON(map[string]any{"manual": true, "followUpdates": true, "lastNoopResolveHeadSha": "head-1", "lastNoopResolveStateHash": hashFixItemsState(collectFixItems(detail)), "lastNoopResolveAt": legacyAt})
 	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_manual_legacy", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
@@ -1988,6 +1988,165 @@ func TestDiscoverPullRequestsRecoversManualForeignLegacyNoopLoop(t *testing.T) {
 	}
 }
 
+func TestDiscoverPullRequestSkipsManualLoopWhenFollowUpdatesDisabled(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"manual":true,"followUpdates":false}`
+	loop := storage.LoopRecord{ID: "loop_manual_single_shot", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
+	github := &fakeGitHubGateway{currentUser: "looper-bot", viewResponses: []PullRequestDetail{{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{comment}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequest() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want no follow-up queue item for disabled manual fixer loop", result.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestAllowsManualLoopWhenFollowUpdatesEnabled(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"manual":true,"followUpdates":true}`
+	loop := storage.LoopRecord{ID: "loop_manual_followup", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
+	github := &fakeGitHubGateway{currentUser: "looper-bot", viewResponses: []PullRequestDetail{{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{comment}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequest(context.Background(), TargetedDiscoveryInput{ProjectID: "project_1", Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequest() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want one manual follow-up queue item", result.QueueItems)
+	}
+	if result.QueueItems[0].LoopID == nil || *result.QueueItems[0].LoopID != loop.ID {
+		t.Fatalf("queue item = %#v, want manual follow-up loop %q", result.QueueItems[0], loop.ID)
+	}
+}
+
+func TestDiscoverPullRequestsSkipsClosedManualFollowUpCandidate(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"manual":true,"followUpdates":true}`
+	loop := storage.LoopRecord{ID: "loop_manual_followup_closed", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{currentUser: "looper-bot", viewResponses: []PullRequestDetail{{Number: prNumber, State: "CLOSED", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want no queue items for closed manual follow-up candidate", result.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsSkipsStoppedManualFollowUpCandidate(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"manual":true,"followUpdates":true}`
+	loop := storage.LoopRecord{ID: "loop_manual_followup_stopped", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "stopped", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
+	github := &fakeGitHubGateway{currentUser: "looper-bot", viewResponses: []PullRequestDetail{{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{comment}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want no queue items for stopped manual follow-up loop", result.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsForBaseBranchUpdateSkipsManualFollowUpOnDifferentBase(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"manual":true,"followUpdates":true}`
+	loop := storage.LoopRecord{ID: "loop_manual_followup_other_base", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
+	github := &fakeGitHubGateway{currentUser: "looper-bot", viewResponses: []PullRequestDetail{{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "release", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{comment}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequestsForBaseBranchUpdate(context.Background(), BaseBranchDiscoveryInput{ProjectID: "project_1", Repo: repo, BaseRefName: "main"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequestsForBaseBranchUpdate() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want no queue items for manual follow-up loop on another base branch", result.QueueItems)
+	}
+}
+
+func TestSchedulePendingRediscoveryAfterRunSkipsDisabledManualLoop(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(84)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	projectID := "project_1"
+	metadata := mustMarshalJSON(map[string]any{"manual": true, "followUpdates": false, "pendingFixerRediscovery": map[string]any{"headSha": "head-84", "fixItemsStateHash": "state-84", "unresolvedThreadIds": []string{"t1"}, "recordedAt": nowISO}})
+	loop := storage.LoopRecord{ID: "loop_manual_pending_disabled", Seq: 98, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+
+	scheduled, err := runner.schedulePendingRediscoveryAfterRun(context.Background(), loop, repo, prNumber)
+	if err != nil {
+		t.Fatalf("schedulePendingRediscoveryAfterRun() error = %v", err)
+	}
+	if scheduled {
+		t.Fatal("schedulePendingRediscoveryAfterRun() = true, want disabled manual loop to stay single-shot")
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if _, ok := parsePendingFixerRediscoveryState(parseJSONObject(persisted.MetadataJSON)); ok {
+		t.Fatalf("pending rediscovery still present in %#v", parseJSONObject(persisted.MetadataJSON))
+	}
+}
+
 func TestDiscoverPullRequestsRecoversManualLegacyNoopLoopDespiteLabelMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -1998,7 +2157,7 @@ func TestDiscoverPullRequestsRecoversManualLegacyNoopLoopDespiteLabelMismatch(t 
 	legacyAt := fixture.nowISO()
 	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
 	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{comment}}
-	metadata := mustMarshalJSON(map[string]any{"manual": true, "lastNoopResolveHeadSha": "head-1", "lastNoopResolveStateHash": hashFixItemsState(collectFixItems(detail)), "lastNoopResolveAt": legacyAt})
+	metadata := mustMarshalJSON(map[string]any{"manual": true, "followUpdates": true, "lastNoopResolveHeadSha": "head-1", "lastNoopResolveStateHash": hashFixItemsState(collectFixItems(detail)), "lastNoopResolveAt": legacyAt})
 	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_manual_legacy_labels", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
@@ -2024,7 +2183,7 @@ func TestDiscoverPullRequestsRecoversManualLegacyNoopDraftLoopDespiteDraftPolicy
 	legacyAt := fixture.nowISO()
 	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
 	detail := PullRequestDetail{Number: prNumber, State: "OPEN", IsDraft: true, HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{comment}}
-	metadata := mustMarshalJSON(map[string]any{"manual": true, "lastNoopResolveHeadSha": "head-1", "lastNoopResolveStateHash": hashFixItemsState(collectFixItems(detail)), "lastNoopResolveAt": legacyAt})
+	metadata := mustMarshalJSON(map[string]any{"manual": true, "followUpdates": true, "lastNoopResolveHeadSha": "head-1", "lastNoopResolveStateHash": hashFixItemsState(collectFixItems(detail)), "lastNoopResolveAt": legacyAt})
 	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_manual_legacy_draft", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1872,6 +1872,68 @@ func TestDiscoverPullRequestsLeavesPendingRediscoveryUnchangedForDuplicateSignal
 	}
 }
 
+func TestDiscoverPullRequestsPreservesPendingRediscoveryForRunningAutomaticLoopWithManualFollowup(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(85)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	projectID := "project_1"
+	automaticLoopID := "loop_fixer_midrun_automatic"
+	automaticLoop := storage.LoopRecord{ID: automaticLoopID, Seq: 99, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), automaticLoop); err != nil {
+		t.Fatalf("Loops.Upsert() automatic error = %v", err)
+	}
+	manualMetadata := `{"manual":true,"followUpdates":true}`
+	manualLoop := storage.LoopRecord{ID: "loop_manual_followup_completed", Seq: 100, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &manualMetadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), manualLoop); err != nil {
+		t.Fatalf("Loops.Upsert() manual error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_fixer_midrun_automatic", LoopID: automaticLoopID, Status: "running", CurrentStep: stringPtr(string(stepRepair)), LastCompletedStep: stringPtr(string(stepCollectFixes)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	lockKey := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+	if acquired, err := fixture.repos.Locks.Acquire(context.Background(), storage.LockRecord{Key: lockKey, Owner: automaticLoopID, ExpiresAt: eventlog.FormatJavaScriptISOString(fixture.now().Add(time.Minute).UTC()), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Locks.Acquire() error = %v", err)
+	} else if !acquired {
+		t.Fatal("Locks.Acquire() = false, want active fixer PR lock")
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_midrun_automatic", ProjectID: &projectID, LoopID: &automaticLoopID, Type: "fixer", TargetType: "pull_request", TargetID: loopTarget, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:midrun-automatic:active", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, LockKey: &lockKey, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-85", HeadRefName: "feature/fix-85", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: detail.HeadSHA}}, viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: projectID, Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("QueueItems = %#v, want no parallel queue item while automatic run continues", result.QueueItems)
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), automaticLoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	pending, ok := parsePendingFixerRediscoveryState(parseJSONObject(persisted.MetadataJSON))
+	if !ok {
+		t.Fatalf("parsePendingFixerRediscoveryState() = false, want pending rediscovery metadata on automatic loop")
+	}
+	if pending.HeadSHA != detail.HeadSHA || pending.FixItemsStateHash == "" || !sameStringSlices(pending.UnresolvedThreadIDs, []string{"t1"}) {
+		t.Fatalf("pending = %#v, want persisted pending rediscovery state on automatic loop", pending)
+	}
+	manualPersisted, err := fixture.repos.Loops.GetByID(context.Background(), manualLoop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() manual error = %v", err)
+	}
+	if _, ok := parsePendingFixerRediscoveryState(parseJSONObject(manualPersisted.MetadataJSON)); ok {
+		t.Fatalf("manual pending rediscovery present in %#v, want automatic loop to own rediscovery state", parseJSONObject(manualPersisted.MetadataJSON))
+	}
+}
+
 func TestDiscoverPullRequestsRecoversLegacyNoopLoopWithoutOpenPRListing(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1934,6 +1934,55 @@ func TestDiscoverPullRequestsPreservesPendingRediscoveryForRunningAutomaticLoopW
 	}
 }
 
+func TestDiscoverPullRequestsSkipsAutoQueueWhileManualSingleShotRunHoldsLock(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(86)
+	nowISO := fixture.nowISO()
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	projectID := "project_1"
+	metadata := `{"manual":true,"followUpdates":false}`
+	manualLoopID := "loop_manual_single_shot_running"
+	manualLoop := storage.LoopRecord{ID: manualLoopID, Seq: 101, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), manualLoop); err != nil {
+		t.Fatalf("Loops.Upsert() manual error = %v", err)
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_manual_single_shot_running", LoopID: manualLoopID, Status: "running", CurrentStep: stringPtr(string(stepRepair)), LastCompletedStep: stringPtr(string(stepCollectFixes)), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	lockKey := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+	if acquired, err := fixture.repos.Locks.Acquire(context.Background(), storage.LockRecord{Key: lockKey, Owner: manualLoopID, ExpiresAt: eventlog.FormatJavaScriptISOString(fixture.now().Add(time.Minute).UTC()), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Locks.Acquire() error = %v", err)
+	} else if !acquired {
+		t.Fatal("Locks.Acquire() = false, want active fixer PR lock")
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_manual_single_shot_running", ProjectID: &projectID, LoopID: &manualLoopID, Type: "fixer", TargetType: "pull_request", TargetID: loopTarget, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:manual-single-shot:active", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, LockKey: &lockKey, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{listOpen: []PullRequestSummary{{Number: prNumber, State: "OPEN", HeadSHA: "head-86"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: projectID, Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 0 || len(result.CreatedLoopIDs) != 0 || result.Skipped != 1 {
+		t.Fatalf("result = %#v, want active manual single-shot run to suppress auto rediscovery", result)
+	}
+	if github.viewIndex != 0 {
+		t.Fatalf("viewIndex = %d, want discovery to stop before opening PR detail", github.viewIndex)
+	}
+	queueItems, err := fixture.repos.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(queueItems) != 1 || queueItems[0].ID != "queue_manual_single_shot_running" {
+		t.Fatalf("queueItems = %#v, want only the active manual queue item", queueItems)
+	}
+}
+
 func TestDiscoverPullRequestsRecoversLegacyNoopLoopWithoutOpenPRListing(t *testing.T) {
 	t.Parallel()
 
@@ -2047,6 +2096,39 @@ func TestDiscoverPullRequestsRecoversManualForeignLegacyNoopLoop(t *testing.T) {
 	}
 	if result.QueueItems[0].TargetID != loopTarget {
 		t.Fatalf("queue item = %#v, want recovered manual foreign PR target", result.QueueItems[0])
+	}
+}
+
+func TestDiscoverPullRequestsRecoversAutomaticLegacyNoopLoopAfterManualSingleShotHistory(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	manualMetadata := `{"manual":true,"followUpdates":false}`
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_manual_single_shot_history", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &manualMetadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Loops.Upsert() manual error = %v", err)
+	}
+	legacyAt := eventlog.FormatJavaScriptISOString(fixture.now().Add(-10 * time.Minute))
+	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{comment}}
+	automaticMetadata := mustMarshalJSON(map[string]any{"lastNoopResolveHeadSha": "head-1", "lastNoopResolveStateHash": hashFixItemsState(collectFixItems(detail)), "lastNoopResolveAt": legacyAt})
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_legacy_after_manual", Seq: 2, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &automaticMetadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Loops.Upsert() automatic error = %v", err)
+	}
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want recovered automatic legacy queue item", result.QueueItems)
+	}
+	if result.QueueItems[0].LoopID == nil || *result.QueueItems[0].LoopID != "loop_fixer_legacy_after_manual" {
+		t.Fatalf("queue item = %#v, want automatic legacy loop to be recovered", result.QueueItems[0])
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1959,6 +1959,87 @@ func TestDiscoverPullRequestsRecoversLegacyNoopLoopAfterCooldownWhenPRListingMis
 	}
 }
 
+func TestDiscoverPullRequestsRecoversManualForeignLegacyNoopLoop(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	legacyAt := fixture.nowISO()
+	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{comment}}
+	metadata := mustMarshalJSON(map[string]any{"manual": true, "lastNoopResolveHeadSha": "head-1", "lastNoopResolveStateHash": hashFixItemsState(collectFixItems(detail)), "lastNoopResolveAt": legacyAt})
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_manual_legacy", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{currentUser: "looper-bot", viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want recovered manual foreign queue item", result.QueueItems)
+	}
+	if result.QueueItems[0].TargetID != loopTarget {
+		t.Fatalf("queue item = %#v, want recovered manual foreign PR target", result.QueueItems[0])
+	}
+}
+
+func TestDiscoverPullRequestsRecoversManualLegacyNoopLoopDespiteLabelMismatch(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	legacyAt := fixture.nowISO()
+	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{comment}}
+	metadata := mustMarshalJSON(map[string]any{"manual": true, "lastNoopResolveHeadSha": "head-1", "lastNoopResolveStateHash": hashFixItemsState(collectFixItems(detail)), "lastNoopResolveAt": legacyAt})
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_manual_legacy_labels", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{currentUser: "looper-bot", viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, AuthorFilter: config.FixerAuthorFilterCurrentUser, Labels: []string{"bug"}, LabelMode: config.LabelModeAll}})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want recovered manual queue item despite label mismatch", result.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsRecoversManualLegacyNoopDraftLoopDespiteDraftPolicy(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	legacyAt := fixture.nowISO()
+	comment := map[string]any{"id": "c1", "threadId": "t1", "body": "please fix"}
+	detail := PullRequestDetail{Number: prNumber, State: "OPEN", IsDraft: true, HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{comment}}
+	metadata := mustMarshalJSON(map[string]any{"manual": true, "lastNoopResolveHeadSha": "head-1", "lastNoopResolveStateHash": hashFixItemsState(collectFixItems(detail)), "lastNoopResolveAt": legacyAt})
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fixer_manual_legacy_draft", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	github := &fakeGitHubGateway{currentUser: "looper-bot", viewResponses: []PullRequestDetail{detail}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, AuthorFilter: config.FixerAuthorFilterCurrentUser}})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want recovered manual queue item despite draft policy", result.QueueItems)
+	}
+}
+
 func TestDiscoverPullRequestsRecoverySkipsLegacyNoopLoopWhenPRLocked(t *testing.T) {
 	t.Parallel()
 
@@ -3485,6 +3566,98 @@ func TestProcessClaimedItemSkipsPRsNotOwnedByCurrentUser(t *testing.T) {
 	}
 	if result.Status != "skipped" || !contains(result.Summary, "does not match fixer owner") {
 		t.Fatalf("result = %#v, want skipped foreign PR", result)
+	}
+}
+
+func TestProcessClaimedItemAllowsManualFixerRunForForeignPR(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		currentUser: "looper-bot",
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:   CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult:  PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+		inspectResults: []InspectHeadResult{{HeadSHA: "base-head"}, {HeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}}, {HeadSHA: "new-head"}},
+	}
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"manual":true}`
+	loop := storage.LoopRecord{ID: "loop_manual_foreign", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue := storage.QueueItemRecord{ID: "queue_manual_foreign", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "fixer", TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:manual-foreign", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Queue.Upsert(context.Background(), queue); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), queue)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success for manual foreign PR", result)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want manual fixer run to execute", len(agent.starts))
+	}
+}
+
+func TestProcessClaimedItemAllowsRecoveredManualFixerRunForForeignPR(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		currentUser: "looper-bot",
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:   CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult:  PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+		inspectResults: []InspectHeadResult{{HeadSHA: "base-head"}, {HeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}}, {HeadSHA: "new-head"}},
+	}
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"manual":true}`
+	loop := storage.LoopRecord{ID: "loop_manual_foreign_recovered", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue := storage.QueueItemRecord{ID: "queue_manual_foreign_recovered", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "fixer", TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:manual-foreign-recovered", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Queue.Upsert(context.Background(), queue); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), queue)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success for recovered manual foreign PR", result)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want recovered manual fixer run to execute", len(agent.starts))
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -3661,6 +3661,53 @@ func TestProcessClaimedItemAllowsRecoveredManualFixerRunForForeignPR(t *testing.
 	}
 }
 
+func TestProcessClaimedItemAllowsRecoveredManualFixerRunDespiteRuntimeLabelMismatch(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		currentUser: "looper-bot",
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Author: "human", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:   CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult:  PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+		inspectResults: []InspectHeadResult{{HeadSHA: "base-head"}, {HeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}}, {HeadSHA: "new-head"}},
+	}
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, AuthorFilter: config.FixerAuthorFilterCurrentUser, Labels: []string{"bug"}, LabelMode: config.LabelModeAll}})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"manual":true}`
+	payloadJSON := mustMarshalJSON(map[string]any{"discoveryFingerprint": buildFixerDiscoveryFingerprint(repo, prNumber, "head-1", "hash-1")})
+	loop := storage.LoopRecord{ID: "loop_manual_runtime_label_bypass", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue := storage.QueueItemRecord{ID: "queue_manual_runtime_label_bypass", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "fixer", TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber, DedupeKey: buildFixerDedupeKey("project_1", loop.ID, repo, prNumber, "head-1", "hash-1"), Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, PayloadJSON: &payloadJSON, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Queue.Upsert(context.Background(), queue); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), queue)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success for recovered manual fixer run", result)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("len(agent.starts) = %d, want recovered manual fixer run to execute", len(agent.starts))
+	}
+}
+
 func TestProcessClaimedItemPausesWhenLabelsNoLongerMatchAtRuntime(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -548,6 +548,36 @@ func TestBuildRecoveryQueueItemDoesNotRestoreManualPlannerPayloadFromLoopMetadat
 	}
 }
 
+func TestBuildRecoveryQueueItemKeepsManualFixerRecoveryQueuePayloadEmpty(t *testing.T) {
+	t.Parallel()
+
+	loop := storage.LoopRecord{
+		ID:           "loop_fixer_manual",
+		ProjectID:    "project_1",
+		Type:         "fixer",
+		TargetType:   "pull_request",
+		TargetID:     stringPtr("pr:acme/looper:82"),
+		Repo:         stringPtr("acme/looper"),
+		PRNumber:     int64Ptr(82),
+		Status:       "failed",
+		MetadataJSON: stringPtr(`{"manual":true}`),
+	}
+
+	record, ok, err := buildRecoveryQueueItem(loop, "2026-04-17T12:34:56.000Z", 3)
+	if err != nil {
+		t.Fatalf("buildRecoveryQueueItem() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("buildRecoveryQueueItem() ok = false, want true")
+	}
+	if record.PayloadJSON != nil {
+		t.Fatalf("record.PayloadJSON = %#v, want nil for manual fixer recovery queue", record.PayloadJSON)
+	}
+	if record.DedupeKey != "fixer:loop_fixer_manual" {
+		t.Fatalf("record.DedupeKey = %q, want loop-scoped fixer dedupe key", record.DedupeKey)
+	}
+}
+
 func TestRuntimeStartConfiguresDefaultSchedulerTickAtStartup(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- allow manual fixer runs to target foreign PRs by marking fixer loop creates as manual server-side
- bypass author, label, and draft auto-discovery gates when resuming manual fixer legacy/noop follow-up loops
- add regression coverage for manual foreign PR execution and recovery paths

## Testing
- go test ./...