### PR TITLE
fix: report partial stop outcomes truthfully

### DIFF
--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -90,13 +90,31 @@ type daemonRuntime struct {
 }
 
 type stopLoopResult struct {
-	Stopped     bool   `json:"stopped"`
-	LoopID      string `json:"loopId"`
-	RunID       string `json:"runId,omitempty"`
-	ExecutionID string `json:"executionId,omitempty"`
-	Vendor      string `json:"vendor,omitempty"`
-	PID         int64  `json:"pid,omitempty"`
+	Stopped           bool   `json:"stopped"`
+	LoopID            string `json:"loopId"`
+	RunID             string `json:"runId,omitempty"`
+	ExecutionID       string `json:"executionId,omitempty"`
+	Vendor            string `json:"vendor,omitempty"`
+	PID               int64  `json:"pid,omitempty"`
+	Outcome           string `json:"outcome,omitempty"`
+	ProcessSkipReason string `json:"processSkipReason,omitempty"`
 }
+
+const (
+	stopOutcomeProcessSignaled = "process_signaled"
+	stopOutcomePausedOnly      = "paused_only"
+	stopOutcomeAlreadyStopping = "already_stopping"
+	stopOutcomeAlreadyFinished = "already_finished"
+
+	processSkipNoRuns              = "no_running_run"
+	processSkipNoExecution         = "no_execution"
+	processSkipAlreadyFinished     = "execution_already_finished"
+	processSkipAlreadyStopping     = "execution_already_stopping"
+	processSkipNoPID               = "pid_unavailable"
+	processSkipNoSignal            = "signal_unavailable"
+	processSkipVerifierNotRunning  = "pid_not_running"
+	processSkipVerifierRejectedPID = "pid_verification_rejected"
+)
 
 type signalProcessFunc func(int, syscall.Signal) error
 
@@ -228,7 +246,7 @@ func takeoverLoop(ctx context.Context, services looperdruntime.Services, loopID,
 }
 
 func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, reason string, now func() time.Time, signal signalProcessFunc, executionMatchesProcess executionMatchesProcessFunc, terminal bool) (any, error) {
-	result := stopLoopResult{Stopped: false, LoopID: loopID}
+	result := stopLoopResult{Stopped: false, LoopID: loopID, Outcome: stopOutcomePausedOnly}
 	if services.Loops == nil {
 		return nil, fmt.Errorf("loops service is not configured")
 	}
@@ -257,6 +275,7 @@ func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 	}
 
 	if services.Repositories == nil || services.Repositories.Runs == nil {
+		result.ProcessSkipReason = processSkipNoRuns
 		return complete()
 	}
 
@@ -265,11 +284,14 @@ func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 		return nil, err
 	}
 	if latestRun == nil || latestRun.Status != "running" {
+		result.Outcome = stopOutcomeAlreadyFinished
+		result.ProcessSkipReason = processSkipNoRuns
 		return complete()
 	}
 	result.RunID = latestRun.ID
 
 	if services.Repositories.AgentExecutions == nil {
+		result.ProcessSkipReason = processSkipNoExecution
 		return complete()
 	}
 
@@ -278,13 +300,20 @@ func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 		return nil, err
 	}
 	if latestExecution == nil {
+		result.ProcessSkipReason = processSkipNoExecution
 		return complete()
 	}
 
 	result.ExecutionID = latestExecution.ID
 	result.Vendor = latestExecution.Vendor
 	if !isStoppableExecutionStatus(latestExecution.Status) {
+		result.Outcome = stopOutcomeAlreadyFinished
+		result.ProcessSkipReason = processSkipAlreadyFinished
 		return complete()
+	}
+	if latestExecution.Status == "cancelling" {
+		result.Outcome = stopOutcomeAlreadyStopping
+		result.ProcessSkipReason = processSkipAlreadyStopping
 	}
 	if services.ActiveExecutions != nil {
 		killed, err := services.ActiveExecutions.Kill(result.LoopID, latestRun.ID, latestExecution.ID, reason)
@@ -292,6 +321,8 @@ func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 			return nil, err
 		}
 		if killed {
+			result.Outcome = stopOutcomeProcessSignaled
+			result.ProcessSkipReason = ""
 			if err := markExecutionCancelling(ctx, services, *latestExecution, reasonCopy, now); err != nil {
 				return nil, err
 			}
@@ -299,6 +330,7 @@ func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 		}
 	}
 	if latestExecution.PID == nil || *latestExecution.PID <= 0 {
+		result.ProcessSkipReason = processSkipNoPID
 		return complete()
 	}
 
@@ -309,6 +341,12 @@ func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 			return nil, err
 		}
 		if !running || !matches {
+			if !running {
+				result.Outcome = stopOutcomeAlreadyFinished
+				result.ProcessSkipReason = processSkipVerifierNotRunning
+			} else {
+				result.ProcessSkipReason = processSkipVerifierRejectedPID
+			}
 			return complete()
 		}
 	}
@@ -317,6 +355,11 @@ func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 		if err := signalAgentProcessGroup(pid, signal, 5*time.Second); err != nil {
 			return nil, err
 		}
