### PR TITLE
fix(e2e): restore fake-agent gh path in fixer sandbox config (unblocks release)

### DIFF
--- a/internal/e2e/github_sandbox_test.go
+++ b/internal/e2e/github_sandbox_test.go
@@ -350,7 +350,14 @@ func workerSandboxConfig(tb testing.TB, bins harness.BuiltBinaries, home harness
 
 func fixerSandboxConfig(tb testing.TB, bins harness.BuiltBinaries, home harness.TempHome, repo harness.SeededRepo, fakeAgent harness.FakeAgent, port int, agentMode string) config.Config {
 	tb.Helper()
-	vendor, command, agentEnv := fakeAgent.AgentConfig(agentMode, "git", "")
+	// The fixer's resolve-comments drift guard requires the agent's reply to
+	// carry a `threadCommentsObserved` snapshot; a "fixed" decision without one
+	// is treated as drift and skipped (fixedDecisionMissingThreadSnapshot).
+	// The fake agent only fetches that snapshot when it has a gh path, so pass
+	// the same real `gh` the daemon uses. Before #513 the fake agent defaulted
+	// to `gh` on PATH; that fallback was removed, which silently regressed this
+	// live sandbox test into a deterministic thread-drift failure.
+	vendor, command, agentEnv := fakeAgent.AgentConfig(agentMode, "git", "gh")
 	cfg := harness.DefaultConfig(tb, home, harness.ConfigOptions{
 		Port:              port,
 		ToolPaths:         harness.TestToolPaths{Git: "git", GH: "gh", Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},


### PR DESCRIPTION
## What

`TestGitHubSandboxFixerResolvesReviewThread` has failed **deterministically** on `main` since **#513** (last green: **#511**), which blocks the release gate. The three consecutive red runs (#513, #518, #517) are the *identical* resolve-comments thread-drift skip — not a flake.

## Root cause

#513 removed the fake agent's `gh`-on-PATH fallback in `fetchObservedThreadHashes` (it now returns an empty snapshot map unless `LOOPER_E2E_FAKE_AGENT_GH_PATH` is set). The GitHub sandbox **fixer** config (`fixerSandboxConfig`) passed an empty `ghPath`, so the fake agent emitted no `threadCommentsObserved` snapshot. The fixer's `fixedDecisionMissingThreadSnapshot` guard then classifies every `fixed` decision as thread drift → skips it → `retryable_after_resume` failure.

Production is unaffected: the real agent is prompted to emit `threadCommentsObserved`; only the E2E fake agent regressed.

## Fix

Pass the same real `gh` the daemon uses (`ToolPaths.GH: "gh"`) into the fixer sandbox config's fake agent, so it fetches the observed-thread snapshot the drift guard expects. This mirrors the env-opt-in design #513 introduced — Forgejo intentionally keeps `""` since it doesn't use `gh`.

One line + a comment; no production code touched.

## Validation

`sandbox-e2e` doesn't run on PRs (only `push: main` + `workflow_dispatch`), so I dispatched it on this branch:
- Run [28767042136](https://github.com/nexu-io/looper/actions/runs/28767042136) → **success** (`ok internal/e2e 80.154s`), the previously-failing test now passes against the live sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)