### PR TITLE
feat: PR takeover — daemon command + agent skill to drive a PR until it merges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .ralph/
 .task/
+.DS_Store
 node_modules/
 dist/
 *.test

--- a/README.md
+++ b/README.md
@@ -90,6 +90,44 @@ Inside a registered repo, `--project` is usually optional for `review` and `work
 
 The full workflow — label conventions, assignment rules, how planner / reviewer / fixer / worker hand off — is in **[docs/users-guide.md](docs/users-guide.md)**.
 
+## Take over a single PR
+
+Want Looper to babysit *one* pull request — review it, fix review threads, and keep going until it's mergeable — without registering the whole repo for autonomous work? Run `looper takeover` from inside the checkout:
+
+```bash
+# detect the current branch's PR automatically
+looper takeover
+
+# or target an explicit PR
+looper takeover acme/repo#42
+```
+
+`takeover` is the one-command path that, behind the scenes:
+
+- installs/starts the managed `looperd` daemon if it isn't already running;
+- registers the repository **scoped to that single PR** — every autonomous discovery loop is disabled, so Looper only touches the PR you named, never the rest of the repo;
+- starts a continuous **reviewer** loop and **fixer** loop on the PR, which ping-pong until the review comes back clean;
+- with `--merge`, lets the reviewer enable GitHub auto-merge so the PR merges itself once it's approved and green.
+
+It picks your coding agent automatically when exactly one of `claude` / `codex` / `opencode` is on `PATH`, prompts when it's ambiguous, and accepts `--agent-vendor` / `--yes` for non-interactive (agent-driven) runs:
+
+```bash
+looper takeover acme/repo#42 --merge --agent-vendor claude-code
+looper takeover --yes --agent-vendor codex          # fully non-interactive
+```
+
+Requirements: `git`, an authenticated `gh`, and one supported agent CLI installed locally (the agent runs on your machine with your own credentials).
+
+### One-liner for not-yet-installed users
+
+For someone who doesn't have Looper yet, a single piped command installs the CLI and hands off to `takeover`. This is what an automation/bot can drop into a PR comment so the author can adopt the PR in one step (run it from inside the repo checkout):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/nexu-io/looper/main/scripts/takeover.sh | sh -s -- acme/repo#42
+```
+
+Everything after `--` is forwarded to `looper takeover`, so `--merge` and `--agent-vendor` work there too.
+
 ## Agent skill
 
 Looper includes an installable agent skill for setup, status, config, daemon lifecycle, and troubleshooting guidance:
@@ -165,6 +203,7 @@ looper project add /path/to/repo
 **Start loops manually**
 
 ```bash
+looper takeover [<owner>/<repo>#<pr>] [--merge]   # adopt one PR until it merges
 looper plan   --project <id> --issue <num>
 looper review <owner>/<repo>#<pr> [--loop]
 looper work   --project <id> --issue <num>

--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ looper takeover acme/repo#42 --merge --agent-vendor claude-code
 looper takeover --yes --agent-vendor codex          # fully non-interactive
 ```
 
+List and stop takeovers:
+
+```bash
+looper takeover list                 # active takeovers + live loop status
+looper takeover stop acme/repo#42    # stop this takeover's reviewer + fixer loops
+looper takeover stop --all
+```
+
 Requirements: `git`, an authenticated `gh`, and one supported agent CLI installed locally (the agent runs on your machine with your own credentials).
 
 ### One-liner for not-yet-installed users

--- a/README.md
+++ b/README.md
@@ -92,12 +92,18 @@ The full workflow — label conventions, assignment rules, how planner / reviewe
 
 ## Take over a single PR
 
-Want to babysit *one* pull request — review it, fix review threads, dismiss unreasonable change requests, and keep going until it merges? There are two ways, depending on whether you want it **attended** or **unattended**:
+Want to babysit *one* pull request — review it, fix review threads, dismiss unreasonable change requests, and keep going until it merges?
 
-- **Agent-driven (zero install, attended)** — paste a prompt into the coding agent you're already running (Claude Code, Cursor, Codex…) and it drives the PR using `gh` + `git`. No daemon, and it uses your already-authenticated agent. Install the [`pr-takeover` skill](skills/pr-takeover/SKILL.md) (`npx skills add ./skills/pr-takeover`) or just paste its copy-paste prompt. Best when you're actively working; it only runs while your agent session is alive.
-- **Daemon-driven (unattended)** — `looper takeover` registers the PR with the background `looperd` daemon, which runs the reviewer + fixer loops on their own. Survives closing your terminal and can grind for days. Best for "set it and forget it".
+**The simplest path is one prompt.** Paste this into whatever coding agent you already run (Claude Code, Codex, opencode, Gemini, …):
 
-The rest of this section covers the daemon-driven `looper takeover` command. Run it from inside the checkout:
+> Take over this PR until it merges — read https://raw.githubusercontent.com/nexu-io/looper/main/skills/pr-takeover/SKILL.md and follow it.
+
+That points the agent at the [`pr-takeover` skill](skills/pr-takeover/SKILL.md), which decides — confirming with you when unclear — between two modes:
+
+- **Live (default, zero install)** — your own session drives the PR with `gh` + `git`. Uses your already-authenticated agent; runs while your session is alive.
+- **Background (unattended)** — hands the PR to the `looper takeover` command below, so the `looperd` daemon runs the reviewer + fixer loops on their own and it survives you closing your terminal.
+
+The rest of this section covers the `looper takeover` command that powers the background mode. Run it from inside the checkout:
 
 ```bash
 # detect the current branch's PR automatically
@@ -146,7 +152,7 @@ Everything after `--` is forwarded to `looper takeover`, so `--merge` and `--age
 Looper ships installable agent skills:
 
 - **`looper`** — setup, status, config, daemon lifecycle, and troubleshooting guidance.
-- **`pr-takeover`** — drive a single PR to merge from inside your own coding-agent session (read review feedback → fix → resolve threads → dismiss unreasonable change requests → merge when approved and green). Zero install beyond `gh` + `git`; no daemon. This is the agent-driven counterpart to the `looper takeover` command.
+- **`pr-takeover`** — drive a single PR to merge (read review feedback → fix → resolve threads → dismiss unreasonable change requests → merge when approved and green). One skill, two modes: it runs **live** in your own agent session (`gh` + `git`, zero install) or hands off to the **background** `looper takeover` daemon, confirming with you when unclear. Works in any agent via one universal prompt — see [`skills/pr-takeover/SKILL.md`](skills/pr-takeover/SKILL.md).
 
 ```bash
 npx skills add ./skills/looper

--- a/README.md
+++ b/README.md
@@ -92,7 +92,12 @@ The full workflow — label conventions, assignment rules, how planner / reviewe
 
 ## Take over a single PR
 
-Want Looper to babysit *one* pull request — review it, fix review threads, and keep going until it's mergeable — without registering the whole repo for autonomous work? Run `looper takeover` from inside the checkout:
+Want to babysit *one* pull request — review it, fix review threads, dismiss unreasonable change requests, and keep going until it merges? There are two ways, depending on whether you want it **attended** or **unattended**:
+
+- **Agent-driven (zero install, attended)** — paste a prompt into the coding agent you're already running (Claude Code, Cursor, Codex…) and it drives the PR using `gh` + `git`. No daemon, and it uses your already-authenticated agent. Install the [`pr-takeover` skill](skills/pr-takeover/SKILL.md) (`npx skills add ./skills/pr-takeover`) or just paste its copy-paste prompt. Best when you're actively working; it only runs while your agent session is alive.
+- **Daemon-driven (unattended)** — `looper takeover` registers the PR with the background `looperd` daemon, which runs the reviewer + fixer loops on their own. Survives closing your terminal and can grind for days. Best for "set it and forget it".
+
+The rest of this section covers the daemon-driven `looper takeover` command. Run it from inside the checkout:
 
 ```bash
 # detect the current branch's PR automatically
@@ -136,21 +141,26 @@ curl -fsSL https://raw.githubusercontent.com/nexu-io/looper/main/scripts/takeove
 
 Everything after `--` is forwarded to `looper takeover`, so `--merge` and `--agent-vendor` work there too.
 
-## Agent skill
+## Agent skills
 
-Looper includes an installable agent skill for setup, status, config, daemon lifecycle, and troubleshooting guidance:
+Looper ships installable agent skills:
+
+- **`looper`** — setup, status, config, daemon lifecycle, and troubleshooting guidance.
+- **`pr-takeover`** — drive a single PR to merge from inside your own coding-agent session (read review feedback → fix → resolve threads → dismiss unreasonable change requests → merge when approved and green). Zero install beyond `gh` + `git`; no daemon. This is the agent-driven counterpart to the `looper takeover` command.
 
 ```bash
 npx skills add ./skills/looper
+npx skills add ./skills/pr-takeover
 ```
 
-Or install it directly from GitHub:
+Or install directly from GitHub:
 
 ```bash
 npx skills add https://github.com/nexu-io/looper/tree/main/skills/looper
+npx skills add https://github.com/nexu-io/looper/tree/main/skills/pr-takeover
 ```
 
-See [`skills/looper/SKILL.md`](skills/looper/SKILL.md) for install and verification details.
+See [`skills/looper/SKILL.md`](skills/looper/SKILL.md) and [`skills/pr-takeover/SKILL.md`](skills/pr-takeover/SKILL.md) for details.
 
 ## How it works
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -515,7 +515,15 @@ looper takeover owner/repo#42 --merge   # also auto-merge once approved + green
 
 Agent selection: `takeover` reuses the vendor already in your config; otherwise it auto-detects an installed `claude` / `codex` / `opencode` CLI, prompts when the choice is ambiguous, and accepts `--agent-vendor` plus `--yes` for non-interactive runs. Auto-merge still depends on the repository allowing it (and, by default, on branch protection with required checks); when GitHub refuses, the reviewer keeps reviewing and reports why instead.
 
-To stop, run `looper ps` and `looper stop <id>` for the reviewer and fixer loops.
+Manage and stop takeovers:
+
+```bash
+looper takeover list                 # all active takeovers + live loop status
+looper takeover stop owner/repo#42   # stop this takeover's reviewer + fixer loops
+looper takeover stop --all           # stop every takeover
+```
+
+`takeover list` / `stop` are backed by a local index at `~/.looper/takeovers.json`; stopping closes the underlying loops by id (so it works even while they are idle/waiting between commits).
 
 ## 14. Quick decision guide
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -495,12 +495,35 @@ looper loop start --type fixer --pr owner/repo#42
 
 This is useful when you already have a PR and only want Looper to handle the review/fix cycle.
 
+### Option C: take over one PR in a single command
+
+`looper review --loop` + `looper loop start --type fixer` (Option B) requires the repo to already be a registered project, and a plain `looper project add` turns on autonomous discovery for *every* PR in that repo. When you only want Looper on a single PR — for example a contributor adopting their own PR — use `takeover`, which does the whole setup in one step and scopes Looper to just that PR:
+
+```bash
+# from inside the repo checkout
+looper takeover                 # detect the current branch's PR
+looper takeover owner/repo#42   # or name it explicitly
+looper takeover owner/repo#42 --merge   # also auto-merge once approved + green
+```
+
+`takeover`:
+
+1. installs/starts the managed daemon if needed;
+2. writes (or reuses) `~/.looper/config.json`, registering the repo as a project whose `planner` / `worker` / `fixer` / `reviewer` discovery loops are all disabled — so the daemon never picks up any *other* PR or issue in the repo;
+3. starts a continuous reviewer loop and fixer loop on the target PR (skip the fixer with `--no-fix`);
+4. with `--merge`, sets `roles.reviewer.autoMerge.enabled` for the project so the reviewer enables GitHub auto-merge once the PR is approved and checks are green.
+
+Agent selection: `takeover` reuses the vendor already in your config; otherwise it auto-detects an installed `claude` / `codex` / `opencode` CLI, prompts when the choice is ambiguous, and accepts `--agent-vendor` plus `--yes` for non-interactive runs. Auto-merge still depends on the repository allowing it (and, by default, on branch protection with required checks); when GitHub refuses, the reviewer keeps reviewing and reports why instead.
+
+To stop, run `looper ps` and `looper stop <id>` for the reviewer and fixer loops.
+
 ## 14. Quick decision guide
 
 - You have an issue but no spec yet: use `planner`
 - You have a PR that needs review: use `reviewer`
 - A PR already has review comments to address: use `fixer`
 - The spec is ready and implementation should begin: use `worker`
