### PR TITLE
fix: retry non-retryable runner failures

### DIFF
--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -6015,7 +6015,7 @@ func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts in
 		return false
 	}
 	if maxAttempts < 0 {
-		return true
+		return kind != FailureNonRetryable
 	}
 	return maxAttempts > 0 && nextAttempts < maxAttempts
 }

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -6007,7 +6007,7 @@ func backoffDelay(base time.Duration, attempts int64) time.Duration {
 }
 
 func isRetryableFailure(kind QueueFailureKind) bool {
-	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume
+	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume || kind == FailureNonRetryable
 }
 
 func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -56,6 +56,9 @@ func TestShouldRetryQueueFailureRespectsMaxAttempts(t *testing.T) {
 	if !shouldRetryQueueFailure(FailureRetryableTransient, 5, -1) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for infinite retries")
 	}
+	if shouldRetryQueueFailure(FailureNonRetryable, 5, -1) {
+		t.Fatal("shouldRetryQueueFailure() = true, want false for infinite non_retryable retries")
+	}
 	if !shouldRetryQueueFailure(FailureNonRetryable, 1, 3) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for bounded non_retryable retries")
 	}

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -56,6 +56,9 @@ func TestShouldRetryQueueFailureRespectsMaxAttempts(t *testing.T) {
 	if !shouldRetryQueueFailure(FailureRetryableTransient, 5, -1) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for infinite retries")
 	}
+	if !shouldRetryQueueFailure(FailureNonRetryable, 1, 3) {
+		t.Fatal("shouldRetryQueueFailure() = false, want true for bounded non_retryable retries")
+	}
 	if shouldRetryQueueFailure(FailureRetryableTransient, 3, 3) {
 		t.Fatal("shouldRetryQueueFailure() = true, want false once nextAttempts reaches maxAttempts")
 	}
@@ -5341,8 +5344,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt == nil {
-		t.Fatalf("queue = %#v, want parked non_retryable item", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil {
+		t.Fatalf("queue = %#v, want requeued non_retryable item", queue)
 	}
 }
 

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -2126,7 +2126,7 @@ func backoffDelay(base time.Duration, attempts int64) time.Duration {
 }
 
 func isRetryableFailure(kind QueueFailureKind) bool {
-	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume
+	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume || kind == FailureNonRetryable
 }
 
 func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -2134,7 +2134,7 @@ func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts in
 		return false
 	}
 	if maxAttempts < 0 {
-		return true
+		return kind != FailureNonRetryable
 	}
 	return maxAttempts > 0 && nextAttempts < maxAttempts
 }

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -51,6 +51,9 @@ func TestShouldRetryQueueFailureRespectsMaxAttempts(t *testing.T) {
 	if !shouldRetryQueueFailure(FailureRetryableTransient, 5, -1) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for infinite retries")
 	}
+	if !shouldRetryQueueFailure(FailureNonRetryable, 1, 3) {
+		t.Fatal("shouldRetryQueueFailure() = false, want true for bounded non_retryable retries")
+	}
 	if shouldRetryQueueFailure(FailureRetryableTransient, 3, 3) {
 		t.Fatal("shouldRetryQueueFailure() = true, want false once nextAttempts reaches maxAttempts")
 	}
@@ -1069,8 +1072,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt == nil {
-		t.Fatalf("queue = %#v, want parked non_retryable item", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil {
+		t.Fatalf("queue = %#v, want requeued non_retryable item", queue)
 	}
 }
 

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -51,6 +51,9 @@ func TestShouldRetryQueueFailureRespectsMaxAttempts(t *testing.T) {
 	if !shouldRetryQueueFailure(FailureRetryableTransient, 5, -1) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for infinite retries")
 	}
+	if shouldRetryQueueFailure(FailureNonRetryable, 5, -1) {
+		t.Fatal("shouldRetryQueueFailure() = true, want false for infinite non_retryable retries")
+	}
 	if !shouldRetryQueueFailure(FailureNonRetryable, 1, 3) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for bounded non_retryable retries")
 	}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -6083,7 +6083,7 @@ func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts in
 		return false
 	}
 	if maxAttempts < 0 {
-		return true
+		return kind != FailureNonRetryable
 	}
 	return maxAttempts > 0 && nextAttempts < maxAttempts
 }

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -6075,7 +6075,7 @@ func sleepWithContext(ctx context.Context, delay time.Duration) error {
 }
 
 func isRetryableFailure(kind QueueFailureKind) bool {
-	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume
+	return kind == FailureRetryableTransient || kind == FailureRetryableAfterResume || kind == FailureNonRetryable
 }
 
 func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -62,6 +62,9 @@ func TestShouldRetryQueueFailureRespectsMaxAttempts(t *testing.T) {
 	if !shouldRetryQueueFailure(FailureRetryableTransient, 5, -1) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for infinite retries")
 	}
