### PR TITLE
fix: recover reviewer marker misses around PR drift

### DIFF
--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2813,7 +2813,7 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 	policy := r.discoveryPolicyForProject(input.Project.ID)
 	requireReviewRequest := requireReviewRequestForLoop(input.Loop, policy.RequireReviewRequest, pending.HeadSHA)
 	if requireReviewRequest && !markerResult.Found {
-		staleReason, reviewedReason, login := r.detectMarkerMissingRecovery(ctx, input, pending.HeadSHA, !isManualReviewerLoop(input.Loop))
+		staleReason, reviewedReason, login := r.detectMarkerMissingRecovery(ctx, input, checkpoint, pending.HeadSHA, !isManualReviewerLoop(input.Loop))
 		if staleReason != "" {
 			return markReviewerRunStale(checkpoint, staleReason), nil
 		}
@@ -2835,7 +2835,7 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		}
 	}
 	if !markerResult.Found {
-		staleReason, reviewedReason, login := r.detectMarkerMissingRecovery(ctx, input, pending.HeadSHA, !isManualReviewerLoop(input.Loop))
+		staleReason, reviewedReason, login := r.detectMarkerMissingRecovery(ctx, input, checkpoint, pending.HeadSHA, !isManualReviewerLoop(input.Loop))
 		if staleReason != "" {
 			return markReviewerRunStale(checkpoint, staleReason), nil
 		}
@@ -4811,7 +4811,7 @@ func (r *Runner) detectHeadChangeForExpectedHead(ctx context.Context, input step
 	return "", false
 }
 
-func (r *Runner) detectMarkerMissingRecovery(ctx context.Context, input stepInput, expectedHeadSHA string, allowAlreadyReviewed bool) (string, string, string) {
+func (r *Runner) detectMarkerMissingRecovery(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, expectedHeadSHA string, allowAlreadyReviewed bool) (string, string, string) {
 	expectedHeadSHA = strings.TrimSpace(expectedHeadSHA)
 	if expectedHeadSHA == "" {
 		return "", "", ""
@@ -4822,6 +4822,9 @@ func (r *Runner) detectMarkerMissingRecovery(ctx context.Context, input stepInpu
 	}
 	if detail.HeadSHA != "" && detail.HeadSHA != expectedHeadSHA {
 		return fmt.Sprintf("PR head changed before publish: expected %s, got %s", expectedHeadSHA, detail.HeadSHA), "", ""
+	}
+	if reason := reviewerPublishDriftReason(input, checkpoint, detail); reason != "" {
+		return reason, "", ""
 	}
 	if !allowAlreadyReviewed {
 		return "", "", ""

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2813,6 +2813,18 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 	policy := r.discoveryPolicyForProject(input.Project.ID)
 	requireReviewRequest := requireReviewRequestForLoop(input.Loop, policy.RequireReviewRequest, pending.HeadSHA)
 	if requireReviewRequest && !markerResult.Found {
+		staleReason, reviewedReason, login := r.detectMarkerMissingRecovery(ctx, input, pending.HeadSHA, !isManualReviewerLoop(input.Loop))
+		if staleReason != "" {
+			return markReviewerRunStale(checkpoint, staleReason), nil
+		}
+		if reviewedReason != "" {
+			checkpoint.SkipReason = reviewedReason
+			checkpoint.SkipKind = "already_reviewed_by_current_user"
+			checkpoint.SkipReviewerLogin = login
+			checkpoint.PendingReview = nil
+			checkpoint.ResumePolicy = ""
+			return checkpoint, nil
+		}
 		currentLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
 		if err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
@@ -2823,8 +2835,17 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		}
 	}
 	if !markerResult.Found {
-		if reason, ok := r.detectHeadChangeForExpectedHead(ctx, input, pending.HeadSHA); ok {
-			return markReviewerRunStale(checkpoint, reason), nil
+		staleReason, reviewedReason, login := r.detectMarkerMissingRecovery(ctx, input, pending.HeadSHA, !isManualReviewerLoop(input.Loop))
+		if staleReason != "" {
+			return markReviewerRunStale(checkpoint, staleReason), nil
+		}
+		if reviewedReason != "" {
+			checkpoint.SkipReason = reviewedReason
+			checkpoint.SkipKind = "already_reviewed_by_current_user"
+			checkpoint.SkipReviewerLogin = login
+			checkpoint.PendingReview = nil
+			checkpoint.ResumePolicy = ""
+			return checkpoint, nil
 		}
 		message := missingReviewMarkerMessage(input, pending)
 		if pending.MarkerVerificationMisses == 0 {
@@ -4788,6 +4809,32 @@ func (r *Runner) detectHeadChangeForExpectedHead(ctx context.Context, input step
 		return fmt.Sprintf("PR head changed before publish: expected %s, got %s", expectedHeadSHA, detail.HeadSHA), true
 	}
 	return "", false
+}
+
+func (r *Runner) detectMarkerMissingRecovery(ctx context.Context, input stepInput, expectedHeadSHA string, allowAlreadyReviewed bool) (string, string, string) {
+	expectedHeadSHA = strings.TrimSpace(expectedHeadSHA)
+	if expectedHeadSHA == "" {
+		return "", "", ""
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
+	if err != nil {
+		return "", "", ""
+	}
+	if detail.HeadSHA != "" && detail.HeadSHA != expectedHeadSHA {
+		return fmt.Sprintf("PR head changed before publish: expected %s, got %s", expectedHeadSHA, detail.HeadSHA), "", ""
+	}
+	if !allowAlreadyReviewed {
+		return "", "", ""
+	}
+	currentLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+	if err != nil {
+		return "", "", ""
+	}
+	currentLogin = normalizeLogin(currentLogin)
+	if !hasReviewByAuthorForHead(detail.Reviews, currentLogin, expectedHeadSHA) {
+		return "", "", ""
+	}
+	return "", fmt.Sprintf("Skipped pull request %s#%d because current user already reviewed head %s but no Looper review marker was found", input.Repo, input.PRNumber, expectedHeadSHA), currentLogin
 }
 
 func hasReviewByAuthorForHead(reviews []map[string]any, login string, headSHA string) bool {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2823,15 +2823,19 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		}
 	}
 	if !markerResult.Found {
+		if reason, ok := r.detectHeadChangeForExpectedHead(ctx, input, pending.HeadSHA); ok {
+			return markReviewerRunStale(checkpoint, reason), nil
+		}
+		message := missingReviewMarkerMessage(input, pending)
 		if pending.MarkerVerificationMisses == 0 {
 			pending.MarkerVerificationMisses = 1
 			checkpoint.PendingReview = pending.clone()
 			checkpoint.ResumePolicy = "advance_from_checkpoint"
-			return checkpoint, &loopError{message: "Reviewer agent completed but no matching GitHub review marker was found; retrying marker verification before rerunning review", kind: FailureRetryableAfterResume}
+			return checkpoint, &loopError{message: message + "; retrying marker verification before rerunning review", kind: FailureRetryableAfterResume}
 		}
 		checkpoint.PendingReview = nil
 		checkpoint.ResumePolicy = "rerun_review"
-		return checkpoint, &loopError{message: "Reviewer agent completed but no matching GitHub review marker was found", kind: FailureRetryableAfterResume}
+		return checkpoint, &loopError{message: message, kind: FailureRetryableAfterResume}
 	}
 	reviewPolicy := r.effectiveReviewEvents(input.Loop.MetadataJSON)
 	if cleanReviewNoopSummary(pending.Summary) && reviewPolicy.Clean == config.ReviewerReviewEventApprove && !cleanReviewMarkerSatisfiesCleanPolicy(markerResult, cleanReviewAuthorLogin(checkpoint, detail)) {
@@ -2881,6 +2885,22 @@ func (r *Runner) skipThreadResolutionFollowUpReview(ctx context.Context, input s
 	checkpoint.SkipKind = "not_requested"
 	checkpoint.PendingReview = nil
 	return true, checkpoint, nil
+}
+
+func missingReviewMarkerMessage(input stepInput, pending pendingReviewCheckpoint) string {
+	parts := []string{"Reviewer agent completed but no matching GitHub review marker was found"}
+	parts = append(parts, fmt.Sprintf("repo=%s", input.Repo))
+	parts = append(parts, fmt.Sprintf("pr=%d", input.PRNumber))
+	if strings.TrimSpace(pending.HeadSHA) != "" {
+		parts = append(parts, "head="+strings.TrimSpace(pending.HeadSHA))
+	}
+	if strings.TrimSpace(pending.IdempotencyKey) != "" {
+		parts = append(parts, "idempotencyKey="+strings.TrimSpace(pending.IdempotencyKey))
+	}
+	if pending.MarkerVerificationMisses > 0 {
+		parts = append(parts, fmt.Sprintf("previousMarkerMisses=%d", pending.MarkerVerificationMisses))
+	}
+	return strings.Join(parts, "; ")
 }
 
 func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepInput, headSHA string, idempotencyKey string, prAuthorLogin string) (ReviewMarkerResult, error) {
@@ -4755,12 +4775,17 @@ func (r *Runner) detectHeadChangeRequired(ctx context.Context, input stepInput, 
 	if checkpoint.Snapshot == nil {
 		return "", false
 	}
+	return r.detectHeadChangeForExpectedHead(ctx, input, checkpoint.Snapshot.HeadSHA)
+}
+
+func (r *Runner) detectHeadChangeForExpectedHead(ctx context.Context, input stepInput, expectedHeadSHA string) (string, bool) {
 	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 	if err != nil {
 		return "", false
 	}
-	if detail.HeadSHA != "" && checkpoint.Snapshot.HeadSHA != "" && detail.HeadSHA != checkpoint.Snapshot.HeadSHA {
-		return fmt.Sprintf("PR head changed before publish: expected %s, got %s", checkpoint.Snapshot.HeadSHA, detail.HeadSHA), true
+	expectedHeadSHA = strings.TrimSpace(expectedHeadSHA)
+	if detail.HeadSHA != "" && expectedHeadSHA != "" && detail.HeadSHA != expectedHeadSHA {
+		return fmt.Sprintf("PR head changed before publish: expected %s, got %s", expectedHeadSHA, detail.HeadSHA), true
 	}
 	return "", false
 }

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -7690,6 +7690,145 @@ func TestRunPublishStepMarksStaleWhenAgentNativeMarkerMissingAfterHeadChanges(t 
 	}
 }
 
+func TestRunPublishStepSkipsWhenCurrentUserAlreadyReviewedPendingHeadWithoutMarker(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		reviewRequests:      []string{},
+		currentLogin:        "octocat",
+		reviewMarkerMissing: true,
+		reviews: []map[string]any{{
+			"author": map[string]any{"login": "octocat"},
+			"state":  "COMMENTED",
+			"commit": map[string]any{"oid": "abc123"},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     storage.LoopRecord{ID: "loop_publish_already_reviewed_without_marker", ProjectID: project.ID, Type: "reviewer"},
+		Run:      storage.RunRecord{ID: "run_publish_already_reviewed_without_marker", LoopID: "loop_publish_already_reviewed_without_marker"},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", ReviewRequests: []string{}, CurrentLogin: "octocat"},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pendingReviewCheckpoint{HeadSHA: "abc123", IdempotencyKey: "reviewer:loop_publish_already_reviewed_without_marker:abc123", Event: reviewEventAgentNative, Summary: "posted review"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v, want already-reviewed skip", err)
+	}
+	if checkpoint.SkipKind != "already_reviewed_by_current_user" {
+		t.Fatalf("SkipKind = %q, want already_reviewed_by_current_user", checkpoint.SkipKind)
+	}
+	if !contains(checkpoint.SkipReason, "already reviewed head abc123") || contains(checkpoint.SkipReason, "not requested") {
+		t.Fatalf("SkipReason = %q, want already-reviewed skip", checkpoint.SkipReason)
+	}
+	if checkpoint.PendingReview != nil {
+		t.Fatalf("PendingReview = %#v, want nil after already-reviewed skip", checkpoint.PendingReview)
+	}
+	if github.reviewMarkerCalls == 0 {
+		t.Fatalf("reviewMarkerCalls = %d, want marker lookup before fallback", github.reviewMarkerCalls)
+	}
+	if len(github.addReactionCalls) != 0 || len(github.removeReactionCalls) != 0 || len(github.addLabelCalls) != 0 || len(github.removeLabelCalls) != 0 {
+		t.Fatalf("GitHub side effects = addReaction:%d removeReaction:%d addLabel:%d removeLabel:%d, want none", len(github.addReactionCalls), len(github.removeReactionCalls), len(github.addLabelCalls), len(github.removeLabelCalls))
+	}
+}
+
+func TestRunPublishStepManualLoopKeepsMarkerMissingRetryWhenCurrentUserAlreadyReviewedPendingHead(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		reviewRequests:      []string{},
+		currentLogin:        "octocat",
+		reviewMarkerMissing: true,
+		reviews: []map[string]any{{
+			"author": map[string]any{"login": "octocat"},
+			"state":  "COMMENTED",
+			"commit": map[string]any{"oid": "abc123"},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	metadata := `{"manual":true}`
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     storage.LoopRecord{ID: "loop_publish_manual_already_reviewed", ProjectID: project.ID, Type: "reviewer", MetadataJSON: &metadata},
+		Run:      storage.RunRecord{ID: "run_publish_already_reviewed", LoopID: "loop_publish_already_reviewed"},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", ReviewRequests: []string{}, CurrentLogin: "octocat"},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pendingReviewCheckpoint{HeadSHA: "abc123", IdempotencyKey: "reviewer:loop_publish_already_reviewed:abc123", Event: reviewEventAgentNative, Summary: "posted review"},
+		},
+	})
+	if err == nil || !contains(err.Error(), "no matching GitHub review marker") {
+		t.Fatalf("runPublishStep() error = %v, want marker verification retry", err)
+	}
+	if checkpoint.SkipKind == "already_reviewed_by_current_user" {
+		t.Fatalf("SkipKind = %q, want manual loop to keep marker-missing recovery", checkpoint.SkipKind)
+	}
+	if checkpoint.PendingReview == nil {
+		t.Fatalf("PendingReview = nil, want pending review retained for retry")
+	}
+	if checkpoint.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("ResumePolicy = %q, want advance_from_checkpoint", checkpoint.ResumePolicy)
+	}
+	if github.reviewMarkerCalls == 0 {
+		t.Fatalf("reviewMarkerCalls = %d, want review marker lookup before retry", github.reviewMarkerCalls)
+	}
+	if checkpoint.SkipReason != "" {
+		t.Fatalf("SkipReason = %q, want no skip reason while marker retry remains active", checkpoint.SkipReason)
+	}
+}
+
+func TestRunPublishStepMarksStaleWhenMarkerMissingRecoveryFetchSeesHeadChangeBeforeNotRequested(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{changeHeadOnSecondView: true, removeReviewRequestOnSecondView: true, reviewRequests: []string{"octocat"}, currentLogin: "octocat", reviewMarkerMissing: true}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     storage.LoopRecord{ID: "loop_publish_marker_missing_recovery_stale", ProjectID: project.ID, Type: "reviewer"},
+		Run:      storage.RunRecord{ID: "run_publish_marker_missing_recovery_stale", LoopID: "loop_publish_marker_missing_recovery_stale"},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", ReviewRequests: []string{"octocat"}, CurrentLogin: "octocat"},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pendingReviewCheckpoint{HeadSHA: "abc123", IdempotencyKey: "reviewer:loop_publish_marker_missing_recovery_stale:abc123", Event: reviewEventAgentNative, Summary: "posted review"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v, want stale checkpoint", err)
+	}
+	if checkpoint.SkipKind != "stale" {
+		t.Fatalf("SkipKind = %q, want stale", checkpoint.SkipKind)
+	}
+	if !contains(checkpoint.SkipReason, "PR head changed before publish") {
+		t.Fatalf("SkipReason = %q, want head-change stale reason", checkpoint.SkipReason)
+	}
+	if checkpoint.PendingReview != nil {
+		t.Fatalf("PendingReview = %#v, want nil after stale publish", checkpoint.PendingReview)
+	}
+}
+
 func TestProcessClaimedItemMarksStaleOnUnparsedHeadChangeGuardrail(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -7609,6 +7609,87 @@ func TestRunPublishStepKeepsPendingReviewForExistingLoopFollowUpOnNewHeadWithout
 	}
 }
 
+func TestRunPublishStepMarksStaleWhenAgentNativeMarkerMissingAndHeadChanged(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"octocat"}, reviewMarkerMissing: true, viewHeadSHA: "new-head"}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     storage.LoopRecord{ID: "loop_publish_head_changed", ProjectID: project.ID, Type: "reviewer"},
+		Run:      storage.RunRecord{ID: "run_publish_head_changed", LoopID: "loop_publish_head_changed"},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", ReviewRequests: []string{"octocat"}},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pendingReviewCheckpoint{HeadSHA: "abc123", IdempotencyKey: "reviewer:loop_publish_head_changed:abc123", Event: reviewEventAgentNative, Summary: "posted review"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v, want stale checkpoint", err)
+	}
+	if checkpoint.SkipKind != "stale" {
+		t.Fatalf("SkipKind = %q, want stale", checkpoint.SkipKind)
+	}
+	if !contains(checkpoint.SkipReason, "PR head changed before publish") {
+		t.Fatalf("SkipReason = %q, want head-change stale reason", checkpoint.SkipReason)
+	}
+	if checkpoint.PendingReview != nil {
+		t.Fatalf("PendingReview = %#v, want nil after stale publish", checkpoint.PendingReview)
+	}
+	if github.reviewMarkerCalls != 0 {
+		t.Fatalf("reviewMarkerCalls = %d, want 0 when head drift wins before marker retry", github.reviewMarkerCalls)
+	}
+}
+
+func TestRunPublishStepMarksStaleWhenAgentNativeMarkerMissingAfterHeadChanges(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"octocat"}, reviewMarkerMissing: true, changeHeadOnSecondView: true}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     storage.LoopRecord{ID: "loop_publish_marker_missing_then_head_changed", ProjectID: project.ID, Type: "reviewer"},
+		Run:      storage.RunRecord{ID: "run_publish_marker_missing_then_head_changed", LoopID: "loop_publish_marker_missing_then_head_changed"},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", ReviewRequests: []string{"octocat"}},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pendingReviewCheckpoint{HeadSHA: "abc123", IdempotencyKey: "reviewer:loop_publish_marker_missing_then_head_changed:abc123", Event: reviewEventAgentNative, Summary: "posted review"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v, want stale checkpoint", err)
+	}
+	if checkpoint.SkipKind != "stale" {
+		t.Fatalf("SkipKind = %q, want stale", checkpoint.SkipKind)
+	}
+	if !contains(checkpoint.SkipReason, "PR head changed before publish") {
+		t.Fatalf("SkipReason = %q, want head-change stale reason", checkpoint.SkipReason)
+	}
+	if checkpoint.PendingReview != nil {
+		t.Fatalf("PendingReview = %#v, want nil after stale publish", checkpoint.PendingReview)
+	}
+	if github.reviewMarkerCalls == 0 {
+		t.Fatalf("reviewMarkerCalls = %d, want marker lookup before stale recheck", github.reviewMarkerCalls)
+	}
+	if github.viewCalls < 2 {
+		t.Fatalf("viewCalls = %d, want publish drift check plus stale recheck", github.viewCalls)
+	}
+}
+
 func TestProcessClaimedItemMarksStaleOnUnparsedHeadChangeGuardrail(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -7829,6 +7829,54 @@ func TestRunPublishStepMarksStaleWhenMarkerMissingRecoveryFetchSeesHeadChangeBef
 	}
 }
 
