### PR TITLE
fix: reduce looper ps sqlite contention

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2643,6 +2643,10 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 	for _, loop := range loopsList {
 		loopsByID[loop.ID] = loop
 	}
+	projectNamesByID, err := loadProjectNamesByIDForActiveRunTargets(ctx, services.Repositories.Projects, loopsList)
+	if err != nil {
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
 
 	queuedLoopIDs := make(map[string]struct{})
 	latestQueueByLoopID := latestQueueItemByLoopID(queueItems)
@@ -2676,7 +2680,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			continue
 		}
 		plausiblyLiveRunningLoopIDs[run.LoopID] = struct{}{}
-		target, ok, err := h.tryBuildActiveRunTarget(ctx, loop)
+		target, ok, err := h.tryBuildActiveRunTarget(loop, projectNamesByID)
 		if err != nil {
 			return nil, err
 		}
@@ -2720,7 +2724,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 
 	queuedViews := make([]activeRunView, 0, len(queuedLoops))
 	for _, loop := range queuedLoops {
-		target, ok, err := h.tryBuildActiveRunTarget(ctx, loop)
+		target, ok, err := h.tryBuildActiveRunTarget(loop, projectNamesByID)
 		if err != nil {
 			return nil, err
 		}
@@ -2748,7 +2752,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 
 	runningLoopViews := make([]activeRunView, 0, len(runningLoopsWithoutRuns))
 	for _, loop := range runningLoopsWithoutRuns {
-		target, ok, err := h.tryBuildActiveRunTarget(ctx, loop)
+		target, ok, err := h.tryBuildActiveRunTarget(loop, projectNamesByID)
 		if err != nil {
 			return nil, err
 		}
@@ -2795,7 +2799,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 		if !includeInactiveLoops && !isManualInterventionQueue(latestQueue) && !hasManualInterventionResumePolicy(latestRun) {
 			continue
 		}
-		target, ok, err := h.tryBuildActiveRunTarget(ctx, loop)
+		target, ok, err := h.tryBuildActiveRunTarget(loop, projectNamesByID)
 		if err != nil {
 			return nil, err
 		}
@@ -3112,7 +3116,35 @@ func runningLoopWithoutRunIsFresh(loop storage.LoopRecord, now time.Time, ttl ti
 	return !parsed.UTC().Before(now.UTC().Add(-ttl))
 }
 
-func (h *Handler) tryBuildActiveRunTarget(ctx context.Context, loop storage.LoopRecord) (activeRunTarget, bool, error) {
+func loadProjectNamesByIDForActiveRunTargets(ctx context.Context, repo *storage.ProjectsRepository, loopsList []storage.LoopRecord) (map[string]string, error) {
+	if !hasProjectActiveRunTarget(loopsList) {
+		return map[string]string{}, nil
+	}
+	projectsList, err := repo.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return projectNamesByID(projectsList), nil
+}
+
+func hasProjectActiveRunTarget(loopsList []storage.LoopRecord) bool {
+	for _, loop := range loopsList {
+		if loop.TargetType == string(domain.LoopTargetTypeProject) {
+			return true
+		}
+	}
+	return false
+}
+
+func projectNamesByID(projectsList []storage.ProjectRecord) map[string]string {
+	result := make(map[string]string, len(projectsList))
+	for _, project := range projectsList {
+		result[project.ID] = strings.TrimSpace(project.Name)
+	}
+	return result
+}
+
+func (h *Handler) tryBuildActiveRunTarget(loop storage.LoopRecord, projectNamesByID map[string]string) (activeRunTarget, bool, error) {
 	switch loop.TargetType {
 	case string(domain.LoopTargetTypeProject):
 		projectID := ""
@@ -3126,12 +3158,8 @@ func (h *Handler) tryBuildActiveRunTarget(ctx context.Context, loop storage.Loop
 			return activeRunTarget{}, false, nil
 		}
 		label := projectID
-		project, err := h.context.Runtime.Services().Repositories.Projects.GetByID(ctx, projectID)
-		if err != nil {
-			return activeRunTarget{}, false, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-		}
-		if project != nil && strings.TrimSpace(project.Name) != "" {
-			label = project.Name
+		if name := strings.TrimSpace(projectNamesByID[projectID]); name != "" {
+			label = name
 		}
 		return activeRunTarget{Type: string(domain.LoopTargetTypeProject), ProjectID: &projectID, Label: label}, true, nil
 	case string(domain.LoopTargetTypeIssue):

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -5730,6 +5730,26 @@ func TestActiveRunDetailIncludesRunningLoopWithoutRun(t *testing.T) {
 	assertEqual(t, target["label"], "acme/looper#43")
 }
 
+func TestProjectNamesByIDPreservesEmptyAndTrimmedNames(t *testing.T) {
+	projectsList := []storage.ProjectRecord{
+		{ID: "project_1", Name: "  Looper  "},
+		{ID: "project_2", Name: ""},
+		{ID: "project_3", Name: "   "},
+	}
+
+	got := projectNamesByID(projectsList)
+
+	assertEqual(t, got["project_1"], "Looper")
+	assertEqual(t, got["project_2"], "")
+	assertEqual(t, got["project_3"], "")
+	if _, ok := got["missing"]; ok {
+		t.Fatalf("unexpected entry for missing project: %#v", got)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3", len(got))
+	}
+}
+
 type testFixture struct {
 	rootDir string
 	now     time.Time

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -177,6 +177,7 @@ func sqliteDSN(dbPath string) string {
 		"_foreign_keys": "on",
 		"_busy_timeout": fmt.Sprintf("%d", sqliteBusyTimeoutMilliseconds),
 		"_journal_mode": "WAL",
+		"_txlock":       "immediate",
 	}
 	if dbPath == ":memory:" {
 		values := url.Values{}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 )
 
-const sqliteBusyTimeoutMilliseconds = 5000
+const (
+	sqliteBusyTimeoutMilliseconds = 5000
+	sqliteMaxOpenConnections      = 4
+)
 
 type SQLiteCoordinatorOptions struct {
 	Migrations []EmbeddedMigration
@@ -50,13 +54,17 @@ func OpenSQLiteDB(ctx context.Context, dbPath string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	db, err := sql.Open(DriverName, dbPath)
+	db, err := sql.Open(DriverName, sqliteDSN(dbPath))
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite database: %w", err)
 	}
 
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(1)
+	maxConns := sqliteMaxOpenConnections
+	if dbPath == ":memory:" {
+		maxConns = 1
+	}
+	db.SetMaxOpenConns(maxConns)
+	db.SetMaxIdleConns(maxConns)
 
 	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
@@ -162,6 +170,42 @@ func ensureSQLiteParentDir(dbPath string) error {
 	}
 
 	return nil
+}
+
+func sqliteDSN(dbPath string) string {
+	params := map[string]string{
+		"_foreign_keys": "on",
+		"_busy_timeout": fmt.Sprintf("%d", sqliteBusyTimeoutMilliseconds),
+		"_journal_mode": "WAL",
+	}
+	if dbPath == ":memory:" {
+		values := url.Values{}
+		values.Set("mode", "memory")
+		for key, value := range params {
+			values.Set(key, value)
+		}
+		return "file::memory:?" + values.Encode()
+	}
+
+	if strings.HasPrefix(dbPath, "file:") {
+		parsed, err := url.Parse(dbPath)
+		if err != nil {
+			return dbPath
+		}
+
+		query := parsed.Query()
+		for key, value := range params {
+			query.Set(key, value)
+		}
+		parsed.RawQuery = query.Encode()
+		return parsed.String()
+	}
+
+	values := url.Values{}
+	for key, value := range params {
+		values.Set(key, value)
+	}
+	return dbPath + "?" + values.Encode()
 }
 
 func applySQLitePragmas(ctx context.Context, db *sql.DB) error {

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -25,8 +26,8 @@ func TestOpenSQLiteCoordinatorCreatesParentDirAndAppliesPragmas(t *testing.T) {
 		}
 	})
 
-	if got := coordinator.DB().Stats().MaxOpenConnections; got != 1 {
-		t.Fatalf("db.Stats().MaxOpenConnections = %d, want 1", got)
+	if got := coordinator.DB().Stats().MaxOpenConnections; got != sqliteMaxOpenConnections {
+		t.Fatalf("db.Stats().MaxOpenConnections = %d, want %d", got, sqliteMaxOpenConnections)
 	}
 
 	if got := readStringPragmaForTest(t, coordinator.DB(), `PRAGMA journal_mode;`); got != "wal" {
@@ -39,6 +40,113 @@ func TestOpenSQLiteCoordinatorCreatesParentDirAndAppliesPragmas(t *testing.T) {
 
 	if got := readForeignKeysPragmaForTest(t, coordinator.DB()); !got {
 		t.Fatal("PRAGMA foreign_keys = false, want true")
+	}
+}
+
+func TestOpenSQLiteDBAppliesPragmasToMultipleConnections(t *testing.T) {
+	t.Parallel()
+
+	db, err := OpenSQLiteDB(context.Background(), filepath.Join(t.TempDir(), "looper.sqlite"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteDB() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	conns := make([]*sql.Conn, 0, sqliteMaxOpenConnections)
+	for i := 0; i < sqliteMaxOpenConnections; i++ {
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("db.Conn() #%d error = %v", i, err)
+		}
+		conns = append(conns, conn)
+	}
+	t.Cleanup(func() {
+		for _, conn := range conns {
+			if err := conn.Close(); err != nil {
+				t.Fatalf("conn.Close() error = %v", err)
+			}
+		}
+	})
+
+	for i, conn := range conns {
+		if got := readIntPragmaFromConnForTest(t, conn, `PRAGMA foreign_keys;`); got != 1 {
+			t.Fatalf("conn %d PRAGMA foreign_keys = %d, want 1", i, got)
+		}
+		if got := readIntPragmaFromConnForTest(t, conn, `PRAGMA busy_timeout;`); got != sqliteBusyTimeoutMilliseconds {
+			t.Fatalf("conn %d PRAGMA busy_timeout = %d, want %d", i, got, sqliteBusyTimeoutMilliseconds)
+		}
+		if got := readStringPragmaFromConnForTest(t, conn, `PRAGMA journal_mode;`); got != "wal" {
+			t.Fatalf("conn %d PRAGMA journal_mode = %q, want %q", i, got, "wal")
+		}
+	}
+}
+
+func TestOpenSQLiteDBAllowsReadDuringWriteTransaction(t *testing.T) {
+	t.Parallel()
+
+	db, err := OpenSQLiteDB(context.Background(), filepath.Join(t.TempDir(), "looper.sqlite"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteDB() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)`); err != nil {
+		t.Fatalf("db.ExecContext(CREATE TABLE) error = %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO widgets (id, name) VALUES (1, 'alpha')`); err != nil {
+		t.Fatalf("db.ExecContext(INSERT) error = %v", err)
+	}
+
+	writerConn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("db.Conn(writer) error = %v", err)
+	}
+	defer writerConn.Close()
+
+	tx, err := writerConn.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("writerConn.BeginTx() error = %v", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `UPDATE widgets SET name = 'beta' WHERE id = 1`); err != nil {
+		t.Fatalf("tx.ExecContext(UPDATE) error = %v", err)
+	}
+
+	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	resultCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		var name string
+		err := db.QueryRowContext(readCtx, `SELECT name FROM widgets WHERE id = 1`).Scan(&name)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		resultCh <- name
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("read during write returned error = %v", err)
+	case name := <-resultCh:
+		if name != "alpha" {
+			t.Fatalf("read during write name = %q, want %q", name, "alpha")
+		}
+	case <-readCtx.Done():
+		t.Fatalf("read during write timed out: %v", readCtx.Err())
 	}
 }
 
@@ -324,12 +432,34 @@ func readStringPragmaForTest(t *testing.T, db *sql.DB, query string) string {
 	return value
 }
 
+func readStringPragmaFromConnForTest(t *testing.T, conn *sql.Conn, query string) string {
+	t.Helper()
+
+	var value string
+	if err := conn.QueryRowContext(context.Background(), query).Scan(&value); err != nil {
+		t.Fatalf("conn.QueryRowContext(%q).Scan() error = %v", query, err)
+	}
+
+	return strings.ToLower(value)
+}
+
 func readIntPragmaForTest(t *testing.T, db *sql.DB, query string) int {
 	t.Helper()
 
 	var value int
 	if err := db.QueryRow(query).Scan(&value); err != nil {
 		t.Fatalf("db.QueryRow(%q).Scan() error = %v", query, err)
+	}
+
+	return value
+}
+
+func readIntPragmaFromConnForTest(t *testing.T, conn *sql.Conn, query string) int {
+	t.Helper()
+
+	var value int
+	if err := conn.QueryRowContext(context.Background(), query).Scan(&value); err != nil {
+		t.Fatalf("conn.QueryRowContext(%q).Scan() error = %v", query, err)
 	}
 
 	return value

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -345,6 +345,82 @@ func TestSQLiteCoordinatorSerializesConcurrentTransactionsWithoutDataLoss(t *tes
 	}
 }
 
+func TestSQLiteCoordinatorWithTransactionBeginsImmediateTransactions(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openTestSQLiteCoordinator(t)
+	ctx := context.Background()
+
+	if _, err := coordinator.DB().ExecContext(ctx, `CREATE TABLE counters (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)`); err != nil {
+		t.Fatalf("db.ExecContext(CREATE TABLE counters) error = %v", err)
+	}
+	if _, err := coordinator.DB().ExecContext(ctx, `INSERT INTO counters (id, value) VALUES (1, 0)`); err != nil {
+		t.Fatalf("db.ExecContext(INSERT counters) error = %v", err)
+	}
+
+	firstStarted := make(chan struct{})
+	allowFirstCommit := make(chan struct{})
+	secondStarted := make(chan struct{})
+	errCh := make(chan error, 2)
+
+	go func() {
+		errCh <- coordinator.WithTransaction(ctx, func(tx *sql.Tx) error {
+			var value int
+			if err := tx.QueryRowContext(ctx, `SELECT value FROM counters WHERE id = 1`).Scan(&value); err != nil {
+				return err
+			}
+			close(firstStarted)
+			<-allowFirstCommit
+			_, err := tx.ExecContext(ctx, `UPDATE counters SET value = ? WHERE id = 1`, value+1)
+			return err
+		})
+	}()
+
+	select {
+	case <-firstStarted:
+	case err := <-errCh:
+		t.Fatalf("first transaction returned early: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("first transaction did not start")
+	}
+
+	go func() {
+		errCh <- coordinator.WithTransaction(ctx, func(tx *sql.Tx) error {
+			close(secondStarted)
+			var value int
+			if err := tx.QueryRowContext(ctx, `SELECT value FROM counters WHERE id = 1`).Scan(&value); err != nil {
+				return err
+			}
+			_, err := tx.ExecContext(ctx, `UPDATE counters SET value = ? WHERE id = 1`, value+1)
+			return err
+		})
+	}()
+
+	select {
+	case <-secondStarted:
+		t.Fatal("second transaction began before first transaction committed")
+	case err := <-errCh:
+		t.Fatalf("transaction returned early: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(allowFirstCommit)
+
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("coordinator.WithTransaction() error = %v", err)
+		}
+	}
+
+	var counterValue int
+	if err := coordinator.DB().QueryRowContext(ctx, `SELECT value FROM counters WHERE id = 1`).Scan(&counterValue); err != nil {
+		t.Fatalf("db.QueryRowContext(counter).Scan() error = %v", err)
+	}
+	if counterValue != 2 {
+		t.Fatalf("counter value = %d, want 2", counterValue)
+	}
+}
+
 func TestSQLiteCoordinatorPersistsDataAcrossCloseAndReopenWithEmbeddedMigrations(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- allow file-backed SQLite to use a small WAL connection pool instead of a single global connection
- move SQLite pragmas into the DSN so every pooled connection gets foreign keys, busy timeout, and WAL mode
- avoid per-loop project lookups while building active run targets

## Trade-off
This prevents `looper ps` reads from queueing behind unrelated daemon DB work. Cost: up to four SQLite connections for file-backed databases, with per-connection pragma coverage to avoid lock/FK drift. `:memory:` remains single-connection because separate SQLite memory connections create separate databases.

## Testing
- `go test ./internal/api ./internal/storage`
- `go test ./...` (initial `internal/agent` timeout test flaked once)
- `go test ./internal/agent`
- `go vet ./...`
- `go build ./...`