### PR TITLE
feat: add synclo inbox webhook mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,10 +42,11 @@ For runtime deployment details — container image, required environment variabl
 
 ## Webhook delivery modes
 
-`webhook.enabled=true` supports two delivery modes:
+`webhook.enabled=true` supports three delivery modes:
 
 - `gh-forward` (default): Looper starts `gh webhook forward` against each configured repo and receives deliveries on the daemon API route `/webhook/forward`.
 - `tunnel`: Looper creates an ordinary GitHub repository webhook per repo and expects the user to run a tunnel to `127.0.0.1:<webhook.listenPort>`.
+- `synclo-inbox`: Looper polls an existing synclo webhook inbox and forwards unacked GitHub deliveries into the same local webhook queue used by the other modes.
 
 Tunnel-mode example:
 
@@ -69,6 +70,26 @@ repoPath = "/Users/me/src/private"
 [projects.webhook]
 mode = "gh-forward"
 ```
+
+Synclo inbox example:
+
+```toml
+[webhook]
+enabled = true
+mode = "synclo-inbox"
+fallbackPollIntervalSeconds = 300
+
+[webhook.synclo]
+baseUrl = "https://dashboard.nexu.space"
+consumer = "looper-my-node"
+secretEnv = "SYNC_HMAC_SECRET"
+limit = 100
+pollIntervalSeconds = 5
+```
+
+The `consumer` value is the synclo cursor identity. Keep it stable across daemon restarts and config edits; changing it creates a new consumer and may replay the inbox retention window. `secretEnv` names the environment variable that holds the shared synclo HMAC secret. Looper signs `GET /webhook/pending` with `HMAC(secret, "GET " + requestURI)` and signs `POST /webhook/ack` with `HMAC(secret, rawBody)`.
+
+Synclo inbox delivery is a latency path, not the workflow authority. Looper still keeps GitHub polling enabled as correctness fallback and drift recovery when webhook delivery is missed or delayed.
 
 Rules:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -580,6 +580,10 @@ looper webhook delete owner/repo --confirm
 - `rotate` changes the per-repo HMAC secret and updates the existing hook by id.
 - `delete --confirm` is the only command that removes a Looper-managed tunnel hook from GitHub.
 
+In `synclo-inbox` mode Looper polls a shared synclo webhook inbox and feeds deliveries into the same local webhook queue. Configure a stable `webhook.synclo.consumer`; changing the consumer name creates a new synclo cursor and can replay recent retained events. The HMAC secret is read from the environment variable named by `webhook.synclo.secretEnv`.
+
+Synclo inbox mode reduces the need for low-latency GitHub discovery polling, but it does not make GitHub polling disappear. Polling remains the correctness fallback for missed webhook deliveries, stale state, and workflows that are still discovery-driven.
+
 ## 17. One important clarification
 
 In the current implementation, "automatic triggering" is closer to:

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -240,7 +240,14 @@
             "mode": "gh-forward",
             "listenPort": 0,
             "publicBaseUrl": "",
-            "fallbackPollIntervalSeconds": 300
+            "fallbackPollIntervalSeconds": 300,
+            "synclo": {
+              "baseUrl": "",
+              "consumer": "",
+              "limit": 100,
+              "pollIntervalSeconds": 5,
+              "secretEnv": "SYNC_HMAC_SECRET"
+            }
           },
           "agent": {
             "env": {},

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -87,6 +87,13 @@ func DefaultConfig(cwd string) (Config, error) {
 			ListenPort:                  0,
 			PublicBaseURL:               "",
 			FallbackPollIntervalSeconds: 300,
+			Synclo: SyncloWebhookConfig{
+				BaseURL:             "",
+				Consumer:            "",
+				SecretEnv:           "SYNC_HMAC_SECRET",
+				Limit:               100,
+				PollIntervalSeconds: 5,
+			},
 		},
 		Network: NetworkConfig{},
 		Agent: AgentConfig{

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -371,6 +371,28 @@ func mergeWebhookConfig(config *WebhookConfig, partial PartialWebhookConfig) {
 	if partial.FallbackPollIntervalSeconds != nil {
 		config.FallbackPollIntervalSeconds = *partial.FallbackPollIntervalSeconds
 	}
+
+	if partial.Synclo != nil {
+		mergeSyncloWebhookConfig(&config.Synclo, *partial.Synclo)
+	}
+}
+
+func mergeSyncloWebhookConfig(config *SyncloWebhookConfig, partial PartialSyncloWebhookConfig) {
+	if partial.BaseURL != nil {
+		config.BaseURL = *partial.BaseURL
+	}
+	if partial.Consumer != nil {
+		config.Consumer = *partial.Consumer
+	}
+	if partial.SecretEnv != nil {
+		config.SecretEnv = *partial.SecretEnv
+	}
+	if partial.Limit != nil {
+		config.Limit = *partial.Limit
+	}
+	if partial.PollIntervalSeconds != nil {
+		config.PollIntervalSeconds = *partial.PollIntervalSeconds
+	}
 }
 
 func mergeNetworkConfig(config *NetworkConfig, partial PartialNetworkConfig) {

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -102,7 +102,14 @@
         "fallbackPollIntervalSeconds": 300,
         "listenPort": 0,
         "mode": "gh-forward",
-        "publicBaseUrl": ""
+        "publicBaseUrl": "",
+        "synclo": {
+          "baseUrl": "",
+          "consumer": "",
+          "limit": 100,
+          "pollIntervalSeconds": 5,
+          "secretEnv": "SYNC_HMAC_SECRET"
+        }
       },
       "network": {
         "enrolled": false,

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -42,7 +42,14 @@
         "fallbackPollIntervalSeconds": 300,
         "listenPort": 0,
         "mode": "gh-forward",
-        "publicBaseUrl": ""
+        "publicBaseUrl": "",
+        "synclo": {
+          "baseUrl": "",
+          "consumer": "",
+          "limit": 100,
+          "pollIntervalSeconds": 5,
+          "secretEnv": "SYNC_HMAC_SECRET"
+        }
       },
       "network": {
         "enrolled": false,

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -121,7 +121,14 @@
         "fallbackPollIntervalSeconds": 300,
         "listenPort": 0,
         "mode": "gh-forward",
-        "publicBaseUrl": ""
+        "publicBaseUrl": "",
+        "synclo": {
+          "baseUrl": "",
+          "consumer": "",
+          "limit": 100,
+          "pollIntervalSeconds": 5,
+          "secretEnv": "SYNC_HMAC_SECRET"
+        }
       },
       "network": {
         "enrolled": false,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -158,18 +158,28 @@ type SchedulerConfig struct {
 }
 
 type WebhookConfig struct {
-	Enabled                     bool        `json:"enabled"`
-	Mode                        WebhookMode `json:"mode"`
-	ListenPort                  int         `json:"listenPort"`
-	PublicBaseURL               string      `json:"publicBaseUrl"`
-	FallbackPollIntervalSeconds int         `json:"fallbackPollIntervalSeconds"`
+	Enabled                     bool                `json:"enabled"`
+	Mode                        WebhookMode         `json:"mode"`
+	ListenPort                  int                 `json:"listenPort"`
+	PublicBaseURL               string              `json:"publicBaseUrl"`
+	FallbackPollIntervalSeconds int                 `json:"fallbackPollIntervalSeconds"`
+	Synclo                      SyncloWebhookConfig `json:"synclo"`
+}
+
+type SyncloWebhookConfig struct {
+	BaseURL             string `json:"baseUrl"`
+	Consumer            string `json:"consumer"`
+	SecretEnv           string `json:"secretEnv"`
+	Limit               int    `json:"limit"`
+	PollIntervalSeconds int    `json:"pollIntervalSeconds"`
 }
 
 type WebhookMode string
 
 const (
-	WebhookModeGHForward WebhookMode = "gh-forward"
-	WebhookModeTunnel    WebhookMode = "tunnel"
+	WebhookModeGHForward   WebhookMode = "gh-forward"
+	WebhookModeTunnel      WebhookMode = "tunnel"
+	WebhookModeSyncloInbox WebhookMode = "synclo-inbox"
 )
 
 type AgentConfig struct {
@@ -585,11 +595,20 @@ type PartialSchedulerConfig struct {
 }
 
 type PartialWebhookConfig struct {
-	Enabled                     *bool        `json:"enabled,omitempty"`
-	Mode                        *WebhookMode `json:"mode,omitempty"`
-	ListenPort                  *int         `json:"listenPort,omitempty"`
-	PublicBaseURL               *string      `json:"publicBaseUrl,omitempty"`
-	FallbackPollIntervalSeconds *int         `json:"fallbackPollIntervalSeconds,omitempty"`
+	Enabled                     *bool                       `json:"enabled,omitempty"`
+	Mode                        *WebhookMode                `json:"mode,omitempty"`
+	ListenPort                  *int                        `json:"listenPort,omitempty"`
+	PublicBaseURL               *string                     `json:"publicBaseUrl,omitempty"`
+	FallbackPollIntervalSeconds *int                        `json:"fallbackPollIntervalSeconds,omitempty"`
+	Synclo                      *PartialSyncloWebhookConfig `json:"synclo,omitempty"`
+}
+
+type PartialSyncloWebhookConfig struct {
+	BaseURL             *string `json:"baseUrl,omitempty"`
+	Consumer            *string `json:"consumer,omitempty"`
+	SecretEnv           *string `json:"secretEnv,omitempty"`
+	Limit               *int    `json:"limit,omitempty"`
+	PollIntervalSeconds *int    `json:"pollIntervalSeconds,omitempty"`
 }
 
 type PartialAgentConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -99,10 +99,13 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 		issues = append(issues, ValidationIssue{Path: "webhook.fallbackPollIntervalSeconds", Message: "must be an integer >= 60"})
 	}
 	if !isValidWebhookMode(config.Webhook.Mode) {
-		issues = append(issues, ValidationIssue{Path: "webhook.mode", Message: fmt.Sprintf("must be one of: %s, %s", WebhookModeGHForward, WebhookModeTunnel)})
+		issues = append(issues, ValidationIssue{Path: "webhook.mode", Message: fmt.Sprintf("must be one of: %s, %s, %s", WebhookModeGHForward, WebhookModeTunnel, WebhookModeSyncloInbox)})
 	}
 	if config.Webhook.Enabled && webhookModeRequiresTunnelConfig(config, nil) {
 		validateWebhookTunnelConfig(config.Webhook, "webhook", &issues)
+	}
+	if config.Webhook.Enabled && webhookModeUsesSyncloInbox(config) {
+		validateSyncloWebhookConfig(config.Webhook.Synclo, "webhook.synclo", &issues)
 	}
 
 	if config.Agent.Vendor != nil && !isValidAgentVendor(*config.Agent.Vendor) {
@@ -266,7 +269,7 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 			issues = append(issues, ValidationIssue{Path: prefix + ".path", Message: "must match repoPath when both path and repoPath are set"})
 		}
 		if !isValidWebhookModeOrEmpty(project.Webhook.Mode) {
-			issues = append(issues, ValidationIssue{Path: prefix + ".webhook.mode", Message: fmt.Sprintf("must be one of: %s, %s", WebhookModeGHForward, WebhookModeTunnel)})
+			issues = append(issues, ValidationIssue{Path: prefix + ".webhook.mode", Message: fmt.Sprintf("must be one of: %s, %s, %s", WebhookModeGHForward, WebhookModeTunnel, WebhookModeSyncloInbox)})
 		}
 		if !isValidNetworkMode(project.Network.Mode) {
 			issues = append(issues, ValidationIssue{Path: prefix + ".network.mode", Message: fmt.Sprintf("must be one of: %s, %s", NetworkModeOff, NetworkModeRouted)})
@@ -411,6 +414,36 @@ func webhookModeRequiresTunnelConfig(config Config, project *ProjectRefConfig) b
 		mode = project.Webhook.Mode
 	}
 	return mode == WebhookModeTunnel
+}
+
+func webhookModeUsesSyncloInbox(config Config) bool {
+	if config.Webhook.Mode == WebhookModeSyncloInbox {
+		return true
+	}
+	for _, project := range config.Projects {
+		if project.Webhook.Mode == WebhookModeSyncloInbox {
+			return true
+		}
+	}
+	return false
+}
+
+func validateSyncloWebhookConfig(config SyncloWebhookConfig, prefix string, issues *[]ValidationIssue) {
+	if strings.TrimSpace(config.BaseURL) == "" {
+		*issues = append(*issues, ValidationIssue{Path: prefix + ".baseUrl", Message: "must be non-empty when webhook.mode is synclo-inbox"})
+	}
+	if strings.TrimSpace(config.Consumer) == "" {
+		*issues = append(*issues, ValidationIssue{Path: prefix + ".consumer", Message: "must be a stable non-empty consumer name when webhook.mode is synclo-inbox"})
+	}
+	if strings.TrimSpace(config.SecretEnv) == "" {
+		*issues = append(*issues, ValidationIssue{Path: prefix + ".secretEnv", Message: "must name an environment variable containing the synclo HMAC secret"})
+	}
+	if config.Limit < 1 || config.Limit > 200 {
+		*issues = append(*issues, ValidationIssue{Path: prefix + ".limit", Message: "must be an integer between 1 and 200"})
+	}
+	if config.PollIntervalSeconds < 1 {
+		*issues = append(*issues, ValidationIssue{Path: prefix + ".pollIntervalSeconds", Message: "must be a positive integer"})
+	}
 }
 
 func validateAgentTimeouts(timeouts AgentTimeoutConfig, path string, issues *[]ValidationIssue) {
@@ -752,7 +785,7 @@ func isValidAddSnapshotMode(mode AddSnapshotMode) bool {
 
 func isValidWebhookMode(mode WebhookMode) bool {
 	switch mode {
-	case WebhookModeGHForward, WebhookModeTunnel:
+	case WebhookModeGHForward, WebhookModeTunnel, WebhookModeSyncloInbox:
 		return true
 	default:
 		return false

--- a/internal/config/webhook_config_test.go
+++ b/internal/config/webhook_config_test.go
@@ -24,6 +24,9 @@ func TestDefaultConfigDisablesWebhookMode(t *testing.T) {
 	if cfg.Webhook.PublicBaseURL != "" {
 		t.Fatalf("DefaultConfig().Webhook.PublicBaseURL = %q, want empty", cfg.Webhook.PublicBaseURL)
 	}
+	if cfg.Webhook.Synclo.SecretEnv != "SYNC_HMAC_SECRET" || cfg.Webhook.Synclo.Limit != 100 || cfg.Webhook.Synclo.PollIntervalSeconds != 5 {
+		t.Fatalf("DefaultConfig().Webhook.Synclo = %#v, want default secret env, limit, and poll interval", cfg.Webhook.Synclo)
+	}
 }
 
 func TestValidateRejectsWebhookFallbackBelowMinimum(t *testing.T) {
@@ -80,6 +83,30 @@ func TestValidateRequiresTunnelSettingsForGlobalTunnelMode(t *testing.T) {
 	}
 	if len(validationErr.Issues) != 2 {
 		t.Fatalf("Validate() issues = %#v, want tunnel listen/public issues", validationErr.Issues)
+	}
+}
+
+func TestValidateRequiresSyncloSettingsForGlobalSyncloMode(t *testing.T) {
+	t.Parallel()
+	cfg, err := DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Webhook.Enabled = true
+	cfg.Webhook.Mode = WebhookModeSyncloInbox
+	err = Validate(cfg)
+	validationErr, ok := err.(*ConfigValidationError)
+	if !ok {
+		t.Fatalf("Validate() error = %T, want *ConfigValidationError", err)
+	}
+	if len(validationErr.Issues) != 2 {
+		t.Fatalf("Validate() issues = %#v, want baseUrl and consumer issues", validationErr.Issues)
+	}
+
+	cfg.Webhook.Synclo.BaseURL = "https://dashboard.nexu.space"
+	cfg.Webhook.Synclo.Consumer = "looper-node"
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("Validate() with synclo settings error = %v, want nil", err)
 	}
 }
 

--- a/internal/runtime/webhook.go
+++ b/internal/runtime/webhook.go
@@ -48,6 +48,21 @@ type WebhookStatus struct {
 	RecentOutcomes              []WebhookRecentOutcome  `json:"recentOutcomes"`
 	Forwarders                  []WebhookForwarderState `json:"forwarders"`
 	TunnelHooks                 []WebhookTunnelState    `json:"tunnelHooks"`
+	SyncloInbox                 WebhookSyncloInboxState `json:"syncloInbox"`
+}
+
+type WebhookSyncloInboxState struct {
+	Enabled        bool   `json:"enabled"`
+	Running        bool   `json:"running"`
+	BaseURL        string `json:"baseUrl,omitempty"`
+	Consumer       string `json:"consumer,omitempty"`
+	Limit          int    `json:"limit,omitempty"`
+	LastPollAt     string `json:"lastPollAt,omitempty"`
+	LastAckAt      string `json:"lastAckAt,omitempty"`
+	LastError      string `json:"lastError,omitempty"`
+	PendingFetched int    `json:"pendingFetched"`
+	Forwarded      int    `json:"forwarded"`
+	Acked          int    `json:"acked"`
 }
 
 type WebhookTunnelState struct {
@@ -122,6 +137,8 @@ type webhookRuntime struct {
 	forwarder          func() WebhookForwarder
 	tunnelServer       *webhookTunnelServer
 	bootstrapDone      bool
+	syncloStarted      bool
+	syncloStopCh       chan struct{}
 }
 
 func newWebhookRuntime(cfg config.Config, logger bootstrap.Logger, now func() time.Time) *webhookRuntime {
@@ -143,6 +160,7 @@ func newWebhookRuntime(cfg config.Config, logger bootstrap.Logger, now func() ti
 		RecentOutcomes:              []WebhookRecentOutcome{},
 		Forwarders:                  []WebhookForwarderState{},
 		TunnelHooks:                 []WebhookTunnelState{},
+		SyncloInbox:                 WebhookSyncloInboxState{Enabled: cfg.Webhook.Enabled && wModeNeedsSyncloInbox(cfg), BaseURL: strings.TrimRight(strings.TrimSpace(cfg.Webhook.Synclo.BaseURL), "/"), Consumer: strings.TrimSpace(cfg.Webhook.Synclo.Consumer), Limit: cfg.Webhook.Synclo.Limit},
 	}
 	rt := &webhookRuntime{cfg: cfg, logger: logger, now: now, ghPath: strings.TrimSpace(derefString(cfg.Tools.GHPath)), status: status, stopCh: make(chan struct{}), forwarderStopCh: map[string]chan struct{}{}, allowedTunnelRepos: map[string]struct{}{}, daemonID: newDaemonID(), probe: defaultProcessProbe{}}
 	if !cfg.Webhook.Enabled {
@@ -290,6 +308,7 @@ func (w *webhookRuntime) Reconcile(repos *storage.Repositories) error {
 	w.clearTransientReconcileDegradedReasons()
 	forwarderRepoSet := map[string]struct{}{}
 	tunnelRepoSet := map[string]struct{}{}
+	syncloRepoSet := map[string]struct{}{}
 	for _, project := range projects {
 		if project.Archived {
 			continue
@@ -301,6 +320,8 @@ func (w *webhookRuntime) Reconcile(repos *storage.Repositories) error {
 		switch w.webhookModeForProject(project.ID) {
 		case config.WebhookModeTunnel:
 			tunnelRepoSet[repo] = struct{}{}
+		case config.WebhookModeSyncloInbox:
+			syncloRepoSet[repo] = struct{}{}
 		default:
 			forwarderRepoSet[repo] = struct{}{}
 		}
@@ -311,12 +332,25 @@ func (w *webhookRuntime) Reconcile(repos *storage.Repositories) error {
 			delete(tunnelRepoSet, repo)
 			w.addDegradedReason(fmt.Sprintf("webhook mode conflict for %s: repo is configured for both gh-forward and tunnel", repo))
 		}
+		if _, ok := syncloRepoSet[repo]; ok {
+			delete(forwarderRepoSet, repo)
+			delete(syncloRepoSet, repo)
+			w.addDegradedReason(fmt.Sprintf("webhook mode conflict for %s: repo is configured for both gh-forward and synclo-inbox", repo))
+		}
+	}
+	for repo := range tunnelRepoSet {
+		if _, ok := syncloRepoSet[repo]; ok {
+			delete(tunnelRepoSet, repo)
+			delete(syncloRepoSet, repo)
+			w.addDegradedReason(fmt.Sprintf("webhook mode conflict for %s: repo is configured for both tunnel and synclo-inbox", repo))
+		}
 	}
 	if err := w.reconcileTunnelHooks(context.Background(), repos, tunnelRepoSet); err != nil {
 		return err
 	}
+	w.reconcileSyncloInbox(syncloRepoSet)
 	launchRepos := w.reconcileForwarders(forwarderRepoSet)
-	if len(forwarderRepoSet)+len(tunnelRepoSet) == 0 {
+	if len(forwarderRepoSet)+len(tunnelRepoSet)+len(syncloRepoSet) == 0 {
 		w.addDegradedReason(noConfiguredWebhookReposReason)
 		return nil
 	}

--- a/internal/runtime/webhook_synclo.go
+++ b/internal/runtime/webhook_synclo.go
@@ -1,0 +1,292 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/webhookforward"
+)
+
+const syncloInboxHTTPTimeout = 10 * time.Second
+
+type syncloPendingResponse struct {
+	OK       bool               `json:"ok"`
+	Consumer string             `json:"consumer"`
+	Count    int                `json:"count"`
+	Events   []syncloInboxEvent `json:"events"`
+}
+
+type syncloInboxEvent struct {
+	DeliveryID   string `json:"delivery_id"`
+	EventType    string `json:"event_type"`
+	Action       string `json:"action"`
+	Repo         string `json:"repo"`
+	EntityNumber int64  `json:"entity_number"`
+	PayloadJSON  string `json:"payload_json"`
+	Signature    string `json:"signature"`
+	ReceivedAt   string `json:"received_at"`
+}
+
+type syncloAckRequest struct {
+	DeliveryIDs  []string `json:"delivery_ids"`
+	ConsumerName string   `json:"consumer_name"`
+}
+
+func (w *webhookRuntime) reconcileSyncloInbox(repoSet map[string]struct{}) {
+	w.mu.Lock()
+	w.status.SyncloInbox.Enabled = len(repoSet) > 0
+	w.status.SyncloInbox.BaseURL = strings.TrimRight(strings.TrimSpace(w.cfg.Webhook.Synclo.BaseURL), "/")
+	w.status.SyncloInbox.Consumer = strings.TrimSpace(w.cfg.Webhook.Synclo.Consumer)
+	w.status.SyncloInbox.Limit = w.cfg.Webhook.Synclo.Limit
+	if len(repoSet) == 0 {
+		if w.syncloStarted && w.syncloStopCh != nil {
+			close(w.syncloStopCh)
+			w.syncloStopCh = nil
+		}
+		w.syncloStarted = false
+		w.status.SyncloInbox.Running = false
+		w.mu.Unlock()
+		return
+	}
+	if w.syncloStarted {
+		w.mu.Unlock()
+		return
+	}
+	w.syncloStarted = true
+	stopCh := make(chan struct{})
+	w.syncloStopCh = stopCh
+	w.status.SyncloInbox.Running = true
+	w.mu.Unlock()
+
+	w.wg.Add(1)
+	go w.runSyncloInboxLoop(stopCh)
+}
+
+func (w *webhookRuntime) runSyncloInboxLoop(stopCh <-chan struct{}) {
+	defer w.wg.Done()
+	cfg := w.cfg.Webhook.Synclo
+	interval := time.Duration(cfg.PollIntervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	client := &http.Client{Timeout: syncloInboxHTTPTimeout}
+
+	for {
+		w.pollSyncloInbox(context.Background(), client, cfg)
+		select {
+		case <-w.stopCh:
+			w.setSyncloRunning(false)
+			return
+		case <-stopCh:
+			w.setSyncloRunning(false)
+			return
+		case <-time.After(interval):
+		}
+	}
+}
+
+func (w *webhookRuntime) pollSyncloInbox(ctx context.Context, client *http.Client, cfg config.SyncloWebhookConfig) {
+	secret := os.Getenv(strings.TrimSpace(cfg.SecretEnv))
+	if secret == "" {
+		w.setSyncloError(fmt.Sprintf("synclo secret environment variable %s is empty", strings.TrimSpace(cfg.SecretEnv)))
+		return
+	}
+	response, err := fetchSyncloPending(ctx, client, cfg, secret)
+	if err != nil {
+		w.setSyncloError(err.Error())
+		return
+	}
+	w.recordSyncloPoll(len(response.Events))
+	if len(response.Events) == 0 {
+		w.clearSyncloError()
+		return
+	}
+	forwarder := w.forwarder
+	if forwarder == nil {
+		w.setSyncloError("webhook forwarder is unavailable")
+		return
+	}
+	target := forwarder()
+	if target == nil {
+		w.setSyncloError("webhook forwarder is unavailable")
+		return
+	}
+	delivered := make([]string, 0, len(response.Events))
+	for _, event := range response.Events {
+		deliveryID := strings.TrimSpace(event.DeliveryID)
+		eventType := strings.TrimSpace(event.EventType)
+		if deliveryID == "" || eventType == "" {
+			continue
+		}
+		result, err := target.Forward(ctx, webhookforward.DeliveryRequest{
+			DeliveryID: deliveryID,
+			EventType:  eventType,
+			Payload:    []byte(event.PayloadJSON),
+		})
+		if err != nil {
+			w.setSyncloError(fmt.Sprintf("forward synclo delivery %s: %v", deliveryID, err))
+			continue
+		}
+		if w.logger != nil {
+			w.logger.Info("webhook.synclo.forwarded", map[string]any{"deliveryId": deliveryID, "eventType": eventType, "status": result.Status, "workItems": result.WorkItems})
+		}
+		delivered = append(delivered, deliveryID)
+		w.recordSyncloForwarded(1)
+	}
+	if len(delivered) == 0 {
+		return
+	}
+	if err := ackSyncloDeliveries(ctx, client, cfg, secret, delivered); err != nil {
+		w.setSyncloError(err.Error())
+		return
+	}
+	w.recordSyncloAck(len(delivered))
+	w.clearSyncloError()
+}
+
+func fetchSyncloPending(ctx context.Context, client *http.Client, cfg config.SyncloWebhookConfig, secret string) (syncloPendingResponse, error) {
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	if baseURL == "" {
+		return syncloPendingResponse{}, fmt.Errorf("synclo base URL is empty")
+	}
+	pendingURL, err := url.Parse(baseURL + "/webhook/pending")
+	if err != nil {
+		return syncloPendingResponse{}, fmt.Errorf("parse synclo pending URL: %w", err)
+	}
+	query := pendingURL.Query()
+	query.Set("consumer", strings.TrimSpace(cfg.Consumer))
+	query.Set("limit", fmt.Sprintf("%d", cfg.Limit))
+	pendingURL.RawQuery = query.Encode()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, pendingURL.String(), nil)
+	if err != nil {
+		return syncloPendingResponse{}, err
+	}
+	request.Header.Set("X-Signature", syncloSignature(secret, "GET "+pendingURL.RequestURI()))
+	response, err := client.Do(request)
+	if err != nil {
+		return syncloPendingResponse{}, fmt.Errorf("fetch synclo pending: %w", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxWebhookTunnelPayloadBytes))
+	if err != nil {
+		return syncloPendingResponse{}, fmt.Errorf("read synclo pending response: %w", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return syncloPendingResponse{}, fmt.Errorf("fetch synclo pending: HTTP %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var decoded syncloPendingResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return syncloPendingResponse{}, fmt.Errorf("decode synclo pending response: %w", err)
+	}
+	if !decoded.OK {
+		return syncloPendingResponse{}, fmt.Errorf("synclo pending response ok=false")
+	}
+	return decoded, nil
+}
+
+func ackSyncloDeliveries(ctx context.Context, client *http.Client, cfg config.SyncloWebhookConfig, secret string, deliveryIDs []string) error {
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	ackURL := baseURL + "/webhook/ack"
+	body, err := json.Marshal(syncloAckRequest{DeliveryIDs: deliveryIDs, ConsumerName: strings.TrimSpace(cfg.Consumer)})
+	if err != nil {
+		return err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, ackURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Signature", syncloSignature(secret, string(body)))
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("ack synclo deliveries: %w", err)
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(response.Body, maxWebhookTunnelPayloadBytes))
+	if err != nil {
+		return fmt.Errorf("read synclo ack response: %w", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("ack synclo deliveries: HTTP %d: %s", response.StatusCode, strings.TrimSpace(string(responseBody)))
+	}
+	return nil
+}
+
+func syncloSignature(secret string, message string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(message))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func (w *webhookRuntime) setSyncloRunning(running bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.status.SyncloInbox.Running = running
+}
+
+func (w *webhookRuntime) setSyncloError(message string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.status.SyncloInbox.LastError = strings.TrimSpace(message)
+	w.status.Degraded = true
+	w.status.DegradedReasons = upsertReason(w.status.DegradedReasons, "synclo inbox degraded: "+w.status.SyncloInbox.LastError)
+}
+
+func (w *webhookRuntime) clearSyncloError() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.status.SyncloInbox.LastError = ""
+	w.status.DegradedReasons = filterReasons(w.status.DegradedReasons, func(reason string) bool {
+		return !strings.HasPrefix(reason, "synclo inbox degraded:")
+	})
+	w.status.Degraded = len(w.status.DegradedReasons) > 0
+}
+
+func (w *webhookRuntime) recordSyncloPoll(count int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.status.SyncloInbox.LastPollAt = formatJavaScriptISOString(w.currentTime().UTC())
+	w.status.SyncloInbox.PendingFetched += count
+}
+
+func (w *webhookRuntime) recordSyncloForwarded(count int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.status.SyncloInbox.Forwarded += count
+}
+
+func (w *webhookRuntime) recordSyncloAck(count int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.status.SyncloInbox.LastAckAt = formatJavaScriptISOString(w.currentTime().UTC())
+	w.status.SyncloInbox.Acked += count
+}
+
+func upsertReason(reasons []string, reason string) []string {
+	filtered := filterReasons(reasons, func(existing string) bool {
+		return !strings.HasPrefix(existing, "synclo inbox degraded:")
+	})
+	return append(filtered, reason)
+}
+
+func filterReasons(reasons []string, keep func(string) bool) []string {
+	filtered := reasons[:0]
+	for _, reason := range reasons {
+		if keep(reason) {
+			filtered = append(filtered, reason)
+		}
+	}
+	return filtered
+}

--- a/internal/runtime/webhook_synclo_test.go
+++ b/internal/runtime/webhook_synclo_test.go
@@ -1,0 +1,118 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/webhookforward"
+)
+
+func TestSyncloInboxPollSignsForwardsAndAcks(t *testing.T) {
+	const secret = "test-secret"
+	t.Setenv("SYNC_HMAC_SECRET", secret)
+
+	var acked syncloAckRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/webhook/pending":
+			if r.Method != http.MethodGet {
+				t.Fatalf("pending method = %s, want GET", r.Method)
+			}
+			if r.URL.RequestURI() != "/webhook/pending?consumer=looper-node&limit=100" {
+				t.Fatalf("pending RequestURI = %q, want exact consumer/limit query", r.URL.RequestURI())
+			}
+			wantSignature := syncloSignature(secret, "GET "+r.URL.RequestURI())
+			if got := r.Header.Get("X-Signature"); got != wantSignature {
+				t.Fatalf("pending X-Signature = %q, want %q", got, wantSignature)
+			}
+			w.Header().Set("content-type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"consumer":"looper-node","count":1,"events":[{"delivery_id":"delivery-1","event_type":"pull_request","action":"synchronize","repo":"acme/looper","entity_number":42,"payload_json":"{\"action\":\"synchronize\",\"repository\":{\"full_name\":\"acme/looper\"},\"pull_request\":{\"number\":42}}","received_at":"2026-06-18T00:00:00Z"}]}`))
+		case "/webhook/ack":
+			if r.Method != http.MethodPost {
+				t.Fatalf("ack method = %s, want POST", r.Method)
+			}
+			var raw json.RawMessage
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Fatalf("decode ack body: %v", err)
+			}
+			wantSignature := syncloSignature(secret, string(raw))
+			if got := r.Header.Get("X-Signature"); got != wantSignature {
+				t.Fatalf("ack X-Signature = %q, want %q", got, wantSignature)
+			}
+			if err := json.Unmarshal(raw, &acked); err != nil {
+				t.Fatalf("unmarshal ack body: %v", err)
+			}
+			w.Header().Set("content-type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cfg := config.SyncloWebhookConfig{
+		BaseURL:             server.URL,
+		Consumer:            "looper-node",
+		SecretEnv:           "SYNC_HMAC_SECRET",
+		Limit:               100,
+		PollIntervalSeconds: 5,
+	}
+	forwarder := &recordingSyncloForwarder{}
+	rt := &webhookRuntime{
+		cfg:    config.Config{Webhook: config.WebhookConfig{Synclo: cfg}},
+		now:    func() time.Time { return time.Date(2026, time.June, 18, 12, 0, 0, 0, time.UTC) },
+		stopCh: make(chan struct{}),
+		status: WebhookStatus{SyncloInbox: WebhookSyncloInboxState{}},
+		forwarder: func() WebhookForwarder {
+			return forwarder
+		},
+	}
+
+	rt.pollSyncloInbox(context.Background(), server.Client(), cfg)
+
+	requests := forwarder.recordedRequests()
+	if len(requests) != 1 {
+		t.Fatalf("forwarded requests = %d, want 1", len(requests))
+	}
+	if requests[0].DeliveryID != "delivery-1" || requests[0].EventType != "pull_request" {
+		t.Fatalf("forwarded request = %#v, want delivery-1 pull_request", requests[0])
+	}
+	if len(acked.DeliveryIDs) != 1 || acked.DeliveryIDs[0] != "delivery-1" || acked.ConsumerName != "looper-node" {
+		t.Fatalf("acked = %#v, want delivery-1 for looper-node", acked)
+	}
+	status := rt.Status()
+	if status.SyncloInbox.PendingFetched != 1 || status.SyncloInbox.Forwarded != 1 || status.SyncloInbox.Acked != 1 {
+		t.Fatalf("SyncloInbox status = %#v, want one fetched/forwarded/acked", status.SyncloInbox)
+	}
+	if status.Degraded {
+		t.Fatalf("Status().Degraded = true, want false; reasons=%v", status.DegradedReasons)
+	}
+}
+
+type recordingSyncloForwarder struct {
+	mu       sync.Mutex
+	requests []webhookforward.DeliveryRequest
+}
+
+func (f *recordingSyncloForwarder) Forward(_ context.Context, request webhookforward.DeliveryRequest) (webhookforward.ForwardResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.requests = append(f.requests, request)
+	return webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}, nil
+}
+
+func (f *recordingSyncloForwarder) Stats() webhookforward.Stats { return webhookforward.Stats{} }
+
+func (f *recordingSyncloForwarder) Close() {}
+
+func (f *recordingSyncloForwarder) recordedRequests() []webhookforward.DeliveryRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]webhookforward.DeliveryRequest{}, f.requests...)
+}

