### PR TITLE
feat(worker): per-person Plane routing via planeAssigneeId

### DIFF
--- a/docs/GUIDE-hitl-setup.md
+++ b/docs/GUIDE-hitl-setup.md
@@ -116,27 +116,55 @@ export LOOPER_FEISHU_INBOX_TOKEN=xxx           # shared secret to read /events (
 export LOOPER_CODEX_JSON_EVENTS=1              # optional: live tool-call feed in the thread
 ```
 
-## 3b. Per-person IDs (Feishu open_id · Plane member UUID)
-Two settings are per-person (they go in each teammate's own config, not the shared env):
+## 3b. Where every value comes from
+Nothing here has to be guessed. Grouped by who owns it.
 
-**Feishu `open_id`** — who a decision card @-mentions (`notifications.webhook.mentionOpenIds`). To get yours:
-- Easiest: ask whoever administers the Feishu app — they can read it from the group's member list in one call
-  (`GET open-apis/im/v1/chats/{chat_id}/members?member_id_type=open_id`).
-- Self-serve: Feishu 开放平台 → API 调试台 → `通讯录 / 批量获取用户 ID` (`contact/v3/users/batch_get_id`),
-  set `user_id_type=open_id`, pass your own email or mobile → the returned `user_id` is your `open_id` (`ou_...`).
+### Shared — pre-filled in `hitl.env`, same for the whole team (you don't fetch these)
+| Env var | What it is | Where it comes from |
+| --- | --- | --- |
+| `LOOPER_FEISHU_APP_ID` | Feishu app id (`cli_...`) | Feishu 开放平台 → your app → 凭证与基础信息 |
+| `LOOPER_FEISHU_APP_SECRET` | Feishu app secret | same page (凭证与基础信息) |
+| `LOOPER_FEISHU_VERIFY_TOKEN` | event verification token | Feishu app → 事件与回调 → 加密策略 → Verification Token |
+| `LOOPER_FEISHU_INBOX_URL` | CF inbox worker `/events` URL | the worker's domain + `/events` (see §4) |
+| `LOOPER_FEISHU_INBOX_TOKEN` | worker `POLL_TOKEN` | set when the worker was deployed (§4) |
 
-Leave `mentionOpenIds` empty for no @-mention, or default it to the team lead so an unset teammate still pings someone.
+Whoever set the team up fills these once and distributes the filled `hitl.env` privately.
 
-**Plane member UUID** — only needed for a Plane task-source project, to route work-items per person
-(`roles.worker.triggers.planeAssigneeId`). Get yours with your **own** Plane API key (Plane → Settings → API tokens):
-```sh
-curl -s -H "X-API-Key: <YOUR_PLANE_API_KEY>" -H "Accept: application/json" \
-  https://plane.powerformer.net/api/v1/users/me/ | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])'
-```
-The printed `id` is your Plane member UUID. Put it in `planeAssigneeId` so your looper only picks up Plane
-work-items assigned to you; the daemon can then read the project with the shared `PLANE_API_KEY`. Leaving it empty
-falls back to label-only discovery (every looper watching that project sees every item — use one central looper then).
-See [`skills/looper/references/plane.md`](../skills/looper/references/plane.md) for the full Plane setup.
+### Per-person — Feishu
+- **`open_id`** (`notifications.webhook.mentionOpenIds`, who a card @-mentions):
+  - Easiest: ask the Feishu app admin — one call reads it from the group members
+    (`GET open-apis/im/v1/chats/{chat_id}/members?member_id_type=open_id`).
+  - Self-serve: Feishu 开放平台 → API 调试台 → `通讯录 / 批量获取用户 ID` (`contact/v3/users/batch_get_id`),
+    `user_id_type=open_id`, pass your own email/mobile → the returned `user_id` is your `open_id` (`ou_...`).
+  - Empty = no @-mention; or default it to the team lead so an unset teammate still pings someone.
+
+### Per-person — GitHub
+- **`repo`** (`owner/repo`) — the GitHub repo whose issues/PRs looper handles.
+- **`repoPath`** — the **absolute path** of your local clone of that repo.
+- **GitHub auth** — `gh auth login` as yourself; looper drives `gh`, so PRs/comments show as you.
+
+### Per-person — coding agent
+- **`agent.params.command`** — absolute path to your `codex` / `claude` binary (`which codex`), and it must be **logged in**.
+
+### Per-person — Plane (only if your tasks live in Plane) — use the `plane` CLI
+The self-developed [`plane` CLI](https://github.com/powerformer/plane-cli) reads everything with your own API key. Configure it once — put your key + workspace in `~/.plane/plane.toml` (or export `PLANE_API_KEY` / `PLANE_WORKSPACE_SLUG`) — then:
+
+| Config value | Command to get it |
+| --- | --- |
+| **`PLANE_API_KEY`** (env; each person their **own** key) | Plane → workspace settings → **API Tokens** → create one |
+| **`planeAssigneeId`** = your member UUID (`roles.worker.triggers.planeAssigneeId`) | `plane api me` → the `id:` line |
+| provider **`projectId`** (Plane project UUID) | `plane api project list` → first column of your project |
+| provider **`workspace`** (slug) | it's your workspace slug (e.g. `open-design`); `plane api me` echoes the base |
+| provider **`baseUrl`** | `https://plane.powerformer.net/api/v1` (the default) |
+
+`plane api me` doubles as an auth smoke-test. An admin can hand out anyone's UUID with `plane api member workspace-list`.
+Put your UUID in `planeAssigneeId` so your looper only picks up Plane work-items **assigned to you**; leaving it empty
+falls back to label-only discovery (every looper watching that project grabs every item — use one central looper then).
+Each teammate should use **their own** Plane API key (correct attribution + `plane api me` gives their UUID), not a
+shared one. Full Plane setup: [`skills/looper/references/plane.md`](../skills/looper/references/plane.md).
+
+### looper's own data
+- **`storage` / `daemon` paths** — anywhere you like; default `~/.looper` (`looper.sqlite`, `backups/`, `logs/`).
 
 ## 4. Cloudflare inbox worker (shared Feishu app)
 So one shared Feishu app can reach many NAT'd looper daemons, Feishu posts events

