### PR TITLE
Add linux-amd64 support (install + release artifacts)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,6 +310,11 @@ jobs:
             goos: darwin
             goarch: arm64
             artifact-name: looper-darwin-arm64
+          - target: linux-amd64
+            runner: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            artifact-name: looper-linux-amd64
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -388,12 +393,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Phase 1 intentionally publishes macOS artifacts only.
           - target: darwin-arm64
             runner: macos-14
             goos: darwin
             goarch: arm64
             artifact-name: looperd-darwin-arm64
+          - target: linux-amd64
+            runner: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            artifact-name: looperd-linux-amd64
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It contains a one-shot, step-by-step flow (preflight → install → bootstrap �
 
 ### For humans
 
-Fast path (macOS, `darwin-arm64`):
+Fast path (macOS `darwin-arm64`, Linux `linux-amd64`):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nexu-io/looper/main/scripts/install.sh | sh

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This document contains the detailed install, upgrade, uninstall, and source-buil
 
 For the default supported install path:
 
-- macOS (`darwin-arm64`)
+- macOS (`darwin-arm64`) or Linux (`linux-amd64`)
 - `git`
 - `gh`
 
@@ -34,13 +34,13 @@ looper bootstrap --yes --project-path /path/to/repo --agent-vendor opencode
 
 ### Install the CLI manually
 
-1. Download the matching `looper` release artifact for your macOS architecture from GitHub Releases.
+1. Download the matching `looper` release artifact for your platform from GitHub Releases.
 2. Rename it to `looper` if needed.
 3. Place it on your `PATH`, for example `/usr/local/bin/looper` or `~/.local/bin/looper`.
 
-GitHub Releases publish standalone Go binaries for both `looper` and `looperd` on `darwin-arm64`.
+GitHub Releases publish standalone Go binaries for both `looper` and `looperd` on `darwin-arm64` and `linux-amd64`.
 
-Linux is not currently supported for the managed daemon flow.
+On Linux (`linux-amd64`) the daemon runs in `foreground` (detached) mode, which is the default. Supervised lifecycle management via `systemd` is planned but not yet implemented; `--daemon-mode launchd` remains macOS-only.
 
 ### Install the daemon manually
 
@@ -54,7 +54,7 @@ looper status
 
 This flow:
 
-- detects the current macOS architecture
+- detects the current platform architecture
 - downloads the matching GitHub Release artifact
 - installs it to `~/.looper/bin/looperd`
 

--- a/internal/cliapp/daemon_install.go
+++ b/internal/cliapp/daemon_install.go
@@ -272,8 +272,11 @@ func resolveLooperdTarget(platform string, arch string) (string, error) {
 	if platform == "darwin" && arch == "arm64" {
 		return "darwin-arm64", nil
 	}
+	if platform == "linux" && arch == "amd64" {
+		return "linux-amd64", nil
+	}
 
-	return "", fmt.Errorf("Unsupported platform/arch for looperd install: %s-%s. Supported targets: darwin-arm64", platform, arch)
+	return "", fmt.Errorf("Unsupported platform/arch for looperd install: %s-%s. Supported targets: darwin-arm64, linux-amd64", platform, arch)
 }
 
 func buildGitHubReleaseAPIURL(owner, repo, tag string) string {

--- a/internal/cliapp/daemon_install_test.go
+++ b/internal/cliapp/daemon_install_test.go
@@ -25,9 +25,12 @@ func TestResolveLooperdTarget(t *testing.T) {
 		t.Fatalf("resolveLooperdTarget(darwin, arm64) = %q, want %q", target, "darwin-arm64")
 	}
 
-	_, err = resolveLooperdTarget("linux", "amd64")
-	if err == nil || err.Error() != "Unsupported platform/arch for looperd install: linux-amd64. Supported targets: darwin-arm64" {
+	linuxTarget, err := resolveLooperdTarget("linux", "amd64")
+	if err != nil {
 		t.Fatalf("resolveLooperdTarget(linux, amd64) error = %v", err)
+	}
+	if linuxTarget != "linux-amd64" {
+		t.Fatalf("resolveLooperdTarget(linux, amd64) = %q, want %q", linuxTarget, "linux-amd64")
 	}
 
 	for _, arch := range []string{"amd64", "x64"} {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,11 +23,22 @@ detect_target() {
   os="$(uname -s)"
   arch="$(uname -m)"
 
-  [ "$os" = "Darwin" ] || fail "unsupported platform: $os (supported: macOS)"
-
-  case "$arch" in
-    arm64|aarch64) printf 'darwin-arm64\n' ;;
-    *) fail "unsupported architecture: $arch (supported: arm64)" ;;
+  case "$os" in
+    Darwin)
+      case "$arch" in
+        arm64|aarch64) printf 'darwin-arm64\n' ;;
+        *) fail "unsupported architecture: $arch on macOS (supported: arm64)" ;;
+      esac
+      ;;
+    Linux)
+      case "$arch" in
+        x86_64|amd64) printf 'linux-amd64\n' ;;
+        *) fail "unsupported architecture: $arch on Linux (supported: x86_64)" ;;
+      esac
+      ;;
+    *)
+      fail "unsupported platform: $os (supported: macOS, Linux)"
+      ;;
   esac
 }
 


### PR DESCRIPTION
## What

Adds `linux/amd64` as a supported install/run target for `looper` and `looperd`.

The daemon's default mode is already `foreground`/detached (cross-platform Go), so this change only:

1. **CLI target resolver** (`resolveLooperdTarget`) accepts `linux-amd64`.
2. **Install script** (`scripts/install.sh`) detects Linux/`x86_64`.
3. **Release workflow** publishes `looper-linux-amd64` / `looperd-linux-amd64`, built on an `ubuntu-latest` runner so the post-build `--version` self-check runs the binary natively.
4. **Docs** updated for Linux.

## Out of scope (follow-up)

Supervised lifecycle on Linux via a `systemd` daemon mode (parity with macOS `launchd`). On Linux today the daemon runs in `foreground` mode; `--daemon-mode launchd` stays macOS-only and returns its existing actionable error.

## Testing

- `go test ./internal/cliapp/` passes, including the updated `TestResolveLooperdTarget` (now asserts `linux-amd64` resolves).
- `scripts/install.sh` `detect_target` verified to emit `linux-amd64` on Linux/`x86_64`, `darwin-arm64` on macOS/arm64, and fail cleanly on unsupported arches.
- Built both binaries on `linux/amd64` (WSL2) and confirmed end to end:
  - `looper daemon install --json` → `"target": "linux-amd64"`
  - `looper daemon start` → daemon starts detached
  - `looper status` → `healthy: yes`, `daemonMode: foreground`, DB migrations applied, scheduler healthy
  - `looper daemon stop` → stops cleanly

## Caveat

The release-workflow matrix additions could not be exercised in upstream CI from a fork; they mirror the existing `darwin-arm64` rows exactly, on an `ubuntu-latest` runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)