### PR TITLE
feat: add linux amd64 release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,6 +310,11 @@ jobs:
             goos: darwin
             goarch: arm64
             artifact-name: looper-darwin-arm64
+          - target: linux-amd64
+            runner: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            artifact-name: looper-linux-amd64
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -388,12 +393,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Phase 1 intentionally publishes macOS artifacts only.
           - target: darwin-arm64
             runner: macos-14
             goos: darwin
             goarch: arm64
             artifact-name: looperd-darwin-arm64
+          - target: linux-amd64
+            runner: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            artifact-name: looperd-linux-amd64
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -555,17 +564,18 @@ jobs:
           test -f release-assets/looper-darwin-arm64.sha256
           test -f release-assets/looper-darwin-arm64.tar.gz
           test -f release-assets/looper-darwin-arm64.tar.gz.sha256
+          test -f release-assets/looper-linux-amd64
+          test -f release-assets/looper-linux-amd64.sha256
+          test -f release-assets/looper-linux-amd64.tar.gz
+          test -f release-assets/looper-linux-amd64.tar.gz.sha256
           test -f release-assets/looperd-darwin-arm64
           test -f release-assets/looperd-darwin-arm64.sha256
           test -f release-assets/looperd-darwin-arm64.tar.gz
           test -f release-assets/looperd-darwin-arm64.tar.gz.sha256
-
-      - name: Verify Linux artifacts are not published in Phase 1
-        run: |
-          if find release-assets -maxdepth 1 \( -name '*linux*' -o -name '*.AppImage' \) | grep -q .; then
-            echo "Phase 1 release workflow must not publish Linux artifacts." >&2
-            exit 1
-          fi
+          test -f release-assets/looperd-linux-amd64
+          test -f release-assets/looperd-linux-amd64.sha256
+          test -f release-assets/looperd-linux-amd64.tar.gz
+          test -f release-assets/looperd-linux-amd64.tar.gz.sha256
 
       - name: Generate release manifest
         run: |
@@ -578,7 +588,7 @@ jobs:
             -min-cli-for-daemon "$LOOPER_BUILD_MIN_CLI_FOR_DAEMON" \
             -min-daemon-for-cli "$LOOPER_BUILD_MIN_DAEMON_FOR_CLI" \
             -assets-dir release-assets \
-            -required-assets "looper-darwin-arm64,looper-darwin-arm64.tar.gz,looperd-darwin-arm64,looperd-darwin-arm64.tar.gz" \
+            -required-assets "looper-darwin-arm64,looper-darwin-arm64.tar.gz,looper-linux-amd64,looper-linux-amd64.tar.gz,looperd-darwin-arm64,looperd-darwin-arm64.tar.gz,looperd-linux-amd64,looperd-linux-amd64.tar.gz" \
             -output release-assets/manifest.json
 
       - name: Validate release manifest fields
@@ -607,8 +617,12 @@ jobs:
           required = {
               "looper-darwin-arm64",
               "looper-darwin-arm64.tar.gz",
+              "looper-linux-amd64",
+              "looper-linux-amd64.tar.gz",
               "looperd-darwin-arm64",
               "looperd-darwin-arm64.tar.gz",
+              "looperd-linux-amd64",
+              "looperd-linux-amd64.tar.gz",
           }
           assert required.issubset(set(m["artifacts"].keys())), "manifest missing artifacts"
           for name in required:
@@ -628,10 +642,18 @@ jobs:
             release-assets/looper-darwin-arm64.sha256 \
             release-assets/looper-darwin-arm64.tar.gz \
             release-assets/looper-darwin-arm64.tar.gz.sha256 \
+            release-assets/looper-linux-amd64 \
+            release-assets/looper-linux-amd64.sha256 \
+            release-assets/looper-linux-amd64.tar.gz \
+            release-assets/looper-linux-amd64.tar.gz.sha256 \
             release-assets/looperd-darwin-arm64 \
             release-assets/looperd-darwin-arm64.sha256 \
             release-assets/looperd-darwin-arm64.tar.gz \
             release-assets/looperd-darwin-arm64.tar.gz.sha256 \