--- a/docs/GUIDE-hitl-setup.md
+++ b/docs/GUIDE-hitl-setup.md
@@ -116,6 +116,28 @@ export LOOPER_FEISHU_INBOX_TOKEN=xxx           # shared secret to read /events (
 export LOOPER_CODEX_JSON_EVENTS=1              # optional: live tool-call feed in the thread
 ```
 
+## 3b. Per-person IDs (Feishu open_id · Plane member UUID)
+Two settings are per-person (they go in each teammate's own config, not the shared env):
+
+**Feishu `open_id`** — who a decision card @-mentions (`notifications.webhook.mentionOpenIds`). To get yours:
+- Easiest: ask whoever administers the Feishu app — they can read it from the group's member list in one call
+  (`GET open-apis/im/v1/chats/{chat_id}/members?member_id_type=open_id`).
+- Self-serve: Feishu 开放平台 → API 调试台 → `通讯录 / 批量获取用户 ID` (`contact/v3/users/batch_get_id`),
+  set `user_id_type=open_id`, pass your own email or mobile → the returned `user_id` is your `open_id` (`ou_...`).
+
+Leave `mentionOpenIds` empty for no @-mention, or default it to the team lead so an unset teammate still pings someone.
+
+**Plane member UUID** — only needed for a Plane task-source project, to route work-items per person
+(`roles.worker.triggers.planeAssigneeId`). Get yours with your **own** Plane API key (Plane → Settings → API tokens):
+```sh
+curl -s -H "X-API-Key: <YOUR_PLANE_API_KEY>" -H "Accept: application/json" \
+  https://plane.powerformer.net/api/v1/users/me/ | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])'
+```
+The printed `id` is your Plane member UUID. Put it in `planeAssigneeId` so your looper only picks up Plane
+work-items assigned to you; the daemon can then read the project with the shared `PLANE_API_KEY`. Leaving it empty
+falls back to label-only discovery (every looper watching that project sees every item — use one central looper then).
+See [`skills/looper/references/plane.md`](../skills/looper/references/plane.md) for the full Plane setup.
+
 ## 4. Cloudflare inbox worker (shared Feishu app)
 So one shared Feishu app can reach many NAT'd looper daemons, Feishu posts events
 to a small Cloudflare Worker; each daemon polls it. Setup in

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -1274,6 +1274,9 @@ func mergeIssueRoleTriggersConfig(config *IssueRoleTriggersConfig, partial Parti
 	if partial.RequireAssigneeCurrentUser != nil {
 		config.RequireAssigneeCurrentUser = *partial.RequireAssigneeCurrentUser
 	}
+	if partial.PlaneAssigneeID != nil {
+		config.PlaneAssigneeID = *partial.PlaneAssigneeID
+	}
 }
 
 func mergePullRequestRoleTriggersConfig(config *PullRequestRoleTriggersConfig, partial PartialPullRequestRoleTriggersConfig) {

--- a/internal/config/project_roles.go
+++ b/internal/config/project_roles.go
@@ -15,6 +15,16 @@ func ProjectRoleConfigs(cfg Config, projectID string) RoleConfigs {
 	return roles
 }
 
+// ProjectProviderKind resolves the task-source provider kind for a project by
+// id (github / forgejo / plane). Unknown ids fall back to the GitHub default.
+func ProjectProviderKind(cfg Config, projectID string) ProviderKind {
+	project := findConfiguredProject(cfg.Projects, projectID)
+	if project == nil {
+		return ProviderKindGitHub
+	}
+	return resolvedProjectProviderKind(cfg, *project)
+}
+
 func ProjectRoleAutoDiscoveryEnabled(cfg Config, projectID, role string) bool {
 	roles := ProjectRoleConfigs(cfg, projectID)
 	switch role {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -438,6 +438,13 @@ type IssueRoleTriggersConfig struct {
 	Labels                     []string  `json:"labels"`
 	LabelMode                  LabelMode `json:"labelMode"`
 	RequireAssigneeCurrentUser bool      `json:"requireAssigneeCurrentUser"`
+	// PlaneAssigneeID scopes discovery on a Plane task-source project to
+	// work-items assigned to this Plane member UUID. Plane assignees are UUIDs
+	// (not GitHub logins), so RequireAssigneeCurrentUser can't route them; set
+	// this per person instead so each looper only picks up its owner's items.
+	// Empty = label-only discovery (every watching looper sees every item).
+	// Ignored for non-Plane providers.
+	PlaneAssigneeID string `json:"planeAssigneeId,omitempty"`
 }
 
 type PullRequestRoleTriggersConfig struct {
@@ -922,6 +929,7 @@ type PartialIssueRoleTriggersConfig struct {
 	Labels                     *[]string  `json:"labels,omitempty"`
 	LabelMode                  *LabelMode `json:"labelMode,omitempty"`
 	RequireAssigneeCurrentUser *bool      `json:"requireAssigneeCurrentUser,omitempty"`
+	PlaneAssigneeID            *string    `json:"planeAssigneeId,omitempty"`
 }
 
 type PartialPullRequestRoleTriggersConfig struct {

--- a/internal/forge/plane_live_e2e_test.go
+++ b/internal/forge/plane_live_e2e_test.go
@@ -1,0 +1,84 @@
+package forge
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+// TestPlaneAssigneeFilterLiveE2E exercises the real Plane API to prove that
+// ListOpenIssues(Assignee: <uuid>) — the primitive per-person Plane routing is
+// wired onto — returns only work-items assigned to that member UUID. Gated:
+//
+//	PLANE_LIVE_E2E=1 PLANE_API_KEY=... PLANE_E2E_WORKSPACE=... \
+//	PLANE_E2E_PROJECT=... PLANE_E2E_ASSIGNEE=<present-uuid> \
+//	go test ./internal/forge -run TestPlaneAssigneeFilterLiveE2E -count=1
+func TestPlaneAssigneeFilterLiveE2E(t *testing.T) {
+	if os.Getenv("PLANE_LIVE_E2E") != "1" {
+		t.Skip("set PLANE_LIVE_E2E=1 (+ PLANE_API_KEY/PLANE_E2E_WORKSPACE/PLANE_E2E_PROJECT/PLANE_E2E_ASSIGNEE) to run")
+	}
+	workspace := os.Getenv("PLANE_E2E_WORKSPACE")
+	projectID := os.Getenv("PLANE_E2E_PROJECT")
+	assignee := os.Getenv("PLANE_E2E_ASSIGNEE")
+	if workspace == "" || projectID == "" || assignee == "" || os.Getenv("PLANE_API_KEY") == "" {
+		t.Fatal("PLANE_API_KEY, PLANE_E2E_WORKSPACE, PLANE_E2E_PROJECT, PLANE_E2E_ASSIGNEE are required")
+	}
+	tokenEnv := "PLANE_API_KEY"
+	baseURL := os.Getenv("PLANE_E2E_BASE_URL")
+	provider := config.ProviderConfig{ID: "plane-e2e", Kind: config.ProviderKindPlane, BaseURL: baseURL, TokenEnv: &tokenEnv, Workspace: &workspace, ProjectID: &projectID}
+	client, err := NewPlaneClientFromConfig(provider, "acme/looper")
+	if err != nil {
+		t.Fatalf("NewPlaneClientFromConfig() error = %v", err)
+	}
+	ctx := context.Background()
+
+	all, err := client.ListOpenIssues(ctx, ListIssuesInput{})
+	if err != nil {
+		t.Fatalf("ListOpenIssues(unfiltered) error = %v", err)
+	}
+	mine, err := client.ListOpenIssues(ctx, ListIssuesInput{Assignee: assignee})
+	if err != nil {
+		t.Fatalf("ListOpenIssues(assignee=%s) error = %v", assignee, err)
+	}
+	absent := "00000000-0000-0000-0000-000000000000"
+	none, err := client.ListOpenIssues(ctx, ListIssuesInput{Assignee: absent})
+	if err != nil {
+		t.Fatalf("ListOpenIssues(assignee=%s) error = %v", absent, err)
+	}
+
+	t.Logf("unfiltered=%d assignee(%s)=%d absent=%d", len(all), assignee, len(mine), len(none))
+
+	if len(mine) == 0 {
+		t.Fatalf("assignee-filtered list is empty; expected at least one work-item assigned to %s", assignee)
+	}
+	if len(mine) >= len(all) {
+		t.Fatalf("assignee-filtered=%d not a strict subset of unfiltered=%d; filter had no effect", len(mine), len(all))
+	}
+	if len(none) != 0 {
+		t.Fatalf("filtering by an unassigned UUID returned %d items, want 0", len(none))
+	}
+
+	allNumbers := make(map[int64]bool, len(all))
+	for _, issue := range all {
+		allNumbers[issue.Number] = true
+	}
+	for _, issue := range mine {
+		if !allNumbers[issue.Number] {
+			t.Fatalf("assignee-filtered work-item #%d not present in the unfiltered listing", issue.Number)
+		}
+		if !identityListContains(issue.Assignees, assignee) {
+			t.Fatalf("work-item #%d returned by the assignee filter does not carry assignee %s: %+v", issue.Number, assignee, issue.Assignees)
+		}
+	}
+}
+
+func identityListContains(ids []Identity, want string) bool {
+	for _, id := range ids {
+		if id.Login == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -508,6 +508,10 @@ type DiscoveryPolicy struct {
 	LabelMode                  config.LabelMode
 	RequireAssigneeCurrentUser bool
 	RoutedClaimPolicy          networkpolicy.ProjectPolicy
+	// IsPlane marks a Plane task-source project; PlaneAssigneeID, when set,
+	// scopes discovery to work-items assigned to that Plane member UUID.
+	IsPlane         bool
+	PlaneAssigneeID string
 }
 
 type Runner struct {
@@ -855,7 +859,12 @@ func (r *Runner) DiscoverIssues(ctx context.Context, input DiscoveryInput) (Disc
 		return DiscoveryResult{Skipped: 1}, nil
 	}
 	assigneeFilter := ""
-	if !networkpolicy.IsRouted(policy.RoutedClaimPolicy) && policy.RequireAssigneeCurrentUser {
+	if policy.IsPlane {
+		// Plane assignees are UUIDs, so the GitHub-login assignee gate can't
+		// route them. Scope to the owner's configured Plane member UUID when set
+		// (empty = label-only discovery); never fall back to the GitHub login.
+		assigneeFilter = policy.PlaneAssigneeID
+	} else if !networkpolicy.IsRouted(policy.RoutedClaimPolicy) && policy.RequireAssigneeCurrentUser {
 		assigneeFilter = login
 	}
 	requiredTargetLabel, err := r.requiredTargetLabel(ctx, project.ID)
@@ -902,7 +911,8 @@ func (r *Runner) discoveryPolicyForProject(projectID string) DiscoveryPolicy {
 		return r.discoveryPolicy
 	}
 	roles := config.ProjectRoleConfigs(*r.projectRoleConfig, projectID)
-	return DiscoveryPolicy{AutoDiscovery: roles.Worker.AutoDiscovery, Labels: append([]string(nil), roles.Worker.Triggers.Labels...), LabelMode: roles.Worker.Triggers.LabelMode, RequireAssigneeCurrentUser: roles.Worker.Triggers.RequireAssigneeCurrentUser, RoutedClaimPolicy: networkpolicy.ProjectPolicyForProject(*r.projectRoleConfig, projectID)}
+	isPlane := config.ProjectProviderKind(*r.projectRoleConfig, projectID) == config.ProviderKindPlane
+	return DiscoveryPolicy{AutoDiscovery: roles.Worker.AutoDiscovery, Labels: append([]string(nil), roles.Worker.Triggers.Labels...), LabelMode: roles.Worker.Triggers.LabelMode, RequireAssigneeCurrentUser: roles.Worker.Triggers.RequireAssigneeCurrentUser, RoutedClaimPolicy: networkpolicy.ProjectPolicyForProject(*r.projectRoleConfig, projectID), IsPlane: isPlane, PlaneAssigneeID: strings.TrimSpace(roles.Worker.Triggers.PlaneAssigneeID)}
 }
 
 func (r *Runner) requiredTargetLabel(ctx context.Context, projectID string) (string, error) {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -317,6 +317,54 @@ func TestDiscoverIssuesRoutedProjectCombinesTargetLabelWithAnyTriggerQueries(t *
 	}
 }
 
+func TestDiscoverIssuesScopesPlaneWorkItemsToConfiguredAssigneeUUID(t *testing.T) {
+	t.Parallel()
+	const planeUUID = "11111111-2222-3333-4444-555555555555"
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Providers = []config.ProviderConfig{{ID: "plane-open-design", Kind: config.ProviderKindPlane}}
+	fixture.cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Provider: "plane-open-design", Repo: "acme/looper"}}
+	fixture.cfg.Roles.Worker.AutoDiscovery = true
+	fixture.cfg.Roles.Worker.Triggers.Labels = []string{"looper:plan"}
+	fixture.cfg.Roles.Worker.Triggers.LabelMode = config.LabelModeAll
+	fixture.cfg.Roles.Worker.Triggers.RequireAssigneeCurrentUser = false
+	fixture.cfg.Roles.Worker.Triggers.PlaneAssigneeID = planeUUID
+	github := &fakeGitHubGateway{issues: []IssueSummary{{Number: 7, Title: "Plane item", Labels: []string{"looper:plan"}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: fixture.cfg})
+
+	if _, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(github.listIssueCalls) == 0 {
+		t.Fatalf("no ListOpenIssues call recorded")
+	}
+	if got := github.listIssueCalls[0].Assignee; got != planeUUID {
+		t.Fatalf("ListOpenIssues Assignee = %q, want the configured Plane UUID %q", got, planeUUID)
+	}
+}
+
+func TestDiscoverIssuesPlaneWithoutAssigneeUUIDStaysLabelOnly(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	fixture.cfg.Providers = []config.ProviderConfig{{ID: "plane-open-design", Kind: config.ProviderKindPlane}}
+	fixture.cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Provider: "plane-open-design", Repo: "acme/looper"}}
+	fixture.cfg.Roles.Worker.AutoDiscovery = true
+	fixture.cfg.Roles.Worker.Triggers.Labels = []string{"looper:plan"}
+	fixture.cfg.Roles.Worker.Triggers.LabelMode = config.LabelModeAll
+	fixture.cfg.Roles.Worker.Triggers.RequireAssigneeCurrentUser = false
+	github := &fakeGitHubGateway{issues: []IssueSummary{{Number: 7, Title: "Plane item", Labels: []string{"looper:plan"}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: fixture.cfg})
+
+	if _, err := runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverIssues() error = %v", err)
+	}
+	if len(github.listIssueCalls) == 0 {
+		t.Fatalf("no ListOpenIssues call recorded")
+	}
+	if got := github.listIssueCalls[0].Assignee; got != "" {
+		t.Fatalf("ListOpenIssues Assignee = %q, want empty (label-only) when no Plane UUID configured", got)
+	}
+}
+
 func TestDiscoverIssuesPreservesExistingWorkerMetadataOnRediscovery(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/skills/looper/references/plane.md
+++ b/skills/looper/references/plane.md
@@ -67,7 +67,7 @@ Redact both as `***` in any summary. An authenticated `gh` is still needed for t
   ],
   "roles": {
     "planner": { "autoDiscovery": true, "triggers": { "labels": ["looper:plan"], "labelMode": "all", "requireAssigneeCurrentUser": false } },
-    "worker":  { "autoDiscovery": true, "triggers": { "labels": ["looper:plan"], "labelMode": "all", "requireAssigneeCurrentUser": false } }
+    "worker":  { "autoDiscovery": true, "triggers": { "labels": ["looper:plan"], "labelMode": "all", "requireAssigneeCurrentUser": false, "planeAssigneeId": "<your-plane-member-uuid>" } }
   },
   "notifications": { "webhook": { "enabled": true, "urlEnv": "LOOPER_FEISHU_WEBHOOK_URL", "format": "feishu", "levels": ["action_required", "failure"] } }
 }
@@ -75,7 +75,8 @@ Redact both as `***` in any summary. An authenticated `gh` is still needed for t
 
 Key facts an agent must not get wrong:
 
-- Plane assignees are UUIDs, not GitHub logins, so discovery keys on the label only. Keep `requireAssigneeCurrentUser: false`; setting it `true` makes discovery match nothing.
+- Plane assignees are UUIDs, not GitHub logins, so `requireAssigneeCurrentUser` (which resolves the GitHub login) can't route them — keep it `false`, or discovery matches nothing.
+- To route Plane work-items **per person** (so each teammate's looper only picks up its owner's items instead of every looper racing for every labelled item), set `triggers.planeAssigneeId` to that person's Plane member UUID. Empty = label-only discovery (fine when a single central looper consumes the project). Ignored for github/forgejo providers. Get the UUID with the owner's own Plane API key: `curl -s -H "X-API-Key: <key>" -H "Accept: application/json" https://plane.powerformer.net/api/v1/users/me/` → the `id` field.
 - `repo` is the GitHub code repo where PRs land; `workspace`/`projectId` on the provider point at Plane.
 - Coordinator and Fixer lanes are skipped for plane projects; Reviewer runs against the GitHub PRs Worker opens.
 

