### PR TITLE
feat: add looper describe and surface manual-intervention reasons

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -486,6 +486,7 @@ looper loop start --type fixer --pr owner/repo#42
 
 ```bash
 looper ps
+looper describe 12
 looper logs 12 --follow
 looper jump 12
 looper stop 12
@@ -494,7 +495,8 @@ looper run reconcile-stale
 
 Typical usage:
 
-- `looper ps`: see which loops are currently running
+- `looper ps`: see which loops are currently running (includes a truncated failure reason when present)
+- `looper describe <id>`: show why a loop is blocked (manual intervention reason, diagnosis); same as `looper loop inspect`
 - `looper logs <id> --follow`: stream logs live
 - `looper jump <id>`: print the shell command for the loop's worktree; use `eval "$(looper jump 12)"` to actually change directories, or pass `--print-path` to print just the path
 - `looper worktree cleanup`: inspect Looper-managed worktree cleanup candidates without deleting anything; add `--confirm` for one immediate cleanup pass or `--json` for structured output

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2771,6 +2771,17 @@ func decorateActiveRunView(view *activeRunView, loop storage.LoopRecord, latestQ
 		view.LastFailureKind = latestQueue.LastErrorKind
 		view.LastFailureReason = latestQueue.LastError
 	}
+	// Fall back to the latest run error/summary when no queue error is present
+	// (e.g. checkpoint-only manual holds or failed runs without a parked queue item).
+	if view.LastFailureReason == nil || strings.TrimSpace(*view.LastFailureReason) == "" {
+		if latestRun != nil {
+			if latestRun.ErrorMessage != nil && strings.TrimSpace(*latestRun.ErrorMessage) != "" {
+				view.LastFailureReason = latestRun.ErrorMessage
+			} else if latestRun.Summary != nil && strings.TrimSpace(*latestRun.Summary) != "" {
+				view.LastFailureReason = latestRun.Summary
+			}
+		}
+	}
 	view.ResumePolicy = resumePolicyFromRun(latestRun)
 	// Do not override a closed loop's status with manual_intervention: the loop
 	// is no longer actionable even if the latest queue item still has that status.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2773,11 +2773,13 @@ func decorateActiveRunView(view *activeRunView, loop storage.LoopRecord, latestQ
 	}
 	// Fall back to the latest run error/summary when no queue error is present
 	// (e.g. checkpoint-only manual holds or failed runs without a parked queue item).
+	// Summary is only used for failure-like runs: successful completeRun summaries
+	// must not appear as lastFailureReason on queued/running or --all listings.
 	if view.LastFailureReason == nil || strings.TrimSpace(*view.LastFailureReason) == "" {
 		if latestRun != nil {
 			if latestRun.ErrorMessage != nil && strings.TrimSpace(*latestRun.ErrorMessage) != "" {
 				view.LastFailureReason = latestRun.ErrorMessage
-			} else if latestRun.Summary != nil && strings.TrimSpace(*latestRun.Summary) != "" {
+			} else if shouldUseRunSummaryAsFailureReason(latestRun) && latestRun.Summary != nil && strings.TrimSpace(*latestRun.Summary) != "" {
 				view.LastFailureReason = latestRun.Summary
 			}
 		}
@@ -2792,6 +2794,21 @@ func decorateActiveRunView(view *activeRunView, loop storage.LoopRecord, latestQ
 	}
 	if view.DisplayStatus == "" {
 		view.DisplayStatus = view.Status
+	}
+}
+
+// shouldUseRunSummaryAsFailureReason reports whether a run's Summary is safe to
+// surface as lastFailureReason. Successful completeRun summaries must not be
+// treated as failures for queued/running loops or ps --all completed rows.
+func shouldUseRunSummaryAsFailureReason(run *storage.RunRecord) bool {
+	if run == nil {
+		return false
+	}
+	switch domain.RunStatus(strings.TrimSpace(run.Status)) {
+	case domain.RunStatusFailed, domain.RunStatusInterrupted, domain.RunStatusParseFailed:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -446,7 +446,8 @@ func TestHandlerActiveRunsSurfacesResumePolicyManualIntervention(t *testing.T) {
 	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 47, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
-	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_manual_resume", LoopID: loopID, Status: "failed", CheckpointJSON: &checkpoint, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+	runError := "checkpoint hold: operator must inspect worktree"
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_manual_resume", LoopID: loopID, Status: "failed", CheckpointJSON: &checkpoint, ErrorMessage: &runError, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
 	}
 
@@ -466,6 +467,8 @@ func TestHandlerActiveRunsSurfacesResumePolicyManualIntervention(t *testing.T) {
 	assertEqual(t, item["loopStatus"], "paused")
 	assertEqual(t, item["displayStatus"], "manual_intervention")
 	assertEqual(t, item["resumePolicy"], "manual_intervention")
+	// No queue item: reason falls back to the latest run error so `looper ps` can show it.
+	assertEqual(t, item["lastFailureReason"], runError)
 }
 
 func TestHandlerActiveRunsSurfacesBackingOffDisplayStatus(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -471,6 +471,86 @@ func TestHandlerActiveRunsSurfacesResumePolicyManualIntervention(t *testing.T) {
 	assertEqual(t, item["lastFailureReason"], runError)
 }
 
+// Successful completeRun summaries must not populate lastFailureReason when there
+// is no queue error (queued/running loops and ps --all completed rows).
+func TestHandlerActiveRunsDoesNotUseSuccessSummaryAsFailureReason(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_success_summary"
+	loopID := "loop_success_summary"
+	targetID := projectID
+	successSummary := "worker completed successfully"
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 61, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_success_summary", LoopID: loopID, Status: "success", Summary: &successSummary, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	// Queue has no lastError: decoration would previously fall back to run Summary.
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_success_summary", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:success_summary", Priority: storage.QueuePriorityWorker, Status: "queued", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1: %#v", len(items), items)
+	}
+	item := items[0].(map[string]any)
+	if reason, ok := item["lastFailureReason"]; ok && reason != nil {
+		t.Fatalf("lastFailureReason = %#v, want omitted/nil for successful run summary", reason)
+	}
+}
+
+func TestHandlerActiveRunsUsesFailedRunSummaryAsFailureReason(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_failed_summary"
+	loopID := "loop_failed_summary"
+	targetID := projectID
+	checkpoint := `{"resumePolicy":"manual_intervention"}`
+	failedSummary := "worktree is locked; operator hold"
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 62, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "paused", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	// Summary-only failure (no ErrorMessage): still surfaces as lastFailureReason.
+	if err := services.Repositories.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_failed_summary", LoopID: loopID, Status: "failed", CheckpointJSON: &checkpoint, Summary: &failedSummary, StartedAt: nowISO, EndedAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	items := body["data"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1: %#v", len(items), items)
+	}
+	item := items[0].(map[string]any)
+	assertEqual(t, item["lastFailureReason"], failedSummary)
+}
+
 func TestHandlerActiveRunsSurfacesBackingOffDisplayStatus(t *testing.T) {
 	for _, lastErrorKind := range []string{"retryable_transient", "retryable_after_resume"} {
 		t.Run(lastErrorKind, func(t *testing.T) {

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -107,7 +107,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 	root := newCommand(commandSpec{
 		use:             "looper",
 		short:           "Looper command-line interface",
-		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "network", description: "Network membership commands"}, {name: "netadmin", description: "Network repo operator commands"}, {name: "webhook", description: "Webhook configuration and status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "provider", description: "Provider commands"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "prompt", description: "Prompt inspection commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "labels", description: "GitHub label commands"}, {name: "queue", description: "Queue inspection and maintenance commands"}, {name: "worktree", description: "Worktree maintenance commands"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "fix", description: "Create a fixer task for a pull request"}, {name: "takeover", description: "Continuously review and fix a pull request until it merges"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "pause", description: "Pause a loop by sequence number"}, {name: "unpause", description: "Resume a paused loop by sequence number"}, {name: "stop", description: "Stop an active loop"}, {name: "close", description: "Terminally close a loop"}, {name: "resume", description: "Take over a loop's agent session interactively"}, {name: "handback", description: "Hand a taken-over loop back to the daemon"}, {name: "run", description: "Run commands"}},
+		helpSubcommands: []helpSubcommand{{name: "status", description: "Show service status"}, {name: "network", description: "Network membership commands"}, {name: "netadmin", description: "Network repo operator commands"}, {name: "webhook", description: "Webhook configuration and status"}, {name: "bootstrap", description: "Run first-time setup"}, {name: "version", description: "Show Looper version"}, {name: "provider", description: "Provider commands"}, {name: "project", description: "Project commands"}, {name: "config", description: "Config commands"}, {name: "prompt", description: "Prompt inspection commands"}, {name: "daemon", description: "Daemon commands"}, {name: "upgrade", description: "Check or upgrade Looper installations"}, {name: "labels", description: "GitHub label commands"}, {name: "queue", description: "Queue inspection and maintenance commands"}, {name: "worktree", description: "Worktree maintenance commands"}, {name: "loop", description: "Loop commands"}, {name: "work", description: "Create a worker run"}, {name: "plan", description: "Create a planner run"}, {name: "pr", description: "Pull request commands"}, {name: "review", description: "Create a reviewer task for a pull request"}, {name: "fix", description: "Create a fixer task for a pull request"}, {name: "takeover", description: "Continuously review and fix a pull request until it merges"}, {name: "feedback", description: "Submit feedback as a GitHub issue"}, {name: "ps", description: "Show running loops"}, {name: "describe", description: "Show loop diagnostics detail"}, {name: "jump", description: "Print shell command for a loop worktree"}, {name: "logs", description: "Show logs for a loop"}, {name: "pause", description: "Pause a loop by sequence number"}, {name: "unpause", description: "Resume a paused loop by sequence number"}, {name: "stop", description: "Stop an active loop"}, {name: "close", description: "Terminally close a loop"}, {name: "resume", description: "Take over a loop's agent session interactively"}, {name: "handback", description: "Hand a taken-over loop back to the daemon"}, {name: "run", description: "Run commands"}},
 		helpWhenNoArgs:  true,
 		subcommands: []*cobra.Command{
 			newCommand(commandSpec{use: "status", short: "Show service status", runE: runtime.status}),
@@ -521,6 +521,17 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 					"$ looper ps --status completed --type worker",
 					"$ looper ps --all",
 					"$ looper ps --type reviewer --project project_1",
+				},
+			}),
+			newCommand(commandSpec{
+				use:   "describe <seq|loopId|runId>",
+				short: "Show loop diagnostics detail",
+				args:  cobra.ExactArgs(1),
+				runE:  runtime.loopInspect,
+				exampleLines: []string{
+					"$ looper describe 12",
+					"$ looper describe 12 --json",
+					"$ looper loop inspect 12",
 				},
 			}),
 			newCommand(commandSpec{

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -3397,6 +3397,45 @@ func TestPSWithoutJSONShowsDisplayStatusWhenPresent(t *testing.T) {
 	}
 }
 
+func TestPSWithoutJSONShowsTruncatedFailureReason(t *testing.T) {
+	t.Parallel()
+
+	longReason := "fatal: worktree is locked and cannot be cleaned automatically without operator review of local changes"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/runs/active"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_active_runs", map[string]any{"items": []map[string]any{{
+			"seq":               9,
+			"type":              "worker",
+			"status":            "paused",
+			"displayStatus":     "manual_intervention",
+			"lastFailureReason": longReason,
+			"currentStep":       "prepare_work",
+			"target":            map[string]any{"label": "Looper"},
+		}}}))
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	exitCode, stdout, stderr := runApp(t, "ps", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([ps]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run([ps]) stderr = %q, want empty string", stderr)
+	}
+	if !strings.Contains(stdout, "manual_intervention") {
+		t.Fatalf("Run([ps]) stdout = %q, want display status manual_intervention", stdout)
+	}
+	if !strings.Contains(stdout, "fatal: worktree is locked") || !strings.Contains(stdout, "...") {
+		t.Fatalf("Run([ps]) stdout = %q, want truncated failure reason", stdout)
+	}
+	if strings.Contains(stdout, longReason) {
+		t.Fatalf("Run([ps]) stdout = %q, did not expect full untruncated failure reason", stdout)
+	}
+}
+
 func TestPSStatusAndTypeFiltersUseActiveRunsQueryAndShowInactiveCompletedLoop(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -614,10 +614,38 @@ func writeHumanActiveRuns(w io.Writer, payload json.RawMessage) error {
 		if strings.TrimSpace(item.DisplayStatus) != "" {
 			status = item.DisplayStatus
 		}
-		rows = append(rows, tableRow{"#": item.Seq, "type": item.Type, "target": item.Target.Label, "step": item.CurrentStep, "agent": agentVendor(item.Agent), "pid": agentPID(item.Agent), "status": status, "age": formatRelativeAge(firstNonEmptyCLIString(item.EndedAt, item.StartedAt))})
+		reason := ""
+		if item.LastFailureReason != nil {
+			reason = truncateCLIText(*item.LastFailureReason, 48)
+		}
+		rows = append(rows, tableRow{"#": item.Seq, "type": item.Type, "target": item.Target.Label, "step": item.CurrentStep, "agent": agentVendor(item.Agent), "pid": agentPID(item.Agent), "status": status, "age": formatRelativeAge(firstNonEmptyCLIString(item.EndedAt, item.StartedAt)), "reason": reason})
 	}
-	printTable(w, []string{"#", "type", "target", "step", "agent", "pid", "status", "age"}, rows)
+	printTable(w, []string{"#", "type", "target", "step", "agent", "pid", "status", "age", "reason"}, rows)
 	return nil
+}
+
+func truncateCLIText(value string, max int) string {
+	value = strings.Join(strings.Fields(value), " ")
+	if value == "" {
+		return ""
+	}
+	value = strings.Map(func(r rune) rune {
+		if r < 32 || r == 127 {
+			return -1
+		}
+		return r
+	}, value)
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= max {
+		return value
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
 }
 
 func writeHumanRunReconcileStale(w io.Writer, payload json.RawMessage) error {

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -552,11 +552,15 @@ func diagnosticAgentOutput(agent storage.AgentExecutionRecord, now time.Time) lo
 
 func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storage.QueueItemRecord, metadata loopDiagnosticMetadata, associateQueue bool) loopDiagnosis {
 	state := loop.Status
+	// Run-id selectors diagnose only the selected run. Drop latest-queue and
+	// loop-level metadata signals (e.g. lastFailure from a later run).
 	var diagnosisQueue *storage.QueueItemRecord
+	diagnosisMetadata := loopDiagnosticMetadata{}
 	if associateQueue {
 		diagnosisQueue = queue
+		diagnosisMetadata = metadata
 	}
-	message, source := loopDiagnosticMessage(run, diagnosisQueue, metadata)
+	message, source := loopDiagnosticMessage(run, diagnosisQueue, diagnosisMetadata)
 	// FailureClass/Retryable come from the structured error kind + message.
 	// Queue status "manual_intervention" is an operator-hold signal, not the
 	// underlying failure class — keep them separate.

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -169,6 +169,7 @@ func (r *commandRuntime) queueFailed(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		output := queueFailedOutput{NowISO: eventlog.FormatJavaScriptISOString(time.Now().UTC()), Type: typeFilter, ProjectID: projectFilter, Limit: limit}
+		loopSeqByID := map[string]int64{}
 		for _, item := range items {
 			if item.Status != "failed" && item.Status != "manual_intervention" {
 				continue
@@ -179,7 +180,8 @@ func (r *commandRuntime) queueFailed(cmd *cobra.Command, args []string) error {
 			if projectFilter != "" && (item.ProjectID == nil || *item.ProjectID != projectFilter) {
 				continue
 			}
-			output.Items = append(output.Items, queueFailedItemOutput{QueueItem: queueItemOutput(item), Diagnosis: diagnoseQueueItem(item)})
+			loopSeq := resolveQueueItemLoopSeq(cmd.Context(), repos, item, loopSeqByID)
+			output.Items = append(output.Items, queueFailedItemOutput{QueueItem: queueItemOutput(item), Diagnosis: diagnoseQueueItem(item, loopSeq)})
 			if int64(len(output.Items)) >= limit {
 				break
 			}
@@ -579,7 +581,7 @@ func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storag
 	return diagnosis
 }
 
-func diagnoseQueueItem(item storage.QueueItemRecord) loopDiagnosis {
+func diagnoseQueueItem(item storage.QueueItemRecord, loopSeq int64) loopDiagnosis {
 	// Preserve LastErrorKind as the failure cause. Queue status remains in
 	// diagnosis.State so operators can see a parked manual hold separately.
 	diagnosis := classifyDiagnosticMessage(diagnosticString(item.LastError), diagnosticString(item.LastErrorKind))
@@ -588,7 +590,51 @@ func diagnoseQueueItem(item storage.QueueItemRecord) loopDiagnosis {
 	if diagnosis.RecommendedAction == "" {
 		diagnosis.RecommendedAction = "inspect the owning loop before requeueing"
 	}
+	// Same contract as diagnoseLoop: never serialize the literal <seq>
+	// placeholder. Expand when the owning loop seq is known; otherwise rewrite
+	// guidance so queue-failed JSON does not leak unresolved tokens.
+	if loopSeq > 0 {
+		diagnosis.RecommendedAction = formatActionWithSeq(diagnosis.RecommendedAction, loopSeq)
+	} else {
+		diagnosis.RecommendedAction = actionWithoutSeqPlaceholder(diagnosis.RecommendedAction)
+	}
 	return diagnosis
+}
+
+// resolveQueueItemLoopSeq looks up the owning loop sequence for a queue item,
+// caching results so queue-failed listing does not repeat GetByID per item.
+func resolveQueueItemLoopSeq(ctx context.Context, repos *storage.Repositories, item storage.QueueItemRecord, cache map[string]int64) int64 {
+	if item.LoopID == nil {
+		return 0
+	}
+	loopID := strings.TrimSpace(*item.LoopID)
+	if loopID == "" {
+		return 0
+	}
+	if seq, ok := cache[loopID]; ok {
+		return seq
+	}
+	loop, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil || loop == nil {
+		cache[loopID] = 0
+		return 0
+	}
+	cache[loopID] = loop.Seq
+	return loop.Seq
+}
+
+// actionWithoutSeqPlaceholder rewrites retry/unpause/describe guidance when no
+// loop sequence is available, so consumers never see a literal <seq> token.
+func actionWithoutSeqPlaceholder(action string) string {
+	rewritten := action
+	for _, pair := range [][2]string{
+		{"looper retry <seq>", "retry the owning loop"},
+		{"looper unpause <seq>", "unpause the owning loop"},
+		{"looper describe <seq>", "describe the owning loop"},
+	} {
+		rewritten = strings.ReplaceAll(rewritten, pair[0], pair[1])
+	}
+	return strings.ReplaceAll(rewritten, "<seq>", "the owning loop seq")
 }
 
 func loopDiagnosticMessage(run *storage.RunRecord, queue *storage.QueueItemRecord, metadata loopDiagnosticMetadata) (string, string) {

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -108,6 +108,7 @@ type loopDiagnosticRun struct {
 	LastCompletedStep   *string `json:"lastCompletedStep,omitempty"`
 	Summary             *string `json:"summary,omitempty"`
 	ErrorMessage        *string `json:"errorMessage,omitempty"`
+	ResumePolicy        *string `json:"resumePolicy,omitempty"`
 	StartedAt           string  `json:"startedAt"`
 	LastHeartbeatAt     *string `json:"lastHeartbeatAt,omitempty"`
 	EndedAt             *string `json:"endedAt,omitempty"`
@@ -235,14 +236,14 @@ func (r *commandRuntime) loopFailures(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			if !includeLoopInFailures(loop, queueItem) {
-				continue
-			}
 			run, err := repos.Runs.GetLatestByLoopID(cmd.Context(), loop.ID)
 			if err != nil {
 				return err
 			}
-			item, err := buildLoopInspectOutput(cmd.Context(), repos, fmt.Sprintf("%d", loop.Seq), loopSelectorResult{Loop: loop, Run: run, SelectorKind: "loop"}, now)
+			if !includeLoopInFailures(loop, queueItem, run) {
+				continue
+			}
+			item, err := buildLoopInspectOutput(cmd.Context(), repos, fmt.Sprintf("%d", loop.Seq), loopSelectorResult{Loop: loop, Run: run, SelectorKind: "loopId"}, now)
 			if err != nil {
 				return err
 			}
@@ -364,6 +365,10 @@ func buildLoopInspectOutput(ctx context.Context, repos *storage.Repositories, se
 		return loopInspectOutput{}, err
 	}
 
+	// When the operator selected a historical run, do not let the loop's latest
+	// queue item rewrite that run's failure class/kind. Still surface the latest
+	// queue item as current loop state in LatestQueueItem.
+	associateQueueWithDiagnosis := resolved.SelectorKind != "runId"
 	output := loopInspectOutput{
 		NowISO:          eventlog.FormatJavaScriptISOString(now),
 		Selector:        selector,
@@ -371,7 +376,7 @@ func buildLoopInspectOutput(ctx context.Context, repos *storage.Repositories, se
 		Loop:            diagnosticLoopOutput(resolved.Loop),
 		Metadata:        metadata,
 		LatestQueueItem: queueOutput,
-		Diagnosis:       diagnoseLoop(resolved.Loop, resolved.Run, queueItem, metadata),
+		Diagnosis:       diagnoseLoop(resolved.Loop, resolved.Run, queueItem, metadata, associateQueueWithDiagnosis),
 	}
 	if resolved.Run != nil {
 		run := diagnosticRunOutput(*resolved.Run, now)
@@ -384,14 +389,31 @@ func buildLoopInspectOutput(ctx context.Context, repos *storage.Repositories, se
 	return output, nil
 }
 
-func includeLoopInFailures(loop storage.LoopRecord, queueItem *storage.QueueItemRecord) bool {
+func includeLoopInFailures(loop storage.LoopRecord, queueItem *storage.QueueItemRecord, run *storage.RunRecord) bool {
 	if loop.Status == "failed" {
 		return true
 	}
-	if loop.Status != "paused" || queueItem == nil {
+	if loop.Status != "paused" {
 		return false
 	}
-	return queueItem.Status == "manual_intervention"
+	if isManualInterventionQueueItem(queueItem) {
+		return true
+	}
+	policy := resumePolicyFromCheckpoint(nil)
+	if run != nil {
+		policy = resumePolicyFromCheckpoint(run.CheckpointJSON)
+	}
+	return policy != nil && *policy == "manual_intervention"
+}
+
+func isManualInterventionQueueItem(item *storage.QueueItemRecord) bool {
+	if item == nil {
+		return false
+	}
+	if item.Status == "manual_intervention" {
+		return true
+	}
+	return item.LastErrorKind != nil && strings.TrimSpace(*item.LastErrorKind) == "manual_intervention"
 }
 
 func parseLoopDiagnosticMetadata(raw *string) loopDiagnosticMetadata {
@@ -466,6 +488,7 @@ func diagnosticRunOutput(run storage.RunRecord, now time.Time) loopDiagnosticRun
 		LastCompletedStep: run.LastCompletedStep,
 		Summary:           run.Summary,
 		ErrorMessage:      run.ErrorMessage,
+		ResumePolicy:      resumePolicyFromCheckpoint(run.CheckpointJSON),
 		StartedAt:         run.StartedAt,
 		LastHeartbeatAt:   run.LastHeartbeatAt,
 		EndedAt:           run.EndedAt,
@@ -481,6 +504,23 @@ func diagnosticRunOutput(run storage.RunRecord, now time.Time) loopDiagnosticRun
 		output.HeartbeatAgeSeconds = elapsedSecondsPtr(*run.LastHeartbeatAt, eventlog.FormatJavaScriptISOString(now))
 	}
 	return output
+}
+
+func resumePolicyFromCheckpoint(checkpointJSON *string) *string {
+	if checkpointJSON == nil || strings.TrimSpace(*checkpointJSON) == "" {
+		return nil
+	}
+	var doc struct {
+		ResumePolicy string `json:"resumePolicy"`
+	}
+	if err := json.Unmarshal([]byte(*checkpointJSON), &doc); err != nil {
+		return nil
+	}
+	policy := strings.TrimSpace(doc.ResumePolicy)
+	if policy == "" {
+		return nil
+	}
+	return &policy
 }
 
 func diagnosticAgentOutput(agent storage.AgentExecutionRecord, now time.Time) loopDiagnosticAgent {
@@ -510,10 +550,17 @@ func diagnosticAgentOutput(agent storage.AgentExecutionRecord, now time.Time) lo
 	return output
 }
 
-func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storage.QueueItemRecord, metadata loopDiagnosticMetadata) loopDiagnosis {
+func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storage.QueueItemRecord, metadata loopDiagnosticMetadata, associateQueue bool) loopDiagnosis {
 	state := loop.Status
-	message, source := loopDiagnosticMessage(run, queue, metadata)
-	diagnosis := classifyDiagnosticMessage(message, queueErrorKind(queue))
+	var diagnosisQueue *storage.QueueItemRecord
+	if associateQueue {
+		diagnosisQueue = queue
+	}
+	message, source := loopDiagnosticMessage(run, diagnosisQueue, metadata)
+	// FailureClass/Retryable come from the structured error kind + message.
+	// Queue status "manual_intervention" is an operator-hold signal, not the
+	// underlying failure class — keep them separate.
+	diagnosis := classifyDiagnosticMessage(message, queueErrorKind(diagnosisQueue))
 	diagnosis.State = state
 	diagnosis.Source = source
 	if diagnosis.Message == "" {
@@ -526,6 +573,8 @@ func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storag
 }
 
 func diagnoseQueueItem(item storage.QueueItemRecord) loopDiagnosis {
+	// Preserve LastErrorKind as the failure cause. Queue status remains in
+	// diagnosis.State so operators can see a parked manual hold separately.
 	diagnosis := classifyDiagnosticMessage(diagnosticString(item.LastError), diagnosticString(item.LastErrorKind))
 	diagnosis.State = item.Status
 	diagnosis.Source = "queueItem"
@@ -561,6 +610,15 @@ func classifyDiagnosticMessage(message string, errorKind string) loopDiagnosis {
 	kind := strings.ToLower(strings.TrimSpace(errorKind))
 	if msg == "" && kind == "" {
 		return loopDiagnosis{}
+	}
+	if kind == "manual_intervention" {
+		retryable := false
+		return loopDiagnosis{
+			FailureClass:      "manual_intervention",
+			Retryable:         &retryable,
+			Message:           msg,
+			RecommendedAction: recommendedActionForManualIntervention(msg),
+		}
 	}
 	if strings.Contains(lower, "could not resolve to a pullrequest") {
 		retryable := false
@@ -640,12 +698,29 @@ func isTerminalGitHubDenial(message string) bool {
 	return false
 }
 
+func recommendedActionForManualIntervention(message string) string {
+	lower := strings.ToLower(message)
+	// Match the narrower dirty-worktree classifier used by failureclass.
+	if strings.Contains(lower, "dirty worktree") || strings.Contains(lower, "worktree is dirty") || strings.Contains(lower, "uncommitted changes") {
+		return "fix or discard local worktree changes, then looper retry <seq>"
+	}
+	if strings.Contains(lower, "worktree is locked") {
+		return "unlock or remove the locked worktree, then looper retry <seq>"
+	}
+	if strings.Contains(lower, "worktree") {
+		return "inspect the worktree path/state, then looper retry <seq>"
+	}
+	return "resolve the blocker, then looper retry <seq>"
+}
+
 func recommendedActionForState(state string) string {
 	switch state {
 	case "running":
 		return "monitor active run progress"
 	case "waiting":
 		return "no immediate action; loop is waiting for follow-up work"
+	case "paused":
+		return "use looper unpause <seq> if intentionally paused; otherwise looper describe <seq>"
 	case "failed":
 		return "inspect failure fields before requeueing"
 	case "terminated", "completed", "stopped":
@@ -653,6 +728,26 @@ func recommendedActionForState(state string) string {
 	default:
 		return "inspect loop details"
 	}
+}
+
+func formatActionWithSeq(action string, seq int64) string {
+	return strings.ReplaceAll(action, "<seq>", strconv.FormatInt(seq, 10))
+}
+
+func requiresOperatorHold(output loopInspectOutput) bool {
+	if output.Diagnosis.FailureClass == "manual_intervention" {
+		return true
+	}
+	if output.LatestQueueItem != nil && output.LatestQueueItem.Status == "manual_intervention" {
+		return true
+	}
+	if output.LatestQueueItem != nil && output.LatestQueueItem.LastErrorKind != nil && strings.TrimSpace(*output.LatestQueueItem.LastErrorKind) == "manual_intervention" {
+		return true
+	}
+	if output.Run != nil && output.Run.ResumePolicy != nil && strings.TrimSpace(*output.Run.ResumePolicy) == "manual_intervention" {
+		return true
+	}
+	return false
 }
 
 func queueErrorKind(queue *storage.QueueItemRecord) string {
@@ -692,8 +787,35 @@ func writeHumanLoopInspect(w io.Writer, output loopInspectOutput) error {
 				return err
 			}
 		}
+		if output.Run.ResumePolicy != nil && strings.TrimSpace(*output.Run.ResumePolicy) != "" {
+			if _, err := fmt.Fprintf(w, " · resumePolicy: %s", *output.Run.ResumePolicy); err != nil {
+				return err
+			}
+		}
 		if _, err := fmt.Fprintln(w); err != nil {
 			return err
+		}
+	}
+	queueError := ""
+	if output.LatestQueueItem != nil {
+		if _, err := fmt.Fprintf(w, "Queue %s · attempts %d/%d", output.LatestQueueItem.Status, output.LatestQueueItem.Attempts, output.LatestQueueItem.MaxAttempts); err != nil {
+			return err
+		}
+		if output.LatestQueueItem.LastErrorKind != nil && strings.TrimSpace(*output.LatestQueueItem.LastErrorKind) != "" {
+			if _, err := fmt.Fprintf(w, " · kind %s", *output.LatestQueueItem.LastErrorKind); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		if output.LatestQueueItem.LastError != nil {
+			queueError = strings.TrimSpace(*output.LatestQueueItem.LastError)
+		}
+		if queueError != "" {
+			if _, err := fmt.Fprintf(w, "Error: %s\n", queueError); err != nil {
+				return err
+			}
 		}
 	}
 	if output.Agent != nil {
@@ -713,14 +835,20 @@ func writeHumanLoopInspect(w io.Writer, output loopInspectOutput) error {
 		if _, err := fmt.Fprintf(w, "Diagnosis: state=%s class=%s retryable=%s source=%s\n", output.Diagnosis.State, output.Diagnosis.FailureClass, humanBoolPtr(output.Diagnosis.Retryable), output.Diagnosis.Source); err != nil {
 			return err
 		}
-		if output.Diagnosis.Message != "" {
+		// Avoid printing the same failure text twice when queue Error already showed it.
+		if output.Diagnosis.Message != "" && strings.TrimSpace(output.Diagnosis.Message) != queueError {
 			if _, err := fmt.Fprintf(w, "Message: %s\n", output.Diagnosis.Message); err != nil {
 				return err
 			}
 		}
 	}
 	if output.Diagnosis.RecommendedAction != "" {
-		if _, err := fmt.Fprintf(w, "Action: %s\n", output.Diagnosis.RecommendedAction); err != nil {
+		if _, err := fmt.Fprintf(w, "Action: %s\n", formatActionWithSeq(output.Diagnosis.RecommendedAction, output.Loop.Seq)); err != nil {
+			return err
+		}
+	}
+	if requiresOperatorHold(output) {
+		if _, err := fmt.Fprintf(w, "Next: after resolving the blocker, looper retry %d (see also looper logs %d)\n", output.Loop.Seq, output.Loop.Seq); err != nil {
 			return err
 		}
 	}

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -566,7 +566,16 @@ func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storag
 	// FailureClass/Retryable come from the structured error kind + message.
 	// Queue status "manual_intervention" is an operator-hold signal, not the
 	// underlying failure class — keep them separate.
-	diagnosis := classifyDiagnosticMessage(message, queueErrorKind(diagnosisQueue))
+	// Checkpoint-only holds have no parked queue item, so queueErrorKind is
+	// empty; synthesize manual_intervention from the run resume policy so
+	// failures listing does not surface class=unknown for operator holds.
+	errorKind := queueErrorKind(diagnosisQueue)
+	if errorKind == "" && run != nil {
+		if policy := resumePolicyFromCheckpoint(run.CheckpointJSON); policy != nil && strings.TrimSpace(*policy) == "manual_intervention" {
+			errorKind = "manual_intervention"
+		}
+	}
+	diagnosis := classifyDiagnosticMessage(message, errorKind)
 	diagnosis.State = state
 	diagnosis.Source = source
 	if diagnosis.Message == "" {

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -569,6 +569,9 @@ func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storag
 	if diagnosis.RecommendedAction == "" {
 		diagnosis.RecommendedAction = recommendedActionForState(state)
 	}
+	// Expand <seq> before emitting JSON/human output so operators and scripts
+	// never see the literal placeholder outside writeHumanLoopInspect.
+	diagnosis.RecommendedAction = formatActionWithSeq(diagnosis.RecommendedAction, loop.Seq)
 	return diagnosis
 }
 
@@ -861,7 +864,8 @@ func writeHumanLoopFailures(w io.Writer, output loopFailuresOutput) error {
 		return err
 	}
 	for _, item := range output.Items {
-		if _, err := fmt.Fprintf(w, "#%d\t%s\t%s\tclass=%s\tretryable=%s\t%s\n", item.Loop.Seq, item.Loop.Type, item.Loop.Target.Label, item.Diagnosis.FailureClass, humanBoolPtr(item.Diagnosis.Retryable), item.Diagnosis.RecommendedAction); err != nil {
+		action := formatActionWithSeq(item.Diagnosis.RecommendedAction, item.Loop.Seq)
+		if _, err := fmt.Fprintf(w, "#%d\t%s\t%s\tclass=%s\tretryable=%s\t%s\n", item.Loop.Seq, item.Loop.Type, item.Loop.Target.Label, item.Diagnosis.FailureClass, humanBoolPtr(item.Diagnosis.Retryable), action); err != nil {
 			return err
 		}
 	}

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -163,8 +163,148 @@ func TestLoopFailuresIncludesPausedManualInterventionLoops(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v\noutput=%q", err, stdout)
 	}
+	// Queue status is manual_intervention (operator hold), but LastErrorKind is
+	// non_retryable — FailureClass must preserve the structured kind.
 	if decoded.Count != 1 || len(decoded.Items) != 1 || decoded.Items[0].Loop.Seq != 8 || decoded.Items[0].Loop.Status != "paused" || decoded.Items[0].LatestQueueItem.Status != "manual_intervention" || decoded.Items[0].Diagnosis.FailureClass != "non_retryable" {
-		t.Fatalf("loop failures output = %#v, want one paused manual-intervention worker loop", decoded)
+		t.Fatalf("loop failures output = %#v, want one paused manual-hold worker loop with non_retryable class", decoded)
+	}
+}
+
+func TestDescribeAliasesLoopInspect(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeLoopDiagnosticsFixture(t, "")
+	exitCode, stdout, stderr := runApp(t, "describe", "run_reviewer_failed", "--json", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([describe]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	var decoded struct {
+		SelectorKind string `json:"selectorKind"`
+		Loop         struct {
+			Seq int64 `json:"seq"`
+		} `json:"loop"`
+		Run struct {
+			ID string `json:"id"`
+		} `json:"run"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\noutput=%q", err, stdout)
+	}
+	if decoded.SelectorKind != "runId" || decoded.Loop.Seq != 7 || decoded.Run.ID != "run_reviewer_failed" {
+		t.Fatalf("describe output = %#v, want same resolution as loop inspect", decoded)
+	}
+}
+
+func TestDescribeHumanShowsManualInterventionReason(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeLoopDiagnosticsFixture(t, "")
+	exitCode, stdout, stderr := runApp(t, "describe", "8", "--config", configPath)
+	if exitCode != 0 {
+		t.Fatalf("Run([describe 8]) exit code = %d, want 0; stderr=%q", exitCode, stderr)
+	}
+	for _, want := range []string{"worktree is locked", "manual_intervention", "retry"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("describe human output = %q, want to contain %q", stdout, want)
+		}
+	}
+}
+
+func TestClassifyDiagnosticMessageManualIntervention(t *testing.T) {
+	t.Parallel()
+
+	got := classifyDiagnosticMessage("dirty worktree: uncommitted changes", "manual_intervention")
+	if got.FailureClass != "manual_intervention" || got.Retryable == nil || *got.Retryable {
+		t.Fatalf("diagnosis = %#v, want non-retryable manual_intervention", got)
+	}
+	if !strings.Contains(got.RecommendedAction, "discard") || !strings.Contains(got.RecommendedAction, "retry") {
+		t.Fatalf("RecommendedAction = %q, want dirty-worktree discard/retry guidance", got.RecommendedAction)
+	}
+
+	locked := classifyDiagnosticMessage("fatal: worktree is locked", "manual_intervention")
+	if strings.Contains(locked.RecommendedAction, "discard") {
+		t.Fatalf("RecommendedAction = %q, must not recommend discard for locked worktree", locked.RecommendedAction)
+	}
+	if !strings.Contains(locked.RecommendedAction, "unlock") {
+		t.Fatalf("RecommendedAction = %q, want unlock guidance for locked worktree", locked.RecommendedAction)
+	}
+}
+
+func TestDiagnoseLoopPreservesErrorKindWhenQueueIsManualHold(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		kind      string
+		message   string
+		wantClass string
+		retryable bool
+	}{
+		{name: "retryable_transient", kind: "retryable_transient", message: `Post "https://api.github.com/graphql": EOF`, wantClass: "github_transient", retryable: true},
+		{name: "retryable_after_resume", kind: "retryable_after_resume", message: "agent interrupted", wantClass: "retryable_after_resume", retryable: true},
+		{name: "non_retryable", kind: "non_retryable", message: "fatal: worktree is locked", wantClass: "non_retryable", retryable: false},
+		{name: "manual_intervention kind", kind: "manual_intervention", message: "dirty worktree: uncommitted changes", wantClass: "manual_intervention", retryable: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind := tt.kind
+			msg := tt.message
+			queue := &storage.QueueItemRecord{Status: "manual_intervention", LastError: &msg, LastErrorKind: &kind}
+			run := &storage.RunRecord{Status: "failed", ErrorMessage: &msg}
+			got := diagnoseLoop(storage.LoopRecord{Status: "paused"}, run, queue, loopDiagnosticMetadata{}, true)
+			if got.FailureClass != tt.wantClass {
+				t.Fatalf("FailureClass = %q, want %q", got.FailureClass, tt.wantClass)
+			}
+			if got.Retryable == nil || *got.Retryable != tt.retryable {
+				t.Fatalf("Retryable = %#v, want %v", got.Retryable, tt.retryable)
+			}
+		})
+	}
+}
+
+func TestDiagnoseLoopRunSelectorIgnoresLatestQueueKind(t *testing.T) {
+	t.Parallel()
+
+	runMsg := `Post "https://api.github.com/graphql": EOF`
+	queueMsg := "dirty worktree: uncommitted changes"
+	queueKind := "manual_intervention"
+	run := &storage.RunRecord{Status: "failed", ErrorMessage: &runMsg}
+	queue := &storage.QueueItemRecord{Status: "manual_intervention", LastError: &queueMsg, LastErrorKind: &queueKind}
+
+	got := diagnoseLoop(storage.LoopRecord{Status: "paused"}, run, queue, loopDiagnosticMetadata{}, false)
+	if got.FailureClass != "github_transient" {
+		t.Fatalf("FailureClass = %q, want github_transient from historical run only", got.FailureClass)
+	}
+	if got.Source != "run" || !strings.Contains(got.Message, "api.github.com") {
+		t.Fatalf("diagnosis = %#v, want run-sourced github message", got)
+	}
+}
+
+func TestRecommendedActionForPausedIsNotAlwaysRetry(t *testing.T) {
+	t.Parallel()
+
+	got := recommendedActionForState("paused")
+	if strings.Contains(got, "retry") && !strings.Contains(got, "unpause") {
+		t.Fatalf("paused action = %q, want unpause/describe guidance not forced retry", got)
+	}
+	if !strings.Contains(got, "unpause") {
+		t.Fatalf("paused action = %q, want unpause guidance", got)
+	}
+}
+
+func TestTruncateCLITextIsRuneSafeAndSingleLine(t *testing.T) {
+	t.Parallel()
+
+	// 10 runes of multi-byte text + control/newline collapse.
+	got := truncateCLIText("你好世界测试文本更长\nline2\twith\ttabs", 8)
+	if strings.Contains(got, "\n") || strings.Contains(got, "\t") {
+		t.Fatalf("truncateCLIText = %q, want single-line sanitized text", got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("truncateCLIText = %q, want ellipsis suffix", got)
+	}
+	if len([]rune(got)) != 8 {
+		t.Fatalf("truncateCLIText rune len = %d, want 8 (including ...)", len([]rune(got)))
 	}
 }
 

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -304,6 +304,32 @@ func TestDiagnoseLoopRunSelectorIgnoresLatestQueueKind(t *testing.T) {
 	}
 }
 
