### PR TITLE
fix: reduce discovery GitHub API payload

### DIFF
--- a/internal/infra/github/discovery_snapshot.go
+++ b/internal/infra/github/discovery_snapshot.go
@@ -194,7 +194,7 @@ func (s *DiscoverySnapshot) filteredIssues(input ListOpenIssuesInput) []IssueSum
 
 func (g *Gateway) listOpenPullRequestsForDiscovery(ctx context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
 	if g.discoveryCacheTTL <= 0 {
-		return g.listOpenPullRequestsRaw(ctx, input)
+		return g.listOpenPullRequestsWithFields(ctx, input, prDiscoveryListJSONFields)
 	}
 	key := discoveryPullRequestListCacheKey(input)
 	now := g.now().UTC()
@@ -206,7 +206,7 @@ func (g *Gateway) listOpenPullRequestsForDiscovery(ctx context.Context, input Li
 	}
 	g.discoveryCacheMu.Unlock()
 
-	prs, err := g.listOpenPullRequestsRaw(ctx, input)
+	prs, err := g.listOpenPullRequestsWithFields(ctx, input, prDiscoveryListJSONFields)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -169,9 +169,12 @@ func TestDiscoverySnapshotUsesGatewayDiscoveryTTLCacheAcrossTicks(t *testing.T) 
 		GHRun: func(_ context.Context, options shell.Options) (shell.Result, error) {
 			cmd := strings.Join(options.Args, " ")
 			if strings.Contains(cmd, "pr list") {
+				if strings.Contains(cmd, "reviews") || strings.Contains(cmd, "mergeStateStatus") {
+					t.Fatalf("pr list args = %q, want lightweight discovery fields", cmd)
+				}
 				prListCalls++
 				return shell.Result{Stdout: `[
-					{"number":1,"title":"PR 1","state":"OPEN","labels":[{"name":"bug"}],"baseRefName":"main","headRefOid":"sha-1","author":{"login":"octo"},"reviews":[{"state":"APPROVED","author":{"login":"reviewer"},"commit":{"oid":"sha-1"},"comments":[{"body":"ok"}]}]}
+					{"number":1,"title":"PR 1","state":"OPEN","labels":[{"name":"bug"}],"baseRefName":"main","headRefOid":"sha-1","author":{"login":"octo"}}
 				]`}, nil
 			}
 			return shell.Result{}, errors.New("unexpected command: " + cmd)
@@ -184,25 +187,6 @@ func TestDiscoverySnapshotUsesGatewayDiscoveryTTLCacheAcrossTicks(t *testing.T) 
 		t.Fatalf("ListOpenPullRequests(first) error = %v", err)
 	}
 	first[0].Labels[0] = "mutated"
-	firstReviewAuthor, ok := first[0].Reviews[0]["author"].(map[string]any)
-	if !ok {
-		t.Fatalf("review author = %#v, want object", first[0].Reviews[0]["author"])
-	}
-	firstReviewAuthor["login"] = "mutated"
-	firstReviewCommit, ok := first[0].Reviews[0]["commit"].(map[string]any)
-	if !ok {
-		t.Fatalf("review commit = %#v, want object", first[0].Reviews[0]["commit"])
-	}
-	firstReviewCommit["oid"] = "mutated"
-	firstReviewComments, ok := first[0].Reviews[0]["comments"].([]any)
-	if !ok {
-		t.Fatalf("review comments = %#v, want array", first[0].Reviews[0]["comments"])
-	}
-	firstReviewComment, ok := firstReviewComments[0].(map[string]any)
-	if !ok {
-		t.Fatalf("review comment = %#v, want object", firstReviewComments[0])
-	}
-	firstReviewComment["body"] = "mutated"
 
 	now = now.Add(10 * time.Second)
 	secondCtx := ContextWithDiscoverySnapshot(context.Background(), NewDiscoverySnapshot(gateway, NewDiscoveryTickState(), DiscoverySnapshotOptions{PullRequestLimit: 100}))
@@ -215,31 +199,6 @@ func TestDiscoverySnapshotUsesGatewayDiscoveryTTLCacheAcrossTicks(t *testing.T) 
 	}
 	if got := second[0].Labels[0]; got != "bug" {
 		t.Fatalf("cached label = %q, want cache to be isolated from caller mutation", got)
-	}
-	secondReviewAuthor, ok := second[0].Reviews[0]["author"].(map[string]any)
-	if !ok {
-		t.Fatalf("cached review author = %#v, want object", second[0].Reviews[0]["author"])
-	}
-	if got := secondReviewAuthor["login"]; got != "reviewer" {
-		t.Fatalf("cached review author login = %q, want cache to be isolated from caller mutation", got)
-	}
-	secondReviewCommit, ok := second[0].Reviews[0]["commit"].(map[string]any)
-	if !ok {
-		t.Fatalf("cached review commit = %#v, want object", second[0].Reviews[0]["commit"])
-	}
-	if got := secondReviewCommit["oid"]; got != "sha-1" {
-		t.Fatalf("cached review commit oid = %q, want cache to be isolated from caller mutation", got)
-	}
-	secondReviewComments, ok := second[0].Reviews[0]["comments"].([]any)
-	if !ok {
-		t.Fatalf("cached review comments = %#v, want array", second[0].Reviews[0]["comments"])
-	}
-	secondReviewComment, ok := secondReviewComments[0].(map[string]any)
-	if !ok {
-		t.Fatalf("cached review comment = %#v, want object", secondReviewComments[0])
-	}
-	if got := secondReviewComment["body"]; got != "ok" {
-		t.Fatalf("cached review comment body = %q, want cache to be isolated from caller mutation", got)
 	}
 
 	now = now.Add(31 * time.Second)

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -169,12 +169,12 @@ func TestDiscoverySnapshotUsesGatewayDiscoveryTTLCacheAcrossTicks(t *testing.T) 
 		GHRun: func(_ context.Context, options shell.Options) (shell.Result, error) {
 			cmd := strings.Join(options.Args, " ")
 			if strings.Contains(cmd, "pr list") {
-				if strings.Contains(cmd, "reviews") || strings.Contains(cmd, "mergeStateStatus") {
+				if strings.Contains(cmd, "reviews") || !strings.Contains(cmd, "mergeStateStatus") {
 					t.Fatalf("pr list args = %q, want lightweight discovery fields", cmd)
 				}
 				prListCalls++
 				return shell.Result{Stdout: `[
-					{"number":1,"title":"PR 1","state":"OPEN","labels":[{"name":"bug"}],"baseRefName":"main","headRefOid":"sha-1","author":{"login":"octo"}}
+					{"number":1,"title":"PR 1","state":"OPEN","labels":[{"name":"bug"}],"baseRefName":"main","headRefOid":"sha-1","mergeStateStatus":"DIRTY","author":{"login":"octo"}}
 				]`}, nil
 			}
 			return shell.Result{}, errors.New("unexpected command: " + cmd)
@@ -199,6 +199,9 @@ func TestDiscoverySnapshotUsesGatewayDiscoveryTTLCacheAcrossTicks(t *testing.T) 
 	}
 	if got := second[0].Labels[0]; got != "bug" {
 		t.Fatalf("cached label = %q, want cache to be isolated from caller mutation", got)
+	}
+	if !second[0].HasConflicts {
+		t.Fatal("cached PR HasConflicts = false, want merge state preserved")
 	}
 
 	now = now.Add(31 * time.Second)

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	prListJSONFields          = []string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "mergeStateStatus"}
-	prDiscoveryListJSONFields = []string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests"}
+	prDiscoveryListJSONFields = []string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "mergeStateStatus"}
 	prViewJSONFields          = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}
 )
 
