### PR TITLE
fix: align fixer commit subject guidance

### DIFF
--- a/internal/cliapp/prompt_commands.go
+++ b/internal/cliapp/prompt_commands.go
@@ -97,15 +97,26 @@ func previewLifecycleSafety(role string, project config.ProjectRefConfig, cfg co
 		branch = ""
 		baseBranch = ""
 		if !allowRemote {
-			return "Only repair Looper-provided fix items; do not change remote pull request state unless lifecycle policy allows it.\n\n" + previewNoRemoteLifecyclePromptInstruction(role, branch, baseBranch, cfg.Disclosure, agentRuntime, agentModel)
+			return previewFixerLifecycleSafety(allowRemote, cfg.Disclosure, agentRuntime, agentModel)
 		}
-		return "Only repair Looper-provided fix items; do not change remote pull request state unless lifecycle policy allows it.\n\n" + lifecycle.PromptInstruction(role, branch, baseBranch, true, false, cfg.Disclosure, agentRuntime, agentModel)
+		return previewFixerLifecycleSafety(allowRemote, cfg.Disclosure, agentRuntime, agentModel)
 	default:
 		if !allowRemote {
 			return previewNoRemoteLifecyclePromptInstruction(role, branch, baseBranch, cfg.Disclosure, agentRuntime, agentModel)
 		}
 		return lifecycle.PromptInstruction(role, branch, baseBranch, true, true, cfg.Disclosure, agentRuntime, agentModel)
 	}
+}
+
+func previewFixerLifecycleSafety(allowRemote bool, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string) string {
+	parts := []string{"Only repair Looper-provided fix items; do not change remote pull request state unless lifecycle policy allows it."}
+	if !allowRemote {
+		parts = append(parts, previewNoRemoteLifecyclePromptInstruction("fixer", "", "", disclosureCfg, agentRuntime, agentModel))
+	} else {
+		parts = append(parts, lifecycle.PromptInstruction("fixer", "", "", true, false, disclosureCfg, agentRuntime, agentModel))
+	}
+	parts = append(parts, "For fixer commits, prefer a fresh commit subject that precisely summarizes the repair changes from this round. Do not mechanically reuse the PR title or a previous fixer subject when this round's edits are narrower or different.")
+	return strings.Join(parts, "\n\n")
 }
 
 func promptAgentRuntime(cfg config.Config) string {

--- a/internal/cliapp/prompt_commands_test.go
+++ b/internal/cliapp/prompt_commands_test.go
@@ -91,6 +91,15 @@ func TestPromptPreviewFixerLifecycleMatchesRuntimeBranchFields(t *testing.T) {
 			t.Fatalf("prompt preview = %q, want to contain %q", stdout, want)
 		}
 	}
+	for _, want := range []string{
+		"For fixer commits, prefer a fresh commit subject that precisely summarizes the repair changes from this round.",
+		"Do not mechanically reuse the PR title or a previous fixer subject",
+		"unless a runner-specific instruction tells you to write a new subject",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("prompt preview = %q, want to contain %q", stdout, want)
+		}
+	}
 	for _, notWant := range []string{"branch=\"<branch>\"", "baseBranch=\"main\""} {
 		if strings.Contains(stdout, notWant) {
 			t.Fatalf("fixer prompt preview used lifecycle fields that runtime fixer prompt does not use %q:\n%s", notWant, stdout)

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -5503,6 +5503,7 @@ func buildFixerPrompt(projectID string, instructionConfig config.Config, repo st
 		parts = append(parts, "Do not push the branch or update remote pull request state; leave repository publishing for Looper/manual follow-up after your edits.")
 		parts = append(parts, noRemoteLifecyclePromptInstruction("fixer", "", "", disclosureCfg, agentRuntime, agentModel))
 	}
+	parts = append(parts, "For fixer commits, prefer a fresh commit subject that precisely summarizes the repair changes from this round. Do not mechanically reuse the PR title or a previous fixer subject when this round's edits are narrower or different.")
 	return agent.AppendCompletionInstruction(strings.Join(parts, "\n\n")), instructionBlock
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -104,6 +104,24 @@ func TestBuildFixerPromptCommentReplyInstructionRequiresVerificationWithoutRemot
 	}
 }
 
+func TestBuildFixerPromptPrefersRoundSpecificCommitSubject(t *testing.T) {
+	t.Parallel()
+
+	detail := &checkpointDetail{State: "OPEN", HeadSHA: "abc123", BaseRefName: "main", HeadRefName: "feature/fix"}
+	prompt, _ := buildFixerPrompt("project_1", customInstructionConfig(nil), "acme/looper", 42, detail, []FixItem{{ID: "fix-1", Summary: "repair disclosure"}}, true, config.DefaultDisclosureConfig(), "opencode", "openai/gpt-5.5")
+	for _, want := range []string{
+		"For fixer commits, prefer a fresh commit subject that precisely summarizes the repair changes from this round.",
+		"Do not mechanically reuse the PR title or a previous fixer subject",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "For commits, keep commit subjects unchanged and add a commit body trailer") {
+		t.Fatalf("prompt still contains old conflicting commit-subject guidance:\n%s", prompt)
+	}
+}
+
 func TestRunPrepareWorktreeStepRecreatesUnsafeCheckpointAtRepoPath(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -403,7 +403,7 @@ func disclosurePromptInstruction(runner string, cfg config.DisclosureConfig, age
 
 	parts := []string{"Disclose looper-generated external content only for the disclosure channels enabled by configuration."}
 	if cfg.Channels.GitCommit {
-		parts = append(parts, "For commits, keep commit subjects unchanged and add a commit body trailer like `"+commitTrailer+"`.")
+		parts = append(parts, "For commits, keep commit subjects unchanged unless a runner-specific instruction tells you to write a new subject, and add a commit body trailer like `"+commitTrailer+"`.")
 	} else {
 		parts = append(parts, "Do not add looper Generated-By trailers to commit messages.")
 	}

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -142,6 +142,9 @@ func TestPromptInstructionRespectsDisclosureChannelOptOuts(t *testing.T) {
 
 func TestPromptInstructionLeavesPRDisclosureStampingToLooper(t *testing.T) {
 	prompt := PromptInstruction("worker", "looper/test", "main", true, true, config.DefaultDisclosureConfig(), "opencode", "")
+	if !strings.Contains(prompt, "unless a runner-specific instruction tells you to write a new subject") {
+		t.Fatalf("PromptInstruction missing softened commit-subject guidance:\n%s", prompt)
+	}
 	if !strings.Contains(prompt, "For PR bodies, do not add looper Markdown disclosure footers yourself; Looper will append or normalize the PR disclosure footer during PR creation or update.") {
 		t.Fatalf("PromptInstruction missing PR stamping guidance:\n%s", prompt)
 	}


### PR DESCRIPTION
## Summary
- steer fixer prompts toward fresh, round-specific commit subjects instead of reusing stale subjects
- soften lifecycle disclosure wording so runner-specific commit subject instructions can override it
- align fixer prompt preview and tests with the runtime guidance

## Testing
- go test ./internal/cliapp ./internal/fixer ./internal/lifecycle