### PR TITLE
fix: discover review-requested PRs directly

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -791,6 +791,8 @@ Common fields:
 
 Trigger fields are combined with logical AND. Label lists use `labelMode=all` or `labelMode=any`; an empty labels list means no label constraint.
 
+When reviewer `triggers.requireReviewRequest=true` and no reviewer label filter is configured, discovery queries GitHub directly for PRs review-requested from the current GitHub user. This avoids missing requested reviews that fall outside the generic open-PR discovery window. Reviewer label filters keep using the labeled open-PR query path and are still applied before queuing.
+
 Sweeper terminology used in config, logs, and future operator surfaces:
 
 - **case**: the mutable lifecycle record for one issue or pull request

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -261,6 +261,8 @@ Reviewer mainly watches two kinds of PRs:
 - open PRs where the current GitHub user was requested as a reviewer
 - manually-started reviewer loops from this machine, including `looper review owner/repo#42 --loop`
 
+For the default review-requested path, Looper asks GitHub for PRs requested from the current user instead of only filtering the first page of open PRs locally.
+
 For spec PRs, `looper:spec-reviewing` marks the review phase, but it does not by itself authorize other users' Looper instances to run. Request review from the intended GitHub user to trigger that user's automatic reviewer.
 
 ### What happens after reviewer finishes