+- You want Looper on just one PR until it merges (no repo-wide automation): use `takeover`
 
 As a rule of thumb:
 

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -424,21 +424,28 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				},
 			}),
 			newCommand(commandSpec{
-				use:   "takeover [<pr>]",
-				short: "Continuously review and fix a pull request until it merges",
-				args:  cobra.MaximumNArgs(1),
-				runE:  runtime.takeover,
+				use:             "takeover [<pr>]",
+				short:           "Continuously review and fix a pull request until it merges",
+				args:            cobra.MaximumNArgs(1),
+				runE:            runtime.takeover,
+				helpSubcommands: []helpSubcommand{{name: "list", description: "List active takeovers"}, {name: "stop", description: "Stop a takeover's reviewer and fixer loops"}},
 				localFlags: []flagSpec{
 					stringFlag("agent-vendor", "vendor", "Agent vendor to run loops (claude-code, codex, opencode, cursor-cli)"),
 					boolFlag("merge", "Let the reviewer enable auto-merge once the PR is approved and green"),
 					boolFlag("no-fix", "Only run the reviewer loop; skip the fixer loop"),
 					boolFlag("yes", "Run non-interactively; fail instead of prompting for the agent vendor"),
 				},
+				subcommands: []*cobra.Command{
+					newCommand(commandSpec{use: "list", short: "List active takeovers", args: cobra.NoArgs, runE: runtime.takeoverList, exampleLines: []string{"$ looper takeover list", "$ looper takeover list --json"}}),
+					newCommand(commandSpec{use: "stop [<pr>]", short: "Stop a takeover's reviewer and fixer loops", args: cobra.MaximumNArgs(1), runE: runtime.takeoverStop, localFlags: []flagSpec{boolFlag("all", "Stop every active takeover")}, exampleLines: []string{"$ looper takeover stop", "$ looper takeover stop acme/looper#42", "$ looper takeover stop --all"}}),
+				},
 				exampleLines: []string{
 					"$ looper takeover",
 					"$ looper takeover acme/looper#42",
 					"$ looper takeover acme/looper#42 --merge --agent-vendor claude-code",
 					"$ looper takeover --yes --agent-vendor codex",
+					"$ looper takeover list",
+					"$ looper takeover stop acme/looper#42",
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -107,7 +107,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 	root := newCommand(commandSpec{
 		use:             "looper",
 		short:           "Looper command-line interface",
-		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "network", description: "Network membership commands"}, {name: "netadmin", description: "Network repo operator commands"}, {name: "webhook", description: "Webhook configuration and status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "prompt", description: "Prompt inspection commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "labels", description: "GitHub label commands"}, {name: "queue", description: "Queue inspection and maintenance commands"}, {name: "worktree", description: "Worktree maintenance commands"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "fix", description: "Create a fixer task for a pull request"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "pause", description: "Pause a loop by sequence number"}, {name: "unpause", description: "Resume a paused loop by sequence number"}, {name: "stop", description: "Stop an active loop"}, {name: "close", description: "Terminally close a loop"}, {name: "run", description: "Run commands"}},
+		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "network", description: "Network membership commands"}, {name: "netadmin", description: "Network repo operator commands"}, {name: "webhook", description: "Webhook configuration and status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "prompt", description: "Prompt inspection commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "labels", description: "GitHub label commands"}, {name: "queue", description: "Queue inspection and maintenance commands"}, {name: "worktree", description: "Worktree maintenance commands"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "fix", description: "Create a fixer task for a pull request"}, {name: "takeover", description: "Continuously review and fix a pull request until it merges"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "pause", description: "Pause a loop by sequence number"}, {name: "unpause", description: "Resume a paused loop by sequence number"}, {name: "stop", description: "Stop an active loop"}, {name: "close", description: "Terminally close a loop"}, {name: "run", description: "Run commands"}},
 		helpWhenNoArgs:  true,
 		subcommands: []*cobra.Command{
 			newCommand(commandSpec{use: "status", short: "Show service status", runE: runtime.status}),
@@ -421,6 +421,24 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					"$ looper review submit acme/looper#42 --event COMMENT --commit-id abc123 < review.json",
 					"$ looper review repair acme/looper#42",
 					"$ looper review repair acme/looper#42 --apply",
+				},
+			}),
+			newCommand(commandSpec{
+				use:   "takeover [<pr>]",
+				short: "Continuously review and fix a pull request until it merges",
+				args:  cobra.MaximumNArgs(1),
+				runE:  runtime.takeover,
+				localFlags: []flagSpec{
+					stringFlag("agent-vendor", "vendor", "Agent vendor to run loops (claude-code, codex, opencode, cursor-cli)"),
+					boolFlag("merge", "Let the reviewer enable auto-merge once the PR is approved and green"),
+					boolFlag("no-fix", "Only run the reviewer loop; skip the fixer loop"),
+					boolFlag("yes", "Run non-interactively; fail instead of prompting for the agent vendor"),
+				},
+				exampleLines: []string{
+					"$ looper takeover",
+					"$ looper takeover acme/looper#42",
+					"$ looper takeover acme/looper#42 --merge --agent-vendor claude-code",
+					"$ looper takeover --yes --agent-vendor codex",
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/takeover.go
+++ b/internal/cliapp/takeover.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -169,6 +170,24 @@ func (r *commandRuntime) runTakeover(ctx context.Context, cmd *cobra.Command, op
 			return takeoverResult{}, err
 		}
 		result.Fixer = fixer
+	}
+
+	entry := takeoverStateEntry{
+		Repo:        repo,
+		PRNumber:    prNumber,
+		ProjectID:   project.ID,
+		AgentVendor: string(vendor),
+		AutoMerge:   opts.Merge,
+		StartedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+	if result.Reviewer != nil {
+		entry.ReviewerLoopID = result.Reviewer.ID
+	}
+	if result.Fixer != nil {
+		entry.FixerLoopID = result.Fixer.ID
+	}
+	if err := r.recordTakeover(entry); err != nil {
+		result.Notes = append(result.Notes, fmt.Sprintf("could not record takeover state (%v); `looper takeover list`/`stop` may not see this run", err))
 	}
 
 	result.NextSteps = takeoverNextSteps(repo, prNumber)
@@ -596,6 +615,296 @@ func takeoverNextSteps(repo string, prNumber int64) []string {
 		fmt.Sprintf("looper pr status %s#%d", repo, prNumber),
 		"looper stop <id>",
 	}
+}
+
+// takeoverStateFile is the local index, under ~/.looper, that ties each
+// takeover to the loops it started so `takeover list` / `takeover stop` can
+// manage them without the daemon having to model "a takeover" as a first-class
+// concept.
+const takeoverStateFile = "takeovers.json"
+
+type takeoverStateEntry struct {
+	Repo           string `json:"repo"`
+	PRNumber       int64  `json:"prNumber"`
+	ProjectID      string `json:"projectId"`
+	AgentVendor    string `json:"agentVendor"`
+	AutoMerge      bool   `json:"autoMerge"`
+	ReviewerLoopID string `json:"reviewerLoopId,omitempty"`
+	FixerLoopID    string `json:"fixerLoopId,omitempty"`
+	StartedAt      string `json:"startedAt"`
+}
+
+type takeoverState struct {
+	Version   int                  `json:"version"`
+	Takeovers []takeoverStateEntry `json:"takeovers"`
+}
+
+func (r *commandRuntime) takeoverStatePath() (string, error) {
+	home, err := r.homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".looper", takeoverStateFile), nil
+}
+
+func (r *commandRuntime) loadTakeoverState() (takeoverState, error) {
+	path, err := r.takeoverStatePath()
+	if err != nil {
+		return takeoverState{}, err
+	}
+	data, err := r.readFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return takeoverState{Version: 1}, nil
+		}
+		return takeoverState{}, err
+	}
+	var st takeoverState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return takeoverState{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if st.Version == 0 {
+		st.Version = 1
+	}
+	return st, nil
+}
+
+func (r *commandRuntime) saveTakeoverState(st takeoverState) error {
+	path, err := r.takeoverStatePath()
+	if err != nil {
+		return err
+	}
+	if err := r.mkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	st.Version = 1
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	return r.writeFile(path, append(data, '\n'), 0o644)
+}
+
+func (r *commandRuntime) recordTakeover(entry takeoverStateEntry) error {
+	st, err := r.loadTakeoverState()
+	if err != nil {
+		return err
+	}
+	st.Takeovers = upsertTakeoverEntry(st.Takeovers, entry)
+	return r.saveTakeoverState(st)
+}
+
+func upsertTakeoverEntry(entries []takeoverStateEntry, entry takeoverStateEntry) []takeoverStateEntry {
+	for i := range entries {
+		if entries[i].Repo == entry.Repo && entries[i].PRNumber == entry.PRNumber {
+			entries[i] = entry
+			return entries
+		}
+	}
+	return append(entries, entry)
+}
+
+// matchTakeovers selects the takeover entries targeted by a stop request. With
+// all=true it returns everything; an explicit fully-qualified ref matches
+// repo+number; a bare number matches a unique PR number; an empty ref matches
+// the only takeover when exactly one is recorded.
+func matchTakeovers(entries []takeoverStateEntry, ref string, all bool) ([]takeoverStateEntry, error) {
+	if all {
+		if len(entries) == 0 {
+			return nil, fmt.Errorf("no active takeovers to stop")
+		}
+		return entries, nil
+	}
+
+	if strings.TrimSpace(ref) == "" {
+		switch len(entries) {
+		case 0:
+			return nil, fmt.Errorf("no active takeovers to stop")
+		case 1:
+			return entries, nil
+		default:
+			return nil, fmt.Errorf("multiple takeovers active; pass <owner/repo>#<number> or --all")
+		}
+	}
+
+	repo, prNumber, repoQualified, err := parseOptionalPullRequestRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]takeoverStateEntry, 0, 1)
+	for _, entry := range entries {
+		if entry.PRNumber != prNumber {
+			continue
+		}
+		if repoQualified && entry.Repo != repo {
+			continue
+		}
+		matches = append(matches, entry)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no active takeover matches %s", ref)
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("%s is ambiguous across multiple repos; pass <owner/repo>#<number>", ref)
+	}
+	return matches, nil
+}
+
+func (r *commandRuntime) takeoverList(cmd *cobra.Command, args []string) error {
+	_ = args
+	ctx := cmd.Context()
+	st, err := r.loadTakeoverState()
+	if err != nil {
+		return err
+	}
+
+	statusByID := map[string]string{}
+	if payload, err := r.getJSON(ctx, "/api/v1/loops"); err == nil {
+		var data loopsListOutput
+		if json.Unmarshal(payload, &data) == nil {
+			for _, loop := range data.Items {
+				statusByID[loop.ID] = loop.Status
+			}
+		}
+	}
+
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), takeoverListPayload(st, statusByID))
+	}
+	return writeHumanTakeoverList(cmd.OutOrStdout(), st, statusByID)
+}
+
+func loopLiveStatus(statusByID map[string]string, loopID string) string {
+	if loopID == "" {
+		return "-"
+	}
+	if status, ok := statusByID[loopID]; ok {
+		return status
+	}
+	return "waiting"
+}
+
+func takeoverListPayload(st takeoverState, statusByID map[string]string) map[string]any {
+	items := make([]map[string]any, 0, len(st.Takeovers))
+	for _, entry := range st.Takeovers {
+		items = append(items, map[string]any{
+			"repo":           entry.Repo,
+			"prNumber":       entry.PRNumber,
+			"projectId":      entry.ProjectID,
+			"agentVendor":    entry.AgentVendor,
+			"autoMerge":      entry.AutoMerge,
+			"startedAt":      entry.StartedAt,
+			"reviewerLoopId": entry.ReviewerLoopID,
+			"fixerLoopId":    entry.FixerLoopID,
+			"reviewerStatus": loopLiveStatus(statusByID, entry.ReviewerLoopID),
+			"fixerStatus":    loopLiveStatus(statusByID, entry.FixerLoopID),
+		})
+	}
+	return map[string]any{"items": items}
+}
+
+func writeHumanTakeoverList(w io.Writer, st takeoverState, statusByID map[string]string) error {
+	if len(st.Takeovers) == 0 {
+		_, err := fmt.Fprintln(w, "No active takeovers.")
+		return err
+	}
+	rows := make([]tableRow, 0, len(st.Takeovers))
+	for _, entry := range st.Takeovers {
+		fixer := loopLiveStatus(statusByID, entry.FixerLoopID)
+		if entry.FixerLoopID == "" {
+			fixer = "(none)"
+		}
+		rows = append(rows, tableRow{
+			"pr":        fmt.Sprintf("%s#%d", entry.Repo, entry.PRNumber),
+			"agent":     entry.AgentVendor,
+			"autoMerge": fmt.Sprintf("%t", entry.AutoMerge),
+			"reviewer":  loopLiveStatus(statusByID, entry.ReviewerLoopID),
+			"fixer":     fixer,
+			"startedAt": entry.StartedAt,
+		})
+	}
+	printTable(w, []string{"pr", "agent", "autoMerge", "reviewer", "fixer", "startedAt"}, rows)
+	return nil
+}
+
+type takeoverStopResult struct {
+	Stopped []takeoverStopEntry `json:"stopped"`
+}
+
+type takeoverStopEntry struct {
+	Repo        string   `json:"repo"`
+	PRNumber    int64    `json:"prNumber"`
+	ClosedLoops []string `json:"closedLoops"`
+	Warnings    []string `json:"warnings,omitempty"`
+}
+
+func (r *commandRuntime) takeoverStop(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	ref := ""
+	if len(args) > 0 {
+		ref = strings.TrimSpace(args[0])
+	}
+
+	st, err := r.loadTakeoverState()
+	if err != nil {
+		return err
+	}
+	targets, err := matchTakeovers(st.Takeovers, ref, getBoolFlag(cmd, "all"))
+	if err != nil {
+		return err
+	}
+
+	result := takeoverStopResult{}
+	stopped := map[string]struct{}{}
+	for _, target := range targets {
+		entry := takeoverStopEntry{Repo: target.Repo, PRNumber: target.PRNumber}
+		for _, loopID := range []string{target.ReviewerLoopID, target.FixerLoopID} {
+			if loopID == "" {
+				continue
+			}
+			if _, err := r.postJSON(ctx, "/api/v1/runs/active/"+url.PathEscape(loopID)+"/close", nil); err != nil {
+				entry.Warnings = append(entry.Warnings, fmt.Sprintf("close %s: %v", loopID, err))
+				continue
+			}
+			entry.ClosedLoops = append(entry.ClosedLoops, loopID)
+		}
+		result.Stopped = append(result.Stopped, entry)
+		stopped[takeoverKey(target.Repo, target.PRNumber)] = struct{}{}
+	}
+
+	remaining := make([]takeoverStateEntry, 0, len(st.Takeovers))
+	for _, entry := range st.Takeovers {
+		if _, ok := stopped[takeoverKey(entry.Repo, entry.PRNumber)]; ok {
+			continue
+		}
+		remaining = append(remaining, entry)
+	}
+	st.Takeovers = remaining
+	if err := r.saveTakeoverState(st); err != nil {
+		return err
+	}
+
+	if getBoolFlag(cmd, "json") {
+		return writeJSON(cmd.OutOrStdout(), result)
+	}
+	return writeHumanTakeoverStop(cmd.OutOrStdout(), result)
+}
+
+func takeoverKey(repo string, prNumber int64) string {
+	return fmt.Sprintf("%s#%d", repo, prNumber)
+}
+
+func writeHumanTakeoverStop(w io.Writer, result takeoverStopResult) error {
+	for _, entry := range result.Stopped {
+		printSection(w, "Takeover stopped", [][2]any{
+			{"pr", takeoverKey(entry.Repo, entry.PRNumber)},
+			{"closedLoops", strings.Join(entry.ClosedLoops, ", ")},
+		})
+		for _, warning := range entry.Warnings {
+			_, _ = fmt.Fprintf(w, "- note: %s\n", warning)
+		}
+	}
+	return nil
 }
 
 func writeHumanTakeoverResult(w io.Writer, result takeoverResult) error {

--- a/internal/cliapp/takeover.go
+++ b/internal/cliapp/takeover.go
@@ -1,0 +1,632 @@
+package cliapp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// takeoverProjectSyncTimeout bounds how long takeover waits for the daemon to
+// register the scoped project after (re)starting.
+const takeoverProjectSyncTimeout = 10 * time.Second
+
+// takeoverVendorBinaries maps each supported agent vendor to the CLI binary
+// looper spawns for it (see internal/agent/executor.go resolveCommand). Only
+// vendors with an unambiguous binary name participate in auto-detection;
+// cursor-cli spawns the generic "agent" binary and is intentionally excluded to
+// avoid false positives, so cursor users pass --agent-vendor explicitly.
+var takeoverVendorBinaries = []struct {
+	vendor config.AgentVendor
+	binary string
+}{
+	{config.AgentVendorClaudeCode, "claude"},
+	{config.AgentVendorCodex, "codex"},
+	{config.AgentVendorOpenCode, "opencode"},
+}
+
+type takeoverOptions struct {
+	PRRef       string
+	AgentVendor string
+	Merge       bool
+	Yes         bool
+	NoFix       bool
+	JSON        bool
+}
+
+type takeoverLoopResult struct {
+	ID     string `json:"id"`
+	Seq    int64  `json:"seq"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}
+
+type takeoverResult struct {
+	Repo          string              `json:"repo"`
+	PRNumber      int64               `json:"prNumber"`
+	ProjectID     string              `json:"projectId"`
+	AgentVendor   string              `json:"agentVendor"`
+	AutoMerge     bool                `json:"autoMerge"`
+	ConfigPath    string              `json:"configPath"`
+	DaemonRunning bool                `json:"daemonRunning"`
+	Reviewer      *takeoverLoopResult `json:"reviewer,omitempty"`
+	Fixer         *takeoverLoopResult `json:"fixer,omitempty"`
+	NextSteps     []string            `json:"nextSteps"`
+	Notes         []string            `json:"notes,omitempty"`
+}
+
+func (r *commandRuntime) takeover(cmd *cobra.Command, args []string) error {
+	opts := takeoverOptions{
+		AgentVendor: strings.TrimSpace(getStringFlag(cmd, "agent-vendor")),
+		Merge:       getBoolFlag(cmd, "merge"),
+		Yes:         getBoolFlag(cmd, "yes"),
+		NoFix:       getBoolFlag(cmd, "no-fix"),
+		JSON:        getBoolFlag(cmd, "json"),
+	}
+	if len(args) > 0 {
+		opts.PRRef = strings.TrimSpace(args[0])
+	}
+
+	result, err := r.runTakeover(cmd.Context(), cmd, opts)
+	if err != nil {
+		return err
+	}
+	if opts.JSON {
+		return writeJSON(cmd.OutOrStdout(), result)
+	}
+	return writeHumanTakeoverResult(cmd.OutOrStdout(), result)
+}
+
+func (r *commandRuntime) runTakeover(ctx context.Context, cmd *cobra.Command, opts takeoverOptions) (takeoverResult, error) {
+	cwd, err := r.getwd()
+	if err != nil {
+		return takeoverResult{}, fmt.Errorf("determine current working directory: %w", err)
+	}
+
+	repoRoot, err := r.takeoverRepoRoot(ctx)
+	if err != nil {
+		return takeoverResult{}, err
+	}
+
+	repo, prNumber, err := r.resolveTakeoverTarget(ctx, opts.PRRef, repoRoot)
+	if err != nil {
+		return takeoverResult{}, err
+	}
+
+	vendor, vendorNote, err := r.resolveTakeoverVendor(cmd, opts)
+	if err != nil {
+		return takeoverResult{}, err
+	}
+
+	result := takeoverResult{
+		Repo:        repo,
+		PRNumber:    prNumber,
+		AgentVendor: string(vendor),
+		AutoMerge:   opts.Merge,
+	}
+	if vendorNote != "" {
+		result.Notes = append(result.Notes, vendorNote)
+	}
+
+	configPath, err := r.resolveBootstrapConfigPath(cwd)
+	if err != nil {
+		return takeoverResult{}, err
+	}
+	result.ConfigPath = configPath
+
+	plan := bootstrapConfigPlan{}
+	preflightNotes, err := r.bootstrapPreflight(ctx, configPath, &plan)
+	if err != nil {
+		return takeoverResult{}, err
+	}
+	result.Notes = append(result.Notes, preflightNotes...)
+
+	if err := r.ensureBootstrapDirectories(); err != nil {
+		return takeoverResult{}, err
+	}
+
+	changed, err := r.ensureTakeoverConfig(configPath, cwd, repoRoot, vendor, opts.Merge)
+	if err != nil {
+		return takeoverResult{}, err
+	}
+
+	if _, _, err := r.ensureBootstrapDaemon(ctx, false); err != nil {
+		return takeoverResult{}, err
+	}
+
+	daemonNote, err := r.ensureTakeoverDaemonRunning(ctx, cmd, changed)
+	if err != nil {
+		return takeoverResult{}, err
+	}
+	if daemonNote != "" {
+		result.Notes = append(result.Notes, daemonNote)
+	}
+	result.DaemonRunning = true
+
+	project, err := r.waitForTakeoverProject(ctx, repoRoot)
+	if err != nil {
+		return takeoverResult{}, err
+	}
+	result.ProjectID = project.ID
+
+	reviewer, err := r.startTakeoverLoop(ctx, "reviewer", project.ID, repo, prNumber)
+	if err != nil {
+		return takeoverResult{}, err
+	}
+	result.Reviewer = reviewer
+
+	if !opts.NoFix {
+		fixer, err := r.startTakeoverLoop(ctx, "fixer", project.ID, repo, prNumber)
+		if err != nil {
+			return takeoverResult{}, err
+		}
+		result.Fixer = fixer
+	}
+
+	result.NextSteps = takeoverNextSteps(repo, prNumber)
+	if !opts.Merge {
+		result.Notes = append(result.Notes, "auto-merge is disabled; rerun with --merge to let the reviewer enable auto-merge once the PR is approved and green")
+	}
+	return result, nil
+}
+
+// takeoverRepoRoot resolves the git repository root for the current directory.
+func (r *commandRuntime) takeoverRepoRoot(ctx context.Context) (string, error) {
+	gitPath, err := r.lookPath()("git")
+	if err != nil {
+		return "", fmt.Errorf("git is required for `looper takeover`: %w", err)
+	}
+	out, err := r.runCommand(ctx, gitPath, []string{"rev-parse", "--show-toplevel"}, 5*time.Second)
+	if err != nil {
+		return "", fmt.Errorf("resolve git repository root: %w", err)
+	}
+	if out.ExitCode != 0 {
+		return "", fmt.Errorf("`looper takeover` must run inside a git repository (git rev-parse failed: %s)", strings.TrimSpace(out.Stderr))
+	}
+	root := strings.TrimSpace(out.Stdout)
+	if root == "" {
+		return "", fmt.Errorf("`looper takeover` must run inside a git repository")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve repository root path: %w", err)
+	}
+	return abs, nil
+}
+
+// resolveTakeoverTarget determines the owner/repo slug and PR number to take
+// over. An explicit "<owner/repo>#<n>" or "<n>" ref wins; otherwise the PR for
+// the current branch is discovered via gh.
+func (r *commandRuntime) resolveTakeoverTarget(ctx context.Context, prRef string, repoRoot string) (string, int64, error) {
+	if prRef != "" {
+		repo, prNumber, repoQualified, err := parseOptionalPullRequestRef(prRef)
+		if err != nil {
+			return "", 0, err
+		}
+		if repoQualified {
+			return repo, prNumber, nil
+		}
+		repo, err = r.detectTakeoverRepoSlug(ctx)
+		if err != nil {
+			return "", 0, err
+		}
+		return repo, prNumber, nil
+	}
+
+	repo, err := r.detectTakeoverRepoSlug(ctx)
+	if err != nil {
+		return "", 0, err
+	}
+	prNumber, err := r.detectTakeoverPRNumber(ctx)
+	if err != nil {
+		return "", 0, err
+	}
+	return repo, prNumber, nil
+}
+
+func (r *commandRuntime) detectTakeoverRepoSlug(ctx context.Context) (string, error) {
+	ghPath, err := r.lookPath()("gh")
+	if err != nil {
+		return "", fmt.Errorf("gh is required to detect the repository: %w", err)
+	}
+	out, err := r.runCommand(ctx, ghPath, []string{"repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"}, 15*time.Second)
+	if err != nil {
+		return "", fmt.Errorf("detect repository via gh: %w", err)
+	}
+	if out.ExitCode != 0 {
+		return "", fmt.Errorf("could not detect the GitHub repository (gh repo view failed: %s). Pass an explicit <owner/repo>#<number>", strings.TrimSpace(out.Stderr))
+	}
+	repo := strings.TrimSpace(out.Stdout)
+	if repo == "" {
+		return "", fmt.Errorf("could not detect the GitHub repository; pass an explicit <owner/repo>#<number>")
+	}
+	return repo, nil
+}
+
+func (r *commandRuntime) detectTakeoverPRNumber(ctx context.Context) (int64, error) {
+	ghPath, err := r.lookPath()("gh")
+	if err != nil {
+		return 0, fmt.Errorf("gh is required to detect the current pull request: %w", err)
+	}
+	out, err := r.runCommand(ctx, ghPath, []string{"pr", "view", "--json", "number", "--jq", ".number"}, 15*time.Second)
+	if err != nil {
+		return 0, fmt.Errorf("detect pull request via gh: %w", err)
+	}
+	if out.ExitCode != 0 {
+		return 0, fmt.Errorf("no pull request found for the current branch (gh pr view failed: %s). Push the branch and open a PR, or pass an explicit <owner/repo>#<number>", strings.TrimSpace(out.Stderr))
+	}
+	prNumber, err := parsePositiveInt(strings.TrimSpace(out.Stdout), "pull request number")
+	if err != nil {
+		return 0, fmt.Errorf("parse detected pull request number: %w", err)
+	}
+	return prNumber, nil
+}
+
+// resolveTakeoverVendor decides which agent vendor to configure. An explicit
+// --agent-vendor wins; otherwise it auto-detects installed agent CLIs and, when
+// interactive, prompts. In non-interactive mode (--yes) an ambiguous or empty
+// detection is a hard error so the run never silently picks the wrong agent.
+func (r *commandRuntime) resolveTakeoverVendor(cmd *cobra.Command, opts takeoverOptions) (config.AgentVendor, string, error) {
+	if opts.AgentVendor != "" {
+		vendor := config.AgentVendor(opts.AgentVendor)
+		if !isSupportedBootstrapVendor(vendor) {
+			return "", "", fmt.Errorf("unsupported --agent-vendor %q (supported: claude-code, codex, opencode, cursor-cli)", opts.AgentVendor)
+		}
+		return vendor, "", nil
+	}
+
+	if existing := r.takeoverConfiguredVendor(cmd); existing != "" {
+		return existing, fmt.Sprintf("reusing agent vendor %q from existing config", existing), nil
+	}
+
+	detected := detectInstalledVendors(r.lookPath())
+	if len(detected) == 1 {
+		return detected[0], fmt.Sprintf("detected installed agent CLI: %s", detected[0]), nil
+	}
+
+	if opts.Yes {
+		if len(detected) == 0 {
+			return "", "", fmt.Errorf("no supported agent CLI detected on PATH; install one (claude, codex, or opencode) or pass --agent-vendor")
+		}
+		return "", "", fmt.Errorf("multiple agent CLIs detected (%s); pass --agent-vendor to choose one", joinVendors(detected))
+	}
+
+	vendor, err := r.promptTakeoverVendor(cmd, detected)
+	if err != nil {
+		return "", "", err
+	}
+	return vendor, "", nil
+}
+
+// takeoverConfiguredVendor returns the agent vendor already present in the
+// loaded config, if any, so an existing setup is reused rather than re-prompted.
+func (r *commandRuntime) takeoverConfiguredVendor(cmd *cobra.Command) config.AgentVendor {
+	_ = cmd
+	loaded, err := r.loadConfig()
+	if err != nil {
+		return ""
+	}
+	if loaded.Config.Agent.Vendor == nil {
+		return ""
+	}
+	return *loaded.Config.Agent.Vendor
+}
+
+func (r *commandRuntime) promptTakeoverVendor(cmd *cobra.Command, detected []config.AgentVendor) (config.AgentVendor, error) {
+	reader := bufio.NewReader(cmd.InOrStdin())
+	defaultValue := ""
+	if len(detected) > 0 {
+		defaultValue = string(detected[0])
+	}
+	label := "Agent vendor [claude-code/codex/opencode/cursor-cli]"
+	if len(detected) > 0 {
+		label = fmt.Sprintf("Agent vendor (detected: %s) [claude-code/codex/opencode/cursor-cli]", joinVendors(detected))
+	}
+	answer, err := promptBootstrapString(reader, cmd.OutOrStdout(), label, defaultValue)
+	if err != nil {
+		return "", err
+	}
+	answer = strings.TrimSpace(answer)
+	if answer == "" {
+		return "", fmt.Errorf("an agent vendor is required to run loops; pass --agent-vendor or answer the prompt")
+	}
+	vendor := config.AgentVendor(answer)
+	if !isSupportedBootstrapVendor(vendor) {
+		return "", fmt.Errorf("unsupported agent vendor %q (supported: claude-code, codex, opencode, cursor-cli)", answer)
+	}
+	return vendor, nil
+}
+
+func detectInstalledVendors(look config.LookPathFunc) []config.AgentVendor {
+	found := make([]config.AgentVendor, 0, len(takeoverVendorBinaries))
+	for _, vb := range takeoverVendorBinaries {
+		if _, err := look(vb.binary); err == nil {
+			found = append(found, vb.vendor)
+		}
+	}
+	return found
+}
+
+func joinVendors(vendors []config.AgentVendor) string {
+	parts := make([]string, 0, len(vendors))
+	for _, v := range vendors {
+		parts = append(parts, string(v))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// takeoverScopingRoles builds the per-project role overrides that keep the
+// daemon focused on the single targeted PR: every autonomous discovery loop is
+// disabled so only the manually started reviewer/fixer loops run. When merge is
+// requested, the reviewer is allowed to enable GitHub auto-merge.
+func takeoverScopingRoles(merge bool) *config.PartialRoleConfigs {
+	disabled := false
+	roles := &config.PartialRoleConfigs{
+		Planner:  &config.PartialPlannerRoleConfig{AutoDiscovery: &disabled},
+		Worker:   &config.PartialWorkerRoleConfig{AutoDiscovery: &disabled},
+		Fixer:    &config.PartialFixerRoleConfig{AutoDiscovery: &disabled},
+		Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{AutoDiscovery: &disabled}},
+	}
+	if merge {
+		enabled := true
+		roles.Reviewer.AutoMerge = &config.PartialReviewerAutoMergeConfig{Enabled: &enabled}
+	}
+	return roles
+}
+
+// ensureTakeoverConfig creates or patches the config file so it carries the
+// agent vendor and a project entry (scoped to the single PR) for repoRoot. It
+// returns whether the file content changed.
+func (r *commandRuntime) ensureTakeoverConfig(configPath string, cwd string, repoRoot string, vendor config.AgentVendor, merge bool) (bool, error) {
+	if err := r.mkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return false, fmt.Errorf("create config directory: %w", err)
+	}
+
+	roles := takeoverScopingRoles(merge)
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		cfg, err := config.DefaultConfig(cwd)
+		if err != nil {
+			return false, fmt.Errorf("build default config: %w", err)
+		}
+		v := vendor
+		cfg.Agent.Vendor = &v
+		cfg.Notifications.Osascript.Enabled = false
+		project := buildBootstrapProject(repoRoot, cfg.Defaults.BaseBranch)
+		project.Roles = roles
+		cfg.Projects = append(cfg.Projects, project)
+		if err := writeBootstrapConfig(configPath, cfg); err != nil {
+			return false, err
+		}
+		return true, nil
+	} else if err != nil {
+		return false, fmt.Errorf("check config path %s: %w", configPath, err)
+	}
+
+	partial, err := readBootstrapPartialConfig(configPath)
+	if err != nil {
+		return false, err
+	}
+
+	changed := false
+	if partial.Agent == nil || partial.Agent.Vendor == nil {
+		if partial.Agent == nil {
+			partial.Agent = &config.PartialAgentConfig{}
+		}
+		v := vendor
+		partial.Agent.Vendor = &v
+		changed = true
+	}
+
+	normalized, err := config.Normalize(cwd, partial)
+	if err != nil {
+		return false, err
+	}
+	project := buildBootstrapProject(repoRoot, normalized.Defaults.BaseBranch)
+	project.Roles = roles
+	partialProject := partialProjectFromConfig(project)
+
+	projects := []config.PartialProjectRefConfig{}
+	replaced := false
+	if partial.Projects != nil {
+		for _, existing := range *partial.Projects {
+			if samePath(existing.RepoPath, repoRoot) {
+				// Preserve the user's existing project fields and only enforce
+				// the single-PR scoping roles, so re-running takeover does not
+				// drop custom instructions, worktree roots, or names.
+				merged := existing
+				merged.Roles = roles
+				if !sameTakeoverProject(existing, merged) {
+					changed = true
+				}
+				projects = append(projects, merged)
+				replaced = true
+				continue
+			}
+			projects = append(projects, existing)
+		}
+	}
+	if !replaced {
+		projects = append(projects, partialProject)
+		changed = true
+	}
+	partial.Projects = &projects
+
+	updated, err := config.Normalize(cwd, partial)
+	if err != nil {
+		return false, err
+	}
+	if err := config.Validate(updated); err != nil {
+		return false, err
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	newRaw, err := config.MarshalConfigFile(configPath, partial)
+	if err != nil {
+		return false, fmt.Errorf("marshal config: %w", err)
+	}
+	if err := os.WriteFile(configPath, newRaw, 0o644); err != nil {
+		return false, fmt.Errorf("write config: %w", err)
+	}
+	return true, nil
+}
+
+// sameTakeoverProject reports whether two project entries are equivalent for
+// takeover purposes, so an idempotent re-run does not rewrite the config (and
+// therefore does not trigger a needless daemon restart).
+func sameTakeoverProject(a, b config.PartialProjectRefConfig) bool {
+	left, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	right, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return string(left) == string(right)
+}
+
+// ensureTakeoverDaemonRunning starts the daemon when it is down, or restarts it
+// to reload changed config when it is already running. Daemon lifecycle output
+// is suppressed so takeover prints a single coherent summary.
+func (r *commandRuntime) ensureTakeoverDaemonRunning(ctx context.Context, cmd *cobra.Command, configChanged bool) (string, error) {
+	loaded, err := r.loadConfig()
+	if err != nil {
+		return "", err
+	}
+	client := r.apiClientFromLoaded(loaded)
+	reachable, err := r.bootstrapAPIReachable(ctx, client)
+	if err != nil {
+		return "", err
+	}
+
+	if !reachable {
+		if err := r.takeoverDaemonLifecycle(cmd, r.daemonStart); err != nil {
+			return "", err
+		}
+		if _, err := r.waitForBootstrapHealth(ctx, client); err != nil {
+			return "", err
+		}
+		return "started looperd in detached mode; it will not survive logout or reboot — run `looper daemon start --daemon-mode launchd` for supervised lifecycle", nil
+	}
+
+	if configChanged {
+		if err := r.takeoverDaemonLifecycle(cmd, r.daemonRestart); err != nil {
+			return "", err
+		}
+		if _, err := r.waitForBootstrapHealth(ctx, client); err != nil {
+			return "", err
+		}
+		return "restarted looperd to load the updated configuration", nil
+	}
+
+	return "", nil
+}
+
+func (r *commandRuntime) takeoverDaemonLifecycle(cmd *cobra.Command, action func(*cobra.Command, []string) error) error {
+	originalOut := cmd.OutOrStdout()
+	cmd.SetOut(io.Discard)
+	defer cmd.SetOut(originalOut)
+	return action(cmd, nil)
+}
+
+// waitForTakeoverProject waits for the daemon to register the scoped project
+// (synced from config on startup) and returns it.
+func (r *commandRuntime) waitForTakeoverProject(ctx context.Context, repoRoot string) (projectOutput, error) {
+	deadline := time.Now().Add(takeoverProjectSyncTimeout)
+	var lastErr error
+	for {
+		projects, err := r.listProjects(ctx)
+		if err != nil {
+			lastErr = err
+		} else {
+			for _, project := range projects {
+				if samePath(project.RepoPath, repoRoot) {
+					return project, nil
+				}
+			}
+			lastErr = fmt.Errorf("project for %s was not registered by looperd", repoRoot)
+		}
+		if !time.Now().Before(deadline) {
+			return projectOutput{}, lastErr
+		}
+		r.sleep(250 * time.Millisecond)
+	}
+}
+
+func (r *commandRuntime) startTakeoverLoop(ctx context.Context, loopType string, projectID string, repo string, prNumber int64) (*takeoverLoopResult, error) {
+	body := map[string]any{
+		"projectId":  projectID,
+		"type":       loopType,
+		"targetType": "pull_request",
+		"repo":       repo,
+		"prNumber":   prNumber,
+		"status":     "running",
+		"metadata": map[string]any{
+			"manual":        true,
+			"followUpdates": true,
+		},
+	}
+	payload, err := r.postJSON(ctx, "/api/v1/loops", body)
+	if err != nil {
+		return nil, fmt.Errorf("start %s loop: %w", loopType, err)
+	}
+	var data loopOutput
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return nil, fmt.Errorf("decode %s loop response: %w", loopType, err)
+	}
+	return &takeoverLoopResult{ID: data.ID, Seq: data.Seq, Type: data.Type, Status: data.Status}, nil
+}
+
+func takeoverNextSteps(repo string, prNumber int64) []string {
+	return []string{
+		"looper ps",
+		"looper logs <id> --follow",
+		fmt.Sprintf("looper pr status %s#%d", repo, prNumber),
+		"looper stop <id>",
+	}
+}
+
+func writeHumanTakeoverResult(w io.Writer, result takeoverResult) error {
+	rows := [][2]any{
+		{"pr", fmt.Sprintf("%s#%d", result.Repo, result.PRNumber)},
+		{"projectId", result.ProjectID},
+		{"agentVendor", result.AgentVendor},
+		{"autoMerge", result.AutoMerge},
+		{"daemonRunning", result.DaemonRunning},
+	}
+	if result.Reviewer != nil {
+		rows = append(rows, [2]any{"reviewerLoop", fmt.Sprintf("%s (%s)", result.Reviewer.ID, result.Reviewer.Status)})
+	}
+	if result.Fixer != nil {
+		rows = append(rows, [2]any{"fixerLoop", fmt.Sprintf("%s (%s)", result.Fixer.ID, result.Fixer.Status)})
+	}
+	printSection(w, "Takeover started", rows)
+
+	if len(result.Notes) > 0 {
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, "Notes:")
+		for _, note := range result.Notes {
+			_, _ = fmt.Fprintf(w, "- %s\n", note)
+		}
+	}
+	if len(result.NextSteps) > 0 {
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, "Next steps:")
+		for _, step := range result.NextSteps {
+			_, _ = fmt.Fprintf(w, "- %s\n", step)
+		}
+	}
+	return nil
+}

--- a/internal/cliapp/takeover.go
+++ b/internal/cliapp/takeover.go
@@ -382,23 +382,69 @@ func joinVendors(vendors []config.AgentVendor) string {
 	return strings.Join(parts, ", ")
 }
 
-// takeoverScopingRoles builds the per-project role overrides that keep the
-// daemon focused on the single targeted PR: every autonomous discovery loop is
-// disabled so only the manually started reviewer/fixer loops run. When merge is
-// requested, the reviewer is allowed to enable GitHub auto-merge.
+// takeoverScopingRoles builds a fresh set of per-project role overrides that
+// scope the daemon to the single targeted PR.
 func takeoverScopingRoles(merge bool) *config.PartialRoleConfigs {
+	return applyTakeoverScoping(nil, merge)
+}
+
+// applyTakeoverScoping enforces the single-PR scoping on top of an existing role
+// tree (or a fresh one when roles is nil): every autonomous discovery loop is
+// disabled so only the manually started reviewer/fixer loops run, and the
+// reviewer auto-merge flag is set explicitly to match --merge. Setting
+// auto-merge explicitly (instead of only when merge is true) is required so a
+// takeover without --merge overrides any global roles.reviewer.autoMerge.enabled
+// rather than silently inheriting it. Existing role sub-fields (instructions,
+// reviewer behavior, triggers, …) are preserved — only the scoping leaves are
+// overwritten.
+func applyTakeoverScoping(roles *config.PartialRoleConfigs, merge bool) *config.PartialRoleConfigs {
 	disabled := false
-	roles := &config.PartialRoleConfigs{
-		Planner:  &config.PartialPlannerRoleConfig{AutoDiscovery: &disabled},
-		Worker:   &config.PartialWorkerRoleConfig{AutoDiscovery: &disabled},
-		Fixer:    &config.PartialFixerRoleConfig{AutoDiscovery: &disabled},
-		Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{AutoDiscovery: &disabled}},
+	autoMerge := merge
+	if roles == nil {
+		roles = &config.PartialRoleConfigs{}
 	}
-	if merge {
-		enabled := true
-		roles.Reviewer.AutoMerge = &config.PartialReviewerAutoMergeConfig{Enabled: &enabled}
+	if roles.Planner == nil {
+		roles.Planner = &config.PartialPlannerRoleConfig{}
 	}
+	roles.Planner.AutoDiscovery = &disabled
+	if roles.Worker == nil {
+		roles.Worker = &config.PartialWorkerRoleConfig{}
+	}
+	roles.Worker.AutoDiscovery = &disabled
+	if roles.Fixer == nil {
+		roles.Fixer = &config.PartialFixerRoleConfig{}
+	}
+	roles.Fixer.AutoDiscovery = &disabled
+	if roles.Reviewer == nil {
+		roles.Reviewer = &config.PartialReviewerRoleConfig{}
+	}
+	if roles.Reviewer.Discovery == nil {
+		roles.Reviewer.Discovery = &config.PartialReviewerRoleDiscoveryConfig{}
+	}
+	roles.Reviewer.Discovery.AutoDiscovery = &disabled
+	if roles.Reviewer.AutoMerge == nil {
+		roles.Reviewer.AutoMerge = &config.PartialReviewerAutoMergeConfig{}
+	}
+	roles.Reviewer.AutoMerge.Enabled = &autoMerge
 	return roles
+}
+
+// clonePartialRoleConfigs deep-copies a role tree via JSON so scoping can be
+// applied to a copy without mutating the config read from disk (which would
+// break change detection).
+func clonePartialRoleConfigs(in *config.PartialRoleConfigs) *config.PartialRoleConfigs {
+	if in == nil {
+		return nil
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		return nil
+	}
+	var out config.PartialRoleConfigs
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil
+	}
+	return &out
 }
 
 // ensureTakeoverConfig creates or patches the config file so it carries the
@@ -436,10 +482,14 @@ func (r *commandRuntime) ensureTakeoverConfig(configPath string, cwd string, rep
 	}
 
 	changed := false
-	if partial.Agent == nil || partial.Agent.Vendor == nil {
-		if partial.Agent == nil {
-			partial.Agent = &config.PartialAgentConfig{}
-		}
+	// Always honor the resolved vendor. resolveTakeoverVendor already reuses the
+	// configured vendor when no explicit --agent-vendor was given, so this is a
+	// no-op in the reuse case but applies an explicit override that would
+	// otherwise be silently ignored (leaving the daemon on the old vendor).
+	if partial.Agent == nil {
+		partial.Agent = &config.PartialAgentConfig{}
+	}
+	if partial.Agent.Vendor == nil || *partial.Agent.Vendor != vendor {
 		v := vendor
 		partial.Agent.Vendor = &v
 		changed = true
@@ -458,11 +508,12 @@ func (r *commandRuntime) ensureTakeoverConfig(configPath string, cwd string, rep
 	if partial.Projects != nil {
 		for _, existing := range *partial.Projects {
 			if samePath(existing.RepoPath, repoRoot) {
-				// Preserve the user's existing project fields and only enforce
-				// the single-PR scoping roles, so re-running takeover does not
-				// drop custom instructions, worktree roots, or names.
+				// Preserve the user's existing project fields AND existing role
+				// sub-config (instructions, reviewer behavior, …); only overwrite
+				// the single-PR scoping leaves. Apply scoping to a deep copy so
+				// the original is untouched for change detection.
 				merged := existing
-				merged.Roles = roles
+				merged.Roles = applyTakeoverScoping(clonePartialRoleConfigs(existing.Roles), merge)
 				if !sameTakeoverProject(existing, merged) {
 					changed = true
 				}

--- a/internal/cliapp/takeover_test.go
+++ b/internal/cliapp/takeover_test.go
@@ -283,6 +283,104 @@ func TestResolveTakeoverTarget(t *testing.T) {
 	})
 }
 
+func TestMatchTakeovers(t *testing.T) {
+	t.Parallel()
+
+	entries := []takeoverStateEntry{
+		{Repo: "acme/looper", PRNumber: 42},
+		{Repo: "acme/other", PRNumber: 7},
+		{Repo: "fork/other", PRNumber: 7},
+	}
+
+	t.Run("all", func(t *testing.T) {
+		t.Parallel()
+		got, err := matchTakeovers(entries, "", true)
+		if err != nil || len(got) != 3 {
+			t.Fatalf("matchTakeovers(all) = %v, %v", got, err)
+		}
+	})
+
+	t.Run("qualified ref", func(t *testing.T) {
+		t.Parallel()
+		got, err := matchTakeovers(entries, "acme/looper#42", false)
+		if err != nil || len(got) != 1 || got[0].Repo != "acme/looper" {
+			t.Fatalf("matchTakeovers(qualified) = %v, %v", got, err)
+		}
+	})
+
+	t.Run("bare number unique", func(t *testing.T) {
+		t.Parallel()
+		got, err := matchTakeovers(entries, "42", false)
+		if err != nil || len(got) != 1 || got[0].PRNumber != 42 {
+			t.Fatalf("matchTakeovers(42) = %v, %v", got, err)
+		}
+	})
+
+	t.Run("bare number ambiguous", func(t *testing.T) {
+		t.Parallel()
+		if _, err := matchTakeovers(entries, "7", false); err == nil {
+			t.Fatal("matchTakeovers(7) expected ambiguity error")
+		}
+	})
+
+	t.Run("empty with multiple", func(t *testing.T) {
+		t.Parallel()
+		if _, err := matchTakeovers(entries, "", false); err == nil {
+			t.Fatal("matchTakeovers(empty, multiple) expected error")
+		}
+	})
+
+	t.Run("empty with single", func(t *testing.T) {
+		t.Parallel()
+		got, err := matchTakeovers(entries[:1], "", false)
+		if err != nil || len(got) != 1 {
+			t.Fatalf("matchTakeovers(empty, single) = %v, %v", got, err)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		t.Parallel()
+		if _, err := matchTakeovers(entries, "acme/looper#999", false); err == nil {
+			t.Fatal("matchTakeovers(missing) expected no-match error")
+		}
+	})
+}
+
+func TestTakeoverStateRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	r := newCommandRuntime(New(Deps{HomeDir: home}), nil)
+
+	// Empty state when the file is absent.
+	st, err := r.loadTakeoverState()
+	if err != nil {
+		t.Fatalf("loadTakeoverState() error = %v", err)
+	}
+	if len(st.Takeovers) != 0 {
+		t.Fatalf("expected empty state, got %+v", st)
+	}
+
+	if err := r.recordTakeover(takeoverStateEntry{Repo: "acme/looper", PRNumber: 42, ReviewerLoopID: "loop_r", FixerLoopID: "loop_f"}); err != nil {
+		t.Fatalf("recordTakeover() error = %v", err)
+	}
+	// Re-recording the same PR updates in place rather than duplicating.
+	if err := r.recordTakeover(takeoverStateEntry{Repo: "acme/looper", PRNumber: 42, ReviewerLoopID: "loop_r2"}); err != nil {
+		t.Fatalf("recordTakeover() second error = %v", err)
+	}
+
+	st, err = r.loadTakeoverState()
+	if err != nil {
+		t.Fatalf("loadTakeoverState() reload error = %v", err)
+	}
+	if len(st.Takeovers) != 1 {
+		t.Fatalf("expected one takeover after upsert, got %+v", st.Takeovers)
+	}
+	if st.Takeovers[0].ReviewerLoopID != "loop_r2" {
+		t.Fatalf("expected updated reviewer loop id, got %q", st.Takeovers[0].ReviewerLoopID)
+	}
+}
+
 func TestEnsureTakeoverConfigDoesNotClobberExistingProjects(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/takeover_test.go
+++ b/internal/cliapp/takeover_test.go
@@ -71,8 +71,8 @@ func TestTakeoverScopingRoles(t *testing.T) {
 			t.Fatalf("%s autoDiscovery = %v, want false", name, got)
 		}
 	}
-	if withoutMerge.Reviewer.AutoMerge != nil {
-		t.Fatalf("auto-merge should be unset when merge=false")
+	if withoutMerge.Reviewer.AutoMerge == nil || withoutMerge.Reviewer.AutoMerge.Enabled == nil || *withoutMerge.Reviewer.AutoMerge.Enabled {
+		t.Fatalf("auto-merge should be explicitly disabled when merge=false (to override any global setting), got %+v", withoutMerge.Reviewer.AutoMerge)
 	}
 
 	withMerge := takeoverScopingRoles(true)
@@ -381,6 +381,96 @@ func TestTakeoverStateRoundTrip(t *testing.T) {
 	}
 }
 
+func TestEnsureTakeoverConfigHonorsExplicitVendorOverride(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	repoRoot := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+
+	existingVendor := config.AgentVendorCodex
+	raw, err := config.MarshalConfigFile(configPath, config.PartialConfig{
+		Agent: &config.PartialAgentConfig{Vendor: &existingVendor},
+	})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	r := newTakeoverRuntime(t, configPath, Deps{})
+	changed, err := r.ensureTakeoverConfig(configPath, cwd, repoRoot, config.AgentVendorClaudeCode, false)
+	if err != nil {
+		t.Fatalf("ensureTakeoverConfig() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true after vendor override")
+	}
+
+	partial, _, err := config.ReadPartialConfigFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if partial.Agent == nil || partial.Agent.Vendor == nil || *partial.Agent.Vendor != config.AgentVendorClaudeCode {
+		t.Fatalf("explicit --agent-vendor should override config, got %+v", partial.Agent)
+	}
+}
+
+func TestEnsureTakeoverConfigPreservesExistingRoleSubConfig(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	repoRoot := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+
+	// An existing project for repoRoot with custom reviewer instructions and
+	// auto-discovery left on — takeover must scope it without dropping the
+	// instructions.
+	reviewerInstructions := "Be extra strict about error handling."
+	enabled := true
+	raw, err := config.MarshalConfigFile(configPath, config.PartialConfig{
+		Agent: &config.PartialAgentConfig{Vendor: ptrVendor(config.AgentVendorClaudeCode)},
+		Projects: &[]config.PartialProjectRefConfig{{
+			ID: "repo", Name: "Repo", RepoPath: repoRoot,
+			Roles: &config.PartialRoleConfigs{
+				Reviewer: &config.PartialReviewerRoleConfig{
+					Instructions: &reviewerInstructions,
+					Discovery:    &config.PartialReviewerRoleDiscoveryConfig{AutoDiscovery: &enabled},
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	r := newTakeoverRuntime(t, configPath, Deps{})
+	if _, err := r.ensureTakeoverConfig(configPath, cwd, repoRoot, config.AgentVendorClaudeCode, false); err != nil {
+		t.Fatalf("ensureTakeoverConfig() error = %v", err)
+	}
+
+	partial, _, err := config.ReadPartialConfigFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	project := (*partial.Projects)[0]
+	if project.Roles == nil || project.Roles.Reviewer == nil {
+		t.Fatalf("reviewer roles missing: %+v", project.Roles)
+	}
+	if project.Roles.Reviewer.Instructions == nil || *project.Roles.Reviewer.Instructions != reviewerInstructions {
+		t.Fatalf("custom reviewer instructions should be preserved, got %+v", project.Roles.Reviewer.Instructions)
+	}
+	if project.Roles.Reviewer.Discovery == nil || project.Roles.Reviewer.Discovery.AutoDiscovery == nil || *project.Roles.Reviewer.Discovery.AutoDiscovery {
+		t.Fatalf("reviewer auto-discovery should be scoped off, got %+v", project.Roles.Reviewer.Discovery)
+	}
+}
+
+func ptrVendor(v config.AgentVendor) *config.AgentVendor { return &v }
+
 func TestEnsureTakeoverConfigDoesNotClobberExistingProjects(t *testing.T) {
 	t.Parallel()
 
@@ -401,8 +491,10 @@ func TestEnsureTakeoverConfigDoesNotClobberExistingProjects(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
+	// Reuse the configured vendor (as resolveTakeoverVendor would), so this test
+	// isolates project preservation from the explicit-vendor-override behavior.
 	r := newTakeoverRuntime(t, configPath, Deps{})
-	if _, err := r.ensureTakeoverConfig(configPath, cwd, repoRoot, config.AgentVendorClaudeCode, false); err != nil {
+	if _, err := r.ensureTakeoverConfig(configPath, cwd, repoRoot, config.AgentVendorCodex, false); err != nil {
 		t.Fatalf("ensureTakeoverConfig() error = %v", err)
 	}
 
@@ -411,7 +503,7 @@ func TestEnsureTakeoverConfigDoesNotClobberExistingProjects(t *testing.T) {
 		t.Fatalf("read config: %v", err)
 	}
 	if partial.Agent == nil || partial.Agent.Vendor == nil || *partial.Agent.Vendor != config.AgentVendorCodex {
-		t.Fatalf("existing agent vendor should be preserved, got %+v", partial.Agent)
+		t.Fatalf("configured agent vendor should be preserved when reused, got %+v", partial.Agent)
 	}
 	if partial.Projects == nil || len(*partial.Projects) != 2 {
 		t.Fatalf("want existing + new project, got %+v", partial.Projects)

--- a/internal/cliapp/takeover_test.go
+++ b/internal/cliapp/takeover_test.go
@@ -1,0 +1,336 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func lookPathFor(installed ...string) config.LookPathFunc {
+	set := map[string]struct{}{}
+	for _, name := range installed {
+		set[name] = struct{}{}
+	}
+	return func(name string) (string, error) {
+		if _, ok := set[name]; ok {
+			return "/usr/local/bin/" + name, nil
+		}
+		return "", fmt.Errorf("%s not found", name)
+	}
+}
+
+func TestDetectInstalledVendors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		installed []string
+		want      []config.AgentVendor
+	}{
+		{name: "none", installed: nil, want: []config.AgentVendor{}},
+		{name: "claude only", installed: []string{"claude"}, want: []config.AgentVendor{config.AgentVendorClaudeCode}},
+		{name: "codex and opencode", installed: []string{"codex", "opencode"}, want: []config.AgentVendor{config.AgentVendorCodex, config.AgentVendorOpenCode}},
+		{name: "cursor agent binary not auto-detected", installed: []string{"agent"}, want: []config.AgentVendor{}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := detectInstalledVendors(lookPathFor(tt.installed...))
+			if len(got) != len(tt.want) {
+				t.Fatalf("detectInstalledVendors() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("detectInstalledVendors()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestTakeoverScopingRoles(t *testing.T) {
+	t.Parallel()
+
+	withoutMerge := takeoverScopingRoles(false)
+	for name, got := range map[string]*bool{
+		"planner":  withoutMerge.Planner.AutoDiscovery,
+		"worker":   withoutMerge.Worker.AutoDiscovery,
+		"fixer":    withoutMerge.Fixer.AutoDiscovery,
+		"reviewer": withoutMerge.Reviewer.Discovery.AutoDiscovery,
+	} {
+		if got == nil || *got {
+			t.Fatalf("%s autoDiscovery = %v, want false", name, got)
+		}
+	}
+	if withoutMerge.Reviewer.AutoMerge != nil {
+		t.Fatalf("auto-merge should be unset when merge=false")
+	}
+
+	withMerge := takeoverScopingRoles(true)
+	if withMerge.Reviewer.AutoMerge == nil || withMerge.Reviewer.AutoMerge.Enabled == nil || !*withMerge.Reviewer.AutoMerge.Enabled {
+		t.Fatalf("auto-merge should be enabled when merge=true, got %+v", withMerge.Reviewer.AutoMerge)
+	}
+}
+
+func newTakeoverRuntime(t *testing.T, configPath string, deps Deps) *commandRuntime {
+	t.Helper()
+	if deps.Stdout == nil {
+		deps.Stdout = &bytes.Buffer{}
+	}
+	if deps.Stderr == nil {
+		deps.Stderr = &bytes.Buffer{}
+	}
+	return newCommandRuntime(New(deps), []string{"--config", configPath})
+}
+
+func newTakeoverCmd(t *testing.T, vendor string, yes bool) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.Flags().String("agent-vendor", "", "")
+	cmd.Flags().Bool("merge", false, "")
+	cmd.Flags().Bool("no-fix", false, "")
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().Bool("json", false, "")
+	if vendor != "" {
+		if err := cmd.Flags().Set("agent-vendor", vendor); err != nil {
+			t.Fatalf("set agent-vendor: %v", err)
+		}
+	}
+	if yes {
+		if err := cmd.Flags().Set("yes", "true"); err != nil {
+			t.Fatalf("set yes: %v", err)
+		}
+	}
+	return cmd
+}
+
+func TestResolveTakeoverVendor(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+
+	t.Run("explicit flag wins", func(t *testing.T) {
+		t.Parallel()
+		r := newTakeoverRuntime(t, configPath, Deps{LookPath: lookPathFor()})
+		cmd := newTakeoverCmd(t, "codex", false)
+		vendor, _, err := r.resolveTakeoverVendor(cmd, takeoverOptions{AgentVendor: "codex"})
+		if err != nil {
+			t.Fatalf("resolveTakeoverVendor() error = %v", err)
+		}
+		if vendor != config.AgentVendorCodex {
+			t.Fatalf("vendor = %q, want codex", vendor)
+		}
+	})
+
+	t.Run("invalid flag", func(t *testing.T) {
+		t.Parallel()
+		r := newTakeoverRuntime(t, configPath, Deps{LookPath: lookPathFor()})
+		cmd := newTakeoverCmd(t, "bogus", false)
+		if _, _, err := r.resolveTakeoverVendor(cmd, takeoverOptions{AgentVendor: "bogus"}); err == nil {
+			t.Fatal("resolveTakeoverVendor() error = nil, want unsupported vendor error")
+		}
+	})
+
+	t.Run("single detected", func(t *testing.T) {
+		t.Parallel()
+		r := newTakeoverRuntime(t, configPath, Deps{LookPath: lookPathFor("claude")})
+		cmd := newTakeoverCmd(t, "", false)
+		vendor, note, err := r.resolveTakeoverVendor(cmd, takeoverOptions{})
+		if err != nil {
+			t.Fatalf("resolveTakeoverVendor() error = %v", err)
+		}
+		if vendor != config.AgentVendorClaudeCode {
+			t.Fatalf("vendor = %q, want claude-code", vendor)
+		}
+		if note == "" {
+			t.Fatal("expected a detection note")
+		}
+	})
+
+	t.Run("yes with none detected fails", func(t *testing.T) {
+		t.Parallel()
+		r := newTakeoverRuntime(t, configPath, Deps{LookPath: lookPathFor()})
+		cmd := newTakeoverCmd(t, "", true)
+		if _, _, err := r.resolveTakeoverVendor(cmd, takeoverOptions{Yes: true}); err == nil {
+			t.Fatal("resolveTakeoverVendor() error = nil, want no-agent error")
+		}
+	})
+
+	t.Run("yes with multiple detected fails", func(t *testing.T) {
+		t.Parallel()
+		r := newTakeoverRuntime(t, configPath, Deps{LookPath: lookPathFor("claude", "codex")})
+		cmd := newTakeoverCmd(t, "", true)
+		if _, _, err := r.resolveTakeoverVendor(cmd, takeoverOptions{Yes: true}); err == nil {
+			t.Fatal("resolveTakeoverVendor() error = nil, want ambiguous-agent error")
+		}
+	})
+}
+
+func TestEnsureTakeoverConfigCreatesScopedProject(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	repoRoot := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	r := newTakeoverRuntime(t, configPath, Deps{})
+
+	changed, err := r.ensureTakeoverConfig(configPath, cwd, repoRoot, config.AgentVendorClaudeCode, true)
+	if err != nil {
+		t.Fatalf("ensureTakeoverConfig() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true for new config")
+	}
+
+	partial, present, err := config.ReadPartialConfigFile(configPath)
+	if err != nil || !present {
+		t.Fatalf("read config: present=%v err=%v", present, err)
+	}
+	if partial.Agent == nil || partial.Agent.Vendor == nil || *partial.Agent.Vendor != config.AgentVendorClaudeCode {
+		t.Fatalf("agent vendor not set: %+v", partial.Agent)
+	}
+	if partial.Projects == nil || len(*partial.Projects) != 1 {
+		t.Fatalf("want exactly one project, got %+v", partial.Projects)
+	}
+	project := (*partial.Projects)[0]
+	if !samePath(project.RepoPath, repoRoot) {
+		t.Fatalf("project repoPath = %q, want %q", project.RepoPath, repoRoot)
+	}
+	if project.Roles == nil || project.Roles.Reviewer == nil || project.Roles.Reviewer.Discovery == nil ||
+		project.Roles.Reviewer.Discovery.AutoDiscovery == nil || *project.Roles.Reviewer.Discovery.AutoDiscovery {
+		t.Fatalf("reviewer auto-discovery should be disabled: %+v", project.Roles)
+	}
+	if project.Roles.Reviewer.AutoMerge == nil || project.Roles.Reviewer.AutoMerge.Enabled == nil || !*project.Roles.Reviewer.AutoMerge.Enabled {
+		t.Fatalf("auto-merge should be enabled with --merge: %+v", project.Roles.Reviewer.AutoMerge)
+	}
+
+	// Re-running with identical inputs must be a no-op (no spurious restart).
+	changedAgain, err := r.ensureTakeoverConfig(configPath, cwd, repoRoot, config.AgentVendorClaudeCode, true)
+	if err != nil {
+		t.Fatalf("ensureTakeoverConfig() second call error = %v", err)
+	}
+	if changedAgain {
+		t.Fatal("changed = true on identical re-run, want false")
+	}
+}
+
+func TestResolveTakeoverTarget(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+
+	t.Run("explicit fully qualified ref", func(t *testing.T) {
+		t.Parallel()
+		r := newTakeoverRuntime(t, configPath, Deps{})
+		repo, pr, err := r.resolveTakeoverTarget(context.Background(), "acme/looper#42", t.TempDir())
+		if err != nil {
+			t.Fatalf("resolveTakeoverTarget() error = %v", err)
+		}
+		if repo != "acme/looper" || pr != 42 {
+			t.Fatalf("got %s#%d, want acme/looper#42", repo, pr)
+		}
+	})
+
+	t.Run("detect from current branch", func(t *testing.T) {
+		t.Parallel()
+		deps := Deps{
+			LookPath: lookPathFor("gh", "git"),
+			RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+				if len(args) >= 2 && args[0] == "repo" && args[1] == "view" {
+					return commandExecutionResult{Stdout: "acme/looper\n"}, nil
+				}
+				if len(args) >= 2 && args[0] == "pr" && args[1] == "view" {
+					return commandExecutionResult{Stdout: "57\n"}, nil
+				}
+				return commandExecutionResult{ExitCode: 1, Stderr: "unexpected"}, nil
+			},
+		}
+		r := newTakeoverRuntime(t, configPath, deps)
+		repo, pr, err := r.resolveTakeoverTarget(context.Background(), "", t.TempDir())
+		if err != nil {
+			t.Fatalf("resolveTakeoverTarget() error = %v", err)
+		}
+		if repo != "acme/looper" || pr != 57 {
+			t.Fatalf("got %s#%d, want acme/looper#57", repo, pr)
+		}
+	})
+
+	t.Run("no PR for branch", func(t *testing.T) {
+		t.Parallel()
+		deps := Deps{
+			LookPath: lookPathFor("gh", "git"),
+			RunCommand: func(ctx context.Context, command string, args []string, timeout time.Duration) (commandExecutionResult, error) {
+				if len(args) >= 2 && args[0] == "repo" && args[1] == "view" {
+					return commandExecutionResult{Stdout: "acme/looper\n"}, nil
+				}
+				return commandExecutionResult{ExitCode: 1, Stderr: "no pull requests found"}, nil
+			},
+		}
+		r := newTakeoverRuntime(t, configPath, deps)
+		if _, _, err := r.resolveTakeoverTarget(context.Background(), "", t.TempDir()); err == nil {
+			t.Fatal("resolveTakeoverTarget() error = nil, want missing-PR error")
+		}
+	})
+}
+
+func TestEnsureTakeoverConfigDoesNotClobberExistingProjects(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	repoRoot := t.TempDir()
+	otherRepo := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+
+	existingVendor := config.AgentVendorCodex
+	raw, err := config.MarshalConfigFile(configPath, config.PartialConfig{
+		Agent:    &config.PartialAgentConfig{Vendor: &existingVendor},
+		Projects: &[]config.PartialProjectRefConfig{{ID: "other", Name: "Other", RepoPath: otherRepo}},
+	})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	r := newTakeoverRuntime(t, configPath, Deps{})
+	if _, err := r.ensureTakeoverConfig(configPath, cwd, repoRoot, config.AgentVendorClaudeCode, false); err != nil {
+		t.Fatalf("ensureTakeoverConfig() error = %v", err)
+	}
+
+	partial, _, err := config.ReadPartialConfigFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if partial.Agent == nil || partial.Agent.Vendor == nil || *partial.Agent.Vendor != config.AgentVendorCodex {
+		t.Fatalf("existing agent vendor should be preserved, got %+v", partial.Agent)
+	}
+	if partial.Projects == nil || len(*partial.Projects) != 2 {
+		t.Fatalf("want existing + new project, got %+v", partial.Projects)
+	}
+	foundOther, foundNew := false, false
+	for _, p := range *partial.Projects {
+		if samePath(p.RepoPath, otherRepo) {
+			foundOther = true
+			if p.Roles != nil {
+				t.Fatalf("existing project should be untouched, got roles %+v", p.Roles)
+			}
+		}
+		if samePath(p.RepoPath, repoRoot) {
+			foundNew = true
+		}
+	}
+	if !foundOther || !foundNew {
+		t.Fatalf("foundOther=%v foundNew=%v", foundOther, foundNew)
+	}
+}

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -25,6 +25,7 @@ Subcommands:
   pr         Pull request commands
   review     Create a reviewer task for a pull request
   fix        Create a fixer task for a pull request
+  takeover   Continuously review and fix a pull request until it merges
   feedback   Submit feedback as a GitHub issue
   ps         Show running loops
   jump       Print shell command for a loop worktree

--- a/scripts/takeover.sh
+++ b/scripts/takeover.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# One-line PR takeover bootstrap.
+#
+# Installs the looper CLI if it is missing, then hands off to
+# `looper takeover`, which installs/starts the managed daemon, registers the
+# repository scoped to a single pull request, and runs the reviewer + fixer
+# loops until the PR is approved and merged.
+#
+# Intended to be pasted into a PR comment, for example:
+#
+#   curl -fsSL https://raw.githubusercontent.com/nexu-io/looper/main/scripts/takeover.sh \
+#     | sh -s -- acme/repo#42
+#
+# Everything after `--` is forwarded verbatim to `looper takeover`, so flags
+# work too:
+#
+#   ... | sh -s -- acme/repo#42 --merge --agent-vendor claude-code
+#
+# Run this from inside a checkout of the repository: looper takeover resolves
+# the repo root, and (when no <owner/repo>#<number> is given) the current
+# branch's PR, from the working directory.
+
+set -eu
+
+OWNER="${LOOPER_GITHUB_OWNER:-nexu-io}"
+REPO="${LOOPER_GITHUB_REPO:-looper}"
+REF="${LOOPER_INSTALL_REF:-main}"
+
+log() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+# Resolve a runnable looper binary, installing the CLI when it is absent.
+resolve_looper() {
+  if command -v looper >/dev/null 2>&1; then
+    command -v looper
+    return 0
+  fi
+
+  install_dir="${LOOPER_INSTALL_DIR:-$HOME/.local/bin}"
+  if [ -x "$install_dir/looper" ]; then
+    printf '%s\n' "$install_dir/looper"
+    return 0
+  fi
+
+  log "looper CLI not found; installing it..." >&2
+  need_cmd curl
+  curl -fsSL "https://raw.githubusercontent.com/$OWNER/$REPO/$REF/scripts/install.sh" | sh >&2
+
+  if command -v looper >/dev/null 2>&1; then
+    command -v looper
+    return 0
+  fi
+  if [ -x "$install_dir/looper" ]; then
+    printf '%s\n' "$install_dir/looper"
+    return 0
+  fi
+  fail "looper CLI was installed but is not on PATH; open a new shell or run: export PATH=\"$install_dir:\$PATH\""
+}
+
+need_cmd git
+need_cmd gh
+
+looper_bin="$(resolve_looper)"
+
+log "Starting takeover with: $looper_bin takeover $*"
+exec "$looper_bin" takeover "$@"

--- a/skills/pr-takeover/SKILL.md
+++ b/skills/pr-takeover/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: pr-takeover
+description: Use when asked to take over, adopt, or babysit a GitHub pull request until it merges — continuously read review feedback, fix it, push, reply to and resolve review threads, dismiss unreasonable change requests with a written reason, and merge once the PR is approved and all required checks pass. Triggers on "take over this PR", "接管这个 PR", "持续修复 review comment 直到合并", or a Looper takeover bot comment. Runs in your own coding agent session (Claude Code, Cursor, Codex, opencode) using gh + git — no daemon, no install.
+---
+
+# PR Takeover
+
+Drive a single pull request to merge **autonomously**, from inside your own coding-agent session. You read the live review state, fix what reviewers ask for, resolve the threads, dismiss change requests you can justify as incorrect, and merge once the PR is approved and green — looping until it lands.
+
+This is the **attended / zero-install** path: it uses the agent the user is already running (so GitHub and model credentials are already valid) and needs only `gh` and `git`. For **unattended / background** takeover that survives the user closing their terminal, point them at `looper takeover` instead (see [References](references/github-commands.md#unattended-alternative)).
+
+## When to use
+
+- A PR author wants their agent to shepherd a PR through review → fixes → merge.
+- A Looper bot left a comment recommending takeover.
+- The user says "take over / 接管 / babysit this PR until it merges".
+
+**Do not** silently start an endless loop on a repo you were not asked to act on. Confirm the target PR first.
+
+## Prerequisites (check, then proceed)
+
+```bash
+gh auth status                       # must be authenticated
+git rev-parse --show-toplevel        # must run inside the repo checkout
+```
+
+- `gh` authenticated as an account with **push access to the PR branch** (the PR author, or a collaborator).
+- Merge requires permission to merge into the base repo; dismissing reviews requires write access.
+- Run from inside the repository checkout, or pass an explicit `<owner>/<repo>#<number>`.
+
+## Identify the PR
+
+```bash
+# explicit ref wins; otherwise resolve the current branch's PR
+gh pr view --json number,headRefName,baseRefName,url --jq '{number,head:.headRefName,base:.baseRefName,url}'
+```
+
+If no PR exists for the branch, stop and tell the user to open one (or push the branch first).
+
+## The takeover loop
+
+Repeat until the PR is **merged** or a **hard blocker** needs a human. One iteration:
+
+### 1. Snapshot the live state — never act on stale data
+
+```bash
+gh pr view <num> --json state,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,headRefOid
+```
+
+Also fetch **unresolved review threads** (GraphQL — see [references](references/github-commands.md#list-review-threads)). Work only from what GitHub returns *now*; if a fetch fails (network), retry — do not proceed on assumptions.
+
+Decide the iteration's mode from `state` / `reviewDecision` / checks:
+- `state == MERGED` → **done**, report and stop.
+- `state == CLOSED` → stop, tell the user.
+- unresolved actionable threads exist → go to **2 (fix)**.
+- no actionable threads, `reviewDecision == APPROVED`, all required checks green, `mergeable == MERGEABLE` → go to **4 (merge)**.
+- otherwise (waiting on CI, waiting on a re-review) → go to **5 (wait)**.
+
+### 2. Address every actionable unresolved thread
+
+For each unresolved thread that asks for a real change:
+- Make the change in the worktree. Keep edits **scoped to what the thread asks for** — do not opportunistically rewrite unrelated code.
+- Run the repo's tests/linters if they're quick and obvious.
+- Commit with a clear subject (`fix: <what>`), then push to the PR branch.
+
+```bash
+git add -A && git commit -m "fix: <addresses review comment>"
+git push
+```
+
+Batch related fixes into sensible commits; one commit per thread is fine but not required.
+
+### 3. Reply, then resolve or dismiss
+
+For each thread you addressed: **reply** with a one-line note on how you fixed it, then **resolve** the thread (GraphQL `resolveReviewThread` — see [references](references/github-commands.md#resolve-a-thread)).
+
+For a change request you judge **incorrect or unreasonable** (factually wrong, out of scope, or contradicting the agreed design): **reply with your reasoning first**, then **dismiss** that review (GraphQL `dismissPullRequestReview` — see [references](references/github-commands.md#dismiss-a-review)). The dismissal `message` is mandatory and must state *why*. Never dismiss silently, and never dismiss a comment that raises a legitimate blocking concern just to get to green.
+
+### 4. Merge when approved and green
+
+Only when **all** hold: `reviewDecision == APPROVED`, every required check is `SUCCESS` (none `PENDING`/`FAILURE`), `mergeable == MERGEABLE`, and the PR is not a draft:
+
+```bash
+gh pr merge <num> --squash --delete-branch
+# or, to let GitHub merge automatically as soon as requirements are met:
+gh pr merge <num> --squash --auto
+```
+
+Use the repo's conventional merge method if it differs (`--merge` / `--rebase`). Then report and stop.
+
+### 5. Wait, then re-loop
+
+If you're waiting on CI or a fresh review, poll on an interval rather than spinning:
+- **Claude Code**: use the `/loop` skill (`/loop 5m <this instruction>`) or schedule a wake-up; between ticks, stop consuming tokens.
+- **Cursor / Codex / others**: re-run this instruction on a timer, or iterate in-session with a sleep between checks.
+
+Re-request review after pushing fixes if the reviewer was dismissed or the PR fell out of `REVIEW_REQUIRED`:
+
+```bash
+gh pr edit <num> --add-reviewer <login>   # if a specific reviewer should re-review
+```
+
+## Safety rails (apply even in full-auto)
+
+These keep autonomous runs from doing damage — they are not optional:
+
+- **Never merge with a failing or pending required check**, ever. Green-and-approved is the only merge gate.
+- **Never force-push**, never rewrite or drop other people's commits, never delete the base branch.
+- **Dismiss only with a written justification**; if you can't articulate why a change request is wrong, treat it as valid and address it.
+- **Stop and ask a human** when: a reviewer explicitly says "do not merge" / "hold" / applies a hold label; the fix needs a product/design decision you can't infer; the same thread reopens after 2 fix attempts (you're not converging); or a merge conflict needs non-trivial judgement.
+- **Cap no-progress iterations**: if N consecutive loops produce no new commit and no state change, stop and summarize what's blocking.
+- Keep a short running log of what you changed and why, so the human can audit the session.
+
+## Exact commands
+
+All `gh` / GraphQL recipes (list threads, resolve, dismiss, check status, merge, re-request) are in **[references/github-commands.md](references/github-commands.md)**.
+
+## Copy-paste prompt (for a bot to post under a PR)
+
+> Take over this PR until it merges. Continuously: read all review comments, fix what they ask for and push, reply to and resolve each thread, dismiss any change request you can justify as incorrect (with a written reason), and merge once the PR is approved and all required checks pass. Don't merge on red checks, don't force-push, and stop to ask me if a human says hold or a fix needs a product decision.
+
+For Claude Code, prefix with `/loop 5m` to make it poll until merged.

--- a/skills/pr-takeover/SKILL.md
+++ b/skills/pr-takeover/SKILL.md
@@ -1,122 +1,158 @@
 ---
 name: pr-takeover
-description: Use when asked to take over, adopt, or babysit a GitHub pull request until it merges — continuously read review feedback, fix it, push, reply to and resolve review threads, dismiss unreasonable change requests with a written reason, and merge once the PR is approved and all required checks pass. Triggers on "take over this PR", "接管这个 PR", "持续修复 review comment 直到合并", or a Looper takeover bot comment. Runs in your own coding agent session (Claude Code, Cursor, Codex, opencode) using gh + git — no daemon, no install.
+description: Use when asked to take over, adopt, or babysit a GitHub pull request until it merges — read review feedback, fix it, resolve threads, dismiss unreasonable change requests, and merge once approved and green. Picks between driving the PR live in this session or handing it to the Looper daemon for unattended background runs, confirming with the user when unclear. Triggers on "take over this PR", "接管这个 PR", "持续修复 review 直到合并", or a Looper takeover bot comment. Works in any coding agent (Claude Code, Codex, opencode, Gemini, …) using gh + git.
 ---
 
 # PR Takeover
 
-Drive a single pull request to merge **autonomously**, from inside your own coding-agent session. You read the live review state, fix what reviewers ask for, resolve the threads, dismiss change requests you can justify as incorrect, and merge once the PR is approved and green — looping until it lands.
+Drive one pull request to merge: continuously read the live review state, fix what reviewers ask for, reply to and resolve threads, dismiss change requests you can justify as wrong, and merge once the PR is approved and all required checks pass — looping until it lands.
 
-This is the **attended / zero-install** path: it uses the agent the user is already running (so GitHub and model credentials are already valid) and needs only `gh` and `git`. For **unattended / background** takeover that survives the user closing their terminal, point them at `looper takeover` instead (see [References](references/github-commands.md#unattended-alternative)).
+There are **two ways to run this**. Pick one in Step 0, then execute it.
 
-## When to use
+| Mode | Who runs the agent | Lifetime | Needs |
+| --- | --- | --- | --- |
+| **A · Live** (default) | *you*, in this session | until your session ends | `gh` + `git` only |
+| **B · Background** | the Looper daemon | survives you leaving; runs for days | Looper installed |
 
-- A PR author wants their agent to shepherd a PR through review → fixes → merge.
-- A Looper bot left a comment recommending takeover.
-- The user says "take over / 接管 / babysit this PR until it merges".
+## Step 0 — Choose the mode (confirm with the user only if unclear)
 
-**Do not** silently start an endless loop on a repo you were not asked to act on. Confirm the target PR first.
+1. If the user already signalled a preference, honor it:
+   - "in the background", "while I'm away", "even after I close this", "set and forget" → **Mode B**.
+   - "watch it", "do it now", "in here" → **Mode A**.
+2. Otherwise default to **Mode A** (zero install, uses your already-authenticated session). Mention in one line that Mode B exists for unattended runs, and switch only if they ask.
+3. Choose **Mode B** only if `command -v looper` succeeds *and* the user wants it unattended. If they want unattended but Looper isn't installed, tell them to install it (`https://github.com/nexu-io/looper`) or fall back to Mode A.
 
-## Prerequisites (check, then proceed)
+Keep this lightweight — ask at most one short question, and only when the user gave no signal.
 
-```bash
-gh auth status                       # must be authenticated
-git rev-parse --show-toplevel        # must run inside the repo checkout
-```
-
-- `gh` authenticated as an account with **push access to the PR branch** (the PR author, or a collaborator).
-- Merge requires permission to merge into the base repo; dismissing reviews requires write access.
-- Run from inside the repository checkout, or pass an explicit `<owner>/<repo>#<number>`.
-
-## Identify the PR
+## Prerequisites
 
 ```bash
-# explicit ref wins; otherwise resolve the current branch's PR
-gh pr view --json number,headRefName,baseRefName,url --jq '{number,head:.headRefName,base:.baseRefName,url}'
+gh auth status                  # authenticated, with push access to the PR branch
+git rev-parse --show-toplevel   # run from inside the repo checkout
 ```
 
-If no PR exists for the branch, stop and tell the user to open one (or push the branch first).
+Identify the PR (explicit `<owner>/<repo>#<num>` wins; else the current branch's):
 
-## The takeover loop
+```bash
+gh pr view --json number,headRefName,baseRefName,url
+```
 
-Repeat until the PR is **merged** or a **hard blocker** needs a human. One iteration:
+If no PR exists for the branch, stop and ask the user to open one.
 
-### 1. Snapshot the live state — never act on stale data
+---
+
+## Mode B — Background (Looper daemon)
+
+Hand the PR to Looper and you're done; it runs the reviewer + fixer loops itself.
+
+```bash
+looper takeover <owner>/<repo>#<num> --merge   # --merge enables auto-merge once approved + green
+looper takeover list                           # check status later
+looper takeover stop <owner>/<repo>#<num>      # stop it
+```
+
+Scopes Looper to just this PR (it won't touch other PRs). Note: Looper runs **its own** agent headlessly, so its configured agent vendor must be authenticated for non-interactive use. Report the loop ids it prints, then stop — the rest happens in the background.
+
+---
+
+## Mode A — Live (this session)
+
+Loop until the PR is **merged** or a **hard blocker** needs a human. Each iteration:
+
+### 1. Snapshot the live state (never act on stale data)
 
 ```bash
 gh pr view <num> --json state,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,headRefOid
 ```
 
-Also fetch **unresolved review threads** (GraphQL — see [references](references/github-commands.md#list-review-threads)). Work only from what GitHub returns *now*; if a fetch fails (network), retry — do not proceed on assumptions.
+List **unresolved review threads**:
 
-Decide the iteration's mode from `state` / `reviewDecision` / checks:
-- `state == MERGED` → **done**, report and stop.
-- `state == CLOSED` → stop, tell the user.
-- unresolved actionable threads exist → go to **2 (fix)**.
-- no actionable threads, `reviewDecision == APPROVED`, all required checks green, `mergeable == MERGEABLE` → go to **4 (merge)**.
-- otherwise (waiting on CI, waiting on a re-review) → go to **5 (wait)**.
+```bash
+gh api graphql -f query='
+query($owner:String!,$repo:String!,$num:Int!){
+  repository(owner:$owner,name:$repo){ pullRequest(number:$num){
+    reviewThreads(first:100){ nodes{ id isResolved
+      comments(first:20){ nodes{ author{login} body path line } } } } } }
+}' -F owner=<owner> -F repo=<repo> -F num=<num> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)
+        | {id, file:.comments.nodes[0].path, line:.comments.nodes[0].line, body:.comments.nodes[-1].body, author:.comments.nodes[0].author.login}'
+```
 
-### 2. Address every actionable unresolved thread
+Pick the iteration's action:
+- `state==MERGED` → **done**. `state==CLOSED` → stop, tell the user.
+- actionable unresolved threads → **2**.
+- none, `reviewDecision==APPROVED`, all required checks `SUCCESS`, `mergeable==MERGEABLE` → **4**.
+- else (CI pending / awaiting re-review) → **5**.
 
-For each unresolved thread that asks for a real change:
-- Make the change in the worktree. Keep edits **scoped to what the thread asks for** — do not opportunistically rewrite unrelated code.
-- Run the repo's tests/linters if they're quick and obvious.
-- Commit with a clear subject (`fix: <what>`), then push to the PR branch.
+### 2. Fix each actionable thread
+
+Make the change (scoped to what the thread asks — don't rewrite unrelated code), run quick tests/linters, then:
 
 ```bash
 git add -A && git commit -m "fix: <addresses review comment>"
-git push
+git push        # if rejected non-fast-forward: git pull --rebase && git push. Never --force.
 ```
 
-Batch related fixes into sensible commits; one commit per thread is fine but not required.
+### 3. Reply, then resolve — or dismiss
 
-### 3. Reply, then resolve or dismiss
+Reply with how you fixed it, then resolve:
 
-For each thread you addressed: **reply** with a one-line note on how you fixed it, then **resolve** the thread (GraphQL `resolveReviewThread` — see [references](references/github-commands.md#resolve-a-thread)).
+```bash
+# reply
+gh api graphql -f query='mutation($t:ID!,$b:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){comment{id}}}' -F t=<threadId> -F b="Fixed in <sha>: <summary>."
+# resolve
+gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' -F t=<threadId>
+```
 
-For a change request you judge **incorrect or unreasonable** (factually wrong, out of scope, or contradicting the agreed design): **reply with your reasoning first**, then **dismiss** that review (GraphQL `dismissPullRequestReview` — see [references](references/github-commands.md#dismiss-a-review)). The dismissal `message` is mandatory and must state *why*. Never dismiss silently, and never dismiss a comment that raises a legitimate blocking concern just to get to green.
+For a change request you can justify as **incorrect or out of scope**: reply with your reasoning first, then dismiss it (message is mandatory — state *why*):
+
+```bash
+# get the CHANGES_REQUESTED review's node id (PRR_…)
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviews(first:50){nodes{id state author{login}}}}}}' -F o=<owner> -F r=<repo> -F n=<num> --jq '.data.repository.pullRequest.reviews.nodes[]|select(.state=="CHANGES_REQUESTED")'
+# dismiss with a reason
+gh api graphql -f query='mutation($id:ID!,$m:String!){dismissPullRequestReview(input:{pullRequestReviewId:$id,message:$m}){pullRequestReview{state}}}' -F id=<reviewNodeId> -F m="Dismissing: <why this change request is wrong/out of scope>."
+```
 
 ### 4. Merge when approved and green
 
-Only when **all** hold: `reviewDecision == APPROVED`, every required check is `SUCCESS` (none `PENDING`/`FAILURE`), `mergeable == MERGEABLE`, and the PR is not a draft:
+Only when `reviewDecision==APPROVED`, every required check is `SUCCESS` (none pending/failing), `mergeable==MERGEABLE`, and not a draft:
 
 ```bash
-gh pr merge <num> --squash --delete-branch
-# or, to let GitHub merge automatically as soon as requirements are met:
-gh pr merge <num> --squash --auto
+gh pr merge <num> --squash --delete-branch     # use --merge/--rebase to match repo convention
+# or: gh pr merge <num> --squash --auto         # let GitHub merge as soon as requirements are met
 ```
 
-Use the repo's conventional merge method if it differs (`--merge` / `--rebase`). Then report and stop.
+Then report and stop.
 
 ### 5. Wait, then re-loop
 
-If you're waiting on CI or a fresh review, poll on an interval rather than spinning:
-- **Claude Code**: use the `/loop` skill (`/loop 5m <this instruction>`) or schedule a wake-up; between ticks, stop consuming tokens.
-- **Cursor / Codex / others**: re-run this instruction on a timer, or iterate in-session with a sleep between checks.
+Poll on an interval instead of spinning. Use your agent's own loop/scheduler if it has one:
+- **Claude Code**: `/loop 5m <this instruction>`, or schedule a wake-up; idle between ticks.
+- **Codex / opencode / Gemini / others**: re-run this instruction on a timer, or iterate with a `sleep 180` between checks.
 
-Re-request review after pushing fixes if the reviewer was dismissed or the PR fell out of `REVIEW_REQUIRED`:
+Re-request review after pushing fixes if needed: `gh pr edit <num> --add-reviewer <login>`.
 
-```bash
-gh pr edit <num> --add-reviewer <login>   # if a specific reviewer should re-review
-```
+---
 
 ## Safety rails (apply even in full-auto)
 
-These keep autonomous runs from doing damage — they are not optional:
+- **Never merge with a failing or pending required check.** Green-and-approved is the only gate. Never `--admin`-bypass.
+- **Never force-push**, rewrite others' commits, or delete the base branch.
+- **Dismiss only with a written reason.** If you can't articulate why a change request is wrong, treat it as valid and fix it.
+- **Stop and ask a human** when: someone says "hold" / "do not merge" / adds a hold label; a fix needs a product or design decision; the same thread reopens after 2 fix attempts; or a merge conflict needs real judgement.
+- **Cap no-progress loops**: after N iterations with no new commit and no state change, stop and summarize the blocker.
 
-- **Never merge with a failing or pending required check**, ever. Green-and-approved is the only merge gate.
-- **Never force-push**, never rewrite or drop other people's commits, never delete the base branch.
-- **Dismiss only with a written justification**; if you can't articulate why a change request is wrong, treat it as valid and address it.
-- **Stop and ask a human** when: a reviewer explicitly says "do not merge" / "hold" / applies a hold label; the fix needs a product/design decision you can't infer; the same thread reopens after 2 fix attempts (you're not converging); or a merge conflict needs non-trivial judgement.
-- **Cap no-progress iterations**: if N consecutive loops produce no new commit and no state change, stop and summarize what's blocking.
-- Keep a short running log of what you changed and why, so the human can audit the session.
+## More detail
 
-## Exact commands
+Extended `gh` / GraphQL recipes: `references/github-commands.md` (when installed as a skill), or fetch
+`https://raw.githubusercontent.com/nexu-io/looper/main/skills/pr-takeover/references/github-commands.md`.
 
-All `gh` / GraphQL recipes (list threads, resolve, dismiss, check status, merge, re-request) are in **[references/github-commands.md](references/github-commands.md)**.
+## One universal prompt (for a bot to post under a PR)
 
-## Copy-paste prompt (for a bot to post under a PR)
+Works in any agent, with or without this skill installed — it just points the agent at this file:
 
-> Take over this PR until it merges. Continuously: read all review comments, fix what they ask for and push, reply to and resolve each thread, dismiss any change request you can justify as incorrect (with a written reason), and merge once the PR is approved and all required checks pass. Don't merge on red checks, don't force-push, and stop to ask me if a human says hold or a fix needs a product decision.
+> Take over this PR until it merges — read https://raw.githubusercontent.com/nexu-io/looper/main/skills/pr-takeover/SKILL.md and follow it.
 
-For Claude Code, prefix with `/loop 5m` to make it poll until merged.
+If your agent can't fetch URLs, paste this instead:
+
+> Take over this PR until it merges. Loop: read the open review threads (`gh`), fix what they ask and push, reply + resolve each thread, dismiss any change request you can justify as wrong (with a written reason), and merge once it's approved and all required checks are green. Never merge on red/pending checks, never force-push, and stop to ask me if someone says hold or a fix needs a product decision.

--- a/skills/pr-takeover/references/github-commands.md
+++ b/skills/pr-takeover/references/github-commands.md
@@ -1,0 +1,152 @@
+# GitHub commands for PR takeover
+
+Exact `gh` and GraphQL recipes used by the takeover loop. All assume `gh` is
+authenticated with push/merge access. Replace `<owner>`, `<repo>`, `<num>`.
+
+## Snapshot PR state
+
+```bash
+gh pr view <num> \
+  --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefOid,statusCheckRollup \
+  --jq '{state,isDraft,mergeable,mergeStateStatus,reviewDecision,head:.headRefOid}'
+```
+
+- `reviewDecision`: `APPROVED` | `CHANGES_REQUESTED` | `REVIEW_REQUIRED` | `null`.
+- `mergeable`: `MERGEABLE` | `CONFLICTING` | `UNKNOWN`.
+- `mergeStateStatus`: `CLEAN`, `BLOCKED`, `BEHIND`, `DIRTY`, `UNSTABLE`, … (`BLOCKED` usually = checks/approvals still required).
+
+## Check status of required checks
+
+```bash
+gh pr checks <num>                      # human table; exit code non-zero if any failing
+gh pr view <num> --json statusCheckRollup \
+  --jq '[.statusCheckRollup[] | {name: (.name // .context), status: (.status // .state), conclusion}]'
+```
+
+Merge only when every required check is `SUCCESS` (none `PENDING`/`IN_PROGRESS`/`FAILURE`).
+
+## List review threads
+
+Unresolved threads with their comments and the file/line they target:
+
+```bash
+gh api graphql -f query='
+query($owner:String!,$repo:String!,$num:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$num){
+      reviewDecision
+      reviewThreads(first:100){
+        nodes{
+          id isResolved isOutdated
+          comments(first:20){ nodes{ author{login} body path line } }
+        }
+      }
+    }
+  }
+}' -F owner=<owner> -F repo=<repo> -F num=<num> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | {id, file: .comments.nodes[0].path, line: .comments.nodes[0].line, body: .comments.nodes[-1].body, author: .comments.nodes[0].author.login}'
+```
+
+Each `id` is the `threadId` used to resolve. Skip threads authored by your own
+bot account that are just status/disclosure notes.
+
+## Reply to a thread
+
+```bash
+gh api graphql -f query='
+mutation($threadId:ID!,$body:String!){
+  addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId, body:$body}){
+    comment{ id }
+  }
+}' -F threadId=<threadId> -F body="Fixed in <sha>: <one-line summary>."
+```
+
+## Resolve a thread
+
+```bash
+gh api graphql -f query='
+mutation($threadId:ID!){
+  resolveReviewThread(input:{threadId:$threadId}){ thread{ isResolved } }
+}' -F threadId=<threadId>
+```
+
+## Dismiss a review (for an unreasonable change request)
+
+First get the review id (the `CHANGES_REQUESTED` review you want to dismiss):
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<num>/reviews \
+  --jq '.[] | select(.state=="CHANGES_REQUESTED") | {id, user: .user.login, body}'
+```
+
+Then dismiss it **with a mandatory justification message**:
+
+```bash
+gh api graphql -f query='
+mutation($reviewId:ID!,$message:String!){
+  dismissPullRequestReview(input:{pullRequestReviewId:$reviewId, message:$message}){
+    pullRequestReview{ state }
+  }
+}' -F reviewId=<reviewNodeId> -F message="Dismissing: <clear reason this change request is incorrect / out of scope>."
+```
+
+Note: `dismissPullRequestReview` takes the review's **node id** (`PRR_…`), which
+the GraphQL reviews query returns; the REST `id` above is numeric. To get the
+node id directly:
+
+```bash
+gh api graphql -f query='
+query($owner:String!,$repo:String!,$num:Int!){
+  repository(owner:$owner,name:$repo){ pullRequest(number:$num){
+    reviews(first:50){ nodes{ id state author{login} } } } }
+}' -F owner=<owner> -F repo=<repo> -F num=<num> \
+  --jq '.data.repository.pullRequest.reviews.nodes[] | select(.state=="CHANGES_REQUESTED")'
+```
+
+Dismissing requires write access and does not delete the review — it marks it
+non-blocking and records your message. Never dismiss without a reason.
+
+## Push fixes
+
+```bash
+git add -A && git commit -m "fix: <addresses review comment>"
+git push
+```
+
+If the push is rejected as non-fast-forward, `git pull --rebase` first, then push
+again. Never `git push --force` to a shared PR branch.
+
+## Re-request review
+
+```bash
+gh pr edit <num> --add-reviewer <login>
+```
+
+## Merge
+
+```bash
+# merge now (requirements already met):
+gh pr merge <num> --squash --delete-branch
+
+# or queue auto-merge (GitHub merges as soon as approvals + checks pass):
+gh pr merge <num> --squash --auto
+```
+
+Use `--merge` or `--rebase` instead of `--squash` if that is the repo's
+convention. Do **not** use `--admin` to bypass failing checks.
+
+## Unattended alternative
+
+If the user wants takeover to keep running after they close their terminal,
+Looper's daemon can own the PR instead — it runs the reviewer + fixer loops in
+the background:
+
+```bash
+looper takeover <owner>/<repo>#<num> --merge
+looper takeover list
+looper takeover stop <owner>/<repo>#<num>
+```
+
+This requires installing Looper (`looperd`) and is the heavier, unattended path.
+The agent-driven loop in `SKILL.md` needs nothing but `gh` + `git` and the user's
+own running agent.


### PR DESCRIPTION
## What & why

Two complementary ways to take **one** pull request all the way to merge — review it, fix review threads, dismiss unreasonable change requests, and merge once approved + green — **without** registering the whole repo for autonomous work.

Target use case: a PR author (often an external contributor) adopting their own PR in one step. A bot can drop a one-liner / prompt under the PR.

| Mode | Entry point | Who runs the agent | Lifetime |
| --- | --- | --- | --- |
| **Background (unattended)** | `looper takeover` | the `looperd` daemon | survives closing the terminal; runs for days |
| **Live (attended, zero-install)** | `pr-takeover` skill / one prompt | the user's own coding agent | while their session is alive |

## 1. `looper takeover` command (daemon mode)

```bash
looper takeover                       # detect the current branch's PR
looper takeover acme/repo#42 --merge  # explicit, with auto-merge
looper takeover --yes --agent-vendor codex   # non-interactive / agent-driven
looper takeover list                  # active takeovers + live loop status
looper takeover stop acme/repo#42     # or --all
```

It resolves the PR (explicit ref or current branch via `gh`), picks the agent (reuse config → auto-detect a single installed `claude`/`codex`/`opencode` → prompt → `--agent-vendor`/`--yes`), writes a **per-project scoped** config (planner/worker/fixer/reviewer discovery all disabled, so the daemon only touches this PR), installs/starts (or restarts) the managed daemon, and starts continuous reviewer + fixer loops. With `--merge` it enables per-project reviewer auto-merge. A local index at `~/.looper/takeovers.json` powers `list`/`stop`.

Reuses existing per-project role config + the reviewer auto-merge implementation — **no daemon or core-loop changes**.

## 2. `pr-takeover` agent skill (live mode, zero-install)

`skills/pr-takeover/` is a self-contained, agent-agnostic skill: the user's own coding agent (Claude Code, Codex, opencode, Gemini, …) drives the PR using only `gh` + `git`, so credentials are already valid and nothing needs installing. It encodes the full-autonomy loop with guardrails (snapshot live state → fix + push → reply/resolve threads → dismiss unreasonable change requests **with a written reason** → merge when approved + all required checks green), and a mode-decision step that hands off to `looper takeover` for unattended runs.

One universal prompt a bot can post under any PR, with or without the skill installed:

> Take over this PR until it merges — read https://raw.githubusercontent.com/nexu-io/looper/main/skills/pr-takeover/SKILL.md and follow it.

## 3. `scripts/takeover.sh`

A curl-able one-liner that installs the CLI when missing and forwards args to `looper takeover` (for the daemon path).

## Surface

- `internal/cliapp/takeover.go` (+ registration in `app.go`) — command, `list`/`stop`, scoped-config writer, state index
- `internal/cliapp/takeover_test.go` — unit tests
- `scripts/takeover.sh`
- `skills/pr-takeover/{SKILL.md,references/github-commands.md}`
- `README.md`, `docs/users-guide.md` — both modes documented

## Testing

- `go build ./...`, `go vet ./...` clean; `go test ./internal/cliapp/` green (vendor detection, target resolution, scoped-config upsert incl. idempotent re-runs, vendor override, role preservation, state round-trip, stop matching).
- **Real end-to-end** on `nexu-io/synclo-test#114` with a source-built daemon (isolated sandbox, production daemon untouched): `looper takeover` → scoped registration → reviewer (codex) posted a real inline review catching a typo → fixer (codex) read the thread, fixed it, and pushed a commit → `takeover list`/`stop` worked. The skill's gh/GraphQL recipes were verified against that live PR.

## Review feedback addressed

- **P1** — auto-merge is now written explicitly (`Enabled = merge`), so a takeover without `--merge` overrides a global `roles.reviewer.autoMerge.enabled=true` instead of silently inheriting it.
- **P2** — an explicit `--agent-vendor` now updates the config when it differs (was silently ignored, leaving the daemon on the old vendor).
- **P2** — takeover on an already-configured project now merges scoping into the existing role tree (on a deep copy) instead of replacing it, preserving custom instructions/behavior.

## Caveats

- Daemon platforms: macOS arm64 + linux amd64.
- Background mode runs Looper's **own** agent headlessly; that vendor must be authenticated for non-interactive use. Live mode (the skill) sidesteps this by using the user's session.
- For headless/daemon runs, prefer a token/`gh` git credential helper over macOS keychain (the keychain helper can hang a headless `git`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)