### PR TITLE
fix: avoid oversized PR view payloads

### DIFF
--- a/internal/api/reviewer_repair.go
+++ b/internal/api/reviewer_repair.go
@@ -103,7 +103,7 @@ type reviewerRepairGitHubAdapter struct {
 }
 
 func (a reviewerRepairGitHubAdapter) ViewPullRequest(ctx context.Context, input reviewer.ViewPullRequestInput) (reviewer.PullRequestDetail, error) {
-	detail, err := a.gateway.ViewPullRequest(ctx, github.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
+	detail, err := a.gateway.ViewPullRequestForReviewer(ctx, github.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 	if err != nil {
 		return reviewer.PullRequestDetail{}, err
 	}

--- a/internal/infra/github/discovery_snapshot.go
+++ b/internal/infra/github/discovery_snapshot.go
@@ -168,7 +168,7 @@ func (s *DiscoverySnapshot) viewPullRequest(ctx context.Context, input ViewPullR
 		return detail, nil
 	}
 	s.mu.Unlock()
-	detail, err := s.gateway.viewPullRequestRaw(ctx, input)
+	detail, err := s.gateway.ViewPullRequestForFixer(ctx, input)
 	if err != nil {
 		return PullRequestDetail{}, err
 	}

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -32,11 +32,11 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLoginByCWD(t *testing.T) {
 				{"number":12,"title":"Issue 12","body":"body","url":"https://example.com/issues/12","state":"OPEN","assignees":[{"login":"other"}],"labels":[{"name":"other"}]}
 			]`}, nil
 		case strings.Contains(cmd, "pr view 1"):
-			if !strings.Contains(cmd, "statusCheckRollup") || strings.Contains(cmd, "reviews") {
+			if !strings.Contains(cmd, "statusCheckRollup") || !strings.Contains(cmd, "reviewRequests") || strings.Contains(cmd, "reviews") {
 				t.Fatalf("pr view args = %q, want fixer fields", cmd)
 			}
 			counts["pr_view"]++
-			return shell.Result{Stdout: `{"number":1,"title":"PR 1","body":"body","url":"https://example.com/pulls/1","state":"OPEN","labels":[{"name":"bug"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-1","baseRefOid":"base-1","author":{"login":"octo"},"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
+			return shell.Result{Stdout: `{"number":1,"title":"PR 1","body":"body","url":"https://example.com/pulls/1","state":"OPEN","labels":[{"name":"bug"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-1","baseRefOid":"base-1","author":{"login":"octo"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"octo"}}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
 		case strings.Contains(cmd, "reviewThreads"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
 		case cmd == "api --paginate --slurp repos/acme/looper/issues/1/comments":
@@ -143,10 +143,10 @@ func TestDiscoverySnapshotDoesNotCacheFailedPullRequestDetailFetch(t *testing.T)
 			if viewCalls == 1 {
 				return shell.Result{}, errors.New("temporary gh failure")
 			}
-			if !strings.Contains(cmd, "statusCheckRollup") || strings.Contains(cmd, "reviews") {
+			if !strings.Contains(cmd, "statusCheckRollup") || !strings.Contains(cmd, "reviewRequests") || strings.Contains(cmd, "reviews") {
 				t.Fatalf("pr view args = %q, want fixer fields", cmd)
 			}
-			return shell.Result{Stdout: `{"number":7,"title":"PR 7","body":"body","url":"https://example.com/pulls/7","state":"OPEN","labels":[],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-7","baseRefOid":"base-7","author":{"login":"octo"},"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
+			return shell.Result{Stdout: `{"number":7,"title":"PR 7","body":"body","url":"https://example.com/pulls/7","state":"OPEN","labels":[],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-7","baseRefOid":"base-7","author":{"login":"octo"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
 		case strings.Contains(cmd, "reviewThreads"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
 		case cmd == "api --paginate --slurp repos/acme/looper/issues/7/comments":
@@ -168,7 +168,7 @@ func TestDiscoverySnapshotDoesNotCacheFailedPullRequestDetailFetch(t *testing.T)
 	}
 }
 
-func TestDiscoverySnapshotPreservesFixerSignalsInPullRequestDetail(t *testing.T) {
+func TestDiscoverySnapshotPreservesPendingWorkSignalsInPullRequestDetail(t *testing.T) {
 	t.Parallel()
 
 	counts := map[string]int{}
@@ -178,10 +178,10 @@ func TestDiscoverySnapshotPreservesFixerSignalsInPullRequestDetail(t *testing.T)
 		case strings.Contains(cmd, "pr view 9"):
 			counts["pr_view"]++
 			fields := strings.TrimPrefix(cmd, "pr view 9 --repo acme/looper --json ")
-			if !strings.Contains(fields, "statusCheckRollup") || strings.Contains(fields, "reviews") || strings.Contains(fields, "reviewRequests") {
-				t.Fatalf("pr view fields = %q, want fixer profile fields", fields)
+			if !strings.Contains(fields, "statusCheckRollup") || !strings.Contains(fields, "reviewRequests") || strings.Contains(fields, "reviews") {
+				t.Fatalf("pr view fields = %q, want pending-work profile fields", fields)
 			}
-			return shell.Result{Stdout: `{"number":9,"title":"PR 9","body":"body","url":"https://example.com/pulls/9","state":"OPEN","labels":[{"name":"looper:fixer"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-9","baseRefOid":"base-9","author":{"login":"octo"},"statusCheckRollup":[{"conclusion":"FAILURE"}]}`}, nil
+			return shell.Result{Stdout: `{"number":9,"title":"PR 9","body":"body","url":"https://example.com/pulls/9","state":"OPEN","labels":[{"name":"looper:fixer"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-9","baseRefOid":"base-9","author":{"login":"octo"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}}],"statusCheckRollup":[{"conclusion":"FAILURE"}]}`}, nil
 		case strings.Contains(cmd, "reviewThreads"):
 			counts["review_threads"]++
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"path":"main.go","line":12,"comments":{"nodes":[{"id":"comment-1","body":"Fix this","updatedAt":"2026-06-29T14:08:40Z","url":"https://example.com/pulls/9#discussion_r1","path":"main.go","line":12,"authorAssociation":"NONE","author":{"login":"reviewer"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
@@ -209,8 +209,11 @@ func TestDiscoverySnapshotPreservesFixerSignalsInPullRequestDetail(t *testing.T)
 	if len(first.Checks) != 1 || !strings.EqualFold(asString(first.Checks[0]["conclusion"]), "FAILURE") {
 		t.Fatalf("Checks = %#v, want failing check preserved", first.Checks)
 	}
-	if len(second.Comments) != 1 || len(second.Checks) != 1 {
-		t.Fatalf("cached detail = %#v, want fixer signals preserved", second)
+	if len(first.ReviewRequests) != 1 || first.ReviewRequests[0] != "reviewer" {
+		t.Fatalf("ReviewRequests = %#v, want pending reviewer preserved", first.ReviewRequests)
+	}
+	if len(second.Comments) != 1 || len(second.Checks) != 1 || len(second.ReviewRequests) != 1 {
+		t.Fatalf("cached detail = %#v, want pending-work signals preserved", second)
 	}
 	if counts["pr_view"] != 1 || counts["review_threads"] != 1 || counts["issue_comments"] != 1 {
 		t.Fatalf("counts = %#v, want each detail source fetched once", counts)

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -31,11 +31,9 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLoginByCWD(t *testing.T) {
 				{"number":11,"title":"Issue 11","body":"body","url":"https://example.com/issues/11","state":"OPEN","assignees":[{"login":"octo"}],"labels":[{"name":"ready"}]},
 				{"number":12,"title":"Issue 12","body":"body","url":"https://example.com/issues/12","state":"OPEN","assignees":[{"login":"other"}],"labels":[{"name":"other"}]}
 			]`}, nil
-		case strings.Contains(cmd, "pr view 1") && strings.Contains(cmd, "statusCheckRollup"):
+		case strings.Contains(cmd, "pr view 1") && !strings.Contains(cmd, "statusCheckRollup") && !strings.Contains(cmd, "comments") && !strings.Contains(cmd, "reviews"):
 			counts["pr_view"]++
-			return shell.Result{Stdout: `{"number":1,"title":"PR 1","body":"body","url":"https://example.com/pulls/1","state":"OPEN","labels":[{"name":"bug"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-1","baseRefOid":"base-1","author":{"login":"octo"},"comments":[],"reviewRequests":[],"reviews":[],"statusCheckRollup":[]}`}, nil
-		case strings.Contains(cmd, "api graphql") && strings.Contains(cmd, "reviewThreads"):
-			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
+			return shell.Result{Stdout: `{"number":1,"title":"PR 1","body":"body","url":"https://example.com/pulls/1","state":"OPEN","labels":[{"name":"bug"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-1","baseRefOid":"base-1","author":{"login":"octo"},"reviewRequests":[]}`}, nil
 		case strings.Contains(cmd, "api user --jq .login"):
 			counts["user_login"]++
 			switch options.CWD {
@@ -133,14 +131,12 @@ func TestDiscoverySnapshotDoesNotCacheFailedPullRequestDetailFetch(t *testing.T)
 	gateway := New(Options{GHRun: func(_ context.Context, options shell.Options) (shell.Result, error) {
 		cmd := strings.Join(options.Args, " ")
 		switch {
-		case strings.Contains(cmd, "pr view 7") && strings.Contains(cmd, "statusCheckRollup"):
+		case strings.Contains(cmd, "pr view 7") && !strings.Contains(cmd, "statusCheckRollup") && !strings.Contains(cmd, "comments") && !strings.Contains(cmd, "reviews"):
 			viewCalls++
 			if viewCalls == 1 {
 				return shell.Result{}, errors.New("temporary gh failure")
 			}
-			return shell.Result{Stdout: `{"number":7,"title":"PR 7","body":"body","url":"https://example.com/pulls/7","state":"OPEN","labels":[],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-7","baseRefOid":"base-7","author":{"login":"octo"},"comments":[],"reviewRequests":[],"reviews":[],"statusCheckRollup":[]}`}, nil
-		case strings.Contains(cmd, "api graphql") && strings.Contains(cmd, "reviewThreads"):
-			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
+			return shell.Result{Stdout: `{"number":7,"title":"PR 7","body":"body","url":"https://example.com/pulls/7","state":"OPEN","labels":[],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-7","baseRefOid":"base-7","author":{"login":"octo"},"reviewRequests":[]}`}, nil
 		default:
 			return shell.Result{}, errors.New("unexpected command: " + cmd)
 		}

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -31,9 +31,16 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLoginByCWD(t *testing.T) {
 				{"number":11,"title":"Issue 11","body":"body","url":"https://example.com/issues/11","state":"OPEN","assignees":[{"login":"octo"}],"labels":[{"name":"ready"}]},
 				{"number":12,"title":"Issue 12","body":"body","url":"https://example.com/issues/12","state":"OPEN","assignees":[{"login":"other"}],"labels":[{"name":"other"}]}
 			]`}, nil
-		case strings.Contains(cmd, "pr view 1") && !strings.Contains(cmd, "statusCheckRollup") && !strings.Contains(cmd, "comments") && !strings.Contains(cmd, "reviews"):
+		case strings.Contains(cmd, "pr view 1"):
+			if !strings.Contains(cmd, "statusCheckRollup") || strings.Contains(cmd, "reviews") {
+				t.Fatalf("pr view args = %q, want fixer fields", cmd)
+			}
 			counts["pr_view"]++
-			return shell.Result{Stdout: `{"number":1,"title":"PR 1","body":"body","url":"https://example.com/pulls/1","state":"OPEN","labels":[{"name":"bug"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-1","baseRefOid":"base-1","author":{"login":"octo"},"reviewRequests":[]}`}, nil
+			return shell.Result{Stdout: `{"number":1,"title":"PR 1","body":"body","url":"https://example.com/pulls/1","state":"OPEN","labels":[{"name":"bug"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-1","baseRefOid":"base-1","author":{"login":"octo"},"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
+		case strings.Contains(cmd, "reviewThreads"):
+			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
+		case cmd == "api --paginate --slurp repos/acme/looper/issues/1/comments":
+			return shell.Result{Stdout: `[[]]`}, nil
 		case strings.Contains(cmd, "api user --jq .login"):
 			counts["user_login"]++
 			switch options.CWD {
@@ -131,12 +138,19 @@ func TestDiscoverySnapshotDoesNotCacheFailedPullRequestDetailFetch(t *testing.T)
 	gateway := New(Options{GHRun: func(_ context.Context, options shell.Options) (shell.Result, error) {
 		cmd := strings.Join(options.Args, " ")
 		switch {
-		case strings.Contains(cmd, "pr view 7") && !strings.Contains(cmd, "statusCheckRollup") && !strings.Contains(cmd, "comments") && !strings.Contains(cmd, "reviews"):
+		case strings.Contains(cmd, "pr view 7"):
 			viewCalls++
 			if viewCalls == 1 {
 				return shell.Result{}, errors.New("temporary gh failure")
 			}
-			return shell.Result{Stdout: `{"number":7,"title":"PR 7","body":"body","url":"https://example.com/pulls/7","state":"OPEN","labels":[],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-7","baseRefOid":"base-7","author":{"login":"octo"},"reviewRequests":[]}`}, nil
+			if !strings.Contains(cmd, "statusCheckRollup") || strings.Contains(cmd, "reviews") {
+				t.Fatalf("pr view args = %q, want fixer fields", cmd)
+			}
+			return shell.Result{Stdout: `{"number":7,"title":"PR 7","body":"body","url":"https://example.com/pulls/7","state":"OPEN","labels":[],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-7","baseRefOid":"base-7","author":{"login":"octo"},"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
+		case strings.Contains(cmd, "reviewThreads"):
+			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
+		case cmd == "api --paginate --slurp repos/acme/looper/issues/7/comments":
+			return shell.Result{Stdout: `[[]]`}, nil
 		default:
 			return shell.Result{}, errors.New("unexpected command: " + cmd)
 		}
@@ -151,6 +165,55 @@ func TestDiscoverySnapshotDoesNotCacheFailedPullRequestDetailFetch(t *testing.T)
 	}
 	if viewCalls != 2 {
 		t.Fatalf("pr view calls = %d, want 2 after retry", viewCalls)
+	}
+}
+
+func TestDiscoverySnapshotPreservesFixerSignalsInPullRequestDetail(t *testing.T) {
+	t.Parallel()
+
+	counts := map[string]int{}
+	gateway := New(Options{GHRun: func(_ context.Context, options shell.Options) (shell.Result, error) {
+		cmd := strings.Join(options.Args, " ")
+		switch {
+		case strings.Contains(cmd, "pr view 9"):
+			counts["pr_view"]++
+			fields := strings.TrimPrefix(cmd, "pr view 9 --repo acme/looper --json ")
+			if !strings.Contains(fields, "statusCheckRollup") || strings.Contains(fields, "reviews") || strings.Contains(fields, "reviewRequests") {
+				t.Fatalf("pr view fields = %q, want fixer profile fields", fields)
+			}
+			return shell.Result{Stdout: `{"number":9,"title":"PR 9","body":"body","url":"https://example.com/pulls/9","state":"OPEN","labels":[{"name":"looper:fixer"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-9","baseRefOid":"base-9","author":{"login":"octo"},"statusCheckRollup":[{"conclusion":"FAILURE"}]}`}, nil
+		case strings.Contains(cmd, "reviewThreads"):
+			counts["review_threads"]++
+			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"path":"main.go","line":12,"comments":{"nodes":[{"id":"comment-1","body":"Fix this","updatedAt":"2026-06-29T14:08:40Z","url":"https://example.com/pulls/9#discussion_r1","path":"main.go","line":12,"authorAssociation":"NONE","author":{"login":"reviewer"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
+		case cmd == "api --paginate --slurp repos/acme/looper/issues/9/comments":
+			counts["issue_comments"]++
+			return shell.Result{Stdout: `[[]]`}, nil
+		default:
+			return shell.Result{}, errors.New("unexpected command: " + cmd)
+		}
+	}})
+
+	ctx := ContextWithDiscoverySnapshot(context.Background(), NewDiscoverySnapshot(gateway, NewDiscoveryTickState(), DiscoverySnapshotOptions{PullRequestLimit: 100, IssueLimit: 100}))
+	first, err := gateway.ViewPullRequest(ctx, ViewPullRequestInput{Repo: "acme/looper", PRNumber: 9, CWD: "/repo"})
+	if err != nil {
+		t.Fatalf("ViewPullRequest(first) error = %v", err)
+	}
+	second, err := gateway.ViewPullRequest(ctx, ViewPullRequestInput{Repo: "acme/looper", PRNumber: 9, CWD: "/repo"})
+	if err != nil {
+		t.Fatalf("ViewPullRequest(second) error = %v", err)
+	}
+
+	if len(first.Comments) != 1 || asBool(first.Comments[0]["isResolved"]) {
+		t.Fatalf("Comments = %#v, want one unresolved review thread", first.Comments)
+	}
+	if len(first.Checks) != 1 || !strings.EqualFold(asString(first.Checks[0]["conclusion"]), "FAILURE") {
+		t.Fatalf("Checks = %#v, want failing check preserved", first.Checks)
+	}
+	if len(second.Comments) != 1 || len(second.Checks) != 1 {
+		t.Fatalf("cached detail = %#v, want fixer signals preserved", second)
+	}
+	if counts["pr_view"] != 1 || counts["review_threads"] != 1 || counts["issue_comments"] != 1 {
+		t.Fatalf("counts = %#v, want each detail source fetched once", counts)
 	}
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -2590,7 +2590,7 @@ func (g *Gateway) InitializeLabels(ctx context.Context, input InitializeLabelsIn
 }
 
 func (g *Gateway) CapturePullRequestSnapshot(ctx context.Context, input CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
-	detail, err := g.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
+	detail, err := g.ViewPullRequestForReviewer(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 	if err != nil {
 		return storage.PullRequestSnapshotRecord{}, err
 	}

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -33,7 +33,7 @@ var (
 	prListJSONFields          = []string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "mergeStateStatus"}
 	prDiscoveryListJSONFields = []string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "mergeStateStatus"}
 	prViewMetadataJSONFields  = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "mergeStateStatus"}
-	prViewFixerJSONFields     = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "statusCheckRollup", "mergeStateStatus"}
+	prViewFixerJSONFields     = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "statusCheckRollup", "mergeStateStatus"}
 	prViewReviewerJSONFields  = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "statusCheckRollup", "mergeStateStatus"}
 )
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -32,7 +32,9 @@ const (
 var (
 	prListJSONFields          = []string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "mergeStateStatus"}
 	prDiscoveryListJSONFields = []string{"number", "title", "url", "state", "updatedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "mergeStateStatus"}
-	prViewJSONFields          = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "comments", "reviews", "statusCheckRollup", "mergeStateStatus"}
+	prViewMetadataJSONFields  = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "mergeStateStatus"}
+	prViewFixerJSONFields     = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "statusCheckRollup", "mergeStateStatus"}
+	prViewReviewerJSONFields  = []string{"number", "title", "body", "url", "state", "createdAt", "updatedAt", "closedAt", "isDraft", "reviewDecision", "labels", "headRefName", "baseRefName", "headRefOid", "baseRefOid", "author", "reviewRequests", "reviews", "statusCheckRollup", "mergeStateStatus"}
 )
 
 var prNumberURLPattern = regexp.MustCompile(`/pull/(\d+)(?:/|$)`)
@@ -1366,21 +1368,47 @@ func (g *Gateway) ViewPullRequest(ctx context.Context, input ViewPullRequestInpu
 	if snapshot := discoverySnapshotFromContext(ctx); snapshot != nil {
 		return snapshot.viewPullRequest(ctx, input)
 	}
-	return g.viewPullRequestRaw(ctx, input)
+	return g.viewPullRequestWithFields(ctx, input, prViewMetadataJSONFields, false, false)
+}
+
+func (g *Gateway) ViewPullRequestForFixer(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
+	return g.viewPullRequestWithFields(ctx, input, prViewFixerJSONFields, true, true)
+}
+
+func (g *Gateway) ViewPullRequestForReviewer(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
+	return g.viewPullRequestWithFields(ctx, input, prViewReviewerJSONFields, true, true)
 }
 
 func (g *Gateway) viewPullRequestRaw(ctx context.Context, input ViewPullRequestInput) (PullRequestDetail, error) {
-	row, err := g.viewPullRequestRow(ctx, input, prViewJSONFields)
+	return g.viewPullRequestWithFields(ctx, input, prViewMetadataJSONFields, false, false)
+}
+
+func (g *Gateway) viewPullRequestWithFields(ctx context.Context, input ViewPullRequestInput, fields []string, includeReviewThreads bool, includeIssueComments bool) (PullRequestDetail, error) {
+	row, err := g.viewPullRequestRow(ctx, input, fields)
 	if err != nil && IsInaccessibleReviewRequestReviewerError(err) {
-		row, err = g.viewPullRequestRow(ctx, input, withoutJSONField(prViewJSONFields, "reviewRequests"))
+		row, err = g.viewPullRequestRow(ctx, input, withoutJSONField(fields, "reviewRequests"))
 	}
 	if err != nil {
 		return PullRequestDetail{}, err
 	}
-	threads, err := g.fetchReviewThreads(ctx, input.Repo, input.PRNumber, input.CWD)
-	if err != nil {
-		return PullRequestDetail{}, err
+	threads := []map[string]any(nil)
+	if includeReviewThreads {
+		threads, err = g.fetchReviewThreads(ctx, input.Repo, input.PRNumber, input.CWD)
+		if err != nil {
+			return PullRequestDetail{}, err
+		}
 	}
+	issueComments := []CommentInfo(nil)
+	if includeIssueComments {
+		issueComments, err = g.ListIssueComments(ctx, ViewIssueInput{Repo: input.Repo, IssueNumber: input.PRNumber, CWD: input.CWD})
+		if err != nil {
+			return PullRequestDetail{}, err
+		}
+	}
+	return pullRequestDetailFromViewRow(row, threads, issueComments), nil
+}
+
+func pullRequestDetailFromViewRow(row map[string]any, threads []map[string]any, issueComments []CommentInfo) PullRequestDetail {
 	return PullRequestDetail{
 		Number:             asInt64(row["number"]),
 		Title:              asString(row["title"]),
@@ -1399,19 +1427,19 @@ func (g *Gateway) viewPullRequestRaw(ctx context.Context, input ViewPullRequestI
 		BaseSHA:            asString(row["baseRefOid"]),
 		Author:             extractAuthor(row["author"]),
 		AuthorAssociation:  asString(row["authorAssociation"]),
-		CommentCount:       len(toObjectSlice(row["comments"])),
+		CommentCount:       len(issueComments),
 		ReviewRequests:     extractReviewRequestLogins(row["reviewRequests"]),
 		ReviewRequestUsers: extractReviewRequestUsers(row["reviewRequests"]),
 		HasConflicts:       asString(row["mergeStateStatus"]) == "DIRTY",
 		Comments:           threads,
-		IssueComments:      extractCommentInfos(toObjectSlice(row["comments"])),
+		IssueComments:      issueComments,
 		Reviews:            toObjectSlice(row["reviews"]),
 		Checks:             toObjectSlice(row["statusCheckRollup"]),
 		Mergeable:          boolPtrFromValue(row["mergeable"]),
 		MergeableState:     asString(row["mergeable_state"]),
 		MergedAt:           asString(row["merged_at"]),
 		AutoMerge:          extractAutoMerge(row["auto_merge"]),
-	}, nil
+	}
 }
 
 func (g *Gateway) viewPullRequestRow(ctx context.Context, input ViewPullRequestInput, fields []string) (map[string]any, error) {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -65,6 +65,8 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 			return shell.Result{Stdout: `[[{"id":14,"number":14,"title":"sub issue","url":"https://api.example.test/issues/14","html_url":"https://example.test/issues/14","repository_url":"https://api.example.test/repos/acme/looper","state":"open","state_reason":"","repository":{"name":"looper","full_name":"acme/looper","url":"https://api.example.test/repos/acme/looper","html_url":"https://example.test/acme/looper"}}]]`}, nil
 		case args == "api --paginate --slurp repos/acme/looper/issues/8/comments":
 			return shell.Result{Stdout: `[[{"id":91,"body":"First human follow-up","html_url":"https://example.test/issues/8#issuecomment-91","created_at":"2026-05-03T13:00:00Z","updated_at":"2026-05-03T13:00:00Z","user":{"login":"reviewer"},"author_association":"MEMBER"}]]`}, nil
+		case args == "api --paginate --slurp repos/acme/looper/issues/42/comments":
+			return shell.Result{Stdout: `[[{"id":92,"body":"conversation notice","html_url":"https://example.test/issues/42#issuecomment-92","created_at":"2026-05-04T13:00:00Z","updated_at":"2026-05-04T13:00:00Z","user":{"login":"reviewer"},"author_association":"MEMBER"}]]`}, nil
 		case args == "api repos/acme/looper/issues/8/comments --method POST -f body=Looper started":
 			return shell.Result{Stdout: `{"id":91,"html_url":"https://example.test/issues/8#issuecomment-91"}`}, nil
 		case args == "api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished":
@@ -192,7 +194,7 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if err := gateway.UpdatePullRequestBody(context.Background(), UpdatePullRequestBodyInput{Repo: "acme/looper", PRNumber: 42, Body: "Updated body"}); err != nil {
 		t.Fatalf("UpdatePullRequestBody() error = %v", err)
 	}
-	detail, err := gateway.ViewPullRequest(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42})
+	detail, err := gateway.ViewPullRequestForReviewer(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42})
 	if err != nil {
 		t.Fatalf("ViewPullRequest() error = %v", err)
 	}
@@ -378,6 +380,9 @@ func TestGatewayViewPullRequestFallsBackWhenReviewRequestReviewerIsInaccessible(
 			}
 			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","createdAt":"2026-05-03T12:00:00Z","updatedAt":"2026-05-04T12:00:00Z","closedAt":"","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","labels":[{"name":"ready"}],"headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"comments":[{"id":"issue-comment-1","body":"conversation notice"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
 		}
+		if args == "api --paginate --slurp repos/acme/looper/issues/42/comments" {
+			return shell.Result{Stdout: `[[]]`}, nil
+		}
 		if strings.Contains(args, "reviewThreads") {
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}`}, nil
 		}
@@ -386,7 +391,7 @@ func TestGatewayViewPullRequestFallsBackWhenReviewRequestReviewerIsInaccessible(
 	}
 
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
-	detail, err := gateway.ViewPullRequest(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42})
+	detail, err := gateway.ViewPullRequestForReviewer(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42})
 	if err != nil {
 		t.Fatalf("ViewPullRequest() error = %v", err)
 	}
@@ -396,8 +401,48 @@ func TestGatewayViewPullRequestFallsBackWhenReviewRequestReviewerIsInaccessible(
 	if detail.ReviewRequests != nil || detail.ReviewRequestUsers != nil {
 		t.Fatalf("fallback review requests = %#v/%#v, want unknown metadata", detail.ReviewRequests, detail.ReviewRequestUsers)
 	}
-	if len(runner.calls) != 3 {
-		t.Fatalf("gh calls = %#v, want primary view, fallback view, and review thread fetch", runner.calls)
+	if len(runner.calls) != 4 {
+		t.Fatalf("gh calls = %#v, want primary view, fallback view, review thread fetch, and issue comments fetch", runner.calls)
+	}
+}
+
+func TestGatewayPullRequestProfilesAvoidUnboundedHistoryFields(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch {
+		case strings.HasPrefix(args, "pr view 42 --repo acme/looper --json "):
+			fields := strings.TrimPrefix(args, "pr view 42 --repo acme/looper --json ")
+			if strings.Contains(fields, "comments") || strings.Contains(fields, "reviews") || strings.Contains(fields, "statusCheckRollup") {
+				t.Fatalf("metadata profile fields = %q, want no comments, reviews, or checks", fields)
+			}
+			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"reviewRequests":[]}`}, nil
+		case strings.HasPrefix(args, "pr view 43 --repo acme/looper --json "):
+			fields := strings.TrimPrefix(args, "pr view 43 --repo acme/looper --json ")
+			if strings.Contains(fields, "comments") || strings.Contains(fields, "reviews") {
+				t.Fatalf("fixer profile fields = %q, want no comments or reviews", fields)
+			}
+			if !strings.Contains(fields, "statusCheckRollup") {
+				t.Fatalf("fixer profile fields = %q, want checks", fields)
+			}
+			return shell.Result{Stdout: `{"number":43,"title":"Fix me","body":"Body","url":"https://example.test/pull/43","state":"OPEN","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"statusCheckRollup":[]}`}, nil
+		case args == "api --paginate --slurp repos/acme/looper/issues/43/comments":
+			return shell.Result{Stdout: `[[]]`}, nil
+		case strings.Contains(args, "reviewThreads"):
+			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	if _, err := gateway.ViewPullRequest(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42}); err != nil {
+		t.Fatalf("ViewPullRequest() error = %v", err)
+	}
+	if _, err := gateway.ViewPullRequestForFixer(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 43}); err != nil {
+		t.Fatalf("ViewPullRequestForFixer() error = %v", err)
 	}
 }
 
@@ -1055,6 +1100,8 @@ func TestGatewayViewPullRequestPaginatesReviewThreads(t *testing.T) {
 		switch {
 		case strings.HasPrefix(args, "pr view 42 --repo acme/looper --json "):
 			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"COMMENTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"reviewRequests":[],"comments":[],"reviews":[],"statusCheckRollup":[]}`}, nil
+		case args == "api --paginate --slurp repos/acme/looper/issues/42/comments":
+			return shell.Result{Stdout: `[[]]`}, nil
 		case strings.Contains(args, "reviewThreads(first: 100, after: $after)") && strings.Contains(args, "-F after=thread-cursor-1"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-2","isResolved":true,"comments":{"nodes":[{"id":"comment-2","body":"second page"}]}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
 		case strings.Contains(args, "reviewThreads(first: 100, after: $after)") && !strings.Contains(args, "-F after="):
@@ -1066,7 +1113,7 @@ func TestGatewayViewPullRequestPaginatesReviewThreads(t *testing.T) {
 	}
 
 	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
-	detail, err := gateway.ViewPullRequest(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42})
+	detail, err := gateway.ViewPullRequestForReviewer(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42})
 	if err != nil {
 		t.Fatalf("ViewPullRequest() error = %v", err)
 	}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -423,10 +423,10 @@ func TestGatewayPullRequestProfilesAvoidUnboundedHistoryFields(t *testing.T) {
 			if strings.Contains(fields, "comments") || strings.Contains(fields, "reviews") {
 				t.Fatalf("fixer profile fields = %q, want no comments or reviews", fields)
 			}
-			if !strings.Contains(fields, "statusCheckRollup") {
-				t.Fatalf("fixer profile fields = %q, want checks", fields)
+			if !strings.Contains(fields, "statusCheckRollup") || !strings.Contains(fields, "reviewRequests") {
+				t.Fatalf("fixer profile fields = %q, want checks and review requests", fields)
 			}
-			return shell.Result{Stdout: `{"number":43,"title":"Fix me","body":"Body","url":"https://example.test/pull/43","state":"OPEN","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"statusCheckRollup":[]}`}, nil
+			return shell.Result{Stdout: `{"number":43,"title":"Fix me","body":"Body","url":"https://example.test/pull/43","state":"OPEN","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"login":"reviewer"}}],"statusCheckRollup":[]}`}, nil
 		case args == "api --paginate --slurp repos/acme/looper/issues/43/comments":
 			return shell.Result{Stdout: `[[]]`}, nil
 		case strings.Contains(args, "reviewThreads"):

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -427,7 +427,18 @@ func TestGatewayPullRequestProfilesAvoidUnboundedHistoryFields(t *testing.T) {
 				t.Fatalf("fixer profile fields = %q, want checks and review requests", fields)
 			}
 			return shell.Result{Stdout: `{"number":43,"title":"Fix me","body":"Body","url":"https://example.test/pull/43","state":"OPEN","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"login":"reviewer"}}],"statusCheckRollup":[]}`}, nil
+		case strings.HasPrefix(args, "pr view 44 --repo acme/looper --json "):
+			fields := strings.TrimPrefix(args, "pr view 44 --repo acme/looper --json ")
+			if strings.Contains(fields, "comments") {
+				t.Fatalf("reviewer profile fields = %q, want no comments", fields)
+			}
+			if !strings.Contains(fields, "reviews") || !strings.Contains(fields, "statusCheckRollup") || !strings.Contains(fields, "reviewRequests") {
+				t.Fatalf("reviewer profile fields = %q, want reviews, checks, and review requests", fields)
+			}
+			return shell.Result{Stdout: `{"number":44,"title":"Review me","body":"Body","url":"https://example.test/pull/44","state":"OPEN","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"login":"reviewer"}}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[]}`}, nil
 		case args == "api --paginate --slurp repos/acme/looper/issues/43/comments":
+			return shell.Result{Stdout: `[[]]`}, nil
+		case args == "api --paginate --slurp repos/acme/looper/issues/44/comments":
 			return shell.Result{Stdout: `[[]]`}, nil
 		case strings.Contains(args, "reviewThreads"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
@@ -443,6 +454,9 @@ func TestGatewayPullRequestProfilesAvoidUnboundedHistoryFields(t *testing.T) {
 	}
 	if _, err := gateway.ViewPullRequestForFixer(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 43}); err != nil {
 		t.Fatalf("ViewPullRequestForFixer() error = %v", err)
+	}
+	if _, err := gateway.ViewPullRequestForReviewer(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 44}); err != nil {
+		t.Fatalf("ViewPullRequestForReviewer() error = %v", err)
 	}
 }
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1846,6 +1846,45 @@ func TestGatewayIgnoresMissingLabelDeleteErrors(t *testing.T) {
 	}
 }
 
+func TestGatewayCapturePullRequestSnapshotPreservesFullDetails(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch {
+		case strings.HasPrefix(args, "pr view 42 --repo acme/looper --json "):
+			fields := strings.TrimPrefix(args, "pr view 42 --repo acme/looper --json ")
+			for _, field := range []string{"reviews", "statusCheckRollup"} {
+				if !strings.Contains(fields, field) {
+					t.Fatalf("snapshot pr view fields = %q, want %s", fields, field)
+				}
+			}
+			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","state":"OPEN","reviewDecision":"CHANGES_REQUESTED","headRefOid":"abc123","baseRefOid":"def456","author":{"login":"octocat"},"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"FAILURE"}]}`}, nil
+		case strings.Contains(args, "reviewThreads"):
+			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"comments":{"nodes":[{"id":"comment-1","body":"Fix this"}]}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
+		case args == "api --paginate --slurp repos/acme/looper/issues/42/comments":
+			return shell.Result{Stdout: `[[]]`}, nil
+		case strings.HasPrefix(args, "pr diff"):
+			return shell.Result{Stdout: "diff --git a/a.go b/a.go\n"}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+	gateway := New(Options{GHPath: "gh", GHRun: runner.run})
+
+	snapshot, err := gateway.CapturePullRequestSnapshot(context.Background(), CapturePullRequestSnapshotInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("CapturePullRequestSnapshot() error = %v", err)
+	}
+	if snapshot.ChecksSummary == nil || *snapshot.ChecksSummary != "FAILURE" {
+		t.Fatalf("ChecksSummary = %v, want FAILURE", snapshot.ChecksSummary)
+	}
+	if snapshot.UnresolvedThreadCount == nil || *snapshot.UnresolvedThreadCount != 1 {
+		t.Fatalf("UnresolvedThreadCount = %v, want 1", snapshot.UnresolvedThreadCount)
+	}
+}
+
 func TestGatewayCapturePullRequestSnapshotTruncatesTooLargeDiff(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}
@@ -1856,6 +1895,8 @@ func TestGatewayCapturePullRequestSnapshotTruncatesTooLargeDiff(t *testing.T) {
 			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","state":"OPEN","headRefOid":"abc123"}`}, nil
 		case strings.Contains(args, "reviewThreads"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}`}, nil
+		case args == "api --paginate --slurp repos/acme/looper/issues/42/comments":
+			return shell.Result{Stdout: `[[]]`}, nil
 		case strings.HasPrefix(args, "pr diff"):
 			result := shell.Result{ExitCode: 1, Stderr: "HTTP 406: diff exceeded maximum number of lines too_large"}
 			return result, &shell.CommandExecutionError{Message: result.Stderr, Result: result}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -682,7 +682,7 @@ func (a reviewerGitHubAdapter) ViewPullRequest(ctx context.Context, input review
 	if a.gateway == nil {
 		return reviewer.PullRequestDetail{}, fmt.Errorf("github gateway is not configured")
 	}
-	detail, err := a.gateway.ViewPullRequest(ctx, githubinfra.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
+	detail, err := a.gateway.ViewPullRequestForReviewer(ctx, githubinfra.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 	if err != nil {
 		return reviewer.PullRequestDetail{}, err
 	}
@@ -926,7 +926,7 @@ func (a fixerGitHubAdapter) GetPullRequestAuthor(ctx context.Context, input fixe
 }
 
 func (a fixerGitHubAdapter) ViewPullRequest(ctx context.Context, input fixer.ViewPullRequestInput) (fixer.PullRequestDetail, error) {
-	detail, err := a.gateway.ViewPullRequest(ctx, githubinfra.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
+	detail, err := a.gateway.ViewPullRequestForFixer(ctx, githubinfra.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 	if err != nil {
 		return fixer.PullRequestDetail{}, err
 	}


### PR DESCRIPTION
## Summary
- Split GitHub PR view retrieval into metadata, fixer, and reviewer profiles.
- Route fixer recheck through a profile that excludes full `comments` and `reviews` from `gh pr view`, while still fetching checks, review threads, and issue comments separately.
- Keep worker and planner on the metadata-only default view.
- Add regression coverage for profile field selection and update snapshot tests for the smaller default payload.

## Trade-off
This introduces named PR view profiles to prevent `gh pr view` from acting as an unbounded transfer channel for long comment and review histories. The cost is another gateway method boundary and profile field lists that must stay aligned with role needs; a simpler output-limit increase was insufficient because it only postpones failures as PR histories grow.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #510

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>