### PR TITLE
fix: suppress reviewer rediscovery after not-requested skips

### DIFF
--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -770,7 +770,7 @@ func (r *Runner) DiscoverPullRequests(ctx context.Context, input DiscoveryInput)
 	}
 	enqueue := func(pr PullRequestSummary, existing *storage.LoopRecord) error {
 
-		return r.enqueueReviewerDiscoveryCandidate(ctx, *project, input.Repo, policy, &currentLogin, pr, existing, &result)
+		return r.enqueueReviewerDiscoveryCandidate(ctx, *project, input.Repo, policy, &currentLogin, pr, existing, false, &result)
 
 	}
 	seenEnqueue := func(pr PullRequestSummary) error {
@@ -916,14 +916,14 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 		result.Skipped++
 		return result, nil
 	}
-	if err := r.enqueueReviewerDiscoveryCandidate(ctx, *project, input.Repo, policy, &currentLogin, pr, nil, &result); err != nil {
+	if err := r.enqueueReviewerDiscoveryCandidate(ctx, *project, input.Repo, policy, &currentLogin, pr, nil, false, &result); err != nil {
 
 		return DiscoveryResult{}, err
 	}
 	return result, nil
 }
 
-func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project storage.ProjectRecord, repo string, policy DiscoveryPolicy, currentLogin *string, pr PullRequestSummary, existing *storage.LoopRecord, result *DiscoveryResult) error {
+func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project storage.ProjectRecord, repo string, policy DiscoveryPolicy, currentLogin *string, pr PullRequestSummary, existing *storage.LoopRecord, allowThreadResolutionFollowUp bool, result *DiscoveryResult) error {
 	loopResult, loopErr := r.ensureLoopForPullRequest(ctx, project, repo, pr.Number, existing)
 	if loopErr != nil {
 		return loopErr
@@ -957,7 +957,7 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		}
 		*currentLogin = normalizeLogin(lookupLogin)
 	}
-	if reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) && !r.allowThreadResolutionFollowUpAfterNotRequestedSkip(ctx, project.RepoPath, repo, pr, *currentLogin, meta, policy) {
+	if reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) && !allowThreadResolutionFollowUp && !r.allowThreadResolutionFollowUpAfterNotRequestedSkip(ctx, project.RepoPath, repo, pr, *currentLogin, meta, policy) {
 		result.Skipped++
 		return nil
 	}
@@ -1020,15 +1020,19 @@ func (r *Runner) discoverExistingReviewerLoop(ctx context.Context, project stora
 		return nil
 	}
 	requireReviewRequest := requireReviewRequestForLoop(loop, policy.RequireReviewRequest, detail.HeadSHA)
-	if !networkpolicy.IsRouted(policy.RoutedClaimPolicy) && requireReviewRequest && reviewRequestsKnownAbsent(detail.ReviewRequests, *currentLogin) && !r.hasThreadResolutionFollowUpCandidate(ctx, project.RepoPath, repo, detail.Number, detail.HeadSHA, *currentLogin) {
-		result.Skipped++
-		return nil
+	allowThreadResolutionFollowUp := false
+	if !networkpolicy.IsRouted(policy.RoutedClaimPolicy) && requireReviewRequest && reviewRequestsKnownAbsent(detail.ReviewRequests, *currentLogin) {
+		allowThreadResolutionFollowUp = r.hasThreadResolutionFollowUpCandidate(ctx, project.RepoPath, repo, detail.Number, detail.HeadSHA, *currentLogin)
+		if !allowThreadResolutionFollowUp {
+			result.Skipped++
+			return nil
+		}
 	}
 	if !isManualReviewerLoop(loop) && !labelsMatch(detail.Labels, policy.Labels, policy.LabelMode) {
 		result.Skipped++
 		return nil
 	}
-	return r.enqueueReviewerDiscoveryCandidate(ctx, project, repo, policy, currentLogin, summaryFromDetail(detail), &loop, result)
+	return r.enqueueReviewerDiscoveryCandidate(ctx, project, repo, policy, currentLogin, summaryFromDetail(detail), &loop, allowThreadResolutionFollowUp, result)
 }
 
 func (r *Runner) findReviewerLoopsByPR(ctx context.Context, projectID, repo string, prNumber int64) ([]storage.LoopRecord, error) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -950,7 +950,7 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		result.Skipped++
 		return nil
 	}
-	if reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) {
+	if reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) && !r.allowThreadResolutionFollowUpAfterNotRequestedSkip(ctx, project.RepoPath, repo, pr, *currentLogin, meta, policy) {
 		result.Skipped++
 		return nil
 	}
