### PR TITLE
fix(e2e): pass GH credentials to fake agent after env allowlist

### DIFF
--- a/internal/e2e/github_sandbox_test.go
+++ b/internal/e2e/github_sandbox_test.go
@@ -120,7 +120,7 @@ func TestGitHubSandboxFixerResolvesReviewThread(t *testing.T) {
 	})
 	defer cleanupSandboxPR(t, sb, pr.Number, pr.HeadBranch)
 
-	cfg := fixerSandboxConfig(t, bins, home, repo, fakeAgent, port, "commit")
+	cfg := fixerSandboxConfig(t, bins, home, repo, fakeAgent, port, "commit", sb)
 	harness.WriteConfig(t, home.ConfigPath, cfg, nil)
 	proc := harness.StartLooperd(t, bins, home, home.ConfigPath, sandboxEnvMap(sb), cfg.Server.Host, cfg.Server.Port)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -200,7 +200,7 @@ func TestGitHubSandboxNoDiffPathsDoNotOpenOrResolve(t *testing.T) {
 			}
 		})
 		defer cleanupSandboxPR(t, sb, pr.Number, pr.HeadBranch)
-		cfg := fixerSandboxConfig(t, bins, home, repo, fakeAgent, port, "success-no-diff")
+		cfg := fixerSandboxConfig(t, bins, home, repo, fakeAgent, port, "success-no-diff", sb)
 		harness.WriteConfig(t, home.ConfigPath, cfg, nil)
 		proc := harness.StartLooperd(t, bins, home, home.ConfigPath, sandboxEnvMap(sb), cfg.Server.Host, cfg.Server.Port)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -348,7 +348,7 @@ func workerSandboxConfig(tb testing.TB, bins harness.BuiltBinaries, home harness
 	return cfg
 }
 
