### PR TITLE
fix: keep retry failures backing off

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2715,7 +2715,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			Agent:       preferredActiveRunAgent(verifiedActiveAgentByRunID[run.ID], activeAgentByRunID[run.ID]),
 			Worktree:    buildWorktreeSummary(loop, run),
 		}
-		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], latestRun)
+		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], latestRun, h.now().UTC())
 		runningViews = append(runningViews, view)
 	}
 
@@ -2759,7 +2759,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			Agent:       nil,
 			Worktree:    nil,
 		}
-		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], latestRunsByLoopID[loop.ID])
+		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], latestRunsByLoopID[loop.ID], h.now().UTC())
 		queuedViews = append(queuedViews, view)
 	}
 
@@ -2787,7 +2787,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			Agent:       nil,
 			Worktree:    nil,
 		}
-		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], latestRunsByLoopID[loop.ID])
+		decorateActiveRunView(&view, loop, latestQueueByLoopID[loop.ID], latestRunsByLoopID[loop.ID], h.now().UTC())
 		runningLoopViews = append(runningLoopViews, view)
 	}
 
@@ -2846,7 +2846,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			Agent:       nil,
 			Worktree:    worktree,
 		}
-		decorateActiveRunView(&view, loop, latestQueue, latestRun)
+		decorateActiveRunView(&view, loop, latestQueue, latestRun, h.now().UTC())
 		inactiveLoopViews = append(inactiveLoopViews, view)
 	}
 
@@ -2980,7 +2980,7 @@ func latestQueueItemByLoopID(items []storage.QueueItemRecord) map[string]*storag
 }
 
 func isManualInterventionQueue(item *storage.QueueItemRecord) bool {
-	return item != nil && item.LastErrorKind != nil && *item.LastErrorKind == "manual_intervention"
+	return item != nil && (item.Status == "manual_intervention" || (item.LastErrorKind != nil && *item.LastErrorKind == "manual_intervention"))
 }
 
 func hasManualInterventionResumePolicy(run *storage.RunRecord) bool {
@@ -2988,7 +2988,7 @@ func hasManualInterventionResumePolicy(run *storage.RunRecord) bool {
 	return policy != nil && *policy == loops.ResumePolicyManualIntervention
 }
 
-func decorateActiveRunView(view *activeRunView, loop storage.LoopRecord, latestQueue *storage.QueueItemRecord, latestRun *storage.RunRecord) {
+func decorateActiveRunView(view *activeRunView, loop storage.LoopRecord, latestQueue *storage.QueueItemRecord, latestRun *storage.RunRecord, now time.Time) {
 	if view.LoopStatus == "" {
 		view.LoopStatus = loop.Status
 	}
@@ -3000,10 +3000,32 @@ func decorateActiveRunView(view *activeRunView, loop storage.LoopRecord, latestQ
 	view.ResumePolicy = resumePolicyFromRun(latestRun)
 	if isManualInterventionQueue(latestQueue) || (view.ResumePolicy != nil && *view.ResumePolicy == loops.ResumePolicyManualIntervention) {
 		view.DisplayStatus = "manual_intervention"
+	} else if isBackingOffQueue(latestQueue, now) {
+		view.DisplayStatus = "backing_off"
 	}
 	if view.DisplayStatus == "" {
 		view.DisplayStatus = view.Status
 	}
+}
+
+func isBackingOffQueue(item *storage.QueueItemRecord, now time.Time) bool {
+	if item == nil || item.Status != "queued" || item.LastErrorKind == nil {
+		return false
+	}
+	switch strings.TrimSpace(*item.LastErrorKind) {
+	case "retryable_transient", "retryable_after_resume":
+	default:
+		return false
+	}
+	availableAt := strings.TrimSpace(item.AvailableAt)
+	if availableAt == "" {
+		return false
+	}
+	availableTime, err := time.Parse(time.RFC3339Nano, availableAt)
+	if err != nil {
+		return availableAt > eventlog.FormatJavaScriptISOString(now)
+	}
+	return availableTime.After(now)
 }
 
 func resumePolicyFromRun(run *storage.RunRecord) *string {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1120,7 +1120,7 @@ func (h *Handler) buildStatusResponse(ctx context.Context) (statusResponse, erro
 			QueuedItems:    int(queueCounts["queued"]),
 			RunningItems:   int(queueCounts["running"]),
 			CompletedItems: int(queueCounts["completed"]),
-			FailedItems:    int(queueCounts["failed"]),
+			FailedItems:    int(queueCounts["failed"] + queueCounts["manual_intervention"]),
 			TotalRuns:      sumStatusCounts(runCounts),
 			ActiveRuns:     int(runCounts["running"]),
 		},

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -611,6 +611,7 @@ func TestHandlerStatusSuccessContainsExpectedSections(t *testing.T) {
 	if queuedItems+runningItems != float64(1) {
 		t.Fatalf("scheduler queued+running = %v, want 1 (queued=%v running=%v)", queuedItems+runningItems, queuedItems, runningItems)
 	}
+	assertEqual(t, scheduler["failedItems"], float64(1))
 	assertEqual(t, scheduler["totalRuns"], float64(1))
 	assertEqual(t, scheduler["activeRuns"], float64(1))
 
@@ -6026,6 +6027,31 @@ func seedStatusData(t *testing.T, rt *looperdruntime.Runtime) {
 		UpdatedAt:   nowISO,
 	}); err != nil {
 		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	manualReason := "dirty worker worktree"
+	manualKind := "manual_intervention"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID:            "queue_manual_1",
+		ProjectID:     &projectID,
+		LoopID:        &loopID,
+		Type:          "reviewer",
+		TargetType:    "pull_request",
+		TargetID:      "pr:acme/looper:42",
+		Repo:          stringPtr("acme/looper"),
+		PRNumber:      int64Ptr(42),
+		DedupeKey:     "reviewer:acme/looper:42:manual",
+		Priority:      2,
+		Status:        "manual_intervention",
+		AvailableAt:   nowISO,
+		Attempts:      1,
+		MaxAttempts:   3,
+		LastError:     &manualReason,
+		LastErrorKind: &manualKind,
+		CreatedAt:     nowISO,
+		UpdatedAt:     nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert(queue_manual_1) error = %v", err)
 	}
 }
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -153,6 +153,56 @@ func TestHandlerLoopRetryAllowsFailedReviewerLoop(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopRetryAllowsManualInterventionQueueItem(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_manual_intervention"
+	loopID := "loop_retry_manual_intervention"
+	targetID := projectID
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 48, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	lastErrorKind := "manual_intervention"
+	lastError := "dirty worker worktree"
+	finishedAt := "2026-04-11T12:01:00.000Z"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_retry_manual_intervention", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:retry_manual_intervention", Priority: storage.QueuePriorityWorker, Status: "manual_intervention", AvailableAt: nowISO, Attempts: 2, MaxAttempts: 3, LastError: &lastError, LastErrorKind: &lastErrorKind, FinishedAt: &finishedAt, CreatedAt: nowISO, UpdatedAt: finishedAt}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/48/retry", strings.NewReader(`{"mode":"auto","resetAttempts":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = %#v, %v", loop, err)
+	}
+	if loop.Status != "queued" {
+		t.Fatalf("loop.Status = %q, want queued", loop.Status)
+	}
+	items, err := services.Repositories.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	var replacement *storage.QueueItemRecord
+	for i := range items {
+		if items[i].LoopID != nil && *items[i].LoopID == loopID && items[i].Status == "queued" {
+			replacement = &items[i]
+		}
+	}
+	if replacement == nil || replacement.ID == "queue_retry_manual_intervention" || replacement.Attempts != 0 || replacement.LastErrorKind != nil {
+		t.Fatalf("replacement queue = %#v, want new queued item with reset attempts and cleared error", replacement)
+	}
+}
+
 func TestHandlerLoopRetryRejectsTerminalReviewerMetadata(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})
@@ -363,6 +413,51 @@ func TestHandlerActiveRunsSurfacesResumePolicyManualIntervention(t *testing.T) {
 	assertEqual(t, item["loopStatus"], "paused")
 	assertEqual(t, item["displayStatus"], "manual_intervention")
 	assertEqual(t, item["resumePolicy"], "manual_intervention")
+}
+
+func TestHandlerActiveRunsSurfacesBackingOffDisplayStatus(t *testing.T) {
+	for _, lastErrorKind := range []string{"retryable_transient", "retryable_after_resume"} {
+		t.Run(lastErrorKind, func(t *testing.T) {
+			rt, cfg := startTestRuntime(t)
+			h := NewHandler(Context{Config: cfg, Runtime: rt})
+			services := rt.Services()
+			now := time.Now().UTC()
+			nowISO := now.Format(time.RFC3339Nano)
+			availableAt := now.Add(5 * time.Minute).Format(time.RFC3339Nano)
+			projectID := "project_backing_off_" + lastErrorKind
+			loopID := "loop_backing_off_" + lastErrorKind
+			targetID := projectID
+			lastError := "temporary network failure"
+
+			if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+				t.Fatalf("Projects.Upsert() error = %v", err)
+			}
+			if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 50, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+				t.Fatalf("Loops.Upsert() error = %v", err)
+			}
+			if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_backing_off_" + lastErrorKind, ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:backing_off:" + lastErrorKind, Priority: storage.QueuePriorityWorker, Status: "queued", AvailableAt: availableAt, Attempts: 1, MaxAttempts: 3, LastError: &lastError, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+				t.Fatalf("Queue.Upsert() error = %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+			recorder := httptest.NewRecorder()
+			h.ServeHTTP(recorder, req)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+			}
+			body := parseJSONMap(t, recorder.Body.Bytes())
+			items := body["data"].(map[string]any)["items"].([]any)
+			if len(items) != 1 {
+				t.Fatalf("items len = %d, want 1: %#v", len(items), items)
+			}
+			item := items[0].(map[string]any)
+			assertEqual(t, item["status"], "queued")
+			assertEqual(t, item["displayStatus"], "backing_off")
+			assertEqual(t, item["loopStatus"], "queued")
+			assertEqual(t, item["lastFailureKind"], lastErrorKind)
+			assertEqual(t, item["lastFailureReason"], "temporary network failure")
+		})
+	}
 }
 
 func TestHandlerActiveRunsDefaultIncludesInterruptedManualResumeAndExcludesCompleted(t *testing.T) {

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -89,7 +89,7 @@
             "queuedItems": 1,
             "runningItems": 0,
             "completedItems": 0,
-            "failedItems": 0,
+            "failedItems": 1,
             "totalRuns": 1,
             "activeRuns": 1
           },

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -3276,6 +3276,42 @@ func TestPSWithoutJSONShowsRunningLoopWithoutRunRow(t *testing.T) {
 	}
 }
 