+func TestDiagnoseLoopRunSelectorIgnoresLoopMetadataLastFailure(t *testing.T) {
+	t.Parallel()
+
+	// Historical run succeeded (or has no error); loop metadata still carries a
+	// later run's lastFailure. Run-id diagnosis must not adopt that signal.
+	laterFailure := "dirty worktree: uncommitted changes from a later run"
+	metadata := loopDiagnosticMetadata{
+		Loop: &loopDiagnosticLoopMetadata{LastFailure: &laterFailure},
+	}
+	run := &storage.RunRecord{Status: "succeeded"}
+	queueMsg := "queue error from current hold"
+	queueKind := "manual_intervention"
+	queue := &storage.QueueItemRecord{Status: "manual_intervention", LastError: &queueMsg, LastErrorKind: &queueKind}
+
+	got := diagnoseLoop(storage.LoopRecord{Status: "paused"}, run, queue, metadata, false)
+	if got.Source == "loopMetadata" || strings.Contains(got.Message, laterFailure) {
+		t.Fatalf("diagnosis = %#v, want no loop metadata lastFailure for run-id selector", got)
+	}
+	if got.Source == "queueItem" || strings.Contains(got.Message, queueMsg) {
+		t.Fatalf("diagnosis = %#v, want no latest queue error for run-id selector", got)
+	}
+	if got.Message != "" && got.Source != "run" {
+		t.Fatalf("diagnosis = %#v, want empty or run-only diagnosis for successful historical run", got)
+	}
+}
+
 func TestRecommendedActionForPausedIsNotAlwaysRetry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -254,6 +254,30 @@ func TestDiagnoseLoopExpandsRetrySeqPlaceholder(t *testing.T) {
 	}
 }
 
