### PR TITLE
fix: allow Looper thread-resolution markers through the outbound guard

### DIFF
--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -1744,7 +1744,7 @@ func (g *Gateway) ListReviewThreads(ctx context.Context, input ListReviewThreads
 }
 
 func (g *Gateway) AddReviewThreadReply(ctx context.Context, input AddReviewThreadReplyInput) error {
-	if err := outboundguard.Validate(outboundguard.Field{Name: "review thread reply body", Text: input.Body}); err != nil {
+	if err := outboundguard.ValidateReviewThreadReply(input.Body, input.ThreadID); err != nil {
 		return err
 	}
 	result, err := g.runGh(ctx, input.CWD, "", "api", "graphql", "-f", "query="+strings.Join([]string{

--- a/internal/outboundguard/guard.go
+++ b/internal/outboundguard/guard.go
@@ -30,12 +30,11 @@ var (
 	// user:password@ or password-only :password@ in URL userinfo.
 	credentialURLRE = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.-]*://[^/@\s:]*:[^/@\s]+@`)
 	// High-confidence query credential params only (not short aliases like pass/pwd).
-	credentialQueryRE        = regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^\s]*[?&](?:[^=&\s]*_)?(?:password|secret|client[_-]?secret|api[_-]?key|access[_-]?token|private[_-]?key)=[^\s&"'<>]+`)
-	privateKeyRE             = regexp.MustCompile(`(?i)-----BEGIN(?: [A-Z0-9]+)? PRIVATE KEY-----`)
-	highEntropyCandidateRE   = regexp.MustCompile(`[A-Za-z0-9_+/=-]{24,}`)
-	threadResolutionMarkerRE = regexp.MustCompile(`<!-- looper:thread-resolution thread=PRRT_[A-Za-z0-9_-]+ head=(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64}) decision=(?:objectively_fixed|needs_human|not_fixed) -->`)
-	gitObjectIDRE            = regexp.MustCompile(`(?i)^[0-9a-f]{40}$|^[0-9a-f]{64}$`)
-	uuidRE                   = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	credentialQueryRE      = regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^\s]*[?&](?:[^=&\s]*_)?(?:password|secret|client[_-]?secret|api[_-]?key|access[_-]?token|private[_-]?key)=[^\s&"'<>]+`)
+	privateKeyRE           = regexp.MustCompile(`(?i)-----BEGIN(?: [A-Z0-9]+)? PRIVATE KEY-----`)
+	highEntropyCandidateRE = regexp.MustCompile(`[A-Za-z0-9_+/=-]{24,}`)
+	gitObjectIDRE          = regexp.MustCompile(`(?i)^[0-9a-f]{40}$|^[0-9a-f]{64}$`)
+	uuidRE                 = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 )
 
 // sensitiveEnvNameKeywords are long, high-confidence segments only. Matched as
@@ -76,15 +75,27 @@ func IsRejection(err error) bool {
 }
 
 func Validate(fields ...Field) error {
+	return validate(nil, fields...)
+}
+
+// ValidateReviewThreadReply validates a review-thread reply while allowing the
+// exact opaque thread ID supplied by GitHub. The exemption is intentionally
+// unavailable to other publication paths and cannot be substituted by content
+// from the reply body.
+func ValidateReviewThreadReply(body, threadID string) error {
+	return validate([]string{threadID}, Field{Name: "review thread reply body", Text: body})
+}
+
+func validate(highEntropyExemptions []string, fields ...Field) error {
 	for _, field := range fields {
-		if reason := unsafeText(field.Text); reason != "" {
+		if reason := unsafeText(field.Text, highEntropyExemptions); reason != "" {
 			return &Rejection{Field: field.Name, Reason: reason}
 		}
 	}
 	return nil
 }
 
-func unsafeText(text string) string {
+func unsafeText(text string, highEntropyExemptions []string) string {
 	if credentialURLRE.MatchString(text) || credentialQueryRE.MatchString(text) {
 		return "contains a credential-bearing connection URL"
 	}
@@ -104,10 +115,12 @@ func unsafeText(text string) string {
 	if environmentAssignments >= environmentAssignmentLimit {
 		return "contains an environment-dump-shaped block"
 	}
-	// Thread-resolution markers are Looper-owned audit metadata. Exclude only
-	// the exact syntax emitted by the reviewer; prose and malformed markers
-	// remain subject to the generic entropy scan.
-	entropyText := threadResolutionMarkerRE.ReplaceAllString(text, "")
+	entropyText := text
+	for _, exemption := range highEntropyExemptions {
+		if exemption != "" {
+			entropyText = strings.ReplaceAll(entropyText, exemption, "")
+		}
+	}
 	for _, token := range highEntropyCandidateRE.FindAllString(entropyText, -1) {
 		if gitObjectIDRE.MatchString(token) || uuidRE.MatchString(token) {
 			continue

--- a/internal/outboundguard/guard.go
+++ b/internal/outboundguard/guard.go
@@ -30,11 +30,12 @@ var (
 	// user:password@ or password-only :password@ in URL userinfo.
 	credentialURLRE = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.-]*://[^/@\s:]*:[^/@\s]+@`)
 	// High-confidence query credential params only (not short aliases like pass/pwd).
-	credentialQueryRE      = regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^\s]*[?&](?:[^=&\s]*_)?(?:password|secret|client[_-]?secret|api[_-]?key|access[_-]?token|private[_-]?key)=[^\s&"'<>]+`)
-	privateKeyRE           = regexp.MustCompile(`(?i)-----BEGIN(?: [A-Z0-9]+)? PRIVATE KEY-----`)
-	highEntropyCandidateRE = regexp.MustCompile(`[A-Za-z0-9_+/=-]{24,}`)
-	gitObjectIDRE          = regexp.MustCompile(`(?i)^[0-9a-f]{40}$|^[0-9a-f]{64}$`)
-	uuidRE                 = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	credentialQueryRE        = regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^\s]*[?&](?:[^=&\s]*_)?(?:password|secret|client[_-]?secret|api[_-]?key|access[_-]?token|private[_-]?key)=[^\s&"'<>]+`)
+	privateKeyRE             = regexp.MustCompile(`(?i)-----BEGIN(?: [A-Z0-9]+)? PRIVATE KEY-----`)
+	highEntropyCandidateRE   = regexp.MustCompile(`[A-Za-z0-9_+/=-]{24,}`)
+	threadResolutionMarkerRE = regexp.MustCompile(`<!-- looper:thread-resolution thread=PRRT_[A-Za-z0-9_-]+ head=(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64}) decision=(?:objectively_fixed|needs_human|not_fixed) -->`)
+	gitObjectIDRE            = regexp.MustCompile(`(?i)^[0-9a-f]{40}$|^[0-9a-f]{64}$`)
+	uuidRE                   = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 )
 
 // sensitiveEnvNameKeywords are long, high-confidence segments only. Matched as
@@ -103,7 +104,11 @@ func unsafeText(text string) string {
 	if environmentAssignments >= environmentAssignmentLimit {
 		return "contains an environment-dump-shaped block"
 	}
-	for _, token := range highEntropyCandidateRE.FindAllString(text, -1) {
+	// Thread-resolution markers are Looper-owned audit metadata. Exclude only
+	// the exact syntax emitted by the reviewer; prose and malformed markers
+	// remain subject to the generic entropy scan.
+	entropyText := threadResolutionMarkerRE.ReplaceAllString(text, "")
+	for _, token := range highEntropyCandidateRE.FindAllString(entropyText, -1) {
 		if gitObjectIDRE.MatchString(token) || uuidRE.MatchString(token) {
 			continue
 		}

--- a/internal/outboundguard/guard_test.go
+++ b/internal/outboundguard/guard_test.go
@@ -74,6 +74,35 @@ func TestValidateAllowsCommonPublicationIdentifiers(t *testing.T) {
 	}
 }
 
+func TestValidateAllowsStrictLooperThreadResolutionMarker(t *testing.T) {
+	t.Parallel()
+	body := "Looper checked this thread.\n<!-- looper:thread-resolution thread=PRRT_kwDOSOgY8s6QeKwr head=0dd6a5019812fc422f9f20626530758ad67ad66e decision=objectively_fixed -->"
+	if err := Validate(Field{Name: "review thread reply body", Text: body}); err != nil {
+		t.Fatalf("Validate() error = %v, want safe Looper marker", err)
+	}
+}
+
+func TestValidateThreadResolutionMarkerDoesNotExemptUntrustedContent(t *testing.T) {
+	t.Parallel()
+	marker := "<!-- looper:thread-resolution thread=PRRT_kwDOSOgY8s6QeKwr head=0dd6a5019812fc422f9f20626530758ad67ad66e decision=objectively_fixed -->"
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "high entropy prose", body: "Agent evidence q8Kz1Wm9P2vR7xL4nB6cD0fH3jS5uY+/\n" + marker},
+		{name: "invalid thread id", body: strings.Replace(marker, "PRRT_", "THREAD_", 1)},
+		{name: "invalid head", body: strings.Replace(marker, "0dd6a5019812fc422f9f20626530758ad67ad66e", "q8Kz1Wm9P2vR7xL4nB6cD0fH3jS5uY+/", 1)},
+		{name: "invalid decision", body: strings.Replace(marker, "objectively_fixed", "agent_approved", 1)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := Validate(Field{Name: "review thread reply body", Text: tc.body}); err == nil || !strings.Contains(err.Error(), "high-entropy") {
+				t.Fatalf("Validate() error = %v, want high-entropy rejection", err)
+			}
+		})
+	}
+}
+
 func TestValidatePrefersLowFalsePositivesOnReviewProse(t *testing.T) {
 	t.Parallel()
 	// Guard is best-effort: ambiguous short names and non-secret config stay open.

--- a/internal/outboundguard/guard_test.go
+++ b/internal/outboundguard/guard_test.go
@@ -74,30 +74,31 @@ func TestValidateAllowsCommonPublicationIdentifiers(t *testing.T) {
 	}
 }
 
-func TestValidateAllowsStrictLooperThreadResolutionMarker(t *testing.T) {
+func TestValidateReviewThreadReplyAllowsExactOpaqueThreadID(t *testing.T) {
 	t.Parallel()
-	body := "Looper checked this thread.\n<!-- looper:thread-resolution thread=PRRT_kwDOSOgY8s6QeKwr head=0dd6a5019812fc422f9f20626530758ad67ad66e decision=objectively_fixed -->"
-	if err := Validate(Field{Name: "review thread reply body", Text: body}); err != nil {
-		t.Fatalf("Validate() error = %v, want safe Looper marker", err)
+	for _, threadID := range []string{"PRRT_kwDOSOgY8s6QeKwr", "MDQ6UHVsbFJlcXVlc3RSZXZpZXdUaHJlYWQxMjM0NTY="} {
+		body := "Looper checked this thread.\n<!-- looper:thread-resolution thread=" + threadID + " head=0dd6a5019812fc422f9f20626530758ad67ad66e decision=objectively_fixed -->"
+		if err := ValidateReviewThreadReply(body, threadID); err != nil {
+			t.Errorf("ValidateReviewThreadReply(%q) error = %v, want safe opaque thread ID", threadID, err)
+		}
 	}
 }
 
-func TestValidateThreadResolutionMarkerDoesNotExemptUntrustedContent(t *testing.T) {
-	t.Parallel()
-	marker := "<!-- looper:thread-resolution thread=PRRT_kwDOSOgY8s6QeKwr head=0dd6a5019812fc422f9f20626530758ad67ad66e decision=objectively_fixed -->"
+func TestThreadIDExemptionIsScopedToMatchingReviewThreadReply(t *testing.T) {
+	threadID := "MDQ6UHVsbFJlcXVlc3RSZXZpZXdUaHJlYWQxMjM0NTY="
+	marker := "<!-- looper:thread-resolution thread=" + threadID + " head=0dd6a5019812fc422f9f20626530758ad67ad66e decision=objectively_fixed -->"
 	tests := []struct {
 		name string
-		body string
+		err  error
 	}{
-		{name: "high entropy prose", body: "Agent evidence q8Kz1Wm9P2vR7xL4nB6cD0fH3jS5uY+/\n" + marker},
-		{name: "invalid thread id", body: strings.Replace(marker, "PRRT_", "THREAD_", 1)},
-		{name: "invalid head", body: strings.Replace(marker, "0dd6a5019812fc422f9f20626530758ad67ad66e", "q8Kz1Wm9P2vR7xL4nB6cD0fH3jS5uY+/", 1)},
-		{name: "invalid decision", body: strings.Replace(marker, "objectively_fixed", "agent_approved", 1)},
+		{name: "generic publication", err: Validate(Field{Name: "pull request body", Text: marker})},
+		{name: "different active thread", err: ValidateReviewThreadReply(marker, "PRRT_kwDOSOgY8s6QeKwr")},
+		{name: "high entropy prose", err: ValidateReviewThreadReply("Agent evidence q8Kz1Wm9P2vR7xL4nB6cD0fH3jS5uY+/\n"+marker, threadID)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := Validate(Field{Name: "review thread reply body", Text: tc.body}); err == nil || !strings.Contains(err.Error(), "high-entropy") {
-				t.Fatalf("Validate() error = %v, want high-entropy rejection", err)
+			if tc.err == nil || !strings.Contains(tc.err.Error(), "high-entropy") {
+				t.Fatalf("validation error = %v, want high-entropy rejection", tc.err)
 			}
 		})
 	}

--- a/internal/reviewer/runner_integration_test.go
+++ b/internal/reviewer/runner_integration_test.go
@@ -23,7 +23,7 @@ func TestThreadResolutionReplyPassesStampedGitHubPublicationBoundary(t *testing.
 	}
 	const (
 		repo     = "acme/looper"
-		threadID = "PRRT_kwDOSOgY8s6QeKwr"
+		threadID = "MDQ6UHVsbFJlcXVlc3RSZXZpZXdUaHJlYWQxMjM0NTY="
 		headSHA  = "0dd6a5019812fc422f9f20626530758ad67ad66e"
 	)
 	fakeGH.WriteState(t, harness.GHState{PullRequests: map[string]harness.GHPullRequest{

--- a/internal/reviewer/runner_integration_test.go
+++ b/internal/reviewer/runner_integration_test.go
@@ -8,11 +8,62 @@ import (
 	"testing"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/e2e/harness"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/reviewer/criteria"
 	"github.com/nexu-io/looper/internal/storage"
 )
+
+func TestThreadResolutionReplyPassesStampedGitHubPublicationBoundary(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	fakeGH := harness.NewFakeGH(t, bins, harness.GHSchema{})
+	for key, value := range fakeGH.EnvMap() {
+		t.Setenv(key, value)
+	}
+	const (
+		repo     = "acme/looper"
+		threadID = "PRRT_kwDOSOgY8s6QeKwr"
+		headSHA  = "0dd6a5019812fc422f9f20626530758ad67ad66e"
+	)
+	fakeGH.WriteState(t, harness.GHState{PullRequests: map[string]harness.GHPullRequest{
+		repo + "#42": {Number: 42, Repo: repo, Threads: []harness.GHThread{{ID: threadID}}},
+	}})
+
+	policy := config.ReviewerThreadResolutionConfig{Mode: config.ReviewerThreadResolutionModeResolveObjective}
+	body := (&Runner{}).buildThreadResolutionReply(threadID, headSHA, threadResolutionAgentDecision{
+		Decision: "objectively_fixed", Evidence: "the nil check is present", Confidence: "high",
+	}, policy)
+	stamper := disclosure.Stamper{Config: config.DisclosureConfig{
+		Enabled:  true,
+		Channels: config.DisclosureChannelsConfig{ReviewComment: true},
+	}}
+	body = stamper.ReviewComment(body, "reviewer")
+
+	gateway := githubinfra.New(githubinfra.Options{GHPath: fakeGH.Path})
+	if err := gateway.AddReviewThreadReply(context.Background(), githubinfra.AddReviewThreadReplyInput{Repo: repo, ThreadID: threadID, Body: body}); err != nil {
+		t.Fatalf("AddReviewThreadReply() error = %v", err)
+	}
+	if err := gateway.ResolveReviewThread(context.Background(), githubinfra.ResolveReviewThreadInput{Repo: repo, ThreadID: threadID}); err != nil {
+		t.Fatalf("ResolveReviewThread() error = %v", err)
+	}
+
+	stateBytes, err := os.ReadFile(fakeGH.StatePath)
+	if err != nil {
+		t.Fatalf("ReadFile(fake gh state) error = %v", err)
+	}
+	var state harness.GHState
+	if err := json.Unmarshal(stateBytes, &state); err != nil {
+		t.Fatalf("Unmarshal(fake gh state) error = %v", err)
+	}
+	thread := state.PullRequests[repo+"#42"].Threads[0]
+	if !thread.IsResolved {
+		t.Fatal("review thread remained unresolved")
+	}
+	if len(thread.Comments) != 1 || thread.Comments[0].Body != body {
+		t.Fatalf("thread comments = %#v, want stamped audit reply", thread.Comments)
+	}
+}
 
 func TestReviewerAutoMergeHappyPathWithFakeGH(t *testing.T) {
 	bins := harness.MustBinaries(t)


### PR DESCRIPTION
## Summary

- exclude only strictly parsed Looper thread-resolution audit markers from the generic entropy scan
- keep agent-authored prose and malformed marker-shaped content subject to all existing outbound checks
- cover reply construction, disclosure stamping, gateway publication, and thread resolution through fake GitHub mutations

## Authority and trade-off

The authority is Looper’s infrastructure-generated thread-resolution marker with the exact reviewer-emitted grammar, not the agent output or the `PRRT_` token shape by itself.

This adds one marker grammar that must stay synchronized with `buildThreadResolutionReply`; malformed markers fail closed. Removing the marker is insufficient because retries use it for audit/idempotency lookup, while raising the entropy threshold would weaken unrelated secret detection.

## Validation

- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- `go build ./...`

Closes #550

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>