### PR TITLE
fix: streamline upgrade command output

### DIFF
--- a/internal/cliapp/download_test.go
+++ b/internal/cliapp/download_test.go
@@ -359,6 +359,12 @@ func TestUpgradeUnifiedDownloadsCLIAndDaemonConcurrently(t *testing.T) {
 		!strings.Contains(stdout.String(), "looperd 9.9.9") {
 		t.Fatalf("stdout = %q, want daemon install confirmation", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "looper daemon restart") {
+		t.Fatalf("stdout = %q, want restart hint", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Downloaded from ") {
+		t.Fatalf("stdout = %q, did not expect download URL noise", stdout.String())
+	}
 	if got := strings.Count(stderr.String(), "Downloading "); got != 2 {
 		t.Fatalf("stderr start line count = %d, want 2 compact start lines; stderr=%q", got, stderr.String())
 	}

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -1043,11 +1043,6 @@ func (r *commandRuntime) finishPreparedDaemonUpgrade(cmd *cobra.Command, prepare
 			return daemonUpgradeOutput{}, err
 		}
 	}
-	if output.DownloadedFrom != nil {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Downloaded from %s\n", *output.DownloadedFrom); err != nil {
-			return daemonUpgradeOutput{}, err
-		}
-	}
 	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Restart the daemon to use the new version:"); err != nil {
 		return daemonUpgradeOutput{}, err
 	}
@@ -1161,7 +1156,12 @@ func (r *commandRuntime) upgradeUnifiedConcurrent(cmd *cobra.Command) error {
 	daemonBuf := &bytes.Buffer{}
 
 	progressMux := newConcurrentProgressMux(cmd.ErrOrStderr())
-	defer progressMux.close()
+	progressClosed := false
+	defer func() {
+		if !progressClosed {
+			progressMux.close()
+		}
+	}()
 
 	cliCmd := mirrorCommandWithIO(cmd, cliBuf, progressMux)
 	daemonCmd := mirrorCommandWithIO(cmd, daemonBuf, progressMux)
@@ -1189,6 +1189,8 @@ func (r *commandRuntime) upgradeUnifiedConcurrent(cmd *cobra.Command) error {
 
 	cliRes := <-cliCh
 	daemonRes := <-daemonCh
+	progressMux.close()
+	progressClosed = true
 
 	// Surface CLI lane output, accepting refusal as a non-fatal outcome since
 	// non-release installs (Homebrew, dev builds, ...) deliberately reject
@@ -1208,12 +1210,6 @@ func (r *commandRuntime) upgradeUnifiedConcurrent(cmd *cobra.Command) error {
 		}
 	} else if !jsonOutput {
 		if _, err := cmd.OutOrStdout().Write(cliBuf.Bytes()); err != nil {
-			return err
-		}
-	}
-
-	if !jsonOutput {
-		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Proceeding with daemon upgrade..."); err != nil {
 			return err
 		}
 	}
@@ -1360,9 +1356,6 @@ func (r *commandRuntime) upgradeCLIWithOutput(cmd *cobra.Command, emitOutput boo
 		return cliUpgradeOutput{}, err
 	}
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Previous binary kept at %s\n", prevPath); err != nil {
-		return cliUpgradeOutput{}, err
-	}
-	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Downloaded from %s\n", asset.PreferredURL); err != nil {
 		return cliUpgradeOutput{}, err
 	}
 	return result, nil

--- a/internal/cliapp/upgrade_test.go
+++ b/internal/cliapp/upgrade_test.go
@@ -1141,11 +1141,17 @@ func TestUpgradeWithoutFlagsContinuesWithDaemonWhenCLISelfUpgradeRefused(t *test
 	if !strings.Contains(stdout.String(), "CLI self-upgrade skipped") {
 		t.Fatalf("stdout = %q, want CLI refusal guidance", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "Proceeding with daemon upgrade") {
-		t.Fatalf("stdout = %q, want daemon continuation note", stdout.String())
-	}
 	if !strings.Contains(stdout.String(), "Installed looperd 0.3.0") {
 		t.Fatalf("stdout = %q, want daemon install message", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "looper daemon restart") {
+		t.Fatalf("stdout = %q, want restart hint", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Proceeding with daemon upgrade") {
+		t.Fatalf("stdout = %q, did not expect duplicate daemon transition note", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Downloaded from ") {
+		t.Fatalf("stdout = %q, did not expect download URL noise", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove redundant human upgrade lines while keeping the manual daemon restart hint
- close the shared progress mux before flushing buffered output so finished progress bars do not render twice
- update upgrade tests to cover the streamlined stdout behavior

## Testing
- go test ./internal/cliapp
- go test ./...
- go build ./...