+func TestPSWithoutJSONShowsDisplayStatusWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/runs/active"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_active_runs", map[string]any{"items": []map[string]any{{
+			"seq":           42,
+			"type":          "worker",
+			"status":        "queued",
+			"displayStatus": "backing_off",
+			"currentStep":   "execute",
+			"target":        map[string]any{"label": "Looper"},
+		}}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "ps", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([ps]) exit code = %d, want 0", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([ps]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"worker", "Looper", "backing_off"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([ps]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+	if strings.Contains(stdout, "queued") {
+		t.Fatalf("Run([ps]) stdout = %q, did not expect fallback status %q when displayStatus is present", stdout, "queued")
+	}
+}
+
 func TestPSStatusAndTypeFiltersUseActiveRunsQueryAndShowInactiveCompletedLoop(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -169,7 +169,7 @@ func (r *commandRuntime) queueFailed(cmd *cobra.Command, args []string) error {
 		}
 		output := queueFailedOutput{NowISO: eventlog.FormatJavaScriptISOString(time.Now().UTC()), Type: typeFilter, ProjectID: projectFilter, Limit: limit}
 		for _, item := range items {
-			if item.Status != "failed" {
+			if item.Status != "failed" && item.Status != "manual_intervention" {
 				continue
 			}
 			if typeFilter != "" && item.Type != typeFilter {

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -225,13 +225,17 @@ func (r *commandRuntime) loopFailures(cmd *cobra.Command, args []string) error {
 		now := time.Now().UTC()
 		output := loopFailuresOutput{NowISO: eventlog.FormatJavaScriptISOString(now), Type: typeFilter, ProjectID: projectFilter, Limit: limit}
 		for _, loop := range loops {
-			if loop.Status != "failed" {
-				continue
-			}
 			if typeFilter != "" && loop.Type != typeFilter {
 				continue
 			}
 			if projectFilter != "" && loop.ProjectID != projectFilter {
+				continue
+			}
+			queueItem, err := repos.Queue.GetLatestByLoopID(cmd.Context(), loop.ID)
+			if err != nil {
+				return err
+			}
+			if !includeLoopInFailures(loop, queueItem) {
 				continue
 			}
 			run, err := repos.Runs.GetLatestByLoopID(cmd.Context(), loop.ID)
@@ -378,6 +382,16 @@ func buildLoopInspectOutput(ctx context.Context, repos *storage.Repositories, se
 		output.Agent = &agentOutput
 	}
 	return output, nil
+}
+
+func includeLoopInFailures(loop storage.LoopRecord, queueItem *storage.QueueItemRecord) bool {
+	if loop.Status == "failed" {
+		return true
+	}
+	if loop.Status != "paused" || queueItem == nil {
+		return false
+	}
+	return queueItem.Status == "manual_intervention"
 }
 
 func parseLoopDiagnosticMetadata(raw *string) loopDiagnosticMetadata {

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -86,6 +86,37 @@ func TestLoopFailuresListsFailedLoops(t *testing.T) {
 	}
 }
 
+func TestLoopFailuresIncludesPausedManualInterventionLoops(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeLoopDiagnosticsFixture(t, "")
+	exitCode, stdout, stderr := runApp(t, "loop", "failures", "--type", "worker", "--json", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([loop failures]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	var decoded struct {
+		Count int `json:"count"`
+		Items []struct {
+			Loop struct {
+				Seq    int64  `json:"seq"`
+				Status string `json:"status"`
+			} `json:"loop"`
+			LatestQueueItem struct {
+				Status string `json:"status"`
+			} `json:"latestQueueItem"`
+			Diagnosis struct {
+				FailureClass string `json:"failureClass"`
+			} `json:"diagnosis"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\noutput=%q", err, stdout)
+	}
+	if decoded.Count != 1 || len(decoded.Items) != 1 || decoded.Items[0].Loop.Seq != 8 || decoded.Items[0].Loop.Status != "paused" || decoded.Items[0].LatestQueueItem.Status != "manual_intervention" || decoded.Items[0].Diagnosis.FailureClass != "non_retryable" {
+		t.Fatalf("loop failures output = %#v, want one paused manual-intervention worker loop", decoded)
+	}
+}
+
 func TestLogsAcceptsRunIDFromPSOutput(t *testing.T) {
 	t.Parallel()
 
@@ -162,6 +193,19 @@ func writeLoopDiagnosticsFixture(t *testing.T, serverURL string) string {
 	}
 	lastErrorKind := "retryable_transient"
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_failed", ProjectID: &projectID, LoopID: stringPtr("loop_failed"), Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "reviewer:failed", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 2, MaxAttempts: 5, LastError: &errorMessage, LastErrorKind: &lastErrorKind, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	workerTargetID := "project:acme/looper"
+	workerMetadata := `{"loop":{"lastFailure":"fatal: worktree is locked"}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_action_required", Seq: 8, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &workerTargetID, Repo: stringPtr("acme/looper"), Status: "paused", MetadataJSON: &workerMetadata, LastRunAt: &now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	workerErrorMessage := "fatal: worktree is locked"
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_worker_paused", LoopID: "loop_paused_action_required", Status: "failed", CurrentStep: stringPtr("prepare_work"), ErrorMessage: &workerErrorMessage, StartedAt: now, LastHeartbeatAt: &now, EndedAt: &now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	workerErrorKind := "non_retryable"
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_worker_manual_intervention", ProjectID: &projectID, LoopID: stringPtr("loop_paused_action_required"), Type: "worker", TargetType: "project", TargetID: workerTargetID, Repo: stringPtr("acme/looper"), DedupeKey: "worker:manual", Priority: 1, Status: "manual_intervention", AvailableAt: now, Attempts: 3, MaxAttempts: 3, LastError: &workerErrorMessage, LastErrorKind: &workerErrorKind, CreatedAt: now, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
 	pid := int64(1234)

--- a/internal/cliapp/queue_commands_test.go
+++ b/internal/cliapp/queue_commands_test.go
@@ -155,12 +155,28 @@ func TestQueueFailedCommandListsFailedItems(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v\noutput=%q", err, stdout)
 	}
-	if decoded.Count != 1 || len(decoded.Items) != 1 {
-		t.Fatalf("queue failed output = %#v, want one item", decoded)
+	if decoded.Count != 2 || len(decoded.Items) != 2 {
+		t.Fatalf("queue failed output = %#v, want two items", decoded)
 	}
-	item := decoded.Items[0]
-	if item.QueueItem.ID != "qi_failed" || item.QueueItem.Status != "failed" || item.Diagnosis.FailureClass != "github_transient" || item.Diagnosis.Retryable == nil || !*item.Diagnosis.Retryable {
-		t.Fatalf("queue failed item = %#v, want retryable github_transient failed item", item)
+	itemsByID := map[string]struct {
+		status       string
+		failureClass string
+		retryable    *bool
+	}{}
+	for _, item := range decoded.Items {
+		itemsByID[item.QueueItem.ID] = struct {
+			status       string
+			failureClass string
+			retryable    *bool
+		}{status: item.QueueItem.Status, failureClass: item.Diagnosis.FailureClass, retryable: item.Diagnosis.Retryable}
+	}
+	failed := itemsByID["qi_failed"]
+	if failed.status != "failed" || failed.failureClass != "github_transient" || failed.retryable == nil || !*failed.retryable {
+		t.Fatalf("qi_failed = %#v, want retryable github_transient failed item", failed)
+	}
+	manual := itemsByID["qi_manual_intervention"]
+	if manual.status != "manual_intervention" {
+		t.Fatalf("qi_manual_intervention = %#v, want manual_intervention status", manual)
 	}
 }
 
@@ -202,6 +218,11 @@ func writeQueueCommandFixture(t *testing.T) (string, *storage.Repositories) {
 	prNumber := int64(42)
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "qi_failed", ProjectID: &projectID, LoopID: stringPtr("loop_failed"), Type: "reviewer", TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "failed", Priority: 1, Status: "failed", AvailableAt: now, Attempts: 2, MaxAttempts: 3, LastError: &lastError, LastErrorKind: &lastErrorKind, CreatedAt: now, UpdatedAt: now}); err != nil {
 		t.Fatalf("Queue.Upsert(qi_failed) error = %v", err)
+	}
+	manualError := "dirty worktree requires cleanup"
+	manualErrorKind := "manual_intervention"
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "qi_manual_intervention", ProjectID: &projectID, LoopID: stringPtr("loop_failed"), Type: "reviewer", TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: stringPtr("acme/looper"), PRNumber: &prNumber, DedupeKey: "manual", Priority: 1, Status: "manual_intervention", AvailableAt: now, Attempts: 1, MaxAttempts: 3, LastError: &manualError, LastErrorKind: &manualErrorKind, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert(qi_manual_intervention) error = %v", err)
 	}
 	configPath := filepath.Join(root, "config.json")
 	raw, err := json.Marshal(map[string]any{"storage": map[string]any{"dbPath": dbPath}})

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -4254,15 +4254,9 @@ func (r *Runner) requeueQueueItem(ctx context.Context, queueItem storage.QueueIt
 
 func (r *Runner) requeueOrFailQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string, nextAttempts int64) (*storage.QueueItemRecord, error) {
 	nowISO := r.nowISO()
-	if isRetryableFailure(kind) && nextAttempts < queueItem.MaxAttempts {
-		retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, nextAttempts)))
-		if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: queueItem.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
-			return nil, err
-		}
+	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, cappedRetryDelayAttempt(nextAttempts, queueItem.MaxAttempts))))
+	if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
+		return nil, err
 	}
 	return r.repos.Queue.GetByID(ctx, queueItem.ID)
 }
@@ -7050,6 +7044,16 @@ func optionalString(value string) *string {
 }
 
 func stringPtr(value string) *string { return &value }
+
+func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {
+	if attempts <= 0 {
+		return 1
+	}
+	if maxAttempts > 0 && attempts > maxAttempts {
+		return maxAttempts
+	}
+	return attempts
+}
 
 func derefString(value *string) string {
 	if value == nil {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1490,7 +1490,7 @@ func (r *Runner) recoverClaimedItem(ctx context.Context, queueItem storage.Queue
 	if err := r.reconcileRecoveredLoop(ctx, queueItem, failedQueue, failure.kind); err != nil {
 		return nil, err
 	}
-	if queueItem.LoopID != nil && queueItem.Repo != nil && queueItem.PRNumber != nil && (failedQueue == nil || failedQueue.Status != "queued") {
+	if queueItem.LoopID != nil && queueItem.Repo != nil && queueItem.PRNumber != nil && queueResultIsTerminalForCleanup(failedQueue) {
 		loop, err := r.repos.Loops.GetByID(ctx, *queueItem.LoopID)
 		if err != nil {
 			return nil, err
@@ -1521,12 +1521,8 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 			updated.Status = "queued"
 			updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 		} else {
-			if loops.ShouldPauseLoopAfterFailure(string(failureKind), failedQueue, "") {
-				updated.Status = "paused"
-			} else {
-				updated.Status = "failed"
-				stampFixerFailedDiscoveryFingerprint(updated, queueItem)
-			}
+			updated.Status = "paused"
+			stampFixerFailedDiscoveryFingerprint(updated, queueItem)
 			updated.NextRunAt = nil
 		}
 	})
@@ -1633,18 +1629,14 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 				updated.Status = "queued"
 				updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 			} else {
-				if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
-					updated.Status = "paused"
-				} else {
-					updated.Status = "failed"
-					stampFixerFailedDiscoveryFingerprint(updated, queueItem)
-				}
+				updated.Status = "paused"
+				stampFixerFailedDiscoveryFingerprint(updated, queueItem)
 				updated.NextRunAt = nil
 			}
 		}); err != nil {
 			return ProcessResult{}, err
 		}
-		if failedQueue == nil || failedQueue.Status != "queued" {
+		if queueResultIsTerminalForCleanup(failedQueue) {
 			if scheduled, err := r.schedulePendingRediscoveryAfterRun(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber); err != nil {
 				return ProcessResult{}, err
 			} else if scheduled {
@@ -1652,7 +1644,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 				return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 			}
 		}
-		if failedQueue == nil || failedQueue.Status != "queued" {
+		if queueResultIsTerminalForCleanup(failedQueue) {
 			r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &latest)
 		}
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
@@ -1769,18 +1761,14 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "queued"
 					updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 				} else {
-					if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
-						updated.Status = "paused"
-					} else {
-						updated.Status = "failed"
-						stampFixerFailedDiscoveryFingerprint(updated, queueItem)
-					}
+					updated.Status = "paused"
+					stampFixerFailedDiscoveryFingerprint(updated, queueItem)
 					updated.NextRunAt = nil
 				}
 			}); err != nil {
 				return ProcessResult{}, err
 			}
-			if failedQueue == nil || failedQueue.Status != "queued" {
+			if queueResultIsTerminalForCleanup(failedQueue) {
 				if scheduled, err := r.schedulePendingRediscoveryAfterRun(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber); err != nil {
 					return ProcessResult{}, err
 				} else if scheduled {
@@ -1788,7 +1776,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
 				}
 			}
-			if failedQueue == nil || failedQueue.Status != "queued" {
+			if queueResultIsTerminalForCleanup(failedQueue) {
 				r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &latest)
 			}
 			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "failed", Summary: failure.message, FailureKind: failure.kind}, nil
@@ -5010,6 +4998,10 @@ func (r *Runner) cleanupFixerWorktreeIfTerminal(ctx context.Context, project sto
 	}
 	checkpoint.Worktree.CleanedAt = r.nowISO()
 	r.appendEvent(ctx, eventInput{eventType: "fixer.worktree.cleaned", projectID: project.ID, entityType: "pull_request", entityID: project.ID, payload: map[string]any{"path": checkpoint.Worktree.Path, "branch": checkpoint.Worktree.Branch}})
+}
+
+func queueResultIsTerminalForCleanup(queue *storage.QueueItemRecord) bool {
+	return queue == nil || (queue.Status != "queued" && queue.Status != "manual_intervention")
 }
 
 type waitForPullRequestHeadSHAInput struct {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -4254,6 +4254,12 @@ func (r *Runner) requeueQueueItem(ctx context.Context, queueItem storage.QueueIt
 
 func (r *Runner) requeueOrFailQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string, nextAttempts int64) (*storage.QueueItemRecord, error) {
 	nowISO := r.nowISO()
+	if !shouldRetryQueueFailure(kind, nextAttempts, queueItem.MaxAttempts) {
+		if err := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: queueItem.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
+			return nil, err
+		}
+		return r.repos.Queue.GetByID(ctx, queueItem.ID)
+	}
 	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, cappedRetryDelayAttempt(nextAttempts, queueItem.MaxAttempts))))
 	if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
 		return nil, err
@@ -5988,6 +5994,13 @@ func backoffDelay(base time.Duration, attempts int64) time.Duration {
 
 func isRetryableFailure(kind QueueFailureKind) bool {
 	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume
+}
+
+func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {
+	if !isRetryableFailure(kind) {
+		return false
+	}
+	return maxAttempts <= 0 || nextAttempts < maxAttempts
 }
 
 func normalizePRState(value string) string {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -5145,22 +5145,19 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "failed" {
-		t.Fatalf("queue = %#v, want failed terminal queue item", queue)
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention queue item", queue)
 	}
 
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_fixer_resume_parse_status")
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want failed terminal loop", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused loop", loop)
 	}
-	if len(git.cleanupCalls) != 1 {
-		t.Fatalf("len(git.cleanupCalls) = %d, want 1", len(git.cleanupCalls))
-	}
-	if git.cleanupCalls[0].WorktreePath == "" || git.cleanupCalls[0].Branch != "feature/fix-42" {
-		t.Fatalf("cleanup call = %#v, want persisted worktree cleanup", git.cleanupCalls[0])
+	if len(git.cleanupCalls) != 0 {
+		t.Fatalf("len(git.cleanupCalls) = %d, want no cleanup for manual intervention", len(git.cleanupCalls))
 	}
 }
 
@@ -5316,8 +5313,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "failed" {
-		t.Fatalf("queue = %#v, want failed", queue)
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention", queue)
 	}
 }
 
@@ -5348,15 +5345,15 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "failed" {
-		t.Fatalf("queue = %#v, want failed", queue)
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want failed terminal loop", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused loop", loop)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -5145,16 +5145,16 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
-		t.Fatalf("queue = %#v, want queued backoff retryable_transient queue item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked retryable_transient queue item after exhaustion", queue)
 	}
 
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_fixer_resume_parse_status")
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil || *loop.NextRunAt <= fixture.nowISO() {
-		t.Fatalf("loop = %#v, want queued loop with scheduled retry", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused parked loop after exhaustion", loop)
 	}
 	if len(git.cleanupCalls) != 0 {
 		t.Fatalf("len(git.cleanupCalls) = %d, want no cleanup for manual intervention", len(git.cleanupCalls))
@@ -5313,8 +5313,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
-		t.Fatalf("queue = %#v, want queued backoff non_retryable item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked non_retryable item", queue)
 	}
 }
 
