### PR TITLE
fix: surface invalid gh JSON payload details

### DIFF
--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -3316,7 +3316,30 @@ func decodeJSONArrayOrPages(value string) ([]map[string]any, error) {
 }
 
 func invalidJSONError(stdout string, err error) error {
-	return &shell.CommandExecutionError{Message: "Invalid gh JSON payload", Result: shell.Result{ExitCode: 0, Stdout: stdout, Stderr: err.Error()}}
+	message := "Invalid gh JSON payload"
+	errText := ""
+	if err != nil {
+		errText = err.Error()
+		message += ": " + errText
+	}
+	message += fmt.Sprintf("; stdoutBytes=%d", len(stdout))
+	if sample := summarizeInvalidJSONPayload(stdout); sample != "" {
+		message += "; stdoutSample=" + strconv.Quote(sample)
+	}
+	return &shell.CommandExecutionError{Message: message, Result: shell.Result{ExitCode: 0, Stdout: stdout, Stderr: errText}}
+}
+
+func summarizeInvalidJSONPayload(stdout string) string {
+	stdout = strings.TrimSpace(stdout)
+	if stdout == "" {
+		return ""
+	}
+	stdout = strings.Join(strings.Fields(stdout), " ")
+	const maxSampleBytes = 240
+	if len(stdout) <= maxSampleBytes {
+		return stdout
+	}
+	return strings.TrimSpace(stdout[:maxSampleBytes]) + "…"
 }
 
 func toObjectSlice(value any) []map[string]any {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -14,6 +14,34 @@ import (
 	"github.com/nexu-io/looper/internal/infra/shell"
 )
 
+func TestInvalidJSONErrorIncludesParserDetailsAndPayloadSample(t *testing.T) {
+	t.Parallel()
+	stdout := strings.Repeat("warning: ", 40) + "not json"
+	_, err := decodeJSONObject(stdout)
+	if err == nil {
+		t.Fatal("decodeJSONObject() error = nil, want invalid JSON error")
+	}
+	var commandErr *shell.CommandExecutionError
+	if !errors.As(err, &commandErr) {
+		t.Fatalf("decodeJSONObject() error = %T, want CommandExecutionError", err)
+	}
+	if !strings.Contains(commandErr.Error(), "Invalid gh JSON payload:") {
+		t.Fatalf("error = %q, want parser details", commandErr.Error())
+	}
+	if !strings.Contains(commandErr.Error(), "stdoutBytes=") {
+		t.Fatalf("error = %q, want stdoutBytes", commandErr.Error())
+	}
+	if !strings.Contains(commandErr.Error(), "stdoutSample=") {
+		t.Fatalf("error = %q, want stdout sample", commandErr.Error())
+	}
+	if !strings.Contains(commandErr.Error(), "…") {
+		t.Fatalf("error = %q, want truncated sample marker", commandErr.Error())
+	}
+	if commandErr.Result.Stdout != stdout {
+		t.Fatalf("Result.Stdout was not preserved")
+	}
+}
+
 func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}


### PR DESCRIPTION
Summary
- Include the JSON parser error, stdout byte count, and a truncated stdout sample in `Invalid gh JSON payload` errors.
- Preserve full stdout/stderr on the command error result for deeper diagnosis.
- Add coverage for malformed GH JSON diagnostics.

Root cause from 24h failures
- The failing reviewer thread-resolution run only recorded `Invalid gh JSON payload`, so the actual `gh api graphql` stdout could not be reconstructed from persisted logs.
- Code path: reviewer thread resolution → `ListReviewThreads` → GitHub GraphQL response decode.

Why this is the safe fix
- The observed instance was already classified retryable; the missing piece is actionable diagnostics for the next occurrence.
- This does not change GitHub side effects or retry semantics.

Validation
- go test ./internal/infra/github
- go test ./...