### PR TITLE
refactor: make SQLite the project authority

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,14 @@ A **Role** is a configured agent that performs one specific job in the issue/PR 
 A configured forge integration that owns remote Issues, Pull Requests, labels, comments, reviews, webhooks, and identity for a Project. Git remains separate and owns local repositories, refs, and worktrees.
 _Avoid_: forge, host, remote.
 
+**Project**:
+A durable local registration that binds one repository to one Provider and supplies the project-level policy consumed by Roles. The SQLite project record is the runtime Authority for whether a Project exists and for its repository/Provider binding; `[[projects]]` is a startup import, not a parallel runtime Authority.
+_Avoid_: config project, runtime binding.
+
+**Project Catalog**:
+The startup-built, immutable view of active Projects materialized from SQLite records after configuration import. Runtime modules consume the Project Catalog through the existing normalized project configuration interface; they do not consult the original `[[projects]]` input.
+_Avoid_: registry, live config projects.
+
 **Planner**:
 A reactive Role that produces a Spec from an Issue.
 _Avoid_: designer, architect.

--- a/docs/adr/0012-sqlite-project-authority.md
+++ b/docs/adr/0012-sqlite-project-authority.md
@@ -1,0 +1,37 @@
+# ADR-0012: SQLite project records are runtime Authority
+
+## Context
+
+Looper currently represents Projects twice: normalized `[[projects]]` entries and SQLite `projects` rows. Runtime modules resolve Provider, repository, project policy, scheduling eligibility, and webhook behavior from `config.Projects`, while CLI/API additions and archival mutate SQLite. A Project can therefore be active in one representation and absent or differently bound in the other.
+
+The concrete failures are incorrect Provider routing, stale Projects continuing to schedule after archival, and API-added Projects being treated as GitHub because their binding is absent from the startup configuration.
+
+## Decision
+
+SQLite project records are the runtime Authority for Project existence and repository/Provider binding.
+
+`[[projects]]` remains a compatibility input. At startup Looper transactionally imports it into SQLite, then materializes a Project Catalog snapshot from active SQLite records. Scheduler, Webhook, and Roles receive the materialized view through the existing normalized project configuration interface. They do not consume the original project list after import.
+
+Every explicit Project mutation validates the complete candidate Catalog before committing SQLite. After commit it publishes that prevalidated snapshot with one atomic replacement. A scheduler pass, claimed run, or accepted webhook delivery captures one snapshot and keeps it for the operation; later operations observe the new snapshot.
+
+Project-level policy from a `[[projects]]` entry is applied only to the matching `source=config` record during materialization. API-owned records use stored fields and global defaults.
+
+## Trade-off
+
+This prevents configuration, storage, Scheduler, and Webhook from disagreeing about which Projects exist or which Provider/repository they use.
+
+The cost is startup materialization, atomic snapshot publication, explicit handling for legacy rows with incomplete metadata, and persisted project-level policy that was previously present only in configuration. Import or validation failures can now block a mutation/startup, already-started work may finish on the prior snapshot, and tests must assert the Project Catalog rather than raw configuration input.
+
+A simpler live mirror from SQLite back into `config.Projects` is insufficient: PR #528 demonstrated that mutation requires synchronization across Scheduler work, webhook forwarding, removal, rebinding, and shutdown. Keeping configuration as the sole Authority is also insufficient because CLI/API-managed Projects are durable product behavior.
+
+## Authority
+
+The Authority for a runtime Project is the active SQLite project record committed by configuration import or an explicit CLI/API project mutation; remote detection is only input to that commit and is never Authority by itself.
+
+## Consequences
+
+- Runtime Project consumers use one atomically published view and capture a stable snapshot per operation.
+- Configured Projects continue to work without an immediate configuration-format break.
+- Removing a `source=config` Project from `[[projects]]` archives it during the next startup import; `source=api` rows are never removed by config import.
+- A config Project ID collision with an API-owned row fails import instead of changing ownership.
+- This authority-bearing change requires `@oracle` review before merge.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,18 @@ Looper's frozen canonical top-level config roots are:
 | `providers` | forge provider definitions such as GitHub or Forgejo hosts and credentials |
 | `projects` | per-project metadata and supported project-scoped overrides |
 