+            release-assets/looperd-linux-amd64 \
+            release-assets/looperd-linux-amd64.sha256 \
+            release-assets/looperd-linux-amd64.tar.gz \
+            release-assets/looperd-linux-amd64.tar.gz.sha256 \
             release-assets/manifest.json \
             --clobber
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It contains a one-shot, step-by-step flow (preflight → install → bootstrap �
 
 ### For humans
 
-Fast path (macOS, `darwin-arm64`):
+Fast path (macOS `darwin-arm64` or Linux `linux-amd64`):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nexu-io/looper/main/scripts/install.sh | sh

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This document contains the detailed install, upgrade, uninstall, and source-buil
 
 For the default supported install path:
 
-- macOS (`darwin-arm64`)
+- macOS (`darwin-arm64`) or Linux (`linux-amd64`)
 - `git`
 - `gh`
 
@@ -34,13 +34,11 @@ looper bootstrap --yes --project-path /path/to/repo --agent-vendor opencode
 
 ### Install the CLI manually
 
-1. Download the matching `looper` release artifact for your macOS architecture from GitHub Releases.
+1. Download the matching `looper` release artifact for your platform from GitHub Releases.
 2. Rename it to `looper` if needed.
 3. Place it on your `PATH`, for example `/usr/local/bin/looper` or `~/.local/bin/looper`.
 
-GitHub Releases publish standalone Go binaries for both `looper` and `looperd` on `darwin-arm64`.
-
-Linux is not currently supported for the managed daemon flow.
+GitHub Releases publish standalone Go binaries for both `looper` and `looperd` on `darwin-arm64` and `linux-amd64`.
 
 ### Install the daemon manually
 
@@ -54,7 +52,7 @@ looper status
 
 This flow:
 
-- detects the current macOS architecture
+- detects the current supported platform and architecture
 - downloads the matching GitHub Release artifact
 - installs it to `~/.looper/bin/looperd`
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1077,7 +1077,7 @@ func (h *Handler) buildStatusResponse(ctx context.Context) (statusResponse, erro
 				InstallDir:       installDir,
 				CurrentTarget:    currentTarget,
 				ArtifactName:     artifactName,
-				SupportedTargets: []string{"darwin-arm64"},
+				SupportedTargets: []string{"darwin-arm64", "linux-amd64"},
 			},
 		},
 		Storage: statusStorage{
@@ -5625,6 +5625,7 @@ func deriveProjectIDFromRepoPath(repoPath string) string {
 func looperdArtifactName(target string) *string {
 	supported := map[string]struct{}{
 		"darwin-arm64": {},
+		"linux-amd64":  {},
 	}
 
 	if _, ok := supported[target]; !ok {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1201,6 +1201,18 @@ func TestHandlerMatchesFrozenSuccessArtifactsForCoreRoutes(t *testing.T) {
 	}
 }
 
+func TestLooperdArtifactNameSupportsLinuxAMD64(t *testing.T) {
+	t.Parallel()
+
+	got := looperdArtifactName("linux-amd64")
+	if got == nil {
+		t.Fatal("looperdArtifactName(linux-amd64) = nil, want non-nil")
+	}
+	if *got != "looperd-linux-amd64" {
+		t.Fatalf("looperdArtifactName(linux-amd64) = %q, want %q", *got, "looperd-linux-amd64")
+	}
+}
+
 func TestHandlerEventAndPullRequestRoutesMatchFrozenSuccessArtifacts(t *testing.T) {
 	routes := loadResponseArtifact(t)
 	fixture := newTestFixture(t)

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -72,7 +72,8 @@
               "currentTarget": "<current-target>",
               "artifactName": "<artifact-name>",
               "supportedTargets": [
-                "darwin-arm64"
+                "darwin-arm64",
+                "linux-amd64"
               ]
             }
           },

--- a/internal/cliapp/daemon_install.go
+++ b/internal/cliapp/daemon_install.go
@@ -272,8 +272,11 @@ func resolveLooperdTarget(platform string, arch string) (string, error) {
 	if platform == "darwin" && arch == "arm64" {
 		return "darwin-arm64", nil
 	}
+	if platform == "linux" && arch == "amd64" {
+		return "linux-amd64", nil
+	}
 
-	return "", fmt.Errorf("Unsupported platform/arch for looperd install: %s-%s. Supported targets: darwin-arm64", platform, arch)
+	return "", fmt.Errorf("Unsupported platform/arch for looperd install: %s-%s. Supported targets: darwin-arm64, linux-amd64", platform, arch)
 }
 
 func buildGitHubReleaseAPIURL(owner, repo, tag string) string {

--- a/internal/cliapp/daemon_install_test.go
+++ b/internal/cliapp/daemon_install_test.go
@@ -25,9 +25,12 @@ func TestResolveLooperdTarget(t *testing.T) {
 		t.Fatalf("resolveLooperdTarget(darwin, arm64) = %q, want %q", target, "darwin-arm64")
 	}
 
-	_, err = resolveLooperdTarget("linux", "amd64")
-	if err == nil || err.Error() != "Unsupported platform/arch for looperd install: linux-amd64. Supported targets: darwin-arm64" {
+	target, err = resolveLooperdTarget("linux", "amd64")
+	if err != nil {
 		t.Fatalf("resolveLooperdTarget(linux, amd64) error = %v", err)
+	}
+	if target != "linux-amd64" {
+		t.Fatalf("resolveLooperdTarget(linux, amd64) = %q, want %q", target, "linux-amd64")
 	}
 
 	for _, arch := range []string{"amd64", "x64"} {

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -1401,11 +1401,14 @@ func detectCLIInstallSourceForChannel(execPath, channel string) cliInstallSource
 	if strings.HasSuffix(path, "/.local/bin/looper") || strings.HasSuffix(path, "/usr/local/bin/looper") || strings.HasSuffix(path, "/.looper/bin/looper") {
 		return cliInstallSourceRelease
 	}
-	if strings.Contains(path, "/go/bin/") || strings.Contains(path, "/go-build/") || strings.Contains(path, "/tmp/") {
+	if strings.Contains(path, "/go/bin/") || strings.Contains(path, "/go-build/") {
 		return cliInstallSourceDev
 	}
 	if isInstallerSelectedUserBinPath(execPath) {
 		return cliInstallSourceRelease
+	}
+	if strings.Contains(path, "/tmp/") {
+		return cliInstallSourceDev
 	}
 	return cliInstallSourceUnknown
 }
@@ -1501,7 +1504,10 @@ func resolveLooperTarget(platform string, arch string) (string, error) {
 	if platform == "darwin" && arch == "arm64" {
 		return "darwin-arm64", nil
 	}
-	return "", fmt.Errorf("unsupported platform/arch for looper upgrade: %s-%s. Supported targets: darwin-arm64", platform, arch)
+	if platform == "linux" && arch == "amd64" {
+		return "linux-amd64", nil
+	}
+	return "", fmt.Errorf("unsupported platform/arch for looper upgrade: %s-%s. Supported targets: darwin-arm64, linux-amd64", platform, arch)
 }
 
 func replaceBinaryAtomically(installPath string, binaryBytes []byte) error {

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -46,6 +46,14 @@ func TestResolveLooperTarget(t *testing.T) {
 		t.Fatalf("resolveLooperTarget(darwin, arm64) = %q, want %q", target, "darwin-arm64")
 	}
 
+	target, err = resolveLooperTarget("linux", "amd64")
+	if err != nil {
+		t.Fatalf("resolveLooperTarget(linux, amd64) error = %v", err)
+	}
+	if target != "linux-amd64" {
+		t.Fatalf("resolveLooperTarget(linux, amd64) = %q, want %q", target, "linux-amd64")
+	}
+
 	for _, arch := range []string{"amd64", "x64"} {
 		_, err = resolveLooperTarget("darwin", arch)
 		if err == nil {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,11 +23,20 @@ detect_target() {
   os="$(uname -s)"
   arch="$(uname -m)"
 
-  [ "$os" = "Darwin" ] || fail "unsupported platform: $os (supported: macOS)"
-
-  case "$arch" in
-    arm64|aarch64) printf 'darwin-arm64\n' ;;
-    *) fail "unsupported architecture: $arch (supported: arm64)" ;;
+  case "$os" in
+    Darwin)
+      case "$arch" in
+        arm64|aarch64) printf 'darwin-arm64\n' ;;
+        *) fail "unsupported architecture for macOS: $arch (supported: arm64)" ;;
+      esac
+      ;;
+    Linux)
+      case "$arch" in
+        x86_64|amd64) printf 'linux-amd64\n' ;;
+        *) fail "unsupported architecture for Linux: $arch (supported: x86_64)" ;;
+      esac
+      ;;
+    *) fail "unsupported platform: $os (supported: macOS, Linux)" ;;
   esac
 }
 

