### PR TITLE
fix: ignore incidental embedded migration files

### DIFF
--- a/internal/storage/embedded_migrations.go
+++ b/internal/storage/embedded_migrations.go
@@ -38,12 +38,17 @@ func mustLoadEmbeddedMigrations() []EmbeddedMigration {
 	migrations := make([]EmbeddedMigration, 0, len(entries))
 
 	for _, entry := range entries {
+		fileName := path.Base(entry)
+		if !isMigrationFileName(fileName) {
+			continue
+		}
+
 		sqlBytes, err := embeddedMigrationFiles.ReadFile(entry)
 		if err != nil {
 			panic("storage: read embedded migration " + entry + ": " + err.Error())
 		}
 
-		migration, err := newEmbeddedMigration(path.Base(entry), string(sqlBytes))
+		migration, err := newEmbeddedMigration(fileName, string(sqlBytes))
 		if err != nil {
 			panic("storage: load embedded migration " + entry + ": " + err.Error())
 		}
@@ -67,7 +72,7 @@ func ReadMigrationsFromDir(migrationsDir string) ([]EmbeddedMigration, error) {
 		}
 
 		fileName := entry.Name()
-		if !migrationFilePattern.MatchString(fileName) {
+		if !isMigrationFileName(fileName) {
 			continue
 		}
 
@@ -94,7 +99,7 @@ func ReadMigrationsFromDir(migrationsDir string) ([]EmbeddedMigration, error) {
 }
 
 func newEmbeddedMigration(fileName string, sql string) (EmbeddedMigration, error) {
-	if !migrationFilePattern.MatchString(fileName) {
+	if !isMigrationFileName(fileName) {
 		return EmbeddedMigration{}, fmt.Errorf("migration file name %q does not match %s", fileName, migrationFilePattern.String())
 	}
 
@@ -103,4 +108,8 @@ func newEmbeddedMigration(fileName string, sql string) (EmbeddedMigration, error
 		FileName: fileName,
 		SQL:      sql,
 	}, nil
+}
+
+func isMigrationFileName(fileName string) bool {
+	return migrationFilePattern.MatchString(fileName)
 }

--- a/internal/storage/embedded_migrations_test.go
+++ b/internal/storage/embedded_migrations_test.go
@@ -60,6 +60,25 @@ func TestEmbeddedMigrationsMirrorSourceFiles(t *testing.T) {
 	}
 }
 
+func TestIsMigrationFileNameRejectsIncidentalSQLFiles(t *testing.T) {
+	t.Parallel()
+
+	for _, fileName := range []string{
+		"._0001_init.sql",
+		"0001 init.sql",
+		"README.sql",
+		"0001_init.sql.bak",
+	} {
+		if isMigrationFileName(fileName) {
+			t.Fatalf("isMigrationFileName(%q) = true, want false", fileName)
+		}
+	}
+
+	if !isMigrationFileName("0001_init.sql") {
+		t.Fatal("isMigrationFileName(\"0001_init.sql\") = false, want true")
+	}
+}
+
 func compareStrings(a string, b string) int {
 	if a < b {
 		return -1


### PR DESCRIPTION
## Summary
- Filter embedded SQLite migration entries through the same migration filename predicate used by directory loading.
- Ignore incidental `*.sql` matches such as macOS AppleDouble `._0001_init.sql` files instead of panicking during package init.
- Add regression coverage for incidental SQL-like filenames.

## Context
The 20m loopernet lab exposed this when a macOS-created tarball copied AppleDouble `._*.sql` files into `internal/storage/migrations`; `//go:embed migrations/*.sql` embedded them and `mustLoadEmbeddedMigrations` panicked before loopernet could start.

## Design note
Authority remains the migration filename contract already enforced by `ReadMigrationsFromDir`; this change reuses that predicate for embedded migrations instead of adding new persisted state or recovery behavior.

## Testing
- `go test ./internal/storage`