### PR TITLE
feat: add runner retry recovery

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -4465,6 +4465,11 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 		if loop.Status == string(domain.LoopStatusStopped) || loop.Status == string(domain.LoopStatusTerminated) || loop.Status == string(domain.LoopStatusCompleted) {
 			return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal %s loop: %s", loop.Status, loop.ID)}
 		}
+		if loop.Type == string(domain.LoopTypeReviewer) {
+			if terminalMetadataStatus := terminalReviewerRetryMetadataStatus(*loop); terminalMetadataStatus != "" {
+				return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal reviewer metadata %s loop: %s", terminalMetadataStatus, loop.ID)}
+			}
+		}
 		if (loop.Type == string(domain.LoopTypeReviewer) || loop.Type == string(domain.LoopTypeFixer) || loop.Type == string(domain.LoopTypeWorker) || loop.Type == string(domain.LoopTypePlanner)) && !isCodingAgentConfigured(h.context.Config) {
 			return retryResult{}, apiError{code: pkgapi.ErrorCodeAgentNotConfigured, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry %s loop without config.agent.vendor", loop.Type)}
 		}
@@ -4924,6 +4929,23 @@ func isTerminalReviewerLoopRecord(loop storage.LoopRecord) bool {
 	return status == "terminated" || status == "stopped" || status == "failed"
 }
 
+func terminalReviewerRetryMetadataStatus(loop storage.LoopRecord) string {
+	if loop.MetadataJSON == nil || strings.TrimSpace(*loop.MetadataJSON) == "" {
+		return ""
+	}
+	metadata := parseJSONObject(loop.MetadataJSON)
+	loopMeta, _ := metadata["loop"].(map[string]any)
+	if loopMeta == nil {
+		return ""
+	}
+	removeDeprecatedReviewerLoopBudgetMetadata(loopMeta)
+	status, _ := loopMeta["status"].(string)
+	if status == "terminated" || status == "stopped" {
+		return status
+	}
+	return ""
+}
+
 func resetReviewerLoopRetryMetadata(current *string) (*string, error) {
 	if current == nil || strings.TrimSpace(*current) == "" {
 		return current, nil
@@ -4933,6 +4955,7 @@ func resetReviewerLoopRetryMetadata(current *string) (*string, error) {
 	if !ok || loopMeta == nil {
 		return current, nil
 	}
+	removeDeprecatedReviewerLoopBudgetMetadata(loopMeta)
 	loopMeta["status"] = "queued"
 	metadata["loop"] = loopMeta
 	encoded, err := json.Marshal(metadata)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/domain"
 	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/loops"
 	networkclient "github.com/nexu-io/looper/internal/network/client"
 	"github.com/nexu-io/looper/internal/projects"
 	"github.com/nexu-io/looper/internal/reviewer"
@@ -1475,18 +1476,35 @@ type activeRunsQuery struct {
 }
 
 type activeRunView struct {
-	Seq         int64              `json:"seq"`
-	RunID       *string            `json:"runId"`
-	LoopID      string             `json:"loopId"`
-	ProjectID   string             `json:"projectId"`
-	Type        string             `json:"type"`
-	Status      string             `json:"status"`
-	CurrentStep *string            `json:"currentStep"`
-	StartedAt   *string            `json:"startedAt"`
-	EndedAt     *string            `json:"endedAt,omitempty"`
-	Target      activeRunTarget    `json:"target"`
-	Agent       *activeRunAgent    `json:"agent"`
-	Worktree    *activeRunWorktree `json:"worktree"`
+	Seq               int64              `json:"seq"`
+	RunID             *string            `json:"runId"`
+	LoopID            string             `json:"loopId"`
+	ProjectID         string             `json:"projectId"`
+	Type              string             `json:"type"`
+	Status            string             `json:"status"`
+	LoopStatus        string             `json:"loopStatus"`
+	DisplayStatus     string             `json:"displayStatus"`
+	LastFailureKind   *string            `json:"lastFailureKind,omitempty"`
+	LastFailureReason *string            `json:"lastFailureReason,omitempty"`
+	ResumePolicy      *string            `json:"resumePolicy,omitempty"`
+	CurrentStep       *string            `json:"currentStep"`
+	StartedAt         *string            `json:"startedAt"`
+	EndedAt           *string            `json:"endedAt,omitempty"`
+	Target            activeRunTarget    `json:"target"`
+	Agent             *activeRunAgent    `json:"agent"`
+	Worktree          *activeRunWorktree `json:"worktree"`
+}
+
+type retryLoopRequest struct {
+	Mode          string `json:"mode"`
+	ResetAttempts *bool  `json:"resetAttempts"`
+}
+
+type retryLoopResponse struct {
+	Loop          loopResponse `json:"loop"`
+	QueueItemID   *string      `json:"queueItemId,omitempty"`
+	Mode          string       `json:"mode"`
+	ResetAttempts bool         `json:"resetAttempts"`
 }
 
 type activeRunTarget struct {
@@ -2550,6 +2568,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 	}
 
 	queuedLoopIDs := make(map[string]struct{})
+	latestQueueByLoopID := latestQueueItemByLoopID(queueItems)
 	for _, item := range queueItems {
 		if item.LoopID != nil && (item.Status == "queued" || item.Status == "running") {
 			queuedLoopIDs[*item.LoopID] = struct{}{}
@@ -2590,19 +2609,22 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			continue
 		}
 		runID := run.ID
-		runningViews = append(runningViews, activeRunView{
+		view := activeRunView{
 			Seq:         loop.Seq,
 			RunID:       &runID,
 			LoopID:      run.LoopID,
 			ProjectID:   loop.ProjectID,
 			Type:        loop.Type,
 			Status:      run.Status,
+			LoopStatus:  loop.Status,
 			CurrentStep: run.CurrentStep,
 			StartedAt:   stringPtrOrNil(run.StartedAt),
 			Target:      target,
 			Agent:       activeAgentByRunID[run.ID],
 			Worktree:    buildWorktreeSummary(loop, run),
-		})
+		}
+		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], latestRun)
+		runningViews = append(runningViews, view)
 	}
 
 	runningLoopsWithoutRuns := make([]storage.LoopRecord, 0)
@@ -2631,19 +2653,22 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			continue
 		}
 		startedAt := firstNonEmptyString(loop.NextRunAt, stringPtrOrNil(loop.UpdatedAt), stringPtrOrNil(loop.CreatedAt))
-		queuedViews = append(queuedViews, activeRunView{
+		view := activeRunView{
 			Seq:         loop.Seq,
 			RunID:       nil,
 			LoopID:      loop.ID,
 			ProjectID:   loop.ProjectID,
 			Type:        loop.Type,
 			Status:      loop.Status,
+			LoopStatus:  loop.Status,
 			CurrentStep: nil,
 			StartedAt:   startedAt,
 			Target:      target,
 			Agent:       nil,
 			Worktree:    nil,
-		})
+		}
+		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], nil)
+		queuedViews = append(queuedViews, view)
 	}
 
 	runningLoopViews := make([]activeRunView, 0, len(runningLoopsWithoutRuns))
@@ -2656,19 +2681,22 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			continue
 		}
 		startedAt := firstNonEmptyString(loop.LastRunAt, loop.NextRunAt, stringPtrOrNil(loop.UpdatedAt), stringPtrOrNil(loop.CreatedAt))
-		runningLoopViews = append(runningLoopViews, activeRunView{
+		view := activeRunView{
 			Seq:         loop.Seq,
 			RunID:       nil,
 			LoopID:      loop.ID,
 			ProjectID:   loop.ProjectID,
 			Type:        loop.Type,
 			Status:      loop.Status,
+			LoopStatus:  loop.Status,
 			CurrentStep: nil,
 			StartedAt:   startedAt,
 			Target:      target,
 			Agent:       nil,
 			Worktree:    nil,
-		})
+		}
+		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], nil)
+		runningLoopViews = append(runningLoopViews, view)
 	}
 
 	includedLoopIDs := make(map[string]struct{}, len(runningViews)+len(runningLoopViews)+len(queuedViews))
@@ -2683,50 +2711,64 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 	}
 
 	inactiveLoopViews := make([]activeRunView, 0)