@@ -5345,15 +5345,15 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
-		t.Fatalf("queue = %#v, want queued backoff non_retryable recovery item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked non_retryable recovery item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil || *loop.NextRunAt <= fixture.nowISO() {
-		t.Fatalf("loop = %#v, want queued loop with scheduled retry", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused parked loop", loop)
 	}
 }
 
@@ -5401,8 +5401,8 @@ func TestProcessClaimedItemAutoPushDisabledSkipsManualIntervention(t *testing.T)
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want queued manual_intervention backoff item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked manual_intervention item", queue)
 	}
 	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
 	if err != nil {
@@ -5422,8 +5422,8 @@ func TestProcessClaimedItemAutoPushDisabledSkipsManualIntervention(t *testing.T)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
-		t.Fatalf("loop = %#v, want queued backoff loop", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused parked loop", loop)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -5145,16 +5145,16 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" {
-		t.Fatalf("queue = %#v, want manual_intervention queue item", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
+		t.Fatalf("queue = %#v, want queued backoff retryable_transient queue item", queue)
 	}
 
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_fixer_resume_parse_status")
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want paused loop", loop)
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil || *loop.NextRunAt <= fixture.nowISO() {
+		t.Fatalf("loop = %#v, want queued loop with scheduled retry", loop)
 	}
 	if len(git.cleanupCalls) != 0 {
 		t.Fatalf("len(git.cleanupCalls) = %d, want no cleanup for manual intervention", len(git.cleanupCalls))
@@ -5313,8 +5313,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" {
-		t.Fatalf("queue = %#v, want manual_intervention", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
+		t.Fatalf("queue = %#v, want queued backoff non_retryable item", queue)
 	}
 }
 
@@ -5345,15 +5345,15 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" {
-		t.Fatalf("queue = %#v, want manual_intervention", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
+		t.Fatalf("queue = %#v, want queued backoff non_retryable recovery item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want paused loop", loop)
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil || *loop.NextRunAt <= fixture.nowISO() {
+		t.Fatalf("loop = %#v, want queued loop with scheduled retry", loop)
 	}
 }
 
@@ -5401,8 +5401,8 @@ func TestProcessClaimedItemAutoPushDisabledSkipsManualIntervention(t *testing.T)
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != string(FailureManualIntervention) || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want failed manual_intervention queue item", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want queued manual_intervention backoff item", queue)
 	}
 	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
 	if err != nil {
@@ -5422,8 +5422,8 @@ func TestProcessClaimedItemAutoPushDisabledSkipsManualIntervention(t *testing.T)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want paused hard-hold loop", loop)
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
+		t.Fatalf("loop = %#v, want queued backoff loop", loop)
 	}
 }
 

--- a/internal/loops/policy.go
+++ b/internal/loops/policy.go
@@ -1,10 +1,6 @@
 package loops
 
-import (
-	"strings"
-
-	"github.com/nexu-io/looper/internal/storage"
-)
+import "strings"
 
 const (
 	FailureKindRetryableAfterResume = "retryable_after_resume"
@@ -51,11 +47,4 @@ func ShouldRestartFromDiscover(status, resumePolicy string) bool {
 		return false
 	}
 	return strings.TrimSpace(resumePolicy) == ResumePolicyRestartFromDiscover
-}
-
-func ShouldPauseLoopAfterFailure(failureKind string, failedQueue *storage.QueueItemRecord, resumePolicy string) bool {
-	if failedQueue != nil && failedQueue.Status == "cancelled" {
-		return true
-	}
-	return IsHardHold(failureKind, resumePolicy)
 }

--- a/internal/loops/policy_test.go
+++ b/internal/loops/policy_test.go
@@ -1,10 +1,6 @@
 package loops
 
-import (
-	"testing"
-
-	"github.com/nexu-io/looper/internal/storage"
-)
+import "testing"
 
 func TestNormalizeResumePolicy(t *testing.T) {
 	t.Parallel()
@@ -42,18 +38,9 @@ func TestShouldRestartFromDiscover(t *testing.T) {
 	}
 }
 
-func TestShouldPauseLoopAfterFailure(t *testing.T) {
+func TestManualHoldPolicy(t *testing.T) {
 	t.Parallel()
 
-	if !ShouldPauseLoopAfterFailure(FailureKindManualIntervention, nil, "") {
-		t.Fatal("ShouldPauseLoopAfterFailure() = false, want true for manual_intervention")
-	}
-	if ShouldPauseLoopAfterFailure(FailureKindRetryableAfterResume, nil, ResumePolicyRestartFromDiscover) {
-		t.Fatal("ShouldPauseLoopAfterFailure() = true, want false for rediscoverable retry")
-	}
-	if !ShouldPauseLoopAfterFailure("retryable_transient", &storage.QueueItemRecord{Status: "cancelled"}, "") {
-		t.Fatal("ShouldPauseLoopAfterFailure() = false, want true for cancelled queue item")
-	}
 	if !SuppressesAutonomousRecovery(FailureKindManualIntervention, "") {
 		t.Fatal("SuppressesAutonomousRecovery() = false, want true for hard hold")
 	}

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -620,12 +620,8 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 			updated.Status = "queued"
 			updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 		} else {
-			if loops.ShouldPauseLoopAfterFailure(string(failureKind), failedQueue, "") {
-				updated.Status = "paused"
-			} else {
-				updated.Status = "failed"
-				r.stampFailedDiscoveryFingerprint(updated, queueItem)
-			}
+			updated.Status = "paused"
+			r.stampFailedDiscoveryFingerprint(updated, queueItem)
 			updated.NextRunAt = nil
 		}
 	})
@@ -719,12 +715,8 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "queued"
 					updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 				} else {
-					if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
-						updated.Status = "paused"
-					} else {
-						updated.Status = "failed"
-						r.stampFailedDiscoveryFingerprint(updated, queueItem)
-					}
+					updated.Status = "paused"
+					r.stampFailedDiscoveryFingerprint(updated, queueItem)
 					updated.NextRunAt = nil
 				}
 			}); err != nil {

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -1501,6 +1501,12 @@ func (r *Runner) wakeSchedulerAfterEnqueue() {
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {
 	nextAttempts := queueItem.Attempts + 1
 	nowISO := r.nowISO()
+	if !shouldRetryQueueFailure(kind, nextAttempts, queueItem.MaxAttempts) {
+		if err := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: queueItem.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
+			return nil, err
+		}
+		return r.repos.Queue.GetByID(ctx, queueItem.ID)
+	}
 	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, cappedRetryDelayAttempt(nextAttempts, queueItem.MaxAttempts))))
 	if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
 		return nil, err
@@ -2108,6 +2114,13 @@ func backoffDelay(base time.Duration, attempts int64) time.Duration {
 
 func isRetryableFailure(kind QueueFailureKind) bool {
 	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume
+}
+
+func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {
+	if !isRetryableFailure(kind) {
+		return false
+	}
+	return maxAttempts <= 0 || nextAttempts < maxAttempts
 }
 
 func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -1501,15 +1501,9 @@ func (r *Runner) wakeSchedulerAfterEnqueue() {
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {
 	nextAttempts := queueItem.Attempts + 1
 	nowISO := r.nowISO()
-	if isRetryableFailure(kind) && nextAttempts < queueItem.MaxAttempts {
-		retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, nextAttempts)))
-		if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: queueItem.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
-			return nil, err
-		}
+	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, cappedRetryDelayAttempt(nextAttempts, queueItem.MaxAttempts))))
+	if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
+		return nil, err
 	}
 	updated, err := r.repos.Queue.GetByID(ctx, queueItem.ID)
 	if err != nil {
@@ -2114,6 +2108,16 @@ func backoffDelay(base time.Duration, attempts int64) time.Duration {
 
 func isRetryableFailure(kind QueueFailureKind) bool {
 	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume
+}
+
+func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {
+	if attempts <= 0 {
+		return 1
+	}
+	if maxAttempts > 0 && attempts > maxAttempts {
+		return maxAttempts
+	}
+	return attempts
 }
 
 func wrapRetryableAfterResume(err error) error {

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -937,15 +937,15 @@ func TestPublishAutoPushDisabledPausesPlannerLoop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want queued manual_intervention backoff item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked manual_intervention item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" {
-		t.Fatalf("loop = %#v, want queued", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused parked loop", loop)
 	}
 }
 
@@ -1041,8 +1041,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
-		t.Fatalf("queue = %#v, want queued backoff non_retryable item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked non_retryable item", queue)
 	}
 }
 
@@ -1073,15 +1073,15 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
-		t.Fatalf("queue = %#v, want queued backoff non_retryable recovery item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked non_retryable recovery item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil || *loop.NextRunAt <= fixture.nowISO() {
-		t.Fatalf("loop = %#v, want queued loop with scheduled retry", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused parked loop", loop)
 	}
 }
 

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -1041,8 +1041,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "failed" {
-		t.Fatalf("queue = %#v, want failed", queue)
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention", queue)
 	}
 }
 
@@ -1073,15 +1073,15 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "failed" {
-		t.Fatalf("queue = %#v, want failed", queue)
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want failed terminal loop", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused loop", loop)
 	}
 }
 

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -937,15 +937,15 @@ func TestPublishAutoPushDisabledPausesPlannerLoop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want terminal manual_intervention item", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want queued manual_intervention backoff item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" {
-		t.Fatalf("loop = %#v, want paused", loop)
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued", loop)
 	}
 }
 
@@ -1041,8 +1041,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" {
-		t.Fatalf("queue = %#v, want manual_intervention", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
+		t.Fatalf("queue = %#v, want queued backoff non_retryable item", queue)
 	}
 }
 
@@ -1073,15 +1073,15 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" {
-		t.Fatalf("queue = %#v, want manual_intervention", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
+		t.Fatalf("queue = %#v, want queued backoff non_retryable recovery item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want paused loop", loop)
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil || *loop.NextRunAt <= fixture.nowISO() {
+		t.Fatalf("loop = %#v, want queued loop with scheduled retry", loop)
 	}
 }
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4329,22 +4329,26 @@ func buildReviewerDedupeKey(projectID, loopID, repo string, prNumber int64) stri
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {
 	nextAttempts := queueItem.Attempts + 1
 	nowISO := r.nowISO()
-	if isRetryableFailure(kind) && nextAttempts < queueItem.MaxAttempts {
-		delay := backoffDelay(r.retryBaseDelay, nextAttempts, r.retryMaxDelayForProject(derefString(queueItem.ProjectID)))
-		retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(delay))
-		if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: queueItem.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
-			return nil, err
-		}
+	delay := backoffDelay(r.retryBaseDelay, cappedRetryDelayAttempt(nextAttempts, queueItem.MaxAttempts), r.retryMaxDelayForProject(derefString(queueItem.ProjectID)))
+	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(delay))
+	if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
+		return nil, err
 	}
 	updated, err := r.repos.Queue.GetByID(ctx, queueItem.ID)
 	if err != nil {
 		return nil, err
 	}
 	return updated, nil
+}
+
+func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {
+	if attempts <= 0 {
+		return 1
+	}
+	if maxAttempts > 0 && attempts > maxAttempts {
+		return maxAttempts
+	}
+	return attempts
 }
 
 func (r *Runner) updateLoop(ctx context.Context, loop storage.LoopRecord, mutate func(*storage.LoopRecord)) (storage.LoopRecord, error) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1497,6 +1497,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			if queueErr != nil {
 				return ProcessResult{}, queueErr
 			}
+			terminalFailure := false
 			_, loopErr := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
 				updated.LastRunAt = stringPtr(r.nowISO())
 				if !failure.interrupted {
@@ -1505,7 +1506,11 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 						updated.MetadataJSON = &metadataJSON
 					}
 				}
-				if failure.interrupted && terminalReviewerLoopReason(*updated) == "failed" {
+				if !failure.interrupted && terminalReviewerLoopReason(*updated) == "failed" {
+					terminalFailure = true
+					updated.Status = "failed"
+					updated.NextRunAt = nil
+				} else if failure.interrupted && terminalReviewerLoopReason(*updated) == "failed" {
 					updated.Status = "paused"
 					updated.NextRunAt = nil
 				} else if updated.Status == "paused" {
@@ -1520,6 +1525,12 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			})
 			if loopErr != nil {
 				return ProcessResult{}, loopErr
+			}
+			if terminalFailure && failedQueue != nil && failedQueue.Status == "queued" {
+				if err := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: failedQueue.ID, FinishedAt: r.nowISO(), ErrorMessage: optionalString(failure.message), ErrorKind: string(failure.kind), UpdatedAt: r.nowISO()}); err != nil {
+					return ProcessResult{}, err
+				}
+				failedQueue.Status = "failed"
 			}
 			if queueResultIsTerminalForCleanup(failedQueue) {
 				r.cleanupReviewerWorktreeIfTerminal(context.Background(), *project, &latest)

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1354,11 +1354,7 @@ func (r *Runner) finalizeClaimSetupFailure(ctx context.Context, queueItem storag
 			updated.Status = "queued"
 			updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 		} else {
-			if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, "") {
-				updated.Status = "paused"
-			} else {
-				updated.Status = "failed"
-			}
+			updated.Status = "paused"
 			updated.NextRunAt = nil
 		}
 	})
@@ -1501,7 +1497,6 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			if queueErr != nil {
 				return ProcessResult{}, queueErr
 			}
-			terminalFailure := false
 			_, loopErr := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
 				updated.LastRunAt = stringPtr(r.nowISO())
 				if !failure.interrupted {
@@ -1510,9 +1505,8 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 						updated.MetadataJSON = &metadataJSON
 					}
 				}
-				if !failure.interrupted && terminalReviewerLoopReason(*updated) == "failed" {
-					terminalFailure = true
-					updated.Status = "failed"
+				if failure.interrupted && terminalReviewerLoopReason(*updated) == "failed" {
+					updated.Status = "paused"
 					updated.NextRunAt = nil
 				} else if updated.Status == "paused" {
 					updated.NextRunAt = nil
@@ -1520,24 +1514,14 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "queued"
 					updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 				} else {
-					if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
-						updated.Status = "paused"
-					} else {
-						updated.Status = "failed"
-					}
+					updated.Status = "paused"
 					updated.NextRunAt = nil
 				}
 			})
 			if loopErr != nil {
 				return ProcessResult{}, loopErr
 			}