--- a/internal/runtime/webhook_tunnel.go
+++ b/internal/runtime/webhook_tunnel.go
@@ -564,6 +564,18 @@ func wModeNeedsTunnel(cfg config.Config) bool {
 	return false
 }
 
+func wModeNeedsSyncloInbox(cfg config.Config) bool {
+	if cfg.Webhook.Mode == config.WebhookModeSyncloInbox {
+		return true
+	}
+	for _, project := range cfg.Projects {
+		if project.Webhook.Mode == config.WebhookModeSyncloInbox {
+			return true
+		}
+	}
+	return false
+}
+
 func configuredTunnelProjectIDs(cfg config.Config) []string {
 	ids := make([]string, 0, len(cfg.Projects))
 	for _, project := range cfg.Projects {


### PR DESCRIPTION
## Summary
- add `webhook.mode = "synclo-inbox"` with explicit `webhook.synclo` config for base URL, stable consumer, secret env, limit, and poll interval
- poll synclo pending deliveries with the required HMAC signatures, forward successful deliveries into the existing local webhook queue, then ack only those delivery IDs
- expose synclo inbox runtime status and document setup, consumer stability, and polling fallback semantics

## Design trade-off
New concept: a synclo inbox poller as a third webhook delivery mode.

Concrete failure prevented: teams sharing a central GitHub webhook inbox can wake Looper without each daemon running its own `gh webhook forward` session or managing duplicate repo hooks.

Cost: this adds a second remote queue dependency, HMAC signing surface, stable consumer naming requirements, ack retry behavior, and another runtime lifecycle to stop/reconcile. It can replay retained events if the consumer changes, and it still depends on synclo retention.

Simpler alternative considered: keep only GitHub polling or only local `gh-forward`/`tunnel`. That avoids a new poller, but it does not use the existing synclo fan-out queue and keeps low-latency wakeups tied to local GitHub forwarding or per-daemon hook management.

Authority for ack: the authority for acknowledging a synclo delivery is the local `WebhookForwarder.Forward` call returning successfully for that exact GitHub `delivery_id`; this is not agent structured output.

## Notes
- This does not make GitHub polling disappear. Polling remains the correctness fallback and drift-recovery path.
- `check_run` support depends on the shared synclo GitHub hook subscribing to `check_run`; this PR consumes it through the existing Looper route once present.

## Tests
- `go test ./...`
- `go vet ./...`
- `go build ./...`