### PR TITLE
fix: keep retryable failures retrying

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -6004,10 +6004,7 @@ func isRetryableFailure(kind QueueFailureKind) bool {
 }
 
 func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {
-	if !isRetryableFailure(kind) {
-		return false
-	}
-	return maxAttempts <= 0 || nextAttempts < maxAttempts
+	return isRetryableFailure(kind)
 }
 
 func normalizePRState(value string) string {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -5145,16 +5145,16 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.FinishedAt == nil {
-		t.Fatalf("queue = %#v, want parked retryable_transient queue item after exhaustion", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.FinishedAt != nil {
+		t.Fatalf("queue = %#v, want requeued retryable_transient queue item after max attempts", queue)
 	}
 
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_fixer_resume_parse_status")
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want paused parked loop after exhaustion", loop)
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
+		t.Fatalf("loop = %#v, want queued loop after max attempts", loop)
 	}
 	if len(git.cleanupCalls) != 0 {
 		t.Fatalf("len(git.cleanupCalls) = %d, want no cleanup for manual intervention", len(git.cleanupCalls))

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -2123,10 +2123,7 @@ func isRetryableFailure(kind QueueFailureKind) bool {
 }
 
 func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {
-	if !isRetryableFailure(kind) {
-		return false
-	}
-	return maxAttempts <= 0 || nextAttempts < maxAttempts
+	return isRetryableFailure(kind)
 }
 
 func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4153,8 +4153,7 @@ func isRetryableTransientWithRemainingAttempts(queue storage.QueueItemRecord) bo
 }
 
 func queueHasRemainingAttempts(queue storage.QueueItemRecord) bool {
-	nextAttempts := queue.Attempts + 1
-	return queue.MaxAttempts > 0 && nextAttempts < queue.MaxAttempts
+	return true
 }
 
 func isKnownReviewerRediscoveryGuardrail(message string) bool {
@@ -6064,10 +6063,7 @@ func isRetryableFailure(kind QueueFailureKind) bool {
 }
 
 func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {
-	if !isRetryableFailure(kind) {
-		return false
-	}
-	return maxAttempts <= 0 || nextAttempts < maxAttempts
+	return isRetryableFailure(kind)
 }
 
 func cloneStrings(values []string) []string {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -445,7 +445,7 @@ func TestReviewerFailedLoopRecoveryEligibilityWhitelist(t *testing.T) {
 		{name: "retryable restart from discover", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
 		{name: "retryable transient attempts remaining", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureRetryableTransient), ErrorMessage: "reviewer agent timed out", QueueAttempts: 3, QueueMaxAttempts: 5}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
 		{name: "historical guardrail non retryable", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureNonRetryable), ErrorMessage: "review request removed before publish"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
-		{name: "retryable transient exhausted on final allowed run", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureRetryableTransient), ErrorMessage: "reviewer agent timed out", QueueAttempts: 4, QueueMaxAttempts: 5}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
+		{name: "retryable transient ignores final allowed run", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureRetryableTransient), ErrorMessage: "reviewer agent timed out", QueueAttempts: 4, QueueMaxAttempts: 5}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: true},
 		{name: "manual intervention kind", seed: failedReviewerRecoverySeed{ResumePolicy: "replay_step", QueueErrorKind: string(FailureManualIntervention), ErrorMessage: "operator needed"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 		{name: "manual intervention resume policy", seed: failedReviewerRecoverySeed{ResumePolicy: "manual_intervention", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "operator needed"}, pr: PullRequestSummary{Number: 42, State: "OPEN"}, want: false},
 		{name: "closed pr", seed: failedReviewerRecoverySeed{ResumePolicy: "restart_from_discover", QueueErrorKind: string(FailureRetryableAfterResume), ErrorMessage: "PR head changed before publish"}, pr: PullRequestSummary{Number: 42, State: "CLOSED"}, want: false},
@@ -6188,7 +6188,7 @@ func TestExecuteStepRetriesTransientDiscoverShellFailure(t *testing.T) {
 	}
 }
 
-func TestProcessClaimedItemPersistsExhaustedTransientDiscoverShellFailureAsRetryable(t *testing.T) {
+func TestProcessClaimedItemRequeuesTransientDiscoverShellFailureAfterMaxAttempts(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, RetryBaseDelay: time.Nanosecond, RetryMaxAttempts: 1})
@@ -6213,8 +6213,8 @@ func TestProcessClaimedItemPersistsExhaustedTransientDiscoverShellFailureAsRetry
 	if err != nil || queue == nil {
 		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queue, err)
 	}
-	if queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.LastError == nil || !strings.Contains(*queue.LastError, "unexpected EOF") || queue.FinishedAt == nil {
-		t.Fatalf("queue = %#v, want parked retryable transient item preserving GitHub error after exhaustion", queue)
+	if queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.LastError == nil || !strings.Contains(*queue.LastError, "unexpected EOF") || queue.FinishedAt != nil {
+		t.Fatalf("queue = %#v, want requeued retryable transient item preserving GitHub error after max attempts", queue)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -2703,8 +2703,7 @@ func runtimeRecoverableEnhancedTransient(policy config.ReviewerRetryConfig, queu
 }
 
 func runtimeQueueHasRemainingAttempts(queue storage.QueueItemRecord) bool {
-	nextAttempts := queue.Attempts + 1
-	return queue.MaxAttempts > 0 && nextAttempts < queue.MaxAttempts
+	return true
 }
 
 func autoRecoveredReviewerLoop(loop storage.LoopRecord, nowISO string) storage.LoopRecord {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3658,8 +3658,8 @@ func TestShouldAutoRecoverFailedReviewerLoopAllowsRetryableTransientWithAttempts
 		t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = false, want true")
 	}
 	queue.Attempts = 4
-	if shouldAutoRecoverFailedReviewerLoop(loop, &run, &queue, policy) {
-		t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = true, want false on final allowed run")
+	if !shouldAutoRecoverFailedReviewerLoop(loop, &run, &queue, policy) {
+		t.Fatalf("shouldAutoRecoverFailedReviewerLoop() = false, want true after max attempts")
 	}
 }
 
@@ -3686,8 +3686,8 @@ func TestShouldAutoRecoverFailedReviewerLoopAllowsEnhancedMatchedTransientWhenCo
 		t.Fatal("shouldAutoRecoverFailedReviewerLoop(enabled) = false, want true")
 	}
 	queue.Attempts = 4
-	if shouldAutoRecoverFailedReviewerLoop(loop, &run, &queue, enabledPolicy) {
-		t.Fatal("shouldAutoRecoverFailedReviewerLoop(enabled final attempt) = true, want false")
+	if !shouldAutoRecoverFailedReviewerLoop(loop, &run, &queue, enabledPolicy) {
+		t.Fatal("shouldAutoRecoverFailedReviewerLoop(enabled final attempt) = false, want true")
 	}
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1773,7 +1773,7 @@ func failSnapshotQueueItem(ctx context.Context, item storage.QueueItemRecord, in
 	}
 	nowISO := formatJavaScriptISOString(now().UTC())
 	nextAttempts := item.Attempts + 1
-	if kind == "retryable_transient" && nextAttempts < item.MaxAttempts {
+	if kind == "retryable_transient" {
 		retryAt := formatJavaScriptISOString(now().UTC().Add(time.Minute * time.Duration(cappedRetryDelayAttempt(nextAttempts, item.MaxAttempts))))
 		return input.Repos.Queue.MarkRetry(ctx, storage.QueueMarkRetryInput{ID: item.ID, AvailableAt: retryAt, Attempts: nextAttempts, ErrorMessage: &message, ErrorKind: kind, UpdatedAt: nowISO})
 	}

--- a/internal/sweeper/runner.go
+++ b/internal/sweeper/runner.go
@@ -381,10 +381,7 @@ func (r *Runner) recoverClaimedQueueItem(ctx context.Context, queueItem storage.
 }
 
 func shouldRetryQueueFailure(kind string, nextAttempts, maxAttempts int64) bool {
-	if kind != "retryable_transient" {
-		return false
-	}
-	return maxAttempts <= 0 || nextAttempts < maxAttempts
+	return kind == "retryable_transient"
 }
 
 func cappedRetryDelayAttempt(attempts, maxAttempts int64) int64 {

--- a/internal/sweeper/runner_test.go
+++ b/internal/sweeper/runner_test.go
@@ -1502,7 +1502,7 @@ func TestProcessWarnRecoversAfterCommentPostedButLabelFails(t *testing.T) {
 	}
 }
 
-func TestProcessWarnFailsQueueItemAfterMaxAttempts(t *testing.T) {
+func TestProcessWarnRequeuesRetryableFailureAfterMaxAttempts(t *testing.T) {
 	t.Parallel()
 
 	fixture := newRunnerFixture(t)
@@ -1525,8 +1525,8 @@ func TestProcessWarnFailsQueueItemAfterMaxAttempts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if stored == nil || stored.Status != "manual_intervention" || stored.Attempts != 3 || stored.FinishedAt == nil || stored.LastErrorKind == nil || *stored.LastErrorKind != "retryable_transient" {
-		t.Fatalf("stored queue item = %#v, want parked queue item after max attempts", stored)
+	if stored == nil || stored.Status != "queued" || stored.Attempts != 3 || stored.FinishedAt != nil || stored.LastErrorKind == nil || *stored.LastErrorKind != "retryable_transient" {
+		t.Fatalf("stored queue item = %#v, want requeued queue item after max attempts", stored)
 	}
 }
 

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -2668,10 +2668,7 @@ func shouldNotifyCompletedRun(kind QueueFailureKind, failedQueue *storage.QueueI
 }
 
 func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {
-	if kind != FailureRetryableTransient && kind != FailureRetryableAfterResume {
-		return false
-	}
-	return maxAttempts <= 0 || nextAttempts < maxAttempts
+	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume
 }
 
 func issueClaimStatusForFailure(checkpoint workerCheckpoint, failedQueue *storage.QueueItemRecord, kind QueueFailureKind) string {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1025,16 +1025,16 @@ func TestProcessClaimedQueueItemResumeValidationFailureUpdatesLoopState(t *testi
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.FinishedAt == nil {
-		t.Fatalf("queue = %#v, want parked retryable_transient queue item after max attempts", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) || queue.FinishedAt != nil {
+		t.Fatalf("queue = %#v, want requeued retryable_transient queue item after max attempts", queue)
 	}
 
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if loop == nil || loop.Status != "paused" || loop.NextRunAt != nil {
-		t.Fatalf("loop = %#v, want paused loop after max attempts", loop)
+	if loop == nil || loop.Status != "queued" || loop.NextRunAt == nil {
+		t.Fatalf("loop = %#v, want queued loop after max attempts", loop)
 	}
 }
 


### PR DESCRIPTION
Summary
- Remove maxAttempts as a stop condition for retryable queue failures across reviewer, fixer, worker, planner, sweeper, and snapshot queue paths.
- Allow runtime and reviewer recovery to requeue retryable legacy failed rows even when their historical attempts reached maxAttempts.
- Update regression coverage so retryable failures remain queued/backing off after the old cap, while non-retryable and explicit manual-intervention paths still park.

Why
- Retryable failures such as PR head drift, transient GitHub/API failures, and agent timeouts were still ending in manual_intervention once attempts reached maxAttempts. That made recoverable loops stop until an operator retried them manually.

Authority and trade-off
- Authority for retry remains the structured failure kind on the queue item: only retryable_transient and retryable_after_resume continue automatically.
- Cost: a persistently retryable failure can now retry indefinitely, consuming queue slots and agent time. Existing capped backoff is retained so delay does not grow without bound, and manual_intervention/non_retryable failures remain terminal.
- A simpler operator-only retry is insufficient because these failures are explicitly classified as retryable and often resolve through external drift, API recovery, or subsequent PR updates.

Validation
- go test ./internal/reviewer ./internal/fixer ./internal/worker ./internal/planner ./internal/sweeper ./internal/runtime
- go test ./...
- go vet ./...
- go build ./...