+func TestDiagnoseQueueItemDoesNotEmitSeqPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	kind := "manual_intervention"
+	msg := "dirty worktree: uncommitted changes"
+	item := storage.QueueItemRecord{Status: "manual_intervention", LastError: &msg, LastErrorKind: &kind}
+
+	withSeq := diagnoseQueueItem(item, 3)
+	if strings.Contains(withSeq.RecommendedAction, "<seq>") {
+		t.Fatalf("RecommendedAction = %q, want expanded seq not literal <seq>", withSeq.RecommendedAction)
+	}
+	if !strings.Contains(withSeq.RecommendedAction, "looper retry 3") {
+		t.Fatalf("RecommendedAction = %q, want looper retry 3", withSeq.RecommendedAction)
+	}
+
+	withoutSeq := diagnoseQueueItem(item, 0)
+	if strings.Contains(withoutSeq.RecommendedAction, "<seq>") {
+		t.Fatalf("RecommendedAction = %q, must not leak unresolved <seq> when loop seq is unknown", withoutSeq.RecommendedAction)
+	}
+	if !strings.Contains(withoutSeq.RecommendedAction, "retry the owning loop") {
+		t.Fatalf("RecommendedAction = %q, want owning-loop retry guidance without placeholder", withoutSeq.RecommendedAction)
+	}
+}
+
 func TestDiagnoseLoopPreservesErrorKindWhenQueueIsManualHold(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -310,6 +310,38 @@ func TestDiagnoseLoopPreservesErrorKindWhenQueueIsManualHold(t *testing.T) {
 	}
 }
 