--- a/skills/looper/references/plane.md
+++ b/skills/looper/references/plane.md
@@ -76,7 +76,7 @@ Redact both as `***` in any summary. An authenticated `gh` is still needed for t
 Key facts an agent must not get wrong:
 
 - Plane assignees are UUIDs, not GitHub logins, so `requireAssigneeCurrentUser` (which resolves the GitHub login) can't route them — keep it `false`, or discovery matches nothing.
-- To route Plane work-items **per person** (so each teammate's looper only picks up its owner's items instead of every looper racing for every labelled item), set `triggers.planeAssigneeId` to that person's Plane member UUID. Empty = label-only discovery (fine when a single central looper consumes the project). Ignored for github/forgejo providers. Get the UUID with the owner's own Plane API key: `curl -s -H "X-API-Key: <key>" -H "Accept: application/json" https://plane.powerformer.net/api/v1/users/me/` → the `id` field.
+- To route Plane work-items **per person** (so each teammate's looper only picks up its owner's items instead of every looper racing for every labelled item), set `triggers.planeAssigneeId` to that person's Plane member UUID. Empty = label-only discovery (fine when a single central looper consumes the project). Ignored for github/forgejo providers. Get the UUID with the `plane` CLI: `plane api me` → the `id:` line (or `plane api member workspace-list` for anyone's; raw: `curl -H "X-API-Key: <key>" .../api/v1/users/me/` → `id`). Get the `projectId` with `plane api project list`.
 - `repo` is the GitHub code repo where PRs land; `workspace`/`projectId` on the provider point at Plane.
 - Coordinator and Fixer lanes are skipped for plane projects; Reviewer runs against the GitHub PRs Worker opens.
 