-	if includeInactiveLoops {
-		for _, loop := range loopsList {
-			if _, ok := includedLoopIDs[loop.ID]; ok {
+	for _, loop := range loopsList {
+		if _, ok := includedLoopIDs[loop.ID]; ok {
+			continue
+		}
+		latestQueue := latestQueueByLoopID[loop.ID]
+		var latestRun *storage.RunRecord
+		if !includeInactiveLoops {
+			var runErr error
+			latestRun, runErr = services.Repositories.Runs.GetLatestByLoopID(ctx, loop.ID)
+			if runErr != nil {
+				return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: runErr.Error()}
+			}
+			if !isManualInterventionQueue(latestQueue) && !hasManualInterventionResumePolicy(latestRun) {
 				continue
 			}
-			target, ok, err := h.tryBuildActiveRunTarget(ctx, loop)
-			if err != nil {
-				return nil, err
-			}
-			if !ok {
-				continue
-			}
-			var (
-				latestRun *storage.RunRecord
-				runID     *string
-				worktree  *activeRunWorktree
-			)
+		}
+		target, ok, err := h.tryBuildActiveRunTarget(ctx, loop)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		var (
+			runID    *string
+			worktree *activeRunWorktree
+		)
+		if latestRun == nil {
 			latestRun, err = services.Repositories.Runs.GetLatestByLoopID(ctx, loop.ID)
 			if err != nil {
 				return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 			}
-			startedAt := firstNonEmptyString(loop.LastRunAt, loop.NextRunAt, stringPtrOrNil(loop.UpdatedAt), stringPtrOrNil(loop.CreatedAt))
-			var endedAt *string
-			if latestRun != nil {
-				runID = &latestRun.ID
-				startedAt = stringPtrOrNil(latestRun.StartedAt)
-				endedAt = latestRun.EndedAt
-				worktree = buildWorktreeSummary(loop, *latestRun)
-			}
-			inactiveLoopViews = append(inactiveLoopViews, activeRunView{
-				Seq:         loop.Seq,
-				RunID:       runID,
-				LoopID:      loop.ID,
-				ProjectID:   loop.ProjectID,
-				Type:        loop.Type,
-				Status:      loop.Status,
-				CurrentStep: nil,
-				StartedAt:   startedAt,
-				EndedAt:     endedAt,
-				Target:      target,
-				Agent:       nil,
-				Worktree:    worktree,
-			})
 		}
+		startedAt := firstNonEmptyString(loop.LastRunAt, loop.NextRunAt, stringPtrOrNil(loop.UpdatedAt), stringPtrOrNil(loop.CreatedAt))
+		var endedAt *string
+		if latestRun != nil {
+			runID = &latestRun.ID
+			startedAt = stringPtrOrNil(latestRun.StartedAt)
+			endedAt = latestRun.EndedAt
+			worktree = buildWorktreeSummary(loop, *latestRun)
+		}
+		view := activeRunView{
+			Seq:         loop.Seq,
+			RunID:       runID,
+			LoopID:      loop.ID,
+			ProjectID:   loop.ProjectID,
+			Type:        loop.Type,
+			Status:      loop.Status,
+			LoopStatus:  loop.Status,
+			CurrentStep: nil,
+			StartedAt:   startedAt,
+			EndedAt:     endedAt,
+			Target:      target,
+			Agent:       nil,
+			Worktree:    worktree,
+		}
+		decorateActiveRunView(&view, loop, latestQueue, latestRun)
+		inactiveLoopViews = append(inactiveLoopViews, view)
 	}
 
 	items := append(runningViews, runningLoopViews...)
@@ -2755,6 +2797,60 @@ func excludeActiveRunViewsByLoopID(items []activeRunView, excluded []activeRunVi
 		filtered = append(filtered, item)
 	}
 	return filtered
+}
+
+func latestQueueItemByLoopID(items []storage.QueueItemRecord) map[string]*storage.QueueItemRecord {
+	latest := make(map[string]*storage.QueueItemRecord)
+	for i := range items {
+		item := &items[i]
+		if item.LoopID == nil || strings.TrimSpace(*item.LoopID) == "" {
+			continue
+		}
+		loopID := *item.LoopID
+		current := latest[loopID]
+		if current == nil || item.UpdatedAt > current.UpdatedAt || (item.UpdatedAt == current.UpdatedAt && item.ID > current.ID) {
+			latest[loopID] = item
+		}
+	}
+	return latest
+}
+
+func isManualInterventionQueue(item *storage.QueueItemRecord) bool {
+	return item != nil && item.LastErrorKind != nil && *item.LastErrorKind == "manual_intervention"
+}
+
+func hasManualInterventionResumePolicy(run *storage.RunRecord) bool {
+	policy := resumePolicyFromRun(run)
+	return policy != nil && *policy == loops.ResumePolicyManualIntervention
+}
+
+func decorateActiveRunView(view *activeRunView, loop storage.LoopRecord, latestQueue *storage.QueueItemRecord, latestRun *storage.RunRecord) {
+	if view.LoopStatus == "" {
+		view.LoopStatus = loop.Status
+	}
+	view.DisplayStatus = view.Status
+	if latestQueue != nil {
+		view.LastFailureKind = latestQueue.LastErrorKind
+		view.LastFailureReason = latestQueue.LastError
+	}
+	view.ResumePolicy = resumePolicyFromRun(latestRun)
+	if isManualInterventionQueue(latestQueue) || (view.ResumePolicy != nil && *view.ResumePolicy == loops.ResumePolicyManualIntervention) {
+		view.DisplayStatus = "manual_intervention"
+	}
+	if view.DisplayStatus == "" {
+		view.DisplayStatus = view.Status
+	}
+}
+
+func resumePolicyFromRun(run *storage.RunRecord) *string {
+	if run == nil || run.CheckpointJSON == nil {
+		return nil
+	}
+	policy := readStringMap(parseJSONObject(run.CheckpointJSON), "resumePolicy")
+	if policy == nil || strings.TrimSpace(*policy) == "" {
+		return nil
+	}
+	return policy
 }
 
 func buildVerifiedActiveAgentByRunID(ctx context.Context, runtime RuntimeState, executions []storage.AgentExecutionRecord) map[string]*activeRunAgent {
@@ -2918,7 +3014,7 @@ func parsePositiveInt64(value, fieldName string) (int64, error) {
 }
 
 func matchesActiveRunQuery(item activeRunView, query activeRunsQuery) bool {
-	if query.Status != "" && item.Status != query.Status {
+	if query.Status != "" && item.Status != query.Status && item.DisplayStatus != query.Status && item.LoopStatus != query.Status {
 		return false
 	}
 	if query.Type != "" && item.Type != query.Type {
@@ -3043,6 +3139,11 @@ func (h *Handler) buildLoopRouteResponse(r *http.Request, path string) (any, err
 			return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
 		}
 		return h.mutateLoopStatus(r.Context(), loop.ID, domain.LoopStatusPaused)
+	case "retry":
+		if r.Method != http.MethodPost {
+			return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
+		}
+		return h.retryLoop(r.Context(), r, loop.ID)
 	default:
 		return nil, apiError{code: pkgapi.ErrorCodeRouteNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Unknown route: %s", path)}
 	}
@@ -4319,6 +4420,161 @@ func (h *Handler) mutateLoopStatus(ctx context.Context, loopID string, status do
 	return serializeLoop(updated), nil
 }
 
+func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string) (retryLoopResponse, error) {
+	var body retryLoopRequest
+	if r.Body != nil {
+		defer r.Body.Close()
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Invalid retry request: %v", err)}
+		}
+	}
+	mode := strings.TrimSpace(body.Mode)
+	if mode == "" {
+		mode = "auto"
+	}
+	if mode != "auto" && mode != "resume" && mode != "rediscover" {
+		return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Unsupported retry mode: %s", mode)}
+	}
+	if mode != "auto" {
+		return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusNotImplemented, message: fmt.Sprintf("Retry mode %s is not implemented safely yet; use mode auto", mode)}
+	}
+	resetAttempts := true
+	if body.ResetAttempts != nil {
+		resetAttempts = *body.ResetAttempts
+	}
+	if !resetAttempts {
+		return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "resetAttempts=false is not supported for explicit operator retry"}
+	}
+
+	services := h.context.Runtime.Services()
+	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
+	type retryResult struct {
+		loop        storage.LoopRecord
+		queueItemID *string
+	}
+	result, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (retryResult, error) {
+		repos := storage.NewRepositories(tx)
+		loop, err := repos.Loops.GetByID(ctx, loopID)
+		if err != nil {
+			return retryResult{}, err
+		}
+		if loop == nil {
+			return retryResult{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
+		}
+		if loop.Status == string(domain.LoopStatusStopped) || loop.Status == string(domain.LoopStatusTerminated) || loop.Status == string(domain.LoopStatusCompleted) {
+			return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal %s loop: %s", loop.Status, loop.ID)}
+		}
+		if (loop.Type == string(domain.LoopTypeReviewer) || loop.Type == string(domain.LoopTypeFixer) || loop.Type == string(domain.LoopTypeWorker) || loop.Type == string(domain.LoopTypePlanner)) && !isCodingAgentConfigured(h.context.Config) {
+			return retryResult{}, apiError{code: pkgapi.ErrorCodeAgentNotConfigured, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry %s loop without config.agent.vendor", loop.Type)}
+		}
+		runningRuns, err := repos.Runs.ListByStatus(ctx, string(domain.RunStatusRunning))
+		if err != nil {
+			return retryResult{}, err
+		}
+		for _, run := range runningRuns {
+			if run.LoopID == loop.ID {
+				return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while a run is active", loop.ID)}
+			}
+		}
+		activeQueue, err := repos.Queue.FindActiveByLoopID(ctx, loop.ID)
+		if err != nil {
+			return retryResult{}, err
+		}
+		if activeQueue != nil {
+			return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while queue item %s is active", loop.ID, activeQueue.ID)}
+		}
+
+		target, targetErr := loopTargetFromRecordCompat(*loop)
+		if targetErr != nil {
+			return retryResult{}, targetErr
+		}
+		existing, err := repos.Loops.List(ctx)
+		if err != nil {
+			return retryResult{}, err
+		}
+		if uniqueErr := assertUniqueActiveLoopCompat(existing, loop.ID, loop.ProjectID, domain.LoopType(loop.Type), target, domain.LoopStatusQueued); uniqueErr != nil {
+			return retryResult{}, uniqueErr
+		}
+		latestQueue, err := repos.Queue.GetLatestByLoopID(ctx, loop.ID)
+		if err != nil {
+			return retryResult{}, err
+		}
+
+		queueLoop := *loop
+		queueLoop.Status = string(domain.LoopStatusQueued)
+		queueLoop.NextRunAt = &nowISO
+		queueLoop.UpdatedAt = nowISO
+		if queueLoop.Type == string(domain.LoopTypeReviewer) {
+			metadataJSON, metadataErr := resetReviewerLoopRetryMetadata(queueLoop.MetadataJSON)
+			if metadataErr != nil {
+				return retryResult{}, metadataErr
+			}
+			queueLoop.MetadataJSON = metadataJSON
+		}
+		var queueRecord storage.QueueItemRecord
+		var ok bool
+		if latestQueue != nil {
+			queueRecord = *latestQueue
+			queueRecord.ID = generateRequestID()
+			queueRecord.Status = "queued"
+			queueRecord.AvailableAt = nowISO
+			if resetAttempts {
+				queueRecord.Attempts = 0
+			}
+			queueRecord.ClaimedBy = nil
+			queueRecord.ClaimedAt = nil
+			queueRecord.StartedAt = nil
+			queueRecord.FinishedAt = nil
+			queueRecord.LastError = nil
+			queueRecord.LastErrorKind = nil
+			queueRecord.CreatedAt = nowISO
+			queueRecord.UpdatedAt = nowISO
+			ok = true
+		} else {
+			built, builtOK, queueErr := buildQueuedLoopQueueRecordCompat(queueLoop, target, nowISO, queueLoop.MetadataJSON, int64(h.context.Config.Scheduler.RetryMaxAttempts))
+			if queueErr != nil {
+				return retryResult{}, queueErr
+			}
+			queueRecord = built
+			ok = builtOK
+		}
+		if !ok {
+			return retryResult{loop: *loop}, nil
+		}
+		if queueRecord.DedupeKey != "" {
+			activeDedupe, err := repos.Queue.FindActiveByDedupe(ctx, queueRecord.DedupeKey)
+			if err != nil {
+				return retryResult{}, err
+			}
+			if activeDedupe != nil {
+				return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while dedupe queue item %s is active", loop.ID, activeDedupe.ID)}
+			}
+		}
+
+		updated := queueLoop
+		if err := repos.Loops.Upsert(ctx, updated); err != nil {
+			return retryResult{}, err
+		}
+		persisted, _, err := repos.Queue.UpsertActiveByDedupeOrGetExisting(ctx, queueRecord)
+		if err != nil {
+			return retryResult{}, err
+		}
+		return retryResult{loop: updated, queueItemID: &persisted.ID}, nil
+	})
+	if err != nil {
+		var typed apiError
+		if asAPIError(err, &typed) {
+			return retryLoopResponse{}, typed
+		}
+		return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	if h.context.TriggerSchedulerTick != nil {
+		h.context.TriggerSchedulerTick()
+	}
+	return retryLoopResponse{Loop: serializeLoop(result.loop), QueueItemID: result.queueItemID, Mode: mode, ResetAttempts: resetAttempts}, nil
+}
+
 func (h *Handler) buildLoopLogsResponse(ctx context.Context, loop storage.LoopRecord) (loopLogsResponse, error) {
 	services := h.context.Runtime.Services()
 	if latestLoop, err := services.Repositories.Loops.GetByID(ctx, loop.ID); err != nil {
@@ -4666,6 +4922,25 @@ func isTerminalReviewerLoopRecord(loop storage.LoopRecord) bool {
 	loopMeta, _ := metadata["loop"].(map[string]any)
 	status, _ := loopMeta["status"].(string)
 	return status == "terminated" || status == "stopped" || status == "failed"
+}
+
+func resetReviewerLoopRetryMetadata(current *string) (*string, error) {
+	if current == nil || strings.TrimSpace(*current) == "" {
+		return current, nil
+	}
+	metadata := parseJSONObject(current)
+	loopMeta, ok := metadata["loop"].(map[string]any)
+	if !ok || loopMeta == nil {
+		return current, nil
+	}
+	loopMeta["status"] = "queued"
+	metadata["loop"] = loopMeta
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, err
+	}
+	value := string(encoded)
+	return &value, nil
 }
 
 func buildQueuedLoopQueueRecordCompat(record storage.LoopRecord, target domain.LoopTarget, nowISO string, metadataJSON *string, maxAttempts int64) (storage.QueueItemRecord, bool, error) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -60,6 +60,210 @@ func TestHandlerHealthzSuccessAndRequestIDEcho(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopRetryCreatesReplacementQueueItem(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry"
+	loopID := "loop_retry"
+	targetID := projectID
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 42, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	lastErrorKind := "manual_intervention"
+	lastError := "dirty worker worktree"
+	finishedAt := "2026-04-11T12:01:00.000Z"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_retry_failed", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:retry", Priority: storage.QueuePriorityWorker, Status: "failed", AvailableAt: nowISO, Attempts: 2, MaxAttempts: 3, LastError: &lastError, LastErrorKind: &lastErrorKind, FinishedAt: &finishedAt, CreatedAt: nowISO, UpdatedAt: finishedAt}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/42/retry", strings.NewReader(`{"mode":"auto","resetAttempts":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = %#v, %v", loop, err)
+	}
+	if loop.Status != "queued" {
+		t.Fatalf("loop.Status = %q, want queued", loop.Status)
+	}
+	items, err := services.Repositories.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	var replacement *storage.QueueItemRecord
+	for i := range items {
+		if items[i].LoopID != nil && *items[i].LoopID == loopID && items[i].Status == "queued" {
+			replacement = &items[i]
+		}
+	}
+	if replacement == nil || replacement.ID == "queue_retry_failed" || replacement.Attempts != 0 || replacement.LastErrorKind != nil {
+		t.Fatalf("replacement queue = %#v, want new queued item with reset attempts and cleared error", replacement)
+	}
+}
+
+func TestHandlerLoopRetryAllowsFailedReviewerLoop(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_reviewer"
+	loopID := "loop_retry_reviewer"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	metadata := `{"loop":{"status":"failed","failureCount":3}}`
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 44, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	lastErrorKind := "non_retryable"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_retry_reviewer_failed", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:retry_reviewer", Priority: storage.QueuePriorityReviewer, Status: "failed", AvailableAt: nowISO, Attempts: 5, MaxAttempts: 5, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/44/retry", strings.NewReader(`{"mode":"auto"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = %#v, %v", loop, err)
+	}
+	if loop.Status != "queued" {
+		t.Fatalf("loop.Status = %q, want queued", loop.Status)
+	}
+	loopMeta := parseJSONObject(loop.MetadataJSON)["loop"].(map[string]any)
+	if loopMeta["status"] != "queued" {
+		t.Fatalf("metadata loop.status = %#v, want queued", loopMeta["status"])
+	}
+}
+
+func TestHandlerLoopRetryRejectsConflictingActiveLoop(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_conflict"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_retry_conflict_active", Seq: 45, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert(active) error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_retry_conflict_candidate", Seq: 46, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert(candidate) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/46/retry", strings.NewReader(`{"mode":"auto"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	}
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), "loop_retry_conflict_candidate")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = %#v, %v", loop, err)
+	}
+	if loop.Status != "paused" {
+		t.Fatalf("loop.Status = %q, want paused", loop.Status)
+	}
+}
+
+func TestHandlerActiveRunsSurfacesManualInterventionStatus(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_manual"
+	loopID := "loop_manual"
+	targetID := projectID
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 43, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	lastErrorKind := "manual_intervention"
+	lastError := "dirty worker worktree"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_manual", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:manual", Priority: storage.QueuePriorityWorker, Status: "manual_intervention", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, LastError: &lastError, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1: %#v", len(items), items)
+	}
+	item := items[0].(map[string]any)
+	assertEqual(t, item["status"], "paused")
+	assertEqual(t, item["displayStatus"], "manual_intervention")
+	assertEqual(t, item["loopStatus"], "paused")
+	assertEqual(t, item["lastFailureKind"], "manual_intervention")
+	assertEqual(t, item["lastFailureReason"], "dirty worker worktree")
+}
+
+func TestHandlerActiveRunsSurfacesResumePolicyManualIntervention(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_manual_resume"
+	loopID := "loop_manual_resume"
+	targetID := projectID
+	checkpoint := `{"resumePolicy":"manual_intervention"}`
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 47, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_manual_resume", LoopID: loopID, Status: "failed", CheckpointJSON: &checkpoint, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1: %#v", len(items), items)
+	}
+	item := items[0].(map[string]any)
+	assertEqual(t, item["status"], "paused")
+	assertEqual(t, item["displayStatus"], "manual_intervention")
+	assertEqual(t, item["resumePolicy"], "manual_intervention")
+}
+
 func TestHandlerReviewerRepairInvokesContextAndTriggersScheduler(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -152,6 +152,105 @@ func TestHandlerLoopRetryAllowsFailedReviewerLoop(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopRetryRejectsTerminalReviewerMetadata(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_reviewer_terminal_metadata"
+	loopID := "loop_retry_reviewer_terminal_metadata"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	metadata := `{"loop":{"status":"terminated","terminationReason":"manual_stop","failureCount":3}}`
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 45, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	lastErrorKind := "non_retryable"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_retry_reviewer_terminal_metadata", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:retry_reviewer_terminal_metadata", Priority: storage.QueuePriorityReviewer, Status: "failed", AvailableAt: nowISO, Attempts: 5, MaxAttempts: 5, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/45/retry", strings.NewReader(`{"mode":"auto"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "Cannot retry terminal reviewer metadata terminated loop") {
+		t.Fatalf("body = %s, want terminal reviewer metadata error", recorder.Body.String())
+	}
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = %#v, %v", loop, err)
+	}
+	if loop.Status != "failed" {
+		t.Fatalf("loop.Status = %q, want failed", loop.Status)
+	}
+	if loop.MetadataJSON == nil || *loop.MetadataJSON != metadata {
+		t.Fatalf("loop.MetadataJSON = %#v, want %q", loop.MetadataJSON, metadata)
+	}
+	items, err := services.Repositories.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("queue items len = %d, want 1", len(items))
+	}
+}
+
+func TestHandlerLoopRetryClearsDeprecatedReviewerBudgetMetadata(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_reviewer_budget_metadata"
+	loopID := "loop_retry_reviewer_budget_metadata"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	metadata := `{"loop":{"status":"terminated","terminationReason":"max_wall_clock","failureCount":3,"maxIterationsPerPR":2,"maxWallClockSeconds":60}}`
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 46, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "failed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	lastErrorKind := "non_retryable"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_retry_reviewer_budget_metadata", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:retry_reviewer_budget_metadata", Priority: storage.QueuePriorityReviewer, Status: "failed", AvailableAt: nowISO, Attempts: 5, MaxAttempts: 5, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/46/retry", strings.NewReader(`{"mode":"auto"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = %#v, %v", loop, err)
+	}
+	loopMeta := parseJSONObject(loop.MetadataJSON)["loop"].(map[string]any)
+	if loopMeta["status"] != "queued" {
+		t.Fatalf("metadata loop.status = %#v, want queued", loopMeta["status"])
+	}
+	if _, ok := loopMeta["terminationReason"]; ok {
+		t.Fatalf("metadata terminationReason still present: %#v", loopMeta)
+	}
+	if _, ok := loopMeta["maxIterationsPerPR"]; ok {
+		t.Fatalf("metadata maxIterationsPerPR still present: %#v", loopMeta)
+	}
+	if _, ok := loopMeta["maxWallClockSeconds"]; ok {
+		t.Fatalf("metadata maxWallClockSeconds still present: %#v", loopMeta)
+	}
+}
+
 func TestHandlerLoopRetryRejectsConflictingActiveLoop(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -992,6 +992,8 @@
               "projectId": "project_1",
               "type": "reviewer",
               "status": "running",
+              "loopStatus": "running",
+              "displayStatus": "running",
               "currentStep": "review",
               "startedAt": "2026-04-11T12:00:00.000Z",
               "target": {
@@ -1010,6 +1012,8 @@
               "projectId": "project_1",
               "type": "worker",
               "status": "queued",
+              "loopStatus": "queued",
+              "displayStatus": "queued",
               "currentStep": null,
               "startedAt": "<generated-timestamp>",
               "target": {
@@ -1037,6 +1041,8 @@
           "projectId": "project_1",
           "type": "reviewer",
           "status": "running",
+          "loopStatus": "running",
+          "displayStatus": "running",
           "currentStep": "review",
           "startedAt": "2026-04-11T12:00:00.000Z",
           "target": {

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -321,7 +321,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 			newCommand(commandSpec{
 				use:             "loop",
 				short:           "Loop commands",
-				helpSubcommands: []helpSubcommand{{name: "list", description: "List loops"}, {name: "inspect", description: "Inspect loop diagnostics"}, {name: "failures", description: "List failed loop diagnostics"}, {name: "start", description: "Start a loop"}, {name: "pause", description: "Pause a loop"}},
+				helpSubcommands: []helpSubcommand{{name: "list", description: "List loops"}, {name: "inspect", description: "Inspect loop diagnostics"}, {name: "failures", description: "List failed loop diagnostics"}, {name: "start", description: "Start a loop"}, {name: "pause", description: "Pause a loop"}, {name: "retry", description: "Retry a failed or paused loop"}},
 				helpWhenNoArgs:  true,
 				exampleLines: []string{
 					"$ looper loop list",
@@ -335,8 +335,10 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					newCommand(commandSpec{use: "failures", short: "List failed loop diagnostics", runE: runtime.loopFailures, localFlags: []flagSpec{stringFlag("type", "type", "Filter by loop type"), stringFlag("project", "projectId", "Filter by project id"), stringFlag("limit", "count", "Maximum number of failed loops to list")}}),
 					newCommand(commandSpec{use: "start", short: "Start a loop", runE: runtime.loopStart, localFlags: []flagSpec{stringFlag("type", "type", "Loop type"), stringFlag("pr", "repo#number", "Pull request reference"), stringFlag("project", "projectId", "Project id")}}),
 					newCommand(commandSpec{use: "pause [id]", short: "Pause a loop", args: cobra.MaximumNArgs(1), runE: runtime.loopPause, localFlags: []flagSpec{stringFlag("id", "id", "Loop id")}}),
+					newCommand(commandSpec{use: "retry <seq|loopId>", short: "Retry a loop", args: cobra.ExactArgs(1), runE: runtime.loopRetry, localFlags: []flagSpec{stringFlag("mode", "auto|resume|rediscover", "Retry mode"), boolFlag("discard-worktree-changes", "Discard dirty worktree changes before retrying"), boolFlag("confirm", "Confirm destructive retry action")}}),
 				},
 			}),
+			newCommand(commandSpec{use: "retry <seq|loopId>", short: "Retry a loop", args: cobra.ExactArgs(1), runE: runtime.loopRetry, localFlags: []flagSpec{stringFlag("mode", "auto|resume|rediscover", "Retry mode"), boolFlag("discard-worktree-changes", "Discard dirty worktree changes before retrying"), boolFlag("confirm", "Confirm destructive retry action")}}),
 			newCommand(commandSpec{
 				use:   "work",
 				short: "Create a worker run",

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -88,6 +88,7 @@ type loopsListOutput struct {
 
 type loopOutput struct {
 	ID         string  `json:"id"`
+	Seq        int64   `json:"seq"`
 	ProjectID  string  `json:"projectId"`
 	Type       string  `json:"type"`
 	TargetType string  `json:"targetType"`
@@ -95,6 +96,13 @@ type loopOutput struct {
 	Repo       *string `json:"repo"`
 	PRNumber   *int64  `json:"prNumber"`
 	Status     string  `json:"status"`
+}
+
+type loopRetryOutput struct {
+	Loop          loopOutput `json:"loop"`
+	QueueItemID   *string    `json:"queueItemId"`
+	Mode          string     `json:"mode"`
+	ResetAttempts bool       `json:"resetAttempts"`
 }
 
 type reviewRepairOutput struct {
@@ -197,13 +205,17 @@ type stopAllOutput struct {
 }
 
 type activeRunOutput struct {
-	Seq         int64   `json:"seq"`
-	Type        string  `json:"type"`
-	Status      string  `json:"status"`
-	CurrentStep *string `json:"currentStep"`
-	StartedAt   *string `json:"startedAt"`
-	EndedAt     *string `json:"endedAt"`
-	Target      struct {
+	Seq               int64   `json:"seq"`
+	Type              string  `json:"type"`
+	Status            string  `json:"status"`
+	LoopStatus        string  `json:"loopStatus"`
+	DisplayStatus     string  `json:"displayStatus"`
+	LastFailureKind   *string `json:"lastFailureKind"`
+	LastFailureReason *string `json:"lastFailureReason"`
+	CurrentStep       *string `json:"currentStep"`
+	StartedAt         *string `json:"startedAt"`
+	EndedAt           *string `json:"endedAt"`
+	Target            struct {
 		Label string `json:"label"`
 	} `json:"target"`
 	Agent *struct {
@@ -360,6 +372,15 @@ func writeHumanLoopUnpaused(w io.Writer, payload json.RawMessage) error {
 	return nil
 }
 
+func writeHumanLoopRetried(w io.Writer, payload json.RawMessage) error {
+	var data loopRetryOutput
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return fmt.Errorf("decode loop retry response: %w", err)
+	}
+	printSection(w, "Loop retry queued", [][2]any{{"id", data.Loop.ID}, {"seq", data.Loop.Seq}, {"status", data.Loop.Status}, {"mode", data.Mode}, {"queueItem", formatScalar(data.QueueItemID)}})
+	return nil
+}
+
 func writeHumanPullRequestList(w io.Writer, payload json.RawMessage) error {
 	var data pullRequestsListOutput
 	if err := json.Unmarshal(payload, &data); err != nil {
@@ -458,7 +479,11 @@ func writeHumanActiveRuns(w io.Writer, payload json.RawMessage) error {
 
 	rows := make([]tableRow, 0, len(data.Items))
 	for _, item := range data.Items {
-		rows = append(rows, tableRow{"#": item.Seq, "type": item.Type, "target": item.Target.Label, "step": item.CurrentStep, "agent": agentVendor(item.Agent), "pid": agentPID(item.Agent), "status": item.Status, "age": formatRelativeAge(firstNonEmptyCLIString(item.EndedAt, item.StartedAt))})
+		status := item.Status
+		if strings.TrimSpace(item.DisplayStatus) != "" {
+			status = item.DisplayStatus
+		}
+		rows = append(rows, tableRow{"#": item.Seq, "type": item.Type, "target": item.Target.Label, "step": item.CurrentStep, "agent": agentVendor(item.Agent), "pid": agentPID(item.Agent), "status": status, "age": formatRelativeAge(firstNonEmptyCLIString(item.EndedAt, item.StartedAt))})
 	}
 	printTable(w, []string{"#", "type", "target", "step", "agent", "pid", "status", "age"}, rows)
 	return nil

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -250,6 +250,27 @@ func (r *commandRuntime) unpauseLoopBySeq(cmd *cobra.Command, args []string) err
 	}, writeHumanLoopUnpaused)
 }
 
+func (r *commandRuntime) loopRetry(cmd *cobra.Command, args []string) error {
+	return r.outputCommand(cmd, func(ctx context.Context) (json.RawMessage, error) {
+		selector := strings.TrimSpace(args[0])
+		if selector == "" {
+			return nil, fmt.Errorf("loop retry requires <seq|loopId>")
+		}
+		if getBoolFlag(cmd, "discard-worktree-changes") && !getBoolFlag(cmd, "confirm") {
+			return nil, fmt.Errorf("--discard-worktree-changes requires --confirm")
+		}
+		if getBoolFlag(cmd, "discard-worktree-changes") {
+			return nil, fmt.Errorf("--discard-worktree-changes is not supported yet; fix or reset the worktree manually, then retry without this flag")
+		}
+		mode := strings.TrimSpace(getStringFlag(cmd, "mode"))
+		if mode == "" {
+			mode = "auto"
+		}
+		body := map[string]any{"mode": mode, "resetAttempts": true}
+		return r.postJSON(ctx, "/api/v1/loops/"+url.PathEscape(selector)+"/retry", body)
+	}, writeHumanLoopRetried)
+}
+
 func loopSeqSelector(value string) (string, error) {
 	seq := strings.TrimSpace(value)
 	if seq == "" {

--- a/internal/fixer/failure_classification_test.go
+++ b/internal/fixer/failure_classification_test.go
@@ -1,0 +1,35 @@
+package fixer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/loops/failureclass"
+)
+
+func TestClassifyFailureRetriesContextCancellation(t *testing.T) {
+	runner := &Runner{}
+	for _, err := range []error{context.Canceled, context.DeadlineExceeded} {
+		got := runner.classifyFailure(err)
+		if got.kind != FailureRetryableTransient {
+			t.Fatalf("classifyFailure(%v) kind = %s, want %s", err, got.kind, FailureRetryableTransient)
+		}
+	}
+}
+
+func TestClassifyFailureDoesNotRetryUnknownExternalLookingMessage(t *testing.T) {
+	runner := &Runner{}
+	got := runner.classifyFailure(errors.New("git push failed: connection reset by peer"))
+	if got.kind != FailureNonRetryable {
+		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureNonRetryable)
+	}
+}
+
+func TestClassifyFailureRetriesBoundaryExternalTransport(t *testing.T) {
+	runner := &Runner{}
+	got := runner.classifyFailure(failureclass.WithBoundary(errors.New("git push failed: connection reset by peer"), failureclass.BoundaryGitRemote))
+	if got.kind != FailureRetryableTransient {
+		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureRetryableTransient)
+	}
+}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/loops/failureclass"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/worktreesafety"
 )
@@ -1749,7 +1750,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		r.logInfo("fixer step started", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": string(step)})
 		checkpoint, err = r.executeStep(ctx, step, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem, Repo: *queueItem.Repo, PRNumber: *queueItem.PRNumber, Checkpoint: checkpoint})
 		if err != nil {
-			failure := r.classifyFailure(err)
+			failure := r.classifyFailureWithBoundary(err, fixerFailureBoundaryForStep(step))
 			latest := checkpoint
 			latest.ResumePolicy = loops.NormalizeResumePolicy(string(failure.kind), latest.ResumePolicy)
 			if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
@@ -4893,6 +4894,10 @@ func hasProgressed(checkpoint fixerCheckpoint) bool {
 }
 
 func (r *Runner) classifyFailure(err error) *loopError {
+	return r.classifyFailureWithBoundary(err, failureclass.BoundaryUnknown)
+}
+
+func (r *Runner) classifyFailureWithBoundary(err error, boundary failureclass.Boundary) *loopError {
 	var typed *loopError
 	if errors.As(err, &typed) {
 		return typed
@@ -4901,10 +4906,41 @@ func (r *Runner) classifyFailure(err error) *loopError {
 	if strings.Contains(strings.ToLower(message), "remote head changed") {
 		return &loopError{message: message, kind: FailureRetryableAfterResume}
 	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return &loopError{message: message, kind: FailureRetryableTransient}
+	}
 	if githubinfra.IsTransientError(err) {
 		return &loopError{message: message, kind: FailureRetryableTransient}
 	}
-	return &loopError{message: message, kind: FailureNonRetryable}
+	return &loopError{message: message, kind: fixerFailureKind(failureclass.Classify(err, failureclass.Context{Runner: failureclass.RunnerFixer, Boundary: boundary}))}
+}
+
+func fixerFailureBoundaryForStep(step FixerStep) failureclass.Boundary {
+	switch step {
+	case stepDiscoverPR, stepClaimPR, stepCollectFixes, stepResolveComments, stepRecheck:
+		return failureclass.BoundaryGitHubAPI
+	case stepPrepareWorktree, stepPush:
+		return failureclass.BoundaryGitRemote
+	case stepRepair:
+		return failureclass.BoundaryModelProvider
+	case stepValidate, stepReconcileCommits:
+		return failureclass.BoundaryAgentProcess
+	default:
+		return failureclass.BoundaryUnknown
+	}
+}
+
+func fixerFailureKind(kind failureclass.Kind) QueueFailureKind {
+	switch kind {
+	case failureclass.RetryableTransient:
+		return FailureRetryableTransient
+	case failureclass.RetryableAfterResume:
+		return FailureRetryableAfterResume
+	case failureclass.ManualIntervention:
+		return FailureManualIntervention
+	default:
+		return FailureNonRetryable
+	}
 }
 
 func (r *Runner) reconcileCommits(ctx context.Context, project storage.ProjectRecord, checkpoint fixerCheckpoint, commitMessage string) (fixerCheckpoint, error) {

--- a/internal/loops/failureclass/failureclass.go
+++ b/internal/loops/failureclass/failureclass.go
@@ -1,0 +1,159 @@
+package failureclass
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+)
+
+type Boundary string
+
+const (
+	BoundaryGitRemote     Boundary = "git_remote"
+	BoundaryGitLocal      Boundary = "git_local"
+	BoundaryGitHubAPI     Boundary = "github_api"
+	BoundaryModelProvider Boundary = "model_provider"
+	BoundaryAgentProcess  Boundary = "agent_process"
+	BoundaryLocalWorktree Boundary = "local_worktree"
+	BoundaryStorage       Boundary = "storage"
+	BoundaryConfig        Boundary = "config"
+	BoundaryCheckpoint    Boundary = "checkpoint"
+	BoundaryPolicy        Boundary = "policy"
+	BoundaryUnknown       Boundary = "unknown"
+)
+
+type RunnerKind string
+
+const (
+	RunnerReviewer RunnerKind = "reviewer"
+	RunnerWorker   RunnerKind = "worker"
+	RunnerFixer    RunnerKind = "fixer"
+	RunnerPlanner  RunnerKind = "planner"
+)
+
+type Kind string
+
+const (
+	RetryableTransient   Kind = "retryable_transient"
+	RetryableAfterResume Kind = "retryable_after_resume"
+	NonRetryable         Kind = "non_retryable"
+	ManualIntervention   Kind = "manual_intervention"
+)
+
+type Context struct {
+	Runner          RunnerKind
+	Step            string
+	Boundary        Boundary
+	SideEffectState string
+}
+
+type BoundaryError struct {
+	Boundary Boundary
+	Err      error
+}
+
+func WithBoundary(err error, boundary Boundary) error {
+	if err == nil {
+		return nil
+	}
+	return &BoundaryError{Boundary: boundary, Err: err}
+}
+
+func (e *BoundaryError) Error() string { return e.Err.Error() }
+
+func (e *BoundaryError) Unwrap() error { return e.Err }
+
+func Classify(err error, ctx Context) Kind {
+	if err == nil {
+		return NonRetryable
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return RetryableTransient
+	}
+	if githubinfra.IsTransientError(err) {
+		return RetryableTransient
+	}
+	if ctx.Boundary == BoundaryUnknown {
+		var boundaryErr *BoundaryError
+		if errors.As(err, &boundaryErr) && boundaryErr.Boundary != "" {
+			ctx.Boundary = boundaryErr.Boundary
+		}
+	}
+
+	message := strings.ToLower(githubinfra.ErrorMessage(err))
+	if message == "" {
+		message = strings.ToLower(err.Error())
+	}
+	if isManualWorktreeMessage(message) || ctx.Boundary == BoundaryLocalWorktree {
+		return ManualIntervention
+	}
+	if isDeterministicDenial(message) || isInternalDeterministicBoundary(ctx.Boundary) {
+		return NonRetryable
+	}
+	if isExternalBoundary(ctx.Boundary) {
+		return RetryableTransient
+	}
+	return NonRetryable
+}
+
+func isExternalBoundary(boundary Boundary) bool {
+	switch boundary {
+	case BoundaryGitRemote, BoundaryGitHubAPI, BoundaryModelProvider, BoundaryAgentProcess:
+		return true
+	default:
+		return false
+	}
+}
+
+func isInternalDeterministicBoundary(boundary Boundary) bool {
+	switch boundary {
+	case BoundaryGitLocal, BoundaryStorage, BoundaryConfig, BoundaryCheckpoint, BoundaryPolicy:
+		return true
+	default:
+		return false
+	}
+}
+
+func isManualWorktreeMessage(message string) bool {
+	return strings.Contains(message, "dirty worktree") ||
+		strings.Contains(message, "worktree is dirty") ||
+		strings.Contains(message, "uncommitted changes") ||
+		strings.Contains(message, "manual intervention required")
+}
+
+func isDeterministicDenial(message string) bool {
+	for _, fragment := range []string{
+		"http 400",
+		"http 401",
+		"http 403",
+		"http 404",
+		"http 422",
+		"400 bad request",
+		"401 unauthorized",
+		"403 forbidden",
+		"404 not found",
+		"422 unprocessable",
+		"bad credentials",
+		"authentication failed",
+		"permission denied",
+		"not authorized",
+		"repository not found",
+		"could not resolve to a repository",
+		"could not resolve to a pullrequest",
+		"protected branch",
+		"branch protection",
+		"policy denied",
+		"invalid model",
+		"unsupported model",
+		"config validation",
+		"schema",
+		"checkpoint invariant",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/loops/failureclass/failureclass.go
+++ b/internal/loops/failureclass/failureclass.go
@@ -89,6 +89,9 @@ func Classify(err error, ctx Context) Kind {
 	if isManualWorktreeMessage(message) || ctx.Boundary == BoundaryLocalWorktree {
 		return ManualIntervention
 	}
+	if ctx.Boundary == BoundaryGitHubAPI && isRetryableGitHubGraphQLUnauthorized(message) {
+		return RetryableTransient
+	}
 	if isDeterministicDenial(message) || isInternalDeterministicBoundary(ctx.Boundary) {
 		return NonRetryable
 	}
@@ -156,4 +159,23 @@ func isDeterministicDenial(message string) bool {
 		}
 	}
 	return false
+}
+
+func isRetryableGitHubGraphQLUnauthorized(message string) bool {
+	if !(strings.Contains(message, "graphql") && strings.Contains(message, "401")) {
+		return false
+	}
+	for _, fragment := range []string{
+		"bad credentials",
+		"authentication failed",
+		"permission denied",
+		"not authorized",
+		"invalid token",
+		"token expired",
+	} {
+		if strings.Contains(message, fragment) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/loops/failureclass/failureclass_test.go
+++ b/internal/loops/failureclass/failureclass_test.go
@@ -39,6 +39,20 @@ func TestClassifyUsesWrappedBoundaryAuthority(t *testing.T) {
 	}
 }
 
+func TestClassifyRetriesGitHubGraphQLUnauthorizedAtGitHubBoundary(t *testing.T) {
+	got := Classify(errors.New(`Post "https://api.github.com/graphql": HTTP 401 Unauthorized`), Context{Runner: RunnerReviewer, Boundary: BoundaryGitHubAPI})
+	if got != RetryableTransient {
+		t.Fatalf("Classify() = %s, want %s", got, RetryableTransient)
+	}
+}
+
+func TestClassifyDoesNotRetryCredentialFailures(t *testing.T) {
+	got := Classify(errors.New("GitHub API failed: HTTP 401 Unauthorized: bad credentials"), Context{Runner: RunnerReviewer, Boundary: BoundaryGitHubAPI})
+	if got != NonRetryable {
+		t.Fatalf("Classify() = %s, want %s", got, NonRetryable)
+	}
+}
+
 func TestClassifyDeterministicFailuresDoNotBecomeTransient(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/loops/failureclass/failureclass_test.go
+++ b/internal/loops/failureclass/failureclass_test.go
@@ -1,0 +1,62 @@
+package failureclass
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClassifyExternalBoundaryTransportFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		boundary Boundary
+		message  string
+	}{
+		{name: "git remote", boundary: BoundaryGitRemote, message: "git fetch origin: ssh_exchange_identification: Connection closed by remote host"},
+		{name: "github api", boundary: BoundaryGitHubAPI, message: "GraphQL request failed: HTTP 504 Gateway Timeout"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Classify(errors.New(tt.message), Context{Runner: RunnerReviewer, Boundary: tt.boundary})
+			if got != RetryableTransient {
+				t.Fatalf("Classify() = %s, want %s", got, RetryableTransient)
+			}
+		})
+	}
+}
+
+func TestClassifyUnknownBoundaryDoesNotPromoteByMessage(t *testing.T) {
+	got := Classify(errors.New("git ls-remote failed: broken pipe"), Context{Runner: RunnerReviewer, Boundary: BoundaryUnknown})
+	if got != NonRetryable {
+		t.Fatalf("Classify() = %s, want %s", got, NonRetryable)
+	}
+}
+
+func TestClassifyUsesWrappedBoundaryAuthority(t *testing.T) {
+	err := WithBoundary(errors.New("git ls-remote failed: broken pipe"), BoundaryGitRemote)
+	got := Classify(err, Context{Runner: RunnerReviewer, Boundary: BoundaryUnknown})
+	if got != RetryableTransient {
+		t.Fatalf("Classify() = %s, want %s", got, RetryableTransient)
+	}
+}
+
+func TestClassifyDeterministicFailuresDoNotBecomeTransient(t *testing.T) {
+	tests := []struct {
+		name     string
+		boundary Boundary
+		message  string
+		want     Kind
+	}{
+		{name: "github auth", boundary: BoundaryGitHubAPI, message: "GitHub API failed: HTTP 403 Forbidden", want: NonRetryable},
+		{name: "config", boundary: BoundaryConfig, message: "config validation failed", want: NonRetryable},
+		{name: "checkpoint", boundary: BoundaryCheckpoint, message: "checkpoint invariant missing", want: NonRetryable},
+		{name: "dirty worktree", boundary: BoundaryLocalWorktree, message: "dirty worktree", want: ManualIntervention},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Classify(errors.New(tt.message), Context{Runner: RunnerWorker, Boundary: tt.boundary})
+			if got != tt.want {
+				t.Fatalf("Classify() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/planner/failure_classification_test.go
+++ b/internal/planner/failure_classification_test.go
@@ -1,0 +1,24 @@
+package planner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/loops/failureclass"
+)
+
+func TestClassifyFailureDoesNotRetryUnknownExternalLookingMessage(t *testing.T) {
+	runner := &Runner{}
+	got := runner.classifyFailure(errors.New("model provider request failed: broken pipe"))
+	if got.kind != FailureNonRetryable {
+		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureNonRetryable)
+	}
+}
+
+func TestClassifyFailureRetriesBoundaryExternalTransport(t *testing.T) {
+	runner := &Runner{}
+	got := runner.classifyFailure(failureclass.WithBoundary(errors.New("model provider request failed: HTTP 503 Service Unavailable"), failureclass.BoundaryModelProvider))
+	if got.kind != FailureRetryableTransient {
+		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureRetryableTransient)
+	}
+}

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/loops/failureclass"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/worktreesafety"
 )
@@ -698,7 +699,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		r.appendEvent(ctx, eventInput{eventType: "loop.step.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"step": string(step)}})
 		checkpoint, err = r.executeStep(ctx, step, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem, Checkpoint: checkpoint})
 		if err != nil {
-			failure := r.classifyFailure(err)
+			failure := r.classifyFailureWithBoundary(err, plannerFailureBoundaryForStep(step))
 			latest := r.getLatestCheckpoint(ctx, run, checkpoint)
 			latest.ResumePolicy = loops.NormalizeResumePolicy(string(failure.kind), latest.ResumePolicy)
 			if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
@@ -1543,6 +1544,10 @@ func (r *Runner) updateLoop(ctx context.Context, loop storage.LoopRecord, mutate
 }
 
 func (r *Runner) classifyFailure(err error) *loopError {
+	return r.classifyFailureWithBoundary(err, failureclass.BoundaryUnknown)
+}
+
+func (r *Runner) classifyFailureWithBoundary(err error, boundary failureclass.Boundary) *loopError {
 	var typed *loopError
 	if errors.As(err, &typed) {
 		return typed
@@ -1557,7 +1562,33 @@ func (r *Runner) classifyFailure(err error) *loopError {
 	if githubinfra.IsTransientError(err) {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
-	return &loopError{message: err.Error(), kind: FailureNonRetryable}
+	return &loopError{message: err.Error(), kind: plannerFailureKind(failureclass.Classify(err, failureclass.Context{Runner: failureclass.RunnerPlanner, Boundary: boundary}))}
+}
+
+func plannerFailureBoundaryForStep(step PlannerStep) failureclass.Boundary {
+	switch step {
+	case stepDiscoverIssues, stepPublish, stepNotify:
+		return failureclass.BoundaryGitHubAPI
+	case stepPrepareWorktree:
+		return failureclass.BoundaryGitRemote
+	case stepWriteSpec:
+		return failureclass.BoundaryModelProvider
+	default:
+		return failureclass.BoundaryUnknown
+	}
+}
+
+func plannerFailureKind(kind failureclass.Kind) QueueFailureKind {
+	switch kind {
+	case failureclass.RetryableTransient:
+		return FailureRetryableTransient
+	case failureclass.RetryableAfterResume:
+		return FailureRetryableAfterResume
+	case failureclass.ManualIntervention:
+		return FailureManualIntervention
+	default:
+		return FailureNonRetryable
+	}
 }
 
 func (r *Runner) nowISO() string { return eventlog.FormatJavaScriptISOString(r.now()) }

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -29,6 +29,7 @@ import (
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/loops/failureclass"
 	"github.com/nexu-io/looper/internal/networkpolicy"
 	"github.com/nexu-io/looper/internal/reviewer/automerge"
 	"github.com/nexu-io/looper/internal/reviewer/criteria"
@@ -1414,7 +1415,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		checkpoint, err = r.executeStep(ctx, step, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem, Repo: *queueItem.Repo, PRNumber: *queueItem.PRNumber, Checkpoint: checkpoint})
 		if err != nil {
 			stepElapsedSeconds := durationSeconds(r.now().Sub(stepStartedAt))
-			failure := r.classifyFailureForProject(project.ID, err)
+			failure := r.classifyFailureForProjectAndBoundary(project.ID, err, reviewerFailureBoundaryForStep(step))
 			latest := r.getLatestCheckpoint(ctx, run, checkpoint)
 			if checkpoint.ResumePolicy == "rerun_review" || hasPendingReviewMarkerMiss(checkpoint) {
 				latest = checkpoint
@@ -4280,6 +4281,10 @@ func (r *Runner) classifyFailure(err error) *loopError {
 }
 
 func (r *Runner) classifyFailureForProject(projectID string, err error) *loopError {
+	return r.classifyFailureForProjectAndBoundary(projectID, err, failureclass.BoundaryUnknown)
+}
+
+func (r *Runner) classifyFailureForProjectAndBoundary(projectID string, err error, boundary failureclass.Boundary) *loopError {
 	var typed *loopError
 	if errors.As(err, &typed) {
 		return typed
@@ -4301,7 +4306,33 @@ func (r *Runner) classifyFailureForProject(projectID string, err error) *loopErr
 	if r.isEnhancedTransientFailureForPolicy(r.retryPolicyForProject(projectID), err) {
 		return &loopError{message: githubinfra.ErrorMessage(err), kind: FailureRetryableTransient}
 	}
-	return &loopError{message: err.Error(), kind: FailureNonRetryable}
+	return &loopError{message: err.Error(), kind: reviewerFailureKind(failureclass.Classify(err, failureclass.Context{Runner: failureclass.RunnerReviewer, Boundary: boundary}))}
+}
+
+func reviewerFailureBoundaryForStep(step ReviewerStep) failureclass.Boundary {
+	switch step {
+	case stepDiscover, stepFilter, stepClaim, stepSnapshot, stepThreadResolution, stepPublish:
+		return failureclass.BoundaryGitHubAPI
+	case stepWorktree:
+		return failureclass.BoundaryGitRemote
+	case stepReview:
+		return failureclass.BoundaryModelProvider
+	default:
+		return failureclass.BoundaryUnknown
+	}
+}
+
+func reviewerFailureKind(kind failureclass.Kind) QueueFailureKind {
+	switch kind {
+	case failureclass.RetryableTransient:
+		return FailureRetryableTransient
+	case failureclass.RetryableAfterResume:
+		return FailureRetryableAfterResume
+	case failureclass.ManualIntervention:
+		return FailureManualIntervention
+	default:
+		return FailureNonRetryable
+	}
 }
 
 func (r *Runner) isTransientExternalFailure(err error) bool {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -17,6 +17,7 @@ import (
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/infra/specpr"
+	"github.com/nexu-io/looper/internal/loops/failureclass"
 	"github.com/nexu-io/looper/internal/networkpolicy"
 	"github.com/nexu-io/looper/internal/reviewer/automerge"
 	"github.com/nexu-io/looper/internal/reviewer/criteria"
@@ -5937,7 +5938,7 @@ func TestIsTransientExternalFailureDetectsWrappedGitHubStatus(t *testing.T) {
 	}
 }
 
-func TestEnhancedTransientClassificationIsOptIn(t *testing.T) {
+func TestUnknownBoundaryDoesNotRetryExternalLookingCommandError(t *testing.T) {
 	err := &shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: `Post "https://api.github.com/graphql": EOF`}}
 
 	defaultRunner := New(Options{})
@@ -5946,6 +5947,11 @@ func TestEnhancedTransientClassificationIsOptIn(t *testing.T) {
 	}
 	if defaultRunner.isTransientExternalFailure(err) {
 		t.Fatal("default isTransientExternalFailure() = true, want false")
+	}
+
+	boundaryErr := failureclass.WithBoundary(err, failureclass.BoundaryGitHubAPI)
+	if got := defaultRunner.classifyFailure(boundaryErr); got.kind != FailureRetryableTransient {
+		t.Fatalf("boundary classifyFailure() kind = %s, want %s", got.kind, FailureRetryableTransient)
 	}
 
 	enabledRunner := New(Options{RetryPolicy: config.ReviewerRetryConfig{EnhancedTransientClassification: true}})

--- a/internal/worker/failure_classification_test.go
+++ b/internal/worker/failure_classification_test.go
@@ -1,0 +1,33 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/loops/failureclass"
+)
+
+func TestClassifyFailureDoesNotRetryUnknownExternalLookingMessage(t *testing.T) {
+	runner := &Runner{}
+	got := runner.classifyFailure(errors.New("git fetch origin failed: broken pipe"))
+	if got.kind != FailureNonRetryable {
+		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureNonRetryable)
+	}
+}
+
+func TestClassifyFailureRetriesBoundaryExternalTransport(t *testing.T) {
+	runner := &Runner{}
+	got := runner.classifyFailure(failureclass.WithBoundary(errors.New("git fetch origin failed: broken pipe"), failureclass.BoundaryGitRemote))
+	if got.kind != FailureRetryableTransient {
+		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureRetryableTransient)
+	}
+}
+
+func TestClassifyFailurePreservesContextTransient(t *testing.T) {
+	runner := &Runner{}
+	got := runner.classifyFailure(context.DeadlineExceeded)
+	if got.kind != FailureRetryableTransient {
+		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureRetryableTransient)
+	}
+}

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/loops/failureclass"
 	"github.com/nexu-io/looper/internal/network/protocol"
 	"github.com/nexu-io/looper/internal/networkpolicy"
 	"github.com/nexu-io/looper/internal/storage"
@@ -972,7 +973,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		return ProcessResult{}, err
 	}
 	if err := validateWorkerResumeCheckpoint(resumedRun.StartStep, checkpoint); err != nil {
-		failure := r.classifyFailure(err)
+		failure := r.classifyFailureWithBoundary(err, failureclass.BoundaryCheckpoint)
 		latest := r.getLatestCheckpoint(ctx, run, checkpoint)
 		if latest.ResumePolicy == "" {
 			latest.ResumePolicy = "replay_step"
@@ -1016,7 +1017,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		}
 		checkpoint, err = r.executeStep(ctx, step, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem, Checkpoint: checkpoint})
 		if err != nil {
-			failure := r.classifyFailure(err)
+			failure := r.classifyFailureWithBoundary(err, workerFailureBoundaryForStep(step))
 			latest := r.getLatestCheckpoint(ctx, run, checkpoint)
 			latest.ResumePolicy = loops.NormalizeResumePolicy(string(failure.kind), latest.ResumePolicy)
 			if _, err := r.completeRun(ctx, run, "failed", failure.message, failure.message, latest); err != nil {
@@ -2680,6 +2681,10 @@ func (r *Runner) githubCLIAutoPROpeningAvailable(ctx context.Context, repo, cwd 
 }
 
 func (r *Runner) classifyFailure(err error) *loopError {
+	return r.classifyFailureWithBoundary(err, failureclass.BoundaryUnknown)
+}
+
+func (r *Runner) classifyFailureWithBoundary(err error, boundary failureclass.Boundary) *loopError {
 	var typed *loopError
 	if errors.As(err, &typed) {
 		return typed
@@ -2690,7 +2695,35 @@ func (r *Runner) classifyFailure(err error) *loopError {
 	if githubinfra.IsTransientError(err) {
 		return &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
-	return &loopError{message: err.Error(), kind: FailureNonRetryable}
+	return &loopError{message: err.Error(), kind: workerFailureKind(failureclass.Classify(err, failureclass.Context{Runner: failureclass.RunnerWorker, Boundary: boundary}))}
+}
+
+func workerFailureBoundaryForStep(step WorkerStep) failureclass.Boundary {
+	switch step {
+	case stepPrepareWork, stepOpenPR:
+		return failureclass.BoundaryGitHubAPI
+	case stepPrepareWorktree:
+		return failureclass.BoundaryGitRemote
+	case stepPlan, stepExecute:
+		return failureclass.BoundaryModelProvider
+	case stepValidate:
+		return failureclass.BoundaryAgentProcess
+	default:
+		return failureclass.BoundaryUnknown
+	}
+}
+
+func workerFailureKind(kind failureclass.Kind) QueueFailureKind {
+	switch kind {
+	case failureclass.RetryableTransient:
+		return FailureRetryableTransient
+	case failureclass.RetryableAfterResume:
+		return FailureRetryableAfterResume
+	case failureclass.ManualIntervention:
+		return FailureManualIntervention
+	default:
+		return FailureNonRetryable
+	}
 }
 
 func (r *Runner) nowISO() string { return eventlog.FormatJavaScriptISOString(r.now()) }

--- a/specs/2026-05-27-runner-retry-recovery/spec.md
+++ b/specs/2026-05-27-runner-retry-recovery/spec.md
@@ -1,0 +1,749 @@
+# Runner retry recovery: boundary-aware transient classification, explicit manual retry, and safe worktree handling
+
+Issue: TBD
+Base branch: `main`
+
+## Scope
+
+This spec covers retry classification and recovery UX for **all four loop runners**:
+
+- `internal/reviewer/runner.go`
+- `internal/worker/runner.go`
+- `internal/fixer/runner.go`
+- `internal/planner/runner.go`
+
+It is **not** reviewer-only. Reviewer is the most exposed case (most remote
+git/GitHub touches, lowest tolerance for unstable transport), but the underlying
+classifier weakness is shared by every runner.
+
+## Problem
+
+All four runners share the same final fallback in their `classifyFailure`
+helper: any error that is not already a typed `loopError`, not a
+`context.Canceled` / `DeadlineExceeded`, not `githubinfra.IsTransientError`, and
+not a runner-specific narrow rule, lands as `FailureNonRetryable`.
+
+Concretely today:
+
+- `reviewer.classifyFailureForProject` (`internal/reviewer/runner.go`) — has
+  enhanced transient string matching gated by
+  `enhancedTransientClassification`, but defaults to `non_retryable` when the
+  feature flag is off (it is off by default).
+- `worker.classifyFailure` (`internal/worker/runner.go`) — only
+  `context.Canceled/DeadlineExceeded` and `githubinfra.IsTransientError` are
+  retryable; everything else is `non_retryable`.
+- `fixer.classifyFailure` (`internal/fixer/runner.go`) — only
+  `remote head changed` (string match) and `githubinfra.IsTransientError` are
+  treated as recoverable; **does not** retry `context.Canceled` /
+  `DeadlineExceeded`; everything else is `non_retryable`.
+- `planner.classifyFailure` (`internal/planner/runner.go`) — same shape as
+  worker, plus a `transientFailure` interface check.
+
+This causes remote-dependency failures such as `git ls-remote`, `git fetch`,
+SSH disconnects, broken pipes, early EOFs, and similar transport failures to
+sometimes land as terminal `failed` after a single attempt — across any runner
+that touches the network, not just reviewer.
+
+The result is an unsatisfying split for every runner:
+
+- truly transient external failures are not retried often enough;
+- truly deterministic local failures are hard-stopped (correct), but resuming
+  after a human fix is too cumbersome;
+- the system has no explicit concept of failure provenance, so message matching
+  is doing too much work, and each runner reinvents a slightly different
+  fragment of it.
+
+`dirty worktree` is already treated as `manual_intervention` in
+`reviewer`, `worker`, and `fixer` (planner has no worktree). What is missing
+in all four is a first-class operator retry UX that makes the post-fix path
+obvious.
+
+## Goals
+
+- Make retry behavior resilient for **unknown external boundary failures** by
+  default, uniformly across all runners.
+- Preserve current terminal loop and queue semantics: automatic retry must
+  remain bounded and must still end in terminal `failed` after budget
+  exhaustion.
+- Preserve existing hard-stop behavior for **manual intervention** and
+  **deterministic local failures**.
+- Introduce an explicit failure-classification model based on
+  **provenance / boundary**, shared across runners, not only on free-form
+  message matching.
+- Add a first-class operator retry flow so user-fixed deterministic failures
+  can be resumed conveniently for any runner type.
+- Make `manual_intervention` failures highly visible in operator tooling,
+  especially `looper ps`, so they are not silently buried inside generic
+  `paused` or `failed` output.
+- Keep `dirty worktree` conservative by default for reviewer/worker/fixer,
+  while still providing an explicit, convenient recovery path.
+- Preserve dedupe, active-run, queue, and scheduler invariants.
+- Fix the small fixer-specific gap where `context.Canceled` /
+  `DeadlineExceeded` is not classified as transient.
+
+## Non-goals
+
+- Do not make any runner's loops non-terminal forever.
+- Do not auto-delete dirty worktree state by default.
+- Do not weaken queue-attempt budgets or retry ceilings.
+- Do not silently convert config, schema, checkpoint, or storage bugs into
+  endless retries.
+- Do not redesign reviewer publish, worker validation, fixer reconcile, or
+  planner spec semantics beyond what is required to support safe
+  retry-after-resume.
+- Do not unify the four runner state machines themselves; only the
+  classification and recovery UX are unified.
+
+## Proposed approach
+
+### 1. Keep terminal semantics and retry budgets unchanged
+
+This change does **not** replace terminal states with endless non-terminal
+retries.
+
+The following semantics remain authoritative for every runner:
+
+- terminal loop statuses stay `terminated`, `failed`, `paused`, `stopped`;
+- queue items remain bounded by `max_attempts`;
+- automatic retry still requires remaining attempt budget;
+- once retry budget is exhausted, the queue item and loop still reach terminal
+  `failed`.
+
+Relevant code today:
+
+- `internal/reviewer/runner.go:isTerminalReviewerLoopStatus`,
+  `terminalReviewerLoopReason`, `failQueueItem`
+- `internal/runtime/runtime.go:shouldAutoRecoverFailedReviewerLoop`
+- equivalents in worker / fixer / planner runners and their queue-failure paths
+
+This spec changes **how failures are classified**, not whether terminal states
+exist.
+
+### 2. Introduce a shared boundary-aware failure classifier
+
+The core design change is to stop treating all unknown errors the same, and to
+share the classifier across runners.
+
+Replace the implicit per-runner rule:
+
+- `unknown error => non_retryable`
+
+with an explicit shared rule:
+
+- `unknown external transport/service boundary failure => retryable_transient`
+- `unknown internal deterministic failure => non_retryable or manual_intervention`
+
+This requires explicit provenance, not just free-form string matching, and the
+classifier should be shared infrastructure rather than duplicated per runner.
+
+Add a classifier package, for example `internal/loops/failureclass`, with a
+shared model:
+
+```go
+package failureclass
+
+type Boundary string
+
+const (
+    BoundaryGitRemote     Boundary = "git_remote"
+    BoundaryGitLocal      Boundary = "git_local"
+    BoundaryGitHubAPI     Boundary = "github_api"
+    BoundaryModelProvider Boundary = "model_provider"
+    BoundaryAgentProcess  Boundary = "agent_process"
+    BoundaryLocalWorktree Boundary = "local_worktree"
+    BoundaryStorage       Boundary = "storage"
+    BoundaryConfig        Boundary = "config"
+    BoundaryCheckpoint    Boundary = "checkpoint"
+    BoundaryPolicy        Boundary = "policy"
+    BoundaryUnknown       Boundary = "unknown"
+)
+
+type RunnerKind string
+
+const (
+    RunnerReviewer RunnerKind = "reviewer"
+    RunnerWorker   RunnerKind = "worker"
+    RunnerFixer    RunnerKind = "fixer"
+    RunnerPlanner  RunnerKind = "planner"
+)
+
+type Context struct {
+    Runner          RunnerKind
+    Step            string // runner-specific step name, opaque to the classifier
+    Boundary        Boundary
+    SideEffectState string // none, pre_publish, post_publish_ambiguous, etc.
+}
+```
+
+The classifier maps `(error, Context)` to one of the existing per-runner
+`QueueFailureKind` values:
+
+- `FailureRetryableTransient`
+- `FailureRetryableAfterResume`
+- `FailureNonRetryable`
+- `FailureManualIntervention`
+
+Each runner keeps its own `QueueFailureKind` constants but delegates to the
+shared classifier for the unknown-error decision. Runner-specific narrow rules
+(for example fixer's `remote head changed → retryable_after_resume`) stay in
+the runner, but call into the shared classifier for the residual case.
+
+### 3. Define the default retry policy by boundary
+
+#### 3a. External boundary defaults to retryable transient
+
+Unknown failures should default to `retryable_transient` when they originate
+from external boundaries, regardless of runner:
+
+- git remote operations:
+  - `ls-remote`
+  - `fetch`
+  - `pull`
+  - `push`
+  - remote head checks
+- GitHub API calls
+- model/provider network calls
+- agent process transport failures
+- shell command transport failures that are clearly remote/network/service
+  related
+
+Examples include:
+
+- SSH disconnects
+- `closed by remote host`
+- `broken pipe`
+- `early EOF`
+- `connection reset by peer`
+- `context deadline exceeded`
+- service-side timeouts and transient 5xx responses
+
+These should consume bounded retry attempts automatically.
+
+#### 3b. Deterministic external denials stay hard-stop
+
+External does **not** mean retryable by default when the error is a known
+deterministic denial, for example:
+
+- GitHub auth/scope failures (`401`, `403`)
+- missing resource / bad request (`404`, `422`) when clearly not transient
+- branch or repo policy denials
+- unsupported or invalid provider/model configuration
+
+These remain `non_retryable` or `manual_intervention` depending on authority
+and recovery path.
+
+#### 3c. Internal deterministic failures stay hard-stop
+
+The following remain explicit hard-stop classes for any runner:
+
+- dirty worktree (reviewer, worker, fixer)
+- invalid checkpoint / missing invariant state that should never be absent in a
+  healthy run
+- config validation failures
+- schema/storage failures
+- local repo corruption or unexpected git-local invariants
+- policy / permission denials
+- explicit manual-intervention cases already modeled in code
+
+### 4. Keep dirty worktree as `manual_intervention` by default (reviewer / worker / fixer)
+
+`dirty worktree` should remain `manual_intervention` by default in reviewer,
+worker, and fixer. Planner has no worktree and is unaffected.
+
+Reason:
+
+- the runner checkpoint authorizes the expected branch / PR head;
+- it does **not** authorize deletion of local dirty state;
+- dirty files may be human edits, partial agent output, generated evidence, or
+  corruption;
+- `git status` cannot tell whether those files are disposable.
+
+Therefore Looper must not silently `reset --hard` or remove untracked files in
+the generic retry path of any runner.
+
+Current behavior in:
+
+- `reviewer.runPrepareWorktreeStep`
+- `worker` worktree prepare paths (dirty branch worktree → manual_intervention)
+- `fixer` worktree prepare and adopt paths (dirty worktree → manual_intervention)
+
+is correct and should be preserved.
+
+#### Optional narrow future automation
+
+This spec permits a future, strictly narrower optimization for disposable
+worktree cleanup, but **not** in the base path for this change.
+
+Any future auto-clean subset would need all of the following:
+
+- managed Looper worktree provenance;
+- no active run using the worktree;
+- no tracked modifications;
+- only allowlisted disposable untracked paths;
+- explicit persisted authority that the worktree is disposable.
+
+Without those guarantees, default auto-clean is out of scope.
+
+### 5. Make retry behavior step-aware per runner
+
+The correct retry mode depends on both the boundary and the runner-specific
+step. The classifier is shared; the step-to-boundary mapping lives in each
+runner.
+
+#### Reviewer
+
+- discover / snapshot / thread resolution / review:
+  - unknown external boundary failures default to `retryable_transient`;
+  - deterministic local/config/policy failures remain hard-stop.
+- worktree (`runPrepareWorktreeStep`):
+  - remote transport failures and remote-head fetch problems become retryable;
+  - remote-head changed remains `retryable_after_resume` / stale rediscovery as
+    today;
+  - local dirty or inconsistent worktree stays `manual_intervention`.
+- publish:
+  - if failure occurs before any side effect, normal transient classification
+    applies;
+  - if failure occurs after a side effect but before durable confirmation,
+    classify as `retryable_after_resume` **only if** checkpoint/marker state is
+    persisted sufficiently to make replay safe;
+  - otherwise keep current conservative behavior.
+  - This prevents duplicate review/comment side effects.
+
+#### Worker
+
+- claim / route / spec lookup steps:
+  - `manual_intervention` outcomes from routing decisions remain hard-stop;
+  - GitHub API transport failures classify via the shared classifier.
+- worktree prepare:
+  - dirty branch worktree → `manual_intervention` (unchanged);
+  - stale worktree path → `manual_intervention` (unchanged);
+  - remote transport failures → `retryable_transient` via shared classifier.
+- agent / validation:
+  - validation hints already escalate dirty worktree / merge conflict to
+    `manual_intervention` (see `containsAnyValidationHint`); preserve.
+  - transport-level agent failures → `retryable_transient`.
+- push / open PR:
+  - transport failures → `retryable_transient`;
+  - GitHub auth/scope/policy denials → `non_retryable` or
+    `manual_intervention`.
+
+#### Fixer
+
+- discover / collect-fixes / repair / reconcile / push:
+  - unknown external boundary failures → `retryable_transient`;
+  - existing `remote head changed → retryable_after_resume` rule preserved;
+  - dirty fixer worktree → `manual_intervention` (unchanged);
+  - auto-commit/auto-push disabled with uncommitted changes →
+    `manual_intervention` (unchanged).
+- **fix the missing `context.Canceled` / `DeadlineExceeded` transient case** in
+  fixer's `classifyFailure` to match worker / planner / reviewer behavior.
+
+#### Planner
+
+- spec lookup / generation / commit steps:
+  - existing `transientFailure` interface check preserved;
+  - existing `manual_intervention` cases (e.g. spec generation explicitly
+    requiring intervention) preserved;
+  - other unknown external boundary failures → `retryable_transient` via
+    shared classifier.
+
+### 6. Keep enhanced transient matching as an additive signal, not the authority
+
+Reviewer's `enhancedTransientClassification` and
+`recoverExistingMatchedFailures` are useful, but they are not the long-term
+authority for retry behavior, and they should not be silently extended to other
+runners as the primary mechanism.
+
+This spec keeps enhanced transient matching as an additive signal for
+**external-boundary** failures only:
+
+- helpful for `git ls-remote`, SSH, EOF, broken pipe, and similar transport
+  text;
+- useful for recovery of already-failed loops when attempts remain;
+- but not sufficient as a global classifier.
+
+If defaults are changed, scope them carefully:
+
+- enhanced matching should be consulted inside external-boundary
+  wrappers/classifiers;
+- it should not be used to globally convert arbitrary local/storage/checkpoint
+  errors into transient failures just because a string contains `EOF` or
+  `timeout`.
+
+### 7. Add explicit operator retry after manual fix (all runner types)
+
+Deterministic failures that a human can fix should be easy to retry afterward,
+regardless of runner type.
+
+Add a first-class retry operation for loops. The command operates at the loop
+level and works for any loop type (`reviewer`, `worker`, `fixer`, `planner`).
+
+#### CLI
+
+```bash
+looper loop retry <seq> [--mode auto|resume|rediscover]
+```
+
+Optional shorthand:
+
+```bash
+looper retry <seq>
+```
+
+#### API
+
+```http
+POST /api/v1/loops/{id}/retry
+```
+
+Payload:
+
+```json
+{
+  "mode": "auto",
+  "resetAttempts": true
+}
+```
+
+#### Retry modes
+
+##### `auto`
+
+Recommended default:
+
+- `manual_intervention` + valid checkpoint ⇒ resume from checkpoint;
+- user-fixed config / setup / storage condition ⇒ restart from the runner's
+  initial step unless a known-safe resume policy exists;
+- ambiguous post-side-effect failure with durable marker/checkpoint ⇒ resume
+  from checkpoint / verification step;
+- corrupt checkpoint ⇒ restart from the runner's initial step.
+
+##### `resume`
+
+Force resume from checkpoint.
+
+Only valid when checkpoint invariants are intact.
+
+##### `rediscover`
+
+Force restart from the runner's initial step (`discover` for reviewer / fixer,
+`claim` for worker, `spec_lookup` for planner, etc.). Each runner declares its
+own canonical "restart from beginning" step.
+
+Recommended for user-fixed config, auth, routing, and similar setup failures.
+
+### 8. Add explicit worktree-discard retry, but keep it opt-in
+
+Applies to runners with worktrees (reviewer / worker / fixer).
+
+Add an explicit destructive retry option for dirty-worktree recovery:
+
+```bash
+looper loop retry <seq> --discard-worktree-changes --confirm
+```
+
+or, if a separate operation is preferred:
+
+```bash
+looper worktree reset <seq> --confirm
+looper loop retry <seq> --mode resume
+```
+
+The destructive worktree reset path must:
+
+- refuse to run when there is an active run or active queue item;
+- clearly state which worktree path will be reset;
+- require explicit confirmation;
+- preserve old run/queue history rather than mutating it in place;
+- be a no-op for runners without a worktree (planner).
+
+### 9. Preserve retry and queue invariants
+
+This design must preserve the following invariants for every runner:
+
+- never auto-delete dirty worktree contents without explicit authority or
+  explicit user confirmation;
+- never requeue when an active run or active queue item already exists for the
+  same loop;
+- preserve runner-specific dedupe-key behavior;
+- preserve terminal semantics for `terminated` and `stopped`;
+- keep automatic retry attempt budgets separate from explicit operator
+  retries;
+- preserve old failed run/queue history and append new retry lineage rather
+  than rewriting history;
+- resume from checkpoint only when checkpoint invariants are valid and
+  side-effect idempotency is understood.
+
+### 10. Surface `manual_intervention` explicitly in `looper ps`
+
+`manual_intervention` is operationally different from both generic `failed`
+and generic `paused`:
+
+- it means Looper intentionally stopped because the next safe action requires
+  human judgment or a user-applied fix;
+- it is actionable now;
+- if it is not surfaced prominently, operators are likely to miss it and
+  assume the system is simply idle.
+
+This applies to all runner types, not only reviewer.
+
+`looper ps` should expose both `paused` and `manual_intervention` clearly,
+with `manual_intervention` rendered as a more specific operator-facing status
+instead of being buried under a generic top-level loop status.
+
+#### Required behavior
+
+- Add a visible `manual_intervention` status in `looper ps` output for any
+  loop type.
+- Keep `paused` visible in `looper ps` output as its own explicit status for
+  loops that are intentionally halted but do not currently require the
+  stronger `manual_intervention` label.
+- A loop whose latest failure kind / effective resume policy indicates manual
+  intervention should render as `manual_intervention` in list output even if
+  its persisted loop status is currently `paused`.
+- `looper ps --json` should include a structured field that distinguishes:
+  - persisted loop status (`paused`, `failed`, etc.)
+  - effective operator-facing status (`manual_intervention`, `retrying`,
+    `running`, etc.)
+  - last failure kind / resume policy
+  - loop type (`reviewer`, `worker`, `fixer`, `planner`) so operators can
+    filter
+- `looper ps` table output should make manual-intervention items easy to
+  notice, for example by using the status column value directly rather than
+  requiring users to inspect logs.
+- `looper ps` table output should continue to show ordinary `paused` loops
+  directly as `paused`.
+- When available, `looper ps --json` should also include a short actionable
+  reason string, such as:
+  - `dirty reviewer worktree`
+  - `dirty worker worktree`
+  - `dirty fixer worktree`
+  - `config validation failed`
+  - `auto push disabled`
+  - `manual retry required after user fix`
+
+#### Status derivation
+
+Do **not** change the persisted loop state machine solely for display.
+
+Instead, derive an operator-facing status roughly as follows:
+
+- if latest queue failure kind is `manual_intervention`, or effective resume
+  policy is `manual_intervention` ⇒ display `manual_intervention`
+- else if persisted loop status is `paused` ⇒ display `paused`
+- else follow normal loop status rendering
+
+This derivation logic lives once, near the `ps` rendering code, and is shared
+across loop types.
+
+#### Why `looper ps` must own this
+
+Manual intervention is exactly the class of problem that users scan
+`looper ps` to discover. If the signal lives only in checkpoint JSON, queue
+metadata, or logs, users will miss it. This is especially important once retry
+behavior becomes more resilient, because the remaining non-automatic cases are
+precisely the ones that need explicit operator action.
+
+## Concrete implementation touchpoints
+
+### Shared classifier
+
+- new `internal/loops/failureclass/` (or similar) package with `Boundary`,
+  `RunnerKind`, `Context`, and a `Classify(error, Context) QueueFailureKind`
+  function;
+- shared transient-pattern table reused by reviewer enhanced matching, fixer's
+  `remote head changed`, etc., but consulted only in external-boundary
+  contexts.
+
+### Git boundary typing
+
+- `internal/infra/git/gateway.go`:
+  - remote-head lookup, fetch, push, and prepare paths return richer typed
+    errors for remote transport vs local deterministic git failures;
+  - all four runners consume the typed errors via the shared classifier.
+
+### GitHub boundary typing
+
+- `internal/infra/github/errors.go`:
+  - distinguish transient service failures from deterministic auth / scope /
+    resource denials;
+  - reuse from all runners.
+
+### Reviewer runner
+
+- `internal/reviewer/runner.go`:
+  - `classifyFailureForProject` delegates unknown-error decision to shared
+    classifier;
+  - `runPrepareWorktreeStep`, `runReviewStep`, `runPublishStep`,
+    `failedReviewerLoopRecoveryEligibility`, and step wrappers updated to
+    pass `Context` (step + boundary + side-effect state).
+
+### Worker runner
+
+- `internal/worker/runner.go`:
+  - `classifyFailure` delegates to shared classifier;
+  - claim / worktree prepare / agent / validation / push / open-PR step
+    wrappers pass `Context`;
+  - existing `FailureManualIntervention` cases (routing, dirty worktree, stale
+    worktree, validation hints, auto-commit gates) preserved.
+
+### Fixer runner
+
+- `internal/fixer/runner.go`:
+  - `classifyFailure` delegates to shared classifier;
+  - **add `context.Canceled` / `DeadlineExceeded` transient handling** to
+    match other runners;
+  - existing `remote head changed → retryable_after_resume` rule and
+    manual-intervention worktree gates preserved.
+
+### Planner runner
+
+- `internal/planner/runner.go`:
+  - `classifyFailure` delegates to shared classifier;
+  - existing `transientFailure` interface and `FailureManualIntervention`
+    paths preserved.
+
+### Runtime auto-recovery
+
+- `internal/runtime/runtime.go`:
+  - keep failed-loop recovery whitelisted and bounded;
+  - generalize `shouldAutoRecoverFailedReviewerLoop` (or add equivalents) so
+    auto-recovery rules apply consistently per loop type;
+  - allow enhanced transient recovery only when provenance indicates external
+    boundary safety.
+
+### API / CLI retry UX
+
+- `internal/api/handler.go`:
+  - add `POST /api/v1/loops/{id}/retry` endpoint that works for any loop type;
+  - preserve existing terminal-loop guards except for explicit retry path.
+- `internal/cliapp/app.go`:
+  - add `loop retry` (and shorthand `retry`).
+- `internal/cliapp/ps.go` (or equivalent):
+  - derive and render operator-facing `manual_intervention` status for all
+    loop types.
+- `internal/cliapp/json_output.go`:
+  - add structured retry output;
+  - add structured `manual_intervention` / effective-status / loop-type
+    fields for `ps`.
+- `internal/cliapp/loop_diagnostics_commands.go`:
+  - surface next-step guidance for manual intervention and retry commands.
+
+### Worktree safety / cleanup
+
+- `internal/worktreesafety/safety.go`
+- `internal/worktreecleanup/*`
+
+These should remain authority-preserving. Generic background cleanup must not
+silently replace explicit destructive operator retry.
+
+## Tests
+
+### Classification tests (shared)
+
+Add tests for the shared classifier verifying:
+
+- unknown git-remote transport failures classify as `retryable_transient`;
+- unknown GitHub transport failures classify as `retryable_transient`;
+- deterministic GitHub auth/scope/resource denials do **not** classify as
+  transient;
+- storage/config/checkpoint invariant failures remain `non_retryable`;
+- dirty worktree contexts classify as `manual_intervention`.
+
+### Per-runner classification tests
+
+For each of reviewer / worker / fixer / planner:
+
+- unknown external boundary failures from runner-specific steps classify as
+  `retryable_transient`;
+- existing manual-intervention cases continue to classify as
+  `manual_intervention`;
+- existing `retryable_after_resume` cases (e.g. fixer `remote head changed`,
+  reviewer publish ambiguity) preserved;
+- runner-specific narrow rules (worker validation hints, planner
+  `transientFailure` interface, reviewer enhanced matching) preserved.
+- fixer specifically: `context.Canceled` and `context.DeadlineExceeded`
+  classify as `retryable_transient`.
+
+### Worktree tests
+
+For reviewer / worker / fixer:
+
+- `git ls-remote` / fetch / push disconnect during worktree prepare ⇒
+  retryable;
+- dirty worktree ⇒ `manual_intervention`;
+- explicit destructive retry path refuses without confirmation or with active
+  run present.
+
+### Reviewer publish tests
+
+- ambiguous post-side-effect publish failures use `retryable_after_resume`
+  only when safe checkpoint/marker state is durable;
+- retry does not duplicate review/comment side effects.
+
+### Retry UX tests
+
+- `loop retry --mode auto` chooses resume vs rediscover appropriately for each
+  loop type;
+- explicit retry creates new queued work while preserving prior failure
+  history;
+- retry is rejected when there is already an active run/queue item;
+- retry after manual fix works for paused/manual-intervention and
+  failed/non-retryable loops, for any runner type.
+
+### `looper ps` visibility tests
+
+- loop with latest `manual_intervention` failure renders as
+  `manual_intervention` in table output, regardless of loop type;
+- `looper ps --json` includes persisted status, effective display status,
+  loop type, and actionable reason;
+- generic paused loops that are not manual-intervention continue to render as
+  `paused`;
+- failed loops without manual intervention continue to render as `failed`;
+- paused loops remain visible in aggregated/status output and are not
+  collapsed into an ambiguous catch-all bucket.
+
+### Budget tests
+
+- automatic retries stop after budget exhaustion and end terminal `failed`;
+- explicit operator retry starts a new attempt lineage and does not mutate
+  old queue attempt counts in place.
+
+## Rollout plan
+
+### Phase 1
+
+- introduce shared `failureclass` package and typed git/GitHub external
+  failures;
+- wire reviewer, worker, fixer, planner `classifyFailure` to consult the
+  shared classifier for the unknown-error case;
+- fix fixer `context.Canceled` / `DeadlineExceeded` gap;
+- preserve current defaults unless explicitly enabled in code paths with
+  clear provenance.
+
+### Phase 2
+
+- add explicit `loop retry` API + CLI (loop-type agnostic);
+- add operator guidance in diagnostics and failure summaries;
+- add `looper ps` `manual_intervention` rendering and JSON fields.
+
+### Phase 3
+
+- evaluate whether enhanced transient classification should be enabled by
+  default for external-boundary paths in each runner;
+- evaluate whether reviewer-specific `recoverExistingMatchedFailures` becomes
+  a uniform per-runner setting.
+
+## Open questions
+
+- Should explicit operator retry reset attempts on a replacement queue item,
+  or carry a separate retry lineage field in metadata for observability?
+- Should `loop retry --mode auto` prefer rediscover more aggressively for all
+  user-fixed deterministic failures, even when a checkpoint technically
+  exists?
+- Should the destructive worktree reset path live under `loop retry` as a
+  flag, or under a separate `worktree reset` command for stronger operator
+  clarity?
+- Should the shared classifier live under `internal/loops/failureclass`, or
+  under a more neutral path such as `internal/runners/failureclass`, given
+  that `internal/loops` currently hosts loop policy and not classification?


### PR DESCRIPTION
## Summary
- add shared boundary-aware failure classification for reviewer, worker, fixer, and planner runners
- add explicit loop retry API/CLI commands with safe auto-only semantics
- surface manual_intervention status and resume policy in active-runs/ps output
- add regression coverage for boundary provenance, failed reviewer retry, active-loop conflicts, and resumePolicy visibility

## Trade-off: shared classifier and retry gate
- Failure prevented: runner fallback paths were treating transient external boundary failures inconsistently and operators had no safe explicit retry path after paused/failed loops.
- Cost: a new classifier package and retry endpoint add another policy surface that each runner must keep boundary mappings in sync with.
- Simpler alternative considered: keep per-runner string heuristics or trust raw error text. Rejected because it retries or rejects based on message shape rather than runner/step provenance.

## Authority
The authority for retry classification is the runner step boundary/provenance passed into the shared classifier; queue status and run checkpoints are used only to display/manual-retry state and detect drift/conflicts.

## Safety notes
- destructive --discard-worktree-changes is explicitly rejected until safe semantics exist
- non-auto retry modes are explicitly rejected until resume/rediscover semantics are implemented
- retry checks active runs, active queue items, dedupe conflicts, and active-loop conflicts before mutation

## Validation
- go test ./...
- go vet ./...
- go build ./...
- @oracle blocker review: no blocker