-			if terminalFailure && failedQueue != nil && failedQueue.Status == "queued" {
-				if err := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: failedQueue.ID, Attempts: failedQueue.Attempts, FinishedAt: r.nowISO(), ErrorMessage: optionalString(failure.message), ErrorKind: string(failure.kind), UpdatedAt: r.nowISO()}); err != nil {
-					return ProcessResult{}, err
-				}
-				failedQueue.Status = "failed"
-			}
-			if failedQueue == nil || failedQueue.Status != "queued" {
+			if queueResultIsTerminalForCleanup(failedQueue) {
 				r.cleanupReviewerWorktreeIfTerminal(context.Background(), *project, &latest)
 			}
 			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: runStatus, Summary: failure.message, FailureKind: failure.kind}, nil
@@ -5850,6 +5834,10 @@ func (r *Runner) cleanupReviewerWorktreeIfTerminal(ctx context.Context, project 
 		return
 	}
 	checkpoint.Worktree.CleanedAt = r.nowISO()
+}
+
+func queueResultIsTerminalForCleanup(queue *storage.QueueItemRecord) bool {
+	return queue == nil || (queue.Status != "queued" && queue.Status != "manual_intervention")
 }
 
 func requireWorktree(checkpoint reviewerCheckpoint) (*checkpointWorktree, error) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4329,6 +4329,12 @@ func buildReviewerDedupeKey(projectID, loopID, repo string, prNumber int64) stri
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {
 	nextAttempts := queueItem.Attempts + 1
 	nowISO := r.nowISO()
+	if !shouldRetryQueueFailure(kind, nextAttempts, queueItem.MaxAttempts) {
+		if err := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: queueItem.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
+			return nil, err
+		}
+		return r.repos.Queue.GetByID(ctx, queueItem.ID)
+	}
 	delay := backoffDelay(r.retryBaseDelay, cappedRetryDelayAttempt(nextAttempts, queueItem.MaxAttempts), r.retryMaxDelayForProject(derefString(queueItem.ProjectID)))
 	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(delay))
 	if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
@@ -6038,6 +6044,13 @@ func sleepWithContext(ctx context.Context, delay time.Duration) error {
 
 func isRetryableFailure(kind QueueFailureKind) bool {
 	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume
+}
+
+func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {
+	if !isRetryableFailure(kind) {
+		return false
+	}
+	return maxAttempts <= 0 || nextAttempts < maxAttempts
 }
 
 func cloneStrings(values []string) []string {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -6077,8 +6077,8 @@ func TestProcessClaimedItemDoesNotRetryGitHubSelfApprovalFailure(t *testing.T) {
 	if err != nil || queue == nil {
 		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queue, err)
 	}
-	if queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
-		t.Fatalf("queue = %#v, want queued backoff non_retryable queue item", queue)
+	if queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked non_retryable queue item", queue)
 	}
 }
 
@@ -6163,8 +6163,8 @@ func TestProcessClaimedItemPersistsExhaustedTransientDiscoverShellFailureAsRetry
 	if err != nil || queue == nil {
 		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queue, err)
 	}
-	if queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.LastError == nil || !strings.Contains(*queue.LastError, "unexpected EOF") || queue.FinishedAt != nil {
-		t.Fatalf("queue = %#v, want queued backoff retryable transient item preserving GitHub error", queue)
+	if queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.LastError == nil || !strings.Contains(*queue.LastError, "unexpected EOF") || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked retryable transient item preserving GitHub error after exhaustion", queue)
 	}
 }
 
@@ -6652,8 +6652,8 @@ func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	if getErr != nil {
 		t.Fatalf("Queue.GetByID() error = %v", getErr)
 	}
-	if queue == nil || queue.Status != "queued" || queue.FinishedAt != nil || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.AvailableAt <= fixture.nowISO() {
-		t.Fatalf("queue = %#v, want queued backoff queue item with non_retryable error kind", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.FinishedAt == nil || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
+		t.Fatalf("queue = %#v, want parked queue item with non_retryable error kind", queue)
 	}
 	if queue.LastError == nil || !contains(*queue.LastError, "start run blocked") {
 		t.Fatalf("queue.LastError = %#v, want start run blocked", queue.LastError)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -6077,8 +6077,8 @@ func TestProcessClaimedItemDoesNotRetryGitHubSelfApprovalFailure(t *testing.T) {
 	if err != nil || queue == nil {
 		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queue, err)
 	}
-	if queue.Status != "failed" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
-		t.Fatalf("queue = %#v, want failed non_retryable queue item", queue)
+	if queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
+		t.Fatalf("queue = %#v, want manual_intervention non_retryable queue item", queue)
 	}
 }
 
@@ -6163,8 +6163,8 @@ func TestProcessClaimedItemPersistsExhaustedTransientDiscoverShellFailureAsRetry
 	if err != nil || queue == nil {
 		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queue, err)
 	}
-	if queue.Status != "failed" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.LastError == nil || !strings.Contains(*queue.LastError, "unexpected EOF") {
-		t.Fatalf("queue = %#v, want exhausted retryable transient failure preserving GitHub error", queue)
+	if queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.LastError == nil || !strings.Contains(*queue.LastError, "unexpected EOF") {
+		t.Fatalf("queue = %#v, want exhausted retryable transient manual intervention preserving GitHub error", queue)
 	}
 }
 
@@ -6652,8 +6652,8 @@ func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	if getErr != nil {
 		t.Fatalf("Queue.GetByID() error = %v", getErr)
 	}
-	if queue == nil || queue.Status != "failed" || queue.FinishedAt == nil || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
-		t.Fatalf("queue = %#v, want failed queue item with non_retryable error kind", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.FinishedAt == nil || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
+		t.Fatalf("queue = %#v, want manual_intervention queue item with non_retryable error kind", queue)
 	}
 	if queue.LastError == nil || !contains(*queue.LastError, "start run blocked") {
 		t.Fatalf("queue.LastError = %#v, want start run blocked", queue.LastError)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -5039,6 +5039,56 @@ func TestProcessClaimedItemRetriesWhenAgentReviewMarkerMissing(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemPreservesTerminalReviewerFailureMetadata(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{reviewRequests: []string{"octocat"}, reviewMarkerMissing: true}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "posted", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+	ctx := context.Background()
+
+	if _, err := runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claim, err)
+	}
+	agent.onStart = func(AgentRunInput) {
+		loop, err := fixture.repos.Loops.GetByID(ctx, *claim.LoopID)
+		if err != nil || loop == nil {
+			t.Fatalf("Loops.GetByID() = (%#v, %v), want loop during agent start", loop, err)
+		}
+		metadata := mustMarshalJSON(map[string]any{"loop": map[string]any{"status": "failed"}})
+		loop.MetadataJSON = &metadata
+		if err := fixture.repos.Loops.Upsert(ctx, *loop); err != nil {
+			t.Fatalf("Loops.Upsert() error = %v", err)
+		}
+	}
+
+	result, err := runner.ProcessClaimedItem(ctx, *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume || !contains(result.Summary, "no matching GitHub review marker") {
+		t.Fatalf("result = %#v, want retryable failed marker-miss result", result)
+	}
+	queue, err := fixture.repos.Queue.GetByID(ctx, claim.ID)
+	if err != nil || queue == nil {
+		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queue, err)
+	}
+	if queue.Status != "manual_intervention" || queue.FinishedAt == nil || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableAfterResume) {
+		t.Fatalf("queue = %#v, want terminal manual_intervention queue preserving retryable failure", queue)
+	}
+	loop, err := fixture.repos.Loops.GetByID(ctx, result.LoopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+	if loop.Status != "failed" || loop.NextRunAt != nil || terminalReviewerLoopReason(*loop) != "failed" {
+		t.Fatalf("loop = %#v, want failed terminal loop with no next run", loop)
+	}
+}
+
 func TestProcessClaimedItemRerunsReviewAfterRepeatedAgentReviewMarkerMisses(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -6077,8 +6077,8 @@ func TestProcessClaimedItemDoesNotRetryGitHubSelfApprovalFailure(t *testing.T) {
 	if err != nil || queue == nil {
 		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queue, err)
 	}
-	if queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
-		t.Fatalf("queue = %#v, want manual_intervention non_retryable queue item", queue)
+	if queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
+		t.Fatalf("queue = %#v, want queued backoff non_retryable queue item", queue)
 	}
 }
 
@@ -6163,8 +6163,8 @@ func TestProcessClaimedItemPersistsExhaustedTransientDiscoverShellFailureAsRetry
 	if err != nil || queue == nil {
 		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queue, err)
 	}
-	if queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.LastError == nil || !strings.Contains(*queue.LastError, "unexpected EOF") {
-		t.Fatalf("queue = %#v, want exhausted retryable transient manual intervention preserving GitHub error", queue)
+	if queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.LastError == nil || !strings.Contains(*queue.LastError, "unexpected EOF") || queue.FinishedAt != nil {
+		t.Fatalf("queue = %#v, want queued backoff retryable transient item preserving GitHub error", queue)
 	}
 }
 
@@ -6652,8 +6652,8 @@ func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	if getErr != nil {
 		t.Fatalf("Queue.GetByID() error = %v", getErr)
 	}
-	if queue == nil || queue.Status != "manual_intervention" || queue.FinishedAt == nil || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
-		t.Fatalf("queue = %#v, want manual_intervention queue item with non_retryable error kind", queue)
+	if queue == nil || queue.Status != "queued" || queue.FinishedAt != nil || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.AvailableAt <= fixture.nowISO() {
+		t.Fatalf("queue = %#v, want queued backoff queue item with non_retryable error kind", queue)
 	}
 	if queue.LastError == nil || !contains(*queue.LastError, "start run blocked") {
 		t.Fatalf("queue.LastError = %#v, want start run blocked", queue.LastError)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1284,6 +1284,41 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 		_, latestRunHasActiveAgent := activeAgentRunIDs[derefRunID(latestRun)]
 		_, latestRunHasUncertainAgent := uncertainAgentRunIDs[derefRunID(latestRun)]
 		if latestQueueIsManualIntervention(latestQueue) && (loop.Status == "running" || loop.Status == "queued") {
+			if latestQueue.Status == "manual_intervention" {
+				normalizedLoop := loop
+				normalizedLoop.Status = normalizeStaleQueuedLoopStatus(loop, derefRunOrZero(latestRun))
+				normalizedLoop.NextRunAt = nil
+				if latestRun != nil {
+					normalizedLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
+				}
+				normalizedLoop.UpdatedAt = nowISO
+				if err := repositories.Loops.Upsert(ctx, normalizedLoop); err != nil {
+					return RecoverySummary{}, err
+				}
+				terminalNormalizedLoopIDs[loop.ID] = struct{}{}
+				latestRunStatus := ""
+				if latestRun != nil {
+					latestRunStatus = latestRun.Status
+				}
+				if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
+					ID:         newRuntimeEventID(),
+					EventType:  "looperd.recovery.loop_queue_normalized",
+					LoopID:     stringPtr(loop.ID),
+					EntityType: stringPtr("loop"),
+					EntityID:   stringPtr(loop.ID),
+					PayloadJSON: mustMarshalJSON(map[string]any{
+						"previousStatus":  loop.Status,
+						"recoveredStatus": normalizedLoop.Status,
+						"latestRunStatus": latestRunStatus,
+					}),
+					CreatedAt: nowISO,
+				}); err != nil {
+					return RecoverySummary{}, err
+				}
+				eventsWritten += 1
+				continue
+			}
+
 			requeuedLoop := loop
 			requeuedLoop.Status = "queued"
 			requeuedLoop.NextRunAt = stringPtr(nowISO)
@@ -1291,14 +1326,8 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				requeuedLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
 			}
 			requeuedLoop.UpdatedAt = nowISO
-			if latestQueue.Status == "manual_intervention" {
-				if _, err := repositories.Queue.RequeueFailedByIDWithAttempts(ctx, loop.ID, latestQueue.ID, nowISO, latestQueue.Attempts); err != nil {
-					return RecoverySummary{}, err
-				}
-			} else if latestQueue.Status == "running" {
-				if _, err := repositories.Queue.RequeueRunningByLoop(ctx, loop.ID, nowISO); err != nil {
-					return RecoverySummary{}, err
-				}
+			if _, err := repositories.Queue.RequeueRunningByLoop(ctx, loop.ID, nowISO); err != nil {
+				return RecoverySummary{}, err
 			}
 			if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
 				return RecoverySummary{}, err
@@ -1878,27 +1907,34 @@ func (r *Runtime) repairStaleRunQueueState(ctx context.Context, repositories *st
 	}
 	if latestQueueIsManualIntervention(latestQueue) {
 		if loop.Status == "running" || loop.Status == "queued" {
-			requeuedLoop := loop
-			requeuedLoop.Status = "queued"
-			requeuedLoop.NextRunAt = stringPtr(nowISO)
-			if latestRun != nil {
-				requeuedLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
-			}
-			requeuedLoop.UpdatedAt = nowISO
 			if latestQueue.Status == "manual_intervention" {
-				if _, err := repositories.Queue.RequeueFailedByIDWithAttempts(ctx, loop.ID, latestQueue.ID, nowISO, latestQueue.Attempts); err != nil {
+				normalizedLoop := loop
+				normalizedLoop.Status = normalizeStaleQueuedLoopStatus(loop, derefRunOrZero(latestRun))
+				normalizedLoop.NextRunAt = nil
+				if latestRun != nil {
+					normalizedLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
+				}
+				normalizedLoop.UpdatedAt = nowISO
+				if err := repositories.Loops.Upsert(ctx, normalizedLoop); err != nil {
 					return staleRunQueueRepairSummary{}, err
 				}
 			} else if latestQueue.Status == "running" {
+				requeuedLoop := loop
+				requeuedLoop.Status = "queued"
+				requeuedLoop.NextRunAt = stringPtr(nowISO)
+				if latestRun != nil {
+					requeuedLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
+				}
+				requeuedLoop.UpdatedAt = nowISO
 				if _, err := repositories.Queue.RequeueRunningByLoop(ctx, loop.ID, nowISO); err != nil {
 					return staleRunQueueRepairSummary{}, err
 				}
+				if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
+					return staleRunQueueRepairSummary{}, err
+				}
+				summary.LoopsRequeued = 1
+				summary.QueueItemsRequeued = 1
 			}
-			if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
-				return staleRunQueueRepairSummary{}, err
-			}
-			summary.LoopsRequeued = 1
-			summary.QueueItemsRequeued = 1
 		}
 		return summary, nil
 	}
