### PR TITLE
feat: include agent runtime in looper status

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -783,6 +783,7 @@ type statusResponse struct {
 	Service         statusService       `json:"service"`
 	Storage         statusStorage       `json:"storage"`
 	Scheduler       statusScheduler     `json:"scheduler"`
+	Agent           statusAgent         `json:"agent"`
 	WorktreeCleanup any                 `json:"worktreeCleanup"`
 	Webhook         statusWebhook       `json:"webhook"`
 	Loops           statusLoops         `json:"loops"`
@@ -850,6 +851,25 @@ type statusScheduler struct {
 	FailedItems    int  `json:"failedItems"`
 	TotalRuns      int  `json:"totalRuns"`
 	ActiveRuns     int  `json:"activeRuns"`
+}
+
+type statusAgent struct {
+	Vendor              *config.AgentVendor `json:"vendor,omitempty"`
+	Model               *string             `json:"model,omitempty"`
+	NativeResumeEnabled bool                `json:"nativeResumeEnabled"`
+	Timeouts            statusAgentTimeouts `json:"timeouts"`
+}
+
+type statusAgentTimeouts struct {
+	Planner  statusAgentRoleTimeouts `json:"planner"`
+	Worker   statusAgentRoleTimeouts `json:"worker"`
+	Reviewer statusAgentRoleTimeouts `json:"reviewer"`
+	Fixer    statusAgentRoleTimeouts `json:"fixer"`
+}
+
+type statusAgentRoleTimeouts struct {
+	IdleTimeoutSeconds int `json:"idleTimeoutSeconds"`
+	MaxRuntimeSeconds  int `json:"maxRuntimeSeconds"`
 }
 
 type statusWebhook struct {
@@ -1075,6 +1095,17 @@ func (h *Handler) buildStatusResponse(ctx context.Context) (statusResponse, erro
 			FailedItems:    queueCounts["failed"],
 			TotalRuns:      len(runs),
 			ActiveRuns:     runCounts["running"],
+		},
+		Agent: statusAgent{
+			Vendor:              h.context.Config.Agent.Vendor,
+			Model:               h.context.Config.Agent.Model,
+			NativeResumeEnabled: h.context.Config.Agent.NativeResume.Enabled,
+			Timeouts: statusAgentTimeouts{
+				Planner:  statusAgentRoleTimeouts{IdleTimeoutSeconds: h.context.Config.Agent.Timeouts.PlannerIdleTimeoutSeconds, MaxRuntimeSeconds: h.context.Config.Agent.Timeouts.PlannerMaxRuntimeSeconds},
+				Worker:   statusAgentRoleTimeouts{IdleTimeoutSeconds: h.context.Config.Agent.Timeouts.WorkerIdleTimeoutSeconds, MaxRuntimeSeconds: h.context.Config.Agent.Timeouts.WorkerMaxRuntimeSeconds},
+				Reviewer: statusAgentRoleTimeouts{IdleTimeoutSeconds: h.context.Config.Agent.Timeouts.ReviewerIdleTimeoutSeconds, MaxRuntimeSeconds: h.context.Config.Agent.Timeouts.ReviewerMaxRuntimeSeconds},
+				Fixer:    statusAgentRoleTimeouts{IdleTimeoutSeconds: h.context.Config.Agent.Timeouts.FixerIdleTimeoutSeconds, MaxRuntimeSeconds: h.context.Config.Agent.Timeouts.FixerMaxRuntimeSeconds},
+			},
 		},
 		WorktreeCleanup: h.buildWorktreeCleanupStatusResponse(),
 		Webhook:         summarizeWebhookStatus(h.buildWebhookStatusResponse()),

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -416,6 +416,10 @@ func TestIsTerminalReviewerLoopRecordTreatsFailedAsTerminal(t *testing.T) {
 
 func TestHandlerStatusSuccessContainsExpectedSections(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
+	vendor := config.AgentVendorOpenCode
+	model := "gpt-5.4"
+	cfg.Agent.Vendor = &vendor
+	cfg.Agent.Model = &model
 	seedStatusData(t, rt)
 	seedStatusLoopCounts(t, rt)
 
@@ -437,6 +441,7 @@ func TestHandlerStatusSuccessContainsExpectedSections(t *testing.T) {
 	binaryInfo := service["binary"].(map[string]any)
 	storageInfo := data["storage"].(map[string]any)
 	scheduler := data["scheduler"].(map[string]any)
+	agentInfo := data["agent"].(map[string]any)
 	loops := data["loops"].(map[string]any)
 
 	assertEqual(t, service["healthy"], true)
@@ -446,6 +451,12 @@ func TestHandlerStatusSuccessContainsExpectedSections(t *testing.T) {
 		t.Fatalf("service.binary.path missing/invalid: %#v", binaryInfo["path"])
 	}
 	assertEqual(t, storageInfo["healthy"], true)
+	assertEqual(t, agentInfo["vendor"], string(vendor))
+	assertEqual(t, agentInfo["model"], model)
+	assertEqual(t, agentInfo["nativeResumeEnabled"], true)
+	plannerTimeouts := agentInfo["timeouts"].(map[string]any)["planner"].(map[string]any)
+	assertEqual(t, plannerTimeouts["idleTimeoutSeconds"], float64(cfg.Agent.Timeouts.PlannerIdleTimeoutSeconds))
+	assertEqual(t, plannerTimeouts["maxRuntimeSeconds"], float64(cfg.Agent.Timeouts.PlannerMaxRuntimeSeconds))
 	queuedItems, queuedOK := scheduler["queuedItems"].(float64)
 	runningItems, runningOK := scheduler["runningItems"].(float64)
 	if !queuedOK || !runningOK {

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -92,6 +92,28 @@
             "totalRuns": 1,
             "activeRuns": 1
           },
+          "agent": {
+            "vendor": "opencode",
+            "nativeResumeEnabled": true,
+            "timeouts": {
+              "planner": {
+                "idleTimeoutSeconds": 600,
+                "maxRuntimeSeconds": 3600
+              },
+              "worker": {
+                "idleTimeoutSeconds": 900,
+                "maxRuntimeSeconds": 10800
+              },
+              "reviewer": {
+                "idleTimeoutSeconds": 600,
+                "maxRuntimeSeconds": 5400
+              },
+              "fixer": {
+                "idleTimeoutSeconds": 600,
+                "maxRuntimeSeconds": 7200
+              }
+            }
+          },
           "worktreeCleanup": {
             "enabled": true,
             "dryRun": false,

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -1368,6 +1368,47 @@ func TestStatusWithoutJSONPrintsHumanReadableSections(t *testing.T) {
 	}
 }
 
+func TestStatusWithoutJSONOmitsAgentSectionWhenStatusPayloadHasNoAgent(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/status" {
+			t.Fatalf("request path = %q, want %q", r.URL.Path, "/api/v1/status")
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_status", map[string]any{
+			"service":   map[string]any{"healthy": true, "version": "1.2.3", "daemonMode": "full", "startedAt": "2026-04-20T10:00:00.000Z"},
+			"storage":   map[string]any{"dbPath": "/tmp/looper.sqlite", "schemaVersion": "12", "healthy": true, "pendingMigrations": []string{}},
+			"scheduler": map[string]any{"healthy": true, "queuedItems": 2, "runningItems": 1},
+			"loops": map[string]any{
+				"planner":  map[string]any{"running": 0, "paused": 1, "failed": 0},
+				"reviewer": map[string]any{"running": 1, "paused": 0, "failed": 0},
+				"worker":   map[string]any{"running": 2, "paused": 0, "failed": 1},
+				"fixer":    map[string]any{"running": 0, "paused": 0, "failed": 0},
+			},
+			"tools":         map[string]any{"git": true, "gh": false, "osascript": true},
+			"notifications": map[string]any{"inAppEnabled": true, "osascriptEnabled": false},
+		}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "status", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([status]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([status]) stderr = %q, want empty string", stderr)
+	}
+	if strings.Contains(stdout, "Agent\n") {
+		t.Fatalf("Run([status]) stdout = %q, want Agent section omitted", stdout)
+	}
+	for _, want := range []string{"Service", "Storage", "Scheduler", "Webhook", "Tools", "Notifications"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([status]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
 func TestConfigShowWithoutJSONPrintsJSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -999,7 +999,7 @@ func TestStatusJSONPrintsDaemonPayload(t *testing.T) {
 		if r.URL.Path != "/api/v1/status" {
 			t.Fatalf("request path = %q, want %q", r.URL.Path, "/api/v1/status")
 		}
-		writeEnvelope(t, w, pkgapi.Success("req_status", map[string]any{"healthy": true, "version": "1.2.3"}))
+		writeEnvelope(t, w, pkgapi.Success("req_status", map[string]any{"healthy": true, "version": "1.2.3", "agent": map[string]any{"vendor": "opencode", "model": "gpt-5.4"}}))
 	}))
 	defer server.Close()
 
@@ -1013,6 +1013,7 @@ func TestStatusJSONPrintsDaemonPayload(t *testing.T) {
 	}
 	assertJSONContains(t, stdout, "healthy", true)
 	assertJSONContains(t, stdout, "version", "1.2.3")
+	assertJSONContains(t, stdout, "agent", map[string]any{"vendor": "opencode", "model": "gpt-5.4"})
 }
 
 func TestStatusAcceptsReviewerLoopConfigOverrideFlag(t *testing.T) {
@@ -1329,6 +1330,17 @@ func TestStatusWithoutJSONPrintsHumanReadableSections(t *testing.T) {
 			"service":   map[string]any{"healthy": true, "version": "1.2.3", "daemonMode": "full", "startedAt": "2026-04-20T10:00:00.000Z"},
 			"storage":   map[string]any{"dbPath": "/tmp/looper.sqlite", "schemaVersion": "12", "healthy": true, "pendingMigrations": []string{}},
 			"scheduler": map[string]any{"healthy": true, "queuedItems": 2, "runningItems": 1},
+			"agent": map[string]any{
+				"vendor":              "opencode",
+				"model":               "gpt-5.4",
+				"nativeResumeEnabled": true,
+				"timeouts": map[string]any{
+					"planner":  map[string]any{"idleTimeoutSeconds": 600, "maxRuntimeSeconds": 3600},
+					"worker":   map[string]any{"idleTimeoutSeconds": 900, "maxRuntimeSeconds": 10800},
+					"reviewer": map[string]any{"idleTimeoutSeconds": 600, "maxRuntimeSeconds": 5400},
+					"fixer":    map[string]any{"idleTimeoutSeconds": 600, "maxRuntimeSeconds": 7200},
+				},
+			},
 			"loops": map[string]any{
 				"planner":  map[string]any{"running": 0, "paused": 1, "failed": 0},
 				"reviewer": map[string]any{"running": 1, "paused": 0, "failed": 0},
@@ -1349,7 +1361,7 @@ func TestStatusWithoutJSONPrintsHumanReadableSections(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("Run([status]) stderr = %q, want empty string", stderr)
 	}
-	for _, want := range []string{"Service", "healthy    : yes", "version    : 1.2.3", "Storage", "Scheduler", "type", "reviewer", "Tools", "gh        : no", "Notifications"} {
+	for _, want := range []string{"Service", "healthy    : yes", "version    : 1.2.3", "Storage", "Scheduler", "Agent", "vendor                     : opencode", "model                      : gpt-5.4", "plannerMaxRuntimeSeconds   : 3600", "type", "reviewer", "Tools", "gh        : no", "Notifications"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("Run([status]) stdout = %q, want to contain %q", stdout, want)
 		}

--- a/internal/cliapp/golden_test.go
+++ b/internal/cliapp/golden_test.go
@@ -58,6 +58,7 @@ func TestCLIGoldenOutputs(t *testing.T) {
 						"service":   map[string]any{"healthy": true, "version": "1.2.3", "daemonMode": "full", "startedAt": "2026-04-20T10:00:00.000Z"},
 						"storage":   map[string]any{"dbPath": "/tmp/looper.sqlite", "schemaVersion": "12", "healthy": true, "pendingMigrations": []string{}},
 						"scheduler": map[string]any{"healthy": true, "queuedItems": 2, "runningItems": 1},
+						"agent":     map[string]any{"vendor": "opencode", "model": "gpt-5.4", "nativeResumeEnabled": true, "timeouts": map[string]any{"planner": map[string]any{"idleTimeoutSeconds": 600, "maxRuntimeSeconds": 3600}, "worker": map[string]any{"idleTimeoutSeconds": 900, "maxRuntimeSeconds": 10800}, "reviewer": map[string]any{"idleTimeoutSeconds": 600, "maxRuntimeSeconds": 5400}, "fixer": map[string]any{"idleTimeoutSeconds": 600, "maxRuntimeSeconds": 7200}}},
 						"loops": map[string]any{
 							"planner":  map[string]any{"queued": 0, "running": 0, "waiting": 0, "paused": 1, "failed": 0, "terminated": 0, "stopped": 0},
 							"reviewer": map[string]any{"queued": 1, "running": 1, "waiting": 1, "paused": 0, "failed": 0, "terminated": 0, "stopped": 0},

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -28,6 +28,17 @@ type statusOutput struct {
 		QueuedItems  int  `json:"queuedItems"`
 		RunningItems int  `json:"runningItems"`
 	} `json:"scheduler"`
+	Agent struct {
+		Vendor              *string `json:"vendor"`
+		Model               *string `json:"model"`
+		NativeResumeEnabled bool    `json:"nativeResumeEnabled"`
+		Timeouts            struct {
+			Planner  statusAgentRoleTimeoutOutput `json:"planner"`
+			Worker   statusAgentRoleTimeoutOutput `json:"worker"`
+			Reviewer statusAgentRoleTimeoutOutput `json:"reviewer"`
+			Fixer    statusAgentRoleTimeoutOutput `json:"fixer"`
+		} `json:"timeouts"`
+	} `json:"agent"`
 	Webhook struct {
 		Enabled                     bool     `json:"enabled"`
 		EndpointURL                 string   `json:"endpointUrl"`
@@ -62,6 +73,11 @@ type statusLoopSummary struct {
 	Failed     int `json:"failed"`
 	Terminated int `json:"terminated"`
 	Stopped    int `json:"stopped"`
+}
+
+type statusAgentRoleTimeoutOutput struct {
+	IdleTimeoutSeconds int `json:"idleTimeoutSeconds"`
+	MaxRuntimeSeconds  int `json:"maxRuntimeSeconds"`
 }
 
 type projectsListOutput struct {
@@ -283,6 +299,8 @@ func writeHumanStatus(w io.Writer, payload json.RawMessage) error {
 	printSection(w, "Storage", [][2]any{{"dbPath", data.Storage.DBPath}, {"schemaVersion", data.Storage.SchemaVersion}, {"healthy", data.Storage.Healthy}, {"pendingMigrations", joinOrNone(data.Storage.PendingMigrations)}})
 	fmt.Fprintln(w)
 	printSection(w, "Scheduler", [][2]any{{"healthy", data.Scheduler.Healthy}, {"queuedItems", data.Scheduler.QueuedItems}, {"runningItems", data.Scheduler.RunningItems}})
+	fmt.Fprintln(w)
+	printSection(w, "Agent", [][2]any{{"vendor", data.Agent.Vendor}, {"model", data.Agent.Model}, {"nativeResumeEnabled", data.Agent.NativeResumeEnabled}, {"plannerIdleTimeoutSeconds", data.Agent.Timeouts.Planner.IdleTimeoutSeconds}, {"plannerMaxRuntimeSeconds", data.Agent.Timeouts.Planner.MaxRuntimeSeconds}, {"workerIdleTimeoutSeconds", data.Agent.Timeouts.Worker.IdleTimeoutSeconds}, {"workerMaxRuntimeSeconds", data.Agent.Timeouts.Worker.MaxRuntimeSeconds}, {"reviewerIdleTimeoutSeconds", data.Agent.Timeouts.Reviewer.IdleTimeoutSeconds}, {"reviewerMaxRuntimeSeconds", data.Agent.Timeouts.Reviewer.MaxRuntimeSeconds}, {"fixerIdleTimeoutSeconds", data.Agent.Timeouts.Fixer.IdleTimeoutSeconds}, {"fixerMaxRuntimeSeconds", data.Agent.Timeouts.Fixer.MaxRuntimeSeconds}})
 	fmt.Fprintln(w)
 	printSection(w, "Webhook", [][2]any{{"enabled", data.Webhook.Enabled}, {"endpointUrl", data.Webhook.EndpointURL}, {"fallbackPollIntervalSeconds", data.Webhook.FallbackPollIntervalSeconds}, {"degraded", data.Webhook.Degraded}, {"configuredForwarders", data.Webhook.ConfiguredForwarders}, {"runningForwarders", data.Webhook.RunningForwarders}, {"degradedReasons", joinOrNone(data.Webhook.DegradedReasons)}})
 	fmt.Fprintln(w)

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -28,17 +28,7 @@ type statusOutput struct {
 		QueuedItems  int  `json:"queuedItems"`
 		RunningItems int  `json:"runningItems"`
 	} `json:"scheduler"`
-	Agent struct {
-		Vendor              *string `json:"vendor"`
-		Model               *string `json:"model"`
-		NativeResumeEnabled bool    `json:"nativeResumeEnabled"`
-		Timeouts            struct {
-			Planner  statusAgentRoleTimeoutOutput `json:"planner"`
-			Worker   statusAgentRoleTimeoutOutput `json:"worker"`
-			Reviewer statusAgentRoleTimeoutOutput `json:"reviewer"`
-			Fixer    statusAgentRoleTimeoutOutput `json:"fixer"`
-		} `json:"timeouts"`
-	} `json:"agent"`
+	Agent   *statusAgentOutput `json:"agent"`
 	Webhook struct {
 		Enabled                     bool     `json:"enabled"`
 		EndpointURL                 string   `json:"endpointUrl"`
@@ -63,6 +53,18 @@ type statusOutput struct {
 		GH        bool `json:"gh"`
 		Osascript bool `json:"osascript"`
 	} `json:"tools"`
+}
+
+type statusAgentOutput struct {
+	Vendor              *string `json:"vendor"`
+	Model               *string `json:"model"`
+	NativeResumeEnabled bool    `json:"nativeResumeEnabled"`
+	Timeouts            struct {
+		Planner  statusAgentRoleTimeoutOutput `json:"planner"`
+		Worker   statusAgentRoleTimeoutOutput `json:"worker"`
+		Reviewer statusAgentRoleTimeoutOutput `json:"reviewer"`
+		Fixer    statusAgentRoleTimeoutOutput `json:"fixer"`
+	} `json:"timeouts"`
 }
 
 type statusLoopSummary struct {
@@ -299,8 +301,10 @@ func writeHumanStatus(w io.Writer, payload json.RawMessage) error {
 	printSection(w, "Storage", [][2]any{{"dbPath", data.Storage.DBPath}, {"schemaVersion", data.Storage.SchemaVersion}, {"healthy", data.Storage.Healthy}, {"pendingMigrations", joinOrNone(data.Storage.PendingMigrations)}})
 	fmt.Fprintln(w)
 	printSection(w, "Scheduler", [][2]any{{"healthy", data.Scheduler.Healthy}, {"queuedItems", data.Scheduler.QueuedItems}, {"runningItems", data.Scheduler.RunningItems}})
-	fmt.Fprintln(w)
-	printSection(w, "Agent", [][2]any{{"vendor", data.Agent.Vendor}, {"model", data.Agent.Model}, {"nativeResumeEnabled", data.Agent.NativeResumeEnabled}, {"plannerIdleTimeoutSeconds", data.Agent.Timeouts.Planner.IdleTimeoutSeconds}, {"plannerMaxRuntimeSeconds", data.Agent.Timeouts.Planner.MaxRuntimeSeconds}, {"workerIdleTimeoutSeconds", data.Agent.Timeouts.Worker.IdleTimeoutSeconds}, {"workerMaxRuntimeSeconds", data.Agent.Timeouts.Worker.MaxRuntimeSeconds}, {"reviewerIdleTimeoutSeconds", data.Agent.Timeouts.Reviewer.IdleTimeoutSeconds}, {"reviewerMaxRuntimeSeconds", data.Agent.Timeouts.Reviewer.MaxRuntimeSeconds}, {"fixerIdleTimeoutSeconds", data.Agent.Timeouts.Fixer.IdleTimeoutSeconds}, {"fixerMaxRuntimeSeconds", data.Agent.Timeouts.Fixer.MaxRuntimeSeconds}})
+	if data.Agent != nil {
+		fmt.Fprintln(w)
+		printSection(w, "Agent", [][2]any{{"vendor", data.Agent.Vendor}, {"model", data.Agent.Model}, {"nativeResumeEnabled", data.Agent.NativeResumeEnabled}, {"plannerIdleTimeoutSeconds", data.Agent.Timeouts.Planner.IdleTimeoutSeconds}, {"plannerMaxRuntimeSeconds", data.Agent.Timeouts.Planner.MaxRuntimeSeconds}, {"workerIdleTimeoutSeconds", data.Agent.Timeouts.Worker.IdleTimeoutSeconds}, {"workerMaxRuntimeSeconds", data.Agent.Timeouts.Worker.MaxRuntimeSeconds}, {"reviewerIdleTimeoutSeconds", data.Agent.Timeouts.Reviewer.IdleTimeoutSeconds}, {"reviewerMaxRuntimeSeconds", data.Agent.Timeouts.Reviewer.MaxRuntimeSeconds}, {"fixerIdleTimeoutSeconds", data.Agent.Timeouts.Fixer.IdleTimeoutSeconds}, {"fixerMaxRuntimeSeconds", data.Agent.Timeouts.Fixer.MaxRuntimeSeconds}})
+	}
 	fmt.Fprintln(w)
 	printSection(w, "Webhook", [][2]any{{"enabled", data.Webhook.Enabled}, {"endpointUrl", data.Webhook.EndpointURL}, {"fallbackPollIntervalSeconds", data.Webhook.FallbackPollIntervalSeconds}, {"degraded", data.Webhook.Degraded}, {"configuredForwarders", data.Webhook.ConfiguredForwarders}, {"runningForwarders", data.Webhook.RunningForwarders}, {"degradedReasons", joinOrNone(data.Webhook.DegradedReasons)}})
 	fmt.Fprintln(w)

--- a/internal/cliapp/testdata/golden/status-human.stdout.golden
+++ b/internal/cliapp/testdata/golden/status-human.stdout.golden
@@ -15,6 +15,19 @@ Scheduler
   queuedItems  : 2
   runningItems : 1
 
+Agent
+  vendor                     : opencode
+  model                      : gpt-5.4
+  nativeResumeEnabled        : yes
+  plannerIdleTimeoutSeconds  : 600
+  plannerMaxRuntimeSeconds   : 3600
+  workerIdleTimeoutSeconds   : 900
+  workerMaxRuntimeSeconds    : 10800
+  reviewerIdleTimeoutSeconds : 600
+  reviewerMaxRuntimeSeconds  : 5400
+  fixerIdleTimeoutSeconds    : 600
+  fixerMaxRuntimeSeconds     : 7200
+
 Webhook
   enabled                     : no
   endpointUrl                 : -


### PR DESCRIPTION
## Summary
- add an `agent` section to the daemon status API with runtime vendor, model, native resume, and per-role timeout settings
- render the new agent runtime details in `looper status` human output and preserve them in JSON status payloads
- extend status API/CLI contract coverage and golden fixtures for the new section

## Testing
- go test ./...
- go build ./...

Closes #468

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>