### PR TITLE
fix: preserve active agent metadata in active runs

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2584,7 +2584,8 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 		}
 	}
 
-	activeAgentByRunID := buildVerifiedActiveAgentByRunID(ctx, h.context.Runtime, activeExecutions)
+	verifiedActiveAgentByRunID := buildVerifiedActiveAgentByRunID(ctx, h.context.Runtime, activeExecutions)
+	activeAgentByRunID := buildActiveAgentByRunID(activeExecutions)
 	plausiblyLiveRunningLoopIDs := make(map[string]struct{}, len(activeRuns))
 	runningViews := make([]activeRunView, 0, len(activeRuns))
 	for _, run := range activeRuns {
@@ -2596,7 +2597,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 		if err != nil {
 			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
-		hasActiveAgent := activeAgentByRunID[run.ID] != nil
+		hasActiveAgent := verifiedActiveAgentByRunID[run.ID] != nil
 		if !isPlausiblyLiveActiveRun(run, loop, latestRun, hasActiveAgent, h.now().UTC()) {
 			continue
 		}
@@ -2620,7 +2621,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			CurrentStep: run.CurrentStep,
 			StartedAt:   stringPtrOrNil(run.StartedAt),
 			Target:      target,
-			Agent:       activeAgentByRunID[run.ID],
+			Agent:       preferredActiveRunAgent(verifiedActiveAgentByRunID[run.ID], activeAgentByRunID[run.ID]),
 			Worktree:    buildWorktreeSummary(loop, run),
 		}
 		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], latestRun)