@@ -2947,6 +2983,13 @@ func normalizeStaleQueuedLoopStatus(loop storage.LoopRecord, latestRun storage.R
 
 func latestQueueIsManualIntervention(queue *storage.QueueItemRecord) bool {
 	return queue != nil && (queue.Status == "manual_intervention" || (queue.LastErrorKind != nil && *queue.LastErrorKind == "manual_intervention"))
+}
+
+func derefRunOrZero(run *storage.RunRecord) storage.RunRecord {
+	if run == nil {
+		return storage.RunRecord{}
+	}
+	return *run
 }
 
 func mustMarshalJSON(value any) string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1284,34 +1284,31 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 		_, latestRunHasActiveAgent := activeAgentRunIDs[derefRunID(latestRun)]
 		_, latestRunHasUncertainAgent := uncertainAgentRunIDs[derefRunID(latestRun)]
 		if latestQueueIsManualIntervention(latestQueue) && (loop.Status == "running" || loop.Status == "queued") {
-			if latestQueue.Status != "manual_intervention" {
-				attempts := latestQueue.Attempts
-				if attempts <= 0 {
-					attempts = 1
-				}
-				if err := repositories.Queue.Fail(ctx, storage.QueueFailInput{ID: latestQueue.ID, Attempts: attempts, FinishedAt: nowISO, ErrorMessage: latestQueue.LastError, ErrorKind: derefString(latestQueue.LastErrorKind), UpdatedAt: nowISO}); err != nil {
+			requeuedLoop := loop
+			requeuedLoop.Status = "queued"
+			requeuedLoop.NextRunAt = stringPtr(nowISO)
+			if latestRun != nil {
+				requeuedLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
+			}
+			requeuedLoop.UpdatedAt = nowISO
+			if latestQueue.Status == "manual_intervention" {
+				if _, err := repositories.Queue.RequeueFailedByIDWithAttempts(ctx, loop.ID, latestQueue.ID, nowISO, latestQueue.Attempts); err != nil {
 					return RecoverySummary{}, err
 				}
 			}
-			heldLoop := loop
-			heldLoop.Status = "paused"
-			heldLoop.NextRunAt = nil
-			if latestRun != nil {
-				heldLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
-			}
-			heldLoop.UpdatedAt = nowISO
-			if err := repositories.Loops.Upsert(ctx, heldLoop); err != nil {
+			if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
 				return RecoverySummary{}, err
 			}
+			requeuedLoopIDs[loop.ID] = struct{}{}
 			if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
 				ID:         newRuntimeEventID(),
-				EventType:  "looperd.recovery.loop_manual_intervention_held",
+				EventType:  "looperd.recovery.loop_manual_intervention_requeued",
 				LoopID:     stringPtr(loop.ID),
 				EntityType: stringPtr("loop"),
 				EntityID:   stringPtr(loop.ID),
 				PayloadJSON: mustMarshalJSON(map[string]any{
 					"previousStatus":  loop.Status,
-					"recoveredStatus": heldLoop.Status,
+					"recoveredStatus": requeuedLoop.Status,
 					"queueItemId":     latestQueue.ID,
 					"lastErrorKind":   derefString(latestQueue.LastErrorKind),
 				}),
@@ -1320,7 +1317,6 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				return RecoverySummary{}, err
 			}
 			eventsWritten += 1
-			terminalNormalizedLoopIDs[loop.ID] = struct{}{}
 			continue
 		}
 		if shouldRequeueLoop(loop, latestRun, latestRunHasActiveAgent || latestRunHasUncertainAgent) {
@@ -1877,27 +1873,24 @@ func (r *Runtime) repairStaleRunQueueState(ctx context.Context, repositories *st
 		return staleRunQueueRepairSummary{}, err
 	}
 	if latestQueueIsManualIntervention(latestQueue) {
-		if latestQueue.Status != "manual_intervention" {
-			attempts := latestQueue.Attempts
-			if attempts <= 0 {
-				attempts = 1
-			}
-			if err := repositories.Queue.Fail(ctx, storage.QueueFailInput{ID: latestQueue.ID, Attempts: attempts, FinishedAt: nowISO, ErrorMessage: latestQueue.LastError, ErrorKind: derefString(latestQueue.LastErrorKind), UpdatedAt: nowISO}); err != nil {
-				return staleRunQueueRepairSummary{}, err
-			}
-		}
 		if loop.Status == "running" || loop.Status == "queued" {
-			heldLoop := loop
-			heldLoop.Status = "paused"
-			heldLoop.NextRunAt = nil
+			requeuedLoop := loop
+			requeuedLoop.Status = "queued"
+			requeuedLoop.NextRunAt = stringPtr(nowISO)
 			if latestRun != nil {
-				heldLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
+				requeuedLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
 			}
-			heldLoop.UpdatedAt = nowISO
-			if err := repositories.Loops.Upsert(ctx, heldLoop); err != nil {
+			requeuedLoop.UpdatedAt = nowISO
+			if latestQueue.Status == "manual_intervention" {
+				if _, err := repositories.Queue.RequeueFailedByIDWithAttempts(ctx, loop.ID, latestQueue.ID, nowISO, latestQueue.Attempts); err != nil {
+					return staleRunQueueRepairSummary{}, err
+				}
+			}
+			if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
 				return staleRunQueueRepairSummary{}, err
 			}
-			summary.LoopsRequeued = 0
+			summary.LoopsRequeued = 1
+			summary.QueueItemsRequeued = 1
 		}
 		return summary, nil
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1277,11 +1277,52 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				return RecoverySummary{}, err
 			}
 			eventsWritten += 1
+			terminalNormalizedLoopIDs[loop.ID] = struct{}{}
 			continue
 		}
 
 		_, latestRunHasActiveAgent := activeAgentRunIDs[derefRunID(latestRun)]
 		_, latestRunHasUncertainAgent := uncertainAgentRunIDs[derefRunID(latestRun)]
+		if latestQueueIsManualIntervention(latestQueue) && (loop.Status == "running" || loop.Status == "queued") {
+			if latestQueue.Status != "manual_intervention" {
+				attempts := latestQueue.Attempts
+				if attempts <= 0 {
+					attempts = 1
+				}
+				if err := repositories.Queue.Fail(ctx, storage.QueueFailInput{ID: latestQueue.ID, Attempts: attempts, FinishedAt: nowISO, ErrorMessage: latestQueue.LastError, ErrorKind: derefString(latestQueue.LastErrorKind), UpdatedAt: nowISO}); err != nil {
+					return RecoverySummary{}, err
+				}
+			}
+			heldLoop := loop
+			heldLoop.Status = "paused"
+			heldLoop.NextRunAt = nil
+			if latestRun != nil {
+				heldLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
+			}
+			heldLoop.UpdatedAt = nowISO
+			if err := repositories.Loops.Upsert(ctx, heldLoop); err != nil {
+				return RecoverySummary{}, err
+			}
+			if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
+				ID:         newRuntimeEventID(),
+				EventType:  "looperd.recovery.loop_manual_intervention_held",
+				LoopID:     stringPtr(loop.ID),
+				EntityType: stringPtr("loop"),
+				EntityID:   stringPtr(loop.ID),
+				PayloadJSON: mustMarshalJSON(map[string]any{
+					"previousStatus":  loop.Status,
+					"recoveredStatus": heldLoop.Status,
+					"queueItemId":     latestQueue.ID,
+					"lastErrorKind":   derefString(latestQueue.LastErrorKind),
+				}),
+				CreatedAt: nowISO,
+			}); err != nil {
+				return RecoverySummary{}, err
+			}
+			eventsWritten += 1
+			terminalNormalizedLoopIDs[loop.ID] = struct{}{}
+			continue
+		}
 		if shouldRequeueLoop(loop, latestRun, latestRunHasActiveAgent || latestRunHasUncertainAgent) {
 			requeuedLoop := loop
 			requeuedLoop.Status = "queued"
@@ -1829,6 +1870,35 @@ func (r *Runtime) verifyRunExecutionLiveness(ctx context.Context, repositories *
 func (r *Runtime) repairStaleRunQueueState(ctx context.Context, repositories *storage.Repositories, loop storage.LoopRecord, latestRun *storage.RunRecord, latestRunHasLiveAgent bool, nowISO string) (staleRunQueueRepairSummary, error) {
 	summary := staleRunQueueRepairSummary{}
 	if repositories == nil || repositories.Queue == nil {
+		return summary, nil
+	}
+	latestQueue, err := repositories.Queue.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return staleRunQueueRepairSummary{}, err
+	}
+	if latestQueueIsManualIntervention(latestQueue) {
+		if latestQueue.Status != "manual_intervention" {
+			attempts := latestQueue.Attempts
+			if attempts <= 0 {
+				attempts = 1
+			}
+			if err := repositories.Queue.Fail(ctx, storage.QueueFailInput{ID: latestQueue.ID, Attempts: attempts, FinishedAt: nowISO, ErrorMessage: latestQueue.LastError, ErrorKind: derefString(latestQueue.LastErrorKind), UpdatedAt: nowISO}); err != nil {
+				return staleRunQueueRepairSummary{}, err
+			}
+		}
+		if loop.Status == "running" || loop.Status == "queued" {
+			heldLoop := loop
+			heldLoop.Status = "paused"
+			heldLoop.NextRunAt = nil
+			if latestRun != nil {
+				heldLoop.LastRunAt = coalesceString(latestRun.EndedAt, stringPtr(latestRun.StartedAt), loop.LastRunAt)
+			}
+			heldLoop.UpdatedAt = nowISO
+			if err := repositories.Loops.Upsert(ctx, heldLoop); err != nil {
+				return staleRunQueueRepairSummary{}, err
+			}
+			summary.LoopsRequeued = 0
+		}
 		return summary, nil
 	}
 	if shouldRequeueLoop(loop, latestRun, latestRunHasLiveAgent) {
@@ -2870,8 +2940,12 @@ func normalizeStaleQueuedLoopStatus(loop storage.LoopRecord, latestRun storage.R
 	case "interrupted", "running":
 		return "interrupted"
 	default:
-		return "failed"
+		return "paused"
 	}
+}
+
+func latestQueueIsManualIntervention(queue *storage.QueueItemRecord) bool {
+	return queue != nil && (queue.Status == "manual_intervention" || (queue.LastErrorKind != nil && *queue.LastErrorKind == "manual_intervention"))
 }
 
 func mustMarshalJSON(value any) string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1934,9 +1934,9 @@ func (r *Runtime) repairStaleRunQueueState(ctx context.Context, repositories *st
 				}
 				summary.LoopsRequeued = 1
 				summary.QueueItemsRequeued = 1
+				return summary, nil
 			}
 		}
-		return summary, nil
 	}
 	if shouldRequeueLoop(loop, latestRun, latestRunHasLiveAgent) {
 		requeuedLoop := loop

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1295,6 +1295,10 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				if _, err := repositories.Queue.RequeueFailedByIDWithAttempts(ctx, loop.ID, latestQueue.ID, nowISO, latestQueue.Attempts); err != nil {
 					return RecoverySummary{}, err
 				}
+			} else if latestQueue.Status == "running" {
+				if _, err := repositories.Queue.RequeueRunningByLoop(ctx, loop.ID, nowISO); err != nil {
+					return RecoverySummary{}, err
+				}
 			}
 			if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
 				return RecoverySummary{}, err