@@ -961,7 +961,7 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		}
 		*currentLogin = normalizeLogin(lookupLogin)
 	}
-	if reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) {
+	if reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) && !r.allowThreadResolutionFollowUpAfterNotRequestedSkip(ctx, project.RepoPath, repo, pr, *currentLogin, meta, policy) {
 		result.Skipped++
 		return nil
 	}
@@ -986,6 +986,25 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 	}
 	result.QueueItems = append(result.QueueItems, queueItem)
 	return nil
+}
+
+func (r *Runner) allowThreadResolutionFollowUpAfterNotRequestedSkip(ctx context.Context, cwd, repo string, pr PullRequestSummary, currentLogin string, meta map[string]any, policy DiscoveryPolicy) bool {
+	if networkpolicy.IsRouted(policy.RoutedClaimPolicy) || !policy.RequireReviewRequest {
+		return false
+	}
+	raw, _ := meta["lastFilterSkip"].(map[string]any)
+	if raw == nil {
+		return false
+	}
+	kind, _ := stringFromAny(raw["kind"])
+	if kind != "not_requested" || !reviewRequestsKnownAbsent(pr.ReviewRequests, currentLogin) {
+		return false
+	}
+	reviewerLogin, _ := stringFromAny(raw["reviewerLogin"])
+	if normalizeLogin(reviewerLogin) == "" || normalizeLogin(currentLogin) == "" || normalizeLogin(reviewerLogin) != normalizeLogin(currentLogin) {
+		return false
+	}
+	return r.hasThreadResolutionFollowUpCandidate(ctx, cwd, repo, pr.Number, pr.HeadSHA, currentLogin)
 }
 
 func (r *Runner) discoverExistingReviewerLoop(ctx context.Context, project storage.ProjectRecord, repo string, policy DiscoveryPolicy, currentLogin *string, loop storage.LoopRecord, detail PullRequestDetail, result *DiscoveryResult) error {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4928,6 +4928,10 @@ func reviewerDiscoverySuppressedByLastSkip(meta map[string]any, pr PullRequestSu
 		if normalizeLogin(reviewerLogin) == "" || normalizeLogin(currentLogin) == "" || normalizeLogin(reviewerLogin) != normalizeLogin(currentLogin) {
 			return false
 		}
+		if networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
+			decision := routedReviewerClaimDecision(policy, currentLogin, pr.Author, pr.Labels, pr.ReviewRequestUsers)
+			return !decision.Allowed && decision.Reason == "local GitHub identity is not requested for review"
+		}
 		if !reviewRequestsKnownAbsent(pr.ReviewRequests, currentLogin) {
 			return false
 		}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4920,6 +4920,17 @@ func reviewerDiscoverySuppressedByLastSkip(meta map[string]any, pr PullRequestSu
 		if draft, ok := raw["isDraft"].(bool); ok && draft != pr.IsDraft {
 			return false
 		}
+	case "not_requested":
+		if !policy.RequireReviewRequest {
+			return false
+		}
+		reviewerLogin, _ := stringFromAny(raw["reviewerLogin"])
+		if normalizeLogin(reviewerLogin) == "" || normalizeLogin(currentLogin) == "" || normalizeLogin(reviewerLogin) != normalizeLogin(currentLogin) {
+			return false
+		}
+		if !reviewRequestsKnownAbsent(pr.ReviewRequests, currentLogin) {
+			return false
+		}
 	}
 	return true
 }
@@ -4930,7 +4941,7 @@ func reviewerLastSkipNeedsCurrentLogin(meta map[string]any, pr PullRequestSummar
 		return false
 	}
 	kind, _ := stringFromAny(raw["kind"])