### PR DESCRIPTION
## Why

Plane assignees are UUIDs, not GitHub logins, so `requireAssigneeCurrentUser` (which resolves the GitHub login via `gh`) can't route them — it's documented as "must stay false for Plane". That leaves Plane discovery **label-only**: every looper watching a shared Plane project races for every labelled work-item, and since the claim lock lives in each daemon's local SQLite there's **no cross-daemon dedup** → duplicate work / duplicate PRs.

So there was no way to say "*this* teammate's looper handles *these* Plane items."

## What

Add `roles.<planner|worker>.triggers.planeAssigneeId` — a Plane member UUID. When set on a Plane task-source project, worker discovery scopes the work-item listing to that assignee, so each teammate's looper only picks up items assigned to them.

The plumbing mostly existed: `ListIssuesInput.Assignee` → the Plane client's `workItemHasAssignee` UUID filter is already there. This wires **config → discovery**:
- `IssueRoleTriggersConfig.PlaneAssigneeID` (+ partial + merge).
- `config.ProjectProviderKind(cfg, projectID)` helper.
- `DiscoveryPolicy` gains `IsPlane` + `PlaneAssigneeID`; for a Plane project the discovery assignee filter is **exclusively** the UUID (never the GitHub login), so a stray `requireAssigneeCurrentUser: true` can't silently break Plane discovery.

Empty `planeAssigneeId` = label-only discovery (correct when a single central looper consumes the project). Off by default; GitHub/Forgejo unaffected.

## Docs
- `GUIDE-hitl-setup.md`: how to obtain your **Plane member UUID** (`users/me`) and your **Feishu open_id**.
- `skills/looper/references/plane.md`: `planeAssigneeId` in the config shape + key facts.

## Tests
- `TestDiscoverIssuesScopesPlaneWorkItemsToConfiguredAssigneeUUID` — Plane project with `planeAssigneeId` set → discovery lists with that UUID as the assignee filter.
- `TestDiscoverIssuesPlaneWithoutAssigneeUUIDStaysLabelOnly` — no UUID → no assignee filter (label-only, prior behavior).

Local `scripts/verify.sh` (gofmt/vet/test/build) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)