@@ -1883,6 +1887,10 @@ func (r *Runtime) repairStaleRunQueueState(ctx context.Context, repositories *st
 			requeuedLoop.UpdatedAt = nowISO
 			if latestQueue.Status == "manual_intervention" {
 				if _, err := repositories.Queue.RequeueFailedByIDWithAttempts(ctx, loop.ID, latestQueue.ID, nowISO, latestQueue.Attempts); err != nil {
+					return staleRunQueueRepairSummary{}, err
+				}
+			} else if latestQueue.Status == "running" {
+				if _, err := repositories.Queue.RequeueRunningByLoop(ctx, loop.ID, nowISO); err != nil {
 					return staleRunQueueRepairSummary{}, err
 				}
 			}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -685,7 +685,7 @@ func TestRuntimeStartNormalizesStaleQueuedLoops(t *testing.T) {
 
 	services := rt.Services()
 	assertLoopStatus(t, services.Repositories, "loop_success", "completed")
-	assertLoopStatus(t, services.Repositories, "loop_failed", "failed")
+	assertLoopStatus(t, services.Repositories, "loop_failed", "paused")
 	assertLoopStatus(t, services.Repositories, "loop_legit", "queued")
 	assertLoopStatus(t, services.Repositories, "loop_requeued", "queued")
 
@@ -1110,6 +1110,142 @@ func TestRunRecoveryPipelineRepairsFailedReviewerLoopToTerminalMetadataStatus(t 
 	}
 	if !containsEventType(events, "looperd.recovery.reviewer_terminal_metadata_normalized") {
 		t.Fatalf("events = %#v, want reviewer terminal normalization event", events)
+	}
+}
+
+func TestRunRecoveryPipelineKeepsQueuedReviewerLoopPausedWhenLatestRunFailed(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	coordinator := openMigratedCoordinator(t, cfg.Storage.DBPath, "")
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.June, 4, 17, 5, 32, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "nexu-io/vela"
+	prNumber := int64(223)
+	targetID := "pr:nexu-io/vela:223"
+	loopID := "loop_reviewer_queued_failed_run_pauses"
+	if err := repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1700, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "queued", NextRunAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	errorMessage := "review failed"
+	checkpoint := `{"resumePolicy":"manual_intervention"}`
+	if err := repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_reviewer_queued_failed_run_pauses", LoopID: loopID, Status: "failed", CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	queueErrorKind := "manual_intervention"
+	if err := repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_queued_failed_run_pauses", ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:project_1:loop_reviewer_queued_failed_run_pauses:nexu-io/vela:223", Priority: storage.QueuePriorityReviewer, Status: "queued", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 5, LastError: &errorMessage, LastErrorKind: &queueErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+
+	if _, err := rt.runRecoveryPipeline(context.Background(), repositories, nil, now); err != nil {
+		t.Fatalf("runRecoveryPipeline() error = %v", err)
+	}
+	loop, err := repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused", loop)
+	}
+	queue, err := repositories.Queue.GetByID(context.Background(), "queue_reviewer_queued_failed_run_pauses")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention hold", queue)
+	}
+	events, err := repositories.Events.ListByEntity(context.Background(), "loop", loopID)
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	if containsEventType(events, "looperd.recovery.loop_requeued") {
+		t.Fatalf("events = %#v, want no loop_requeued event", events)
+	}
+	if containsEventType(events, "looperd.recovery.loop_queue_normalized") {
+		t.Fatalf("events = %#v, want no failed normalization event", events)
+	}
+	if containsEventType(events, "looperd.recovery.reviewer_terminal_metadata_normalized") {
+		t.Fatalf("events = %#v, want no terminal metadata normalization", events)
+	}
+	if !containsEventType(events, "looperd.recovery.loop_manual_intervention_held") {
+		t.Fatalf("events = %#v, want manual intervention recovery event", events)
+	}
+}
+
+func TestRunRecoveryPipelineDoesNotRequeueManualInterventionQueueWhenLoopStillRunning(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	coordinator := openMigratedCoordinator(t, cfg.Storage.DBPath, "")
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.June, 4, 17, 5, 32, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	loopID := "loop_manual_intervention_crash_window"
+	targetID := projectID
+	errorMessage := "dirty worktree"
+	checkpoint := `{"resumePolicy":"manual_intervention"}`
+	if err := repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1701, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_manual_intervention_crash_window", LoopID: loopID, Status: "failed", CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	queueErrorKind := "manual_intervention"
+	if err := repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_manual_intervention_crash_window", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:project_1:loop_manual_intervention_crash_window", Priority: storage.QueuePriorityWorker, Status: "manual_intervention", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, LastError: &errorMessage, LastErrorKind: &queueErrorKind, FinishedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+
+	if _, err := rt.runRecoveryPipeline(context.Background(), repositories, nil, now); err != nil {
+		t.Fatalf("runRecoveryPipeline() error = %v", err)
+	}
+	loop, err := repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused manual hold", loop)
+	}
+	items, err := repositories.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("queue items = %#v, want exactly original manual_intervention item", items)
+	}
+	if items[0].Status != "manual_intervention" || items[0].ID != "queue_manual_intervention_crash_window" {
+		t.Fatalf("queue item = %#v, want original manual_intervention hold", items[0])
+	}
+	events, err := repositories.Events.ListByEntity(context.Background(), "loop", loopID)
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	if containsEventType(events, "looperd.recovery.loop_requeued") {
+		t.Fatalf("events = %#v, want no loop_requeued event", events)
+	}
+	if containsEventType(events, "looperd.recovery.loop_queue_normalized") {
+		t.Fatalf("events = %#v, want no queued normalization", events)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1155,15 +1155,15 @@ func TestRunRecoveryPipelineKeepsQueuedReviewerLoopPausedWhenLatestRunFailed(t *
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" {
-		t.Fatalf("loop = %#v, want paused", loop)
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued", loop)
 	}
 	queue, err := repositories.Queue.GetByID(context.Background(), "queue_reviewer_queued_failed_run_pauses")
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" {
-		t.Fatalf("queue = %#v, want manual_intervention hold", queue)
+	if queue == nil || queue.Status != "queued" {
+		t.Fatalf("queue = %#v, want queued recovery", queue)
 	}
 	events, err := repositories.Events.ListByEntity(context.Background(), "loop", loopID)
 	if err != nil {
@@ -1178,7 +1178,7 @@ func TestRunRecoveryPipelineKeepsQueuedReviewerLoopPausedWhenLatestRunFailed(t *
 	if containsEventType(events, "looperd.recovery.reviewer_terminal_metadata_normalized") {
 		t.Fatalf("events = %#v, want no terminal metadata normalization", events)
 	}
-	if !containsEventType(events, "looperd.recovery.loop_manual_intervention_held") {
+	if !containsEventType(events, "looperd.recovery.loop_manual_intervention_requeued") {
 		t.Fatalf("events = %#v, want manual intervention recovery event", events)
 	}
 }
@@ -1224,18 +1224,18 @@ func TestRunRecoveryPipelineDoesNotRequeueManualInterventionQueueWhenLoopStillRu
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" {
-		t.Fatalf("loop = %#v, want paused manual hold", loop)
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued recovery", loop)
 	}
 	items, err := repositories.Queue.List(context.Background())
 	if err != nil {
 		t.Fatalf("Queue.List() error = %v", err)
 	}
 	if len(items) != 1 {
-		t.Fatalf("queue items = %#v, want exactly original manual_intervention item", items)
+		t.Fatalf("queue items = %#v, want exactly original requeued item", items)
 	}
-	if items[0].Status != "manual_intervention" || items[0].ID != "queue_manual_intervention_crash_window" {
-		t.Fatalf("queue item = %#v, want original manual_intervention hold", items[0])
+	if items[0].Status != "queued" || items[0].ID != "queue_manual_intervention_crash_window" {
+		t.Fatalf("queue item = %#v, want original queue item requeued", items[0])
 	}
 	events, err := repositories.Events.ListByEntity(context.Background(), "loop", loopID)
 	if err != nil {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1315,6 +1315,92 @@ func TestRunRecoveryPipelineRequeuesClaimedManualInterventionRetry(t *testing.T)
 	}
 }
 
+func TestRepairStaleRunQueueStateFallsBackForQueuedManualInterventionRetry(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	now := time.Date(2026, time.June, 11, 9, 30, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	oldISO := formatJavaScriptISOString(now.Add(-2 * time.Hour))
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer rt.Stop("test cleanup")
+	repos := rt.Services().Repositories
+	projectID := "project_1"
+	loopID := "loop_manual_intervention_queued_retry"
+	targetID := projectID
+	errorMessage := "dirty worktree"
+	queueErrorKind := "manual_intervention"
+	queueAvailableAt := formatJavaScriptISOString(now.Add(15 * time.Minute))
+
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loop := storage.LoopRecord{ID: loopID, Seq: 1703, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}
+	if err := repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	latestRun := &storage.RunRecord{ID: "run_manual_intervention_queued_retry", LoopID: loopID, Status: "failed", Summary: &errorMessage, ErrorMessage: &errorMessage, StartedAt: oldISO, EndedAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}
+	if err := repos.Runs.Upsert(context.Background(), *latestRun); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_manual_intervention_queued_retry", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:project_1:loop_manual_intervention_queued_retry", Priority: storage.QueuePriorityWorker, Status: "queued", AvailableAt: queueAvailableAt, Attempts: 1, MaxAttempts: 3, LastError: &errorMessage, LastErrorKind: &queueErrorKind, CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	summary, err := rt.repairStaleRunQueueState(context.Background(), repos, loop, latestRun, false, nowISO)
+	if err != nil {
+		t.Fatalf("repairStaleRunQueueState() error = %v", err)
+	}
+	if summary.LoopsRequeued != 1 || summary.QueueItemsRequeued != 1 || summary.QueueItemsCancelled != 0 {
+		t.Fatalf("summary = %#v, want generic stale-run requeue accounting", summary)
+	}
+	repairedLoop, err := repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if repairedLoop == nil || repairedLoop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued recovery", repairedLoop)
+	}
+	queue, err := repos.Queue.GetByID(context.Background(), "queue_manual_intervention_queued_retry")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "queued" || queue.AvailableAt != queueAvailableAt {
+		t.Fatalf("queue = %#v, want existing queued retry preserved", queue)
+	}
+	activeCount, err := repos.Queue.CountActiveByLoopID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Queue.CountActiveByLoopID() error = %v", err)
+	}
+	if activeCount != 1 {
+		t.Fatalf("active queue count = %d, want exactly one queued retry", activeCount)
+	}
+	events, err := repos.Events.ListByEntity(context.Background(), "loop", loopID)
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	if !containsEventType(events, "looperd.recovery.loop_requeued") {
+		t.Fatalf("events = %#v, want generic loop_requeued event", events)
+	}
+	if containsEventType(events, "looperd.recovery.loop_manual_intervention_requeued") {
+		t.Fatalf("events = %#v, want no manual intervention requeue event", events)
+	}
+	if containsEventType(events, "looperd.recovery.loop_queue_normalized") {
+		t.Fatalf("events = %#v, want no queue normalization event", events)
+	}
+}
+
 func TestRuntimeRecoveryRequeuesRunningQueueItemWithoutRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1183,7 +1183,7 @@ func TestRunRecoveryPipelineKeepsQueuedReviewerLoopPausedWhenLatestRunFailed(t *
 	}
 }
 