@@ -699,6 +699,7 @@ query($searchQuery: String!, $first: Int!) {
         baseRefName
         headRefOid
         baseRefOid
+        mergeStateStatus
         author { login }
       }
     }
@@ -737,6 +738,7 @@ query($searchQuery: String!, $first: Int!) {
 			BaseRefName:        asString(node["baseRefName"]),
 			HeadSHA:            asString(node["headRefOid"]),
 			BaseSHA:            asString(node["baseRefOid"]),
+			HasConflicts:       asString(node["mergeStateStatus"]) == "DIRTY",
 			Author:             extractAuthor(node["author"]),
 			ReviewRequests:     []string{reviewer},
 			ReviewRequestUsers: []GitHubUser{{Login: reviewer}},

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -30,8 +30,9 @@ const (
 )
 
 var (
-	prListJSONFields = []string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "mergeStateStatus"}
-	prViewJSONFields = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}
+	prListJSONFields          = []string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "mergeStateStatus"}
+	prDiscoveryListJSONFields = []string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests"}
+	prViewJSONFields          = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}
 )
 
 var prNumberURLPattern = regexp.MustCompile(`/pull/(\d+)(?:/|$)`)
@@ -698,16 +699,7 @@ query($searchQuery: String!, $first: Int!) {
         baseRefName
         headRefOid
         baseRefOid
-        mergeStateStatus
         author { login }
-        reviews(last: 20) {
-          nodes {
-            state
-            author { login }
-            submittedAt
-            updatedAt
-          }
-        }
       }
     }
   }