+	if !shouldRetryQueueFailure(FailureNonRetryable, 1, 3) {
+		t.Fatal("shouldRetryQueueFailure() = false, want true for bounded non_retryable retries")
+	}
 	if shouldRetryQueueFailure(FailureRetryableTransient, 3, 3) {
 		t.Fatal("shouldRetryQueueFailure() = true, want false once nextAttempts reaches maxAttempts")
 	}
@@ -6156,8 +6159,8 @@ func TestProcessClaimedItemDoesNotRetryGitHubSelfApprovalFailure(t *testing.T) {
 	if err != nil || queue == nil {
 		t.Fatalf("Queue.GetByID() = (%#v, %v), want queue", queue, err)
 	}
-	if queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt == nil {
-		t.Fatalf("queue = %#v, want parked non_retryable queue item", queue)
+	if queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil {
+		t.Fatalf("queue = %#v, want requeued non_retryable queue item", queue)
 	}
 }
 
@@ -6806,8 +6809,8 @@ func TestProcessNextFinalizesClaimedQueueItemOnSetupFailure(t *testing.T) {
 	if getErr != nil {
 		t.Fatalf("Queue.GetByID() error = %v", getErr)
 	}
-	if queue == nil || queue.Status != "manual_intervention" || queue.FinishedAt == nil || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
-		t.Fatalf("queue = %#v, want parked queue item with non_retryable error kind", queue)
+	if queue == nil || queue.Status != "queued" || queue.FinishedAt != nil || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
+		t.Fatalf("queue = %#v, want requeued queue item with non_retryable error kind", queue)
 	}
 	if queue.LastError == nil || !contains(*queue.LastError, "start run blocked") {
 		t.Fatalf("queue.LastError = %#v, want start run blocked", queue.LastError)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -62,6 +62,9 @@ func TestShouldRetryQueueFailureRespectsMaxAttempts(t *testing.T) {
 	if !shouldRetryQueueFailure(FailureRetryableTransient, 5, -1) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for infinite retries")
 	}
+	if shouldRetryQueueFailure(FailureNonRetryable, 5, -1) {
+		t.Fatal("shouldRetryQueueFailure() = true, want false for infinite non_retryable retries")
+	}
 	if !shouldRetryQueueFailure(FailureNonRetryable, 1, 3) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for bounded non_retryable retries")
 	}

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -2153,8 +2153,8 @@ const scheduledQueueOrderBy = `
 		qi.priority ASC, qi.available_at ASC, qi.created_at ASC
 `
 
-const longTermRetryPredicateLiteral = `qi.attempts >= 5 AND COALESCE(qi.last_error_kind, '') IN ('retryable_transient', 'retryable_after_resume')`
-const longTermRetryPredicateParam = `qi.attempts >= ? AND COALESCE(qi.last_error_kind, '') IN ('retryable_transient', 'retryable_after_resume')`
+const longTermRetryPredicateLiteral = `qi.attempts >= 5 AND COALESCE(qi.last_error_kind, '') IN ('retryable_transient', 'retryable_after_resume', 'non_retryable')`
+const longTermRetryPredicateParam = `qi.attempts >= ? AND COALESCE(qi.last_error_kind, '') IN ('retryable_transient', 'retryable_after_resume', 'non_retryable')`
 
 const scheduledQueueQuery = scheduledQueueBaseQuery + scheduledQueueOrderBy
 

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -1248,6 +1248,53 @@ func TestQueueRecoveredRetryWithoutErrorKindStaysNonLongTerm(t *testing.T) {
 	}
 }
 