--- a/skills/looper/SKILL.md
+++ b/skills/looper/SKILL.md
@@ -39,12 +39,22 @@ Use this when the user wants Looper installed, configured, and running end-to-en
 
 ### Step 0 — Preflight (read-only)
 
-Looper currently supports macOS (`darwin-arm64`) only. Stop and ask the user how to proceed if the host is not macOS:
+Looper currently supports macOS (`darwin-arm64`) and Linux (`linux-amd64`). Stop and ask the user how to proceed if the host is not supported:
+
+```bash
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64|Darwin-aarch64) ;;
+  Linux-x86_64|Linux-amd64) ;;
+  *) echo "Looper supports macOS arm64 and Linux x64 only; stop and confirm with the user before continuing." >&2 ;;
+esac
+```
+
+On Linux, use detached foreground-mode daemon management; launchd supervision is macOS-only.
 
 ```bash
 case "$(uname -s)" in
   Darwin) ;;
-  *) echo "Looper supports macOS only; stop and confirm with the user before continuing." >&2 ;;
+  *) echo "Skip macOS launchd assumptions on this host." >&2 ;;
 esac
 ```
 


### PR DESCRIPTION
## Summary
- publish linux-amd64 release artifacts for both looper and looperd
- teach install, daemon install, and CLI upgrade target resolution about linux-amd64
- update installation docs and the Looper skill from macOS-only to macOS arm64 plus Linux amd64
- preserve dev-build classification for Go build paths while allowing installer-selected user PATH bin installs under temp HOME

## Validation
- local: go test ./...
- local: bash -n scripts/install.sh
- local: git diff --check
- remote 20m.us.zxi worker temp dir: HOME=/tmp/looper-verify.MsbdgS/home2 go test ./...
- remote 20m.us.zxi worker temp dir: release-style looper and looperd builds produced ELF x86-64 Linux binaries
- remote 20m.us.zxi worker temp dir: fake-curl scripts/install.sh smoke selected looper-linux-amd64
- remote 20m.us.zxi worker temp dir: release-manifest smoke accepted linux-amd64 required assets