--- a/internal/infra/github/discovery_snapshot.go
+++ b/internal/infra/github/discovery_snapshot.go
@@ -33,6 +33,8 @@ type DiscoverySnapshot struct {
 	openPRsFetchCWD  string
 	openPRsLimit     int
 
+	reviewRequestedPRs map[string]reviewRequestedPullRequestSnapshotEntry
+
 	openIssues          []IssueSummary
 	openIssuesFetched   bool
 	openIssuesFetchRepo string
@@ -53,7 +55,7 @@ func NewDiscoverySnapshot(gateway *Gateway, tick *DiscoveryTickState, options Di
 	if tick == nil {
 		tick = NewDiscoveryTickState()
 	}
-	return &DiscoverySnapshot{gateway: gateway, tick: tick, prLimit: max(defaultLimit(options.PullRequestLimit), 30), issueLimit: max(defaultLimit(options.IssueLimit), 30), prDetails: map[string]PullRequestDetail{}}
+	return &DiscoverySnapshot{gateway: gateway, tick: tick, prLimit: max(defaultLimit(options.PullRequestLimit), 30), issueLimit: max(defaultLimit(options.IssueLimit), 30), reviewRequestedPRs: map[string]reviewRequestedPullRequestSnapshotEntry{}, prDetails: map[string]PullRequestDetail{}}
 }
 
 func ContextWithDiscoverySnapshot(ctx context.Context, snapshot *DiscoverySnapshot) context.Context {
@@ -80,6 +82,27 @@ func (s *DiscoverySnapshot) listOpenPullRequests(ctx context.Context, input List
 		return s.gateway.listOpenPullRequestsRaw(ctx, input)
 	}
 	return limitPullRequests(prs, input.Limit), nil
+}
+
+func (s *DiscoverySnapshot) listReviewRequestedPullRequests(ctx context.Context, input ListReviewRequestedPullRequestsInput) ([]PullRequestSummary, error) {
+	key := reviewRequestedPullRequestSnapshotKey(input)
+	s.mu.Lock()
+	if entry, ok := s.reviewRequestedPRs[key]; ok {
+		prs := clonePullRequestSummaries(entry.items)
+		s.mu.Unlock()
+		return limitPullRequests(prs, input.Limit), nil
+	}
+	s.mu.Unlock()
+
+	requiredLimit := s.prLimit
+	prs, err := s.gateway.listReviewRequestedPullRequestsForDiscovery(ctx, ListReviewRequestedPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: requiredLimit, Reviewer: input.Reviewer, Timeout: input.Timeout})
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	s.reviewRequestedPRs[key] = reviewRequestedPullRequestSnapshotEntry{items: clonePullRequestSummaries(prs)}
+	s.mu.Unlock()
+	return limitPullRequests(clonePullRequestSummaries(prs), input.Limit), nil
 }
 
 func (s *DiscoverySnapshot) ensureOpenPullRequests(ctx context.Context, input ListOpenPullRequestsInput) error {
@@ -190,6 +213,31 @@ func (g *Gateway) listOpenPullRequestsForDiscovery(ctx context.Context, input Li
 	expiresAt := g.now().UTC().Add(g.discoveryCacheTTL)
 	g.discoveryCacheMu.Lock()
 	g.discoveryPRCache[key] = discoveryPullRequestListCacheEntry{expiresAt: expiresAt, items: clonePullRequestSummaries(prs)}
+	g.discoveryCacheMu.Unlock()
+	return clonePullRequestSummaries(prs), nil
+}
+
+func (g *Gateway) listReviewRequestedPullRequestsForDiscovery(ctx context.Context, input ListReviewRequestedPullRequestsInput) ([]PullRequestSummary, error) {
+	if g.discoveryCacheTTL <= 0 {
+		return g.listReviewRequestedPullRequestsRaw(ctx, input)
+	}
+	key := discoveryReviewRequestedPullRequestListCacheKey(input)
+	now := g.now().UTC()
+	g.discoveryCacheMu.Lock()
+	if entry, ok := g.discoveryReviewPRCache[key]; ok && now.Before(entry.expiresAt) {
+		items := clonePullRequestSummaries(entry.items)
+		g.discoveryCacheMu.Unlock()
+		return items, nil
+	}
+	g.discoveryCacheMu.Unlock()
+
+	prs, err := g.listReviewRequestedPullRequestsRaw(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	expiresAt := g.now().UTC().Add(g.discoveryCacheTTL)
+	g.discoveryCacheMu.Lock()
+	g.discoveryReviewPRCache[key] = discoveryPullRequestListCacheEntry{expiresAt: expiresAt, items: clonePullRequestSummaries(prs)}
 	g.discoveryCacheMu.Unlock()
 	return clonePullRequestSummaries(prs), nil
 }
@@ -348,8 +396,20 @@ func discoveryPullRequestListCacheKey(input ListOpenPullRequestsInput) string {
 	return fmt.Sprintf("pr|%s|%s|%d", strings.TrimSpace(input.Repo), strings.TrimSpace(input.CWD), defaultLimit(input.Limit))
 }
 
+func discoveryReviewRequestedPullRequestListCacheKey(input ListReviewRequestedPullRequestsInput) string {
+	return fmt.Sprintf("review-pr|%s|%s|%s|%d", strings.TrimSpace(input.Repo), strings.TrimSpace(input.CWD), normalizeGitHubLogin(input.Reviewer), defaultLimit(input.Limit))
+}
+
 func discoveryIssueListCacheKey(input ListOpenIssuesInput) string {
 	return fmt.Sprintf("issue|%s|%s|%d", strings.TrimSpace(input.Repo), strings.TrimSpace(input.CWD), defaultLimit(input.Limit))
+}
+
+func reviewRequestedPullRequestSnapshotKey(input ListReviewRequestedPullRequestsInput) string {
+	return fmt.Sprintf("%s|%s|%s", strings.TrimSpace(input.Repo), strings.TrimSpace(input.CWD), normalizeGitHubLogin(input.Reviewer))
+}
+
+type reviewRequestedPullRequestSnapshotEntry struct {
+	items []PullRequestSummary
 }
 
 func clonePullRequestSummaries(prs []PullRequestSummary) []PullRequestSummary {

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -251,6 +252,80 @@ func TestDiscoverySnapshotUsesGatewayDiscoveryTTLCacheAcrossTicks(t *testing.T) 
 	}
 }
 
+func TestDiscoverySnapshotCachesReviewRequestedPullRequestsPerTickAndTTL(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 5, 10, 0, 0, 0, time.UTC)
+	graphQLCalls := 0
+	gateway := New(Options{
+		Now:               func() time.Time { return now },
+		DiscoveryCacheTTL: 30 * time.Second,
+		GHRun: func(_ context.Context, options shell.Options) (shell.Result, error) {
+			cmd := strings.Join(options.Args, " ")
+			if !strings.Contains(cmd, "api graphql") {
+				return shell.Result{}, errors.New("unexpected command: " + cmd)
+			}
+			if !strings.Contains(cmd, "repo:acme/looper is:pr is:open review-requested:reviewer") {
+				return shell.Result{}, errors.New("missing review-requested search qualifier: " + cmd)
+			}
+			graphQLCalls++
+			switch graphQLCalls {
+			case 1:
+				return shell.Result{Stdout: reviewRequestedSearchResponse(7, "sha-7")}, nil
+			case 2:
+				return shell.Result{Stdout: reviewRequestedSearchResponse(8, "sha-8")}, nil
+			default:
+				return shell.Result{}, errors.New("unexpected extra graphql call: " + cmd)
+			}
+		},
+	})
+
+	firstCtx := ContextWithDiscoverySnapshot(context.Background(), NewDiscoverySnapshot(gateway, NewDiscoveryTickState(), DiscoverySnapshotOptions{PullRequestLimit: 100}))
+	first, err := gateway.ListReviewRequestedPullRequests(firstCtx, ListReviewRequestedPullRequestsInput{Repo: "acme/looper", CWD: "/repo", Reviewer: "Reviewer", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListReviewRequestedPullRequests(first) error = %v", err)
+	}
+	first[0].Labels[0] = "mutated"
+	first[0].ReviewRequests[0] = "mutated"
+
+	again, err := gateway.ListReviewRequestedPullRequests(firstCtx, ListReviewRequestedPullRequestsInput{Repo: "acme/looper", CWD: "/repo", Reviewer: "reviewer", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListReviewRequestedPullRequests(same tick) error = %v", err)
+	}
+	if graphQLCalls != 1 {
+		t.Fatalf("graphql calls in same tick = %d, want 1", graphQLCalls)
+	}
+	if again[0].Number != 7 || again[0].Labels[0] != "ready" || again[0].ReviewRequests[0] != "reviewer" {
+		t.Fatalf("same tick PR = %#v, want stable cloned snapshot for PR 7", again[0])
+	}
+
+	now = now.Add(10 * time.Second)
+	secondCtx := ContextWithDiscoverySnapshot(context.Background(), NewDiscoverySnapshot(gateway, NewDiscoveryTickState(), DiscoverySnapshotOptions{PullRequestLimit: 100}))
+	second, err := gateway.ListReviewRequestedPullRequests(secondCtx, ListReviewRequestedPullRequestsInput{Repo: "acme/looper", CWD: "/repo", Reviewer: "reviewer", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListReviewRequestedPullRequests(ttl hit) error = %v", err)
+	}
+	if graphQLCalls != 1 {
+		t.Fatalf("graphql calls after ttl hit = %d, want 1", graphQLCalls)
+	}
+	if second[0].Number != 7 || second[0].Labels[0] != "ready" {
+		t.Fatalf("ttl cached PR = %#v, want PR 7 from gateway cache", second[0])
+	}
+
+	now = now.Add(31 * time.Second)
+	thirdCtx := ContextWithDiscoverySnapshot(context.Background(), NewDiscoverySnapshot(gateway, NewDiscoveryTickState(), DiscoverySnapshotOptions{PullRequestLimit: 100}))
+	third, err := gateway.ListReviewRequestedPullRequests(thirdCtx, ListReviewRequestedPullRequestsInput{Repo: "acme/looper", CWD: "/repo", Reviewer: "reviewer", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListReviewRequestedPullRequests(ttl expired) error = %v", err)
+	}
+	if graphQLCalls != 2 {
+		t.Fatalf("graphql calls after ttl expiry = %d, want 2", graphQLCalls)
+	}
+	if third[0].Number != 8 {
+		t.Fatalf("ttl expired PR number = %d, want 8", third[0].Number)
+	}
+}
+
 func TestDiscoverySnapshotDiscoveryCacheTTLZeroDisablesGatewayCache(t *testing.T) {
 	t.Parallel()
 
@@ -278,4 +353,8 @@ func TestDiscoverySnapshotDiscoveryCacheTTLZeroDisablesGatewayCache(t *testing.T
 	if prListCalls != 2 {
 		t.Fatalf("pr list calls with ttl disabled = %d, want 2", prListCalls)
 	}
+}
+
+func reviewRequestedSearchResponse(number int, sha string) string {
+	return fmt.Sprintf(`{"data":{"search":{"nodes":[{"number":%d,"title":"Review me","url":"https://example.test/pull/%d","state":"OPEN","updatedAt":"2026-06-05T10:00:00Z","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","labels":{"nodes":[{"name":"ready"}]},"headRefName":"feature","baseRefName":"main","headRefOid":%q,"baseRefOid":"base","mergeStateStatus":"CLEAN","author":{"login":"contributor"},"reviews":{"nodes":[]}}]}}}`, number, number, sha)
 }

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -54,6 +54,7 @@ type Gateway struct {
 	discoveryCacheTTL      time.Duration
 	discoveryCacheMu       sync.Mutex
 	discoveryPRCache       map[string]discoveryPullRequestListCacheEntry
+	discoveryReviewPRCache map[string]discoveryPullRequestListCacheEntry
 	discoveryIssueCache    map[string]discoveryIssueListCacheEntry
 	ghRun                  func(context.Context, shell.Options) (shell.Result, error)
 	reviewSubmitDiagnostic func(event string, fields map[string]any)
@@ -658,7 +659,7 @@ func New(options Options) *Gateway {
 	if ghRun == nil {
 		ghRun = shell.Run
 	}
-	return &Gateway{ghPath: ghPath, cwd: options.CWD, now: now, discoveryCacheTTL: options.DiscoveryCacheTTL, discoveryPRCache: map[string]discoveryPullRequestListCacheEntry{}, discoveryIssueCache: map[string]discoveryIssueListCacheEntry{}, ghRun: ghRun, reviewSubmitDiagnostic: options.ReviewSubmitDiagnostic}
+	return &Gateway{ghPath: ghPath, cwd: options.CWD, now: now, discoveryCacheTTL: options.DiscoveryCacheTTL, discoveryPRCache: map[string]discoveryPullRequestListCacheEntry{}, discoveryReviewPRCache: map[string]discoveryPullRequestListCacheEntry{}, discoveryIssueCache: map[string]discoveryIssueListCacheEntry{}, ghRun: ghRun, reviewSubmitDiagnostic: options.ReviewSubmitDiagnostic}
 }
 
 func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
@@ -669,6 +670,13 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 }
 
 func (g *Gateway) ListReviewRequestedPullRequests(ctx context.Context, input ListReviewRequestedPullRequestsInput) ([]PullRequestSummary, error) {
+	if snapshot := discoverySnapshotFromContext(ctx); snapshot != nil {
+		return snapshot.listReviewRequestedPullRequests(ctx, input)
+	}
+	return g.listReviewRequestedPullRequestsRaw(ctx, input)
+}
+
+func (g *Gateway) listReviewRequestedPullRequestsRaw(ctx context.Context, input ListReviewRequestedPullRequestsInput) ([]PullRequestSummary, error) {
 	reviewer := normalizeGitHubLogin(input.Reviewer)
 	if reviewer == "" {
 		return nil, fmt.Errorf("review requester login is required")

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -501,6 +501,14 @@ type ListOpenPullRequestsInput struct {
 	Timeout     time.Duration
 }
 
+type ListReviewRequestedPullRequestsInput struct {
+	Repo     string
+	CWD      string
+	Limit    int
+	Reviewer string
+	Timeout  time.Duration
+}
+
 type ListOpenIssuesInput struct {
 	Repo     string
 	CWD      string
@@ -658,6 +666,85 @@ func (g *Gateway) ListOpenPullRequests(ctx context.Context, input ListOpenPullRe
 		return snapshot.listOpenPullRequests(ctx, input)
 	}
 	return g.listOpenPullRequestsRaw(ctx, input)
+}
+
+func (g *Gateway) ListReviewRequestedPullRequests(ctx context.Context, input ListReviewRequestedPullRequestsInput) ([]PullRequestSummary, error) {
+	reviewer := normalizeGitHubLogin(input.Reviewer)
+	if reviewer == "" {
+		return nil, fmt.Errorf("review requester login is required")
+	}
+	query := `
+query($searchQuery: String!, $first: Int!) {
+  search(type: ISSUE, query: $searchQuery, first: $first) {
+    nodes {
+      ... on PullRequest {
+        number
+        title
+        url
+        state
+        updatedAt
+        isDraft
+        reviewDecision
+        labels(first: 20) { nodes { name } }
+        headRefName
+        baseRefName
+        headRefOid
+        baseRefOid
+        mergeStateStatus
+        author { login }
+        reviews(last: 20) {
+          nodes {
+            state
+            author { login }
+            submittedAt
+            updatedAt
+          }
+        }
+      }
+    }
+  }
+}`
+	searchQuery := fmt.Sprintf("repo:%s is:pr is:open review-requested:%s", input.Repo, reviewer)
+	timeout := input.Timeout
+	if timeout <= 0 {
+		timeout = defaultGhCommandTimeout
+	}
+	result, err := g.runGhWithTimeout(ctx, input.CWD, "", timeout, "api", "graphql", "-f", "query="+query, "-F", "searchQuery="+searchQuery, "-F", fmt.Sprintf("first=%d", defaultLimit(input.Limit)))
+	if err != nil {
+		return nil, err
+	}
+	row, err := decodeJSONObject(result.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	nodes := digNodes(row, "data", "search")
+	out := make([]PullRequestSummary, 0, len(nodes))
+	for _, node := range nodes {
+		number := asInt64(node["number"])
+		if number <= 0 {
+			continue
+		}
+		out = append(out, PullRequestSummary{
+			Number:             number,
+			Title:              asString(node["title"]),
+			URL:                asString(node["url"]),
+			State:              asString(node["state"]),
+			UpdatedAt:          asString(node["updatedAt"]),
+			IsDraft:            asBool(node["isDraft"]),
+			ReviewDecision:     asString(node["reviewDecision"]),
+			Labels:             extractLabelNamesFromConnection(node["labels"]),
+			HeadRefName:        asString(node["headRefName"]),
+			BaseRefName:        asString(node["baseRefName"]),
+			HeadSHA:            asString(node["headRefOid"]),
+			BaseSHA:            asString(node["baseRefOid"]),
+			HasConflicts:       asString(node["mergeStateStatus"]) == "DIRTY",
+			Author:             extractAuthor(node["author"]),
+			ReviewRequests:     []string{reviewer},
+			ReviewRequestUsers: []GitHubUser{{Login: reviewer}},
+			Reviews:            extractReviewNodesFromConnection(node["reviews"]),
+		})
+	}
+	return out, nil
 }
 
 func (g *Gateway) listOpenPullRequestsRaw(ctx context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
@@ -3394,6 +3481,26 @@ func extractLabelNames(value any) []string {
 		}
 	}
 	return out
+}
+
+func extractLabelNamesFromConnection(value any) []string {
+	row, _ := value.(map[string]any)
+	if row == nil {
+		return []string{}
+	}
+	return extractLabelNames(row["nodes"])
+}
+
+func extractReviewNodesFromConnection(value any) []map[string]any {
+	row, _ := value.(map[string]any)
+	if row == nil {
+		return []map[string]any{}
+	}
+	return toObjectSlice(row["nodes"])
+}
+
+func normalizeGitHubLogin(login string) string {
+	return strings.ToLower(strings.TrimSpace(login))
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2170,6 +2171,40 @@ func TestListOpenIssuesPassesAllLabelsToGH(t *testing.T) {
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
 	if _, err := gateway.ListOpenIssues(context.Background(), ListOpenIssuesInput{Repo: "acme/looper", Assignee: "reviewer", Labels: []string{"bug", "priority"}}); err != nil {
 		t.Fatalf("ListOpenIssues() error = %v", err)
+	}
+}
+
+func TestGatewayListsReviewRequestedPullRequestsThroughSearch(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		if !strings.Contains(args, "api graphql") {
+			t.Fatalf("gh args = %q, want graphql search", args)
+		}
+		if !strings.Contains(args, "repo:acme/looper is:pr is:open review-requested:reviewer") {
+			t.Fatalf("gh args = %q, want review-requested search qualifier", args)
+		}
+		if !strings.Contains(args, "-F first=50") {
+			t.Fatalf("gh args = %q, want caller limit", args)
+		}
+		return shell.Result{Stdout: `{"data":{"search":{"nodes":[{"number":77,"title":"Review me","url":"https://example.test/pull/77","state":"OPEN","updatedAt":"2026-06-04T10:00:00Z","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","labels":{"nodes":[{"name":"ready"}]},"headRefName":"feature","baseRefName":"main","headRefOid":"head77","baseRefOid":"base77","mergeStateStatus":"CLEAN","author":{"login":"contributor"},"reviews":{"nodes":[{"state":"COMMENTED","author":{"login":"reviewer"},"submittedAt":"2026-06-04T10:01:00Z"}]}}]}}}`}, nil
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	prs, err := gateway.ListReviewRequestedPullRequests(context.Background(), ListReviewRequestedPullRequestsInput{Repo: "acme/looper", Reviewer: "Reviewer", Limit: 50})
+	if err != nil {
+		t.Fatalf("ListReviewRequestedPullRequests() error = %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("PR count = %d, want 1", len(prs))
+	}
+	pr := prs[0]
+	if pr.Number != 77 || pr.HeadSHA != "head77" || pr.Author != "contributor" || !slices.Contains(pr.Labels, "ready") {
+		t.Fatalf("PR = %#v, want parsed search result", pr)
+	}
+	if !slices.Contains(pr.ReviewRequests, "reviewer") || len(pr.Reviews) != 1 {
+		t.Fatalf("PR review metadata = %#v / %#v, want synthetic reviewer and parsed reviews", pr.ReviewRequests, pr.Reviews)
 	}
 }
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -238,6 +238,13 @@ type ListOpenPullRequestsInput struct {
 	Labels []string
 }
 
+type ListReviewRequestedPullRequestsInput struct {
+	Repo     string
+	CWD      string
+	Limit    int
+	Reviewer string
+}
+
 type ViewPullRequestInput struct {
 	Repo     string
 	PRNumber int64
@@ -341,6 +348,7 @@ type ResolveReviewThreadInput struct {
 
 type GitHubGateway interface {
 	ListOpenPullRequests(context.Context, ListOpenPullRequestsInput) ([]PullRequestSummary, error)
+	ListReviewRequestedPullRequests(context.Context, ListReviewRequestedPullRequestsInput) ([]PullRequestSummary, error)
 	GetCurrentUserLogin(context.Context, string) (string, error)
 	ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error)
 	ViewIssue(context.Context, githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error)
@@ -731,7 +739,16 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 	if !policy.AutoDiscovery {
 		return DiscoveryResult{Skipped: 1}, nil
 	}
-	openPRs, err := r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, input.Repo, project.RepoPath, input.Limit, policy)
+	currentLogin := ""
+	if policy.RequireReviewRequest || !policy.EnableSelfReview {
+		var err error
+		currentLogin, err = r.github.GetCurrentUserLogin(ctx, project.RepoPath)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		currentLogin = normalizeLogin(currentLogin)
+	}
+	openPRs, err := r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, input.Repo, project.RepoPath, input.Limit, policy, currentLogin)
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
@@ -742,15 +759,6 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
-	}
-	currentLogin := ""
-	if policy.RequireReviewRequest || !policy.EnableSelfReview {
-		var err error
-		currentLogin, err = r.github.GetCurrentUserLogin(ctx, project.RepoPath)
-		if err != nil {
-			return DiscoveryResult{}, err
-		}
-		currentLogin = normalizeLogin(currentLogin)
 	}
 	result := DiscoveryResult{}
 	seen := map[string]struct{}{}
@@ -1032,11 +1040,22 @@ func (r *Runner) findReviewerLoopsByPR(ctx context.Context, projectID, repo stri
 }
 
 func (r *Runner) listOpenPullRequestsForDiscovery(ctx context.Context, repo, cwd string, limit int) ([]PullRequestSummary, error) {
-	return r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, repo, cwd, limit, r.discoveryPolicy)
+	currentLogin := ""
+	if r.discoveryPolicy.RequireReviewRequest {
+		login, err := r.github.GetCurrentUserLogin(ctx, cwd)
+		if err != nil {
+			return nil, err
+		}
+		currentLogin = normalizeLogin(login)
+	}
+	return r.listOpenPullRequestsForDiscoveryWithPolicy(ctx, repo, cwd, limit, r.discoveryPolicy, currentLogin)
 }
 
-func (r *Runner) listOpenPullRequestsForDiscoveryWithPolicy(ctx context.Context, repo, cwd string, limit int, policy DiscoveryPolicy) ([]PullRequestSummary, error) {
+func (r *Runner) listOpenPullRequestsForDiscoveryWithPolicy(ctx context.Context, repo, cwd string, limit int, policy DiscoveryPolicy, currentLogin string) ([]PullRequestSummary, error) {
 	labels := prQueryLabels(policy.Labels)
+	if policy.RequireReviewRequest && strings.TrimSpace(currentLogin) != "" && len(labels) == 0 && !networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
+		return r.github.ListReviewRequestedPullRequests(ctx, ListReviewRequestedPullRequestsInput{Repo: repo, CWD: cwd, Limit: limit, Reviewer: currentLogin})
+	}
 	effectiveLimit := defaultDiscoveryLimit(limit)
 	if len(labels) == 0 {
 		return r.github.ListOpenPullRequests(ctx, ListOpenPullRequestsInput{Repo: repo, CWD: cwd, Limit: limit})

--- a/internal/reviewer/runner_integration_test.go
+++ b/internal/reviewer/runner_integration_test.go
@@ -176,6 +176,18 @@ func (a reviewerIntegrationGatewayAdapter) ListOpenPullRequests(ctx context.Cont
 	return out, nil
 }
 
+func (a reviewerIntegrationGatewayAdapter) ListReviewRequestedPullRequests(ctx context.Context, input ListReviewRequestedPullRequestsInput) ([]PullRequestSummary, error) {
+	prs, err := a.Gateway.ListReviewRequestedPullRequests(ctx, githubinfra.ListReviewRequestedPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: input.Limit, Reviewer: input.Reviewer})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PullRequestSummary, 0, len(prs))
+	for _, pr := range prs {
+		out = append(out, PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: pr.ReviewDecision, Labels: append([]string(nil), pr.Labels...), HeadSHA: pr.HeadSHA, BaseSHA: pr.BaseSHA, HasConflicts: pr.HasConflicts, Author: pr.Author, ReviewRequests: append([]string(nil), pr.ReviewRequests...), Reviews: pr.Reviews})
+	}
+	return out, nil
+}
+
 func (a reviewerIntegrationGatewayAdapter) GetCurrentUserLogin(ctx context.Context, cwd string) (string, error) {
 	return a.Gateway.GetCurrentUserLogin(ctx, cwd)
 }

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -6327,6 +6327,43 @@ func TestRunPrepareWorktreeStepPersistsCreatedWorktreeBeforeManualIntervention(t
 	}
 }
 
+func TestDiscoverPullRequestsUsesReviewRequestedQueryWhenReviewRequestRequired(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		currentLogin: "OctoCat",
+		reviewRequestedPullRequests: []PullRequestSummary{{
+			Number:             77,
+			Title:              "Window-external review request",
+			State:              "OPEN",
+			HeadSHA:            "head77",
+			BaseSHA:            "base77",
+			Author:             "contributor",
+			ReviewRequests:     []string{"octocat"},
+			ReviewRequestUsers: []networkpolicy.GitHubUser{{Login: "octocat"}},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper", Limit: 10})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(github.listCalls) != 0 {
+		t.Fatalf("generic list calls = %#v, want targeted review-request query only", github.listCalls)
+	}
+	if len(github.listReviewRequestedCalls) != 1 {
+		t.Fatalf("review-requested calls = %#v, want one call", github.listReviewRequestedCalls)
+	}
+	call := github.listReviewRequestedCalls[0]
+	if call.Reviewer != "octocat" || call.Limit != 10 {
+		t.Fatalf("review-requested call = %#v, want normalized reviewer and discovery limit", call)
+	}
+	if len(result.QueueItems) != 1 || result.QueueItems[0].PRNumber == nil || *result.QueueItems[0].PRNumber != 77 {
+		t.Fatalf("queue items = %#v, want PR 77 queued", result.QueueItems)
+	}
+}
+
 func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -7941,6 +7978,8 @@ type fakeGitHubGateway struct {
 	addLabelCalls                   []PullRequestLabelsInput
 	removeLabelCalls                []PullRequestLabelsInput
 	listCalls                       []ListOpenPullRequestsInput
+	listReviewRequestedCalls        []ListReviewRequestedPullRequestsInput
+	reviewRequestedPullRequests     []PullRequestSummary
 	listOpenByLabel                 map[string][]PullRequestSummary
 }
 
@@ -7948,6 +7987,30 @@ func (g *fakeGitHubGateway) ListOpenPullRequests(_ context.Context, input ListOp
 	g.listCalls = append(g.listCalls, input)
 	if g.listOpenByLabel != nil {
 		return append([]PullRequestSummary(nil), g.listOpenByLabel[input.Label]...), nil
+	}
+	reviewRequests := g.effectiveReviewRequests()
+	headSHA := g.listHeadSHA
+	if headSHA == "" {
+		headSHA = "abc123"
+	}
+	author := g.effectiveAuthor()
+	users := append([]networkpolicy.GitHubUser(nil), g.reviewRequestUsers...)
+	if len(users) == 0 && reviewRequests != nil {
+		users = make([]networkpolicy.GitHubUser, 0, len(reviewRequests))
+		for _, login := range reviewRequests {
+			users = append(users, networkpolicy.GitHubUser{Login: login})
+		}
+	}
+	return []PullRequestSummary{{Number: 42, Title: "Review me", State: "OPEN", ReviewDecision: g.reviewDecision, Labels: append([]string(nil), g.labels...), HeadSHA: headSHA, BaseSHA: "base123", HasConflicts: g.hasConflicts, Author: author, ReviewRequests: reviewRequests, ReviewRequestUsers: users, Reviews: cloneCommentMaps(g.reviews)}, {Number: 99, Title: "Draft", State: "OPEN", IsDraft: true, HeadSHA: "draft123", BaseSHA: "base123", Author: author, ReviewRequests: reviewRequests, ReviewRequestUsers: users}}, nil
+}
+
+func (g *fakeGitHubGateway) ListReviewRequestedPullRequests(_ context.Context, input ListReviewRequestedPullRequestsInput) ([]PullRequestSummary, error) {
+	g.listReviewRequestedCalls = append(g.listReviewRequestedCalls, input)
+	if g.reviewRequestedPullRequests != nil {
+		return append([]PullRequestSummary(nil), g.reviewRequestedPullRequests...), nil
+	}
+	if g.listOpenByLabel != nil {
+		return append([]PullRequestSummary(nil), g.listOpenByLabel[""]...), nil
 	}
 	reviewRequests := g.effectiveReviewRequests()
 	headSHA := g.listHeadSHA

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -339,6 +339,18 @@ func (a reviewerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input r
 	return result, nil
 }
 
+func (a reviewerGitHubAdapter) ListReviewRequestedPullRequests(ctx context.Context, input reviewer.ListReviewRequestedPullRequestsInput) ([]reviewer.PullRequestSummary, error) {
+	pullRequests, err := a.gateway.ListReviewRequestedPullRequests(ctx, githubinfra.ListReviewRequestedPullRequestsInput{Repo: input.Repo, CWD: input.CWD, Limit: input.Limit, Reviewer: input.Reviewer})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]reviewer.PullRequestSummary, 0, len(pullRequests))
+	for _, pr := range pullRequests {
+		result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: pr.ReviewDecision, Labels: pr.Labels, HeadSHA: pr.HeadSHA, BaseSHA: pr.BaseSHA, HasConflicts: pr.HasConflicts, Author: pr.Author, ReviewRequests: pr.ReviewRequests, ReviewRequestUsers: networkPolicyUsers(pr.ReviewRequestUsers), Reviews: pr.Reviews})
+	}
+	return result, nil
+}
+
 func (a reviewerGitHubAdapter) GetCurrentUserLogin(ctx context.Context, cwd string) (string, error) {
 	return a.gateway.GetCurrentUserLogin(ctx, cwd)
 }


### PR DESCRIPTION
## Summary
- query GitHub directly for PRs review-requested from the current user when reviewer `requireReviewRequest=true` and no reviewer label filter is configured
- keep labeled reviewer discovery on the existing labeled open-PR path for backward-compatible server-side label filtering
- document the targeted review-requested discovery path

## Compatibility
- no config shape changes
- `requireReviewRequest=true` keeps the same eligibility semantics, but now finds requested PRs outside the generic open-PR window
- label-filtered reviewer discovery keeps using the existing open PR query path

## Tests
- `go test ./internal/infra/github ./internal/reviewer`
- `go test ./internal/agent` after the first full run hit unrelated 5s timeout flakes
- `go test ./...`