### PR TITLE
fix: speed up CLI status queries

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2621,7 +2621,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 	} else {
-		queueItems, err = services.Repositories.Queue.ListByStatuses(ctx, []string{"queued", "running", "manual_intervention"})
+		queueItems, err = services.Repositories.Queue.ListLatestByLoopStatuses(ctx, []string{"queued", "running", "manual_intervention"})
 		if err != nil {
 			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -242,6 +242,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		h.writeSuccess(w, requestID, payload)
 		return
+	case apiBasePath + "/version":
+		if !assertMethod(r.Method, http.MethodGet, path, w, requestID, h.writeError) {
+			return
+		}
+
+		h.writeSuccess(w, requestID, h.buildVersionResponse())
+		return
 	case apiBasePath + "/config":
 		if !assertMethod(r.Method, http.MethodGet, path, w, requestID, h.writeError) {
 			return
@@ -812,6 +819,17 @@ type statusBinary struct {
 	SupportedTargets []string `json:"supportedTargets"`
 }
 
+type versionResponse struct {
+	Version string                `json:"version"`
+	Build   version.BuildMetadata `json:"build"`
+	Binary  versionBinaryResponse `json:"binary"`
+}
+
+type versionBinaryResponse struct {
+	Name string `json:"name"`
+	Path string `json:"path,omitempty"`
+}
+
 func daemonExecutablePath() string {
 	executablePath, err := os.Executable()
 	if err != nil {
@@ -1033,6 +1051,17 @@ func serverBaseURL(cfg config.ServerConfig) string {
 	return fmt.Sprintf("http://%s:%d", cfg.Host, cfg.Port)
 }
 
+func (h *Handler) buildVersionResponse() versionResponse {
+	return versionResponse{
+		Version: version.Current().Version,
+		Build:   version.Current().Metadata,
+		Binary: versionBinaryResponse{
+			Name: "looperd",
+			Path: daemonExecutablePath(),
+		},
+	}
+}
+
 func (h *Handler) buildStatusResponse(ctx context.Context) (statusResponse, error) {
 	storageState, err := h.loadStorageState(ctx)
 	if err != nil {
@@ -1040,24 +1069,22 @@ func (h *Handler) buildStatusResponse(ctx context.Context) (statusResponse, erro
 	}
 
 	services := h.context.Runtime.Services()
-	loops, err := services.Repositories.Loops.List(ctx)
+	loopCountsByType, err := services.Repositories.Loops.CountByTypeAndStatus(ctx)
 	if err != nil {
 		return statusResponse{}, err
 	}
 
-	runs, err := services.Repositories.Runs.List(ctx)
+	runCounts, err := services.Repositories.Runs.CountByStatus(ctx)
 	if err != nil {
 		return statusResponse{}, err
 	}
 
-	queueItems, err := services.Repositories.Queue.List(ctx)
+	queueCounts, err := services.Repositories.Queue.CountByAllStatuses(ctx)
 	if err != nil {
 		return statusResponse{}, err
 	}
 
-	loopCounts := countLoops(loops)
-	queueCounts := countQueueByStatus(queueItems)
-	runCounts := countRunsByStatus(runs)
+	loopCounts := countLoops(loopCountsByType)
 
 	currentTarget := currentLooperdTarget()
 	installDir := filepath.Join(homeDirOrEmpty(), ".looper", "bin")
@@ -1089,12 +1116,12 @@ func (h *Handler) buildStatusResponse(ctx context.Context) (statusResponse, erro
 		},
 		Scheduler: statusScheduler{
 			Healthy:        true,
-			QueuedItems:    queueCounts["queued"],
-			RunningItems:   queueCounts["running"],
-			CompletedItems: queueCounts["completed"],
-			FailedItems:    queueCounts["failed"],
-			TotalRuns:      len(runs),
-			ActiveRuns:     runCounts["running"],
+			QueuedItems:    int(queueCounts["queued"]),
+			RunningItems:   int(queueCounts["running"]),
+			CompletedItems: int(queueCounts["completed"]),
+			FailedItems:    int(queueCounts["failed"]),
+			TotalRuns:      sumStatusCounts(runCounts),
+			ActiveRuns:     int(runCounts["running"]),
 		},
 		Agent: statusAgent{
 			Vendor:              h.context.Config.Agent.Vendor,
@@ -1199,11 +1226,11 @@ func (s storageState) schemaVersion() string {
 	return s.LatestAppliedID
 }
 
-func countLoops(loops []storage.LoopRecord) statusLoops {
+func countLoops(countsByType map[string]map[string]int64) statusLoops {
 	counts := statusLoops{}
-	for _, loop := range loops {
+	for loopType, statuses := range countsByType {
 		var target *statusLoopType
-		switch loop.Type {
+		switch loopType {
 		case "planner":
 			target = &counts.Planner
 		case "reviewer":
@@ -1216,43 +1243,35 @@ func countLoops(loops []storage.LoopRecord) statusLoops {
 			continue
 		}
 
-		switch loop.Status {
-		case "queued":
-			target.Queued++
-		case "running":
-			target.Running++
-		case "waiting":
-			target.Waiting++
-		case "paused":
-			target.Paused++
-		case "failed":
-			target.Failed++
-		case "terminated":
-			target.Terminated++
-		case "stopped":
-			target.Stopped++
+		for status, count := range statuses {
+			switch status {
+			case "queued":
+				target.Queued = int(count)
+			case "running":
+				target.Running = int(count)
+			case "waiting":
+				target.Waiting = int(count)
+			case "paused":
+				target.Paused = int(count)
+			case "failed":
+				target.Failed = int(count)
+			case "terminated":
+				target.Terminated = int(count)
+			case "stopped":
+				target.Stopped = int(count)
+			}
 		}
 	}
 
 	return counts
 }
 
-func countQueueByStatus(items []storage.QueueItemRecord) map[string]int {
-	counts := map[string]int{}
-	for _, item := range items {
-		counts[item.Status]++
+func sumStatusCounts(counts map[string]int64) int {
+	total := 0
+	for _, count := range counts {
+		total += int(count)
 	}
-
-	return counts
-}
-
-func countRunsByStatus(items []storage.RunRecord) map[string]int {
-	counts := map[string]int{}
-	for _, item := range items {
-		counts[item.Status]++
-	}
-
-	return counts
+	return total
 }
 
 func generateRequestID() string {
@@ -2580,17 +2599,44 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 	if err != nil {
 		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
-	queueItems, err := services.Repositories.Queue.List(ctx)
-	if err != nil {
-		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-	}
-	loopsList, err := services.Repositories.Loops.List(ctx)
-	if err != nil {
-		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-	}
 	activeExecutions, err := services.Repositories.AgentExecutions.ListActive(ctx)
 	if err != nil {
 		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+
+	queueItems := make([]storage.QueueItemRecord, 0)
+	loopsList := make([]storage.LoopRecord, 0)
+	latestRunsByLoopID := map[string]*storage.RunRecord{}
+	if includeInactiveLoops {
+		queueItems, err = services.Repositories.Queue.List(ctx)
+		if err != nil {
+			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		loopsList, err = services.Repositories.Loops.List(ctx)
+		if err != nil {
+			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		latestRunsByLoopID, err = h.latestRunsByLoopID(ctx, services.Repositories.Runs, loopIDsFromLoops(loopsList))
+		if err != nil {
+			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+	} else {
+		queueItems, err = services.Repositories.Queue.ListByStatuses(ctx, []string{"queued", "running", "manual_intervention"})
+		if err != nil {
+			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		manualResumeRuns, err := services.Repositories.Runs.ListLatestByLoopStatusesAndResumePolicy(ctx, manualResumeCandidateLoopStatuses(), string(loops.ResumePolicyManualIntervention))
+		if err != nil {
+			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		loopsList, err = h.listDefaultActiveRunLoops(ctx, services.Repositories, activeRuns, queueItems, manualResumeRuns, includeRunningLoopsWithoutRuns)
+		if err != nil {
+			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		latestRunsByLoopID, err = h.latestRunsForDefaultActiveRuns(ctx, services.Repositories, activeRuns, queueItems, manualResumeRuns, loopsList)
+		if err != nil {
+			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
 	}
 
 	loopsByID := make(map[string]storage.LoopRecord, len(loopsList))
@@ -2624,10 +2670,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 		if !ok {
 			continue
 		}
-		latestRun, err := services.Repositories.Runs.GetLatestByLoopID(ctx, run.LoopID)
-		if err != nil {
-			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-		}
+		latestRun := latestRunsByLoopID[run.LoopID]
 		hasActiveAgent := verifiedActiveAgentByRunID[run.ID] != nil
 		if !isPlausiblyLiveActiveRun(run, loop, latestRun, hasActiveAgent, h.now().UTC()) {
 			continue
@@ -2699,7 +2742,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			Agent:       nil,
 			Worktree:    nil,
 		}
-		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], nil)
+		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], latestRunsByLoopID[loop.ID])
 		queuedViews = append(queuedViews, view)
 	}
 
@@ -2727,7 +2770,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			Agent:       nil,
 			Worktree:    nil,
 		}
-		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], nil)
+		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], latestRunsByLoopID[loop.ID])
 		runningLoopViews = append(runningLoopViews, view)
 	}
 
@@ -2748,16 +2791,9 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			continue
 		}
 		latestQueue := latestQueueByLoopID[loop.ID]
-		var latestRun *storage.RunRecord
-		if !includeInactiveLoops {
-			var runErr error
-			latestRun, runErr = services.Repositories.Runs.GetLatestByLoopID(ctx, loop.ID)
-			if runErr != nil {
-				return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: runErr.Error()}
-			}
-			if !isManualInterventionQueue(latestQueue) && !hasManualInterventionResumePolicy(latestRun) {
-				continue
-			}
+		latestRun := latestRunsByLoopID[loop.ID]
+		if !includeInactiveLoops && !isManualInterventionQueue(latestQueue) && !hasManualInterventionResumePolicy(latestRun) {
+			continue
 		}
 		target, ok, err := h.tryBuildActiveRunTarget(ctx, loop)
 		if err != nil {
@@ -2770,12 +2806,6 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			runID    *string
 			worktree *activeRunWorktree
 		)
-		if latestRun == nil {
-			latestRun, err = services.Repositories.Runs.GetLatestByLoopID(ctx, loop.ID)
-			if err != nil {
-				return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-			}
-		}
 		startedAt := firstNonEmptyString(loop.LastRunAt, loop.NextRunAt, stringPtrOrNil(loop.UpdatedAt), stringPtrOrNil(loop.CreatedAt))
 		var endedAt *string
 		if latestRun != nil {
@@ -2829,6 +2859,91 @@ func excludeActiveRunViewsByLoopID(items []activeRunView, excluded []activeRunVi
 		filtered = append(filtered, item)
 	}
 	return filtered
+}
+
+func (h *Handler) listDefaultActiveRunLoops(ctx context.Context, repos *storage.Repositories, activeRuns []storage.RunRecord, queueItems []storage.QueueItemRecord, manualResumeRuns []storage.RunRecord, includeRunningLoopsWithoutRuns bool) ([]storage.LoopRecord, error) {
+	loopIDs := make(map[string]struct{}, len(activeRuns)+len(queueItems)+len(manualResumeRuns))
+	for _, run := range activeRuns {
+		loopIDs[run.LoopID] = struct{}{}
+	}
+	for _, item := range queueItems {
+		if item.LoopID != nil && strings.TrimSpace(*item.LoopID) != "" {
+			loopIDs[*item.LoopID] = struct{}{}
+		}
+	}
+	for _, run := range manualResumeRuns {
+		loopIDs[run.LoopID] = struct{}{}
+	}
+	if includeRunningLoopsWithoutRuns {
+		runningAndQueued, err := repos.Loops.ListByStatuses(ctx, []string{string(domain.LoopStatusRunning), string(domain.LoopStatusQueued)})
+		if err != nil {
+			return nil, err
+		}
+		for _, loop := range runningAndQueued {
+			loopIDs[loop.ID] = struct{}{}
+		}
+	}
+	return repos.Loops.ListByIDs(ctx, mapKeys(loopIDs))
+}
+
+func (h *Handler) latestRunsForDefaultActiveRuns(ctx context.Context, repos *storage.Repositories, activeRuns []storage.RunRecord, queueItems []storage.QueueItemRecord, manualResumeRuns []storage.RunRecord, loopsList []storage.LoopRecord) (map[string]*storage.RunRecord, error) {
+	loopIDs := make(map[string]struct{}, len(activeRuns)+len(queueItems)+len(manualResumeRuns)+len(loopsList))
+	for _, run := range activeRuns {
+		loopIDs[run.LoopID] = struct{}{}
+	}
+	for _, item := range queueItems {
+		if item.LoopID != nil && strings.TrimSpace(*item.LoopID) != "" {
+			loopIDs[*item.LoopID] = struct{}{}
+		}
+	}
+	for _, loop := range loopsList {
+		loopIDs[loop.ID] = struct{}{}
+	}
+	latestRunsByLoopID, err := h.latestRunsByLoopID(ctx, repos.Runs, mapKeys(loopIDs))
+	if err != nil {
+		return nil, err
+	}
+	for i := range manualResumeRuns {
+		latestRunsByLoopID[manualResumeRuns[i].LoopID] = &manualResumeRuns[i]
+	}
+	return latestRunsByLoopID, nil
+}
+
+func manualResumeCandidateLoopStatuses() []string {
+	return []string{
+		string(domain.LoopStatusPaused),
+		string(domain.LoopStatusWaiting),
+		string(domain.LoopStatusFailed),
+		string(domain.LoopStatusInterrupted),
+	}
+}
+
+func (h *Handler) latestRunsByLoopID(ctx context.Context, runs *storage.RunsRepository, loopIDs []string) (map[string]*storage.RunRecord, error) {
+	latestRuns, err := runs.ListLatestByLoopIDs(ctx, loopIDs)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]*storage.RunRecord, len(latestRuns))
+	for i := range latestRuns {
+		result[latestRuns[i].LoopID] = &latestRuns[i]
+	}
+	return result, nil
+}
+
+func loopIDsFromLoops(loopsList []storage.LoopRecord) []string {
+	ids := make([]string, 0, len(loopsList))
+	for _, loop := range loopsList {
+		ids = append(ids, loop.ID)
+	}
+	return ids
+}
+
+func mapKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 func latestQueueItemByLoopID(items []storage.QueueItemRecord) map[string]*storage.QueueItemRecord {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nexu-io/looper/internal/reviewer"
 	looperdruntime "github.com/nexu-io/looper/internal/runtime"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/version"
 	"github.com/nexu-io/looper/internal/webhookforward"
 )
 
@@ -359,6 +360,56 @@ func TestHandlerActiveRunsSurfacesResumePolicyManualIntervention(t *testing.T) {
 	}
 	item := items[0].(map[string]any)
 	assertEqual(t, item["status"], "paused")
+	assertEqual(t, item["loopStatus"], "paused")
+	assertEqual(t, item["displayStatus"], "manual_intervention")
+	assertEqual(t, item["resumePolicy"], "manual_intervention")
+}
+
+func TestHandlerActiveRunsDefaultIncludesInterruptedManualResumeAndExcludesCompleted(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_manual_resume_status_filter"
+	checkpoint := `{"resumePolicy":"manual_intervention"}`
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	interruptedLoopID := "loop_manual_resume_interrupted"
+	interruptedTargetID := interruptedLoopID + ":target"
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: interruptedLoopID, Seq: 48, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &interruptedTargetID, Status: "interrupted", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert(interrupted) error = %v", err)
+	}
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_manual_resume_interrupted", LoopID: interruptedLoopID, Status: "interrupted", CheckpointJSON: &checkpoint, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert(interrupted) error = %v", err)
+	}
+
+	completedLoopID := "loop_manual_resume_completed"
+	completedTargetID := completedLoopID + ":target"
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: completedLoopID, Seq: 49, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &completedTargetID, Status: "completed", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert(completed) error = %v", err)
+	}
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_manual_resume_completed", LoopID: completedLoopID, Status: "failed", CheckpointJSON: &checkpoint, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert(completed) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1: %#v", len(items), items)
+	}
+	item := items[0].(map[string]any)
+	assertEqual(t, item["loopId"], interruptedLoopID)
+	assertEqual(t, item["status"], "interrupted")
+	assertEqual(t, item["loopStatus"], "interrupted")
 	assertEqual(t, item["displayStatus"], "manual_intervention")
 	assertEqual(t, item["resumePolicy"], "manual_intervention")
 }
@@ -474,6 +525,36 @@ func TestHandlerStatusSuccessContainsExpectedSections(t *testing.T) {
 	assertEqual(t, reviewer["waiting"], float64(1))
 	assertEqual(t, reviewer["terminated"], float64(1))
 	assertEqual(t, reviewer["stopped"], float64(1))
+}
+
+func TestHandlerVersionSuccessContainsExpectedFields(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	req.Header.Set("x-request-id", "fixture-request-id")
+	recorder := httptest.NewRecorder()
+
+	NewHandler(Context{Config: cfg, Runtime: rt}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	assertEqual(t, body["ok"], true)
+	assertEqual(t, body["requestId"], "fixture-request-id")
+
+	data := body["data"].(map[string]any)
+	binaryInfo := data["binary"].(map[string]any)
+	assertEqual(t, data["version"], version.Current().Version)
+	assertEqual(t, binaryInfo["name"], "looperd")
+	binaryPath, ok := binaryInfo["path"].(string)
+	if !ok || strings.TrimSpace(binaryPath) == "" {
+		t.Fatalf("binary.path missing/invalid: %#v", binaryInfo["path"])
+	}
+	build, ok := data["build"].(map[string]any)
+	if !ok {
+		t.Fatalf("build missing/invalid: %#v", data["build"])
+	}
+	assertEqual(t, build["apiVersion"], version.Current().Metadata.APIVersion)
 }
 
 func TestHandlerConfigSuccessContainsExpectedSections(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -5488,6 +5488,67 @@ func TestActiveRunsStatusAndTypeFiltersIncludeInactiveCompletedWorkerLoops(t *te
 	assertEqual(t, filteredItem["agent"], nil)
 }
 
+func TestActiveRunsIgnoresStaleManualInterventionQueueHistory(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	manualAt := fixture.now.Add(-2 * time.Minute).UTC().Format(javaScriptISOString)
+	completedAt := fixture.now.Add(-time.Minute).UTC().Format(javaScriptISOString)
+	projectID := "project_1"
+	loopID := "loop_worker_completed_after_manual"
+	targetID := "issue:acme/looper:45"
+	manualReason := "needs manual intervention"
+	manualKind := "manual_intervention"
+
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID:        projectID,
+		Name:      "Looper",
+		RepoPath:  "/tmp/repos/looper",
+		Archived:  false,
+		CreatedAt: nowISO,
+		UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID:         loopID,
+		Seq:        15,
+		ProjectID:  projectID,
+		Type:       "worker",
+		TargetType: "issue",
+		TargetID:   stringPtr(targetID),
+		Repo:       stringPtr("acme/looper"),
+		Status:     "completed",
+		LastRunAt:  stringPtr(completedAt),
+		CreatedAt:  nowISO,
+		UpdatedAt:  completedAt,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	for _, item := range []storage.QueueItemRecord{
+		{ID: "queue_manual", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "issue", TargetID: targetID, Repo: stringPtr("acme/looper"), DedupeKey: "worker:manual", Priority: storage.QueuePriorityWorker, Status: "manual_intervention", AvailableAt: manualAt, Attempts: 1, MaxAttempts: 3, LastError: &manualReason, LastErrorKind: &manualKind, CreatedAt: manualAt, UpdatedAt: manualAt},
+		{ID: "queue_completed", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "issue", TargetID: targetID, Repo: stringPtr("acme/looper"), DedupeKey: "worker:completed", Priority: storage.QueuePriorityWorker, Status: "completed", AvailableAt: completedAt, Attempts: 1, MaxAttempts: 3, FinishedAt: &completedAt, CreatedAt: completedAt, UpdatedAt: completedAt},
+	} {
+		if err := fixture.runtime.Services().Repositories.Queue.Upsert(context.Background(), item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 0 {
+		t.Fatalf("len(items) = %d, want 0", len(items))
+	}
+}
+
 func TestActiveRunsAllIncludesInactiveCompletedLoopWithLatestRunFields(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -667,15 +667,17 @@ func TestVersionCommandPrintsCLIAndServerVersionSeparately(t *testing.T) {
 	runningPath := filepath.Join(homeDir, "running", "looperd")
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
+	requestPaths := []string{}
 	app := New(Deps{
 		Stdout:  stdout,
 		Stderr:  stderr,
 		HomeDir: homeDir,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Path != "/api/v1/status" {
+			requestPaths = append(requestPaths, req.URL.Path)
+			if req.URL.Path != "/api/v1/version" {
 				t.Fatalf("unexpected request path %q", req.URL.Path)
 			}
-			return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"data":{"service":{"version":"0.7.0","binary":{"name":"looperd","path":%q}}}}`, runningPath)), nil
+			return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"data":{"version":"0.7.0","build":{"apiVersion":%q},"binary":{"name":"looperd","path":%q}}}`, version.Current().Metadata.APIVersion, runningPath)), nil
 		}),
 		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
 			_ = ctx
@@ -696,6 +698,9 @@ func TestVersionCommandPrintsCLIAndServerVersionSeparately(t *testing.T) {
 	}
 	if got, want := stdout.String(), "CLI version: "+version.Current().Version+"\nlooperd server version: 0.7.0\n"; got != want {
 		t.Fatalf("Run([version]) stdout = %q, want %q", got, want)
+	}
+	if !reflect.DeepEqual(requestPaths, []string{"/api/v1/version"}) {
+		t.Fatalf("request paths = %#v, want only /api/v1/version", requestPaths)
 	}
 }
 
@@ -753,15 +758,17 @@ func TestVersionCommandJSONPrintsServerVersionSeparately(t *testing.T) {
 	runningPath := filepath.Join(homeDir, "running", "looperd")
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
+	requestPaths := []string{}
 	app := New(Deps{
 		Stdout:  stdout,
 		Stderr:  stderr,
 		HomeDir: homeDir,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Path != "/api/v1/status" {
+			requestPaths = append(requestPaths, req.URL.Path)
+			if req.URL.Path != "/api/v1/version" {
 				t.Fatalf("unexpected request path %q", req.URL.Path)
 			}
-			return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"data":{"service":{"version":"0.7.0","binary":{"name":"looperd","path":%q}}}}`, runningPath)), nil
+			return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"data":{"version":"0.7.0","build":{"apiVersion":%q},"binary":{"name":"looperd","path":%q}}}`, version.Current().Metadata.APIVersion, runningPath)), nil
 		}),
 		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
 			_ = ctx
@@ -797,6 +804,9 @@ func TestVersionCommandJSONPrintsServerVersionSeparately(t *testing.T) {
 		"source":     "api",
 		"binaryPath": runningPath,
 	})
+	if !reflect.DeepEqual(requestPaths, []string{"/api/v1/version"}) {
+		t.Fatalf("request paths = %#v, want only /api/v1/version", requestPaths)
+	}
 }
 
 func TestVersionCommandUsesConfiguredBaseURLForServerVersionLookup(t *testing.T) {
@@ -816,10 +826,10 @@ func TestVersionCommandUsesConfiguredBaseURLForServerVersionLookup(t *testing.T)
 		Stdout: stdout,
 		Stderr: stderr,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if got, want := req.URL.String(), "https://daemon.example.test/base/api/v1/status"; got != want {
-				t.Fatalf("status URL = %q, want %q", got, want)
+			if got, want := req.URL.String(), "https://daemon.example.test/base/api/v1/version"; got != want {
+				t.Fatalf("version URL = %q, want %q", got, want)
 			}
-			return jsonResponse(t, http.StatusOK, `{"ok":true,"data":{"service":{"version":"0.8.0"}}}`), nil
+			return jsonResponse(t, http.StatusOK, `{"ok":true,"data":{"version":"0.8.0","build":{"apiVersion":"v1"},"binary":{"name":"looperd"}}}`), nil
 		}),
 		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
 			_ = ctx
@@ -839,6 +849,112 @@ func TestVersionCommandUsesConfiguredBaseURLForServerVersionLookup(t *testing.T)
 	}
 	if got, want := stdout.String(), "CLI version: "+version.Current().Version+"\nlooperd server version: 0.8.0\n"; got != want {
 		t.Fatalf("Run([version --config]) stdout = %q, want %q", got, want)
+	}
+}
+
+func TestVersionCommandFallsBackToStatusForOlderDaemon(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	runningPath := filepath.Join(homeDir, "running", "looperd")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	requestPaths := []string{}
+	app := New(Deps{
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: homeDir,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			requestPaths = append(requestPaths, req.URL.Path)
+			switch req.URL.Path {
+			case "/api/v1/version":
+				return jsonResponse(t, http.StatusNotFound, `{"ok":false,"error":{"code":"NOT_FOUND","message":"not found"}}`), nil
+			case "/api/v1/status":
+				return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"data":{"service":{"version":"0.7.0","binary":{"name":"looperd","path":%q}}}}`, runningPath)), nil
+			default:
+				t.Fatalf("unexpected request path %q", req.URL.Path)
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = command
+			_ = args
+			_ = timeout
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	exitCode := app.Run(context.Background(), []string{"version", "--json"})
+	if exitCode != 0 {
+		t.Fatalf("Run([version --json]) exit code = %d, want 0", exitCode)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("Run([version --json]) stderr = %q, want empty string", got)
+	}
+	assertJSONContains(t, stdout.String(), "server", map[string]any{
+		"version":    "0.7.0",
+		"source":     "api",
+		"binaryPath": runningPath,
+	})
+	if !reflect.DeepEqual(requestPaths, []string{"/api/v1/version", "/api/v1/status"}) {
+		t.Fatalf("request paths = %#v, want version then status", requestPaths)
+	}
+}
+
+func TestVersionCommandSlowStatusFallbackUsesBinaryVersion(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	managedPath := filepath.Join(homeDir, ".looper", "bin", "looperd")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	requestPaths := []string{}
+	app := New(Deps{
+		Stdout:  stdout,
+		Stderr:  stderr,
+		HomeDir: homeDir,
+		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
+			requestPaths = append(requestPaths, req.URL.Path)
+			switch req.URL.Path {
+			case "/api/v1/version":
+				return jsonResponse(t, http.StatusNotFound, `{"ok":false,"error":{"code":"NOT_FOUND","message":"not found"}}`), nil
+			case "/api/v1/status":
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			default:
+				t.Fatalf("unexpected request path %q", req.URL.Path)
+				return nil, nil
+			}
+		}),
+		RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+			_ = ctx
+			_ = timeout
+			if command == managedPath && strings.Join(args, " ") == "--version" {
+				return commandExecutionResult{Stdout: "0.6.0\n", ExitCode: 0}, nil
+			}
+			return commandExecutionResult{ExitCode: 1, Stderr: "not found"}, nil
+		},
+	})
+
+	startedAt := time.Now()
+	exitCode := app.Run(context.Background(), []string{"version", "--json"})
+	if exitCode != 0 {
+		t.Fatalf("Run([version --json]) exit code = %d, want 0", exitCode)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("Run([version --json]) stderr = %q, want empty string", got)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("Run([version --json]) took %v, want quick fallback", elapsed)
+	}
+	assertJSONContains(t, stdout.String(), "server", map[string]any{
+		"version":    "0.6.0",
+		"source":     "binary",
+		"binaryPath": managedPath,
+	})
+	if !reflect.DeepEqual(requestPaths, []string{"/api/v1/version", "/api/v1/status"}) {
+		t.Fatalf("request paths = %#v, want version then status", requestPaths)
 	}
 }
 

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -11,11 +11,14 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/version"
 	"github.com/spf13/cobra"
 )
+
+const daemonVersionProbeTimeout = 250 * time.Millisecond
 
 type commandRuntime struct {
 	app                *App
@@ -81,7 +84,19 @@ type daemonVersionPayload struct {
 func (r *commandRuntime) bestEffortDaemonVersion(ctx context.Context) *daemonVersionPayload {
 	if loaded, err := r.loadConfig(); err == nil {
 		client := r.apiClientFromLoaded(loaded)
-		if payload, err := r.getJSONWithClient(ctx, client, "/api/v1/status"); err == nil {
+		if payload, err := r.getJSONWithClient(ctx, client, "/api/v1/version"); err == nil {
+			if state := extractDaemonVersionEndpointState(payload); state != nil && strings.TrimSpace(state.Version) != "" {
+				return &daemonVersionPayload{
+					Version:    state.Version,
+					Source:     state.Source,
+					BinaryPath: state.BinaryPath,
+				}
+			}
+		}
+
+		statusProbeCtx, cancel := context.WithTimeout(ctx, daemonVersionProbeTimeout)
+		if payload, err := r.getJSONWithClient(statusProbeCtx, client, "/api/v1/status"); err == nil {
+			cancel()
 			if state, err := r.detectDaemonVersionState(ctx, payload); err == nil && state != nil && strings.TrimSpace(state.Version) != "" {
 				return &daemonVersionPayload{
 					Version:    state.Version,
@@ -90,6 +105,7 @@ func (r *commandRuntime) bestEffortDaemonVersion(ctx context.Context) *daemonVer
 				}
 			}
 		}
+		cancel()
 	}
 
 	state, err := r.readManagedDaemonVersion(ctx)
@@ -104,6 +120,33 @@ func (r *commandRuntime) bestEffortDaemonVersion(ctx context.Context) *daemonVer
 		Source:     state.Source,
 		BinaryPath: state.BinaryPath,
 	}
+}
+func extractDaemonVersionEndpointState(payload json.RawMessage) *daemonVersionState {
+	if len(payload) == 0 {
+		return nil
+	}
+
+	var decoded struct {
+		Version string `json:"version"`
+		Binary  struct {
+			Name string `json:"name"`
+			Path string `json:"path"`
+		} `json:"binary"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return nil
+	}
+
+	versionText := strings.TrimSpace(decoded.Version)
+	if versionText == "" {
+		return nil
+	}
+
+	state := &daemonVersionState{Version: versionText, Source: "api"}
+	if path := strings.TrimSpace(decoded.Binary.Path); path != "" {
+		state.BinaryPath = stringPtr(path)
+	}
+	return state
 }
 
 func (r *commandRuntime) projectList(cmd *cobra.Command, args []string) error {

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -14,12 +14,14 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/nexu-io/looper/internal/version"
 )
 
 func allowVersionStatusProbeOnly(t *testing.T) *http.Client {
 	t.Helper()
 	return newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
-		if req.URL.Path == "/api/v1/status" {
+		if req.URL.Path == "/api/v1/status" || req.URL.Path == "/api/v1/version" {
 			return nil, os.ErrNotExist
 		}
 		t.Fatalf("unexpected auto-upgrade request to %q", req.URL.String())
@@ -819,10 +821,12 @@ func TestAutoUpgradeReadyNoticePrintsRestartCommand(t *testing.T) {
 		CLIChannel:     cliInstallChannelStable,
 		HTTPClient: newTestHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.String() {
+			case "http://127.0.0.1:4321/api/v1/version":
+				return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"requestId":"req_version","data":{"version":"0.2.0","build":{"apiVersion":%q},"binary":{"name":"looperd","path":%q}}}`, version.Current().Metadata.APIVersion, managedPath)), nil
 			case "http://127.0.0.1:4321/api/v1/status":
 				return jsonResponse(t, http.StatusOK, fmt.Sprintf(`{"ok":true,"requestId":"req_status","data":{"service":{"version":"0.2.0","binary":{"name":"looperd","path":%q}}}}`, managedPath)), nil
 			default:
-				if req.URL.Path == "/api/v1/status" {
+				if req.URL.Path == "/api/v1/status" || req.URL.Path == "/api/v1/version" {
 					return nil, os.ErrNotExist
 				}
 				t.Fatalf("unexpected request URL %q", req.URL.String())

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -822,6 +822,7 @@ func (r *RunsRepository) ListLatestByLoopStatusesAndResumePolicy(ctx context.Con
 			)
 		) r ON r.loop_id = l.id
 		WHERE l.status IN (`+sqlPlaceholders(len(statuses))+`)
+		AND json_valid(r.checkpoint_json)
 		AND json_extract(r.checkpoint_json, '$.resumePolicy') = ?
 		ORDER BY r.started_at DESC, r.created_at DESC, r.id DESC
 	`, args...)

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -591,6 +592,87 @@ func (r *LoopsRepository) List(ctx context.Context) ([]LoopRecord, error) {
 	return scanLoops(rows)
 }
 
+func (r *LoopsRepository) ListByStatuses(ctx context.Context, statuses []string) ([]LoopRecord, error) {
+	if len(statuses) == 0 {
+		return []LoopRecord{}, nil
+	}
+	args := make([]any, 0, len(statuses))
+	for _, status := range statuses {
+		args = append(args, status)
+	}
+	rows, err := r.q.QueryContext(ctx, `SELECT * FROM loops WHERE status IN (`+sqlPlaceholders(len(statuses))+`) ORDER BY updated_at DESC, seq DESC`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list loops by statuses: %w", err)
+	}
+	defer rows.Close()
+
+	return scanLoops(rows)
+}
+
+func (r *LoopsRepository) ListByIDs(ctx context.Context, ids []string) ([]LoopRecord, error) {
+	if len(ids) == 0 {
+		return []LoopRecord{}, nil
+	}
+	chunks := chunkStrings(ids, sqliteMaxVariables)
+	items := make([]LoopRecord, 0, len(ids))
+	for _, chunk := range chunks {
+		args := make([]any, 0, len(chunk))
+		for _, id := range chunk {
+			args = append(args, id)
+		}
+		rows, err := r.q.QueryContext(ctx, `SELECT * FROM loops WHERE id IN (`+sqlPlaceholders(len(chunk))+`) ORDER BY updated_at DESC, seq DESC`, args...)
+		if err != nil {
+			return nil, fmt.Errorf("list loops by ids: %w", err)
+		}
+		chunkItems, scanErr := scanLoops(rows)
+		closeErr := rows.Close()
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close list loops by ids rows: %w", closeErr)
+		}
+		items = append(items, chunkItems...)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].UpdatedAt != items[j].UpdatedAt {
+			return items[i].UpdatedAt > items[j].UpdatedAt
+		}
+		if items[i].Seq != items[j].Seq {
+			return items[i].Seq > items[j].Seq
+		}
+		return items[i].ID > items[j].ID
+	})
+	return items, nil
+}
+
+func (r *LoopsRepository) CountByTypeAndStatus(ctx context.Context) (map[string]map[string]int64, error) {
+	rows, err := r.q.QueryContext(ctx, `SELECT type, status, COUNT(*) FROM loops GROUP BY type, status`)
+	if err != nil {
+		return nil, fmt.Errorf("count loops by type and status: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]map[string]int64{}
+	for rows.Next() {
+		var loopType string
+		var status string
+		var count int64
+		if err := rows.Scan(&loopType, &status, &count); err != nil {
+			return nil, fmt.Errorf("scan loop counts by type and status: %w", err)
+		}
+		if counts[loopType] == nil {
+			counts[loopType] = map[string]int64{}
+		}
+		counts[loopType][status] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate loop counts by type and status: %w", err)
+	}
+
+	return counts, nil
+}
+
 type RunsRepository struct{ q sqliteQuerier }
 
 type AgentExecutionsRepository struct{ q sqliteQuerier }
@@ -650,6 +732,107 @@ func (r *RunsRepository) GetLatestByLoopID(ctx context.Context, loopID string) (
 	return &record, nil
 }
 
+func (r *RunsRepository) ListLatestByLoopIDs(ctx context.Context, loopIDs []string) ([]RunRecord, error) {
+	if len(loopIDs) == 0 {
+		return []RunRecord{}, nil
+	}
+	chunks := chunkStrings(loopIDs, sqliteMaxVariables/2)
+	items := make([]RunRecord, 0, len(loopIDs))
+	for _, chunk := range chunks {
+		args := make([]any, 0, len(chunk)*2)
+		for _, loopID := range chunk {
+			args = append(args, loopID)
+		}
+		for _, loopID := range chunk {
+			args = append(args, loopID)
+		}
+		rows, err := r.q.QueryContext(ctx, `
+			SELECT r.*
+			FROM runs r
+			JOIN (
+				SELECT loop_id, MAX(started_at) AS started_at
+				FROM runs
+				WHERE loop_id IN (`+sqlPlaceholders(len(chunk))+`)
+				GROUP BY loop_id
+			) latest ON latest.loop_id = r.loop_id AND latest.started_at = r.started_at
+			WHERE r.loop_id IN (`+sqlPlaceholders(len(chunk))+`)
+			AND r.id = (
+				SELECT id FROM runs latest_id
+				WHERE latest_id.loop_id = r.loop_id AND latest_id.started_at = r.started_at
+				ORDER BY latest_id.created_at DESC, latest_id.id DESC
+				LIMIT 1
+			)
+			ORDER BY r.started_at DESC, r.created_at DESC, r.id DESC
+		`, args...)
+		if err != nil {
+			return nil, fmt.Errorf("list latest runs by loop ids: %w", err)
+		}
+		chunkItems, scanErr := scanRuns(rows)
+		closeErr := rows.Close()
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close list latest runs by loop ids rows: %w", closeErr)
+		}
+		items = append(items, chunkItems...)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].StartedAt != items[j].StartedAt {
+			return items[i].StartedAt > items[j].StartedAt
+		}
+		if items[i].CreatedAt != items[j].CreatedAt {
+			return items[i].CreatedAt > items[j].CreatedAt
+		}
+		return items[i].ID > items[j].ID
+	})
+	return items, nil
+}
+
+func (r *RunsRepository) ListLatestByLoopStatusesAndResumePolicy(ctx context.Context, statuses []string, resumePolicy string) ([]RunRecord, error) {
+	if len(statuses) == 0 || strings.TrimSpace(resumePolicy) == "" {
+		return []RunRecord{}, nil
+	}
+	args := make([]any, 0, len(statuses)+1)
+	for _, status := range statuses {
+		args = append(args, status)
+	}
+	for _, status := range statuses {
+		args = append(args, status)
+	}
+	args = append(args, resumePolicy)
+	rows, err := r.q.QueryContext(ctx, `
+		SELECT r.*
+		FROM loops l
+		JOIN (
+			SELECT latest_runs.*
+			FROM runs latest_runs
+			JOIN (
+				SELECT runs.loop_id, MAX(runs.started_at) AS started_at
+				FROM runs
+				JOIN loops candidate_loops ON candidate_loops.id = runs.loop_id
+				WHERE candidate_loops.status IN (`+sqlPlaceholders(len(statuses))+`)
+				GROUP BY runs.loop_id
+			) latest ON latest.loop_id = latest_runs.loop_id AND latest.started_at = latest_runs.started_at
+			WHERE latest_runs.id = (
+				SELECT id FROM runs latest_id
+				WHERE latest_id.loop_id = latest_runs.loop_id AND latest_id.started_at = latest_runs.started_at
+				ORDER BY latest_id.created_at DESC, latest_id.id DESC
+				LIMIT 1
+			)
+		) r ON r.loop_id = l.id
+		WHERE l.status IN (`+sqlPlaceholders(len(statuses))+`)
+		AND json_extract(r.checkpoint_json, '$.resumePolicy') = ?
+		ORDER BY r.started_at DESC, r.created_at DESC, r.id DESC
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list latest runs by loop statuses and resume policy: %w", err)
+	}
+	defer rows.Close()
+
+	return scanRuns(rows)
+}
+
 func (r *RunsRepository) HasRunningByLoopID(ctx context.Context, loopID string) (bool, error) {
 	var count int64
 	if err := r.q.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs WHERE loop_id = ? AND status = 'running'`, loopID).Scan(&count); err != nil {
@@ -667,6 +850,29 @@ func (r *RunsRepository) List(ctx context.Context) ([]RunRecord, error) {
 	defer rows.Close()
 
 	return scanRuns(rows)
+}
+
+func (r *RunsRepository) CountByStatus(ctx context.Context) (map[string]int64, error) {
+	rows, err := r.q.QueryContext(ctx, `SELECT status, COUNT(*) FROM runs GROUP BY status`)
+	if err != nil {
+		return nil, fmt.Errorf("count runs by status: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]int64{}
+	for rows.Next() {
+		var status string
+		var count int64
+		if err := rows.Scan(&status, &count); err != nil {
+			return nil, fmt.Errorf("scan run counts by status: %w", err)
+		}
+		counts[status] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate run counts by status: %w", err)
+	}
+
+	return counts, nil
 }
 
 func (r *RunsRepository) ListSince(ctx context.Context, sinceISO string) ([]RunRecord, error) {
@@ -1390,6 +1596,46 @@ func (r *QueueRepository) List(ctx context.Context) ([]QueueItemRecord, error) {
 	return scanQueueItems(rows)
 }
 
+func (r *QueueRepository) ListByStatuses(ctx context.Context, statuses []string) ([]QueueItemRecord, error) {
+	if len(statuses) == 0 {
+		return []QueueItemRecord{}, nil
+	}
+	args := make([]any, 0, len(statuses))
+	for _, status := range statuses {
+		args = append(args, status)
+	}
+	rows, err := r.q.QueryContext(ctx, `SELECT * FROM queue_items WHERE status IN (`+sqlPlaceholders(len(statuses))+`) ORDER BY created_at DESC, id DESC`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list queue items by statuses: %w", err)
+	}
+	defer rows.Close()
+
+	return scanQueueItems(rows)
+}
+
+func (r *QueueRepository) CountByAllStatuses(ctx context.Context) (map[string]int64, error) {
+	rows, err := r.q.QueryContext(ctx, `SELECT status, COUNT(*) FROM queue_items GROUP BY status`)
+	if err != nil {
+		return nil, fmt.Errorf("count queue items by all statuses: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]int64{}
+	for rows.Next() {
+		var status string
+		var count int64
+		if err := rows.Scan(&status, &count); err != nil {
+			return nil, fmt.Errorf("scan queue item counts by all statuses: %w", err)
+		}
+		counts[status] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate queue item counts by all statuses: %w", err)
+	}
+
+	return counts, nil
+}
+
 func (r *QueueRepository) ListQueued(ctx context.Context, limit int64) ([]QueueItemRecord, error) {
 	if limit <= 0 {
 		limit = 100
@@ -2061,6 +2307,33 @@ func nullableInt64(value sql.NullInt64) *int64 {
 
 	intValue := value.Int64
 	return &intValue
+}
+
+func sqlPlaceholders(count int) string {
+	if count <= 0 {
+		return ""
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", count), ",")
+}
+
+const sqliteMaxVariables = 900
+
+func chunkStrings(values []string, chunkSize int) [][]string {
+	if len(values) == 0 {
+		return nil
+	}
+	if chunkSize <= 0 {
+		chunkSize = len(values)
+	}
+	chunks := make([][]string, 0, (len(values)+chunkSize-1)/chunkSize)
+	for start := 0; start < len(values); start += chunkSize {
+		end := start + chunkSize
+		if end > len(values) {
+			end = len(values)
+		}
+		chunks = append(chunks, values[start:end])
+	}
+	return chunks
 }
 
 const scheduledQueueBaseQuery = `

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -1613,6 +1613,41 @@ func (r *QueueRepository) ListByStatuses(ctx context.Context, statuses []string)
 	return scanQueueItems(rows)
 }
 
+func (r *QueueRepository) ListLatestByLoopStatuses(ctx context.Context, statuses []string) ([]QueueItemRecord, error) {
+	if len(statuses) == 0 {
+		return []QueueItemRecord{}, nil
+	}
+	args := make([]any, 0, len(statuses))
+	for _, status := range statuses {
+		args = append(args, status)
+	}
+	rows, err := r.q.QueryContext(ctx, `
+		SELECT
+			id, project_id, loop_id, type, target_type, target_id, repo, pr_number, dedupe_key,
+			priority, status, available_at, attempts, max_attempts, claimed_by, claimed_at,
+			started_at, finished_at, lock_key, payload_json, last_error, last_error_kind,
+			created_at, updated_at
+		FROM (
+			SELECT
+				queue_items.*,
+				ROW_NUMBER() OVER (
+					PARTITION BY loop_id
+					ORDER BY updated_at DESC, created_at DESC, id DESC
+				) AS row_num
+			FROM queue_items
+			WHERE loop_id IS NOT NULL AND TRIM(loop_id) != ''
+		)
+		WHERE row_num = 1 AND status IN (`+sqlPlaceholders(len(statuses))+`)
+		ORDER BY created_at DESC, id DESC
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list latest queue items by loop statuses: %w", err)
+	}
+	defer rows.Close()
+
+	return scanQueueItems(rows)
+}
+
 func (r *QueueRepository) CountByAllStatuses(ctx context.Context) (map[string]int64, error) {
 	rows, err := r.q.QueryContext(ctx, `SELECT status, COUNT(*) FROM queue_items GROUP BY status`)
 	if err != nil {

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -1657,6 +1657,51 @@ func TestTargetedListRepositories(t *testing.T) {
 
 }
 
+func TestRunsListLatestByLoopStatusesAndResumePolicySkipsMalformedCheckpointJSON(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	ctx := context.Background()
+	repos := NewRepositories(coordinator.DB())
+
+	now := "2026-04-11T12:00:00.000Z"
+	later := "2026-04-11T12:10:00.000Z"
+	projectID := "project_resume_policy"
+	checkpoint := `{"resumePolicy":"manual_intervention"}`
+	malformedCheckpoint := `{"resumePolicy":`
+
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	for _, loop := range []LoopRecord{
+		{ID: "loop_valid", Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "failed", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_malformed", Seq: 2, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "failed", CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := repos.Loops.Upsert(ctx, loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+	for _, run := range []RunRecord{
+		{ID: "run_valid", LoopID: "loop_valid", Status: "failed", CheckpointJSON: &checkpoint, StartedAt: later, CreatedAt: later, UpdatedAt: later},
+		{ID: "run_malformed", LoopID: "loop_malformed", Status: "failed", CheckpointJSON: &malformedCheckpoint, StartedAt: later, CreatedAt: later, UpdatedAt: later},
+	} {
+		if err := repos.Runs.Upsert(ctx, run); err != nil {
+			t.Fatalf("Runs.Upsert(%s) error = %v", run.ID, err)
+		}
+	}
+
+	runs, err := repos.Runs.ListLatestByLoopStatusesAndResumePolicy(ctx, []string{"failed"}, "manual_intervention")
+	if err != nil {
+		t.Fatalf("Runs.ListLatestByLoopStatusesAndResumePolicy() error = %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("len(Runs.ListLatestByLoopStatusesAndResumePolicy()) = %d, want 1", len(runs))
+	}
+	if runs[0].ID != "run_valid" {
+		t.Fatalf("Runs.ListLatestByLoopStatusesAndResumePolicy()[0].ID = %q, want run_valid", runs[0].ID)
+	}
+}
+
 func TestRepositoriesListByIDHelpersChunkLargeInput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -1599,6 +1599,7 @@ func TestTargetedListRepositories(t *testing.T) {
 	for _, item := range []QueueItemRecord{
 		{ID: "queue_queued", ProjectID: &projectID, LoopID: &loopQueued, Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "queued", Priority: QueuePriorityWorker, Status: "queued", AvailableAt: now, Attempts: 0, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
 		{ID: "queue_manual", ProjectID: &projectID, LoopID: &loopManual, Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "manual", Priority: QueuePriorityWorker, Status: "manual_intervention", AvailableAt: now, Attempts: 1, MaxAttempts: 3, LastErrorKind: &manualKind, CreatedAt: later, UpdatedAt: later},
+		{ID: "queue_done_manual_old", ProjectID: &projectID, LoopID: &loopDone, Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "done_manual_old", Priority: QueuePriorityWorker, Status: "manual_intervention", AvailableAt: now, Attempts: 1, MaxAttempts: 3, LastErrorKind: &manualKind, CreatedAt: now, UpdatedAt: now},
 		{ID: "queue_done", ProjectID: &projectID, LoopID: &loopDone, Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "done", Priority: QueuePriorityWorker, Status: "completed", AvailableAt: now, Attempts: 1, MaxAttempts: 3, CreatedAt: later, UpdatedAt: later},
 	} {
 		if err := repos.Queue.Upsert(ctx, item); err != nil {
@@ -1627,8 +1628,21 @@ func TestTargetedListRepositories(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.ListByStatuses() error = %v", err)
 	}
-	if len(queueByStatus) != 2 {
-		t.Fatalf("len(Queue.ListByStatuses()) = %d, want 2", len(queueByStatus))
+	if len(queueByStatus) != 3 {
+		t.Fatalf("len(Queue.ListByStatuses()) = %d, want 3", len(queueByStatus))
+	}
+
+	latestQueueByStatus, err := repos.Queue.ListLatestByLoopStatuses(ctx, []string{"queued", "manual_intervention"})
+	if err != nil {
+		t.Fatalf("Queue.ListLatestByLoopStatuses() error = %v", err)
+	}
+	if len(latestQueueByStatus) != 2 {
+		t.Fatalf("len(Queue.ListLatestByLoopStatuses()) = %d, want 2", len(latestQueueByStatus))
+	}
+	latestQueueIDs := []string{latestQueueByStatus[0].ID, latestQueueByStatus[1].ID}
+	sort.Strings(latestQueueIDs)
+	if want := []string{"queue_manual", "queue_queued"}; !reflect.DeepEqual(latestQueueIDs, want) {
+		t.Fatalf("Queue.ListLatestByLoopStatuses() ids = %#v, want %#v", latestQueueIDs, want)
 	}
 
 	latestRuns, err := repos.Runs.ListLatestByLoopIDs(ctx, []string{loopManual, loopDone})

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -297,6 +299,95 @@ func TestRepositoriesRoundTripForProjectsLoopsRunsAndRuntimeMetadata(t *testing.
 	}
 	if worktree.BaseBranch == nil || *worktree.BaseBranch != mainBranch {
 		t.Fatalf("Worktrees.GetByBranch().BaseBranch = %#v, want %q", worktree.BaseBranch, mainBranch)
+	}
+}
+
+func TestRepositoriesStatusAggregates(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	ctx := context.Background()
+	repos := NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/looper", Archived: false, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	for _, loop := range []LoopRecord{
+		{ID: "loop_reviewer_running", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Status: "running", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_reviewer_waiting", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Status: "waiting", CreatedAt: now, UpdatedAt: now},
+		{ID: "loop_worker_failed", Seq: 3, ProjectID: "project_1", Type: "worker", TargetType: "project", Status: "failed", CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := repos.Loops.Upsert(ctx, loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+
+	largeCheckpoint := make([]byte, 64*1024)
+	for i := range largeCheckpoint {
+		largeCheckpoint[i] = 'x'
+	}
+	checkpointJSON := string(largeCheckpoint)
+	for _, run := range []RunRecord{
+		{ID: "run_running", LoopID: "loop_reviewer_running", Status: "running", CheckpointJSON: &checkpointJSON, StartedAt: now, CreatedAt: now, UpdatedAt: now},
+		{ID: "run_failed", LoopID: "loop_worker_failed", Status: "failed", CheckpointJSON: &checkpointJSON, StartedAt: now, CreatedAt: now, UpdatedAt: now},
+		{ID: "run_completed", LoopID: "loop_reviewer_waiting", Status: "completed", CheckpointJSON: &checkpointJSON, StartedAt: now, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := repos.Runs.Upsert(ctx, run); err != nil {
+			t.Fatalf("Runs.Upsert(%s) error = %v", run.ID, err)
+		}
+	}
+
+	for _, item := range []QueueItemRecord{
+		{ID: "queue_queued", Type: "reviewer", TargetType: "pull_request", TargetID: "pr:1", DedupeKey: "reviewer:1", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "queue_running", Type: "worker", TargetType: "project", TargetID: "project:1", DedupeKey: "worker:1", Priority: 1, Status: "running", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "queue_failed", Type: "fixer", TargetType: "project", TargetID: "project:2", DedupeKey: "fixer:2", Priority: 1, Status: "failed", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := repos.Queue.Upsert(ctx, item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+
+	loopCounts, err := repos.Loops.CountByTypeAndStatus(ctx)
+	if err != nil {
+		t.Fatalf("Loops.CountByTypeAndStatus() error = %v", err)
+	}
+	if got := loopCounts["reviewer"]["running"]; got != 1 {
+		t.Fatalf("reviewer/running loop count = %d, want 1", got)
+	}
+	if got := loopCounts["reviewer"]["waiting"]; got != 1 {
+		t.Fatalf("reviewer/waiting loop count = %d, want 1", got)
+	}
+	if got := loopCounts["worker"]["failed"]; got != 1 {
+		t.Fatalf("worker/failed loop count = %d, want 1", got)
+	}
+
+	runCounts, err := repos.Runs.CountByStatus(ctx)
+	if err != nil {
+		t.Fatalf("Runs.CountByStatus() error = %v", err)
+	}
+	if got := runCounts["running"]; got != 1 {
+		t.Fatalf("running run count = %d, want 1", got)
+	}
+	if got := runCounts["failed"]; got != 1 {
+		t.Fatalf("failed run count = %d, want 1", got)
+	}
+	if got := runCounts["completed"]; got != 1 {
+		t.Fatalf("completed run count = %d, want 1", got)
+	}
+
+	queueCounts, err := repos.Queue.CountByAllStatuses(ctx)
+	if err != nil {
+		t.Fatalf("Queue.CountByAllStatuses() error = %v", err)
+	}
+	if got := queueCounts["queued"]; got != 1 {
+		t.Fatalf("queued queue count = %d, want 1", got)
+	}
+	if got := queueCounts["running"]; got != 1 {
+		t.Fatalf("running queue count = %d, want 1", got)
+	}
+	if got := queueCounts["failed"]; got != 1 {
+		t.Fatalf("failed queue count = %d, want 1", got)
 	}
 }
 
@@ -1475,6 +1566,121 @@ func TestQueueRetryFailCompleteTransitions(t *testing.T) {
 	}
 	if gotFailed == nil || gotFailed.Status != "manual_intervention" || gotFailed.LastError == nil || *gotFailed.LastError != failReason || gotFailed.Attempts != 4 {
 		t.Fatalf("Queue.GetByID(qi_fail) after fail = %#v, want manual_intervention", gotFailed)
+	}
+}
+
+func TestTargetedListRepositories(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	ctx := context.Background()
+	repos := NewRepositories(coordinator.DB())
+
+	now := "2026-04-11T12:00:00.000Z"
+	later := "2026-04-11T12:10:00.000Z"
+	projectID := "project_targeted"
+	loopQueued := "loop_queued"
+	loopManual := "loop_manual"
+	loopDone := "loop_done"
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	for _, loop := range []LoopRecord{
+		{ID: loopQueued, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "queued", CreatedAt: now, UpdatedAt: now},
+		{ID: loopManual, Seq: 2, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "failed", CreatedAt: now, UpdatedAt: later},
+		{ID: loopDone, Seq: 3, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "completed", CreatedAt: now, UpdatedAt: later},
+	} {
+		if err := repos.Loops.Upsert(ctx, loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+	manualKind := "manual_intervention"
+	checkpoint := `{"resumePolicy":"manual_intervention"}`
+	for _, item := range []QueueItemRecord{
+		{ID: "queue_queued", ProjectID: &projectID, LoopID: &loopQueued, Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "queued", Priority: QueuePriorityWorker, Status: "queued", AvailableAt: now, Attempts: 0, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "queue_manual", ProjectID: &projectID, LoopID: &loopManual, Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "manual", Priority: QueuePriorityWorker, Status: "manual_intervention", AvailableAt: now, Attempts: 1, MaxAttempts: 3, LastErrorKind: &manualKind, CreatedAt: later, UpdatedAt: later},
+		{ID: "queue_done", ProjectID: &projectID, LoopID: &loopDone, Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "done", Priority: QueuePriorityWorker, Status: "completed", AvailableAt: now, Attempts: 1, MaxAttempts: 3, CreatedAt: later, UpdatedAt: later},
+	} {
+		if err := repos.Queue.Upsert(ctx, item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+	for _, run := range []RunRecord{
+		{ID: "run_manual_old", LoopID: loopManual, Status: "running", StartedAt: now, CreatedAt: now, UpdatedAt: now},
+		{ID: "run_manual_latest", LoopID: loopManual, Status: "failed", CheckpointJSON: &checkpoint, StartedAt: later, CreatedAt: later, UpdatedAt: later},
+		{ID: "run_done", LoopID: loopDone, Status: "completed", StartedAt: later, CreatedAt: later, UpdatedAt: later},
+	} {
+		if err := repos.Runs.Upsert(ctx, run); err != nil {
+			t.Fatalf("Runs.Upsert(%s) error = %v", run.ID, err)
+		}
+	}
+
+	loopsByStatus, err := repos.Loops.ListByStatuses(ctx, []string{"queued", "running"})
+	if err != nil {
+		t.Fatalf("Loops.ListByStatuses() error = %v", err)
+	}
+	if len(loopsByStatus) != 1 || loopsByStatus[0].ID != loopQueued {
+		t.Fatalf("Loops.ListByStatuses() = %#v, want queued loop only", loopsByStatus)
+	}
+
+	queueByStatus, err := repos.Queue.ListByStatuses(ctx, []string{"queued", "manual_intervention"})
+	if err != nil {
+		t.Fatalf("Queue.ListByStatuses() error = %v", err)
+	}
+	if len(queueByStatus) != 2 {
+		t.Fatalf("len(Queue.ListByStatuses()) = %d, want 2", len(queueByStatus))
+	}
+
+	latestRuns, err := repos.Runs.ListLatestByLoopIDs(ctx, []string{loopManual, loopDone})
+	if err != nil {
+		t.Fatalf("Runs.ListLatestByLoopIDs() error = %v", err)
+	}
+	gotRunIDs := []string{latestRuns[0].ID, latestRuns[1].ID}
+	sort.Strings(gotRunIDs)
+	if want := []string{"run_done", "run_manual_latest"}; !reflect.DeepEqual(gotRunIDs, want) {
+		t.Fatalf("Runs.ListLatestByLoopIDs() ids = %#v, want %#v", gotRunIDs, want)
+	}
+
+}
+
+func TestRepositoriesListByIDHelpersChunkLargeInput(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	ctx := context.Background()
+	repos := NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: "project_chunk", Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	loopIDs := make([]string, 0, sqliteMaxVariables+5)
+	for i := 0; i < sqliteMaxVariables+5; i++ {
+		loopID := fmt.Sprintf("loop_chunk_%04d", i)
+		loopIDs = append(loopIDs, loopID)
+		if err := repos.Loops.Upsert(ctx, LoopRecord{ID: loopID, Seq: int64(i + 1), ProjectID: "project_chunk", Type: "worker", TargetType: "project", Status: "paused", CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loopID, err)
+		}
+		runID := fmt.Sprintf("run_chunk_%04d", i)
+		if err := repos.Runs.Upsert(ctx, RunRecord{ID: runID, LoopID: loopID, Status: "failed", StartedAt: now, CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("Runs.Upsert(%s) error = %v", runID, err)
+		}
+	}
+
+	loopsList, err := repos.Loops.ListByIDs(ctx, loopIDs)
+	if err != nil {
+		t.Fatalf("Loops.ListByIDs() error = %v", err)
+	}
+	if got := len(loopsList); got != len(loopIDs) {
+		t.Fatalf("len(Loops.ListByIDs()) = %d, want %d", got, len(loopIDs))
+	}
+
+	latestRuns, err := repos.Runs.ListLatestByLoopIDs(ctx, loopIDs)
+	if err != nil {
+		t.Fatalf("Runs.ListLatestByLoopIDs() error = %v", err)
+	}
+	if got := len(latestRuns); got != len(loopIDs) {
+		t.Fatalf("len(Runs.ListLatestByLoopIDs()) = %d, want %d", got, len(loopIDs))
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a lightweight daemon version endpoint and make `looper version` avoid slow legacy status probes
- replace `/api/v1/status` full row scans with aggregate count queries
- optimize `looper ps` active-runs loading with targeted queue/loop/latest-run queries and chunked bulk ID lookups

## Validation
- `go test ./internal/storage ./internal/api ./internal/cliapp`
- `go vet ./...`
- `go build ./...`
- `go test ./...`

## Local performance notes
- legacy `/api/v1/status` was dominated by reading large `runs.checkpoint_json` payloads
- final manual-intervention latest-run candidate SQL measured about 0.07s on the local DB