+func TestDiagnoseLoopCheckpointOnlyManualHoldUsesResumePolicy(t *testing.T) {
+	t.Parallel()
+
+	// Paused loops included via checkpoint resumePolicy with no parked queue
+	// must classify as manual_intervention, not unknown.
+	msg := "dirty worktree: uncommitted changes"
+	checkpoint := `{"resumePolicy":"manual_intervention"}`
+	run := &storage.RunRecord{Status: "failed", ErrorMessage: &msg, CheckpointJSON: &checkpoint}
+
+	got := diagnoseLoop(storage.LoopRecord{Seq: 9, Status: "paused"}, run, nil, loopDiagnosticMetadata{}, true)
+	if got.FailureClass != "manual_intervention" {
+		t.Fatalf("FailureClass = %q, want manual_intervention for checkpoint-only hold", got.FailureClass)
+	}
+	if got.Retryable == nil || *got.Retryable {
+		t.Fatalf("Retryable = %#v, want false for manual_intervention", got.Retryable)
+	}
+	if !strings.Contains(got.RecommendedAction, "looper retry 9") {
+		t.Fatalf("RecommendedAction = %q, want operator-hold retry guidance for seq 9", got.RecommendedAction)
+	}
+	if got.Source != "run" || !strings.Contains(got.Message, "dirty worktree") {
+		t.Fatalf("diagnosis = %#v, want run-sourced dirty worktree message", got)
+	}
+
+	// Queue LastErrorKind still wins when present (do not overwrite with policy).
+	queueKind := "non_retryable"
+	queue := &storage.QueueItemRecord{Status: "manual_intervention", LastError: &msg, LastErrorKind: &queueKind}
+	withQueue := diagnoseLoop(storage.LoopRecord{Seq: 9, Status: "paused"}, run, queue, loopDiagnosticMetadata{}, true)
+	if withQueue.FailureClass != "non_retryable" {
+		t.Fatalf("FailureClass = %q, want non_retryable from queue kind over resumePolicy", withQueue.FailureClass)
+	}
+}
+
 func TestDiagnoseLoopRunSelectorIgnoresLatestQueueKind(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -230,6 +230,30 @@ func TestClassifyDiagnosticMessageManualIntervention(t *testing.T) {
 	}
 }
 