-func TestRunRecoveryPipelineDoesNotRequeueManualInterventionQueueWhenLoopStillRunning(t *testing.T) {
+func TestRunRecoveryPipelineNormalizesManualInterventionQueueWhenLoopStillRunning(t *testing.T) {
 	t.Parallel()
 
 	workingDir := t.TempDir()
@@ -1224,18 +1224,15 @@ func TestRunRecoveryPipelineDoesNotRequeueManualInterventionQueueWhenLoopStillRu
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" {
-		t.Fatalf("loop = %#v, want queued recovery", loop)
+	if loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused recovery", loop)
 	}
-	items, err := repositories.Queue.List(context.Background())
+	queue, err := repositories.Queue.GetByID(context.Background(), "queue_manual_intervention_crash_window")
 	if err != nil {
-		t.Fatalf("Queue.List() error = %v", err)
+		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if len(items) != 1 {
-		t.Fatalf("queue items = %#v, want exactly original requeued item", items)
-	}
-	if items[0].Status != "queued" || items[0].ID != "queue_manual_intervention_crash_window" {
-		t.Fatalf("queue item = %#v, want original queue item requeued", items[0])
+	if queue == nil || queue.Status != "manual_intervention" || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked manual intervention item", queue)
 	}
 	events, err := repositories.Events.ListByEntity(context.Background(), "loop", loopID)
 	if err != nil {
@@ -1244,8 +1241,11 @@ func TestRunRecoveryPipelineDoesNotRequeueManualInterventionQueueWhenLoopStillRu
 	if containsEventType(events, "looperd.recovery.loop_requeued") {
 		t.Fatalf("events = %#v, want no loop_requeued event", events)
 	}
-	if containsEventType(events, "looperd.recovery.loop_queue_normalized") {
-		t.Fatalf("events = %#v, want no queued normalization", events)
+	if !containsEventType(events, "looperd.recovery.loop_queue_normalized") {
+		t.Fatalf("events = %#v, want queued normalization", events)
+	}
+	if containsEventType(events, "looperd.recovery.loop_manual_intervention_requeued") {
+		t.Fatalf("events = %#v, want no manual intervention requeue event", events)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1249,6 +1249,72 @@ func TestRunRecoveryPipelineDoesNotRequeueManualInterventionQueueWhenLoopStillRu
 	}
 }
 
+func TestRunRecoveryPipelineRequeuesClaimedManualInterventionRetry(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	coordinator := openMigratedCoordinator(t, cfg.Storage.DBPath, "")
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.June, 4, 17, 5, 32, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	projectID := "project_1"
+	loopID := "loop_manual_intervention_claimed_retry"
+	targetID := projectID
+	errorMessage := "dirty worktree"
+	checkpoint := `{"resumePolicy":"manual_intervention"}`
+	if err := repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1702, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "queued", NextRunAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_manual_intervention_claimed_retry", LoopID: loopID, Status: "failed", CheckpointJSON: &checkpoint, Summary: &errorMessage, ErrorMessage: &errorMessage, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	queueErrorKind := "manual_intervention"
+	if err := repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_manual_intervention_claimed_retry", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:project_1:loop_manual_intervention_claimed_retry", Priority: storage.QueuePriorityWorker, Status: "running", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, LastError: &errorMessage, LastErrorKind: &queueErrorKind, ClaimedBy: stringPtr("scheduler"), ClaimedAt: stringPtr(nowISO), StartedAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+
+	if _, err := rt.runRecoveryPipeline(context.Background(), repositories, nil, now); err != nil {
+		t.Fatalf("runRecoveryPipeline() error = %v", err)
+	}
+	loop, err := repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued recovery", loop)
+	}
+	queue, err := repositories.Queue.GetByID(context.Background(), "queue_manual_intervention_claimed_retry")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if queue == nil || queue.Status != "queued" {
+		t.Fatalf("queue = %#v, want queued retry", queue)
+	}
+	if queue.ClaimedBy != nil || queue.ClaimedAt != nil || queue.StartedAt != nil {
+		t.Fatalf("queue = %#v, want claimed fields cleared", queue)
+	}
+	events, err := repositories.Events.ListByEntity(context.Background(), "loop", loopID)
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	if !containsEventType(events, "looperd.recovery.loop_manual_intervention_requeued") {
+		t.Fatalf("events = %#v, want manual intervention recovery event", events)
+	}
+	if containsEventType(events, "looperd.recovery.loop_requeued") {
+		t.Fatalf("events = %#v, want no generic loop_requeued event", events)
+	}
+}
+
 func TestRuntimeRecoveryRequeuesRunningQueueItemWithoutRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1771,7 +1771,8 @@ func failSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord, in
 	nowISO := formatJavaScriptISOString(now().UTC())
 	nextAttempts := item.Attempts + 1
 	if kind == "retryable_transient" && nextAttempts < item.MaxAttempts {
-		return input.Repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: item.ID, AvailableAt: nowISO, Attempts: nextAttempts, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
+		retryAt := formatJavaScriptISOString(now().UTC().Add(time.Minute * time.Duration(nextAttempts)))
+		return input.Repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: item.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
 	}
 	return input.Repos.Queue.Fail(ctx, storage.QueueFailInput{ID: item.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
 }

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1770,8 +1770,11 @@ func failSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord, in
 	}
 	nowISO := formatJavaScriptISOString(now().UTC())
 	nextAttempts := item.Attempts + 1
-	retryAt := formatJavaScriptISOString(now().UTC().Add(time.Minute * time.Duration(cappedRetryDelayAttempt(nextAttempts, item.MaxAttempts))))
-	return input.Repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: item.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
+	if kind == "retryable_transient" && nextAttempts < item.MaxAttempts {
+		retryAt := formatJavaScriptISOString(now().UTC().Add(time.Minute * time.Duration(cappedRetryDelayAttempt(nextAttempts, item.MaxAttempts))))
+		return input.Repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: item.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
+	}
+	return input.Repos.Queue.Fail(ctx, storage.QueueFailInput{ID: item.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
 }
 
 func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1770,11 +1770,18 @@ func failSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord, in
 	}
 	nowISO := formatJavaScriptISOString(now().UTC())
 	nextAttempts := item.Attempts + 1
-	if kind == "retryable_transient" && nextAttempts < item.MaxAttempts {
-		retryAt := formatJavaScriptISOString(now().UTC().Add(time.Minute * time.Duration(nextAttempts)))
-		return input.Repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: item.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
+	retryAt := formatJavaScriptISOString(now().UTC().Add(time.Minute * time.Duration(cappedRetryDelayAttempt(nextAttempts, item.MaxAttempts))))
+	return input.Repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: item.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
+}
+
+func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {
+	if attempts <= 0 {
+		return 1
 	}
-	return input.Repos.Queue.Fail(ctx, storage.QueueFailInput{ID: item.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
+	if maxAttempts > 0 && attempts > maxAttempts {
+		return maxAttempts
+	}
+	return attempts
 }
 
 func repoFromProjectMetadata(metadataJSON *string) string {

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -929,6 +929,42 @@ func TestProcessSnapshotQueueItemRetriesTransientCompletionFailure(t *testing.T)
 	assertQueueRetryError(t, updated, "database is locked")
 }
 
+func TestProcessSnapshotQueueItemFailsNonRetryableInvalidItem(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "snapshot-project-missing-fail.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	repo := "nexu-io/looper"
+	prNumber := int64(109)
+	queueItem := storage.QueueItemRecord{ID: "queue_snapshot_invalid_item", Type: "snapshot", TargetType: "pull_request", TargetID: "nexu-io/looper#109", Repo: &repo, PRNumber: &prNumber, DedupeKey: "snapshot:nexu-io/looper:109", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Queue.Upsert(context.Background(), queueItem); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	err := processSnapshotQueueItem(context.Background(), queueItem, defaultSchedulerTickInput{
+		Repos:       repos,
+		Now:         func() time.Time { return now },
+		Snapshotter: stubSnapshotScheduler{},
+	})
+	if err != nil {
+		t.Fatalf("processSnapshotQueueItem() error = %v", err)
+	}
+	updated, err := repos.Queue.GetByID(context.Background(), queueItem.ID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if updated == nil || updated.Status != "manual_intervention" || updated.FinishedAt == nil {
+		t.Fatalf("queue item = %#v, want parked queue item", updated)
+	}
+	if updated.LastError == nil || *updated.LastError != "invalid snapshot queue item" || updated.LastErrorKind == nil || *updated.LastErrorKind != "non_retryable" {
+		t.Fatalf("queue item error = (%v, %v), want non-retryable invalid-item failure", updated.LastError, updated.LastErrorKind)
+	}
+}
+
 func TestSchedulerAvailableSlotsAccountsForRunningQueueItems(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -1960,11 +1960,6 @@ func (r *QueueRepository) MarkRetry(ctx context.Context, input QueueMarkRetryInp
 }
 
 func (r *QueueRepository) Fail(ctx context.Context, input QueueFailInput) error {
-	terminalStatus := "failed"
-	if input.ErrorKind == "manual_intervention" {
-		terminalStatus = "manual_intervention"
-	}
-
 	_, err := r.q.ExecContext(ctx, `
 		UPDATE queue_items
 		SET status = ?,
@@ -1974,7 +1969,7 @@ func (r *QueueRepository) Fail(ctx context.Context, input QueueFailInput) error 
 			last_error_kind = ?,
 			updated_at = ?
 		WHERE id = ?
-	`, terminalStatus, input.Attempts, input.Attempts, input.FinishedAt, input.ErrorMessage, input.ErrorKind, input.UpdatedAt, input.ID)
+	`, "manual_intervention", input.Attempts, input.Attempts, input.FinishedAt, input.ErrorMessage, input.ErrorKind, input.UpdatedAt, input.ID)
 	if err != nil {
 		return fmt.Errorf("fail queue item: %w", err)
 	}
@@ -2051,7 +2046,7 @@ func (r *QueueRepository) RequeueLatestCancelledByLoop(ctx context.Context, loop
 }
 
 func (r *QueueRepository) RequeueLatestFailedByLoop(ctx context.Context, loopID, queuedAt string) (int64, error) {
-	queueID, err := r.findLatestQueueIDByLoopStatus(ctx, loopID, "failed")
+	queueID, err := r.findLatestQueueIDByLoopStatuses(ctx, loopID, []string{"manual_intervention", "failed"})
 	if err != nil {
 		return 0, err
 	}
@@ -2079,7 +2074,7 @@ func (r *QueueRepository) RequeueFailedByID(ctx context.Context, loopID, queueID
 			last_error = NULL,
 			last_error_kind = NULL,
 			updated_at = ?
-		WHERE id = ? AND loop_id = ? AND status = 'failed'
+		WHERE id = ? AND loop_id = ? AND status IN ('manual_intervention', 'failed')
 			AND NOT EXISTS (
 				SELECT 1 FROM queue_items
 				WHERE loop_id = ? AND status IN ('queued', 'running') AND id != ?
@@ -2117,7 +2112,7 @@ func (r *QueueRepository) RequeueFailedByIDWithAttempts(ctx context.Context, loo
 			last_error = NULL,
 			last_error_kind = NULL,
 			updated_at = ?
-		WHERE id = ? AND loop_id = ? AND status = 'failed'
+		WHERE id = ? AND loop_id = ? AND status IN ('manual_intervention', 'failed')
 			AND NOT EXISTS (
 				SELECT 1 FROM queue_items
 				WHERE loop_id = ? AND status IN ('queued', 'running') AND id != ?
@@ -2136,18 +2131,31 @@ func (r *QueueRepository) RequeueFailedByIDWithAttempts(ctx context.Context, loo
 }
 
 func (r *QueueRepository) findLatestQueueIDByLoopStatus(ctx context.Context, loopID, status string) (string, error) {
+	return r.findLatestQueueIDByLoopStatuses(ctx, loopID, []string{status})
+}
+
+func (r *QueueRepository) findLatestQueueIDByLoopStatuses(ctx context.Context, loopID string, statuses []string) (string, error) {
+	if len(statuses) == 0 {
+		return "", nil
+	}
+	placeholders := make([]string, 0, len(statuses))
+	args := []any{loopID}
+	for _, status := range statuses {
+		placeholders = append(placeholders, "?")
+		args = append(args, status)
+	}
 	row := r.q.QueryRowContext(ctx, `
 		SELECT id
 		FROM queue_items
-		WHERE loop_id = ? AND status = ?
+		WHERE loop_id = ? AND status IN (`+strings.Join(placeholders, ", ")+`)
 		ORDER BY updated_at DESC, created_at DESC, id DESC LIMIT 1
-	`, loopID, status)
+	`, args...)
 	var queueID string
 	if err := row.Scan(&queueID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", nil
 		}
-		return "", fmt.Errorf("get latest %s queue item by loop: %w", status, err)
+		return "", fmt.Errorf("get latest queue item by loop statuses %s: %w", strings.Join(statuses, ","), err)
 	}
 	return queueID, nil
 }

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -363,17 +363,21 @@ func (r *Runner) recoverClaimedQueueItem(ctx context.Context, queueItem storage.
 	failureKind, failureMessage := classifyQueueFailure(err)
 	nowISO := r.nowISO()
 	nextAttempts := queueItem.Attempts + 1
-	if failureKind == "retryable_transient" && nextAttempts < queueItem.MaxAttempts {
-		retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryDelay, nextAttempts)))
-		if markErr := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: stringPtr(failureMessage), ErrorKind: failureKind, UpdatedAt: nowISO}); markErr != nil {
-			return nil, markErr
-		}
-	} else {
-		if failErr := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: queueItem.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: stringPtr(failureMessage), ErrorKind: failureKind, UpdatedAt: nowISO}); failErr != nil {
-			return nil, failErr
-		}
+	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryDelay, cappedRetryDelayAttempt(nextAttempts, queueItem.MaxAttempts))))
+	if markErr := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: stringPtr(failureMessage), ErrorKind: failureKind, UpdatedAt: nowISO}); markErr != nil {
+		return nil, markErr
 	}
 	return &ProcessResult{QueueItemID: queueItem.ID, Status: "failed", Summary: failureMessage}, nil
+}
+
+func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {
+	if attempts <= 0 {
+		return 1
+	}
+	if maxAttempts > 0 && attempts > maxAttempts {
+		return maxAttempts
+	}
+	return attempts
 }
 
 func (r *Runner) discoverIssuesAndClosures(ctx context.Context, input DiscoveryInput) (DiscoveryResult, error) {

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -363,11 +363,24 @@ func (r *Runner) recoverClaimedQueueItem(ctx context.Context, queueItem storage.
 	failureKind, failureMessage := classifyQueueFailure(err)
 	nowISO := r.nowISO()
 	nextAttempts := queueItem.Attempts + 1
+	if !shouldRetryQueueFailure(failureKind, nextAttempts, queueItem.MaxAttempts) {
+		if failErr := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: queueItem.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: stringPtr(failureMessage), ErrorKind: failureKind, UpdatedAt: nowISO}); failErr != nil {
+			return nil, failErr
+		}
+		return &ProcessResult{QueueItemID: queueItem.ID, Status: "failed", Summary: failureMessage}, nil
+	}
 	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryDelay, cappedRetryDelayAttempt(nextAttempts, queueItem.MaxAttempts))))
 	if markErr := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: stringPtr(failureMessage), ErrorKind: failureKind, UpdatedAt: nowISO}); markErr != nil {
 		return nil, markErr
 	}
 	return &ProcessResult{QueueItemID: queueItem.ID, Status: "failed", Summary: failureMessage}, nil
+}
+
+func shouldRetryQueueFailure(kind string, nextAttempts, maxAttempts int64) bool {
+	if kind != "retryable_transient" {
+		return false
+	}
+	return maxAttempts <= 0 || nextAttempts < maxAttempts
 }
 
 func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -1525,8 +1525,8 @@ func TestProcessWarnFailsQueueItemAfterMaxAttempts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if stored == nil || stored.Status != "queued" || stored.Attempts != 3 || stored.FinishedAt != nil || stored.LastErrorKind == nil || *stored.LastErrorKind != "retryable_transient" || stored.AvailableAt <= fixture.nowISO {
-		t.Fatalf("stored queue item = %#v, want queued backoff queue item after max attempts", stored)
+	if stored == nil || stored.Status != "manual_intervention" || stored.Attempts != 3 || stored.FinishedAt == nil || stored.LastErrorKind == nil || *stored.LastErrorKind != "retryable_transient" {
+		t.Fatalf("stored queue item = %#v, want parked queue item after max attempts", stored)
 	}
 }
 

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -1525,8 +1525,8 @@ func TestProcessWarnFailsQueueItemAfterMaxAttempts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if stored == nil || stored.Status != "failed" || stored.Attempts != 3 || stored.FinishedAt == nil || stored.LastErrorKind == nil || *stored.LastErrorKind != "retryable_transient" {
-		t.Fatalf("stored queue item = %#v, want terminal failed queue item after max attempts", stored)
+	if stored == nil || stored.Status != "manual_intervention" || stored.Attempts != 3 || stored.FinishedAt == nil || stored.LastErrorKind == nil || *stored.LastErrorKind != "retryable_transient" {
+		t.Fatalf("stored queue item = %#v, want manual_intervention queue item after max attempts", stored)
 	}
 }
 

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -1525,8 +1525,8 @@ func TestProcessWarnFailsQueueItemAfterMaxAttempts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if stored == nil || stored.Status != "manual_intervention" || stored.Attempts != 3 || stored.FinishedAt == nil || stored.LastErrorKind == nil || *stored.LastErrorKind != "retryable_transient" {
-		t.Fatalf("stored queue item = %#v, want manual_intervention queue item after max attempts", stored)
+	if stored == nil || stored.Status != "queued" || stored.Attempts != 3 || stored.FinishedAt != nil || stored.LastErrorKind == nil || *stored.LastErrorKind != "retryable_transient" || stored.AvailableAt <= fixture.nowISO {
+		t.Fatalf("stored queue item = %#v, want queued backoff queue item after max attempts", stored)
 	}
 }
 

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -2425,15 +2425,9 @@ func (r *Runner) wakeSchedulerAfterEnqueue() {
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {
 	nextAttempts := queueItem.Attempts + 1
 	nowISO := r.nowISO()
-	if isRetryableFailure(kind) && nextAttempts < queueItem.MaxAttempts {
-		retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, nextAttempts)))
-		if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: queueItem.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
-			return nil, err
-		}
+	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, cappedRetryDelayAttempt(nextAttempts, queueItem.MaxAttempts))))
+	if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
+		return nil, err
 	}
 	return r.repos.Queue.GetByID(ctx, queueItem.ID)
 }
