### PR TITLE
feat: implement loop retry --discard-worktree-changes

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5038,7 +5038,9 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
 
 	// Opt-in discard runs before requeue so git mutation stays outside the
-	// queue transaction. Active run/queue and terminal checks still apply.
+	// queue transaction. Every non-mutating retry blocker must pass first so a
+	// later precondition failure never leaves discarded worktree changes
+	// without creating a replacement queue item.
 	var worktreeDiscard *worktreeDiscardResult
 	if discardWorktreeChanges {
 		if services.Repositories == nil || services.Coordinator == nil {
@@ -5051,34 +5053,12 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 		if preflightLoop == nil {
 			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
 		}
-		if strings.TrimSpace(preflightLoop.ProjectID) != "" {
-			if _, err := requireActiveProjectRecord(ctx, services.Repositories.Projects, preflightLoop.ProjectID); err != nil {
-				return retryLoopResponse{}, err
+		if err := h.assertLoopRetryPreconditions(ctx, services.Repositories, *preflightLoop, nowISO); err != nil {
+			var typed apiError
+			if asAPIError(err, &typed) {
+				return retryLoopResponse{}, typed
 			}
-		}
-		if preflightLoop.Status == string(domain.LoopStatusStopped) || preflightLoop.Status == string(domain.LoopStatusTerminated) || preflightLoop.Status == string(domain.LoopStatusCompleted) {
-			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal %s loop: %s", preflightLoop.Status, preflightLoop.ID)}
-		}
-		if preflightLoop.Type == string(domain.LoopTypeReviewer) {
-			if terminalMetadataStatus := terminalReviewerRetryMetadataStatus(*preflightLoop); terminalMetadataStatus != "" {
-				return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal reviewer metadata %s loop: %s", terminalMetadataStatus, preflightLoop.ID)}
-			}
-		}
-		runningRuns, err := services.Repositories.Runs.ListByStatus(ctx, string(domain.RunStatusRunning))
-		if err != nil {
 			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-		}
-		for _, run := range runningRuns {
-			if run.LoopID == preflightLoop.ID {
-				return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while a run is active", preflightLoop.ID)}
-			}
-		}
-		activeQueue, err := services.Repositories.Queue.FindActiveByLoopID(ctx, preflightLoop.ID)
-		if err != nil {
-			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-		}
-		if activeQueue != nil {
-			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while queue item %s is active", preflightLoop.ID, activeQueue.ID)}
 		}
 		discardResult, discardErr := h.discardLoopWorktreeChanges(ctx, services, *preflightLoop)
 		if discardErr != nil {
@@ -5104,49 +5084,13 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 		if loop == nil {
 			return retryResult{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
 		}
-		if strings.TrimSpace(loop.ProjectID) != "" {
-			if _, err := requireActiveProjectRecord(ctx, repos.Projects, loop.ProjectID); err != nil {
-				return retryResult{}, err
-			}
-		}
-		if loop.Status == string(domain.LoopStatusStopped) || loop.Status == string(domain.LoopStatusTerminated) || loop.Status == string(domain.LoopStatusCompleted) {
-			return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal %s loop: %s", loop.Status, loop.ID)}
-		}
-		if loop.Type == string(domain.LoopTypeReviewer) {
-			if terminalMetadataStatus := terminalReviewerRetryMetadataStatus(*loop); terminalMetadataStatus != "" {
-				return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal reviewer metadata %s loop: %s", terminalMetadataStatus, loop.ID)}
-			}
-		}
-		if (loop.Type == string(domain.LoopTypeReviewer) || loop.Type == string(domain.LoopTypeFixer) || loop.Type == string(domain.LoopTypeWorker) || loop.Type == string(domain.LoopTypePlanner)) && !isCodingAgentConfigured(h.context.Config) {
-			return retryResult{}, apiError{code: pkgapi.ErrorCodeAgentNotConfigured, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry %s loop without config.agent.vendor", loop.Type)}
-		}
-		runningRuns, err := repos.Runs.ListByStatus(ctx, string(domain.RunStatusRunning))
-		if err != nil {
+		if err := h.assertLoopRetryPreconditions(ctx, repos, *loop, nowISO); err != nil {
 			return retryResult{}, err
-		}
-		for _, run := range runningRuns {
-			if run.LoopID == loop.ID {
-				return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while a run is active", loop.ID)}
-			}
-		}
-		activeQueue, err := repos.Queue.FindActiveByLoopID(ctx, loop.ID)
-		if err != nil {
-			return retryResult{}, err
-		}
-		if activeQueue != nil {
-			return retryResult{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while queue item %s is active", loop.ID, activeQueue.ID)}
 		}
 
 		target, targetErr := loopTargetFromRecordCompat(*loop)
 		if targetErr != nil {
 			return retryResult{}, targetErr
-		}
-		existing, err := repos.Loops.List(ctx)
-		if err != nil {
-			return retryResult{}, err
-		}
-		if uniqueErr := assertUniqueActiveLoopCompat(existing, loop.ID, loop.ProjectID, domain.LoopType(loop.Type), target, domain.LoopStatusQueued); uniqueErr != nil {
-			return retryResult{}, uniqueErr
 		}
 		latestQueue, err := repos.Queue.GetLatestByLoopID(ctx, loop.ID)
 		if err != nil {
@@ -5194,6 +5138,8 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 		if !ok {
 			return retryResult{loop: *loop}, nil
 		}
+		// Dedupe is already asserted by assertLoopRetryPreconditions; re-check
+		// inside the transaction for races between preflight and commit.
 		if queueRecord.DedupeKey != "" {
 			activeDedupe, err := repos.Queue.FindActiveByDedupe(ctx, queueRecord.DedupeKey)
 			if err != nil {
@@ -5584,6 +5530,87 @@ func isTerminalReviewerLoopRecord(loop storage.LoopRecord) bool {
 	loopMeta, _ := metadata["loop"].(map[string]any)
 	status, _ := loopMeta["status"].(string)
 	return status == "terminated" || status == "stopped" || status == "failed"
+}
+
+// assertLoopRetryPreconditions validates non-mutating retry blockers that must
+// pass before any destructive worktree discard or requeue. Callers that discard
+// dirty worktree state must invoke this first so a failed retry never deletes
+// local changes without creating a replacement queue item.
+func (h *Handler) assertLoopRetryPreconditions(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) error {
+	if strings.TrimSpace(loop.ProjectID) != "" {
+		if _, err := requireActiveProjectRecord(ctx, repos.Projects, loop.ProjectID); err != nil {
+			return err
+		}
+	}
+	if loop.Status == string(domain.LoopStatusStopped) || loop.Status == string(domain.LoopStatusTerminated) || loop.Status == string(domain.LoopStatusCompleted) {
+		return apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal %s loop: %s", loop.Status, loop.ID)}
+	}
+	if loop.Type == string(domain.LoopTypeReviewer) {
+		if terminalMetadataStatus := terminalReviewerRetryMetadataStatus(loop); terminalMetadataStatus != "" {
+			return apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal reviewer metadata %s loop: %s", terminalMetadataStatus, loop.ID)}
+		}
+	}
+	if (loop.Type == string(domain.LoopTypeReviewer) || loop.Type == string(domain.LoopTypeFixer) || loop.Type == string(domain.LoopTypeWorker) || loop.Type == string(domain.LoopTypePlanner)) && !isCodingAgentConfigured(h.context.Config) {
+		return apiError{code: pkgapi.ErrorCodeAgentNotConfigured, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry %s loop without config.agent.vendor", loop.Type)}
+	}
+	runningRuns, err := repos.Runs.ListByStatus(ctx, string(domain.RunStatusRunning))
+	if err != nil {
+		return err
+	}
+	for _, run := range runningRuns {
+		if run.LoopID == loop.ID {
+			return apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while a run is active", loop.ID)}
+		}
+	}
+	activeQueue, err := repos.Queue.FindActiveByLoopID(ctx, loop.ID)
+	if err != nil {
+		return err
+	}
+	if activeQueue != nil {
+		return apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while queue item %s is active", loop.ID, activeQueue.ID)}
+	}
+
+	target, targetErr := loopTargetFromRecordCompat(loop)
+	if targetErr != nil {
+		return targetErr
+	}
+	existing, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	if uniqueErr := assertUniqueActiveLoopCompat(existing, loop.ID, loop.ProjectID, domain.LoopType(loop.Type), target, domain.LoopStatusQueued); uniqueErr != nil {
+		return uniqueErr
+	}
+
+	latestQueue, err := repos.Queue.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return err
+	}
+	dedupeKey := ""
+	if latestQueue != nil {
+		dedupeKey = latestQueue.DedupeKey
+	} else {
+		// Match requeue path: when there is no prior queue row, building the
+		// replacement record can fail on target/repo requirements and must
+		// block discard just as it blocks requeue.
+		built, ok, queueErr := buildQueuedLoopQueueRecordCompat(loop, target, nowISO, loop.MetadataJSON, int64(h.context.Config.Scheduler.RetryMaxAttempts))
+		if queueErr != nil {
+			return queueErr
+		}
+		if ok {
+			dedupeKey = built.DedupeKey
+		}
+	}
+	if dedupeKey != "" {
+		activeDedupe, err := repos.Queue.FindActiveByDedupe(ctx, dedupeKey)
+		if err != nil {
+			return err
+		}
+		if activeDedupe != nil {
+			return apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while dedupe queue item %s is active", loop.ID, activeDedupe.ID)}
+		}
+	}
+	return nil
 }
 
 func terminalReviewerRetryMetadataStatus(loop storage.LoopRecord) string {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1485,15 +1485,18 @@ type activeRunView struct {
 }
 
 type retryLoopRequest struct {
-	Mode          string `json:"mode"`
-	ResetAttempts *bool  `json:"resetAttempts"`
+	Mode                   string `json:"mode"`
+	ResetAttempts          *bool  `json:"resetAttempts"`
+	DiscardWorktreeChanges *bool  `json:"discardWorktreeChanges"`
 }
 
 type retryLoopResponse struct {
-	Loop          loopResponse `json:"loop"`
-	QueueItemID   *string      `json:"queueItemId,omitempty"`
-	Mode          string       `json:"mode"`
-	ResetAttempts bool         `json:"resetAttempts"`
+	Loop                   loopResponse           `json:"loop"`
+	QueueItemID            *string                `json:"queueItemId,omitempty"`
+	Mode                   string                 `json:"mode"`
+	ResetAttempts          bool                   `json:"resetAttempts"`
+	DiscardWorktreeChanges bool                   `json:"discardWorktreeChanges"`
+	WorktreeDiscard        *worktreeDiscardResult `json:"worktreeDiscard,omitempty"`
 }
 
 type activeRunTarget struct {
@@ -5029,9 +5032,65 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 	if !resetAttempts {
 		return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "resetAttempts=false is not supported for explicit operator retry"}
 	}
+	discardWorktreeChanges := body.DiscardWorktreeChanges != nil && *body.DiscardWorktreeChanges
 
 	services := h.context.Runtime.Services()
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
+
+	// Opt-in discard runs before requeue so git mutation stays outside the
+	// queue transaction. Active run/queue and terminal checks still apply.
+	var worktreeDiscard *worktreeDiscardResult
+	if discardWorktreeChanges {
+		if services.Repositories == nil || services.Coordinator == nil {
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
+		}
+		preflightLoop, err := services.Repositories.Loops.GetByID(ctx, loopID)
+		if err != nil {
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		if preflightLoop == nil {
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
+		}
+		if strings.TrimSpace(preflightLoop.ProjectID) != "" {
+			if _, err := requireActiveProjectRecord(ctx, services.Repositories.Projects, preflightLoop.ProjectID); err != nil {
+				return retryLoopResponse{}, err
+			}
+		}
+		if preflightLoop.Status == string(domain.LoopStatusStopped) || preflightLoop.Status == string(domain.LoopStatusTerminated) || preflightLoop.Status == string(domain.LoopStatusCompleted) {
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal %s loop: %s", preflightLoop.Status, preflightLoop.ID)}
+		}
+		if preflightLoop.Type == string(domain.LoopTypeReviewer) {
+			if terminalMetadataStatus := terminalReviewerRetryMetadataStatus(*preflightLoop); terminalMetadataStatus != "" {
+				return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Cannot retry terminal reviewer metadata %s loop: %s", terminalMetadataStatus, preflightLoop.ID)}
+			}
+		}
+		runningRuns, err := services.Repositories.Runs.ListByStatus(ctx, string(domain.RunStatusRunning))
+		if err != nil {
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		for _, run := range runningRuns {
+			if run.LoopID == preflightLoop.ID {
+				return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while a run is active", preflightLoop.ID)}
+			}
+		}
+		activeQueue, err := services.Repositories.Queue.FindActiveByLoopID(ctx, preflightLoop.ID)
+		if err != nil {
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		if activeQueue != nil {
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusConflict, message: fmt.Sprintf("Cannot retry loop %s while queue item %s is active", preflightLoop.ID, activeQueue.ID)}
+		}
+		discardResult, discardErr := h.discardLoopWorktreeChanges(ctx, services, *preflightLoop)
+		if discardErr != nil {
+			var typed apiError
+			if asAPIError(discardErr, &typed) {
+				return retryLoopResponse{}, typed
+			}
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: discardErr.Error()}
+		}
+		worktreeDiscard = &discardResult
+	}
+
 	type retryResult struct {
 		loop        storage.LoopRecord
 		queueItemID *string
@@ -5165,7 +5224,14 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 	if h.context.TriggerSchedulerTick != nil {
 		h.context.TriggerSchedulerTick()
 	}
-	return retryLoopResponse{Loop: serializeLoop(result.loop), QueueItemID: result.queueItemID, Mode: mode, ResetAttempts: resetAttempts}, nil
+	return retryLoopResponse{
+		Loop:                   serializeLoop(result.loop),
+		QueueItemID:            result.queueItemID,
+		Mode:                   mode,
+		ResetAttempts:          resetAttempts,
+		DiscardWorktreeChanges: discardWorktreeChanges,
+		WorktreeDiscard:        worktreeDiscard,
+	}, nil
 }
 
 func (h *Handler) buildLoopLogsResponse(ctx context.Context, loop storage.LoopRecord) (loopLogsResponse, error) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5237,6 +5237,17 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string,
 			}
 			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
+		// Same-type uniqueness is not enough for discard: PR worktrees are shared
+		// across fixer/reviewer/worker. An already queued/running/human_takeover
+		// sibling is not held by the target mutex (that only serializes mutations),
+		// so refuse git reset/clean while any conflicting-active sibling owns the PR.
+		if err := h.assertDiscardSharedPRWorktreeClear(ctx, services.Repositories, *preflightLoop); err != nil {
+			var typed apiError
+			if asAPIError(err, &typed) {
+				return retryLoopResponse{}, typed
+			}
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
 
 		// Recheck immediately before git mutation as defense in depth. Runtime
 		// free-text enqueue now shares LockLoopRequeue with this path, so the
@@ -5257,6 +5268,13 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string,
 			return retryLoopResponse{}, err
 		}
 		if err := h.assertLoopRetryPreconditions(ctx, services.Repositories, *freshLoop, nowISO); err != nil {
+			var typed apiError
+			if asAPIError(err, &typed) {
+				return retryLoopResponse{}, typed
+			}
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		if err := h.assertDiscardSharedPRWorktreeClear(ctx, services.Repositories, *freshLoop); err != nil {
 			var typed apiError
 			if asAPIError(err, &typed) {
 				return retryLoopResponse{}, typed
@@ -5758,6 +5776,60 @@ func rejectDiscardWhileParkedForHuman(status, loopID string) error {
 	default:
 		return nil
 	}
+}
+
+// assertDiscardSharedPRWorktreeClear refuses discard when another loop of any
+// type already holds a conflicting-active status on the same pull-request
+// target. assertUniqueActiveLoopCompat only conflicts same-type loops; managed
+// PR worktrees (looper-fix-<project>-pr-N) are shared across fixer/reviewer/
+// worker, so a sibling that is queued, running, or human_takeover would lose
+// its checkout to git reset/clean. Non-PR targets and non-discard retries are
+// unaffected.
+func (h *Handler) assertDiscardSharedPRWorktreeClear(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord) error {
+	if loop.TargetType != string(domain.LoopTargetTypePullRequest) {
+		return nil
+	}
+	existing, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	return assertNoActiveSiblingPRWorktreeLoops(existing, loop)
+}
+
+// assertNoActiveSiblingPRWorktreeLoops reports a conflict when any other
+// conflicting-active loop on the same project+PR key exists, regardless of
+// loop type. Used only for destructive discard preflight.
+func assertNoActiveSiblingPRWorktreeLoops(existing []storage.LoopRecord, candidate storage.LoopRecord) error {
+	if candidate.TargetType != string(domain.LoopTargetTypePullRequest) {
+		return nil
+	}
+	candidateKey := loopTargetKeyFromRecordCompat(candidate)
+	if candidateKey == "pull_request:" {
+		return nil
+	}
+	for _, loop := range existing {
+		if loop.ID == candidate.ID || loop.ProjectID != candidate.ProjectID {
+			continue
+		}
+		if loop.TargetType != string(domain.LoopTargetTypePullRequest) {
+			continue
+		}
+		if !domain.IsConflictingActiveLoopStatus(domain.LoopStatus(loop.Status)) {
+			continue
+		}
+		if loopTargetKeyFromRecordCompat(loop) != candidateKey {
+			continue
+		}
+		return apiError{
+			code:   pkgapi.ErrorCodeLoopConflict,
+			status: http.StatusConflict,
+			message: fmt.Sprintf(
+				"Cannot discard worktree changes for loop %s while active %s loop %s shares the same PR worktree (%s)",
+				candidate.ID, loop.Type, loop.ID, candidateKey,
+			),
+		}
+	}
+	return nil
 }
 
 // assertLoopRetryPreconditions validates non-mutating retry blockers that must

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -109,6 +109,11 @@ type Handler struct {
 	// from creating a *different* active loop for the same target after discard
 	// preflight, which leaves a wiped worktree when the retry TX then conflicts.
 	loopTargetLocks sync.Map // project|type|targetKey -> *sync.Mutex
+	// discardBeforeGitHook is test-only: invoked after discard preflight recheck
+	// and immediately before git reset/clean so tests can inject a runtime-style
+	// requeue race (Feishu/GitHub free-text message enqueue) without holding the
+	// API locks.
+	discardBeforeGitHook func(loopID string)
 }
 
 func NewHandler(context Context) *Handler {
@@ -3205,7 +3210,7 @@ func (h *Handler) buildLoopRouteResponse(r *http.Request, path string) (any, err
 		if r.Method != http.MethodPost {
 			return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
 		}
-		return h.retryLoop(r.Context(), r, loop.ID)
+		return h.retryLoop(r.Context(), r, loop.ID, false)
 	case "respond":
 		if r.Method != http.MethodPost {
 			return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
@@ -4822,6 +4827,19 @@ func (h *Handler) takeoverLoop(ctx context.Context, loopID string) (takeoverLoop
 // THAT session and sees their turns), clears any queue item that survived the
 // takeover race, then re-arms via the shared retry path.
 func (h *Handler) handbackLoop(ctx context.Context, r *http.Request, loopID string) (any, error) {
+	// Reject discard before any handback mutation. retryLoop is shared with
+	// /retry, but handback must never wipe the human's interactive worktree edits
+	// even if an API client includes discardWorktreeChanges on the handback body.
+	if discardRequested, err := retryRequestRequestsDiscard(r); err != nil {
+		return nil, err
+	} else if discardRequested {
+		return nil, apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusBadRequest,
+			message: "discardWorktreeChanges is not allowed on handback; human interactive worktree edits must be preserved (retry with --discard-worktree-changes after handback if needed)",
+		}
+	}
+
 	services := h.context.Runtime.Services()
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
 	_, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (struct{}, error) {
@@ -4852,7 +4870,31 @@ func (h *Handler) handbackLoop(ctx context.Context, r *http.Request, loopID stri
 	if err != nil {
 		return nil, err
 	}
-	return h.retryLoop(ctx, r, loopID)
+	// Handback reuses retry re-arm; fromHandback also rejects discard if body is
+	// re-read after a client races another field in (defense in depth).
+	return h.retryLoop(ctx, r, loopID, true)
+}
+
+// retryRequestRequestsDiscard peeks at a retry/handback JSON body for
+// discardWorktreeChanges without consuming the request for a later retryLoop decode.
+func retryRequestRequestsDiscard(r *http.Request) (bool, error) {
+	if r == nil || r.Body == nil {
+		return false, nil
+	}
+	raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	_ = r.Body.Close()
+	r.Body = io.NopCloser(strings.NewReader(string(raw)))
+	if err != nil {
+		return false, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Invalid retry request: %v", err)}
+	}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return false, nil
+	}
+	var body retryLoopRequest
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return false, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Invalid retry request: %v", err)}
+	}
+	return body.DiscardWorktreeChanges != nil && *body.DiscardWorktreeChanges, nil
 }
 
 type respondLoopRequest struct {
@@ -5122,7 +5164,10 @@ func (h *Handler) handleFeishuThreadReply(w http.ResponseWriter, r *http.Request
 	h.writeSuccess(w, requestID, map[string]any{"loopId": loopID, "delivered": true})
 }
 
-func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string) (retryLoopResponse, error) {
+// retryLoop re-arms a loop for another scheduler pass. fromHandback is true when
+// invoked via /loops/{id}/handback so discardWorktreeChanges is rejected: that
+// path preserves human interactive edits in the worktree for the resumed session.
+func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string, fromHandback bool) (retryLoopResponse, error) {
 	var body retryLoopRequest
 	if r.Body != nil {
 		defer r.Body.Close()
@@ -5149,6 +5194,13 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 		return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "resetAttempts=false is not supported for explicit operator retry"}
 	}
 	discardWorktreeChanges := body.DiscardWorktreeChanges != nil && *body.DiscardWorktreeChanges
+	if discardWorktreeChanges && fromHandback {
+		return retryLoopResponse{}, apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusBadRequest,
+			message: "discardWorktreeChanges is not allowed on handback; human interactive worktree edits must be preserved (retry with --discard-worktree-changes after handback if needed)",
+		}
+	}
 
 	// Serialize per-loop retry with start/requeue so discard cannot race another
 	// retry or /loops/{id}/start that enqueues replacement work between preflight
@@ -5206,6 +5258,38 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 			}
 			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
+
+		// Recheck immediately before git mutation. Feishu/GitHub free-text inbox
+		// can call enqueueHumanMessageToLoop for paused/waiting loops without
+		// these handler locks, requeueing cancelled work after the first preflight
+		// and before reset; without this second check the retry TX would conflict
+		// after the message-driven continuation's worktree was already wiped.
+		if h.discardBeforeGitHook != nil {
+			h.discardBeforeGitHook(loopID)
+		}
+		freshLoop, freshErr := services.Repositories.Loops.GetByID(ctx, loopID)
+		if freshErr != nil {
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: freshErr.Error()}
+		}
+		if freshLoop == nil {
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
+		}
+		if freshLoop.Status == string(domain.LoopStatusAwaitingHuman) {
+			return retryLoopResponse{}, apiError{
+				code:    pkgapi.ErrorCodeValidationFailed,
+				status:  http.StatusConflict,
+				message: fmt.Sprintf("Cannot discard worktree changes while loop %s is awaiting_human; answer or cancel the HITL ask first, or retry without --discard-worktree-changes", loopID),
+			}
+		}
+		if err := h.assertLoopRetryPreconditions(ctx, services.Repositories, *freshLoop, nowISO); err != nil {
+			var typed apiError
+			if asAPIError(err, &typed) {
+				return retryLoopResponse{}, typed
+			}
+			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		preflightLoop = freshLoop
+
 		discardResult, discardErr := h.discardLoopWorktreeChanges(ctx, services, *preflightLoop)
 		if discardErr != nil {
 			var typed apiError

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -104,6 +104,11 @@ type Handler struct {
 	// between discard preflight and git reset, then the retry transaction
 	// conflicts after the worktree for the newly queued item was already wiped.
 	loopRetryLocks sync.Map // loopID -> *sync.Mutex
+	// loopTargetLocks serializes same-target active loop creation against
+	// discard+retry. Per-loop locks alone cannot block POST /loops (or workers)
+	// from creating a *different* active loop for the same target after discard
+	// preflight, which leaves a wiped worktree when the retry TX then conflicts.
+	loopTargetLocks sync.Map // project|type|targetKey -> *sync.Mutex
 }
 
 func NewHandler(context Context) *Handler {
@@ -152,6 +157,31 @@ func (h *Handler) lockLoopRetry(loopID string) func() {
 	mu := value.(*sync.Mutex)
 	mu.Lock()
 	return mu.Unlock
+}
+
+// lockLoopTarget acquires a mutex keyed by project+loopType+target so discard
+// retry and same-target active loop creation cannot race. Concurrent project-
+// scoped workers are exempt (assertUniqueActiveLoopCompat allows them).
+// Call order with lockLoopRetry: take the per-loop lock first, then the target
+// lock, to avoid deadlocks with start/reuse paths that only take the loop lock.
+func (h *Handler) lockLoopTarget(projectID string, loopType domain.LoopType, target domain.LoopTarget) func() {
+	if loopType == domain.LoopTypeWorker && target.TargetType == domain.LoopTargetTypeProject {
+		return func() {}
+	}
+	key := fmt.Sprintf("%s|%s|%s", strings.TrimSpace(projectID), loopType, loopTargetKeyCompat(target))
+	value, _ := h.loopTargetLocks.LoadOrStore(key, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+// lockLoopTargetForStatus is a no-op when the candidate status is not a
+// uniqueness-conflicting active status (create of failed/completed/etc.).
+func (h *Handler) lockLoopTargetForStatus(projectID string, loopType domain.LoopType, target domain.LoopTarget, status domain.LoopStatus) func() {
+	if !domain.IsConflictingActiveLoopStatus(status) {
+		return func() {}
+	}
+	return h.lockLoopTarget(projectID, loopType, target)
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -3516,6 +3546,15 @@ func (h *Handler) buildCreateLoopResponse(r *http.Request) (loopResponse, error)
 		return loopResponse{}, err
 	}
 
+	// Share the same-target lock with discard+retry so create cannot enqueue a
+	// new active loop for this target between discard preflight and requeue.
+	candidateStatusForLock := domain.LoopStatus(status)
+	if (domain.LoopType(loopType) == domain.LoopTypeReviewer || domain.LoopType(loopType) == domain.LoopTypeFixer || domain.LoopType(loopType) == domain.LoopTypeWorker) && candidateStatusForLock == domain.LoopStatusRunning {
+		candidateStatusForLock = domain.LoopStatusQueued
+	}
+	unlockTarget := h.lockLoopTargetForStatus(projectID, domain.LoopType(loopType), target, candidateStatusForLock)
+	defer unlockTarget()
+
 	record, err := storage.WithTransactionValue(r.Context(), services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
 		transactionRepos := storage.NewRepositories(tx)
 		_, err := requireActiveProjectRecord(r.Context(), transactionRepos.Projects, projectID)
@@ -3781,6 +3820,11 @@ func (h *Handler) buildWorkersCreateResponse(r *http.Request) (workerCreateRespo
 			defer unlock()
 		}
 	}
+	// New worker create (and non-reuse paths) share the same-target lock with
+	// discard+retry so a concurrent create for this target cannot pass unique
+	// checks after discard preflight and leave a wiped worktree.
+	unlockWorkerTarget := h.lockLoopTargetForStatus(projectID, domain.LoopTypeWorker, target, domain.LoopStatusQueued)
+	defer unlockWorkerTarget()
 
 	record, err := storage.WithTransactionValue(r.Context(), services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
 		repos := storage.NewRepositories(tx)
@@ -4237,6 +4281,11 @@ func (h *Handler) buildPlannersCreateResponse(r *http.Request) (plannerCreateRes
 	if err := h.validateManualHoldBypassForLoopTarget(r.Context(), projectID, domain.LoopTypePlanner, target, derefBool(body.Force)); err != nil {
 		return plannerCreateResponse{}, err
 	}
+
+	// Share same-target lock with discard+retry (planner discard is a no-op, but
+	// uniqueness races still matter for the requeue half of retry).
+	unlockPlannerTarget := h.lockLoopTargetForStatus(projectID, domain.LoopTypePlanner, target, domain.LoopStatusRunning)
+	defer unlockPlannerTarget()
 
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
 	targetID := fmt.Sprintf("issue:%s:%d", *repo, *issueNumber)
@@ -5103,6 +5152,28 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 		if preflightLoop == nil {
 			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
 		}
+		// Runtime HITL poll requeues awaiting_human loops without the API lock
+		// (hitl_github_poll / Feishu helpers). Refuse discard so a poll-delivered
+		// answer cannot requeue between preflight and git reset, wiping the
+		// worktree for the answered continuation when the retry TX then conflicts.
+		if preflightLoop.Status == string(domain.LoopStatusAwaitingHuman) {
+			return retryLoopResponse{}, apiError{
+				code:    pkgapi.ErrorCodeValidationFailed,
+				status:  http.StatusConflict,
+				message: fmt.Sprintf("Cannot discard worktree changes while loop %s is awaiting_human; answer or cancel the HITL ask first, or retry without --discard-worktree-changes", loopID),
+			}
+		}
+		// Hold the same-target create lock for the whole discard+requeue window
+		// so a concurrent POST /loops (or worker) create for this target cannot
+		// pass assertUniqueActiveLoopCompat after preflight and leave a wiped
+		// worktree when the retry TX conflicts.
+		target, targetErr := loopTargetFromRecordCompat(*preflightLoop)
+		if targetErr != nil {
+			return retryLoopResponse{}, targetErr
+		}
+		unlockTarget := h.lockLoopTarget(preflightLoop.ProjectID, domain.LoopType(preflightLoop.Type), target)
+		defer unlockTarget()
+
 		if err := h.assertLoopRetryPreconditions(ctx, services.Repositories, *preflightLoop, nowISO); err != nil {
 			var typed apiError
 			if asAPIError(err, &typed) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/nexu-io/looper/internal/agent"
@@ -97,12 +96,6 @@ type Handler struct {
 	now              func() time.Time
 	recoverySummary  func() any
 	webhookForwarder webhookforward.Forwarder
-	// loopTargetLocks serializes same-target active loop creation against
-	// discard+retry. Per-loop requeue locks alone cannot block POST /loops (or
-	// workers) from creating a *different* active loop for the same target after
-	// discard preflight, which leaves a wiped worktree when the retry TX then
-	// conflicts.
-	loopTargetLocks sync.Map // project|type|targetKey -> *sync.Mutex
 	// discardBeforeGitHook is test-only: invoked after discard preflight recheck
 	// and immediately before git reset/clean so tests can inject a requeue race
 	// that bypasses LockLoopRequeue (defense-in-depth for the pre-git recheck).
@@ -157,21 +150,16 @@ func (h *Handler) lockLoopRetry(loopID string) func() {
 	return looperdruntime.LockLoopRequeue(loopID)
 }
 
-// lockLoopTarget acquires a mutex keyed by project+loopType+target so discard
-// retry, same-target requeue (regular retry / start), and active loop creation
-// cannot race. Concurrent project-scoped workers are exempt
-// (assertUniqueActiveLoopCompat allows them).
+// lockLoopTarget acquires the process-wide same-target mutex so discard retry,
+// same-target requeue (regular retry / start), active loop creation, and runtime
+// HITL requeues cannot race. Concurrent project-scoped workers are exempt
+// (assertUniqueActiveLoopCompat allows them). Pull-request targets omit loop
+// type so fixer/reviewer/worker share one key for the shared PR worktree.
 // Call order with lockLoopRetry: take the per-loop lock first, then the target
 // lock, so retry/start/reuse paths share a consistent order with discard.
 func (h *Handler) lockLoopTarget(projectID string, loopType domain.LoopType, target domain.LoopTarget) func() {
-	if loopType == domain.LoopTypeWorker && target.TargetType == domain.LoopTargetTypeProject {
-		return func() {}
-	}
-	key := fmt.Sprintf("%s|%s|%s", strings.TrimSpace(projectID), loopType, loopTargetKeyCompat(target))
-	value, _ := h.loopTargetLocks.LoadOrStore(key, &sync.Mutex{})
-	mu := value.(*sync.Mutex)
-	mu.Lock()
-	return mu.Unlock
+	key := looperdruntime.LoopTargetGuardKey(projectID, string(loopType), string(target.TargetType), loopTargetKeyCompat(target))
+	return looperdruntime.LockLoopTarget(key)
 }
 
 // lockLoopTargetForStatus is a no-op when the candidate status is not a

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5238,9 +5238,10 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string,
 			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 		// Same-type uniqueness is not enough for discard: PR worktrees are shared
-		// across fixer/reviewer/worker. An already queued/running/human_takeover
-		// sibling is not held by the target mutex (that only serializes mutations),
-		// so refuse git reset/clean while any conflicting-active sibling owns the PR.
+		// across fixer/reviewer/worker. An already queued/running/waiting/
+		// human_takeover sibling is not held by the target mutex (that only
+		// serializes mutations), so refuse git reset/clean while any worktree-
+		// owning sibling holds the PR checkout.
 		if err := h.assertDiscardSharedPRWorktreeClear(ctx, services.Repositories, *preflightLoop); err != nil {
 			var typed apiError
 			if asAPIError(err, &typed) {
@@ -5787,12 +5788,12 @@ func rejectDiscardWhileParkedForHuman(status, loopID string) error {
 }
 
 // assertDiscardSharedPRWorktreeClear refuses discard when another loop of any
-// type already holds a conflicting-active status on the same pull-request
-// target. assertUniqueActiveLoopCompat only conflicts same-type loops; managed
-// PR worktrees (looper-fix-<project>-pr-N) are shared across fixer/reviewer/
-// worker, so a sibling that is queued, running, or human_takeover would lose
-// its checkout to git reset/clean. Non-PR targets and non-discard retries are
-// unaffected.
+// type already holds a worktree-owning status on the same pull-request target.
+// assertUniqueActiveLoopCompat only conflicts same-type loops; managed PR
+// worktrees (looper-fix-<project>-pr-N) are shared across fixer/reviewer/
+// worker, so a sibling that is queued, running, waiting, or human_takeover
+// would lose its checkout to git reset/clean. Non-PR targets and non-discard
+// retries are unaffected.
 func (h *Handler) assertDiscardSharedPRWorktreeClear(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord) error {
 	if loop.TargetType != string(domain.LoopTargetTypePullRequest) {
 		return nil
@@ -5804,9 +5805,18 @@ func (h *Handler) assertDiscardSharedPRWorktreeClear(ctx context.Context, repos 
 	return assertNoActiveSiblingPRWorktreeLoops(existing, loop)
 }
 
+// isDiscardBlockingSiblingPRStatus reports whether a sibling loop's status
+// still pins the shared PR managed worktree. Includes IsConflictingActiveLoopStatus
+// plus waiting: waiting is intentionally excluded from uniqueness conflicts
+// (reviewer debounce can sit waiting while another type fails), but cleanup and
+// worktree ownership still treat waiting as an active owner.
+func isDiscardBlockingSiblingPRStatus(status domain.LoopStatus) bool {
+	return domain.IsConflictingActiveLoopStatus(status) || status == domain.LoopStatusWaiting
+}
+
 // assertNoActiveSiblingPRWorktreeLoops reports a conflict when any other
-// conflicting-active loop on the same project+PR key exists, regardless of
-// loop type. Used only for destructive discard preflight.
+// worktree-owning loop on the same project+PR key exists, regardless of loop
+// type. Used only for destructive discard preflight.
 func assertNoActiveSiblingPRWorktreeLoops(existing []storage.LoopRecord, candidate storage.LoopRecord) error {
 	if candidate.TargetType != string(domain.LoopTargetTypePullRequest) {
 		return nil
@@ -5822,7 +5832,7 @@ func assertNoActiveSiblingPRWorktreeLoops(existing []storage.LoopRecord, candida
 		if loop.TargetType != string(domain.LoopTargetTypePullRequest) {
 			continue
 		}
-		if !domain.IsConflictingActiveLoopStatus(domain.LoopStatus(loop.Status)) {
+		if !isDiscardBlockingSiblingPRStatus(domain.LoopStatus(loop.Status)) {
 			continue
 		}
 		if loopTargetKeyFromRecordCompat(loop) != candidateKey {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -98,10 +98,11 @@ type Handler struct {
 	recoverySummary  func() any
 	webhookForwarder webhookforward.Forwarder
 	// loopRetryLocks serializes per-loop queue rearm paths that can race with
-	// discard+retry: explicit retry, and start/unpause requeue via
-	// mutateLoopStatus(Running). Without this, /loops/{id}/start can enqueue
+	// discard+retry: explicit retry, start/unpause requeue via
+	// mutateLoopStatus(Running), and issue-worker reuse via POST /workers
+	// (resumeReusableWorkerLoopCompat). Without this, those paths can enqueue
 	// between discard preflight and git reset, then the retry transaction
-	// conflicts after the worktree for the start-created item was already wiped.
+	// conflicts after the worktree for the newly queued item was already wiped.
 	loopRetryLocks sync.Map // loopID -> *sync.Mutex
 }
 
@@ -142,9 +143,10 @@ func NewHandler(context Context) *Handler {
 	}
 }
 
-// lockLoopRetry acquires a per-loop mutex shared by retryLoop and start/requeue
-// (mutateLoopStatus → Running) so destructive discard cannot interleave with a
-// concurrent operator start that requeues from the latest failed item.
+// lockLoopRetry acquires a per-loop mutex shared by retryLoop, start/requeue
+// (mutateLoopStatus → Running), and issue-worker reuse (POST /workers) so
+// destructive discard cannot interleave with a concurrent requeue that creates
+// replacement work between preflight and git reset.
 func (h *Handler) lockLoopRetry(loopID string) func() {
 	value, _ := h.loopRetryLocks.LoadOrStore(loopID, &sync.Mutex{})
 	mu := value.(*sync.Mutex)
@@ -3762,6 +3764,23 @@ func (h *Handler) buildWorkersCreateResponse(r *http.Request) (workerCreateRespo
 	}
 	metadataJSON := string(payloadJSONBytes)
 	reusedWorkerLoop := false
+
+	// Issue-worker reuse enqueues the existing loop (same as start requeue).
+	// Take the shared per-loop retry lock before the TX so discard+retry cannot
+	// wipe the managed worktree after reuse preflight/enqueue races in.
+	// Pre-scan is best-effort identity for the lock; the TX re-evaluates reuse.
+	if issueNumber != nil && requestedIssueTarget != nil {
+		existing, listErr := services.Repositories.Loops.List(r.Context())
+		if listErr != nil {
+			return workerCreateResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: listErr.Error()}
+		}
+		if existingLoop, _, ok, reuseErr := reusableWorkerLoopForIssueRequestCompat(existing, projectID, *requestedIssueTarget, target); reuseErr != nil {
+			return workerCreateResponse{}, reuseErr
+		} else if ok {
+			unlock := h.lockLoopRetry(existingLoop.ID)
+			defer unlock()
+		}
+	}
 
 	record, err := storage.WithTransactionValue(r.Context(), services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
 		repos := storage.NewRepositories(tx)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -160,10 +160,11 @@ func (h *Handler) lockLoopRetry(loopID string) func() {
 }
 
 // lockLoopTarget acquires a mutex keyed by project+loopType+target so discard
-// retry and same-target active loop creation cannot race. Concurrent project-
-// scoped workers are exempt (assertUniqueActiveLoopCompat allows them).
+// retry, same-target requeue (regular retry / start), and active loop creation
+// cannot race. Concurrent project-scoped workers are exempt
+// (assertUniqueActiveLoopCompat allows them).
 // Call order with lockLoopRetry: take the per-loop lock first, then the target
-// lock, to avoid deadlocks with start/reuse paths that only take the loop lock.
+// lock, so retry/start/reuse paths share a consistent order with discard.
 func (h *Handler) lockLoopTarget(projectID string, loopType domain.LoopType, target domain.LoopTarget) func() {
 	if loopType == domain.LoopTypeWorker && target.TargetType == domain.LoopTargetTypeProject {
 		return func() {}
@@ -4611,14 +4612,36 @@ func (h *Handler) resolveLoop(ctx context.Context, selector string) (storage.Loo
 
 func (h *Handler) mutateLoopStatus(ctx context.Context, loopID string, status domain.LoopStatus) (loopResponse, error) {
 	// Running requeues from the latest failed/cancelled/manual_intervention item
-	// and can start replacement work. Share the per-loop retry lock so this cannot
-	// race discard+retry between preflight and destructive git reset.
+	// and can start replacement work. Share the per-loop retry lock and the
+	// same-target lock so this cannot race discard+retry between preflight and
+	// destructive git reset — including when the requeued loop is a *different*
+	// failed loop for the same PR/issue target.
 	if status == domain.LoopStatusRunning {
 		unlock := h.lockLoopRetry(loopID)
 		defer unlock()
 	}
 
 	services := h.context.Runtime.Services()
+	if status == domain.LoopStatusRunning {
+		if services.Repositories == nil || services.Coordinator == nil {
+			return loopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
+		}
+		// Resolve target outside the TX so we can hold the target mutex for the
+		// whole requeue window (same key as discard+retry / loop create).
+		preflightLoop, err := services.Repositories.Loops.GetByID(ctx, loopID)
+		if err != nil {
+			return loopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		if preflightLoop != nil {
+			target, targetErr := loopTargetFromRecordCompat(*preflightLoop)
+			if targetErr != nil {
+				return loopResponse{}, targetErr
+			}
+			unlockTarget := h.lockLoopTarget(preflightLoop.ProjectID, domain.LoopType(preflightLoop.Type), target)
+			defer unlockTarget()
+		}
+	}
+
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
 	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
 		repos := storage.NewRepositories(tx)
@@ -5134,7 +5157,29 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 	defer unlock()
 
 	services := h.context.Runtime.Services()
+	if services.Repositories == nil || services.Coordinator == nil {
+		return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
+	}
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
+
+	// Always resolve the loop target and hold the same-target lock for the whole
+	// retry window — not only when discarding. Regular retry and /start for a
+	// *different* failed loop on this target would otherwise create an active
+	// queue item after discard preflight and before git reset, then the discard
+	// TX would conflict after the worktree was already wiped.
+	preflightLoop, err := services.Repositories.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	if preflightLoop == nil {
+		return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
+	}
+	target, targetErr := loopTargetFromRecordCompat(*preflightLoop)
+	if targetErr != nil {
+		return retryLoopResponse{}, targetErr
+	}
+	unlockTarget := h.lockLoopTarget(preflightLoop.ProjectID, domain.LoopType(preflightLoop.Type), target)
+	defer unlockTarget()
 
 	// Opt-in discard runs before requeue so git mutation stays outside the
 	// queue transaction. Every non-mutating retry blocker must pass first so a
@@ -5142,16 +5187,6 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 	// without creating a replacement queue item.
 	var worktreeDiscard *worktreeDiscardResult
 	if discardWorktreeChanges {
-		if services.Repositories == nil || services.Coordinator == nil {
-			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
-		}
-		preflightLoop, err := services.Repositories.Loops.GetByID(ctx, loopID)
-		if err != nil {
-			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
-		}
-		if preflightLoop == nil {
-			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
-		}
 		// Runtime HITL poll requeues awaiting_human loops without the API lock
 		// (hitl_github_poll / Feishu helpers). Refuse discard so a poll-delivered
 		// answer cannot requeue between preflight and git reset, wiping the
@@ -5163,16 +5198,6 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 				message: fmt.Sprintf("Cannot discard worktree changes while loop %s is awaiting_human; answer or cancel the HITL ask first, or retry without --discard-worktree-changes", loopID),
 			}
 		}
-		// Hold the same-target create lock for the whole discard+requeue window
-		// so a concurrent POST /loops (or worker) create for this target cannot
-		// pass assertUniqueActiveLoopCompat after preflight and leave a wiped
-		// worktree when the retry TX conflicts.
-		target, targetErr := loopTargetFromRecordCompat(*preflightLoop)
-		if targetErr != nil {
-			return retryLoopResponse{}, targetErr
-		}
-		unlockTarget := h.lockLoopTarget(preflightLoop.ProjectID, domain.LoopType(preflightLoop.Type), target)
-		defer unlockTarget()
 
 		if err := h.assertLoopRetryPreconditions(ctx, services.Repositories, *preflightLoop, nowISO); err != nil {
 			var typed apiError

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -97,9 +97,11 @@ type Handler struct {
 	now              func() time.Time
 	recoverySummary  func() any
 	webhookForwarder webhookforward.Forwarder
-	// loopRetryLocks serializes retry (especially discard+retry) per loop so two
-	// concurrent operator retries cannot discard after another has already
-	// requeued/started work for the same loop.
+	// loopRetryLocks serializes per-loop queue rearm paths that can race with
+	// discard+retry: explicit retry, and start/unpause requeue via
+	// mutateLoopStatus(Running). Without this, /loops/{id}/start can enqueue
+	// between discard preflight and git reset, then the retry transaction
+	// conflicts after the worktree for the start-created item was already wiped.
 	loopRetryLocks sync.Map // loopID -> *sync.Mutex
 }
 
@@ -140,8 +142,9 @@ func NewHandler(context Context) *Handler {
 	}
 }
 
-// lockLoopRetry acquires a per-loop mutex for the duration of retryLoop so
-// destructive discard and requeue cannot interleave across concurrent requests.
+// lockLoopRetry acquires a per-loop mutex shared by retryLoop and start/requeue
+// (mutateLoopStatus → Running) so destructive discard cannot interleave with a
+// concurrent operator start that requeues from the latest failed item.
 func (h *Handler) lockLoopRetry(loopID string) func() {
 	value, _ := h.loopRetryLocks.LoadOrStore(loopID, &sync.Mutex{})
 	mu := value.(*sync.Mutex)
@@ -4539,6 +4542,14 @@ func (h *Handler) resolveLoop(ctx context.Context, selector string) (storage.Loo
 }
 
 func (h *Handler) mutateLoopStatus(ctx context.Context, loopID string, status domain.LoopStatus) (loopResponse, error) {
+	// Running requeues from the latest failed/cancelled/manual_intervention item
+	// and can start replacement work. Share the per-loop retry lock so this cannot
+	// race discard+retry between preflight and destructive git reset.
+	if status == domain.LoopStatusRunning {
+		unlock := h.lockLoopRetry(loopID)
+		defer unlock()
+	}
+
 	services := h.context.Runtime.Services()
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
 	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
@@ -5048,8 +5059,9 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 	}
 	discardWorktreeChanges := body.DiscardWorktreeChanges != nil && *body.DiscardWorktreeChanges
 
-	// Serialize per-loop retry so discard cannot race another retry's requeue or
-	// a scheduler-started run for the same loop between preflight and reset.
+	// Serialize per-loop retry with start/requeue so discard cannot race another
+	// retry or /loops/{id}/start that enqueues replacement work between preflight
+	// and reset (or a scheduler-started run for that replacement).
 	unlock := h.lockLoopRetry(loopID)
 	defer unlock()
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5224,12 +5224,10 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string,
 		// (hitl_github_poll / Feishu helpers). Refuse discard so a poll-delivered
 		// answer cannot requeue between preflight and git reset, wiping the
 		// worktree for the answered continuation when the retry TX then conflicts.
-		if preflightLoop.Status == string(domain.LoopStatusAwaitingHuman) {
-			return retryLoopResponse{}, apiError{
-				code:    pkgapi.ErrorCodeValidationFailed,
-				status:  http.StatusConflict,
-				message: fmt.Sprintf("Cannot discard worktree changes while loop %s is awaiting_human; answer or cancel the HITL ask first, or retry without --discard-worktree-changes", loopID),
-			}
+		// human_takeover pins the same worktree for interactive human edits;
+		// /handback already rejects discard, and direct /retry must match that.
+		if err := rejectDiscardWhileParkedForHuman(preflightLoop.Status, loopID); err != nil {
+			return retryLoopResponse{}, err
 		}
 
 		if err := h.assertLoopRetryPreconditions(ctx, services.Repositories, *preflightLoop, nowISO); err != nil {
@@ -5255,12 +5253,8 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string,
 		if freshLoop == nil {
 			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
 		}
-		if freshLoop.Status == string(domain.LoopStatusAwaitingHuman) {
-			return retryLoopResponse{}, apiError{
-				code:    pkgapi.ErrorCodeValidationFailed,
-				status:  http.StatusConflict,
-				message: fmt.Sprintf("Cannot discard worktree changes while loop %s is awaiting_human; answer or cancel the HITL ask first, or retry without --discard-worktree-changes", loopID),
-			}
+		if err := rejectDiscardWhileParkedForHuman(freshLoop.Status, loopID); err != nil {
+			return retryLoopResponse{}, err
 		}
 		if err := h.assertLoopRetryPreconditions(ctx, services.Repositories, *freshLoop, nowISO); err != nil {
 			var typed apiError
@@ -5741,6 +5735,29 @@ func isTerminalReviewerLoopRecord(loop storage.LoopRecord) bool {
 	loopMeta, _ := metadata["loop"].(map[string]any)
 	status, _ := loopMeta["status"].(string)
 	return status == "terminated" || status == "stopped" || status == "failed"
+}
+
+// rejectDiscardWhileParkedForHuman refuses discard+retry when the loop is
+// parked for a human so interactive worktree edits stay intact. awaiting_human
+// is blocked against HITL poll requeue races; human_takeover matches /handback
+// which never honors discardWorktreeChanges.
+func rejectDiscardWhileParkedForHuman(status, loopID string) error {
+	switch status {
+	case string(domain.LoopStatusAwaitingHuman):
+		return apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusConflict,
+			message: fmt.Sprintf("Cannot discard worktree changes while loop %s is awaiting_human; answer or cancel the HITL ask first, or retry without --discard-worktree-changes", loopID),
+		}
+	case string(domain.LoopStatusHumanTakeover):
+		return apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusConflict,
+			message: fmt.Sprintf("Cannot discard worktree changes while loop %s is human_takeover; hand back without --discard-worktree-changes first, or retry without discard", loopID),
+		}
+	default:
+		return nil
+	}
 }
 
 // assertLoopRetryPreconditions validates non-mutating retry blockers that must

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nexu-io/looper/internal/agent"
@@ -96,6 +97,10 @@ type Handler struct {
 	now              func() time.Time
 	recoverySummary  func() any
 	webhookForwarder webhookforward.Forwarder
+	// loopRetryLocks serializes retry (especially discard+retry) per loop so two
+	// concurrent operator retries cannot discard after another has already
+	// requeued/started work for the same loop.
+	loopRetryLocks sync.Map // loopID -> *sync.Mutex
 }
 
 func NewHandler(context Context) *Handler {
@@ -133,6 +138,15 @@ func NewHandler(context Context) *Handler {
 		recoverySummary:  recoverySummary,
 		webhookForwarder: forwarder,
 	}
+}
+
+// lockLoopRetry acquires a per-loop mutex for the duration of retryLoop so
+// destructive discard and requeue cannot interleave across concurrent requests.
+func (h *Handler) lockLoopRetry(loopID string) func() {
+	value, _ := h.loopRetryLocks.LoadOrStore(loopID, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -5033,6 +5047,11 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string)
 		return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: "resetAttempts=false is not supported for explicit operator retry"}
 	}
 	discardWorktreeChanges := body.DiscardWorktreeChanges != nil && *body.DiscardWorktreeChanges
+
+	// Serialize per-loop retry so discard cannot race another retry's requeue or
+	// a scheduler-started run for the same loop between preflight and reset.
+	unlock := h.lockLoopRetry(loopID)
+	defer unlock()
 
 	services := h.context.Runtime.Services()
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -4269,8 +4269,8 @@ func (h *Handler) buildPlannersCreateResponse(r *http.Request) (plannerCreateRes
 		return plannerCreateResponse{}, err
 	}
 
-	// Share same-target lock with discard+retry (planner discard is a no-op, but
-	// uniqueness races still matter for the requeue half of retry).
+	// Share same-target lock with discard+retry so planner uniqueness races
+	// cannot interleave with requeue while discard mutates the worktree.
 	unlockPlannerTarget := h.lockLoopTargetForStatus(projectID, domain.LoopTypePlanner, target, domain.LoopStatusRunning)
 	defer unlockPlannerTarget()
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -97,22 +97,15 @@ type Handler struct {
 	now              func() time.Time
 	recoverySummary  func() any
 	webhookForwarder webhookforward.Forwarder
-	// loopRetryLocks serializes per-loop queue rearm paths that can race with
-	// discard+retry: explicit retry, start/unpause requeue via
-	// mutateLoopStatus(Running), and issue-worker reuse via POST /workers
-	// (resumeReusableWorkerLoopCompat). Without this, those paths can enqueue
-	// between discard preflight and git reset, then the retry transaction
-	// conflicts after the worktree for the newly queued item was already wiped.
-	loopRetryLocks sync.Map // loopID -> *sync.Mutex
 	// loopTargetLocks serializes same-target active loop creation against
-	// discard+retry. Per-loop locks alone cannot block POST /loops (or workers)
-	// from creating a *different* active loop for the same target after discard
-	// preflight, which leaves a wiped worktree when the retry TX then conflicts.
+	// discard+retry. Per-loop requeue locks alone cannot block POST /loops (or
+	// workers) from creating a *different* active loop for the same target after
+	// discard preflight, which leaves a wiped worktree when the retry TX then
+	// conflicts.
 	loopTargetLocks sync.Map // project|type|targetKey -> *sync.Mutex
 	// discardBeforeGitHook is test-only: invoked after discard preflight recheck
-	// and immediately before git reset/clean so tests can inject a runtime-style
-	// requeue race (Feishu/GitHub free-text message enqueue) without holding the
-	// API locks.
+	// and immediately before git reset/clean so tests can inject a requeue race
+	// that bypasses LockLoopRequeue (defense-in-depth for the pre-git recheck).
 	discardBeforeGitHook func(loopID string)
 }
 
@@ -153,15 +146,15 @@ func NewHandler(context Context) *Handler {
 	}
 }
 
-// lockLoopRetry acquires a per-loop mutex shared by retryLoop, start/requeue
-// (mutateLoopStatus → Running), and issue-worker reuse (POST /workers) so
-// destructive discard cannot interleave with a concurrent requeue that creates
-// replacement work between preflight and git reset.
+// lockLoopRetry acquires the process-wide per-loop requeue mutex shared by
+// retryLoop, start/requeue (mutateLoopStatus → Running), issue-worker reuse
+// (POST /workers), and runtime HITL free-text / answer requeues
+// (looperdruntime.LockLoopRequeue). Without this shared exclusion, runtime
+// inbox delivery can requeue after discard preflight and before git reset,
+// wiping the worktree for the message-driven continuation when the retry TX
+// then conflicts.
 func (h *Handler) lockLoopRetry(loopID string) func() {
-	value, _ := h.loopRetryLocks.LoadOrStore(loopID, &sync.Mutex{})
-	mu := value.(*sync.Mutex)
-	mu.Lock()
-	return mu.Unlock
+	return looperdruntime.LockLoopRequeue(loopID)
 }
 
 // lockLoopTarget acquires a mutex keyed by project+loopType+target so discard
@@ -5259,11 +5252,11 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string,
 			return retryLoopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 
-		// Recheck immediately before git mutation. Feishu/GitHub free-text inbox
-		// can call enqueueHumanMessageToLoop for paused/waiting loops without
-		// these handler locks, requeueing cancelled work after the first preflight
-		// and before reset; without this second check the retry TX would conflict
-		// after the message-driven continuation's worktree was already wiped.
+		// Recheck immediately before git mutation as defense in depth. Runtime
+		// free-text enqueue now shares LockLoopRequeue with this path, so the
+		// common race is serialized; this snapshot still catches any unlocked
+		// requeue injected under discardBeforeGitHook in tests (or future
+		// callers that forget the shared guard).
 		if h.discardBeforeGitHook != nil {
 			h.discardBeforeGitHook(loopID)
 		}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5791,9 +5791,9 @@ func rejectDiscardWhileParkedForHuman(status, loopID string) error {
 // type already holds a worktree-owning status on the same pull-request target.
 // assertUniqueActiveLoopCompat only conflicts same-type loops; managed PR
 // worktrees (looper-fix-<project>-pr-N) are shared across fixer/reviewer/
-// worker, so a sibling that is queued, running, waiting, or human_takeover
-// would lose its checkout to git reset/clean. Non-PR targets and non-discard
-// retries are unaffected.
+// worker, so a sibling that is queued, running, waiting, failed, interrupted,
+// or human_takeover would lose its checkout to git reset/clean. Non-PR targets
+// and non-discard retries are unaffected.
 func (h *Handler) assertDiscardSharedPRWorktreeClear(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord) error {
 	if loop.TargetType != string(domain.LoopTargetTypePullRequest) {
 		return nil
@@ -5807,11 +5807,16 @@ func (h *Handler) assertDiscardSharedPRWorktreeClear(ctx context.Context, repos 
 
 // isDiscardBlockingSiblingPRStatus reports whether a sibling loop's status
 // still pins the shared PR managed worktree. Includes IsConflictingActiveLoopStatus
-// plus waiting: waiting is intentionally excluded from uniqueness conflicts
-// (reviewer debounce can sit waiting while another type fails), but cleanup and
-// worktree ownership still treat waiting as an active owner.
+// plus waiting/failed/interrupted: those are intentionally excluded from
+// uniqueness conflicts (reviewer debounce can sit waiting while another type
+// fails; failed/interrupted are retryable terminals), but worktree cleanup
+// (protectsLoopStatus) and ownership still treat them as active owners whose
+// checkpointed local state must not be wiped by a sibling discard retry.
 func isDiscardBlockingSiblingPRStatus(status domain.LoopStatus) bool {
-	return domain.IsConflictingActiveLoopStatus(status) || status == domain.LoopStatusWaiting
+	if domain.IsConflictingActiveLoopStatus(status) || status == domain.LoopStatusWaiting {
+		return true
+	}
+	return status == domain.LoopStatusFailed || status == domain.LoopStatusInterrupted
 }
 
 // assertNoActiveSiblingPRWorktreeLoops reports a conflict when any other

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5310,6 +5310,14 @@ func (h *Handler) retryLoop(ctx context.Context, r *http.Request, loopID string,
 		if err := h.assertLoopRetryPreconditions(ctx, repos, *loop, nowISO); err != nil {
 			return retryResult{}, err
 		}
+		// When discard already mutated the worktree, re-check shared-PR siblings
+		// inside the TX so a concurrent runtime requeue/create that raced past
+		// preflight cannot leave both an active sibling and a successful retry.
+		if discardWorktreeChanges {
+			if err := h.assertDiscardSharedPRWorktreeClear(ctx, repos, *loop); err != nil {
+				return retryResult{}, err
+			}
+		}
 
 		target, targetErr := loopTargetFromRecordCompat(*loop)
 		if targetErr != nil {

--- a/internal/api/loop_retry_discard.go
+++ b/internal/api/loop_retry_discard.go
@@ -392,8 +392,11 @@ func findProjectWorktreeByBranch(ctx context.Context, repos *storage.Repositorie
 }
 
 // worktreeBelongsToPR reports whether a worktree row is owned by the given PR.
-// True when the directory embeds pr-<N>, the branch is bare pr-<N> (push-existing),
-// or the path embeds no PR marker at all (legacy non-PR-named checkouts).
+// True only when ownership is proven: the directory embeds pr-<N>, or the branch
+// is bare pr-<N> (push-existing). Untagged paths are refused when prNumber is
+// known — RestoreWorktree can adopt a branch checkout without a pr-<N> path, and
+// accepting those would let two PRs that share a head branch name discard each
+// other's untagged worktree.
 func worktreeBelongsToPR(record storage.WorktreeRecord, prNumber int64) bool {
 	if prNumber <= 0 {
 		return true
@@ -404,11 +407,8 @@ func worktreeBelongsToPR(record storage.WorktreeRecord, prNumber int64) bool {
 	if strings.TrimSpace(record.Branch) == fmt.Sprintf("pr-%d", prNumber) {
 		return true
 	}
-	if embedded, ok := worktreePathEmbeddedPR(record.WorktreePath); ok && embedded != prNumber {
-		return false
-	}
-	// No conflicting PR marker in the path — accept (legacy / non-PR path shapes).
-	return !worktreePathHasPRMarker(record.WorktreePath)
+	// Known PR scope: untagged or differently-tagged paths cannot prove ownership.
+	return false
 }
 
 // findProjectWorktreeByPR finds the active managed worktree whose path embeds

--- a/internal/api/loop_retry_discard.go
+++ b/internal/api/loop_retry_discard.go
@@ -27,9 +27,10 @@ type worktreeDiscardResult struct {
 }
 
 type checkpointWorktreeRef struct {
-	ID     string `json:"id,omitempty"`
-	Path   string `json:"path,omitempty"`
-	Branch string `json:"branch,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Branch   string `json:"branch,omitempty"`
+	PRNumber int64  `json:"prNumber,omitempty"`
 }
 
 // checkpointWithWorktree extracts worktree location hints from a run checkpoint.
@@ -38,6 +39,8 @@ type checkpointWorktreeRef struct {
 // (fixer). Those branch hints still resolve the managed worktree row.
 // For push-existing workers, work.branch may be empty while the worktree was
 // created under pr-<PRNumber>; executionMode + prNumber recover that branch.
+// PRNumber (from work.prNumber or detail.prNumber) disambiguates branch-only
+// lookups when multiple PRs share a head branch name.
 type checkpointWithWorktree struct {
 	Worktree *checkpointWorktreeRef `json:"worktree,omitempty"`
 	Work     *struct {
@@ -47,6 +50,7 @@ type checkpointWithWorktree struct {
 	} `json:"work,omitempty"`
 	Detail *struct {
 		HeadRefName string `json:"headRefName,omitempty"`
+		PRNumber    int64  `json:"prNumber,omitempty"`
 	} `json:"detail,omitempty"`
 }
 
@@ -191,20 +195,22 @@ func resolveManagedWorktreeForLoop(ctx context.Context, repos *storage.Repositor
 		fromCheckpoint = parseCheckpointWorktree(latestRun.CheckpointJSON)
 	}
 
+	// Prefer loop.PRNumber, then checkpoint PR hints. GitHub head branch names are
+	// not unique across forks/PRs; CreateWorktree embeds pr-<N> in the directory.
+	prNumber := int64(0)
+	if loop.PRNumber != nil && *loop.PRNumber > 0 {
+		prNumber = *loop.PRNumber
+	}
+	if prNumber == 0 && fromCheckpoint != nil && fromCheckpoint.PRNumber > 0 {
+		prNumber = fromCheckpoint.PRNumber
+	}
+
 	var record *storage.WorktreeRecord
 	if fromCheckpoint != nil {
 		if id := strings.TrimSpace(fromCheckpoint.ID); id != "" {
 			record, err = repos.Worktrees.GetByID(ctx, id)
 			if err != nil {
 				return nil, err
-			}
-		}
-		if record == nil {
-			if branch := strings.TrimSpace(fromCheckpoint.Branch); branch != "" {
-				record, err = repos.Worktrees.GetByBranch(ctx, project.ID, branch)
-				if err != nil {
-					return nil, err
-				}
 			}
 		}
 		if record == nil {
@@ -215,6 +221,22 @@ func resolveManagedWorktreeForLoop(ctx context.Context, repos *storage.Repositor
 					return nil, err
 				}
 			}
+		}
+		if record == nil {
+			if branch := strings.TrimSpace(fromCheckpoint.Branch); branch != "" {
+				record, err = findProjectWorktreeByBranch(ctx, repos, project.ID, branch, prNumber)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	// When checkpoint only has a branch (or none) but the loop is PR-scoped,
+	// resolve via PR-tagged managed path so we never pick a sibling PR's row.
+	if record == nil && prNumber > 0 {
+		record, err = findProjectWorktreeByPR(ctx, repos, project.ID, prNumber)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -279,6 +301,7 @@ func parseCheckpointWorktree(raw *string) *checkpointWorktreeRef {
 	path := ""
 	branch := ""
 	id := ""
+	prNumber := int64(0)
 	if checkpoint.Worktree != nil {
 		path = strings.TrimSpace(checkpoint.Worktree.Path)
 		branch = strings.TrimSpace(checkpoint.Worktree.Branch)
@@ -287,7 +310,13 @@ func parseCheckpointWorktree(raw *string) *checkpointWorktreeRef {
 	// Dirty prepare-worktree often aborts before checkpoint.worktree is set.
 	// Prefer an explicit worktree.branch, then worker work.branch, then
 	// push-existing pr-<N> (CreateWorktree branch when work.branch is empty),
-	// then fixer detail.headRefName so GetByBranch can still locate the row.
+	// then fixer detail.headRefName so branch/PR lookup can still locate the row.
+	if checkpoint.Work != nil && checkpoint.Work.PRNumber > 0 {
+		prNumber = checkpoint.Work.PRNumber
+	}
+	if prNumber == 0 && checkpoint.Detail != nil && checkpoint.Detail.PRNumber > 0 {
+		prNumber = checkpoint.Detail.PRNumber
+	}
 	if branch == "" && checkpoint.Work != nil {
 		branch = strings.TrimSpace(checkpoint.Work.Branch)
 		if branch == "" &&
@@ -300,10 +329,10 @@ func parseCheckpointWorktree(raw *string) *checkpointWorktreeRef {
 	if branch == "" && checkpoint.Detail != nil {
 		branch = strings.TrimSpace(checkpoint.Detail.HeadRefName)
 	}
-	if path == "" && branch == "" && id == "" {
+	if path == "" && branch == "" && id == "" && prNumber == 0 {
 		return nil
 	}
-	return &checkpointWorktreeRef{ID: id, Path: path, Branch: branch}
+	return &checkpointWorktreeRef{ID: id, Path: path, Branch: branch, PRNumber: prNumber}
 }
 
 func findProjectWorktreeByPath(ctx context.Context, repos *storage.Repositories, projectID, path string) (*storage.WorktreeRecord, error) {
@@ -320,6 +349,157 @@ func findProjectWorktreeByPath(ctx context.Context, repos *storage.Repositories,
 		}
 	}
 	return nil, nil
+}
+
+// findProjectWorktreeByBranch resolves an active worktree row for project+branch.
+// When prNumber is known, refuse rows whose CreateWorktree directory embeds a
+// different pr-<M>: GitHub head branch names are not unique across PRs, and the
+// unique (project_id, branch) index means the stored row may belong to a sibling
+// PR that last claimed the branch. Prefer path/branch markers for pr-<N>.
+func findProjectWorktreeByBranch(ctx context.Context, repos *storage.Repositories, projectID, branch string, prNumber int64) (*storage.WorktreeRecord, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return nil, nil
+	}
+	items, err := repos.Worktrees.ListByProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	var matches []storage.WorktreeRecord
+	for i := range items {
+		if items[i].CleanedAt != nil {
+			continue
+		}
+		if strings.TrimSpace(items[i].Branch) != branch {
+			continue
+		}
+		matches = append(matches, items[i])
+	}
+	if prNumber <= 0 {
+		return pickUniqueActiveWorktree(matches), nil
+	}
+	var preferred []storage.WorktreeRecord
+	for i := range matches {
+		if worktreeBelongsToPR(matches[i], prNumber) {
+			preferred = append(preferred, matches[i])
+		}
+	}
+	if len(preferred) > 0 {
+		return pickUniqueActiveWorktree(preferred), nil
+	}
+	// Known PR but no row clearly owned by it: do not discard a sibling PR path.
+	return nil, nil
+}
+
+// worktreeBelongsToPR reports whether a worktree row is owned by the given PR.
+// True when the directory embeds pr-<N>, the branch is bare pr-<N> (push-existing),
+// or the path embeds no PR marker at all (legacy non-PR-named checkouts).
+func worktreeBelongsToPR(record storage.WorktreeRecord, prNumber int64) bool {
+	if prNumber <= 0 {
+		return true
+	}
+	if worktreePathMatchesPR(record.WorktreePath, prNumber) {
+		return true
+	}
+	if strings.TrimSpace(record.Branch) == fmt.Sprintf("pr-%d", prNumber) {
+		return true
+	}
+	if embedded, ok := worktreePathEmbeddedPR(record.WorktreePath); ok && embedded != prNumber {
+		return false
+	}
+	// No conflicting PR marker in the path — accept (legacy / non-PR path shapes).
+	return !worktreePathHasPRMarker(record.WorktreePath)
+}
+
+// findProjectWorktreeByPR finds the active managed worktree whose path embeds
+// pr-<N>, used when branch lookup is empty or ambiguous but the loop is PR-scoped.
+func findProjectWorktreeByPR(ctx context.Context, repos *storage.Repositories, projectID string, prNumber int64) (*storage.WorktreeRecord, error) {
+	if prNumber <= 0 {
+		return nil, nil
+	}
+	items, err := repos.Worktrees.ListByProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	var matches []storage.WorktreeRecord
+	for i := range items {
+		if items[i].CleanedAt != nil {
+			continue
+		}
+		if worktreePathMatchesPR(items[i].WorktreePath, prNumber) {
+			matches = append(matches, items[i])
+		}
+	}
+	return pickUniqueActiveWorktree(matches), nil
+}
+
+func worktreePathMatchesPR(worktreePath string, prNumber int64) bool {
+	if prNumber <= 0 {
+		return false
+	}
+	base := filepath.Base(strings.TrimSpace(worktreePath))
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return false
+	}
+	// CreateWorktree dirs: looper-fix-<project>-pr-<N>[ -detached]
+	// Worker push-existing may also use bare pr-<N>.
+	marker := fmt.Sprintf("-pr-%d", prNumber)
+	if strings.HasSuffix(base, marker) || strings.HasSuffix(base, marker+"-detached") {
+		return true
+	}
+	return base == fmt.Sprintf("pr-%d", prNumber)
+}
+
+func worktreePathHasPRMarker(worktreePath string) bool {
+	_, ok := worktreePathEmbeddedPR(worktreePath)
+	return ok
+}
+
+// worktreePathEmbeddedPR extracts pr-<N> from a CreateWorktree directory base name.
+func worktreePathEmbeddedPR(worktreePath string) (int64, bool) {
+	base := filepath.Base(strings.TrimSpace(worktreePath))
+	if base == "" || base == "." {
+		return 0, false
+	}
+	// Bare pr-<N>
+	var bare int64
+	if _, err := fmt.Sscanf(base, "pr-%d", &bare); err == nil && bare > 0 && base == fmt.Sprintf("pr-%d", bare) {
+		return bare, true
+	}
+	// …-pr-<N> or …-pr-<N>-detached
+	const marker = "-pr-"
+	idx := strings.LastIndex(base, marker)
+	if idx < 0 {
+		return 0, false
+	}
+	rest := base[idx+len(marker):]
+	rest = strings.TrimSuffix(rest, "-detached")
+	var n int64
+	if _, err := fmt.Sscanf(rest, "%d", &n); err != nil || n <= 0 {
+		return 0, false
+	}
+	if rest != fmt.Sprintf("%d", n) {
+		return 0, false
+	}
+	return n, true
+}
+
+func pickUniqueActiveWorktree(matches []storage.WorktreeRecord) *storage.WorktreeRecord {
+	switch len(matches) {
+	case 0:
+		return nil
+	case 1:
+		return &matches[0]
+	default:
+		// Prefer most recently updated among remaining PR-scoped matches.
+		best := 0
+		for i := 1; i < len(matches); i++ {
+			if matches[i].UpdatedAt > matches[best].UpdatedAt {
+				best = i
+			}
+		}
+		return &matches[best]
+	}
 }
 
 func projectWorktreeRoot(project storage.ProjectRecord) (string, error) {

--- a/internal/api/loop_retry_discard.go
+++ b/internal/api/loop_retry_discard.go
@@ -1,0 +1,316 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/domain"
+	"github.com/nexu-io/looper/internal/eventlog"
+	gitinfra "github.com/nexu-io/looper/internal/infra/git"
+	looperdruntime "github.com/nexu-io/looper/internal/runtime"
+	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worktreesafety"
+	pkgapi "github.com/nexu-io/looper/pkg/api"
+)
+
+type worktreeDiscardResult struct {
+	WorktreePath *string `json:"worktreePath,omitempty"`
+	Discarded    bool    `json:"discarded"`
+	NoOp         bool    `json:"noOp"`
+	Reason       string  `json:"reason,omitempty"`
+}
+
+type checkpointWorktreeRef struct {
+	ID     string `json:"id,omitempty"`
+	Path   string `json:"path,omitempty"`
+	Branch string `json:"branch,omitempty"`
+}
+
+type checkpointWithWorktree struct {
+	Worktree *checkpointWorktreeRef `json:"worktree,omitempty"`
+}
+
+// discardLoopWorktreeChanges performs the operator opt-in dirty-worktree discard
+// for loop retry. Planner loops and loops without a resolvable managed worktree
+// are no-ops. Active run/queue must already be refused by the caller.
+func (h *Handler) discardLoopWorktreeChanges(ctx context.Context, services looperdruntime.Services, loop storage.LoopRecord) (worktreeDiscardResult, error) {
+	if loop.Type == string(domain.LoopTypePlanner) {
+		return worktreeDiscardResult{NoOp: true, Reason: "planner_no_worktree"}, nil
+	}
+	if loop.Type != string(domain.LoopTypeFixer) && loop.Type != string(domain.LoopTypeReviewer) && loop.Type != string(domain.LoopTypeWorker) {
+		return worktreeDiscardResult{NoOp: true, Reason: "loop_type_without_worktree"}, nil
+	}
+	if services.Repositories == nil {
+		return worktreeDiscardResult{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
+	}
+
+	project, err := requireActiveProjectRecord(ctx, services.Repositories.Projects, loop.ProjectID)
+	if err != nil {
+		return worktreeDiscardResult{}, err
+	}
+
+	resolved, err := resolveManagedWorktreeForLoop(ctx, services.Repositories, *project, loop)
+	if err != nil {
+		return worktreeDiscardResult{}, err
+	}
+	if resolved == nil || strings.TrimSpace(resolved.Path) == "" {
+		return worktreeDiscardResult{NoOp: true, Reason: "no_worktree"}, nil
+	}
+
+	if err := worktreesafety.Validate(worktreesafety.CheckInput{
+		WorktreePath: resolved.Path,
+		RepoPath:     project.RepoPath,
+		WorktreeRoot: resolved.WorktreeRoot,
+	}); err != nil {
+		return worktreeDiscardResult{}, apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusBadRequest,
+			message: fmt.Sprintf("Cannot discard worktree changes for loop %s: %v", loop.ID, err),
+		}
+	}
+	if sameFilesystemPath(resolved.Path, project.RepoPath) {
+		return worktreeDiscardResult{}, apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusBadRequest,
+			message: fmt.Sprintf("Cannot discard worktree changes for loop %s: path must not equal project repo path", loop.ID),
+		}
+	}
+	if !resolved.Managed {
+		return worktreeDiscardResult{}, apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusBadRequest,
+			message: fmt.Sprintf("Cannot discard worktree changes for loop %s: path %s is not a Looper-managed worktree", loop.ID, resolved.Path),
+		}
+	}
+
+	gitPath := ""
+	if h.context.Config.Tools.GitPath != nil {
+		gitPath = strings.TrimSpace(*h.context.Config.Tools.GitPath)
+	}
+	gateway := gitinfra.New(gitinfra.Options{GitPath: gitPath, Repos: services.Repositories, Now: h.now})
+	discard, err := gateway.DiscardWorktreeChanges(ctx, gitinfra.DiscardWorktreeChangesInput{
+		RepoPath:     project.RepoPath,
+		WorktreeRoot: resolved.WorktreeRoot,
+		WorktreePath: resolved.Path,
+	})
+	if err != nil {
+		return worktreeDiscardResult{}, apiError{
+			code:    pkgapi.ErrorCodeInternalError,
+			status:  http.StatusInternalServerError,
+			message: fmt.Sprintf("Failed to discard worktree changes at %s: %v", resolved.Path, err),
+		}
+	}
+
+	path := discard.WorktreePath
+	if path == "" {
+		path = resolved.Path
+	}
+	result := worktreeDiscardResult{
+		WorktreePath: stringPtrOrNil(path),
+		Discarded:    !discard.NoOp,
+		NoOp:         discard.NoOp,
+	}
+	if discard.NoOp {
+		if _, statErr := os.Stat(path); statErr != nil && os.IsNotExist(statErr) {
+			result.Reason = "worktree_missing"
+		} else {
+			result.Reason = "already_clean"
+		}
+	} else {
+		result.Reason = "discarded"
+	}
+
+	projectID := loop.ProjectID
+	loopID := loop.ID
+	payload := map[string]any{
+		"worktreePath": path,
+		"branch":       resolved.Branch,
+		"noOp":         result.NoOp,
+		"reason":       result.Reason,
+		"discarded":    result.Discarded,
+		"source":       resolved.Source,
+	}
+	if resolved.ID != "" {
+		payload["worktreeId"] = resolved.ID
+	}
+	if err := eventlog.Append(ctx, services.Repositories, eventlog.AppendInput{
+		EventType: "looper.worktree.changes_discarded",
+		ProjectID: &projectID,
+		LoopID:    &loopID,
+		ActorType: stringPtrOrNil("operator"),
+		ActorID:   stringPtrOrNil("cli"),
+		Payload:   payload,
+		CreatedAt: h.now().UTC(),
+	}); err != nil {
+		return worktreeDiscardResult{}, apiError{
+			code:    pkgapi.ErrorCodeInternalError,
+			status:  http.StatusInternalServerError,
+			message: fmt.Sprintf("Failed to record worktree discard event: %v", err),
+		}
+	}
+	return result, nil
+}
+
+type managedWorktreeRef struct {
+	Path         string
+	Branch       string
+	ID           string
+	WorktreeRoot string
+	Source       string
+	Managed      bool
+}
+
+func resolveManagedWorktreeForLoop(ctx context.Context, repos *storage.Repositories, project storage.ProjectRecord, loop storage.LoopRecord) (*managedWorktreeRef, error) {
+	worktreeRoot, err := projectWorktreeRoot(project)
+	if err != nil {
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+
+	var fromCheckpoint *checkpointWorktreeRef
+	latestRun, err := repos.Runs.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return nil, err
+	}
+	if latestRun != nil && latestRun.CheckpointJSON != nil {
+		fromCheckpoint = parseCheckpointWorktree(latestRun.CheckpointJSON)
+	}
+
+	var record *storage.WorktreeRecord
+	if fromCheckpoint != nil {
+		if id := strings.TrimSpace(fromCheckpoint.ID); id != "" {
+			record, err = repos.Worktrees.GetByID(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if record == nil {
+			if branch := strings.TrimSpace(fromCheckpoint.Branch); branch != "" {
+				record, err = repos.Worktrees.GetByBranch(ctx, project.ID, branch)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+		if record == nil {
+			path := strings.TrimSpace(fromCheckpoint.Path)
+			if path != "" {
+				record, err = findProjectWorktreeByPath(ctx, repos, project.ID, path)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	path := ""
+	branch := ""
+	id := ""
+	source := ""
+	if record != nil && strings.TrimSpace(record.WorktreePath) != "" && record.CleanedAt == nil {
+		path = strings.TrimSpace(record.WorktreePath)
+		branch = strings.TrimSpace(record.Branch)
+		id = record.ID
+		source = "worktree_record"
+	}
+	if path == "" && fromCheckpoint != nil && strings.TrimSpace(fromCheckpoint.Path) != "" {
+		path = strings.TrimSpace(fromCheckpoint.Path)
+		branch = strings.TrimSpace(fromCheckpoint.Branch)
+		id = strings.TrimSpace(fromCheckpoint.ID)
+		source = "checkpoint"
+	}
+	if path == "" {
+		return nil, nil
+	}
+
+	managed := false
+	if worktreeRoot != "" && worktreesafety.IsSafe(worktreesafety.CheckInput{
+		WorktreePath: path,
+		RepoPath:     project.RepoPath,
+		WorktreeRoot: worktreeRoot,
+	}) {
+		managed = true
+	}
+	if record != nil && sameFilesystemPath(record.WorktreePath, path) && record.ProjectID == project.ID {
+		// Recorded worktree rows for this project are managed, even when the
+		// path only barely satisfies root checks via the stored record.
+		if worktreesafety.IsSafe(worktreesafety.CheckInput{
+			WorktreePath: path,
+			RepoPath:     project.RepoPath,
+			WorktreeRoot: worktreeRoot,
+		}) {
+			managed = true
+		}
+	}
+
+	return &managedWorktreeRef{
+		Path:         path,
+		Branch:       branch,
+		ID:           id,
+		WorktreeRoot: worktreeRoot,
+		Source:       source,
+		Managed:      managed,
+	}, nil
+}
+
+func parseCheckpointWorktree(raw *string) *checkpointWorktreeRef {
+	if raw == nil || strings.TrimSpace(*raw) == "" {
+		return nil
+	}
+	var checkpoint checkpointWithWorktree
+	if err := json.Unmarshal([]byte(*raw), &checkpoint); err != nil {
+		return nil
+	}
+	if checkpoint.Worktree == nil {
+		return nil
+	}
+	path := strings.TrimSpace(checkpoint.Worktree.Path)
+	branch := strings.TrimSpace(checkpoint.Worktree.Branch)
+	id := strings.TrimSpace(checkpoint.Worktree.ID)
+	if path == "" && branch == "" && id == "" {
+		return nil
+	}
+	return &checkpointWorktreeRef{ID: id, Path: path, Branch: branch}
+}
+
+func findProjectWorktreeByPath(ctx context.Context, repos *storage.Repositories, projectID, path string) (*storage.WorktreeRecord, error) {
+	items, err := repos.Worktrees.ListByProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range items {
+		if items[i].CleanedAt != nil {
+			continue
+		}
+		if sameFilesystemPath(items[i].WorktreePath, path) {
+			return &items[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func projectWorktreeRoot(project storage.ProjectRecord) (string, error) {
+	if project.MetadataJSON != nil && strings.TrimSpace(*project.MetadataJSON) != "" {
+		var metadata map[string]any
+		if err := json.Unmarshal([]byte(*project.MetadataJSON), &metadata); err == nil {
+			if value, ok := metadata["worktreeRoot"].(string); ok && strings.TrimSpace(value) != "" {
+				return strings.TrimSpace(value), nil
+			}
+		}
+	}
+	return config.DefaultProjectWorktreeRoot(project.ID, project.RepoPath)
+}
+
+func sameFilesystemPath(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}

--- a/internal/api/loop_retry_discard.go
+++ b/internal/api/loop_retry_discard.go
@@ -36,10 +36,14 @@ type checkpointWorktreeRef struct {
 // When prepare-worktree fails on a dirty tree it often returns before writing
 // checkpoint.worktree, leaving only work.branch (worker) or detail.headRefName
 // (fixer). Those branch hints still resolve the managed worktree row.
+// For push-existing workers, work.branch may be empty while the worktree was
+// created under pr-<PRNumber>; executionMode + prNumber recover that branch.
 type checkpointWithWorktree struct {
 	Worktree *checkpointWorktreeRef `json:"worktree,omitempty"`
 	Work     *struct {
-		Branch string `json:"branch,omitempty"`
+		Branch        string `json:"branch,omitempty"`
+		ExecutionMode string `json:"executionMode,omitempty"`
+		PRNumber      int64  `json:"prNumber,omitempty"`
 	} `json:"work,omitempty"`
 	Detail *struct {
 		HeadRefName string `json:"headRefName,omitempty"`
@@ -281,10 +285,17 @@ func parseCheckpointWorktree(raw *string) *checkpointWorktreeRef {
 		id = strings.TrimSpace(checkpoint.Worktree.ID)
 	}
 	// Dirty prepare-worktree often aborts before checkpoint.worktree is set.
-	// Prefer an explicit worktree.branch, then worker work.branch, then fixer
-	// detail.headRefName so GetByBranch can still locate the managed row.
+	// Prefer an explicit worktree.branch, then worker work.branch, then
+	// push-existing pr-<N> (CreateWorktree branch when work.branch is empty),
+	// then fixer detail.headRefName so GetByBranch can still locate the row.
 	if branch == "" && checkpoint.Work != nil {
 		branch = strings.TrimSpace(checkpoint.Work.Branch)
+		if branch == "" &&
+			strings.TrimSpace(checkpoint.Work.ExecutionMode) == "push-existing" &&
+			checkpoint.Work.PRNumber > 0 {
+			// Matches worker runPrepareWorktreeStep when work.Branch is empty.
+			branch = fmt.Sprintf("pr-%d", checkpoint.Work.PRNumber)
+		}
 	}
 	if branch == "" && checkpoint.Detail != nil {
 		branch = strings.TrimSpace(checkpoint.Detail.HeadRefName)

--- a/internal/api/loop_retry_discard.go
+++ b/internal/api/loop_retry_discard.go
@@ -32,8 +32,18 @@ type checkpointWorktreeRef struct {
 	Branch string `json:"branch,omitempty"`
 }
 
+// checkpointWithWorktree extracts worktree location hints from a run checkpoint.
+// When prepare-worktree fails on a dirty tree it often returns before writing
+// checkpoint.worktree, leaving only work.branch (worker) or detail.headRefName
+// (fixer). Those branch hints still resolve the managed worktree row.
 type checkpointWithWorktree struct {
 	Worktree *checkpointWorktreeRef `json:"worktree,omitempty"`
+	Work     *struct {
+		Branch string `json:"branch,omitempty"`
+	} `json:"work,omitempty"`
+	Detail *struct {
+		HeadRefName string `json:"headRefName,omitempty"`
+	} `json:"detail,omitempty"`
 }
 
 // discardLoopWorktreeChanges performs the operator opt-in dirty-worktree discard
@@ -139,7 +149,9 @@ func (h *Handler) discardLoopWorktreeChanges(ctx context.Context, services loope
 	if resolved.ID != "" {
 		payload["worktreeId"] = resolved.ID
 	}
-	if err := eventlog.Append(ctx, services.Repositories, eventlog.AppendInput{
+	// Audit is best-effort: git discard already succeeded, and retry must still
+	// requeue. A transient events write failure must not strand the operator.
+	_ = eventlog.Append(ctx, services.Repositories, eventlog.AppendInput{
 		EventType: "looper.worktree.changes_discarded",
 		ProjectID: &projectID,
 		LoopID:    &loopID,
@@ -147,13 +159,7 @@ func (h *Handler) discardLoopWorktreeChanges(ctx context.Context, services loope
 		ActorID:   stringPtrOrNil("cli"),
 		Payload:   payload,
 		CreatedAt: h.now().UTC(),
-	}); err != nil {
-		return worktreeDiscardResult{}, apiError{
-			code:    pkgapi.ErrorCodeInternalError,
-			status:  http.StatusInternalServerError,
-			message: fmt.Sprintf("Failed to record worktree discard event: %v", err),
-		}
-	}
+	})
 	return result, nil
 }
 
@@ -266,12 +272,23 @@ func parseCheckpointWorktree(raw *string) *checkpointWorktreeRef {
 	if err := json.Unmarshal([]byte(*raw), &checkpoint); err != nil {
 		return nil
 	}
-	if checkpoint.Worktree == nil {
-		return nil
+	path := ""
+	branch := ""
+	id := ""
+	if checkpoint.Worktree != nil {
+		path = strings.TrimSpace(checkpoint.Worktree.Path)
+		branch = strings.TrimSpace(checkpoint.Worktree.Branch)
+		id = strings.TrimSpace(checkpoint.Worktree.ID)
 	}
-	path := strings.TrimSpace(checkpoint.Worktree.Path)
-	branch := strings.TrimSpace(checkpoint.Worktree.Branch)
-	id := strings.TrimSpace(checkpoint.Worktree.ID)
+	// Dirty prepare-worktree often aborts before checkpoint.worktree is set.
+	// Prefer an explicit worktree.branch, then worker work.branch, then fixer
+	// detail.headRefName so GetByBranch can still locate the managed row.
+	if branch == "" && checkpoint.Work != nil {
+		branch = strings.TrimSpace(checkpoint.Work.Branch)
+	}
+	if branch == "" && checkpoint.Detail != nil {
+		branch = strings.TrimSpace(checkpoint.Detail.HeadRefName)
+	}
 	if path == "" && branch == "" && id == "" {
 		return nil
 	}

--- a/internal/api/loop_retry_discard.go
+++ b/internal/api/loop_retry_discard.go
@@ -55,13 +55,12 @@ type checkpointWithWorktree struct {
 }
 
 // discardLoopWorktreeChanges performs the operator opt-in dirty-worktree discard
-// for loop retry. Planner loops and loops without a resolvable managed worktree
-// are no-ops. Active run/queue must already be refused by the caller.
+// for loop retry. Agent loops (planner/fixer/reviewer/worker) resolve a managed
+// worktree from the latest run checkpoint or worktree row; loops without a
+// resolvable managed worktree are no-ops. Active run/queue must already be
+// refused by the caller.
 func (h *Handler) discardLoopWorktreeChanges(ctx context.Context, services looperdruntime.Services, loop storage.LoopRecord) (worktreeDiscardResult, error) {
-	if loop.Type == string(domain.LoopTypePlanner) {
-		return worktreeDiscardResult{NoOp: true, Reason: "planner_no_worktree"}, nil
-	}
-	if loop.Type != string(domain.LoopTypeFixer) && loop.Type != string(domain.LoopTypeReviewer) && loop.Type != string(domain.LoopTypeWorker) {
+	if loop.Type != string(domain.LoopTypePlanner) && loop.Type != string(domain.LoopTypeFixer) && loop.Type != string(domain.LoopTypeReviewer) && loop.Type != string(domain.LoopTypeWorker) {
 		return worktreeDiscardResult{NoOp: true, Reason: "loop_type_without_worktree"}, nil
 	}
 	if services.Repositories == nil {

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -600,6 +600,114 @@ func TestHandlerLoopRetryDiscardPreservesDirtyWorktreeOnUniqueLoopConflict(t *te
 	}
 }
 
+// TestHandlerLoopRetryDiscardRejectsActiveSiblingPRLoop ensures discard+retry
+// refuses when a different loop type already holds a conflicting-active status
+// on the same PR. Same-type uniqueness alone would allow a failed fixer discard
+// to git reset/clean under a queued/running/human_takeover reviewer or worker
+// that shares the managed PR worktree.
+func TestHandlerLoopRetryDiscardRejectsActiveSiblingPRLoop(t *testing.T) {
+	cases := []struct {
+		name          string
+		siblingType   string
+		siblingStatus string
+	}{
+		{name: "queued_reviewer", siblingType: "reviewer", siblingStatus: "queued"},
+		{name: "running_worker", siblingType: "worker", siblingStatus: "running"},
+		{name: "human_takeover_reviewer", siblingType: "reviewer", siblingStatus: "human_takeover"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt, cfg := startTestRuntime(t)
+			h := NewHandler(Context{Config: cfg, Runtime: rt})
+			services := rt.Services()
+			nowISO := "2026-04-11T12:00:00.000Z"
+			projectID := "project_retry_discard_sibling_" + tc.name
+
+			fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+				ProjectID: projectID,
+				LoopID:    "loop_retry_discard_sibling_" + tc.name,
+				LoopSeq:   3140,
+				LoopType:  "fixer",
+				Branch:    "feature/discard-sibling-" + tc.name,
+				NowISO:    nowISO,
+				Dirty:     true,
+			})
+
+			repo := "acme/looper"
+			prNumber := int64(42)
+			prTarget := "pr:acme/looper:42"
+			if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+				ID: "loop_sibling_" + tc.name, Seq: 3141, ProjectID: projectID,
+				Type: tc.siblingType, TargetType: "pull_request", TargetID: &prTarget, Repo: &repo, PRNumber: &prNumber,
+				Status: tc.siblingStatus, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}); err != nil {
+				t.Fatalf("Loops.Upsert(sibling) error = %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/"+fixture.LoopID+"/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+			recorder := httptest.NewRecorder()
+			h.ServeHTTP(recorder, req)
+			if recorder.Code != http.StatusConflict {
+				t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+			}
+			if !strings.Contains(recorder.Body.String(), "shares the same PR worktree") {
+				t.Fatalf("body = %s, want sibling PR worktree conflict", recorder.Body.String())
+			}
+			if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+				t.Fatalf("dirty.txt after sibling conflict = %q, want preserved", got)
+			}
+			if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "README.md")); got != "dirty tracked\n" {
+				t.Fatalf("README.md after sibling conflict = %q, want preserved", got)
+			}
+			loop, err := services.Repositories.Loops.GetByID(context.Background(), fixture.LoopID)
+			if err != nil || loop == nil || loop.Status != "paused" {
+				t.Fatalf("loop after sibling reject = %#v, %v, want paused", loop, err)
+			}
+		})
+	}
+}
+
+// TestHandlerLoopRetryDiscardAllowsFailedSiblingPRLoop documents that a
+// terminal/non-conflicting sibling on the same PR does not block discard.
+func TestHandlerLoopRetryDiscardAllowsFailedSiblingPRLoop(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_failed_sibling"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: projectID,
+		LoopID:    "loop_retry_discard_failed_sibling",
+		LoopSeq:   3142,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-failed-sibling",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	repo := "acme/looper"
+	prNumber := int64(42)
+	prTarget := "pr:acme/looper:42"
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID: "loop_failed_sibling_reviewer", Seq: 3143, ProjectID: projectID,
+		Type: "reviewer", TargetType: "pull_request", TargetID: &prTarget, Repo: &repo, PRNumber: &prNumber,
+		Status: "failed", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert(failed sibling) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/"+fixture.LoopID+"/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(fixture.WorktreePath, "dirty.txt")); !os.IsNotExist(err) {
+		t.Fatalf("dirty.txt still present after discard with failed sibling: %v", err)
+	}
+}
+
 // TestHandlerWorkersCreateReuseSharesRetryLockWithDiscard ensures POST /workers
 // issue-worker reuse takes the same per-loop mutex as discard+retry, so reuse
 // cannot enqueue between discard preflight and git reset (wiping the worktree

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -941,6 +941,212 @@ func TestHandlerLoopRetryDiscardRejectsAwaitingHuman(t *testing.T) {
 	}
 }
 
+// TestHandlerHandbackRejectsDiscardWorktreeChanges ensures /handback never honors
+// discardWorktreeChanges: the worktree may hold the human's interactive edits.
+func TestHandlerHandbackRejectsDiscardWorktreeChanges(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_handback_reject_discard",
+		LoopID:    "loop_handback_reject_discard",
+		LoopSeq:   3132,
+		LoopType:  "fixer",
+		Branch:    "feature/handback-reject-discard",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), fixture.LoopID)
+	if err != nil || loop == nil {
+		t.Fatalf("GetByID() = %#v, %v", loop, err)
+	}
+	loop.Status = "human_takeover"
+	if err := services.Repositories.Loops.Upsert(context.Background(), *loop); err != nil {
+		t.Fatalf("Loops.Upsert(human_takeover) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3132/handback", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	req.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "discardWorktreeChanges is not allowed on handback") {
+		t.Fatalf("body = %s, want handback discard rejection", recorder.Body.String())
+	}
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("dirty.txt after handback discard reject = %q, want preserved", got)
+	}
+	loopAfter, err := services.Repositories.Loops.GetByID(context.Background(), fixture.LoopID)
+	if err != nil || loopAfter == nil || loopAfter.Status != "human_takeover" {
+		t.Fatalf("loop after rejected handback = %#v, %v, want human_takeover", loopAfter, err)
+	}
+}
+
+// TestHandlerLoopRetryDiscardRejectsUntaggedPRWorktree ensures branch-only lookup
+// for a PR-scoped loop does not discard an untagged worktree row that cannot prove
+// pr-<N> ownership (shared head branch across PRs).
+func TestHandlerLoopRetryDiscardRejectsUntaggedPRWorktree(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_untagged_pr"
+	branch := "feature/shared-untagged"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: projectID,
+		LoopID:    "loop_retry_discard_untagged_pr",
+		LoopSeq:   3133,
+		LoopType:  "fixer",
+		Branch:    branch,
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	// Retarget the stored row to an untagged path (RestoreWorktree-style adopt by
+	// branch under worktree root with no pr-<N> marker).
+	untaggedPath := filepath.Join(fixture.WorktreeRoot, "adopted-shared-head")
+	if err := os.MkdirAll(untaggedPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(untagged) error = %v", err)
+	}
+	runGitTest(t, fixture.RepoPath, "worktree", "add", "--force", untaggedPath, branch)
+	if err := os.WriteFile(filepath.Join(untaggedPath, "untagged-dirty.txt"), []byte("keep me\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(untagged dirty) error = %v", err)
+	}
+	existing, err := services.Repositories.Worktrees.GetByBranch(context.Background(), projectID, branch)
+	if err != nil || existing == nil {
+		t.Fatalf("GetByBranch() = %#v, %v", existing, err)
+	}
+	existing.WorktreePath = untaggedPath
+	existing.UpdatedAt = nowISO
+	if err := services.Repositories.Worktrees.Upsert(context.Background(), *existing); err != nil {
+		t.Fatalf("Worktrees.Upsert(untagged path) error = %v", err)
+	}
+
+	// Branch-only checkpoint (dirty prepare): no worktree path/id, PR from detail.
+	detailOnly := fmt.Sprintf(`{"detail":{"headRefName":%q,"state":"OPEN","prNumber":42},"pause":{"reason":"dirty_worktree"}}`, branch)
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_" + fixture.LoopID, LoopID: fixture.LoopID, Status: "failed", CheckpointJSON: &detailOnly,
+		StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(detail-only) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3133/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	discard := data["worktreeDiscard"].(map[string]any)
+	assertEqual(t, discard["discarded"], false)
+	assertEqual(t, discard["noOp"], true)
+
+	if got := readTestFile(t, filepath.Join(untaggedPath, "untagged-dirty.txt")); got != "keep me\n" {
+		t.Fatalf("untagged worktree was discarded: untagged-dirty.txt = %q", got)
+	}
+}
+
+// TestHandlerLoopRetryDiscardRechecksBeforeGitReset ensures a runtime-style
+// free-text message requeue (paused → queued + active queue) injected after the
+// first preflight and before git reset causes conflict without wiping the tree.
+func TestHandlerLoopRetryDiscardRechecksBeforeGitReset(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_recheck",
+		LoopID:    "loop_retry_discard_recheck",
+		LoopSeq:   3134,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-recheck",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	// Simulate Feishu/GitHub enqueueHumanMessageToLoop: mark the loop queued and
+	// create an active queue item after the first discard preflight passes.
+	// Fixture rows are manual_intervention (not cancelled), so requeue-by-cancelled
+	// is a no-op — promote the latest row the same way a message-driven rearm would.
+	h.discardBeforeGitHook = func(loopID string) {
+		if loopID != fixture.LoopID {
+			return
+		}
+		loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+		if err != nil || loop == nil {
+			t.Errorf("hook GetByID() = %#v, %v", loop, err)
+			return
+		}
+		loop.Status = "queued"
+		loop.NextRunAt = &nowISO
+		loop.UpdatedAt = nowISO
+		if err := services.Repositories.Loops.Upsert(context.Background(), *loop); err != nil {
+			t.Errorf("hook Loops.Upsert() error = %v", err)
+			return
+		}
+		latest, qerr := services.Repositories.Queue.GetLatestByLoopID(context.Background(), loopID)
+		if qerr != nil || latest == nil {
+			t.Errorf("hook GetLatestByLoopID() = %#v, %v", latest, qerr)
+			return
+		}
+		latest.Status = "queued"
+		latest.AvailableAt = nowISO
+		latest.UpdatedAt = nowISO
+		if uerr := services.Repositories.Queue.Upsert(context.Background(), *latest); uerr != nil {
+			t.Errorf("hook Queue.Upsert(active) error = %v", uerr)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3134/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "while queue item") {
+		t.Fatalf("body = %s, want active queue conflict from pre-git recheck", recorder.Body.String())
+	}
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("dirty.txt after recheck conflict = %q, want preserved", got)
+	}
+}
+
+// TestWorktreeBelongsToPRRejectsUntagged ensures PR-scoped ownership requires an
+// explicit pr-<N> path or bare pr-<N> branch — untagged paths do not qualify.
+func TestWorktreeBelongsToPRRejectsUntagged(t *testing.T) {
+	if worktreeBelongsToPR(storage.WorktreeRecord{
+		WorktreePath: "/tmp/worktrees/adopted-feature-foo",
+		Branch:       "feature/foo",
+	}, 42) {
+		t.Fatal("untagged path must not belong to PR 42")
+	}
+	if !worktreeBelongsToPR(storage.WorktreeRecord{
+		WorktreePath: "/tmp/worktrees/looper-fix-proj-pr-42",
+		Branch:       "feature/foo",
+	}, 42) {
+		t.Fatal("pr-42 path must belong to PR 42")
+	}
+	if worktreeBelongsToPR(storage.WorktreeRecord{
+		WorktreePath: "/tmp/worktrees/looper-fix-proj-pr-99",
+		Branch:       "feature/foo",
+	}, 42) {
+		t.Fatal("pr-99 path must not belong to PR 42")
+	}
+	if !worktreeBelongsToPR(storage.WorktreeRecord{
+		WorktreePath: "/tmp/worktrees/some-dir",
+		Branch:       "pr-42",
+	}, 42) {
+		t.Fatal("bare pr-42 branch must belong to PR 42")
+	}
+}
+
 // TestHandlerLoopCreateSharesTargetLockWithDiscard ensures POST /loops for the
 // same PR target takes the shared target mutex held by discard+retry, so create
 // cannot enqueue between preflight and git reset.

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -349,6 +349,92 @@ func TestHandlerLoopRetryWithoutDiscardDoesNotReportDiscard(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopRetryDiscardPreservesDirtyWorktreeWhenAgentNotConfigured(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.Agent.Vendor = nil
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_no_agent",
+		LoopID:    "loop_retry_discard_no_agent",
+		LoopSeq:   3116,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-no-agent",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3116/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "without config.agent.vendor") {
+		t.Fatalf("body = %s, want agent not configured rejection", recorder.Body.String())
+	}
+
+	// Destructive discard must not run when a later retry precondition fails.
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("dirty.txt after failed discard retry = %q, want preserved untracked content", got)
+	}
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "README.md")); got != "dirty tracked\n" {
+		t.Fatalf("README.md after failed discard retry = %q, want preserved dirty tracked content", got)
+	}
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), fixture.LoopID)
+	if err != nil || loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop after failed discard retry = %#v, %v, want paused", loop, err)
+	}
+}
+
+func TestHandlerLoopRetryDiscardPreservesDirtyWorktreeOnUniqueLoopConflict(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_unique"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: projectID,
+		LoopID:    "loop_retry_discard_unique",
+		LoopSeq:   3117,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-unique",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	// Another active fixer on the same PR target must block retry before discard.
+	repo := "acme/looper"
+	prNumber := int64(42)
+	prTarget := "pr:acme/looper:42"
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID: "loop_retry_discard_unique_active", Seq: 3118, ProjectID: projectID,
+		Type: "fixer", TargetType: "pull_request", TargetID: &prTarget, Repo: &repo, PRNumber: &prNumber,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert(conflict) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3117/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "active loop already exists") {
+		t.Fatalf("body = %s, want unique loop conflict", recorder.Body.String())
+	}
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("dirty.txt after unique conflict = %q, want preserved", got)
+	}
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "README.md")); got != "dirty tracked\n" {
+		t.Fatalf("README.md after unique conflict = %q, want preserved", got)
+	}
+}
+
 type managedWorktreeSeed struct {
 	ProjectID string
 	LoopID    string

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -942,6 +942,51 @@ func TestHandlerLoopRetryDiscardRejectsAwaitingHuman(t *testing.T) {
 	}
 }
 
+// TestHandlerLoopRetryDiscardRejectsHumanTakeover ensures discard+retry refuses
+// human_takeover loops so interactive edits pinned by takeover are not wiped
+// via direct /retry (mirroring /handback which also rejects discard).
+func TestHandlerLoopRetryDiscardRejectsHumanTakeover(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_human_takeover",
+		LoopID:    "loop_retry_discard_human_takeover",
+		LoopSeq:   3135,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-human-takeover",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), fixture.LoopID)
+	if err != nil || loop == nil {
+		t.Fatalf("GetByID() = %#v, %v", loop, err)
+	}
+	loop.Status = "human_takeover"
+	if err := services.Repositories.Loops.Upsert(context.Background(), *loop); err != nil {
+		t.Fatalf("Loops.Upsert(human_takeover) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3135/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "human_takeover") {
+		t.Fatalf("body = %s, want human_takeover rejection", recorder.Body.String())
+	}
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("dirty.txt after human_takeover reject = %q, want preserved", got)
+	}
+	loopAfter, err := services.Repositories.Loops.GetByID(context.Background(), fixture.LoopID)
+	if err != nil || loopAfter == nil || loopAfter.Status != "human_takeover" {
+		t.Fatalf("loop after rejected discard retry = %#v, %v, want human_takeover", loopAfter, err)
+	}
+}
+
 // TestHandlerHandbackRejectsDiscardWorktreeChanges ensures /handback never honors
 // discardWorktreeChanges: the worktree may hold the human's interactive edits.
 func TestHandlerHandbackRejectsDiscardWorktreeChanges(t *testing.T) {

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -601,10 +601,11 @@ func TestHandlerLoopRetryDiscardPreservesDirtyWorktreeOnUniqueLoopConflict(t *te
 }
 
 // TestHandlerLoopRetryDiscardRejectsActiveSiblingPRLoop ensures discard+retry
-// refuses when a different loop type already holds a conflicting-active status
-// on the same PR. Same-type uniqueness alone would allow a failed fixer discard
-// to git reset/clean under a queued/running/human_takeover reviewer or worker
-// that shares the managed PR worktree.
+// refuses when a different loop type already holds a worktree-owning status on
+// the same PR. Same-type uniqueness alone would allow a failed fixer discard to
+// git reset/clean under a queued/running/waiting/human_takeover reviewer or
+// worker that shares the managed PR worktree. waiting is intentionally outside
+// IsConflictingActiveLoopStatus but still pins the checkout.
 func TestHandlerLoopRetryDiscardRejectsActiveSiblingPRLoop(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -613,6 +614,7 @@ func TestHandlerLoopRetryDiscardRejectsActiveSiblingPRLoop(t *testing.T) {
 	}{
 		{name: "queued_reviewer", siblingType: "reviewer", siblingStatus: "queued"},
 		{name: "running_worker", siblingType: "worker", siblingStatus: "running"},
+		{name: "waiting_reviewer", siblingType: "reviewer", siblingStatus: "waiting"},
 		{name: "human_takeover_reviewer", siblingType: "reviewer", siblingStatus: "human_takeover"},
 	}
 	for _, tc := range cases {

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -653,9 +653,10 @@ func TestHandlerLoopRetryDiscardPreservesDirtyWorktreeOnUniqueLoopConflict(t *te
 // TestHandlerLoopRetryDiscardRejectsActiveSiblingPRLoop ensures discard+retry
 // refuses when a different loop type already holds a worktree-owning status on
 // the same PR. Same-type uniqueness alone would allow a failed fixer discard to
-// git reset/clean under a queued/running/waiting/human_takeover reviewer or
-// worker that shares the managed PR worktree. waiting is intentionally outside
-// IsConflictingActiveLoopStatus but still pins the checkout.
+// git reset/clean under a queued/running/waiting/failed/interrupted/
+// human_takeover reviewer or worker that shares the managed PR worktree.
+// waiting/failed/interrupted are outside IsConflictingActiveLoopStatus but
+// still pin the checkout (worktree cleanup protects them).
 func TestHandlerLoopRetryDiscardRejectsActiveSiblingPRLoop(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -665,6 +666,8 @@ func TestHandlerLoopRetryDiscardRejectsActiveSiblingPRLoop(t *testing.T) {
 		{name: "queued_reviewer", siblingType: "reviewer", siblingStatus: "queued"},
 		{name: "running_worker", siblingType: "worker", siblingStatus: "running"},
 		{name: "waiting_reviewer", siblingType: "reviewer", siblingStatus: "waiting"},
+		{name: "failed_reviewer", siblingType: "reviewer", siblingStatus: "failed"},
+		{name: "interrupted_worker", siblingType: "worker", siblingStatus: "interrupted"},
 		{name: "human_takeover_reviewer", siblingType: "reviewer", siblingStatus: "human_takeover"},
 	}
 	for _, tc := range cases {
@@ -719,21 +722,22 @@ func TestHandlerLoopRetryDiscardRejectsActiveSiblingPRLoop(t *testing.T) {
 	}
 }
 
-// TestHandlerLoopRetryDiscardAllowsFailedSiblingPRLoop documents that a
-// terminal/non-conflicting sibling on the same PR does not block discard.
-func TestHandlerLoopRetryDiscardAllowsFailedSiblingPRLoop(t *testing.T) {
+// TestHandlerLoopRetryDiscardAllowsCompletedSiblingPRLoop documents that a
+// truly terminal sibling (completed/stopped/terminated) on the same PR does
+// not pin the managed worktree and therefore does not block discard.
+func TestHandlerLoopRetryDiscardAllowsCompletedSiblingPRLoop(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})
 	services := rt.Services()
 	nowISO := "2026-04-11T12:00:00.000Z"
-	projectID := "project_retry_discard_failed_sibling"
+	projectID := "project_retry_discard_completed_sibling"
 
 	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
 		ProjectID: projectID,
-		LoopID:    "loop_retry_discard_failed_sibling",
+		LoopID:    "loop_retry_discard_completed_sibling",
 		LoopSeq:   3142,
 		LoopType:  "fixer",
-		Branch:    "feature/discard-failed-sibling",
+		Branch:    "feature/discard-completed-sibling",
 		NowISO:    nowISO,
 		Dirty:     true,
 	})
@@ -742,11 +746,11 @@ func TestHandlerLoopRetryDiscardAllowsFailedSiblingPRLoop(t *testing.T) {
 	prNumber := int64(42)
 	prTarget := "pr:acme/looper:42"
 	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
-		ID: "loop_failed_sibling_reviewer", Seq: 3143, ProjectID: projectID,
+		ID: "loop_completed_sibling_reviewer", Seq: 3143, ProjectID: projectID,
 		Type: "reviewer", TargetType: "pull_request", TargetID: &prTarget, Repo: &repo, PRNumber: &prNumber,
-		Status: "failed", CreatedAt: nowISO, UpdatedAt: nowISO,
+		Status: "completed", CreatedAt: nowISO, UpdatedAt: nowISO,
 	}); err != nil {
-		t.Fatalf("Loops.Upsert(failed sibling) error = %v", err)
+		t.Fatalf("Loops.Upsert(completed sibling) error = %v", err)
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/"+fixture.LoopID+"/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
@@ -756,7 +760,7 @@ func TestHandlerLoopRetryDiscardAllowsFailedSiblingPRLoop(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
 	}
 	if _, err := os.Stat(filepath.Join(fixture.WorktreePath, "dirty.txt")); !os.IsNotExist(err) {
-		t.Fatalf("dirty.txt still present after discard with failed sibling: %v", err)
+		t.Fatalf("dirty.txt still present after discard with completed sibling: %v", err)
 	}
 }
 

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -10,7 +10,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	gitinfra "github.com/nexu-io/looper/internal/infra/git"
 	"github.com/nexu-io/looper/internal/storage"
@@ -593,6 +595,153 @@ func TestHandlerLoopRetryDiscardPreservesDirtyWorktreeOnUniqueLoopConflict(t *te
 	}
 	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "README.md")); got != "dirty tracked\n" {
 		t.Fatalf("README.md after unique conflict = %q, want preserved", got)
+	}
+}
+
+// TestHandlerLoopStartSharesRetryLockWithDiscard ensures /start requeue takes
+// the same per-loop mutex as discard+retry, so start cannot enqueue between
+// discard preflight and git reset (wiping the worktree for start-created work).
+func TestHandlerLoopStartSharesRetryLockWithDiscard(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_start_lock",
+		LoopID:    "loop_retry_discard_start_lock",
+		LoopSeq:   3122,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-start-lock",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	// Hold the shared retry lock as if discard+retry is between preflight and reset.
+	unlock := h.lockLoopRetry(fixture.LoopID)
+
+	started := make(chan struct{})
+	finished := make(chan int, 1)
+	go func() {
+		close(started)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3122/start", nil)
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		finished <- recorder.Code
+	}()
+
+	<-started
+	select {
+	case code := <-finished:
+		unlock()
+		t.Fatalf("start completed while retry/discard lock held: status=%d", code)
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked on the shared lock — expected.
+	}
+
+	unlock()
+
+	select {
+	case code := <-finished:
+		if code != http.StatusOK {
+			t.Fatalf("start status after lock release = %d, want 200", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("start did not complete after retry/discard lock release")
+	}
+
+	// Start requeued from manual_intervention; dirty worktree must still exist
+	// because no discard ran (only start held the lock after release).
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("dirty.txt after blocked start = %q, want preserved", got)
+	}
+	active, err := services.Repositories.Queue.FindActiveByLoopID(context.Background(), fixture.LoopID)
+	if err != nil {
+		t.Fatalf("FindActiveByLoopID() error = %v", err)
+	}
+	if active == nil || active.Status != "queued" || active.ID == fixture.FailedQueueID {
+		t.Fatalf("active queue after start = %#v, want new queued replacement", active)
+	}
+}
+
+// TestHandlerLoopRetryDiscardConflictsAfterStartSerializes verifies that when
+// start requeues first under the shared lock, a following discard+retry refuses
+// with conflict and does not wipe the worktree (the failure the race caused).
+func TestHandlerLoopRetryDiscardConflictsAfterStartSerializes(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_after_start",
+		LoopID:    "loop_retry_discard_after_start",
+		LoopSeq:   3123,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-after-start",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	startCode := make(chan int, 1)
+	retryCode := make(chan int, 1)
+	retryBody := make(chan string, 1)
+
+	go func() {
+		defer wg.Done()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3123/start", nil)
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		startCode <- recorder.Code
+	}()
+	go func() {
+		defer wg.Done()
+		// Small delay so start is more likely to acquire the lock first; both
+		// orders are correct under serialization, but this path asserts the
+		// conflict+preserve-dirty outcome when start wins.
+		time.Sleep(20 * time.Millisecond)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3123/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		retryCode <- recorder.Code
+		retryBody <- recorder.Body.String()
+	}()
+	wg.Wait()
+
+	gotStart := <-startCode
+	gotRetry := <-retryCode
+	body := <-retryBody
+	if gotStart != http.StatusOK {
+		t.Fatalf("start status = %d, want 200", gotStart)
+	}
+
+	// Under shared lock, either order is valid:
+	// - start first → retry 409, dirty preserved
+	// - retry first → retry 200 (discarded), start 200 with active queue already present
+	switch gotRetry {
+	case http.StatusConflict:
+		if !strings.Contains(body, "while queue item") && !strings.Contains(body, "while a run is active") {
+			t.Fatalf("retry body = %s, want active queue/run conflict", body)
+		}
+		if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+			t.Fatalf("dirty.txt after conflicted discard retry = %q, want preserved", got)
+		}
+	case http.StatusOK:
+		if _, err := os.Stat(filepath.Join(fixture.WorktreePath, "dirty.txt")); !os.IsNotExist(err) {
+			t.Fatalf("dirty.txt still present after successful discard retry: %v", err)
+		}
+	default:
+		t.Fatalf("retry status = %d, want 200 or 409; body=%s", gotRetry, body)
+	}
+
+	active, err := services.Repositories.Queue.FindActiveByLoopID(context.Background(), fixture.LoopID)
+	if err != nil {
+		t.Fatalf("FindActiveByLoopID() error = %v", err)
+	}
+	if active == nil || active.Status != "queued" {
+		t.Fatalf("active queue after serialized start/retry = %#v, want queued", active)
 	}
 }
 

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -195,9 +195,65 @@ func TestParseCheckpointWorktreeFallsBackToWorkBranchAndDetail(t *testing.T) {
 	if ref == nil || ref.Branch != "feature/worktree" || ref.Path != "/tmp/wt" {
 		t.Fatalf("worktree preference = %#v", ref)
 	}
+	// push-existing with empty work.branch derives pr-<PRNumber>, matching
+	// worker runPrepareWorktreeStep before checkpoint.worktree is saved.
+	pushExisting := `{"work":{"executionMode":"push-existing","prNumber":42}}`
+	ref = parseCheckpointWorktree(&pushExisting)
+	if ref == nil || ref.Branch != "pr-42" {
+		t.Fatalf("push-existing empty branch = %#v, want branch pr-42", ref)
+	}
+	// Explicit work.branch wins over pr-N derivation.
+	pushExistingNamed := `{"work":{"branch":"feature/named","executionMode":"push-existing","prNumber":42}}`
+	ref = parseCheckpointWorktree(&pushExistingNamed)
+	if ref == nil || ref.Branch != "feature/named" {
+		t.Fatalf("push-existing named branch = %#v, want feature/named", ref)
+	}
 	empty := `{"work":{},"detail":{}}`
 	if got := parseCheckpointWorktree(&empty); got != nil {
 		t.Fatalf("empty hints = %#v, want nil", got)
+	}
+}
+
+func TestHandlerLoopRetryDiscardWorktreeChangesResolvesPushExistingPRBranch(t *testing.T) {
+	// push-existing dirty prepare creates worktree under pr-<N> but leaves
+	// work.branch empty and omits checkpoint.worktree.
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_push_existing",
+		LoopID:    "loop_retry_discard_push_existing",
+		LoopSeq:   3121,
+		LoopType:  "worker",
+		Branch:    "pr-77",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	pushExistingOnly := `{"work":{"executionMode":"push-existing","prNumber":77}}`
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_" + fixture.LoopID, LoopID: fixture.LoopID, Status: "failed", CheckpointJSON: &pushExistingOnly,
+		StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(push-existing) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3121/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	discard := data["worktreeDiscard"].(map[string]any)
+	assertEqual(t, discard["discarded"], true)
+	assertEqual(t, discard["reason"], "discarded")
+	assertEqual(t, discard["worktreePath"], fixture.WorktreePath)
+	if _, err := os.Stat(filepath.Join(fixture.WorktreePath, "dirty.txt")); !os.IsNotExist(err) {
+		t.Fatalf("dirty.txt still present after push-existing discard: %v", err)
 	}
 }
 

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -1394,6 +1394,126 @@ func TestHandlerLoopStartSharesTargetLockAcrossLoops(t *testing.T) {
 	}
 }
 
+// TestHandlerLoopTargetLockSharedAcrossPRLoopTypes ensures fixer and worker for
+// the same PR share one target mutex so discard+retry cannot race another type
+// on the shared looper-fix-<project>-pr-N worktree.
+func TestHandlerLoopTargetLockSharedAcrossPRLoopTypes(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_pr_type_lock"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: projectID,
+		LoopID:    "loop_retry_pr_type_lock_fixer",
+		LoopSeq:   3140,
+		LoopType:  "fixer",
+		Branch:    "feature/pr-type-lock",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+	markLoopFailed(t, services.Repositories, fixture.LoopID, nowISO)
+
+	// Failed worker on the same PR (different type — uniqueness allows this).
+	repo := "acme/looper"
+	prNumber := int64(42)
+	prTarget := "pr:acme/looper:42"
+	workerID := "loop_retry_pr_type_lock_worker"
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID: workerID, Seq: 3141, ProjectID: projectID, Type: "worker",
+		TargetType: "pull_request", TargetID: &prTarget, Repo: &repo, PRNumber: &prNumber,
+		Status: "failed", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert(worker) error = %v", err)
+	}
+	lastErrorKind := "manual_intervention"
+	lastError := "prior failure"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: "queue_" + workerID, ProjectID: &projectID, LoopID: &workerID, Type: "worker",
+		TargetType: "pull_request", TargetID: prTarget, Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: "worker:" + projectID + ":" + repo + ":42", Priority: storage.QueuePriorityWorker,
+		Status: "failed", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3,
+		LastError: &lastError, LastErrorKind: &lastErrorKind,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert(worker) error = %v", err)
+	}
+
+	// Hold fixer PR target lock as discard would; worker retry must block.
+	target := mustLoopTargetFromFixture(t, services.Repositories, fixture.LoopID)
+	unlockTarget := h.lockLoopTarget(projectID, domain.LoopTypeFixer, target)
+
+	started := make(chan struct{})
+	finished := make(chan int, 1)
+	go func() {
+		close(started)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3141/retry", strings.NewReader(`{"mode":"auto","resetAttempts":true}`))
+		req.Header.Set("content-type", "application/json")
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		finished <- recorder.Code
+	}()
+
+	<-started
+	select {
+	case code := <-finished:
+		unlockTarget()
+		t.Fatalf("worker retry completed while fixer PR target lock held: status=%d", code)
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked — expected shared PR worktree key.
+	}
+
+	unlockTarget()
+
+	select {
+	case code := <-finished:
+		if code != http.StatusOK {
+			t.Fatalf("worker retry status after PR target lock release = %d, want 200", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker retry did not complete after PR target lock release")
+	}
+}
+
+// TestHandlerLockLoopTargetIsProcessWideWithRuntime ensures API lockLoopTarget
+// and runtime LockLoopTarget share the same mutex entry for a PR target.
+func TestHandlerLockLoopTargetIsProcessWideWithRuntime(t *testing.T) {
+	h := NewHandler(Context{})
+	projectID := "project_target_lock_process_wide"
+	target := domain.LoopTarget{
+		TargetType: domain.LoopTargetTypePullRequest,
+		Repo:       "acme/looper",
+		PRNumber:   42,
+	}
+	unlock := h.lockLoopTarget(projectID, domain.LoopTypeFixer, target)
+
+	started := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		close(started)
+		// Worker type, same PR — must wait on the shared PR key.
+		key := looperdruntime.LoopTargetGuardKey(projectID, string(domain.LoopTypeWorker), string(domain.LoopTargetTypePullRequest), loopTargetKeyCompat(target))
+		unlockRuntime := looperdruntime.LockLoopTarget(key)
+		unlockRuntime()
+		close(finished)
+	}()
+
+	<-started
+	select {
+	case <-finished:
+		unlock()
+		t.Fatal("runtime LockLoopTarget completed while Handler.lockLoopTarget held — PR keys not shared across types")
+	case <-time.After(150 * time.Millisecond):
+	}
+	unlock()
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runtime LockLoopTarget did not complete after Handler.lockLoopTarget release")
+	}
+}
+
 func markLoopFailed(t *testing.T, repos *storage.Repositories, loopID, nowISO string) {
 	t.Helper()
 	loop, err := repos.Loops.GetByID(context.Background(), loopID)

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -1,0 +1,508 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gitinfra "github.com/nexu-io/looper/internal/infra/git"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestHandlerLoopRetryDiscardWorktreeChangesDirtyFixer(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_fixer",
+		LoopID:    "loop_retry_discard_fixer",
+		LoopSeq:   3108,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-fixer",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3108/retry", strings.NewReader(`{"mode":"auto","resetAttempts":true,"discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	assertEqual(t, data["discardWorktreeChanges"], true)
+	discard := data["worktreeDiscard"].(map[string]any)
+	assertEqual(t, discard["discarded"], true)
+	assertEqual(t, discard["noOp"], false)
+	assertEqual(t, discard["worktreePath"], fixture.WorktreePath)
+	assertEqual(t, discard["reason"], "discarded")
+
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), fixture.LoopID)
+	if err != nil || loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop after retry = %#v, %v, want queued", loop, err)
+	}
+	items, err := services.Repositories.Queue.List(context.Background())
+	if err != nil {
+		t.Fatalf("Queue.List() error = %v", err)
+	}
+	var replacement *storage.QueueItemRecord
+	for i := range items {
+		if items[i].LoopID != nil && *items[i].LoopID == fixture.LoopID && items[i].Status == "queued" {
+			replacement = &items[i]
+		}
+	}
+	if replacement == nil || replacement.ID == fixture.FailedQueueID || replacement.Attempts != 0 {
+		t.Fatalf("replacement queue = %#v, want new queued item", replacement)
+	}
+
+	if _, err := os.Stat(filepath.Join(fixture.WorktreePath, "dirty.txt")); !os.IsNotExist(err) {
+		t.Fatalf("dirty.txt still present after discard: %v", err)
+	}
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "README.md")); got != "hello\n" {
+		t.Fatalf("README.md after discard = %q, want restored contents", got)
+	}
+	clean, err := gitinfra.New(gitinfra.Options{GitPath: "git"}).WorktreeClean(context.Background(), fixture.WorktreePath)
+	if err != nil || !clean {
+		t.Fatalf("worktree clean after discard = %v, %v", clean, err)
+	}
+
+	events, err := services.Repositories.Events.List(context.Background(), 50)
+	if err != nil {
+		t.Fatalf("Events.List() error = %v", err)
+	}
+	found := false
+	for _, event := range events {
+		if event.EventType == "looper.worktree.changes_discarded" {
+			found = true
+			if event.LoopID == nil || *event.LoopID != fixture.LoopID {
+				t.Fatalf("discard event loop id = %#v, want %s", event.LoopID, fixture.LoopID)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected looper.worktree.changes_discarded event")
+	}
+}
+
+func TestHandlerLoopRetryDiscardWorktreeChangesAlreadyClean(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_clean",
+		LoopID:    "loop_retry_discard_clean",
+		LoopSeq:   3109,
+		LoopType:  "worker",
+		Branch:    "feature/discard-clean",
+		NowISO:    nowISO,
+		Dirty:     false,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3109/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	discard := data["worktreeDiscard"].(map[string]any)
+	assertEqual(t, discard["discarded"], false)
+	assertEqual(t, discard["noOp"], true)
+	assertEqual(t, discard["reason"], "already_clean")
+	assertEqual(t, discard["worktreePath"], fixture.WorktreePath)
+
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), fixture.LoopID)
+	if err != nil || loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop after retry = %#v, %v, want queued", loop, err)
+	}
+}
+
+func TestHandlerLoopRetryDiscardWorktreeChangesPlannerNoOp(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_planner"
+	loopID := "loop_retry_discard_planner"
+	targetID := projectID
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Planner", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 3110, ProjectID: projectID, Type: "planner", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	lastErrorKind := "manual_intervention"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_retry_discard_planner", ProjectID: &projectID, LoopID: &loopID, Type: "planner", TargetType: "project", TargetID: targetID, DedupeKey: "planner:retry_discard", Priority: storage.QueuePriorityPlanner, Status: "failed", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3110/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	discard := data["worktreeDiscard"].(map[string]any)
+	assertEqual(t, discard["noOp"], true)
+	assertEqual(t, discard["reason"], "planner_no_worktree")
+	assertEqual(t, discard["discarded"], false)
+
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop after retry = %#v, %v, want queued", loop, err)
+	}
+}
+
+func TestHandlerLoopRetryDiscardWorktreeChangesRejectsActiveRun(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_active_run"
+	loopID := "loop_retry_discard_active_run"
+	targetID := projectID
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 3111, ProjectID: projectID, Type: "fixer", TargetType: "project", TargetID: &targetID, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_active_discard", LoopID: loopID, Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3111/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "while a run is active") {
+		t.Fatalf("body = %s, want active run rejection", recorder.Body.String())
+	}
+}
+
+func TestHandlerLoopRetryDiscardWorktreeChangesRejectsActiveQueue(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_active_queue"
+	loopID := "loop_retry_discard_active_queue"
+	targetID := projectID
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 3112, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_active_discard", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:active_discard", Priority: storage.QueuePriorityWorker, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3112/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "while queue item") {
+		t.Fatalf("body = %s, want active queue rejection", recorder.Body.String())
+	}
+}
+
+func TestHandlerLoopRetryDiscardWorktreeChangesRejectsNonManagedPath(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_nonmanaged"
+	loopID := "loop_retry_discard_nonmanaged"
+	targetID := projectID
+	repoPath := t.TempDir()
+	outsidePath := filepath.Join(t.TempDir(), "outside-worktree")
+	if err := os.MkdirAll(outsidePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(outside) error = %v", err)
+	}
+	worktreeRoot := filepath.Join(t.TempDir(), "managed-worktrees")
+	metadata, _ := json.Marshal(map[string]any{"worktreeRoot": worktreeRoot})
+	metadataJSON := string(metadata)
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: repoPath, MetadataJSON: &metadataJSON, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 3113, ProjectID: projectID, Type: "reviewer", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpoint := fmt.Sprintf(`{"worktree":{"path":%q,"branch":"feature/outside"}}`, outsidePath)
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_nonmanaged", LoopID: loopID, Status: "failed", CheckpointJSON: &checkpoint, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	lastErrorKind := "manual_intervention"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_nonmanaged", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "project", TargetID: targetID, DedupeKey: "reviewer:nonmanaged", Priority: storage.QueuePriorityReviewer, Status: "manual_intervention", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3113/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "not a Looper-managed worktree") && !strings.Contains(recorder.Body.String(), "unsafe worktree path") {
+		t.Fatalf("body = %s, want non-managed path rejection", recorder.Body.String())
+	}
+
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil || loop.Status != "paused" {
+		t.Fatalf("loop after failed discard = %#v, %v, want paused", loop, err)
+	}
+}
+
+func TestHandlerLoopRetryDiscardWorktreeChangesRejectsPrimaryRepoPath(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_repo_path"
+	loopID := "loop_retry_discard_repo_path"
+	targetID := projectID
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	metadata, _ := json.Marshal(map[string]any{"worktreeRoot": worktreeRoot})
+	metadataJSON := string(metadata)
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: repoPath, MetadataJSON: &metadataJSON, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 3114, ProjectID: projectID, Type: "fixer", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	checkpoint := fmt.Sprintf(`{"worktree":{"path":%q,"branch":"main"}}`, repoPath)
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_repo_path", LoopID: loopID, Status: "failed", CheckpointJSON: &checkpoint, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	lastErrorKind := "manual_intervention"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_repo_path", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "project", TargetID: targetID, DedupeKey: "fixer:repo_path", Priority: storage.QueuePriorityFixer, Status: "manual_intervention", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3114/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "must not equal project repo path") && !strings.Contains(recorder.Body.String(), "unsafe worktree path") {
+		t.Fatalf("body = %s, want primary repo path rejection", recorder.Body.String())
+	}
+}
+
+func TestHandlerLoopRetryWithoutDiscardDoesNotReportDiscard(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_no_discard"
+	loopID := "loop_retry_no_discard"
+	targetID := projectID
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 3115, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	lastErrorKind := "manual_intervention"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_retry_no_discard", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:no_discard", Priority: storage.QueuePriorityWorker, Status: "failed", AvailableAt: nowISO, Attempts: 2, MaxAttempts: 3, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3115/retry", strings.NewReader(`{"mode":"auto","resetAttempts":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	assertEqual(t, data["discardWorktreeChanges"], false)
+	if _, ok := data["worktreeDiscard"]; ok {
+		t.Fatalf("worktreeDiscard present without flag: %#v", data["worktreeDiscard"])
+	}
+}
+
+type managedWorktreeSeed struct {
+	ProjectID string
+	LoopID    string
+	LoopSeq   int64
+	LoopType  string
+	Branch    string
+	NowISO    string
+	Dirty     bool
+}
+
+type managedWorktreeFixture struct {
+	LoopID        string
+	FailedQueueID string
+	WorktreePath  string
+	RepoPath      string
+	WorktreeRoot  string
+}
+
+func seedManagedWorktreeFixture(t *testing.T, repos *storage.Repositories, seed managedWorktreeSeed) managedWorktreeFixture {
+	t.Helper()
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	worktreeRoot := filepath.Join(root, "worktrees")
+	remotePath := filepath.Join(root, "remote.git")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(repo) error = %v", err)
+	}
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktreeRoot) error = %v", err)
+	}
+	if err := os.MkdirAll(remotePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(remote) error = %v", err)
+	}
+
+	runGitTest(t, repoPath, "init", "-b", "main")
+	runGitTest(t, remotePath, "init", "--bare")
+	runGitTest(t, repoPath, "config", "user.email", "looper@example.com")
+	runGitTest(t, repoPath, "config", "user.name", "Looper Test")
+	runGitTest(t, repoPath, "remote", "add", "origin", remotePath)
+	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(README) error = %v", err)
+	}
+	runGitTest(t, repoPath, "add", "README.md")
+	runGitTest(t, repoPath, "commit", "-m", "init")
+	runGitTest(t, repoPath, "push", "-u", "origin", "main")
+	runGitTest(t, repoPath, "checkout", "-b", seed.Branch)
+	runGitTest(t, repoPath, "push", "-u", "origin", seed.Branch)
+	runGitTest(t, repoPath, "checkout", "main")
+
+	// Project must exist before CreateWorktree can store the worktree row.
+	metadata, _ := json.Marshal(map[string]any{"worktreeRoot": worktreeRoot})
+	metadataJSON := string(metadata)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: seed.ProjectID, Name: "Looper", RepoPath: repoPath, MetadataJSON: &metadataJSON, CreatedAt: seed.NowISO, UpdatedAt: seed.NowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	gateway := gitinfra.New(gitinfra.Options{GitPath: "git", Repos: repos})
+	worktree, err := gateway.CreateWorktree(context.Background(), gitinfra.CreateWorktreeInput{
+		ProjectID:    seed.ProjectID,
+		RepoPath:     repoPath,
+		WorktreeRoot: worktreeRoot,
+		Branch:       seed.Branch,
+		BaseBranch:   "main",
+		PRNumber:     42,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+	if seed.Dirty {
+		if err := os.WriteFile(filepath.Join(worktree.WorktreePath, "README.md"), []byte("dirty tracked\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(dirty tracked) error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(worktree.WorktreePath, "dirty.txt"), []byte("untracked\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(dirty untracked) error = %v", err)
+		}
+	}
+
+	targetID := seed.ProjectID
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{
+		ID: seed.LoopID, Seq: seed.LoopSeq, ProjectID: seed.ProjectID, Type: seed.LoopType,
+		TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: seed.NowISO, UpdatedAt: seed.NowISO,
+	}
+	if seed.LoopType == "fixer" || seed.LoopType == "reviewer" {
+		loop.TargetType = "pull_request"
+		prTarget := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+		loop.TargetID = &prTarget
+		loop.Repo = &repo
+		loop.PRNumber = &prNumber
+	}
+	if err := repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	checkpoint := fmt.Sprintf(`{"worktree":{"id":%q,"path":%q,"branch":%q}}`, worktree.ID, worktree.WorktreePath, seed.Branch)
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_" + seed.LoopID, LoopID: seed.LoopID, Status: "failed", CheckpointJSON: &checkpoint,
+		StartedAt: seed.NowISO, CreatedAt: seed.NowISO, UpdatedAt: seed.NowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	failedQueueID := "queue_" + seed.LoopID
+	lastErrorKind := "manual_intervention"
+	lastError := "dirty worktree"
+	queue := storage.QueueItemRecord{
+		ID: failedQueueID, ProjectID: &seed.ProjectID, LoopID: &seed.LoopID, Type: seed.LoopType,
+		TargetType: loop.TargetType, TargetID: *loop.TargetID, DedupeKey: seed.LoopType + ":" + seed.LoopID,
+		Priority: storage.QueuePriorityWorker, Status: "manual_intervention", AvailableAt: seed.NowISO,
+		Attempts: 2, MaxAttempts: 3, LastError: &lastError, LastErrorKind: &lastErrorKind,
+		CreatedAt: seed.NowISO, UpdatedAt: seed.NowISO,
+	}
+	if seed.LoopType == "fixer" {
+		queue.Priority = storage.QueuePriorityFixer
+		queue.Repo = &repo
+		queue.PRNumber = &prNumber
+	}
+	if seed.LoopType == "reviewer" {
+		queue.Priority = storage.QueuePriorityReviewer
+		queue.Repo = &repo
+		queue.PRNumber = &prNumber
+	}
+	if err := repos.Queue.Upsert(context.Background(), queue); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	return managedWorktreeFixture{
+		LoopID:        seed.LoopID,
+		FailedQueueID: failedQueueID,
+		WorktreePath:  worktree.WorktreePath,
+		RepoPath:      repoPath,
+		WorktreeRoot:  worktreeRoot,
+	}
+}
+
+func runGitTest(t *testing.T, cwd string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s failed: %v\n%s", args, cwd, err, out)
+	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	return string(raw)
+}

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nexu-io/looper/internal/domain"
 	gitinfra "github.com/nexu-io/looper/internal/infra/git"
 	"github.com/nexu-io/looper/internal/storage"
 )
@@ -823,6 +824,221 @@ func TestHandlerLoopRetryDiscardConflictsAfterStartSerializes(t *testing.T) {
 	if active == nil || active.Status != "queued" {
 		t.Fatalf("active queue after serialized start/retry = %#v, want queued", active)
 	}
+}
+
+// TestHandlerLoopRetryDiscardResolvesByPRNotSiblingBranch ensures that when the
+// sole (project, branch) worktree row points at a sibling PR's CreateWorktree
+// path (last writer won the unique branch index), discard+retry for PR 42 does
+// not reset/clean that sibling checkout.
+func TestHandlerLoopRetryDiscardResolvesByPRNotSiblingBranch(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_pr_disambig"
+	branch := "feature/shared-head"
+
+	// Primary fixture creates ...-pr-42 for branch, then we retarget the row to a
+	// sibling PR-99 path (simulating another PR with the same head branch name
+	// overwriting the unique project+branch worktree record).
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: projectID,
+		LoopID:    "loop_retry_discard_pr_disambig",
+		LoopSeq:   3125,
+		LoopType:  "fixer",
+		Branch:    branch,
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	siblingPath := filepath.Join(fixture.WorktreeRoot, fmt.Sprintf("looper-fix-%s-pr-99", projectID))
+	if err := os.MkdirAll(siblingPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(sibling) error = %v", err)
+	}
+	// Real git worktree so DiscardWorktreeChanges would succeed if wrongly selected.
+	runGitTest(t, fixture.RepoPath, "worktree", "add", "--force", siblingPath, branch)
+	if err := os.WriteFile(filepath.Join(siblingPath, "sibling-dirty.txt"), []byte("keep me\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(sibling dirty) error = %v", err)
+	}
+	existing, err := services.Repositories.Worktrees.GetByBranch(context.Background(), projectID, branch)
+	if err != nil || existing == nil {
+		t.Fatalf("GetByBranch() = %#v, %v", existing, err)
+	}
+	existing.WorktreePath = siblingPath
+	existing.UpdatedAt = nowISO
+	if err := services.Repositories.Worktrees.Upsert(context.Background(), *existing); err != nil {
+		t.Fatalf("Worktrees.Upsert(retarget sibling) error = %v", err)
+	}
+
+	// Branch-only checkpoint (dirty prepare): no worktree path/id.
+	detailOnly := fmt.Sprintf(`{"detail":{"headRefName":%q,"state":"OPEN","prNumber":42},"pause":{"reason":"dirty_worktree"}}`, branch)
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_" + fixture.LoopID, LoopID: fixture.LoopID, Status: "failed", CheckpointJSON: &detailOnly,
+		StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(detail-only) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3125/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	discard := data["worktreeDiscard"].(map[string]any)
+	// Must not discard the sibling PR-99 tree; no resolvable PR-42 worktree → no-op.
+	assertEqual(t, discard["discarded"], false)
+	assertEqual(t, discard["noOp"], true)
+
+	if got := readTestFile(t, filepath.Join(siblingPath, "sibling-dirty.txt")); got != "keep me\n" {
+		t.Fatalf("sibling worktree was discarded: sibling-dirty.txt = %q", got)
+	}
+	// Original PR-42 checkout dirt should also remain (we did not resolve it).
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("pr-42 dirty.txt = %q, want preserved (unresolved worktree)", got)
+	}
+}
+
+// TestHandlerLoopRetryDiscardRejectsAwaitingHuman ensures discard+retry refuses
+// awaiting_human loops so runtime HITL poll requeue cannot race after preflight
+// and leave a wiped worktree when the retry TX conflicts.
+func TestHandlerLoopRetryDiscardRejectsAwaitingHuman(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_awaiting_human",
+		LoopID:    "loop_retry_discard_awaiting_human",
+		LoopSeq:   3126,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-awaiting-human",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), fixture.LoopID)
+	if err != nil || loop == nil {
+		t.Fatalf("GetByID() = %#v, %v", loop, err)
+	}
+	loop.Status = "awaiting_human"
+	if err := services.Repositories.Loops.Upsert(context.Background(), *loop); err != nil {
+		t.Fatalf("Loops.Upsert(awaiting_human) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3126/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "awaiting_human") {
+		t.Fatalf("body = %s, want awaiting_human rejection", recorder.Body.String())
+	}
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("dirty.txt after awaiting_human reject = %q, want preserved", got)
+	}
+}
+
+// TestHandlerLoopCreateSharesTargetLockWithDiscard ensures POST /loops for the
+// same PR target takes the shared target mutex held by discard+retry, so create
+// cannot enqueue between preflight and git reset.
+func TestHandlerLoopCreateSharesTargetLockWithDiscard(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_target_lock"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: projectID,
+		LoopID:    "loop_retry_discard_target_lock",
+		LoopSeq:   3127,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-target-lock",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	// Align project metadata with create-loop validation (repo + no hold labels).
+	project, err := services.Repositories.Projects.GetByID(context.Background(), projectID)
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = %#v, %v", project, err)
+	}
+	meta, _ := json.Marshal(map[string]any{"worktreeRoot": fixture.WorktreeRoot, "repo": "acme/looper"})
+	metaJSON := string(meta)
+	project.MetadataJSON = &metaJSON
+	if err := services.Repositories.Projects.Upsert(context.Background(), *project); err != nil {
+		t.Fatalf("Projects.Upsert(repo meta) error = %v", err)
+	}
+
+	// Hold the same-target lock as discard+retry does after loading the loop.
+	target := mustLoopTargetFromFixture(t, services.Repositories, fixture.LoopID)
+	unlockTarget := h.lockLoopTarget(projectID, domain.LoopTypeFixer, target)
+
+	started := make(chan struct{})
+	finished := make(chan struct {
+		code int
+		body string
+	}, 1)
+	go func() {
+		close(started)
+		// Creating another fixer for the same PR target should block on the target lock.
+		// Use a different PR number so uniqueness does not 409 after the lock is released;
+		// we only need the create path to take lockLoopTargetForStatus for fixer+PR targets.
+		// Actually same target is required to share the key — expect 200 or conflict after.
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/loops", strings.NewReader(
+			`{"projectId":"project_retry_discard_target_lock","type":"fixer","targetType":"pull_request","repo":"acme/looper","prNumber":42,"force":true}`,
+		))
+		req.Header.Set("content-type", "application/json")
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		finished <- struct {
+			code int
+			body string
+		}{recorder.Code, recorder.Body.String()}
+	}()
+
+	<-started
+	select {
+	case got := <-finished:
+		unlockTarget()
+		t.Fatalf("loop create completed while target lock held: status=%d body=%s", got.code, got.body)
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked — expected.
+	}
+
+	unlockTarget()
+
+	select {
+	case got := <-finished:
+		// After release, create may 200 (failed loop is not uniqueness-conflicting)
+		// or 409 for other reasons; we only require it was serialized behind the lock.
+		if got.code != http.StatusOK && got.code != http.StatusConflict {
+			t.Fatalf("loop create status after lock release = %d, want 200/409; body=%s", got.code, got.body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop create did not complete after target lock release")
+	}
+
+	// Dirty worktree must still be present: only the lock was held, no discard ran.
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("dirty.txt after blocked create = %q, want preserved", got)
+	}
+}
+
+func mustLoopTargetFromFixture(t *testing.T, repos *storage.Repositories, loopID string) domain.LoopTarget {
+	t.Helper()
+	loop, err := repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("GetByID(%s) = %#v, %v", loopID, loop, err)
+	}
+	target, err := loopTargetFromRecordCompat(*loop)
+	if err != nil {
+		t.Fatalf("loopTargetFromRecordCompat() error = %v", err)
+	}
+	return target
 }
 
 type managedWorktreeSeed struct {

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -96,6 +96,111 @@ func TestHandlerLoopRetryDiscardWorktreeChangesDirtyFixer(t *testing.T) {
 	}
 }
 
+func TestHandlerLoopRetryDiscardWorktreeChangesResolvesBranchOnlyCheckpoint(t *testing.T) {
+	// Worker dirty prepare leaves work.branch without checkpoint.worktree.
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_branch_only",
+		LoopID:    "loop_retry_discard_branch_only",
+		LoopSeq:   3119,
+		LoopType:  "worker",
+		Branch:    "feature/discard-branch-only",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	// Overwrite the run checkpoint to mimic prepare-worktree dirty failure:
+	// work.branch present, worktree absent.
+	branchOnly := fmt.Sprintf(`{"work":{"branch":%q,"executionMode":"push-existing"}}`, "feature/discard-branch-only")
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_" + fixture.LoopID, LoopID: fixture.LoopID, Status: "failed", CheckpointJSON: &branchOnly,
+		StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(branch-only) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3119/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	discard := data["worktreeDiscard"].(map[string]any)
+	assertEqual(t, discard["discarded"], true)
+	assertEqual(t, discard["reason"], "discarded")
+	assertEqual(t, discard["worktreePath"], fixture.WorktreePath)
+	if _, err := os.Stat(filepath.Join(fixture.WorktreePath, "dirty.txt")); !os.IsNotExist(err) {
+		t.Fatalf("dirty.txt still present after branch-only discard: %v", err)
+	}
+}
+
+func TestHandlerLoopRetryDiscardWorktreeChangesResolvesDetailHeadRef(t *testing.T) {
+	// Fixer dirty prepare leaves detail.headRefName without checkpoint.worktree.
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_detail_head",
+		LoopID:    "loop_retry_discard_detail_head",
+		LoopSeq:   3120,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-detail-head",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+
+	detailOnly := fmt.Sprintf(`{"detail":{"headRefName":%q,"state":"OPEN"},"pause":{"reason":"dirty_worktree"}}`, "feature/discard-detail-head")
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_" + fixture.LoopID, LoopID: fixture.LoopID, Status: "failed", CheckpointJSON: &detailOnly,
+		StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(detail-only) error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3120/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	data := body["data"].(map[string]any)
+	discard := data["worktreeDiscard"].(map[string]any)
+	assertEqual(t, discard["discarded"], true)
+	assertEqual(t, discard["worktreePath"], fixture.WorktreePath)
+}
+
+func TestParseCheckpointWorktreeFallsBackToWorkBranchAndDetail(t *testing.T) {
+	t.Parallel()
+	workOnly := `{"work":{"branch":"feature/from-work"}}`
+	ref := parseCheckpointWorktree(&workOnly)
+	if ref == nil || ref.Branch != "feature/from-work" || ref.Path != "" {
+		t.Fatalf("work-only = %#v, want branch feature/from-work", ref)
+	}
+	detailOnly := `{"detail":{"headRefName":"feature/from-detail"}}`
+	ref = parseCheckpointWorktree(&detailOnly)
+	if ref == nil || ref.Branch != "feature/from-detail" {
+		t.Fatalf("detail-only = %#v, want branch feature/from-detail", ref)
+	}
+	worktreeWins := `{"worktree":{"branch":"feature/worktree","path":"/tmp/wt"},"work":{"branch":"feature/work"}}`
+	ref = parseCheckpointWorktree(&worktreeWins)
+	if ref == nil || ref.Branch != "feature/worktree" || ref.Path != "/tmp/wt" {
+		t.Fatalf("worktree preference = %#v", ref)
+	}
+	empty := `{"work":{},"detail":{}}`
+	if got := parseCheckpointWorktree(&empty); got != nil {
+		t.Fatalf("empty hints = %#v, want nil", got)
+	}
+}
+
 func TestHandlerLoopRetryDiscardWorktreeChangesAlreadyClean(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -296,25 +296,23 @@ func TestHandlerLoopRetryDiscardWorktreeChangesAlreadyClean(t *testing.T) {
 	}
 }
 
-func TestHandlerLoopRetryDiscardWorktreeChangesPlannerNoOp(t *testing.T) {
+func TestHandlerLoopRetryDiscardWorktreeChangesDirtyPlanner(t *testing.T) {
+	// Planner prepare-worktree checkpoints a managed worktree; discard must clear
+	// it the same way as fixer/reviewer/worker rather than no-opping.
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})
 	services := rt.Services()
 	nowISO := "2026-04-11T12:00:00.000Z"
-	projectID := "project_retry_discard_planner"
-	loopID := "loop_retry_discard_planner"
-	targetID := projectID
 
-	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Planner", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
-		t.Fatalf("Projects.Upsert() error = %v", err)
-	}
-	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 3110, ProjectID: projectID, Type: "planner", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
-		t.Fatalf("Loops.Upsert() error = %v", err)
-	}
-	lastErrorKind := "manual_intervention"
-	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_retry_discard_planner", ProjectID: &projectID, LoopID: &loopID, Type: "planner", TargetType: "project", TargetID: targetID, DedupeKey: "planner:retry_discard", Priority: storage.QueuePriorityPlanner, Status: "failed", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
-		t.Fatalf("Queue.Upsert() error = %v", err)
-	}
+	fixture := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_retry_discard_planner",
+		LoopID:    "loop_retry_discard_planner",
+		LoopSeq:   3110,
+		LoopType:  "planner",
+		Branch:    "looper/planner/42-plan-this",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3110/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
 	recorder := httptest.NewRecorder()
@@ -323,9 +321,61 @@ func TestHandlerLoopRetryDiscardWorktreeChangesPlannerNoOp(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
 	}
 	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	assertEqual(t, data["discardWorktreeChanges"], true)
+	discard := data["worktreeDiscard"].(map[string]any)
+	assertEqual(t, discard["discarded"], true)
+	assertEqual(t, discard["noOp"], false)
+	assertEqual(t, discard["worktreePath"], fixture.WorktreePath)
+	assertEqual(t, discard["reason"], "discarded")
+
+	if _, err := os.Stat(filepath.Join(fixture.WorktreePath, "dirty.txt")); !os.IsNotExist(err) {
+		t.Fatalf("dirty.txt still present after planner discard: %v", err)
+	}
+	if got := readTestFile(t, filepath.Join(fixture.WorktreePath, "README.md")); got != "hello\n" {
+		t.Fatalf("README.md after planner discard = %q, want restored contents", got)
+	}
+	clean, err := gitinfra.New(gitinfra.Options{GitPath: "git"}).WorktreeClean(context.Background(), fixture.WorktreePath)
+	if err != nil || !clean {
+		t.Fatalf("planner worktree clean after discard = %v, %v", clean, err)
+	}
+
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), fixture.LoopID)
+	if err != nil || loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop after retry = %#v, %v, want queued", loop, err)
+	}
+}
+
+func TestHandlerLoopRetryDiscardWorktreeChangesPlannerNoWorktree(t *testing.T) {
+	// Planner without a resolvable worktree still retries as a no-op discard.
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_discard_planner_none"
+	loopID := "loop_retry_discard_planner_none"
+	targetID := projectID
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Planner", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 3136, ProjectID: projectID, Type: "planner", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	lastErrorKind := "manual_intervention"
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_retry_discard_planner_none", ProjectID: &projectID, LoopID: &loopID, Type: "planner", TargetType: "project", TargetID: targetID, DedupeKey: "planner:retry_discard_none", Priority: storage.QueuePriorityPlanner, Status: "failed", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3, LastErrorKind: &lastErrorKind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3136/retry", strings.NewReader(`{"mode":"auto","discardWorktreeChanges":true}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
 	discard := data["worktreeDiscard"].(map[string]any)
 	assertEqual(t, discard["noOp"], true)
-	assertEqual(t, discard["reason"], "planner_no_worktree")
+	assertEqual(t, discard["reason"], "no_worktree")
 	assertEqual(t, discard["discarded"], false)
 
 	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
@@ -1848,6 +1898,9 @@ func seedManagedWorktreeFixture(t *testing.T, repos *storage.Repositories, seed 
 		queue.Priority = storage.QueuePriorityReviewer
 		queue.Repo = &repo
 		queue.PRNumber = &prNumber
+	}
+	if seed.LoopType == "planner" {
+		queue.Priority = storage.QueuePriorityPlanner
 	}
 	if err := repos.Queue.Upsert(context.Background(), queue); err != nil {
 		t.Fatalf("Queue.Upsert() error = %v", err)

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -598,6 +598,86 @@ func TestHandlerLoopRetryDiscardPreservesDirtyWorktreeOnUniqueLoopConflict(t *te
 	}
 }
 
+// TestHandlerWorkersCreateReuseSharesRetryLockWithDiscard ensures POST /workers
+// issue-worker reuse takes the same per-loop mutex as discard+retry, so reuse
+// cannot enqueue between discard preflight and git reset (wiping the worktree
+// for the reuse-created queue item, then failing retry with active-queue conflict).
+func TestHandlerWorkersCreateReuseSharesRetryLockWithDiscard(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	baseBranch := "main"
+	metadata := `{"repo":"acme/looper"}`
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: "project_retry_discard_worker_reuse", Name: "Looper", RepoPath: "/tmp/repos/looper",
+		BaseBranch: &baseBranch, MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	loopID := "loop_retry_discard_worker_reuse"
+	targetID := "issue:acme/looper:88"
+	repo := "acme/looper"
+	workerMeta := `{"worker":{"title":"Paused issue worker","repo":"acme/looper","baseBranch":"main","issueNumber":88}}`
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID: loopID, Seq: 3124, ProjectID: "project_retry_discard_worker_reuse", Type: "worker",
+		TargetType: "issue", TargetID: &targetID, Repo: &repo, Status: "paused",
+		MetadataJSON: &workerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	// Hold the shared retry lock as if discard+retry is between preflight and reset.
+	unlock := h.lockLoopRetry(loopID)
+
+	started := make(chan struct{})
+	finished := make(chan int, 1)
+	go func() {
+		close(started)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/workers", strings.NewReader(
+			`{"projectId":"project_retry_discard_worker_reuse","repo":"acme/looper","issueNumber":88,"baseBranch":"main"}`,
+		))
+		req.Header.Set("content-type", "application/json")
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		finished <- recorder.Code
+	}()
+
+	<-started
+	select {
+	case code := <-finished:
+		unlock()
+		t.Fatalf("worker reuse completed while retry/discard lock held: status=%d", code)
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked on the shared lock — expected.
+	}
+
+	unlock()
+
+	select {
+	case code := <-finished:
+		if code != http.StatusOK {
+			t.Fatalf("worker reuse status after lock release = %d, want 200", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker reuse did not complete after retry/discard lock release")
+	}
+
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop after reuse = %#v, %v, want queued", loop, err)
+	}
+	active, err := services.Repositories.Queue.FindActiveByLoopID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("FindActiveByLoopID() error = %v", err)
+	}
+	if active == nil || active.Status != "queued" {
+		t.Fatalf("active queue after worker reuse = %#v, want queued", active)
+	}
+}
+
 // TestHandlerLoopStartSharesRetryLockWithDiscard ensures /start requeue takes
 // the same per-loop mutex as discard+retry, so start cannot enqueue between
 // discard preflight and git reset (wiping the worktree for start-created work).

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -1028,6 +1028,174 @@ func TestHandlerLoopCreateSharesTargetLockWithDiscard(t *testing.T) {
 	}
 }
 
+// TestHandlerLoopRetrySharesTargetLockAcrossLoops ensures a regular (non-discard)
+// retry for a different failed loop on the same PR target takes the shared target
+// mutex, so it cannot create an active queue item between another request's
+// discard preflight and git reset.
+func TestHandlerLoopRetrySharesTargetLockAcrossLoops(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_retry_target_lock_across"
+
+	// Loop A owns the shared PR target key; hold its target lock as discard would.
+	// Both loops stay failed (non-conflicting) so B's requeue is only gated by the lock.
+	fixtureA := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: projectID,
+		LoopID:    "loop_retry_target_lock_a",
+		LoopSeq:   3128,
+		LoopType:  "fixer",
+		Branch:    "feature/discard-target-lock-a",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+	markLoopFailed(t, services.Repositories, fixtureA.LoopID, nowISO)
+	// Loop B: second failed fixer for the same PR (non-conflicting while failed).
+	seedSecondFailedFixerSamePR(t, services.Repositories, projectID, "loop_retry_target_lock_b", 3129, nowISO)
+
+	target := mustLoopTargetFromFixture(t, services.Repositories, fixtureA.LoopID)
+	unlockTarget := h.lockLoopTarget(projectID, domain.LoopTypeFixer, target)
+
+	started := make(chan struct{})
+	finished := make(chan int, 1)
+	go func() {
+		close(started)
+		// Regular retry (no discard) of the *other* loop must wait on target lock.
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3129/retry", strings.NewReader(`{"mode":"auto","resetAttempts":true}`))
+		req.Header.Set("content-type", "application/json")
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		finished <- recorder.Code
+	}()
+
+	<-started
+	select {
+	case code := <-finished:
+		unlockTarget()
+		t.Fatalf("regular retry completed while same-target lock held: status=%d", code)
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked — expected.
+	}
+
+	unlockTarget()
+
+	select {
+	case code := <-finished:
+		if code != http.StatusOK {
+			t.Fatalf("regular retry status after target lock release = %d, want 200", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("regular retry did not complete after target lock release")
+	}
+
+	// Dirty worktree for loop A must remain: only the lock was held, no discard.
+	if got := readTestFile(t, filepath.Join(fixtureA.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("dirty.txt after blocked regular retry = %q, want preserved", got)
+	}
+}
+
+// TestHandlerLoopStartSharesTargetLockAcrossLoops ensures /start for a different
+// failed loop on the same PR target takes the shared target mutex with discard.
+func TestHandlerLoopStartSharesTargetLockAcrossLoops(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_start_target_lock_across"
+
+	fixtureA := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: projectID,
+		LoopID:    "loop_start_target_lock_a",
+		LoopSeq:   3130,
+		LoopType:  "fixer",
+		Branch:    "feature/start-target-lock-a",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+	markLoopFailed(t, services.Repositories, fixtureA.LoopID, nowISO)
+	seedSecondFailedFixerSamePR(t, services.Repositories, projectID, "loop_start_target_lock_b", 3131, nowISO)
+
+	target := mustLoopTargetFromFixture(t, services.Repositories, fixtureA.LoopID)
+	unlockTarget := h.lockLoopTarget(projectID, domain.LoopTypeFixer, target)
+
+	started := make(chan struct{})
+	finished := make(chan int, 1)
+	go func() {
+		close(started)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/3131/start", nil)
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		finished <- recorder.Code
+	}()
+
+	<-started
+	select {
+	case code := <-finished:
+		unlockTarget()
+		t.Fatalf("start completed while same-target lock held: status=%d", code)
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked — expected.
+	}
+
+	unlockTarget()
+
+	select {
+	case code := <-finished:
+		if code != http.StatusOK {
+			t.Fatalf("start status after target lock release = %d, want 200", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("start did not complete after target lock release")
+	}
+
+	if got := readTestFile(t, filepath.Join(fixtureA.WorktreePath, "dirty.txt")); got != "untracked\n" {
+		t.Fatalf("dirty.txt after blocked start = %q, want preserved", got)
+	}
+}
+
+func markLoopFailed(t *testing.T, repos *storage.Repositories, loopID, nowISO string) {
+	t.Helper()
+	loop, err := repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID(%s) = %#v, %v", loopID, loop, err)
+	}
+	loop.Status = "failed"
+	loop.UpdatedAt = nowISO
+	if err := repos.Loops.Upsert(context.Background(), *loop); err != nil {
+		t.Fatalf("Loops.Upsert(failed %s) error = %v", loopID, err)
+	}
+}
+
+// seedSecondFailedFixerSamePR inserts another failed fixer loop for PR #42 so
+// two non-conflicting failed loops share one target key (fixture hardcodes 42).
+func seedSecondFailedFixerSamePR(t *testing.T, repos *storage.Repositories, projectID, loopID string, seq int64, nowISO string) {
+	t.Helper()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	prTarget := fmt.Sprintf("pr:%s:%d", repo, prNumber)
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID: loopID, Seq: seq, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &prTarget, Repo: &repo, PRNumber: &prNumber,
+		Status: "failed", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert(%s) error = %v", loopID, err)
+	}
+	failedQueueID := "queue_" + loopID
+	lastErrorKind := "manual_intervention"
+	lastError := "prior failure"
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: failedQueueID, ProjectID: &projectID, LoopID: &loopID, Type: "fixer",
+		TargetType: "pull_request", TargetID: prTarget, Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: "fixer:" + loopID, Priority: storage.QueuePriorityFixer,
+		Status: "failed", AvailableAt: nowISO, Attempts: 1, MaxAttempts: 3,
+		LastError: &lastError, LastErrorKind: &lastErrorKind,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert(%s) error = %v", failedQueueID, err)
+	}
+}
+
 func mustLoopTargetFromFixture(t *testing.T, repos *storage.Repositories, loopID string) domain.LoopTarget {
 	t.Helper()
 	loop, err := repos.Loops.GetByID(context.Background(), loopID)

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/nexu-io/looper/internal/domain"
 	gitinfra "github.com/nexu-io/looper/internal/infra/git"
+	looperdruntime "github.com/nexu-io/looper/internal/runtime"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -1049,6 +1050,39 @@ func TestHandlerLoopRetryDiscardRejectsUntaggedPRWorktree(t *testing.T) {
 
 	if got := readTestFile(t, filepath.Join(untaggedPath, "untagged-dirty.txt")); got != "keep me\n" {
 		t.Fatalf("untagged worktree was discarded: untagged-dirty.txt = %q", got)
+	}
+}
+
+// TestHandlerLockLoopRetryIsProcessWideRequeueGuard ensures API lockLoopRetry
+// is the same mutex runtime free-text enqueue takes (LockLoopRequeue), so
+// discard+retry serializes against inbox requeues rather than relying only on
+// a non-atomic pre-git recheck.
+func TestHandlerLockLoopRetryIsProcessWideRequeueGuard(t *testing.T) {
+	h := NewHandler(Context{})
+	const loopID = "loop_shared_requeue_guard"
+
+	unlock := h.lockLoopRetry(loopID)
+	started := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		close(started)
+		// Runtime enqueue takes this exact process-wide guard.
+		unlockRuntime := looperdruntime.LockLoopRequeue(loopID)
+		unlockRuntime()
+		close(finished)
+	}()
+	<-started
+	select {
+	case <-finished:
+		unlock()
+		t.Fatal("LockLoopRequeue completed while Handler.lockLoopRetry held — locks are not shared")
+	case <-time.After(150 * time.Millisecond):
+	}
+	unlock()
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("LockLoopRequeue did not complete after Handler.lockLoopRetry release")
 	}
 }
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -149,11 +149,20 @@ type loopOutput struct {
 	Status     string  `json:"status"`
 }
 
+type loopRetryWorktreeDiscardOutput struct {
+	WorktreePath *string `json:"worktreePath"`
+	Discarded    bool    `json:"discarded"`
+	NoOp         bool    `json:"noOp"`
+	Reason       string  `json:"reason"`
+}
+
 type loopRetryOutput struct {
-	Loop          loopOutput `json:"loop"`
-	QueueItemID   *string    `json:"queueItemId"`
-	Mode          string     `json:"mode"`
-	ResetAttempts bool       `json:"resetAttempts"`
+	Loop                   loopOutput                      `json:"loop"`
+	QueueItemID            *string                         `json:"queueItemId"`
+	Mode                   string                          `json:"mode"`
+	ResetAttempts          bool                            `json:"resetAttempts"`
+	DiscardWorktreeChanges bool                            `json:"discardWorktreeChanges"`
+	WorktreeDiscard        *loopRetryWorktreeDiscardOutput `json:"worktreeDiscard"`
 }
 
 type reviewRepairOutput struct {
@@ -508,7 +517,24 @@ func writeHumanLoopRetried(w io.Writer, payload json.RawMessage) error {
 	if err := json.Unmarshal(payload, &data); err != nil {
 		return fmt.Errorf("decode loop retry response: %w", err)
 	}
-	printSection(w, "Loop retry queued", [][2]any{{"id", data.Loop.ID}, {"seq", data.Loop.Seq}, {"status", data.Loop.Status}, {"mode", data.Mode}, {"queueItem", formatScalar(data.QueueItemID)}})
+	fields := [][2]any{
+		{"id", data.Loop.ID},
+		{"seq", data.Loop.Seq},
+		{"status", data.Loop.Status},
+		{"mode", data.Mode},
+		{"queueItem", formatScalar(data.QueueItemID)},
+	}
+	if data.DiscardWorktreeChanges {
+		fields = append(fields, [2]any{"discardWorktreeChanges", true})
+		if data.WorktreeDiscard != nil {
+			fields = append(fields,
+				[2]any{"worktreePath", formatScalar(data.WorktreeDiscard.WorktreePath)},
+				[2]any{"worktreeDiscardNoOp", data.WorktreeDiscard.NoOp},
+				[2]any{"worktreeDiscardReason", data.WorktreeDiscard.Reason},
+			)
+		}
+	}
+	printSection(w, "Loop retry queued", fields)
 	return nil
 }
 

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -307,14 +307,14 @@ func (r *commandRuntime) loopRetry(cmd *cobra.Command, args []string) error {
 		if getBoolFlag(cmd, "discard-worktree-changes") && !getBoolFlag(cmd, "confirm") {
 			return nil, fmt.Errorf("--discard-worktree-changes requires --confirm")
 		}
-		if getBoolFlag(cmd, "discard-worktree-changes") {
-			return nil, fmt.Errorf("--discard-worktree-changes is not supported yet; fix or reset the worktree manually, then retry without this flag")
-		}
 		mode := strings.TrimSpace(getStringFlag(cmd, "mode"))
 		if mode == "" {
 			mode = "auto"
 		}
 		body := map[string]any{"mode": mode, "resetAttempts": true}
+		if getBoolFlag(cmd, "discard-worktree-changes") {
+			body["discardWorktreeChanges"] = true
+		}
 		return r.postJSON(ctx, "/api/v1/loops/"+url.PathEscape(selector)+"/retry", body)
 	}, writeHumanLoopRetried)
 }

--- a/internal/cliapp/loop_retry_discard_test.go
+++ b/internal/cliapp/loop_retry_discard_test.go
@@ -1,0 +1,87 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	pkgapi "github.com/nexu-io/looper/pkg/api"
+)
+
+func TestLoopRetryDiscardWorktreeChangesRequiresConfirm(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeCLIConfig(t, "http://127.0.0.1:1", "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr})
+	args := []string{"--config", configPath, "loop", "retry", "3108", "--discard-worktree-changes"}
+	exitCode := app.Run(context.Background(), args)
+	if exitCode == 0 {
+		t.Fatalf("Run() exit code = 0, want failure; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--discard-worktree-changes requires --confirm") {
+		t.Fatalf("stderr = %q, want confirm requirement error", stderr.String())
+	}
+}
+
+func TestLoopRetryDiscardWorktreeChangesWiresAPIBodyAndHumanOutput(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/loops/3108/retry" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &gotBody); err != nil {
+			t.Fatalf("unmarshal body: %v body=%q", err, raw)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_retry_discard", map[string]any{
+			"loop": map[string]any{
+				"id": "loop_retry_discard", "seq": 3108, "projectId": "project_1",
+				"type": "fixer", "targetType": "pull_request", "status": "queued",
+			},
+			"queueItemId":            "queue_new",
+			"mode":                   "auto",
+			"resetAttempts":          true,
+			"discardWorktreeChanges": true,
+			"worktreeDiscard": map[string]any{
+				"worktreePath": "/tmp/managed/wt",
+				"discarded":    true,
+				"noOp":         false,
+				"reason":       "discarded",
+			},
+		}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+	args := []string{"--config", configPath, "loop", "retry", "3108", "--discard-worktree-changes", "--confirm"}
+	if exitCode := app.Run(context.Background(), args); exitCode != 0 {
+		t.Fatalf("Run() exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if gotBody["discardWorktreeChanges"] != true {
+		t.Fatalf("request body = %#v, want discardWorktreeChanges=true", gotBody)
+	}
+	if gotBody["mode"] != "auto" || gotBody["resetAttempts"] != true {
+		t.Fatalf("request body = %#v, want mode=auto resetAttempts=true", gotBody)
+	}
+	out := stdout.String()
+	for _, needle := range []string{"Loop retry queued", "discardWorktreeChanges", "/tmp/managed/wt", "worktreeDiscardNoOp"} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("stdout missing %q\n%s", needle, out)
+		}
+	}
+}

--- a/internal/cliapp/review_submit_contract_helpers_test.go
+++ b/internal/cliapp/review_submit_contract_helpers_test.go
@@ -95,8 +95,17 @@ case "$1" in
     ;;
 esac
 `, submitLog, baseSHA, headSHA, diffMode, filepath.Join(root, "gh-invocations.log"))
-	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake gh: %v", err)
+	// Write via temp + rename so the final path is never open for write when
+	// tests immediately exec it (avoids intermittent Linux ETXTBSY / "text file busy").
+	ghTmp := ghPath + ".tmp"
+	if err := os.WriteFile(ghTmp, []byte(script), 0o644); err != nil {
+		t.Fatalf("write fake gh tmp: %v", err)
+	}
+	if err := os.Chmod(ghTmp, 0o755); err != nil {
+		t.Fatalf("chmod fake gh: %v", err)
+	}
+	if err := os.Rename(ghTmp, ghPath); err != nil {
+		t.Fatalf("rename fake gh: %v", err)
 	}
 
 	configPayload := map[string]any{

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1606,6 +1606,20 @@ func (r *Runner) pullRequestEligibleForDiscovery(ctx context.Context, projectID 
 }
 
 func (r *Runner) discoverPullRequestFromDetail(ctx context.Context, project storage.ProjectRecord, repo string, detail PullRequestDetail, result *DiscoveryResult) error {
+	// Share the PR worktree target mutex with API discard+retry so fixer
+	// discovery cannot create/requeue for the same PR between discard
+	// preflight and git reset. Per-loop lock first when a loop already exists.
+	existingForLock, lockErr := r.findFixerLoopByPR(ctx, project.ID, repo, detail.Number)
+	if lockErr != nil {
+		return lockErr
+	}
+	if existingForLock != nil && strings.TrimSpace(existingForLock.ID) != "" {
+		unlock := loops.LockLoopRequeue(existingForLock.ID)
+		defer unlock()
+	}
+	unlockTarget := loops.LockLoopTarget(loops.PullRequestTargetGuardKey(project.ID, repo, detail.Number))
+	defer unlockTarget()
+
 	loop, err := r.findFixerLoopByPR(ctx, project.ID, repo, detail.Number)
 	if err != nil {
 		return err

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -115,6 +115,21 @@ type CleanupWorktreeInput struct {
 	ProtectedBranches []string
 }
 
+// DiscardWorktreeChangesInput discards tracked and untracked local changes in a
+// managed worktree, leaving HEAD and the worktree directory itself intact.
+type DiscardWorktreeChangesInput struct {
+	RepoPath     string
+	WorktreeRoot string
+	WorktreePath string
+}
+
+// DiscardWorktreeChangesResult reports whether discard mutated the worktree.
+type DiscardWorktreeChangesResult struct {
+	WorktreePath string
+	WasDirty     bool
+	NoOp         bool
+}
+
 type PushInput struct {
 	RepoPath              string
 	WorktreeRoot          string
@@ -518,6 +533,49 @@ func (g *Gateway) WorktreeClean(ctx context.Context, worktreePath string) (bool,
 
 func (g *Gateway) IsWorktreeClean(ctx context.Context, worktreePath string) (bool, error) {
 	return g.WorktreeClean(ctx, worktreePath)
+}
+
+// DiscardWorktreeChanges hard-resets tracked files and removes untracked files
+// in a managed worktree. It never deletes the worktree directory, remote
+// branches, or force-pushes.
+func (g *Gateway) DiscardWorktreeChanges(ctx context.Context, input DiscardWorktreeChangesInput) (DiscardWorktreeChangesResult, error) {
+	worktreePath := strings.TrimSpace(input.WorktreePath)
+	if worktreePath == "" {
+		return DiscardWorktreeChangesResult{}, fmt.Errorf("worktree path is required")
+	}
+	if err := g.validateMutationWorktree(worktreePath, input.RepoPath, input.WorktreeRoot); err != nil {
+		return DiscardWorktreeChangesResult{}, err
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return DiscardWorktreeChangesResult{WorktreePath: worktreePath, NoOp: true}, nil
+		}
+		return DiscardWorktreeChangesResult{}, err
+	}
+
+	clean, err := g.WorktreeClean(ctx, worktreePath)
+	if err != nil {
+		return DiscardWorktreeChangesResult{}, err
+	}
+	if clean {
+		return DiscardWorktreeChangesResult{WorktreePath: worktreePath, WasDirty: false, NoOp: true}, nil
+	}
+
+	if err := g.runGit(ctx, worktreePath, nil, "reset", "--hard", "HEAD"); err != nil {
+		return DiscardWorktreeChangesResult{}, err
+	}
+	if err := g.runGit(ctx, worktreePath, nil, "clean", "-fd"); err != nil {
+		return DiscardWorktreeChangesResult{}, err
+	}
+
+	clean, err = g.WorktreeClean(ctx, worktreePath)
+	if err != nil {
+		return DiscardWorktreeChangesResult{}, err
+	}
+	if !clean {
+		return DiscardWorktreeChangesResult{}, fmt.Errorf("worktree still dirty after discard at %s", worktreePath)
+	}
+	return DiscardWorktreeChangesResult{WorktreePath: worktreePath, WasDirty: true, NoOp: false}, nil
 }
 
 func (g *Gateway) Push(ctx context.Context, input PushInput) error {

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -564,7 +564,11 @@ func (g *Gateway) DiscardWorktreeChanges(ctx context.Context, input DiscardWorkt
 	if err := g.runGit(ctx, worktreePath, nil, "reset", "--hard", "HEAD"); err != nil {
 		return DiscardWorktreeChangesResult{}, err
 	}
-	if err := g.runGit(ctx, worktreePath, nil, "clean", "-fd"); err != nil {
+	// Double -f is required so git clean also removes nested repositories
+	// (untracked checkouts with their own .git). Single -f leaves those
+	// behind, which fails the post-clean cleanliness check after tracked
+	// edits were already discarded via reset --hard.
+	if err := g.runGit(ctx, worktreePath, nil, "clean", "-ffd"); err != nil {
 		return DiscardWorktreeChangesResult{}, err
 	}
 

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -561,7 +561,11 @@ func (g *Gateway) DiscardWorktreeChanges(ctx context.Context, input DiscardWorkt
 		return DiscardWorktreeChangesResult{WorktreePath: worktreePath, WasDirty: false, NoOp: true}, nil
 	}
 
-	if err := g.runGit(ctx, worktreePath, nil, "reset", "--hard", "HEAD"); err != nil {
+	// Recurse into submodules so a dirty tracked submodule is reset with the
+	// superproject. Without --recurse-submodules, top-level tracked edits are
+	// discarded while submodule dirt remains, and the post-clean check fails
+	// after partial discard (not all-or-nothing for repos with submodules).
+	if err := g.runGit(ctx, worktreePath, nil, "reset", "--hard", "--recurse-submodules", "HEAD"); err != nil {
 		return DiscardWorktreeChangesResult{}, err
 	}
 	// Double -f is required so git clean also removes nested repositories
@@ -569,6 +573,12 @@ func (g *Gateway) DiscardWorktreeChanges(ctx context.Context, input DiscardWorkt
 	// behind, which fails the post-clean cleanliness check after tracked
 	// edits were already discarded via reset --hard.
 	if err := g.runGit(ctx, worktreePath, nil, "clean", "-ffd"); err != nil {
+		return DiscardWorktreeChangesResult{}, err
+	}
+	// Top-level clean does not enter tracked submodules. Reset+clean each
+	// submodule so untracked/modified files inside them are discarded too.
+	// No-op when the worktree has no submodules.
+	if err := g.runGit(ctx, worktreePath, nil, "submodule", "foreach", "--recursive", "git reset --hard && git clean -ffd"); err != nil {
 		return DiscardWorktreeChangesResult{}, err
 	}
 

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -1074,6 +1074,56 @@ func TestGatewayDiscardWorktreeChangesResetsTrackedAndUntracked(t *testing.T) {
 	}
 }
 
+func TestGatewayDiscardWorktreeChangesRemovesNestedRepositories(t *testing.T) {
+	fixture := newFixture(t)
+	fixture.createRemoteRepo(t, "feature/fixer")
+	ctx := context.Background()
+	gateway := fixture.gateway()
+
+	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       "feature/fixer",
+		BaseBranch:   "main",
+		PRNumber:     42,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	// Tracked dirt so discard does real work (not the clean no-op path).
+	writeFile(t, filepath.Join(worktree.WorktreePath, "README.md"), "dirty tracked\n")
+
+	// Untracked nested Git checkout: single-force git clean -fd leaves these
+	// behind; double-force -ffd is required to remove them.
+	nestedPath := filepath.Join(worktree.WorktreePath, "vendor-checkout")
+	mustMkdirAll(t, nestedPath)
+	runGit(t, nestedPath, "init")
+	writeFile(t, filepath.Join(nestedPath, "nested.txt"), "nested repo content\n")
+	runGit(t, nestedPath, "add", "nested.txt")
+	runGit(t, nestedPath, "-c", "user.email=test@example.com", "-c", "user.name=test", "commit", "-m", "nested")
+
+	result, err := gateway.DiscardWorktreeChanges(ctx, DiscardWorktreeChangesInput{
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		WorktreePath: worktree.WorktreePath,
+	})
+	if err != nil {
+		t.Fatalf("DiscardWorktreeChanges() error = %v", err)
+	}
+	if result.NoOp || !result.WasDirty {
+		t.Fatalf("DiscardWorktreeChanges() = %#v, want dirty discard including nested repo", result)
+	}
+	if _, err := os.Stat(nestedPath); !os.IsNotExist(err) {
+		t.Fatalf("nested repository still exists after discard: %v", err)
+	}
+	clean, err := gateway.WorktreeClean(ctx, worktree.WorktreePath)
+	if err != nil || !clean {
+		t.Fatalf("WorktreeClean() = %v, %v, want clean after nested-repo discard", clean, err)
+	}
+}
+
 func TestGatewayDiscardWorktreeChangesRejectsUnsafePaths(t *testing.T) {
 	fixture := newFixture(t)
 	fixture.createMainOnlyRepo(t)

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -1135,19 +1135,23 @@ func TestGatewayDiscardWorktreeChangesResetsDirtySubmodules(t *testing.T) {
 
 	// Build a bare submodule remote, commit it into the feature branch, then
 	// create a managed worktree from that branch so discard runs under safety.
+	// Pin bare HEAD to main: CI often has init.defaultBranch=master, so a push of
+	// only main leaves HEAD on an unborn branch and `submodule add` fails with
+	// "You are on a branch yet to be born".
 	subRemote := filepath.Join(fixture.rootDir, "submodule.git")
 	subWork := filepath.Join(fixture.rootDir, "submodule-work")
 	mustMkdirAll(t, subRemote)
-	runGit(t, fixture.rootDir, "init", "--bare", subRemote)
+	runGit(t, fixture.rootDir, "init", "--bare", "-b", "main", subRemote)
 	runGit(t, fixture.rootDir, "clone", subRemote, subWork)
 	configureRepo(t, subWork)
 	writeFile(t, filepath.Join(subWork, "module.txt"), "module-v1\n")
 	runGit(t, subWork, "add", "module.txt")
 	runGit(t, subWork, "commit", "-m", "submodule init")
 	runGit(t, subWork, "push", "origin", "HEAD:main")
+	runGit(t, subRemote, "symbolic-ref", "HEAD", "refs/heads/main")
 
 	runGit(t, fixture.repoPath, "checkout", "feature/fixer")
-	runGit(t, fixture.repoPath, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "vendor")
+	runGit(t, fixture.repoPath, "-c", "protocol.file.allow=always", "submodule", "add", "-b", "main", subRemote, "vendor")
 	runGit(t, fixture.repoPath, "commit", "-m", "add vendor submodule")
 	runGit(t, fixture.repoPath, "push", "origin", "feature/fixer")
 	runGit(t, fixture.repoPath, "checkout", "main")

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -1124,6 +1124,84 @@ func TestGatewayDiscardWorktreeChangesRemovesNestedRepositories(t *testing.T) {
 	}
 }
 
+func TestGatewayDiscardWorktreeChangesResetsDirtySubmodules(t *testing.T) {
+	// Tracked submodule dirt is invisible to top-level git clean -ffd and to
+	// reset --hard without --recurse-submodules. Discard must recurse so the
+	// post-clean check can pass after top-level edits are discarded.
+	fixture := newFixture(t)
+	fixture.createRemoteRepo(t, "feature/fixer")
+	ctx := context.Background()
+	gateway := fixture.gateway()
+
+	// Build a bare submodule remote, commit it into the feature branch, then
+	// create a managed worktree from that branch so discard runs under safety.
+	subRemote := filepath.Join(fixture.rootDir, "submodule.git")
+	subWork := filepath.Join(fixture.rootDir, "submodule-work")
+	mustMkdirAll(t, subRemote)
+	runGit(t, fixture.rootDir, "init", "--bare", subRemote)
+	runGit(t, fixture.rootDir, "clone", subRemote, subWork)
+	configureRepo(t, subWork)
+	writeFile(t, filepath.Join(subWork, "module.txt"), "module-v1\n")
+	runGit(t, subWork, "add", "module.txt")
+	runGit(t, subWork, "commit", "-m", "submodule init")
+	runGit(t, subWork, "push", "origin", "HEAD:main")
+
+	runGit(t, fixture.repoPath, "checkout", "feature/fixer")
+	runGit(t, fixture.repoPath, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "vendor")
+	runGit(t, fixture.repoPath, "commit", "-m", "add vendor submodule")
+	runGit(t, fixture.repoPath, "push", "origin", "feature/fixer")
+	runGit(t, fixture.repoPath, "checkout", "main")
+
+	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       "feature/fixer",
+		BaseBranch:   "main",
+		PRNumber:     42,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	// Worktrees do not always materialize submodule checkouts; ensure vendor is present.
+	vendorPath := filepath.Join(worktree.WorktreePath, "vendor")
+	if _, err := os.Stat(filepath.Join(vendorPath, ".git")); err != nil {
+		runGit(t, worktree.WorktreePath, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
+	}
+	if _, err := os.Stat(filepath.Join(vendorPath, "module.txt")); err != nil {
+		t.Fatalf("submodule content missing after init: %v", err)
+	}
+	originalModule := readFile(t, filepath.Join(vendorPath, "module.txt"))
+
+	// Top-level tracked dirt + dirty submodule (modified tracked + untracked).
+	writeFile(t, filepath.Join(worktree.WorktreePath, "README.md"), "dirty tracked\n")
+	writeFile(t, filepath.Join(vendorPath, "module.txt"), "dirty submodule tracked\n")
+	writeFile(t, filepath.Join(vendorPath, "untracked-in-sub.txt"), "sub untracked\n")
+
+	result, err := gateway.DiscardWorktreeChanges(ctx, DiscardWorktreeChangesInput{
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		WorktreePath: worktree.WorktreePath,
+	})
+	if err != nil {
+		t.Fatalf("DiscardWorktreeChanges() error = %v", err)
+	}
+	if result.NoOp || !result.WasDirty {
+		t.Fatalf("DiscardWorktreeChanges() = %#v, want dirty discard including submodule", result)
+	}
+	if got := readFile(t, filepath.Join(vendorPath, "module.txt")); got != originalModule {
+		t.Fatalf("submodule module.txt after discard = %q, want %q", got, originalModule)
+	}
+	if _, err := os.Stat(filepath.Join(vendorPath, "untracked-in-sub.txt")); !os.IsNotExist(err) {
+		t.Fatalf("submodule untracked file still exists after discard: %v", err)
+	}
+	clean, err := gateway.WorktreeClean(ctx, worktree.WorktreePath)
+	if err != nil || !clean {
+		t.Fatalf("WorktreeClean() = %v, %v, want clean after submodule discard", clean, err)
+	}
+}
+
 func TestGatewayDiscardWorktreeChangesRejectsUnsafePaths(t *testing.T) {
 	fixture := newFixture(t)
 	fixture.createMainOnlyRepo(t)

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -1008,6 +1008,97 @@ func TestGatewayRemoteBranchExistsUsesFetchedTrackingRef(t *testing.T) {
 	}
 }
 
+func TestGatewayDiscardWorktreeChangesResetsTrackedAndUntracked(t *testing.T) {
+	fixture := newFixture(t)
+	fixture.createRemoteRepo(t, "feature/fixer")
+	ctx := context.Background()
+	gateway := fixture.gateway()
+
+	worktree, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       "feature/fixer",
+		BaseBranch:   "main",
+		PRNumber:     42,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	originalREADME := readFile(t, filepath.Join(worktree.WorktreePath, "README.md"))
+	writeFile(t, filepath.Join(worktree.WorktreePath, "README.md"), "dirty tracked\n")
+	writeFile(t, filepath.Join(worktree.WorktreePath, "untracked.txt"), "dirty untracked\n")
+	mustMkdirAll(t, filepath.Join(worktree.WorktreePath, "untracked-dir"))
+	writeFile(t, filepath.Join(worktree.WorktreePath, "untracked-dir", "nested.txt"), "nested\n")
+
+	result, err := gateway.DiscardWorktreeChanges(ctx, DiscardWorktreeChangesInput{
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		WorktreePath: worktree.WorktreePath,
+	})
+	if err != nil {
+		t.Fatalf("DiscardWorktreeChanges() error = %v", err)
+	}
+	if result.NoOp || !result.WasDirty || result.WorktreePath != worktree.WorktreePath {
+		t.Fatalf("DiscardWorktreeChanges() = %#v, want dirty discard of managed path", result)
+	}
+	if got := readFile(t, filepath.Join(worktree.WorktreePath, "README.md")); got != originalREADME {
+		t.Fatalf("README.md after discard = %q, want %q", got, originalREADME)
+	}
+	if _, err := os.Stat(filepath.Join(worktree.WorktreePath, "untracked.txt")); !os.IsNotExist(err) {
+		t.Fatalf("untracked.txt still exists after discard: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(worktree.WorktreePath, "untracked-dir")); !os.IsNotExist(err) {
+		t.Fatalf("untracked-dir still exists after discard: %v", err)
+	}
+	if _, err := os.Stat(worktree.WorktreePath); err != nil {
+		t.Fatalf("worktree directory missing after discard: %v", err)
+	}
+	clean, err := gateway.WorktreeClean(ctx, worktree.WorktreePath)
+	if err != nil || !clean {
+		t.Fatalf("WorktreeClean() = %v, %v, want clean", clean, err)
+	}
+
+	// Second call is a no-op when already clean.
+	second, err := gateway.DiscardWorktreeChanges(ctx, DiscardWorktreeChangesInput{
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		WorktreePath: worktree.WorktreePath,
+	})
+	if err != nil {
+		t.Fatalf("DiscardWorktreeChanges(clean) error = %v", err)
+	}
+	if !second.NoOp || second.WasDirty {
+		t.Fatalf("DiscardWorktreeChanges(clean) = %#v, want no-op", second)
+	}
+}
+
+func TestGatewayDiscardWorktreeChangesRejectsUnsafePaths(t *testing.T) {
+	fixture := newFixture(t)
+	fixture.createMainOnlyRepo(t)
+	ctx := context.Background()
+	gateway := fixture.gateway()
+
+	if _, err := gateway.DiscardWorktreeChanges(ctx, DiscardWorktreeChangesInput{
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		WorktreePath: fixture.repoPath,
+	}); err == nil {
+		t.Fatal("DiscardWorktreeChanges(repoPath) error = nil, want safety rejection")
+	}
+
+	outside := filepath.Join(fixture.rootDir, "outside-wt")
+	mustMkdirAll(t, outside)
+	if _, err := gateway.DiscardWorktreeChanges(ctx, DiscardWorktreeChangesInput{
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		WorktreePath: outside,
+	}); err == nil {
+		t.Fatal("DiscardWorktreeChanges(outside) error = nil, want safety rejection")
+	}
+}
+
 func TestGatewayRestoreWorktreePropagatesHealthCheckFailureForStoredWorktree(t *testing.T) {
 	t.Parallel()
 

--- a/internal/loops/requeue_guard.go
+++ b/internal/loops/requeue_guard.go
@@ -1,0 +1,122 @@
+package loops
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/nexu-io/looper/internal/domain"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// loopRequeueGuards serializes per-loop queue rearm across the API discard/retry
+// path and runtime free-text / HITL / recovery / discovery requeues. Without a
+// process-wide mutex, concurrent requeue can land after API preflight and
+// before git reset, wiping the worktree for a continuation that then loses the
+// retry transaction to an active-queue conflict.
+var loopRequeueGuards sync.Map // loopID -> *sync.Mutex
+
+// loopTargetGuards serializes same worktree-target mutations across API
+// discard/retry/start/create and runtime recovery/discovery/HITL requeues.
+// Per-loop locks alone cannot block a *different* loop on the shared PR
+// worktree from requeuing between discard preflight and git reset.
+var loopTargetGuards sync.Map // targetGuardKey -> *sync.Mutex
+
+// LockLoopRequeue acquires the process-wide per-loop requeue mutex shared by:
+//   - API retry/start/reuse
+//   - runtime HITL free-text / answer requeues
+//   - runtime deferred/startup recovery requeues
+//   - reviewer/fixer discovery enqueue for an existing loop
+//
+// Callers must unlock via the returned function (typically defer). Nested
+// acquisitions on the same loop from the same goroutine deadlock — do not
+// call requeue helpers while already holding this lock for that loopID.
+// Call order with LockLoopTarget: take the per-loop lock first, then the
+// target lock.
+func LockLoopRequeue(loopID string) func() {
+	value, _ := loopRequeueGuards.LoadOrStore(loopID, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+// LoopTargetGuardKey builds the process-wide target mutex key shared by API
+// discard/retry/start/create and runtime recovery/discovery/HITL requeues.
+//
+// Empty string means no lock (concurrent project-scoped workers are exempt).
+// Pull-request targets omit loop type so fixer/reviewer/worker share one key —
+// they share the managed PR worktree (looper-fix-<project>-pr-N).
+func LoopTargetGuardKey(projectID, loopType, targetType, targetKey string) string {
+	projectID = strings.TrimSpace(projectID)
+	loopType = strings.TrimSpace(loopType)
+	targetType = strings.TrimSpace(targetType)
+	targetKey = strings.TrimSpace(targetKey)
+	if targetKey == "" {
+		return ""
+	}
+	if loopType == string(domain.LoopTypeWorker) && targetType == string(domain.LoopTargetTypeProject) {
+		return ""
+	}
+	if targetType == string(domain.LoopTargetTypePullRequest) {
+		return fmt.Sprintf("%s|%s", projectID, targetKey)
+	}
+	return fmt.Sprintf("%s|%s|%s", projectID, loopType, targetKey)
+}
+
+// LoopTargetGuardKeyFromRecord derives LoopTargetGuardKey from a stored loop.
+// Key formatting matches API loopTargetKeyFromRecordCompat / loopTargetKeyCompat
+// so API and runtime share the same mutex entries.
+func LoopTargetGuardKeyFromRecord(loop storage.LoopRecord) string {
+	return LoopTargetGuardKey(loop.ProjectID, loop.Type, loop.TargetType, TargetKeyFromLoopRecord(loop))
+}
+
+// PullRequestTargetGuardKey builds the shared PR worktree target mutex key from
+// project + repo + PR number (loop type omitted). Use when discovery creates or
+// requeues a reviewer/fixer for a PR before a loop record is available.
+func PullRequestTargetGuardKey(projectID, repo string, prNumber int64) string {
+	projectID = strings.TrimSpace(projectID)
+	repo = strings.TrimSpace(repo)
+	if projectID == "" || repo == "" || prNumber <= 0 {
+		return ""
+	}
+	return LoopTargetGuardKey(projectID, string(domain.LoopTypeReviewer), string(domain.LoopTargetTypePullRequest), fmt.Sprintf("pull_request:%s:%d", repo, prNumber))
+}
+
+// TargetKeyFromLoopRecord returns the canonical target key for a stored loop
+// (project:/issue:/pull_request:...), matching API loopTargetKeyFromRecordCompat.
+func TargetKeyFromLoopRecord(loop storage.LoopRecord) string {
+	switch loop.TargetType {
+	case string(domain.LoopTargetTypeProject):
+		if loop.TargetID == nil {
+			return "project:"
+		}
+		normalized := strings.TrimSpace(*loop.TargetID)
+		for strings.HasPrefix(normalized, "project:") {
+			normalized = strings.TrimPrefix(normalized, "project:")
+		}
+		return "project:" + normalized
+	case string(domain.LoopTargetTypeIssue):
+		if loop.TargetID == nil {
+			return "issue:"
+		}
+		return *loop.TargetID
+	default:
+		if loop.Repo == nil || loop.PRNumber == nil {
+			return "pull_request:"
+		}
+		return fmt.Sprintf("pull_request:%s:%d", *loop.Repo, *loop.PRNumber)
+	}
+}
+
+// LockLoopTarget acquires the process-wide same-target mutex. An empty key is a
+// no-op. Callers that also take LockLoopRequeue must acquire the per-loop lock
+// first to avoid deadlocks with API discard+retry.
+func LockLoopTarget(key string) func() {
+	if strings.TrimSpace(key) == "" {
+		return func() {}
+	}
+	value, _ := loopTargetGuards.LoadOrStore(key, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}

--- a/internal/loops/requeue_guard_test.go
+++ b/internal/loops/requeue_guard_test.go
@@ -1,0 +1,50 @@
+package loops
+
+import (
+	"testing"
+
+	"github.com/nexu-io/looper/internal/domain"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestPullRequestTargetGuardKeyMatchesLoopRecordKey(t *testing.T) {
+	t.Parallel()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	loop := storage.LoopRecord{
+		ProjectID:  "proj",
+		Type:       string(domain.LoopTypeFixer),
+		TargetType: string(domain.LoopTargetTypePullRequest),
+		TargetID:   &targetID,
+		Repo:       &repo,
+		PRNumber:   &prNumber,
+	}
+	fromRecord := LoopTargetGuardKeyFromRecord(loop)
+	fromPR := PullRequestTargetGuardKey("proj", repo, prNumber)
+	if fromRecord == "" || fromRecord != fromPR {
+		t.Fatalf("PR keys = record %q / explicit %q, want equal non-empty", fromRecord, fromPR)
+	}
+	// Cross-type identity: reviewer discovery and fixer discard share one mutex.
+	reviewerKey := LoopTargetGuardKey("proj", string(domain.LoopTypeReviewer), string(domain.LoopTargetTypePullRequest), TargetKeyFromLoopRecord(loop))
+	if reviewerKey != fromPR {
+		t.Fatalf("reviewer key %q != fixer PR key %q", reviewerKey, fromPR)
+	}
+}
+
+func TestLoopTargetGuardKeyOmitsTypeForPullRequest(t *testing.T) {
+	t.Parallel()
+	fixer := LoopTargetGuardKey("proj", "fixer", "pull_request", "pull_request:acme/looper:42")
+	worker := LoopTargetGuardKey("proj", "worker", "pull_request", "pull_request:acme/looper:42")
+	if fixer == "" || fixer != worker {
+		t.Fatalf("PR keys = %q / %q, want equal non-empty shared key", fixer, worker)
+	}
+	issueFixer := LoopTargetGuardKey("proj", "fixer", "issue", "issue:acme/looper:7")
+	issueWorker := LoopTargetGuardKey("proj", "worker", "issue", "issue:acme/looper:7")
+	if issueFixer == "" || issueFixer == issueWorker {
+		t.Fatalf("issue keys = %q / %q, want distinct type-scoped keys", issueFixer, issueWorker)
+	}
+	if got := LoopTargetGuardKey("proj", "worker", "project", "project:proj"); got != "" {
+		t.Fatalf("project worker key = %q, want empty (concurrent workers)", got)
+	}
+}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -999,6 +999,17 @@ func (r *Runner) DiscoverPullRequest(ctx context.Context, input TargetedDiscover
 }
 
 func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project storage.ProjectRecord, repo string, policy DiscoveryPolicy, currentLogin *string, pr PullRequestSummary, existing *storage.LoopRecord, allowThreadResolutionFollowUp bool, result *DiscoveryResult) error {
+	// Share the PR worktree target mutex with API discard+retry so discovery
+	// cannot create/requeue a reviewer for the same PR between discard
+	// preflight and git reset (managed worktree is shared across loop types).
+	// When an existing loop is known, take the per-loop lock first (API order).
+	if existing != nil && strings.TrimSpace(existing.ID) != "" {
+		unlock := loops.LockLoopRequeue(existing.ID)
+		defer unlock()
+	}
+	unlockTarget := loops.LockLoopTarget(loops.PullRequestTargetGuardKey(project.ID, repo, pr.Number))
+	defer unlockTarget()
+
 	loopResult, loopErr := r.ensureLoopForPullRequest(ctx, project, repo, pr.Number, existing)
 	if loopErr != nil {
 		return loopErr

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -156,6 +156,7 @@ func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories,
 	// Share process-wide requeue exclusion with API discard+retry so free-text
 	// inbox delivery cannot requeue paused/waiting/manual_intervention loops
 	// between discard preflight and git reset (see LockLoopRequeue).
+	// Call order: per-loop lock first, then same-target lock (matches API).
 	unlock := LockLoopRequeue(loopID)
 	defer unlock()
 
@@ -167,6 +168,12 @@ func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories,
 	case "completed", "failed", "stopped", "terminated", "human_takeover":
 		return nil
 	}
+	// Same-target exclusion: a different waiting loop on this PR/issue can
+	// otherwise requeue while discard+retry holds only that other loop's
+	// per-loop mutex and wipes the shared worktree before the retry TX.
+	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
+	defer unlockTarget()
+
 	meta, werr := loops.AppendHumanMessage(loop.MetadataJSON, loops.HumanMessage{At: nowISO, Text: text})
 	if werr != nil {
 		return werr
@@ -191,7 +198,7 @@ func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories,
 }
 
 func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, answer string) error {
-	// Same requeue exclusion as free-text enqueue / API discard+retry.
+	// Same requeue + target exclusion as free-text enqueue / API discard+retry.
 	unlock := LockLoopRequeue(loopID)
 	defer unlock()
 
@@ -202,6 +209,8 @@ func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, n
 	if loop.Status != "awaiting_human" {
 		return nil
 	}
+	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
+	defer unlockTarget()
 	ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
 	if !ok {
 		return nil

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -153,6 +153,12 @@ func pollGitHubHITLAnswersOnce(ctx contextType, loops []githubHITLAwaitingLoop, 
 // answer, a message does NOT resolve a pending ask — the agent reads it and
 // decides whether to proceed, answer, or ask again.
 func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, text string) error {
+	// Share process-wide requeue exclusion with API discard+retry so free-text
+	// inbox delivery cannot requeue paused/waiting/manual_intervention loops
+	// between discard preflight and git reset (see LockLoopRequeue).
+	unlock := LockLoopRequeue(loopID)
+	defer unlock()
+
 	loop, err := repos.Loops.GetByID(ctx, loopID)
 	if err != nil || loop == nil {
 		return err
@@ -185,6 +191,10 @@ func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories,
 }
 
 func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, answer string) error {
+	// Same requeue exclusion as free-text enqueue / API discard+retry.
+	unlock := LockLoopRequeue(loopID)
+	defer unlock()
+
 	loop, err := repos.Loops.GetByID(ctx, loopID)
 	if err != nil || loop == nil {
 		return err

--- a/internal/runtime/loop_requeue_lock.go
+++ b/internal/runtime/loop_requeue_lock.go
@@ -1,107 +1,31 @@
 package runtime
 
 import (
-	"fmt"
-	"strings"
-	"sync"
-
-	"github.com/nexu-io/looper/internal/domain"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
-// loopRequeueGuards serializes per-loop queue rearm across the API discard/retry
-// path and runtime free-text / HITL requeues. Without a process-wide mutex,
-// Feishu/GitHub inbox delivery can call enqueueHumanMessageToLoop after API
-// preflight and before git reset, wiping the worktree for a message-driven
-// continuation that then loses the retry transaction to an active-queue conflict.
-var loopRequeueGuards sync.Map // loopID -> *sync.Mutex
-
-// loopTargetGuards serializes same worktree-target mutations across API
-// discard/retry/start/create and runtime HITL requeues. Per-loop locks alone
-// cannot block a *different* loop on the shared PR worktree from requeuing
-// between discard preflight and git reset.
-var loopTargetGuards sync.Map // targetGuardKey -> *sync.Mutex
-
-// LockLoopRequeue acquires the process-wide per-loop requeue mutex shared by:
-//   - API retry/start/reuse (via Handler.lockLoopRetry)
-//   - runtime HITL free-text enqueue (enqueueHumanMessageToLoop)
-//   - runtime HITL answer requeue (deliverHITLAnswerToLoop)
-//
-// Callers must unlock via the returned function (typically defer). Nested
-// acquisitions on the same loop from the same goroutine deadlock — do not
-// call requeue helpers while already holding this lock for that loopID.
+// LockLoopRequeue acquires the process-wide per-loop requeue mutex shared by
+// API discard+retry and runtime requeue paths. See loops.LockLoopRequeue.
 // Call order with LockLoopTarget: take the per-loop lock first, then the
 // target lock.
 func LockLoopRequeue(loopID string) func() {
-	value, _ := loopRequeueGuards.LoadOrStore(loopID, &sync.Mutex{})
-	mu := value.(*sync.Mutex)
-	mu.Lock()
-	return mu.Unlock
+	return loops.LockLoopRequeue(loopID)
 }
 
-// LoopTargetGuardKey builds the process-wide target mutex key shared by API
-// discard/retry/start/create and runtime HITL requeues.
-//
-// Empty string means no lock (concurrent project-scoped workers are exempt).
-// Pull-request targets omit loop type so fixer/reviewer/worker share one key —
-// they share the managed PR worktree (looper-fix-<project>-pr-N).
+// LoopTargetGuardKey builds the process-wide target mutex key. See
+// loops.LoopTargetGuardKey.
 func LoopTargetGuardKey(projectID, loopType, targetType, targetKey string) string {
-	projectID = strings.TrimSpace(projectID)
-	loopType = strings.TrimSpace(loopType)
-	targetType = strings.TrimSpace(targetType)
-	targetKey = strings.TrimSpace(targetKey)
-	if targetKey == "" {
-		return ""
-	}
-	if loopType == string(domain.LoopTypeWorker) && targetType == string(domain.LoopTargetTypeProject) {
-		return ""
-	}
-	if targetType == string(domain.LoopTargetTypePullRequest) {
-		return fmt.Sprintf("%s|%s", projectID, targetKey)
-	}
-	return fmt.Sprintf("%s|%s|%s", projectID, loopType, targetKey)
+	return loops.LoopTargetGuardKey(projectID, loopType, targetType, targetKey)
 }
 
 // LoopTargetGuardKeyFromRecord derives LoopTargetGuardKey from a stored loop.
-// Key formatting matches API loopTargetKeyFromRecordCompat / loopTargetKeyCompat
-// so API and runtime share the same mutex entries.
 func LoopTargetGuardKeyFromRecord(loop storage.LoopRecord) string {
-	return LoopTargetGuardKey(loop.ProjectID, loop.Type, loop.TargetType, targetKeyFromLoopRecord(loop))
+	return loops.LoopTargetGuardKeyFromRecord(loop)
 }
 
-func targetKeyFromLoopRecord(loop storage.LoopRecord) string {
-	switch loop.TargetType {
-	case string(domain.LoopTargetTypeProject):
-		if loop.TargetID == nil {
-			return "project:"
-		}
-		normalized := strings.TrimSpace(*loop.TargetID)
-		for strings.HasPrefix(normalized, "project:") {
-			normalized = strings.TrimPrefix(normalized, "project:")
-		}
-		return "project:" + normalized
-	case string(domain.LoopTargetTypeIssue):
-		if loop.TargetID == nil {
-			return "issue:"
-		}
-		return *loop.TargetID
-	default:
-		if loop.Repo == nil || loop.PRNumber == nil {
-			return "pull_request:"
-		}
-		return fmt.Sprintf("pull_request:%s:%d", *loop.Repo, *loop.PRNumber)
-	}
-}
-
-// LockLoopTarget acquires the process-wide same-target mutex. An empty key is a
-// no-op. Callers that also take LockLoopRequeue must acquire the per-loop lock
-// first to avoid deadlocks with API discard+retry.
+// LockLoopTarget acquires the process-wide same-target mutex. See
+// loops.LockLoopTarget.
 func LockLoopTarget(key string) func() {
-	if strings.TrimSpace(key) == "" {
-		return func() {}
-	}
-	value, _ := loopTargetGuards.LoadOrStore(key, &sync.Mutex{})
-	mu := value.(*sync.Mutex)
-	mu.Lock()
-	return mu.Unlock
+	return loops.LockLoopTarget(key)
 }

--- a/internal/runtime/loop_requeue_lock.go
+++ b/internal/runtime/loop_requeue_lock.go
@@ -1,0 +1,25 @@
+package runtime
+
+import "sync"
+
+// loopRequeueGuards serializes per-loop queue rearm across the API discard/retry
+// path and runtime free-text / HITL requeues. Without a process-wide mutex,
+// Feishu/GitHub inbox delivery can call enqueueHumanMessageToLoop after API
+// preflight and before git reset, wiping the worktree for a message-driven
+// continuation that then loses the retry transaction to an active-queue conflict.
+var loopRequeueGuards sync.Map // loopID -> *sync.Mutex
+
+// LockLoopRequeue acquires the process-wide per-loop requeue mutex shared by:
+//   - API retry/start/reuse (via Handler.lockLoopRetry)
+//   - runtime HITL free-text enqueue (enqueueHumanMessageToLoop)
+//   - runtime HITL answer requeue (deliverHITLAnswerToLoop)
+//
+// Callers must unlock via the returned function (typically defer). Nested
+// acquisitions on the same loop from the same goroutine deadlock — do not
+// call requeue helpers while already holding this lock for that loopID.
+func LockLoopRequeue(loopID string) func() {
+	value, _ := loopRequeueGuards.LoadOrStore(loopID, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}

--- a/internal/runtime/loop_requeue_lock.go
+++ b/internal/runtime/loop_requeue_lock.go
@@ -1,6 +1,13 @@
 package runtime
 
-import "sync"
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/nexu-io/looper/internal/domain"
+	"github.com/nexu-io/looper/internal/storage"
+)
 
 // loopRequeueGuards serializes per-loop queue rearm across the API discard/retry
 // path and runtime free-text / HITL requeues. Without a process-wide mutex,
@@ -8,6 +15,12 @@ import "sync"
 // preflight and before git reset, wiping the worktree for a message-driven
 // continuation that then loses the retry transaction to an active-queue conflict.
 var loopRequeueGuards sync.Map // loopID -> *sync.Mutex
+
+// loopTargetGuards serializes same worktree-target mutations across API
+// discard/retry/start/create and runtime HITL requeues. Per-loop locks alone
+// cannot block a *different* loop on the shared PR worktree from requeuing
+// between discard preflight and git reset.
+var loopTargetGuards sync.Map // targetGuardKey -> *sync.Mutex
 
 // LockLoopRequeue acquires the process-wide per-loop requeue mutex shared by:
 //   - API retry/start/reuse (via Handler.lockLoopRetry)
@@ -17,8 +30,77 @@ var loopRequeueGuards sync.Map // loopID -> *sync.Mutex
 // Callers must unlock via the returned function (typically defer). Nested
 // acquisitions on the same loop from the same goroutine deadlock — do not
 // call requeue helpers while already holding this lock for that loopID.
+// Call order with LockLoopTarget: take the per-loop lock first, then the
+// target lock.
 func LockLoopRequeue(loopID string) func() {
 	value, _ := loopRequeueGuards.LoadOrStore(loopID, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+// LoopTargetGuardKey builds the process-wide target mutex key shared by API
+// discard/retry/start/create and runtime HITL requeues.
+//
+// Empty string means no lock (concurrent project-scoped workers are exempt).
+// Pull-request targets omit loop type so fixer/reviewer/worker share one key —
+// they share the managed PR worktree (looper-fix-<project>-pr-N).
+func LoopTargetGuardKey(projectID, loopType, targetType, targetKey string) string {
+	projectID = strings.TrimSpace(projectID)
+	loopType = strings.TrimSpace(loopType)
+	targetType = strings.TrimSpace(targetType)
+	targetKey = strings.TrimSpace(targetKey)
+	if targetKey == "" {
+		return ""
+	}
+	if loopType == string(domain.LoopTypeWorker) && targetType == string(domain.LoopTargetTypeProject) {
+		return ""
+	}
+	if targetType == string(domain.LoopTargetTypePullRequest) {
+		return fmt.Sprintf("%s|%s", projectID, targetKey)
+	}
+	return fmt.Sprintf("%s|%s|%s", projectID, loopType, targetKey)
+}
+
+// LoopTargetGuardKeyFromRecord derives LoopTargetGuardKey from a stored loop.
+// Key formatting matches API loopTargetKeyFromRecordCompat / loopTargetKeyCompat
+// so API and runtime share the same mutex entries.
+func LoopTargetGuardKeyFromRecord(loop storage.LoopRecord) string {
+	return LoopTargetGuardKey(loop.ProjectID, loop.Type, loop.TargetType, targetKeyFromLoopRecord(loop))
+}
+
+func targetKeyFromLoopRecord(loop storage.LoopRecord) string {
+	switch loop.TargetType {
+	case string(domain.LoopTargetTypeProject):
+		if loop.TargetID == nil {
+			return "project:"
+		}
+		normalized := strings.TrimSpace(*loop.TargetID)
+		for strings.HasPrefix(normalized, "project:") {
+			normalized = strings.TrimPrefix(normalized, "project:")
+		}
+		return "project:" + normalized
+	case string(domain.LoopTargetTypeIssue):
+		if loop.TargetID == nil {
+			return "issue:"
+		}
+		return *loop.TargetID
+	default:
+		if loop.Repo == nil || loop.PRNumber == nil {
+			return "pull_request:"
+		}
+		return fmt.Sprintf("pull_request:%s:%d", *loop.Repo, *loop.PRNumber)
+	}
+}
+
+// LockLoopTarget acquires the process-wide same-target mutex. An empty key is a
+// no-op. Callers that also take LockLoopRequeue must acquire the per-loop lock
+// first to avoid deadlocks with API discard+retry.
+func LockLoopTarget(key string) func() {
+	if strings.TrimSpace(key) == "" {
+		return func() {}
+	}
+	value, _ := loopTargetGuards.LoadOrStore(key, &sync.Mutex{})
 	mu := value.(*sync.Mutex)
 	mu.Lock()
 	return mu.Unlock

--- a/internal/runtime/loop_requeue_lock_test.go
+++ b/internal/runtime/loop_requeue_lock_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/domain"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -302,4 +305,83 @@ func TestLoopTargetGuardKeyOmitsTypeForPullRequest(t *testing.T) {
 	if got := LoopTargetGuardKey("proj", "worker", "project", "project:proj"); got != "" {
 		t.Fatalf("project worker key = %q, want empty (concurrent workers)", got)
 	}
+}
+
+// TestDeferredReviewerRecoverySharesPRTargetLock ensures deferred recovery
+// requeue waits on the same PR target mutex discard+retry holds, so it cannot
+// activate a reviewer sibling between discard preflight and git reset.
+func TestDeferredReviewerRecoverySharesPRTargetLock(t *testing.T) {
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.StopOnApproved = true
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	coordinator := openMigratedCoordinator(t, cfg.Storage.DBPath, filepath.Join(workingDir, "backups"))
+	defer coordinator.Close()
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 14, 18, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+
+	projectRepoPath := filepath.Join(workingDir, "repo")
+	if err := repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: "project_deferred_target_lock", Name: "Deferred target lock", RepoPath: projectRepoPath, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	const loopID = "loop_deferred_target_lock"
+	seedFailedReviewerRecoveryLoop(t, repositories, "project_deferred_target_lock", loopID, 1, nowISO)
+
+	// seedFailedReviewerRecoveryLoop uses prNumber = 42+seq → 43.
+	key := LoopTargetGuardKey("project_deferred_target_lock", string(domain.LoopTypeFixer), string(domain.LoopTargetTypePullRequest), "pull_request:acme/looper:43")
+	unlockTarget := LockLoopTarget(key)
+
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
+		return shell.Result{Stdout: "other\n"}, nil
+	}})
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, Now: func() time.Time { return now }})
+
+	started := make(chan struct{})
+	done := make(chan struct {
+		n   int64
+		err error
+	}, 1)
+	go func() {
+		close(started)
+		n, err := rt.runDeferredReviewerRecovery(context.Background(), repositories, githubGateway, now)
+		done <- struct {
+			n   int64
+			err error
+		}{n, err}
+	}()
+	<-started
+	select {
+	case result := <-done:
+		unlockTarget()
+		t.Fatalf("runDeferredReviewerRecovery completed while PR target lock held: n=%d err=%v", result.n, result.err)
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked — expected.
+	}
+
+	loop, err := repositories.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil || loop.Status != "failed" {
+		unlockTarget()
+		t.Fatalf("loop while target lock held = %#v, %v, want failed", loop, err)
+	}
+
+	unlockTarget()
+
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("runDeferredReviewerRecovery after unlock error = %v", result.err)
+		}
+		if result.n != 1 {
+			t.Fatalf("runDeferredReviewerRecovery after unlock = %d, want 1", result.n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runDeferredReviewerRecovery did not complete after PR target lock release")
+	}
+	assertLoopStatus(t, repositories, loopID, "queued")
 }

--- a/internal/runtime/loop_requeue_lock_test.go
+++ b/internal/runtime/loop_requeue_lock_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nexu-io/looper/internal/domain"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -182,5 +183,123 @@ func TestDeliverHITLAnswerToLoopSharesRequeueLock(t *testing.T) {
 	loop, err := repos.Loops.GetByID(context.Background(), loopID)
 	if err != nil || loop == nil || loop.Status != "running" {
 		t.Fatalf("loop after answer = %#v, %v, want running", loop, err)
+	}
+}
+
+// TestEnqueueHumanMessageToLoopSharesTargetLock ensures free-text requeue of a
+// different loop on the same PR target waits on the target mutex held by
+// discard+retry — per-loop exclusion alone cannot prevent that race.
+func TestEnqueueHumanMessageToLoopSharesTargetLock(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.July, 14, 17, 0, 0, 0, time.UTC)
+	nowISO := now.Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+
+	projectID := "project_requeue_target_lock"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	prTarget := "pr:acme/looper:42"
+	const waitingLoopID = "loop_requeue_target_waiting"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Target lock", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID: waitingLoopID, Seq: 3, ProjectID: projectID, Type: "worker",
+		TargetType: "pull_request", TargetID: &prTarget, Repo: &repo, PRNumber: &prNumber,
+		Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	loopIDPtr, projectIDPtr := waitingLoopID, projectID
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: "queue_requeue_target_waiting", LoopID: &loopIDPtr, ProjectID: &projectIDPtr,
+		Type: "worker", TargetType: "pull_request", TargetID: prTarget, Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: "worker:" + projectID + ":" + repo + ":42", Priority: storage.QueuePriorityWorker,
+		Status: "cancelled", AvailableAt: nowISO, MaxAttempts: 3,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	// Hold the shared PR target lock as discard+retry of a *different* fixer would.
+	key := LoopTargetGuardKey(projectID, string(domain.LoopTypeFixer), string(domain.LoopTargetTypePullRequest), "pull_request:acme/looper:42")
+	unlockTarget := LockLoopTarget(key)
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		done <- enqueueHumanMessageToLoop(context.Background(), repos, nowISO, waitingLoopID, "please continue")
+	}()
+
+	<-started
+	select {
+	case err := <-done:
+		unlockTarget()
+		t.Fatalf("enqueueHumanMessageToLoop completed while PR target lock held: err=%v", err)
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked on shared PR worktree key — expected.
+	}
+
+	// While blocked, the waiting loop must not have been requeued yet.
+	loop, err := repos.Loops.GetByID(context.Background(), waitingLoopID)
+	if err != nil || loop == nil || loop.Status != "waiting" {
+		unlockTarget()
+		t.Fatalf("loop while target lock held = %#v, %v, want waiting", loop, err)
+	}
+	active, err := repos.Queue.FindActiveByLoopID(context.Background(), waitingLoopID)
+	if err != nil {
+		unlockTarget()
+		t.Fatalf("FindActiveByLoopID() error = %v", err)
+	}
+	if active != nil {
+		unlockTarget()
+		t.Fatalf("active queue while target lock held = %#v, want nil", active)
+	}
+
+	unlockTarget()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("enqueueHumanMessageToLoop after target unlock error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("enqueueHumanMessageToLoop did not complete after PR target lock release")
+	}
+
+	loop, err = repos.Loops.GetByID(context.Background(), waitingLoopID)
+	if err != nil || loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop after enqueue = %#v, %v, want queued", loop, err)
+	}
+}
+
+// TestLoopTargetGuardKeyOmitsTypeForPullRequest documents that PR worktree
+// keys are shared across loop types while non-PR keys remain type-scoped.
+func TestLoopTargetGuardKeyOmitsTypeForPullRequest(t *testing.T) {
+	fixer := LoopTargetGuardKey("proj", "fixer", "pull_request", "pull_request:acme/looper:42")
+	worker := LoopTargetGuardKey("proj", "worker", "pull_request", "pull_request:acme/looper:42")
+	if fixer == "" || fixer != worker {
+		t.Fatalf("PR keys = %q / %q, want equal non-empty shared key", fixer, worker)
+	}
+	issueFixer := LoopTargetGuardKey("proj", "fixer", "issue", "issue:acme/looper:7")
+	issueWorker := LoopTargetGuardKey("proj", "worker", "issue", "issue:acme/looper:7")
+	if issueFixer == "" || issueFixer == issueWorker {
+		t.Fatalf("issue keys = %q / %q, want distinct type-scoped keys", issueFixer, issueWorker)
+	}
+	if got := LoopTargetGuardKey("proj", "worker", "project", "project:proj"); got != "" {
+		t.Fatalf("project worker key = %q, want empty (concurrent workers)", got)
 	}
 }

--- a/internal/runtime/loop_requeue_lock_test.go
+++ b/internal/runtime/loop_requeue_lock_test.go
@@ -1,0 +1,186 @@
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// TestEnqueueHumanMessageToLoopSharesRequeueLock ensures free-text requeue waits
+// on LockLoopRequeue — the same exclusion API discard+retry holds — so a
+// concurrent discard cannot wipe the worktree for a message-driven continuation.
+func TestEnqueueHumanMessageToLoopSharesRequeueLock(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.July, 14, 16, 0, 0, 0, time.UTC)
+	nowISO := now.Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+
+	const loopID = "loop_requeue_lock_message"
+	projectID := "project_requeue_lock_message"
+	targetID := projectID
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Requeue lock", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID: loopID, Seq: 1, ProjectID: projectID, Type: "fixer",
+		TargetType: "project", TargetID: &targetID, Status: "paused",
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	loopIDPtr, projectIDPtr := loopID, projectID
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: "queue_requeue_lock_message", LoopID: &loopIDPtr, ProjectID: &projectIDPtr,
+		Type: "fixer", TargetType: "project", TargetID: targetID, DedupeKey: "fixer:requeue_lock_message",
+		Priority: storage.QueuePriorityFixer, Status: "cancelled", AvailableAt: nowISO, MaxAttempts: 3,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	// Simulate discard+retry holding the shared exclusion across preflight→git.
+	unlock := LockLoopRequeue(loopID)
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		done <- enqueueHumanMessageToLoop(context.Background(), repos, nowISO, loopID, "please continue")
+	}()
+
+	<-started
+	select {
+	case err := <-done:
+		unlock()
+		t.Fatalf("enqueueHumanMessageToLoop completed while LockLoopRequeue held: err=%v", err)
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked — expected.
+	}
+
+	// While blocked, the loop must still be paused with no active queue.
+	loop, err := repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil || loop.Status != "paused" {
+		unlock()
+		t.Fatalf("loop while lock held = %#v, %v, want paused", loop, err)
+	}
+	active, err := repos.Queue.FindActiveByLoopID(context.Background(), loopID)
+	if err != nil {
+		unlock()
+		t.Fatalf("FindActiveByLoopID() error = %v", err)
+	}
+	if active != nil {
+		unlock()
+		t.Fatalf("active queue while lock held = %#v, want nil", active)
+	}
+
+	unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("enqueueHumanMessageToLoop after unlock error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("enqueueHumanMessageToLoop did not complete after LockLoopRequeue release")
+	}
+
+	loop, err = repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop after enqueue = %#v, %v, want queued", loop, err)
+	}
+	active, err = repos.Queue.FindActiveByLoopID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("FindActiveByLoopID() after enqueue error = %v", err)
+	}
+	if active == nil || active.Status != "queued" {
+		t.Fatalf("active queue after enqueue = %#v, want queued", active)
+	}
+}
+
+// TestDeliverHITLAnswerToLoopSharesRequeueLock mirrors free-text exclusion for
+// poll-delivered HITL answers that requeue without the API Handler locks.
+func TestDeliverHITLAnswerToLoopSharesRequeueLock(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.July, 14, 16, 0, 0, 0, time.UTC)
+	nowISO := now.Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+
+	const loopID = "loop_requeue_lock_answer"
+	projectID := "project_requeue_lock_answer"
+	targetID := projectID
+	meta := `{"hitl":{"question":"ok?","sessionId":"s1","status":"awaiting","askedAt":"2026-07-14T15:00:00.000Z"}}`
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Requeue answer lock", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID: loopID, Seq: 2, ProjectID: projectID, Type: "worker",
+		TargetType: "project", TargetID: &targetID, Status: "awaiting_human",
+		MetadataJSON: &meta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	loopIDPtr, projectIDPtr := loopID, projectID
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: "queue_requeue_lock_answer", LoopID: &loopIDPtr, ProjectID: &projectIDPtr,
+		Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:requeue_lock_answer",
+		Priority: storage.QueuePriorityWorker, Status: "cancelled", AvailableAt: nowISO, MaxAttempts: 3,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	unlock := LockLoopRequeue(loopID)
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		done <- deliverHITLAnswerToLoop(context.Background(), repos, nowISO, loopID, "yes")
+	}()
+	<-started
+	select {
+	case err := <-done:
+		unlock()
+		t.Fatalf("deliverHITLAnswerToLoop completed while LockLoopRequeue held: err=%v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+	unlock()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("deliverHITLAnswerToLoop after unlock error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("deliverHITLAnswerToLoop did not complete after LockLoopRequeue release")
+	}
+	loop, err := repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil || loop.Status != "running" {
+		t.Fatalf("loop after answer = %#v, %v, want running", loop, err)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1381,23 +1381,13 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 			continue
 		}
 		if shouldAutoRecoverFailedReviewerLoop(loop, latestRun, latestQueue, policy) {
-			failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage), derefString(latestQueue.LastError))
-			recoveredQueueItems, err := requeueFailedReviewerQueueItemForRecovery(ctx, repositories, loop.ID, latestQueue, nowISO, policy, failureSummary)
+			// Share discard/retry exclusion with deferred recovery and discovery.
+			didRequeue, recoveredQueueItems, err := requeueFailedReviewerWithSharedGuards(ctx, repositories, loop, latestQueue, nowISO, policy, latestRun)
 			if err != nil {
 				return RecoverySummary{}, err
 			}
-			if recoveredQueueItems == 0 {
-				active, activeErr := repositories.Queue.FindActiveByLoopID(ctx, loop.ID)
-				if activeErr != nil {
-					return RecoverySummary{}, activeErr
-				}
-				if active == nil {
-					return RecoverySummary{}, fmt.Errorf("reviewer recovery did not requeue failed queue item %s for loop %s", latestQueue.ID, loop.ID)
-				}
-			}
-			requeuedLoop := autoRecoveredReviewerLoop(loop, nowISO)
-			if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
-				return RecoverySummary{}, err
+			if !didRequeue {
+				continue
 			}
 			requeuedLoopIDs[loop.ID] = struct{}{}
 			summary.LoopsRequeued += 1
@@ -1676,23 +1666,15 @@ func (r *Runtime) runDeferredReviewerRecovery(ctx context.Context, repositories 
 		if currentLoop == nil || !shouldAutoRecoverFailedReviewerLoop(*currentLoop, latestRun, latestQueue, policy) {
 			continue
 		}
-		failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage), derefString(latestQueue.LastError))
-		recoveredQueueItems, err := requeueFailedReviewerQueueItemForRecovery(ctx, repositories, loop.ID, latestQueue, nowISO, policy, failureSummary)
+		// Share discard/retry exclusion: recovery requeue of a PR reviewer must
+		// not interleave with operator discard of a sibling loop on the same
+		// managed worktree between preflight and git reset.
+		didRequeue, recoveredQueueItems, err := requeueFailedReviewerWithSharedGuards(ctx, repositories, *currentLoop, latestQueue, nowISO, policy, latestRun)
 		if err != nil {
 			return requeued, err
 		}
-		if recoveredQueueItems == 0 {
-			active, activeErr := repositories.Queue.FindActiveByLoopID(ctx, loop.ID)
-			if activeErr != nil {
-				return requeued, activeErr
-			}
-			if active == nil {
-				return requeued, fmt.Errorf("reviewer deferred recovery did not requeue failed queue item %s for loop %s", latestQueue.ID, loop.ID)
-			}
-		}
-		requeuedLoop := autoRecoveredReviewerLoop(*currentLoop, nowISO)
-		if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
-			return requeued, err
+		if !didRequeue {
+			continue
 		}
 		requeued += 1
 		if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
@@ -2837,6 +2819,47 @@ func requeueFailedReviewerQueueItemForRecovery(ctx context.Context, repositories
 		return 0, nil
 	}
 	return repositories.Queue.RequeueFailedByID(ctx, loopID, latestQueue.ID, queuedAt)
+}
+
+// requeueFailedReviewerWithSharedGuards requeues a failed reviewer under the
+// same per-loop + same-target locks as API discard+retry, so deferred/startup
+// recovery cannot activate a PR worktree sibling between discard preflight and
+// git reset/clean. didRequeue is false when eligibility no longer holds under
+// the lock (no error).
+func requeueFailedReviewerWithSharedGuards(ctx context.Context, repositories *storage.Repositories, loop storage.LoopRecord, latestQueue *storage.QueueItemRecord, nowISO string, policy runtimeReviewerRecoveryPolicy, latestRun *storage.RunRecord) (didRequeue bool, recoveredQueueItems int64, err error) {
+	unlock := LockLoopRequeue(loop.ID)
+	defer unlock()
+	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(loop))
+	defer unlockTarget()
+
+	// Re-check eligibility under the lock: discard/retry may have already
+	// requeued or otherwise changed status while we waited.
+	current, err := repositories.Loops.GetByID(ctx, loop.ID)
+	if err != nil {
+		return false, 0, err
+	}
+	if current == nil || !shouldAutoRecoverFailedReviewerLoop(*current, latestRun, latestQueue, policy) {
+		return false, 0, nil
+	}
+	failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage), derefString(latestQueue.LastError))
+	recoveredQueueItems, err = requeueFailedReviewerQueueItemForRecovery(ctx, repositories, loop.ID, latestQueue, nowISO, policy, failureSummary)
+	if err != nil {
+		return false, 0, err
+	}
+	if recoveredQueueItems == 0 {
+		active, activeErr := repositories.Queue.FindActiveByLoopID(ctx, loop.ID)
+		if activeErr != nil {
+			return false, 0, activeErr
+		}
+		if active == nil {
+			return false, 0, fmt.Errorf("reviewer recovery did not requeue failed queue item %s for loop %s", latestQueue.ID, loop.ID)
+		}
+	}
+	requeuedLoop := autoRecoveredReviewerLoop(*current, nowISO)
+	if err := repositories.Loops.Upsert(ctx, requeuedLoop); err != nil {
+		return false, 0, err
+	}
+	return true, recoveredQueueItems, nil
 }
 
 func isRuntimeRetryableTransientWithRemainingAttempts(queue storage.QueueItemRecord) bool {


### PR DESCRIPTION
## Summary

Implements the already-stubbed operator flag:

```bash
looper loop retry <seq|loopId> --discard-worktree-changes --confirm
```

Dirty managed worktrees for fixer/reviewer/worker loops previously forced manual `git restore` / `git clean` before retry. This wires the CLI flag through the retry API so operators can discard tracked + untracked local changes in the managed worktree, then requeue with the same retry lineage rules.

## Changes

- **Git gateway**: `DiscardWorktreeChanges` hard-resets to `HEAD` and runs `git clean -fd` under worktree safety validation (never touches primary `repoPath`, never deletes the worktree directory).
- **Retry API**: accepts `discardWorktreeChanges`; resolves managed worktree from latest run checkpoint / worktree row; discards before requeue; emits `looper.worktree.changes_discarded`.
- **CLI**: removes the "not supported yet" stub; requires `--confirm`; human/`--json` output report path, no-op, and queue status.
- **Safety**: refuses active run/queue; planner is a discard no-op; already-clean / missing worktree still retries successfully.

## Trade-offs

- **Authority**: operator explicit `--confirm` is the authority for destructive discard (not agent output, not autonomous recovery).
- **Why not a separate `worktree reset` command**: the flag already exists in CLI surface area; implementing it minimizes operator surprise (spec §8 allows either shape).
- **Why not auto-discard on dirty hold**: dirty remains hard `manual_intervention` by default; only this opt-in path clears it.

Closes #563

## Test plan

- [x] Unit: dirty managed worktree discard cleans tracked + untracked; unsafe paths rejected
- [x] API: dirty fixer discard+retry → queued, worktree clean, event emitted
- [x] API: already-clean worktree still retries (no-op discard)
- [x] API: planner discard is no-op and retries
- [x] API: active run / active queue rejected
- [x] API: non-managed path and primary repo path rejected
- [x] CLI: missing `--confirm` rejected; body wiring + human output fields
- [x] `go test ./internal/api/ ./internal/infra/git/ ./internal/cliapp/`
- [x] `go vet` + `go build ./...`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=grok-build · An autonomous AI dev team for your GitHub repos.</sub>