+func TestRunPublishStepMarksStaleWhenMarkerMissingRecoveryFetchSeesClosedPRBeforeAlreadyReviewedSkip(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		currentLogin:            "octocat",
+		reviewMarkerMissing:     true,
+		viewStateAfterFirstView: "CLOSED",
+		reviews: []map[string]any{{
+			"author": map[string]any{"login": "octocat"},
+			"state":  "COMMENTED",
+			"commit": map[string]any{"oid": "abc123"},
+		}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}})
+
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v), want project", project, err)
+	}
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     storage.LoopRecord{ID: "loop_publish_marker_missing_recovery_closed", ProjectID: project.ID, Type: "reviewer"},
+		Run:      storage.RunRecord{ID: "run_publish_marker_missing_recovery_closed", LoopID: "loop_publish_marker_missing_recovery_closed"},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", ReviewRequests: []string{}, CurrentLogin: "octocat"},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pendingReviewCheckpoint{HeadSHA: "abc123", IdempotencyKey: "reviewer:loop_publish_marker_missing_recovery_closed:abc123", Event: reviewEventAgentNative, Summary: "posted review"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v, want stale checkpoint", err)
+	}
+	if checkpoint.SkipKind != "stale" {
+		t.Fatalf("SkipKind = %q, want stale", checkpoint.SkipKind)
+	}
+	if !contains(checkpoint.SkipReason, "expected PR state OPEN, observed CLOSED") {
+		t.Fatalf("SkipReason = %q, want closed PR stale reason", checkpoint.SkipReason)
+	}
+	if checkpoint.PendingReview != nil {
+		t.Fatalf("PendingReview = %#v, want nil after stale publish", checkpoint.PendingReview)
+	}
+	if checkpoint.SkipReviewerLogin != "" {
+		t.Fatalf("SkipReviewerLogin = %q, want empty when stale wins over already-reviewed skip", checkpoint.SkipReviewerLogin)
+	}
+}
+
 func TestProcessClaimedItemMarksStaleOnUnparsedHeadChangeGuardrail(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)


### PR DESCRIPTION
Summary
- Treat missing reviewer markers as stale when the PR head has moved before marker recovery.
- Skip non-manual marker-missing publishes when GitHub shows the current user already submitted a review on the pending head, without applying publish side effects.
- Keep manual reviewer loops on the strict marker-missing retry path.

24h failure assessment
- This targets the dominant reviewer publish failures: missing GitHub review markers, especially when paired with rapid head changes or review-request removal after review submission.
- It does not address unrelated failures seen in the same window: invalid gh JSON payloads, GitHub auth/network errors, or bad repo/worktree paths.

Validation
- go test ./internal/reviewer
- go test ./...
- oracle review: no blockers