### PR TITLE
fix: archive projects on remove

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -4297,18 +4297,23 @@ func (h *Handler) resolveWorkerProject(ctx context.Context, input resolveWorkerP
 	}
 
 	if input.Repo != nil && input.PRNumber != nil {
+		requestedRepo := strings.TrimSpace(*input.Repo)
 		snapshots, err := services.Repositories.PullRequestSnapshots.List(ctx)
 		if err != nil {
 			return storage.ProjectRecord{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 		matchedProjectIDs := map[string]struct{}{}
 		for _, snapshot := range snapshots {
-			if snapshot.Repo == *input.Repo && snapshot.PRNumber == *input.PRNumber {
+			if snapshot.Repo == requestedRepo && snapshot.PRNumber == *input.PRNumber {
 				project, getErr := services.Repositories.Projects.GetByID(ctx, snapshot.ProjectID)
 				if getErr != nil {
 					return storage.ProjectRecord{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: getErr.Error()}
 				}
 				if project != nil && !project.Archived {
+					configuredRepo := strings.TrimSpace(derefString(stringMetadataPtr(parseProjectMetadata(project.MetadataJSON), "repo")))
+					if configuredRepo != "" && configuredRepo != requestedRepo {
+						continue
+					}
 					matchedProjectIDs[snapshot.ProjectID] = struct{}{}
 				}
 			}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3689,12 +3689,9 @@ func (h *Handler) buildCreateLoopResponse(r *http.Request) (loopResponse, error)
 
 	record, err := storage.WithTransactionValue(r.Context(), services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
 		transactionRepos := storage.NewRepositories(tx)
-		project, err := transactionRepos.Projects.GetByID(r.Context(), projectID)
+		project, err := requireActiveProjectRecord(r.Context(), transactionRepos.Projects, projectID)
 		if err != nil {
 			return storage.LoopRecord{}, err
-		}
-		if project == nil {
-			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeProjectNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Project not found: %s", projectID)}
 		}
 		if err := validateLoopTargetProjectCompatibility(projectID, parseProjectMetadata(project.MetadataJSON), target); err != nil {
 			return storage.LoopRecord{}, err
@@ -4187,12 +4184,9 @@ func (h *Handler) buildPlannersCreateResponse(r *http.Request) (plannerCreateRes
 	if projectID == "" {
 		return plannerCreateResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "projectId is required"}
 	}
-	project, err := services.Repositories.Projects.GetByID(r.Context(), projectID)
+	project, err := requireActiveProjectRecord(r.Context(), services.Repositories.Projects, projectID)
 	if err != nil {
-		return plannerCreateResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-	}
-	if project == nil {
-		return plannerCreateResponse{}, apiError{code: pkgapi.ErrorCodeProjectNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Project not found: %s", projectID)}
+		return plannerCreateResponse{}, err
 	}
 
 	issueNumber := normalizePositiveInt64Ptr(body.IssueNumber)
@@ -4285,12 +4279,9 @@ type resolveWorkerProjectInput struct {
 func (h *Handler) resolveWorkerProject(ctx context.Context, input resolveWorkerProjectInput) (storage.ProjectRecord, error) {
 	services := h.context.Runtime.Services()
 	if input.ProjectID != nil {
-		project, err := services.Repositories.Projects.GetByID(ctx, *input.ProjectID)
+		project, err := requireActiveProjectRecord(ctx, services.Repositories.Projects, *input.ProjectID)
 		if err != nil {
-			return storage.ProjectRecord{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-		}
-		if project == nil {
-			return storage.ProjectRecord{}, apiError{code: pkgapi.ErrorCodeProjectNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Project not found: %s", *input.ProjectID)}
+			return storage.ProjectRecord{}, err
 		}
 		if input.Repo != nil {
 			configuredRepo := strings.TrimSpace(derefString(stringMetadataPtr(parseProjectMetadata(project.MetadataJSON), "repo")))
@@ -4313,7 +4304,13 @@ func (h *Handler) resolveWorkerProject(ctx context.Context, input resolveWorkerP
 		matchedProjectIDs := map[string]struct{}{}
 		for _, snapshot := range snapshots {
 			if snapshot.Repo == *input.Repo && snapshot.PRNumber == *input.PRNumber {
-				matchedProjectIDs[snapshot.ProjectID] = struct{}{}
+				project, getErr := services.Repositories.Projects.GetByID(ctx, snapshot.ProjectID)
+				if getErr != nil {
+					return storage.ProjectRecord{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: getErr.Error()}
+				}
+				if project != nil && !project.Archived {
+					matchedProjectIDs[snapshot.ProjectID] = struct{}{}
+				}
 			}
 		}
 		if len(matchedProjectIDs) > 1 {
@@ -4337,6 +4334,9 @@ func (h *Handler) resolveWorkerProject(ctx context.Context, input resolveWorkerP
 		}
 		matches := make([]storage.ProjectRecord, 0)
 		for _, candidate := range projectsList {
+			if candidate.Archived {
+				continue
+			}
 			candidateRepo := stringMetadataPtr(parseProjectMetadata(candidate.MetadataJSON), "repo")
 			if candidateRepo != nil && *candidateRepo == *input.Repo {
 				matches = append(matches, candidate)
@@ -4361,12 +4361,9 @@ type requirePullRequestTargetInput struct {
 
 func (h *Handler) requirePullRequestTarget(ctx context.Context, input requirePullRequestTargetInput) (int64, error) {
 	services := h.context.Runtime.Services()
-	project, err := services.Repositories.Projects.GetByID(ctx, input.ProjectID)
+	project, err := requireActiveProjectRecord(ctx, services.Repositories.Projects, input.ProjectID)
 	if err != nil {
-		return 0, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-	}
-	if project == nil {
-		return 0, apiError{code: pkgapi.ErrorCodeProjectNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Project not found: %s", input.ProjectID)}
+		return 0, err
 	}
 	projectRepo := stringMetadataPtr(parseProjectMetadata(project.MetadataJSON), "repo")
 	if projectRepo == nil || *projectRepo != input.Repo {
@@ -5735,6 +5732,17 @@ func serializeProject(project storage.ProjectRecord, defaultBaseBranch string) p
 		CreatedAt:    project.CreatedAt,
 		UpdatedAt:    project.UpdatedAt,
 	}
+}
+
+func requireActiveProjectRecord(ctx context.Context, repo *storage.ProjectsRepository, projectID string) (*storage.ProjectRecord, error) {
+	project, err := repo.GetByID(ctx, projectID)
+	if err != nil {
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	if project == nil || project.Archived {
+		return nil, apiError{code: pkgapi.ErrorCodeProjectNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Project not found: %s", projectID)}
+	}
+	return project, nil
 }
 
 func parseProjectMetadata(metadataJSON *string) map[string]any {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -4529,6 +4529,11 @@ func (h *Handler) mutateLoopStatus(ctx context.Context, loopID string, status do
 		if loop == nil {
 			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
 		}
+		if status == domain.LoopStatusRunning && strings.TrimSpace(loop.ProjectID) != "" {
+			if _, err := requireActiveProjectRecord(ctx, repos.Projects, loop.ProjectID); err != nil {
+				return storage.LoopRecord{}, err
+			}
+		}
 
 		if status == domain.LoopStatusRunning && (loop.Type == string(domain.LoopTypeReviewer) || loop.Type == string(domain.LoopTypeFixer) || loop.Type == string(domain.LoopTypeWorker) || loop.Type == string(domain.LoopTypePlanner)) && !isCodingAgentConfigured(h.context.Config) {
 			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeAgentNotConfigured, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot start %s loop without config.agent.vendor", loop.Type)}
@@ -4691,6 +4696,11 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 		}
 		if loop == nil {
 			return retryResult{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
+		}
+		if strings.TrimSpace(loop.ProjectID) != "" {
+			if _, err := requireActiveProjectRecord(ctx, repos.Projects, loop.ProjectID); err != nil {
+				return retryResult{}, err
+			}
 		}
 		if loop.Status == string(domain.LoopStatusStopped) || loop.Status == string(domain.LoopStatusTerminated) || loop.Status == string(domain.LoopStatusCompleted) {
 			return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal %s loop: %s", loop.Status, loop.ID)}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2961,6 +2961,69 @@ func TestHandlerWorkerCreateUsesProjectScopedPullRequestSnapshot(t *testing.T) {
 	}
 }
 
+func TestHandlerWorkerCreateIgnoresSnapshotForProjectReactivatedToDifferentRepo(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	baseBranch := "main"
+	otherMetadata := `{"repo":"acme/other","worktreeRoot":null,"source":"api"}`
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID:           "project_2",
+		Name:         "Looper Reused",
+		RepoPath:     "/tmp/repos/looper-reused",
+		BaseBranch:   &baseBranch,
+		Archived:     false,
+		MetadataJSON: &otherMetadata,
+		CreatedAt:    nowISO,
+		UpdatedAt:    nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert(project_2) error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.PullRequestSnapshots.Upsert(context.Background(), storage.PullRequestSnapshotRecord{
+		ID:         "prs_project_1_latest",
+		ProjectID:  "project_1",
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		HeadSHA:    "head-project-1",
+		CapturedAt: fixture.now.UTC().Format(javaScriptISOString),
+		CreatedAt:  nowISO,
+	}); err != nil {
+		t.Fatalf("PullRequestSnapshots.Upsert(project_1) error = %v", err)
+	}
+	if err := fixture.runtime.Services().Repositories.PullRequestSnapshots.Upsert(context.Background(), storage.PullRequestSnapshotRecord{
+		ID:         "prs_project_2_stale",
+		ProjectID:  "project_2",
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		HeadSHA:    "head-project-2-stale",
+		CapturedAt: fixture.now.Add(time.Minute).UTC().Format(javaScriptISOString),
+		CreatedAt:  nowISO,
+	}); err != nil {
+		t.Fatalf("PullRequestSnapshots.Upsert(project_2) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workers", bytes.NewReader([]byte(`{"repo":"acme/looper","prNumber":42,"baseBranch":"main"}`)))
+	req.Header.Set("x-request-id", "error-request-id")
+	req.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(2 * time.Minute) }}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	queueItems, err := fixture.runtime.Services().Repositories.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(queueItems) != 1 {
+		t.Fatalf("Queue.List() = %#v, want one enqueued worker", queueItems)
+	}
+	if queueItems[0].ProjectID == nil || *queueItems[0].ProjectID != "project_1" {
+		t.Fatalf("queueItems[0].ProjectID = %#v, want project_1", queueItems[0].ProjectID)
+	}
+}
+
 func TestHandlerWorkerCreateRejectsRepoMismatchForExplicitProject(t *testing.T) {
 	fixture := newTestFixture(t)
 	seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1679,7 +1679,7 @@ func TestHandlerProjectsCreateRouteReturnsSuccessWhenWebhookRefreshFails(t *test
 	}
 }
 
-func TestHandlerProjectsRemoveRouteDeletesProject(t *testing.T) {
+func TestHandlerProjectsRemoveRouteArchivesProject(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)
 	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
@@ -1698,12 +1698,13 @@ func TestHandlerProjectsRemoveRouteDeletesProject(t *testing.T) {
 	data := body["data"].(map[string]any)
 	assertEqual(t, data["id"], "project_1")
 	assertEqual(t, data["name"], "Looper")
+	assertEqual(t, data["archived"], true)
 	project, err := fixture.runtime.Services().Repositories.Projects.GetByID(context.Background(), "project_1")
 	if err != nil {
 		t.Fatalf("Projects.GetByID() error = %v", err)
 	}
-	if project != nil {
-		t.Fatalf("project after delete = %#v, want nil", project)
+	if project == nil || !project.Archived {
+		t.Fatalf("project after archive = %#v, want archived project", project)
 	}
 }
 
@@ -1728,7 +1729,7 @@ func TestHandlerProjectsRemoveRouteReconcilesWebhookForwarders(t *testing.T) {
 	}
 }
 
-func TestHandlerProjectsRemoveRouteDeletesProjectWithEscapedSlashInName(t *testing.T) {
+func TestHandlerProjectsRemoveRouteArchivesProjectWithEscapedSlashInName(t *testing.T) {
 	fixture := newTestFixture(t)
 	nowISO := fixture.now.UTC().Format(javaScriptISOString)
 	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper/Core", RepoPath: "/tmp/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
@@ -1747,12 +1748,13 @@ func TestHandlerProjectsRemoveRouteDeletesProjectWithEscapedSlashInName(t *testi
 	data := body["data"].(map[string]any)
 	assertEqual(t, data["id"], "project_1")
 	assertEqual(t, data["name"], "Looper/Core")
+	assertEqual(t, data["archived"], true)
 	project, err := fixture.runtime.Services().Repositories.Projects.GetByID(context.Background(), "project_1")
 	if err != nil {
 		t.Fatalf("Projects.GetByID() error = %v", err)
 	}
-	if project != nil {
-		t.Fatalf("project after delete = %#v, want nil", project)
+	if project == nil || !project.Archived {
+		t.Fatalf("project after archive = %#v, want archived project", project)
 	}
 }
 
@@ -2732,6 +2734,57 @@ func TestHandlerWorkerAndPlannerCreateRejectActiveLoopConflicts(t *testing.T) {
 	plannerBody := parseJSONMap(t, plannerRecorder.Body.Bytes())
 	plannerError := plannerBody["error"].(map[string]any)
 	assertEqual(t, plannerError["code"], "LOOP_CONFLICT")
+}
+
+func TestHandlerWorkerCreateRejectsArchivedProject(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	metadata := `{"repo":"acme/looper","worktreeRoot":null,"source":"api"}`
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/repos/looper", Archived: true, MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workers", bytes.NewReader([]byte(`{"projectId":"project_1","prompt":"Wire runtime","repo":"acme/looper","baseBranch":"main"}`)))
+	req.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", recorder.Code)
+	}
+}
+
+func TestHandlerPlannersCreateRejectsArchivedProject(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	metadata := `{"repo":"acme/looper","worktreeRoot":null,"source":"api"}`
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/repos/looper", Archived: true, MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/planners", bytes.NewReader([]byte(`{"projectId":"project_1","issueNumber":77}`)))
+	req.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", recorder.Code)
+	}
+}
+
+func TestHandlerLoopsCreateRejectsArchivedProject(t *testing.T) {
+	fixture := newTestFixture(t)
+	seedWorkerPlannerArtifactsData(t, fixture.runtime, fixture.now)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	metadata := `{"repo":"acme/looper","worktreeRoot":null,"source":"api"}`
+	if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: "/tmp/repos/looper", Archived: true, MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops", bytes.NewReader([]byte(`{"projectId":"project_1","type":"reviewer","targetType":"pull_request","repo":"acme/looper","prNumber":42}`)))
+	req.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", recorder.Code)
+	}
 }
 
 func TestAssertUniqueActiveLoopCompatAllowsWaitingReviewerRerun(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -203,6 +203,54 @@ func TestHandlerLoopRetryAllowsManualInterventionQueueItem(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopRetryRejectsArchivedProject(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_archived"
+	loopID := "loop_retry_archived"
+	targetID := projectID
+	finishedAt := "2026-04-11T12:01:00.000Z"
+	lastErrorKind := "manual_intervention"
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", Archived: true, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 49, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_retry_archived", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:retry_archived", Priority: storage.QueuePriorityWorker, Status: "failed", AvailableAt: nowISO, Attempts: 2, MaxAttempts: 3, LastErrorKind: &lastErrorKind, FinishedAt: &finishedAt, CreatedAt: nowISO, UpdatedAt: finishedAt}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/49/retry", strings.NewReader(`{"mode":"auto"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	errorMap := body["error"].(map[string]any)
+	assertEqual(t, errorMap["code"], "PROJECT_NOT_FOUND")
+	assertEqual(t, errorMap["message"], "Project not found: "+projectID)
+
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = %#v, %v", loop, err)
+	}
+	if loop.Status != "paused" {
+		t.Fatalf("loop.Status = %q, want paused", loop.Status)
+	}
+	items, err := services.Repositories.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(items) != 1 || items[0].Status != "failed" {
+		t.Fatalf("queue items = %#v, want single failed item", items)
+	}
+}
+
 func TestHandlerLoopRetryRejectsTerminalReviewerMetadata(t *testing.T) {
 	fixture := newTestFixture(t, func(options *looperdruntime.Options) {
 		options.DeferRecovery = true
@@ -2200,6 +2248,50 @@ func TestHandlerLoopStartRejectsTerminalReviewerLoop(t *testing.T) {
 		if updated.Status != loop.Status {
 			t.Fatalf("loop %s status = %q, want unchanged %q", loop.ID, updated.Status, loop.Status)
 		}
+	}
+}
+
+func TestHandlerLoopStartRejectsArchivedProject(t *testing.T) {
+	fixture := newTestFixture(t)
+	services := fixture.runtime.Services()
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	projectID := "project_archived_start"
+	loopID := "loop_archived_start"
+	targetID := "project:" + projectID
+	metadata := `{"worker":{"title":"Implement worker loop","prompt":"Do the thing","repo":"acme/looper","baseBranch":"main"}}`
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", Archived: true, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 12, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "terminated", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/"+loopID+"/start", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	errorMap := body["error"].(map[string]any)
+	assertEqual(t, errorMap["code"], "PROJECT_NOT_FOUND")
+	assertEqual(t, errorMap["message"], "Project not found: "+projectID)
+
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+	if loop.Status != "terminated" || loop.NextRunAt != nil {
+		t.Fatalf("loop = %#v, want unchanged terminated loop", loop)
+	}
+	items, err := services.Repositories.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("queue items = %#v, want none", items)
 	}
 }
 

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -1321,7 +1321,7 @@ func TestProjectAddResolvesRelativePathsBeforePosting(t *testing.T) {
 	}
 }
 
-func TestProjectRemoveForceDeletesResolvedProject(t *testing.T) {
+func TestProjectRemoveForceArchivesResolvedProject(t *testing.T) {
 	t.Parallel()
 
 	var seenList atomic.Bool
@@ -1333,7 +1333,7 @@ func TestProjectRemoveForceDeletesResolvedProject(t *testing.T) {
 			writeEnvelope(t, w, pkgapi.Success("req_projects", map[string]any{"items": []map[string]any{{"id": "project_1", "name": "Looper", "repoPath": "/tmp/repo", "baseBranch": "main", "updatedAt": "2026-04-20T10:00:00.000Z"}}}))
 		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/projects/project_1":
 			seenDelete.Store(true)
-			writeEnvelope(t, w, pkgapi.Success("req_project_remove", map[string]any{"id": "project_1", "name": "Looper", "repoPath": "/tmp/repo", "baseBranch": "main", "updatedAt": "2026-04-20T10:00:00.000Z"}))
+			writeEnvelope(t, w, pkgapi.Success("req_project_remove", map[string]any{"id": "project_1", "name": "Looper", "repoPath": "/tmp/repo", "baseBranch": "main", "archived": true, "updatedAt": "2026-04-20T10:00:00.000Z"}))
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -1352,6 +1352,7 @@ func TestProjectRemoveForceDeletesResolvedProject(t *testing.T) {
 		t.Fatalf("requests seen list=%v delete=%v, want both", seenList.Load(), seenDelete.Load())
 	}
 	assertJSONContains(t, stdout, "id", "project_1")
+	assertJSONContains(t, stdout, "archived", true)
 }
 
 func TestProjectRemovePromptsForConfirmation(t *testing.T) {
@@ -1380,8 +1381,11 @@ func TestProjectRemovePromptsForConfirmation(t *testing.T) {
 	if !strings.Contains(stderr.String(), "Type \"project_1\" to confirm") {
 		t.Fatalf("stderr = %q, want confirmation prompt", stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Project removed") {
-		t.Fatalf("stdout = %q, want removal summary", stdout.String())
+	if !strings.Contains(stdout.String(), "Project archived") {
+		t.Fatalf("stdout = %q, want archive summary", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "preserving history") {
+		t.Fatalf("stderr = %q, want archive wording", stderr.String())
 	}
 }
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -91,6 +91,7 @@ type projectOutput struct {
 	Name                   string   `json:"name"`
 	RepoPath               string   `json:"repoPath"`
 	BaseBranch             string   `json:"baseBranch"`
+	Archived               bool     `json:"archived"`
 	Repo                   *string  `json:"repo"`
 	UpdatedAt              string   `json:"updatedAt"`
 	DiscoveredPullRequests int      `json:"discoveredPullRequests"`
@@ -354,7 +355,7 @@ func writeHumanProjectRemove(w io.Writer, payload json.RawMessage) error {
 		return fmt.Errorf("decode project response: %w", err)
 	}
 
-	printSection(w, "Project removed", [][2]any{{"id", data.ID}, {"name", data.Name}, {"repoPath", data.RepoPath}})
+	printSection(w, "Project archived", [][2]any{{"id", data.ID}, {"name", data.Name}, {"repoPath", data.RepoPath}, {"historyPreserved", true}})
 	return nil
 }
 

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -1069,16 +1069,16 @@ func resolveProjectByIdentifier(projects []projectOutput, identifier projectRemo
 }
 
 func confirmProjectRemoval(cmd *cobra.Command, project projectOutput) error {
-	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Remove project %s (%s) and associated runtime records? Type %q to confirm: ", project.ID, project.Name, project.ID)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Archive project %s (%s) and unregister it from new work while preserving history? Type %q to confirm: ", project.ID, project.Name, project.ID)
 	scanner := bufio.NewScanner(cmd.InOrStdin())
 	if !scanner.Scan() {
 		if err := scanner.Err(); err != nil {
 			return fmt.Errorf("read confirmation: %w", err)
 		}
-		return fmt.Errorf("project removal cancelled")
+		return fmt.Errorf("project archive cancelled")
 	}
 	if strings.TrimSpace(scanner.Text()) != project.ID {
-		return fmt.Errorf("project removal cancelled")
+		return fmt.Errorf("project archive cancelled")
 	}
 	return nil
 }

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1804,6 +1804,10 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	}
 	r.appendEvent(ctx, eventInput{eventType: "run.completed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"summary": summary}})
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
+		if errors.Is(err, storage.ErrQueueItemNotActive) {
+			r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
+			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: statusForSkip(checkpoint.SkipReason), Summary: summary}, nil
+		}
 		return ProcessResult{}, err
 	}
 	if hasProgressed(checkpoint) {
@@ -4271,6 +4275,9 @@ func (r *Runner) updateLoop(ctx context.Context, loop storage.LoopRecord, mutate
 	current, err := r.repos.Loops.GetByID(ctx, loop.ID)
 	if err != nil {
 		return storage.LoopRecord{}, err
+	}
+	if current != nil && current.Status == "terminated" {
+		return *current, nil
 	}
 	updated := loop
 	if current != nil {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -6813,3 +6813,33 @@ func TestSkippedNoEvidenceThreadIDs(t *testing.T) {
 		t.Fatalf("skippedNoEvidenceThreadIDs() = %v, want %v", got, want)
 	}
 }
+
+func TestUpdateLoopPreservesTerminatedLoop(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_fixer_terminated", Seq: 901, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "terminated", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	runner := &Runner{repos: fixture.repos, now: fixture.now}
+	updated, err := runner.updateLoop(context.Background(), loop, func(current *storage.LoopRecord) {
+		current.Status = "completed"
+	})
+	if err != nil {
+		t.Fatalf("updateLoop() error = %v", err)
+	}
+	if updated.Status != "terminated" {
+		t.Fatalf("updateLoop().Status = %q, want terminated", updated.Status)
+	}
+
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "terminated" {
+		t.Fatalf("Loops.GetByID() = %#v, want terminated loop", persisted)
+	}
+}

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -751,7 +751,18 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		return ProcessResult{}, err
 	}
 	r.appendEvent(ctx, eventInput{eventType: "run.completed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"summary": summary}})
+	status := "success"
+	if checkpoint.SkipReason != "" {
+		status = "skipped"
+	}
+	prNumber := int64(0)
+	if checkpoint.Publish != nil && checkpoint.Publish.PullRequest != nil {
+		prNumber = checkpoint.Publish.PullRequest.Number
+	}
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
+		if errors.Is(err, storage.ErrQueueItemNotActive) {
+			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary, PullRequestNumber: prNumber}, nil
+		}
 		return ProcessResult{}, err
 	}
 	if _, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
@@ -760,14 +771,6 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		updated.NextRunAt = nil
 	}); err != nil {
 		return ProcessResult{}, err
-	}
-	status := "success"
-	if checkpoint.SkipReason != "" {
-		status = "skipped"
-	}
-	prNumber := int64(0)
-	if checkpoint.Publish != nil && checkpoint.Publish.PullRequest != nil {
-		prNumber = checkpoint.Publish.PullRequest.Number
 	}
 	return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary, PullRequestNumber: prNumber}, nil
 }
@@ -1525,6 +1528,9 @@ func (r *Runner) updateLoop(ctx context.Context, loop storage.LoopRecord, mutate
 	}
 	if current == nil {
 		return storage.LoopRecord{}, fmt.Errorf("loop not found: %s", loop.ID)
+	}
+	if current.Status == "terminated" {
+		return *current, nil
 	}
 	updated := *current
 	mutate(&updated)

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -1353,3 +1353,31 @@ func (*testLogger) Warn(string, map[string]any)  {}
 func (*testLogger) Error(string, map[string]any) {}
 
 func boolPtr(value bool) *bool { return &value }
+
+func TestUpdateLoopPreservesTerminatedLoop(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{ID: "loop_planner_terminated", Seq: 901, ProjectID: "project_1", Type: "planner", TargetType: "issue", Status: "terminated", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	runner := &Runner{repos: fixture.repos, now: fixture.now}
+	updated, err := runner.updateLoop(context.Background(), loop, func(current *storage.LoopRecord) {
+		current.Status = "completed"
+	})
+	if err != nil {
+		t.Fatalf("updateLoop() error = %v", err)
+	}
+	if updated.Status != "terminated" {
+		t.Fatalf("updateLoop().Status = %q, want terminated", updated.Status)
+	}
+
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "terminated" {
+		t.Fatalf("Loops.GetByID() = %#v, want terminated loop", persisted)
+	}
+}

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -309,6 +309,9 @@ func (s *Service) RemoveProject(ctx context.Context, identifier string) (storage
 		if !archived {
 			return false, nil
 		}
+		if _, err := repos.Loops.TerminateByProject(ctx, project.ID, nowISO); err != nil {
+			return false, err
+		}
 		if _, err := repos.Queue.CancelByProject(ctx, project.ID, nowISO, &cancelReason); err != nil {
 			return false, err
 		}
@@ -331,7 +334,10 @@ func (s *Service) resolveActiveProjectForRemoval(ctx context.Context, identifier
 	if err != nil {
 		return nil, err
 	}
-	if project != nil && !project.Archived {
+	if project != nil {
+		if project.Archived {
+			return nil, nil
+		}
 		return project, nil
 	}
 

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -299,7 +299,21 @@ func (s *Service) RemoveProject(ctx context.Context, identifier string) (storage
 	}
 
 	nowISO := currentISO(s.Now)
-	archived, err := s.Repos.Projects.Archive(ctx, project.ID, nowISO)
+	cancelReason := "project archived"
+	archived, err := storage.WithTransactionValue(ctx, s.DB, nil, func(tx *sql.Tx) (bool, error) {
+		repos := storage.NewRepositories(tx)
+		archived, err := repos.Projects.Archive(ctx, project.ID, nowISO)
+		if err != nil {
+			return false, err
+		}
+		if !archived {
+			return false, nil
+		}
+		if _, err := repos.Queue.CancelByProject(ctx, project.ID, nowISO, &cancelReason); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
 	if err != nil {
 		return storage.ProjectRecord{}, err
 	}

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -137,7 +137,7 @@ func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, er
 	if err != nil {
 		return AddResult{}, err
 	}
-	if existing != nil && input.IDSource != "derived" {
+	if existing != nil && !existing.Archived && input.IDSource != "derived" {
 		return AddResult{}, ProjectIDCollisionError{ProjectID: input.ID}
 	}
 	projectID := input.ID
@@ -264,7 +264,17 @@ func (s *Service) List(ctx context.Context) ([]storage.ProjectRecord, error) {
 	if s.Repos == nil || s.Repos.Projects == nil {
 		return nil, fmt.Errorf("projects repository is not configured")
 	}
-	return s.Repos.Projects.List(ctx)
+	items, err := s.Repos.Projects.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	active := make([]storage.ProjectRecord, 0, len(items))
+	for _, item := range items {
+		if !item.Archived {
+			active = append(active, item)
+		}
+	}
+	return active, nil
 }
 
 func (s *Service) RemoveProject(ctx context.Context, identifier string) (storage.ProjectRecord, error) {
@@ -277,24 +287,9 @@ func (s *Service) RemoveProject(ctx context.Context, identifier string) (storage
 		return storage.ProjectRecord{}, ProjectValidationError{Message: "project identifier is required"}
 	}
 
-	project, err := s.Repos.Projects.GetByID(ctx, trimmed)
+	project, err := s.resolveActiveProjectForRemoval(ctx, trimmed)
 	if err != nil {
 		return storage.ProjectRecord{}, err
-	}
-	if project == nil {
-		items, err := s.Repos.Projects.List(ctx)
-		if err != nil {
-			return storage.ProjectRecord{}, err
-		}
-
-		for index := range items {
-			if strings.EqualFold(strings.TrimSpace(items[index].Name), trimmed) {
-				if project != nil {
-					return storage.ProjectRecord{}, AmbiguousProjectIdentifierError{Identifier: trimmed}
-				}
-				project = &items[index]
-			}
-		}
 	}
 	if project == nil {
 		return storage.ProjectRecord{}, ProjectNotFoundError{Identifier: trimmed}
@@ -303,15 +298,45 @@ func (s *Service) RemoveProject(ctx context.Context, identifier string) (storage
 		return storage.ProjectRecord{}, ProjectValidationError{Message: fmt.Sprintf("project %s is managed by config and cannot be removed from the CLI", project.ID)}
 	}
 
-	deleted, err := s.Repos.Projects.Delete(ctx, project.ID)
+	nowISO := currentISO(s.Now)
+	archived, err := s.Repos.Projects.Archive(ctx, project.ID, nowISO)
 	if err != nil {
 		return storage.ProjectRecord{}, err
 	}
-	if !deleted {
+	if !archived {
 		return storage.ProjectRecord{}, ProjectNotFoundError{Identifier: trimmed}
 	}
+	project.Archived = true
+	project.UpdatedAt = nowISO
 
 	return *project, nil
+}
+
+func (s *Service) resolveActiveProjectForRemoval(ctx context.Context, identifier string) (*storage.ProjectRecord, error) {
+	project, err := s.Repos.Projects.GetByID(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	if project != nil && !project.Archived {
+		return project, nil
+	}
+
+	items, err := s.Repos.Projects.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var matched *storage.ProjectRecord
+	for index := range items {
+		if items[index].Archived || !strings.EqualFold(strings.TrimSpace(items[index].Name), identifier) {
+			continue
+		}
+		if matched != nil {
+			return nil, AmbiguousProjectIdentifierError{Identifier: identifier}
+		}
+		matched = &items[index]
+	}
+	return matched, nil
 }
 
 func (s *Service) SyncConfigured(ctx context.Context, cfg config.Config, now time.Time) error {

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -842,6 +842,79 @@ func TestServiceRemoveProjectTerminatesActiveLoopsBeforeReactivation(t *testing.
 	}
 }
 
+func TestServiceRemoveProjectTerminatesFailedLoopsAndCancelsRecoverableQueueItems(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC)
+	nowISO := now.UTC().Format(time.RFC3339Nano)
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repoName := "acme/looper"
+	prNumber := int64(42)
+	failedTargetID := "pr:acme/looper:42"
+	if err := repos.Loops.Upsert(ctx, storage.LoopRecord{ID: "loop_failed", Seq: 1, ProjectID: "looper", Type: string(domain.LoopTypeReviewer), TargetType: string(domain.LoopTargetTypePullRequest), TargetID: &failedTargetID, Repo: &repoName, PRNumber: &prNumber, Status: string(domain.LoopStatusFailed), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_failed) error = %v", err)
+	}
+	manualTargetID := "pr:acme/looper:43"
+	manualPRNumber := int64(43)
+	if err := repos.Loops.Upsert(ctx, storage.LoopRecord{ID: "loop_manual", Seq: 2, ProjectID: "looper", Type: string(domain.LoopTypeReviewer), TargetType: string(domain.LoopTargetTypePullRequest), TargetID: &manualTargetID, Repo: &repoName, PRNumber: &manualPRNumber, Status: string(domain.LoopStatusPaused), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_manual) error = %v", err)
+	}
+	errorMessage := "review failed"
+	errorKind := "retryable_transient"
+	if err := repos.Queue.Upsert(ctx, storage.QueueItemRecord{ID: "queue_failed", ProjectID: stringPointer("looper"), LoopID: stringPointer("loop_failed"), Type: "reviewer", TargetType: "pull_request", TargetID: failedTargetID, Repo: &repoName, PRNumber: &prNumber, DedupeKey: "reviewer:project_1:loop_failed:acme/looper:42", Priority: storage.QueuePriorityReviewer, Status: "failed", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 5, LastError: &errorMessage, LastErrorKind: &errorKind, FinishedAt: stringPointer(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert(queue_failed) error = %v", err)
+	}
+	manualErrorKind := "manual_intervention"
+	manualError := "needs manual follow-up"
+	if err := repos.Queue.Upsert(ctx, storage.QueueItemRecord{ID: "queue_manual", ProjectID: stringPointer("looper"), LoopID: stringPointer("loop_manual"), Type: "reviewer", TargetType: "pull_request", TargetID: manualTargetID, Repo: &repoName, PRNumber: &manualPRNumber, DedupeKey: "reviewer:project_1:loop_manual:acme/looper:43", Priority: storage.QueuePriorityReviewer, Status: "manual_intervention", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 5, LastError: &manualError, LastErrorKind: &manualErrorKind, FinishedAt: stringPointer(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert(queue_manual) error = %v", err)
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now.Add(time.Minute) }}
+	removed, err := service.RemoveProject(ctx, "looper")
+	if err != nil {
+		t.Fatalf("RemoveProject() error = %v", err)
+	}
+	if !removed.Archived {
+		t.Fatalf("RemoveProject().Archived = %v, want true", removed.Archived)
+	}
+
+	failedLoop, err := repos.Loops.GetByID(ctx, "loop_failed")
+	if err != nil {
+		t.Fatalf("Loops.GetByID(loop_failed) error = %v", err)
+	}
+	if failedLoop == nil || failedLoop.Status != string(domain.LoopStatusTerminated) {
+		t.Fatalf("failed loop = %#v, want terminated", failedLoop)
+	}
+	manualLoop, err := repos.Loops.GetByID(ctx, "loop_manual")
+	if err != nil {
+		t.Fatalf("Loops.GetByID(loop_manual) error = %v", err)
+	}
+	if manualLoop == nil || manualLoop.Status != string(domain.LoopStatusTerminated) {
+		t.Fatalf("manual loop = %#v, want terminated", manualLoop)
+	}
+
+	failedQueue, err := repos.Queue.GetByID(ctx, "queue_failed")
+	if err != nil {
+		t.Fatalf("Queue.GetByID(queue_failed) error = %v", err)
+	}
+	if failedQueue == nil || failedQueue.Status != "cancelled" || failedQueue.FinishedAt == nil || failedQueue.LastError == nil || *failedQueue.LastError != "project archived" {
+		t.Fatalf("failed queue = %#v, want cancelled archived queue item", failedQueue)
+	}
+	manualQueue, err := repos.Queue.GetByID(ctx, "queue_manual")
+	if err != nil {
+		t.Fatalf("Queue.GetByID(queue_manual) error = %v", err)
+	}
+	if manualQueue == nil || manualQueue.Status != "cancelled" || manualQueue.FinishedAt == nil || manualQueue.LastError == nil || *manualQueue.LastError != "project archived" {
+		t.Fatalf("manual queue = %#v, want cancelled archived queue item", manualQueue)
+	}
+}
+
 func TestServiceListSkipsArchivedProjects(t *testing.T) {
 	t.Parallel()
 

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -842,7 +842,7 @@ func TestServiceRemoveProjectTerminatesActiveLoopsBeforeReactivation(t *testing.
 	}
 }
 
-func TestServiceRemoveProjectTerminatesFailedLoopsAndCancelsRecoverableQueueItems(t *testing.T) {
+func TestServiceRemoveProjectTerminatesFailedAndInterruptedLoopsAndCancelsRecoverableQueueItems(t *testing.T) {
 	t.Parallel()
 
 	coordinator := openCoordinator(t)
@@ -858,6 +858,11 @@ func TestServiceRemoveProjectTerminatesFailedLoopsAndCancelsRecoverableQueueItem
 	failedTargetID := "pr:acme/looper:42"
 	if err := repos.Loops.Upsert(ctx, storage.LoopRecord{ID: "loop_failed", Seq: 1, ProjectID: "looper", Type: string(domain.LoopTypeReviewer), TargetType: string(domain.LoopTargetTypePullRequest), TargetID: &failedTargetID, Repo: &repoName, PRNumber: &prNumber, Status: string(domain.LoopStatusFailed), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Loops.Upsert(loop_failed) error = %v", err)
+	}
+	interruptedTargetID := "pr:acme/looper:44"
+	interruptedPRNumber := int64(44)
+	if err := repos.Loops.Upsert(ctx, storage.LoopRecord{ID: "loop_interrupted", Seq: 3, ProjectID: "looper", Type: string(domain.LoopTypeReviewer), TargetType: string(domain.LoopTargetTypePullRequest), TargetID: &interruptedTargetID, Repo: &repoName, PRNumber: &interruptedPRNumber, Status: string(domain.LoopStatusInterrupted), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert(loop_interrupted) error = %v", err)
 	}
 	manualTargetID := "pr:acme/looper:43"
 	manualPRNumber := int64(43)
@@ -890,6 +895,13 @@ func TestServiceRemoveProjectTerminatesFailedLoopsAndCancelsRecoverableQueueItem
 	}
 	if failedLoop == nil || failedLoop.Status != string(domain.LoopStatusTerminated) {
 		t.Fatalf("failed loop = %#v, want terminated", failedLoop)
+	}
+	interruptedLoop, err := repos.Loops.GetByID(ctx, "loop_interrupted")
+	if err != nil {
+		t.Fatalf("Loops.GetByID(loop_interrupted) error = %v", err)
+	}
+	if interruptedLoop == nil || interruptedLoop.Status != string(domain.LoopStatusTerminated) {
+		t.Fatalf("interrupted loop = %#v, want terminated", interruptedLoop)
 	}
 	manualLoop, err := repos.Loops.GetByID(ctx, "loop_manual")
 	if err != nil {

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -2,6 +2,7 @@ package projects
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -659,6 +660,228 @@ func TestServiceSyncConfiguredDoesNotDeleteUnlistedProjects(t *testing.T) {
 	}
 	if other == nil || other.Name != "Other" {
 		t.Fatalf("other = %#v, want configured project upserted", other)
+	}
+}
+
+func TestServiceRemoveProjectArchivesProjectAndPreservesHistory(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC)
+	nowISO := now.UTC().Format(time.RFC3339Nano)
+	baseBranch := "main"
+	metadata := `{"repo":"nexu-io/looper","source":"api"}`
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: &baseBranch, MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(ctx, storage.LoopRecord{ID: "loop_1", Seq: 1, ProjectID: "looper", Type: "reviewer", TargetType: "pull_request", Status: "idle", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now.Add(time.Minute) }}
+
+	removed, err := service.RemoveProject(ctx, "looper")
+	if err != nil {
+		t.Fatalf("RemoveProject() error = %v", err)
+	}
+	if !removed.Archived {
+		t.Fatalf("RemoveProject().Archived = %v, want true", removed.Archived)
+	}
+
+	stored, err := repos.Projects.GetByID(ctx, "looper")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	if stored == nil || !stored.Archived {
+		t.Fatalf("stored project = %#v, want archived project", stored)
+	}
+	wantUpdatedAt := currentISO(func() time.Time { return now.Add(time.Minute) })
+	if stored.UpdatedAt != wantUpdatedAt {
+		t.Fatalf("stored.UpdatedAt = %q, want %q", stored.UpdatedAt, wantUpdatedAt)
+	}
+	loop, err := repos.Loops.GetByID(ctx, "loop_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.ProjectID != "looper" {
+		t.Fatalf("loop = %#v, want preserved loop history", loop)
+	}
+}
+
+func TestServiceListSkipsArchivedProjects(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	nowISO := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC).UTC().Format(time.RFC3339Nano)
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "active", Name: "Active", RepoPath: "/tmp/active", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(active) error = %v", err)
+	}
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "archived", Name: "Archived", RepoPath: "/tmp/archived", Archived: true, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(archived) error = %v", err)
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos}
+	items, err := service.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "active" {
+		t.Fatalf("List() = %#v, want only active project", items)
+	}
+}
+
+func TestServiceRemoveProjectTreatsArchivedProjectAsNotFound(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC)
+	nowISO := now.UTC().Format(time.RFC3339Nano)
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", Archived: true, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now.Add(time.Minute) }}
+	_, err := service.RemoveProject(ctx, "looper")
+	if err == nil {
+		t.Fatal("RemoveProject(id) error = nil, want not found")
+	}
+	var notFound ProjectNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("RemoveProject(id) error = %T, want ProjectNotFoundError", err)
+	}
+	_, err = service.RemoveProject(ctx, "Looper")
+	if err == nil {
+		t.Fatal("RemoveProject(name) error = nil, want not found")
+	}
+	if !errors.As(err, &notFound) {
+		t.Fatalf("RemoveProject(name) error = %T, want ProjectNotFoundError", err)
+	}
+}
+
+func TestServiceAddProjectReactivatesArchivedExplicitID(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	nowISO := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC).UTC().Format(time.RFC3339Nano)
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "looper", Name: "Old", RepoPath: "/tmp/old", Archived: true, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos}
+	result, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main"})
+	if err != nil {
+		t.Fatalf("AddProject() error = %v", err)
+	}
+	if result.Project.Archived {
+		t.Fatalf("AddProject().Project.Archived = %v, want false", result.Project.Archived)
+	}
+}
+
+func TestServiceRemoveProjectRejectsConfigManagedProject(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	nowISO := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC).UTC().Format(time.RFC3339Nano)
+	metadata := `{"repo":null,"worktreeRoot":null,"source":"config"}`
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos}
+	_, err := service.RemoveProject(ctx, "looper")
+	if err == nil {
+		t.Fatal("RemoveProject() error = nil, want validation error")
+	}
+	var validationErr ProjectValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("RemoveProject() error = %T, want ProjectValidationError", err)
+	}
+
+	stored, err := repos.Projects.GetByID(ctx, "looper")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	if stored == nil || stored.Archived {
+		t.Fatalf("stored project = %#v, want non-archived project", stored)
+	}
+}
+
+func TestProjectsRepositoryArchiveMarksArchivedWithoutDeletingRow(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	nowISO := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC).UTC().Format(time.RFC3339Nano)
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	archivedAt := time.Date(2026, time.June, 11, 12, 5, 0, 0, time.UTC).UTC().Format(time.RFC3339Nano)
+
+	ok, err := repos.Projects.Archive(ctx, "looper", archivedAt)
+	if err != nil {
+		t.Fatalf("Projects.Archive() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Projects.Archive() = false, want true")
+	}
+
+	var archived int
+	var updatedAt string
+	row := coordinator.DB().QueryRowContext(ctx, `SELECT archived, updated_at FROM projects WHERE id = ?`, "looper")
+	if err := row.Scan(&archived, &updatedAt); err != nil {
+		t.Fatalf("scan archived project row: %v", err)
+	}
+	if archived != 1 || updatedAt != archivedAt {
+		t.Fatalf("project row = archived:%d updated_at:%q, want 1/%q", archived, updatedAt, archivedAt)
+	}
+	var count int
+	if err := coordinator.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM projects WHERE id = ?`, "looper").Scan(&count); err != nil {
+		t.Fatalf("count archived project row: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("project row count = %d, want 1", count)
+	}
+	if err := coordinator.DB().QueryRowContext(ctx, `SELECT archived FROM projects WHERE id = ?`, "missing").Scan(&archived); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("missing project query error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestProjectsRepositoryArchiveSkipsArchivedProjectUpdates(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	nowISO := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC).UTC().Format(time.RFC3339Nano)
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", Archived: true, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	archivedAt := time.Date(2026, time.June, 11, 12, 5, 0, 0, time.UTC).UTC().Format(time.RFC3339Nano)
+
+	ok, err := repos.Projects.Archive(ctx, "looper", archivedAt)
+	if err != nil {
+		t.Fatalf("Projects.Archive() error = %v", err)
+	}
+	if ok {
+		t.Fatal("Projects.Archive() = true, want false for already archived project")
+	}
+	stored, err := repos.Projects.GetByID(ctx, "looper")
+	if err != nil {
+		t.Fatalf("Projects.GetByID() error = %v", err)
+	}
+	if stored == nil || stored.UpdatedAt != nowISO {
+		t.Fatalf("stored = %#v, want unchanged updatedAt %q", stored, nowISO)
 	}
 }
 

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/domain"
 	"github.com/nexu-io/looper/internal/infra/shell"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -787,6 +789,59 @@ func TestServiceRemoveProjectCancelsActiveProjectQueueItems(t *testing.T) {
 	}
 }
 
+func TestServiceRemoveProjectTerminatesActiveLoopsBeforeReactivation(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC)
+	nowISO := now.UTC().Format(time.RFC3339Nano)
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	prNumber := int64(42)
+	repoName := "acme/looper"
+	if err := repos.Loops.Upsert(ctx, storage.LoopRecord{ID: "loop_1", Seq: 1, ProjectID: "looper", Type: string(domain.LoopTypeReviewer), TargetType: string(domain.LoopTargetTypePullRequest), Repo: &repoName, PRNumber: &prNumber, Status: string(domain.LoopStatusRunning), CreatedAt: nowISO, UpdatedAt: nowISO, NextRunAt: stringPointer(nowISO)}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now.Add(time.Minute) }}
+	removed, err := service.RemoveProject(ctx, "looper")
+	if err != nil {
+		t.Fatalf("RemoveProject() error = %v", err)
+	}
+	if !removed.Archived {
+		t.Fatalf("RemoveProject().Archived = %v, want true", removed.Archived)
+	}
+
+	loop, err := repos.Loops.GetByID(ctx, "loop_1")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != string(domain.LoopStatusTerminated) || loop.NextRunAt != nil {
+		t.Fatalf("archived loop = %#v, want terminated with cleared next_run_at", loop)
+	}
+
+	if _, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main"}); err != nil {
+		t.Fatalf("AddProject() error = %v", err)
+	}
+
+	loopService := &loops.Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now.Add(2 * time.Minute) }}
+	created, err := loopService.Create(ctx, loops.CreateInput{
+		ProjectID: "looper",
+		Type:      domain.LoopTypeReviewer,
+		Target:    domain.LoopTarget{TargetType: domain.LoopTargetTypePullRequest, Repo: repoName, PRNumber: prNumber},
+		Status:    domain.LoopStatusQueued,
+	})
+	if err != nil {
+		t.Fatalf("loops.Create() error = %v", err)
+	}
+	if created.ProjectID != "looper" || created.Status != string(domain.LoopStatusQueued) {
+		t.Fatalf("loops.Create() = %#v, want queued loop for reactivated project", created)
+	}
+}
+
 func TestServiceListSkipsArchivedProjects(t *testing.T) {
 	t.Parallel()
 
@@ -838,6 +893,47 @@ func TestServiceRemoveProjectTreatsArchivedProjectAsNotFound(t *testing.T) {
 	}
 	if !errors.As(err, &notFound) {
 		t.Fatalf("RemoveProject(name) error = %T, want ProjectNotFoundError", err)
+	}
+}
+
+func TestServiceRemoveProjectDoesNotFallbackToNameAfterArchivedIDMatch(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC)
+	nowISO := now.UTC().Format(time.RFC3339Nano)
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "foo", Name: "Archived", RepoPath: "/tmp/archived", Archived: true, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(foo archived) error = %v", err)
+	}
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "active", Name: "foo", RepoPath: "/tmp/active", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(active) error = %v", err)
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now.Add(time.Minute) }}
+	_, err := service.RemoveProject(ctx, "foo")
+	if err == nil {
+		t.Fatal("RemoveProject() error = nil, want not found")
+	}
+	var notFound ProjectNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("RemoveProject() error = %T, want ProjectNotFoundError", err)
+	}
+
+	active, err := repos.Projects.GetByID(ctx, "active")
+	if err != nil {
+		t.Fatalf("Projects.GetByID(active) error = %v", err)
+	}
+	if active == nil || active.Archived {
+		t.Fatalf("active project = %#v, want still active", active)
+	}
+	archived, err := repos.Projects.GetByID(ctx, "foo")
+	if err != nil {
+		t.Fatalf("Projects.GetByID(foo) error = %v", err)
+	}
+	if archived == nil || !archived.Archived {
+		t.Fatalf("archived project = %#v, want unchanged archived project", archived)
 	}
 }
 

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -710,6 +710,83 @@ func TestServiceRemoveProjectArchivesProjectAndPreservesHistory(t *testing.T) {
 	}
 }
 
+func TestServiceRemoveProjectCancelsActiveProjectQueueItems(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.June, 11, 12, 0, 0, 0, time.UTC)
+	nowISO := now.UTC().Format(time.RFC3339Nano)
+	repoName := "acme/looper"
+	prNumber := int64(42)
+	runningPRNumber := int64(43)
+	dedupeKey := "sweeper:acme/looper:42"
+	runningDedupeKey := "sweeper:acme/looper:43"
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(looper) error = %v", err)
+	}
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: "other", Name: "Other", RepoPath: "/tmp/other", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert(other) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(ctx, storage.QueueItemRecord{ID: "queue_looper", ProjectID: stringPointer("looper"), Type: "sweeper", TargetType: "pull_request", TargetID: "pr:42", Repo: &repoName, PRNumber: &prNumber, DedupeKey: dedupeKey, Priority: storage.QueuePriorityWorker, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert(queue_looper) error = %v", err)
+	}
+	if err := repos.Queue.Upsert(ctx, storage.QueueItemRecord{ID: "queue_running", ProjectID: stringPointer("looper"), Type: "sweeper", TargetType: "pull_request", TargetID: "pr:43", Repo: &repoName, PRNumber: &runningPRNumber, DedupeKey: runningDedupeKey, Priority: storage.QueuePriorityWorker, Status: "running", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert(queue_running) error = %v", err)
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now.Add(time.Minute) }}
+
+	removed, err := service.RemoveProject(ctx, "looper")
+	if err != nil {
+		t.Fatalf("RemoveProject() error = %v", err)
+	}
+	if !removed.Archived {
+		t.Fatalf("RemoveProject().Archived = %v, want true", removed.Archived)
+	}
+
+	for _, id := range []string{"queue_looper", "queue_running"} {
+		item, err := repos.Queue.GetByID(ctx, id)
+		if err != nil {
+			t.Fatalf("Queue.GetByID(%s) error = %v", id, err)
+		}
+		if item == nil || item.Status != "cancelled" || item.FinishedAt == nil || item.LastError == nil || *item.LastError != "project archived" {
+			t.Fatalf("Queue.GetByID(%s) = %#v, want cancelled item with archive reason", id, item)
+		}
+	}
+
+	if err := repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: "queue_running", AvailableAt: nowISO, Attempts: 2, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.MarkRetry(queue_running) error = %v", err)
+	}
+	retried, err := repos.Queue.GetByID(ctx, "queue_running")
+	if err != nil {
+		t.Fatalf("Queue.GetByID(queue_running after retry) error = %v", err)
+	}
+	if retried == nil || retried.Status != "cancelled" {
+		t.Fatalf("Queue.GetByID(queue_running after retry) = %#v, want cancelled", retried)
+	}
+
+	if active, err := repos.Queue.FindActiveByDedupe(ctx, dedupeKey); err != nil {
+		t.Fatalf("Queue.FindActiveByDedupe() error = %v", err)
+	} else if active != nil {
+		t.Fatalf("Queue.FindActiveByDedupe() = %#v, want nil after archive", active)
+	}
+	if active, err := repos.Queue.FindActiveByDedupe(ctx, runningDedupeKey); err != nil {
+		t.Fatalf("Queue.FindActiveByDedupe(running) error = %v", err)
+	} else if active != nil {
+		t.Fatalf("Queue.FindActiveByDedupe(running) = %#v, want nil after archive", active)
+	}
+
+	created, didCreate, err := repos.Queue.CreateOrGetActiveByDedupe(ctx, storage.QueueItemRecord{ID: "queue_other", ProjectID: stringPointer("other"), Type: "sweeper", TargetType: "pull_request", TargetID: "pr:42", Repo: &repoName, PRNumber: &prNumber, DedupeKey: dedupeKey, Priority: storage.QueuePriorityWorker, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO})
+	if err != nil {
+		t.Fatalf("Queue.CreateOrGetActiveByDedupe() error = %v", err)
+	}
+	if !didCreate || created.ID != "queue_other" {
+		t.Fatalf("Queue.CreateOrGetActiveByDedupe() = (%#v, %v), want created queue_other", created, didCreate)
+	}
+}
+
 func TestServiceListSkipsArchivedProjects(t *testing.T) {
 	t.Parallel()
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1560,7 +1560,14 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		return ProcessResult{}, err
 	}
 	r.appendEvent(ctx, eventInput{eventType: "run.completed", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"summary": summary}})
+	status := "success"
+	if checkpoint.SkipReason != "" {
+		status = "skipped"
+	}
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
+		if errors.Is(err, storage.ErrQueueItemNotActive) {
+			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
+		}
 		return ProcessResult{}, err
 	}
 	updatedLoop, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
@@ -1581,10 +1588,6 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		}
 	}
 	r.cleanupReviewerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
-	status := "success"
-	if checkpoint.SkipReason != "" {
-		status = "skipped"
-	}
 	return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
 }
 
@@ -4372,6 +4375,9 @@ func (r *Runner) updateLoop(ctx context.Context, loop storage.LoopRecord, mutate
 	current, err := r.repos.Loops.GetByID(ctx, loop.ID)
 	if err != nil {
 		return storage.LoopRecord{}, err
+	}
+	if current != nil && current.Status == "terminated" {
+		return *current, nil
 	}
 	updated := loop
 	if current != nil {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -9055,3 +9055,33 @@ func (l *testLogger) hasMessage(want string) bool {
 }
 
 func contains(haystack, needle string) bool { return strings.Contains(haystack, needle) }
+
+func TestUpdateLoopPreservesTerminatedLoop(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{ID: "loop_reviewer_terminated", Seq: 901, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "terminated", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	runner := &Runner{repos: fixture.repos, now: fixture.now}
+	updated, err := runner.updateLoop(context.Background(), loop, func(current *storage.LoopRecord) {
+		current.Status = "completed"
+	})
+	if err != nil {
+		t.Fatalf("updateLoop() error = %v", err)
+	}
+	if updated.Status != "terminated" {
+		t.Fatalf("updateLoop().Status = %q, want terminated", updated.Status)
+	}
+
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "terminated" {
+		t.Fatalf("Loops.GetByID() = %#v, want terminated loop", persisted)
+	}
+}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1758,6 +1758,9 @@ func processSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord,
 		return failSnapshotQueueItem(ctx, item, input, err.Error(), "retryable_transient")
 	}
 	if err := input.Repos.Queue.Complete(ctx, item.ID, formatJavaScriptISOString(now().UTC())); err != nil {
+		if errors.Is(err, storage.ErrQueueItemNotActive) {
+			return nil
+		}
 		return failSnapshotQueueItem(ctx, item, input, err.Error(), "retryable_transient")
 	}
 	return nil

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -683,7 +683,7 @@ func (r *LoopsRepository) TerminateByProject(ctx context.Context, projectID, upd
 		SET status = 'terminated',
 			next_run_at = NULL,
 			updated_at = ?
-		WHERE project_id = ? AND status IN ('idle', 'queued', 'running', 'paused', 'waiting', 'failed')
+		WHERE project_id = ? AND status IN ('idle', 'queued', 'running', 'paused', 'waiting', 'failed', 'interrupted')
 	`, updatedAt, projectID)
 	if err != nil {
 		return 0, fmt.Errorf("terminate loops by project: %w", err)

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -1940,7 +1940,7 @@ func (r *QueueRepository) Complete(ctx context.Context, id, finishedAt string) e
 	_, err := r.q.ExecContext(ctx, `
 		UPDATE queue_items
 		SET status = 'completed', finished_at = ?, updated_at = ?
-		WHERE id = ?
+		WHERE id = ? AND status IN ('queued', 'running')
 	`, finishedAt, finishedAt, id)
 	if err != nil {
 		return fmt.Errorf("complete queue item: %w", err)
@@ -1997,7 +1997,7 @@ func (r *QueueRepository) Fail(ctx context.Context, input QueueFailInput) error 
 			last_error = ?,
 			last_error_kind = ?,
 			updated_at = ?
-		WHERE id = ?
+		WHERE id = ? AND status IN ('queued', 'running')
 	`, "manual_intervention", input.Attempts, input.Attempts, input.FinishedAt, input.ErrorMessage, input.ErrorKind, input.UpdatedAt, input.ID)
 	if err != nil {
 		return fmt.Errorf("fail queue item: %w", err)

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -673,6 +673,30 @@ func (r *LoopsRepository) CountByTypeAndStatus(ctx context.Context) (map[string]
 	return counts, nil
 }
 
+func (r *LoopsRepository) TerminateByProject(ctx context.Context, projectID, updatedAt string) (int64, error) {
+	if strings.TrimSpace(projectID) == "" {
+		return 0, nil
+	}
+
+	result, err := r.q.ExecContext(ctx, `
+		UPDATE loops
+		SET status = 'terminated',
+			next_run_at = NULL,
+			updated_at = ?
+		WHERE project_id = ? AND status IN ('idle', 'queued', 'running', 'paused', 'waiting')
+	`, updatedAt, projectID)
+	if err != nil {
+		return 0, fmt.Errorf("terminate loops by project: %w", err)
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read terminate loops by project rows affected: %w", err)
+	}
+
+	return affected, nil
+}
+
 type RunsRepository struct{ q sqliteQuerier }
 
 type AgentExecutionsRepository struct{ q sqliteQuerier }

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -683,7 +683,7 @@ func (r *LoopsRepository) TerminateByProject(ctx context.Context, projectID, upd
 		SET status = 'terminated',
 			next_run_at = NULL,
 			updated_at = ?
-		WHERE project_id = ? AND status IN ('idle', 'queued', 'running', 'paused', 'waiting')
+		WHERE project_id = ? AND status IN ('idle', 'queued', 'running', 'paused', 'waiting', 'failed')
 	`, updatedAt, projectID)
 	if err != nil {
 		return 0, fmt.Errorf("terminate loops by project: %w", err)
@@ -2244,7 +2244,7 @@ func (r *QueueRepository) CancelByProject(ctx context.Context, projectID, finish
 			finished_at = ?,
 			last_error = COALESCE(?, last_error),
 			updated_at = ?
-		WHERE project_id = ? AND status IN ('queued', 'running')
+		WHERE project_id = ? AND status IN ('queued', 'running', 'failed', 'manual_intervention')
 	`, finishedAt, reason, finishedAt, projectID)
 	if err != nil {
 		return 0, fmt.Errorf("cancel queue items by project: %w", err)

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+var ErrQueueItemNotActive = errors.New("queue item not active")
+
 type sqliteQuerier interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
@@ -1937,13 +1939,20 @@ func (r *QueueRepository) ClaimNextOfType(ctx context.Context, nowISO, claimedBy
 }
 
 func (r *QueueRepository) Complete(ctx context.Context, id, finishedAt string) error {
-	_, err := r.q.ExecContext(ctx, `
+	result, err := r.q.ExecContext(ctx, `
 		UPDATE queue_items
 		SET status = 'completed', finished_at = ?, updated_at = ?
 		WHERE id = ? AND status IN ('queued', 'running')
 	`, finishedAt, finishedAt, id)
 	if err != nil {
 		return fmt.Errorf("complete queue item: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read complete queue item rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("complete queue item: %w", ErrQueueItemNotActive)
 	}
 
 	return nil

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -479,15 +479,15 @@ func (r *ProjectsRepository) List(ctx context.Context) ([]ProjectRecord, error) 
 	return scanProjects(rows)
 }
 
-func (r *ProjectsRepository) Delete(ctx context.Context, id string) (bool, error) {
-	result, err := r.q.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, id)
+func (r *ProjectsRepository) Archive(ctx context.Context, id string, updatedAt string) (bool, error) {
+	result, err := r.q.ExecContext(ctx, `UPDATE projects SET archived = 1, updated_at = ? WHERE id = ? AND archived = 0`, updatedAt, id)
 	if err != nil {
-		return false, fmt.Errorf("delete project: %w", err)
+		return false, fmt.Errorf("archive project: %w", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return false, fmt.Errorf("delete project rows affected: %w", err)
+		return false, fmt.Errorf("archive project rows affected: %w", err)
 	}
 
 	return rowsAffected > 0, nil
@@ -2384,8 +2384,10 @@ const scheduledQueueBaseQuery = `
 	SELECT qi.*
 	FROM queue_items qi
 	LEFT JOIN loops l ON l.id = qi.loop_id
+	LEFT JOIN projects p ON p.id = qi.project_id
 	WHERE qi.status = 'queued'
 		AND qi.available_at <= ?
+		AND (qi.project_id IS NULL OR p.archived = 0)
 		AND COALESCE(l.status, 'queued') NOT IN ('paused', 'completed', 'failed', 'interrupted', 'terminated', 'stopped')
 		AND (
 			qi.lock_key IS NULL

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -1951,6 +1951,11 @@ func (r *QueueRepository) MarkRetry(ctx context.Context, input QueueMarkRetryInp
 			finished_at = NULL,
 			updated_at = ?
 		WHERE id = ?
+			AND NOT EXISTS (
+				SELECT 1
+				FROM projects p
+				WHERE p.id = queue_items.project_id AND p.archived = 1
+			)
 	`, input.AvailableAt, input.Attempts, input.ErrorMessage, input.ErrorKind, input.UpdatedAt, input.ID)
 	if err != nil {
 		return fmt.Errorf("mark queue item for retry: %w", err)
@@ -2199,6 +2204,31 @@ func (r *QueueRepository) CancelByLoop(ctx context.Context, loopID, finishedAt s
 	affected, err := result.RowsAffected()
 	if err != nil {
 		return 0, fmt.Errorf("read cancel queue items rows affected: %w", err)
+	}
+
+	return affected, nil
+}
+
+func (r *QueueRepository) CancelByProject(ctx context.Context, projectID, finishedAt string, reason *string) (int64, error) {
+	if strings.TrimSpace(projectID) == "" {
+		return 0, nil
+	}
+
+	result, err := r.q.ExecContext(ctx, `
+		UPDATE queue_items
+		SET status = 'cancelled',
+			finished_at = ?,
+			last_error = COALESCE(?, last_error),
+			updated_at = ?
+		WHERE project_id = ? AND status IN ('queued', 'running')
+	`, finishedAt, reason, finishedAt, projectID)
+	if err != nil {
+		return 0, fmt.Errorf("cancel queue items by project: %w", err)
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read cancel queue items by project rows affected: %w", err)
 	}
 
 	return affected, nil

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -1604,8 +1604,8 @@ func TestQueueTerminalWritersDoNotOverwriteCancelledProjectItems(t *testing.T) {
 		t.Fatalf("Queue.CancelByProject() error = %v", err)
 	}
 
-	if err := repos.Queue.Complete(ctx, "qi_cancelled_complete", "2026-04-11T12:02:00.000Z"); err != nil {
-		t.Fatalf("Queue.Complete() error = %v", err)
+	if err := repos.Queue.Complete(ctx, "qi_cancelled_complete", "2026-04-11T12:02:00.000Z"); !errors.Is(err, ErrQueueItemNotActive) {
+		t.Fatalf("Queue.Complete() error = %v, want ErrQueueItemNotActive", err)
 	}
 	failReason := "late failure"
 	if err := repos.Queue.Fail(ctx, QueueFailInput{ID: "qi_cancelled_fail", Attempts: 2, FinishedAt: "2026-04-11T12:02:30.000Z", ErrorMessage: &failReason, ErrorKind: "manual_intervention", UpdatedAt: "2026-04-11T12:02:30.000Z"}); err != nil {

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -1863,6 +1863,39 @@ func TestQueueClaimNextOfTypeSkipsTerminatedAndStoppedLoops(t *testing.T) {
 	}
 }
 
+func TestQueueClaimNextSkipsArchivedProjects(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	activeProjectID := "project_active"
+	archivedProjectID := "project_archived"
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: activeProjectID, Name: "Active", RepoPath: "/tmp/active", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert(active) error = %v", err)
+	}
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: archivedProjectID, Name: "Archived", RepoPath: "/tmp/archived", Archived: true, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert(archived) error = %v", err)
+	}
+	for index, tc := range []struct{ projectID, loopID, queueID string }{{archivedProjectID, "loop_archived", "queue_archived"}, {activeProjectID, "loop_active", "queue_active"}} {
+		if err := repos.Loops.Upsert(ctx, LoopRecord{ID: tc.loopID, Seq: int64(index + 1), ProjectID: tc.projectID, Type: "planner", TargetType: "project", Status: "running", CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", tc.loopID, err)
+		}
+		if err := repos.Queue.Upsert(ctx, QueueItemRecord{ID: tc.queueID, ProjectID: &tc.projectID, LoopID: &tc.loopID, Type: "planner", TargetType: "project", TargetID: tc.projectID, DedupeKey: tc.queueID, Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 1, CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", tc.queueID, err)
+		}
+	}
+
+	claimed, err := repos.Queue.ClaimNext(ctx, now, "scheduler")
+	if err != nil {
+		t.Fatalf("Queue.ClaimNext() error = %v", err)
+	}
+	if claimed == nil || claimed.ID != "queue_active" {
+		t.Fatalf("Queue.ClaimNext() = %#v, want queue_active", claimed)
+	}
+}
+
 func TestQueueStatsAndCleanupStaleQueued(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -1569,6 +1569,66 @@ func TestQueueRetryFailCompleteTransitions(t *testing.T) {
 	}
 }
 
+func TestQueueTerminalWritersDoNotOverwriteCancelledProjectItems(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	ctx := context.Background()
+	repos := NewRepositories(coordinator.DB())
+
+	now := "2026-04-11T12:00:00.000Z"
+	projectID := "project_archived"
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	loopID := "loop_archived"
+	if err := repos.Loops.Upsert(ctx, LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	claimedBy := "worker-a"
+	claimedAt := "2026-04-11T12:00:10.000Z"
+	for _, item := range []QueueItemRecord{
+		{ID: "qi_cancelled_complete", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "d_cancelled_complete", Priority: 1, Status: "running", AvailableAt: now, Attempts: 1, MaxAttempts: 3, ClaimedBy: &claimedBy, ClaimedAt: &claimedAt, StartedAt: &claimedAt, CreatedAt: now, UpdatedAt: claimedAt},
+		{ID: "qi_cancelled_fail", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "d_cancelled_fail", Priority: 1, Status: "running", AvailableAt: now, Attempts: 1, MaxAttempts: 3, ClaimedBy: &claimedBy, ClaimedAt: &claimedAt, StartedAt: &claimedAt, CreatedAt: now, UpdatedAt: claimedAt},
+	} {
+		if err := repos.Queue.Upsert(ctx, item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+
+	archivedAt := "2026-04-11T12:01:00.000Z"
+	reason := "project archived"
+	if _, err := repos.Queue.CancelByProject(ctx, projectID, archivedAt, &reason); err != nil {
+		t.Fatalf("Queue.CancelByProject() error = %v", err)
+	}
+
+	if err := repos.Queue.Complete(ctx, "qi_cancelled_complete", "2026-04-11T12:02:00.000Z"); err != nil {
+		t.Fatalf("Queue.Complete() error = %v", err)
+	}
+	failReason := "late failure"
+	if err := repos.Queue.Fail(ctx, QueueFailInput{ID: "qi_cancelled_fail", Attempts: 2, FinishedAt: "2026-04-11T12:02:30.000Z", ErrorMessage: &failReason, ErrorKind: "manual_intervention", UpdatedAt: "2026-04-11T12:02:30.000Z"}); err != nil {
+		t.Fatalf("Queue.Fail() error = %v", err)
+	}
+
+	for _, id := range []string{"qi_cancelled_complete", "qi_cancelled_fail"} {
+		item, err := repos.Queue.GetByID(ctx, id)
+		if err != nil {
+			t.Fatalf("Queue.GetByID(%s) error = %v", id, err)
+		}
+		if item == nil || item.Status != "cancelled" {
+			t.Fatalf("Queue.GetByID(%s) = %#v, want cancelled", id, item)
+		}
+		if item.FinishedAt == nil || *item.FinishedAt != archivedAt {
+			t.Fatalf("Queue.GetByID(%s).FinishedAt = %#v, want %q", id, item.FinishedAt, archivedAt)
+		}
+		if item.LastError == nil || *item.LastError != reason {
+			t.Fatalf("Queue.GetByID(%s).LastError = %#v, want %q", id, item.LastError, reason)
+		}
+	}
+}
+
 func TestTargetedListRepositories(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -3,6 +3,7 @@ package sweeper
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -354,6 +355,9 @@ func (r *Runner) ProcessClaimedQueueItem(ctx context.Context, queueItem storage.
 		return r.recoverClaimedQueueItem(ctx, queueItem, err)
 	}
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
+		if errors.Is(err, storage.ErrQueueItemNotActive) {
+			return &ProcessResult{QueueItemID: queueItem.ID, Status: outcomeCancelled, Summary: summary}, nil
+		}
 		return nil, err
 	}
 	return &ProcessResult{QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1090,7 +1090,14 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if _, err := r.completeRun(ctx, run, "success", summary, "", checkpoint); err != nil {
 		return ProcessResult{}, err
 	}
+	status := "success"
+	if checkpoint.SkipReason != "" {
+		status = "skipped"
+	}
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
+		if errors.Is(err, storage.ErrQueueItemNotActive) {
+			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary, PullRequestNumber: pullRequestNumber(checkpoint.PullRequest)}, nil
+		}
 		return ProcessResult{}, err
 	}
 	if _, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
@@ -1099,10 +1106,6 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		updated.NextRunAt = nil
 	}); err != nil {
 		return ProcessResult{}, err
-	}
-	status := "success"
-	if checkpoint.SkipReason != "" {
-		status = "skipped"
 	}
 	finalIssueClaimStatus := issueClaimStatusSuccess
 	if checkpoint.SkipReason != "" {
@@ -1210,6 +1213,9 @@ func (r *Runner) stopObsoleteResumedIssueRun(ctx context.Context, project storag
 			return ProcessResult{}, true, err
 		}
 		if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
+			if errors.Is(err, storage.ErrQueueItemNotActive) {
+				return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, true, nil
+			}
 			return ProcessResult{}, true, err
 		}
 		if _, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
@@ -2442,6 +2448,9 @@ func (r *Runner) updateLoop(ctx context.Context, loop storage.LoopRecord, mutate
 	current, err := r.repos.Loops.GetByID(ctx, loop.ID)
 	if err != nil {
 		return storage.LoopRecord{}, err
+	}
+	if current != nil && current.Status == "terminated" {
+		return *current, nil
 	}
 	updated := loop
 	if current != nil {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -3794,3 +3794,31 @@ func (*testLogger) Debug(string, map[string]any) {}
 func (*testLogger) Info(string, map[string]any)  {}
 func (*testLogger) Warn(string, map[string]any)  {}
 func (*testLogger) Error(string, map[string]any) {}
+
+func TestUpdateLoopPreservesTerminatedLoop(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{ID: "loop_worker_terminated", Seq: 901, ProjectID: "project_1", Type: "worker", TargetType: "project", TargetID: stringPtr("project_1"), Status: "terminated", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	runner := &Runner{repos: fixture.repos, now: fixture.now}
+	updated, err := runner.updateLoop(context.Background(), loop, func(current *storage.LoopRecord) {
+		current.Status = "completed"
+	})
+	if err != nil {
+		t.Fatalf("updateLoop() error = %v", err)
+	}
+	if updated.Status != "terminated" {
+		t.Fatalf("updateLoop().Status = %q, want terminated", updated.Status)
+	}
+
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if persisted == nil || persisted.Status != "terminated" {
+		t.Fatalf("Loops.GetByID() = %#v, want terminated loop", persisted)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #496.

Changes `looper project remove` from a destructive project-row delete into an archive/unregister operation:

- marks the project `archived=true` instead of deleting it
- preserves loops, runs, event logs, queue history, snapshots, executions, notifications, and worktrees
- hides archived projects from the public project list used by API/CLI
- treats archived projects as inactive for new planner/worker/loop work
- skips queued work for archived projects
- updates CLI wording to say the project is archived and history is preserved

## Authority / trade-off

Authority for active-project decisions is the persisted `projects.archived` field. This is not inferred from queue, loop, or history state; those records are retained as history, not used as lifecycle authority.

No new lifecycle concept or schema field was added. The trade-off is that archived rows remain in storage and must be filtered at active-project boundaries. That cost is smaller than hard-deleting history or adding a parallel tombstone table/state machine.

## Simpler alternative considered

Adding FK indexes would make the old hard-delete faster, but it would still destroy/detach history. This PR uses the existing archive field instead, then gates active flows consistently.

## Verification

- `go test ./internal/projects ./internal/storage ./internal/api ./internal/cliapp`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
