### PR TITLE
refactor: use provider-qualified repository identity across forge integrations

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1761,13 +1761,14 @@ func (h *Handler) buildPullRequestsRouteResponse(r *http.Request) (pullRequestsL
 	identities := collectPullRequestIdentities(latestSnapshots, loops)
 	snapshotByKey := map[string]storage.PullRequestSnapshotRecord{}
 	for _, snapshot := range latestSnapshots {
-		snapshotByKey[pullRequestKey(snapshot.Repo, snapshot.PRNumber)] = snapshot
+		snapshotByKey[pullRequestKey(snapshot.ProjectID, snapshot.Repo, snapshot.PRNumber)] = snapshot
 	}
 
 	items := make([]pullRequestResponse, 0, len(identities))
 	for _, identity := range identities {
-		loopMatches := loopMatchesByPullRequest[pullRequestKey(identity.Repo, identity.PRNumber)]
-		snapshot, ok := snapshotByKey[pullRequestKey(identity.Repo, identity.PRNumber)]
+		key := pullRequestKey(identity.ProjectID, identity.Repo, identity.PRNumber)
+		loopMatches := loopMatchesByPullRequest[key]
+		snapshot, ok := snapshotByKey[key]
 		if ok {
 			items = append(items, h.serializePullRequestListItem(identity.Repo, identity.PRNumber, &snapshot, loopMatches))
 			continue
@@ -1801,7 +1802,37 @@ func (h *Handler) buildPullRequestRouteResponse(r *http.Request, path string) (a
 		return nil, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "prNumber must be a positive integer"}
 	}
 
-	snapshot, err := services.Repositories.PullRequestSnapshots.GetLatest(r.Context(), repo, prNumber)
+	projectID := strings.TrimSpace(r.URL.Query().Get("projectId"))
+	var snapshot *storage.PullRequestSnapshotRecord
+	if projectID != "" {
+		snapshot, err = services.Repositories.PullRequestSnapshots.GetLatestByProject(r.Context(), projectID, repo, prNumber)
+	} else {
+		snapshots, listErr := services.Repositories.PullRequestSnapshots.ListLatestByRepoAndPR(r.Context(), repo, prNumber)
+		if listErr != nil {
+			err = listErr
+		} else {
+			matchedProjects := map[string]struct{}{}
+			for index := range snapshots {
+				candidate := snapshots[index]
+				matchedProjects[candidate.ProjectID] = struct{}{}
+				if snapshot == nil {
+					candidateCopy := candidate
+					snapshot = &candidateCopy
+				}
+			}
+			loops, loopErr := services.Repositories.Loops.ListByRepoAndPR(r.Context(), repo, prNumber)
+			if loopErr != nil {
+				err = loopErr
+			} else {
+				for _, loop := range loops {
+					matchedProjects[loop.ProjectID] = struct{}{}
+				}
+			}
+			if err == nil && len(matchedProjects) > 1 {
+				return nil, apiError{code: pkgapi.ErrorCodeProjectAmbiguous, status: http.StatusConflict, message: fmt.Sprintf("Multiple projects match pull request %s#%d; pass projectId explicitly", repo, prNumber)}
+			}
+		}
+	}
 	if err != nil {
 		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
@@ -1823,7 +1854,7 @@ func (h *Handler) buildPullRequestRouteResponse(r *http.Request, path string) (a
 		return nil, apiError{code: pkgapi.ErrorCodeRouteNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Unknown route: %s", path)}
 	}
 
-	loopMatches, err := h.findPullRequestLoops(r.Context(), repo, prNumber)
+	loopMatches, err := h.findPullRequestLoops(r.Context(), snapshot.ProjectID, snapshot.Repo, prNumber)
 	if err != nil {
 		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
@@ -1831,7 +1862,7 @@ func (h *Handler) buildPullRequestRouteResponse(r *http.Request, path string) (a
 }
 
 func (h *Handler) buildPullRequestStatusResponse(ctx context.Context, snapshot storage.PullRequestSnapshotRecord) (pullRequestStatusResponse, error) {
-	loopMatches, err := h.findPullRequestLoops(ctx, snapshot.Repo, snapshot.PRNumber)
+	loopMatches, err := h.findPullRequestLoops(ctx, snapshot.ProjectID, snapshot.Repo, snapshot.PRNumber)
 	if err != nil {
 		return pullRequestStatusResponse{}, err
 	}
@@ -1886,14 +1917,14 @@ func (h *Handler) buildPullRequestStatusResponse(ctx context.Context, snapshot s
 	}, nil
 }
 
-func (h *Handler) findPullRequestLoops(ctx context.Context, repo string, prNumber int64) ([]storage.LoopRecord, error) {
-	loops, err := h.context.Runtime.Services().Repositories.Loops.List(ctx)
+func (h *Handler) findPullRequestLoops(ctx context.Context, projectID, repo string, prNumber int64) ([]storage.LoopRecord, error) {
+	loops, err := h.context.Runtime.Services().Repositories.Loops.ListByRepoAndPR(ctx, repo, prNumber)
 	if err != nil {
 		return nil, err
 	}
 	matches := make([]storage.LoopRecord, 0)
 	for _, loop := range loops {
-		if loop.Repo != nil && loop.PRNumber != nil && *loop.Repo == repo && *loop.PRNumber == prNumber {
+		if loop.ProjectID == projectID {
 			matches = append(matches, loop)
 		}
 	}
@@ -2047,8 +2078,8 @@ func snapshotString(snapshot *storage.PullRequestSnapshotRecord, getter func(sto
 	return getter(*snapshot)
 }
 
-func pullRequestKey(repo string, prNumber int64) string {
-	return fmt.Sprintf("%s#%d", repo, prNumber)
+func pullRequestKey(projectID, repo string, prNumber int64) string {
+	return fmt.Sprintf("%s:%s#%d", projectID, repo, prNumber)
 }
 
 func groupPullRequestLoops(loops []storage.LoopRecord) map[string][]storage.LoopRecord {
@@ -2057,7 +2088,7 @@ func groupPullRequestLoops(loops []storage.LoopRecord) map[string][]storage.Loop
 		if loop.Repo == nil || loop.PRNumber == nil {
 			continue
 		}
-		key := pullRequestKey(*loop.Repo, *loop.PRNumber)
+		key := pullRequestKey(loop.ProjectID, *loop.Repo, *loop.PRNumber)
 		grouped[key] = append(grouped[key], loop)
 	}
 	return grouped
@@ -2067,7 +2098,7 @@ func dedupeLatestSnapshots(snapshots []storage.PullRequestSnapshotRecord) []stor
 	seen := map[string]struct{}{}
 	deduped := make([]storage.PullRequestSnapshotRecord, 0, len(snapshots))
 	for _, snapshot := range snapshots {
-		key := fmt.Sprintf("%s#%d", snapshot.Repo, snapshot.PRNumber)
+		key := pullRequestKey(snapshot.ProjectID, snapshot.Repo, snapshot.PRNumber)
 		if _, ok := seen[key]; ok {
 			continue
 		}
@@ -2090,7 +2121,7 @@ func collectPullRequestIdentities(snapshots []storage.PullRequestSnapshotRecord,
 		if repo == nil || prNumber == nil {
 			return
 		}
-		key := fmt.Sprintf("%s#%d", *repo, *prNumber)
+		key := pullRequestKey(projectID, *repo, *prNumber)
 		if _, ok := seen[key]; ok {
 			return
 		}
@@ -3694,10 +3725,10 @@ func (h *Handler) buildWorkersCreateResponse(r *http.Request) (workerCreateRespo
 		lockKey := "worker:" + loopID
 		if effectivePRNumber != nil {
 			dedupeKey = fmt.Sprintf("worker:%s:%s:%d", projectID, *repo, *effectivePRNumber)
-			lockKey = fmt.Sprintf("pr:%s:%d", *repo, *effectivePRNumber)
+			lockKey = storage.PullRequestLockKey(projectID, *repo, *effectivePRNumber)
 		} else if issueNumber != nil {
 			dedupeKey = fmt.Sprintf("worker:%s:%s:%d", projectID, *repo, *issueNumber)
-			lockKey = fmt.Sprintf("issue:%s:%d", *repo, *issueNumber)
+			lockKey = storage.IssueLockKey(projectID, *repo, *issueNumber)
 		}
 		payloadJSON := string(queuePayloadJSONBytes)
 		queueRecord := storage.QueueItemRecord{
@@ -5304,7 +5335,8 @@ func buildQueuedLoopQueueRecordCompat(record storage.LoopRecord, target domain.L
 		if target.TargetType != domain.LoopTargetTypeIssue || repo == "" || issueNumber <= 0 {
 			return storage.QueueItemRecord{}, false, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("%s loop requires repo and issueNumber", record.Type)}
 		}
-		lockKey := fmt.Sprintf("issue:%s:%d", repo, issueNumber)
+		lockKey := storage.IssueLockKey(record.ProjectID, repo, issueNumber)
+		targetID := fmt.Sprintf("issue:%s:%d", repo, issueNumber)
 		manual := false
 		if metadata := parseJSONObject(metadataJSON); metadata["manual"] == true {
 			if boolValue, ok := metadata["manual"].(bool); ok {
@@ -5321,7 +5353,7 @@ func buildQueuedLoopQueueRecordCompat(record storage.LoopRecord, target domain.L
 		}
 		payloadJSON := string(payloadBytes)
 		queueRecord.TargetType = string(domain.LoopTargetTypeIssue)
-		queueRecord.TargetID = lockKey
+		queueRecord.TargetID = targetID
 		queueRecord.Repo = &repo
 		queueRecord.PRNumber = nil
 		queueRecord.DedupeKey = fmt.Sprintf("planner:%s:%s:%s:%d", record.ProjectID, record.ID, repo, issueNumber)
@@ -5334,9 +5366,10 @@ func buildQueuedLoopQueueRecordCompat(record storage.LoopRecord, target domain.L
 			return storage.QueueItemRecord{}, false, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("%s loop requires repo and prNumber", record.Type)}
 		}
 		prNumber := *record.PRNumber
-		lockKey := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+		lockKey := storage.PullRequestLockKey(record.ProjectID, repo, prNumber)
+		targetID := fmt.Sprintf("pr:%s:%d", repo, prNumber)
 		queueRecord.TargetType = string(domain.LoopTargetTypePullRequest)
-		queueRecord.TargetID = lockKey
+		queueRecord.TargetID = targetID
 		queueRecord.Repo = &repo
 		queueRecord.PRNumber = &prNumber
 		queueRecord.DedupeKey = fmt.Sprintf("reviewer:%s:%s:%s:%d", record.ProjectID, record.ID, repo, prNumber)
@@ -5348,9 +5381,10 @@ func buildQueuedLoopQueueRecordCompat(record storage.LoopRecord, target domain.L
 			return storage.QueueItemRecord{}, false, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("%s loop requires repo and prNumber", record.Type)}
 		}
 		prNumber := *record.PRNumber
-		lockKey := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+		lockKey := storage.PullRequestLockKey(record.ProjectID, repo, prNumber)
+		targetID := fmt.Sprintf("pr:%s:%d", repo, prNumber)
 		queueRecord.TargetType = string(domain.LoopTargetTypePullRequest)
-		queueRecord.TargetID = lockKey
+		queueRecord.TargetID = targetID
 		queueRecord.Repo = &repo
 		queueRecord.PRNumber = &prNumber
 		queueRecord.DedupeKey = fmt.Sprintf("fixer:%s", record.ID)
@@ -5370,9 +5404,10 @@ func buildQueuedLoopQueueRecordCompat(record storage.LoopRecord, target domain.L
 			if repo == "" || issueNumber <= 0 {
 				return storage.QueueItemRecord{}, false, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("%s loop requires repo and issueNumber", record.Type)}
 			}
-			lockKey = fmt.Sprintf("issue:%s:%d", repo, issueNumber)
+			lockKey = storage.IssueLockKey(record.ProjectID, repo, issueNumber)
+			targetID := fmt.Sprintf("issue:%s:%d", repo, issueNumber)
 			queueRecord.TargetType = string(domain.LoopTargetTypeIssue)
-			queueRecord.TargetID = lockKey
+			queueRecord.TargetID = targetID
 			queueRecord.Repo = &repo
 			queueRecord.PRNumber = nil
 			queueRecord.DedupeKey = fmt.Sprintf("worker:%s:%s:%d", record.ProjectID, repo, issueNumber)
@@ -5382,9 +5417,10 @@ func buildQueuedLoopQueueRecordCompat(record storage.LoopRecord, target domain.L
 				return storage.QueueItemRecord{}, false, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("%s loop requires repo and prNumber", record.Type)}
 			}
 			prNumber := *record.PRNumber
-			lockKey = fmt.Sprintf("pr:%s:%d", repo, prNumber)
+			lockKey = storage.PullRequestLockKey(record.ProjectID, repo, prNumber)
+			targetID := fmt.Sprintf("pr:%s:%d", repo, prNumber)
 			queueRecord.TargetType = string(domain.LoopTargetTypePullRequest)
-			queueRecord.TargetID = lockKey
+			queueRecord.TargetID = targetID
 			queueRecord.Repo = &repo
 			queueRecord.PRNumber = &prNumber
 			queueRecord.DedupeKey = fmt.Sprintf("worker:%s:%s:%d", record.ProjectID, repo, prNumber)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1106,7 +1106,7 @@ func TestHandlerPullRequestRouteReturnsInternalErrorWhenLoopLookupFails(t *testi
 
 	services := fixture.runtime.Services()
 	services.Repositories = storage.NewRepositories(errorInjectingQuerier{db: services.Coordinator.DB(), queryError: func(query string) error {
-		if strings.Contains(query, "SELECT * FROM loops ORDER BY updated_at DESC, seq DESC") {
+		if strings.Contains(query, "SELECT * FROM loops WHERE repo = ? COLLATE NOCASE AND pr_number = ?") {
 			return errors.New("database is locked")
 		}
 		return nil
@@ -1123,7 +1123,92 @@ func TestHandlerPullRequestRouteReturnsInternalErrorWhenLoopLookupFails(t *testi
 	body := parseJSONMap(t, recorder.Body.Bytes())
 	errMap := body["error"].(map[string]any)
 	assertEqual(t, errMap["code"], "INTERNAL_ERROR")
-	assertEqual(t, errMap["message"], "list loops: database is locked")
+	assertEqual(t, errMap["message"], "list loops by repository and pull request: database is locked")
+}
+
+func TestHandlerPullRequestRouteRequiresProjectForDuplicateRepoIdentity(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	for _, projectID := range []string{"github", "forgejo"} {
+		metadata := `{"repo":"acme/app"}`
+		if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: projectID, RepoPath: "/tmp/" + projectID, MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+			t.Fatalf("Projects.Upsert(%s) error = %v", projectID, err)
+		}
+	}
+	for _, snapshot := range []storage.PullRequestSnapshotRecord{
+		{ID: "snapshot_github", ProjectID: "github", Repo: "acme/app", PRNumber: 42, HeadSHA: "github-head", CapturedAt: nowISO, CreatedAt: nowISO},
+		{ID: "snapshot_forgejo", ProjectID: "forgejo", Repo: "acme/app", PRNumber: 42, HeadSHA: "forgejo-head", CapturedAt: nowISO, CreatedAt: nowISO},
+	} {
+		if err := fixture.runtime.Services().Repositories.PullRequestSnapshots.Upsert(context.Background(), snapshot); err != nil {
+			t.Fatalf("PullRequestSnapshots.Upsert(%s) error = %v", snapshot.ProjectID, err)
+		}
+	}
+	repo := "acme/app"
+	prNumber := int64(42)
+	for index, loop := range []storage.LoopRecord{
+		{ID: "github_reviewer", ProjectID: "github", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed"},
+		{ID: "forgejo_reviewer", ProjectID: "forgejo", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running"},
+	} {
+		loop.Seq = int64(index + 1)
+		loop.CreatedAt = nowISO
+		loop.UpdatedAt = nowISO
+		if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+
+	handler := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now }})
+	ambiguous := httptest.NewRecorder()
+	handler.ServeHTTP(ambiguous, httptest.NewRequest(http.MethodGet, "/api/v1/pull-requests/acme%2Fapp/42", nil))
+	if ambiguous.Code != http.StatusConflict {
+		t.Fatalf("ambiguous status = %d, want 409; body=%s", ambiguous.Code, ambiguous.Body.String())
+	}
+
+	qualified := httptest.NewRecorder()
+	handler.ServeHTTP(qualified, httptest.NewRequest(http.MethodGet, "/api/v1/pull-requests/AcMe%2FApp/42?projectId=forgejo", nil))
+	if qualified.Code != http.StatusOK {
+		t.Fatalf("qualified status = %d, want 200; body=%s", qualified.Code, qualified.Body.String())
+	}
+	body := parseJSONMap(t, qualified.Body.Bytes())
+	data := body["data"].(map[string]any)
+	if data["projectId"] != "forgejo" || data["headSha"] != "forgejo-head" {
+		t.Fatalf("qualified data = %#v, want Forgejo snapshot", data)
+	}
+	if data["reviewer"] != "running" {
+		t.Fatalf("qualified reviewer = %#v, want only Forgejo loop state", data["reviewer"])
+	}
+}
+
+func TestHandlerPullRequestRouteCountsLoopOnlyProjectAsAmbiguous(t *testing.T) {
+	fixture := newTestFixture(t)
+	nowISO := fixture.now.UTC().Format(javaScriptISOString)
+	metadata := `{"repo":"acme/app"}`
+	for _, projectID := range []string{"github", "forgejo"} {
+		if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: projectID, RepoPath: "/tmp/" + projectID, MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+			t.Fatalf("Projects.Upsert(%s) error = %v", projectID, err)
+		}
+	}
+	if err := fixture.runtime.Services().Repositories.PullRequestSnapshots.Upsert(context.Background(), storage.PullRequestSnapshotRecord{ID: "snapshot_github_only", ProjectID: "github", Repo: "acme/app", PRNumber: 42, HeadSHA: "github-head", CapturedAt: nowISO, CreatedAt: nowISO}); err != nil {
+		t.Fatalf("PullRequestSnapshots.Upsert() error = %v", err)
+	}
+	repo := "ACME/APP"
+	prNumber := int64(42)
+	if err := fixture.runtime.Services().Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "forgejo_loop_only", Seq: 1, ProjectID: "forgejo", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	handler := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now }})
+	ambiguous := httptest.NewRecorder()
+	handler.ServeHTTP(ambiguous, httptest.NewRequest(http.MethodGet, "/api/v1/pull-requests/acme%2Fapp/42", nil))
+	if ambiguous.Code != http.StatusConflict {
+		t.Fatalf("ambiguous status = %d, want 409; body=%s", ambiguous.Code, ambiguous.Body.String())
+	}
+
+	qualified := httptest.NewRecorder()
+	handler.ServeHTTP(qualified, httptest.NewRequest(http.MethodGet, "/api/v1/pull-requests/acme%2Fapp/42?projectId=github", nil))
+	if qualified.Code != http.StatusOK {
+		t.Fatalf("qualified status = %d, want 200; body=%s", qualified.Code, qualified.Body.String())
+	}
 }
 
 func TestHandlerPullRequestStatusReturnsInternalErrorWhenLoopLookupFails(t *testing.T) {
@@ -1145,7 +1230,7 @@ func TestHandlerPullRequestStatusReturnsInternalErrorWhenLoopLookupFails(t *test
 
 	services := fixture.runtime.Services()
 	services.Repositories = storage.NewRepositories(errorInjectingQuerier{db: services.Coordinator.DB(), queryError: func(query string) error {
-		if strings.Contains(query, "SELECT * FROM loops ORDER BY updated_at DESC, seq DESC") {
+		if strings.Contains(query, "SELECT * FROM loops WHERE repo = ? COLLATE NOCASE AND pr_number = ?") {
 			return errors.New("database is locked")
 		}
 		return nil
@@ -1162,7 +1247,7 @@ func TestHandlerPullRequestStatusReturnsInternalErrorWhenLoopLookupFails(t *test
 	body := parseJSONMap(t, recorder.Body.Bytes())
 	errMap := body["error"].(map[string]any)
 	assertEqual(t, errMap["code"], "INTERNAL_ERROR")
-	assertEqual(t, errMap["message"], "list loops: database is locked")
+	assertEqual(t, errMap["message"], "list loops by repository and pull request: database is locked")
 }
 
 func TestReadAgentOutputLogReadsTailToPreserveCompletionMarker(t *testing.T) {
@@ -3844,12 +3929,12 @@ func TestHandlerWorkerCreateUsesOnlyNewestMatchingPlannerLoop(t *testing.T) {
 	}
 	assertEqual(t, queueItem.TargetType, "issue")
 	assertEqual(t, queueItem.TargetID, "issue:acme/looper:77")
-	assertEqual(t, derefString(queueItem.LockKey), "issue:acme/looper:77")
+	assertEqual(t, derefString(queueItem.LockKey), storage.IssueLockKey("project_1", "acme/looper", 77))
 	assertEqual(t, queueItem.DedupeKey, "worker:project_1:acme/looper:77")
 	if queueItem.PRNumber != nil {
 		t.Fatalf("queueItem.PRNumber = %#v, want nil", queueItem.PRNumber)
 	}
-	if queueItem.LockKey == nil || *queueItem.LockKey != "issue:acme/looper:77" {
+	if queueItem.LockKey == nil || *queueItem.LockKey != storage.IssueLockKey("project_1", "acme/looper", 77) {
 		t.Fatalf("queueItem.LockKey = %#v, want issue lock key", queueItem.LockKey)
 	}
 	payload := parseJSONMap(t, []byte(*queueItem.PayloadJSON))

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -389,8 +389,8 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				},
 				subcommands: []*cobra.Command{
 					newCommand(commandSpec{use: "list", short: "List pull requests", runE: runtime.pullRequestList}),
-					newCommand(commandSpec{use: "show", short: "Show a pull request", args: cobra.ExactArgs(1), runE: runtime.pullRequestShow}),
-					newCommand(commandSpec{use: "status", short: "Show pull request status", args: cobra.ExactArgs(1), runE: runtime.pullRequestStatus}),
+					newCommand(commandSpec{use: "show", short: "Show a pull request", args: cobra.ExactArgs(1), runE: runtime.pullRequestShow, localFlags: []flagSpec{stringFlag("project", "projectId", "Project id")}}),
+					newCommand(commandSpec{use: "status", short: "Show pull request status", args: cobra.ExactArgs(1), runE: runtime.pullRequestStatus, localFlags: []flagSpec{stringFlag("project", "projectId", "Project id")}}),
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -221,6 +221,17 @@ func TestPullRequestListShowsMergeabilityAndBlocker(t *testing.T) {
 			t.Fatalf("request path = %q, want %q", got, want)
 		}
 		writeEnvelope(t, w, pkgapi.Success("req_prs", map[string]any{"items": []map[string]any{{
+			"projectId":      "github",
+			"repo":           "acme/looper",
+			"prNumber":       42,
+			"title":          "Fix queue visibility",
+			"mergeability":   "blocked",
+			"blockingReason": "checks",
+			"reviewState":    "APPROVED",
+			"checksSummary":  "FAILURE",
+			"reviewer":       "completed",
+		}, {
+			"projectId":      "forgejo",
 			"repo":           "acme/looper",
 			"prNumber":       42,
 			"title":          "Fix queue visibility",
@@ -238,10 +249,41 @@ func TestPullRequestListShowsMergeabilityAndBlocker(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Run([pr list]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
 	}
-	for _, want := range []string{"mergeability", "blocker", "blocked", "checks"} {
+	for _, want := range []string{"project", "github", "forgejo", "mergeability", "blocker", "blocked", "checks"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout = %q, want to contain %q", stdout, want)
 		}
+	}
+}
+
+func TestPullRequestShowAndStatusPassProjectSelection(t *testing.T) {
+	t.Parallel()
+
+	for _, command := range []string{"show", "status"} {
+		command := command
+		t.Run(command, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				wantPath := "/api/v1/pull-requests/acme%2Flooper/42"
+				if command == "status" {
+					wantPath += "/status"
+				}
+				if got := r.URL.EscapedPath(); got != wantPath {
+					t.Fatalf("request path = %q, want %q", got, wantPath)
+				}
+				if got := r.URL.Query().Get("projectId"); got != "forgejo" {
+					t.Fatalf("projectId = %q, want forgejo", got)
+				}
+				writeEnvelope(t, w, pkgapi.Success("req_pr", map[string]any{"projectId": "forgejo", "repo": "acme/looper", "prNumber": 42, "reviewState": "OPEN"}))
+			}))
+			defer server.Close()
+
+			configPath := writeCLIConfig(t, server.URL, "")
+			exitCode, _, stderr := runApp(t, "pr", command, "acme/looper#42", "--project", "forgejo", "--config", configPath)
+			if exitCode != 0 {
+				t.Fatalf("Run([pr %s]) exit code = %d, want 0; stderr=%q", command, exitCode, stderr)
+			}
+		})
 	}
 }
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -445,9 +445,9 @@ func writeHumanPullRequestList(w io.Writer, payload json.RawMessage) error {
 
 	rows := make([]tableRow, 0, len(data.Items))
 	for _, item := range data.Items {
-		rows = append(rows, tableRow{"pr": fmt.Sprintf("%s#%d", item.Repo, item.PRNumber), "title": item.Title, "mergeability": item.Mergeability, "blocker": item.BlockingReason, "reviewState": item.ReviewState, "checks": item.ChecksSummary, "reviewer": item.Reviewer, "fixer": item.Fixer})
+		rows = append(rows, tableRow{"project": item.ProjectID, "pr": fmt.Sprintf("%s#%d", item.Repo, item.PRNumber), "title": item.Title, "mergeability": item.Mergeability, "blocker": item.BlockingReason, "reviewState": item.ReviewState, "checks": item.ChecksSummary, "reviewer": item.Reviewer, "fixer": item.Fixer})
 	}
-	printTable(w, []string{"pr", "title", "mergeability", "blocker", "reviewState", "checks", "reviewer", "fixer"}, rows)
+	printTable(w, []string{"project", "pr", "title", "mergeability", "blocker", "reviewState", "checks", "reviewer", "fixer"}, rows)
 	return nil
 }
 
@@ -456,7 +456,7 @@ func writeHumanPullRequestShow(w io.Writer, payload json.RawMessage) error {
 	if err := json.Unmarshal(payload, &data); err != nil {
 		return fmt.Errorf("decode pull request response: %w", err)
 	}
-	printSection(w, "Pull request", [][2]any{{"repo", data.Repo}, {"prNumber", data.PRNumber}, {"title", data.Title}, {"reviewState", data.ReviewState}, {"checksSummary", data.ChecksSummary}})
+	printSection(w, "Pull request", [][2]any{{"projectId", data.ProjectID}, {"repo", data.Repo}, {"prNumber", data.PRNumber}, {"title", data.Title}, {"reviewState", data.ReviewState}, {"checksSummary", data.ChecksSummary}})
 	return nil
 }
 
@@ -465,7 +465,7 @@ func writeHumanPullRequestStatus(w io.Writer, payload json.RawMessage) error {
 	if err := json.Unmarshal(payload, &data); err != nil {
 		return fmt.Errorf("decode pull request status response: %w", err)
 	}
-	printSection(w, "Pull request status", [][2]any{{"pr", fmt.Sprintf("%s#%d", data.Repo, data.PRNumber)}, {"reviewState", data.ReviewState}, {"checksSummary", data.ChecksSummary}, {"unresolvedThreads", data.UnresolvedThreadCount}, {"latestRunStatus", data.LoopStatus.LatestRunStatus}})
+	printSection(w, "Pull request status", [][2]any{{"projectId", data.ProjectID}, {"pr", fmt.Sprintf("%s#%d", data.Repo, data.PRNumber)}, {"reviewState", data.ReviewState}, {"checksSummary", data.ChecksSummary}, {"unresolvedThreads", data.UnresolvedThreadCount}, {"latestRunStatus", data.LoopStatus.LatestRunStatus}})
 	return nil
 }
 

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -338,7 +338,7 @@ func (r *commandRuntime) pullRequestShow(cmd *cobra.Command, args []string) erro
 		if err != nil {
 			return nil, err
 		}
-		return r.getJSON(ctx, pullRequestPath(repo, prNumber))
+		return r.getJSON(ctx, withProjectQuery(pullRequestPath(repo, prNumber), getStringFlag(cmd, "project")))
 	}, writeHumanPullRequestShow)
 }
 
@@ -348,7 +348,7 @@ func (r *commandRuntime) pullRequestStatus(cmd *cobra.Command, args []string) er
 		if err != nil {
 			return nil, err
 		}
-		return r.getJSON(ctx, pullRequestPath(repo, prNumber)+"/status")
+		return r.getJSON(ctx, withProjectQuery(pullRequestPath(repo, prNumber)+"/status", getStringFlag(cmd, "project")))
 	}, writeHumanPullRequestStatus)
 }
 
@@ -778,6 +778,16 @@ func writeJSON(w io.Writer, payload any) error {
 
 func pullRequestPath(repo string, prNumber int64) string {
 	return "/api/v1/pull-requests/" + url.PathEscape(repo) + "/" + strconv.FormatInt(prNumber, 10)
+}
+
+func withProjectQuery(path, projectID string) string {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return path
+	}
+	query := url.Values{}
+	query.Set("projectId", projectID)
+	return path + "?" + query.Encode()
 }
 
 type activeRunDetailOutput struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -525,6 +525,72 @@ func TestForgejoProviderConfigRequiresRepoAndRejectsDuplicateBareRepos(t *testin
 	}
 }
 
+func TestValidateAllowsSameRepoAcrossForgeProviders(t *testing.T) {
+	t.Parallel()
+
+	tokenEnv := "FORGE_TOKEN"
+	cfg, err := Normalize(t.TempDir(), PartialConfig{
+		Providers: &[]PartialProviderConfig{
+			{ID: "forgejo-one", Kind: providerKindPtr(ProviderKindForgejo), BaseURL: stringPtr("https://one.example.test/"), TokenEnv: &tokenEnv},
+			{ID: "forgejo-two", Kind: providerKindPtr(ProviderKindForgejo), BaseURL: stringPtr("https://two.example.test"), TokenEnv: &tokenEnv},
+		},
+		Projects: &[]PartialProjectRefConfig{
+			{ID: "github", Name: "GitHub", Repo: stringPtr("Acme/App"), RepoPath: "/tmp/github"},
+			{ID: "one", Name: "One", Provider: stringPtr("forgejo-one"), Repo: stringPtr("acme/app"), RepoPath: "/tmp/one"},
+			{ID: "two", Name: "Two", Provider: stringPtr("forgejo-two"), Repo: stringPtr("ACME/APP"), RepoPath: "/tmp/two"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if err := ValidateWithOptions(cfg, ValidateOptions{DefaultWorktreeRoot: t.TempDir()}); err != nil {
+		t.Fatalf("ValidateWithOptions() error = %v, want provider-qualified repositories to coexist", err)
+	}
+}
+
+func TestValidateRejectsSameRepoThroughProviderAliases(t *testing.T) {
+	t.Parallel()
+
+	tokenEnv := "FORGE_TOKEN"
+	cfg, err := Normalize(t.TempDir(), PartialConfig{
+		Providers: &[]PartialProviderConfig{
+			{ID: "alias-one", Kind: providerKindPtr(ProviderKindForgejo), BaseURL: stringPtr("https://code.example.test/"), TokenEnv: &tokenEnv},
+			{ID: "alias-two", Kind: providerKindPtr(ProviderKindForgejo), BaseURL: stringPtr("HTTPS://CODE.EXAMPLE.TEST"), TokenEnv: &tokenEnv},
+		},
+		Projects: &[]PartialProjectRefConfig{
+			{ID: "one", Name: "One", Provider: stringPtr("alias-one"), Repo: stringPtr("acme/app"), RepoPath: "/tmp/one"},
+			{ID: "two", Name: "Two", Provider: stringPtr("alias-two"), Repo: stringPtr("ACME/APP"), RepoPath: "/tmp/two"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if err := ValidateWithOptions(cfg, ValidateOptions{DefaultWorktreeRoot: t.TempDir()}); err == nil || !strings.Contains(err.Error(), "duplicates") {
+		t.Fatalf("ValidateWithOptions() error = %v, want physical endpoint duplicate rejection", err)
+	}
+}
+
+func TestValidateTreatsPlaneCodeRepoAsGitHubIdentity(t *testing.T) {
+	t.Parallel()
+
+	tokenEnv := "PLANE_TOKEN"
+	workspace := "acme"
+	planeProjectID := "plane-project"
+	cfg, err := Normalize(t.TempDir(), PartialConfig{
+		Providers: &[]PartialProviderConfig{{ID: "plane", Kind: providerKindPtr(ProviderKindPlane), TokenEnv: &tokenEnv, Workspace: &workspace, ProjectID: &planeProjectID}},
+		Projects: &[]PartialProjectRefConfig{
+			{ID: "github", Name: "GitHub", Repo: stringPtr("acme/app"), RepoPath: "/tmp/github"},
+			{ID: "plane", Name: "Plane", Provider: stringPtr("plane"), Repo: stringPtr("ACME/APP"), RepoPath: "/tmp/plane"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if err := ValidateWithOptions(cfg, ValidateOptions{DefaultWorktreeRoot: t.TempDir()}); err == nil || !strings.Contains(err.Error(), "duplicates") {
+		t.Fatalf("ValidateWithOptions() error = %v, want Plane/GitHub code repo duplicate rejection", err)
+	}
+}
+
 func TestMixedGitHubWebhookAndForgejoPollingConfigValidates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/repository_identity.go
+++ b/internal/config/repository_identity.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	defaultGitHubProviderID  = "github"
+	defaultGitHubProviderURL = "https://github.com"
+)
+
+// RepositoryIdentity is the forge-qualified identity of a configured project.
+// The explicit project-to-provider binding is authoritative; the implicit
+// GitHub values preserve legacy projects that predate provider configuration.
+type RepositoryIdentity struct {
+	ProviderID string
+	Kind       ProviderKind
+	BaseURL    string
+	Repo       string
+}
+
+// Key returns a normalized, collision-safe key for in-process indexing.
+func (identity RepositoryIdentity) Key() string {
+	kind := string(identity.Kind)
+	return fmt.Sprintf("%d:%s%d:%s%d:%s", len(kind), kind, len(identity.BaseURL), identity.BaseURL, len(identity.Repo), identity.Repo)
+}
+
+// ProjectRepositoryIdentity resolves a project through its configured provider
+// binding. It returns false when the binding is unknown or the repository is
+// empty, allowing validation to report those errors at their original paths.
+func ProjectRepositoryIdentity(cfg Config, project ProjectRefConfig) (RepositoryIdentity, bool) {
+	repo := strings.ToLower(strings.TrimSpace(project.Repo))
+	if repo == "" {
+		return RepositoryIdentity{}, false
+	}
+
+	providerID := strings.TrimSpace(project.Provider)
+	if providerID == "" {
+		return RepositoryIdentity{ProviderID: defaultGitHubProviderID, Kind: ProviderKindGitHub, BaseURL: defaultGitHubProviderURL, Repo: repo}, true
+	}
+	for _, provider := range cfg.Providers {
+		if provider.ID != providerID {
+			continue
+		}
+		if provider.Kind == ProviderKindPlane {
+			return RepositoryIdentity{ProviderID: defaultGitHubProviderID, Kind: ProviderKindGitHub, BaseURL: defaultGitHubProviderURL, Repo: repo}, true
+		}
+		baseURL := normalizeBaseURL(provider.BaseURL)
+		if provider.Kind == ProviderKindGitHub && baseURL == "" {
+			baseURL = defaultGitHubProviderURL
+		}
+		return RepositoryIdentity{ProviderID: provider.ID, Kind: provider.Kind, BaseURL: baseURL, Repo: repo}, true
+	}
+	return RepositoryIdentity{}, false
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -348,11 +348,11 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 			}
 		}
 		if strings.TrimSpace(project.Repo) != "" {
-			repo := strings.ToLower(strings.TrimSpace(project.Repo))
-			if previousIndex, exists := projectRepos[repo]; exists {
+			identity, resolved := ProjectRepositoryIdentity(config, project)
+			if previousIndex, exists := projectRepos[identity.Key()]; resolved && exists {
 				issues = append(issues, ValidationIssue{Path: prefix + ".repo", Message: fmt.Sprintf("duplicates projects[%d].repo: %s", previousIndex, project.Repo)})
-			} else {
-				projectRepos[repo] = index
+			} else if resolved {
+				projectRepos[identity.Key()] = index
 			}
 		}
 		if project.Path != "" && project.RepoPath != "" && project.Path != project.RepoPath {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1540,7 +1540,7 @@ func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID 
 	if manualFollowupLoop == nil && !policy.IncludeDrafts && pr.IsDraft {
 		return false
 	}
-	if r.hasActivePRLock(ctx, repo, pr.Number) {
+	if r.hasActivePRLock(ctx, projectID, repo, pr.Number) {
 		var (
 			loop *storage.LoopRecord
 			err  error
@@ -4568,7 +4568,7 @@ func (r *Runner) recoverLegacyNoopFollowupLoops(ctx context.Context, project sto
 		if isManualFixerLoop(loop) && !isManualFixerFollowupCandidate(loop) {
 			continue
 		}
-		if r.hasActivePRLock(ctx, repo, *loop.PRNumber) {
+		if r.hasActivePRLock(ctx, project.ID, repo, *loop.PRNumber) {
 			continue
 		}
 		metadata := parseJSONObject(loop.MetadataJSON)
@@ -4781,7 +4781,7 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 	}
 	nowISO := r.nowISO()
 	targetID := buildPullRequestTargetID(input.Repo, input.PRNumber)
-	lockKey := fmt.Sprintf("pr:%s:%d", input.Repo, input.PRNumber)
+	lockKey := storage.PullRequestLockKey(input.ProjectID, input.Repo, input.PRNumber)
 	projectID := input.ProjectID
 	loopID := input.LoopID
 	queueItem := storage.QueueItemRecord{ID: eventlog.NewEventID("queue"), ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: targetID, Repo: &input.Repo, PRNumber: &input.PRNumber, DedupeKey: dedupeKey, Priority: storage.QueuePriorityFixer, Status: "queued", AvailableAt: availableAt, Attempts: 0, MaxAttempts: r.retryMaxAttempts, LockKey: &lockKey, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}
@@ -5649,16 +5649,19 @@ func (r *Runner) appendEvent(ctx context.Context, input eventInput) {
 	_ = eventlog.Append(ctx, r.repos, eventlog.AppendInput{EventType: input.eventType, ProjectID: optionalString(input.projectID), LoopID: optionalString(input.loopID), RunID: optionalString(input.runID), EntityType: optionalString(input.entityType), EntityID: optionalString(input.entityID), ActorType: optionalString("system"), ActorID: optionalString("fixer-loop"), ActorDisplayName: optionalString("fixer-loop"), Payload: input.payload, CreatedAt: r.now()})
 }
 
-func (r *Runner) hasActivePRLock(ctx context.Context, repo string, prNumber int64) bool {
-	lock, err := r.repos.Locks.Get(ctx, fmt.Sprintf("pr:%s:%d", repo, prNumber))
-	if err != nil || lock == nil {
-		return false
+func (r *Runner) hasActivePRLock(ctx context.Context, projectID, repo string, prNumber int64) bool {
+	keys := []string{storage.PullRequestLockKey(projectID, repo, prNumber), fmt.Sprintf("pr:%s:%d", repo, prNumber)}
+	for _, key := range keys {
+		lock, err := r.repos.Locks.Get(ctx, key)
+		if err != nil || lock == nil {
+			continue
+		}
+		expiresAt, err := time.Parse(time.RFC3339Nano, lock.ExpiresAt)
+		if err == nil && expiresAt.After(r.now()) {
+			return true
+		}
 	}
-	expiresAt, err := time.Parse(time.RFC3339Nano, lock.ExpiresAt)
-	if err != nil {
-		return false
-	}
-	return expiresAt.After(r.now())
+	return false
 }
 
 func (r *Runner) nowISO() string { return eventlog.FormatJavaScriptISOString(r.now()) }
@@ -7940,10 +7943,10 @@ func nilIfEmpty(value string) any {
 }
 
 func buildPullRequestLockKey(item storage.QueueItemRecord) string {
-	if item.Repo == nil || item.PRNumber == nil {
+	if item.ProjectID == nil || item.Repo == nil || item.PRNumber == nil {
 		return ""
 	}
-	return fmt.Sprintf("pr:%s:%d", *item.Repo, *item.PRNumber)
+	return storage.PullRequestLockKey(*item.ProjectID, *item.Repo, *item.PRNumber)
 }
 
 // reRequestReviewersAfterFix re-requests the human reviewers who left a review

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -808,7 +808,7 @@ func (r *Runner) runDiscoverIssueStep(ctx context.Context, input stepInput) (pla
 		return input.Checkpoint, err
 	}
 	currentLogin := firstNonEmpty(normalizeLogin(stringFromAnyDefault(payload["currentUserLogin"])), input.CheckpointIssueLogin())
-	lockKey := firstNonEmpty(derefString(input.QueueItem.LockKey), buildIssueLockKey(repo, issueNumber))
+	lockKey := firstNonEmpty(derefString(input.QueueItem.LockKey), storage.IssueLockKey(input.Project.ID, repo, issueNumber))
 	nowISO := r.nowISO()
 	reason := "planner-run"
 	acquired, err := r.repos.Locks.Acquire(ctx, storage.LockRecord{Key: lockKey, Owner: input.QueueItem.ID, Reason: &reason, ExpiresAt: eventlog.FormatJavaScriptISOString(r.now().Add(r.claimTTL)), CreatedAt: nowISO, UpdatedAt: nowISO})
@@ -1481,7 +1481,7 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 	}
 	nowISO := r.nowISO()
 	targetID := buildIssueTargetID(input.Repo, input.IssueNumber)
-	lockKey := buildIssueLockKey(input.Repo, input.IssueNumber)
+	lockKey := storage.IssueLockKey(input.ProjectID, input.Repo, input.IssueNumber)
 	projectID := input.ProjectID
 	loopID := input.LoopID
 	payload := mustMarshalJSON(input.Payload)
@@ -2017,10 +2017,6 @@ func (r *Runner) stampFailedDiscoveryFingerprint(updated *storage.LoopRecord, qu
 func buildPlannerDedupeKey(projectID, loopID, repo string, issueNumber int64) string {
 	return fmt.Sprintf("planner:%s:%s:%s:%d", projectID, loopID, repo, issueNumber)
 }
-func buildIssueLockKey(repo string, issueNumber int64) string {
-	return fmt.Sprintf("issue:%s:%d", repo, issueNumber)
-}
-
 func parseIssueNumberFromTargetID(targetID string) int64 {
 	if targetID == "" {
 		return 0

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -138,7 +138,7 @@ func TestDiscoverIssuesEnqueuesAcrossProjectsForSameIssue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensureLoopForIssue(project_1) error = %v", err)
 	}
-	project1Queue := storage.QueueItemRecord{ID: "queue_existing", ProjectID: stringPtr("project_1"), LoopID: &loopResult.record.ID, Type: "planner", TargetType: "issue", TargetID: buildIssueTargetID("acme/looper", issue.Number), Repo: stringPtr("acme/looper"), DedupeKey: buildPlannerDedupeKey("project_1", loopResult.record.ID, "acme/looper", issue.Number), Priority: storage.QueuePriorityPlanner, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, LockKey: stringPtr(buildIssueLockKey("acme/looper", issue.Number)), CreatedAt: nowISO, UpdatedAt: nowISO}
+	project1Queue := storage.QueueItemRecord{ID: "queue_existing", ProjectID: stringPtr("project_1"), LoopID: &loopResult.record.ID, Type: "planner", TargetType: "issue", TargetID: buildIssueTargetID("acme/looper", issue.Number), Repo: stringPtr("acme/looper"), DedupeKey: buildPlannerDedupeKey("project_1", loopResult.record.ID, "acme/looper", issue.Number), Priority: storage.QueuePriorityPlanner, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, LockKey: stringPtr(storage.IssueLockKey("project_1", "acme/looper", issue.Number)), CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Queue.Upsert(context.Background(), project1Queue); err != nil {
 		t.Fatalf("Queue.Upsert(existing) error = %v", err)
 	}
@@ -844,7 +844,7 @@ func TestProcessClaimedItemResumeReleasesClaimedLockWhenSetupFails(t *testing.T)
 	if err != nil {
 		t.Fatalf("enqueue() error = %v", err)
 	}
-	checkpointJSON := `{"claimedLockKey":"` + buildIssueLockKey("acme/looper", issue.Number) + `"}`
+	checkpointJSON := `{"claimedLockKey":"` + storage.IssueLockKey("project_1", "acme/looper", issue.Number) + `"}`
 	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_failed_resume", LoopID: loopResult.record.ID, Status: "failed", LastCompletedStep: stringPtr(string(stepDiscoverIssues)), CheckpointJSON: &checkpointJSON, StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
@@ -872,7 +872,7 @@ func TestProcessClaimedItemResumeReleasesClaimedLockWhenSetupFails(t *testing.T)
 	if err == nil || !strings.Contains(err.Error(), "forced loop update failure") {
 		t.Fatalf("ProcessClaimedItem() error = %v, want forced loop update failure", err)
 	}
-	lockKey := buildIssueLockKey("acme/looper", issue.Number)
+	lockKey := storage.IssueLockKey("project_1", "acme/looper", issue.Number)
 	lock, err := fixture.repos.Locks.Get(context.Background(), lockKey)
 	if err != nil {
 		t.Fatalf("Locks.Get() error = %v", err)

--- a/internal/projects/catalog.go
+++ b/internal/projects/catalog.go
@@ -115,7 +115,11 @@ func MaterializeCatalog(global config.Config, records []storage.ProjectRecord) (
 			return nil, fmt.Errorf("project %q references unknown provider %q", project.ID, project.Provider)
 		}
 		if project.Repo != "" {
-			repoKey := strings.ToLower(project.Repo)
+			identity, resolved := config.ProjectRepositoryIdentity(global, project)
+			if !resolved {
+				return nil, fmt.Errorf("project %q repository identity cannot be resolved", project.ID)
+			}
+			repoKey := identity.Key()
 			if existingID, ok := seenRepos[repoKey]; ok {
 				return nil, fmt.Errorf("project %q repo %q duplicates active project %q", project.ID, project.Repo, existingID)
 			}

--- a/internal/projects/catalog_test.go
+++ b/internal/projects/catalog_test.go
@@ -171,19 +171,34 @@ func TestMaterializeCatalogRejectsUnknownProvider(t *testing.T) {
 	}
 }
 
-func TestMaterializeCatalogRejectsDuplicateActiveRepoBindings(t *testing.T) {
+func TestMaterializeCatalogAllowsDuplicateReposAcrossProviders(t *testing.T) {
 	t.Parallel()
 
 	githubMetadata := `{"repo":"nexu-io/looper","source":"config"}`
 	forgejoMetadata := `{"provider":"forgejo-main","repo":"NEXU-IO/LOOPER","source":"api"}`
 	global := config.Config{Providers: []config.ProviderConfig{{ID: "forgejo-main", Kind: config.ProviderKindForgejo}}}
 
-	_, err := MaterializeCatalog(global, []storage.ProjectRecord{
+	got, err := MaterializeCatalog(global, []storage.ProjectRecord{
 		{ID: "github", MetadataJSON: &githubMetadata},
 		{ID: "forgejo", MetadataJSON: &forgejoMetadata},
 	})
-	if err == nil || !strings.Contains(err.Error(), `repo "NEXU-IO/LOOPER" duplicates active project "github"`) {
-		t.Fatalf("MaterializeCatalog() error = %v, want duplicate active repo binding", err)
+	if err != nil {
+		t.Fatalf("MaterializeCatalog() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("MaterializeCatalog() projects = %d, want 2", len(got))
+	}
+}
+
+func TestMaterializeCatalogRejectsDuplicateRepoWithinProvider(t *testing.T) {
+	t.Parallel()
+
+	first := `{"provider":"forgejo-main","repo":"nexu-io/looper"}`
+	second := `{"provider":"forgejo-main","repo":"NEXU-IO/LOOPER"}`
+	global := config.Config{Providers: []config.ProviderConfig{{ID: "forgejo-main", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example.test"}}}
+	_, err := MaterializeCatalog(global, []storage.ProjectRecord{{ID: "one", MetadataJSON: &first}, {ID: "two", MetadataJSON: &second}})
+	if err == nil || !strings.Contains(err.Error(), `duplicates active project "one"`) {
+		t.Fatalf("MaterializeCatalog() error = %v, want same-provider duplicate rejection", err)
 	}
 }
 

--- a/internal/projects/service_provider_test.go
+++ b/internal/projects/service_provider_test.go
@@ -167,18 +167,18 @@ func TestServiceAddProjectRejectsDuplicateActiveRepoBeforeUpsert(t *testing.T) {
 	}
 	repo := "NEXU-IO/LOOPER"
 	provider := "forgejo-main"
-	_, err = service.AddProject(context.Background(), AddInput{
+	added, err := service.AddProject(context.Background(), AddInput{
 		ID: "forgejo", Name: "Forgejo", RepoPath: "/tmp/forgejo", Repo: &repo, Provider: &provider,
 	})
-	if err == nil || !strings.Contains(err.Error(), `duplicates active project "github"`) {
-		t.Fatalf("AddProject() error = %v, want duplicate active repo binding", err)
+	if err != nil {
+		t.Fatalf("AddProject() error = %v, want cross-provider duplicate repo accepted", err)
 	}
 	stored, getErr := repos.Projects.GetByID(context.Background(), "forgejo")
 	if getErr != nil {
 		t.Fatalf("Projects.GetByID() error = %v", getErr)
 	}
-	if stored != nil || published {
-		t.Fatalf("stored = %#v, published = %v; want rejection before upsert and publish", stored, published)
+	if stored == nil || added.Project.ID != "forgejo" || !published {
+		t.Fatalf("stored = %#v, added = %#v, published = %v; want persisted provider-qualified project", stored, added, published)
 	}
 }
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4757,7 +4757,7 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 	}
 	nowISO := r.nowISO()
 	targetID := fmt.Sprintf("pr:%s:%d", input.Repo, input.PRNumber)
-	lockKey := fmt.Sprintf("pr:%s:%d", input.Repo, input.PRNumber)
+	lockKey := storage.PullRequestLockKey(input.ProjectID, input.Repo, input.PRNumber)
 	projectID := input.ProjectID
 	loopID := input.LoopID
 	queueItem := storage.QueueItemRecord{ID: eventlog.NewEventID("queue"), ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: targetID, Repo: &input.Repo, PRNumber: &input.PRNumber, DedupeKey: dedupeKey, Priority: storage.QueuePriorityReviewer, Status: "queued", AvailableAt: availableAt, Attempts: 0, MaxAttempts: r.retryMaxAttempts, LockKey: &lockKey, CreatedAt: nowISO, UpdatedAt: nowISO}
@@ -6011,10 +6011,10 @@ func reviewRequestsKnownAbsent(requested []string, currentLogin string) bool {
 }
 
 func buildPullRequestLockKey(item storage.QueueItemRecord) string {
-	if item.Repo == nil || item.PRNumber == nil {
+	if item.ProjectID == nil || item.Repo == nil || item.PRNumber == nil {
 		return ""
 	}
-	return fmt.Sprintf("pr:%s:%d", *item.Repo, *item.PRNumber)
+	return storage.PullRequestLockKey(*item.ProjectID, *item.Repo, *item.PRNumber)
 }
 
 func buildReviewPrompt(repo string, prNumber int64, checkpoint reviewerCheckpoint, runID string, idempotencyKey string, reviewEvents config.ReviewerReviewEventsConfig, manual bool, scope config.ReviewerScope, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string, looperCLIPath string) string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -2408,11 +2408,12 @@ func buildRecoveryQueueItem(loop storage.LoopRecord, nowISO string, maxAttempts 
 			}
 			return storage.QueueItemRecord{}, false, err
 		}
-		lockKey := fmt.Sprintf("issue:%s:%d", repo, issueNumber)
+		lockKey := storage.IssueLockKey(loop.ProjectID, repo, issueNumber)
+		targetID := fmt.Sprintf("issue:%s:%d", repo, issueNumber)
 		payload := map[string]any{"issueNumber": issueNumber}
 		payloadJSON := mustMarshalJSON(payload)
 		queueRecord.TargetType = string(domain.LoopTargetTypeIssue)
-		queueRecord.TargetID = lockKey
+		queueRecord.TargetID = targetID
 		queueRecord.Repo = &repo
 		queueRecord.PRNumber = nil
 		queueRecord.DedupeKey = fmt.Sprintf("planner:%s:%s:%s:%d", loop.ProjectID, loop.ID, repo, issueNumber)
@@ -2425,9 +2426,10 @@ func buildRecoveryQueueItem(loop storage.LoopRecord, nowISO string, maxAttempts 
 			return storage.QueueItemRecord{}, false, fmt.Errorf("reviewer loop requires repo and pull request target")
 		}
 		prNumber := *loop.PRNumber
-		lockKey := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+		lockKey := storage.PullRequestLockKey(loop.ProjectID, repo, prNumber)
+		targetID := fmt.Sprintf("pr:%s:%d", repo, prNumber)
 		queueRecord.TargetType = string(domain.LoopTargetTypePullRequest)
-		queueRecord.TargetID = lockKey
+		queueRecord.TargetID = targetID
 		queueRecord.Repo = &repo
 		queueRecord.PRNumber = &prNumber
 		queueRecord.DedupeKey = fmt.Sprintf("reviewer:%s:%s:%s:%d", loop.ProjectID, loop.ID, repo, prNumber)
@@ -2439,9 +2441,10 @@ func buildRecoveryQueueItem(loop storage.LoopRecord, nowISO string, maxAttempts 
 			return storage.QueueItemRecord{}, false, fmt.Errorf("fixer loop requires repo and pull request target")
 		}
 		prNumber := *loop.PRNumber
-		lockKey := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+		lockKey := storage.PullRequestLockKey(loop.ProjectID, repo, prNumber)
+		targetID := fmt.Sprintf("pr:%s:%d", repo, prNumber)
 		queueRecord.TargetType = string(domain.LoopTargetTypePullRequest)
-		queueRecord.TargetID = lockKey
+		queueRecord.TargetID = targetID
 		queueRecord.Repo = &repo
 		queueRecord.PRNumber = &prNumber
 		queueRecord.DedupeKey = fmt.Sprintf("fixer:%s", loop.ID)
@@ -2464,9 +2467,10 @@ func buildRecoveryQueueItem(loop storage.LoopRecord, nowISO string, maxAttempts 
 				}
 				return storage.QueueItemRecord{}, false, err
 			}
-			lockKey = fmt.Sprintf("issue:%s:%d", repo, issueNumber)
+			lockKey = storage.IssueLockKey(loop.ProjectID, repo, issueNumber)
+			targetID := fmt.Sprintf("issue:%s:%d", repo, issueNumber)
 			queueRecord.TargetType = string(domain.LoopTargetTypeIssue)
-			queueRecord.TargetID = lockKey
+			queueRecord.TargetID = targetID
 			queueRecord.Repo = &repo
 			queueRecord.PRNumber = nil
 			queueRecord.DedupeKey = fmt.Sprintf("worker:%s:%s:%d", loop.ProjectID, repo, issueNumber)
@@ -2476,9 +2480,10 @@ func buildRecoveryQueueItem(loop storage.LoopRecord, nowISO string, maxAttempts 
 				return storage.QueueItemRecord{}, false, fmt.Errorf("worker loop requires repo and prNumber")
 			}
 			prNumber := *loop.PRNumber
-			lockKey = fmt.Sprintf("pr:%s:%d", repo, prNumber)
+			lockKey = storage.PullRequestLockKey(loop.ProjectID, repo, prNumber)
+			targetID := fmt.Sprintf("pr:%s:%d", repo, prNumber)
 			queueRecord.TargetType = string(domain.LoopTargetTypePullRequest)
-			queueRecord.TargetID = lockKey
+			queueRecord.TargetID = targetID
 			queueRecord.Repo = &repo
 			queueRecord.PRNumber = &prNumber
 			queueRecord.DedupeKey = fmt.Sprintf("worker:%s:%s:%d", loop.ProjectID, repo, prNumber)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -622,7 +622,7 @@ func TestBuildRecoveryQueueItemRecordUsesIssueLockForWorkerTargets(t *testing.T)
 	if record.TargetID != "issue:acme/looper:77" {
 		t.Fatalf("record.TargetID = %q, want issue target id", record.TargetID)
 	}
-	if record.LockKey == nil || *record.LockKey != "issue:acme/looper:77" {
+	if record.LockKey == nil || *record.LockKey != storage.IssueLockKey("project_1", "acme/looper", 77) {
 		t.Fatalf("record.LockKey = %#v, want issue lock key", record.LockKey)
 	}
 	if record.DedupeKey != "worker:project_1:acme/looper:77" {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -211,70 +211,138 @@ func forgejoProviderForRepo(cfg *config.Config, repo string) (config.ProviderCon
 		return config.ProviderConfig{}, false, nil
 	}
 	repo = strings.TrimSpace(repo)
+	var matched *config.ProjectRefConfig
 	for _, project := range cfg.Projects {
-		if strings.TrimSpace(project.Repo) != repo {
+		if !strings.EqualFold(strings.TrimSpace(project.Repo), repo) {
 			continue
 		}
-		if config.ResolvedProjectProviderKind(*cfg, project) != config.ProviderKindForgejo {
+		if matched != nil {
+			return config.ProviderConfig{}, false, fmt.Errorf("repository %s is bound to multiple projects; project path or id is required", repo)
+		}
+		projectCopy := project
+		matched = &projectCopy
+	}
+	if matched != nil {
+		if config.ResolvedProjectProviderKind(*cfg, *matched) != config.ProviderKindForgejo {
 			return config.ProviderConfig{}, false, nil
 		}
-		provider, ok := forgejoProviderByID(*cfg, project.Provider)
+		provider, ok := forgejoProviderByID(*cfg, matched.Provider)
 		if !ok {
-			return config.ProviderConfig{}, false, fmt.Errorf("forgejo provider %q not configured for repo %s", project.Provider, repo)
+			return config.ProviderConfig{}, false, fmt.Errorf("forgejo provider %q not configured for repo %s", matched.Provider, repo)
 		}
 		return provider, true, nil
 	}
 	return config.ProviderConfig{}, false, nil
 }
 
-func forgejoReviewerDiscoveryLabelsForRepo(cfg *config.Config, repo string) []string {
+func forgejoReviewerDiscoveryLabelsForRepo(cfg *config.Config, repo, cwd string) []string {
 	if cfg == nil {
 		return nil
 	}
 	repo = strings.TrimSpace(repo)
+	if strings.TrimSpace(cwd) != "" {
+		for _, project := range cfg.Projects {
+			if cwdBelongsToProject(project, cwd) {
+				return forgejoReviewerDiscoveryLabelsForProject(*cfg, project)
+			}
+		}
+	}
+	var matched *config.ProjectRefConfig
 	for _, project := range cfg.Projects {
-		if strings.TrimSpace(project.Repo) != repo {
+		if !strings.EqualFold(strings.TrimSpace(project.Repo), repo) {
 			continue
 		}
-		if config.ResolvedProjectProviderKind(*cfg, project) != config.ProviderKindForgejo {
+		if matched != nil {
 			return nil
 		}
-		labels := config.ProjectRoleConfigs(*cfg, project.ID).Reviewer.Discovery.Triggers.Labels
-		result := make([]string, 0, len(labels))
-		for _, label := range labels {
-			label = strings.TrimSpace(label)
-			if label == "" {
-				continue
-			}
-			result = append(result, label)
-		}
-		return result
+		projectCopy := project
+		matched = &projectCopy
+	}
+	if matched != nil {
+		return forgejoReviewerDiscoveryLabelsForProject(*cfg, *matched)
 	}
 	return nil
+}
+
+func forgejoReviewerDiscoveryLabelsForProject(cfg config.Config, project config.ProjectRefConfig) []string {
+	if config.ResolvedProjectProviderKind(cfg, project) != config.ProviderKindForgejo {
+		return nil
+	}
+	labels := config.ProjectRoleConfigs(cfg, project.ID).Reviewer.Discovery.Triggers.Labels
+	result := make([]string, 0, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label != "" {
+			result = append(result, label)
+		}
+	}
+	return result
 }
 
 func forgejoProjectProviderForCWD(cfg *config.Config, cwd string) (config.ProjectRefConfig, config.ProviderConfig, bool, error) {
 	if cfg == nil {
 		return config.ProjectRefConfig{}, config.ProviderConfig{}, false, nil
 	}
-	cwd = strings.TrimSpace(cwd)
-	for _, project := range cfg.Projects {
-		if strings.TrimSpace(project.RepoPath) != cwd {
-			continue
-		}
-		if config.ResolvedProjectProviderKind(*cfg, project) != config.ProviderKindForgejo {
-			return config.ProjectRefConfig{}, config.ProviderConfig{}, false, nil
-		}
-		provider, ok := forgejoProviderByID(*cfg, project.Provider)
-		if !ok {
-			return config.ProjectRefConfig{}, config.ProviderConfig{}, false, fmt.Errorf("forgejo provider %q not configured for project %s", project.Provider, project.ID)
-		}
-		if strings.TrimSpace(project.Repo) == "" {
-			return config.ProjectRefConfig{}, config.ProviderConfig{}, false, fmt.Errorf("forgejo project %s is missing repo", project.ID)
-		}
-		return project, provider, true, nil
+	project, matched, err := projectForCWD(*cfg, cwd)
+	if err != nil || !matched {
+		return config.ProjectRefConfig{}, config.ProviderConfig{}, false, err
 	}
-	return config.ProjectRefConfig{}, config.ProviderConfig{}, false, nil
+	if config.ResolvedProjectProviderKind(*cfg, project) != config.ProviderKindForgejo {
+		return config.ProjectRefConfig{}, config.ProviderConfig{}, false, nil
+	}
+	provider, ok := forgejoProviderByID(*cfg, project.Provider)
+	if !ok {
+		return config.ProjectRefConfig{}, config.ProviderConfig{}, false, fmt.Errorf("forgejo provider %q not configured for project %s", project.Provider, project.ID)
+	}
+	if strings.TrimSpace(project.Repo) == "" {
+		return config.ProjectRefConfig{}, config.ProviderConfig{}, false, fmt.Errorf("forgejo project %s is missing repo", project.ID)
+	}
+	return project, provider, true, nil
+}
+
+func projectForCWD(cfg config.Config, cwd string) (config.ProjectRefConfig, bool, error) {
+	matches := make([]config.ProjectRefConfig, 0, 1)
+	for _, project := range cfg.Projects {
+		if cwdBelongsToProject(project, cwd) {
+			matches = append(matches, project)
+		}
+	}
+	if len(matches) == 0 {
+		return config.ProjectRefConfig{}, false, nil
+	}
+	if len(matches) > 1 {
+		ids := make([]string, 0, len(matches))
+		for _, project := range matches {
+			ids = append(ids, project.ID)
+		}
+		return config.ProjectRefConfig{}, false, fmt.Errorf("working directory %s matches multiple projects: %s", strings.TrimSpace(cwd), strings.Join(ids, ", "))
+	}
+	return matches[0], true, nil
+}
+
+func cwdBelongsToProject(project config.ProjectRefConfig, cwd string) bool {
+	cwd = filepath.Clean(strings.TrimSpace(cwd))
+	if cwd == "." || cwd == "" {
+		return false
+	}
+	repoPath := filepath.Clean(strings.TrimSpace(project.RepoPath))
+	if repoPath != "." && cwd == repoPath {
+		return true
+	}
+	worktreeRoot := ""
+	if project.WorktreeRoot != nil {
+		worktreeRoot = strings.TrimSpace(*project.WorktreeRoot)
+	}
+	if worktreeRoot == "" {
+		resolved, err := config.DefaultProjectWorktreeRoot(project.ID, project.RepoPath)
+		if err != nil {
+			return false
+		}
+		worktreeRoot = resolved
+	}
+	worktreeRoot = filepath.Clean(worktreeRoot)
+	relative, err := filepath.Rel(worktreeRoot, cwd)
+	return err == nil && relative != "." && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 func forgejoProviderByID(cfg config.Config, providerID string) (config.ProviderConfig, bool) {
@@ -323,18 +391,26 @@ func planeProviderForRepo(cfg *config.Config, repo string) (config.ProviderConfi
 		return config.ProviderConfig{}, "", false, nil
 	}
 	repo = strings.TrimSpace(repo)
+	var matched *config.ProjectRefConfig
 	for _, project := range cfg.Projects {
-		if strings.TrimSpace(project.Repo) != repo {
+		if !strings.EqualFold(strings.TrimSpace(project.Repo), repo) {
 			continue
 		}
-		if config.ResolvedProjectProviderKind(*cfg, project) != config.ProviderKindPlane {
+		if matched != nil {
+			return config.ProviderConfig{}, "", false, fmt.Errorf("repository %s is bound to multiple projects; project path or id is required", repo)
+		}
+		projectCopy := project
+		matched = &projectCopy
+	}
+	if matched != nil {
+		if config.ResolvedProjectProviderKind(*cfg, *matched) != config.ProviderKindPlane {
 			return config.ProviderConfig{}, "", false, nil
 		}
-		provider, ok := forgejoProviderByID(*cfg, project.Provider)
+		provider, ok := forgejoProviderByID(*cfg, matched.Provider)
 		if !ok {
-			return config.ProviderConfig{}, "", false, fmt.Errorf("plane provider %q not configured for repo %s", project.Provider, repo)
+			return config.ProviderConfig{}, "", false, fmt.Errorf("plane provider %q not configured for repo %s", matched.Provider, repo)
 		}
-		return provider, strings.TrimSpace(project.Repo), true, nil
+		return provider, strings.TrimSpace(matched.Repo), true, nil
 	}
 	return config.ProviderConfig{}, "", false, nil
 }
@@ -343,24 +419,21 @@ func planeProjectProviderForCWD(cfg *config.Config, cwd string) (config.ProjectR
 	if cfg == nil {
 		return config.ProjectRefConfig{}, config.ProviderConfig{}, false, nil
 	}
-	cwd = strings.TrimSpace(cwd)
-	for _, project := range cfg.Projects {
-		if strings.TrimSpace(project.RepoPath) != cwd {
-			continue
-		}
-		if config.ResolvedProjectProviderKind(*cfg, project) != config.ProviderKindPlane {
-			return config.ProjectRefConfig{}, config.ProviderConfig{}, false, nil
-		}
-		provider, ok := forgejoProviderByID(*cfg, project.Provider)
-		if !ok {
-			return config.ProjectRefConfig{}, config.ProviderConfig{}, false, fmt.Errorf("plane provider %q not configured for project %s", project.Provider, project.ID)
-		}
-		if strings.TrimSpace(project.Repo) == "" {
-			return config.ProjectRefConfig{}, config.ProviderConfig{}, false, fmt.Errorf("plane project %s is missing repo", project.ID)
-		}
-		return project, provider, true, nil
+	project, matched, err := projectForCWD(*cfg, cwd)
+	if err != nil || !matched {
+		return config.ProjectRefConfig{}, config.ProviderConfig{}, false, err
 	}
-	return config.ProjectRefConfig{}, config.ProviderConfig{}, false, nil
+	if config.ResolvedProjectProviderKind(*cfg, project) != config.ProviderKindPlane {
+		return config.ProjectRefConfig{}, config.ProviderConfig{}, false, nil
+	}
+	provider, ok := forgejoProviderByID(*cfg, project.Provider)
+	if !ok {
+		return config.ProjectRefConfig{}, config.ProviderConfig{}, false, fmt.Errorf("plane provider %q not configured for project %s", project.Provider, project.ID)
+	}
+	if strings.TrimSpace(project.Repo) == "" {
+		return config.ProjectRefConfig{}, config.ProviderConfig{}, false, fmt.Errorf("plane project %s is missing repo", project.ID)
+	}
+	return project, provider, true, nil
 }
 
 func forgeIdentityLogins(identities []forge.Identity) []string {
@@ -409,21 +482,40 @@ func forgeNetworkPolicyUsers(users []forge.Identity) []networkpolicy.GitHubUser 
 	return converted
 }
 
-func (a plannerGitHubAdapter) forgejo(ctx context.Context, repo string) (*forge.ForgejoClient, bool, error) {
-	client, ok, err := forgejoClientForRepo(a.config, repo)
+func (a plannerGitHubAdapter) forgejo(ctx context.Context, repo string, cwd ...string) (*forge.ForgejoClient, bool, error) {
+	client, ok, err := forgeClientForLocation(a.config, repo, cwd, forgejoClientForCWD, forgejoClientForRepo)
 	return client, ok, err
 }
 
 // plane returns a Plane task-source client when repo belongs to a plane-kind
 // project. Issue-side reads/mutations for such projects are served by Plane;
 // pull-request operations are left to the GitHub path (repo is the code repo).
-func (a plannerGitHubAdapter) plane(ctx context.Context, repo string) (*forge.PlaneClient, bool, error) {
-	client, ok, err := planeClientForRepo(a.config, repo)
+func (a plannerGitHubAdapter) plane(ctx context.Context, repo string, cwd ...string) (*forge.PlaneClient, bool, error) {
+	client, ok, err := forgeClientForLocation(a.config, repo, cwd, planeClientForCWD, planeClientForRepo)
 	return client, ok, err
 }
 
+func forgeClientForLocation[T any](cfg *config.Config, repo string, cwd []string, byCWD func(*config.Config, string) (*T, bool, error), byRepo func(*config.Config, string) (*T, bool, error)) (*T, bool, error) {
+	if len(cwd) > 0 && strings.TrimSpace(cwd[0]) != "" {
+		client, ok, err := byCWD(cfg, cwd[0])
+		if ok || err != nil {
+			return client, ok, err
+		}
+		// A configured project path is authoritative even when it belongs to
+		// GitHub; do not fall through and select a same-slug Forgejo project.
+		if cfg != nil {
+			for _, project := range cfg.Projects {
+				if cwdBelongsToProject(project, cwd[0]) {
+					return nil, false, nil
+				}
+			}
+		}
+	}
+	return byRepo(cfg, repo)
+}
+
 func (a plannerGitHubAdapter) ListOpenIssues(ctx context.Context, input planner.ListOpenIssuesInput) ([]planner.IssueSummary, error) {
-	if client, ok, err := a.plane(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.plane(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -437,7 +529,7 @@ func (a plannerGitHubAdapter) ListOpenIssues(ctx context.Context, input planner.
 		}
 		return result, nil
 	}
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -466,7 +558,7 @@ func (a plannerGitHubAdapter) ListOpenIssues(ctx context.Context, input planner.
 }
 
 func (a plannerGitHubAdapter) ViewIssue(ctx context.Context, input planner.ViewIssueInput) (planner.IssueDetail, error) {
-	if client, ok, err := a.plane(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.plane(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return planner.IssueDetail{}, err
 		}
@@ -476,7 +568,7 @@ func (a plannerGitHubAdapter) ViewIssue(ctx context.Context, input planner.ViewI
 		}
 		return planner.IssueDetail{Number: issue.Number, Title: issue.Title, Body: issue.Body, URL: issue.HTMLURL, Assignees: forgeIdentityLogins(issue.Assignees), Labels: forgeLabelNames(issue.Labels)}, nil
 	}
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return planner.IssueDetail{}, err
 		}
@@ -518,13 +610,13 @@ func (a plannerGitHubAdapter) GetCurrentUserLogin(ctx context.Context, cwd strin
 }
 
 func (a plannerGitHubAdapter) AddIssueAssignees(ctx context.Context, input planner.IssueAssigneesInput) error {
-	if client, ok, err := a.plane(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.plane(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
 		return client.AddIssueAssignees(ctx, input.IssueNumber, input.Assignees)
 	}
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -548,7 +640,7 @@ func networkPolicyUsers(users []githubinfra.GitHubUser) []networkpolicy.GitHubUs
 }
 
 func (a plannerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input planner.ListOpenPullRequestsInput) ([]planner.PullRequestSummary, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -577,7 +669,7 @@ func (a plannerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input pl
 }
 
 func (a plannerGitHubAdapter) ViewPullRequest(ctx context.Context, input planner.ViewPullRequestInput) (planner.PullRequestDetail, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return planner.PullRequestDetail{}, err
 		}
@@ -599,7 +691,7 @@ func (a plannerGitHubAdapter) ViewPullRequest(ctx context.Context, input planner
 
 func (a plannerGitHubAdapter) CreatePullRequest(ctx context.Context, input planner.CreatePullRequestInput) (planner.CreatePullRequestResult, error) {
 	body := a.stamper.Markdown(input.Body, "planner", disclosure.ChannelPullRequest)
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return planner.CreatePullRequestResult{}, err
 		}
@@ -621,7 +713,7 @@ func (a plannerGitHubAdapter) CreatePullRequest(ctx context.Context, input plann
 
 func (a plannerGitHubAdapter) UpdatePullRequestBody(ctx context.Context, input planner.UpdatePullRequestBodyInput) error {
 	body := a.stamper.Markdown(input.Body, "planner", disclosure.ChannelPullRequest)
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -635,7 +727,7 @@ func (a plannerGitHubAdapter) UpdatePullRequestBody(ctx context.Context, input p
 }
 
 func (a plannerGitHubAdapter) AddPullRequestLabels(ctx context.Context, input planner.PullRequestLabelsInput) error {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -649,7 +741,7 @@ func (a plannerGitHubAdapter) AddPullRequestLabels(ctx context.Context, input pl
 }
 
 func (a plannerGitHubAdapter) AddPullRequestReviewers(ctx context.Context, input planner.PullRequestReviewersInput) error {
-	if _, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if _, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -720,13 +812,13 @@ type reviewerGitHubAdapter struct {
 	config  *config.Config
 }
 
-func (a reviewerGitHubAdapter) forgejo(ctx context.Context, repo string) (*forge.ForgejoClient, bool, error) {
-	client, ok, err := forgejoClientForRepo(a.config, repo)
+func (a reviewerGitHubAdapter) forgejo(ctx context.Context, repo string, cwd ...string) (*forge.ForgejoClient, bool, error) {
+	client, ok, err := forgeClientForLocation(a.config, repo, cwd, forgejoClientForCWD, forgejoClientForRepo)
 	return client, ok, err
 }
 
 func (a reviewerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input reviewer.ListOpenPullRequestsInput) ([]reviewer.PullRequestSummary, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -759,7 +851,7 @@ func (a reviewerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input r
 }
 
 func (a reviewerGitHubAdapter) ListReviewRequestedPullRequests(ctx context.Context, input reviewer.ListReviewRequestedPullRequestsInput) ([]reviewer.PullRequestSummary, error) {
-	if _, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if _, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -794,7 +886,7 @@ func (a reviewerGitHubAdapter) GetCurrentUserLogin(ctx context.Context, cwd stri
 }
 
 func (a reviewerGitHubAdapter) ViewPullRequest(ctx context.Context, input reviewer.ViewPullRequestInput) (reviewer.PullRequestDetail, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return reviewer.PullRequestDetail{}, err
 		}
@@ -835,7 +927,7 @@ func (a reviewerGitHubAdapter) GetBranchProtection(ctx context.Context, input gi
 }
 
 func (a reviewerGitHubAdapter) GetPullRequestHeadSHA(ctx context.Context, input reviewer.ViewPullRequestInput) (string, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return "", err
 		}
@@ -849,7 +941,7 @@ func (a reviewerGitHubAdapter) GetPullRequestHeadSHA(ctx context.Context, input 
 }
 
 func (a reviewerGitHubAdapter) CapturePullRequestSnapshot(ctx context.Context, input reviewer.CapturePullRequestSnapshotInput) (storage.PullRequestSnapshotRecord, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return storage.PullRequestSnapshotRecord{}, err
 		}
@@ -867,7 +959,7 @@ func (a reviewerGitHubAdapter) CapturePullRequestSnapshot(ctx context.Context, i
 		}
 		baseSHA := strings.TrimSpace(pr.Base.SHA)
 		return storage.PullRequestSnapshotRecord{
-			ID:          fmt.Sprintf("snapshot:%d:%s", input.PRNumber, input.CapturedAt),
+			ID:          fmt.Sprintf("snapshot:%s:%d:%s", input.ProjectID, input.PRNumber, input.CapturedAt),
 			ProjectID:   input.ProjectID,
 			Repo:        input.Repo,
 			PRNumber:    input.PRNumber,
@@ -888,7 +980,7 @@ func (a reviewerGitHubAdapter) CapturePullRequestSnapshot(ctx context.Context, i
 }
 
 func (a reviewerGitHubAdapter) FindReviewMarker(ctx context.Context, input reviewer.VerifyReviewMarkerInput) (reviewer.ReviewMarkerResult, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return reviewer.ReviewMarkerResult{}, err
 		}
@@ -1033,7 +1125,7 @@ func forgejoReviewMarkerAllowed(outcome string, allowed []reviewer.ReviewEvent, 
 
 func (a reviewerGitHubAdapter) CreateIssueComment(ctx context.Context, input reviewer.IssueCommentInput) (reviewer.IssueCommentResult, error) {
 	body := a.stamper.Markdown(input.Body, "reviewer", disclosure.ChannelIssueComment)
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return reviewer.IssueCommentResult{}, err
 		}
@@ -1054,7 +1146,7 @@ func (a reviewerGitHubAdapter) CreateIssueComment(ctx context.Context, input rev
 }
 
 func (a reviewerGitHubAdapter) ListIssueComments(ctx context.Context, input reviewer.ViewPullRequestInput) ([]reviewer.IssueComment, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -1084,7 +1176,7 @@ func (a reviewerGitHubAdapter) ListIssueComments(ctx context.Context, input revi
 
 func (a reviewerGitHubAdapter) UpdateIssueComment(ctx context.Context, input reviewer.UpdateIssueCommentInput) error {
 	body := a.stamper.Markdown(input.Body, "reviewer", disclosure.ChannelIssueComment)
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1118,7 +1210,7 @@ func (a reviewerGitHubAdapter) AddPullRequestLabels(ctx context.Context, input r
 }
 
 func (a reviewerGitHubAdapter) RemovePullRequestLabels(ctx context.Context, input reviewer.PullRequestLabelsInput) error {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1140,7 +1232,7 @@ func (a reviewerGitHubAdapter) RemoveIssueLabels(ctx context.Context, input gith
 }
 
 func (a reviewerGitHubAdapter) ListReviewThreads(ctx context.Context, input reviewer.ListReviewThreadsInput) ([]reviewer.ReviewThread, error) {
-	if _, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if _, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -1165,7 +1257,7 @@ func (a reviewerGitHubAdapter) ListReviewThreads(ctx context.Context, input revi
 }
 
 func (a reviewerGitHubAdapter) AddReviewThreadReply(ctx context.Context, input reviewer.AddReviewThreadReplyInput) error {
-	if _, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if _, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		return err
 	}
 	if a.gateway == nil {
@@ -1176,7 +1268,7 @@ func (a reviewerGitHubAdapter) AddReviewThreadReply(ctx context.Context, input r
 }
 
 func (a reviewerGitHubAdapter) ResolveReviewThread(ctx context.Context, input reviewer.ResolveReviewThreadInput) error {
-	if _, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if _, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		return err
 	}
 	if a.gateway == nil {
@@ -1236,8 +1328,8 @@ type fixerGitHubAdapter struct {
 	config  *config.Config
 }
 
-func (a fixerGitHubAdapter) forgejo(ctx context.Context, repo string) (*forge.ForgejoClient, bool, error) {
-	client, ok, err := forgejoClientForRepo(a.config, repo)
+func (a fixerGitHubAdapter) forgejo(ctx context.Context, repo string, cwd ...string) (*forge.ForgejoClient, bool, error) {
+	client, ok, err := forgeClientForLocation(a.config, repo, cwd, forgejoClientForCWD, forgejoClientForRepo)
 	return client, ok, err
 }
 
@@ -1247,7 +1339,7 @@ func (a fixerGitHubAdapter) forgejoForCWD(ctx context.Context, cwd string) (*for
 }
 
 func (a fixerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input fixer.ListOpenPullRequestsInput) ([]fixer.PullRequestSummary, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -1290,7 +1382,7 @@ func (a fixerGitHubAdapter) GetCurrentUserLogin(ctx context.Context, cwd string)
 }
 
 func (a fixerGitHubAdapter) GetPullRequestAuthor(ctx context.Context, input fixer.ViewPullRequestInput) (string, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return "", err
 		}
@@ -1304,7 +1396,7 @@ func (a fixerGitHubAdapter) GetPullRequestAuthor(ctx context.Context, input fixe
 }
 
 func (a fixerGitHubAdapter) ViewPullRequest(ctx context.Context, input fixer.ViewPullRequestInput) (fixer.PullRequestDetail, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return fixer.PullRequestDetail{}, err
 		}
@@ -1356,7 +1448,7 @@ func commentInfosToObjects(items []githubinfra.CommentInfo) []map[string]any {
 }
 
 func (a fixerGitHubAdapter) ListReviewThreads(ctx context.Context, input fixer.ListReviewThreadsInput) ([]fixer.ReviewThread, error) {
-	if _, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if _, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -1396,7 +1488,7 @@ func (a fixerGitHubAdapter) ViewReviewThread(ctx context.Context, input fixer.Vi
 }
 
 func (a fixerGitHubAdapter) ResolveReviewThread(ctx context.Context, input fixer.ResolveReviewThreadInput) error {
-	if _, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if _, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1406,7 +1498,7 @@ func (a fixerGitHubAdapter) ResolveReviewThread(ctx context.Context, input fixer
 }
 
 func (a fixerGitHubAdapter) ListNativeReviewComments(ctx context.Context, input fixer.ListNativeReviewCommentsInput) ([]fixer.NativeReviewComment, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -1435,7 +1527,7 @@ func (a fixerGitHubAdapter) ListNativeReviewComments(ctx context.Context, input 
 }
 
 func (a fixerGitHubAdapter) ResolveNativeReviewComment(ctx context.Context, input fixer.ResolveNativeReviewCommentInput) error {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1445,7 +1537,7 @@ func (a fixerGitHubAdapter) ResolveNativeReviewComment(ctx context.Context, inpu
 }
 
 func (a fixerGitHubAdapter) AddReviewThreadReply(ctx context.Context, input fixer.AddReviewThreadReplyInput) error {
-	if _, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if _, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1456,7 +1548,7 @@ func (a fixerGitHubAdapter) AddReviewThreadReply(ctx context.Context, input fixe
 }
 
 func (a fixerGitHubAdapter) CompareCommits(ctx context.Context, input fixer.CompareCommitsInput) (fixer.CompareCommitsResult, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return fixer.CompareCommitsResult{}, err
 		}
@@ -1475,7 +1567,7 @@ func (a fixerGitHubAdapter) CompareCommits(ctx context.Context, input fixer.Comp
 
 func (a fixerGitHubAdapter) CreateIssueComment(ctx context.Context, input fixer.IssueCommentInput) (fixer.IssueCommentResult, error) {
 	body := a.stamper.Markdown(input.Body, "fixer", disclosure.ChannelIssueComment)
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return fixer.IssueCommentResult{}, err
 		}
@@ -1494,7 +1586,7 @@ func (a fixerGitHubAdapter) CreateIssueComment(ctx context.Context, input fixer.
 
 func (a fixerGitHubAdapter) UpdateIssueComment(ctx context.Context, input fixer.UpdateIssueCommentInput) error {
 	body := a.stamper.Markdown(input.Body, "fixer", disclosure.ChannelIssueComment)
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1505,7 +1597,7 @@ func (a fixerGitHubAdapter) UpdateIssueComment(ctx context.Context, input fixer.
 }
 
 func (a fixerGitHubAdapter) AddPullRequestLabels(ctx context.Context, input fixer.PullRequestLabelsInput) error {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1516,7 +1608,7 @@ func (a fixerGitHubAdapter) AddPullRequestLabels(ctx context.Context, input fixe
 }
 
 func (a fixerGitHubAdapter) RemovePullRequestLabels(ctx context.Context, input fixer.PullRequestLabelsInput) error {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1637,21 +1729,21 @@ type workerGitHubAdapter struct {
 	config  *config.Config
 }
 
-func (a workerGitHubAdapter) forgejo(ctx context.Context, repo string) (*forge.ForgejoClient, bool, error) {
-	client, ok, err := forgejoClientForRepo(a.config, repo)
+func (a workerGitHubAdapter) forgejo(ctx context.Context, repo string, cwd ...string) (*forge.ForgejoClient, bool, error) {
+	client, ok, err := forgeClientForLocation(a.config, repo, cwd, forgejoClientForCWD, forgejoClientForRepo)
 	return client, ok, err
 }
 
 // plane returns a Plane task-source client when repo belongs to a plane-kind
 // project. The worker reads issues and posts issue-side comments/labels through
 // Plane; pull-request creation stays on the GitHub code repo.
-func (a workerGitHubAdapter) plane(ctx context.Context, repo string) (*forge.PlaneClient, bool, error) {
-	client, ok, err := planeClientForRepo(a.config, repo)
+func (a workerGitHubAdapter) plane(ctx context.Context, repo string, cwd ...string) (*forge.PlaneClient, bool, error) {
+	client, ok, err := forgeClientForLocation(a.config, repo, cwd, planeClientForCWD, planeClientForRepo)
 	return client, ok, err
 }
 
 func (a workerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input worker.ListOpenPullRequestsInput) ([]worker.PullRequestSummary, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -1680,7 +1772,7 @@ func (a workerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input wor
 }
 
 func (a workerGitHubAdapter) ListOpenIssues(ctx context.Context, input worker.ListOpenIssuesInput) ([]worker.IssueSummary, error) {
-	if client, ok, err := a.plane(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.plane(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -1694,7 +1786,7 @@ func (a workerGitHubAdapter) ListOpenIssues(ctx context.Context, input worker.Li
 		}
 		return result, nil
 	}
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -1744,13 +1836,13 @@ func (a workerGitHubAdapter) GetCurrentUserLogin(ctx context.Context, cwd string
 }
 
 func (a workerGitHubAdapter) AddIssueAssignees(ctx context.Context, input worker.IssueAssigneesInput) error {
-	if client, ok, err := a.plane(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.plane(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
 		return client.AddIssueAssignees(ctx, input.IssueNumber, input.Assignees)
 	}
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1763,7 +1855,7 @@ func (a workerGitHubAdapter) AddIssueAssignees(ctx context.Context, input worker
 }
 
 func (a workerGitHubAdapter) ViewPullRequest(ctx context.Context, input worker.ViewPullRequestInput) (worker.PullRequestDetail, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return worker.PullRequestDetail{}, err
 		}
@@ -1784,7 +1876,7 @@ func (a workerGitHubAdapter) ViewPullRequest(ctx context.Context, input worker.V
 }
 
 func (a workerGitHubAdapter) ViewIssue(ctx context.Context, input worker.ViewIssueInput) (worker.IssueDetail, error) {
-	if client, ok, err := a.plane(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.plane(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return worker.IssueDetail{}, err
 		}
@@ -1794,7 +1886,7 @@ func (a workerGitHubAdapter) ViewIssue(ctx context.Context, input worker.ViewIss
 		}
 		return worker.IssueDetail{Number: issue.Number, Title: issue.Title, Body: issue.Body, URL: issue.HTMLURL, State: issue.State, AssigneeUsers: forgeNetworkPolicyUsers(issue.Assignees), Labels: forgeLabelNames(issue.Labels)}, nil
 	}
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return worker.IssueDetail{}, err
 		}
@@ -1816,7 +1908,7 @@ func (a workerGitHubAdapter) ViewIssue(ctx context.Context, input worker.ViewIss
 
 func (a workerGitHubAdapter) CreateIssueComment(ctx context.Context, input worker.IssueCommentInput) (worker.IssueCommentResult, error) {
 	body := a.stamper.Markdown(input.Body, "worker", disclosure.ChannelIssueComment)
-	if client, ok, err := a.plane(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.plane(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return worker.IssueCommentResult{}, err
 		}
@@ -1828,7 +1920,7 @@ func (a workerGitHubAdapter) CreateIssueComment(ctx context.Context, input worke
 		// ID stays 0; the URL points at the work-item web page.
 		return worker.IssueCommentResult{ID: comment.ID, URL: comment.HTMLURL}, nil
 	}
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return worker.IssueCommentResult{}, err
 		}
@@ -1850,7 +1942,7 @@ func (a workerGitHubAdapter) CreateIssueComment(ctx context.Context, input worke
 
 func (a workerGitHubAdapter) UpdateIssueComment(ctx context.Context, input worker.UpdateIssueCommentInput) error {
 	body := a.stamper.Markdown(input.Body, "worker", disclosure.ChannelIssueComment)
-	if _, ok, err := a.plane(ctx, input.Repo); ok || err != nil {
+	if _, ok, err := a.plane(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1861,7 +1953,7 @@ func (a workerGitHubAdapter) UpdateIssueComment(ctx context.Context, input worke
 		// TODO(plane): track the Plane comment UUID to enable true updates.
 		return nil
 	}
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1876,7 +1968,7 @@ func (a workerGitHubAdapter) UpdateIssueComment(ctx context.Context, input worke
 
 func (a workerGitHubAdapter) CreatePullRequest(ctx context.Context, input worker.CreatePullRequestInput) (worker.CreatePullRequestResult, error) {
 	body := a.stamper.Markdown(input.Body, "worker", disclosure.ChannelPullRequest)
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return worker.CreatePullRequestResult{}, err
 		}
@@ -1897,7 +1989,7 @@ func (a workerGitHubAdapter) CreatePullRequest(ctx context.Context, input worker
 }
 
 func (a workerGitHubAdapter) AddPullRequestLabels(ctx context.Context, input worker.PullRequestLabelsInput) error {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1930,7 +2022,7 @@ func hitlGitHubSettings(cfg *config.HITLGitHubConfig) worker.HITLGitHubSettings 
 }
 
 func (a workerGitHubAdapter) CompareBranches(ctx context.Context, input worker.CompareBranchesInput) (worker.CompareBranchesResult, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return worker.CompareBranchesResult{}, err
 		}
@@ -1952,7 +2044,7 @@ func (a workerGitHubAdapter) CompareBranches(ctx context.Context, input worker.C
 
 func (a workerGitHubAdapter) UpdatePullRequestBody(ctx context.Context, input worker.UpdatePullRequestBodyInput) error {
 	body := a.stamper.Markdown(input.Body, "worker", disclosure.ChannelPullRequest)
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1966,7 +2058,7 @@ func (a workerGitHubAdapter) UpdatePullRequestBody(ctx context.Context, input wo
 }
 
 func (a workerGitHubAdapter) UpdatePullRequestTitle(ctx context.Context, input worker.UpdatePullRequestTitleInput) error {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1980,7 +2072,7 @@ func (a workerGitHubAdapter) UpdatePullRequestTitle(ctx context.Context, input w
 }
 
 func (a workerGitHubAdapter) RemovePullRequestLabels(ctx context.Context, input worker.PullRequestLabelsInput) error {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
@@ -1998,11 +2090,11 @@ func (a workerGitHubAdapter) RemovePullRequestLabels(ctx context.Context, input 
 }
 
 func (a workerGitHubAdapter) AddPullRequestReviewers(ctx context.Context, input worker.PullRequestReviewersInput) error {
-	if client, ok, err := a.forgejo(ctx, input.Repo); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
-		labels := forgejoReviewerDiscoveryLabelsForRepo(a.config, input.Repo)
+		labels := forgejoReviewerDiscoveryLabelsForRepo(a.config, input.Repo, input.CWD)
 		if len(labels) > 0 {
 			if _, err := client.AddIssueLabels(ctx, input.PRNumber, labels); err != nil {
 				return err

--- a/internal/runtime/scheduler_forgejo_test.go
+++ b/internal/runtime/scheduler_forgejo_test.go
@@ -72,6 +72,76 @@ func TestPlannerGitHubAdapterForgejoCreatePullRequestAndLabels(t *testing.T) {
 	}
 }
 
+func TestPlannerAdapterRoutesSameRepoSlugByProjectPath(t *testing.T) {
+	t.Setenv("FORGEJO_TOKEN", "secret")
+
+	serverFor := func(title string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || r.URL.Path != "/api/v1/repos/acme/app/issues" {
+				t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"number": 1, "title": title, "state": "open"}})
+		}))
+	}
+	first := serverFor("first")
+	defer first.Close()
+	second := serverFor("second")
+	defer second.Close()
+
+	root := t.TempDir()
+	firstPath := filepath.Join(root, "first")
+	secondPath := filepath.Join(root, "second")
+	cfg := config.Config{
+		Providers: []config.ProviderConfig{
+			{ID: "forgejo-one", Kind: config.ProviderKindForgejo, BaseURL: first.URL, TokenEnv: stringPtr("FORGEJO_TOKEN")},
+			{ID: "forgejo-two", Kind: config.ProviderKindForgejo, BaseURL: second.URL, TokenEnv: stringPtr("FORGEJO_TOKEN")},
+		},
+		Projects: []config.ProjectRefConfig{
+			{ID: "one", Provider: "forgejo-one", Repo: "acme/app", RepoPath: firstPath},
+			{ID: "two", Provider: "forgejo-two", Repo: "acme/app", RepoPath: secondPath},
+		},
+	}
+	adapter := plannerGitHubAdapter{config: &cfg}
+	for _, testCase := range []struct {
+		cwd  string
+		want string
+	}{{cwd: firstPath, want: "first"}, {cwd: secondPath, want: "second"}} {
+		issues, err := adapter.ListOpenIssues(context.Background(), planner.ListOpenIssuesInput{Repo: "acme/app", CWD: testCase.cwd})
+		if err != nil {
+			t.Fatalf("ListOpenIssues(%s) error = %v", testCase.want, err)
+		}
+		if len(issues) != 1 || issues[0].Title != testCase.want {
+			t.Fatalf("ListOpenIssues(%s) = %#v", testCase.want, issues)
+		}
+	}
+
+	if _, _, err := forgejoClientForRepo(&cfg, "acme/app"); err == nil || !strings.Contains(err.Error(), "multiple projects") {
+		t.Fatalf("forgejoClientForRepo() error = %v, want ambiguous bare-repo rejection", err)
+	}
+}
+
+func TestForgeRoutingRejectsOverlappingWorktreeRoots(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outerRoot := filepath.Join(root, "worktrees")
+	innerRoot := filepath.Join(outerRoot, "nested")
+	cfg := config.Config{
+		Providers: []config.ProviderConfig{
+			{ID: "forgejo-one", Kind: config.ProviderKindForgejo},
+			{ID: "forgejo-two", Kind: config.ProviderKindForgejo},
+		},
+		Projects: []config.ProjectRefConfig{
+			{ID: "outer", Provider: "forgejo-one", Repo: "acme/outer", RepoPath: filepath.Join(root, "outer"), WorktreeRoot: &outerRoot},
+			{ID: "inner", Provider: "forgejo-two", Repo: "acme/inner", RepoPath: filepath.Join(root, "inner"), WorktreeRoot: &innerRoot},
+		},
+	}
+	_, _, ok, err := forgejoProjectProviderForCWD(&cfg, filepath.Join(innerRoot, "feature"))
+	if err == nil || !strings.Contains(err.Error(), "matches multiple projects") {
+		t.Fatalf("forgejoProjectProviderForCWD() = ok %v, error %v; want ambiguous root rejection", ok, err)
+	}
+}
+
 func TestWorkerGitHubAdapterForgejoCreatePullRequestQueuesReviewerDiscoveryLabel(t *testing.T) {
 	t.Setenv("FORGEJO_TOKEN", "secret")
 	var createdBody map[string]any

--- a/internal/storage/forge_keys.go
+++ b/internal/storage/forge_keys.go
@@ -1,0 +1,47 @@
+package storage
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IssueLockKey scopes a forge issue lock to the authoritative project binding.
+// Existing queue records retain their persisted legacy keys during migration.
+func IssueLockKey(projectID, repo string, issueNumber int64) string {
+	return fmt.Sprintf("issue:%s:%s:%d", strings.TrimSpace(projectID), strings.ToLower(strings.TrimSpace(repo)), issueNumber)
+}
+
+// PullRequestLockKey scopes a forge pull-request lock to the authoritative
+// project binding while keeping the key opaque to older queue processors.
+func PullRequestLockKey(projectID, repo string, prNumber int64) string {
+	return fmt.Sprintf("pr:%s:%s:%d", strings.TrimSpace(projectID), strings.ToLower(strings.TrimSpace(repo)), prNumber)
+}
+
+// lockTransitionAlias describes the legacy/scoped equivalent of a forge lock
+// key during the rolling migration. The persisted queue key remains opaque;
+// this alias is used only to preserve mutual exclusion across versions.
+func lockTransitionAlias(key string) (legacyKey, scopedSuffix, kind string, scoped, ok bool) {
+	key = strings.TrimSpace(key)
+	firstSeparator := strings.IndexByte(key, ':')
+	lastSeparator := strings.LastIndexByte(key, ':')
+	if firstSeparator <= 0 || lastSeparator <= firstSeparator {
+		return "", "", "", false, false
+	}
+	kind = key[:firstSeparator]
+	if kind != "issue" && kind != "pr" {
+		return "", "", "", false, false
+	}
+	beforeRepo := strings.LastIndexByte(key[:lastSeparator], ':')
+	if beforeRepo < firstSeparator {
+		return "", "", "", false, false
+	}
+	if beforeRepo == firstSeparator {
+		suffix := key[firstSeparator:]
+		return key, suffix, kind, false, true
+	}
+	repoAndNumber := key[beforeRepo:]
+	if strings.TrimSpace(key[firstSeparator+1:beforeRepo]) == "" || strings.TrimSpace(key[beforeRepo+1:lastSeparator]) == "" || strings.TrimSpace(key[lastSeparator+1:]) == "" {
+		return "", "", "", false, false
+	}
+	return kind + repoAndNumber, repoAndNumber, kind, true, true
+}

--- a/internal/storage/forge_keys_test.go
+++ b/internal/storage/forge_keys_test.go
@@ -1,0 +1,175 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestForgeLockKeysAreProjectScoped(t *testing.T) {
+	t.Parallel()
+
+	firstIssue := IssueLockKey("github", "Acme/App", 42)
+	secondIssue := IssueLockKey("forgejo", "acme/app", 42)
+	if firstIssue == secondIssue {
+		t.Fatalf("issue lock keys collide: %q", firstIssue)
+	}
+	firstPR := PullRequestLockKey("forgejo-one", "acme/app", 7)
+	secondPR := PullRequestLockKey("forgejo-two", "ACME/APP", 7)
+	if firstPR == secondPR {
+		t.Fatalf("pull request lock keys collide: %q", firstPR)
+	}
+	if got := IssueLockKey(" github ", " Acme/App ", 42); got != firstIssue {
+		t.Fatalf("IssueLockKey() normalization = %q, want %q", got, firstIssue)
+	}
+}
+
+func TestForgeLockAcquirePreservesLegacyTransitionExclusion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	repos.Locks.SetNow(func() time.Time { return now })
+	record := func(key, owner string) LockRecord {
+		return LockRecord{Key: key, Owner: owner, ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano), CreatedAt: now.Format(time.RFC3339Nano), UpdatedAt: now.Format(time.RFC3339Nano)}
+	}
+	legacy := "pr:Acme/App:42"
+	github := PullRequestLockKey("github", "acme/app", 42)
+	forgejo := PullRequestLockKey("forgejo", "acme/app", 42)
+
+	if acquired, err := repos.Locks.Acquire(ctx, record(legacy, "legacy")); err != nil || !acquired {
+		t.Fatalf("Acquire(legacy) = %v, %v", acquired, err)
+	}
+	if acquired, err := repos.Locks.Acquire(ctx, record(github, "new")); err != nil || acquired {
+		t.Fatalf("Acquire(scoped after legacy) = %v, %v; want blocked", acquired, err)
+	}
+	if err := repos.Locks.Release(ctx, legacy); err != nil {
+		t.Fatalf("Release(legacy) error = %v", err)
+	}
+	if acquired, err := repos.Locks.Acquire(ctx, record(github, "new")); err != nil || !acquired {
+		t.Fatalf("Acquire(scoped) = %v, %v", acquired, err)
+	}
+	if acquired, err := repos.Locks.Acquire(ctx, record(legacy, "old")); err != nil || acquired {
+		t.Fatalf("Acquire(legacy after scoped) = %v, %v; want blocked", acquired, err)
+	}
+	if acquired, err := repos.Locks.Acquire(ctx, record(forgejo, "other-provider")); err != nil || !acquired {
+		t.Fatalf("Acquire(other scoped project) = %v, %v; want independent lock", acquired, err)
+	}
+}
+
+func TestForgeLockTransitionSupportsColonProjectID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	repos.Locks.SetNow(func() time.Time { return now })
+	legacy := "issue:acme/app:42"
+	scoped := IssueLockKey("team:forgejo", "acme/app", 42)
+	legacyKey, suffix, kind, isScoped, ok := lockTransitionAlias(scoped)
+	if !ok || !isScoped || legacyKey != legacy || suffix != ":acme/app:42" || kind != "issue" {
+		t.Fatalf("lockTransitionAlias(%q) = %q, %q, %q, %v, %v", scoped, legacyKey, suffix, kind, isScoped, ok)
+	}
+	record := func(key string) LockRecord {
+		return LockRecord{Key: key, Owner: key, ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano), CreatedAt: now.Format(time.RFC3339Nano), UpdatedAt: now.Format(time.RFC3339Nano)}
+	}
+	if acquired, err := repos.Locks.Acquire(ctx, record(legacy)); err != nil || !acquired {
+		t.Fatalf("Acquire(legacy) = %v, %v", acquired, err)
+	}
+	if acquired, err := repos.Locks.Acquire(ctx, record(scoped)); err != nil || acquired {
+		t.Fatalf("Acquire(colon-scoped after legacy) = %v, %v; want blocked", acquired, err)
+	}
+}
+
+func TestQueueSchedulerTreatsLegacyAndScopedLockKeysAsEquivalent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	now := "2026-07-13T12:00:00.000Z"
+	projectID := "github"
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: projectID, Name: projectID, RepoPath: "/tmp/github", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	for index, loopID := range []string{"legacy", "scoped"} {
+		if err := repos.Loops.Upsert(ctx, LoopRecord{ID: loopID, Seq: int64(index + 1), ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", Status: "running", CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loopID, err)
+		}
+	}
+	repo := "acme/app"
+	prNumber := int64(42)
+	legacyLoop, scopedLoop := "legacy", "scoped"
+	legacyKey := "pr:acme/app:42"
+	scopedKey := PullRequestLockKey(projectID, repo, prNumber)
+	for _, item := range []QueueItemRecord{
+		{ID: "legacy_running", ProjectID: &projectID, LoopID: &legacyLoop, Type: "reviewer", TargetType: "pull_request", TargetID: legacyKey, Repo: &repo, PRNumber: &prNumber, DedupeKey: "legacy", Priority: 1, Status: "running", AvailableAt: now, LockKey: &legacyKey, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "scoped_queued", ProjectID: &projectID, LoopID: &scopedLoop, Type: "reviewer", TargetType: "pull_request", TargetID: legacyKey, Repo: &repo, PRNumber: &prNumber, DedupeKey: "scoped", Priority: 1, Status: "queued", AvailableAt: now, LockKey: &scopedKey, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := repos.Queue.Upsert(ctx, item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+	scheduled, err := repos.Queue.ListScheduled(ctx, now, 10)
+	if err != nil {
+		t.Fatalf("Queue.ListScheduled() error = %v", err)
+	}
+	if len(scheduled) != 0 {
+		t.Fatalf("Queue.ListScheduled() = %#v, want scoped item blocked by legacy running item", scheduled)
+	}
+	stats, err := repos.Queue.Stats(ctx, now)
+	if err != nil {
+		t.Fatalf("Queue.Stats() error = %v", err)
+	}
+	if stats.BlockedByLockKey != 1 {
+		t.Fatalf("BlockedByLockKey = %d, want 1", stats.BlockedByLockKey)
+	}
+}
+
+func TestReviewerFixerDependencyIsProjectScoped(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	now := "2026-07-13T12:00:00.000Z"
+	for index, projectID := range []string{"github", "forgejo"} {
+		if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: projectID, Name: projectID, RepoPath: "/tmp/" + projectID, CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("Projects.Upsert(%s) error = %v", projectID, err)
+		}
+		loopID := "loop_" + projectID
+		if err := repos.Loops.Upsert(ctx, LoopRecord{ID: loopID, Seq: int64(index + 1), ProjectID: projectID, Type: "worker", TargetType: "pull_request", Status: "running", CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loopID, err)
+		}
+	}
+	repo := "acme/app"
+	prNumber := int64(42)
+	github, forgejo := "github", "forgejo"
+	githubLoop, forgejoLoop := "loop_github", "loop_forgejo"
+	items := []QueueItemRecord{
+		{ID: "github_reviewer", ProjectID: &github, LoopID: &githubLoop, Type: "reviewer", TargetType: "pull_request", TargetID: "pr:acme/app:42", Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:github", Priority: 1, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+		{ID: "forgejo_fixer", ProjectID: &forgejo, LoopID: &forgejoLoop, Type: "fixer", TargetType: "pull_request", TargetID: "pr:acme/app:42", Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:forgejo", Priority: 2, Status: "queued", AvailableAt: now, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now},
+	}
+	for _, item := range items {
+		if err := repos.Queue.Upsert(ctx, item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+	scheduled, err := repos.Queue.ListScheduled(ctx, now, 10)
+	if err != nil {
+		t.Fatalf("Queue.ListScheduled() error = %v", err)
+	}
+	if len(scheduled) != 2 {
+		t.Fatalf("Queue.ListScheduled() = %#v, want both cross-project items eligible", scheduled)
+	}
+	stats, err := repos.Queue.Stats(ctx, now)
+	if err != nil {
+		t.Fatalf("Queue.Stats() error = %v", err)
+	}
+	if stats.BlockedByReviewerFixerDependency != 0 {
+		t.Fatalf("BlockedByReviewerFixerDependency = %d, want 0", stats.BlockedByReviewerFixerDependency)
+	}
+}

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -586,6 +586,16 @@ func (r *LoopsRepository) List(ctx context.Context) ([]LoopRecord, error) {
 	return scanLoops(rows)
 }
 
+func (r *LoopsRepository) ListByRepoAndPR(ctx context.Context, repo string, prNumber int64) ([]LoopRecord, error) {
+	rows, err := r.q.QueryContext(ctx, `SELECT * FROM loops WHERE repo = ? COLLATE NOCASE AND pr_number = ? ORDER BY updated_at DESC, seq DESC`, repo, prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("list loops by repository and pull request: %w", err)
+	}
+	defer rows.Close()
+
+	return scanLoops(rows)
+}
+
 func (r *LoopsRepository) ListByStatuses(ctx context.Context, statuses []string) ([]LoopRecord, error) {
 	if len(statuses) == 0 {
 		return []LoopRecord{}, nil
@@ -1082,21 +1092,49 @@ func (r *PullRequestSnapshotsRepository) List(ctx context.Context) ([]PullReques
 	return scanPullRequestSnapshots(rows)
 }
 
-func (r *PullRequestSnapshotsRepository) GetLatest(ctx context.Context, repo string, prNumber int64) (*PullRequestSnapshotRecord, error) {
-	row := r.q.QueryRowContext(ctx, `SELECT * FROM pull_request_snapshots WHERE repo = ? AND pr_number = ? ORDER BY captured_at DESC LIMIT 1`, repo, prNumber)
-	record, err := scanPullRequestSnapshot(row)
+func (r *PullRequestSnapshotsRepository) ListLatestByRepoAndPR(ctx context.Context, repo string, prNumber int64) ([]PullRequestSnapshotRecord, error) {
+	rows, err := r.q.QueryContext(ctx, `
+		WITH ranked AS (
+			SELECT id, ROW_NUMBER() OVER (
+				PARTITION BY project_id
+				ORDER BY captured_at DESC, created_at DESC, id DESC
+			) AS row_number
+			FROM pull_request_snapshots
+			WHERE repo = ? COLLATE NOCASE AND pr_number = ?
+		)
+		SELECT snapshots.*
+		FROM pull_request_snapshots snapshots
+		JOIN ranked ON ranked.id = snapshots.id
+		WHERE ranked.row_number = 1
+		ORDER BY snapshots.captured_at DESC, snapshots.created_at DESC, snapshots.id DESC
+	`, repo, prNumber)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
+		return nil, fmt.Errorf("list latest pull request snapshots by repository and pull request: %w", err)
+	}
+	defer rows.Close()
+
+	return scanPullRequestSnapshots(rows)
+}
+
+func (r *PullRequestSnapshotsRepository) GetLatest(ctx context.Context, repo string, prNumber int64) (*PullRequestSnapshotRecord, error) {
+	records, err := r.ListLatestByRepoAndPR(ctx, repo, prNumber)
+	if err != nil {
 		return nil, fmt.Errorf("get latest pull request snapshot: %w", err)
 	}
-
-	return &record, nil
+	if len(records) == 0 {
+		return nil, nil
+	}
+	projectID := records[0].ProjectID
+	for _, record := range records[1:] {
+		if record.ProjectID != projectID {
+			return nil, fmt.Errorf("get latest pull request snapshot: repository %s#%d matches multiple projects; use GetLatestByProject", repo, prNumber)
+		}
+	}
+	return &records[0], nil
 }
 
 func (r *PullRequestSnapshotsRepository) GetLatestByProject(ctx context.Context, projectID, repo string, prNumber int64) (*PullRequestSnapshotRecord, error) {
-	row := r.q.QueryRowContext(ctx, `SELECT * FROM pull_request_snapshots WHERE project_id = ? AND repo = ? AND pr_number = ? ORDER BY captured_at DESC, created_at DESC LIMIT 1`, projectID, repo, prNumber)
+	row := r.q.QueryRowContext(ctx, `SELECT * FROM pull_request_snapshots WHERE project_id = ? AND repo = ? COLLATE NOCASE AND pr_number = ? ORDER BY captured_at DESC, created_at DESC LIMIT 1`, projectID, repo, prNumber)
 	record, err := scanPullRequestSnapshot(row)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1119,7 +1157,7 @@ func (r *LocksRepository) SetNow(now func() time.Time) {
 
 func (r *LocksRepository) Acquire(ctx context.Context, record LockRecord) (bool, error) {
 	nowISO := r.now().UTC().Format(javaScriptISOStringLayout)
-	result, err := r.q.ExecContext(ctx, `
+	query := `
 		INSERT INTO locks (key, owner, reason, expires_at, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT(key) DO UPDATE SET
@@ -1128,7 +1166,37 @@ func (r *LocksRepository) Acquire(ctx context.Context, record LockRecord) (bool,
 			expires_at=excluded.expires_at,
 			updated_at=excluded.updated_at
 		WHERE locks.expires_at <= ?
-	`, record.Key, record.Owner, record.Reason, record.ExpiresAt, record.CreatedAt, record.UpdatedAt, nowISO)
+	`
+	args := []any{record.Key, record.Owner, record.Reason, record.ExpiresAt, record.CreatedAt, record.UpdatedAt, nowISO}
+	legacyKey, scopedSuffix, kind, scoped, transitionKey := lockTransitionAlias(record.Key)
+	if transitionKey {
+		aliasPredicate := "key = ?"
+		aliasArgs := []any{legacyKey}
+		if !scoped {
+			aliasPredicate = "key LIKE ? AND lower(substr(key, -?)) = lower(?)"
+			aliasArgs = []any{kind + ":%", len(scopedSuffix), scopedSuffix}
+		} else {
+			aliasPredicate = "lower(key) = lower(?)"
+		}
+		query = `
+			INSERT INTO locks (key, owner, reason, expires_at, created_at, updated_at)
+			SELECT ?, ?, ?, ?, ?, ?
+			WHERE NOT EXISTS (
+				SELECT 1 FROM locks
+				WHERE key != ? AND expires_at > ? AND (` + aliasPredicate + `)
+			)
+			ON CONFLICT(key) DO UPDATE SET
+				owner=excluded.owner,
+				reason=excluded.reason,
+				expires_at=excluded.expires_at,
+				updated_at=excluded.updated_at
+			WHERE locks.expires_at <= ?
+		`
+		args = []any{record.Key, record.Owner, record.Reason, record.ExpiresAt, record.CreatedAt, record.UpdatedAt, record.Key, nowISO}
+		args = append(args, aliasArgs...)
+		args = append(args, nowISO)
+	}
+	result, err := r.q.ExecContext(ctx, query, args...)
 	if err != nil {
 		return false, fmt.Errorf("acquire lock: %w", err)
 	}
@@ -1522,7 +1590,7 @@ func (r *QueueRepository) Stats(ctx context.Context, nowISO string) (QueueStats,
 				AND EXISTS (
 					SELECT 1
 					FROM queue_items lock_blocker
-					WHERE lock_blocker.lock_key = qi.lock_key
+					WHERE ` + queueLockConflictPredicate + `
 						AND lock_blocker.status = 'running'
 						AND lock_blocker.id != qi.id
 				)
@@ -1541,6 +1609,7 @@ func (r *QueueRepository) Stats(ctx context.Context, nowISO string) (QueueStats,
 					WHERE blocker.type = 'reviewer'
 						AND blocker.repo = qi.repo
 						AND blocker.pr_number = qi.pr_number
+						AND (blocker.project_id = qi.project_id OR blocker.project_id IS NULL OR qi.project_id IS NULL)
 						AND blocker.status IN ('queued', 'running')
 						AND blocker.id != qi.id
 				)
@@ -2160,6 +2229,16 @@ func chunkStrings(values []string, chunkSize int) [][]string {
 	return chunks
 }
 
+const queueLockConflictPredicate = `(
+	lock_blocker.lock_key = qi.lock_key
+	OR (
+		lock_blocker.repo = qi.repo
+		AND lock_blocker.target_type = qi.target_type
+		AND lock_blocker.target_id = qi.target_id
+		AND (lock_blocker.lock_key = lock_blocker.target_id OR qi.lock_key = qi.target_id)
+	)
+)`
+
 const scheduledQueueBaseQuery = `
 	SELECT qi.*
 	FROM queue_items qi
@@ -2174,7 +2253,7 @@ const scheduledQueueBaseQuery = `
 			OR NOT EXISTS (
 				SELECT 1
 				FROM queue_items lock_blocker
-				WHERE lock_blocker.lock_key = qi.lock_key
+				WHERE ` + queueLockConflictPredicate + `
 					AND lock_blocker.status = 'running'
 					AND lock_blocker.id != qi.id
 			)
@@ -2189,6 +2268,7 @@ const scheduledQueueBaseQuery = `
 				WHERE blocker.type = 'reviewer'
 					AND blocker.repo = qi.repo
 					AND blocker.pr_number = qi.pr_number
+					AND (blocker.project_id = qi.project_id OR blocker.project_id IS NULL OR qi.project_id IS NULL)
 					AND blocker.status IN ('queued', 'running')
 					AND blocker.id != qi.id
 			)

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -302,6 +302,77 @@ func TestRepositoriesRoundTripForProjectsLoopsRunsAndRuntimeMetadata(t *testing.
 	}
 }
 
+func TestPullRequestLookupsStayScopedAndReturnLatestSnapshotPerProject(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	ctx := context.Background()
+	repos := NewRepositories(coordinator.DB())
+	const repo = "acme/looper"
+	const prNumber int64 = 42
+
+	for _, projectID := range []string{"github", "forgejo", "unrelated"} {
+		if err := repos.Projects.Upsert(ctx, ProjectRecord{
+			ID:        projectID,
+			Name:      projectID,
+			RepoPath:  "/tmp/" + projectID,
+			CreatedAt: "2026-07-13T09:00:00.000Z",
+			UpdatedAt: "2026-07-13T09:00:00.000Z",
+		}); err != nil {
+			t.Fatalf("Projects.Upsert(%q) error = %v", projectID, err)
+		}
+	}
+
+	snapshots := []PullRequestSnapshotRecord{
+		{ID: "github-old", ProjectID: "github", Repo: repo, PRNumber: prNumber, HeadSHA: "github-old", CapturedAt: "2026-07-13T09:00:00.000Z", CreatedAt: "2026-07-13T09:00:00.000Z"},
+		{ID: "github-new", ProjectID: "github", Repo: repo, PRNumber: prNumber, HeadSHA: "github-new", CapturedAt: "2026-07-13T10:00:00.000Z", CreatedAt: "2026-07-13T10:00:00.000Z"},
+		{ID: "forgejo-new", ProjectID: "forgejo", Repo: repo, PRNumber: prNumber, HeadSHA: "forgejo-new", CapturedAt: "2026-07-13T11:00:00.000Z", CreatedAt: "2026-07-13T11:00:00.000Z"},
+		{ID: "other-pr", ProjectID: "unrelated", Repo: repo, PRNumber: 99, HeadSHA: "other-pr", CapturedAt: "2026-07-13T12:00:00.000Z", CreatedAt: "2026-07-13T12:00:00.000Z"},
+		{ID: "other-repo", ProjectID: "unrelated", Repo: "acme/other", PRNumber: prNumber, HeadSHA: "other-repo", CapturedAt: "2026-07-13T13:00:00.000Z", CreatedAt: "2026-07-13T13:00:00.000Z"},
+	}
+	for _, snapshot := range snapshots {
+		if err := repos.PullRequestSnapshots.Upsert(ctx, snapshot); err != nil {
+			t.Fatalf("PullRequestSnapshots.Upsert(%q) error = %v", snapshot.ID, err)
+		}
+	}
+
+	gotSnapshots, err := repos.PullRequestSnapshots.ListLatestByRepoAndPR(ctx, "Acme/Looper", prNumber)
+	if err != nil {
+		t.Fatalf("PullRequestSnapshots.ListLatestByRepoAndPR() error = %v", err)
+	}
+	if got := snapshotIDs(gotSnapshots); !reflect.DeepEqual(got, []string{"forgejo-new", "github-new"}) {
+		t.Fatalf("PullRequestSnapshots.ListLatestByRepoAndPR() IDs = %v, want [forgejo-new github-new]", got)
+	}
+
+	matchingRepo := "Acme/Looper"
+	matchingPR := prNumber
+	otherPR := int64(99)
+	for _, loop := range []LoopRecord{
+		{ID: "github-loop", Seq: 1, ProjectID: "github", Type: "reviewer", TargetType: "pull_request", Repo: &matchingRepo, PRNumber: &matchingPR, Status: "idle", CreatedAt: "2026-07-13T09:00:00.000Z", UpdatedAt: "2026-07-13T09:00:00.000Z"},
+		{ID: "other-loop", Seq: 2, ProjectID: "unrelated", Type: "reviewer", TargetType: "pull_request", Repo: &matchingRepo, PRNumber: &otherPR, Status: "idle", CreatedAt: "2026-07-13T09:00:00.000Z", UpdatedAt: "2026-07-13T09:00:00.000Z"},
+	} {
+		if err := repos.Loops.Upsert(ctx, loop); err != nil {
+			t.Fatalf("Loops.Upsert(%q) error = %v", loop.ID, err)
+		}
+	}
+
+	gotLoops, err := repos.Loops.ListByRepoAndPR(ctx, repo, prNumber)
+	if err != nil {
+		t.Fatalf("Loops.ListByRepoAndPR() error = %v", err)
+	}
+	if len(gotLoops) != 1 || gotLoops[0].ID != "github-loop" {
+		t.Fatalf("Loops.ListByRepoAndPR() = %#v, want github-loop", gotLoops)
+	}
+}
+
+func snapshotIDs(records []PullRequestSnapshotRecord) []string {
+	ids := make([]string, 0, len(records))
+	for _, record := range records {
+		ids = append(ids, record.ID)
+	}
+	return ids
+}
+
 func TestRepositoriesStatusAggregates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/webhookforward/forwarder.go
+++ b/internal/webhookforward/forwarder.go
@@ -363,6 +363,9 @@ func (f *forwarder) enqueueLocked(projects []storage.ProjectRecord, routed route
 		if project.Archived {
 			continue
 		}
+		if configured, ok := configuredProjectByID(cfg, project.ID); ok && config.ResolvedProjectProviderKind(cfg, configured) == config.ProviderKindForgejo {
+			continue
+		}
 		repo := repoFromProjectMetadata(project.MetadataJSON)
 		if !strings.EqualFold(repo, routed.repo) {
 			continue
@@ -423,6 +426,15 @@ func (f *forwarder) enqueueLocked(projects []storage.ProjectRecord, routed route
 		f.cond.Signal()
 	}
 	return matched, nil
+}
+
+func configuredProjectByID(cfg config.Config, projectID string) (config.ProjectRefConfig, bool) {
+	for _, project := range cfg.Projects {
+		if project.ID == projectID {
+			return project, true
+		}
+	}
+	return config.ProjectRefConfig{}, false
 }
 
 func (f *forwarder) worker() {

--- a/internal/webhookforward/forwarder_test.go
+++ b/internal/webhookforward/forwarder_test.go
@@ -208,6 +208,39 @@ func TestForwardFansOutToMultipleProjectsForSameRepo(t *testing.T) {
 	reviewerRunner.assertRepos(t, []string{"acme/looper", "acme/looper"})
 }
 
+func TestForwardDoesNotRouteGitHubWebhookToSameSlugForgejoProject(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "github", "acme/looper")
+	seedProject(t, repos, "plane", "acme/looper")
+	forgejoMetadata := `{"provider":"forgejo-main","repo":"acme/looper"}`
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "forgejo", Name: "forgejo", RepoPath: "/tmp/forgejo", MetadataJSON: &forgejoMetadata, CreatedAt: "2026-05-16T12:00:00.000Z", UpdatedAt: "2026-05-16T12:00:00.000Z"}); err != nil {
+		t.Fatalf("Projects.Upsert(forgejo) error = %v", err)
+	}
+	cfg := testConfig(t)
+	cfg.Providers = []config.ProviderConfig{
+		{ID: "forgejo-main", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example.test"},
+		{ID: "plane-main", Kind: config.ProviderKindPlane},
+	}
+	cfg.Projects = []config.ProjectRefConfig{
+		{ID: "github", Repo: "acme/looper", RepoPath: "/tmp/github"},
+		{ID: "forgejo", Provider: "forgejo-main", Repo: "acme/looper", RepoPath: "/tmp/forgejo"},
+		{ID: "plane", Provider: "plane-main", Repo: "acme/looper", RepoPath: "/tmp/plane"},
+	}
+	reviewerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: cfg, Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: newFakeTargetedRunner(nil)}, MaxConcurrent: 2, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	result, err := forwarder.Forward(context.Background(), DeliveryRequest{DeliveryID: "github-only", EventType: "pull_request", Payload: pullRequestPayload("review_requested", "acme/looper", 55)})
+	if err != nil {
+		t.Fatalf("Forward() error = %v", err)
+	}
+	if result.WorkItems != 2 {
+		t.Fatalf("WorkItems = %d, want GitHub and Plane projects", result.WorkItems)
+	}
+	reviewerRunner.waitForCalls(t, 2)
+	reviewerRunner.assertProjects(t, []string{"github", "plane"})
+}
+
 func TestForwardCoalescesQueuedWorkAndUnionsLanes(t *testing.T) {
 	repos := newTestRepositories(t)
 	seedProject(t, repos, "project_1", "acme/looper")

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1059,7 +1059,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			releaseCtx := context.Background()
 			_ = r.repos.Locks.Release(releaseCtx, claimedLockKey)
 			if strings.HasPrefix(claimedLockKey, "issue:") && checkpoint.PullRequest != nil && checkpoint.Work != nil && checkpoint.Work.Repo != "" && checkpoint.PullRequest.Number > 0 {
-				prLockKey := fmt.Sprintf("pr:%s:%d", checkpoint.Work.Repo, checkpoint.PullRequest.Number)
+				prLockKey := storage.PullRequestLockKey(derefString(queueItem.ProjectID), checkpoint.Work.Repo, checkpoint.PullRequest.Number)
 				if err := r.repos.Queue.UpdateLockKey(releaseCtx, queueItem.ID, prLockKey, r.nowISO()); err != nil {
 					if r.logger != nil {
 						r.logger.Warn("worker queue lock retarget failed", map[string]any{"queueItemId": queueItem.ID, "lockKey": prLockKey, "error": err.Error()})
@@ -1381,9 +1381,9 @@ func (r *Runner) runPrepareWorkStep(ctx context.Context, input stepInput) (worke
 	lockKey := derefString(input.QueueItem.LockKey)
 	if lockKey == "" {
 		if work.ExecutionMode == "push-existing" && work.Repo != "" && work.PRNumber > 0 {
-			lockKey = fmt.Sprintf("pr:%s:%d", work.Repo, work.PRNumber)
+			lockKey = storage.PullRequestLockKey(input.Project.ID, work.Repo, work.PRNumber)
 		} else if work.IssueNumber > 0 {
-			lockKey = buildIssueLockKey(issueLookupRepo(work), work.IssueNumber)
+			lockKey = storage.IssueLockKey(input.Project.ID, issueLookupRepo(work), work.IssueNumber)
 		} else {
 			lockKey = fmt.Sprintf("worker:%s", input.Loop.ID)
 		}
@@ -2504,7 +2504,7 @@ func (r *Runner) persistPullRequestReference(ctx context.Context, loop storage.L
 	updatedQueue.Repo = stringPtr(repo)
 	updatedQueue.PRNumber = int64Ptr(pr.Number)
 	if !strings.HasPrefix(derefString(queueItem.LockKey), "issue:") {
-		updatedQueue.LockKey = stringPtr(targetID)
+		updatedQueue.LockKey = stringPtr(storage.PullRequestLockKey(derefString(queueItem.ProjectID), repo, pr.Number))
 	}
 	projectID := derefString(queueItem.ProjectID)
 	if projectID != "" {
@@ -2605,7 +2605,7 @@ func (r *Runner) enqueueDiscoveredIssue(ctx context.Context, project storage.Pro
 	baseBranch := firstNonEmpty(derefString(project.BaseBranch), "main")
 	payload := mustMarshalJSON(map[string]any{"title": firstNonEmpty(issue.Title, buildDefaultIssueWorkerTitle(repo, issue.Number)), "repo": repo, "baseBranch": baseBranch, "executionMode": "create-pr", "issueNumber": issue.Number, "issueUrl": issue.URL, "triggerLogin": issue.Author, "autoDiscovered": true, "discoveryFingerprint": fingerprint})
 	targetID := buildIssueTargetID(repo, issue.Number)
-	lockKey := targetID
+	lockKey := storage.IssueLockKey(project.ID, repo, issue.Number)
 	projectID := project.ID
 	loopID := loop.ID
 	queueItem := storage.QueueItemRecord{ID: eventlog.NewEventID("queue"), ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "issue", TargetID: targetID, Repo: &repo, DedupeKey: dedupeKey, Priority: storage.QueuePriorityWorker, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: r.retryMaxAttempts, LockKey: &lockKey, PayloadJSON: &payload, CreatedAt: nowISO, UpdatedAt: nowISO}
@@ -3116,10 +3116,6 @@ func (c *workerCheckpoint) markLifecycleAgentPullRequest(branch, baseBranch stri
 	c.Lifecycle.PRAdopted = true
 	c.Lifecycle.Actions.PR = lifecycle.ActionSourceAgent
 	c.Lifecycle.Normalize()
-}
-
-func buildIssueLockKey(repo string, issueNumber int64) string {
-	return fmt.Sprintf("issue:%s:%d", strings.TrimSpace(repo), issueNumber)
 }
 
 func buildWorkerFallbackCommitMessage(work workerInput) string {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -596,7 +596,7 @@ func TestProcessClaimedItemCompletesCreatePRFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if queue == nil || queue.TargetType != "pull_request" || queue.TargetID != "pr:acme/looper:101" || queue.LockKey == nil || *queue.LockKey != "pr:acme/looper:101" || queue.PRNumber == nil || *queue.PRNumber != 101 {
+	if queue == nil || queue.TargetType != "pull_request" || queue.TargetID != "pr:acme/looper:101" || queue.LockKey == nil || *queue.LockKey != storage.PullRequestLockKey("project_1", "acme/looper", 101) || queue.PRNumber == nil || *queue.PRNumber != 101 {
 		t.Fatalf("queue = %#v, want retargeted queue item", queue)
 	}
 	run, err := fixture.repos.Runs.GetByID(context.Background(), result.RunID)
@@ -1540,7 +1540,7 @@ func TestProcessClaimedItemKeepsIssueLockKeyWhileRetargetingWorkerToPullRequest(
 	if err != nil {
 		t.Fatalf("Queue.GetByID() after run error = %v", err)
 	}
-	if updatedQueue == nil || updatedQueue.TargetType != "pull_request" || updatedQueue.TargetID != "pr:acme/looper:101" || updatedQueue.LockKey == nil || *updatedQueue.LockKey != "pr:acme/looper:101" {
+	if updatedQueue == nil || updatedQueue.TargetType != "pull_request" || updatedQueue.TargetID != "pr:acme/looper:101" || updatedQueue.LockKey == nil || *updatedQueue.LockKey != storage.PullRequestLockKey("project_1", "acme/looper", 101) {
 		t.Fatalf("queue = %#v, want retargeted queue item with persisted PR lock key", updatedQueue)
 	}
 	latestRun, err := fixture.repos.Runs.GetLatestByLoopID(context.Background(), "loop_worker_1")
@@ -1554,7 +1554,7 @@ func TestProcessClaimedItemKeepsIssueLockKeyWhileRetargetingWorkerToPullRequest(
 	if err != nil {
 		t.Fatalf("parseCheckpoint(latestRun) error = %v", err)
 	}
-	if latestCheckpoint.ClaimedLockKey != "pr:acme/looper:101" {
+	if latestCheckpoint.ClaimedLockKey != storage.PullRequestLockKey("project_1", "acme/looper", 101) {
 		t.Fatalf("checkpoint.ClaimedLockKey = %q, want pr:acme/looper:101", latestCheckpoint.ClaimedLockKey)
 	}
 	issueLock, err := fixture.repos.Locks.Get(context.Background(), issueTarget)


### PR DESCRIPTION
Closes #533.

## Summary

- model repository authority from the configured forge endpoint plus normalized `owner/repo`, while preserving GitHub as the code authority for Plane projects
- allow identical slugs across distinct GitHub/Forgejo authorities and reject aliases that resolve to the same physical forge repository
- route runtime provider selection through project bindings and reject ambiguous worktree roots
- scope locks, queue dependencies, snapshots, API responses, and CLI selection by project, with compatibility exclusion for legacy lock keys
- keep Plane GitHub webhook forwarding enabled while excluding Forgejo-backed repositories

## Root cause

Repository identity was primarily represented by a bare `owner/repo` slug. That slug is not globally unique across GitHub and Forgejo instances, so configuration either rejected valid multi-forge setups or downstream routing, locking, snapshot lookup, and queue behavior could cross project/provider boundaries.

## Authority and trade-offs

The authority for repository actions is the explicit project-to-provider binding and the provider's normalized endpoint; it is not agent output or an inferred Git remote.

This prevents work, snapshots, webhooks, and locks from being attributed to the wrong forge when repository slugs collide. Plane remains GitHub-authoritative for code because Plane supplies work items while `project.repo` names the GitHub code repository.

The cost is more explicit project identity in API/CLI routing, transitional handling for legacy lock keys, stricter ambiguity detection for worktree paths, and additional provider-aware test coverage. No new persisted schema or inference layer is introduced. Continuing to reject duplicate bare slugs is insufficient because it blocks legitimate multi-forge configurations, while trusting the slug alone cannot identify a physical repository.

The simpler deletion option was considered: removing provider inference helps, but project bindings still must be carried through locks, snapshots, queue dependencies, and user-facing PR selection to prevent cross-forge collisions.

This is an authority-bearing change. Review from `@oracle` is required before merge.

## User impact

- GitHub and Forgejo projects may use the same repository slug safely.
- Separate Forgejo endpoints may host the same slug safely.
- `looper pull-request show/status` accepts `--project` when a slug is ambiguous, and human list output identifies the project.
- Legacy GitHub-only configurations and active legacy lock keys remain compatible during upgrade.

## Validation

- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- `go build ./...`