+func TestDiagnoseLoopExpandsRetrySeqPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	kind := "manual_intervention"
+	msg := "dirty worktree: uncommitted changes"
+	queue := &storage.QueueItemRecord{Status: "manual_intervention", LastError: &msg, LastErrorKind: &kind}
+	run := &storage.RunRecord{Status: "failed", ErrorMessage: &msg}
+	got := diagnoseLoop(storage.LoopRecord{Seq: 42, Status: "paused"}, run, queue, loopDiagnosticMetadata{}, true)
+	if strings.Contains(got.RecommendedAction, "<seq>") {
+		t.Fatalf("RecommendedAction = %q, want expanded loop seq not literal <seq>", got.RecommendedAction)
+	}
+	if !strings.Contains(got.RecommendedAction, "looper retry 42") {
+		t.Fatalf("RecommendedAction = %q, want looper retry 42", got.RecommendedAction)
+	}
+
+	paused := diagnoseLoop(storage.LoopRecord{Seq: 7, Status: "paused"}, nil, nil, loopDiagnosticMetadata{}, false)
+	if strings.Contains(paused.RecommendedAction, "<seq>") {
+		t.Fatalf("paused RecommendedAction = %q, want expanded seq", paused.RecommendedAction)
+	}
+	if !strings.Contains(paused.RecommendedAction, "looper unpause 7") || !strings.Contains(paused.RecommendedAction, "looper describe 7") {
+		t.Fatalf("paused RecommendedAction = %q, want unpause/describe with seq 7", paused.RecommendedAction)
+	}
+}
+
 func TestDiagnoseLoopPreservesErrorKindWhenQueueIsManualHold(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/queue_commands_test.go
+++ b/internal/cliapp/queue_commands_test.go
@@ -147,8 +147,9 @@ func TestQueueFailedCommandListsFailedItems(t *testing.T) {
 				Status string `json:"status"`
 			} `json:"queueItem"`
 			Diagnosis struct {
-				FailureClass string `json:"failureClass"`
-				Retryable    *bool  `json:"retryable"`
+				FailureClass      string `json:"failureClass"`
+				Retryable         *bool  `json:"retryable"`
+				RecommendedAction string `json:"recommendedAction"`
 			} `json:"diagnosis"`
 		} `json:"items"`
 	}
