### PR TITLE
fix: do not retry invalid git repo paths

### DIFF
--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -154,7 +154,10 @@ func TestHandlerLoopRetryAllowsFailedReviewerLoop(t *testing.T) {
 }
 
 func TestHandlerLoopRetryRejectsTerminalReviewerMetadata(t *testing.T) {
-	rt, cfg := startTestRuntime(t)
+	fixture := newTestFixture(t, func(options *looperdruntime.Options) {
+		options.DeferRecovery = true
+	})
+	rt, cfg := fixture.runtime, fixture.config
 	h := NewHandler(Context{Config: cfg, Runtime: rt})
 	services := rt.Services()
 	nowISO := "2026-04-11T12:00:00.000Z"
@@ -5806,7 +5809,7 @@ func (r executionVerifierRuntime) ExecutionMatchesProcess(ctx context.Context, e
 	return r.Runtime.ExecutionMatchesProcess(ctx, execution, pid)
 }
 
-func newTestFixture(t *testing.T) testFixture {
+func newTestFixture(t *testing.T, configure ...func(*looperdruntime.Options)) testFixture {
 	t.Helper()
 
 	rootDir := t.TempDir()
@@ -5834,7 +5837,7 @@ func newTestFixture(t *testing.T) testFixture {
 	cfg.Agent.Vendor = &vendor
 
 	now := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC)
-	rt := looperdruntime.New(looperdruntime.Options{
+	options := looperdruntime.Options{
 		Config: cfg,
 		Logger: noopLogger{},
 		Now: func() time.Time {
@@ -5843,7 +5846,11 @@ func newTestFixture(t *testing.T) testFixture {
 		RunSchedulerTick: func(context.Context, looperdruntime.Services) error {
 			return nil
 		},
-	})
+	}
+	for _, apply := range configure {
+		apply(&options)
+	}
+	rt := looperdruntime.New(options)
 
 	if err := rt.Start(context.Background()); err != nil {
 		t.Fatalf("Runtime.Start() error = %v", err)

--- a/internal/fixer/failure_classification_test.go
+++ b/internal/fixer/failure_classification_test.go
@@ -33,3 +33,11 @@ func TestClassifyFailureRetriesBoundaryExternalTransport(t *testing.T) {
 		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureRetryableTransient)
 	}
 }
+
+func TestClassifyFailureDoesNotRetryInvalidProjectRepoPath(t *testing.T) {
+	runner := &Runner{}
+	got := runner.classifyFailureWithBoundary(errors.New("git worktree list --porcelain: fatal: not a git repository (or any of the parent directories): .git"), failureclass.BoundaryGitRemote)
+	if got.kind != FailureNonRetryable {
+		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureNonRetryable)
+	}
+}

--- a/internal/fixer/failure_classification_test.go
+++ b/internal/fixer/failure_classification_test.go
@@ -41,3 +41,11 @@ func TestClassifyFailureDoesNotRetryInvalidProjectRepoPath(t *testing.T) {
 		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureNonRetryable)
 	}
 }
+
+func TestClassifyFailureDoesNotRetryMissingProjectRepoDirectory(t *testing.T) {
+	runner := &Runner{}
+	got := runner.classifyFailureWithBoundary(errors.New("start command: chdir /tmp/missing-repo: no such file or directory"), failureclass.BoundaryGitRemote)
+	if got.kind != FailureNonRetryable {
+		t.Fatalf("classifyFailure() kind = %s, want %s", got.kind, FailureNonRetryable)
+	}
+}

--- a/internal/loops/failureclass/failureclass.go
+++ b/internal/loops/failureclass/failureclass.go
@@ -127,6 +127,10 @@ func isManualWorktreeMessage(message string) bool {
 }
 
 func isDeterministicDenial(message string) bool {
+	if strings.Contains(message, "start command: chdir") && strings.Contains(message, "no such file or directory") {
+		return true
+	}
+
 	for _, fragment := range []string{
 		"http 400",
 		"http 401",

--- a/internal/loops/failureclass/failureclass.go
+++ b/internal/loops/failureclass/failureclass.go
@@ -143,6 +143,8 @@ func isDeterministicDenial(message string) bool {
 		"permission denied",
 		"not authorized",
 		"repository not found",
+		"not a git repository",
+		"not in a git directory",
 		"could not resolve to a repository",
 		"could not resolve to a pullrequest",
 		"protected branch",

--- a/internal/loops/failureclass/failureclass_test.go
+++ b/internal/loops/failureclass/failureclass_test.go
@@ -61,6 +61,7 @@ func TestClassifyDeterministicFailuresDoNotBecomeTransient(t *testing.T) {
 		want     Kind
 	}{
 		{name: "github auth", boundary: BoundaryGitHubAPI, message: "GitHub API failed: HTTP 403 Forbidden", want: NonRetryable},
+		{name: "invalid git repository", boundary: BoundaryGitRemote, message: "git worktree list --porcelain: fatal: not a git repository (or any of the parent directories): .git", want: NonRetryable},
 		{name: "config", boundary: BoundaryConfig, message: "config validation failed", want: NonRetryable},
 		{name: "checkpoint", boundary: BoundaryCheckpoint, message: "checkpoint invariant missing", want: NonRetryable},
 		{name: "dirty worktree", boundary: BoundaryLocalWorktree, message: "dirty worktree", want: ManualIntervention},

--- a/internal/loops/failureclass/failureclass_test.go
+++ b/internal/loops/failureclass/failureclass_test.go
@@ -62,6 +62,7 @@ func TestClassifyDeterministicFailuresDoNotBecomeTransient(t *testing.T) {
 	}{
 		{name: "github auth", boundary: BoundaryGitHubAPI, message: "GitHub API failed: HTTP 403 Forbidden", want: NonRetryable},
 		{name: "invalid git repository", boundary: BoundaryGitRemote, message: "git worktree list --porcelain: fatal: not a git repository (or any of the parent directories): .git", want: NonRetryable},
+		{name: "missing repo directory", boundary: BoundaryGitRemote, message: "start command: chdir /tmp/missing-repo: no such file or directory", want: NonRetryable},
 		{name: "config", boundary: BoundaryConfig, message: "config validation failed", want: NonRetryable},
 		{name: "checkpoint", boundary: BoundaryCheckpoint, message: "checkpoint invariant missing", want: NonRetryable},
 		{name: "dirty worktree", boundary: BoundaryLocalWorktree, message: "dirty worktree", want: ManualIntervention},


### PR DESCRIPTION
Summary
- Classify `not a git repository` / `not in a git directory` failures as deterministic non-retryable failures, even at git boundaries.
- Add failure-classification coverage and fixer-level coverage.

Root cause from 24h failures
- The `recruitment` project is registered with `repo_path=/Users/mrc/Projects/recruitment`, but that directory is not a Git repository; the actual checkout appears to be `/Users/mrc/Projects/talent-os`.
- Because `git worktree list --porcelain` ran with the invalid repo path, Looper treated the error as retryable and retried repeatedly.

Operational follow-up
- The project registration should still be corrected locally to point at the real repo checkout.
- This PR prevents the retry storm and surfaces the failure as deterministic configuration.

Validation
- go test ./internal/loops/failureclass ./internal/fixer
- go test ./...