@@ -745,20 +737,22 @@ query($searchQuery: String!, $first: Int!) {
 			BaseRefName:        asString(node["baseRefName"]),
 			HeadSHA:            asString(node["headRefOid"]),
 			BaseSHA:            asString(node["baseRefOid"]),
-			HasConflicts:       asString(node["mergeStateStatus"]) == "DIRTY",
 			Author:             extractAuthor(node["author"]),
 			ReviewRequests:     []string{reviewer},
 			ReviewRequestUsers: []GitHubUser{{Login: reviewer}},
-			Reviews:            extractReviewNodesFromConnection(node["reviews"]),
 		})
 	}
 	return out, nil
 }
 
 func (g *Gateway) listOpenPullRequestsRaw(ctx context.Context, input ListOpenPullRequestsInput) ([]PullRequestSummary, error) {
-	rows, err := g.listOpenPullRequestRows(ctx, input, prListJSONFields)
+	return g.listOpenPullRequestsWithFields(ctx, input, prListJSONFields)
+}
+
+func (g *Gateway) listOpenPullRequestsWithFields(ctx context.Context, input ListOpenPullRequestsInput, fields []string) ([]PullRequestSummary, error) {
+	rows, err := g.listOpenPullRequestRows(ctx, input, fields)
 	if err != nil && IsInaccessibleReviewRequestReviewerError(err) {
-		rows, err = g.listOpenPullRequestRows(ctx, input, withoutJSONField(prListJSONFields, "reviewRequests"))
+		rows, err = g.listOpenPullRequestRows(ctx, input, withoutJSONField(fields, "reviewRequests"))
 	}
 	if err != nil {
 		return nil, err

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -2188,7 +2188,11 @@ func TestGatewayListsReviewRequestedPullRequestsThroughSearch(t *testing.T) {
 		if !strings.Contains(args, "-F first=50") {
 			t.Fatalf("gh args = %q, want caller limit", args)
 		}
-		return shell.Result{Stdout: `{"data":{"search":{"nodes":[{"number":77,"title":"Review me","url":"https://example.test/pull/77","state":"OPEN","updatedAt":"2026-06-04T10:00:00Z","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","labels":{"nodes":[{"name":"ready"}]},"headRefName":"feature","baseRefName":"main","headRefOid":"head77","baseRefOid":"base77","mergeStateStatus":"CLEAN","author":{"login":"contributor"},"reviews":{"nodes":[{"state":"COMMENTED","author":{"login":"reviewer"},"submittedAt":"2026-06-04T10:01:00Z"}]}}]}}}`}, nil
+		query := strings.Join(options.Args, " ")
+		if strings.Contains(query, "reviews(") || strings.Contains(query, "mergeStateStatus") {
+			t.Fatalf("gh args = %q, want lightweight discovery query", query)
+		}
+		return shell.Result{Stdout: `{"data":{"search":{"nodes":[{"number":77,"title":"Review me","url":"https://example.test/pull/77","state":"OPEN","updatedAt":"2026-06-04T10:00:00Z","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","labels":{"nodes":[{"name":"ready"}]},"headRefName":"feature","baseRefName":"main","headRefOid":"head77","baseRefOid":"base77","author":{"login":"contributor"}}]}}}`}, nil
 	}
 
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
@@ -2203,8 +2207,8 @@ func TestGatewayListsReviewRequestedPullRequestsThroughSearch(t *testing.T) {
 	if pr.Number != 77 || pr.HeadSHA != "head77" || pr.Author != "contributor" || !slices.Contains(pr.Labels, "ready") {
 		t.Fatalf("PR = %#v, want parsed search result", pr)
 	}
-	if !slices.Contains(pr.ReviewRequests, "reviewer") || len(pr.Reviews) != 1 {
-		t.Fatalf("PR review metadata = %#v / %#v, want synthetic reviewer and parsed reviews", pr.ReviewRequests, pr.Reviews)
+	if !slices.Contains(pr.ReviewRequests, "reviewer") || len(pr.Reviews) != 0 {
+		t.Fatalf("PR review metadata = %#v / %#v, want synthetic reviewer and no reviews in discovery", pr.ReviewRequests, pr.Reviews)
 	}
 }
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -2189,10 +2189,10 @@ func TestGatewayListsReviewRequestedPullRequestsThroughSearch(t *testing.T) {
 			t.Fatalf("gh args = %q, want caller limit", args)
 		}
 		query := strings.Join(options.Args, " ")
-		if strings.Contains(query, "reviews(") || strings.Contains(query, "mergeStateStatus") {
+		if strings.Contains(query, "reviews(") || !strings.Contains(query, "mergeStateStatus") {
 			t.Fatalf("gh args = %q, want lightweight discovery query", query)
 		}
-		return shell.Result{Stdout: `{"data":{"search":{"nodes":[{"number":77,"title":"Review me","url":"https://example.test/pull/77","state":"OPEN","updatedAt":"2026-06-04T10:00:00Z","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","labels":{"nodes":[{"name":"ready"}]},"headRefName":"feature","baseRefName":"main","headRefOid":"head77","baseRefOid":"base77","author":{"login":"contributor"}}]}}}`}, nil
+		return shell.Result{Stdout: `{"data":{"search":{"nodes":[{"number":77,"title":"Review me","url":"https://example.test/pull/77","state":"OPEN","updatedAt":"2026-06-04T10:00:00Z","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","labels":{"nodes":[{"name":"ready"}]},"headRefName":"feature","baseRefName":"main","headRefOid":"head77","baseRefOid":"base77","mergeStateStatus":"DIRTY","author":{"login":"contributor"}}]}}}`}, nil
 	}
 
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
@@ -2204,7 +2204,7 @@ func TestGatewayListsReviewRequestedPullRequestsThroughSearch(t *testing.T) {
 		t.Fatalf("PR count = %d, want 1", len(prs))
 	}
 	pr := prs[0]
-	if pr.Number != 77 || pr.HeadSHA != "head77" || pr.Author != "contributor" || !slices.Contains(pr.Labels, "ready") {
+	if pr.Number != 77 || pr.HeadSHA != "head77" || pr.Author != "contributor" || !pr.HasConflicts || !slices.Contains(pr.Labels, "ready") {
 		t.Fatalf("PR = %#v, want parsed search result", pr)
 	}
 	if !slices.Contains(pr.ReviewRequests, "reviewer") || len(pr.Reviews) != 0 {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4010,14 +4010,35 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 		return false, "", "manual_intervention", nil
 	}
 	approvedByCurrentUser := func() (bool, error) {
-		if !r.loopConfig.StopOnApproved || len(pr.Reviews) == 0 {
+		if !r.loopConfig.StopOnApproved {
+			return false, nil
+		}
+		reviews := pr.Reviews
+		headSHA := pr.HeadSHA
+		if len(reviews) == 0 && loop.Repo != nil && loop.PRNumber != nil && r.github != nil && r.repos != nil && r.repos.Projects != nil {
+			project, err := r.repos.Projects.GetByID(ctx, loop.ProjectID)
+			if err != nil {
+				return false, err
+			}
+			if project != nil {
+				detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: *loop.Repo, PRNumber: *loop.PRNumber, CWD: project.RepoPath})
+				if err != nil {
+					return false, err
+				}
+				reviews = detail.Reviews
+				if headSHA == "" {
+					headSHA = detail.HeadSHA
+				}
+			}
+		}
+		if len(reviews) == 0 {
 			return false, nil
 		}
 		currentLogin, err := r.currentLoginForLoop(ctx, loop)
 		if err != nil {
 			return false, err
 		}
-		return hasApprovedReviewByAuthorForHead(pr.Reviews, currentLogin, pr.HeadSHA), nil
+		return hasApprovedReviewByAuthorForHead(reviews, currentLogin, headSHA), nil
 	}
 	if queueKind == string(FailureRetryableAfterResume) && (resumePolicy == loops.ResumePolicyRestartFromDiscover || resumePolicy == "rerun_review") {
 		approved, err := approvedByCurrentUser()

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4026,7 +4026,7 @@ func (r *Runner) failedReviewerLoopRecoveryEligibility(ctx context.Context, loop
 					return false, err
 				}
 				reviews = detail.Reviews
-				if headSHA == "" {
+				if detail.HeadSHA != "" {
 					headSHA = detail.HeadSHA
 				}
 			}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -6364,6 +6364,48 @@ func TestDiscoverPullRequestsUsesReviewRequestedQueryWhenReviewRequestRequired(t
 	}
 }
 
+func TestDiscoverPullRequestsSuppressesConflictedLastFilterSkipFromReviewRequestedQuery(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		currentLogin: "OctoCat",
+		reviewRequestedPullRequests: []PullRequestSummary{{
+			Number:             77,
+			Title:              "Conflicted review request",
+			State:              "OPEN",
+			HeadSHA:            "head77",
+			BaseSHA:            "base77",
+			HasConflicts:       true,
+			Author:             "contributor",
+			ReviewRequests:     []string{"octocat"},
+			ReviewRequestUsers: []networkpolicy.GitHubUser{{Login: "octocat"}},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(77)
+	metadata := `{"followUpdates":true,"lastFilterSkip":{"kind":"conflicted","reason":"Skipped conflicted pull request acme/looper#77","recordedAt":"2026-06-05T10:00:00Z","headSha":"head77"}}`
+	loop := storage.LoopRecord{ID: "loop_conflicted_review_request", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo, Limit: 10})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(github.listReviewRequestedCalls) != 1 {
+		t.Fatalf("review-requested calls = %#v, want one call", github.listReviewRequestedCalls)
+	}
+	if len(result.QueueItems) != 0 {
+		t.Fatalf("queue items = %#v, want conflicted lastFilterSkip preserved", result.QueueItems)
+	}
+	if result.Skipped != 1 {
+		t.Fatalf("Skipped = %d, want conflicted lastFilterSkip suppression", result.Skipped)
+	}
+}
+
 func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -476,6 +476,34 @@ func TestReviewerFailedLoopRecoveryEligibilityWhitelist(t *testing.T) {
 	}
 }
 
+func TestReviewerFailedLoopRecoveryEligibilityUsesFreshDetailHeadForApproval(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	loopID, _ := seedFailedReviewerRecoveryLoop(t, fixture, failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"})
+	github := &fakeGitHubGateway{
+		viewHeadSHA: "fresh-head",
+		reviews: []map[string]any{{
+			"author": map[string]any{"login": "octocat"},
+			"state":  "APPROVED",
+			"commit": map[string]any{"oid": "fresh-head"},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: true, StopOnReadyLabel: true}})
+	loop, _ := fixture.repos.Loops.GetByID(context.Background(), loopID)
+
+	eligible, _, reason, err := runner.failedReviewerLoopRecoveryEligibility(context.Background(), *loop, PullRequestSummary{Number: 42, State: "OPEN", HeadSHA: "stale-head"})
+	if err != nil {
+		t.Fatalf("failedReviewerLoopRecoveryEligibility() error = %v", err)
+	}
+	if eligible || reason != "approved" {
+		t.Fatalf("eligible=%v reason=%q, want approved suppression", eligible, reason)
+	}
+	if github.viewCalls != 1 {
+		t.Fatalf("viewCalls = %d, want 1", github.viewCalls)
+	}
+}
+
 func TestReviewerFailedLoopRecoveryEnhancedTransientIsOptIn(t *testing.T) {
 	t.Parallel()
 	message := `Post "https://api.github.com/graphql": EOF`


### PR DESCRIPTION
## Summary
- use lightweight PR fields for cached discovery list queries
- keep full PR list fields for non-discovery callers
- keep reviewer failed-loop approved recovery correct by fetching full PR detail only when that rare path needs reviews
- remove reviews/conflict fields from review-requested discovery search

## Validation
- go test ./...

## Notes
This follows #478 and targets the API-budget pressure observed during active discovery waves. It is intended for the next consolidated release rather than immediate VPS deployment.