@@ -2858,6 +2859,20 @@ func buildVerifiedActiveAgentByRunID(ctx context.Context, runtime RuntimeState, 
 	if verifier == nil {
 		return map[string]*activeRunAgent{}
 	}
+	grouped := groupActiveExecutionsByRunID(executions, func(execution storage.AgentExecutionRecord) bool {
+		matches, running, err := verifier.ExecutionMatchesProcess(ctx, execution, int(*execution.PID))
+		return err == nil && running && matches
+	})
+	return buildActiveRunAgents(grouped)
+}
+
+func buildActiveAgentByRunID(executions []storage.AgentExecutionRecord) map[string]*activeRunAgent {
+	return buildActiveRunAgents(groupActiveExecutionsByRunID(executions, func(storage.AgentExecutionRecord) bool {
+		return true
+	}))
+}
+
+func groupActiveExecutionsByRunID(executions []storage.AgentExecutionRecord, include func(storage.AgentExecutionRecord) bool) map[string][]storage.AgentExecutionRecord {
 	grouped := make(map[string][]storage.AgentExecutionRecord)
 	for _, execution := range executions {
 		if execution.RunID == nil || strings.TrimSpace(*execution.RunID) == "" {
@@ -2866,14 +2881,16 @@ func buildVerifiedActiveAgentByRunID(ctx context.Context, runtime RuntimeState, 
 		if execution.PID == nil || *execution.PID <= 0 {
 			continue
 		}
-		matches, running, err := verifier.ExecutionMatchesProcess(ctx, execution, int(*execution.PID))
-		if err != nil || !running || !matches {
+		if !include(execution) {
 			continue
 		}
 		runID := *execution.RunID
 		grouped[runID] = append(grouped[runID], execution)
 	}
+	return grouped
+}
 
+func buildActiveRunAgents(grouped map[string][]storage.AgentExecutionRecord) map[string]*activeRunAgent {
 	result := make(map[string]*activeRunAgent, len(grouped))
 	for runID, bucket := range grouped {
 		sort.Slice(bucket, func(i, j int) bool {
@@ -2897,6 +2914,13 @@ func buildVerifiedActiveAgentByRunID(ctx context.Context, runtime RuntimeState, 
 	}
 
 	return result
+}
+
+func preferredActiveRunAgent(verified *activeRunAgent, fallback *activeRunAgent) *activeRunAgent {
+	if verified != nil {
+		return verified
+	}
+	return fallback
 }
 
 func isPlausiblyLiveActiveRun(run storage.RunRecord, loop storage.LoopRecord, latestRun *storage.RunRecord, hasActiveAgent bool, now time.Time) bool {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2859,7 +2859,7 @@ func buildVerifiedActiveAgentByRunID(ctx context.Context, runtime RuntimeState, 
 	if verifier == nil {
 		return map[string]*activeRunAgent{}
 	}
-	grouped := groupActiveExecutionsByRunID(executions, func(execution storage.AgentExecutionRecord) bool {
+	grouped := groupActiveExecutionsByRunID(executions, true, func(execution storage.AgentExecutionRecord) bool {
 		matches, running, err := verifier.ExecutionMatchesProcess(ctx, execution, int(*execution.PID))
 		return err == nil && running && matches
 	})
@@ -2867,18 +2867,18 @@ func buildVerifiedActiveAgentByRunID(ctx context.Context, runtime RuntimeState, 
 }
 
 func buildActiveAgentByRunID(executions []storage.AgentExecutionRecord) map[string]*activeRunAgent {
-	return buildActiveRunAgents(groupActiveExecutionsByRunID(executions, func(storage.AgentExecutionRecord) bool {
+	return buildActiveRunAgents(groupActiveExecutionsByRunID(executions, false, func(storage.AgentExecutionRecord) bool {
 		return true
 	}))
 }
 
-func groupActiveExecutionsByRunID(executions []storage.AgentExecutionRecord, include func(storage.AgentExecutionRecord) bool) map[string][]storage.AgentExecutionRecord {
+func groupActiveExecutionsByRunID(executions []storage.AgentExecutionRecord, requirePID bool, include func(storage.AgentExecutionRecord) bool) map[string][]storage.AgentExecutionRecord {
 	grouped := make(map[string][]storage.AgentExecutionRecord)
 	for _, execution := range executions {
 		if execution.RunID == nil || strings.TrimSpace(*execution.RunID) == "" {
 			continue
 		}
-		if execution.PID == nil || *execution.PID <= 0 {
+		if requirePID && (execution.PID == nil || *execution.PID <= 0) {
 			continue
 		}
 		if !include(execution) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -4777,7 +4777,12 @@ func TestHandlerActiveRunsSupportFiltersAgentsAndWorktrees(t *testing.T) {
 	assertEqual(t, first["type"], "worker")
 	target := first["target"].(map[string]any)
 	assertEqual(t, target["label"], "Looper")
-	assertEqual(t, first["agent"], nil)
+	agent := first["agent"].(map[string]any)
+	assertEqual(t, agent["executionId"], "agent_exec_worker_new")
+	assertEqual(t, agent["vendor"], "opencode")
+	assertEqual(t, agent["pid"], float64(22222))
+	assertEqual(t, agent["activeCount"], float64(2))
+	assertEqual(t, agent["status"], "running")
 
 	detailReq := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active/1", nil)
 	detailRecorder := httptest.NewRecorder()
@@ -4790,6 +4795,18 @@ func TestHandlerActiveRunsSupportFiltersAgentsAndWorktrees(t *testing.T) {
 	worktree := detail["worktree"].(map[string]any)
 	assertEqual(t, worktree["path"], "/tmp/worktrees/loop-1")
 	assertEqual(t, worktree["branch"], "feature/loop-1")
+
+	workerDetailReq := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active/5", nil)
+	workerDetailRecorder := httptest.NewRecorder()
+	h.ServeHTTP(workerDetailRecorder, workerDetailReq)
+	if workerDetailRecorder.Code != http.StatusOK {
+		t.Fatalf("worker detail status = %d, want 200", workerDetailRecorder.Code)
+	}
+	workerDetailBody := parseJSONMap(t, workerDetailRecorder.Body.Bytes())
+	workerDetail := workerDetailBody["data"].(map[string]any)
+	detailAgent := workerDetail["agent"].(map[string]any)
+	assertEqual(t, detailAgent["executionId"], "agent_exec_worker_new")
+	assertEqual(t, detailAgent["pid"], float64(22222))
 
 	validationReq := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active?repo=acme/looper", nil)
 	validationRecorder := httptest.NewRecorder()
@@ -5067,6 +5084,82 @@ func TestActiveRunsDefaultExcludesPausedLoopWithStaleRunningRun(t *testing.T) {
 	if len(items) != 0 {
 		t.Fatalf("len(items) = %d, want 0: %#v", len(items), items)
 	}
+}
+
+func TestActiveRunsDefaultExcludesStaleRunningRunWithUnverifiedAgent(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	oldHeartbeat := fixture.now.Add(-2 * time.Hour).UTC().Format(javaScriptISOString)
+
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_stale_unverified_agent", Seq: 21, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: stringPtr("pr:nexu-io/looper:185"), Repo: stringPtr("nexu-io/looper"), PRNumber: int64Ptr(185), Status: "running", LastRunAt: stringPtr(oldHeartbeat), CreatedAt: oldHeartbeat, UpdatedAt: oldHeartbeat}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_stale_unverified_agent", LoopID: "loop_stale_unverified_agent", Status: "running", CurrentStep: stringPtr("review"), StartedAt: oldHeartbeat, LastHeartbeatAt: stringPtr(oldHeartbeat), CreatedAt: oldHeartbeat, UpdatedAt: oldHeartbeat}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_exec_stale_unverified", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_stale_unverified_agent"), RunID: stringPtr("run_stale_unverified_agent"), Vendor: "opencode", Status: "running", PID: int64Ptr(54321), StartedAt: oldHeartbeat, LastHeartbeatAt: stringPtr(oldHeartbeat), CreatedAt: oldHeartbeat, UpdatedAt: oldHeartbeat}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now }})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 0 {
+		t.Fatalf("len(items) = %d, want 0: %#v", len(items), items)
+	}
+}
+
+func TestActiveRunsPrefersVerifiedAgentOverNewerFallback(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	runtimeWithVerifier := executionVerifierRuntime{
+		Runtime: fixture.runtime,
+		matchProcess: func(_ context.Context, execution storage.AgentExecutionRecord, _ int) (bool, bool, error) {
+			return execution.ID == "agent_exec_verified", true, nil
+		},
+	}
+
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_verified_preferred", Seq: 22, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: stringPtr("pr:nexu-io/looper:186"), Repo: stringPtr("nexu-io/looper"), PRNumber: int64Ptr(186), Status: "running", LastRunAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_verified_preferred", LoopID: "loop_verified_preferred", Status: "running", CurrentStep: stringPtr("review"), StartedAt: nowISO, LastHeartbeatAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_exec_verified", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_verified_preferred"), RunID: stringPtr("run_verified_preferred"), Vendor: "opencode", Status: "running", PID: int64Ptr(12345), StartedAt: fixture.now.Add(-time.Minute).UTC().Format(javaScriptISOString), LastHeartbeatAt: stringPtr(nowISO), CreatedAt: fixture.now.Add(-time.Minute).UTC().Format(javaScriptISOString), UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(verified) error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_exec_unverified_newer", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_verified_preferred"), RunID: stringPtr("run_verified_preferred"), Vendor: "opencode", Status: "running", PID: int64Ptr(67890), StartedAt: fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString), LastHeartbeatAt: stringPtr(nowISO), CreatedAt: fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString), UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(unverified) error = %v", err)
+	}
+
+	h := NewHandler(Context{Config: fixture.config, Runtime: runtimeWithVerifier, Now: func() time.Time { return fixture.now }})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
+	}
+	agent := items[0].(map[string]any)["agent"].(map[string]any)
+	assertEqual(t, agent["executionId"], "agent_exec_verified")
+	assertEqual(t, agent["pid"], float64(12345))
+	assertEqual(t, agent["activeCount"], float64(1))
 }
 
 func TestActiveRunsDedupesQueuedLoopWhenRunIsRunning(t *testing.T) {
@@ -5464,6 +5557,11 @@ type webhookForwardRuntime struct {
 	record func(string, string)
 }
 
+type executionVerifierRuntime struct {
+	*looperdruntime.Runtime
+	matchProcess func(context.Context, storage.AgentExecutionRecord, int) (bool, bool, error)
+}
+
 func (r webhookForwardRuntime) WebhookStatus() looperdruntime.WebhookStatus {
 	if r.status != nil {
 		return r.status()
@@ -5477,6 +5575,13 @@ func (r webhookForwardRuntime) RecordWebhookDelivery(eventType, deliveryID strin
 		return
 	}
 	r.Runtime.RecordWebhookDelivery(eventType, deliveryID)
+}
+
+func (r executionVerifierRuntime) ExecutionMatchesProcess(ctx context.Context, execution storage.AgentExecutionRecord, pid int) (bool, bool, error) {
+	if r.matchProcess != nil {
+		return r.matchProcess(ctx, execution, pid)
+	}
+	return r.Runtime.ExecutionMatchesProcess(ctx, execution, pid)
 }
 
 func newTestFixture(t *testing.T) testFixture {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -5118,6 +5118,43 @@ func TestActiveRunsDefaultExcludesStaleRunningRunWithUnverifiedAgent(t *testing.
 	}
 }
 
+func TestActiveRunsFallbackIncludesAgentWithoutPID(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_fallback_nil_pid", Seq: 22, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: stringPtr("pr:nexu-io/looper:186"), Repo: stringPtr("nexu-io/looper"), PRNumber: int64Ptr(186), Status: "running", LastRunAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_fallback_nil_pid", LoopID: "loop_fallback_nil_pid", Status: "running", CurrentStep: stringPtr("review"), StartedAt: nowISO, LastHeartbeatAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "agent_exec_nil_pid", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_fallback_nil_pid"), RunID: stringPtr("run_fallback_nil_pid"), Vendor: "opencode", Status: "running", StartedAt: fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString), LastHeartbeatAt: stringPtr(nowISO), CreatedAt: fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString), UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now }})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
+	}
+	agent := items[0].(map[string]any)["agent"].(map[string]any)
+	assertEqual(t, agent["executionId"], "agent_exec_nil_pid")
+	assertEqual(t, agent["vendor"], "opencode")
+	assertEqual(t, agent["pid"], nil)
+	assertEqual(t, agent["activeCount"], float64(1))
+	assertEqual(t, agent["status"], "running")
+}
+
 func TestActiveRunsPrefersVerifiedAgentOverNewerFallback(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)


### PR DESCRIPTION
## Summary
- keep showing persisted active agent metadata for running runs even when live process verification cannot confirm the execution
- continue using verified executions for active-run liveness so stale runs are not revived by fallback metadata
- add regression coverage for fallback display behavior, stale unverified runs, and verified-over-fallback precedence

## Validation
- go test ./...
- go build ./...

Closes #467

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>