### PR TITLE
feat: enable default worktree cleanup

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -914,12 +914,12 @@ Looper records worktrees it creates for planner, reviewer, fixer, and worker loo
 
 Defaults:
 
-- `daemon.worktreeCleanup.enabled = false`
+- `daemon.worktreeCleanup.enabled = true`
 - `daemon.worktreeCleanup.interval = "24h"`
 - `daemon.worktreeCleanup.retentionDays = 7`
 - `daemon.worktreeCleanup.maxPerTick = 10`
 - `daemon.worktreeCleanup.includeOrphans = false`
-- `daemon.worktreeCleanup.dryRun = true`
+- `daemon.worktreeCleanup.dryRun = false`
 
 To disable automatic cleanup:
 

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -93,8 +93,8 @@
             "activeRuns": 1
           },
           "worktreeCleanup": {
-            "enabled": false,
-            "dryRun": true,
+            "enabled": true,
+            "dryRun": false,
             "lastStatus": "idle",
             "scanned": 0,
             "candidates": 0,
@@ -269,12 +269,12 @@
             "workingDirectory": "<tmp-root>",
             "environment": {},
             "worktreeCleanup": {
-              "enabled": false,
+              "enabled": true,
               "interval": "24h",
               "retentionDays": 7,
               "maxPerTick": 10,
               "includeOrphans": false,
-              "dryRun": true
+              "dryRun": false
             }
           },
           "package": {

--- a/internal/cliapp/worktree_commands.go
+++ b/internal/cliapp/worktree_commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 
 	gitinfra "github.com/nexu-io/looper/internal/infra/git"
 	"github.com/nexu-io/looper/internal/storage"
@@ -63,10 +64,12 @@ func writeHumanWorktreeCleanup(w io.Writer, result worktreecleanup.Result) error
 	if !result.DryRun {
 		mode = "confirmed"
 	}
+	reasonCounts := map[string]int{}
 	if _, err := fmt.Fprintf(w, "Worktree cleanup (%s): inspected=%d eligible=%d cleaned=%d skipped=%d errors=%d\n", mode, result.Summary.Inspected, result.Summary.Eligible, result.Summary.Cleaned, result.Summary.Skipped, result.Summary.Errors); err != nil {
 		return err
 	}
 	for _, candidate := range result.Candidates {
+		reasonCounts[candidate.Reason]++
 		if candidate.Error != "" {
 			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", candidate.Action, candidate.Reason, candidate.ProjectID, candidate.Branch, candidate.Error); err != nil {
 				return err
@@ -77,5 +80,30 @@ func writeHumanWorktreeCleanup(w io.Writer, result worktreecleanup.Result) error
 			return err
 		}
 	}
+	if reasonCounts["project_not_configured"] > 0 {
+		projectIDs := unconfiguredProjectIDs(result.Candidates)
+		if _, err := fmt.Fprintf(w, "note\tproject_not_configured\t%d candidate(s) belong to project(s) missing from the current config: %s\n", reasonCounts["project_not_configured"], projectIDs); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func unconfiguredProjectIDs(candidates []worktreecleanup.Candidate) string {
+	set := map[string]struct{}{}
+	for _, candidate := range candidates {
+		if candidate.Reason != "project_not_configured" || candidate.ProjectID == "" {
+			continue
+		}
+		set[candidate.ProjectID] = struct{}{}
+	}
+	ids := make([]string, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	if len(ids) == 0 {
+		return "unknown"
+	}
+	return fmt.Sprintf("%v", ids)
 }

--- a/internal/cliapp/worktree_commands_test.go
+++ b/internal/cliapp/worktree_commands_test.go
@@ -142,8 +142,40 @@ func TestWorktreeCleanupSkipsActiveLoopWorktree(t *testing.T) {
 	requirePathExists(t, record.WorktreePath)
 }
 
+func TestWorktreeCleanupExplainsUnconfiguredProjectSkips(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorktreeCleanupFixture(t)
+	record := fixture.createWorktree(t, "looper/test-unconfigured")
+	fixture.writeConfig(t, map[string]any{
+		"storage": map[string]any{"dbPath": fixture.dbPath},
+		"tools":   map[string]any{"gitPath": "git"},
+		"daemon": map[string]any{
+			"worktreeCleanup": map[string]any{
+				"retentionDays":  0,
+				"maxPerTick":     10,
+				"includeOrphans": true,
+			},
+		},
+		"projects": []map[string]any{},
+	})
+
+	exitCode, stdout, stderr := fixture.run("worktree", "cleanup")
+	if exitCode != 0 {
+		t.Fatalf("Run(worktree cleanup) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, record.WorktreePath) || !strings.Contains(stdout, "skip\tproject_not_configured") {
+		t.Fatalf("stdout = %q, want project_not_configured skip", stdout)
+	}
+	if !strings.Contains(stdout, "note\tproject_not_configured\t1 candidate(s) belong to project(s) missing from the current config: [project_1]") {
+		t.Fatalf("stdout = %q, want actionable unconfigured-project note", stdout)
+	}
+	requirePathExists(t, record.WorktreePath)
+}
+
 type worktreeCleanupFixture struct {
 	configPath string
+	dbPath     string
 	repoPath   string
 	root       string
 	repos      *storage.Repositories
@@ -195,7 +227,7 @@ func newWorktreeCleanupFixture(t *testing.T) worktreeCleanupFixture {
 	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Test Project", RepoPath: repoPath, BaseBranch: &baseBranch, CreatedAt: now, UpdatedAt: now}); err != nil {
 		t.Fatalf("Projects.Upsert() error = %v", err)
 	}
-	return worktreeCleanupFixture{configPath: configPath, repoPath: repoPath, root: root, repos: repos}
+	return worktreeCleanupFixture{configPath: configPath, dbPath: dbPath, repoPath: repoPath, root: root, repos: repos}
 }
 
 func (f worktreeCleanupFixture) createWorktree(t *testing.T, branch string) storage.WorktreeRecord {
@@ -216,6 +248,17 @@ func (f worktreeCleanupFixture) run(args ...string) (int, string, string) {
 	fullArgs = append(fullArgs, "--config", f.configPath)
 	exitCode := app.Run(context.Background(), fullArgs)
 	return exitCode, stdout.String(), stderr.String()
+}
+
+func (f worktreeCleanupFixture) writeConfig(t *testing.T, cfg map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(f.configPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 }
 
 func jsonString(value string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3183,8 +3183,8 @@ func TestDefaultConfigMatchesDaemonDefaults(t *testing.T) {
 		t.Fatalf("DefaultConfig().Daemon.WorkingDirectory = %q, want %q", config.Daemon.WorkingDirectory, "/tmp/looper-cwd")
 	}
 
-	if config.Daemon.WorktreeCleanup.Enabled {
-		t.Fatal("DefaultConfig().Daemon.WorktreeCleanup.Enabled = true, want false")
+	if !config.Daemon.WorktreeCleanup.Enabled {
+		t.Fatal("DefaultConfig().Daemon.WorktreeCleanup.Enabled = false, want true")
 	}
 	if config.Daemon.WorktreeCleanup.Interval != "24h" {
 		t.Fatalf("DefaultConfig().Daemon.WorktreeCleanup.Interval = %q, want %q", config.Daemon.WorktreeCleanup.Interval, "24h")
@@ -3198,8 +3198,8 @@ func TestDefaultConfigMatchesDaemonDefaults(t *testing.T) {
 	if config.Daemon.WorktreeCleanup.IncludeOrphans {
 		t.Fatal("DefaultConfig().Daemon.WorktreeCleanup.IncludeOrphans = true, want false")
 	}
-	if !config.Daemon.WorktreeCleanup.DryRun {
-		t.Fatal("DefaultConfig().Daemon.WorktreeCleanup.DryRun = false, want true")
+	if config.Daemon.WorktreeCleanup.DryRun {
+		t.Fatal("DefaultConfig().Daemon.WorktreeCleanup.DryRun = true, want false")
 	}
 
 	if config.Defaults.OpenPRStrategy != OpenPRStrategyAllDone {
@@ -3239,7 +3239,7 @@ func TestNormalizeMergesPartialWorktreeCleanupConfig(t *testing.T) {
 	if cfg.Daemon.WorktreeCleanup.RetentionDays != 14 {
 		t.Fatalf("Normalize().Daemon.WorktreeCleanup.RetentionDays = %d, want 14", cfg.Daemon.WorktreeCleanup.RetentionDays)
 	}
-	if cfg.Daemon.WorktreeCleanup.Interval != "24h" || cfg.Daemon.WorktreeCleanup.MaxPerTick != 10 || !cfg.Daemon.WorktreeCleanup.DryRun {
+	if cfg.Daemon.WorktreeCleanup.Interval != "24h" || cfg.Daemon.WorktreeCleanup.MaxPerTick != 10 || cfg.Daemon.WorktreeCleanup.DryRun {
 		t.Fatalf("Normalize().Daemon.WorktreeCleanup = %#v, want unspecified defaults preserved", cfg.Daemon.WorktreeCleanup)
 	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -135,12 +135,12 @@ func DefaultConfig(cwd string) (Config, error) {
 			WorkingDirectory:       cwd,
 			Environment:            map[string]string{},
 			WorktreeCleanup: WorktreeCleanupConfig{
-				Enabled:        false,
+				Enabled:        true,
 				Interval:       "24h",
 				RetentionDays:  7,
 				MaxPerTick:     10,
 				IncludeOrphans: false,
-				DryRun:         true,
+				DryRun:         false,
 			},
 		},
 		Package: PackageConfig{

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -179,12 +179,12 @@
           "FROM_FILE": "1"
         },
         "worktreeCleanup": {
-          "enabled": false,
+          "enabled": true,
           "interval": "24h",
           "retentionDays": 7,
           "maxPerTick": 10,
           "includeOrphans": false,
-          "dryRun": true
+          "dryRun": false
         }
       },
       "package": {

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -112,12 +112,12 @@
         "workingDirectory": "__TMP__/runtime",
         "environment": {},
         "worktreeCleanup": {
-          "enabled": false,
+          "enabled": true,
           "interval": "24h",
           "retentionDays": 7,
           "maxPerTick": 10,
           "includeOrphans": false,
-          "dryRun": true
+          "dryRun": false
         }
       },
       "package": {

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -199,12 +199,12 @@
           "LAUNCHD": "1"
         },
         "worktreeCleanup": {
-          "enabled": false,
+          "enabled": true,
           "interval": "24h",
           "retentionDays": 7,
           "maxPerTick": 10,
           "includeOrphans": false,
-          "dryRun": true
+          "dryRun": false
         }
       },
       "package": {


### PR DESCRIPTION
## Summary
- enable automatic worktree cleanup by default and make the default cleanup pass perform real removals instead of dry-run only
- update config/docs/contracts/tests to match the new default daemon worktree cleanup settings
- make `looper worktree cleanup` explain when candidates are skipped because their projects are missing from the current config

## Testing
- go test ./internal/cliapp ./internal/config ./internal/api ./internal/worktreecleanup
- go test ./internal/config -run 'TestDefaultConfigMatchesDaemonDefaults|TestNormalizeMergesPartialWorktreeCleanupConfig|TestLoadFileMatchesFrozenParityFixtures/(cli-file-env-priority|default-path-missing)$' -v