-func fixerSandboxConfig(tb testing.TB, bins harness.BuiltBinaries, home harness.TempHome, repo harness.SeededRepo, fakeAgent harness.FakeAgent, port int, agentMode string) config.Config {
+func fixerSandboxConfig(tb testing.TB, bins harness.BuiltBinaries, home harness.TempHome, repo harness.SeededRepo, fakeAgent harness.FakeAgent, port int, agentMode string, sb sandboxConfig) config.Config {
 	tb.Helper()
 	// The fixer's resolve-comments drift guard requires the agent's reply to
 	// carry a `threadCommentsObserved` snapshot; a "fixed" decision without one
@@ -357,7 +357,12 @@ func fixerSandboxConfig(tb testing.TB, bins harness.BuiltBinaries, home harness.
 	// the same real `gh` the daemon uses. Before #513 the fake agent defaulted
 	// to `gh` on PATH; that fallback was removed, which silently regressed this
 	// live sandbox test into a deterministic thread-drift failure.
-	vendor, command, agentEnv := fakeAgent.AgentConfig(agentMode, "git", "gh")
+	//
+	// After #530, agent subprocesses no longer inherit ambient credentials from
+	// the daemon. GH_TOKEN must be supplied explicitly through agent.env so the
+	// fake agent can authenticate `gh api graphql` while building the observed
+	// thread snapshot (otherwise gh exits 4 and the repair step panics).
+	vendor, command, agentEnv := fakeAgent.AgentConfig(agentMode, "git", "gh", sandboxEnvMap(sb))
 	cfg := harness.DefaultConfig(tb, home, harness.ConfigOptions{
 		Port:              port,
 		ToolPaths:         harness.TestToolPaths{Git: "git", GH: "gh", Looper: bins.LooperPath, Osascript: bins.FakeOsascriptPath},

--- a/internal/e2e/harness/cmd/fake-agent/main.go
+++ b/internal/e2e/harness/cmd/fake-agent/main.go
@@ -247,7 +247,10 @@ func mustOutput(command string, args ...string) string {
 	cmd := exec.Command(command, args...)
 	output, err := cmd.Output()
 	if err != nil {
-		panic(err)
+		if exitErr, ok := err.(*exec.ExitError); ok && len(exitErr.Stderr) > 0 {
+			panic(fmt.Errorf("%s %v: %w\nstderr: %s", command, args, err, strings.TrimSpace(string(exitErr.Stderr))))
+		}
+		panic(fmt.Errorf("%s %v: %w", command, args, err))
 	}
 	return string(output)
 }

--- a/internal/e2e/harness/fake_agent_test.go
+++ b/internal/e2e/harness/fake_agent_test.go
@@ -38,6 +38,31 @@ func TestFakeAgentWritesEvidenceAndCompletion(t *testing.T) {
 	}
 }
 
+func TestFakeAgentConfigMergesExtraEnv(t *testing.T) {
+	bins := MustBinaries(t)
+	agent := NewFakeAgent(t, bins)
+	_, command, env := agent.AgentConfig("commit", "git", "gh", map[string]string{
+		"GH_TOKEN":           "sandbox-token",
+		"GITHUB_TOKEN":       "sandbox-token",
+		"GH_PROMPT_DISABLED": "1",
+	})
+	if command != agent.Path {
+		t.Fatalf("command = %q, want fake-agent path", command)
+	}
+	if env[envFakeAgentMode] != "commit" {
+		t.Fatalf("mode = %q, want commit", env[envFakeAgentMode])
+	}
+	if env[envFakeAgentGHPath] != "gh" {
+		t.Fatalf("gh path = %q, want gh", env[envFakeAgentGHPath])
+	}
+	if env["GH_TOKEN"] != "sandbox-token" || env["GITHUB_TOKEN"] != "sandbox-token" {
+		t.Fatalf("agent env missing sandbox GitHub credentials: %#v", env)
+	}
+	if env["GH_PROMPT_DISABLED"] != "1" {
+		t.Fatalf("GH_PROMPT_DISABLED = %q, want 1", env["GH_PROMPT_DISABLED"])
+	}
+}
+
 func TestFakeAgentTransientFailure(t *testing.T) {
 	bins := MustBinaries(t)
 	agent := NewFakeAgent(t, bins)


### PR DESCRIPTION
## Summary

- Restore GitHub sandbox fixer E2E after #530's agent env allowlist: supply `GH_TOKEN` / `GITHUB_TOKEN` / `GH_PROMPT_DISABLED` through `agent.env` so the fake agent can authenticate `gh api graphql` while building `threadCommentsObserved`.
- Surface command stderr in fake-agent `mustOutput` panics so the next auth/API failure is diagnosable without guessing `exit status 4`.
- Add a harness unit test that `AgentConfig` merges explicit extra env (regression lock for the extraEnv path introduced in #530).

## Root cause

[Sandbox E2E job](https://github.com/nexu-io/looper/actions/runs/29200197934/job/86670129512) failed on `TestGitHubSandboxFixerResolvesReviewThread` immediately after #530 merged:

```
panic: exit status 4
main.fetchObservedThreadHashes → mustOutput(gh api graphql ...)
```

#519 already passes a real `gh` path so the fake agent can fetch thread snapshots for the resolve-comments drift guard. Before #530 the agent inherited ambient `GH_TOKEN` from the daemon process. #530 correctly stopped inheriting full `os.Environ()` and only allows a fixed host allowlist — credentials must be declared via `agent.env`. The sandbox config never did that, so `gh` failed auth (exit 4) and the repair step aborted.

## Authority / trade-off

Sandbox credentials for the e2e fake agent are intentionally supplied through `agent.env` (the documented authority channel after #530). We do **not** widen the host allowlist to ambient `GH_TOKEN` — that would re-open the leak surface #530 closed. Cost is one explicit env map in the sandbox fixer config; no production path changes.

## Test plan

- [x] `go test ./internal/e2e/harness/... ./internal/agent/...`
- [x] `go test ./internal/e2e -run 'TestDoesNotExist'` (package compiles)
- [ ] CI GitHub sandbox E2E (`TestGitHubSandbox*`) on this PR