+		result.Outcome = stopOutcomeProcessSignaled
+		result.ProcessSkipReason = ""
+	} else {
+		result.ProcessSkipReason = processSkipNoSignal
+		return complete()
 	}
 
 	if err := markExecutionCancelling(ctx, services, *latestExecution, reasonCopy, now); err != nil {
@@ -330,6 +373,7 @@ type stopAllResult string
 
 const (
 	stopAllResultStopped         stopAllResult = "stopped"
+	stopAllResultPausedOnly      stopAllResult = "pausedOnly"
 	stopAllResultAlreadyFinished stopAllResult = "alreadyFinished"
 	stopAllResultAlreadyStopping stopAllResult = "alreadyStopping"
 	stopAllResultFailed          stopAllResult = "failed"
@@ -338,6 +382,7 @@ const (
 type stopAllSummary struct {
 	Total           int `json:"total"`
 	Stopped         int `json:"stopped"`
+	PausedOnly      int `json:"pausedOnly"`
 	AlreadyFinished int `json:"alreadyFinished"`
 	AlreadyStopping int `json:"alreadyStopping"`
 	Failed          int `json:"failed"`
@@ -353,6 +398,8 @@ type stopAllItem struct {
 	PreviousRunStatus       string `json:"previousRunStatus,omitempty"`
 	PreviousExecutionStatus string `json:"previousExecutionStatus,omitempty"`
 	Result                  string `json:"result"`
+	Outcome                 string `json:"outcome,omitempty"`
+	ProcessSkipReason       string `json:"processSkipReason,omitempty"`
 	Error                   string `json:"error,omitempty"`
 }
 
@@ -405,11 +452,11 @@ func stopAllLoops(ctx context.Context, services looperdruntime.Services, reason 
 			continue
 		}
 
-		_, err := stopLoop(ctx, services, candidate.Loop.ID, reason, now, signal, executionMatchesProcess)
+		stopResultValue, err := stopLoop(ctx, services, candidate.Loop.ID, reason, now, signal, executionMatchesProcess)
 		if err != nil {
 			stopErr := err
 			if candidate.Execution != nil && candidate.Execution.Status == "running" {
-				if fallbackErr := stopCandidateExecution(ctx, services, candidate, reason, now, signal, executionMatchesProcess); fallbackErr != nil {
+				if _, fallbackErr := stopCandidateExecution(ctx, services, candidate, reason, now, signal, executionMatchesProcess); fallbackErr != nil {
 					err = errors.Join(stopErr, fallbackErr)
 				} else {
 					err = stopErr
@@ -428,15 +475,26 @@ func stopAllLoops(ctx context.Context, services looperdruntime.Services, reason 
 				item.Error = err.Error()
 			}
 		} else {
+			if stopResult, ok := stopResultValue.(stopLoopResult); ok {
+				item.Outcome = stopResult.Outcome
+				item.ProcessSkipReason = stopResult.ProcessSkipReason
+				item.Result = classifyStopAllItemResult(stopResult)
+			}
 			for _, execution := range candidate.Executions {
 				if execution.Status != "running" {
 					continue
 				}
 				execCandidate := candidate
 				execCandidate.Execution = &execution
-				if execErr := stopCandidateExecution(ctx, services, execCandidate, reason, now, signal, executionMatchesProcess); execErr != nil && item.Error == "" {
+				execResult, execErr := stopCandidateExecution(ctx, services, execCandidate, reason, now, signal, executionMatchesProcess)
+				if execErr != nil && item.Error == "" {
 					item.Result = string(stopAllResultFailed)
 					item.Error = execErr.Error()
+					continue
+				}
+				item = mergeStopAllItemExecutionOutcome(item, execResult)
+				if item.Result == string(stopAllResultPausedOnly) && item.Outcome == stopOutcomeProcessSignaled {
+					item.Outcome = stopOutcomePausedOnly
 				}
 			}
 		}
@@ -456,6 +514,8 @@ func stopAllLoops(ctx context.Context, services looperdruntime.Services, reason 
 		switch stopAllResult(item.Result) {
 		case stopAllResultStopped:
 			response.Summary.Stopped++
+		case stopAllResultPausedOnly:
+			response.Summary.PausedOnly++
 		case stopAllResultAlreadyFinished:
 			response.Summary.AlreadyFinished++
 		case stopAllResultAlreadyStopping:
@@ -466,6 +526,55 @@ func stopAllLoops(ctx context.Context, services looperdruntime.Services, reason 
 	}
 
 	return response, nil
+}
+
+func classifyStopAllItemResult(result stopLoopResult) string {
+	switch result.Outcome {
+	case stopOutcomeProcessSignaled:
+		return string(stopAllResultStopped)
+	case stopOutcomePausedOnly:
+		return string(stopAllResultPausedOnly)
+	case stopOutcomeAlreadyStopping:
+		return string(stopAllResultAlreadyStopping)
+	case stopOutcomeAlreadyFinished:
+		return string(stopAllResultAlreadyFinished)
+	default:
+		return string(stopAllResultStopped)
+	}
+}
+
+func mergeStopAllItemExecutionOutcome(item stopAllItem, result stopLoopResult) stopAllItem {
+	mergedResult, mergedOutcome := mergeStopOutcomes(item.Result, item.Outcome, classifyStopAllItemResult(result), result.Outcome)
+	item.Result = mergedResult
+	item.Outcome = mergedOutcome
+	if item.ProcessSkipReason == "" && result.ProcessSkipReason != "" {
+		item.ProcessSkipReason = result.ProcessSkipReason
+	}
+	return item
+}
+
+func mergeStopOutcomes(currentResult, currentOutcome, nextResult, nextOutcome string) (string, string) {
+	if stopAllResultRank(nextResult) > stopAllResultRank(currentResult) {
+		return nextResult, nextOutcome
+	}
+	return currentResult, currentOutcome
+}
+
+func stopAllResultRank(result string) int {
+	switch stopAllResult(result) {
+	case stopAllResultFailed:
+		return 4
+	case stopAllResultPausedOnly:
+		return 3
+	case stopAllResultAlreadyStopping:
+		return 2
+	case stopAllResultAlreadyFinished:
+		return 1
+	case stopAllResultStopped:
+		return 0
+	default:
+		return 0
+	}
 }
 
 func collectStopAllCandidates(ctx context.Context, repos *storage.Repositories) ([]stopAllCandidate, error) {
@@ -662,9 +771,17 @@ func classifyStopAllResult(candidate stopAllCandidate) stopAllResult {
 	return stopAllResultStopped
 }
 
-func stopCandidateExecution(ctx context.Context, services looperdruntime.Services, candidate stopAllCandidate, reason string, now func() time.Time, signal signalProcessFunc, executionMatchesProcess executionMatchesProcessFunc) error {
+func stopCandidateExecution(ctx context.Context, services looperdruntime.Services, candidate stopAllCandidate, reason string, now func() time.Time, signal signalProcessFunc, executionMatchesProcess executionMatchesProcessFunc) (stopLoopResult, error) {
+	result := stopLoopResult{LoopID: candidate.Loop.ID, Outcome: stopOutcomePausedOnly}
 	if candidate.Execution == nil {
-		return nil
+		result.Outcome = stopOutcomeAlreadyFinished
+		result.ProcessSkipReason = processSkipNoExecution
+		return result, nil
+	}
+	result.ExecutionID = candidate.Execution.ID
+	result.Vendor = candidate.Execution.Vendor
+	if candidate.Execution.RunID != nil {
+		result.RunID = *candidate.Execution.RunID
 	}
 	runID := ""
 	if candidate.Execution.RunID != nil {
@@ -672,35 +789,55 @@ func stopCandidateExecution(ctx context.Context, services looperdruntime.Service
 	}
 	if runID == "" && candidate.Run != nil {
 		runID = candidate.Run.ID
+		result.RunID = candidate.Run.ID
 	}
 	if services.ActiveExecutions != nil && runID != "" {
 		killed, err := services.ActiveExecutions.Kill(candidate.Loop.ID, runID, candidate.Execution.ID, reason)
 		if err != nil {
-			return err
+			return result, err
 		}
 		if killed {
-			return markExecutionCancelling(ctx, services, *candidate.Execution, reason, now)
+			result.Outcome = stopOutcomeProcessSignaled
+			if err := markExecutionCancelling(ctx, services, *candidate.Execution, reason, now); err != nil {
+				return result, err
+			}
+			return result, nil
 		}
 	}
 	if candidate.Execution.PID == nil || *candidate.Execution.PID <= 0 {
-		return nil
+		result.ProcessSkipReason = processSkipNoPID
+		return result, nil
 	}
+	result.PID = *candidate.Execution.PID
 	pid := int(*candidate.Execution.PID)
 	if executionMatchesProcess != nil {
 		matches, running, err := executionMatchesProcess(ctx, *candidate.Execution, pid)
 		if err != nil {
-			return err
+			return result, err
 		}
 		if !running || !matches {
-			return nil
+			if !running {
+				result.Outcome = stopOutcomeAlreadyFinished
+				result.ProcessSkipReason = processSkipVerifierNotRunning
+			} else {
+				result.ProcessSkipReason = processSkipVerifierRejectedPID
+			}
+			return result, nil
 		}
 	}
-	if signal != nil {
-		if err := signalAgentProcessGroup(pid, signal, 5*time.Second); err != nil {
-			return err
-		}
+	if signal == nil {
+		result.ProcessSkipReason = processSkipNoSignal
+		return result, nil
 	}
-	return markExecutionCancelling(ctx, services, *candidate.Execution, reason, now)
+	if err := signalAgentProcessGroup(pid, signal, 5*time.Second); err != nil {
+		return result, err
+	}
+	result.Outcome = stopOutcomeProcessSignaled
+	result.ProcessSkipReason = ""
+	if err := markExecutionCancelling(ctx, services, *candidate.Execution, reason, now); err != nil {
+		return result, err
+	}
+	return result, nil
 }
 
 func isStoppableExecutionStatus(status string) bool {

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -362,7 +362,7 @@ func TestStopLoopPausesLoopAndSignalsActiveExecution(t *testing.T) {
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != pid {
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != pid || result.Outcome != stopOutcomeProcessSignaled || result.ProcessSkipReason != "" {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
 	if !called || gotSignalPID != -int(pid) {
@@ -591,7 +591,7 @@ func TestStopLoopKillsActiveInMemoryExecution(t *testing.T) {
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 {
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 || result.Outcome != stopOutcomeProcessSignaled || result.ProcessSkipReason != "" {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
 	if signaled {
@@ -606,6 +606,70 @@ func TestStopLoopKillsActiveInMemoryExecution(t *testing.T) {
 	}
 	if storedExecution == nil || storedExecution.Status != "cancelling" {
 		t.Fatalf("AgentExecutions.GetByID() = %#v, want cancelling execution", storedExecution)
+	}
+}
+
+func TestStopLoopActiveInMemoryExecutionWinsBeforeVerifierRejectsPID(t *testing.T) {
+	ctx := context.Background()
+	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(ctx); err != nil {
+		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 12, 0, 0, 0, time.UTC)
+	nowISO := "2026-04-21T12:00:00.000Z"
+	project := storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Projects.Upsert(ctx, project); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 30, ProjectID: project.ID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_1", LoopID: loop.ID, Status: "running", StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	pid := int64(4321)
+	agentExecution := storage.AgentExecutionRecord{ID: "agentexec_1", ProjectID: &project.ID, LoopID: &loop.ID, RunID: &run.ID, Vendor: "codex", Status: "running", PID: &pid, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.AgentExecutions.Upsert(ctx, agentExecution); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	registry := looperdruntime.NewActiveExecutionRegistry()
+	active := &fakeActiveExecution{}
+	unregister := registry.Register(loop.ID, run.ID, agentExecution.ID, active)
+	defer unregister()
+	services := looperdruntime.Services{Coordinator: coordinator, Repositories: repos, Loops: &loops.Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }}, ActiveExecutions: registry}
+
+	verifierCalled := false
+	gotResult, err := stopLoop(ctx, services, loop.ID, "Stopped by test", func() time.Time { return now }, func(int, syscall.Signal) error {
+		t.Fatal("signal invoked, want active execution kill path")
+		return nil
+	}, func(context.Context, storage.AgentExecutionRecord, int) (bool, bool, error) {
+		verifierCalled = true
+		return false, true, nil
+	})
+	if err != nil {
+		t.Fatalf("stopLoop() error = %v", err)
+	}
+	result, ok := gotResult.(stopLoopResult)
+	if !ok {
+		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
+	}
+	if !result.Stopped || result.Outcome != stopOutcomeProcessSignaled || result.ProcessSkipReason != "" {
+		t.Fatalf("stopLoop() result = %#v", result)
+	}
+	if verifierCalled {
+		t.Fatal("execution verifier called, want in-memory authority to win first")
+	}
+	if !active.killed {
+		t.Fatal("active execution Kill was not invoked")
 	}
 }
 
@@ -663,7 +727,7 @@ func TestStopLoopRetriesActiveInMemoryExecutionAlreadyCancelling(t *testing.T) {
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 {
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 || result.Outcome != stopOutcomeProcessSignaled || result.ProcessSkipReason != "" {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
 	if !active.killed {
@@ -729,11 +793,56 @@ func TestStopLoopSignalsExecutionAlreadyCancelling(t *testing.T) {
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != pid {
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != pid || result.Outcome != stopOutcomeProcessSignaled || result.ProcessSkipReason != "" {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
 	if len(signalCalls) != 2 || signalCalls[0] != -int(pid) || signalCalls[1] != int(pid) {
 		t.Fatalf("signal calls = %#v, want process group then process", signalCalls)
+	}
+}
+
+func TestStopLoopDoesNotClaimProcessSignaledWithoutSignaler(t *testing.T) {
+	ctx := context.Background()
+	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(ctx); err != nil {
+		t.Fatalf("MigrationRunner().RunPending() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 12, 0, 0, 0, time.UTC)
+	nowISO := "2026-04-21T12:00:00.000Z"
+	project := storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Projects.Upsert(ctx, project); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loop := storage.LoopRecord{ID: "loop_1", Seq: 30, ProjectID: project.ID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_1", LoopID: loop.ID, Status: "running", StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.Runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	pid := int64(4321)
+	agentExecution := storage.AgentExecutionRecord{ID: "agentexec_1", ProjectID: &project.ID, LoopID: &loop.ID, RunID: &run.ID, Vendor: "codex", Status: "running", PID: &pid, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := repos.AgentExecutions.Upsert(ctx, agentExecution); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+	services := looperdruntime.Services{Coordinator: coordinator, Repositories: repos, Loops: &loops.Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }}}
+
+	gotResult, err := stopLoop(ctx, services, loop.ID, "Stopped by test", func() time.Time { return now }, nil, func(context.Context, storage.AgentExecutionRecord, int) (bool, bool, error) {
+		return true, true, nil
+	})
+	if err != nil {
+		t.Fatalf("stopLoop() error = %v", err)
+	}
+	result := gotResult.(stopLoopResult)
+	if result.Outcome != stopOutcomePausedOnly || result.ProcessSkipReason != processSkipNoSignal {
+		t.Fatalf("stopLoop() result = %#v, want paused-only without signal authority", result)
 	}
 }
 
@@ -793,7 +902,7 @@ func TestStopLoopSkipsStaleActiveExecutionWhenLatestExecutionCompleted(t *testin
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 {
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 || result.Outcome != stopOutcomeAlreadyFinished || result.ProcessSkipReason != processSkipAlreadyFinished {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
 	if active.killed {
@@ -866,7 +975,7 @@ func TestStopLoopDoesNotOverwriteCompletedExecutionAfterActiveKill(t *testing.T)
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" {
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.Outcome != stopOutcomeProcessSignaled || result.ProcessSkipReason != "" {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
 	if !active.killed {
@@ -937,7 +1046,7 @@ func TestStopLoopSkipsSignalWhenExecutionVerifierRejectsPID(t *testing.T) {
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 {
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 || result.Outcome != stopOutcomePausedOnly || result.ProcessSkipReason != processSkipVerifierRejectedPID {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
 	if signaled {
@@ -982,7 +1091,7 @@ func TestStopAllLoopsHandlesMixedTypesPartialFailureAndRepeatedCalls(t *testing.
 		t.Fatalf("stopAllLoops() error = %v", err)
 	}
 
-	if got, want := response.Summary, (stopAllSummary{Total: 7, Stopped: 6, Failed: 1}); got != want {
+	if got, want := response.Summary, (stopAllSummary{Total: 7, Stopped: 4, AlreadyFinished: 2, Failed: 1}); got != want {
 		t.Fatalf("stopAllLoops() summary = %#v, want %#v", got, want)
 	}
 	if got := stopAllItemTypes(response.Items); !slices.Equal(got, []string{"planner", "reviewer", "worker", "fixer", "auditor", "worker", "reviewer"}) {
@@ -991,8 +1100,8 @@ func TestStopAllLoopsHandlesMixedTypesPartialFailureAndRepeatedCalls(t *testing.
 	assertStopAllItemResult(t, response.Items, "loop_reviewer", string(stopAllResultFailed))
 	assertStopAllItemResult(t, response.Items, "loop_fixer", string(stopAllResultStopped))
 	assertStopAllItemResult(t, response.Items, "loop_future", string(stopAllResultStopped))
-	assertStopAllItemResult(t, response.Items, "loop_queued", string(stopAllResultStopped))
-	assertStopAllItemResult(t, response.Items, "loop_waiting", string(stopAllResultStopped))
+	assertStopAllItemResult(t, response.Items, "loop_queued", string(stopAllResultAlreadyFinished))
+	assertStopAllItemResult(t, response.Items, "loop_waiting", string(stopAllResultAlreadyFinished))
 	if !slices.Contains(signalPIDs, -4101) || !slices.Contains(signalPIDs, -4103) || !slices.Contains(signalPIDs, -4105) {
 		t.Fatalf("signal pids = %#v, want other loops processed after failure", signalPIDs)
 	}
@@ -1012,6 +1121,69 @@ func TestStopAllLoopsHandlesMixedTypesPartialFailureAndRepeatedCalls(t *testing.
 		t.Fatalf("second stopAllLoops() summary = %#v, want repeated call to report alreadyStopping", repeated.Summary)
 	}
 	assertStopAllItemResult(t, repeated.Items, "loop_future", string(stopAllResultAlreadyStopping))
+}
+
+func TestStopAllLoopsReportsPausedOnlyWhenPIDVerificationRejectsOwnership(t *testing.T) {
+	ctx := context.Background()
+	services, repos, now := newStopAllTestServices(t)
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_worker", seq: 1, loopType: "worker", loopStatus: "running", runID: "run_worker", runStatus: "running", executionID: "exec_worker", executionStatus: "running", pid: 4103})
+
+	response, err := stopAllLoops(ctx, services, "Stopped by test", func() time.Time { return now }, func(int, syscall.Signal) error {
+		t.Fatal("signal invoked, want verifier-rejected PID skipped")
+		return nil
+	}, func(_ context.Context, execution storage.AgentExecutionRecord, pid int) (bool, bool, error) {
+		return false, true, nil
+	})
+	if err != nil {
+		t.Fatalf("stopAllLoops() error = %v", err)
+	}
+	if got, want := response.Summary, (stopAllSummary{Total: 1, PausedOnly: 1}); got != want {
+		t.Fatalf("stopAllLoops() summary = %#v, want %#v", got, want)
+	}
+	if len(response.Items) != 1 {
+		t.Fatalf("len(response.Items) = %d, want 1", len(response.Items))
+	}
+	if item := response.Items[0]; item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipVerifierRejectedPID {
+		t.Fatalf("stopAllLoops() item = %#v", item)
+	}
+}
+
+func TestStopAllLoopsReportsPausedOnlyWhenSecondaryExecutionIsVerifierRejected(t *testing.T) {
+	ctx := context.Background()
+	services, repos, now := newStopAllTestServices(t)
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_worker", seq: 1, loopType: "worker", loopStatus: "running", runID: "run_worker", runStatus: "running", executionID: "exec_primary", executionStatus: "running", pid: 4103})
+	secondaryPID := int64(4104)
+	nowISO := now.Format("2006-01-02T15:04:05.000Z")
+	if err := repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{ID: "exec_secondary", ProjectID: stringPtr("project_1"), LoopID: stringPtr("loop_worker"), RunID: stringPtr("run_worker"), Vendor: "codex", Status: "running", PID: &secondaryPID, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(exec_secondary) error = %v", err)
+	}
+
+	var signalPIDs []int
+	response, err := stopAllLoops(ctx, services, "Stopped by test", func() time.Time { return now }, func(pid int, sig syscall.Signal) error {
+		if sig != syscall.SIGTERM {
+			return nil
+		}
+		signalPIDs = append(signalPIDs, pid)
+		return syscall.ESRCH
+	}, func(_ context.Context, execution storage.AgentExecutionRecord, pid int) (bool, bool, error) {
+		return execution.ID == "exec_primary", true, nil
+	})
+	if err != nil {
+		t.Fatalf("stopAllLoops() error = %v", err)
+	}
+	if got, want := response.Summary, (stopAllSummary{Total: 1, PausedOnly: 1}); got != want {
+		t.Fatalf("stopAllLoops() summary = %#v, want %#v", got, want)
+	}
+	if len(response.Items) != 1 {
+		t.Fatalf("len(response.Items) = %d, want 1", len(response.Items))
+	}
+	item := response.Items[0]
+	if item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipVerifierRejectedPID {
+		t.Fatalf("stopAllLoops() item = %#v", item)
+	}
+	if !slices.Contains(signalPIDs, -4103) {
+		t.Fatalf("signal pids = %#v, want primary execution signaled", signalPIDs)
+	}
 }
 
 func TestClassifyStopAllResultChecksAllActiveExecutionsBeforeAlreadyStopping(t *testing.T) {

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -3453,6 +3453,80 @@ func TestCloseWithoutJSONUsesCloseRoute(t *testing.T) {
 	}
 }
 
+func TestStopWithoutJSONPrintsPausedOnlyOutcomeTruthfully(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Method, http.MethodPost; got != want {
+			t.Fatalf("method = %q, want %q", got, want)
+		}
+		if got, want := r.URL.Path, "/api/v1/runs/active/12/stop"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_stop", map[string]any{"stopped": true, "loopId": "loop_12", "outcome": "paused_only", "processSkipReason": "pid_verification_rejected"}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "stop", "12", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([stop 12]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([stop 12]) stderr = %q, want empty string", stderr)
+	}
+	for _, want := range []string{"Loop paused only", "loop_12", "paused_only", "pid_verification_rejected"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([stop 12]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+	if strings.Contains(stdout, "Loop stopped") {
+		t.Fatalf("Run([stop 12]) stdout = %q, want paused-only title instead of plain stopped", stdout)
+	}
+}
+
+func TestStopWithoutJSONPrintsAlreadyStoppingOutcomeTruthfully(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(t, w, pkgapi.Success("req_stop", map[string]any{"stopped": true, "loopId": "loop_12", "outcome": "already_stopping", "processSkipReason": "execution_already_stopping"}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "stop", "12", "--config", configPath)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("Run([stop 12]) = (%d, %q), want success with empty stderr", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "Loop already stopping") {
+		t.Fatalf("Run([stop 12]) stdout = %q, want already-stopping title", stdout)
+	}
+	if strings.Contains(stdout, "Loop stopped") {
+		t.Fatalf("Run([stop 12]) stdout = %q, want non-success title", stdout)
+	}
+}
+
+func TestStopWithoutJSONPrintsAlreadyFinishedOutcomeTruthfully(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(t, w, pkgapi.Success("req_stop", map[string]any{"stopped": true, "loopId": "loop_12", "outcome": "already_finished", "processSkipReason": "execution_already_finished"}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "stop", "12", "--config", configPath)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("Run([stop 12]) = (%d, %q), want success with empty stderr", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "Loop already finished") {
+		t.Fatalf("Run([stop 12]) stdout = %q, want already-finished title", stdout)
+	}
+	if strings.Contains(stdout, "Loop stopped") {
+		t.Fatalf("Run([stop 12]) stdout = %q, want non-success title", stdout)
+	}
+}
+
 func TestStopAllWithoutJSONPrintsNoRunningWorkMessage(t *testing.T) {
 	t.Parallel()
 
@@ -3474,6 +3548,32 @@ func TestStopAllWithoutJSONPrintsNoRunningWorkMessage(t *testing.T) {
 	}
 }
 
+func TestStopAllWithoutJSONReturnsNonZeroForPausedOnlyItems(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(t, w, pkgapi.Success("req_stop_all_partial", map[string]any{"summary": map[string]any{"total": 1, "stopped": 0, "pausedOnly": 1, "alreadyFinished": 0, "alreadyStopping": 0, "failed": 0}, "items": []map[string]any{{"seq": 1, "type": "worker", "loopId": "loop_1", "runId": "run_1", "executionId": "exec_1", "result": "pausedOnly", "outcome": "paused_only", "processSkipReason": "pid_verification_rejected"}}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "stop", "all", "--config", configPath)
+	if exitCode == 0 {
+		t.Fatalf("Run([stop all]) exit code = 0, want non-zero for paused-only partial outcome")
+	}
+	if !strings.Contains(stderr, "paused 1 task(s) without signaling a verified process") {
+		t.Fatalf("Run([stop all]) stderr = %q, want paused-only partial error", stderr)
+	}
+	for _, want := range []string{"Stop results", "pausedOnly", "paused_only", "pid_verification_rejected"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("Run([stop all]) stdout = %q, want to contain %q", stdout, want)
+		}
+	}
+	if strings.Contains(stdout, "Stopped running tasks") {
+		t.Fatalf("Run([stop all]) stdout = %q, want non-full-success heading", stdout)
+	}
+}
+
 func TestStopAllWithoutJSONReturnsNonZeroForPartialFailure(t *testing.T) {
 	t.Parallel()
 
@@ -3487,7 +3587,7 @@ func TestStopAllWithoutJSONReturnsNonZeroForPartialFailure(t *testing.T) {
 	if exitCode == 0 {
 		t.Fatal("Run([stop all]) exit code = 0, want non-zero")
 	}
-	if !strings.Contains(stdout, "Stopped running tasks") || !strings.Contains(stdout, "signal failed") {
+	if !strings.Contains(stdout, "Stop results") || !strings.Contains(stdout, "signal failed") {
 		t.Fatalf("Run([stop all]) stdout = %q, want summary and failure row", stdout)
 	}
 	if !strings.Contains(stderr, "failed to stop 1 running task(s)") {

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -188,13 +188,26 @@ type pullRequestOutput struct {
 	LoopStatus            struct {
 		LatestRunStatus *string `json:"latestRunStatus"`
 	} `json:"loopStatus"`
-	Stopped     bool    `json:"stopped"`
-	Reused      bool    `json:"reused"`
-	LoopID      string  `json:"loopId"`
-	RunID       *string `json:"runId"`
-	ExecutionID *string `json:"executionId"`
-	Vendor      *string `json:"vendor"`
-	PID         *int64  `json:"pid"`
+	Stopped           bool    `json:"stopped"`
+	Reused            bool    `json:"reused"`
+	LoopID            string  `json:"loopId"`
+	RunID             *string `json:"runId"`
+	ExecutionID       *string `json:"executionId"`
+	Vendor            *string `json:"vendor"`
+	PID               *int64  `json:"pid"`
+	Outcome           string  `json:"outcome"`
+	ProcessSkipReason *string `json:"processSkipReason"`
+}
+
+type stopLoopOutput struct {
+	Stopped           bool    `json:"stopped"`
+	LoopID            string  `json:"loopId"`
+	RunID             *string `json:"runId"`
+	ExecutionID       *string `json:"executionId"`
+	Vendor            *string `json:"vendor"`
+	PID               *int64  `json:"pid"`
+	Outcome           string  `json:"outcome"`
+	ProcessSkipReason *string `json:"processSkipReason"`
 }
 
 type activeRunsOutput struct {
@@ -205,6 +218,7 @@ type stopAllOutput struct {
 	Summary struct {
 		Total           int `json:"total"`
 		Stopped         int `json:"stopped"`
+		PausedOnly      int `json:"pausedOnly"`
 		AlreadyFinished int `json:"alreadyFinished"`
 		AlreadyStopping int `json:"alreadyStopping"`
 		Failed          int `json:"failed"`
@@ -219,6 +233,8 @@ type stopAllOutput struct {
 		PreviousRunStatus       string `json:"previousRunStatus"`
 		PreviousExecutionStatus string `json:"previousExecutionStatus"`
 		Result                  string `json:"result"`
+		Outcome                 string `json:"outcome"`
+		ProcessSkipReason       string `json:"processSkipReason"`
 		Error                   string `json:"error"`
 	} `json:"items"`
 }
@@ -694,11 +710,12 @@ func writeLoopLogContent(w io.Writer, content string) error {
 }
 
 func writeHumanStopLoop(w io.Writer, payload json.RawMessage) error {
-	var data pullRequestOutput
+	var data stopLoopOutput
 	if err := json.Unmarshal(payload, &data); err != nil {
 		return fmt.Errorf("decode stop response: %w", err)
 	}
-	printSection(w, "Loop stopped", [][2]any{{"loopId", data.LoopID}, {"runId", data.RunID}, {"executionId", data.ExecutionID}, {"vendor", data.Vendor}, {"pid", data.PID}, {"stopped", data.Stopped}})
+	title := stopOutcomeTitle(data.Outcome)
+	printSection(w, title, [][2]any{{"loopId", data.LoopID}, {"runId", data.RunID}, {"executionId", data.ExecutionID}, {"vendor", data.Vendor}, {"pid", data.PID}, {"outcome", data.Outcome}, {"processSkipReason", data.ProcessSkipReason}, {"stopped", data.Stopped}})
 	if !data.Stopped {
 		return fmt.Errorf("Loop %s could not be stopped", data.LoopID)
 	}
@@ -726,22 +743,43 @@ func writeHumanStopAll(w io.Writer, payload json.RawMessage) error {
 		_, err := fmt.Fprintln(w, "No running tasks to stop.")
 		return err
 	}
-	printSection(w, "Stopped running tasks", [][2]any{
+	title := "Stop results"
+	if data.Summary.Failed == 0 && data.Summary.PausedOnly == 0 && data.Summary.AlreadyFinished == 0 && data.Summary.AlreadyStopping == 0 {
+		title = "Stopped running tasks"
+	}
+	printSection(w, title, [][2]any{
 		{"total", data.Summary.Total},
 		{"stopped", data.Summary.Stopped},
+		{"pausedOnly", data.Summary.PausedOnly},
 		{"alreadyFinished", data.Summary.AlreadyFinished},
 		{"alreadyStopping", data.Summary.AlreadyStopping},
 		{"failed", data.Summary.Failed},
 	})
 	rows := make([]tableRow, 0, len(data.Items))
 	for _, item := range data.Items {
-		rows = append(rows, tableRow{"seq": item.Seq, "type": item.Type, "loopId": item.LoopID, "runId": item.RunID, "executionId": item.ExecutionID, "result": item.Result, "error": item.Error})
+		rows = append(rows, tableRow{"seq": item.Seq, "type": item.Type, "loopId": item.LoopID, "runId": item.RunID, "executionId": item.ExecutionID, "result": item.Result, "outcome": item.Outcome, "processSkipReason": item.ProcessSkipReason, "error": item.Error})
 	}
-	printTable(w, []string{"seq", "type", "loopId", "runId", "executionId", "result", "error"}, rows)
+	printTable(w, []string{"seq", "type", "loopId", "runId", "executionId", "result", "outcome", "processSkipReason", "error"}, rows)
 	if data.Summary.Failed > 0 {
 		return fmt.Errorf("failed to stop %d running task(s)", data.Summary.Failed)
 	}
+	if data.Summary.PausedOnly > 0 {
+		return fmt.Errorf("paused %d task(s) without signaling a verified process", data.Summary.PausedOnly)
+	}
 	return nil
+}
+
+func stopOutcomeTitle(outcome string) string {
+	switch outcome {
+	case "paused_only":
+		return "Loop paused only"
+	case "already_stopping":
+		return "Loop already stopping"
+	case "already_finished":
+		return "Loop already finished"
+	default:
+		return "Loop stopped"
+	}
 }
 
 func writeHumanRunList(w io.Writer, payload json.RawMessage) error {

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -563,10 +563,12 @@ func (r *commandRuntime) stopLoop(cmd *cobra.Command, args []string) error {
 		} else if err := writeHumanStopAll(cmd.OutOrStdout(), payload); err != nil {
 			return err
 		}
-		if failed, err := stopAllFailedCount(payload); err != nil {
+		if failed, pausedOnly, err := stopAllResultCounts(payload); err != nil {
 			return err
 		} else if failed > 0 {
 			return fmt.Errorf("failed to stop %d running task(s)", failed)
+		} else if pausedOnly > 0 {
+			return fmt.Errorf("paused %d task(s) without signaling a verified process", pausedOnly)
 		}
 		return nil
 	}
@@ -585,16 +587,17 @@ func (r *commandRuntime) closeLoop(cmd *cobra.Command, args []string) error {
 	}, writeHumanCloseLoop)
 }
 
-func stopAllFailedCount(payload json.RawMessage) (int, error) {
+func stopAllResultCounts(payload json.RawMessage) (int, int, error) {
 	var data struct {
 		Summary struct {
-			Failed int `json:"failed"`
+			Failed     int `json:"failed"`
+			PausedOnly int `json:"pausedOnly"`
 		} `json:"summary"`
 	}
 	if err := json.Unmarshal(payload, &data); err != nil {
-		return 0, fmt.Errorf("decode stop-all response: %w", err)
+		return 0, 0, fmt.Errorf("decode stop-all response: %w", err)
 	}
-	return data.Summary.Failed, nil
+	return data.Summary.Failed, data.Summary.PausedOnly, nil
 }
 
 func (r *commandRuntime) runList(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- make stop results distinguish loop pause from actual process signaling
- keep strict ps ownership checks while preferring in-memory active execution authority
- carry truthful partial-stop semantics through stop-all output and regression coverage

## Tests
- go test ./cmd/looperd ./internal/cliapp ./internal/runtime
- go vet ./... && go test ./...