@@ -159,16 +160,18 @@ func TestQueueFailedCommandListsFailedItems(t *testing.T) {
 		t.Fatalf("queue failed output = %#v, want two items", decoded)
 	}
 	itemsByID := map[string]struct {
-		status       string
-		failureClass string
-		retryable    *bool
+		status            string
+		failureClass      string
+		retryable         *bool
+		recommendedAction string
 	}{}
 	for _, item := range decoded.Items {
 		itemsByID[item.QueueItem.ID] = struct {
-			status       string
-			failureClass string
-			retryable    *bool
-		}{status: item.QueueItem.Status, failureClass: item.Diagnosis.FailureClass, retryable: item.Diagnosis.Retryable}
+			status            string
+			failureClass      string
+			retryable         *bool
+			recommendedAction string
+		}{status: item.QueueItem.Status, failureClass: item.Diagnosis.FailureClass, retryable: item.Diagnosis.Retryable, recommendedAction: item.Diagnosis.RecommendedAction}
 	}
 	failed := itemsByID["qi_failed"]
 	if failed.status != "failed" || failed.failureClass != "github_transient" || failed.retryable == nil || !*failed.retryable {
@@ -177,6 +180,16 @@ func TestQueueFailedCommandListsFailedItems(t *testing.T) {
 	manual := itemsByID["qi_manual_intervention"]
 	if manual.status != "manual_intervention" {
 		t.Fatalf("qi_manual_intervention = %#v, want manual_intervention status", manual)
+	}
+	if manual.failureClass != "manual_intervention" {
+		t.Fatalf("qi_manual_intervention failureClass = %q, want manual_intervention", manual.failureClass)
+	}
+	if strings.Contains(manual.recommendedAction, "<seq>") {
+		t.Fatalf("qi_manual_intervention recommendedAction = %q, must not leak unresolved <seq>", manual.recommendedAction)
+	}
+	// loop_failed has seq 3 in the fixture; expand so operators get a real retry command.
+	if !strings.Contains(manual.recommendedAction, "looper retry 3") {
+		t.Fatalf("qi_manual_intervention recommendedAction = %q, want expanded looper retry 3", manual.recommendedAction)
 	}
 }
 

--- a/internal/cliapp/review_submit_contract_helpers_test.go
+++ b/internal/cliapp/review_submit_contract_helpers_test.go
@@ -95,9 +95,9 @@ case "$1" in
     ;;
 esac
 `, submitLog, baseSHA, headSHA, diffMode, filepath.Join(root, "gh-invocations.log"))
-	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake gh: %v", err)
-	}
+	// Write via temp+sync+rename so fork/exec never races a still-open write fd
+	// (Linux ETXTBSY "text file busy" under parallel package tests on CI).
+	writeExecutableScript(t, ghPath, script)
 
 	configPayload := map[string]any{
 		"tools": map[string]any{
@@ -209,6 +209,44 @@ func seedReviewSubmitDeletedRepo(t *testing.T, repo string) (baseSHA, headSHA st
 	headSHA = strings.TrimSpace(runReviewSubmitGitOutput(t, repo, "rev-parse", "HEAD"))
 	deletedLine = 4
 	return baseSHA, headSHA, deletedLine
+}
+
+// writeExecutableScript atomically installs an executable script at path.
+// Direct WriteFile+immediate exec can fail with ETXTBSY on Linux when the
+// write fd is still visible to the kernel at fork/exec under load.
+func writeExecutableScript(t *testing.T, path, contents string) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".exec-*")
+	if err != nil {
+		t.Fatalf("create temp executable: %v", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.WriteString(contents); err != nil {
+		_ = tmp.Close()
+		t.Fatalf("write temp executable: %v", err)
+	}
+	if err := tmp.Chmod(0o755); err != nil {
+		_ = tmp.Close()
+		t.Fatalf("chmod temp executable: %v", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		t.Fatalf("sync temp executable: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close temp executable: %v", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		t.Fatalf("rename temp executable to %s: %v", path, err)
+	}
+	cleanup = false
 }
 
 func runReviewSubmitGit(t *testing.T, repo string, args ...string) {

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -29,6 +29,7 @@ Subcommands:
   takeover   Continuously review and fix a pull request until it merges
   feedback   Submit feedback as a GitHub issue
   ps         Show running loops
+  describe   Show loop diagnostics detail
   jump       Print shell command for a loop worktree
   logs       Show logs for a loop
   pause      Pause a loop by sequence number

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +16,10 @@ import (
 const (
 	defaultMaxOutputBytes = 256 * 1024
 	defaultGracefulStop   = 5 * time.Second
+	// startAttempts covers transient Linux ETXTBSY after a binary/script is
+	// installed (common when tests write a fake tool then exec it immediately).
+	startAttempts      = 8
+	startRetryBaseWait = 5 * time.Millisecond
 )
 
 type Result struct {
@@ -60,21 +65,11 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		gracefulShutdown = defaultGracefulStop
 	}
 
-	cmd := exec.Command(options.Command, options.Args...)
-	cmd.Dir = options.CWD
-	if len(options.Env) > 0 {
-		cmd.Env = envSlice(options.Env)
-	}
-	if options.Stdin != "" {
-		cmd.Stdin = strings.NewReader(options.Stdin)
-	}
-
 	stdoutBuffer := newBoundedBuffer(maxCapturedBytes)
 	stderrBuffer := newBoundedBuffer(maxCapturedBytes)
-	cmd.Stdout = stdoutBuffer
-	cmd.Stderr = stderrBuffer
 
-	if err := cmd.Start(); err != nil {
+	cmd, err := startCommand(ctx, options, stdoutBuffer, stderrBuffer)
+	if err != nil {
 		return Result{}, fmt.Errorf("start command: %w", err)
 	}
 
@@ -161,6 +156,51 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	return result, nil
 }
 
+func startCommand(ctx context.Context, options Options, stdout, stderr *boundedBuffer) (*exec.Cmd, error) {
+	var lastErr error
+	for attempt := 0; attempt < startAttempts; attempt++ {
+		if attempt > 0 {
+			wait := startRetryBaseWait * time.Duration(attempt)
+			timer := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+		}
+
+		cmd := exec.Command(options.Command, options.Args...)
+		cmd.Dir = options.CWD
+		if len(options.Env) > 0 {
+			cmd.Env = envSlice(options.Env)
+		}
+		if options.Stdin != "" {
+			cmd.Stdin = strings.NewReader(options.Stdin)
+		}
+		// Fresh buffers each attempt: Start never ran on failure, but reset
+		// so a partial Write cannot leak across retries if that ever changes.
+		stdout.reset()
+		stderr.reset()
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
+
+		if err := cmd.Start(); err != nil {
+			lastErr = err
+			if isTextFileBusy(err) {
+				continue
+			}
+			return nil, err
+		}
+		return cmd, nil
+	}
+	return nil, lastErr
+}
+
+func isTextFileBusy(err error) bool {
+	return errors.Is(err, syscall.ETXTBSY)
+}
+
 func commandFailureMessage(result Result) string {
 	message := fmt.Sprintf("Command exited with code %d", result.ExitCode)
 	stderr := strings.TrimSpace(result.Stderr)
@@ -233,6 +273,13 @@ func (b *boundedBuffer) Write(p []byte) (int, error) {
 	}
 	b.data = append(b.data, p...)
 	return originalLen, nil
+}
+
+func (b *boundedBuffer) reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.data = b.data[:0]
+	b.truncated = false
 }
 
 func (b *boundedBuffer) String() string {

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -3,7 +3,10 @@ package shell
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -122,5 +125,63 @@ func TestRunRespectsContextCancellation(t *testing.T) {
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestIsTextFileBusy(t *testing.T) {
+	t.Parallel()
+	if !isTextFileBusy(syscall.ETXTBSY) {
+		t.Fatal("isTextFileBusy(syscall.ETXTBSY) = false, want true")
+	}
+	if isTextFileBusy(os.ErrNotExist) {
+		t.Fatal("isTextFileBusy(os.ErrNotExist) = true, want false")
+	}
+	if isTextFileBusy(nil) {
+		t.Fatal("isTextFileBusy(nil) = true, want false")
+	}
+}
+
+func TestRunRetriesStartOnTextFileBusy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "tool")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf ok\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	// Keep an exclusive write fd open so the first Start hits ETXTBSY on Linux.
+	// Release it shortly after Run begins so a later retry succeeds.
+	holder, err := os.OpenFile(script, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open script for write hold: %v", err)
+	}
+	// Confirm this platform produces ETXTBSY under a write hold; skip otherwise
+	// (some filesystems / kernels do not surface it for shell scripts).
+	if probe, probeErr := startCommand(context.Background(), Options{Command: script}, newBoundedBuffer(64), newBoundedBuffer(64)); probeErr == nil {
+		_ = holder.Close()
+		if waitErr := probe.Wait(); waitErr != nil {
+			t.Fatalf("probe Wait() error = %v", waitErr)
+		}
+		t.Skip("filesystem does not return ETXTBSY while script is open for write")
+	} else if !isTextFileBusy(probeErr) {
+		_ = holder.Close()
+		t.Skipf("probe start error = %v, want ETXTBSY to exercise retry", probeErr)
+	}
+
+	release := make(chan struct{})
+	go func() {
+		<-release
+		time.Sleep(15 * time.Millisecond)
+		_ = holder.Close()
+	}()
+
+	close(release)
+	result, err := Run(context.Background(), Options{Command: script})
+	if err != nil {
+		t.Fatalf("Run() error = %v, want retry past ETXTBSY", err)
+	}
+	if result.Stdout != "ok" {
+		t.Fatalf("Stdout = %q, want ok", result.Stdout)
 	}
 }

--- a/skills/looper/references/cli.md
+++ b/skills/looper/references/cli.md
@@ -252,10 +252,13 @@ Loop inspection commands:
 
 ```bash
 looper ps
+looper describe <id>
 looper logs <id> --follow
 looper jump <id>
 looper stop <id>
 ```
+
+`looper describe` is the top-level alias for `looper loop inspect` and shows diagnosis detail for blocked or failed loops.
 
 Manual fixer trigger:
 


### PR DESCRIPTION
## Summary

- Add top-level `looper describe <seq|loopId|runId>` as an alias of `loop inspect` so operators can see why a loop is blocked without digging under `loop`.
- Human `looper ps` now shows a truncated `reason` column from `lastFailureReason`.
- Active-runs API falls back to the latest run error/summary when no queue error exists (checkpoint-only holds).
- Diagnosis keeps **queue hold status** separate from **structured failure class** (`LastErrorKind`); only kind `manual_intervention` sets that class.
- Human describe/inspect shows queue status/attempts/kind, resumePolicy, de-duplicated error text, and operator-hold next steps with real seq numbers.
- Docs + root-help golden updated.

## Oracle review follow-ups addressed

- Do not overwrite FailureClass when queue status is `manual_intervention` but kind is `retryable_*` / `non_retryable`.
- Run-id selectors do not let the latest queue rewrite historical run diagnosis.
- Intentionally paused loops no longer get forced “retry” guidance.
- Dirty-worktree discard guidance only for explicit dirty/uncommitted phrases.
- Rune-safe single-line truncation for `ps` reason cells.

## Test plan

- [x] `go test ./internal/cliapp/ ./internal/api/ -count=1`
- [x] Golden root help includes `describe`
- [ ] Manual: `looper ps` shows reason for a parked loop
- [ ] Manual: `looper describe <seq>` shows queue hold + root-cause class + next steps