@@ -3626,6 +3620,16 @@ func backoffDelay(base time.Duration, attempts int64) time.Duration {
 
 func isRetryableFailure(kind QueueFailureKind) bool {
 	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume
+}
+
+func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {
+	if attempts <= 0 {
+		return 1
+	}
+	if maxAttempts > 0 && attempts > maxAttempts {
+		return maxAttempts
+	}
+	return attempts
 }
 
 func compactStrings(values []string) []string {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -916,12 +916,8 @@ func (r *Runner) reconcileRecoveredLoop(ctx context.Context, queueItem storage.Q
 			updated.Status = "queued"
 			updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 		} else {
-			if loops.ShouldPauseLoopAfterFailure(string(failureKind), failedQueue, "") {
-				updated.Status = "paused"
-			} else {
-				updated.Status = "failed"
-				stampWorkerFailedDiscoveryFingerprint(updated, queueItem)
-			}
+			updated.Status = "paused"
+			stampWorkerFailedDiscoveryFingerprint(updated, queueItem)
 			updated.NextRunAt = nil
 		}
 	})
@@ -1029,12 +1025,8 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 				updated.Status = "queued"
 				updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 			} else {
-				if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
-					updated.Status = "paused"
-				} else {
-					updated.Status = "failed"
-					stampWorkerFailedDiscoveryFingerprint(updated, queueItem)
-				}
+				updated.Status = "paused"
+				stampWorkerFailedDiscoveryFingerprint(updated, queueItem)
 				updated.NextRunAt = nil
 			}
 		}); err != nil {
@@ -1071,12 +1063,8 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 					updated.Status = "queued"
 					updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
 				} else {
-					if loops.ShouldPauseLoopAfterFailure(string(failure.kind), failedQueue, latest.ResumePolicy) {
-						updated.Status = "paused"
-					} else {
-						updated.Status = "failed"
-						stampWorkerFailedDiscoveryFingerprint(updated, queueItem)
-					}
+					updated.Status = "paused"
+					stampWorkerFailedDiscoveryFingerprint(updated, queueItem)
 					updated.NextRunAt = nil
 				}
 			}); err != nil {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -2425,6 +2425,12 @@ func (r *Runner) wakeSchedulerAfterEnqueue() {
 func (r *Runner) failQueueItem(ctx context.Context, queueItem storage.QueueItemRecord, kind QueueFailureKind, message string) (*storage.QueueItemRecord, error) {
 	nextAttempts := queueItem.Attempts + 1
 	nowISO := r.nowISO()
+	if !shouldRetryQueueFailure(kind, nextAttempts, queueItem.MaxAttempts) {
+		if err := r.repos.Queue.Fail(ctx, storage.QueueFailInput{ID: queueItem.ID, Attempts: nextAttempts, FinishedAt: nowISO, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
+			return nil, err
+		}
+		return r.repos.Queue.GetByID(ctx, queueItem.ID)
+	}
 	retryAt := eventlog.FormatJavaScriptISOString(r.now().Add(backoffDelay(r.retryBaseDelay, cappedRetryDelayAttempt(nextAttempts, queueItem.MaxAttempts))))
 	if err := r.repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: queueItem.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: optionalString(message), ErrorKind: string(kind), UpdatedAt: nowISO}); err != nil {
 		return nil, err
@@ -2650,6 +2656,13 @@ func shouldNotifyCompletedRun(kind QueueFailureKind, failedQueue *storage.QueueI
 		return true
 	}
 	return failedQueue != nil && failedQueue.Status != "queued" && failedQueue.Status != "cancelled"
+}
+
+func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {
+	if kind != FailureRetryableTransient && kind != FailureRetryableAfterResume {
+		return false
+	}
+	return maxAttempts <= 0 || nextAttempts < maxAttempts
 }
 
 func issueClaimStatusForFailure(checkpoint workerCheckpoint, failedQueue *storage.QueueItemRecord, kind QueueFailureKind) string {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1025,16 +1025,16 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" {
-		t.Fatalf("queue = %#v, want manual_intervention queue item", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
+		t.Fatalf("queue = %#v, want queued backoff retryable_transient queue item", queue)
 	}
 
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want paused loop", loop)
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil || *loop.NextRunAt <= fixture.nowISO() {
+		t.Fatalf("loop = %#v, want queued loop with scheduled retry", loop)
 	}
 }
 
@@ -1940,15 +1940,15 @@ func TestProcessClaimedItemKeepsUnsafeValidationFailurePaused(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want terminal manual_intervention item", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want queued manual_intervention backoff item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" {
-		t.Fatalf("loop = %#v, want paused", loop)
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued", loop)
 	}
 }
 
@@ -2229,8 +2229,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" {
-		t.Fatalf("queue = %#v, want manual_intervention", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
+		t.Fatalf("queue = %#v, want queued non_retryable backoff", queue)
 	}
 }
 
@@ -2261,22 +2261,22 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	if result == nil || result.Status != "failed" || result.FailureKind != FailureNonRetryable {
 		t.Fatalf("result = %#v, want failed non-retryable recovery", result)
 	}
-	if len(completed) != 1 || completed[0].Status != "failed" || completed[0].FailureKind != FailureNonRetryable {
-		t.Fatalf("completed = %#v, want terminal recovery notification", completed)
+	if len(completed) != 0 {
+		t.Fatalf("completed = %#v, want no terminal recovery notification", completed)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_running")
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" {
-		t.Fatalf("queue = %#v, want manual_intervention", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
+		t.Fatalf("queue = %#v, want queued non_retryable backoff", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want paused loop", loop)
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
+		t.Fatalf("loop = %#v, want queued backoff loop", loop)
 	}
 }
 
@@ -2313,11 +2313,8 @@ func TestRecoverClaimedItemDoesNotReusePreviousRunID(t *testing.T) {
 	if result == nil || result.Status != "failed" || result.FailureKind != FailureNonRetryable {
 		t.Fatalf("result = %#v, want failed non-retryable recovery", result)
 	}
-	if len(completed) != 1 {
-		t.Fatalf("completed = %#v, want one recovery notification", completed)
-	}
-	if completed[0].RunID != "" {
-		t.Fatalf("completed[0].RunID = %q, want empty run ID for recovery before new run creation", completed[0].RunID)
+	if len(completed) != 0 {
+		t.Fatalf("completed = %#v, want no terminal recovery notification", completed)
 	}
 }
 
@@ -2341,21 +2338,21 @@ func TestProcessClaimedItemSkippedFlowEmitsCompletionNotification(t *testing.T) 
 		t.Fatalf("result = %#v, want manual_intervention summary", result)
 	}
 	if len(completed) != 1 || completed[0].Status != "failed" || completed[0].FailureKind != FailureManualIntervention || !strings.Contains(completed[0].Summary, "manual PR opening required") {
-		t.Fatalf("completed = %#v, want manual_intervention completion notification", completed)
+		t.Fatalf("completed = %#v, want run failure completion notification", completed)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want terminal manual_intervention item", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want queued manual_intervention backoff item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" {
-		t.Fatalf("loop = %#v, want paused", loop)
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued", loop)
 	}
 }
 
@@ -2396,21 +2393,21 @@ func TestProcessClaimedItemSkipsAutoPROpenWhenGitHubCLIUnavailable(t *testing.T)
 		t.Fatalf("len(git.pushCalls) = %d, want 0 when PR opening is gated before push", len(git.pushCalls))
 	}
 	if len(completed) != 1 || completed[0].Status != "failed" || completed[0].FailureKind != FailureManualIntervention || !strings.Contains(completed[0].Summary, "GitHub CLI unavailable") {
-		t.Fatalf("completed = %#v, want manual_intervention completion notification for missing GitHub CLI", completed)
+		t.Fatalf("completed = %#v, want run failure completion notification for missing GitHub CLI", completed)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want terminal manual_intervention item", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want queued manual_intervention backoff item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" {
-		t.Fatalf("loop = %#v, want paused", loop)
+	if loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop = %#v, want queued", loop)
 	}
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1025,16 +1025,16 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.FinishedAt != nil || queue.AvailableAt <= fixture.nowISO() {
-		t.Fatalf("queue = %#v, want queued backoff retryable_transient queue item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.FinishedAt == nil {
+		t.Fatalf("queue = %#v, want parked retryable_transient queue item after max attempts", queue)
 	}
 
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil || *loop.NextRunAt <= fixture.nowISO() {
-		t.Fatalf("loop = %#v, want queued loop with scheduled retry", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused loop after max attempts", loop)
 	}
 }
 
@@ -1940,15 +1940,15 @@ func TestProcessClaimedItemKeepsUnsafeValidationFailurePaused(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want queued manual_intervention backoff item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want parked manual_intervention item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" {
-		t.Fatalf("loop = %#v, want queued", loop)
+	if loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused", loop)
 	}
 }
 
@@ -2229,8 +2229,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
-		t.Fatalf("queue = %#v, want queued non_retryable backoff", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
+		t.Fatalf("queue = %#v, want parked non_retryable item", queue)
 	}
 }
 
@@ -2261,22 +2261,22 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	if result == nil || result.Status != "failed" || result.FailureKind != FailureNonRetryable {
 		t.Fatalf("result = %#v, want failed non-retryable recovery", result)
 	}
-	if len(completed) != 0 {
-		t.Fatalf("completed = %#v, want no terminal recovery notification", completed)
+	if len(completed) != 1 || completed[0].Status != "failed" || completed[0].FailureKind != FailureNonRetryable || !strings.Contains(completed[0].Summary, "persist step failed") {
+		t.Fatalf("completed = %#v, want terminal recovery notification", completed)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_worker_running")
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
-		t.Fatalf("queue = %#v, want queued non_retryable backoff", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
+		t.Fatalf("queue = %#v, want parked non_retryable item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
-		t.Fatalf("loop = %#v, want queued backoff loop", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused loop", loop)
 	}
 }
 
@@ -2313,8 +2313,8 @@ func TestRecoverClaimedItemDoesNotReusePreviousRunID(t *testing.T) {
 	if result == nil || result.Status != "failed" || result.FailureKind != FailureNonRetryable {
 		t.Fatalf("result = %#v, want failed non-retryable recovery", result)
 	}
-	if len(completed) != 0 {
-		t.Fatalf("completed = %#v, want no terminal recovery notification", completed)
+	if len(completed) != 1 || completed[0].Status != "failed" || completed[0].FailureKind != FailureNonRetryable || !strings.Contains(completed[0].Summary, "project lookup failed") {
+		t.Fatalf("completed = %#v, want terminal recovery notification", completed)
 	}
 }
 
@@ -2344,15 +2344,15 @@ func TestProcessClaimedItemSkippedFlowEmitsCompletionNotification(t *testing.T) 
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want queued manual_intervention backoff item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want parked manual_intervention item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" {
-		t.Fatalf("loop = %#v, want queued", loop)
+	if loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused", loop)
 	}
 }
 
@@ -2399,15 +2399,15 @@ func TestProcessClaimedItemSkipsAutoPROpenWhenGitHubCLIUnavailable(t *testing.T)
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
-		t.Fatalf("queue = %#v, want queued manual_intervention backoff item", queue)
+	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureManualIntervention) {
+		t.Fatalf("queue = %#v, want parked manual_intervention item", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "queued" {
-		t.Fatalf("loop = %#v, want queued", loop)
+	if loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop = %#v, want paused", loop)
 	}
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1025,16 +1025,16 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "failed" {
-		t.Fatalf("queue = %#v, want failed terminal queue item", queue)
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention queue item", queue)
 	}
 
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want failed terminal loop", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused loop", loop)
 	}
 }
 
@@ -2229,8 +2229,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "failed" {
-		t.Fatalf("queue = %#v, want failed", queue)
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention", queue)
 	}
 }
 
@@ -2268,15 +2268,15 @@ func TestRecoverClaimedItemReconcilesRunningLoopState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "failed" {
-		t.Fatalf("queue = %#v, want failed", queue)
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention", queue)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "failed" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want failed terminal loop", loop)
+	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want paused loop", loop)
 	}
 }
 


### PR DESCRIPTION
Summary
- Derive `backing_off` display status for queued retryable work with a future `available_at`, so `looper ps` shows backoff explicitly.
- Keep non-user failures in `queued` with capped backoff instead of parking them in `manual_intervention`, preserving automatic recovery when blockers are fixed.
- Preserve the original `last_error_kind`/`last_error` on queued backoff items for diagnostics.
- Pause/terminal states are not used for ordinary runner failure paths; user stop/terminate paths remain separate.
- Runtime recovery converts legacy/manual-intervention crash-window rows back into queued work rather than holding them indefinitely.
- Keep reviewer/fixer worktrees when work is still queued for retry, so evidence is not lost.

Authority and trade-off
- Authority for autonomous retry is the queue item itself: `status=queued`, `available_at`, attempts, and `last_error_kind`; `backing_off` is display-only, not persisted state.
- Attempts still increase and delay is capped to avoid retry storms, but exhausted attempts no longer require user intervention.
- `manual_intervention` remains supported for legacy/operator-created rows and can be retried, but normal runner failures no longer flow there.

Validation
- go test ./internal/fixer ./internal/planner ./internal/worker ./internal/sweeper ./internal/reviewer ./internal/runtime ./internal/api
- go test ./...
- go build ./...