+### Project authority and import
+
+`[[projects]]` is a declarative startup import, not a second runtime project store. During daemon startup Looper validates and transactionally imports configured projects into SQLite, then builds the runtime Project Catalog exclusively from active database records. Scheduler, Webhook, Network, and Roles all capture that same Catalog.
+
+- Removing a config-managed project from `[[projects]]` archives its SQLite record on the next startup.
+- Config import never removes API-managed projects.
+- Reusing an API-managed project ID in `[[projects]]` fails startup instead of transferring ownership implicitly.
+- CLI/API add and remove operations publish one atomic Catalog replacement after the database commit; already-started work keeps its captured snapshot, while new work observes the new Catalog.
+- A project referencing a missing Provider fails validation; it never falls back to GitHub.
+
+See [ADR-0012](adr/0012-sqlite-project-authority.md) for the Authority and lifecycle decision.
+
 Legacy top-level `reviewer.*` input is compatibility-only. The canonical reviewer behavior home is `roles.reviewer.behavior.*`.
 
 Schema migration is independent from config-file format migration: precedence stays `defaults → config file → environment variables → CLI flags` regardless of whether a file still uses legacy reviewer paths or legacy JSON defaults.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -886,6 +886,9 @@ type configDaemonResponse struct {
 
 func (h *Handler) buildConfigResponse() configResponse {
 	cfg := h.context.Config
+	if runtimeConfig, ok := any(h.context.Runtime).(interface{ Config() config.Config }); ok {
+		cfg = runtimeConfig.Config()
+	}
 
 	return configResponse{
 		Server: configServerResponse{

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -755,6 +755,34 @@ func TestHandlerConfigSuccessContainsExpectedSections(t *testing.T) {
 	}
 }
 
+func TestHandlerConfigProjectsComeFromRuntimeCatalog(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	projectService := rt.Services().Projects
+	projectService.ListWorktrees = nil
+	repo := "acme/catalog"
+	if _, err := projectService.AddProject(context.Background(), projects.AddInput{
+		ID: "catalog", Name: "Catalog", RepoPath: t.TempDir(), Repo: &repo, SnapshotMode: projects.SnapshotModeOff,
+	}); err != nil {
+		t.Fatalf("AddProject() error = %v", err)
+	}
+	if len(cfg.Projects) != 0 {
+		t.Fatalf("fixture config projects = %#v, want original config unchanged", cfg.Projects)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config", nil)
+	recorder := httptest.NewRecorder()
+	NewHandler(Context{Config: cfg, Runtime: rt}).ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	projectItems := data["projects"].([]any)
+	if len(projectItems) != 1 || projectItems[0].(map[string]any)["id"] != "catalog" {
+		t.Fatalf("config projects = %#v, want runtime catalog project", projectItems)
+	}
+}
+
 func TestReviewerLoopMetadataJSONRemovesDeprecatedBudgetMetadata(t *testing.T) {
 	t.Parallel()
 	cfg, err := config.DefaultConfig("")

--- a/internal/network/client/manager.go
+++ b/internal/network/client/manager.go
@@ -57,6 +57,21 @@ func NewManager(statePath string, cfg config.Config, repos *storage.Repositories
 	return &Manager{statePath: statePath, config: cfg, repos: repos, gh: gh, client: &http.Client{Timeout: 10 * time.Second}, now: time.Now, done: make(chan struct{})}
 }
 
+func (m *Manager) UpdateConfig(cfg config.Config) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.config = cfg
+	m.mu.Unlock()
+}
+
+func (m *Manager) configSnapshot() config.Config {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.config
+}
+
 func (m *Manager) Start(parent context.Context) error {
 	if m.started {
 		return nil
@@ -77,9 +92,10 @@ func (m *Manager) Start(parent context.Context) error {
 	m.mu.Lock()
 	m.status = Status{Configured: true, NetworkID: state.NetworkID, NodeID: state.NodeID, NodeName: state.NodeName, GitHub: state.GitHub}
 	m.mu.Unlock()
-	routed, _ := countProjectModes(m.config)
+	cfg := m.configSnapshot()
+	routed, _ := countProjectModes(cfg)
 	if routed == 0 {
-		_, local := countProjectModes(m.config)
+		_, local := countProjectModes(cfg)
 		m.mu.Lock()
 		m.status.RoutedProjects = routed
 		m.status.LocalProjects = local
@@ -124,8 +140,9 @@ func (m *Manager) Status() Status {
 
 func (m *Manager) tick(ctx context.Context, state LocalState) {
 	current, _ := m.currentGitHubIdentity(ctx)
-	routed, local := countProjectModes(m.config)
-	capabilities := protocol.NodeCapabilities{Roles: supportedRoles(m.config), CoordinatorEligible: routed > 0 && m.config.Roles.Coordinator.Enabled, RoutedProjects: routed, RoutedProjectIDs: routedProjectIDs(m.config), ReviewerProjects: reviewerProjectCapabilities(m.config), LocalProjects: local, DynamicLoad: m.dynamicLoad(ctx)}
+	cfg := m.configSnapshot()
+	routed, local := countProjectModes(cfg)
+	capabilities := protocol.NodeCapabilities{Roles: supportedRoles(cfg), CoordinatorEligible: routed > 0 && cfg.Roles.Coordinator.Enabled, RoutedProjects: routed, RoutedProjectIDs: routedProjectIDs(cfg), ReviewerProjects: reviewerProjectCapabilities(cfg), LocalProjects: local, DynamicLoad: m.dynamicLoad(ctx)}
 	drift, reason := identityDrift(state.GitHub, current)
 	capabilities.IdentityDrift = drift
 	capabilities.DriftReason = reason

--- a/internal/network/client/manager_test.go
+++ b/internal/network/client/manager_test.go
@@ -27,6 +27,20 @@ func TestManagerStartWithoutNetworkStateLeavesStatusUnconfigured(t *testing.T) {
 	}
 }
 
+func TestManagerUpdateConfigPublishesProjectCatalog(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(filepath.Join(t.TempDir(), "network.json"), config.Config{}, nil, nil)
+	manager.UpdateConfig(config.Config{Projects: []config.ProjectRefConfig{
+		{ID: "routed", Network: config.ProjectNetworkConfig{Mode: config.NetworkModeRouted}},
+		{ID: "local"},
+	}})
+	routed, local := countProjectModes(manager.configSnapshot())
+	if routed != 1 || local != 1 {
+		t.Fatalf("countProjectModes(updated config) = (%d, %d), want (1, 1)", routed, local)
+	}
+}
+
 func TestManagerStartWithoutRoutedProjectsPreservesProjectCounts(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "network.json")
 	if err := SaveState(statePath, LocalState{NetworkID: "net-1", NodeID: "node-1", NodeName: "worker-1", GitHub: protocol.GitHubIdentity{NumericID: 101, Login: "stored-user"}}); err != nil {

--- a/internal/projects/catalog.go
+++ b/internal/projects/catalog.go
@@ -1,0 +1,166 @@
+package projects
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// ConfigSource supplies a coherent runtime configuration snapshot. Consumers
+// capture one snapshot at the start of an operation and retain it for that
+// operation's lifetime.
+type ConfigSource interface {
+	Snapshot() config.Config
+}
+
+// Catalog owns the immutable runtime view of Projects. The non-project portion
+// of the configuration is frozen at construction; Publish atomically replaces
+// only the already-materialized Projects view.
+//
+// Catalog keeps no caller-owned slices, maps, or pointers. Snapshot likewise
+// returns a detached copy so a consumer cannot mutate the published view.
+type Catalog struct {
+	global  config.Config
+	current atomic.Pointer[config.Config]
+}
+
+// NewCatalog creates a Catalog from the normalized global configuration. Its
+// initial snapshot includes global.Projects so callers can construct and read a
+// Catalog before the first database materialization is published.
+func NewCatalog(global config.Config) *Catalog {
+	frozen := cloneCatalogConfig(global)
+	catalog := &Catalog{global: frozen}
+	initial := cloneCatalogConfig(frozen)
+	catalog.current.Store(&initial)
+	return catalog
+}
+
+// Publish atomically installs a prevalidated, materialized Project view. It is
+// intentionally infallible: validation belongs to MaterializeCatalog before a
+// database mutation commits, while publication after commit is only a swap.
+func (c *Catalog) Publish(projects []config.ProjectRefConfig) {
+	if c == nil {
+		return
+	}
+	next := cloneCatalogConfig(c.global)
+	next.Projects = cloneCatalogProjects(projects)
+	c.current.Store(&next)
+}
+
+// Snapshot returns a coherent, detached copy of the currently published full
+// configuration.
+func (c *Catalog) Snapshot() config.Config {
+	if c == nil {
+		return config.Config{}
+	}
+	current := c.current.Load()
+	if current == nil {
+		return config.Config{}
+	}
+	return cloneCatalogConfig(*current)
+}
+
+func cloneCatalogProjects(projects []config.ProjectRefConfig) []config.ProjectRefConfig {
+	cloned := cloneCatalogConfig(config.Config{Projects: projects})
+	return cloned.Projects
+}
+
+// Config is composed exclusively of JSON configuration values. JSON
+// round-tripping gives the Catalog a single complete deep-copy boundary,
+// including nested role overrides and map[string]any agent parameters. A
+// failure indicates a programming error: normalized Config must remain JSON
+// representable.
+func cloneCatalogConfig(source config.Config) config.Config {
+	encoded, err := json.Marshal(source)
+	if err != nil {
+		panic(fmt.Sprintf("clone project catalog config: %v", err))
+	}
+	var cloned config.Config
+	if err := json.Unmarshal(encoded, &cloned); err != nil {
+		panic(fmt.Sprintf("clone project catalog config: %v", err))
+	}
+	return cloned
+}
+
+// MaterializeCatalog builds the immutable runtime Project view from active
+// SQLite records. global supplies Providers and global defaults, but its
+// Projects list is import input and is not consulted here.
+func MaterializeCatalog(global config.Config, records []storage.ProjectRecord) ([]config.ProjectRefConfig, error) {
+	projects := make([]config.ProjectRefConfig, 0, len(records))
+	seen := make(map[string]struct{}, len(records))
+	for _, record := range records {
+		if record.Archived {
+			continue
+		}
+		if _, ok := seen[record.ID]; ok {
+			return nil, fmt.Errorf("duplicate active project id %q", record.ID)
+		}
+		seen[record.ID] = struct{}{}
+
+		metadata := parseMetadata(record.MetadataJSON)
+		project := config.ProjectRefConfig{
+			ID:         record.ID,
+			Name:       record.Name,
+			RepoPath:   record.RepoPath,
+			BaseBranch: cloneStringPointer(record.BaseBranch),
+			Provider:   metadataString(metadata, "provider"),
+			Repo:       metadataString(metadata, "repo"),
+		}
+		if project.Provider != "" && !configuredProviderExists(global, project.Provider) {
+			return nil, fmt.Errorf("project %q references unknown provider %q", project.ID, project.Provider)
+		}
+		if worktreeRoot := metadataString(metadata, "worktreeRoot"); worktreeRoot != "" {
+			project.WorktreeRoot = &worktreeRoot
+		}
+		project.Path = metadataString(metadata, "path")
+		if err := decodeMetadataValue(metadata, "network", &project.Network); err != nil {
+			return nil, fmt.Errorf("decode project %q network policy: %w", project.ID, err)
+		}
+		if err := decodeMetadataValue(metadata, "webhook", &project.Webhook); err != nil {
+			return nil, fmt.Errorf("decode project %q webhook policy: %w", project.ID, err)
+		}
+		if err := decodeMetadataValue(metadata, "roles", &project.Roles); err != nil {
+			return nil, fmt.Errorf("decode project %q role policy: %w", project.ID, err)
+		}
+		projects = append(projects, project)
+	}
+	return projects, nil
+}
+
+func configuredProviderExists(cfg config.Config, providerID string) bool {
+	for _, provider := range cfg.Providers {
+		if provider.ID == providerID {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeMetadataValue(metadata map[string]any, key string, target any) error {
+	value, ok := metadata[key]
+	if !ok || value == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(encoded, target)
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	value, _ := metadata[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func cloneStringPointer(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}

--- a/internal/projects/catalog_test.go
+++ b/internal/projects/catalog_test.go
@@ -1,0 +1,210 @@
+package projects
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+var _ ConfigSource = (*Catalog)(nil)
+
+func TestCatalogPublishesFullConfigAtomically(t *testing.T) {
+	t.Parallel()
+
+	vendor := config.AgentVendorCodex
+	global := config.Config{
+		Agent:     config.AgentConfig{Vendor: &vendor, Params: map[string]any{"nested": map[string]any{"value": "original"}}},
+		Providers: []config.ProviderConfig{{ID: "forgejo-main", Kind: config.ProviderKindForgejo}},
+		Projects:  []config.ProjectRefConfig{{ID: "import-input"}},
+	}
+	catalog := NewCatalog(global)
+	catalog.Publish([]config.ProjectRefConfig{{ID: "database", Repo: "core/database", Roles: &config.PartialRoleConfigs{}}})
+
+	got := catalog.Snapshot()
+	if len(got.Projects) != 1 || got.Projects[0].ID != "database" {
+		t.Fatalf("Snapshot().Projects = %#v, want published database project", got.Projects)
+	}
+	if len(got.Providers) != 1 || got.Providers[0].ID != "forgejo-main" || got.Agent.Vendor == nil || *got.Agent.Vendor != vendor {
+		t.Fatalf("Snapshot() lost global config: %#v", got)
+	}
+}
+
+func TestCatalogDoesNotRetainOrReturnMutableAliases(t *testing.T) {
+	t.Parallel()
+
+	roles := &config.PartialRoleConfigs{}
+	projects := []config.ProjectRefConfig{{ID: "database", Repo: "core/database", Roles: roles}}
+	global := config.Config{
+		Agent:     config.AgentConfig{Params: map[string]any{"nested": map[string]any{"value": "original"}}, Env: map[string]string{"TOKEN": "env"}},
+		Providers: []config.ProviderConfig{{ID: "forgejo-main", Kind: config.ProviderKindForgejo}},
+	}
+	catalog := NewCatalog(global)
+	catalog.Publish(projects)
+
+	projects[0].ID = "caller-mutated"
+	projects[0].Roles = nil
+	global.Providers[0].ID = "caller-mutated"
+	global.Agent.Env["TOKEN"] = "caller-mutated"
+
+	first := catalog.Snapshot()
+	first.Projects[0].ID = "snapshot-mutated"
+	first.Projects[0].Roles = nil
+	first.Providers[0].ID = "snapshot-mutated"
+	first.Agent.Env["TOKEN"] = "snapshot-mutated"
+	first.Agent.Params["nested"].(map[string]any)["value"] = "snapshot-mutated"
+
+	got := catalog.Snapshot()
+	if got.Projects[0].ID != "database" || got.Projects[0].Roles == nil {
+		t.Fatalf("published projects were mutated through an alias: %#v", got.Projects)
+	}
+	if got.Providers[0].ID != "forgejo-main" || got.Agent.Env["TOKEN"] != "env" {
+		t.Fatalf("published globals were mutated through an alias: %#v", got)
+	}
+	nested := got.Agent.Params["nested"].(map[string]any)
+	if nested["value"] != "original" {
+		t.Fatalf("Snapshot().Agent.Params nested value = %v, want original", nested["value"])
+	}
+}
+
+func TestCatalogConcurrentSnapshotsObserveWholePublications(t *testing.T) {
+	t.Parallel()
+
+	catalog := NewCatalog(config.Config{})
+	catalog.Publish([]config.ProjectRefConfig{{ID: "a", Name: "a"}})
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if i%2 == 0 {
+				catalog.Publish([]config.ProjectRefConfig{{ID: "a", Name: "a"}})
+			} else {
+				catalog.Publish([]config.ProjectRefConfig{{ID: "b", Name: "b"}, {ID: "b2", Name: "b2"}})
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			snapshot := catalog.Snapshot()
+			switch len(snapshot.Projects) {
+			case 1:
+				if snapshot.Projects[0].ID != "a" || snapshot.Projects[0].Name != "a" {
+					t.Errorf("observed torn a publication: %#v", snapshot.Projects)
+					return
+				}
+			case 2:
+				if snapshot.Projects[0].ID != "b" || snapshot.Projects[0].Name != "b" || snapshot.Projects[1].ID != "b2" || snapshot.Projects[1].Name != "b2" {
+					t.Errorf("observed torn b publication: %#v", snapshot.Projects)
+					return
+				}
+			default:
+				t.Errorf("observed unexpected publication: %#v", snapshot.Projects)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+func TestMaterializeCatalogUsesRecordsAsProjectAuthority(t *testing.T) {
+	t.Parallel()
+
+	baseBranch := "main"
+	metadata := `{"network":{"mode":"routed"},"provider":"forgejo-main","repo":"core/odcrew","source":"config","worktreeRoot":"/tmp/worktrees"}`
+	archivedMetadata := `{"repo":"acme/removed","source":"config"}`
+	imported := config.Config{Providers: []config.ProviderConfig{{ID: "forgejo-main", Kind: config.ProviderKindForgejo}}, Projects: []config.ProjectRefConfig{
+		{ID: "odcrew", Name: "stale name", RepoPath: "/stale", Provider: "stale-provider", Repo: "stale/repo"},
+		{ID: "config-only", Name: "must not appear", RepoPath: "/config-only"},
+	}}
+
+	got, err := MaterializeCatalog(imported, []storage.ProjectRecord{
+		{ID: "odcrew", Name: "ODCrew", RepoPath: "/repos/odcrew", BaseBranch: &baseBranch, MetadataJSON: &metadata},
+		{ID: "removed", Name: "Removed", RepoPath: "/repos/removed", Archived: true, MetadataJSON: &archivedMetadata},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeCatalog() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(MaterializeCatalog()) = %d, want 1", len(got))
+	}
+	project := got[0]
+	if project.ID != "odcrew" || project.Name != "ODCrew" || project.RepoPath != "/repos/odcrew" {
+		t.Fatalf("project identity = %#v, want database record", project)
+	}
+	if project.Provider != "forgejo-main" || project.Repo != "core/odcrew" {
+		t.Fatalf("project binding = (%q, %q), want stored binding", project.Provider, project.Repo)
+	}
+	if project.Network.Mode != config.NetworkModeRouted {
+		t.Fatalf("project policy network mode = %q, want imported routed policy", project.Network.Mode)
+	}
+}
+
+func TestMaterializeCatalogDoesNotApplyConfigPolicyToAPIRecord(t *testing.T) {
+	t.Parallel()
+
+	metadata := `{"repo":"acme/api","source":"api"}`
+	imported := config.Config{Projects: []config.ProjectRefConfig{{
+		ID: "api", Network: config.ProjectNetworkConfig{Mode: config.NetworkModeRouted},
+	}}}
+	got, err := MaterializeCatalog(imported, []storage.ProjectRecord{{ID: "api", Name: "API", RepoPath: "/repos/api", MetadataJSON: &metadata}})
+	if err != nil {
+		t.Fatalf("MaterializeCatalog() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Network.Mode != "" {
+		t.Fatalf("MaterializeCatalog() = %#v, want record without unstored imported policy", got)
+	}
+}
+
+func TestMaterializeCatalogRejectsUnknownProvider(t *testing.T) {
+	t.Parallel()
+
+	metadata := `{"provider":"removed","repo":"core/odcrew","source":"api"}`
+	_, err := MaterializeCatalog(config.Config{}, []storage.ProjectRecord{{ID: "odcrew", MetadataJSON: &metadata}})
+	if err == nil || !strings.Contains(err.Error(), `unknown provider "removed"`) {
+		t.Fatalf("MaterializeCatalog() error = %v, want unknown provider", err)
+	}
+}
+
+func TestConfiguredProjectMetadataRoundTripsRuntimePolicy(t *testing.T) {
+	t.Parallel()
+
+	project := config.ProjectRefConfig{
+		ID:       "odcrew",
+		Name:     "ODCrew",
+		Provider: "forgejo-main",
+		Repo:     "core/odcrew",
+		RepoPath: "/repos/odcrew",
+		Path:     "nested/path",
+		Network:  config.ProjectNetworkConfig{Mode: config.NetworkModeRouted},
+		Webhook:  config.ProjectWebhookConfig{Mode: config.WebhookModeTunnel},
+		Roles:    &config.PartialRoleConfigs{},
+	}
+	repo := project.Repo
+	metadata, err := buildProjectMetadataJSON(nil, project, &repo)
+	if err != nil {
+		t.Fatalf("buildProjectMetadataJSON() error = %v", err)
+	}
+	global := config.Config{Providers: []config.ProviderConfig{{ID: "forgejo-main", Kind: config.ProviderKindForgejo}}}
+	got, err := MaterializeCatalog(global, []storage.ProjectRecord{{
+		ID: project.ID, Name: project.Name, RepoPath: project.RepoPath, MetadataJSON: &metadata,
+	}})
+	if err != nil {
+		t.Fatalf("MaterializeCatalog() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(MaterializeCatalog()) = %d, want 1", len(got))
+	}
+	materialized := got[0]
+	if materialized.Provider != project.Provider || materialized.Repo != project.Repo || materialized.Path != project.Path {
+		t.Fatalf("materialized binding = %#v, want %#v", materialized, project)
+	}
+	if materialized.Network.Mode != project.Network.Mode || materialized.Webhook.Mode != project.Webhook.Mode || materialized.Roles == nil {
+		t.Fatalf("materialized policy = %#v, want persisted project policy", materialized)
+	}
+}

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nexu-io/looper/internal/bootstrap"
@@ -71,6 +72,7 @@ type CapturePullRequestSnapshotInput struct {
 }
 
 type Service struct {
+	mutationMu                 sync.Mutex
 	DB                         *sql.DB
 	Repos                      *storage.Repositories
 	Logger                     bootstrap.Logger
@@ -134,6 +136,8 @@ func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, er
 	if s.Repos == nil || s.Repos.Projects == nil {
 		return AddResult{}, fmt.Errorf("projects repository is not configured")
 	}
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
 
 	existing, err := s.Repos.Projects.GetByID(ctx, input.ID)
 	if err != nil {
@@ -292,6 +296,8 @@ func (s *Service) RemoveProject(ctx context.Context, identifier string) (storage
 	if s.Repos == nil || s.Repos.Projects == nil {
 		return storage.ProjectRecord{}, fmt.Errorf("projects repository is not configured")
 	}
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
 
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
@@ -381,6 +387,8 @@ func (s *Service) SyncConfigured(ctx context.Context, cfg config.Config, now tim
 	if s.Repos == nil || s.Repos.Projects == nil {
 		return fmt.Errorf("projects repository is not configured")
 	}
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
 
 	nowISO := currentISO(func() time.Time { return now })
 	existingProjects, err := s.Repos.Projects.List(ctx)

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -391,6 +391,7 @@ func (s *Service) SyncConfigured(ctx context.Context, cfg config.Config, now tim
 	defer s.mutationMu.Unlock()
 
 	nowISO := currentISO(func() time.Time { return now })
+	cancelReason := "project archived"
 	existingProjects, err := s.Repos.Projects.List(ctx)
 	if err != nil {
 		return err
@@ -465,6 +466,12 @@ func (s *Service) SyncConfigured(ctx context.Context, cfg config.Config, now tim
 			}
 			if _, configured := desiredIDs[existing.ID]; configured {
 				continue
+			}
+			if _, err := repos.Loops.TerminateByProject(ctx, existing.ID, nowISO); err != nil {
+				return err
+			}
+			if _, err := repos.Queue.CancelByProject(ctx, existing.ID, nowISO, &cancelReason); err != nil {
+				return err
 			}
 			if _, err := repos.Projects.Archive(ctx, existing.ID, nowISO); err != nil {
 				return err

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -75,6 +75,7 @@ type Service struct {
 	Repos                      *storage.Repositories
 	Logger                     bootstrap.Logger
 	Config                     config.Config
+	ConfigSource               ConfigSource
 	Now                        func() time.Time
 	DetectRepo                 DetectRepoFunc
 	GetRepositorySettings      GetRepositorySettingsFunc
@@ -83,6 +84,7 @@ type Service struct {
 	ListOpenPullRequests       ListOpenPullRequestsFunc
 	CapturePullRequestSnapshot CapturePullRequestSnapshotFunc
 	AsyncSnapshotQueueEnabled  func() bool
+	PublishProjects            func([]config.ProjectRefConfig)
 }
 
 type AddInput struct {
@@ -137,6 +139,9 @@ func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, er
 	if err != nil {
 		return AddResult{}, err
 	}
+	if existing != nil && metadataString(parseMetadata(existing.MetadataJSON), "source") == "config" {
+		return AddResult{}, ProjectValidationError{Message: fmt.Sprintf("project %s is managed by config and cannot be changed through the project API", existing.ID)}
+	}
 	if existing != nil && !existing.Archived && input.IDSource != "derived" {
 		return AddResult{}, ProjectIDCollisionError{ProjectID: input.ID}
 	}
@@ -175,7 +180,7 @@ func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, er
 		}
 	}
 
-	if err := s.validateReviewerAutoMergeForProject(ctx, projectID, repo, input.BaseBranch, s.Config); err != nil {
+	if err := s.validateReviewerAutoMergeForProject(ctx, projectID, repo, input.BaseBranch, s.currentConfig()); err != nil {
 		return AddResult{}, err
 	}
 
@@ -229,8 +234,15 @@ func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, er
 	if existing != nil {
 		record.CreatedAt = existing.CreatedAt
 	}
+	nextProjects, err := s.materializeCandidate(ctx, &record, "")
+	if err != nil {
+		return AddResult{}, ProjectValidationError{Message: err.Error()}
+	}
 	if err := s.Repos.Projects.Upsert(ctx, record); err != nil {
 		return AddResult{}, err
+	}
+	if s.PublishProjects != nil {
+		s.PublishProjects(nextProjects)
 	}
 
 	discoveredWorktrees, err := s.discoverWorktrees(ctx, record, nowISO, &warnings)
@@ -241,7 +253,6 @@ func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, er
 	if err != nil {
 		return AddResult{}, err
 	}
-
 	return AddResult{
 		Project:                record,
 		Repo:                   repo,
@@ -300,6 +311,10 @@ func (s *Service) RemoveProject(ctx context.Context, identifier string) (storage
 
 	nowISO := currentISO(s.Now)
 	cancelReason := "project archived"
+	nextProjects, err := s.materializeCandidate(ctx, nil, project.ID)
+	if err != nil {
+		return storage.ProjectRecord{}, err
+	}
 	archived, err := storage.WithTransactionValue(ctx, s.DB, nil, func(tx *sql.Tx) (bool, error) {
 		repos := storage.NewRepositories(tx)
 		archived, err := repos.Projects.Archive(ctx, project.ID, nowISO)
@@ -325,6 +340,9 @@ func (s *Service) RemoveProject(ctx context.Context, identifier string) (storage
 	}
 	project.Archived = true
 	project.UpdatedAt = nowISO
+	if s.PublishProjects != nil {
+		s.PublishProjects(nextProjects)
+	}
 
 	return *project, nil
 }
@@ -365,11 +383,27 @@ func (s *Service) SyncConfigured(ctx context.Context, cfg config.Config, now tim
 	}
 
 	nowISO := currentISO(func() time.Time { return now })
+	existingProjects, err := s.Repos.Projects.List(ctx)
+	if err != nil {
+		return err
+	}
+	desiredIDs := make(map[string]struct{}, len(cfg.Projects))
+	existingByID := make(map[string]*storage.ProjectRecord, len(existingProjects))
+	for index := range existingProjects {
+		existingByID[existingProjects[index].ID] = &existingProjects[index]
+	}
+	desiredRecords := make([]storage.ProjectRecord, 0, len(cfg.Projects))
 	for _, project := range cfg.Projects {
-		existing, err := s.Repos.Projects.GetByID(ctx, project.ID)
-		if err != nil {
-			return err
+		desiredIDs[project.ID] = struct{}{}
+		if existing := existingByID[project.ID]; existing != nil {
+			if source, _ := parseMetadata(existing.MetadataJSON)["source"].(string); source == "api" {
+				return ProjectValidationError{Message: fmt.Sprintf("configured project %s conflicts with an API-managed project", project.ID)}
+			}
 		}
+	}
+
+	for _, project := range cfg.Projects {
+		existing := existingByID[project.ID]
 
 		repo, err := s.detectConfiguredProjectRepo(ctx, existing, project)
 		if err != nil {
@@ -404,19 +438,49 @@ func (s *Service) SyncConfigured(ctx context.Context, cfg config.Config, now tim
 			CreatedAt:    createdAt,
 			UpdatedAt:    nowISO,
 		}
-		if err := s.Repos.Projects.Upsert(ctx, record); err != nil {
-			return err
-		}
+		desiredRecords = append(desiredRecords, record)
 	}
 
-	return nil
+	applyImport := func(repos *storage.Repositories) error {
+		for _, record := range desiredRecords {
+			if err := repos.Projects.Upsert(ctx, record); err != nil {
+				return err
+			}
+		}
+		for index := range existingProjects {
+			existing := existingProjects[index]
+			if existing.Archived {
+				continue
+			}
+			if source, _ := parseMetadata(existing.MetadataJSON)["source"].(string); source != "config" {
+				continue
+			}
+			if _, configured := desiredIDs[existing.ID]; configured {
+				continue
+			}
+			if _, err := repos.Projects.Archive(ctx, existing.ID, nowISO); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if s.DB == nil {
+		return applyImport(s.Repos)
+	}
+	_, err = storage.WithTransactionValue(ctx, s.DB, nil, func(tx *sql.Tx) (struct{}, error) {
+		if err := applyImport(storage.NewRepositories(tx)); err != nil {
+			return struct{}{}, err
+		}
+		return struct{}{}, nil
+	})
+	return err
 }
 
 func (s *Service) detectConfiguredProjectRepo(ctx context.Context, existing *storage.ProjectRecord, project config.ProjectRefConfig) (*string, error) {
 	if repo := strings.TrimSpace(project.Repo); repo != "" {
 		return &repo, nil
 	}
-	if config.ResolvedProjectProviderKind(s.Config, project) != config.ProviderKindGitHub {
+	if config.ResolvedProjectProviderKind(s.currentConfig(), project) != config.ProviderKindGitHub {
 		if existing != nil && existing.RepoPath == project.RepoPath {
 			return stringMetadataPtr(existing.MetadataJSON, "repo"), nil
 		}
@@ -552,6 +616,33 @@ func buildProjectMetadataJSON(existing *storage.ProjectRecord, project config.Pr
 			return "", err
 		}
 		repoRaw = encoded
+	}
+	setProjectMetadata := func(key string, value any, keep bool) error {
+		if !keep {
+			delete(extras, key)
+			return nil
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		extras[key] = encoded
+		return nil
+	}
+	if err := setProjectMetadata("provider", strings.TrimSpace(project.Provider), strings.TrimSpace(project.Provider) != ""); err != nil {
+		return "", err
+	}
+	if err := setProjectMetadata("path", strings.TrimSpace(project.Path), strings.TrimSpace(project.Path) != ""); err != nil {
+		return "", err
+	}
+	if err := setProjectMetadata("network", project.Network, project.Network.Mode != ""); err != nil {
+		return "", err
+	}
+	if err := setProjectMetadata("webhook", project.Webhook, project.Webhook.Mode != ""); err != nil {
+		return "", err
+	}
+	if err := setProjectMetadata("roles", project.Roles, project.Roles != nil); err != nil {
+		return "", err
 	}
 
 	entries := make([]orderedJSONEntry, 0, len(extras)+3)
@@ -849,10 +940,45 @@ func (s *Service) enqueuePullRequestSnapshot(ctx context.Context, project storag
 }
 
 func (s *Service) snapshotRetryMaxAttempts() int64 {
-	if s.Config.Scheduler.RetryMaxAttempts == 0 {
+	cfg := s.currentConfig()
+	if cfg.Scheduler.RetryMaxAttempts == 0 {
 		return -1
 	}
-	return int64(s.Config.Scheduler.RetryMaxAttempts)
+	return int64(cfg.Scheduler.RetryMaxAttempts)
+}
+
+func (s *Service) currentConfig() config.Config {
+	if s != nil && s.ConfigSource != nil {
+		return s.ConfigSource.Snapshot()
+	}
+	if s == nil {
+		return config.Config{}
+	}
+	return s.Config
+}
+
+func (s *Service) materializeCandidate(ctx context.Context, replacement *storage.ProjectRecord, archiveID string) ([]config.ProjectRefConfig, error) {
+	if s == nil || s.Repos == nil || s.Repos.Projects == nil {
+		return nil, fmt.Errorf("projects repository is not configured")
+	}
+	records, err := s.Repos.Projects.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	replaced := false
+	for index := range records {
+		if replacement != nil && records[index].ID == replacement.ID {
+			records[index] = *replacement
+			replaced = true
+		}
+		if records[index].ID == archiveID {
+			records[index].Archived = true
+		}
+	}
+	if replacement != nil && !replaced {
+		records = append(records, *replacement)
+	}
+	return MaterializeCatalog(s.currentConfig(), records)
 }
 
 func snapshotModeOrDefault(mode SnapshotMode) SnapshotMode {

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -748,6 +748,13 @@ func TestServiceSyncConfiguredArchivesConfigProjectsRemovedFromConfig(t *testing
 			t.Fatalf("Projects.Upsert(%s) error = %v", project.ID, err)
 		}
 	}
+	targetID := "pr:nexu-io/removed:531"
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_removed", Seq: 1, ProjectID: "removed", Type: string(domain.LoopTypeReviewer), TargetType: string(domain.LoopTargetTypePullRequest), TargetID: &targetID, Status: string(domain.LoopStatusQueued), CreatedAt: createdAt, UpdatedAt: createdAt}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_removed", ProjectID: stringPointer("removed"), LoopID: stringPointer("loop_removed"), Type: "reviewer", TargetType: "pull_request", TargetID: targetID, DedupeKey: "reviewer:removed:loop_removed", Priority: storage.QueuePriorityReviewer, Status: "queued", AvailableAt: createdAt, MaxAttempts: 3, CreatedAt: createdAt, UpdatedAt: createdAt}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
 
 	service := &Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }}
 	cfg, err := config.DefaultConfig(t.TempDir())
@@ -765,6 +772,20 @@ func TestServiceSyncConfiguredArchivesConfigProjectsRemovedFromConfig(t *testing
 	}
 	if removed == nil || !removed.Archived || removed.UpdatedAt != currentISO(func() time.Time { return now }) {
 		t.Fatalf("removed = %#v, want archived config project at import time", removed)
+	}
+	removedLoop, err := repos.Loops.GetByID(context.Background(), "loop_removed")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if removedLoop == nil || removedLoop.Status != string(domain.LoopStatusTerminated) {
+		t.Fatalf("removed loop = %#v, want terminated", removedLoop)
+	}
+	removedQueue, err := repos.Queue.GetByID(context.Background(), "queue_removed")
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if removedQueue == nil || removedQueue.Status != "cancelled" || removedQueue.LastError == nil || *removedQueue.LastError != "project archived" {
+		t.Fatalf("removed queue = %#v, want cancelled with archive reason", removedQueue)
 	}
 	apiProject, err := repos.Projects.GetByID(context.Background(), "api-project")
 	if err != nil {

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -668,6 +668,89 @@ func TestServiceSyncConfiguredDoesNotDeleteUnlistedProjects(t *testing.T) {
 	}
 }
 
+func TestServiceSyncConfiguredArchivesConfigProjectsRemovedFromConfig(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 12, 10, 0, 0, 0, time.UTC)
+	createdAt := now.Add(-time.Hour).Format(time.RFC3339Nano)
+	configMetadata := `{"repo":"nexu-io/removed","source":"config"}`
+	apiMetadata := `{"repo":"nexu-io/api","source":"api"}`
+	baseBranch := "main"
+	for _, project := range []storage.ProjectRecord{
+		{ID: "removed", Name: "Removed", RepoPath: "/tmp/removed", BaseBranch: &baseBranch, MetadataJSON: &configMetadata, CreatedAt: createdAt, UpdatedAt: createdAt},
+		{ID: "api-project", Name: "API", RepoPath: "/tmp/api", BaseBranch: &baseBranch, MetadataJSON: &apiMetadata, CreatedAt: createdAt, UpdatedAt: createdAt},
+	} {
+		if err := repos.Projects.Upsert(context.Background(), project); err != nil {
+			t.Fatalf("Projects.Upsert(%s) error = %v", project.ID, err)
+		}
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Projects = nil
+
+	if err := service.SyncConfigured(context.Background(), cfg, now); err != nil {
+		t.Fatalf("SyncConfigured() error = %v", err)
+	}
+	removed, err := repos.Projects.GetByID(context.Background(), "removed")
+	if err != nil {
+		t.Fatalf("Projects.GetByID(removed) error = %v", err)
+	}
+	if removed == nil || !removed.Archived || removed.UpdatedAt != currentISO(func() time.Time { return now }) {
+		t.Fatalf("removed = %#v, want archived config project at import time", removed)
+	}
+	apiProject, err := repos.Projects.GetByID(context.Background(), "api-project")
+	if err != nil {
+		t.Fatalf("Projects.GetByID(api-project) error = %v", err)
+	}
+	if apiProject == nil || apiProject.Archived || apiProject.UpdatedAt != createdAt {
+		t.Fatalf("api project = %#v, want untouched active API project", apiProject)
+	}
+}
+
+func TestServiceSyncConfiguredRejectsAPIManagedIDCollision(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 12, 10, 0, 0, 0, time.UTC)
+	createdAt := now.Add(-time.Hour).Format(time.RFC3339Nano)
+	baseBranch := "main"
+	metadata := `{"repo":"nexu-io/api","source":"api"}`
+	existing := storage.ProjectRecord{ID: "shared", Name: "API Project", RepoPath: "/tmp/api", BaseBranch: &baseBranch, MetadataJSON: &metadata, CreatedAt: createdAt, UpdatedAt: createdAt}
+	if err := repos.Projects.Upsert(context.Background(), existing); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	service := &Service{DB: coordinator.DB(), Repos: repos, Now: func() time.Time { return now }}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Projects = []config.ProjectRefConfig{{ID: "shared", Name: "Configured Project", RepoPath: "/tmp/config"}}
+
+	err = service.SyncConfigured(context.Background(), cfg, now)
+	var validationErr ProjectValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("SyncConfigured() error = %T %v, want ProjectValidationError", err, err)
+	}
+	if !strings.Contains(err.Error(), "conflicts with an API-managed project") {
+		t.Fatalf("SyncConfigured() error = %q, want API ownership conflict", err)
+	}
+	stored, getErr := repos.Projects.GetByID(context.Background(), "shared")
+	if getErr != nil {
+		t.Fatalf("Projects.GetByID() error = %v", getErr)
+	}
+	if stored == nil || stored.Name != existing.Name || stored.RepoPath != existing.RepoPath || stored.UpdatedAt != existing.UpdatedAt || stored.MetadataJSON == nil || *stored.MetadataJSON != metadata {
+		t.Fatalf("stored = %#v, want API project unchanged", stored)
+	}
+}
+
 func TestServiceRemoveProjectArchivesProjectAndPreservesHistory(t *testing.T) {
 	t.Parallel()
 
@@ -1074,6 +1157,32 @@ func TestServiceRemoveProjectRejectsConfigManagedProject(t *testing.T) {
 	}
 	if stored == nil || stored.Archived {
 		t.Fatalf("stored project = %#v, want non-archived project", stored)
+	}
+}
+
+func TestServiceAddProjectRejectsConfigManagedProject(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	metadata := `{"repo":"acme/configured","source":"config"}`
+	nowISO := "2026-07-12T10:00:00.000Z"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: "configured", Name: "Configured", RepoPath: "/repos/configured", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	service := &Service{DB: coordinator.DB(), Repos: repos}
+	_, err := service.AddProject(context.Background(), AddInput{ID: "configured", IDSource: "derived", Name: "Changed", RepoPath: "/repos/changed"})
+	if err == nil || !strings.Contains(err.Error(), "managed by config") {
+		t.Fatalf("AddProject() error = %v, want config authority rejection", err)
+	}
+	stored, getErr := repos.Projects.GetByID(context.Background(), "configured")
+	if getErr != nil {
+		t.Fatalf("GetByID() error = %v", getErr)
+	}
+	if stored == nil || stored.Name != "Configured" || stored.RepoPath != "/repos/configured" {
+		t.Fatalf("stored project = %#v, want unchanged config project", stored)
 	}
 }
 

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,6 +40,67 @@ func TestServiceAddProjectCreatesAPIProject(t *testing.T) {
 	}
 	if result.Project.MetadataJSON == nil || *result.Project.MetadataJSON != `{"repo":null,"worktreeRoot":null,"source":"api"}` {
 		t.Fatalf("AddProject().Project.MetadataJSON = %v, want api metadata", result.Project.MetadataJSON)
+	}
+}
+
+func TestServiceConcurrentAddsPublishCommittedCatalog(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	firstPublishStarted := make(chan struct{})
+	releaseFirstPublish := make(chan struct{})
+	var publishMu sync.Mutex
+	var published []config.ProjectRefConfig
+	publishCount := 0
+	service := &Service{
+		DB:    coordinator.DB(),
+		Repos: repos,
+		Now:   time.Now,
+		PublishProjects: func(projects []config.ProjectRefConfig) {
+			publishMu.Lock()
+			publishCount++
+			count := publishCount
+			published = append([]config.ProjectRefConfig(nil), projects...)
+			publishMu.Unlock()
+			if count == 1 {
+				close(firstPublishStarted)
+				<-releaseFirstPublish
+			}
+		},
+	}
+
+	errorsCh := make(chan error, 2)
+	go func() {
+		_, err := service.AddProject(ctx, AddInput{ID: "a", Name: "A", RepoPath: "/tmp/a", BaseBranch: "main"})
+		errorsCh <- err
+	}()
+	<-firstPublishStarted
+	go func() {
+		_, err := service.AddProject(ctx, AddInput{ID: "b", Name: "B", RepoPath: "/tmp/b", BaseBranch: "main"})
+		errorsCh <- err
+	}()
+
+	close(releaseFirstPublish)
+	for range 2 {
+		if err := <-errorsCh; err != nil {
+			t.Fatalf("AddProject() error = %v", err)
+		}
+	}
+
+	publishMu.Lock()
+	got := append([]config.ProjectRefConfig(nil), published...)
+	publishMu.Unlock()
+	if len(got) != 2 || got[0].ID != "a" || got[1].ID != "b" {
+		t.Fatalf("last published projects = %#v, want a and b", got)
+	}
+	stored, err := service.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(stored) != 2 {
+		t.Fatalf("len(List()) = %d, want 2", len(stored))
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -149,6 +149,7 @@ type Runtime struct {
 	recoveryCancel              context.CancelFunc
 	recoveryDone                chan struct{}
 	activeExecutions            *ActiveExecutionRegistry
+	projectCatalog              *projects.Catalog
 	githubGateway               *githubinfra.Gateway
 	webhook                     *webhookRuntime
 	webhookDaemonLock           *daemonLock
@@ -199,6 +200,7 @@ func New(options Options) *Runtime {
 		shutdownTimeout = time.Second
 	}
 
+	projectCatalog := projects.NewCatalog(options.Config)
 	rt := &Runtime{
 		config:                      options.Config,
 		logger:                      options.Logger,
@@ -215,6 +217,7 @@ func New(options Options) *Runtime {
 		recovery:                    createEmptyRecoverySummary(),
 		shutdownCh:                  make(chan struct{}),
 		activeExecutions:            NewActiveExecutionRegistry(),
+		projectCatalog:              projectCatalog,
 		webhook:                     newWebhookRuntime(options.Config, options.Logger, now),
 	}
 	if rt.webhook != nil {
@@ -316,6 +319,17 @@ func (r *Runtime) Services() Services {
 	return r.services
 }
 
+// Config returns the current runtime configuration with Projects materialized
+// from the authoritative Project Catalog.
+func (r *Runtime) Config() config.Config {
+	if r.projectCatalog != nil {
+		return r.projectCatalog.Snapshot()
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.config
+}
+
 func (r *Runtime) StartedAt() (time.Time, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -349,13 +363,6 @@ func runtimeHomeDirOrEmpty() string {
 		return ""
 	}
 	return homeDir
-}
-
-func (r *Runtime) Config() config.Config {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	return r.config
 }
 
 func (r *Runtime) RecoverySummary() RecoverySummary {
@@ -542,15 +549,16 @@ func (r *Runtime) start(ctx context.Context) error {
 	repositories := storage.NewRepositories(coordinator.DB())
 	gitGateway := gitinfra.New(gitinfra.Options{GitPath: derefString(r.config.Tools.GitPath), Repos: repositories, Now: r.now})
 	var githubGateway *githubinfra.Gateway
-	if runtimeConfigHasGitHubProjects(r.config) {
+	if strings.TrimSpace(derefString(r.config.Tools.GHPath)) != "" || runtimeConfigHasGitHubProjects(r.config) {
 		githubGateway = githubinfra.New(githubinfra.Options{GHPath: derefString(r.config.Tools.GHPath), Now: r.now, DiscoveryCacheTTL: time.Duration(r.config.Scheduler.DiscoveryCacheTTLSeconds) * time.Second})
 	}
 	projectService := &projects.Service{
-		DB:     coordinator.DB(),
-		Repos:  repositories,
-		Logger: r.logger,
-		Config: r.config,
-		Now:    r.now,
+		DB:           coordinator.DB(),
+		Repos:        repositories,
+		Logger:       r.logger,
+		Config:       r.config,
+		ConfigSource: r.projectCatalog,
+		Now:          r.now,
 		DetectRepo: func(ctx context.Context, repoPath string) (string, error) {
 			return gitGateway.DetectGitHubRepo(ctx, repoPath)
 		},
@@ -600,12 +608,28 @@ func (r *Runtime) start(ctx context.Context) error {
 		AsyncSnapshotQueueEnabled: func() bool {
 			return r.customSchedulerTick || r.config.Agent.Vendor != nil
 		},
+		PublishProjects: func(projects []config.ProjectRefConfig) {
+			r.publishProjects(projects)
+		},
 	}
 	loopService := &loops.Service{DB: coordinator.DB(), Repos: repositories, Now: r.now}
 	runService := &runs.Service{DB: coordinator.DB(), Repos: repositories, Loops: loopService, Now: r.now}
 	startedAt := r.now().UTC()
 	if err := r.syncConfiguredProjects(ctx, projectService, r.config, startedAt); err != nil {
 		return err
+	}
+	// Project import is already committed. Materialize that durable state even
+	// when the startup request is canceled; CompleteStartup still observes ctx.
+	if err := r.reloadProjectCatalog(context.Background(), repositories); err != nil {
+		return err
+	}
+	r.config = r.projectCatalog.Snapshot()
+	if strings.TrimSpace(derefString(r.config.Tools.GHPath)) != "" || runtimeConfigHasGitHubProjects(r.config) {
+		if githubGateway == nil {
+			githubGateway = githubinfra.New(githubinfra.Options{GHPath: derefString(r.config.Tools.GHPath), Now: r.now, DiscoveryCacheTTL: time.Duration(r.config.Scheduler.DiscoveryCacheTTLSeconds) * time.Second})
+		}
+	} else {
+		githubGateway = nil
 	}
 	r.mu.Lock()
 	if r.stopped {
@@ -623,7 +647,7 @@ func (r *Runtime) start(ctx context.Context) error {
 	}
 	schedulerDisabled := false
 	if !r.customSchedulerTick {
-		handlers := buildDefaultSchedulerHandlers(r.config, r.logger, coordinator, repositories, gitGateway, githubGateway, r.activeExecutions, func() schedulerAsyncRunner {
+		handlers := buildCatalogSchedulerHandlers(r.projectCatalog, r.logger, coordinator, repositories, gitGateway, githubGateway, r.activeExecutions, func() schedulerAsyncRunner {
 			r.mu.RLock()
 			defer r.mu.RUnlock()
 			return r.schedulerTasks
@@ -719,9 +743,10 @@ func (r *Runtime) CompleteStartup(ctx context.Context) error {
 		r.startDeferredReviewerRecovery(githubGateway)
 
 		if r.logger != nil {
+			catalog := r.Config()
 			r.logger.Info("looperd runtime assembled", map[string]any{
 				"dbPath":                 r.config.Storage.DBPath,
-				"projectCount":           len(r.config.Projects),
+				"projectCount":           len(catalog.Projects),
 				"autoMigrate":            r.config.Package.AutoMigrateOnStartup,
 				"backupRequired":         r.config.Package.RequireBackupBeforeMigrate,
 				"recoverySummary":        recoverySummary,
@@ -741,11 +766,12 @@ func (r *Runtime) validateCoordinatorDependencyGates(ctx context.Context, reposi
 	if err != nil {
 		return err
 	}
+	catalog := r.Config()
 	for _, project := range projectsList {
 		if project.Archived {
 			continue
 		}
-		roleCfg := config.ProjectRoleConfigs(r.config, project.ID).Coordinator
+		roleCfg := config.ProjectRoleConfigs(catalog, project.ID).Coordinator
 		if !roleCfg.Enabled || !roleCfg.Dependencies.Enabled {
 			continue
 		}
@@ -824,6 +850,48 @@ func runtimeProjectProviderKind(cfg config.Config, projectID string) config.Prov
 		}
 	}
 	return config.ProviderKindGitHub
+}
+
+func (r *Runtime) reloadProjectCatalog(ctx context.Context, repos *storage.Repositories) error {
+	if r.projectCatalog == nil || repos == nil || repos.Projects == nil {
+		return fmt.Errorf("project catalog dependencies are not configured")
+	}
+	records, err := repos.Projects.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list projects for runtime catalog: %w", err)
+	}
+	global := r.projectCatalog.Snapshot()
+	materialized, err := projects.MaterializeCatalog(global, records)
+	if err != nil {
+		return fmt.Errorf("materialize runtime project catalog: %w", err)
+	}
+	r.publishProjects(materialized)
+	return nil
+}
+
+func (r *Runtime) publishProjects(materialized []config.ProjectRefConfig) {
+	if r == nil || r.projectCatalog == nil {
+		return
+	}
+	r.projectCatalog.Publish(materialized)
+	next := r.projectCatalog.Snapshot()
+
+	r.mu.Lock()
+	webhook := r.webhook
+	networkManager := r.networkManager
+	started := r.startedAt != nil
+	r.mu.Unlock()
+	if webhook != nil {
+		webhook.updateConfig(next)
+	}
+	if networkManager != nil {
+		networkManager.UpdateConfig(next)
+	}
+	if started {
+		r.TriggerSchedulerTick()
+		r.TriggerSchedulerClaim()
+		r.ReconcileWebhookForwarders()
+	}
 }
 
 func runtimeDependencyTimeout(seconds int) time.Duration {
@@ -2618,7 +2686,7 @@ type runtimeReviewerRecoveryPolicy struct {
 }
 
 func (r *Runtime) reviewerRecoveryPolicyForProject(projectID string) runtimeReviewerRecoveryPolicy {
-	roles := config.ProjectRoleConfigs(r.config, projectID)
+	roles := config.ProjectRoleConfigs(r.Config(), projectID)
 	return runtimeReviewerRecoveryPolicy{
 		includeDrafts:    roles.Reviewer.Discovery.Triggers.IncludeDrafts,
 		stopOnApproved:   roles.Reviewer.Behavior.Loop.StopOnApproved,

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -141,6 +141,83 @@ func TestRuntimeStartForgejoOnlyDoesNotRequireGitHubGateway(t *testing.T) {
 	}
 }
 
+func TestRuntimeStartMaterializesProjectCatalogFromDatabase(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	cfg.Projects = []config.ProjectRefConfig{{ID: "config-only", Name: "Config Only", RepoPath: "/stale"}}
+	metadata := `{"repo":"acme/database","source":"api"}`
+	nowISO := "2026-07-12T00:00:00.000Z"
+
+	rt := New(Options{
+		Config: cfg,
+		Logger: &testLogger{},
+		SyncConfiguredProjects: func(ctx context.Context, service *projects.Service, _ config.Config, _ time.Time) error {
+			return service.Repos.Projects.Upsert(ctx, storage.ProjectRecord{
+				ID: "database", Name: "Database", RepoPath: "/repos/database", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			})
+		},
+		RunSchedulerTick: func(context.Context, Services) error { return nil },
+	})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { rt.Stop("test cleanup") })
+
+	if len(rt.config.Projects) != 1 || rt.config.Projects[0].ID != "database" || rt.config.Projects[0].Repo != "acme/database" {
+		t.Fatalf("runtime project catalog = %#v, want database-owned project only", rt.config.Projects)
+	}
+}
+
+func TestRuntimeProjectMutationsAtomicallyPublishCatalog(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	rt := New(Options{
+		Config:           cfg,
+		Logger:           &testLogger{},
+		RunSchedulerTick: func(context.Context, Services) error { return nil },
+	})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { rt.Stop("test cleanup") })
+
+	projectService := rt.Services().Projects
+	projectService.ListWorktrees = nil
+	repo := "acme/live"
+	added, err := projectService.AddProject(context.Background(), projects.AddInput{
+		ID: "live", Name: "Live", RepoPath: workingDir, Repo: &repo, SnapshotMode: projects.SnapshotModeOff,
+	})
+	if err != nil {
+		t.Fatalf("AddProject() error = %v", err)
+	}
+	if added.Project.ID != "live" {
+		t.Fatalf("AddProject().Project.ID = %q, want live", added.Project.ID)
+	}
+	afterAdd := rt.Config()
+	if len(afterAdd.Projects) != 1 || afterAdd.Projects[0].ID != "live" || afterAdd.Projects[0].Repo != repo {
+		t.Fatalf("Config().Projects after add = %#v, want live project", afterAdd.Projects)
+	}
+
+	if _, err := projectService.RemoveProject(context.Background(), "live"); err != nil {
+		t.Fatalf("RemoveProject() error = %v", err)
+	}
+	if got := rt.Config().Projects; len(got) != 0 {
+		t.Fatalf("Config().Projects after remove = %#v, want empty catalog", got)
+	}
+}
+
 func TestRuntimeStartIsIdempotent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nexu-io/looper/internal/network/protocol"
 	"github.com/nexu-io/looper/internal/networkpolicy"
 	"github.com/nexu-io/looper/internal/planner"
+	"github.com/nexu-io/looper/internal/projects"
 	"github.com/nexu-io/looper/internal/reviewer"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/webhookforward"
@@ -2101,7 +2102,33 @@ func (a workerAgentExecutionAdapter) Kill(reason string) error {
 	return a.execution.Kill(reason)
 }
 
+func buildCatalogSchedulerHandlers(source projects.ConfigSource, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time, reconcileStaleRuns func(context.Context) (StaleRunReconcileSummary, error)) defaultSchedulerHandlers {
+	if source == nil {
+		fail := func(context.Context, Services) error { return fmt.Errorf("project catalog is not configured") }
+		return defaultSchedulerHandlers{tick: fail, claim: fail}
+	}
+	claimMu := &sync.Mutex{}
+	initial := buildDefaultSchedulerHandlersWithOptions(source.Snapshot(), logger, coordinator, repos, gitGateway, githubGateway, activeExecutions, asyncRunner, requestWake, now, reconcileStaleRuns, true, claimMu, source)
+	buildSnapshot := func() defaultSchedulerHandlers {
+		return buildDefaultSchedulerHandlersWithOptions(source.Snapshot(), logger, coordinator, repos, gitGateway, githubGateway, activeExecutions, asyncRunner, requestWake, now, reconcileStaleRuns, false, claimMu, nil)
+	}
+	handlers := defaultSchedulerHandlers{
+		tick: func(ctx context.Context, services Services) error {
+			return buildSnapshot().tick(ctx, services)
+		},
+		claim: func(ctx context.Context, services Services) error {
+			return buildSnapshot().claim(ctx, services)
+		},
+		webhook: initial.webhook,
+	}
+	return handlers
+}
+
 func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time, reconcileStaleRuns func(context.Context) (StaleRunReconcileSummary, error)) defaultSchedulerHandlers {
+	return buildDefaultSchedulerHandlersWithOptions(cfg, logger, coordinator, repos, gitGateway, githubGateway, activeExecutions, asyncRunner, requestWake, now, reconcileStaleRuns, true, nil, nil)
+}
+
+func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time, reconcileStaleRuns func(context.Context) (StaleRunReconcileSummary, error), includeWebhook bool, claimMu *sync.Mutex, configSource projects.ConfigSource) defaultSchedulerHandlers {
 	if now == nil {
 		now = time.Now
 	}
@@ -2412,7 +2439,9 @@ func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, c
 			})
 		},
 	})
-	claimMu := &sync.Mutex{}
+	if claimMu == nil {
+		claimMu = &sync.Mutex{}
+	}
 
 	inputForServices := func(services Services) defaultSchedulerTickInput {
 		var runner schedulerAsyncRunner
@@ -2445,22 +2474,26 @@ func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, c
 		}
 	}
 
-	return defaultSchedulerHandlers{
+	handlers := defaultSchedulerHandlers{
 		tick: func(ctx context.Context, services Services) error {
 			return runDefaultSchedulerTick(ctx, inputForServices(services))
 		},
 		claim: func(ctx context.Context, services Services) error {
 			return runIndependentClaimPass(ctx, inputForServices(services))
 		},
-		webhook: webhookforward.New(webhookforward.Options{
-			Repos:    repos,
-			Config:   cfg,
-			Reviewer: reviewerRunner,
-			Fixer:    fixerRunner,
-			Logger:   logger,
-			Now:      now,
-		}),
 	}
+	if includeWebhook {
+		handlers.webhook = webhookforward.New(webhookforward.Options{
+			Repos:        repos,
+			Config:       cfg,
+			ConfigSource: configSource,
+			Reviewer:     reviewerRunner,
+			Fixer:        fixerRunner,
+			Logger:       logger,
+			Now:          now,
+		})
+	}
+	return handlers
 }
 
 func githubCLIAutoPROpeningAvailable(ctx context.Context, cfg config.Config, githubGateway *githubinfra.Gateway, logger bootstrap.Logger, repo, cwd string) bool {

--- a/internal/runtime/webhook.go
+++ b/internal/runtime/webhook.go
@@ -157,6 +157,27 @@ func newWebhookRuntime(cfg config.Config, logger bootstrap.Logger, now func() ti
 	return rt
 }
 
+func (w *webhookRuntime) updateConfig(cfg config.Config) {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	w.cfg.Projects = append([]config.ProjectRefConfig(nil), cfg.Projects...)
+	w.status.ConfiguredTunnelProjectIDs = configuredTunnelProjectIDs(cfg)
+	w.mu.Unlock()
+}
+
+func (w *webhookRuntime) configSnapshot() config.Config {
+	if w == nil {
+		return config.Config{}
+	}
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	cfg := w.cfg
+	cfg.Projects = append([]config.ProjectRefConfig(nil), w.cfg.Projects...)
+	return cfg
+}
+
 func (w *webhookRuntime) RecordDelivery(eventType, deliveryID string) {
 	if w == nil {
 		return

--- a/internal/runtime/webhook_tunnel.go
+++ b/internal/runtime/webhook_tunnel.go
@@ -527,8 +527,9 @@ func (w *webhookRuntime) configuredWebhookReposForMode(projects []storage.Projec
 }
 
 func (w *webhookRuntime) webhookModeForProject(projectID string) config.WebhookMode {
-	mode := w.cfg.Webhook.Mode
-	for _, project := range w.cfg.Projects {
+	cfg := w.configSnapshot()
+	mode := cfg.Webhook.Mode
+	for _, project := range cfg.Projects {
 		if project.ID == projectID && project.Webhook.Mode != "" {
 			mode = project.Webhook.Mode
 			break

--- a/internal/runtime/worktree_cleanup.go
+++ b/internal/runtime/worktree_cleanup.go
@@ -137,8 +137,8 @@ func (r *Runtime) executeWorktreeCleanupPass(ctx context.Context) {
 	}
 	r.worktreeCleanupRunning = true
 	services := r.services
-	cfg := r.config
 	r.mu.Unlock()
+	cfg := r.Config()
 
 	defer func() {
 		r.mu.Lock()

--- a/internal/webhookforward/forwarder.go
+++ b/internal/webhookforward/forwarder.go
@@ -94,9 +94,14 @@ type TargetedFixer interface {
 	DiscoverPullRequestsForBaseBranchUpdate(context.Context, fixer.BaseBranchDiscoveryInput) (fixer.DiscoveryResult, error)
 }
 
+type ConfigSource interface {
+	Snapshot() config.Config
+}
+
 type Options struct {
 	Repos              *storage.Repositories
 	Config             config.Config
+	ConfigSource       ConfigSource
 	Reviewer           TargetedReviewer
 	Fixer              TargetedFixer
 	Logger             bootstrap.Logger
@@ -195,6 +200,7 @@ type checkRunEnvelope struct {
 type forwarder struct {
 	repos              *storage.Repositories
 	cfg                config.Config
+	configSource       ConfigSource
 	reviewer           TargetedReviewer
 	fixer              TargetedFixer
 	logger             bootstrap.Logger
@@ -245,6 +251,7 @@ func New(options Options) Forwarder {
 	f := &forwarder{
 		repos:              options.Repos,
 		cfg:                options.Config,
+		configSource:       options.ConfigSource,
 		reviewer:           options.Reviewer,
 		fixer:              options.Fixer,
 		logger:             options.Logger,
@@ -348,6 +355,10 @@ func (f *forwarder) enqueueLocked(projects []storage.ProjectRecord, routed route
 	candidates := make([]candidate, 0, len(projects))
 	newQueueEntries := 0
 	matched := 0
+	cfg := f.cfg
+	if f.configSource != nil {
+		cfg = f.configSource.Snapshot()
+	}
 	for _, project := range projects {
 		if project.Archived {
 			continue
@@ -356,7 +367,7 @@ func (f *forwarder) enqueueLocked(projects []storage.ProjectRecord, routed route
 		if !strings.EqualFold(repo, routed.repo) {
 			continue
 		}
-		lanes := enabledLanesForProject(f.cfg, project.ID, routed.lanes)
+		lanes := enabledLanesForProject(cfg, project.ID, routed.lanes)
 		if len(lanes) == 0 {
 			continue
 		}

--- a/internal/webhookforward/forwarder_test.go
+++ b/internal/webhookforward/forwarder_test.go
@@ -56,6 +56,36 @@ func TestForwardDedupesDeliveriesWithinTTLAndExpiresAfterAnHour(t *testing.T) {
 	}
 }
 
+func TestForwardCapturesCurrentProjectCatalog(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	cfg := testConfig(t)
+	cfg.Roles.Reviewer.Discovery.AutoDiscovery = false
+	source := &mutableConfigSource{cfg: cfg}
+	reviewerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: cfg, ConfigSource: source, Reviewer: reviewerRunner, MaxConcurrent: 1, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	first, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "before", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 42)})
+	if err != nil {
+		t.Fatalf("first Forward() error = %v", err)
+	}
+	if first.Status != "ignored" {
+		t.Fatalf("first status = %q, want ignored", first.Status)
+	}
+
+	cfg.Roles.Reviewer.Discovery.AutoDiscovery = true
+	source.Store(cfg)
+	second, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "after", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 42)})
+	if err != nil {
+		t.Fatalf("second Forward() error = %v", err)
+	}
+	if second.Status != "accepted" {
+		t.Fatalf("second status = %q, want accepted", second.Status)
+	}
+	reviewerRunner.waitForCalls(t, 1)
+}
+
 func TestForwardIgnoresUnsupportedAndIssueComments(t *testing.T) {
 	repos := newTestRepositories(t)
 	seedProject(t, repos, "project_1", "acme/looper")
@@ -554,6 +584,23 @@ func testConfig(t *testing.T) config.Config {
 	cfg.Roles.Reviewer.Discovery.AutoDiscovery = true
 	cfg.Roles.Fixer.AutoDiscovery = true
 	return cfg
+}
+
+type mutableConfigSource struct {
+	mu  sync.RWMutex
+	cfg config.Config
+}
+
+func (s *mutableConfigSource) Snapshot() config.Config {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.cfg
+}
+
+func (s *mutableConfigSource) Store(cfg config.Config) {
+	s.mu.Lock()
+	s.cfg = cfg
+	s.mu.Unlock()
 }
 
 func newTestRepositories(t *testing.T) *storage.Repositories {


### PR DESCRIPTION
## Summary

- Treat active SQLite project records as the sole runtime Authority for Project existence, repository/Provider binding, and project policy.
- Keep `[[projects]]` as a transactional startup import, then materialize one atomic Project Catalog consumed by Scheduler, Roles, Webhook, Network, cleanup, and `/config`.
- Validate the complete candidate Catalog before add/remove commits and publish it atomically afterward, so an operation retains one coherent snapshot.
- Archive removed config-owned Projects, preserve API-owned Projects, and reject ownership collisions or unknown Providers instead of silently falling back to GitHub.

## Root cause

Looper had two Project authorities: normalized `config.Projects` drove provider/policy decisions while SQLite drove API additions, archival, scheduling discovery, and persistence. The two representations could disagree, causing Forgejo Projects to route through GitHub, removed Projects to remain visible, and runtime consumers to observe different lifecycle states.

## Authority

The Authority for a runtime Project is the active SQLite project record committed by configuration import or an explicit CLI/API mutation; remote detection and the original `[[projects]]` input are not runtime Authority.

## Trade-off

The concrete failure prevented is cross-consumer disagreement about Project existence, Provider, repository, and policy during startup and live mutations.

The cost is a persisted project-policy representation in existing metadata, a startup materialization step, atomic Catalog publication, explicit config/API ownership rules, and snapshot semantics where already-started work may finish using the prior Catalog. Import and mutation validation can now fail loud when a Provider is missing or ownership conflicts.

Deletion was attempted first: runtime binding mirrors, visibility gates, scheduler config mutation, and webhook forwarder replacement were removed. Keeping configuration as the only Authority is insufficient because CLI/API-managed Projects are durable behavior. Keeping both sources and synchronizing them was rejected because PR #528 demonstrated that the synchronization surface spreads across Scheduler, Webhook, removal, rebinding, and shutdown.

See ADR-0012 for the full decision.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- targeted race coverage for Catalog publication, runtime add/remove, Webhook policy refresh, Network refresh, and `/config`
- `gofmt -l .`
- `git diff --check`

## Review gate

- [ ] Mandatory `@oracle` review: this PR changes Project Authority, persists project policy, and introduces an atomic Catalog publication gate.