+func TestQueueBoundedNonRetryableRetryMovesToLongTermLane(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	ctx := context.Background()
+	repos := NewRepositories(coordinator.DB())
+
+	now := "2026-04-11T12:00:00.000Z"
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: "project_non_retryable_long_term", Name: "Looper", RepoPath: "/tmp/looper", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loopID := "loop_non_retryable_long_term"
+	if err := repos.Loops.Upsert(ctx, LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_non_retryable_long_term", Type: "planner", TargetType: "issue", Status: "running", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	nonRetryableKind := "non_retryable"
+	items := []QueueItemRecord{
+		{ID: "fresh_retryable", LoopID: &loopID, Type: "planner", TargetType: "issue", TargetID: "issue:1", DedupeKey: "planner:fresh", Priority: QueuePriorityPlanner, Status: "queued", AvailableAt: now, Attempts: 0, MaxAttempts: 8, CreatedAt: "2026-04-11T11:30:00.000Z", UpdatedAt: now},
+		{ID: "bounded_non_retryable", LoopID: &loopID, Type: "planner", TargetType: "issue", TargetID: "issue:2", DedupeKey: "planner:bounded_non_retryable", Priority: QueuePriorityPlanner, Status: "queued", AvailableAt: now, Attempts: QueueLongTermRetryAttemptThreshold, MaxAttempts: 8, LastErrorKind: &nonRetryableKind, CreatedAt: "2026-04-11T11:00:00.000Z", UpdatedAt: now},
+	}
+	for _, item := range items {
+		if err := repos.Queue.Upsert(ctx, item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+
+	claimed, err := repos.Queue.ClaimNextNonLongTermRetry(ctx, now, "worker-a")
+	if err != nil {
+		t.Fatalf("Queue.ClaimNextNonLongTermRetry() error = %v", err)
+	}
+	if claimed == nil || claimed.ID != "fresh_retryable" {
+		t.Fatalf("Queue.ClaimNextNonLongTermRetry() = %#v, want fresh_retryable", claimed)
+	}
+
+	claimedLong, err := repos.Queue.ClaimNextLongTermRetry(ctx, now, "worker-b")
+	if err != nil {
+		t.Fatalf("Queue.ClaimNextLongTermRetry() error = %v", err)
+	}
+	if claimedLong == nil || claimedLong.ID != "bounded_non_retryable" {
+		t.Fatalf("Queue.ClaimNextLongTermRetry() = %#v, want bounded_non_retryable", claimedLong)
+	}
+	if claimedLong.LastErrorKind == nil || *claimedLong.LastErrorKind != nonRetryableKind {
+		t.Fatalf("claimedLong.LastErrorKind = %#v, want %q", claimedLong.LastErrorKind, nonRetryableKind)
+	}
+}
+
 func TestQueueRetryFailCompleteTransitions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -2673,7 +2673,7 @@ func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts in
 		return false
 	}
 	if maxAttempts < 0 {
-		return true
+		return kind != FailureNonRetryable
 	}
 	return maxAttempts > 0 && nextAttempts < maxAttempts
 }

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -2669,7 +2669,7 @@ func shouldNotifyCompletedRun(kind QueueFailureKind, failedQueue *storage.QueueI
 }
 
 func shouldRetryQueueFailure(kind QueueFailureKind, nextAttempts, maxAttempts int64) bool {
-	if kind != FailureRetryableTransient && kind != FailureRetryableAfterResume {
+	if kind != FailureRetryableTransient && kind != FailureRetryableAfterResume && kind != FailureNonRetryable {
 		return false
 	}
 	if maxAttempts < 0 {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -51,6 +51,9 @@ func TestShouldRetryQueueFailureRespectsMaxAttempts(t *testing.T) {
 	if !shouldRetryQueueFailure(FailureRetryableTransient, 5, -1) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for infinite retries")
 	}
+	if !shouldRetryQueueFailure(FailureNonRetryable, 1, 3) {
+		t.Fatal("shouldRetryQueueFailure() = false, want true for bounded non_retryable retries")
+	}
 	if shouldRetryQueueFailure(FailureRetryableTransient, 3, 3) {
 		t.Fatal("shouldRetryQueueFailure() = true, want false once nextAttempts reaches maxAttempts")
 	}
@@ -2257,8 +2260,8 @@ func TestProcessNextSetupFailureMarksQueueFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.Status != "manual_intervention" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) {
-		t.Fatalf("queue = %#v, want parked non_retryable item", queue)
+	if queue == nil || queue.Status != "queued" || queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureNonRetryable) || queue.FinishedAt != nil {
+		t.Fatalf("queue = %#v, want requeued non_retryable item", queue)
 	}
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -51,6 +51,9 @@ func TestShouldRetryQueueFailureRespectsMaxAttempts(t *testing.T) {
 	if !shouldRetryQueueFailure(FailureRetryableTransient, 5, -1) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for infinite retries")
 	}
+	if shouldRetryQueueFailure(FailureNonRetryable, 5, -1) {
+		t.Fatal("shouldRetryQueueFailure() = true, want false for infinite non_retryable retries")
+	}
 	if !shouldRetryQueueFailure(FailureNonRetryable, 1, 3) {
 		t.Fatal("shouldRetryQueueFailure() = false, want true for bounded non_retryable retries")
 	}


### PR DESCRIPTION
## Summary
- retry `non_retryable` queue failures in planner, worker, reviewer, and fixer while attempts remain
- keep `manual_intervention` as the terminal parked state after retry budget is exhausted
- update runner tests to expect requeue-before-park behavior

## Testing
- go test ./internal/fixer ./internal/planner ./internal/reviewer ./internal/worker