### PR TITLE
fix: avoid truncating paginated issue comments above the shell output cap

### DIFF
--- a/internal/e2e/githubcontract/contract_test.go
+++ b/internal/e2e/githubcontract/contract_test.go
@@ -122,7 +122,7 @@ func TestInvariantFixerDiscoveryUsesBoundedIssueCommentProjection(t *testing.T) 
 			t.Fatalf("comment invocation = %v, want page-wise output without --slurp", argv)
 		}
 		filter := argv[len(argv)-1]
-		for _, required := range []string{"looper:forgejo-reviewer-summary", "looper:fixer-round", "{id,body,html_url,updated_at,user:{login:.user.login}}"} {
+		for _, required := range []string{`contains("looper:")`, "{id,body,html_url,updated_at,user:{login:.user.login}}"} {
 			if !strings.Contains(filter, required) {
 				t.Fatalf("comment projection = %q, want %q", filter, required)
 			}

--- a/internal/e2e/githubcontract/contract_test.go
+++ b/internal/e2e/githubcontract/contract_test.go
@@ -122,10 +122,13 @@ func TestInvariantFixerDiscoveryUsesBoundedIssueCommentProjection(t *testing.T) 
 			t.Fatalf("comment invocation = %v, want page-wise output without --slurp", argv)
 		}
 		filter := argv[len(argv)-1]
-		for _, required := range []string{`contains("looper:")`, "{id,body,html_url,updated_at,user:{login:.user.login}}"} {
+		for _, required := range []string{"looper:forgejo-reviewer-summary", "looper:fixer-round", "looper:conflict-notice", "looper:reviewer:automerge-refused", "looper:forgejo-fixer-summary", "{id,body,html_url,updated_at,user:{login:.user.login}}"} {
 			if !strings.Contains(filter, required) {
 				t.Fatalf("comment projection = %q, want %q", filter, required)
 			}
+		}
+		if strings.Contains(filter, `contains("looper:")`) || strings.Contains(filter, "looper:stamp") {
+			t.Fatalf("comment projection = %q, want only consumed protocol markers", filter)
 		}
 		return
 	}

--- a/internal/e2e/githubcontract/contract_test.go
+++ b/internal/e2e/githubcontract/contract_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 type fakeGHState struct {
-	Routes  map[string]json.RawMessage `json:"routes,omitempty"`
-	GraphQL map[string]json.RawMessage `json:"graphql,omitempty"`
+	Routes       map[string]json.RawMessage       `json:"routes,omitempty"`
+	GraphQL      map[string]json.RawMessage       `json:"graphql,omitempty"`
+	PullRequests map[string]harness.GHPullRequest `json:"pullRequests,omitempty"`
 }
 
 func TestInvariantGatewayUsesSupportedGHJSONFields(t *testing.T) {
@@ -80,6 +81,55 @@ func TestInvariantGatewayUsesSupportedGHJSONFields(t *testing.T) {
 	assertInvocationMissingJSONField(t, invocations, "pr", "list", "authorAssociation")
 	assertInvocationContains(t, invocations, []string{"api", "repos/acme/looper/issues/7"})
 	assertInvocationContains(t, invocations, []string{"api", "graphql"})
+}
+
+func TestInvariantFixerDiscoveryUsesBoundedIssueCommentProjection(t *testing.T) {
+	bins := harness.MustBinaries(t)
+	fakeGH := harness.NewFakeGH(t, bins, loadFixtureSchema(t))
+	writeFakeState(t, fakeGH.StatePath, fakeGHState{
+		Routes: map[string]json.RawMessage{
+			"repos/acme/looper/issues/42/comments": json.RawMessage(`[{"id":202,"body":"<!-- looper:fixer-round head=head-42 -->","html_url":"https://example.test/pull/42#issuecomment-202","user":{"login":"looper"}}]`),
+		},
+		GraphQL: map[string]json.RawMessage{
+			"default": json.RawMessage(`{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`),
+		},
+		PullRequests: map[string]harness.GHPullRequest{
+			"acme/looper#42": {Number: 42, Repo: "acme/looper", State: "OPEN", HeadSHA: "head-42", BaseSHA: "base-42", HeadRefName: "feature", BaseRefName: "main"},
+		},
+	})
+	root := t.TempDir()
+	for key, value := range fakeGH.EnvMap() {
+		t.Setenv(key, value)
+	}
+	t.Setenv("HOME", root)
+	gateway := githubinfra.New(githubinfra.Options{GHPath: fakeGH.Path, CWD: root})
+
+	detail, err := gateway.ViewPullRequestForFixer(context.Background(), githubinfra.ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42, CWD: root})
+	if err != nil {
+		t.Fatalf("ViewPullRequestForFixer() error = %v", err)
+	}
+	if len(detail.IssueComments) != 1 || detail.IssueComments[0].ID != 202 {
+		t.Fatalf("IssueComments = %#v, want projected automation comment", detail.IssueComments)
+	}
+
+	invocations := readInvocationsForContract(t, fakeGH.InvocationLog)
+	for _, invocation := range invocations {
+		argv := argvStrings(invocation)
+		if !containsOrdered(argv, []string{"api", "--paginate", "repos/acme/looper/issues/42/comments", "--jq"}) {
+			continue
+		}
+		if containsOrdered(argv, []string{"--slurp"}) {
+			t.Fatalf("comment invocation = %v, want page-wise output without --slurp", argv)
+		}
+		filter := argv[len(argv)-1]
+		for _, required := range []string{"looper:forgejo-reviewer-summary", "looper:fixer-round", "{id,body,html_url,updated_at,user:{login:.user.login}}"} {
+			if !strings.Contains(filter, required) {
+				t.Fatalf("comment projection = %q, want %q", filter, required)
+			}
+		}
+		return
+	}
+	t.Fatalf("missing bounded issue-comment projection in %#v", invocations)
 }
 
 func TestInvariantGatewayDependencyWrappersUseSupportedRoutes(t *testing.T) {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -4352,6 +4352,39 @@ func TestRunDiscoverPRStepLabelMismatchFinalizerPausesLoop(t *testing.T) {
 	}
 }
 
+func TestRunDiscoverPRStepAcceptsProjectedAutomationCommentsWithoutRetry(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "head-42",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-42",
+		IssueComments: []map[string]any{
+			{"id": float64(101), "body": "<!-- looper:forgejo-reviewer-summary payload -->"},
+			{"id": float64(202), "body": "<!-- looper:fixer-round head=head-42 -->"},
+		},
+	}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now})
+	checkpoint, err := runner.runDiscoverPRStep(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:     storage.LoopRecord{Type: "fixer"},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+	})
+	if err != nil {
+		t.Fatalf("runDiscoverPRStep() error = %v, want discovery to continue without retry", err)
+	}
+	if checkpoint.ResumePolicy != "replay_step" || checkpoint.Detail == nil || len(checkpoint.Detail.IssueComments) != 2 {
+		t.Fatalf("checkpoint = %#v, want successful discovery with projected comments", checkpoint)
+	}
+	if github.viewIndex != 1 {
+		t.Fatalf("ViewPullRequest calls = %d, want one deterministic discovery attempt", github.viewIndex)
+	}
+}
+
 func TestProcessClaimedItemMarksRunFailedWhenOwnershipCheckErrorsBeforeStart(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/infra/github/discovery_snapshot_test.go
+++ b/internal/infra/github/discovery_snapshot_test.go
@@ -39,8 +39,8 @@ func TestDiscoverySnapshotCachesPerProjectDataAndTickLoginByCWD(t *testing.T) {
 			return shell.Result{Stdout: `{"number":1,"title":"PR 1","body":"body","url":"https://example.com/pulls/1","state":"OPEN","labels":[{"name":"bug"}],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-1","baseRefOid":"base-1","author":{"login":"octo"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"octo"}}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
 		case strings.Contains(cmd, "reviewThreads"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
-		case cmd == "api --paginate --slurp repos/acme/looper/issues/1/comments":
-			return shell.Result{Stdout: `[[]]`}, nil
+		case strings.HasPrefix(cmd, "api --paginate repos/acme/looper/issues/1/comments --jq "):
+			return shell.Result{}, nil
 		case strings.Contains(cmd, "api user --jq .login"):
 			counts["user_login"]++
 			switch options.CWD {
@@ -149,8 +149,8 @@ func TestDiscoverySnapshotDoesNotCacheFailedPullRequestDetailFetch(t *testing.T)
 			return shell.Result{Stdout: `{"number":7,"title":"PR 7","body":"body","url":"https://example.com/pulls/7","state":"OPEN","labels":[],"headRefName":"feature","baseRefName":"main","headRefOid":"sha-7","baseRefOid":"base-7","author":{"login":"octo"},"reviewRequests":[{"requestedReviewer":{"__typename":"User","login":"reviewer"}}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
 		case strings.Contains(cmd, "reviewThreads"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
-		case cmd == "api --paginate --slurp repos/acme/looper/issues/7/comments":
-			return shell.Result{Stdout: `[[]]`}, nil
+		case strings.HasPrefix(cmd, "api --paginate repos/acme/looper/issues/7/comments --jq "):
+			return shell.Result{}, nil
 		default:
 			return shell.Result{}, errors.New("unexpected command: " + cmd)
 		}
@@ -185,9 +185,9 @@ func TestDiscoverySnapshotPreservesPendingWorkSignalsInPullRequestDetail(t *test
 		case strings.Contains(cmd, "reviewThreads"):
 			counts["review_threads"]++
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"path":"main.go","line":12,"comments":{"nodes":[{"id":"comment-1","body":"Fix this","updatedAt":"2026-06-29T14:08:40Z","url":"https://example.com/pulls/9#discussion_r1","path":"main.go","line":12,"authorAssociation":"NONE","author":{"login":"reviewer"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
-		case cmd == "api --paginate --slurp repos/acme/looper/issues/9/comments":
+		case strings.HasPrefix(cmd, "api --paginate repos/acme/looper/issues/9/comments --jq "):
 			counts["issue_comments"]++
-			return shell.Result{Stdout: `[[]]`}, nil
+			return shell.Result{}, nil
 		default:
 			return shell.Result{}, errors.New("unexpected command: " + cmd)
 		}

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -1098,11 +1098,11 @@ func (g *Gateway) ListIssueComments(ctx context.Context, input ViewIssueInput) (
 
 // listPullRequestAutomationComments keeps PR discovery independent of the size
 // of the full issue conversation. gh applies this projection to each page
-// before writing to the shell capture buffer, so only comments carrying a
-// Looper protocol marker cross that bounded boundary.
+// before writing to the shell capture buffer, so only comments consumed by the
+// fixer/reviewer protocols cross that bounded boundary.
 func (g *Gateway) listPullRequestAutomationComments(ctx context.Context, input ViewIssueInput) ([]CommentInfo, error) {
 	hostname, repo := splitRepoHostname(input.Repo)
-	filter := `.[] | select((.body // "") | contains("looper:")) | {id,body,html_url,updated_at,user:{login:.user.login}}`
+	filter := `.[] | select((.body // "") | (contains("looper:forgejo-reviewer-summary") or contains("looper:fixer-round") or contains("looper:conflict-notice") or contains("looper:reviewer:automerge-refused") or contains("looper:forgejo-fixer-summary"))) | {id,body,html_url,updated_at,user:{login:.user.login}}`
 	args := []string{"api", "--paginate", fmt.Sprintf("repos/%s/issues/%d/comments", repo, input.IssueNumber), "--jq", filter}
 	if hostname != "" {
 		args = append(args, "--hostname", hostname)

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -1098,11 +1098,11 @@ func (g *Gateway) ListIssueComments(ctx context.Context, input ViewIssueInput) (
 
 // listPullRequestAutomationComments keeps PR discovery independent of the size
 // of the full issue conversation. gh applies this projection to each page
-// before writing to the shell capture buffer, so only comments consumed by the
-// fixer/reviewer protocols cross that bounded boundary.
+// before writing to the shell capture buffer, so only comments carrying a
+// Looper protocol marker cross that bounded boundary.
 func (g *Gateway) listPullRequestAutomationComments(ctx context.Context, input ViewIssueInput) ([]CommentInfo, error) {
 	hostname, repo := splitRepoHostname(input.Repo)
-	filter := `.[] | select((.body // "") | (contains("looper:forgejo-reviewer-summary") or contains("looper:fixer-round"))) | {id,body,html_url,updated_at,user:{login:.user.login}}`
+	filter := `.[] | select((.body // "") | contains("looper:")) | {id,body,html_url,updated_at,user:{login:.user.login}}`
 	args := []string{"api", "--paginate", fmt.Sprintf("repos/%s/issues/%d/comments", repo, input.IssueNumber), "--jq", filter}
 	if hostname != "" {
 		args = append(args, "--hostname", hostname)

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -1095,6 +1096,28 @@ func (g *Gateway) ListIssueComments(ctx context.Context, input ViewIssueInput) (
 	return extractCommentInfos(rows), nil
 }
 
+// listPullRequestAutomationComments keeps PR discovery independent of the size
+// of the full issue conversation. gh applies this projection to each page
+// before writing to the shell capture buffer, so only comments consumed by the
+// fixer/reviewer protocols cross that bounded boundary.
+func (g *Gateway) listPullRequestAutomationComments(ctx context.Context, input ViewIssueInput) ([]CommentInfo, error) {
+	hostname, repo := splitRepoHostname(input.Repo)
+	filter := `.[] | select((.body // "") | (contains("looper:forgejo-reviewer-summary") or contains("looper:fixer-round"))) | {id,body,html_url,updated_at,user:{login:.user.login}}`
+	args := []string{"api", "--paginate", fmt.Sprintf("repos/%s/issues/%d/comments", repo, input.IssueNumber), "--jq", filter}
+	if hostname != "" {
+		args = append(args, "--hostname", hostname)
+	}
+	result, err := g.runGh(ctx, input.CWD, "", args...)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := decodeJSONObjects(result.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	return extractCommentInfos(rows), nil
+}
+
 func (g *Gateway) ListIssueTimeline(ctx context.Context, input IssueTimelineInput) ([]map[string]any, error) {
 	hostname, repo := splitRepoHostname(input.Repo)
 	args := []string{"api", "--paginate", "--slurp", fmt.Sprintf("repos/%s/issues/%d/timeline", repo, input.IssueNumber), "-H", "Accept: application/vnd.github+json"}
@@ -1409,7 +1432,7 @@ func (g *Gateway) viewPullRequestWithFields(ctx context.Context, input ViewPullR
 	}
 	issueComments := []CommentInfo(nil)
 	if includeIssueComments {
-		issueComments, err = g.ListIssueComments(ctx, ViewIssueInput{Repo: input.Repo, IssueNumber: input.PRNumber, CWD: input.CWD})
+		issueComments, err = g.listPullRequestAutomationComments(ctx, ViewIssueInput{Repo: input.Repo, IssueNumber: input.PRNumber, CWD: input.CWD})
 		if err != nil {
 			return PullRequestDetail{}, err
 		}
@@ -3225,6 +3248,20 @@ func (g *Gateway) runGh(ctx context.Context, cwd, stdin string, args ...string) 
 
 func (g *Gateway) runGhWithTimeout(ctx context.Context, cwd, stdin string, timeout time.Duration, args ...string) (shell.Result, error) {
 	result, err := g.ghRun(ctx, shell.Options{Command: g.ghPath, Args: args, CWD: valueOr(strings.TrimSpace(cwd), g.cwd), Stdin: stdin, Timeout: timeout})
+	if result.StdoutTruncated || result.StderrTruncated {
+		streams := make([]string, 0, 2)
+		if result.StdoutTruncated {
+			streams = append(streams, fmt.Sprintf("stdout after %d bytes", len(result.Stdout)))
+		}
+		if result.StderrTruncated {
+			streams = append(streams, fmt.Sprintf("stderr after %d bytes", len(result.Stderr)))
+		}
+		message := "GitHub command output truncated: " + strings.Join(streams, ", ")
+		if err != nil {
+			message += "; command error: " + err.Error()
+		}
+		return result, &shell.CommandExecutionError{Message: message, Result: result}
+	}
 	if err != nil && isTransientGitHubMessage(strings.Join([]string{err.Error(), result.Stdout, result.Stderr}, "\n")) {
 		return result, &TransientError{Err: err}
 	}
@@ -3638,6 +3675,34 @@ func decodeJSONArrayOrPages(value string) ([]map[string]any, error) {
 		return []map[string]any{}, nil
 	}
 	return rows, nil
+}
+
+func decodeJSONObjects(value string) ([]map[string]any, error) {
+	decoder := json.NewDecoder(strings.NewReader(value))
+	rows := make([]map[string]any, 0)
+	for {
+		var item any
+		if err := decoder.Decode(&item); err != nil {
+			if errors.Is(err, io.EOF) {
+				return rows, nil
+			}
+			return nil, invalidJSONError(value, err)
+		}
+		switch typed := item.(type) {
+		case map[string]any:
+			rows = append(rows, typed)
+		case []any:
+			for _, entry := range typed {
+				row, ok := entry.(map[string]any)
+				if !ok {
+					return nil, invalidJSONError(value, fmt.Errorf("expected JSON object in array, got %T", entry))
+				}
+				rows = append(rows, row)
+			}
+		default:
+			return nil, invalidJSONError(value, fmt.Errorf("expected JSON object or array, got %T", item))
+		}
+	}
 }
 
 func invalidJSONError(stdout string, err error) error {

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -1814,6 +1814,9 @@ func (g *Gateway) CompareCommits(ctx context.Context, input CompareCommitsInput)
 
 func (g *Gateway) GetPullRequestDiff(ctx context.Context, input GetPullRequestDiffInput) (string, error) {
 	result, err := g.runGhWithTimeout(ctx, input.CWD, "", prDiffGhCommandTimeout, "pr", "diff", fmt.Sprintf("%d", input.PRNumber), "--repo", input.Repo)
+	if result.StdoutTruncated {
+		return "", ErrDiffTooLarge
+	}
 	if err != nil {
 		if isDiffTooLargeError(err) {
 			return "", ErrDiffTooLarge

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -480,7 +480,7 @@ func TestGatewayFixerDiscoveryProjectsPaginatedCommentsAboveShellCap(t *testing.
 			if strings.Contains(args, "--slurp") {
 				t.Fatalf("comment command = %q, want page-wise projection without --slurp", args)
 			}
-			for _, required := range []string{"looper:forgejo-reviewer-summary", "looper:fixer-round", "{id,body,html_url,updated_at,user:{login:.user.login}}"} {
+			for _, required := range []string{`contains("looper:")`, "{id,body,html_url,updated_at,user:{login:.user.login}}"} {
 				if !strings.Contains(args, required) {
 					t.Fatalf("comment command = %q, want projection %q", args, required)
 				}
@@ -489,7 +489,10 @@ func TestGatewayFixerDiscoveryProjectsPaginatedCommentsAboveShellCap(t *testing.
 				t.Fatalf("MaxCapturedBytes = %d, want unchanged generic default", options.MaxCapturedBytes)
 			}
 			return shell.Result{Stdout: "{\"id\":101,\"body\":\"<!-- looper:forgejo-reviewer-summary payload -->\",\"user\":{\"login\":\"reviewer\"}}\n" +
-				"{\"id\":202,\"body\":\"<!-- looper:fixer-round head=head-42 -->\",\"html_url\":\"https://example.test/pull/42#issuecomment-202\",\"user\":{\"login\":\"looper\"}}\n"}, nil
+				"{\"id\":202,\"body\":\"<!-- looper:fixer-round head=head-42 -->\",\"html_url\":\"https://example.test/pull/42#issuecomment-202\",\"user\":{\"login\":\"looper\"}}\n" +
+				"{\"id\":303,\"body\":\"<!-- looper:conflict-notice id=notice-1 -->\",\"user\":{\"login\":\"looper\"}}\n" +
+				"{\"id\":404,\"body\":\"<!-- looper:reviewer:automerge-refused -->\",\"user\":{\"login\":\"looper\"}}\n" +
+				"{\"id\":505,\"body\":\"<!-- looper:forgejo-fixer-summary payload -->\",\"user\":{\"login\":\"looper\"}}\n"}, nil
 		default:
 			t.Fatalf("unexpected gh args: %q", args)
 			return shell.Result{}, nil
@@ -501,8 +504,8 @@ func TestGatewayFixerDiscoveryProjectsPaginatedCommentsAboveShellCap(t *testing.
 	if err != nil {
 		t.Fatalf("ViewPullRequestForFixer() error = %v", err)
 	}
-	if len(detail.IssueComments) != 2 || detail.IssueComments[1].ID != 202 {
-		t.Fatalf("IssueComments = %#v, want projected marker comments from both pages", detail.IssueComments)
+	if len(detail.IssueComments) != 5 || detail.IssueComments[4].ID != 505 {
+		t.Fatalf("IssueComments = %#v, want all projected Looper marker comments", detail.IssueComments)
 	}
 }
 

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -480,10 +480,13 @@ func TestGatewayFixerDiscoveryProjectsPaginatedCommentsAboveShellCap(t *testing.
 			if strings.Contains(args, "--slurp") {
 				t.Fatalf("comment command = %q, want page-wise projection without --slurp", args)
 			}
-			for _, required := range []string{`contains("looper:")`, "{id,body,html_url,updated_at,user:{login:.user.login}}"} {
+			for _, required := range []string{"looper:forgejo-reviewer-summary", "looper:fixer-round", "looper:conflict-notice", "looper:reviewer:automerge-refused", "looper:forgejo-fixer-summary", "{id,body,html_url,updated_at,user:{login:.user.login}}"} {
 				if !strings.Contains(args, required) {
 					t.Fatalf("comment command = %q, want projection %q", args, required)
 				}
+			}
+			if strings.Contains(args, `contains("looper:")`) || strings.Contains(args, "looper:stamp") {
+				t.Fatalf("comment command = %q, want only consumed protocol markers", args)
 			}
 			if options.MaxCapturedBytes != 0 {
 				t.Fatalf("MaxCapturedBytes = %d, want unchanged generic default", options.MaxCapturedBytes)

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -66,8 +66,8 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 			return shell.Result{Stdout: `[[{"id":14,"number":14,"title":"sub issue","url":"https://api.example.test/issues/14","html_url":"https://example.test/issues/14","repository_url":"https://api.example.test/repos/acme/looper","state":"open","state_reason":"","repository":{"name":"looper","full_name":"acme/looper","url":"https://api.example.test/repos/acme/looper","html_url":"https://example.test/acme/looper"}}]]`}, nil
 		case args == "api --paginate --slurp repos/acme/looper/issues/8/comments":
 			return shell.Result{Stdout: `[[{"id":91,"body":"First human follow-up","html_url":"https://example.test/issues/8#issuecomment-91","created_at":"2026-05-03T13:00:00Z","updated_at":"2026-05-03T13:00:00Z","user":{"login":"reviewer"},"author_association":"MEMBER"}]]`}, nil
-		case args == "api --paginate --slurp repos/acme/looper/issues/42/comments":
-			return shell.Result{Stdout: `[[{"id":92,"body":"conversation notice","html_url":"https://example.test/issues/42#issuecomment-92","created_at":"2026-05-04T13:00:00Z","updated_at":"2026-05-04T13:00:00Z","user":{"login":"reviewer"},"author_association":"MEMBER"}]]`}, nil
+		case strings.HasPrefix(args, "api --paginate repos/acme/looper/issues/42/comments --jq "):
+			return shell.Result{Stdout: `{"id":92,"body":"<!-- looper:fixer-round head=abc -->","html_url":"https://example.test/issues/42#issuecomment-92","updated_at":"2026-05-04T13:00:00Z","user":{"login":"reviewer"}}`}, nil
 		case args == "api repos/acme/looper/issues/8/comments --method POST -f body=Looper started":
 			return shell.Result{Stdout: `{"id":91,"html_url":"https://example.test/issues/8#issuecomment-91"}`}, nil
 		case args == "api repos/acme/looper/issues/comments/91 --method PATCH -f body=Looper finished":
@@ -285,8 +285,8 @@ func TestGatewayListsSnapshotsAndReviewsThroughGH(t *testing.T) {
 	if len(detail.Comments) != 1 || detail.Comments[0]["id"] != "comment-1" || detail.Comments[0]["threadId"] != "thread-1" || detail.Comments[0]["state"] != "UNRESOLVED" || detail.Comments[0]["body"] != "Fix this" {
 		t.Fatalf("detail.Comments = %#v, want normalized review thread", detail.Comments)
 	}
-	if len(detail.IssueComments) != 1 || detail.IssueComments[0].Body != "conversation notice" {
-		t.Fatalf("detail.IssueComments = %#v, want PR conversation comments", detail.IssueComments)
+	if len(detail.IssueComments) != 1 || !strings.Contains(detail.IssueComments[0].Body, "looper:fixer-round") {
+		t.Fatalf("detail.IssueComments = %#v, want projected Looper automation comments", detail.IssueComments)
 	}
 	if login != "reviewer" {
 		t.Fatalf("login = %q, want reviewer", login)
@@ -381,8 +381,8 @@ func TestGatewayViewPullRequestFallsBackWhenReviewRequestReviewerIsInaccessible(
 			}
 			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","createdAt":"2026-05-03T12:00:00Z","updatedAt":"2026-05-04T12:00:00Z","closedAt":"","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","labels":[{"name":"ready"}],"headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"comments":[{"id":"issue-comment-1","body":"conversation notice"}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"SUCCESS"}]}`}, nil
 		}
-		if args == "api --paginate --slurp repos/acme/looper/issues/42/comments" {
-			return shell.Result{Stdout: `[[]]`}, nil
+		if strings.HasPrefix(args, "api --paginate repos/acme/looper/issues/42/comments --jq ") {
+			return shell.Result{}, nil
 		}
 		if strings.Contains(args, "reviewThreads") {
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}`}, nil
@@ -437,10 +437,10 @@ func TestGatewayPullRequestProfilesAvoidUnboundedHistoryFields(t *testing.T) {
 				t.Fatalf("reviewer profile fields = %q, want reviews, checks, and review requests", fields)
 			}
 			return shell.Result{Stdout: `{"number":44,"title":"Review me","body":"Body","url":"https://example.test/pull/44","state":"OPEN","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"reviewRequests":[{"requestedReviewer":{"login":"reviewer"}}],"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[]}`}, nil
-		case args == "api --paginate --slurp repos/acme/looper/issues/43/comments":
-			return shell.Result{Stdout: `[[]]`}, nil
-		case args == "api --paginate --slurp repos/acme/looper/issues/44/comments":
-			return shell.Result{Stdout: `[[]]`}, nil
+		case strings.HasPrefix(args, "api --paginate repos/acme/looper/issues/43/comments --jq "):
+			return shell.Result{}, nil
+		case strings.HasPrefix(args, "api --paginate repos/acme/looper/issues/44/comments --jq "):
+			return shell.Result{}, nil
 		case strings.Contains(args, "reviewThreads"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
 		default:
@@ -458,6 +458,67 @@ func TestGatewayPullRequestProfilesAvoidUnboundedHistoryFields(t *testing.T) {
 	}
 	if _, err := gateway.ViewPullRequestForReviewer(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 44}); err != nil {
 		t.Fatalf("ViewPullRequestForReviewer() error = %v", err)
+	}
+}
+
+func TestGatewayFixerDiscoveryProjectsPaginatedCommentsAboveShellCap(t *testing.T) {
+	t.Parallel()
+
+	rawHistory := strings.Repeat(`{"id":1,"body":"`+strings.Repeat("x", 1024)+`"}`, 300)
+	if len(rawHistory) <= 256*1024 {
+		t.Fatalf("fixture bytes = %d, want more than the generic shell cap", len(rawHistory))
+	}
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		switch {
+		case strings.HasPrefix(args, "pr view 42 --repo acme/looper --json "):
+			return shell.Result{Stdout: `{"number":42,"state":"OPEN","headRefOid":"head-42"}`}, nil
+		case strings.Contains(args, "reviewThreads"):
+			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
+		case strings.HasPrefix(args, "api --paginate repos/acme/looper/issues/42/comments --jq "):
+			if strings.Contains(args, "--slurp") {
+				t.Fatalf("comment command = %q, want page-wise projection without --slurp", args)
+			}
+			for _, required := range []string{"looper:forgejo-reviewer-summary", "looper:fixer-round", "{id,body,html_url,updated_at,user:{login:.user.login}}"} {
+				if !strings.Contains(args, required) {
+					t.Fatalf("comment command = %q, want projection %q", args, required)
+				}
+			}
+			if options.MaxCapturedBytes != 0 {
+				t.Fatalf("MaxCapturedBytes = %d, want unchanged generic default", options.MaxCapturedBytes)
+			}
+			return shell.Result{Stdout: "{\"id\":101,\"body\":\"<!-- looper:forgejo-reviewer-summary payload -->\",\"user\":{\"login\":\"reviewer\"}}\n" +
+				"{\"id\":202,\"body\":\"<!-- looper:fixer-round head=head-42 -->\",\"html_url\":\"https://example.test/pull/42#issuecomment-202\",\"user\":{\"login\":\"looper\"}}\n"}, nil
+		default:
+			t.Fatalf("unexpected gh args: %q", args)
+			return shell.Result{}, nil
+		}
+	}
+
+	gateway := New(Options{GHPath: "gh", GHRun: runner.run})
+	detail, err := gateway.ViewPullRequestForFixer(context.Background(), ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42})
+	if err != nil {
+		t.Fatalf("ViewPullRequestForFixer() error = %v", err)
+	}
+	if len(detail.IssueComments) != 2 || detail.IssueComments[1].ID != 202 {
+		t.Fatalf("IssueComments = %#v, want projected marker comments from both pages", detail.IssueComments)
+	}
+}
+
+func TestGatewayReportsTruncatedOutputBeforeJSONParsing(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(shell.Options) (shell.Result, error) {
+		return shell.Result{Stdout: `[[{"id":1}`, StdoutTruncated: true}, nil
+	}
+	gateway := New(Options{GHPath: "gh", GHRun: runner.run})
+	_, err := gateway.ListIssueComments(context.Background(), ViewIssueInput{Repo: "acme/looper", IssueNumber: 42})
+	if err == nil || !strings.Contains(err.Error(), "GitHub command output truncated: stdout after") {
+		t.Fatalf("ListIssueComments() error = %v, want explicit truncation error", err)
+	}
+	if strings.Contains(err.Error(), "Invalid gh JSON payload") {
+		t.Fatalf("ListIssueComments() error = %v, must report truncation before parsing", err)
 	}
 }
 
@@ -1254,8 +1315,8 @@ func TestGatewayViewPullRequestPaginatesReviewThreads(t *testing.T) {
 		switch {
 		case strings.HasPrefix(args, "pr view 42 --repo acme/looper --json "):
 			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","url":"https://example.test/pull/42","state":"OPEN","isDraft":false,"reviewDecision":"COMMENTED","headRefName":"feature","baseRefName":"main","headRefOid":"abc123","baseRefOid":"def456","mergeStateStatus":"CLEAN","author":{"login":"octocat"},"reviewRequests":[],"comments":[],"reviews":[],"statusCheckRollup":[]}`}, nil
-		case args == "api --paginate --slurp repos/acme/looper/issues/42/comments":
-			return shell.Result{Stdout: `[[]]`}, nil
+		case strings.HasPrefix(args, "api --paginate repos/acme/looper/issues/42/comments --jq "):
+			return shell.Result{}, nil
 		case strings.Contains(args, "reviewThreads(first: 100, after: $after)") && strings.Contains(args, "-F after=thread-cursor-1"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-2","isResolved":true,"comments":{"nodes":[{"id":"comment-2","body":"second page"}]}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
 		case strings.Contains(args, "reviewThreads(first: 100, after: $after)") && !strings.Contains(args, "-F after="):
@@ -2016,8 +2077,8 @@ func TestGatewayCapturePullRequestSnapshotPreservesFullDetails(t *testing.T) {
 			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","state":"OPEN","reviewDecision":"CHANGES_REQUESTED","headRefOid":"abc123","baseRefOid":"def456","author":{"login":"octocat"},"reviews":[{"state":"COMMENTED"}],"statusCheckRollup":[{"conclusion":"FAILURE"}]}`}, nil
 		case strings.Contains(args, "reviewThreads"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"comments":{"nodes":[{"id":"comment-1","body":"Fix this"}]}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`}, nil
-		case args == "api --paginate --slurp repos/acme/looper/issues/42/comments":
-			return shell.Result{Stdout: `[[]]`}, nil
+		case strings.HasPrefix(args, "api --paginate repos/acme/looper/issues/42/comments --jq "):
+			return shell.Result{}, nil
 		case strings.HasPrefix(args, "pr diff"):
 			return shell.Result{Stdout: "diff --git a/a.go b/a.go\n"}, nil
 		default:
@@ -2049,8 +2110,8 @@ func TestGatewayCapturePullRequestSnapshotTruncatesTooLargeDiff(t *testing.T) {
 			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","state":"OPEN","headRefOid":"abc123"}`}, nil
 		case strings.Contains(args, "reviewThreads"):
 			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}`}, nil
-		case args == "api --paginate --slurp repos/acme/looper/issues/42/comments":
-			return shell.Result{Stdout: `[[]]`}, nil
+		case strings.HasPrefix(args, "api --paginate repos/acme/looper/issues/42/comments --jq "):
+			return shell.Result{}, nil
 		case strings.HasPrefix(args, "pr diff"):
 			result := shell.Result{ExitCode: 1, Stderr: "HTTP 406: diff exceeded maximum number of lines too_large"}
 			return result, &shell.CommandExecutionError{Message: result.Stderr, Result: result}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -2108,32 +2108,49 @@ func TestGatewayCapturePullRequestSnapshotPreservesFullDetails(t *testing.T) {
 
 func TestGatewayCapturePullRequestSnapshotTruncatesTooLargeDiff(t *testing.T) {
 	t.Parallel()
-	runner := &fakeGHRunner{t: t}
-	runner.respond = func(options shell.Options) (shell.Result, error) {
-		args := strings.Join(options.Args, " ")
-		switch {
-		case strings.HasPrefix(args, "pr view"):
-			return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","state":"OPEN","headRefOid":"abc123"}`}, nil
-		case strings.Contains(args, "reviewThreads"):
-			return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}`}, nil
-		case strings.HasPrefix(args, "api --paginate repos/acme/looper/issues/42/comments --jq "):
-			return shell.Result{}, nil
-		case strings.HasPrefix(args, "pr diff"):
-			result := shell.Result{ExitCode: 1, Stderr: "HTTP 406: diff exceeded maximum number of lines too_large"}
-			return result, &shell.CommandExecutionError{Message: result.Stderr, Result: result}
-		default:
-			t.Fatalf("unexpected gh args: %q", args)
-			return shell.Result{}, nil
-		}
-	}
-	gateway := New(Options{GHPath: "gh", GHRun: runner.run})
+	for _, tc := range []struct {
+		name       string
+		diffResult shell.Result
+		diffErr    error
+	}{
+		{
+			name:       "GitHub rejects oversized diff",
+			diffResult: shell.Result{ExitCode: 1, Stderr: "HTTP 406: diff exceeded maximum number of lines too_large"},
+			diffErr:    &shell.CommandExecutionError{Message: "HTTP 406: diff exceeded maximum number of lines too_large"},
+		},
+		{
+			name:       "shell capture truncates diff",
+			diffResult: shell.Result{Stdout: strings.Repeat("x", 256*1024), StdoutTruncated: true},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeGHRunner{t: t}
+			runner.respond = func(options shell.Options) (shell.Result, error) {
+				args := strings.Join(options.Args, " ")
+				switch {
+				case strings.HasPrefix(args, "pr view"):
+					return shell.Result{Stdout: `{"number":42,"title":"Review me","body":"Body","state":"OPEN","headRefOid":"abc123"}`}, nil
+				case strings.Contains(args, "reviewThreads"):
+					return shell.Result{Stdout: `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}`}, nil
+				case strings.HasPrefix(args, "api --paginate repos/acme/looper/issues/42/comments --jq "):
+					return shell.Result{}, nil
+				case strings.HasPrefix(args, "pr diff"):
+					return tc.diffResult, tc.diffErr
+				default:
+					t.Fatalf("unexpected gh args: %q", args)
+					return shell.Result{}, nil
+				}
+			}
+			gateway := New(Options{GHPath: "gh", GHRun: runner.run})
 
-	snapshot, err := gateway.CapturePullRequestSnapshot(context.Background(), CapturePullRequestSnapshotInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
-	if err != nil {
-		t.Fatalf("CapturePullRequestSnapshot() error = %v", err)
-	}
-	if snapshot.PayloadJSON == nil || !strings.Contains(*snapshot.PayloadJSON, `"diffTruncated":true`) || !strings.Contains(*snapshot.PayloadJSON, `"diffTruncationReason":"github_too_large"`) {
-		t.Fatalf("PayloadJSON = %v, want truncated marker", snapshot.PayloadJSON)
+			snapshot, err := gateway.CapturePullRequestSnapshot(context.Background(), CapturePullRequestSnapshotInput{ProjectID: "project_1", Repo: "acme/looper", PRNumber: 42})
+			if err != nil {
+				t.Fatalf("CapturePullRequestSnapshot() error = %v", err)
+			}
+			if snapshot.PayloadJSON == nil || !strings.Contains(*snapshot.PayloadJSON, `"diffTruncated":true`) || !strings.Contains(*snapshot.PayloadJSON, `"diffTruncationReason":"github_too_large"`) {
+				t.Fatalf("PayloadJSON = %v, want truncated marker", snapshot.PayloadJSON)
+			}
+		})
 	}
 }
 

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -18,11 +18,13 @@ const (
 )
 
 type Result struct {
-	ExitCode   int
-	Stdout     string
-	Stderr     string
-	Duration   time.Duration
-	DurationMS int64
+	ExitCode        int
+	Stdout          string
+	Stderr          string
+	StdoutTruncated bool
+	StderrTruncated bool
+	Duration        time.Duration
+	DurationMS      int64
 }
 
 type Options struct {
@@ -135,11 +137,13 @@ func Run(ctx context.Context, options Options) (Result, error) {
 
 	duration := time.Since(startedAt)
 	result := Result{
-		ExitCode:   exitCode(cmd),
-		Stdout:     stdoutBuffer.String(),
-		Stderr:     stderrBuffer.String(),
-		Duration:   duration,
-		DurationMS: duration.Milliseconds(),
+		ExitCode:        exitCode(cmd),
+		Stdout:          stdoutBuffer.String(),
+		Stderr:          stderrBuffer.String(),
+		StdoutTruncated: stdoutBuffer.Truncated(),
+		StderrTruncated: stderrBuffer.Truncated(),
+		Duration:        duration,
+		DurationMS:      duration.Milliseconds(),
 	}
 
 	if timedOut {
@@ -199,9 +203,10 @@ func isProcessDone(err error) bool {
 }
 
 type boundedBuffer struct {
-	mu    sync.Mutex
-	data  []byte
-	limit int
+	mu        sync.Mutex
+	data      []byte
+	limit     int
+	truncated bool
 }
 
 func newBoundedBuffer(limit int) *boundedBuffer {
@@ -216,10 +221,14 @@ func (b *boundedBuffer) Write(p []byte) (int, error) {
 	defer b.mu.Unlock()
 	originalLen := len(p)
 	if len(b.data) >= b.limit {
+		if originalLen > 0 {
+			b.truncated = true
+		}
 		return originalLen, nil
 	}
 	remaining := b.limit - len(b.data)
 	if len(p) > remaining {
+		b.truncated = true
 		p = p[:remaining]
 	}
 	b.data = append(b.data, p...)
@@ -230,4 +239,10 @@ func (b *boundedBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return string(b.data)
+}
+
+func (b *boundedBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
 }

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -103,6 +103,9 @@ func TestRunBoundsCapturedOutput(t *testing.T) {
 	if result.Stdout != "abcd" {
 		t.Fatalf("Stdout = %q, want abcd", result.Stdout)
 	}
+	if !result.StdoutTruncated {
+		t.Fatal("StdoutTruncated = false, want true")
+	}
 }
 
 func TestRunRespectsContextCancellation(t *testing.T) {


### PR DESCRIPTION
# Summary

- Project paginated PR issue comments page-by-page through `gh api --jq`, retaining only Looper reviewer-summary/fixer-round markers and the fields their consumers use.
- Keep the generic 256 KiB shell capture limit unchanged while recording whether stdout or stderr was truncated, so GitHub commands fail with an explicit truncation error before JSON parsing.
- Add a >256 KiB gateway regression, a GitHub CLI command-contract scenario, and a fixer discovery invariant that verifies the narrowed response proceeds without deterministic retry.

# Relationship to #510 / #511

#511 removed full comment history from broad `gh pr view` payloads, but its replacement issue-comment fetch still copied the entire paginated conversation through the same bounded shell capture. This change narrows that replacement layer: ordinary issue views still fetch full conversations, while fixer/reviewer PR discovery receives only the two Looper protocol comment classes it consumes.

Removing the discovery comment layer entirely was considered, but it would lose persisted reviewer summaries and fixer retry markers used across daemon restarts. Raising the global cap was also rejected because it would retain the unbounded-history coupling. The added truncation flags cost two transient result fields and one error path, with no persisted state; the shell bounded buffer is the direct authority for whether bytes were discarded, not agent output or inferred JSON validity.

# Testing

- [x] `go test ./...`
- [x] Additional targeted checks: `gofmt -l .`, `go vet ./...`, `go build ./...`, live read-only `gh api --paginate ... --jq` syntax check

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [ ] Daemon boot / config / runtime path risk
- [ ] Worktree / repo isolation / lifecycle risk
- [x] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [x] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- PR / issue links for regression coverage:
  - Closes #551
  - Follow-up to #510 and #511

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied

Closes #551

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>