### PR TITLE
fix: accept tea 0.14 string default in login list JSON

### DIFF
--- a/internal/forge/tea.go
+++ b/internal/forge/tea.go
@@ -52,14 +52,50 @@ const (
 
 // TeaLogin describes a tea CLI login entry from `tea logins list -o json`.
 // Tokens are never present in this output and must never be requested.
-// Default is a boolean in current tea versions (not a string).
+// Default accepts both JSON bool and string forms: tea 0.14.x emits
+// "default":"true", while some builds emit a real boolean.
 type TeaLogin struct {
-	Name    string `json:"name"`
-	URL     string `json:"url"`
-	SSHHost string `json:"ssh_host"`
-	User    string `json:"user"`
-	Default bool   `json:"default"`
+	Name    string         `json:"name"`
+	URL     string         `json:"url"`
+	SSHHost string         `json:"ssh_host"`
+	User    string         `json:"user"`
+	Default teaDefaultFlag `json:"default"`
 }
+
+// teaDefaultFlag unmarshals tea's login "default" field, which is a bool in
+// some tea builds and a string ("true"/"false") in Homebrew tea 0.14.x.
+type teaDefaultFlag bool
+
+func (f *teaDefaultFlag) UnmarshalJSON(data []byte) error {
+	if f == nil {
+		return errors.New("teaDefaultFlag: nil receiver")
+	}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*f = false
+		return nil
+	}
+	var asBool bool
+	if err := json.Unmarshal(trimmed, &asBool); err == nil {
+		*f = teaDefaultFlag(asBool)
+		return nil
+	}
+	var asString string
+	if err := json.Unmarshal(trimmed, &asString); err != nil {
+		return fmt.Errorf("tea login default: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(asString)) {
+	case "true", "1", "yes":
+		*f = true
+	case "false", "0", "no", "":
+		*f = false
+	default:
+		return fmt.Errorf("tea login default: unsupported value %q", asString)
+	}
+	return nil
+}
+
+func (f teaDefaultFlag) Bool() bool { return bool(f) }
 
 // TeaCommandRunner executes tea CLI invocations. Tests inject a fake runner.
 type TeaCommandRunner interface {

--- a/internal/forge/tea_test.go
+++ b/internal/forge/tea_test.go
@@ -250,6 +250,42 @@ func TestNewForgejoClientFromConfigTeaMissingBinary(t *testing.T) {
 	}
 }
 
+func TestListTeaLoginsAcceptsStringDefaultFromTea014(t *testing.T) {
+	// Homebrew tea 0.14.x emits "default":"true" (string), not a JSON bool.
+	// Regression: unmarshaling that form used to fail as tea_auth_failed.
+	runner := &recordingTeaRunner{
+		loginsJSON: `[
+  {
+    "name": "powerformer-code",
+    "url": "https://code.powerformer.net",
+    "ssh_host": "code.powerformer.net",
+    "user": "mrcfps",
+    "default": "true"
+  },
+  {
+    "name": "other",
+    "url": "https://other.example.com",
+    "ssh_host": "other.example.com",
+    "user": "bob",
+    "default": false
+  }
+]`,
+	}
+	logins, err := ListTeaLogins(context.Background(), "/usr/bin/fake-tea", runner)
+	if err != nil {
+		t.Fatalf("ListTeaLogins() error = %v", err)
+	}
+	if len(logins) != 2 {
+		t.Fatalf("len(logins) = %d, want 2", len(logins))
+	}
+	if logins[0].Name != "powerformer-code" || !logins[0].Default.Bool() {
+		t.Fatalf("logins[0] = %#v, want powerformer-code default=true", logins[0])
+	}
+	if logins[1].Name != "other" || logins[1].Default.Bool() {
+		t.Fatalf("logins[1] = %#v, want other default=false", logins[1])
+	}
+}
+
 func mustJSON(t *testing.T, value any) string {
 	t.Helper()
 	raw, err := json.Marshal(value)


### PR DESCRIPTION
## Summary

- Accept both JSON bool and string forms of tea login `default` from `tea logins list -o json`
- Add regression coverage for Homebrew tea 0.14.x (`"default":"true"`)
- Unblocks tea-backed Forgejo providers that failed with `tea_auth_failed: tea logins list returned invalid JSON`

## Problem

PR #559 assumed tea emits `"default"` as a boolean. Homebrew tea **0.14.x** emits a string:

```json
{ "name": "powerformer-code", "url": "https://code.powerformer.net", "default": "true" }
```

`json.Unmarshal` into `bool` fails, so `ListTeaLogins` returns `tea_auth_failed` even when the login exists and `tea api` works.

## Verification

- `go test ./internal/forge -count=1 -run 'Tea|tea|ListTeaLogins'`
- Live smoke against `mrcfps/looper-sandbox` on `code.powerformer.net` with `auth=tea` / `teaLogin=powerformer-code`:
  - `provider test` → identity `mrcfps`
  - `CurrentUser`, `CheckRepository`, `ListOpenIssues`, `ListOpenPullRequests` succeeded
  - Negative cases: `tea_login_missing`, `tea_login_host_mismatch`

## Authority

No change to action authority: tea-backed Forgejo still requires an **explicit** configured `teaLogin` whose URL matches `baseUrl`. Ambient default login is still never selected.

Follow-up to #559 / #556.