-	if kind != "already_reviewed_by_current_user" && kind != "self_authored" {
+	if kind != "already_reviewed_by_current_user" && kind != "self_authored" && kind != "not_requested" {
 		return false
 	}
 	headSHA, _ := stringFromAny(raw["headSha"])
@@ -4939,7 +4950,7 @@ func reviewerLastSkipNeedsCurrentLogin(meta map[string]any, pr PullRequestSummar
 
 func isDiscoverySuppressingSkipKind(kind string) bool {
 	switch kind {
-	case "conflicted", "already_reviewed_by_current_user", "already_published_head", "draft", "approved", "ready_label", "self_authored":
+	case "conflicted", "already_reviewed_by_current_user", "already_published_head", "draft", "approved", "ready_label", "self_authored", "not_requested":
 		return true
 	default:
 		return false
@@ -5228,6 +5239,9 @@ func filterSkipMetadata(checkpoint reviewerCheckpoint, recordedAt string) map[st
 	}
 	if checkpoint.SkipKind == "already_reviewed_by_current_user" && checkpoint.SkipReviewerLogin != "" {
 		metadata["reviewerLogin"] = normalizeLogin(checkpoint.SkipReviewerLogin)
+	}
+	if checkpoint.SkipKind == "not_requested" && checkpoint.Detail.CurrentLogin != "" {
+		metadata["reviewerLogin"] = normalizeLogin(checkpoint.Detail.CurrentLogin)
 	}
 	if checkpoint.SkipKind == "self_authored" {
 		if author := normalizeLogin(checkpoint.Detail.Author); author != "" {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -950,10 +950,6 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		result.Skipped++
 		return nil
 	}
-	if reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) && !r.allowThreadResolutionFollowUpAfterNotRequestedSkip(ctx, project.RepoPath, repo, pr, *currentLogin, meta, policy) {
-		result.Skipped++
-		return nil
-	}
 	if reviewerLastSkipNeedsCurrentLogin(meta, pr) && *currentLogin == "" {
 		lookupLogin, lookupErr := r.github.GetCurrentUserLogin(ctx, project.RepoPath)
 		if lookupErr != nil {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2722,6 +2722,42 @@ func TestDiscoverPullRequestsAllowsThreadResolutionFollowUpAfterNotRequestedSkip
 	}
 }
 
+func TestDiscoverPullRequestsChecksNotRequestedThreadResolutionFollowUpOncePerCandidate(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		currentLogin:   "bob",
+		reviewRequests: []string{},
+		listHeadSHA:    "new-head",
+		viewHeadSHA:    "new-head",
+		reviewThreads:  []ReviewThread{{ID: "thread_1", Comments: []ReviewThreadComment{{ID: "comment_1", Author: "bob", Body: "Please update this. <!-- looper:stamp v=1 -->", CommitOID: "old-head"}}}},
+	}
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = true
+	policy.Mode = config.ReviewerThreadResolutionModeResolveObjective
+	policy.RequireCurrentReviewRequest = false
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig(), ThreadResolution: policy})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"followUpdates":true,"lastPublishedHeadSha":"old-head","lastFilterSkip":{"kind":"not_requested","reason":"Skipped pull request acme/looper#42 because current user is not requested for review","recordedAt":"2026-05-01T00:00:00Z","headSha":"new-head","reviewerLogin":"bob"},"loop":{"enabled":true,"iterationCount":1,"iterationsByHead":{"old-head":1}}}`
+	loop := storage.LoopRecord{ID: "loop_not_requested_thread_resolution_once", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("len(QueueItems) = %d, want 1", len(result.QueueItems))
+	}
+	if github.listReviewThreadsCalls != 1 {
+		t.Fatalf("ListReviewThreads calls = %d, want 1", github.listReviewThreadsCalls)
+	}
+}
+
 func TestReviewerDiscoverySuppressedByLastSkipDoesNotUseCurrentReviewRequestsInRoutedMode(t *testing.T) {
 	t.Parallel()
 	meta := map[string]any{"lastFilterSkip": map[string]any{"kind": "not_requested", "headSha": "new-head", "reviewerLogin": "bob"}}
@@ -8078,6 +8114,7 @@ type fakeGitHubGateway struct {
 	issueCommentErr                 error
 	issueCommentResult              IssueCommentResult
 	reviewThreads                   []ReviewThread
+	listReviewThreadsCalls          int
 	viewHeadSHA                     string
 	headSHACalls                    int
 	issueCommentCalls               []IssueCommentInput
@@ -8399,6 +8436,7 @@ func (g *fakeGitHubGateway) RemoveIssueLabels(_ context.Context, input githubinf
 }
 
 func (g *fakeGitHubGateway) ListReviewThreads(context.Context, ListReviewThreadsInput) ([]ReviewThread, error) {
+	g.listReviewThreadsCalls++
 	out := make([]ReviewThread, len(g.reviewThreads))
 	copy(out, g.reviewThreads)
 	return out, nil

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2740,7 +2740,7 @@ func TestDiscoverPullRequestsChecksNotRequestedThreadResolutionFollowUpOncePerCa
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
-	metadata := `{"followUpdates":true,"lastPublishedHeadSha":"old-head","lastFilterSkip":{"kind":"not_requested","reason":"Skipped pull request acme/looper#42 because current user is not requested for review","recordedAt":"2026-05-01T00:00:00Z","headSha":"new-head","reviewerLogin":"bob"},"loop":{"enabled":true,"iterationCount":1,"iterationsByHead":{"old-head":1}}}`
+	metadata := `{"followUpdates":true,"lastFilterSkip":{"kind":"not_requested","reason":"Skipped pull request acme/looper#42 because current user is not requested for review","recordedAt":"2026-05-01T00:00:00Z","headSha":"new-head","reviewerLogin":"bob"},"loop":{"enabled":true,"iterationCount":1}}`
 	loop := storage.LoopRecord{ID: "loop_not_requested_thread_resolution_once", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2689,6 +2689,31 @@ func TestDiscoverPullRequestsDoesNotSuppressNotRequestedSkipAfterHeadChange(t *t
 	}
 }
 
+func TestReviewerDiscoverySuppressedByLastSkipDoesNotUseCurrentReviewRequestsInRoutedMode(t *testing.T) {
+	t.Parallel()
+	meta := map[string]any{"lastFilterSkip": map[string]any{"kind": "not_requested", "headSha": "new-head", "reviewerLogin": "bob"}}
+	pr := PullRequestSummary{
+		Number:             42,
+		HeadSHA:            "new-head",
+		Author:             "alice",
+		Labels:             []string{"looper:target:red"},
+		ReviewRequests:     []string{},
+		ReviewRequestUsers: []networkpolicy.GitHubUser{{Login: "bob", ID: 42}},
+	}
+	policy := DiscoveryPolicy{
+		RequireReviewRequest: true,
+		RoutedClaimPolicy: networkpolicy.ProjectPolicy{
+			Mode:         config.NetworkModeRouted,
+			NodeName:     "red",
+			GitHubLogin:  "bob",
+			GitHubUserID: 42,
+		},
+	}
+	if reviewerDiscoverySuppressedByLastSkip(meta, pr, "bob", policy) {
+		t.Fatalf("reviewerDiscoverySuppressedByLastSkip() = true, want false when routed claim still allows reviewer")
+	}
+}
+
 func TestFilterSkipMetadataRecordsReviewerForNotRequested(t *testing.T) {
 	t.Parallel()
 	metadata := filterSkipMetadata(reviewerCheckpoint{

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2613,6 +2613,100 @@ func TestDiscoverPullRequestsSuppressesRepeatedConflictSkipUntilHeadChanges(t *t
 	}
 }
 
+func TestDiscoverPullRequestsSuppressesRepeatedNotRequestedSkipUntilRequested(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "bob", reviewRequests: []string{}, listHeadSHA: "new-head", viewHeadSHA: "new-head"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"followUpdates":true,"lastPublishedHeadSha":"old-head","lastFilterSkip":{"kind":"not_requested","reason":"Skipped pull request acme/looper#42 because current user is not requested for review","recordedAt":"2026-05-01T00:00:00Z","headSha":"new-head","reviewerLogin":"bob"},"loop":{"enabled":true,"iterationCount":1,"iterationsByHead":{"old-head":1}}}`
+	loop := storage.LoopRecord{ID: "loop_not_requested_followup", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	first, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("first DiscoverPullRequests() error = %v", err)
+	}
+	if len(first.QueueItems) != 0 {
+		t.Fatalf("first QueueItems = %#v, want suppression for unchanged not_requested head", first.QueueItems)
+	}
+
+	second, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("second DiscoverPullRequests() error = %v", err)
+	}
+	if len(second.QueueItems) != 0 {
+		t.Fatalf("second QueueItems = %#v, want no repeated re-enqueue while request remains absent", second.QueueItems)
+	}
+
+	github.reviewRequests = []string{"bob"}
+	third, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("third DiscoverPullRequests() error = %v", err)
+	}
+	if len(third.QueueItems) != 1 {
+		t.Fatalf("third QueueItems = %#v, want re-enqueue when current reviewer is requested", third.QueueItems)
+	}
+}
+
+func TestDiscoverPullRequestsDoesNotSuppressNotRequestedSkipAfterHeadChange(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLogin: "bob", reviewRequests: []string{}, listHeadSHA: "new-head", viewHeadSHA: "new-head"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"followUpdates":true,"lastPublishedHeadSha":"old-head","lastFilterSkip":{"kind":"not_requested","reason":"Skipped pull request acme/looper#42 because current user is not requested for review","recordedAt":"2026-05-01T00:00:00Z","headSha":"new-head","reviewerLogin":"bob"},"loop":{"enabled":true,"iterationCount":1,"iterationsByHead":{"old-head":1}}}`
+	loop := storage.LoopRecord{ID: "loop_not_requested_head_change", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	first, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("first DiscoverPullRequests() error = %v", err)
+	}
+	if len(first.QueueItems) != 0 {
+		t.Fatalf("first QueueItems = %#v, want suppression for unchanged not_requested head", first.QueueItems)
+	}
+
+	second, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("second DiscoverPullRequests() error = %v", err)
+	}
+	if len(second.QueueItems) != 0 {
+		t.Fatalf("second QueueItems = %#v, want no repeated re-enqueue for same head", second.QueueItems)
+	}
+
+	meta := parseJSONObject(loop.MetadataJSON)
+	if reviewerDiscoverySuppressedByLastSkip(meta, PullRequestSummary{Number: 42, HeadSHA: "newer-head", ReviewRequests: []string{}}, "bob", DiscoveryPolicy{RequireReviewRequest: true}) {
+		t.Fatalf("reviewerDiscoverySuppressedByLastSkip() = true, want false after head change")
+	}
+}
+
+func TestFilterSkipMetadataRecordsReviewerForNotRequested(t *testing.T) {
+	t.Parallel()
+	metadata := filterSkipMetadata(reviewerCheckpoint{
+		SkipKind:   "not_requested",
+		SkipReason: "Skipped pull request acme/looper#42 because current user is not requested for review",
+		Detail:     &checkpointDetail{HeadSHA: "abc123", CurrentLogin: "Bob"},
+	}, "2026-05-01T00:00:00Z")
+	if metadata == nil {
+		t.Fatalf("filterSkipMetadata() = nil, want metadata")
+	}
+	if got, _ := stringFromAny(metadata["reviewerLogin"]); got != "bob" {
+		t.Fatalf("metadata.reviewerLogin = %q, want bob", got)
+	}
+	if got, _ := stringFromAny(metadata["headSha"]); got != "abc123" {
+		t.Fatalf("metadata.headSha = %q, want abc123", got)
+	}
+}
+
 func TestDiscoverPullRequestsRequeuesConflictedSkipWhenConflictClears(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2689,6 +2689,39 @@ func TestDiscoverPullRequestsDoesNotSuppressNotRequestedSkipAfterHeadChange(t *t
 	}
 }
 
+func TestDiscoverPullRequestsAllowsThreadResolutionFollowUpAfterNotRequestedSkip(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		currentLogin:   "bob",
+		reviewRequests: []string{},
+		listHeadSHA:    "new-head",
+		viewHeadSHA:    "new-head",
+		reviewThreads:  []ReviewThread{{ID: "thread_1", Comments: []ReviewThreadComment{{ID: "comment_1", Author: "bob", Body: "Please update this. <!-- looper:stamp v=1 -->", CommitOID: "old-head"}}}},
+	}
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = true
+	policy.Mode = config.ReviewerThreadResolutionModeResolveObjective
+	policy.RequireCurrentReviewRequest = false
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig(), ThreadResolution: policy})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	metadata := `{"followUpdates":true,"lastPublishedHeadSha":"old-head","lastFilterSkip":{"kind":"not_requested","reason":"Skipped pull request acme/looper#42 because current user is not requested for review","recordedAt":"2026-05-01T00:00:00Z","headSha":"new-head","reviewerLogin":"bob"},"loop":{"enabled":true,"iterationCount":1,"iterationsByHead":{"old-head":1}}}`
+	loop := storage.LoopRecord{ID: "loop_not_requested_thread_resolution", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("len(QueueItems) = %d, want 1", len(result.QueueItems))
+	}
+}
+
 func TestReviewerDiscoverySuppressedByLastSkipDoesNotUseCurrentReviewRequestsInRoutedMode(t *testing.T) {
 	t.Parallel()
 	meta := map[string]any{"lastFilterSkip": map[string]any{"kind": "not_requested", "headSha": "new-head", "reviewerLogin": "bob"}}


### PR DESCRIPTION
## Summary
- treat reviewer `not_requested` skips as discovery-suppressing reviewer loop state
- persist the reviewer login for `not_requested` skips and only suppress rediscovery when the same reviewer, head SHA, review-request policy, and absent-request state still match
- add regression coverage for suppression, re-request recovery, head-change re-evaluation, and stored skip metadata

## Testing
- go test ./internal/reviewer
- go test ./...

Closes #484

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>