### PR TITLE
fix: enforce agent process lifecycle ownership

### DIFF
--- a/cmd/looperd/lifecycle_contract_test.go
+++ b/cmd/looperd/lifecycle_contract_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/agent"
+	"github.com/nexu-io/looper/internal/config"
+	looperdruntime "github.com/nexu-io/looper/internal/runtime"
+)
+
+func TestTakeoverWaitsForTermResistantLiveProcessGroupReap(t *testing.T) {
+	ctx := context.Background()
+	services, repos, now := newStopAllTestServices(t)
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{
+		loopID: "loop_live_takeover", seq: 1, loopType: "worker", loopStatus: "running",
+		runID: "run_live_takeover", runStatus: "running", executionID: "exec_live_takeover", executionStatus: "running",
+	})
+
+	workDir := t.TempDir()
+	pidFile := filepath.Join(workDir, "agent.pid")
+	script := filepath.Join(workDir, "term-resistant-agent.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\ntrap '' TERM\necho $$ > \"$PID_FILE\"\nwhile :; do sleep 1; done\n"), 0o755); err != nil {
+		t.Fatalf("write agent script: %v", err)
+	}
+	executor := agent.New(agent.ExecutorOptions{Config: agent.ExecutorConfig{
+		Vendor: config.AgentVendor("lifecycle-test"),
+		Params: map[string]any{"command": script},
+	}})
+	execution, err := executor.Start(ctx, agent.RunInput{
+		ExecutionID: "exec_live_takeover", LoopID: "loop_live_takeover", RunID: "run_live_takeover",
+		Prompt: "hold worktree", WorkingDirectory: workDir, Timeout: 5 * time.Second,
+		GracefulShutdown: 120 * time.Millisecond, Env: map[string]string{"PID_FILE": pidFile},
+	})
+	if err != nil {
+		t.Fatalf("executor.Start() error = %v", err)
+	}
+	registry := looperdruntime.NewActiveExecutionRegistry()
+	registry.Register("loop_live_takeover", "run_live_takeover", "exec_live_takeover", execution)
+	services.ActiveExecutions = registry
+
+	pid := waitForProcessPIDFile(t, pidFile)
+	t.Cleanup(func() { _ = syscall.Kill(-pid, syscall.SIGKILL) })
+	returned := make(chan error, 1)
+	go func() {
+		_, err := takeoverLoop(ctx, services, "loop_live_takeover", "live takeover", time.Now, syscall.Kill, nil)
+		returned <- err
+	}()
+
+	select {
+	case err := <-returned:
+		t.Fatalf("takeover returned before TERM grace/reap: %v", err)
+	case <-time.After(40 * time.Millisecond):
+	}
+	loop, err := repos.Loops.GetByID(ctx, "loop_live_takeover")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "running" {
+		t.Fatalf("loop during TERM grace = %#v, want running until process reap", loop)
+	}
+
+	select {
+	case err := <-returned:
+		if err != nil {
+			t.Fatalf("takeoverLoop() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("takeover did not finish after executor SIGKILL escalation")
+	}
+	if processGroupExists(pid) {
+		t.Fatalf("process group %d still exists after takeover completed", pid)
+	}
+	loop, err = repos.Loops.GetByID(ctx, "loop_live_takeover")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "human_takeover" {
+		t.Fatalf("loop after reap = %#v, want human_takeover", loop)
+	}
+}
+
+func TestCloseWaitsForTermResistantLiveProcessGroupReap(t *testing.T) {
+	ctx := context.Background()
+	services, repos, now := newStopAllTestServices(t)
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{
+		loopID: "loop_live_close", seq: 2, loopType: "worker", loopStatus: "running",
+		runID: "run_live_close", runStatus: "running", executionID: "exec_live_close", executionStatus: "running",
+	})
+
+	workDir := t.TempDir()
+	pidFile := filepath.Join(workDir, "agent.pid")
+	script := filepath.Join(workDir, "term-resistant-agent.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\ntrap '' TERM\necho $$ > \"$PID_FILE\"\nwhile :; do sleep 1; done\n"), 0o755); err != nil {
+		t.Fatalf("write agent script: %v", err)
+	}
+	executor := agent.New(agent.ExecutorOptions{Config: agent.ExecutorConfig{
+		Vendor: config.AgentVendor("lifecycle-test"),
+		Params: map[string]any{"command": script},
+	}})
+	execution, err := executor.Start(ctx, agent.RunInput{
+		ExecutionID: "exec_live_close", LoopID: "loop_live_close", RunID: "run_live_close",
+		Prompt: "hold worktree", WorkingDirectory: workDir, Timeout: 5 * time.Second,
+		GracefulShutdown: 120 * time.Millisecond, Env: map[string]string{"PID_FILE": pidFile},
+	})
+	if err != nil {
+		t.Fatalf("executor.Start() error = %v", err)
+	}
+	registry := looperdruntime.NewActiveExecutionRegistry()
+	registry.Register("loop_live_close", "run_live_close", "exec_live_close", execution)
+	services.ActiveExecutions = registry
+
+	pid := waitForProcessPIDFile(t, pidFile)
+	t.Cleanup(func() { _ = syscall.Kill(-pid, syscall.SIGKILL) })
+	returned := make(chan error, 1)
+	go func() {
+		_, err := closeLoop(ctx, services, "loop_live_close", "live close", time.Now, nil, nil)
+		returned <- err
+	}()
+
+	select {
+	case err := <-returned:
+		t.Fatalf("close returned before TERM grace/reap: %v", err)
+	case <-time.After(40 * time.Millisecond):
+	}
+	loop, err := repos.Loops.GetByID(ctx, "loop_live_close")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "running" {
+		t.Fatalf("loop during TERM grace = %#v, want running until process reap", loop)
+	}
+
+	select {
+	case err := <-returned:
+		if err != nil {
+			t.Fatalf("closeLoop() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("close did not finish after executor SIGKILL escalation")
+	}
+	if processGroupExists(pid) {
+		t.Fatalf("process group %d still exists after close completed", pid)
+	}
+	loop, err = repos.Loops.GetByID(ctx, "loop_live_close")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "terminated" {
+		t.Fatalf("loop after reap = %#v, want terminated", loop)
+	}
+}
+
+func waitForProcessPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process pid file %s was not written", path)
+	return 0
+}
+
+func processGroupExists(pid int) bool {
+	err := syscall.Kill(-pid, 0)
+	return err == nil || !errors.Is(err, syscall.ESRCH)
+}

--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -107,14 +107,11 @@ const (
 	stopOutcomeAlreadyStopping = "already_stopping"
 	stopOutcomeAlreadyFinished = "already_finished"
 
-	processSkipNoRuns              = "no_running_run"
-	processSkipNoExecution         = "no_execution"
-	processSkipAlreadyFinished     = "execution_already_finished"
-	processSkipAlreadyStopping     = "execution_already_stopping"
-	processSkipNoPID               = "pid_unavailable"
-	processSkipNoSignal            = "signal_unavailable"
-	processSkipVerifierNotRunning  = "pid_not_running"
-	processSkipVerifierRejectedPID = "pid_verification_rejected"
+	processSkipNoRuns          = "no_running_run"
+	processSkipNoExecution     = "no_execution"
+	processSkipAlreadyFinished = "execution_already_finished"
+	processSkipAlreadyStopping = "execution_already_stopping"
+	processSkipNoLiveExecution = "live_execution_unavailable"
 )
 
 type signalProcessFunc func(int, syscall.Signal) error
@@ -132,23 +129,25 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 		return nil, err
 	}
 
+	startupReady := make(chan struct{})
 	apiHandler := looperdapi.NewHandler(looperdapi.Context{
-		Config:  deps.Config,
-		Runtime: rt,
+		Config:       deps.Config,
+		Runtime:      rt,
+		StartupReady: startupReady,
 		ReconcileStaleRuns: func(ctx context.Context) (looperdruntime.StaleRunReconcileSummary, error) {
 			return rt.ReconcileStaleRunningRuns(ctx)
 		},
 		StopLoop: func(ctx context.Context, loopID, reason string) (any, error) {
-			return stopLoop(ctx, rt.Services(), loopID, reason, time.Now, syscall.Kill, rt.ExecutionMatchesProcess)
+			return stopLoop(ctx, rt.Services(), loopID, reason, time.Now, nil, nil)
 		},
 		CloseLoop: func(ctx context.Context, loopID, reason string) (any, error) {
-			return closeLoop(ctx, rt.Services(), loopID, reason, time.Now, syscall.Kill, rt.ExecutionMatchesProcess)
+			return closeLoop(ctx, rt.Services(), loopID, reason, time.Now, nil, nil)
 		},
 		StopAll: func(ctx context.Context, reason string) (any, error) {
-			return stopAllLoops(ctx, rt.Services(), reason, time.Now, syscall.Kill, rt.ExecutionMatchesProcess)
+			return stopAllLoops(ctx, rt.Services(), reason, time.Now, nil, nil)
 		},
 		TakeoverLoop: func(ctx context.Context, loopID, reason string) (looperdapi.TakeoverResult, error) {
-			return takeoverLoop(ctx, rt.Services(), loopID, reason, time.Now, syscall.Kill, rt.ExecutionMatchesProcess)
+			return takeoverLoop(ctx, rt.Services(), loopID, reason, time.Now, nil, nil)
 		},
 		TriggerSchedulerTick: func() {
 			rt.TriggerSchedulerTick()
@@ -170,18 +169,47 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 		shutdownTimeout = time.Second
 	}
 
-	if err := rt.CompleteStartup(ctx); err != nil {
+	if err := completeStartupAndOpenGate(ctx, rt.CompleteStartup, startupReady); err != nil {
 		_ = stopServerWithTimeout(server.Stop, shutdownTimeout)
 		rt.Stop("runtime startup failed after api server ownership")
 		rt.WaitForShutdown()
 		return nil, err
 	}
 
-	return &daemonRuntime{
+	daemon := &daemonRuntime{
 		runtime:         rt,
 		server:          server,
 		shutdownTimeout: shutdownTimeout,
-	}, nil
+	}
+	monitorAPIServerErrors(server.Errors(), deps.Logger, daemon.Stop)
+	return daemon, nil
+}
+
+// completeStartupAndOpenGate makes successful runtime startup the sole
+// authority for admitting API mutations. Failure leaves the gate closed until
+// the already-bound server is shut down by the caller.
+func completeStartupAndOpenGate(ctx context.Context, complete func(context.Context) error, startupReady chan struct{}) error {
+	if err := complete(ctx); err != nil {
+		return err
+	}
+	close(startupReady)
+	return nil
+}
+
+func monitorAPIServerErrors(serverErrors <-chan error, logger bootstrap.Logger, stop func(string)) {
+	if serverErrors == nil || stop == nil {
+		return
+	}
+	go func() {
+		err, ok := <-serverErrors
+		if !ok || err == nil {
+			return
+		}
+		if logger != nil {
+			logger.Error("looperd API server stopped unexpectedly", map[string]any{"error": err.Error()})
+		}
+		stop("api server failed: " + err.Error())
+	}()
 }
 
 func stopServerWithTimeout(stop func(context.Context) error, timeout time.Duration) error {
@@ -239,8 +267,13 @@ func takeoverLoop(ctx context.Context, services looperdruntime.Services, loopID,
 			}
 		}
 	}
-	if _, err := stopLoop(ctx, services, loopID, reason, now, signal, executionMatchesProcess); err != nil {
+	stopValue, err := stopLoop(ctx, services, loopID, reason, now, signal, executionMatchesProcess)
+	if err != nil {
 		return result, err
+	}
+	stopResult, ok := stopValue.(stopLoopResult)
+	if !ok || !stopResultAllowsOwnershipTransfer(stopResult) {
+		return result, fmt.Errorf("cannot transfer loop %s while its prior execution is not confirmed stopped", loopID)
 	}
 	if _, err := services.Loops.TransitionStatus(ctx, loopID, loops.TransitionInput{Status: domain.LoopStatusHumanTakeover}); err != nil {
 		return result, err
@@ -248,67 +281,99 @@ func takeoverLoop(ctx context.Context, services looperdruntime.Services, loopID,
 	return result, nil
 }
 
-func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, reason string, now func() time.Time, signal signalProcessFunc, executionMatchesProcess executionMatchesProcessFunc, terminal bool) (any, error) {
+func stopResultAllowsOwnershipTransfer(result stopLoopResult) bool {
+	return result.Outcome == stopOutcomeProcessSignaled || result.Outcome == stopOutcomeAlreadyFinished
+}
+
+func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, reason string, now func() time.Time, _ signalProcessFunc, _ executionMatchesProcessFunc, terminal bool) (any, error) {
 	result := stopLoopResult{Stopped: false, LoopID: loopID, Outcome: stopOutcomePausedOnly}
 	if services.Loops == nil {
 		return nil, fmt.Errorf("loops service is not configured")
 	}
+	releaseLoopStop := func() {}
+	if services.ActiveExecutions != nil {
+		releaseLoopStop = services.ActiveExecutions.BeginLoopStop(loopID)
+	}
+	defer releaseLoopStop()
 
 	reasonCopy := reason
 	complete := func() (any, error) {
-		if !terminal {
-			return result, nil
-		}
-		terminated, err := services.Loops.Terminate(ctx, loopID, &reasonCopy)
-		if err != nil {
-			return nil, err
+		if terminal {
+			terminated, err := services.Loops.Terminate(ctx, loopID, &reasonCopy)
+			if err != nil {
+				return nil, err
+			}
+			result.LoopID = terminated.Loop.ID
+		} else {
+			paused, err := services.Loops.Pause(ctx, loopID, &reasonCopy)
+			if err != nil {
+				return nil, err
+			}
+			result.LoopID = paused.Loop.ID
 		}
 		result.Stopped = true
-		result.LoopID = terminated.Loop.ID
 		return result, nil
 	}
 
-	if !terminal {
-		paused, err := services.Loops.Pause(ctx, loopID, &reasonCopy)
+	liveStopped := false
+	if services.ActiveExecutions != nil {
+		var err error
+		liveStopped, err = services.ActiveExecutions.StopAndWait(ctx, result.LoopID, "", "", reason)
 		if err != nil {
 			return nil, err
 		}
-		result.Stopped = true
-		result.LoopID = paused.Loop.ID
 	}
 
 	if services.Repositories == nil || services.Repositories.Runs == nil {
+		if liveStopped {
+			result.Outcome = stopOutcomeProcessSignaled
+			return complete()
+		}
 		result.ProcessSkipReason = processSkipNoRuns
-		return complete()
+		return result, nil
 	}
 
 	latestRun, err := services.Repositories.Runs.GetLatestByLoopID(ctx, loopID)
 	if err != nil {
 		return nil, err
 	}
+	if latestRun != nil {
+		result.RunID = latestRun.ID
+	}
+
+	var latestExecution *storage.AgentExecutionRecord
+	if latestRun != nil && services.Repositories.AgentExecutions != nil {
+		latestExecution, err = services.Repositories.AgentExecutions.GetLatestByRunID(ctx, latestRun.ID)
+		if err != nil {
+			return nil, err
+		}
+		if latestExecution != nil {
+			result.ExecutionID = latestExecution.ID
+			result.Vendor = latestExecution.Vendor
+		}
+	}
+
+	if liveStopped {
+		result.Outcome = stopOutcomeProcessSignaled
+		result.ProcessSkipReason = ""
+		if latestExecution != nil && isStoppableExecutionStatus(latestExecution.Status) {
+			if err := markExecutionCancelling(ctx, services, *latestExecution, reasonCopy, now); err != nil {
+				return nil, err
+			}
+		}
+		return complete()
+	}
+
 	if latestRun == nil || latestRun.Status != "running" {
 		result.Outcome = stopOutcomeAlreadyFinished
 		result.ProcessSkipReason = processSkipNoRuns
 		return complete()
 	}
-	result.RunID = latestRun.ID
 
-	if services.Repositories.AgentExecutions == nil {
-		result.ProcessSkipReason = processSkipNoExecution
-		return complete()
-	}
-
-	latestExecution, err := services.Repositories.AgentExecutions.GetLatestByRunID(ctx, latestRun.ID)
-	if err != nil {
-		return nil, err
-	}
 	if latestExecution == nil {
 		result.ProcessSkipReason = processSkipNoExecution
-		return complete()
+		return result, nil
 	}
-
-	result.ExecutionID = latestExecution.ID
-	result.Vendor = latestExecution.Vendor
 	if !isStoppableExecutionStatus(latestExecution.Status) {
 		result.Outcome = stopOutcomeAlreadyFinished
 		result.ProcessSkipReason = processSkipAlreadyFinished
@@ -318,58 +383,12 @@ func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 		result.Outcome = stopOutcomeAlreadyStopping
 		result.ProcessSkipReason = processSkipAlreadyStopping
 	}
-	if services.ActiveExecutions != nil {
-		killed, err := services.ActiveExecutions.Kill(result.LoopID, latestRun.ID, latestExecution.ID, reason)
-		if err != nil {
-			return nil, err
-		}
-		if killed {
-			result.Outcome = stopOutcomeProcessSignaled
-			result.ProcessSkipReason = ""
-			if err := markExecutionCancelling(ctx, services, *latestExecution, reasonCopy, now); err != nil {
-				return nil, err
-			}
-			return complete()
-		}
-	}
-	if latestExecution.PID == nil || *latestExecution.PID <= 0 {
-		result.ProcessSkipReason = processSkipNoPID
-		return complete()
-	}
-
-	pid := int(*latestExecution.PID)
-	if executionMatchesProcess != nil {
-		matches, running, err := executionMatchesProcess(ctx, *latestExecution, pid)
-		if err != nil {
-			return nil, err
-		}
-		if !running || !matches {
-			if !running {
-				result.Outcome = stopOutcomeAlreadyFinished
-				result.ProcessSkipReason = processSkipVerifierNotRunning
-			} else {
-				result.ProcessSkipReason = processSkipVerifierRejectedPID
-			}
-			return complete()
-		}
-	}
-	result.PID = *latestExecution.PID
-	if signal != nil {
-		if err := signalAgentProcessGroup(pid, signal, 5*time.Second); err != nil {
-			return nil, err
-		}
-		result.Outcome = stopOutcomeProcessSignaled
-		result.ProcessSkipReason = ""
-	} else {
-		result.ProcessSkipReason = processSkipNoSignal
-		return complete()
-	}
-
-	if err := markExecutionCancelling(ctx, services, *latestExecution, reasonCopy, now); err != nil {
-		return nil, err
-	}
-
-	return complete()
+	// A persisted PID is not cancellation authority. If the live handle/run is
+	// absent, this may be the narrow spawn-to-register window; raw signaling
+	// would bypass executor state and could trigger a native-resume replacement.
+	// Startup recovery exclusively owns conservative PID/command cleanup.
+	result.ProcessSkipReason = processSkipNoLiveExecution
+	return result, nil
 }
 
 type stopAllResult string
@@ -478,12 +497,17 @@ func stopAllLoops(ctx context.Context, services looperdruntime.Services, reason 
 				item.Error = err.Error()
 			}
 		} else {
+			liveOwnershipResolved := false
 			if stopResult, ok := stopResultValue.(stopLoopResult); ok {
 				item.Outcome = stopResult.Outcome
 				item.ProcessSkipReason = stopResult.ProcessSkipReason
 				item.Result = classifyStopAllItemResult(stopResult)
+				liveOwnershipResolved = stopResult.Outcome == stopOutcomeProcessSignaled
 			}
 			for _, execution := range candidate.Executions {
+				if liveOwnershipResolved {
+					break
+				}
 				if execution.Status != "running" {
 					continue
 				}
@@ -778,8 +802,13 @@ func classifyStopAllResult(candidate stopAllCandidate) stopAllResult {
 	return stopAllResultStopped
 }
 
-func stopCandidateExecution(ctx context.Context, services looperdruntime.Services, candidate stopAllCandidate, reason string, now func() time.Time, signal signalProcessFunc, executionMatchesProcess executionMatchesProcessFunc) (stopLoopResult, error) {
+func stopCandidateExecution(ctx context.Context, services looperdruntime.Services, candidate stopAllCandidate, reason string, now func() time.Time, _ signalProcessFunc, _ executionMatchesProcessFunc) (stopLoopResult, error) {
 	result := stopLoopResult{LoopID: candidate.Loop.ID, Outcome: stopOutcomePausedOnly}
+	releaseLoopStop := func() {}
+	if services.ActiveExecutions != nil {
+		releaseLoopStop = services.ActiveExecutions.BeginLoopStop(candidate.Loop.ID)
+	}
+	defer releaseLoopStop()
 	if candidate.Execution == nil {
 		result.Outcome = stopOutcomeAlreadyFinished
 		result.ProcessSkipReason = processSkipNoExecution
@@ -799,11 +828,11 @@ func stopCandidateExecution(ctx context.Context, services looperdruntime.Service
 		result.RunID = candidate.Run.ID
 	}
 	if services.ActiveExecutions != nil && runID != "" {
-		killed, err := services.ActiveExecutions.Kill(candidate.Loop.ID, runID, candidate.Execution.ID, reason)
+		stopped, err := services.ActiveExecutions.StopAndWait(ctx, candidate.Loop.ID, runID, candidate.Execution.ID, reason)
 		if err != nil {
 			return result, err
 		}
-		if killed {
+		if stopped {
 			result.Outcome = stopOutcomeProcessSignaled
 			if err := markExecutionCancelling(ctx, services, *candidate.Execution, reason, now); err != nil {
 				return result, err
@@ -811,73 +840,12 @@ func stopCandidateExecution(ctx context.Context, services looperdruntime.Service
 			return result, nil
 		}
 	}
-	if candidate.Execution.PID == nil || *candidate.Execution.PID <= 0 {
-		result.ProcessSkipReason = processSkipNoPID
-		return result, nil
-	}
-	result.PID = *candidate.Execution.PID
-	pid := int(*candidate.Execution.PID)
-	if executionMatchesProcess != nil {
-		matches, running, err := executionMatchesProcess(ctx, *candidate.Execution, pid)
-		if err != nil {
-			return result, err
-		}
-		if !running || !matches {
-			if !running {
-				result.Outcome = stopOutcomeAlreadyFinished
-				result.ProcessSkipReason = processSkipVerifierNotRunning
-			} else {
-				result.ProcessSkipReason = processSkipVerifierRejectedPID
-			}
-			return result, nil
-		}
-	}
-	if signal == nil {
-		result.ProcessSkipReason = processSkipNoSignal
-		return result, nil
-	}
-	if err := signalAgentProcessGroup(pid, signal, 5*time.Second); err != nil {
-		return result, err
-	}
-	result.Outcome = stopOutcomeProcessSignaled
-	result.ProcessSkipReason = ""
-	if err := markExecutionCancelling(ctx, services, *candidate.Execution, reason, now); err != nil {
-		return result, err
-	}
+	result.ProcessSkipReason = processSkipNoLiveExecution
 	return result, nil
 }
 
 func isStoppableExecutionStatus(status string) bool {
 	return status == "running" || status == "cancelling"
-}
-
-func signalAgentProcessGroup(pid int, signalProcess signalProcessFunc, grace time.Duration) error {
-	termSignaled := false
-	if err := signalProcess(-pid, syscall.SIGTERM); err != nil {
-		if !errors.Is(err, syscall.ESRCH) {
-			return err
-		}
-		if err := signalProcess(pid, syscall.SIGTERM); err != nil {
-			if errors.Is(err, syscall.ESRCH) {
-				return nil
-			}
-			return err
-		}
-		termSignaled = true
-	} else {
-		termSignaled = true
-	}
-	if grace > 0 && termSignaled {
-		go func() {
-			timer := time.NewTimer(grace)
-			defer timer.Stop()
-			<-timer.C
-			if err := signalProcess(-pid, syscall.SIGKILL); errors.Is(err, syscall.ESRCH) {
-				_ = signalProcess(pid, syscall.SIGKILL)
-			}
-		}()
-	}
-	return nil
 }
 
 func markExecutionCancelling(ctx context.Context, services looperdruntime.Services, execution storage.AgentExecutionRecord, reason string, now func() time.Time) error {

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -9,10 +9,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/bootstrap"
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/loops"
@@ -51,6 +54,21 @@ func TestRunPrintsVersionWithoutBootstrappingCommandHandling(t *testing.T) {
 
 	if got := stderr.String(); got != "" {
 		t.Fatalf("run([--version]) stderr = %q, want empty string", got)
+	}
+}
+
+func TestMonitorAPIServerErrorsStopsDaemonOnUnexpectedServeFailure(t *testing.T) {
+	serverErrors := make(chan error, 1)
+	stopped := make(chan string, 1)
+	monitorAPIServerErrors(serverErrors, nil, func(reason string) { stopped <- reason })
+	serverErrors <- errors.New("accept failed")
+	select {
+	case reason := <-stopped:
+		if !strings.Contains(reason, "accept failed") {
+			t.Fatalf("stop reason = %q, want serve error", reason)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("daemon was not stopped after API serve failure")
 	}
 }
 
@@ -270,6 +288,23 @@ func TestStartRuntimeWithAPIDoesNotRunRecoveryBeforeServerOwnership(t *testing.T
 	}
 }
 
+func TestCompleteStartupAndOpenGateLeavesGateClosedOnFailure(t *testing.T) {
+	startupReady := make(chan struct{})
+	wantErr := errors.New("startup recovery failed")
+
+	err := completeStartupAndOpenGate(context.Background(), func(context.Context) error {
+		return wantErr
+	}, startupReady)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("completeStartupAndOpenGate() error = %v, want %v", err, wantErr)
+	}
+	select {
+	case <-startupReady:
+		t.Fatal("startup mutation gate opened after failed startup recovery")
+	default:
+	}
+}
+
 func TestStopServerWithTimeoutUsesDeadline(t *testing.T) {
 	t.Parallel()
 
@@ -294,7 +329,7 @@ func TestStopServerWithTimeoutUsesDeadline(t *testing.T) {
 	}
 }
 
-func TestStopLoopPausesLoopAndSignalsActiveExecution(t *testing.T) {
+func TestStopLoopDoesNotUsePersistedPIDWithoutLiveOwnership(t *testing.T) {
 	ctx := context.Background()
 	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
 	if err != nil {
@@ -337,6 +372,7 @@ func TestStopLoopPausesLoopAndSignalsActiveExecution(t *testing.T) {
 	called := false
 	gotSignalPID := 0
 	verified := false
+	processRunning := true
 	gotResult, err := stopLoop(ctx, services, loop.ID, "Stopped by test", func() time.Time { return now }, func(pid int, sig syscall.Signal) error {
 		if sig == syscall.SIGKILL {
 			return nil
@@ -346,13 +382,14 @@ func TestStopLoopPausesLoopAndSignalsActiveExecution(t *testing.T) {
 		if sig != syscall.SIGTERM {
 			t.Fatalf("signal = %v, want %v", sig, syscall.SIGTERM)
 		}
+		processRunning = false
 		return nil
 	}, func(_ context.Context, execution storage.AgentExecutionRecord, gotPID int) (bool, bool, error) {
 		verified = true
 		if execution.ID != agentExecution.ID || gotPID != int(pid) {
 			t.Fatalf("execution verifier received execution=%q pid=%d, want %q pid=%d", execution.ID, gotPID, agentExecution.ID, pid)
 		}
-		return true, true, nil
+		return processRunning, processRunning, nil
 	})
 	if err != nil {
 		t.Fatalf("stopLoop() error = %v", err)
@@ -362,55 +399,29 @@ func TestStopLoopPausesLoopAndSignalsActiveExecution(t *testing.T) {
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != pid || result.Outcome != stopOutcomeProcessSignaled || result.ProcessSkipReason != "" {
+	if result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 || result.Outcome != stopOutcomePausedOnly || result.ProcessSkipReason != processSkipNoLiveExecution {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
-	if !called || gotSignalPID != -int(pid) {
-		t.Fatalf("signal invoked = %v pid=%d, want true pid=%d", called, gotSignalPID, -pid)
+	if called || gotSignalPID != 0 {
+		t.Fatalf("signal invoked = %v pid=%d, want no raw PID signaling", called, gotSignalPID)
 	}
-	if !verified {
-		t.Fatal("execution verifier was not called")
+	if verified {
+		t.Fatal("process verifier was called during normal stop")
 	}
 
 	storedLoop, err := repos.Loops.GetByID(ctx, loop.ID)
 	if err != nil {
 		t.Fatalf("Loops.GetByID() error = %v", err)
 	}
-	if storedLoop == nil || storedLoop.Status != "paused" {
-		t.Fatalf("Loops.GetByID() = %#v, want paused loop", storedLoop)
+	if storedLoop == nil || storedLoop.Status != "running" {
+		t.Fatalf("Loops.GetByID() = %#v, want running until live ownership is available", storedLoop)
 	}
 	storedExecution, err := repos.AgentExecutions.GetByID(ctx, agentExecution.ID)
 	if err != nil {
 		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
 	}
-	if storedExecution == nil || storedExecution.Status != "cancelling" {
-		t.Fatalf("AgentExecutions.GetByID() = %#v, want cancelling execution", storedExecution)
-	}
-}
-
-func TestSignalAgentProcessGroupDoesNotEscalateAfterESRCH(t *testing.T) {
-	pid := 4321
-	grace := 10 * time.Millisecond
-	killCalled := make(chan struct{}, 1)
-
-	err := signalAgentProcessGroup(pid, func(gotPID int, sig syscall.Signal) error {
-		if sig == syscall.SIGKILL {
-			killCalled <- struct{}{}
-			return nil
-		}
-		if sig != syscall.SIGTERM {
-			t.Fatalf("signal = %v, want SIGTERM", sig)
-		}
-		return syscall.ESRCH
-	}, grace)
-	if err != nil {
-		t.Fatalf("signalAgentProcessGroup() error = %v", err)
-	}
-
-	select {
-	case <-killCalled:
-		t.Fatal("SIGKILL escalation was armed after SIGTERM returned ESRCH")
-	case <-time.After(3 * grace):
+	if storedExecution == nil || storedExecution.Status != "running" {
+		t.Fatalf("AgentExecutions.GetByID() = %#v, want untouched running execution", storedExecution)
 	}
 }
 
@@ -534,6 +545,51 @@ func TestCloseLoopDoesNotTerminateLoopWhenActiveKillFails(t *testing.T) {
 	}
 	if storedLoop == nil || storedLoop.Status != "running" {
 		t.Fatalf("Loops.GetByID() = %#v, want running loop after kill failure", storedLoop)
+	}
+}
+
+func TestCloseLoopDoesNotAdvanceTerminalStateWithoutStopAuthority(t *testing.T) {
+	ctx := context.Background()
+	services, repos, now := newStopAllTestServices(t)
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_close", seq: 1, loopType: "worker", loopStatus: "running", runID: "run_close", runStatus: "running", executionID: "exec_close", executionStatus: "running"})
+
+	got, err := closeLoop(ctx, services, "loop_close", "close test", func() time.Time { return now }, nil, nil)
+	if err != nil {
+		t.Fatalf("closeLoop() error = %v", err)
+	}
+	result := got.(stopLoopResult)
+	if result.Stopped || result.Outcome != stopOutcomePausedOnly || result.ProcessSkipReason != processSkipNoLiveExecution {
+		t.Fatalf("closeLoop() result = %#v, want unconfirmed stop", result)
+	}
+	loop, err := repos.Loops.GetByID(ctx, "loop_close")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "running" {
+		t.Fatalf("loop = %#v, want running until execution is confirmed stopped", loop)
+	}
+}
+
+func TestTakeoverLoopDoesNotTransferOwnershipWhenVerifierRejectsRecoveredPID(t *testing.T) {
+	ctx := context.Background()
+	services, repos, now := newStopAllTestServices(t)
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_takeover", seq: 1, loopType: "worker", loopStatus: "running", runID: "run_takeover", runStatus: "running", executionID: "exec_takeover", executionStatus: "running", pid: 4103})
+
+	_, err := takeoverLoop(ctx, services, "loop_takeover", "takeover test", func() time.Time { return now }, func(int, syscall.Signal) error {
+		t.Fatal("signal invoked for verifier-rejected pid")
+		return nil
+	}, func(context.Context, storage.AgentExecutionRecord, int) (bool, bool, error) {
+		return false, true, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "not confirmed stopped") {
+		t.Fatalf("takeoverLoop() error = %v, want unconfirmed-stop error", err)
+	}
+	loop, err := repos.Loops.GetByID(ctx, "loop_takeover")
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if loop == nil || loop.Status != "running" {
+		t.Fatalf("loop = %#v, want ownership unchanged", loop)
 	}
 }
 
@@ -673,6 +729,48 @@ func TestStopLoopActiveInMemoryExecutionWinsBeforeVerifierRejectsPID(t *testing.
 	}
 }
 
+func TestControlTransferStopsLiveHandleDespiteTerminalDurableRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		act        func(context.Context, looperdruntime.Services, time.Time) error
+		wantStatus string
+	}{
+		{name: "takeover", wantStatus: "human_takeover", act: func(ctx context.Context, services looperdruntime.Services, now time.Time) error {
+			_, err := takeoverLoop(ctx, services, "loop_stale", "takeover stale run", func() time.Time { return now }, nil, nil)
+			return err
+		}},
+		{name: "close", wantStatus: "terminated", act: func(ctx context.Context, services looperdruntime.Services, now time.Time) error {
+			_, err := closeLoop(ctx, services, "loop_stale", "close stale run", func() time.Time { return now }, nil, nil)
+			return err
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			services, repos, now := newStopAllTestServices(t)
+			insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_stale", seq: 1, loopType: "worker", loopStatus: "running", runID: "run_stale", runStatus: "success", executionID: "exec_stale", executionStatus: "completed"})
+			registry := looperdruntime.NewActiveExecutionRegistry()
+			active := &fakeActiveExecution{}
+			registry.Register("loop_stale", "run_stale", "exec_stale", active)
+			services.ActiveExecutions = registry
+
+			if err := tt.act(ctx, services, now); err != nil {
+				t.Fatalf("control action error = %v", err)
+			}
+			if !active.killed {
+				t.Fatal("live handle was not killed before control transfer")
+			}
+			loop, err := repos.Loops.GetByID(ctx, "loop_stale")
+			if err != nil {
+				t.Fatalf("Loops.GetByID() error = %v", err)
+			}
+			if loop == nil || loop.Status != tt.wantStatus {
+				t.Fatalf("loop after control action = %#v, want status %q", loop, tt.wantStatus)
+			}
+		})
+	}
+}
+
 func TestStopLoopRetriesActiveInMemoryExecutionAlreadyCancelling(t *testing.T) {
 	ctx := context.Background()
 	coordinator, err := storage.OpenSQLiteCoordinator(ctx, filepath.Join(t.TempDir(), "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations})
@@ -780,11 +878,13 @@ func TestStopLoopSignalsExecutionAlreadyCancelling(t *testing.T) {
 	}
 
 	var signalCalls []int
+	processRunning := true
 	gotResult, err := stopLoop(ctx, services, loop.ID, "Stopped by test", func() time.Time { return now }, func(gotPID int, _ syscall.Signal) error {
 		signalCalls = append(signalCalls, gotPID)
+		processRunning = false
 		return syscall.ESRCH
 	}, func(context.Context, storage.AgentExecutionRecord, int) (bool, bool, error) {
-		return true, true, nil
+		return processRunning, processRunning, nil
 	})
 	if err != nil {
 		t.Fatalf("stopLoop() error = %v", err)
@@ -793,11 +893,11 @@ func TestStopLoopSignalsExecutionAlreadyCancelling(t *testing.T) {
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != pid || result.Outcome != stopOutcomeProcessSignaled || result.ProcessSkipReason != "" {
+	if result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 || result.Outcome != stopOutcomeAlreadyStopping || result.ProcessSkipReason != processSkipNoLiveExecution {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
-	if len(signalCalls) != 2 || signalCalls[0] != -int(pid) || signalCalls[1] != int(pid) {
-		t.Fatalf("signal calls = %#v, want process group then process", signalCalls)
+	if len(signalCalls) != 0 {
+		t.Fatalf("signal calls = %#v, want no raw PID signaling", signalCalls)
 	}
 }
 
@@ -841,7 +941,7 @@ func TestStopLoopDoesNotClaimProcessSignaledWithoutSignaler(t *testing.T) {
 		t.Fatalf("stopLoop() error = %v", err)
 	}
 	result := gotResult.(stopLoopResult)
-	if result.Outcome != stopOutcomePausedOnly || result.ProcessSkipReason != processSkipNoSignal {
+	if result.Outcome != stopOutcomePausedOnly || result.ProcessSkipReason != processSkipNoLiveExecution {
 		t.Fatalf("stopLoop() result = %#v, want paused-only without signal authority", result)
 	}
 }
@@ -902,11 +1002,11 @@ func TestStopLoopSkipsStaleActiveExecutionWhenLatestExecutionCompleted(t *testin
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 || result.Outcome != stopOutcomeAlreadyFinished || result.ProcessSkipReason != processSkipAlreadyFinished {
+	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 || result.Outcome != stopOutcomeProcessSignaled || result.ProcessSkipReason != "" {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
-	if active.killed {
-		t.Fatal("active execution Kill invoked, want stale registry entry skipped")
+	if !active.killed {
+		t.Fatal("active execution Kill was not invoked; live handle must outrank persisted status")
 	}
 	if signaled {
 		t.Fatal("signal invoked, want completed execution to be skipped")
@@ -1046,7 +1146,7 @@ func TestStopLoopSkipsSignalWhenExecutionVerifierRejectsPID(t *testing.T) {
 	if !ok {
 		t.Fatalf("stopLoop() result type = %T, want stopLoopResult", gotResult)
 	}
-	if !result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 || result.Outcome != stopOutcomePausedOnly || result.ProcessSkipReason != processSkipVerifierRejectedPID {
+	if result.Stopped || result.LoopID != loop.ID || result.RunID != run.ID || result.ExecutionID != agentExecution.ID || result.Vendor != "codex" || result.PID != 0 || result.Outcome != stopOutcomePausedOnly || result.ProcessSkipReason != processSkipNoLiveExecution {
 		t.Fatalf("stopLoop() result = %#v", result)
 	}
 	if signaled {
@@ -1075,35 +1175,37 @@ func TestStopAllLoopsHandlesMixedTypesPartialFailureAndRepeatedCalls(t *testing.
 	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_waiting", seq: 7, loopType: "reviewer", loopStatus: "waiting", runID: "run_waiting", runStatus: "success"})
 
 	var signalPIDs []int
+	deadPIDs := map[int]bool{}
 	response, err := stopAllLoops(ctx, services, "Stopped by test", func() time.Time { return now }, func(pid int, sig syscall.Signal) error {
 		if sig != syscall.SIGTERM {
 			return nil
 		}
 		signalPIDs = append(signalPIDs, pid)
-		if pid == -4102 || pid == 4102 {
+		if pid == -4102 {
 			return fmt.Errorf("signal failed")
 		}
+		deadPIDs[-pid] = true
 		return syscall.ESRCH
 	}, func(_ context.Context, execution storage.AgentExecutionRecord, pid int) (bool, bool, error) {
-		return true, true, nil
+		return !deadPIDs[pid], !deadPIDs[pid], nil
 	})
 	if err != nil {
 		t.Fatalf("stopAllLoops() error = %v", err)
 	}
 
-	if got, want := response.Summary, (stopAllSummary{Total: 7, Stopped: 4, AlreadyFinished: 2, Failed: 1}); got != want {
+	if got, want := response.Summary, (stopAllSummary{Total: 7, PausedOnly: 4, AlreadyFinished: 2, AlreadyStopping: 1}); got != want {
 		t.Fatalf("stopAllLoops() summary = %#v, want %#v", got, want)
 	}
 	if got := stopAllItemTypes(response.Items); !slices.Equal(got, []string{"planner", "reviewer", "worker", "fixer", "auditor", "worker", "reviewer"}) {
 		t.Fatalf("item types = %#v, want mixed known and future types", got)
 	}
-	assertStopAllItemResult(t, response.Items, "loop_reviewer", string(stopAllResultFailed))
-	assertStopAllItemResult(t, response.Items, "loop_fixer", string(stopAllResultStopped))
-	assertStopAllItemResult(t, response.Items, "loop_future", string(stopAllResultStopped))
+	assertStopAllItemResult(t, response.Items, "loop_reviewer", string(stopAllResultPausedOnly))
+	assertStopAllItemResult(t, response.Items, "loop_fixer", string(stopAllResultAlreadyStopping))
+	assertStopAllItemResult(t, response.Items, "loop_future", string(stopAllResultPausedOnly))
 	assertStopAllItemResult(t, response.Items, "loop_queued", string(stopAllResultAlreadyFinished))
 	assertStopAllItemResult(t, response.Items, "loop_waiting", string(stopAllResultAlreadyFinished))
-	if !slices.Contains(signalPIDs, -4101) || !slices.Contains(signalPIDs, -4103) || !slices.Contains(signalPIDs, -4105) {
-		t.Fatalf("signal pids = %#v, want other loops processed after failure", signalPIDs)
+	if len(signalPIDs) != 0 {
+		t.Fatalf("signal pids = %#v, want no persisted PID signaling", signalPIDs)
 	}
 
 	repeated, err := stopAllLoops(ctx, services, "Stopped by test again", func() time.Time { return now.Add(time.Minute) }, func(pid int, sig syscall.Signal) error {
@@ -1117,10 +1219,32 @@ func TestStopAllLoopsHandlesMixedTypesPartialFailureAndRepeatedCalls(t *testing.
 	if err != nil {
 		t.Fatalf("second stopAllLoops() error = %v", err)
 	}
-	if repeated.Summary.AlreadyStopping < 4 {
-		t.Fatalf("second stopAllLoops() summary = %#v, want repeated call to report alreadyStopping", repeated.Summary)
+	if repeated.Summary.PausedOnly != 4 || repeated.Summary.AlreadyStopping != 1 {
+		t.Fatalf("second stopAllLoops() summary = %#v, want ownership gaps preserved", repeated.Summary)
 	}
-	assertStopAllItemResult(t, repeated.Items, "loop_future", string(stopAllResultAlreadyStopping))
+	assertStopAllItemResult(t, repeated.Items, "loop_future", string(stopAllResultPausedOnly))
+}
+
+func TestStopAllLoopsReportsStoppedAfterLiveRegistryReap(t *testing.T) {
+	ctx := context.Background()
+	services, repos, now := newStopAllTestServices(t)
+	insertStopAllTestLoop(t, ctx, repos, now, stopAllLoopFixture{loopID: "loop_live", seq: 1, loopType: "worker", loopStatus: "running", runID: "run_live", runStatus: "running", executionID: "exec_live", executionStatus: "running"})
+	registry := looperdruntime.NewActiveExecutionRegistry()
+	active := &fakeActiveExecution{}
+	registry.Register("loop_live", "run_live", "exec_live", active)
+	services.ActiveExecutions = registry
+
+	response, err := stopAllLoops(ctx, services, "stop all", func() time.Time { return now }, nil, nil)
+	if err != nil {
+		t.Fatalf("stopAllLoops() error = %v", err)
+	}
+	if got, want := response.Summary, (stopAllSummary{Total: 1, Stopped: 1}); got != want {
+		t.Fatalf("stopAllLoops() summary = %#v, want %#v", got, want)
+	}
+	if !active.killed {
+		t.Fatal("live execution was not killed")
+	}
+	assertStopAllItemResult(t, response.Items, "loop_live", string(stopAllResultStopped))
 }
 
 func TestStopAllLoopsReportsPausedOnlyWhenPIDVerificationRejectsOwnership(t *testing.T) {
@@ -1143,7 +1267,7 @@ func TestStopAllLoopsReportsPausedOnlyWhenPIDVerificationRejectsOwnership(t *tes
 	if len(response.Items) != 1 {
 		t.Fatalf("len(response.Items) = %d, want 1", len(response.Items))
 	}
-	if item := response.Items[0]; item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipVerifierRejectedPID {
+	if item := response.Items[0]; item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipNoLiveExecution {
 		t.Fatalf("stopAllLoops() item = %#v", item)
 	}
 }
@@ -1159,14 +1283,21 @@ func TestStopAllLoopsReportsPausedOnlyWhenSecondaryExecutionIsVerifierRejected(t
 	}
 
 	var signalPIDs []int
+	primaryRunning := true
 	response, err := stopAllLoops(ctx, services, "Stopped by test", func() time.Time { return now }, func(pid int, sig syscall.Signal) error {
 		if sig != syscall.SIGTERM {
 			return nil
 		}
 		signalPIDs = append(signalPIDs, pid)
+		if pid == -4103 {
+			primaryRunning = false
+		}
 		return syscall.ESRCH
 	}, func(_ context.Context, execution storage.AgentExecutionRecord, pid int) (bool, bool, error) {
-		return execution.ID == "exec_primary", true, nil
+		if execution.ID != "exec_primary" {
+			return false, true, nil
+		}
+		return primaryRunning, primaryRunning, nil
 	})
 	if err != nil {
 		t.Fatalf("stopAllLoops() error = %v", err)
@@ -1178,11 +1309,11 @@ func TestStopAllLoopsReportsPausedOnlyWhenSecondaryExecutionIsVerifierRejected(t
 		t.Fatalf("len(response.Items) = %d, want 1", len(response.Items))
 	}
 	item := response.Items[0]
-	if item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipVerifierRejectedPID {
+	if item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipNoLiveExecution {
 		t.Fatalf("stopAllLoops() item = %#v", item)
 	}
-	if !slices.Contains(signalPIDs, -4103) {
-		t.Fatalf("signal pids = %#v, want primary execution signaled", signalPIDs)
+	if len(signalPIDs) != 0 {
+		t.Fatalf("signal pids = %#v, want no persisted PID signaling", signalPIDs)
 	}
 }
 
@@ -1196,29 +1327,31 @@ func TestStopAllLoopsReportsStoppedWhenOlderExecutionSignalsAfterLatestFinished(
 	}
 
 	var signalPIDs []int
+	running := true
 	response, err := stopAllLoops(ctx, services, "Stopped by test", func() time.Time { return now }, func(pid int, sig syscall.Signal) error {
 		if sig == syscall.SIGTERM {
 			signalPIDs = append(signalPIDs, pid)
+			running = false
 		}
 		return nil
 	}, func(_ context.Context, execution storage.AgentExecutionRecord, pid int) (bool, bool, error) {
-		return execution.ID == "exec_running", true, nil
+		return execution.ID == "exec_running" && running, running, nil
 	})
 	if err != nil {
 		t.Fatalf("stopAllLoops() error = %v", err)
 	}
-	if got, want := response.Summary, (stopAllSummary{Total: 1, Stopped: 1}); got != want {
+	if got, want := response.Summary, (stopAllSummary{Total: 1, PausedOnly: 1}); got != want {
 		t.Fatalf("stopAllLoops() summary = %#v, want %#v", got, want)
 	}
 	if len(response.Items) != 1 {
 		t.Fatalf("len(response.Items) = %d, want 1", len(response.Items))
 	}
 	item := response.Items[0]
-	if item.Result != string(stopAllResultStopped) || item.Outcome != stopOutcomeProcessSignaled || item.ProcessSkipReason != "" {
+	if item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipNoLiveExecution {
 		t.Fatalf("stopAllLoops() item = %#v", item)
 	}
-	if !slices.Contains(signalPIDs, -4103) {
-		t.Fatalf("signal pids = %#v, want running execution signaled", signalPIDs)
+	if len(signalPIDs) != 0 {
+		t.Fatalf("signal pids = %#v, want no persisted PID signaling", signalPIDs)
 	}
 }
 
@@ -1232,29 +1365,31 @@ func TestStopAllLoopsReportsStoppedWhenOlderExecutionSignalsAfterLatestCancellin
 	}
 
 	var signalPIDs []int
+	running := true
 	response, err := stopAllLoops(ctx, services, "Stopped by test", func() time.Time { return now }, func(pid int, sig syscall.Signal) error {
 		if sig == syscall.SIGTERM {
 			signalPIDs = append(signalPIDs, pid)
+			running = false
 		}
 		return nil
 	}, func(_ context.Context, execution storage.AgentExecutionRecord, pid int) (bool, bool, error) {
-		return execution.ID == "exec_running", true, nil
+		return execution.ID == "exec_running" && running, running, nil
 	})
 	if err != nil {
 		t.Fatalf("stopAllLoops() error = %v", err)
 	}
-	if got, want := response.Summary, (stopAllSummary{Total: 1, Stopped: 1}); got != want {
+	if got, want := response.Summary, (stopAllSummary{Total: 1, PausedOnly: 1}); got != want {
 		t.Fatalf("stopAllLoops() summary = %#v, want %#v", got, want)
 	}
 	if len(response.Items) != 1 {
 		t.Fatalf("len(response.Items) = %d, want 1", len(response.Items))
 	}
 	item := response.Items[0]
-	if item.Result != string(stopAllResultStopped) || item.Outcome != stopOutcomeProcessSignaled || item.ProcessSkipReason != "" {
+	if item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipNoLiveExecution {
 		t.Fatalf("stopAllLoops() item = %#v", item)
 	}
-	if !slices.Contains(signalPIDs, -4103) {
-		t.Fatalf("signal pids = %#v, want running execution signaled", signalPIDs)
+	if len(signalPIDs) != 0 {
+		t.Fatalf("signal pids = %#v, want no persisted PID signaling", signalPIDs)
 	}
 }
 
@@ -1283,7 +1418,7 @@ func TestStopAllLoopsReplacesFinishedSkipReasonWhenOlderExecutionVerifierRejecte
 		t.Fatalf("len(response.Items) = %d, want 1", len(response.Items))
 	}
 	item := response.Items[0]
-	if item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipVerifierRejectedPID {
+	if item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipNoLiveExecution {
 		t.Fatalf("stopAllLoops() item = %#v", item)
 	}
 }
@@ -1340,15 +1475,39 @@ type fakeActiveExecution struct {
 	killed bool
 	reason string
 	onKill func() error
+	mu     sync.Mutex
+	done   chan struct{}
+	once   sync.Once
 }
 
 func (f *fakeActiveExecution) Kill(reason string) error {
 	f.killed = true
 	f.reason = reason
 	if f.onKill != nil {
-		return f.onKill()
+		if err := f.onKill(); err != nil {
+			return err
+		}
 	}
+	f.once.Do(func() { close(f.doneChannel()) })
 	return nil
+}
+
+func (f *fakeActiveExecution) Wait(ctx context.Context) (agent.Result, error) {
+	select {
+	case <-f.doneChannel():
+		return agent.Result{Status: "killed"}, nil
+	case <-ctx.Done():
+		return agent.Result{}, ctx.Err()
+	}
+}
+
+func (f *fakeActiveExecution) doneChannel() chan struct{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.done == nil {
+		f.done = make(chan struct{})
+	}
+	return f.done
 }
 
 type stopAllLoopFixture struct {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9
 	github.com/vbauerster/mpb/v8 v8.9.3
+	golang.org/x/sys v0.30.0
 	golang.org/x/term v0.29.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -19,5 +20,4 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
-	golang.org/x/sys v0.30.0 // indirect
 )

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -587,10 +587,28 @@ func (x *execution) killProcessGroup() error {
 	process := x.process.Process
 	pid := process.Pid
 	if pid > 0 {
+		// Probe before SIGKILL. After Wait reaps a short-lived leader with no
+		// descendants, the numeric PGID may already be free for reuse; treating
+		// no-members/ESRCH as resolved avoids an unconditional kill(-pid) that
+		// could hit an unrelated process group. Zombie-only groups are not live
+		// ownership barriers. Hold the execution lock across the probe so a
+		// concurrent ForceKill cannot race a successful "no runnable members"
+		// observation and signal a newly reused numeric PGID.
+		live, err := shellinfra.ProcessGroupRunnable(pid)
+		if err != nil {
+			return fmt.Errorf("probe process group %d before SIGKILL: %w", pid, err)
+		}
+		if !live {
+			x.processGroupResolved = true
+			x.processGroupSignalsDone = true
+			return os.ErrProcessDone
+		}
 		if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil {
 			x.processGroupKillSent = true
 			return nil
 		} else if err == syscall.ESRCH {
+			x.processGroupResolved = true
+			x.processGroupSignalsDone = true
 			return os.ErrProcessDone
 		} else {
 			return err
@@ -659,9 +677,10 @@ func (x *execution) awaitProcessGroupExit(cmd *exec.Cmd) error {
 
 	// Hold the execution lock across the bounded probe barrier. ForceKill cannot
 	// race a successful "no runnable members" observation and signal a newly
-	// reused numeric PGID. SIGKILL was sent before entering this function;
-	// probes never resend it. Zombie-only groups count as resolved so unreaped
-	// orphans cannot fail an otherwise completed agent.
+	// reused numeric PGID. When SIGKILL was sent, probes never resend it; when
+	// the pre-kill probe already resolved an empty group, this is a no-op.
+	// Zombie-only groups count as resolved so unreaped orphans cannot fail an
+	// otherwise completed agent.
 	pid := cmd.Process.Pid
 	deadline := time.Now().Add(processGroupExitTimeout)
 	for {

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -1515,9 +1515,13 @@ func (x *execution) persistFinal(status string, result Result, errorMessage, end
 		CreatedAt:          x.startedAtISO,
 		UpdatedAt:          endedAtISO,
 	}
-	runBoundedSideEffect(outputPersistenceTimeout, func(ctx context.Context) {
-		_ = x.executor.repos.AgentExecutions.Upsert(ctx, record)
-	})
+	// Terminal status is authoritative for startup/reconcile ListActive. Wait for
+	// the durable write with the ownership budget instead of the short best-effort
+	// output side-effect timeout, which can leave status as running/cancelling
+	// after the live handle is released.
+	ctx, cancel := context.WithTimeout(context.Background(), ownershipPersistenceTimeout)
+	defer cancel()
+	_ = x.executor.repos.AgentExecutions.Upsert(ctx, record)
 }
 
 func (x *execution) currentStatus() string {

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -1864,7 +1864,11 @@ func (x *execution) processOutputPersistence() {
 func (x *execution) stopOutputPersistence() {
 	x.outputPersistenceOnce.Do(func() {
 		x.outputPersistenceCancel()
-		_ = waitForWorker(x.outputPersistenceDone, outputPersistenceTimeout)
+		// Fully drain the live worker before any terminal AgentExecutions write.
+		// A bounded wait would allow an in-flight "running" Upsert to complete
+		// after persistFinal and reanimate ListActive/startup recovery, because
+		// repository Upsert has no monotonic terminal-state guard.
+		<-x.outputPersistenceDone
 	})
 }
 

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -24,9 +25,15 @@ import (
 )
 
 const (
-	defaultMaxOutputBytes    = 256 * 1024
-	maxPersistedLogReadBytes = 16 * 1024 * 1024
-	completionMarkerEnv      = "LOOPER_COMPLETION_MARKER"
+	defaultMaxOutputBytes       = 256 * 1024
+	maxPersistedLogReadBytes    = 16 * 1024 * 1024
+	completionMarkerEnv         = "LOOPER_COMPLETION_MARKER"
+	descendantPipeDrainGrace    = 100 * time.Millisecond
+	outputQueueCapacity         = 512
+	outputPersistenceTimeout    = 250 * time.Millisecond
+	ownershipPersistenceTimeout = 6 * time.Second
+	processGroupExitTimeout     = time.Second
+	processGroupProbeInterval   = 5 * time.Millisecond
 )
 
 var unsafeAgentEnvKeys = []string{
@@ -169,19 +176,39 @@ type Execution interface {
 }
 
 type ConfiguredExecutor struct {
-	config     ExecutorConfig
-	repos      *storage.Repositories
-	logDir     string
-	now        func() time.Time
-	onProgress func(context.Context, ProgressUpdate)
+	config                ExecutorConfig
+	repos                 *storage.Repositories
+	logDir                string
+	now                   func() time.Time
+	onProgress            func(context.Context, ProgressUpdate)
+	appendPersistedLog    func(string, []byte) bool
+	appendLifecycleRecord func(context.Context, storage.EventLogRecord) error
 }
 
 func New(options ExecutorOptions) *ConfiguredExecutor {
-	now := options.Now
-	if now == nil {
-		now = time.Now
+	rawNow := options.Now
+	if rawNow == nil {
+		rawNow = time.Now
 	}
-	return &ConfiguredExecutor{config: options.Config, repos: options.Repos, logDir: options.LogDir, now: now, onProgress: options.OnProgress}
+	var nowMu sync.Mutex
+	now := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return rawNow()
+	}
+	var appendLifecycleRecord func(context.Context, storage.EventLogRecord) error
+	if options.Repos != nil && options.Repos.Events != nil {
+		appendLifecycleRecord = options.Repos.Events.Append
+	}
+	return &ConfiguredExecutor{
+		config:                options.Config,
+		repos:                 options.Repos,
+		logDir:                options.LogDir,
+		now:                   now,
+		onProgress:            options.OnProgress,
+		appendPersistedLog:    appendPersistedLogFile,
+		appendLifecycleRecord: appendLifecycleRecord,
+	}
 }
 
 // liveProgressInterval throttles OnProgress so a chatty agent doesn't hammer the
@@ -262,6 +289,9 @@ func isRecoverableNativeResumeSource(status string, resumeStatus *string) bool {
 }
 
 func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Execution, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(input.Prompt) == "" {
 		return nil, fmt.Errorf("agent prompt is required")
 	}
@@ -288,39 +318,73 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 	cmd := exec.Command(command, args...)
 	cmd.Dir = input.WorkingDirectory
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.WaitDelay = descendantPipeDrainGrace
 	cmd.Env = buildCommandEnv(input.WorkingDirectory, spawnPrompt, e.config.Env, input.Env)
 
 	maxOutputBytes := input.MaxOutputBytes
 	if maxOutputBytes <= 0 {
 		maxOutputBytes = defaultMaxOutputBytes
 	}
+	progressCtx, progressCancel := context.WithCancel(ctx)
+	outputCtx, outputCancel := context.WithCancel(context.Background())
+	outputPersistenceCtx, outputPersistenceCancel := context.WithCancel(context.Background())
+	ownershipTransferred := false
+	defer func() {
+		if !ownershipTransferred {
+			progressCancel()
+		}
+	}()
 
 	x := &execution{
-		executor:           e,
-		input:              input,
-		executionID:        executionID,
-		startedAt:          startedAt,
-		command:            command,
-		args:               args,
-		startedAtISO:       startedAtISO,
-		process:            cmd,
-		timeout:            input.Timeout,
-		heartbeatTimeout:   input.HeartbeatTimeout,
-		gracefulShutdown:   input.GracefulShutdown,
-		maxOutputBytes:     maxOutputBytes,
-		lastHeartbeatAtISO: startedAtISO,
-		lastOutputAt:       startedAt,
-		status:             "running",
-		nativeSessionID:    resume.SessionID,
-		nativeResumeMode:   resume.Mode,
-		nativeResumeStatus: resume.Status,
-		killCh:             make(chan string, 1),
-		doneCh:             make(chan execOutcome, 1),
+		executor:                e,
+		input:                   input,
+		executionID:             executionID,
+		startedAt:               startedAt,
+		command:                 command,
+		args:                    args,
+		startedAtISO:            startedAtISO,
+		process:                 cmd,
+		timeout:                 input.Timeout,
+		heartbeatTimeout:        input.HeartbeatTimeout,
+		gracefulShutdown:        input.GracefulShutdown,
+		maxOutputBytes:          maxOutputBytes,
+		lastHeartbeatAtISO:      startedAtISO,
+		lastOutputAt:            startedAt,
+		status:                  "running",
+		nativeSessionID:         resume.SessionID,
+		nativeResumeMode:        resume.Mode,
+		nativeResumeStatus:      resume.Status,
+		progressCtx:             progressCtx,
+		progressCancel:          progressCancel,
+		outputCtx:               outputCtx,
+		outputCancel:            outputCancel,
+		outputCh:                make(chan outputMessage, outputQueueCapacity),
+		outputDone:              make(chan struct{}),
+		outputPersistenceCtx:    outputPersistenceCtx,
+		outputPersistenceCancel: outputPersistenceCancel,
+		outputPersistenceCh:     make(chan outputPersistence, 1),
+		outputPersistenceDone:   make(chan struct{}),
+		killCh:                  make(chan string, 1),
+		doneCh:                  make(chan execOutcome, 1),
+	}
+	go x.processOutput()
+	go x.processOutputPersistence()
+	defer func() {
+		if !ownershipTransferred {
+			x.stopOutput()
+			x.stopOutputPersistence()
+		}
+	}()
+	if input.Timeout > 0 {
+		x.maxRuntimeDeadline = time.Now().Add(input.Timeout)
 	}
 	x.stdoutLogPath, x.stderrLogPath = e.executionLogPaths(input, executionID)
 	x.initializePersistedLogs()
-	cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stdout", chunk) }}
-	cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stderr", chunk) }}
+	cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.enqueueOutput("stdout", chunk) }}
+	cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.enqueueOutput("stderr", chunk) }}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if err := cmd.Start(); err != nil {
 		if resume.Enabled {
 			if markErr := e.markNativeResumeFailed(ctx, resume.SourceExecutionID, err.Error()); markErr == nil && e.logDir != "" {
@@ -330,18 +394,25 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 			cmd = exec.Command(command, args...)
 			cmd.Dir = input.WorkingDirectory
 			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+			cmd.WaitDelay = descendantPipeDrainGrace
 			cmd.Env = buildCommandEnv(input.WorkingDirectory, input.Prompt, e.config.Env, input.Env)
-			cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stdout", chunk) }}
-			cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stderr", chunk) }}
+			cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.enqueueOutput("stdout", chunk) }}
+			cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.enqueueOutput("stderr", chunk) }}
 			x.mu.Lock()
 			x.command = command
 			x.args = args
 			x.process = cmd
+			x.processGroupResolved = false
+			x.processGroupKillSent = false
+			x.processGroupSignalsDone = false
 			x.nativeSessionID = ""
 			x.nativeResumeMode = "checkpoint_restart"
 			x.nativeResumeStatus = "fallback_started"
 			x.nativeResumeError = err.Error()
 			x.mu.Unlock()
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
 			if startErr := cmd.Start(); startErr != nil {
 				return nil, fmt.Errorf("start agent command: %w (native resume fallback after: %v)", startErr, err)
 			}
@@ -349,12 +420,34 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 			return nil, fmt.Errorf("start agent command: %w", err)
 		}
 	}
+	if reason, stopped := x.pendingStop(ctx); stopped {
+		cleanupErr := x.reapStartedProcess(cmd)
+		if err := ctx.Err(); err != nil {
+			return nil, errors.Join(err, cleanupErr)
+		}
+		return nil, errors.Join(fmt.Errorf("agent execution stopped before ownership persisted: %s", reason), cleanupErr)
+	}
 
 	resumeSessionID, resumeMode, resumeStatus, _ := x.nativeResumeSnapshot()
-	x.persistStatus("running", nil, nil, nil)
-	e.appendLifecycleEvent("agent.invoked", input, executionID, map[string]any{"command": command, "args": args, "cwd": input.WorkingDirectory, "nativeResumeMode": resumeMode, "nativeResumeStatus": resumeStatus, "nativeSessionId": resumeSessionID}, startedAtISO)
-
+	stopReason, err := x.persistRunningOwnership(ctx, cmd)
+	if stopReason != "" {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, errors.Join(ctxErr, err)
+		}
+		return nil, errors.Join(fmt.Errorf("agent execution stopped before ownership persisted: %s", stopReason), err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("persist running agent execution: %w", err)
+	}
+	x.mu.Lock()
+	x.progressReady = true
+	x.outputPersistenceReady = true
+	x.mu.Unlock()
 	go x.run(ctx)
+	ownershipTransferred = true
+	// The live run owns cancellation/reaping before non-authoritative event I/O.
+	// A slow event sink must never leave a spawned process without a run goroutine.
+	e.appendLifecycleEvent("agent.invoked", input, executionID, map[string]any{"command": command, "args": args, "cwd": input.WorkingDirectory, "nativeResumeMode": resumeMode, "nativeResumeStatus": resumeStatus, "nativeSessionId": resumeSessionID}, startedAtISO)
 	return x, nil
 }
 
@@ -379,6 +472,7 @@ type execution struct {
 	lastHeartbeatAtISO string
 	lastOutputAt       time.Time
 	lastProgressAt     time.Time
+	maxRuntimeDeadline time.Time
 
 	mu                      sync.Mutex
 	status                  string
@@ -392,6 +486,26 @@ type execution struct {
 	nativeResumeMode        string
 	nativeResumeStatus      string
 	nativeResumeError       string
+	progressCtx             context.Context
+	progressCancel          context.CancelFunc
+	progressReady           bool
+	progressInFlight        bool
+	outputCtx               context.Context
+	outputCancel            context.CancelFunc
+	outputCh                chan outputMessage
+	outputDone              chan struct{}
+	outputStopOnce          sync.Once
+	outputPersistenceCtx    context.Context
+	outputPersistenceCancel context.CancelFunc
+	outputPersistenceCh     chan outputPersistence
+	outputPersistenceDone   chan struct{}
+	outputPersistenceReady  bool
+	outputPersistenceOnce   sync.Once
+	killRequested           bool
+	killRequestedReason     string
+	processGroupResolved    bool
+	processGroupKillSent    bool
+	processGroupSignalsDone bool
 
 	killCh chan string
 	doneCh chan execOutcome
@@ -400,7 +514,10 @@ type execution struct {
 func (x *execution) Wait(ctx context.Context) (Result, error) {
 	select {
 	case <-ctx.Done():
-		return Result{}, ctx.Err()
+		_ = x.Kill(ctx.Err().Error())
+		out := <-x.doneCh
+		x.doneCh <- out
+		return out.result, out.err
 	case out := <-x.doneCh:
 		x.doneCh <- out
 		return out.result, out.err
@@ -408,6 +525,12 @@ func (x *execution) Wait(ctx context.Context) (Result, error) {
 }
 
 func (x *execution) Kill(reason string) error {
+	x.mu.Lock()
+	x.killRequested = true
+	if x.killRequestedReason == "" {
+		x.killRequestedReason = reason
+	}
+	x.mu.Unlock()
 	select {
 	case x.killCh <- reason:
 	default:
@@ -415,13 +538,32 @@ func (x *execution) Kill(reason string) error {
 	return nil
 }
 
+// ForceKill escalates an already-requested stop to SIGKILL for the whole
+// process group and confirms that the group is no longer signalable. SIGKILL is
+// sent at most once; after an earlier cleanup barrier timed out, later calls
+// only re-probe the still-owned group. A nil result therefore authorizes the
+// live-handle registry to release ownership safely.
+func (x *execution) ForceKill() error {
+	killErr := x.killProcessGroup()
+	if errors.Is(killErr, os.ErrProcessDone) {
+		killErr = nil
+	}
+	x.mu.Lock()
+	cmd := x.process
+	x.mu.Unlock()
+	return processGroupCleanupError(killErr, x.awaitProcessGroupExit(cmd))
+}
+
 func (x *execution) signalProcessGroup(signal syscall.Signal) error {
-	if x.process.Process == nil {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if x.processGroupResolved || x.processGroupSignalsDone || x.process == nil || x.process.Process == nil {
 		return os.ErrProcessDone
 	}
-	pid := x.process.Process.Pid
+	process := x.process.Process
+	pid := process.Pid
 	if pid <= 0 {
-		return x.process.Process.Signal(signal)
+		return process.Signal(signal)
 	}
 	if err := syscall.Kill(-pid, signal); err != nil {
 		if err == syscall.ESRCH {
@@ -433,34 +575,129 @@ func (x *execution) signalProcessGroup(signal syscall.Signal) error {
 }
 
 func (x *execution) killProcessGroup() error {
-	if x.process.Process == nil {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if x.processGroupResolved || x.processGroupSignalsDone || x.process == nil || x.process.Process == nil {
 		return os.ErrProcessDone
 	}
-	pid := x.process.Process.Pid
+	if x.processGroupKillSent {
+		return nil
+	}
+	process := x.process.Process
+	pid := process.Pid
 	if pid > 0 {
-		if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil || err == syscall.ESRCH {
+		if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil {
+			x.processGroupKillSent = true
 			return nil
+		} else if err == syscall.ESRCH {
+			return os.ErrProcessDone
+		} else {
+			return err
 		}
 	}
-	return x.process.Process.Kill()
+	if err := process.Kill(); err == nil {
+		x.processGroupKillSent = true
+		return nil
+	} else {
+		return err
+	}
+}
+
+func (x *execution) retireUnstartedProcess(cmd *exec.Cmd) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if x.process == cmd && (cmd == nil || cmd.Process == nil) {
+		x.processGroupResolved = true
+		x.processGroupSignalsDone = true
+	}
+}
+
+func (x *execution) reapStartedProcess(cmd *exec.Cmd) error {
+	killErr := x.killProcessGroup()
+	if errors.Is(killErr, os.ErrProcessDone) {
+		killErr = nil
+	}
+	_ = cmd.Wait()
+	cleanupErr := x.awaitProcessGroupExit(cmd)
+	x.flushOutput()
+	return processGroupCleanupError(killErr, cleanupErr)
+}
+
+func (x *execution) finishProcessGroup(cmd *exec.Cmd) error {
+	killErr := x.killProcessGroup()
+	if errors.Is(killErr, os.ErrProcessDone) {
+		killErr = nil
+	}
+	return processGroupCleanupError(killErr, x.awaitProcessGroupExit(cmd))
+}
+
+func processGroupCleanupError(killErr, barrierErr error) error {
+	// A failed signal can race the group's natural exit. Once the barrier proves
+	// ESRCH, ownership is resolved and the earlier signal error is no longer a
+	// cleanup failure. Without that proof, retain both diagnostics.
+	if barrierErr == nil {
+		return nil
+	}
+	return errors.Join(killErr, barrierErr)
+}
+
+func (x *execution) awaitProcessGroupExit(cmd *exec.Cmd) error {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if x.process != cmd {
+		return fmt.Errorf("process group cleanup lost command ownership")
+	}
+	if x.processGroupResolved {
+		return nil
+	}
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		x.processGroupResolved = true
+		x.processGroupSignalsDone = true
+		return nil
+	}
+
+	// Hold the execution lock across the bounded probe barrier. ForceKill cannot
+	// race a successful ESRCH observation and signal a newly reused numeric PGID.
+	// SIGKILL was sent before entering this function; probes never resend it.
+	pid := cmd.Process.Pid
+	deadline := time.Now().Add(processGroupExitTimeout)
+	for {
+		err := syscall.Kill(-pid, 0)
+		if err == syscall.ESRCH {
+			x.processGroupResolved = true
+			x.processGroupSignalsDone = true
+			return nil
+		}
+		if err != nil && err != syscall.EPERM {
+			x.processGroupSignalsDone = true
+			return fmt.Errorf("probe process group %d after SIGKILL: %w", pid, err)
+		}
+		if !time.Now().Before(deadline) {
+			x.processGroupSignalsDone = true
+			return fmt.Errorf("process group %d still exists %s after SIGKILL", pid, processGroupExitTimeout)
+		}
+		time.Sleep(processGroupProbeInterval)
+	}
 }
 
 func (x *execution) run(ctx context.Context) {
+	cmd := x.process
 	waitCh := make(chan error, 1)
-	go func() { waitCh <- x.process.Wait() }()
+	go func() { waitCh <- cmd.Wait() }()
 
 	var (
-		waitErr         error
-		timedOut        bool
-		timeoutType     string
-		killed          bool
-		killReason      string
-		graceKillTimer  <-chan time.Time
-		timeoutTimer    <-chan time.Time
-		inactivityTimer *time.Ticker
-		termDelivered   bool
-		terminateOnce   sync.Once
-		terminateSignal = func() {
+		waitErr          error
+		timedOut         bool
+		timeoutType      string
+		killed           bool
+		killReason       string
+		graceKillTimer   *time.Timer
+		graceKillTimerCh <-chan time.Time
+		timeoutTimer     *time.Timer
+		timeoutTimerCh   <-chan time.Time
+		inactivityTimer  *time.Ticker
+		terminateOnce    sync.Once
+		terminateSignal  = func() {
 			terminateOnce.Do(func() {
 				if x.process.Process == nil {
 					return
@@ -471,19 +708,26 @@ func (x *execution) run(ctx context.Context) {
 					}
 					return
 				}
-				termDelivered = true
 				grace := x.gracefulShutdown
 				if grace <= 0 {
 					grace = 5 * time.Second
 				}
-				graceKillTimer = time.After(grace)
+				graceKillTimer = time.NewTimer(grace)
+				graceKillTimerCh = graceKillTimer.C
 			})
 		}
 	)
 
 	if x.timeout > 0 {
-		timeoutTimer = time.After(x.timeout)
+		timeoutTimer = time.NewTimer(x.remainingMaxRuntime())
+		timeoutTimerCh = timeoutTimer.C
+		defer timeoutTimer.Stop()
 	}
+	defer func() {
+		if graceKillTimer != nil {
+			graceKillTimer.Stop()
+		}
+	}()
 	if x.heartbeatTimeout > 0 {
 		interval := x.heartbeatTimeout
 		if interval > time.Second {
@@ -493,13 +737,14 @@ func (x *execution) run(ctx context.Context) {
 		defer inactivityTimer.Stop()
 	}
 
+	ctxDone := ctx.Done()
 	waiting := true
 	for waiting {
 		select {
 		case waitErr = <-waitCh:
 			waiting = false
-		case <-timeoutTimer:
-			timeoutTimer = nil
+		case <-timeoutTimerCh:
+			timeoutTimerCh = nil
 			select {
 			case waitErr = <-waitCh:
 				waiting = false
@@ -540,35 +785,44 @@ func (x *execution) run(ctx context.Context) {
 			killReason = reason
 			x.setStatus("killed")
 			terminateSignal()
-		case <-ctx.Done():
+		case <-ctxDone:
+			ctxDone = nil
 			killed = true
 			if killReason == "" {
 				killReason = ctx.Err().Error()
 			}
 			x.setStatus("killed")
 			terminateSignal()
-		case <-graceKillTimer:
-			graceKillTimer = nil
+		case <-graceKillTimerCh:
+			graceKillTimerCh = nil
 			_ = x.killProcessGroup()
 		}
 	}
-	if termDelivered && (killed || timedOut) {
-		_ = x.killProcessGroup()
-	}
+	stopTimer(timeoutTimer)
+	stopTimer(graceKillTimer)
+	cleanupErr := x.finishProcessGroup(cmd)
+	x.flushOutput()
 
 	stdout, stderr := x.resolveOutputLogs()
 	status := x.finalStatus(timedOut, killed)
+	if cleanupErr != nil && status == "completed" {
+		status = "failed"
+		x.setStatus(status)
+	}
 	if waitErr != nil && status == "failed" && strings.TrimSpace(stderr) == "" {
 		stderr = waitErr.Error()
-		if x.appendPersistedLog(x.stderrLogPath, []byte(stderr)) {
-			x.markPersistedLogWriteFailed()
-		}
+		// The result retains this diagnostic in memory/final persistence. Do not
+		// perform synchronous log I/O on the lifecycle teardown path.
+		x.markPersistedLogWriteFailed()
 	}
 	errorMessage := ""
 	if status == "failed" || status == "timeout" || status == "killed" {
 		errorMessage = strings.TrimSpace(stderr)
 		if errorMessage == "" {
 			errorMessage = killReason
+		}
+		if cleanupErr != nil {
+			errorMessage = joinReasonAndError(errorMessage, cleanupErr)
 		}
 	}
 	completion := parseCompletion(stdout, stderr)
@@ -611,9 +865,9 @@ func (x *execution) run(ctx context.Context) {
 		ConfiguredMaxRuntimeSeconds:  durationSeconds(x.timeout),
 		ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
 		LastProgressAt:               lastProgressAt,
-		PID:                          pidOrZero(x.process.Process),
+		PID:                          pidOrZero(cmd.Process),
 	}
-	if x.shouldFallbackNativeResume(status, stdout, stderr) {
+	if cleanupErr == nil && x.shouldFallbackNativeResume(status, stdout, stderr) {
 		if fallbackResult, fallbackErrorMessage, ok := x.runCheckpointFallback(ctx, errorMessage); ok {
 			result = fallbackResult
 			status = fallbackResult.Status
@@ -623,6 +877,8 @@ func (x *execution) run(ctx context.Context) {
 		}
 	}
 
+	x.stopOutput()
+	x.stopOutputPersistence()
 	x.persistFinal(status, result, errorMessage, endedAtISO)
 	eventType := "agent.completed"
 	if status == "timeout" {
@@ -649,7 +905,8 @@ func (x *execution) run(ctx context.Context) {
 		"summary":                      result.Summary,
 	}, endedAtISO)
 
-	x.doneCh <- execOutcome{result: result, err: nil}
+	x.stopProgress()
+	x.doneCh <- execOutcome{result: result, err: cleanupErr}
 }
 
 func (x *execution) shouldFallbackNativeResume(status string, stdout string, stderr string) bool {
@@ -687,13 +944,17 @@ func normalizeNativeResumeErrorLine(line string) string {
 }
 
 func (x *execution) runCheckpointFallback(ctx context.Context, nativeError string) (Result, string, bool) {
+	if reason, stopped := x.pendingStop(ctx); stopped {
+		return x.stoppedFallbackResult(reason)
+	}
 	command, args := ResolveSpawn(x.executor.config, x.input.WorkingDirectory, x.input.Prompt)
 	cmd := exec.Command(command, args...)
 	cmd.Dir = x.input.WorkingDirectory
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.WaitDelay = descendantPipeDrainGrace
 	cmd.Env = buildCommandEnv(x.input.WorkingDirectory, x.input.Prompt, x.executor.config.Env, x.input.Env)
-	cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stdout", chunk) }}
-	cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stderr", chunk) }}
+	cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.enqueueOutput("stdout", chunk) }}
+	cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.enqueueOutput("stderr", chunk) }}
 
 	now := x.executor.now().UTC()
 	nowISO := eventlog.FormatJavaScriptISOString(now)
@@ -701,6 +962,9 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 	x.command = command
 	x.args = args
 	x.process = cmd
+	x.processGroupResolved = false
+	x.processGroupKillSent = false
+	x.processGroupSignalsDone = false
 	x.status = "running"
 	x.stdout = nil
 	x.stderr = nil
@@ -711,10 +975,13 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 	x.lastHeartbeatAtISO = nowISO
 	x.lastOutputAt = now
 	x.mu.Unlock()
-	x.persistStatus("running", nil, nil, nil)
-	x.executor.appendLifecycleEvent("agent.native_resume_fallback_started", x.input, x.executionID, map[string]any{"command": command, "args": args, "nativeResumeError": nativeError}, nowISO)
+	if reason, stopped := x.pendingStop(ctx); stopped {
+		x.retireUnstartedProcess(cmd)
+		return x.stoppedFallbackResult(reason)
+	}
 
 	if err := cmd.Start(); err != nil {
+		x.retireUnstartedProcess(cmd)
 		x.mu.Lock()
 		x.status = "failed"
 		x.nativeResumeStatus = "fallback_failed"
@@ -722,22 +989,53 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 		x.mu.Unlock()
 		return Result{}, "", false
 	}
+	if reason, stopped := x.pendingStop(ctx); stopped {
+		cleanupErr := x.reapStartedProcess(cmd)
+		return x.stoppedFallbackResult(joinReasonAndError(reason, cleanupErr))
+	}
+	stopReason, err := x.persistRunningOwnership(ctx, cmd)
+	if stopReason != "" {
+		return x.stoppedFallbackResult(joinReasonAndError(stopReason, err))
+	}
+	if err != nil {
+		message := fmt.Sprintf("persist running checkpoint fallback: %v", err)
+		x.mu.Lock()
+		x.status = "failed"
+		x.nativeResumeStatus = "fallback_failed"
+		x.nativeResumeError = message
+		x.mu.Unlock()
+		return Result{
+			Status:                       "failed",
+			Summary:                      message,
+			ParseStatus:                  "missing",
+			ConfiguredIdleTimeoutSeconds: durationSeconds(x.heartbeatTimeout),
+			ConfiguredMaxRuntimeSeconds:  durationSeconds(x.timeout),
+			ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
+			LastProgressAt:               x.lastProgressAtISO(),
+			PID:                          pidOrZero(cmd.Process),
+		}, message, true
+	}
+	x.executor.appendLifecycleEvent("agent.native_resume_fallback_started", x.input, x.executionID, map[string]any{"command": command, "args": args, "nativeResumeError": nativeError}, nowISO)
 
 	waitCh := make(chan error, 1)
 	go func() { waitCh <- cmd.Wait() }()
 	var (
-		waitErr        error
-		timedOut       bool
-		killed         bool
-		timeoutType    string
-		killReason     string
-		timeoutTimer   <-chan time.Time
-		graceKillTimer <-chan time.Time
-		idleTicker     *time.Ticker
-		termDelivered  bool
+		waitErr          error
+		timedOut         bool
+		killed           bool
+		timeoutType      string
+		killReason       string
+		timeoutTimer     *time.Timer
+		timeoutTimerCh   <-chan time.Time
+		graceKillTimer   *time.Timer
+		graceKillTimerCh <-chan time.Time
+		idleTicker       *time.Ticker
+		terminateOnce    sync.Once
 	)
 	if x.timeout > 0 {
-		timeoutTimer = time.After(x.timeout)
+		timeoutTimer = time.NewTimer(x.remainingMaxRuntime())
+		timeoutTimerCh = timeoutTimer.C
+		defer timeoutTimer.Stop()
 	}
 	if x.heartbeatTimeout > 0 {
 		interval := x.heartbeatTimeout
@@ -748,29 +1046,37 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 		defer idleTicker.Stop()
 	}
 	terminate := func() {
-		if cmd.Process == nil {
-			return
-		}
-		if err := x.signalProcessGroup(syscall.SIGTERM); err != nil {
-			if err != os.ErrProcessDone {
-				_ = x.killProcessGroup()
+		terminateOnce.Do(func() {
+			if cmd.Process == nil {
+				return
 			}
-			return
-		}
-		termDelivered = true
-		grace := x.gracefulShutdown
-		if grace <= 0 {
-			grace = 5 * time.Second
-		}
-		graceKillTimer = time.After(grace)
+			if err := x.signalProcessGroup(syscall.SIGTERM); err != nil {
+				if err != os.ErrProcessDone {
+					_ = x.killProcessGroup()
+				}
+				return
+			}
+			grace := x.gracefulShutdown
+			if grace <= 0 {
+				grace = 5 * time.Second
+			}
+			graceKillTimer = time.NewTimer(grace)
+			graceKillTimerCh = graceKillTimer.C
+		})
 	}
+	defer func() {
+		if graceKillTimer != nil {
+			graceKillTimer.Stop()
+		}
+	}()
+	ctxDone := ctx.Done()
 	waiting := true
 	for waiting {
 		select {
 		case waitErr = <-waitCh:
 			waiting = false
-		case <-timeoutTimer:
-			timeoutTimer = nil
+		case <-timeoutTimerCh:
+			timeoutTimerCh = nil
 			if !timedOut {
 				timedOut = true
 				timeoutType = "max_runtime"
@@ -789,18 +1095,22 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 			killed = true
 			killReason = reason
 			terminate()
-		case <-ctx.Done():
+		case <-ctxDone:
+			ctxDone = nil
 			killed = true
-			killReason = ctx.Err().Error()
+			if killReason == "" {
+				killReason = ctx.Err().Error()
+			}
 			terminate()
-		case <-graceKillTimer:
-			graceKillTimer = nil
+		case <-graceKillTimerCh:
+			graceKillTimerCh = nil
 			_ = x.killProcessGroup()
 		}
 	}
-	if termDelivered && (killed || timedOut) {
-		_ = x.killProcessGroup()
-	}
+	stopTimer(timeoutTimer)
+	stopTimer(graceKillTimer)
+	cleanupErr := x.finishProcessGroup(cmd)
+	x.flushOutput()
 	stdout := x.stdoutString()
 	stderr := x.stderrString()
 	now = x.executor.now().UTC()
@@ -817,7 +1127,10 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 		status = "timeout"
 	} else if killed {
 		status = "killed"
-	} else if waitErr != nil || (cmd.ProcessState != nil && cmd.ProcessState.ExitCode() != 0) {
+	} else if waitErr != nil && !errors.Is(waitErr, exec.ErrWaitDelay) || (cmd.ProcessState != nil && cmd.ProcessState.ExitCode() != 0) {
+		status = "failed"
+	}
+	if cleanupErr != nil {
 		status = "failed"
 	}
 	errorMessage := ""
@@ -828,6 +1141,9 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 		}
 		if errorMessage == "" {
 			errorMessage = killReason
+		}
+		if cleanupErr != nil {
+			errorMessage = joinReasonAndError(errorMessage, cleanupErr)
 		}
 	}
 	completion := parseCompletion(stdout, stderr)
@@ -865,7 +1181,42 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 	}, errorMessage, true
 }
 
-func (x *execution) onOutput(stream string, chunk []byte) {
+func (x *execution) pendingStop(ctx context.Context) (string, bool) {
+	if err := ctx.Err(); err != nil {
+		return err.Error(), true
+	}
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if !x.killRequested {
+		return "", false
+	}
+	return firstNonEmpty(x.killRequestedReason, "agent execution stopped"), true
+}
+
+func (x *execution) stoppedFallbackResult(reason string) (Result, string, bool) {
+	x.setStatus("killed")
+	return Result{
+		Status:                       "killed",
+		Summary:                      reason,
+		ParseStatus:                  "missing",
+		ConfiguredIdleTimeoutSeconds: durationSeconds(x.heartbeatTimeout),
+		ConfiguredMaxRuntimeSeconds:  durationSeconds(x.timeout),
+		ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
+		LastProgressAt:               x.lastProgressAtISO(),
+	}, reason, true
+}
+
+func joinReasonAndError(reason string, err error) string {
+	if err == nil {
+		return reason
+	}
+	if strings.TrimSpace(reason) == "" {
+		return err.Error()
+	}
+	return reason + "; " + err.Error()
+}
+
+func (x *execution) captureOutput(stream string, chunk []byte) {
 	now := x.executor.now().UTC()
 	nowISO := eventlog.FormatJavaScriptISOString(now)
 	x.mu.Lock()
@@ -873,37 +1224,34 @@ func (x *execution) onOutput(stream string, chunk []byte) {
 	x.lastHeartbeatAtISO = nowISO
 	x.lastOutputAt = now
 	if stream == "stdout" {
-		if x.appendPersistedLog(x.stdoutLogPath, chunk) {
-			x.persistedLogWriteFailed = true
-		}
 		x.stdout = appendTailBounded(x.stdout, chunk, x.maxOutputBytes)
 	} else {
-		if x.appendPersistedLog(x.stderrLogPath, chunk) {
-			x.persistedLogWriteFailed = true
-		}
 		x.stderr = appendTailBounded(x.stderr, chunk, x.maxOutputBytes)
 	}
-	heartbeatCount := x.heartbeatCount
 	stdout := string(x.stdout)
 	stderr := string(x.stderr)
+	x.mu.Unlock()
+
 	// Capture the native session id AS SOON as it appears, so it's persisted while
 	// the run is live (a human taking over mid-run needs it — completion is too
 	// late). Text-mode ids can stream in across chunks, so re-extract each time; the
 	// codex --json thread id arrives whole in a thread.started line, so capture it
 	// once (only when text extraction found nothing and it's not already known).
-	if nativeSessionID := extractNativeSessionID(stdout, stderr); nativeSessionID != "" {
-		x.nativeSessionID = nativeSessionID
-	} else if x.jsonMode() && strings.TrimSpace(x.nativeSessionID) == "" {
-		if threadID := extractCodexThreadID(stdout); threadID != "" {
-			x.nativeSessionID = threadID
-		}
+	nativeSessionID := extractNativeSessionID(stdout, stderr)
+	jsonSessionID := ""
+	if nativeSessionID == "" && x.jsonMode() {
+		jsonSessionID = extractCodexThreadID(stdout)
 	}
-	x.mu.Unlock()
-
-	outputJSON := x.outputJSON(stdout, stderr)
-	x.persistStatus(x.currentStatus(), &heartbeatCount, &nowISO, &outputJSON)
-	x.bumpRunHeartbeat(nowISO)
-	x.maybeEmitProgress(now, stdout, stderr)
+	if nativeSessionID == "" && jsonSessionID == "" {
+		return
+	}
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if nativeSessionID != "" {
+		x.nativeSessionID = nativeSessionID
+	} else if jsonSessionID != "" && strings.TrimSpace(x.nativeSessionID) == "" {
+		x.nativeSessionID = jsonSessionID
+	}
 }
 
 // maybeEmitProgress hands a throttled activity snapshot (last few output lines +
@@ -915,11 +1263,13 @@ func (x *execution) maybeEmitProgress(now time.Time, stdout, stderr string) {
 		return
 	}
 	x.mu.Lock()
-	if !x.lastProgressAt.IsZero() && now.Sub(x.lastProgressAt) < liveProgressInterval {
+	if !x.progressReady || x.progressInFlight || (!x.lastProgressAt.IsZero() && now.Sub(x.lastProgressAt) < liveProgressInterval) {
 		x.mu.Unlock()
 		return
 	}
 	x.lastProgressAt = now
+	x.progressInFlight = true
+	progressCtx := x.progressCtx
 	x.mu.Unlock()
 	elapsed := int64(now.Sub(x.startedAt).Seconds())
 	if elapsed < 0 {
@@ -933,13 +1283,27 @@ func (x *execution) maybeEmitProgress(now time.Time, stdout, stderr string) {
 		// Combine streams; the last N lines skew toward whichever is actively writing.
 		tail = lastNonEmptyLines(stdout+"\n"+stderr, liveProgressTailLines)
 	}
-	x.executor.onProgress(context.Background(), ProgressUpdate{
+	update := ProgressUpdate{
 		LoopID:         x.input.LoopID,
 		RunID:          x.input.RunID,
-		ExecutionID:    x.input.ExecutionID,
+		ExecutionID:    x.executionID,
 		TailLines:      tail,
 		ElapsedSeconds: elapsed,
-	})
+	}
+	go func() {
+		defer func() {
+			x.mu.Lock()
+			x.progressInFlight = false
+			x.mu.Unlock()
+		}()
+		x.executor.onProgress(progressCtx, update)
+	}()
+}
+
+func (x *execution) stopProgress() {
+	if x.progressCancel != nil {
+		x.progressCancel()
+	}
 }
 
 // jsonMode reports whether this run is a codex `--json` run (structured events).
@@ -994,11 +1358,10 @@ func meaningfulProgressLine(line string) bool {
 	return true
 }
 
-func (x *execution) bumpRunHeartbeat(nowISO string) {
+func (x *execution) bumpRunHeartbeat(ctx context.Context, nowISO string) {
 	if x.input.RunID == "" || x.executor.repos == nil || x.executor.repos.Runs == nil {
 		return
 	}
-	ctx := context.Background()
 	run, err := x.executor.repos.Runs.GetByID(ctx, x.input.RunID)
 	if err != nil || run == nil {
 		return
@@ -1009,14 +1372,59 @@ func (x *execution) bumpRunHeartbeat(nowISO string) {
 	_ = x.executor.repos.Runs.Upsert(ctx, updated)
 }
 
-func (x *execution) persistStatus(status string, heartbeatCount *int64, heartbeatAt *string, outputJSON *string) {
-	if x.executor.repos == nil || x.executor.repos.AgentExecutions == nil {
-		return
+func (x *execution) persistRunningOwnership(ctx context.Context, cmd *exec.Cmd) (string, error) {
+	persistCtx, cancel := context.WithTimeout(ctx, ownershipPersistenceTimeout)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- x.persistStatusContext(persistCtx, "running", nil, nil, nil)
+	}()
+
+	select {
+	case err := <-done:
+		if reason, stopped := x.pendingStop(ctx); stopped {
+			cleanupErr := x.reapStartedProcess(cmd)
+			return reason, errors.Join(ctx.Err(), cleanupErr)
+		}
+		if err != nil {
+			err = errors.Join(err, x.reapStartedProcess(cmd))
+		}
+		return "", err
+	case reason := <-x.killCh:
+		cancel()
+		cleanupErr := x.reapStartedProcess(cmd)
+		return firstNonEmpty(reason, "agent execution stopped"), cleanupErr
+	case <-persistCtx.Done():
+		persistErr := persistCtx.Err()
+		persistErr = errors.Join(persistErr, x.reapStartedProcess(cmd))
+		if reason, stopped := x.pendingStop(ctx); stopped {
+			return reason, persistErr
+		}
+		return "", persistErr
 	}
-	nativeSessionID, nativeResumeMode, nativeResumeStatus, nativeResumeError := x.nativeResumeSnapshot()
+}
+
+func (x *execution) persistStatusContext(ctx context.Context, status string, heartbeatCount *int64, heartbeatAt *string, outputJSON *string) error {
+	if x.executor.repos == nil || x.executor.repos.AgentExecutions == nil {
+		return nil
+	}
+	x.mu.Lock()
+	nativeSessionID := x.nativeSessionID
+	nativeResumeMode := x.nativeResumeMode
+	nativeResumeStatus := x.nativeResumeStatus
+	nativeResumeError := x.nativeResumeError
+	command := x.command
+	args := append([]string(nil), x.args...)
+	process := x.process
+	x.mu.Unlock()
 	metadata := mustJSON(x.executionMetadata(""))
-	commandJSON := mustJSON(map[string]any{"command": x.command, "args": x.args})
-	pid := int64(pidOrZero(x.process.Process))
+	commandJSON := mustJSON(map[string]any{"command": command, "args": args})
+	var osProcess *os.Process
+	if process != nil {
+		osProcess = process.Process
+	}
+	pid := int64(pidOrZero(osProcess))
 	record := storage.AgentExecutionRecord{
 		ID:                 x.executionID,
 		ProjectID:          emptyToNil(x.input.ProjectID),
@@ -1046,7 +1454,7 @@ func (x *execution) persistStatus(status string, heartbeatCount *int64, heartbea
 	if outputJSON != nil {
 		record.OutputJSON = outputJSON
 	}
-	_ = x.executor.repos.AgentExecutions.Upsert(context.Background(), record)
+	return x.executor.repos.AgentExecutions.Upsert(ctx, record)
 }
 
 func (x *execution) persistFinal(status string, result Result, errorMessage, endedAtISO string) {
@@ -1104,7 +1512,9 @@ func (x *execution) persistFinal(status string, result Result, errorMessage, end
 		CreatedAt:          x.startedAtISO,
 		UpdatedAt:          endedAtISO,
 	}
-	_ = x.executor.repos.AgentExecutions.Upsert(context.Background(), record)
+	runBoundedSideEffect(outputPersistenceTimeout, func(ctx context.Context) {
+		_ = x.executor.repos.AgentExecutions.Upsert(ctx, record)
+	})
 }
 
 func (x *execution) currentStatus() string {
@@ -1200,6 +1610,30 @@ func durationSeconds(duration time.Duration) int64 {
 	return seconds
 }
 
+func (x *execution) remainingMaxRuntime() time.Duration {
+	if x.timeout <= 0 {
+		return 0
+	}
+	if x.maxRuntimeDeadline.IsZero() {
+		return x.timeout
+	}
+	remaining := time.Until(x.maxRuntimeDeadline)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer == nil || timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
+	}
+}
+
 func (x *execution) resolveOutputLogs() (string, string) {
 	stdout := x.stdoutString()
 	stderr := x.stderrString()
@@ -1247,6 +1681,200 @@ func (w *streamCapture) Write(p []byte) (int, error) {
 		w.onChunk(chunk)
 	}
 	return len(p), nil
+}
+
+type outputMessage struct {
+	stream string
+	chunk  []byte
+	done   chan struct{}
+}
+
+type outputSnapshot struct {
+	now            time.Time
+	nowISO         string
+	heartbeatCount int64
+	stdout         string
+	stderr         string
+	status         string
+	persistOutput  bool
+}
+
+type outputPersistence struct {
+	status         string
+	heartbeatCount int64
+	heartbeatAt    string
+	outputJSON     string
+}
+
+func (x *execution) enqueueOutput(stream string, chunk []byte) {
+	if len(chunk) == 0 {
+		return
+	}
+	x.captureOutput(stream, chunk)
+	message := outputMessage{stream: stream, chunk: chunk}
+	select {
+	case <-x.outputCtx.Done():
+		x.markPersistedLogWriteFailed()
+	case x.outputCh <- message:
+	default:
+		x.markPersistedLogWriteFailed()
+	}
+}
+
+func (x *execution) processOutput() {
+	defer close(x.outputDone)
+	for {
+		select {
+		case <-x.outputCtx.Done():
+			return
+		case message := <-x.outputCh:
+			if x.outputCtx.Err() != nil {
+				return
+			}
+			if len(message.chunk) > 0 {
+				x.processOutputSideEffects(message)
+			}
+			if message.done != nil {
+				close(message.done)
+			}
+		}
+	}
+}
+
+func (x *execution) processOutputSideEffects(message outputMessage) {
+	if x.outputCtx.Err() != nil {
+		return
+	}
+	path := x.stderrLogPath
+	if message.stream == "stdout" {
+		path = x.stdoutLogPath
+	}
+	if x.appendPersistedLog(path, message.chunk) {
+		x.markPersistedLogWriteFailed()
+	}
+	if x.outputCtx.Err() != nil {
+		return
+	}
+	snapshot := x.currentOutputSnapshot()
+	if snapshot.persistOutput {
+		x.submitOutputPersistence(outputPersistence{
+			status:         snapshot.status,
+			heartbeatCount: snapshot.heartbeatCount,
+			heartbeatAt:    snapshot.nowISO,
+			outputJSON:     x.outputJSON(snapshot.stdout, snapshot.stderr),
+		})
+	}
+	x.maybeEmitProgress(snapshot.now, snapshot.stdout, snapshot.stderr)
+}
+
+func (x *execution) currentOutputSnapshot() outputSnapshot {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	return outputSnapshot{
+		now:            x.lastOutputAt,
+		nowISO:         x.lastHeartbeatAtISO,
+		heartbeatCount: x.heartbeatCount,
+		stdout:         string(x.stdout),
+		stderr:         string(x.stderr),
+		status:         x.status,
+		persistOutput:  x.outputPersistenceReady,
+	}
+}
+
+func (x *execution) flushOutput() {
+	done := make(chan struct{})
+	select {
+	case <-x.outputCtx.Done():
+		return
+	case x.outputCh <- outputMessage{done: done}:
+	default:
+		x.markPersistedLogWriteFailed()
+		return
+	}
+	if !waitForWorker(done, outputPersistenceTimeout) {
+		x.markPersistedLogWriteFailed()
+	}
+}
+
+func (x *execution) stopOutput() {
+	x.outputStopOnce.Do(func() {
+		x.outputCancel()
+		_ = waitForWorker(x.outputDone, outputPersistenceTimeout)
+	})
+}
+
+func (x *execution) submitOutputPersistence(update outputPersistence) {
+	select {
+	case x.outputPersistenceCh <- update:
+		return
+	default:
+	}
+	select {
+	case <-x.outputPersistenceCh:
+	default:
+	}
+	select {
+	case x.outputPersistenceCh <- update:
+	default:
+	}
+}
+
+func (x *execution) processOutputPersistence() {
+	defer close(x.outputPersistenceDone)
+	for {
+		select {
+		case <-x.outputPersistenceCtx.Done():
+			return
+		case update := <-x.outputPersistenceCh:
+			if x.outputPersistenceCtx.Err() != nil {
+				return
+			}
+			ctx, cancel := context.WithTimeout(x.outputPersistenceCtx, outputPersistenceTimeout)
+			_ = x.persistStatusContext(ctx, update.status, &update.heartbeatCount, &update.heartbeatAt, &update.outputJSON)
+			x.bumpRunHeartbeat(ctx, update.heartbeatAt)
+			cancel()
+		}
+	}
+}
+
+func (x *execution) stopOutputPersistence() {
+	x.outputPersistenceOnce.Do(func() {
+		x.outputPersistenceCancel()
+		_ = waitForWorker(x.outputPersistenceDone, outputPersistenceTimeout)
+	})
+}
+
+func waitForWorker(done <-chan struct{}, timeout time.Duration) bool {
+	if done == nil {
+		return true
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+func runBoundedSideEffect(timeout time.Duration, sideEffect func(context.Context)) bool {
+	if sideEffect == nil {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		sideEffect(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 func ResolveSpawn(cfg ExecutorConfig, workingDirectory string, prompt string) (string, []string) {
@@ -1741,6 +2369,13 @@ func firstNonEmpty(values ...string) string {
 }
 
 func (x *execution) appendPersistedLog(path string, chunk []byte) bool {
+	if x.executor != nil && x.executor.appendPersistedLog != nil {
+		return x.executor.appendPersistedLog(path, chunk)
+	}
+	return appendPersistedLogFile(path, chunk)
+}
+
+func appendPersistedLogFile(path string, chunk []byte) bool {
 	if path == "" || len(chunk) == 0 {
 		return false
 	}
@@ -1953,10 +2588,10 @@ func summarizeLogs(stdout, stderr string) string {
 }
 
 func (e *ConfiguredExecutor) appendLifecycleEvent(eventType string, input RunInput, executionID string, payload any, createdAt string) {
-	if e.repos == nil || e.repos.Events == nil {
+	if e.appendLifecycleRecord == nil {
 		return
 	}
-	_ = e.repos.Events.Append(context.Background(), storage.EventLogRecord{
+	record := storage.EventLogRecord{
 		ID:               eventlog.NewEventID("event"),
 		EventType:        eventType,
 		ProjectID:        emptyToNil(input.ProjectID),
@@ -1969,6 +2604,9 @@ func (e *ConfiguredExecutor) appendLifecycleEvent(eventType string, input RunInp
 		ActorDisplayName: stringPtr(string(e.config.Vendor)),
 		PayloadJSON:      mustJSON(payload),
 		CreatedAt:        createdAt,
+	}
+	runBoundedSideEffect(outputPersistenceTimeout, func(ctx context.Context) {
+		_ = e.appendLifecycleRecord(ctx, record)
 	})
 }
 

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -568,6 +568,11 @@ func (x *execution) signalProcessGroup(signal syscall.Signal) error {
 	}
 	if err := syscall.Kill(-pid, signal); err != nil {
 		if err == syscall.ESRCH {
+			// Wait may have reaped the original group before this stop signal
+			// runs. Mark ownership resolved so finishProcessGroup/ForceKill do
+			// not later SIGKILL a numeric PGID that has been reused.
+			x.processGroupResolved = true
+			x.processGroupSignalsDone = true
 			return os.ErrProcessDone
 		}
 		return err

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/eventlog"
 	"github.com/nexu-io/looper/internal/forge"
+	shellinfra "github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/storage"
 )
@@ -657,24 +658,26 @@ func (x *execution) awaitProcessGroupExit(cmd *exec.Cmd) error {
 	}
 
 	// Hold the execution lock across the bounded probe barrier. ForceKill cannot
-	// race a successful ESRCH observation and signal a newly reused numeric PGID.
-	// SIGKILL was sent before entering this function; probes never resend it.
+	// race a successful "no runnable members" observation and signal a newly
+	// reused numeric PGID. SIGKILL was sent before entering this function;
+	// probes never resend it. Zombie-only groups count as resolved so unreaped
+	// orphans cannot fail an otherwise completed agent.
 	pid := cmd.Process.Pid
 	deadline := time.Now().Add(processGroupExitTimeout)
 	for {
-		err := syscall.Kill(-pid, 0)
-		if err == syscall.ESRCH {
+		live, err := shellinfra.ProcessGroupRunnable(pid)
+		if err != nil {
+			x.processGroupSignalsDone = true
+			return fmt.Errorf("probe process group %d after SIGKILL: %w", pid, err)
+		}
+		if !live {
 			x.processGroupResolved = true
 			x.processGroupSignalsDone = true
 			return nil
 		}
-		if err != nil && err != syscall.EPERM {
-			x.processGroupSignalsDone = true
-			return fmt.Errorf("probe process group %d after SIGKILL: %w", pid, err)
-		}
 		if !time.Now().Before(deadline) {
 			x.processGroupSignalsDone = true
-			return fmt.Errorf("process group %d still exists %s after SIGKILL", pid, processGroupExitTimeout)
+			return fmt.Errorf("process group %d still has runnable members %s after SIGKILL", pid, processGroupExitTimeout)
 		}
 		time.Sleep(processGroupProbeInterval)
 	}

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -837,7 +837,10 @@ func (x *execution) run(ctx context.Context) {
 		tr.ingestAll(stdout)
 		completion = parseCompletion(tr.combinedText(), stderr)
 		if tr.threadID != "" {
+			// Guard against concurrent live persistence reads of nativeSessionID.
+			x.mu.Lock()
 			x.nativeSessionID = tr.threadID
+			x.mu.Unlock()
 		}
 	}
 	if status != "completed" {
@@ -871,12 +874,15 @@ func (x *execution) run(ctx context.Context) {
 		PID:                          pidOrZero(cmd.Process),
 	}
 	if cleanupErr == nil && x.shouldFallbackNativeResume(status, stdout, stderr) {
-		if fallbackResult, fallbackErrorMessage, ok := x.runCheckpointFallback(ctx, errorMessage); ok {
+		if fallbackResult, fallbackErrorMessage, fallbackCleanupErr, ok := x.runCheckpointFallback(ctx, errorMessage); ok {
 			result = fallbackResult
 			status = fallbackResult.Status
 			timeoutType = fallbackResult.TimeoutType
 			errorMessage = fallbackErrorMessage
 			endedAtISO = eventlog.FormatJavaScriptISOString(x.executor.now().UTC())
+			// Fallback owns a new process group; its cleanup barrier is the
+			// authority for Wait, not the original native-resume cleanupErr.
+			cleanupErr = fallbackCleanupErr
 		}
 	}
 
@@ -946,9 +952,9 @@ func normalizeNativeResumeErrorLine(line string) string {
 	return strings.TrimSpace(line)
 }
 
-func (x *execution) runCheckpointFallback(ctx context.Context, nativeError string) (Result, string, bool) {
+func (x *execution) runCheckpointFallback(ctx context.Context, nativeError string) (Result, string, error, bool) {
 	if reason, stopped := x.pendingStop(ctx); stopped {
-		return x.stoppedFallbackResult(reason)
+		return x.stoppedFallbackResult(reason, nil)
 	}
 	command, args := ResolveSpawn(x.executor.config, x.input.WorkingDirectory, x.input.Prompt)
 	cmd := exec.Command(command, args...)
@@ -980,7 +986,7 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 	x.mu.Unlock()
 	if reason, stopped := x.pendingStop(ctx); stopped {
 		x.retireUnstartedProcess(cmd)
-		return x.stoppedFallbackResult(reason)
+		return x.stoppedFallbackResult(reason, nil)
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -990,17 +996,22 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 		x.nativeResumeStatus = "fallback_failed"
 		x.nativeResumeError = firstNonEmpty(err.Error(), nativeError)
 		x.mu.Unlock()
-		return Result{}, "", false
+		return Result{}, "", nil, false
 	}
 	if reason, stopped := x.pendingStop(ctx); stopped {
 		cleanupErr := x.reapStartedProcess(cmd)
-		return x.stoppedFallbackResult(joinReasonAndError(reason, cleanupErr))
+		return x.stoppedFallbackResult(joinReasonAndError(reason, cleanupErr), cleanupErr)
 	}
 	stopReason, err := x.persistRunningOwnership(ctx, cmd)
 	if stopReason != "" {
-		return x.stoppedFallbackResult(joinReasonAndError(stopReason, err))
+		// persistRunningOwnership already reaped on stop; only an unresolved
+		// process-group barrier must become Wait's cleanup error (not ctx cancel).
+		cleanupErr := x.finishProcessGroup(cmd)
+		return x.stoppedFallbackResult(joinReasonAndError(stopReason, err), cleanupErr)
 	}
 	if err != nil {
+		// Reap already ran for the persistence failure path; confirm the barrier.
+		cleanupErr := x.finishProcessGroup(cmd)
 		message := fmt.Sprintf("persist running checkpoint fallback: %v", err)
 		x.mu.Lock()
 		x.status = "failed"
@@ -1016,7 +1027,7 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 			ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
 			LastProgressAt:               x.lastProgressAtISO(),
 			PID:                          pidOrZero(cmd.Process),
-		}, message, true
+		}, joinReasonAndError(message, cleanupErr), cleanupErr, true
 	}
 	x.executor.appendLifecycleEvent("agent.native_resume_fallback_started", x.input, x.executionID, map[string]any{"command": command, "args": args, "nativeResumeError": nativeError}, nowISO)
 
@@ -1181,7 +1192,7 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 		ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
 		LastProgressAt:               x.lastProgressAtISO(),
 		PID:                          pidOrZero(cmd.Process),
-	}, errorMessage, true
+	}, errorMessage, cleanupErr, true
 }
 
 func (x *execution) pendingStop(ctx context.Context) (string, bool) {
@@ -1196,7 +1207,7 @@ func (x *execution) pendingStop(ctx context.Context) (string, bool) {
 	return firstNonEmpty(x.killRequestedReason, "agent execution stopped"), true
 }
 
-func (x *execution) stoppedFallbackResult(reason string) (Result, string, bool) {
+func (x *execution) stoppedFallbackResult(reason string, cleanupErr error) (Result, string, error, bool) {
 	x.setStatus("killed")
 	return Result{
 		Status:                       "killed",
@@ -1206,7 +1217,7 @@ func (x *execution) stoppedFallbackResult(reason string) (Result, string, bool) 
 		ConfiguredMaxRuntimeSeconds:  durationSeconds(x.timeout),
 		ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
 		LastProgressAt:               x.lastProgressAtISO(),
-	}, reason, true
+	}, reason, cleanupErr, true
 }
 
 func joinReasonAndError(reason string, err error) string {

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -1426,6 +1426,11 @@ func (x *execution) persistRunningOwnership(ctx context.Context, cmd *exec.Cmd) 
 	case err := <-done:
 		if reason, stopped := x.pendingStop(ctx); stopped {
 			cleanupErr := x.reapStartedProcess(cmd)
+			// Running Upsert already committed: Start will not launch run/persistFinal,
+			// so write terminal status here or recovery sees a dead PID as live.
+			if err == nil {
+				cleanupErr = errors.Join(cleanupErr, x.persistAbortedOwnership(reason, cleanupErr))
+			}
 			return reason, errors.Join(ctx.Err(), cleanupErr)
 		}
 		if err != nil {
@@ -1435,15 +1440,76 @@ func (x *execution) persistRunningOwnership(ctx context.Context, cmd *exec.Cmd) 
 	case reason := <-x.killCh:
 		cancel()
 		cleanupErr := x.reapStartedProcess(cmd)
-		return firstNonEmpty(reason, "agent execution stopped"), cleanupErr
-	case <-persistCtx.Done():
-		persistErr := persistCtx.Err()
-		persistErr = errors.Join(persistErr, x.reapStartedProcess(cmd))
-		if reason, stopped := x.pendingStop(ctx); stopped {
-			return reason, persistErr
+		stopReason := firstNonEmpty(reason, "agent execution stopped")
+		// Prefer an immediate drain when the running write already finished; otherwise
+		// finish terminalization asynchronously so Start is not blocked on a locked Upsert.
+		select {
+		case persistErr := <-done:
+			if persistErr == nil {
+				cleanupErr = errors.Join(cleanupErr, x.persistAbortedOwnership(stopReason, cleanupErr))
+			}
+		default:
+			go x.finishAbortedOwnershipAfterPersist(done, stopReason)
 		}
-		return "", persistErr
+		return stopReason, cleanupErr
+	case <-persistCtx.Done():
+		cleanupErr := x.reapStartedProcess(cmd)
+		reason, stopped := x.pendingStop(ctx)
+		select {
+		case persistErr := <-done:
+			if persistErr == nil {
+				stopReason := reason
+				if !stopped {
+					stopReason = firstNonEmpty(persistCtx.Err().Error(), "ownership persistence deadline exceeded")
+				}
+				cleanupErr = errors.Join(cleanupErr, x.persistAbortedOwnership(stopReason, cleanupErr))
+			}
+			if stopped {
+				return reason, errors.Join(persistCtx.Err(), cleanupErr)
+			}
+			if persistErr != nil {
+				return "", errors.Join(persistErr, cleanupErr)
+			}
+			return "", errors.Join(persistCtx.Err(), cleanupErr)
+		default:
+			// Upsert still in flight (e.g. SQLite write lock). Do not block Start; if the
+			// write later commits, clear the stranded running row asynchronously.
+			stopReason := reason
+			if !stopped {
+				stopReason = firstNonEmpty(persistCtx.Err().Error(), "ownership persistence deadline exceeded")
+			}
+			go x.finishAbortedOwnershipAfterPersist(done, stopReason)
+			if stopped {
+				return reason, errors.Join(persistCtx.Err(), cleanupErr)
+			}
+			return "", errors.Join(persistCtx.Err(), cleanupErr)
+		}
 	}
+}
+
+func (x *execution) finishAbortedOwnershipAfterPersist(done <-chan error, reason string) {
+	if err := <-done; err == nil {
+		_ = x.persistAbortedOwnership(reason, nil)
+	}
+}
+
+// persistAbortedOwnership writes a durable killed terminal row when Start reaps a
+// process after the running ownership Upsert already committed but before run starts.
+func (x *execution) persistAbortedOwnership(reason string, cleanupErr error) error {
+	x.setStatus("killed")
+	endedAtISO := eventlog.FormatJavaScriptISOString(x.executor.now().UTC())
+	errorMessage := joinReasonAndError(reason, cleanupErr)
+	result := Result{
+		Status:                       "killed",
+		Summary:                      errorMessage,
+		ParseStatus:                  "missing",
+		ConfiguredIdleTimeoutSeconds: durationSeconds(x.heartbeatTimeout),
+		ConfiguredMaxRuntimeSeconds:  durationSeconds(x.timeout),
+		ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
+		LastProgressAt:               x.lastProgressAtISO(),
+		PID:                          pidOrZero(x.process.Process),
+	}
+	return x.persistFinal("killed", result, errorMessage, endedAtISO)
 }
 
 func (x *execution) persistStatusContext(ctx context.Context, status string, heartbeatCount *int64, heartbeatAt *string, outputJSON *string) error {

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -888,7 +888,10 @@ func (x *execution) run(ctx context.Context) {
 
 	x.stopOutput()
 	x.stopOutputPersistence()
-	x.persistFinal(status, result, errorMessage, endedAtISO)
+	// Terminal AgentExecutions.Upsert is authoritative for ListActive/startup
+	// recovery. Propagate failures so ActiveExecutionRegistry keeps the live
+	// handle instead of releasing ownership while the durable row stays active.
+	persistErr := x.persistFinal(status, result, errorMessage, endedAtISO)
 	eventType := "agent.completed"
 	if status == "timeout" {
 		switch timeoutType {
@@ -915,7 +918,7 @@ func (x *execution) run(ctx context.Context) {
 	}, endedAtISO)
 
 	x.stopProgress()
-	x.doneCh <- execOutcome{result: result, err: cleanupErr}
+	x.doneCh <- execOutcome{result: result, err: errors.Join(cleanupErr, persistErr)}
 }
 
 func (x *execution) shouldFallbackNativeResume(status string, stdout string, stderr string) bool {
@@ -1471,9 +1474,9 @@ func (x *execution) persistStatusContext(ctx context.Context, status string, hea
 	return x.executor.repos.AgentExecutions.Upsert(ctx, record)
 }
 
-func (x *execution) persistFinal(status string, result Result, errorMessage, endedAtISO string) {
+func (x *execution) persistFinal(status string, result Result, errorMessage, endedAtISO string) error {
 	if x.executor.repos == nil || x.executor.repos.AgentExecutions == nil {
-		return
+		return nil
 	}
 	nativeSessionID, nativeResumeMode, nativeResumeStatus, nativeResumeError := x.nativeResumeSnapshot()
 	commandJSON := mustJSON(map[string]any{"command": x.command, "args": x.args})
@@ -1532,7 +1535,10 @@ func (x *execution) persistFinal(status string, result Result, errorMessage, end
 	// after the live handle is released.
 	ctx, cancel := context.WithTimeout(context.Background(), ownershipPersistenceTimeout)
 	defer cancel()
-	_ = x.executor.repos.AgentExecutions.Upsert(ctx, record)
+	if err := x.executor.repos.AgentExecutions.Upsert(ctx, record); err != nil {
+		return fmt.Errorf("persist terminal agent execution status: %w", err)
+	}
+	return nil
 }
 
 func (x *execution) currentStatus() string {

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -1878,11 +1878,21 @@ func (x *execution) processOutputPersistence() {
 				return
 			}
 			ctx, cancel := context.WithTimeout(x.outputPersistenceCtx, outputPersistenceTimeout)
-			_ = x.persistStatusContext(ctx, update.status, &update.heartbeatCount, &update.heartbeatAt, &update.outputJSON)
+			// Best-effort progress must not full-Upsert ownership fields. A stale
+			// output write can otherwise clobber a later fallback/start PID and
+			// native-resume metadata after the live process group has changed.
+			_ = x.persistLiveProgress(ctx, update.heartbeatCount, update.heartbeatAt, update.outputJSON)
 			x.bumpRunHeartbeat(ctx, update.heartbeatAt)
 			cancel()
 		}
 	}
+}
+
+func (x *execution) persistLiveProgress(ctx context.Context, heartbeatCount int64, heartbeatAt string, outputJSON string) error {
+	if x.executor.repos == nil || x.executor.repos.AgentExecutions == nil {
+		return nil
+	}
+	return x.executor.repos.AgentExecutions.UpdateLiveProgress(ctx, x.executionID, heartbeatCount, heartbeatAt, outputJSON)
 }
 
 func (x *execution) stopOutputPersistence() {

--- a/internal/agent/executor_force_reprobe_test.go
+++ b/internal/agent/executor_force_reprobe_test.go
@@ -1,0 +1,43 @@
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestExecutionForceKillAfterFailedBarrierOnlyReprobesOwnedGroup(t *testing.T) {
+	markerPath := filepath.Join(t.TempDir(), "natural-exit")
+	cmd := exec.Command("/bin/sh", "-c", `sleep 0.05; : > "$MARKER_PATH"`)
+	cmd.Env = append(os.Environ(), "MARKER_PATH="+markerPath)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start process group: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	t.Cleanup(func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		<-done
+	})
+
+	execution := &execution{
+		process:                 cmd,
+		processGroupKillSent:    true,
+		processGroupSignalsDone: true,
+	}
+	if err := execution.ForceKill(); err != nil {
+		t.Fatalf("ForceKill() re-probe error = %v", err)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("ForceKill() resent SIGKILL instead of waiting for the owned group to disappear: %v", err)
+	}
+	execution.mu.Lock()
+	resolved := execution.processGroupResolved
+	execution.mu.Unlock()
+	if !resolved {
+		t.Fatal("ForceKill() returned nil without confirming process-group disappearance")
+	}
+}

--- a/internal/agent/executor_lifecycle_contract_test.go
+++ b/internal/agent/executor_lifecycle_contract_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	shellinfra "github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -47,8 +48,12 @@ func TestExecutionWaitCancellationKeepsOwnershipUntilProcessGroupIsReaped(t *tes
 	if result.Status != "killed" {
 		t.Fatalf("result.Status = %q, want killed", result.Status)
 	}
-	if err := syscall.Kill(-pid, 0); err != syscall.ESRCH {
-		t.Fatalf("process group %d remains after Wait: %v", pid, err)
+	live, err := shellinfra.ProcessGroupRunnable(pid)
+	if err != nil {
+		t.Fatalf("probe process group %d: %v", pid, err)
+	}
+	if live {
+		t.Fatalf("process group %d still has runnable members after Wait", pid)
 	}
 }
 

--- a/internal/agent/executor_lifecycle_contract_test.go
+++ b/internal/agent/executor_lifecycle_contract_test.go
@@ -57,6 +57,85 @@ func TestExecutionWaitCancellationKeepsOwnershipUntilProcessGroupIsReaped(t *tes
 	}
 }
 
+func TestFinishProcessGroupSkipsSIGKILLWhenReapedGroupHasNoMembers(t *testing.T) {
+	// After Wait reaps a short-lived leader with no descendants, the numeric
+	// PGID is free for reuse. finishProcessGroup/killProcessGroup must probe
+	// first and treat no-members as resolved instead of unconditionally SIGKILLing.
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	originalPID := cmd.Process.Pid
+	if _, err := cmd.Process.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		live, err := shellinfra.ProcessGroupRunnable(originalPID)
+		if err != nil {
+			t.Fatalf("ProcessGroupRunnable(%d) error = %v", originalPID, err)
+		}
+		if !live {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process group %d remained live after Wait", originalPID)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	x := &execution{process: cmd}
+	if err := x.finishProcessGroup(cmd); err != nil {
+		t.Fatalf("finishProcessGroup() after reaped exit error = %v", err)
+	}
+	x.mu.Lock()
+	resolved := x.processGroupResolved
+	killSent := x.processGroupKillSent
+	x.mu.Unlock()
+	if !resolved {
+		t.Fatal("finishProcessGroup() did not mark empty group resolved")
+	}
+	if killSent {
+		t.Fatal("finishProcessGroup() sent SIGKILL to an empty reaped group")
+	}
+
+	// Live descendants must still be cleaned up by probe-then-SIGKILL.
+	live := exec.Command("/bin/sh", "-c", `trap '' TERM; while :; do sleep 1; done`)
+	live.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := live.Start(); err != nil {
+		t.Fatalf("Start(live) error = %v", err)
+	}
+	liveDone := make(chan error, 1)
+	go func() { liveDone <- live.Wait() }()
+	t.Cleanup(func() {
+		_ = syscall.Kill(-live.Process.Pid, syscall.SIGKILL)
+		select {
+		case <-liveDone:
+		case <-time.After(time.Second):
+		}
+	})
+	xLive := &execution{process: live}
+	if err := xLive.finishProcessGroup(live); err != nil {
+		t.Fatalf("finishProcessGroup(live) error = %v", err)
+	}
+	select {
+	case <-liveDone:
+	case <-time.After(time.Second):
+		t.Fatal("live process group was not cleaned up")
+	}
+	xLive.mu.Lock()
+	liveResolved := xLive.processGroupResolved
+	liveKillSent := xLive.processGroupKillSent
+	xLive.mu.Unlock()
+	if !liveResolved {
+		t.Fatal("finishProcessGroup(live) did not mark group resolved")
+	}
+	if !liveKillSent {
+		t.Fatal("finishProcessGroup(live) did not send SIGKILL to live descendants")
+	}
+}
+
 func TestExecutionForceKillEscalatesProcessGroupAndIsSafeAfterExit(t *testing.T) {
 	workDir := t.TempDir()
 	pidPath := filepath.Join(workDir, "agent.pid")

--- a/internal/agent/executor_lifecycle_contract_test.go
+++ b/internal/agent/executor_lifecycle_contract_test.go
@@ -154,9 +154,12 @@ func TestCheckpointFallbackDoesNotSpawnAfterCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	result, _, ok := x.runCheckpointFallback(ctx, "resume failed")
+	result, _, cleanupErr, ok := x.runCheckpointFallback(ctx, "resume failed")
 	if !ok || result.Status != "killed" {
 		t.Fatalf("fallback result = %#v, ok=%v, want killed without spawn", result, ok)
+	}
+	if cleanupErr != nil {
+		t.Fatalf("cleanupErr = %v, want nil for unstarted fallback stop", cleanupErr)
 	}
 	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
 		t.Fatalf("fallback marker stat error = %v, want no fallback process", err)

--- a/internal/agent/executor_lifecycle_contract_test.go
+++ b/internal/agent/executor_lifecycle_contract_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -54,6 +55,75 @@ func TestExecutionWaitCancellationKeepsOwnershipUntilProcessGroupIsReaped(t *tes
 	}
 	if live {
 		t.Fatalf("process group %d still has runnable members after Wait", pid)
+	}
+}
+
+func TestSignalProcessGroupMarksResolvedOnESRCH(t *testing.T) {
+	// Stop can race after Wait reaps a naturally exited agent but before run
+	// consumes waitCh. ESRCH proves the original group is gone; leave the
+	// resolved/signals-done bits set so later finishProcessGroup/ForceKill do
+	// not SIGKILL a reused numeric PGID.
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	originalPID := cmd.Process.Pid
+	if _, err := cmd.Process.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if err := syscall.Kill(-originalPID, 0); errors.Is(err, syscall.ESRCH) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process group %d remained signalable after Wait", originalPID)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	x := &execution{process: cmd}
+	if err := x.signalProcessGroup(syscall.SIGTERM); !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("signalProcessGroup() error = %v, want os.ErrProcessDone", err)
+	}
+	x.mu.Lock()
+	resolved := x.processGroupResolved
+	signalsDone := x.processGroupSignalsDone
+	killSent := x.processGroupKillSent
+	x.mu.Unlock()
+	if !resolved || !signalsDone {
+		t.Fatalf("processGroupResolved=%v processGroupSignalsDone=%v, want both true after ESRCH", resolved, signalsDone)
+	}
+	if killSent {
+		t.Fatal("signalProcessGroup() set processGroupKillSent after ESRCH")
+	}
+
+	// A reused numeric PGID must not be signaled by later cleanup/ForceKill.
+	sentinel := exec.Command("/bin/sh", "-c", "while true; do sleep 1; done")
+	sentinel.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := sentinel.Start(); err != nil {
+		t.Fatalf("start reused-group sentinel: %v", err)
+	}
+	sentinelDone := make(chan error, 1)
+	go func() { sentinelDone <- sentinel.Wait() }()
+	t.Cleanup(func() {
+		_ = syscall.Kill(-sentinel.Process.Pid, syscall.SIGKILL)
+		select {
+		case <-sentinelDone:
+		case <-time.After(time.Second):
+		}
+	})
+	x.mu.Lock()
+	x.process = sentinel
+	x.mu.Unlock()
+	if err := x.ForceKill(); err != nil {
+		t.Fatalf("ForceKill() after ESRCH resolve error = %v", err)
+	}
+	select {
+	case err := <-sentinelDone:
+		t.Fatalf("ForceKill() signaled a reused process group: %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/internal/agent/executor_lifecycle_contract_test.go
+++ b/internal/agent/executor_lifecycle_contract_test.go
@@ -1,0 +1,294 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestExecutionWaitCancellationKeepsOwnershipUntilProcessGroupIsReaped(t *testing.T) {
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	executor := New(ExecutorOptions{Config: ExecutorConfig{
+		Vendor: config.AgentVendor("custom"),
+		Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `trap '' TERM; echo $$ > "$PID_FILE"; while true; do sleep 1; done`},
+		},
+	}})
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      "agent_wait_cancellation",
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          5 * time.Second,
+		GracefulShutdown: 30 * time.Millisecond,
+		Env:              map[string]string{"PID_FILE": pidPath},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	pid := waitForPIDFile(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(-pid, syscall.SIGKILL) })
+
+	waitCtx, cancelWait := context.WithCancel(context.Background())
+	cancelWait()
+	result, err := execHandle.Wait(waitCtx)
+	if err != nil {
+		t.Fatalf("Wait() error = %v, want terminal result after reaping", err)
+	}
+	if result.Status != "killed" {
+		t.Fatalf("result.Status = %q, want killed", result.Status)
+	}
+	if err := syscall.Kill(-pid, 0); err != syscall.ESRCH {
+		t.Fatalf("process group %d remains after Wait: %v", pid, err)
+	}
+}
+
+func TestExecutionForceKillEscalatesProcessGroupAndIsSafeAfterExit(t *testing.T) {
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	executor := New(ExecutorOptions{Config: ExecutorConfig{
+		Vendor: config.AgentVendor("custom"),
+		Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `trap '' TERM; echo $$ > "$PID_FILE"; while true; do sleep 1; done`},
+		},
+	}})
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      "agent_force_kill",
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          5 * time.Second,
+		GracefulShutdown: time.Second,
+		Env:              map[string]string{"PID_FILE": pidPath},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	pid := waitForPIDFile(t, pidPath)
+	forceKiller, ok := execHandle.(interface{ ForceKill() error })
+	if !ok {
+		t.Fatal("execution does not expose optional ForceKill")
+	}
+	if err := execHandle.Kill("shutdown deadline"); err != nil {
+		t.Fatalf("Kill() error = %v", err)
+	}
+	if err := forceKiller.ForceKill(); err != nil {
+		t.Fatalf("ForceKill() error = %v", err)
+	}
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "killed" {
+		t.Fatalf("result.Status = %q, want killed", result.Status)
+	}
+	waitForProcessExit(t, pid, time.Second)
+	concrete := execHandle.(*execution)
+	sentinel := exec.Command("/bin/sh", "-c", "while true; do sleep 1; done")
+	sentinel.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := sentinel.Start(); err != nil {
+		t.Fatalf("start reused-group sentinel: %v", err)
+	}
+	sentinelDone := make(chan error, 1)
+	go func() { sentinelDone <- sentinel.Wait() }()
+	sentinelWaitConsumed := false
+	t.Cleanup(func() {
+		_ = syscall.Kill(-sentinel.Process.Pid, syscall.SIGKILL)
+		if !sentinelWaitConsumed {
+			<-sentinelDone
+		}
+	})
+	concrete.mu.Lock()
+	if !concrete.processGroupResolved {
+		concrete.mu.Unlock()
+		t.Fatal("process group remains signalable after Wait")
+	}
+	// Model a stale pid handle resolving to a newly-created process group. The
+	// resolved bit, not the old numeric pid, must remain authoritative.
+	concrete.process = sentinel
+	concrete.mu.Unlock()
+	if err := forceKiller.ForceKill(); err != nil {
+		t.Fatalf("ForceKill() after exit error = %v", err)
+	}
+	select {
+	case err := <-sentinelDone:
+		sentinelWaitConsumed = true
+		t.Fatalf("ForceKill() signaled a reused process group: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestCheckpointFallbackDoesNotSpawnAfterCancellation(t *testing.T) {
+	markerPath := filepath.Join(t.TempDir(), "fallback-started")
+	scriptPath := filepath.Join(t.TempDir(), "fallback-agent")
+	script := "#!/bin/sh\n: > \"$FALLBACK_MARKER_FILE\"\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(scriptPath) error = %v", err)
+	}
+	executor := New(ExecutorOptions{Config: ExecutorConfig{
+		Vendor: config.AgentVendor("custom"),
+		Params: map[string]any{"command": scriptPath},
+	}})
+	x := &execution{
+		executor:           executor,
+		input:              RunInput{WorkingDirectory: t.TempDir(), Prompt: "checkpoint", Env: map[string]string{"FALLBACK_MARKER_FILE": markerPath}},
+		startedAt:          time.Now(),
+		startedAtISO:       time.Now().UTC().Format(time.RFC3339Nano),
+		timeout:            time.Second,
+		lastHeartbeatAtISO: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, _, ok := x.runCheckpointFallback(ctx, "resume failed")
+	if !ok || result.Status != "killed" {
+		t.Fatalf("fallback result = %#v, ok=%v, want killed without spawn", result, ok)
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Fatalf("fallback marker stat error = %v, want no fallback process", err)
+	}
+}
+
+func TestExecutorProgressCallbackCannotBackpressureAgentOutput(t *testing.T) {
+	workDir := t.TempDir()
+	outputDrainedPath := filepath.Join(workDir, "output-drained")
+	callbackStarted := make(chan struct{})
+	callbackCanceled := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	var callbackOnce sync.Once
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `/bin/dd if=/dev/zero bs=65536 count=16 2>/dev/null; : > "$OUTPUT_DRAINED_FILE"; while true; do sleep 1; done`},
+		}},
+		OnProgress: func(ctx context.Context, _ ProgressUpdate) {
+			callbackOnce.Do(func() { close(callbackStarted) })
+			select {
+			case <-ctx.Done():
+				close(callbackCanceled)
+			case <-releaseCallback:
+			}
+		},
+	})
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      "agent_progress_backpressure",
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          5 * time.Second,
+		GracefulShutdown: 20 * time.Millisecond,
+		Env:              map[string]string{"OUTPUT_DRAINED_FILE": outputDrainedPath},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseCallback) }) }
+	t.Cleanup(func() {
+		release()
+		_ = execHandle.Kill("test cleanup")
+		waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		_, _ = execHandle.Wait(waitCtx)
+		cancel()
+	})
+
+	select {
+	case <-callbackStarted:
+	case <-time.After(time.Second):
+		t.Fatal("progress callback was not invoked")
+	}
+	waitForFile(t, outputDrainedPath)
+	if err := execHandle.Kill("output drained"); err != nil {
+		t.Fatalf("Kill() error = %v", err)
+	}
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "killed" {
+		t.Fatalf("result.Status = %q, want killed", result.Status)
+	}
+	select {
+	case <-callbackCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("progress callback context was not canceled during teardown")
+	}
+	if _, err := os.Stat(outputDrainedPath); err != nil {
+		t.Fatalf("agent did not drain output before teardown: %v", err)
+	}
+	// The callback exited through its execution context, so cleanup need not release it.
+}
+
+func TestExecutorPersistenceCannotBackpressureBufferedAgentOutput(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	workDir := t.TempDir()
+	readyPath := filepath.Join(workDir, "ready")
+	releasePath := filepath.Join(workDir, "release")
+	outputDrainedPath := filepath.Join(workDir, "output-drained")
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh",
+			"args": []any{"-c", `: > "$READY_FILE"; while [ ! -f "$RELEASE_FILE" ]; do :; done; ` +
+				`/bin/dd if=/dev/zero bs=65536 count=16 2>/dev/null; : > "$OUTPUT_DRAINED_FILE"; while true; do sleep 1; done`},
+		}},
+		Repos: repos,
+	})
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      "agent_persistence_backpressure",
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          5 * time.Second,
+		GracefulShutdown: 20 * time.Millisecond,
+		Env: map[string]string{
+			"READY_FILE":          readyPath,
+			"RELEASE_FILE":        releasePath,
+			"OUTPUT_DRAINED_FILE": outputDrainedPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = execHandle.Kill("test cleanup")
+		_, _ = execHandle.Wait(context.Background())
+	})
+	waitForFile(t, readyPath)
+
+	tx, err := coordinator.DB().BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+	if _, err := tx.ExecContext(context.Background(), `UPDATE agent_executions SET status = status WHERE id = ?`, "agent_persistence_backpressure"); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("hold SQLite write lock: %v", err)
+	}
+	if err := os.WriteFile(releasePath, nil, 0o644); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("WriteFile(release) error = %v", err)
+	}
+	waitForFile(t, outputDrainedPath)
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+
+	if err := execHandle.Kill("output drained while persistence was blocked"); err != nil {
+		t.Fatalf("Kill() error = %v", err)
+	}
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "killed" {
+		t.Fatalf("result.Status = %q, want killed", result.Status)
+	}
+}

--- a/internal/agent/executor_output_lifecycle_test.go
+++ b/internal/agent/executor_output_lifecycle_test.go
@@ -1,0 +1,170 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestSpawnedProcessIsOwnedWhileInvokedEventSinkIsBlocked(t *testing.T) {
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	eventStarted := make(chan struct{})
+	releaseEvent := make(chan struct{})
+	var eventOnce sync.Once
+	executor := New(ExecutorOptions{Config: ExecutorConfig{
+		Vendor: config.AgentVendor("custom"),
+		Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `trap '' TERM; echo $$ > "$PID_FILE"; while true; do sleep 1; done`},
+		},
+	}})
+	executor.appendLifecycleRecord = func(context.Context, storage.EventLogRecord) error {
+		eventOnce.Do(func() { close(eventStarted) })
+		<-releaseEvent
+		return nil
+	}
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	type startOutcome struct {
+		execution Execution
+		err       error
+	}
+	started := make(chan startOutcome, 1)
+	go func() {
+		execHandle, err := executor.Start(runCtx, RunInput{
+			ExecutionID:      "agent_blocked_invoked_event",
+			WorkingDirectory: workDir,
+			Prompt:           "ignored",
+			Timeout:          10 * time.Second,
+			GracefulShutdown: 20 * time.Millisecond,
+			Env:              map[string]string{"PID_FILE": pidPath},
+		})
+		started <- startOutcome{execution: execHandle, err: err}
+	}()
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseEvent) }) }
+	t.Cleanup(release)
+
+	select {
+	case <-eventStarted:
+	case <-time.After(time.Second):
+		t.Fatal("invoked-event sink did not start")
+	}
+	pid := waitForPIDFile(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(-pid, syscall.SIGKILL) })
+	cancelRun()
+	waitForProcessExit(t, pid, time.Second)
+
+	select {
+	case outcome := <-started:
+		if outcome.err != nil {
+			t.Fatalf("Start() error = %v", outcome.err)
+		}
+		result, err := outcome.execution.Wait(context.Background())
+		if err != nil {
+			t.Fatalf("Wait() error = %v", err)
+		}
+		if result.Status != "killed" {
+			t.Fatalf("result.Status = %q, want killed", result.Status)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Start()/Wait() remained blocked behind invoked-event sink")
+	}
+}
+
+func TestBlockedLogSideEffectCannotBackpressureOutputOrTeardown(t *testing.T) {
+	workDir := t.TempDir()
+	outputDrainedPath := filepath.Join(workDir, "output-drained")
+	logStarted := make(chan struct{})
+	releaseLog := make(chan struct{})
+	var logOnce sync.Once
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh",
+			"args": []any{"-c", `trap '' TERM; /bin/dd if=/dev/zero bs=65536 count=384 2>/dev/null; ` +
+				`: > "$OUTPUT_DRAINED_FILE"; while true; do sleep 1; done`},
+		}},
+		LogDir: t.TempDir(),
+	})
+	executor.appendPersistedLog = func(string, []byte) bool {
+		logOnce.Do(func() { close(logStarted) })
+		<-releaseLog
+		return false
+	}
+
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      "agent_blocked_log_side_effect",
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          10 * time.Second,
+		GracefulShutdown: 20 * time.Millisecond,
+		Env:              map[string]string{"OUTPUT_DRAINED_FILE": outputDrainedPath},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseLog) }) }
+	t.Cleanup(func() {
+		release()
+		_ = execHandle.Kill("test cleanup")
+		_, _ = execHandle.Wait(context.Background())
+	})
+
+	select {
+	case <-logStarted:
+	case <-time.After(time.Second):
+		t.Fatal("persisted-log side effect did not start")
+	}
+	waitForOutputLifecycleFile(t, outputDrainedPath, 5*time.Second)
+
+	type outcome struct {
+		result Result
+		err    error
+	}
+	finished := make(chan outcome, 1)
+	startedAt := time.Now()
+	go func() {
+		killErr := execHandle.Kill("blocked output side effect")
+		if killErr != nil {
+			finished <- outcome{err: killErr}
+			return
+		}
+		result, waitErr := execHandle.Wait(context.Background())
+		finished <- outcome{result: result, err: waitErr}
+	}()
+	select {
+	case got := <-finished:
+		if got.err != nil {
+			t.Fatalf("Kill()/Wait() error = %v", got.err)
+		}
+		if got.result.Status != "killed" {
+			t.Fatalf("result.Status = %q, want killed", got.result.Status)
+		}
+		if elapsed := time.Since(startedAt); elapsed > 2*time.Second {
+			t.Fatalf("teardown elapsed = %s, want bounded independently of log I/O", elapsed)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Kill()/Wait() blocked behind persisted-log side effect")
+	}
+}
+
+func waitForOutputLifecycleFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for output-drained marker %s", path)
+}

--- a/internal/agent/executor_spawn_ownership_test.go
+++ b/internal/agent/executor_spawn_ownership_test.go
@@ -1,0 +1,144 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestInitialCancellationDuringOwnershipPersistenceReapsProcess(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	tx, err := coordinator.DB().BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+	if _, err := tx.ExecContext(context.Background(), `UPDATE agent_executions SET status = status`); err != nil {
+		t.Fatalf("hold SQLite write lock: %v", err)
+	}
+
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `trap '' TERM; echo $$ > "$PID_FILE"; while true; do sleep 1; done`},
+		}},
+		Repos: repos,
+	})
+	type startOutcome struct {
+		execution Execution
+		err       error
+	}
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	startCh := make(chan startOutcome, 1)
+	go func() {
+		execHandle, startErr := executor.Start(runCtx, RunInput{
+			ExecutionID:      "agent_initial_persist_cancel",
+			WorkingDirectory: workDir,
+			Prompt:           "ignored",
+			Timeout:          10 * time.Second,
+			Env:              map[string]string{"PID_FILE": pidPath},
+		})
+		startCh <- startOutcome{execution: execHandle, err: startErr}
+	}()
+
+	pid := waitForPIDFile(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(-pid, syscall.SIGKILL) })
+	cancelRun()
+	waitForProcessExit(t, pid, time.Second)
+	select {
+	case outcome := <-startCh:
+		if outcome.execution != nil {
+			t.Fatalf("Start() execution = %#v, want nil after cancellation", outcome.execution)
+		}
+		if !errors.Is(outcome.err, context.Canceled) {
+			t.Fatalf("Start() error = %v, want context.Canceled", outcome.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() remained blocked on ownership persistence after cancellation")
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+}
+
+func TestFallbackCancellationDuringOwnershipPersistenceReapsProcess(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	workDir := t.TempDir()
+	resumeReadyPath := filepath.Join(workDir, "resume.ready")
+	resumeReleasePath := filepath.Join(workDir, "resume.release")
+	fallbackPIDPath := filepath.Join(workDir, "fallback.pid")
+	scriptPath := filepath.Join(t.TempDir(), "mock-codex")
+	script := "#!/bin/sh\ncase \"$*\" in *resume*) : > \"$RESUME_READY_FILE\"; while [ ! -f \"$RESUME_RELEASE_FILE\" ]; do :; done; printf '%s\\n' 'resume failed' >&2; exit 2;; esac\ntrap '' TERM\necho $$ > \"$FALLBACK_PID_FILE\"\nwhile true; do sleep 1; done\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(scriptPath) error = %v", err)
+	}
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{
+			Vendor:              config.AgentVendorCodex,
+			Params:              map[string]any{"command": scriptPath},
+			NativeResumeEnabled: true,
+		},
+		Repos: repos,
+	})
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	execHandle, err := executor.Start(runCtx, RunInput{
+		ExecutionID:      "agent_fallback_persist_cancel",
+		WorkingDirectory: workDir,
+		Prompt:           "checkpoint prompt",
+		NativeSessionID:  "session-1",
+		Timeout:          10 * time.Second,
+		GracefulShutdown: 20 * time.Millisecond,
+		Env: map[string]string{
+			"RESUME_READY_FILE":   resumeReadyPath,
+			"RESUME_RELEASE_FILE": resumeReleasePath,
+			"FALLBACK_PID_FILE":   fallbackPIDPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		cancelRun()
+		_ = execHandle.Kill("test cleanup")
+		_, _ = execHandle.Wait(context.Background())
+	})
+	waitForFile(t, resumeReadyPath)
+
+	tx, err := coordinator.DB().BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+	if _, err := tx.ExecContext(context.Background(), `UPDATE agent_executions SET status = status WHERE id = ?`, "agent_fallback_persist_cancel"); err != nil {
+		t.Fatalf("hold SQLite write lock: %v", err)
+	}
+	if err := os.WriteFile(resumeReleasePath, nil, 0o644); err != nil {
+		t.Fatalf("WriteFile(resume release) error = %v", err)
+	}
+	fallbackPID := waitForPIDFile(t, fallbackPIDPath)
+	t.Cleanup(func() { _ = syscall.Kill(-fallbackPID, syscall.SIGKILL) })
+
+	cancelRun()
+	waitForProcessExit(t, fallbackPID, time.Second)
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "killed" {
+		t.Fatalf("result.Status = %q, want killed", result.Status)
+	}
+}

--- a/internal/agent/executor_spawn_ownership_test.go
+++ b/internal/agent/executor_spawn_ownership_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -239,5 +240,95 @@ func TestPersistFinalWaitsForTerminalStatusBeyondOutputTimeout(t *testing.T) {
 		if item.ID == executionID {
 			t.Fatalf("ListActive still includes %s after terminal persistence", executionID)
 		}
+	}
+}
+
+func TestPersistFinalFailurePropagatesFromWait(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `trap '' TERM; echo $$ > "$PID_FILE"; while true; do sleep 1; done`},
+		}},
+		Repos: repos,
+	})
+	const executionID = "agent_terminal_persist_failure"
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      executionID,
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          10 * time.Second,
+		GracefulShutdown: 20 * time.Millisecond,
+		Env:              map[string]string{"PID_FILE": pidPath},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	pid := waitForPIDFile(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(-pid, syscall.SIGKILL) })
+
+	tx, err := coordinator.DB().BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+	if _, err := tx.ExecContext(context.Background(), `UPDATE agent_executions SET status = status WHERE id = ?`, executionID); err != nil {
+		t.Fatalf("hold SQLite write lock: %v", err)
+	}
+
+	type outcome struct {
+		result Result
+		err    error
+	}
+	finished := make(chan outcome, 1)
+	go func() {
+		if killErr := execHandle.Kill("terminal persist timeout"); killErr != nil {
+			finished <- outcome{err: killErr}
+			return
+		}
+		result, waitErr := execHandle.Wait(context.Background())
+		finished <- outcome{result: result, err: waitErr}
+	}()
+
+	// Keep the write lock past ownershipPersistenceTimeout so terminal Upsert fails.
+	// Wait must surface that failure so ActiveExecutionRegistry retains ownership.
+	select {
+	case got := <-finished:
+		if got.err == nil {
+			t.Fatalf("Wait() err = nil after terminal persist deadline; result=%#v", got.result)
+		}
+		if !errors.Is(got.err, context.DeadlineExceeded) && !strings.Contains(got.err.Error(), "persist terminal agent execution status") {
+			t.Fatalf("Wait() error = %v, want terminal persist failure", got.err)
+		}
+		if got.result.Status != "killed" {
+			t.Fatalf("result.Status = %q, want killed (process reaped even when durable write fails)", got.result.Status)
+		}
+	case <-time.After(ownershipPersistenceTimeout + 3*time.Second):
+		t.Fatal("Wait() remained blocked after ownershipPersistenceTimeout for failed terminal Upsert")
+	}
+
+	record, err := repos.AgentExecutions.GetByID(context.Background(), executionID)
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
+	}
+	if record == nil || record.Status != "running" {
+		t.Fatalf("durable execution = %#v, want still running while terminal write failed", record)
+	}
+	active, err := repos.AgentExecutions.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("AgentExecutions.ListActive() error = %v", err)
+	}
+	found := false
+	for _, item := range active {
+		if item.ID == executionID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("ListActive missing %s after failed terminal persistence", executionID)
 	}
 }

--- a/internal/agent/executor_spawn_ownership_test.go
+++ b/internal/agent/executor_spawn_ownership_test.go
@@ -142,3 +142,102 @@ func TestFallbackCancellationDuringOwnershipPersistenceReapsProcess(t *testing.T
 		t.Fatalf("result.Status = %q, want killed", result.Status)
 	}
 }
+
+func TestPersistFinalWaitsForTerminalStatusBeyondOutputTimeout(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `trap '' TERM; echo $$ > "$PID_FILE"; while true; do sleep 1; done`},
+		}},
+		Repos: repos,
+	})
+	const executionID = "agent_terminal_persist_authoritative"
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      executionID,
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          10 * time.Second,
+		GracefulShutdown: 20 * time.Millisecond,
+		Env:              map[string]string{"PID_FILE": pidPath},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	pid := waitForPIDFile(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(-pid, syscall.SIGKILL) })
+
+	running, err := repos.AgentExecutions.GetByID(context.Background(), executionID)
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID(running) error = %v", err)
+	}
+	if running == nil || running.Status != "running" {
+		t.Fatalf("pre-terminal execution = %#v, want status running", running)
+	}
+
+	tx, err := coordinator.DB().BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+	if _, err := tx.ExecContext(context.Background(), `UPDATE agent_executions SET status = status WHERE id = ?`, executionID); err != nil {
+		t.Fatalf("hold SQLite write lock: %v", err)
+	}
+
+	type outcome struct {
+		result Result
+		err    error
+	}
+	finished := make(chan outcome, 1)
+	go func() {
+		if killErr := execHandle.Kill("terminal persist lock"); killErr != nil {
+			finished <- outcome{err: killErr}
+			return
+		}
+		result, waitErr := execHandle.Wait(context.Background())
+		finished <- outcome{result: result, err: waitErr}
+	}()
+
+	// Best-effort outputPersistenceTimeout is 250ms. Terminal persistence must
+	// still be waiting for the durable write after that budget expires.
+	select {
+	case got := <-finished:
+		t.Fatalf("Wait() returned after %v while terminal Upsert was blocked: %#v err=%v", outputPersistenceTimeout, got.result, got.err)
+	case <-time.After(outputPersistenceTimeout + 150*time.Millisecond):
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	select {
+	case got := <-finished:
+		if got.err != nil {
+			t.Fatalf("Kill()/Wait() error = %v", got.err)
+		}
+		if got.result.Status != "killed" {
+			t.Fatalf("result.Status = %q, want killed", got.result.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait() remained blocked after terminal write lock was released")
+	}
+
+	record, err := repos.AgentExecutions.GetByID(context.Background(), executionID)
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID(terminal) error = %v", err)
+	}
+	if record == nil || record.Status != "killed" || record.EndedAt == nil {
+		t.Fatalf("terminal execution = %#v, want durable killed status with ended_at", record)
+	}
+	active, err := repos.AgentExecutions.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("AgentExecutions.ListActive() error = %v", err)
+	}
+	for _, item := range active {
+		if item.ID == executionID {
+			t.Fatalf("ListActive still includes %s after terminal persistence", executionID)
+		}
+	}
+}

--- a/internal/agent/executor_spawn_ownership_test.go
+++ b/internal/agent/executor_spawn_ownership_test.go
@@ -2,10 +2,13 @@ package agent
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -13,6 +16,99 @@ import (
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/storage"
 )
+
+// cancelAfterRunningOwnershipUpsert cancels Start's context immediately after the
+// durable running AgentExecutions row commits, reproducing a stop/shutdown race
+// before run/persistFinal can launch.
+type cancelAfterRunningOwnershipUpsert struct {
+	db     *sql.DB
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (q *cancelAfterRunningOwnershipUpsert) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	result, err := q.db.ExecContext(ctx, query, args...)
+	if err == nil && strings.Contains(query, "INSERT INTO agent_executions") && len(args) > 5 {
+		if status, ok := args[5].(string); ok && status == "running" {
+			q.once.Do(func() {
+				if q.cancel != nil {
+					q.cancel()
+				}
+			})
+		}
+	}
+	return result, err
+}
+
+func (q *cancelAfterRunningOwnershipUpsert) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return q.db.QueryContext(ctx, query, args...)
+}
+
+func (q *cancelAfterRunningOwnershipUpsert) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return q.db.QueryRowContext(ctx, query, args...)
+}
+
+func TestStopAfterRunningOwnershipUpsertPersistsTerminalStatus(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	t.Cleanup(cancelRun)
+	querier := &cancelAfterRunningOwnershipUpsert{db: coordinator.DB(), cancel: cancelRun}
+	repos := storage.NewRepositories(querier)
+
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	const executionID = "agent_stop_after_running_upsert"
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `trap '' TERM; echo $$ > "$PID_FILE"; while true; do sleep 1; done`},
+		}},
+		Repos: repos,
+	})
+
+	execHandle, err := executor.Start(runCtx, RunInput{
+		ExecutionID:      executionID,
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          10 * time.Second,
+		Env:              map[string]string{"PID_FILE": pidPath},
+	})
+	if execHandle != nil {
+		t.Cleanup(func() {
+			_ = execHandle.Kill("test cleanup")
+			_, _ = execHandle.Wait(context.Background())
+		})
+		t.Fatalf("Start() execution = %#v, want nil after post-upsert stop", execHandle)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Start() error = %v, want context.Canceled", err)
+	}
+
+	// Process may already be reaped; best-effort kill if the pid file raced ahead.
+	if data, readErr := os.ReadFile(pidPath); readErr == nil {
+		if pid, convErr := strconv.Atoi(strings.TrimSpace(string(data))); convErr == nil && pid > 0 {
+			_ = syscall.Kill(-pid, syscall.SIGKILL)
+			waitForProcessExit(t, pid, time.Second)
+		}
+	}
+
+	record, getErr := repos.AgentExecutions.GetByID(context.Background(), executionID)
+	if getErr != nil {
+		t.Fatalf("AgentExecutions.GetByID() error = %v", getErr)
+	}
+	if record == nil || record.Status != "killed" || record.EndedAt == nil {
+		t.Fatalf("execution after post-upsert stop = %#v, want durable killed status with ended_at", record)
+	}
+	active, listErr := repos.AgentExecutions.ListActive(context.Background())
+	if listErr != nil {
+		t.Fatalf("AgentExecutions.ListActive() error = %v", listErr)
+	}
+	for _, item := range active {
+		if item.ID == executionID {
+			t.Fatalf("ListActive still includes %s after terminal post-upsert stop", executionID)
+		}
+	}
+}
 
 func TestInitialCancellationDuringOwnershipPersistenceReapsProcess(t *testing.T) {
 	coordinator := openAgentCoordinator(t)

--- a/internal/agent/executor_spawn_ownership_test.go
+++ b/internal/agent/executor_spawn_ownership_test.go
@@ -243,6 +243,120 @@ func TestPersistFinalWaitsForTerminalStatusBeyondOutputTimeout(t *testing.T) {
 	}
 }
 
+func TestStopOutputPersistenceDrainsLiveUpsertBeforeTerminal(t *testing.T) {
+	// Live output persistence must fully drain before persistFinal. If stop only
+	// waited outputPersistenceTimeout, an in-flight "running" Upsert that outlives
+	// cancellation could complete after the terminal row and reanimate ListActive.
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh",
+			"args": []any{"-c", `trap '' TERM; echo $$ > "$PID_FILE"; ` +
+				`while true; do echo live-output-chunk; sleep 0.05; done`},
+		}},
+		Repos: repos,
+	})
+	const executionID = "agent_drain_live_output_before_terminal"
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      executionID,
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          10 * time.Second,
+		GracefulShutdown: 20 * time.Millisecond,
+		Env:              map[string]string{"PID_FILE": pidPath},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	pid := waitForPIDFile(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(-pid, syscall.SIGKILL) })
+
+	// Let the live worker issue at least one running Upsert so the next write is real.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		record, getErr := repos.AgentExecutions.GetByID(context.Background(), executionID)
+		if getErr != nil {
+			t.Fatalf("AgentExecutions.GetByID(pre-lock) error = %v", getErr)
+		}
+		if record != nil && record.Status == "running" && record.HeartbeatCount > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for live output heartbeat on %s: %#v", executionID, record)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	tx, err := coordinator.DB().BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+	if _, err := tx.ExecContext(context.Background(), `UPDATE agent_executions SET status = status WHERE id = ?`, executionID); err != nil {
+		t.Fatalf("hold SQLite write lock: %v", err)
+	}
+	// Keep producing output under the write lock so the live persistence worker is
+	// blocked inside Upsert when teardown begins.
+	time.Sleep(100 * time.Millisecond)
+
+	type outcome struct {
+		result Result
+		err    error
+	}
+	finished := make(chan outcome, 1)
+	go func() {
+		if killErr := execHandle.Kill("drain live output before terminal"); killErr != nil {
+			finished <- outcome{err: killErr}
+			return
+		}
+		result, waitErr := execHandle.Wait(context.Background())
+		finished <- outcome{result: result, err: waitErr}
+	}()
+
+	// Previously stopOutputPersistence returned after 250ms even while the live
+	// Upsert was still in flight. Drain must keep Wait blocked past that budget.
+	select {
+	case got := <-finished:
+		t.Fatalf("Wait() returned after %v while live/terminal Upsert was blocked: %#v err=%v", outputPersistenceTimeout, got.result, got.err)
+	case <-time.After(outputPersistenceTimeout + 200*time.Millisecond):
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	select {
+	case got := <-finished:
+		if got.err != nil {
+			t.Fatalf("Kill()/Wait() error = %v", got.err)
+		}
+		if got.result.Status != "killed" {
+			t.Fatalf("result.Status = %q, want killed", got.result.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait() remained blocked after write lock was released")
+	}
+
+	record, err := repos.AgentExecutions.GetByID(context.Background(), executionID)
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID(terminal) error = %v", err)
+	}
+	if record == nil || record.Status != "killed" || record.EndedAt == nil {
+		t.Fatalf("terminal execution = %#v, want durable killed status with ended_at", record)
+	}
+	active, err := repos.AgentExecutions.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("AgentExecutions.ListActive() error = %v", err)
+	}
+	for _, item := range active {
+		if item.ID == executionID {
+			t.Fatalf("ListActive still includes %s after drained terminal persistence", executionID)
+		}
+	}
+}
+
 func TestPersistFinalFailurePropagatesFromWait(t *testing.T) {
 	coordinator := openAgentCoordinator(t)
 	repos := storage.NewRepositories(coordinator.DB())

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -280,6 +281,31 @@ func TestExecutorStartSanitizesChildEnvAndUsesWorkingDirectory(t *testing.T) {
 	}
 }
 
+func TestExecutorStartDoesNotSpawnWhenContextIsAlreadyCanceled(t *testing.T) {
+	markerPath := filepath.Join(t.TempDir(), "started")
+	executor := New(ExecutorOptions{Config: ExecutorConfig{
+		Vendor: config.AgentVendor("custom"),
+		Params: map[string]any{"command": "/bin/sh", "args": []any{"-c", `printf started > "$MARKER_PATH"`}},
+	}})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := executor.Start(ctx, RunInput{
+		ExecutionID:      "agent_pre_canceled",
+		WorkingDirectory: t.TempDir(),
+		Prompt:           "ignored",
+		Timeout:          time.Second,
+		Env:              map[string]string{"MARKER_PATH": markerPath},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Start() error = %v, want context.Canceled", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("agent marker stat error = %v, want process not spawned", err)
+	}
+}
+
 func TestRecoverableNativeResumeSourceAllowsCompletedPending(t *testing.T) {
 	t.Parallel()
 
@@ -321,7 +347,7 @@ func TestExtractNativeSessionID(t *testing.T) {
 	}
 }
 
-func TestOnOutputRecomputesNativeSessionIDFromBufferedOutput(t *testing.T) {
+func TestCaptureOutputRecomputesNativeSessionIDFromBufferedOutput(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.April, 20, 12, 0, 0, 0, time.UTC)
@@ -329,11 +355,11 @@ func TestOnOutputRecomputesNativeSessionIDFromBufferedOutput(t *testing.T) {
 		executor:       New(ExecutorOptions{Now: func() time.Time { return now }}),
 		maxOutputBytes: 1024,
 	}
-	x.onOutput("stdout", []byte("session_id: abc"))
+	x.captureOutput("stdout", []byte("session_id: abc"))
 	if got := x.nativeSessionID; got != "abc" {
 		t.Fatalf("nativeSessionID after first chunk = %q, want abc", got)
 	}
-	x.onOutput("stdout", []byte("def\n"))
+	x.captureOutput("stdout", []byte("def\n"))
 	if got := x.nativeSessionID; got != "abcdef" {
 		t.Fatalf("nativeSessionID after second chunk = %q, want abcdef", got)
 	}
@@ -629,6 +655,103 @@ func TestExecutorFallbackTimeoutPropagatesTimeoutTypeToLifecycle(t *testing.T) {
 	}
 }
 
+func TestExecutorCancellationEscalatesTermResistantFallbackOnce(t *testing.T) {
+	workDir := t.TempDir()
+	fallbackPIDPath := filepath.Join(workDir, "fallback.pid")
+	scriptPath := filepath.Join(t.TempDir(), "mock-codex")
+	script := "#!/bin/sh\ncase \"$*\" in *resume*) printf '%s\\n' 'resume failed' >&2; exit 2;; esac\ntrap '' TERM\necho $$ > \"$FALLBACK_PID_FILE\"\nwhile true; do sleep 1; done\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(scriptPath) error = %v", err)
+	}
+	executor := New(ExecutorOptions{Config: ExecutorConfig{
+		Vendor:              config.AgentVendorCodex,
+		Params:              map[string]any{"command": scriptPath},
+		NativeResumeEnabled: true,
+	}})
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	execHandle, err := executor.Start(runCtx, RunInput{
+		ExecutionID:      "agent_fallback_cancel",
+		WorkingDirectory: workDir,
+		Prompt:           "checkpoint prompt",
+		NativeSessionID:  "session-1",
+		Timeout:          5 * time.Second,
+		GracefulShutdown: 30 * time.Millisecond,
+		Env:              map[string]string{"FALLBACK_PID_FILE": fallbackPIDPath},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	fallbackPID := waitForPIDFile(t, fallbackPIDPath)
+	t.Cleanup(func() { _ = syscall.Kill(-fallbackPID, syscall.SIGKILL) })
+
+	canceledAt := time.Now()
+	cancelRun()
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), time.Second)
+	defer cancelWait()
+	result, err := execHandle.Wait(waitCtx)
+	if err != nil {
+		t.Fatalf("Wait() error = %v, want fallback reaped after cancellation", err)
+	}
+	if result.Status != "killed" {
+		t.Fatalf("result.Status = %q, want killed", result.Status)
+	}
+	if elapsed := time.Since(canceledAt); elapsed > 500*time.Millisecond {
+		t.Fatalf("fallback cancellation elapsed = %s, want one grace period then escalation", elapsed)
+	}
+	waitForProcessExit(t, fallbackPID, time.Second)
+}
+
+func TestExecutorNativeResumeFallbackSharesLogicalMaxRuntime(t *testing.T) {
+	workDir := t.TempDir()
+	resumeReadyPath := filepath.Join(workDir, "resume.ready")
+	resumeReleasePath := filepath.Join(workDir, "resume.release")
+	fallbackReadyPath := filepath.Join(workDir, "fallback.ready")
+	scriptPath := filepath.Join(t.TempDir(), "mock-codex")
+	script := "#!/bin/sh\ncase \"$*\" in *resume*) : > \"$RESUME_READY_FILE\"; while [ ! -f \"$RESUME_RELEASE_FILE\" ]; do :; done; printf '%s\\n' 'resume failed' >&2; exit 2;; esac\n: > \"$FALLBACK_READY_FILE\"\nwhile true; do sleep 1; done\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(scriptPath) error = %v", err)
+	}
+	executor := New(ExecutorOptions{Config: ExecutorConfig{
+		Vendor:              config.AgentVendorCodex,
+		Params:              map[string]any{"command": scriptPath},
+		NativeResumeEnabled: true,
+	}})
+
+	startedAt := time.Now()
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      "agent_fallback_logical_deadline",
+		WorkingDirectory: workDir,
+		Prompt:           "checkpoint prompt",
+		NativeSessionID:  "session-1",
+		Timeout:          1500 * time.Millisecond,
+		GracefulShutdown: 20 * time.Millisecond,
+		Env: map[string]string{
+			"RESUME_READY_FILE":   resumeReadyPath,
+			"RESUME_RELEASE_FILE": resumeReleasePath,
+			"FALLBACK_READY_FILE": fallbackReadyPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	waitForFile(t, resumeReadyPath)
+	time.Sleep(300 * time.Millisecond)
+	if err := os.WriteFile(resumeReleasePath, nil, 0o644); err != nil {
+		t.Fatalf("WriteFile(resume release) error = %v", err)
+	}
+	waitForFile(t, fallbackReadyPath)
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "timeout" || result.TimeoutType != "max_runtime" {
+		t.Fatalf("result = %#v, want cumulative max-runtime timeout", result)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 1650*time.Millisecond {
+		t.Fatalf("logical execution elapsed = %s, want one shared 1.5s budget", elapsed)
+	}
+}
+
 func TestExecutorSuccessfulExecutionPersistsExecutionAndEvents(t *testing.T) {
 	t.Parallel()
 
@@ -683,6 +806,102 @@ func TestExecutorSuccessfulExecutionPersistsExecutionAndEvents(t *testing.T) {
 	}
 	if !containsEvent(events, "agent.invoked") || !containsEvent(events, "agent.completed") {
 		t.Fatalf("agent events = %#v, want invoked + completed", events)
+	}
+}
+
+func TestExecutorStartFailsAndReapsWhenInitialPersistenceFails(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `trap '' TERM; echo $$ > "$PID_FILE"; while true; do sleep 1; done`},
+		}},
+		Repos: repos,
+	})
+
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      "agent_unpersisted_start",
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          5 * time.Second,
+		Env:              map[string]string{"PID_FILE": pidPath},
+	})
+	if err == nil {
+		if execHandle != nil {
+			_ = execHandle.Kill("test cleanup")
+			waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+			_, _ = execHandle.Wait(waitCtx)
+			cancel()
+		}
+		t.Fatal("Start() error = nil, want persistence failure")
+	}
+	if execHandle != nil {
+		t.Fatalf("Start() execution = %#v, want nil after failed ownership persistence", execHandle)
+	}
+	if data, readErr := os.ReadFile(pidPath); readErr == nil {
+		pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+		if parseErr != nil {
+			t.Fatalf("parse spawned pid: %v", parseErr)
+		}
+		waitForProcessExit(t, pid, time.Second)
+	}
+}
+
+func TestExecutorPersistsSilentFallbackPIDImmediatelyAfterSpawn(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	workDir := t.TempDir()
+	fallbackPIDPath := filepath.Join(workDir, "fallback.pid")
+	scriptPath := filepath.Join(t.TempDir(), "mock-codex")
+	script := "#!/bin/sh\ncase \"$*\" in *resume*) printf '%s\\n' 'resume failed' >&2; exit 2;; esac\ntrap '' TERM\necho $$ > \"$FALLBACK_PID_FILE\"\nwhile true; do sleep 1; done\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(scriptPath) error = %v", err)
+	}
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{
+			Vendor:              config.AgentVendorCodex,
+			Params:              map[string]any{"command": scriptPath},
+			NativeResumeEnabled: true,
+		},
+		Repos: repos,
+	})
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      "agent_silent_fallback",
+		WorkingDirectory: workDir,
+		Prompt:           "checkpoint prompt",
+		NativeSessionID:  "session-1",
+		Timeout:          5 * time.Second,
+		GracefulShutdown: 20 * time.Millisecond,
+		Env:              map[string]string{"FALLBACK_PID_FILE": fallbackPIDPath},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	fallbackPID := waitForPIDFile(t, fallbackPIDPath)
+	t.Cleanup(func() { _ = syscall.Kill(-fallbackPID, syscall.SIGKILL) })
+
+	record, err := repos.AgentExecutions.GetByID(context.Background(), "agent_silent_fallback")
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
+	}
+	if record == nil || record.PID == nil || *record.PID != int64(fallbackPID) {
+		t.Fatalf("fallback execution record = %#v, want live fallback PID %d", record, fallbackPID)
+	}
+	if err := execHandle.Kill("test cleanup"); err != nil {
+		t.Fatalf("Kill() error = %v", err)
+	}
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "killed" {
+		t.Fatalf("result.Status = %q, want killed", result.Status)
 	}
 }
 
@@ -1086,6 +1305,47 @@ func TestExecutorKillTerminatesChildProcessGroup(t *testing.T) {
 	t.Fatalf("child process %d is still running after execution Kill", childPID)
 }
 
+func TestExecutorCleansDescendantsAfterRootExit(t *testing.T) {
+	workDir := t.TempDir()
+	childPIDPath := filepath.Join(workDir, "child.pid")
+	executor := New(ExecutorOptions{Config: ExecutorConfig{
+		Vendor: config.AgentVendor("custom"),
+		Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `/bin/sh -c 'trap "" TERM HUP; while true; do sleep 1; done' & echo $! > "$CHILD_PID_FILE"; printf '__LOOPER_RESULT__={"summary":"root completed"}\n'`},
+		},
+	}})
+
+	startedAt := time.Now()
+	execHandle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID:      "agent_root_exit_cleanup",
+		WorkingDirectory: workDir,
+		Prompt:           "ignored",
+		Timeout:          250 * time.Millisecond,
+		GracefulShutdown: 20 * time.Millisecond,
+		Env:              map[string]string{"CHILD_PID_FILE": childPIDPath},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	childPID := waitForPIDFile(t, childPIDPath)
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+
+	result, err := execHandle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "completed" || result.Summary != "root completed" {
+		t.Fatalf("result = %#v, want completed root while descendants are cleaned", result)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("Wait() elapsed = %s, want prompt cleanup after root exit", elapsed)
+	}
+	if err := syscall.Kill(-result.PID, 0); err != syscall.ESRCH {
+		t.Fatalf("process group %d remains after Wait: %v", result.PID, err)
+	}
+}
+
 func TestExecutorHeartbeatTimeoutMarksTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -1253,7 +1513,7 @@ func strPtr(value string) *string {
 
 func waitForPIDFile(t *testing.T, path string) int {
 	t.Helper()
-	deadline := time.Now().Add(time.Second)
+	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(path)
 		if err == nil {
@@ -1266,6 +1526,30 @@ func waitForPIDFile(t *testing.T, path string) int {
 	}
 	t.Fatalf("timed out waiting for pid file %s", path)
 	return 0
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for file %s", path)
+}
+
+func waitForProcessExit(t *testing.T, pid int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process %d is still running", pid)
 }
 
 func TestLastNonEmptyLines(t *testing.T) {

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/forge"
+	shellinfra "github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -1297,7 +1298,11 @@ func TestExecutorKillTerminatesChildProcessGroup(t *testing.T) {
 	}
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
-		if err := syscall.Kill(childPID, 0); err == syscall.ESRCH {
+		live, err := shellinfra.ProcessRunnable(childPID)
+		if err != nil {
+			t.Fatalf("probe child process %d: %v", childPID, err)
+		}
+		if !live {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -1341,8 +1346,12 @@ func TestExecutorCleansDescendantsAfterRootExit(t *testing.T) {
 	if elapsed := time.Since(startedAt); elapsed > time.Second {
 		t.Fatalf("Wait() elapsed = %s, want prompt cleanup after root exit", elapsed)
 	}
-	if err := syscall.Kill(-result.PID, 0); err != syscall.ESRCH {
-		t.Fatalf("process group %d remains after Wait: %v", result.PID, err)
+	live, err := shellinfra.ProcessGroupRunnable(result.PID)
+	if err != nil {
+		t.Fatalf("probe process group %d: %v", result.PID, err)
+	}
+	if live {
+		t.Fatalf("process group %d still has runnable members after Wait", result.PID)
 	}
 }
 
@@ -1544,7 +1553,11 @@ func waitForProcessExit(t *testing.T, pid int, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+		live, err := shellinfra.ProcessRunnable(pid)
+		if err != nil {
+			t.Fatalf("probe process %d: %v", pid, err)
+		}
+		if !live {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -887,12 +887,28 @@ func TestExecutorPersistsSilentFallbackPIDImmediatelyAfterSpawn(t *testing.T) {
 	fallbackPID := waitForPIDFile(t, fallbackPIDPath)
 	t.Cleanup(func() { _ = syscall.Kill(-fallbackPID, syscall.SIGKILL) })
 
-	record, err := repos.AgentExecutions.GetByID(context.Background(), "agent_silent_fallback")
-	if err != nil {
-		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
+	// Fallback spawn writes the PID file before ownership persistence completes,
+	// and resume stderr can still be draining through the output worker. Poll for
+	// the authoritative fallback PID instead of racing the first GetByID.
+	record := waitForExecutionPID(t, repos, "agent_silent_fallback", fallbackPID)
+	if record.NativeResumeMode == nil || *record.NativeResumeMode != "checkpoint_restart" || record.NativeResumeStatus == nil || *record.NativeResumeStatus != "fallback_started" {
+		t.Fatalf("native resume metadata = mode:%#v status:%#v, want checkpoint_restart/fallback_started", record.NativeResumeMode, record.NativeResumeStatus)
 	}
-	if record == nil || record.PID == nil || *record.PID != int64(fallbackPID) {
-		t.Fatalf("fallback execution record = %#v, want live fallback PID %d", record, fallbackPID)
+	// Give any in-flight resume output progress a chance to land and prove it
+	// cannot restore the dead resume PID or pre-fallback native-resume metadata.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		stable, err := repos.AgentExecutions.GetByID(context.Background(), "agent_silent_fallback")
+		if err != nil {
+			t.Fatalf("AgentExecutions.GetByID(stable) error = %v", err)
+		}
+		if stable == nil || stable.PID == nil || *stable.PID != int64(fallbackPID) {
+			t.Fatalf("fallback ownership clobbered after progress drain: %#v, want PID %d", stable, fallbackPID)
+		}
+		if stable.NativeResumeMode == nil || *stable.NativeResumeMode != "checkpoint_restart" || stable.NativeResumeStatus == nil || *stable.NativeResumeStatus != "fallback_started" {
+			t.Fatalf("fallback native-resume metadata clobbered after progress drain: mode:%#v status:%#v", stable.NativeResumeMode, stable.NativeResumeStatus)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	if err := execHandle.Kill("test cleanup"); err != nil {
 		t.Fatalf("Kill() error = %v", err)
@@ -1535,6 +1551,25 @@ func waitForPIDFile(t *testing.T, path string) int {
 	}
 	t.Fatalf("timed out waiting for pid file %s", path)
 	return 0
+}
+
+func waitForExecutionPID(t *testing.T, repos *storage.Repositories, executionID string, wantPID int) *storage.AgentExecutionRecord {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last *storage.AgentExecutionRecord
+	for time.Now().Before(deadline) {
+		record, err := repos.AgentExecutions.GetByID(context.Background(), executionID)
+		if err != nil {
+			t.Fatalf("AgentExecutions.GetByID(%s) error = %v", executionID, err)
+		}
+		last = record
+		if record != nil && record.PID != nil && *record.PID == int64(wantPID) {
+			return record
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for execution %s PID %d; last record = %#v", executionID, wantPID, last)
+	return nil
 }
 
 func waitForFile(t *testing.T, path string) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -63,8 +63,11 @@ type activeRunExecutionVerifier interface {
 }
 
 type Context struct {
-	Config             config.Config
-	Runtime            RuntimeState
+	Config  config.Config
+	Runtime RuntimeState
+	// StartupReady closes only after deferred startup recovery succeeds. A nil
+	// channel keeps standalone/test handlers backward compatible and ready.
+	StartupReady       <-chan struct{}
 	WebhookForwarder   webhookforward.Forwarder
 	ProjectsService    projectService
 	Now                func() time.Time
@@ -193,6 +196,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Cache-Control", "no-store")
 		}
 		h.writeError(w, requestID, typed)
+		return
+	}
+	if !isSafeRequestMethod(r.Method) && !h.startupReady() {
+		h.writeError(w, requestID, apiError{
+			code:    pkgapi.ErrorCodeRuntimeControlUnavailable,
+			status:  http.StatusServiceUnavailable,
+			message: "Runtime startup recovery is still in progress",
+		})
 		return
 	}
 
@@ -503,6 +514,27 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		status:  http.StatusNotFound,
 		message: fmt.Sprintf("Unknown route: %s", path),
 	})
+}
+
+func (h *Handler) startupReady() bool {
+	if h.context.StartupReady == nil {
+		return true
+	}
+	select {
+	case <-h.context.StartupReady:
+		return true
+	default:
+		return false
+	}
+}
+
+func isSafeRequestMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
 }
 
 func (h *Handler) buildWebhookForwardResponse(r *http.Request) (webhookforward.ForwardResult, error) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,6 +20,7 @@ type Server struct {
 	listener net.Listener
 	server   *http.Server
 	done     chan struct{}
+	errors   chan error
 }
 
 func NewServer(cfg config.Config, handler http.Handler) *Server {
@@ -40,6 +41,7 @@ func (s *Server) Start() error {
 	}
 
 	done := make(chan struct{})
+	serveErrors := make(chan error, 1)
 	server := &http.Server{
 		Handler:           s.handler,
 		ReadHeaderTimeout: 30 * time.Second,
@@ -48,11 +50,13 @@ func (s *Server) Start() error {
 	s.listener = listener
 	s.server = server
 	s.done = done
+	s.errors = serveErrors
 
 	go func() {
 		defer close(done)
+		defer close(serveErrors)
 		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			// Best-effort background serve error path; Start only reports listen errors.
+			serveErrors <- fmt.Errorf("serve API: %w", err)
 		}
 	}()
 
@@ -66,6 +70,7 @@ func (s *Server) Stop(ctx context.Context) error {
 	s.server = nil
 	s.listener = nil
 	s.done = nil
+	s.errors = nil
 	s.mu.Unlock()
 
 	if server == nil {
@@ -74,9 +79,23 @@ func (s *Server) Stop(ctx context.Context) error {
 
 	err := server.Shutdown(ctx)
 	if done != nil {
-		<-done
+		select {
+		case <-done:
+		case <-ctx.Done():
+			if err == nil {
+				err = ctx.Err()
+			}
+		}
 	}
 	return err
+}
+
+// Errors reports failures that happen after the listener has started. The
+// channel closes on an orderly Stop.
+func (s *Server) Errors() <-chan error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.errors
 }
 
 func (s *Server) Addr() net.Addr {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestServerReportsUnexpectedPostStartServeFailure(t *testing.T) {
+	server := NewServer(config.Config{Server: config.ServerConfig{Host: "127.0.0.1", Port: freeTCPPort(t)}}, http.NotFoundHandler())
+	if err := server.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	server.mu.Lock()
+	listener := server.listener
+	server.mu.Unlock()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("listener.Close() error = %v", err)
+	}
+
+	select {
+	case err := <-server.Errors():
+		if err == nil || !strings.Contains(err.Error(), "serve API") {
+			t.Fatalf("Errors() = %v, want post-start serve failure", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Errors() did not report post-start serve failure")
+	}
+	_ = server.Stop(context.Background())
+}
+
+func TestServerStopBoundsDoneWaitByContext(t *testing.T) {
+	server := &Server{server: &http.Server{}, done: make(chan struct{})}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_ = server.Stop(ctx)
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("Stop() elapsed = %s, want context-bounded done wait", elapsed)
+	}
+}

--- a/internal/api/startup_readiness_test.go
+++ b/internal/api/startup_readiness_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	looperdruntime "github.com/nexu-io/looper/internal/runtime"
+)
+
+func TestHandlerRejectsMutationsUntilStartupRecoveryCompletes(t *testing.T) {
+	startupReady := make(chan struct{})
+	reconciliations := 0
+	handler := NewHandler(Context{
+		StartupReady: startupReady,
+		ReconcileStaleRuns: func(context.Context) (looperdruntime.StaleRunReconcileSummary, error) {
+			reconciliations++
+			return looperdruntime.StaleRunReconcileSummary{}, nil
+		},
+	})
+
+	mutation := func() *httptest.ResponseRecorder {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/runs/reconcile-stale", nil))
+		return recorder
+	}
+
+	beforeReady := mutation()
+	if beforeReady.Code != http.StatusServiceUnavailable {
+		t.Fatalf("mutation before startup ready status = %d, want %d; body=%s", beforeReady.Code, http.StatusServiceUnavailable, beforeReady.Body.String())
+	}
+	if reconciliations != 0 {
+		t.Fatalf("reconciliations before startup ready = %d, want 0", reconciliations)
+	}
+
+	readOnly := httptest.NewRecorder()
+	handler.ServeHTTP(readOnly, httptest.NewRequest(http.MethodGet, "/api/v1/version", nil))
+	if readOnly.Code != http.StatusOK {
+		t.Fatalf("read-only request before startup ready status = %d, want %d; body=%s", readOnly.Code, http.StatusOK, readOnly.Body.String())
+	}
+
+	close(startupReady)
+	afterReady := mutation()
+	if afterReady.Code != http.StatusOK {
+		t.Fatalf("mutation after startup ready status = %d, want %d; body=%s", afterReady.Code, http.StatusOK, afterReady.Body.String())
+	}
+	if reconciliations != 1 {
+		t.Fatalf("reconciliations after startup ready = %d, want 1", reconciliations)
+	}
+}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/nexu-io/looper/internal/config"
@@ -109,7 +110,15 @@ func Bootstrap(ctx context.Context, options Options) (Result, error) {
 		return result, nil
 	}
 
-	runtime, err := options.StartRuntime(ctx, RuntimeDependencies{
+	runtimeCtx := ctx
+	shutdownReasons := (<-chan string)(nil)
+	cleanupSignals := func() {}
+	if options.WaitForShutdown {
+		runtimeCtx, shutdownReasons, cleanupSignals = captureShutdownSignals(ctx, logger, signalNotifierOrDefault(options.SignalNotifier))
+		defer cleanupSignals()
+	}
+
+	runtime, err := options.StartRuntime(runtimeCtx, RuntimeDependencies{
 		Config:   loadedConfig.Config,
 		Metadata: loadedConfig.Metadata,
 		Logger:   logger,
@@ -126,7 +135,16 @@ func Bootstrap(ctx context.Context, options Options) (Result, error) {
 			return Result{}, fmt.Errorf("runtime does not support shutdown coordination")
 		}
 
-		waitForShutdownWithSignals(shutdownRuntime, logger, signalNotifierOrDefault(options.SignalNotifier))
+		stopperDone := make(chan struct{})
+		go func() {
+			defer close(stopperDone)
+			if reason, ok := <-shutdownReasons; ok {
+				shutdownRuntime.Stop(reason)
+			}
+		}()
+		shutdownRuntime.WaitForShutdown()
+		cleanupSignals()
+		<-stopperDone
 	}
 
 	return result, nil
@@ -183,10 +201,11 @@ func validateConfiguredToolPaths(cfg config.Config, detection map[string]config.
 	return nil
 }
 
-func waitForShutdownWithSignals(runtime ShutdownRuntime, logger Logger, notifier SignalNotifier) {
+func captureShutdownSignals(ctx context.Context, logger Logger, notifier SignalNotifier) (context.Context, <-chan string, func()) {
 	signals := make(chan os.Signal, 1)
 	notifier.Notify(signals, os.Interrupt, syscall.SIGTERM)
-	defer notifier.Stop(signals)
+	runtimeCtx, cancel := context.WithCancel(ctx)
+	reasons := make(chan string, 1)
 
 	listenerStopped := make(chan struct{})
 	listenerDone := make(chan struct{})
@@ -202,14 +221,23 @@ func waitForShutdownWithSignals(runtime ShutdownRuntime, logger Logger, notifier
 
 			reason := signalReason(sig)
 			logger.Info("received shutdown signal", map[string]any{"signal": reason})
-			runtime.Stop(reason)
+			reasons <- reason
+			cancel()
 		case <-listenerStopped:
 		}
 	}()
 
-	runtime.WaitForShutdown()
-	close(listenerStopped)
-	<-listenerDone
+	var cleanupOnce sync.Once
+	cleanup := func() {
+		cleanupOnce.Do(func() {
+			close(listenerStopped)
+			<-listenerDone
+			close(reasons)
+			cancel()
+			notifier.Stop(signals)
+		})
+	}
+	return runtimeCtx, reasons, cleanup
 }
 
 func signalReason(sig os.Signal) string {

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -252,6 +252,9 @@ func TestBootstrapWaitForShutdownRegistersSignalsAndStopsRuntime(t *testing.T) {
 				return logger, nil
 			},
 			StartRuntime: func(context.Context, RuntimeDependencies) (Runtime, error) {
+				if notifier.ch == nil {
+					return nil, errors.New("signal handling was not installed before runtime startup")
+				}
 				return runtime, nil
 			},
 			WaitForShutdown: true,
@@ -305,6 +308,52 @@ func TestBootstrapWaitForShutdownRegistersSignalsAndStopsRuntime(t *testing.T) {
 	}
 	if got := logger.infoEntries[1].context["signal"]; got != "SIGTERM" {
 		t.Fatalf("logger.Info() context[signal] = %#v, want %#v", got, "SIGTERM")
+	}
+}
+
+func TestBootstrapSignalCancelsRuntimeStartup(t *testing.T) {
+	workingDir := t.TempDir()
+	rootDir := t.TempDir()
+	notifier := &stubSignalNotifier{}
+	startupEntered := make(chan struct{})
+	done := make(chan error, 1)
+
+	go func() {
+		_, err := Bootstrap(context.Background(), Options{
+			LoadConfig: func(config.LoadFileOptions) (config.LoadedFileConfig, error) {
+				return config.LoadedFileConfig{Config: config.Config{
+					Storage: config.StorageConfig{DBPath: filepath.Join(rootDir, "data", "looper.sqlite")},
+					Logging: config.LoggingConfig{Level: config.LogLevelInfo, MaxSizeMB: 10, MaxFiles: 5},
+					Daemon:  config.DaemonConfig{LogDir: filepath.Join(rootDir, "logs"), WorkingDirectory: workingDir},
+				}}, nil
+			},
+			CreateLogger: func(config.LoggingConfig, string, LoggerOptions) (Logger, error) {
+				return &recordingLogger{}, nil
+			},
+			StartRuntime: func(ctx context.Context, _ RuntimeDependencies) (Runtime, error) {
+				close(startupEntered)
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+			WaitForShutdown: true,
+			SignalNotifier:  notifier,
+		})
+		done <- err
+	}()
+
+	notifier.waitForRegistration(t)
+	<-startupEntered
+	notifier.emit(syscall.SIGTERM)
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Bootstrap() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Bootstrap() did not cancel runtime startup after SIGTERM")
+	}
+	if notifier.stopCalls != 1 {
+		t.Fatalf("SignalNotifier.Stop() calls = %d, want 1", notifier.stopCalls)
 	}
 }
 

--- a/internal/cliapp/feedback.go
+++ b/internal/cliapp/feedback.go
@@ -4,20 +4,27 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/disclosure"
+	shellinfra "github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/spf13/cobra"
 )
 
 const feedbackRepo = "nexu-io/looper"
 
-const feedbackCommandTimeout = 5 * time.Minute
+const (
+	feedbackCommandTimeout   = 5 * time.Minute
+	feedbackCommandWaitDelay = time.Second
+)
 
 var feedbackIssueURLPattern = regexp.MustCompile(`https://github\.com/` + regexp.QuoteMeta(feedbackRepo) + `/issues/\d+`)
 
@@ -63,13 +70,30 @@ func (r *commandRuntime) feedback(cmd *cobra.Command, args []string) error {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	process := exec.CommandContext(runCtx, command, commandArgs...)
+	shellinfra.ConfigureProcessGroup(process)
+	var cancellationKillSent atomic.Bool
+	process.Cancel = func() error {
+		cancellationKillSent.Store(true)
+		return shellinfra.KillProcessGroup(process)
+	}
+	process.WaitDelay = feedbackCommandWaitDelay
 	process.Dir = cwd
 	process.Stdout = stdout
 	process.Stderr = stderr
 	process.Env = agent.BuildCommandEnv(cwd, prompt, loaded.Config.Agent.Env)
 
-	if err := process.Run(); err != nil {
-		return feedbackRunError(err, stdout.String(), stderr.String())
+	runErr := process.Run()
+	var cleanupErr error
+	if cancellationKillSent.Load() {
+		cleanupErr = shellinfra.WaitProcessGroupExit(process, feedbackCommandWaitDelay)
+	} else {
+		cleanupErr = shellinfra.KillProcessGroupAndWait(process, feedbackCommandWaitDelay)
+	}
+	if errors.Is(runErr, exec.ErrWaitDelay) && process.ProcessState != nil && process.ProcessState.Success() {
+		runErr = nil
+	}
+	if err := feedbackRunAndCleanupError(runErr, cleanupErr, stdout.String(), stderr.String()); err != nil {
+		return err
 	}
 
 	issueURL := extractFeedbackIssueURL(stdout.String(), stderr.String())
@@ -156,4 +180,17 @@ func feedbackRunError(err error, stdout string, stderr string) error {
 		return fmt.Errorf("run feedback agent: %w (%s)", err, summary)
 	}
 	return fmt.Errorf("run feedback agent: %w", err)
+}
+
+func feedbackRunAndCleanupError(runErr, cleanupErr error, stdout, stderr string) error {
+	if cleanupErr == nil || errors.Is(cleanupErr, os.ErrProcessDone) {
+		cleanupErr = nil
+	} else {
+		cleanupErr = fmt.Errorf("clean up feedback agent process group: %w", cleanupErr)
+	}
+	combinedErr := errors.Join(runErr, cleanupErr)
+	if combinedErr == nil {
+		return nil
+	}
+	return feedbackRunError(combinedErr, stdout, stderr)
 }

--- a/internal/cliapp/feedback_test.go
+++ b/internal/cliapp/feedback_test.go
@@ -1,0 +1,144 @@
+package cliapp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestFeedbackCancellationStopsAgentDescendants(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "child.pid")
+	scriptPath := filepath.Join(dir, "fake-agent.sh")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		`/bin/sh -c 'trap "" TERM; echo $$ > "$1"; while :; do sleep 1; done' sh "` + pidPath + `" </dev/null >/dev/null 2>&1 &`,
+		"wait",
+	}, "\n")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake agent script: %v", err)
+	}
+	configPath := writeCLIConfigWithAgent(t, "http://127.0.0.1:1", string(config.AgentVendorOpenCode), map[string]any{"command": scriptPath})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan int, 1)
+	go func() {
+		exitCode, _, _ := runAppWithContext(t, ctx, "feedback", "test cancellation", "--config", configPath)
+		resultCh <- exitCode
+	}()
+
+	childPID := waitForCLIProcessPID(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+	cancel()
+
+	select {
+	case exitCode := <-resultCh:
+		if exitCode == 0 {
+			t.Fatal("feedback exit code = 0 after cancellation, want non-zero")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("feedback did not return after cancellation")
+	}
+	waitForCLIProcessExit(t, childPID)
+}
+
+func TestFeedbackBoundsInheritedOutputPipeCleanup(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "child.pid")
+	scriptPath := filepath.Join(dir, "fake-agent.sh")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		`/bin/sh -c 'echo $$ > "$1"; sleep 10' sh "` + pidPath + `" &`,
+		"printf 'https://github.com/nexu-io/looper/issues/321\\n'",
+	}, "\n")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake agent script: %v", err)
+	}
+	configPath := writeCLIConfigWithAgent(t, "http://127.0.0.1:1", string(config.AgentVendorOpenCode), map[string]any{"command": scriptPath})
+
+	type appResult struct {
+		exitCode int
+		stdout   string
+	}
+	resultCh := make(chan appResult, 1)
+	go func() {
+		exitCode, stdout, _ := runApp(t, "feedback", "test pipe cleanup", "--config", configPath)
+		resultCh <- appResult{exitCode: exitCode, stdout: stdout}
+	}()
+
+	childPID := waitForCLIProcessPID(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+	select {
+	case result := <-resultCh:
+		if result.exitCode != 0 {
+			t.Fatalf("feedback exit code = %d, want 0", result.exitCode)
+		}
+		if result.stdout != "https://github.com/nexu-io/looper/issues/321\n" {
+			t.Fatalf("feedback stdout = %q, want issue URL", result.stdout)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("feedback waited indefinitely for an inherited output pipe")
+	}
+	waitForCLIProcessExit(t, childPID)
+}
+
+func TestFeedbackRunAndCleanupErrorPreservesBothFailuresAndSummary(t *testing.T) {
+	runErr := context.Canceled
+	cleanupErr := errors.New("process group remained live")
+	stdout := `__LOOPER_RESULT__={"summary":"issue creation was interrupted"}`
+
+	err := feedbackRunAndCleanupError(runErr, cleanupErr, stdout, "")
+	if !errors.Is(err, runErr) {
+		t.Fatalf("error = %v, want run error", err)
+	}
+	if !errors.Is(err, cleanupErr) {
+		t.Fatalf("error = %v, want cleanup barrier error", err)
+	}
+	if !strings.Contains(err.Error(), "clean up feedback agent process group") {
+		t.Fatalf("error = %q, want cleanup context", err)
+	}
+	if !strings.Contains(err.Error(), "issue creation was interrupted") {
+		t.Fatalf("error = %q, want agent summary", err)
+	}
+}
+
+func waitForCLIProcessPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr != nil {
+				t.Fatalf("parse process PID %q: %v", data, parseErr)
+			}
+			return pid
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("read process PID file: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process PID file %q was not created", path)
+	return 0
+}
+
+func waitForCLIProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process %d is still alive", pid)
+}

--- a/internal/cliapp/takeover_commands.go
+++ b/internal/cliapp/takeover_commands.go
@@ -3,14 +3,20 @@ package cliapp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
 	"os/exec"
+	"sync/atomic"
+	"time"
 
+	shellinfra "github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/spf13/cobra"
 )
+
+const takeoverCommandWaitDelay = time.Second
 
 // takeoverResumeResponse mirrors the daemon's POST /loops/{seq}/takeover reply.
 type takeoverResumeResponse struct {
@@ -56,11 +62,47 @@ func (r *commandRuntime) resumeLoopBySeq(cmd *cobra.Command, args []string) erro
 	}
 	fmt.Fprintf(out, "▶ Taking over loop %s — dropping you into its %s session. Exit the agent when done.\n  (%s)\n\n", seq, resp.Vendor, handbackHint)
 	shell := exec.CommandContext(ctx, "sh", "-c", resp.ResumeCommand)
+	shellinfra.ConfigureProcessGroup(shell)
+	var cancelKillAttempted atomic.Bool
+	shell.Cancel = func() error {
+		cancelKillAttempted.Store(true)
+		return shellinfra.KillProcessGroup(shell)
+	}
+	shell.WaitDelay = takeoverCommandWaitDelay
 	shell.Stdin = os.Stdin
 	shell.Stdout = os.Stdout
 	shell.Stderr = os.Stderr
-	// Interactive: a non-zero exit (the human Ctrl-C'ing out of the agent) is normal.
-	_ = shell.Run()
+	restoreTerminal, err := prepareTakeoverTerminal(shell, os.Stdin, systemTakeoverTerminalControl())
+	if err != nil {
+		return err
+	}
+	if err := shell.Start(); err != nil {
+		return errors.Join(fmt.Errorf("start interactive resume command: %w", err), restoreTerminal())
+	}
+	runErr := shell.Wait()
+	var cleanupErr error
+	if cancelKillAttempted.Load() {
+		cleanupErr = shellinfra.WaitProcessGroupExit(shell, takeoverCommandWaitDelay)
+	} else {
+		cleanupErr = shellinfra.KillProcessGroupAndWait(shell, takeoverCommandWaitDelay)
+	}
+	restoreErr := restoreTerminal()
+	if takeoverExitWasInterrupt(runErr) {
+		runErr = nil
+	}
+	var wrappedCleanupErr error
+	if cleanupErr != nil && !errors.Is(cleanupErr, os.ErrProcessDone) {
+		wrappedCleanupErr = fmt.Errorf("clean up interactive resume command: %w", cleanupErr)
+	}
+	if runErr != nil {
+		return errors.Join(fmt.Errorf("run interactive resume command: %w", runErr), wrappedCleanupErr, restoreErr)
+	}
+	if wrappedCleanupErr != nil {
+		return errors.Join(wrappedCleanupErr, restoreErr)
+	}
+	if restoreErr != nil {
+		return restoreErr
+	}
 	fmt.Fprintf(out, "\n✔ Session detached. To let the daemon continue (seeing your turns):  looper handback %s\n", seq)
 	return nil
 }

--- a/internal/cliapp/takeover_commands_test.go
+++ b/internal/cliapp/takeover_commands_test.go
@@ -1,0 +1,177 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	pkgapi "github.com/nexu-io/looper/pkg/api"
+)
+
+func TestPrepareTakeoverTerminalMakesChildForegroundAndRestoresParent(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdin := os.NewFile(17, "fake-tty")
+	restoredPgrp := 0
+	control := takeoverTerminalControl{
+		foregroundProcessGroup: func(fd int) (int, bool, error) {
+			if fd != 17 {
+				t.Fatalf("foreground fd = %d, want 17", fd)
+			}
+			return 42, true, nil
+		},
+		setForegroundProcessGroup: func(fd, pgrp int) error {
+			if fd != 17 {
+				t.Fatalf("restore fd = %d, want 17", fd)
+			}
+			restoredPgrp = pgrp
+			return nil
+		},
+	}
+
+	restore, err := prepareTakeoverTerminal(cmd, stdin, control)
+	if err != nil {
+		t.Fatalf("prepareTakeoverTerminal() error = %v", err)
+	}
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid || !cmd.SysProcAttr.Foreground || cmd.SysProcAttr.Ctty != 17 {
+		t.Fatalf("SysProcAttr = %#v, want owned foreground process group on fd 17", cmd.SysProcAttr)
+	}
+	if err := restore(); err != nil {
+		t.Fatalf("restore() error = %v", err)
+	}
+	if restoredPgrp != 42 {
+		t.Fatalf("restored process group = %d, want 42", restoredPgrp)
+	}
+}
+
+func TestResumeLoopPropagatesNonzeroAgentExit(t *testing.T) {
+	server := newResumeLoopServer(t, "exit 7")
+	defer server.Close()
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+
+	exitCode := app.Run(context.Background(), []string{"--config", configPath, "resume", "12"})
+	if exitCode == 0 {
+		t.Fatalf("resume exit code = 0, want non-zero; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "exit status 7") {
+		t.Fatalf("resume stderr = %q, want child exit status", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Session detached") {
+		t.Fatalf("resume stdout = %q, want no success message after failed child", stdout.String())
+	}
+}
+
+func TestResumeLoopTreatsAgentSIGINTAsNormalDetach(t *testing.T) {
+	for name, resumeCommand := range map[string]string{
+		"shell signaled directly": "kill -INT $$",
+		"shell waits on child":    "sh -c 'kill -INT $$'",
+	} {
+		t.Run(name, func(t *testing.T) {
+			server := newResumeLoopServer(t, resumeCommand)
+			defer server.Close()
+			configPath := writeCLIConfig(t, server.URL, "")
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+
+			exitCode := app.Run(context.Background(), []string{"--config", configPath, "resume", "12"})
+			if exitCode != 0 {
+				t.Fatalf("resume exit code = %d, want normal SIGINT detach; stderr=%q", exitCode, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "Session detached") {
+				t.Fatalf("resume stdout = %q, want detach instructions", stdout.String())
+			}
+		})
+	}
+}
+
+func TestResumeLoopPropagatesShellLaunchFailure(t *testing.T) {
+	server := newResumeLoopServer(t, "true")
+	defer server.Close()
+	configPath := writeEditableCLIConfigWithPayload(t, map[string]any{
+		"server":        map[string]any{"baseUrl": server.URL, "authMode": "none"},
+		"notifications": map[string]any{"osascript": map[string]any{"enabled": false}},
+	})
+	t.Setenv("PATH", t.TempDir())
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+
+	exitCode := app.Run(context.Background(), []string{"--config", configPath, "resume", "12"})
+	if exitCode == 0 {
+		t.Fatalf("resume exit code = 0, want shell launch failure; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `executable file not found`) {
+		t.Fatalf("resume stderr = %q, want shell launch error", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Session detached") {
+		t.Fatalf("resume stdout = %q, want no success message after launch failure", stdout.String())
+	}
+}
+
+func TestResumeLoopCancellationStopsAgentDescendants(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "child.pid")
+	scriptPath := filepath.Join(dir, "resume-agent.sh")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		`/bin/sh -c 'trap "" TERM; echo $$ > "$1"; while :; do sleep 1; done' sh "` + pidPath + `" </dev/null >/dev/null 2>&1 &`,
+		"wait",
+	}, "\n")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write resume agent script: %v", err)
+	}
+	server := newResumeLoopServer(t, `"`+scriptPath+`"`)
+	defer server.Close()
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan int, 1)
+	go func() {
+		resultCh <- app.Run(ctx, []string{"--config", configPath, "resume", "12"})
+	}()
+	childPID := waitForCLIProcessPID(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+	cancel()
+
+	select {
+	case exitCode := <-resultCh:
+		if exitCode == 0 {
+			t.Fatalf("resume exit code = 0 after cancellation, want non-zero; stdout=%q", stdout.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("resume did not return after cancellation")
+	}
+	waitForCLIProcessExit(t, childPID)
+}
+
+func newResumeLoopServer(t *testing.T, resumeCommand string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/loops/12/takeover" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		writeEnvelope(t, w, pkgapi.Success("req_takeover", map[string]any{
+			"loopId":        "loop_12",
+			"vendor":        "codex",
+			"sessionId":     "session_12",
+			"worktreePath":  t.TempDir(),
+			"supported":     true,
+			"resumeCommand": resumeCommand,
+		}))
+	}))
+}

--- a/internal/cliapp/takeover_terminal.go
+++ b/internal/cliapp/takeover_terminal.go
@@ -1,0 +1,39 @@
+package cliapp
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type takeoverTerminalControl struct {
+	foregroundProcessGroup    func(fd int) (pgrp int, isTerminal bool, err error)
+	setForegroundProcessGroup func(fd int, pgrp int) error
+}
+
+func prepareTakeoverTerminal(cmd *exec.Cmd, stdin *os.File, control takeoverTerminalControl) (func() error, error) {
+	noRestore := func() error { return nil }
+	if cmd == nil || stdin == nil || control.foregroundProcessGroup == nil || control.setForegroundProcessGroup == nil {
+		return noRestore, nil
+	}
+	fd := int(stdin.Fd())
+	parentPgrp, isTerminal, err := control.foregroundProcessGroup(fd)
+	if err != nil {
+		return nil, fmt.Errorf("inspect takeover terminal: %w", err)
+	}
+	if !isTerminal {
+		return noRestore, nil
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = takeoverProcessAttributes()
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.SysProcAttr.Foreground = true
+	cmd.SysProcAttr.Ctty = fd
+	return func() error {
+		if err := control.setForegroundProcessGroup(fd, parentPgrp); err != nil {
+			return fmt.Errorf("restore takeover terminal foreground process group: %w", err)
+		}
+		return nil
+	}, nil
+}

--- a/internal/cliapp/takeover_terminal_other.go
+++ b/internal/cliapp/takeover_terminal_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin && !linux
+
+package cliapp
+
+import "syscall"
+
+func takeoverProcessAttributes() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}
+
+func takeoverExitWasInterrupt(error) bool { return false }
+
+func systemTakeoverTerminalControl() takeoverTerminalControl {
+	return takeoverTerminalControl{
+		foregroundProcessGroup:    func(int) (int, bool, error) { return 0, false, nil },
+		setForegroundProcessGroup: func(int, int) error { return nil },
+	}
+}

--- a/internal/cliapp/takeover_terminal_unix.go
+++ b/internal/cliapp/takeover_terminal_unix.go
@@ -1,0 +1,54 @@
+//go:build darwin || linux
+
+package cliapp
+
+import (
+	"errors"
+	"os/exec"
+	"os/signal"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+var takeoverTerminalSignalMu sync.Mutex
+
+func takeoverProcessAttributes() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}
+
+func takeoverExitWasInterrupt(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	waitStatus, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && ((waitStatus.Signaled() && waitStatus.Signal() == syscall.SIGINT) || exitErr.ExitCode() == 128+int(syscall.SIGINT))
+}
+
+func systemTakeoverTerminalControl() takeoverTerminalControl {
+	return takeoverTerminalControl{
+		foregroundProcessGroup: func(fd int) (int, bool, error) {
+			var pgrp int32
+			_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCGPGRP), uintptr(unsafe.Pointer(&pgrp)))
+			if errno != 0 {
+				return 0, false, nil
+			}
+			return int(pgrp), true, nil
+		},
+		setForegroundProcessGroup: func(fd int, pgrp int) error {
+			takeoverTerminalSignalMu.Lock()
+			defer takeoverTerminalSignalMu.Unlock()
+			// The parent is a background process group while the interactive child
+			// owns the terminal. Ignore SIGTTOU only around the restoring ioctl.
+			signal.Ignore(syscall.SIGTTOU)
+			defer signal.Reset(syscall.SIGTTOU)
+			value := int32(pgrp)
+			_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCSPGRP), uintptr(unsafe.Pointer(&value)))
+			if errno != 0 {
+				return errno
+			}
+			return nil
+		},
+	}
+}

--- a/internal/coordinator/agent_llm.go
+++ b/internal/coordinator/agent_llm.go
@@ -12,13 +12,17 @@ import (
 )
 
 type agentLLM struct {
-	executor    *agent.ConfiguredExecutor
+	executor    AgentExecutor
 	now         func() time.Time
 	timeout     time.Duration
 	idleTimeout time.Duration
 }
 
-func NewAgentLLM(executor *agent.ConfiguredExecutor, now func() time.Time, timeout time.Duration, idleTimeout time.Duration) triage.LLM {
+type AgentExecutor interface {
+	Start(context.Context, agent.RunInput) (agent.Execution, error)
+}
+
+func NewAgentLLM(executor AgentExecutor, now func() time.Time, timeout time.Duration, idleTimeout time.Duration) triage.LLM {
 	if now == nil {
 		now = time.Now
 	}
@@ -46,6 +50,9 @@ func (l agentLLM) Complete(ctx context.Context, req triage.Request) (string, err
 	result, err := execHandle.Wait(ctx)
 	if err != nil {
 		return "", err
+	}
+	if result.Status != "completed" {
+		return "", fmt.Errorf("coordinator triage agent execution %s", result.Status)
 	}
 	if strings.TrimSpace(result.Stdout) == "" {
 		return "", fmt.Errorf("coordinator triage returned empty stdout")

--- a/internal/coordinator/agent_llm_test.go
+++ b/internal/coordinator/agent_llm_test.go
@@ -1,0 +1,34 @@
+package coordinator
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/agent"
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/coordinator/triage"
+)
+
+func TestAgentLLMRejectsOutputFromFailedExecution(t *testing.T) {
+	executor := agent.New(agent.ExecutorOptions{Config: agent.ExecutorConfig{
+		Vendor: config.AgentVendor("custom"),
+		Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `printf '{"summary":"looks valid"}\n'; exit 7`},
+		},
+	}})
+	llm := NewAgentLLM(executor, time.Now, time.Second, time.Second)
+
+	_, err := llm.Complete(context.Background(), triage.Request{
+		Prompt:           "triage this issue",
+		WorkingDirectory: t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want failed execution rejection")
+	}
+	if !strings.Contains(err.Error(), "failed") {
+		t.Fatalf("Complete() error = %q, want failed status", err)
+	}
+}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -48,6 +48,10 @@ const (
 	stepResolveComments       FixerStep = "resolve-comments"
 	stepRecheck               FixerStep = "recheck"
 	NativeReviewCommentSource           = "forgejo_review_comment"
+	// Validation is owned by the scheduled-run context. Keep its TERM grace
+	// below the daemon's forced-shutdown reap window so a resistant validation
+	// subprocess cannot outlive looperd after that context is cancelled.
+	validationGracefulShutdown = 250 * time.Millisecond
 )
 
 var fixerStepSequence = []FixerStep{
@@ -5937,12 +5941,15 @@ func (r *Runner) runValidation(ctx context.Context, input ValidationInput) (Vali
 
 	outputs := make([]string, 0, len(input.Commands)*2)
 	for _, command := range input.Commands {
-		result, err := shell.Run(ctx, shell.Options{Command: "/bin/sh", Args: []string{"-c", command}, CWD: input.CWD})
+		result, err := shell.Run(ctx, shell.Options{Command: "/bin/sh", Args: []string{"-c", command}, CWD: input.CWD, Timeout: r.agentTimeout, GracefulShutdown: validationGracefulShutdown})
 		if err != nil {
 			output := "Unknown validation failure"
 			var commandErr *shell.CommandExecutionError
 			if errors.As(err, &commandErr) {
 				output = strings.TrimSpace(strings.Join([]string{commandErr.Result.Stdout, commandErr.Result.Stderr}, "\n"))
+				if output == "" {
+					output = commandErr.Error()
+				}
 			} else {
 				output = err.Error()
 			}

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -5988,6 +5988,24 @@ func TestRunValidationReturnsCommandFailureOutput(t *testing.T) {
 	}
 }
 
+func TestRunValidationUsesRunnerDeadline(t *testing.T) {
+	runner := New(Options{AgentTimeout: 50 * time.Millisecond})
+	startedAt := time.Now()
+	result, err := runner.runValidation(context.Background(), ValidationInput{
+		CWD:      t.TempDir(),
+		Commands: []string{"trap '' TERM; while :; do sleep 1; done"},
+	})
+	if err != nil {
+		t.Fatalf("runValidation() error = %v", err)
+	}
+	if result.Passed || !strings.Contains(result.Output, "timed out") {
+		t.Fatalf("result = %#v, want timed-out validation failure", result)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 2*time.Second {
+		t.Fatalf("runValidation() elapsed = %s, want bounded cancellation", elapsed)
+	}
+}
+
 type runnerFixture struct {
 	coordinator *storage.SQLiteCoordinator
 	repos       *storage.Repositories

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -2,7 +2,9 @@ package forge
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -11,7 +13,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
+
+	shellinfra "github.com/nexu-io/looper/internal/infra/shell"
 )
 
 // TrustedReviewSockEnv is the agent-facing env key for the trusted review-submit
@@ -23,6 +28,12 @@ const TrustedReviewSockEnv = "LOOPER_TRUSTED_REVIEW_SOCK"
 // trustedReviewProxySkipEnv marks a proxy-spawned looper child so it does not
 // re-enter the proxy (the child receives provider tokens directly).
 const trustedReviewProxySkipEnv = "LOOPER_TRUSTED_REVIEW_PROXY_CHILD"
+
+const (
+	trustedReviewProxyRequestTimeout = 2 * time.Minute
+	trustedReviewProxyWaitDelay      = time.Second
+	trustedReviewProxyCleanupTimeout = 2 * time.Second
+)
 
 type trustedReviewProxyRequest struct {
 	Argv  []string `json:"argv"`
@@ -121,6 +132,7 @@ func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, al
 		return "", nil, fmt.Errorf("chmod trusted review proxy socket: %w", err)
 	}
 
+	proxyCtx, cancelProxy := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
 	wg.Add(1)
@@ -139,23 +151,45 @@ func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, al
 			wg.Add(1)
 			go func(c net.Conn) {
 				defer wg.Done()
-				handleTrustedReviewProxyConn(c, realLooper, trustedEnv, normalizedAllowed, boundCwd, boundConfigPath, boundPolicy)
+				handleTrustedReviewProxyConn(proxyCtx, c, realLooper, trustedEnv, normalizedAllowed, boundCwd, boundConfigPath, boundPolicy)
 			}(conn)
 		}
 	}()
 
+	var cleanupOnce sync.Once
 	cleanup = func() {
-		close(stop)
-		_ = listener.Close()
-		wg.Wait()
-		_ = os.RemoveAll(dir)
+		cleanupOnce.Do(func() {
+			cancelProxy()
+			close(stop)
+			_ = listener.Close()
+			waitDone := make(chan struct{})
+			go func() {
+				wg.Wait()
+				close(waitDone)
+			}()
+			cleanupTimer := time.NewTimer(trustedReviewProxyCleanupTimeout)
+			defer cleanupTimer.Stop()
+			select {
+			case <-waitDone:
+				_ = os.RemoveAll(dir)
+			case <-cleanupTimer.C:
+				go func() {
+					<-waitDone
+					_ = os.RemoveAll(dir)
+				}()
+			}
+		})
 	}
 	return sockPath, cleanup, nil
 }
 
-func handleTrustedReviewProxyConn(conn net.Conn, realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd, configPath string, policy TrustedReviewProxyPolicy) {
+func handleTrustedReviewProxyConn(parentCtx context.Context, conn net.Conn, realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd, configPath string, policy TrustedReviewProxyPolicy) {
 	defer func() { _ = conn.Close() }()
-	_ = conn.SetDeadline(time.Now().Add(2 * time.Minute))
+	requestCtx, cancelRequest := context.WithTimeout(parentCtx, trustedReviewProxyRequestTimeout)
+	defer cancelRequest()
+	stopContextClose := context.AfterFunc(requestCtx, func() { _ = conn.Close() })
+	defer stopContextClose()
+	_ = conn.SetDeadline(time.Now().Add(trustedReviewProxyRequestTimeout))
 
 	var req trustedReviewProxyRequest
 	decoder := json.NewDecoder(conn)
@@ -171,7 +205,14 @@ func handleTrustedReviewProxyConn(conn net.Conn, realLooper string, trustedEnv m
 	// Authority for clean/blocking event policy is the daemon-bound policy, not
 	// agent argv. Rewrite local policy flags after shape/PR validation.
 	childArgv := applyTrustedReviewProxyPolicy(req.Argv, policy)
-	cmd := exec.Command(realLooper, childArgv...)
+	cmd := exec.CommandContext(requestCtx, realLooper, childArgv...)
+	shellinfra.ConfigureProcessGroup(cmd)
+	var cancellationKillSent atomic.Bool
+	cmd.Cancel = func() error {
+		cancellationKillSent.Store(true)
+		return shellinfra.KillProcessGroup(cmd)
+	}
+	cmd.WaitDelay = trustedReviewProxyWaitDelay
 	// Never honor request-supplied cwd: project/provider resolution for
 	// provider-qualified same-owner/repo checkouts is CWD-sensitive. The child
 	// always runs in the daemon-selected worktree bound at proxy start.
@@ -182,16 +223,42 @@ func handleTrustedReviewProxyConn(conn net.Conn, realLooper string, trustedEnv m
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	resp := trustedReviewProxyResponse{Stdout: stdout.String(), Stderr: stderr.String()}
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			resp.ExitCode = exitErr.ExitCode()
-		} else {
-			resp.ExitCode = 1
+	var cleanupErr error
+	if cancellationKillSent.Load() {
+		cleanupErr = shellinfra.WaitProcessGroupExit(cmd, trustedReviewProxyWaitDelay)
+	} else {
+		cleanupErr = shellinfra.KillProcessGroupAndWait(cmd, trustedReviewProxyWaitDelay)
+	}
+	if errors.Is(err, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.Success() {
+		err = nil
+	}
+	resp := trustedReviewProxyRunResponse(stdout.String(), stderr.String(), err, cleanupErr)
+	_ = json.NewEncoder(conn).Encode(resp)
+}
+
+func trustedReviewProxyRunResponse(stdout, stderr string, runErr, cleanupErr error) trustedReviewProxyResponse {
+	cleanupFailed := cleanupErr != nil && !errors.Is(cleanupErr, os.ErrProcessDone)
+	if cleanupFailed {
+		cleanupErr = fmt.Errorf("clean up trusted review child process group: %w", cleanupErr)
+	} else {
+		cleanupErr = nil
+	}
+	err := errors.Join(runErr, cleanupErr)
+	resp := trustedReviewProxyResponse{Stdout: stdout, Stderr: stderr}
+	if err == nil {
+		return resp
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		resp.ExitCode = exitErr.ExitCode()
+		if cleanupFailed {
 			resp.Error = err.Error()
 		}
+		return resp
 	}
-	_ = json.NewEncoder(conn).Encode(resp)
+	resp.ExitCode = 1
+	resp.Error = err.Error()
+	return resp
 }
 
 // trustedReviewProxyBlockedFlags are CLI overrides that must never be accepted
@@ -494,14 +561,15 @@ func ProxyReviewSubmit(argv []string, stdin []byte, cwd string) error {
 	if resp.Stderr != "" {
 		_, _ = os.Stderr.WriteString(resp.Stderr)
 	}
+	return trustedReviewProxyResponseError(resp)
+}
+
+func trustedReviewProxyResponseError(resp trustedReviewProxyResponse) error {
 	if resp.Error != "" && resp.ExitCode == 0 {
 		return fmt.Errorf("trusted review proxy: %s", resp.Error)
 	}
 	if resp.ExitCode != 0 {
-		if resp.Error != "" {
-			return fmt.Errorf("trusted review proxy: %s", resp.Error)
-		}
-		return &proxyExitError{code: resp.ExitCode}
+		return &proxyExitError{code: resp.ExitCode, detail: resp.Error}
 	}
 	return nil
 }
@@ -563,10 +631,14 @@ func extractTrustedReviewProxyPRRef(argv []string) string {
 }
 
 type proxyExitError struct {
-	code int
+	code   int
+	detail string
 }
 
 func (e *proxyExitError) Error() string {
+	if e != nil && strings.TrimSpace(e.detail) != "" {
+		return fmt.Sprintf("trusted review proxy: %s", e.detail)
+	}
 	return fmt.Sprintf("review submit exited with code %d", e.code)
 }
 

--- a/internal/forge/trusted_review_proxy_test.go
+++ b/internal/forge/trusted_review_proxy_test.go
@@ -1,10 +1,16 @@
 package forge
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestValidateTrustedReviewProxyArgv(t *testing.T) {
@@ -191,6 +197,114 @@ func TestStartTrustedReviewProxyInjectsTokensIntoChild(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, "proxy-child-ran")); err != nil {
 		t.Fatalf("proxy child did not run in bound cwd %q: %v", dir, err)
 	}
+}
+
+func TestTrustedReviewProxyCleanupStopsChildDescendants(t *testing.T) {
+	dir := t.TempDir()
+	realLooper := filepath.Join(dir, "real-looper")
+	pidPath := filepath.Join(dir, "child.pid")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		`/bin/sh -c 'trap "" TERM; echo $$ > "$1"; while :; do sleep 1; done' sh "` + pidPath + `" </dev/null >/dev/null 2>&1 &`,
+		"wait",
+	}, "\n")
+	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(realLooper) error = %v", err)
+	}
+
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, "", testTrustedReviewPolicy())
+	if err != nil {
+		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
+	}
+	var cleanupOnce sync.Once
+	stop := func() { cleanupOnce.Do(cleanup) }
+	t.Cleanup(stop)
+	t.Setenv(TrustedReviewSockEnv, sockPath)
+	t.Setenv(trustedReviewProxySkipEnv, "")
+
+	requestDone := make(chan error, 1)
+	go func() {
+		requestDone <- ProxyReviewSubmit([]string{"review", "submit", "acme/looper#1", "--event", "COMMENT"}, []byte(`{"body":"x"}`), dir)
+	}()
+	childPID := waitForTrustedReviewProcessPID(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+
+	cleanupDone := make(chan struct{})
+	startedAt := time.Now()
+	go func() {
+		stop()
+		close(cleanupDone)
+	}()
+	select {
+	case <-cleanupDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("trusted review proxy cleanup blocked on child process")
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("trusted review proxy cleanup duration = %s, want bounded cleanup", elapsed)
+	}
+	waitForTrustedReviewProcessExit(t, childPID)
+	select {
+	case <-requestDone:
+	case <-time.After(time.Second):
+		t.Fatal("proxy request did not unblock after cleanup")
+	}
+}
+
+func TestTrustedReviewProxyResponsePreservesExitCodeAndCleanupDiagnostics(t *testing.T) {
+	command := exec.Command("/bin/sh", "-c", "exit 7")
+	runErr := command.Run()
+	cleanupErr := errors.New("process group remained live")
+
+	response := trustedReviewProxyRunResponse("", "review failed", runErr, cleanupErr)
+	if response.ExitCode != 7 {
+		t.Fatalf("response.ExitCode = %d, want 7", response.ExitCode)
+	}
+	if !strings.Contains(response.Error, "clean up trusted review child process group") {
+		t.Fatalf("response.Error = %q, want cleanup diagnostics", response.Error)
+	}
+
+	err := trustedReviewProxyResponseError(response)
+	var exitErr interface{ ExitCode() int }
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("error = %v, want exit code 7", err)
+	}
+	if !strings.Contains(err.Error(), "clean up trusted review child process group") {
+		t.Fatalf("error = %q, want cleanup diagnostics", err)
+	}
+}
+
+func waitForTrustedReviewProcessPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr != nil {
+				t.Fatalf("parse process PID %q: %v", data, parseErr)
+			}
+			return pid
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("read process PID file: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process PID file %q was not created", path)
+	return 0
+}
+
+func waitForTrustedReviewProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process %d is still alive", pid)
 }
 
 func TestStartTrustedReviewProxyRewritesPolicyFlags(t *testing.T) {

--- a/internal/infra/shell/process_group_probe.go
+++ b/internal/infra/shell/process_group_probe.go
@@ -1,0 +1,53 @@
+package shell
+
+import (
+	"errors"
+	"syscall"
+)
+
+// ProcessGroupRunnable reports whether process group pgid still has any
+// non-zombie member. kill(-pgid, 0) can succeed for zombie-only groups on
+// Linux until init reaps them; those groups are not runnable and must not be
+// treated as live ownership barriers after SIGKILL.
+func ProcessGroupRunnable(pgid int) (bool, error) {
+	if pgid <= 0 {
+		return false, nil
+	}
+	err := syscall.Kill(-pgid, 0)
+	switch {
+	case err == nil, errors.Is(err, syscall.EPERM):
+		// Signalable: may still be zombie-only.
+	case errors.Is(err, syscall.ESRCH):
+		return false, nil
+	default:
+		return false, err
+	}
+	runnable, inspected := inspectProcessGroupRunnable(pgid)
+	if !inspected {
+		// Fall back to signalability when member state cannot be inspected.
+		return true, nil
+	}
+	return runnable, nil
+}
+
+// ProcessRunnable reports whether pid still refers to a non-zombie process.
+// Zombies remain signalable via kill(pid, 0) until reaped, but are not live
+// work that ownership barriers should wait on.
+func ProcessRunnable(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, nil
+	}
+	err := syscall.Kill(pid, 0)
+	switch {
+	case err == nil, errors.Is(err, syscall.EPERM):
+	case errors.Is(err, syscall.ESRCH):
+		return false, nil
+	default:
+		return false, err
+	}
+	runnable, inspected := inspectProcessRunnable(pid)
+	if !inspected {
+		return true, nil
+	}
+	return runnable, nil
+}

--- a/internal/infra/shell/process_group_probe_darwin.go
+++ b/internal/infra/shell/process_group_probe_darwin.go
@@ -1,0 +1,30 @@
+//go:build darwin
+
+package shell
+
+import "golang.org/x/sys/unix"
+
+// szomb is SZOMB from Darwin/BSD sys/proc.h.
+const szomb int8 = 5
+
+func inspectProcessGroupRunnable(pgid int) (runnable bool, inspected bool) {
+	kps, err := unix.SysctlKinfoProcSlice("kern.proc.pgrp", pgid)
+	if err != nil {
+		return false, false
+	}
+	for _, kp := range kps {
+		if kp.Proc.P_stat != szomb {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+func inspectProcessRunnable(pid int) (runnable bool, inspected bool) {
+	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		// Process disappeared between kill(0) and the sysctl read.
+		return false, true
+	}
+	return kp.Proc.P_stat != szomb, true
+}

--- a/internal/infra/shell/process_group_probe_linux.go
+++ b/internal/infra/shell/process_group_probe_linux.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package shell
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+func inspectProcessGroupRunnable(pgid int) (runnable bool, inspected bool) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return false, false
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		state, memberPgid, ok := readLinuxProcState(pid)
+		if !ok || memberPgid != pgid {
+			continue
+		}
+		if !isLinuxZombieState(state) {
+			return true, true
+		}
+	}
+	// Full /proc scan completed: group is empty or zombie-only.
+	return false, true
+}
+
+func inspectProcessRunnable(pid int) (runnable bool, inspected bool) {
+	state, _, ok := readLinuxProcState(pid)
+	if !ok {
+		// Process disappeared between kill(0) and the stat read.
+		return false, true
+	}
+	return !isLinuxZombieState(state), true
+}
+
+func isLinuxZombieState(state byte) bool {
+	// Z = zombie, X/x = dead (Linux).
+	return state == 'Z' || state == 'X' || state == 'x'
+}
+
+func readLinuxProcState(pid int) (state byte, pgid int, ok bool) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return 0, 0, false
+	}
+	// /proc/<pid>/stat: pid (comm) state ppid pgrp ...
+	// comm may contain spaces and parentheses, so split on the final ") ".
+	stat := string(data)
+	idx := strings.LastIndex(stat, ") ")
+	if idx < 0 || idx+2 >= len(stat) {
+		return 0, 0, false
+	}
+	rest := stat[idx+2:]
+	fields := strings.Fields(rest)
+	// fields[0]=state, fields[1]=ppid, fields[2]=pgrp
+	if len(fields) < 3 || len(fields[0]) == 0 {
+		return 0, 0, false
+	}
+	pgid, err = strconv.Atoi(fields[2])
+	if err != nil {
+		return 0, 0, false
+	}
+	return fields[0][0], pgid, true
+}

--- a/internal/infra/shell/process_group_probe_other.go
+++ b/internal/infra/shell/process_group_probe_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin
+
+package shell
+
+// Without a portable process-state inspection API, leave inspection to the
+// kill(2) signalability probe in ProcessGroupRunnable / ProcessRunnable.
+func inspectProcessGroupRunnable(int) (runnable bool, inspected bool) {
+	return false, false
+}
+
+func inspectProcessRunnable(int) (runnable bool, inspected bool) {
+	return false, false
+}

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -319,14 +319,27 @@ func KillProcessGroup(cmd *exec.Cmd) error {
 	return err
 }
 
-// KillProcessGroupAndWait sends one terminal SIGKILL using the live command's
-// owned process-group id, then waits until that group has no runnable members.
-// Zombie-only groups are treated as cleaned: kill(-pgid, 0) can still succeed
-// for unreaped zombies, but they are not live work. The poll never sends another
-// destructive signal, so a numeric group id that is reused after disappearance
-// cannot be killed by delayed escalation.
+// KillProcessGroupAndWait sends one terminal SIGKILL only while the owned
+// process group still has runnable members, then waits until that group has no
+// runnable members. After cmd.Wait/cmd.Run reaps a short-lived leader with no
+// descendants, the numeric PGID may already be free for reuse; probing first
+// treats no-members/ESRCH as resolved without an unconditional SIGKILL that
+// could hit an unrelated process group. Zombie-only groups are treated as
+// cleaned. The poll never sends another destructive signal, so a numeric group
+// id reused after disappearance cannot be killed by delayed escalation.
 func KillProcessGroupAndWait(cmd *exec.Cmd, timeout time.Duration) error {
-	err := KillProcessGroup(cmd)
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return nil
+	}
+	pid := cmd.Process.Pid
+	live, err := ProcessGroupRunnable(pid)
+	if err != nil {
+		return fmt.Errorf("probe command process group %d before SIGKILL: %w", pid, err)
+	}
+	if !live {
+		return nil
+	}
+	err = KillProcessGroup(cmd)
 	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
 		return nil
 	}

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -16,6 +16,8 @@ import (
 const (
 	defaultMaxOutputBytes = 256 * 1024
 	defaultGracefulStop   = 5 * time.Second
+	descendantDrainGrace  = 100 * time.Millisecond
+	processGroupExitWait  = time.Second
 	// startAttempts covers transient Linux ETXTBSY after a binary/script is
 	// installed (common when tests write a fake tool then exec it immediately).
 	startAttempts      = 8
@@ -82,6 +84,10 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		waitErr          error
 		timedOut         bool
 		canceledErr      error
+		cleanupErr       error
+		forceKillSent    bool
+		timeoutTimer     *time.Timer
+		killTimer        *time.Timer
 		terminationStart <-chan time.Time
 		killAt           <-chan time.Time
 		terminateOnce    sync.Once
@@ -92,26 +98,45 @@ func Run(ctx context.Context, options Options) (Result, error) {
 			if cmd.Process == nil {
 				return
 			}
-			if err := cmd.Process.Signal(syscall.SIGTERM); err != nil && !isProcessDone(err) {
-				_ = cmd.Process.Kill()
+			if err := signalCommandGroup(cmd, syscall.SIGTERM); err != nil && !isProcessDone(err) {
+				forceKillSent = true
+				_ = signalCommandGroup(cmd, syscall.SIGKILL)
 				return
 			}
 			if gracefulShutdown <= 0 {
-				_ = cmd.Process.Kill()
+				forceKillSent = true
+				_ = signalCommandGroup(cmd, syscall.SIGKILL)
 				return
 			}
-			killAt = time.After(gracefulShutdown)
+			killTimer = time.NewTimer(gracefulShutdown)
+			killAt = killTimer.C
 		})
 	}
 
 	if options.Timeout > 0 {
-		terminationStart = time.After(options.Timeout)
+		timeoutTimer = time.NewTimer(options.Timeout)
+		terminationStart = timeoutTimer.C
 	}
+	defer stopAndDrainTimer(timeoutTimer)
+	defer func() { stopAndDrainTimer(killTimer) }()
 
+	ctxDone := ctx.Done()
 	waiting := true
 	for waiting {
 		select {
 		case waitErr = <-waitCh:
+			// The root can exit while a background descendant remains in the
+			// owned group. Resolve the group on every terminal path, not only
+			// timeout/cancellation, before returning ownership to the caller.
+			var err error
+			if forceKillSent {
+				err = WaitProcessGroupExit(cmd, processGroupExitWait)
+			} else {
+				err = KillProcessGroupAndWait(cmd, processGroupExitWait)
+			}
+			if err != nil && !isProcessDone(err) {
+				cleanupErr = err
+			}
 			waiting = false
 		case <-terminationStart:
 			timedOut = true
@@ -119,14 +144,12 @@ func Run(ctx context.Context, options Options) (Result, error) {
 			terminate()
 		case <-killAt:
 			killAt = nil
-			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
-			}
-		case <-ctx.Done():
-			if canceledErr == nil {
-				canceledErr = ctx.Err()
-				terminate()
-			}
+			forceKillSent = true
+			_ = signalCommandGroup(cmd, syscall.SIGKILL)
+		case <-ctxDone:
+			ctxDone = nil
+			canceledErr = ctx.Err()
+			terminate()
 		}
 	}
 
@@ -142,21 +165,37 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	}
 
 	if timedOut {
-		return result, &CommandExecutionError{Message: "Command timed out", Result: result}
+		primaryErr := &CommandExecutionError{Message: "Command timed out", Result: result}
+		return result, joinProcessGroupCleanupError(primaryErr, cleanupErr)
 	}
 	if canceledErr != nil {
-		return result, canceledErr
+		return result, joinProcessGroupCleanupError(canceledErr, cleanupErr)
 	}
 	if result.ExitCode != 0 {
-		return result, &CommandExecutionError{Message: commandFailureMessage(result), Result: result}
+		primaryErr := &CommandExecutionError{Message: commandFailureMessage(result), Result: result}
+		return result, joinProcessGroupCleanupError(primaryErr, cleanupErr)
+	}
+	if errors.Is(waitErr, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.Success() {
+		waitErr = nil
 	}
 	if waitErr != nil {
-		return result, waitErr
+		return result, joinProcessGroupCleanupError(waitErr, cleanupErr)
 	}
-	return result, nil
+	return result, joinProcessGroupCleanupError(nil, cleanupErr)
+}
+
+func joinProcessGroupCleanupError(primaryErr, cleanupErr error) error {
+	if cleanupErr == nil || isProcessDone(cleanupErr) {
+		return primaryErr
+	}
+	return errors.Join(primaryErr, fmt.Errorf("clean up command process group: %w", cleanupErr))
 }
 
 func startCommand(ctx context.Context, options Options, stdout, stderr *boundedBuffer) (*exec.Cmd, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	var lastErr error
 	for attempt := 0; attempt < startAttempts; attempt++ {
 		if attempt > 0 {
@@ -171,6 +210,8 @@ func startCommand(ctx context.Context, options Options, stdout, stderr *boundedB
 		}
 
 		cmd := exec.Command(options.Command, options.Args...)
+		ConfigureProcessGroup(cmd)
+		cmd.WaitDelay = descendantDrainGrace
 		cmd.Dir = options.CWD
 		if len(options.Env) > 0 {
 			cmd.Env = envSlice(options.Env)
@@ -195,6 +236,16 @@ func startCommand(ctx context.Context, options Options, stdout, stderr *boundedB
 		return cmd, nil
 	}
 	return nil, lastErr
+}
+
+func stopAndDrainTimer(timer *time.Timer) {
+	if timer == nil || timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
+	}
 }
 
 func isTextFileBusy(err error) bool {
@@ -239,7 +290,76 @@ func exitCode(cmd *exec.Cmd) int {
 }
 
 func isProcessDone(err error) bool {
-	return err == nil || err == os.ErrProcessDone
+	return err == nil || errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
+}
+
+func signalCommandGroup(cmd *exec.Cmd, signal syscall.Signal) error {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return os.ErrProcessDone
+	}
+	return syscall.Kill(-cmd.Process.Pid, signal)
+}
+
+// ConfigureProcessGroup gives cmd ownership of a fresh process group so
+// cancellation can stop every descendant that remains in the group.
+func ConfigureProcessGroup(cmd *exec.Cmd) {
+	if cmd != nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
+}
+
+// KillProcessGroup forcibly stops cmd and every descendant remaining in its
+// process group. A command that has not started or whose group has exited is
+// reported as os.ErrProcessDone.
+func KillProcessGroup(cmd *exec.Cmd) error {
+	err := signalCommandGroup(cmd, syscall.SIGKILL)
+	if errors.Is(err, syscall.ESRCH) {
+		return os.ErrProcessDone
+	}
+	return err
+}
+
+// KillProcessGroupAndWait sends one terminal SIGKILL using the live command's
+// owned process-group id, then waits until that group is no longer signalable.
+// The poll never sends another destructive signal, so a numeric group id that
+// is reused after disappearance cannot be killed by delayed escalation.
+func KillProcessGroupAndWait(cmd *exec.Cmd, timeout time.Duration) error {
+	err := KillProcessGroup(cmd)
+	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return WaitProcessGroupExit(cmd, timeout)
+}
+
+// WaitProcessGroupExit waits for a previously signaled owned process group to
+// disappear without sending another signal to its numeric id.
+func WaitProcessGroupExit(cmd *exec.Cmd, timeout time.Duration) error {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return os.ErrProcessDone
+	}
+	if timeout <= 0 {
+		timeout = processGroupExitWait
+	}
+	pid := cmd.Process.Pid
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if err := syscall.Kill(-pid, 0); errors.Is(err, syscall.ESRCH) {
+			return nil
+		} else if err != nil && !errors.Is(err, syscall.EPERM) {
+			return fmt.Errorf("probe command process group %d: %w", pid, err)
+		}
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			return fmt.Errorf("command process group %d remained live after SIGKILL for %s", pid, timeout)
+		}
+	}
 }
 
 type boundedBuffer struct {

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -320,9 +320,11 @@ func KillProcessGroup(cmd *exec.Cmd) error {
 }
 
 // KillProcessGroupAndWait sends one terminal SIGKILL using the live command's
-// owned process-group id, then waits until that group is no longer signalable.
-// The poll never sends another destructive signal, so a numeric group id that
-// is reused after disappearance cannot be killed by delayed escalation.
+// owned process-group id, then waits until that group has no runnable members.
+// Zombie-only groups are treated as cleaned: kill(-pgid, 0) can still succeed
+// for unreaped zombies, but they are not live work. The poll never sends another
+// destructive signal, so a numeric group id that is reused after disappearance
+// cannot be killed by delayed escalation.
 func KillProcessGroupAndWait(cmd *exec.Cmd, timeout time.Duration) error {
 	err := KillProcessGroup(cmd)
 	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
@@ -335,7 +337,8 @@ func KillProcessGroupAndWait(cmd *exec.Cmd, timeout time.Duration) error {
 }
 
 // WaitProcessGroupExit waits for a previously signaled owned process group to
-// disappear without sending another signal to its numeric id.
+// have no runnable members without sending another signal to its numeric id.
+// Zombie-only groups count as exited so unreaped orphans cannot fail cleanup.
 func WaitProcessGroupExit(cmd *exec.Cmd, timeout time.Duration) error {
 	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
 		return os.ErrProcessDone
@@ -349,10 +352,12 @@ func WaitProcessGroupExit(cmd *exec.Cmd, timeout time.Duration) error {
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		if err := syscall.Kill(-pid, 0); errors.Is(err, syscall.ESRCH) {
-			return nil
-		} else if err != nil && !errors.Is(err, syscall.EPERM) {
+		live, err := ProcessGroupRunnable(pid)
+		if err != nil {
 			return fmt.Errorf("probe command process group %d: %w", pid, err)
+		}
+		if !live {
+			return nil
 		}
 		select {
 		case <-ticker.C:

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -81,16 +81,17 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	}()
 
 	var (
-		waitErr          error
-		timedOut         bool
-		canceledErr      error
-		cleanupErr       error
-		forceKillSent    bool
-		timeoutTimer     *time.Timer
-		killTimer        *time.Timer
-		terminationStart <-chan time.Time
-		killAt           <-chan time.Time
-		terminateOnce    sync.Once
+		waitErr              error
+		timedOut             bool
+		canceledErr          error
+		cleanupErr           error
+		forceKillSent        bool
+		processGroupResolved bool
+		timeoutTimer         *time.Timer
+		killTimer            *time.Timer
+		terminationStart     <-chan time.Time
+		killAt               <-chan time.Time
+		terminateOnce        sync.Once
 	)
 
 	terminate := func() {
@@ -98,14 +99,25 @@ func Run(ctx context.Context, options Options) (Result, error) {
 			if cmd.Process == nil {
 				return
 			}
-			if err := signalCommandGroup(cmd, syscall.SIGTERM); err != nil && !isProcessDone(err) {
+			if err := signalCommandGroup(cmd, syscall.SIGTERM); err != nil {
+				if isProcessDone(err) {
+					// Wait may have already reaped the original group. Record
+					// that fact so post-wait cleanup does not SIGKILL a numeric
+					// PGID that has been reused by an unrelated process group.
+					processGroupResolved = true
+					return
+				}
 				forceKillSent = true
-				_ = signalCommandGroup(cmd, syscall.SIGKILL)
+				if killErr := signalCommandGroup(cmd, syscall.SIGKILL); killErr != nil && isProcessDone(killErr) {
+					processGroupResolved = true
+				}
 				return
 			}
 			if gracefulShutdown <= 0 {
 				forceKillSent = true
-				_ = signalCommandGroup(cmd, syscall.SIGKILL)
+				if killErr := signalCommandGroup(cmd, syscall.SIGKILL); killErr != nil && isProcessDone(killErr) {
+					processGroupResolved = true
+				}
 				return
 			}
 			killTimer = time.NewTimer(gracefulShutdown)
@@ -129,7 +141,7 @@ func Run(ctx context.Context, options Options) (Result, error) {
 			// owned group. Resolve the group on every terminal path, not only
 			// timeout/cancellation, before returning ownership to the caller.
 			var err error
-			if forceKillSent {
+			if forceKillSent || processGroupResolved {
 				err = WaitProcessGroupExit(cmd, processGroupExitWait)
 			} else {
 				err = KillProcessGroupAndWait(cmd, processGroupExitWait)
@@ -145,7 +157,9 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		case <-killAt:
 			killAt = nil
 			forceKillSent = true
-			_ = signalCommandGroup(cmd, syscall.SIGKILL)
+			if killErr := signalCommandGroup(cmd, syscall.SIGKILL); killErr != nil && isProcessDone(killErr) {
+				processGroupResolved = true
+			}
 		case <-ctxDone:
 			ctxDone = nil
 			canceledErr = ctx.Err()

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -52,6 +53,30 @@ func TestRunReturnsCommandExecutionErrorOnNonZeroExit(t *testing.T) {
 	}
 	if !strings.Contains(commandErr.Error(), "bad") {
 		t.Fatalf("error = %q, want stderr detail", commandErr.Error())
+	}
+}
+
+func TestJoinProcessGroupCleanupErrorPreservesEveryPrimaryFailure(t *testing.T) {
+	cleanupErr := errors.New("cleanup barrier failed")
+	primaries := map[string]error{
+		"timeout": &CommandExecutionError{Message: "Command timed out"},
+		"cancel":  context.Canceled,
+		"nonzero": &CommandExecutionError{Message: "Command exited with code 7"},
+		"wait":    errors.New("wait failed"),
+	}
+	for name, primaryErr := range primaries {
+		t.Run(name, func(t *testing.T) {
+			err := joinProcessGroupCleanupError(primaryErr, cleanupErr)
+			if !errors.Is(err, primaryErr) {
+				t.Fatalf("error = %v, want primary error %v", err, primaryErr)
+			}
+			if !errors.Is(err, cleanupErr) {
+				t.Fatalf("error = %v, want cleanup barrier error", err)
+			}
+			if !strings.Contains(err.Error(), "clean up command process group") {
+				t.Fatalf("error = %q, want cleanup context", err)
+			}
+		})
 	}
 }
 
@@ -126,6 +151,117 @@ func TestRunRespectsContextCancellation(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v, want context.Canceled", err)
 	}
+}
+
+func TestRunDoesNotStartPreCanceledCommand(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Run(ctx, Options{
+		Command: filepath.Join(t.TempDir(), "missing-command"),
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestRunCancellationStopsDescendants(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := Run(ctx, Options{
+			Command:          "/bin/sh",
+			Args:             []string{"-c", `trap "" TERM; /bin/sh -c 'trap "" TERM; echo $$ > "$1"; while :; do sleep 1; done' sh "$1" </dev/null >/dev/null 2>&1 & wait`, "sh", pidPath},
+			GracefulShutdown: 20 * time.Millisecond,
+		})
+		resultCh <- err
+	}()
+
+	childPID := waitForPIDFile(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run() did not return after cancellation")
+	}
+
+	waitForProcessExit(t, childPID)
+}
+
+func TestRunTimeoutStopsDescendants(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	result, err := Run(context.Background(), Options{
+		Command:          "/bin/sh",
+		Args:             []string{"-c", `/bin/sh -c 'trap "" TERM; echo $$ > "$1"; while :; do sleep 1; done' sh "$1" </dev/null >/dev/null 2>&1 & wait`, "sh", pidPath},
+		Timeout:          100 * time.Millisecond,
+		GracefulShutdown: 20 * time.Millisecond,
+	})
+
+	childPID := waitForPIDFile(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+	var commandErr *CommandExecutionError
+	if !errors.As(err, &commandErr) || commandErr.Message != "Command timed out" {
+		t.Fatalf("Run() error = %v, want Command timed out", err)
+	}
+	if result.Duration > time.Second {
+		t.Fatalf("Run() duration = %s, want bounded timeout cleanup", result.Duration)
+	}
+	waitForProcessExit(t, childPID)
+}
+
+func TestRunSuccessfulRootExitStillStopsBackgroundDescendants(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	_, err := Run(context.Background(), Options{
+		Command: "/bin/sh",
+		Args:    []string{"-c", `/bin/sh -c 'trap "" TERM; echo $$ > "$1"; while :; do sleep 1; done' sh "$1" </dev/null >/dev/null 2>&1 & while [ ! -s "$1" ]; do sleep 0.01; done`, "sh", pidPath},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	childPID := waitForPIDFile(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+	waitForProcessExit(t, childPID)
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr != nil {
+				t.Fatalf("parse child PID %q: %v", data, parseErr)
+			}
+			return pid
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("read child PID file: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("child PID file %q was not created", path)
+	return 0
+}
+
+func waitForProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process %d is still alive", pid)
 }
 
 func TestIsTextFileBusy(t *testing.T) {

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -231,6 +232,63 @@ func TestRunSuccessfulRootExitStillStopsBackgroundDescendants(t *testing.T) {
 	waitForProcessExit(t, childPID)
 }
 
+func TestProcessGroupRunnableTreatsZombieOnlyGroupAsNotLive(t *testing.T) {
+	// Create an owned process, SIGKILL it without Wait so it becomes a zombie
+	// still signalable via kill(-pgid, 0). Cleanup barriers must not treat that
+	// as a live runnable group.
+	cmd := exec.Command("/bin/sh", "-c", "sleep 30")
+	ConfigureProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	pgid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	if err := syscall.Kill(pgid, syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL process: %v", err)
+	}
+	// Give the kernel a moment to mark the process zombie without reaping it.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pgid, 0); err == nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// kill(pgid,0) may still succeed while the process is a zombie.
+	if err := syscall.Kill(pgid, 0); err != nil && !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("kill(%d,0) error = %v", pgid, err)
+	}
+
+	live, err := ProcessGroupRunnable(pgid)
+	if err != nil {
+		t.Fatalf("ProcessGroupRunnable() error = %v", err)
+	}
+	if live {
+		t.Fatalf("ProcessGroupRunnable(%d) = true, want false for zombie-only group", pgid)
+	}
+	live, err = ProcessRunnable(pgid)
+	if err != nil {
+		t.Fatalf("ProcessRunnable() error = %v", err)
+	}
+	if live {
+		t.Fatalf("ProcessRunnable(%d) = true, want false for zombie", pgid)
+	}
+
+	// WaitProcessGroupExit must return promptly instead of timing out on zombies.
+	startedAt := time.Now()
+	if err := WaitProcessGroupExit(cmd, 200*time.Millisecond); err != nil {
+		t.Fatalf("WaitProcessGroupExit() error = %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 150*time.Millisecond {
+		t.Fatalf("WaitProcessGroupExit() elapsed = %s, want immediate zombie-only success", elapsed)
+	}
+}
+
 func waitForPIDFile(t *testing.T, path string) int {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -256,7 +314,11 @@ func waitForProcessExit(t *testing.T, pid int) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+		live, err := ProcessRunnable(pid)
+		if err != nil {
+			t.Fatalf("probe process %d: %v", pid, err)
+		}
+		if !live {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -233,28 +233,38 @@ func TestRunSuccessfulRootExitStillStopsBackgroundDescendants(t *testing.T) {
 }
 
 func TestProcessGroupRunnableTreatsZombieOnlyGroupAsNotLive(t *testing.T) {
-	// Create an owned process, SIGKILL it without Wait so it becomes a zombie
-	// still signalable via kill(-pgid, 0). Cleanup barriers must not treat that
-	// as a live runnable group.
-	cmd := exec.Command("/bin/sh", "-c", "sleep 30")
+	// Leaf process only: /bin/sh -c "sleep …" leaves a live sleep sibling in the
+	// group after the shell is killed on Linux (dash forks), which is not the
+	// zombie-only case under test. SIGKILL the group without Wait so the leader
+	// remains an unreaped zombie still signalable via kill(-pgid, 0).
+	cmd := exec.Command("sleep", "30")
 	ConfigureProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
 	pgid := cmd.Process.Pid
 	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
 		_, _ = cmd.Process.Wait()
 	})
 
-	if err := syscall.Kill(pgid, syscall.SIGKILL); err != nil {
-		t.Fatalf("SIGKILL process: %v", err)
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL process group: %v", err)
 	}
-	// Give the kernel a moment to mark the process zombie without reaping it.
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if err := syscall.Kill(pgid, 0); err == nil {
+	// Wait until the leader is no longer runnable (zombie) without reaping it.
+	// kill(pid, 0) succeeds for both live and zombie processes, so signalability
+	// alone cannot settle this race.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		live, err := ProcessRunnable(pgid)
+		if err != nil {
+			t.Fatalf("ProcessRunnable() settle error = %v", err)
+		}
+		if !live {
 			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process %d remained runnable after SIGKILL", pgid)
 		}
 		time.Sleep(5 * time.Millisecond)
 	}

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -232,6 +232,62 @@ func TestRunSuccessfulRootExitStillStopsBackgroundDescendants(t *testing.T) {
 	waitForProcessExit(t, childPID)
 }
 
+func TestKillProcessGroupAndWaitSkipsSIGKILLWhenReapedGroupHasNoMembers(t *testing.T) {
+	// After Wait reaps a short-lived leader with no descendants, the numeric
+	// PGID is free for reuse. KillProcessGroupAndWait must probe first and treat
+	// no-members/ESRCH as resolved instead of unconditionally SIGKILLing.
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	ConfigureProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	originalPID := cmd.Process.Pid
+	if _, err := cmd.Process.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		live, err := ProcessGroupRunnable(originalPID)
+		if err != nil {
+			t.Fatalf("ProcessGroupRunnable(%d) error = %v", originalPID, err)
+		}
+		if !live {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process group %d remained live after Wait", originalPID)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if err := KillProcessGroupAndWait(cmd, 200*time.Millisecond); err != nil {
+		t.Fatalf("KillProcessGroupAndWait() after reaped exit error = %v", err)
+	}
+
+	// Live descendants must still be cleaned up by probe-then-SIGKILL.
+	live := exec.Command("/bin/sh", "-c", `trap '' TERM; while :; do sleep 1; done`)
+	ConfigureProcessGroup(live)
+	if err := live.Start(); err != nil {
+		t.Fatalf("Start(live) error = %v", err)
+	}
+	liveDone := make(chan error, 1)
+	go func() { liveDone <- live.Wait() }()
+	t.Cleanup(func() {
+		_ = syscall.Kill(-live.Process.Pid, syscall.SIGKILL)
+		select {
+		case <-liveDone:
+		case <-time.After(time.Second):
+		}
+	})
+	if err := KillProcessGroupAndWait(live, time.Second); err != nil {
+		t.Fatalf("KillProcessGroupAndWait(live) error = %v", err)
+	}
+	select {
+	case <-liveDone:
+	case <-time.After(time.Second):
+		t.Fatal("live process group was not cleaned up")
+	}
+}
+
 func TestProcessGroupRunnableTreatsZombieOnlyGroupAsNotLive(t *testing.T) {
 	// Leaf process only: /bin/sh -c "sleep …" leaves a live sleep sibling in the
 	// group after the shell is killed on Linux (dash forks), which is not the

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -989,6 +989,24 @@ func (r *Runner) runWriteSpecStep(ctx context.Context, input stepInput) (planner
 				return checkpoint, &holdSkipError{summary: summary}
 			}
 		}
+		// The lock must cover the agent's entire logical runtime. Keep the normal
+		// claim TTL after that deadline as the teardown/crash-recovery window.
+		lockTTL := r.agentTimeout + r.claimTTL
+		lockReason := "planner-agent"
+		lockUpdatedAt := r.nowISO()
+		refreshed, err := r.repos.Locks.Refresh(ctx, storage.LockRecord{
+			Key:       checkpoint.ClaimedLockKey,
+			Owner:     input.QueueItem.ID,
+			Reason:    &lockReason,
+			ExpiresAt: eventlog.FormatJavaScriptISOString(r.now().Add(lockTTL)),
+			UpdatedAt: lockUpdatedAt,
+		})
+		if err != nil {
+			return checkpoint, err
+		}
+		if !refreshed {
+			return checkpoint, &loopError{message: "Planner issue lock ownership was lost before agent start", kind: FailureRetryableTransient}
+		}
 		execution, err := r.agentExecutor.Start(ctx, AgentRunInput{ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID, Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout, Metadata: metadata, IdempotencyKey: fmt.Sprintf("planner:%s", input.Loop.ID)})
 		if err != nil {
 			return checkpoint, err

--- a/internal/planner/runner_test.go
+++ b/internal/planner/runner_test.go
@@ -628,15 +628,20 @@ func TestRunWriteSpecStepRecreatesCheckpointOutsideWorktreeRootAndRunsAgent(t *t
 	git := &fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
 	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "wrote spec"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now})
+	lockKey := storage.IssueLockKey("project_1", issue.Repo, issue.IssueNumber)
+	queueItem := storage.QueueItemRecord{ID: "queue_write_spec_rebuild"}
+	acquirePlannerTestLock(t, fixture, lockKey, queueItem.ID)
 
 	checkpoint, err := runner.runWriteSpecStep(context.Background(), stepInput{
-		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
-		Loop:    loopResult.record,
-		Run:     storage.RunRecord{ID: runID, LoopID: loopResult.record.ID},
+		Project:   storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Loop:      loopResult.record,
+		Run:       storage.RunRecord{ID: runID, LoopID: loopResult.record.ID},
+		QueueItem: queueItem,
 		Checkpoint: plannerCheckpoint{
-			Issue:     issue,
-			Worktree:  &checkpointWorktree{Path: legacyPath, Branch: "stale", BaseBranch: "main"},
-			WriteSpec: &checkpointWriteSpec{Status: "completed"},
+			Issue:          issue,
+			Worktree:       &checkpointWorktree{Path: legacyPath, Branch: "stale", BaseBranch: "main"},
+			WriteSpec:      &checkpointWriteSpec{Status: "completed"},
+			ClaimedLockKey: lockKey,
 		},
 	})
 	if err != nil {
@@ -727,11 +732,14 @@ func TestRunWriteSpecStepRechecksPlannerHoldAfterAgentCompletion(t *testing.T) {
 	github := &fakeGitHubGateway{issueDetails: []IssueDetail{{Number: 42}, {Number: 42, Labels: []string{domain.HoldLabelGlobal}}}}
 	git := &fakeGitGateway{inspectResult: InspectHeadResult{HasUncommittedChanges: true}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "wrote spec"}}}, Logger: fixture.logger, Now: fixture.now})
+	lockKey := storage.IssueLockKey("project_1", issue.Repo, issue.IssueNumber)
+	queueItem := storage.QueueItemRecord{ID: "queue_write_spec_held_after"}
+	acquirePlannerTestLock(t, fixture, lockKey, queueItem.ID)
 
 	_, err = runner.runWriteSpecStep(context.Background(), stepInput{
 		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir(), MetadataJSON: &metadata},
-		Loop:    loopResult.record, Run: storage.RunRecord{ID: runID, LoopID: loopResult.record.ID},
-		Checkpoint: plannerCheckpoint{Issue: issue, Worktree: &checkpointWorktree{Path: worktreePath, Branch: "looper/planner/42-plan-this", BaseBranch: "main"}},
+		Loop:    loopResult.record, Run: storage.RunRecord{ID: runID, LoopID: loopResult.record.ID}, QueueItem: queueItem,
+		Checkpoint: plannerCheckpoint{Issue: issue, Worktree: &checkpointWorktree{Path: worktreePath, Branch: "looper/planner/42-plan-this", BaseBranch: "main"}, ClaimedLockKey: lockKey},
 	})
 	var holdErr *holdSkipError
 	if !errors.As(err, &holdErr) {
@@ -909,6 +917,68 @@ func TestProcessClaimedItemSuccessfulPlannerPublish(t *testing.T) {
 	}
 	if run == nil || run.CheckpointJSON == nil || !strings.Contains(*run.CheckpointJSON, `"id":"worktree_1"`) {
 		t.Fatalf("run = %#v, want checkpoint with worktree id", run)
+	}
+}
+
+func TestPlannerExtendsIssueLockThroughAgentRuntime(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		issues:         []IssueSummary{{Number: 42, Title: "Plan this", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}}},
+		issueDetail:    IssueDetail{Number: 42, Title: "Plan this", Body: "details", URL: "https://example/issues/42", Assignees: []string{"octocat"}, Labels: []string{"looper:plan"}},
+		createPRResult: CreatePullRequestResult{Number: 101, URL: "https://example/pr/101"},
+	}
+	git := &fakeGitGateway{createResult: CreateWorktreeResult{ID: "worktree_1", WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "looper/planner/42-plan-this", BaseBranch: "main"}}
+	agentWaiting := make(chan struct{})
+	releaseAgent := make(chan struct{})
+	agent := &fakeAgentExecutor{
+		results: []AgentResult{{Status: "completed", Summary: "wrote spec", Stdout: "done"}},
+		wait: func(context.Context) error {
+			close(agentWaiting)
+			<-releaseAgent
+			return nil
+		},
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git,
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+		AgentTimeout: 30 * time.Minute, ClaimTTL: time.Minute, AllowAutoPush: boolPtr(true),
+	})
+
+	_, _ = runner.DiscoverIssues(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "planner-worker-1", "planner")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := runner.ProcessClaimedItem(context.Background(), *claim)
+		done <- err
+	}()
+	select {
+	case <-agentWaiting:
+	case <-time.After(2 * time.Second):
+		t.Fatal("planner agent did not start")
+	}
+
+	lockKey := storage.IssueLockKey("project_1", "acme/looper", 42)
+	lock, err := fixture.repos.Locks.Get(context.Background(), lockKey)
+	if err != nil {
+		t.Fatalf("Locks.Get() error = %v", err)
+	}
+	if lock == nil {
+		t.Fatalf("Locks.Get(%q) = nil, want live planner lock", lockKey)
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, lock.ExpiresAt)
+	if err != nil {
+		t.Fatalf("parse lock expiry %q: %v", lock.ExpiresAt, err)
+	}
+	if want := fixture.now().Add(30 * time.Minute); expiresAt.Before(want) {
+		t.Fatalf("lock expiry = %s, want at least agent deadline %s", expiresAt, want)
+	}
+
+	close(releaseAgent)
+	if err := <-done; err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
 }
 
@@ -1602,6 +1672,19 @@ func (f *runnerFixture) advance(delta time.Duration) { f.current = f.current.Add
 
 func (f *runnerFixture) nowISO() string {
 	return fmt.Sprintf("%s.000Z", f.current.UTC().Format("2006-01-02T15:04:05"))
+}
+
+func acquirePlannerTestLock(t *testing.T, fixture *runnerFixture, key, owner string) {
+	t.Helper()
+	reason := "planner-test"
+	acquired, err := fixture.repos.Locks.Acquire(context.Background(), storage.LockRecord{
+		Key: key, Owner: owner, Reason: &reason,
+		ExpiresAt: fixture.now().Add(time.Hour).UTC().Format(time.RFC3339Nano),
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	})
+	if err != nil || !acquired {
+		t.Fatalf("Locks.Acquire(%q) = (%v, %v), want acquired", key, acquired, err)
+	}
 }
 
 type fakeGitHubGateway struct {

--- a/internal/runtime/active_execution_context_test.go
+++ b/internal/runtime/active_execution_context_test.go
@@ -151,8 +151,10 @@ func TestFailedReapRemainsOwnedUntilForcedResolution(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("StopAndWait() looped after the retained execution reported a failed reap")
 	}
-	if err := registry.ForceKillAndWait(context.Background()); err != nil {
-		t.Fatalf("ForceKillAndWait() error = %v", err)
+	// ForceKill resolves process-group ownership, but the original Wait error is
+	// still preserved so terminal failures (including persistFinal) are not dropped.
+	if err := registry.ForceKillAndWait(context.Background()); !errors.Is(err, errRegistryReapFailed) {
+		t.Fatalf("ForceKillAndWait() error = %v, want failed-reap error preserved", err)
 	}
 	select {
 	case <-execution.forceKilled:
@@ -180,8 +182,11 @@ func TestRuntimeStopLogsGracefulReapFailureAfterSuccessfulForceResolution(t *tes
 	default:
 		t.Fatal("Runtime.Stop() did not force-resolve failed reap ownership")
 	}
-	if !logger.containsMessage("looperd runtime required forced active-execution reap") {
-		t.Fatal("Runtime.Stop() did not log the graceful reap failure")
+	// ForceKill resolves ownership, but the preserved Wait error still makes
+	// ForceKillAndWait fail so Runtime.Stop reports the force-reap failure path
+	// instead of treating durable state as cleanly closed.
+	if !logger.containsMessage("looperd runtime failed while force-reaping active executions") {
+		t.Fatal("Runtime.Stop() dropped the original Wait error after forced process-group resolution")
 	}
 }
 

--- a/internal/runtime/active_execution_context_test.go
+++ b/internal/runtime/active_execution_context_test.go
@@ -1,0 +1,239 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/agent"
+)
+
+func TestStartAgentExecutionKeepsRunContextAliveUntilShutdown(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	starter := &contextObservingRegistryStarter{}
+	handle, err := registry.StartAgentExecution(
+		context.Background(),
+		"loop_context",
+		"run_context",
+		"exec_context",
+		starter,
+		agent.RunInput{ExecutionID: "exec_context"},
+	)
+	if err != nil {
+		t.Fatalf("StartAgentExecution() error = %v", err)
+	}
+	if handle == nil || starter.execution == nil {
+		t.Fatal("StartAgentExecution() did not publish a live execution")
+	}
+
+	select {
+	case <-starter.execution.ctx.Done():
+		t.Fatalf("execution context was cancelled when the live handle was published: %v", starter.execution.ctx.Err())
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	if err := registry.ShutdownAndWait(context.Background(), "test shutdown"); err != nil {
+		t.Fatalf("ShutdownAndWait() error = %v", err)
+	}
+	select {
+	case <-starter.execution.ctx.Done():
+		if err := starter.execution.ctx.Err(); err == nil {
+			t.Fatal("execution context completed during shutdown without a cancellation error")
+		}
+	default:
+		t.Fatal("shutdown returned before cancelling the published execution context")
+	}
+}
+
+func TestRegisterReleaseCannotDropLiveExecutionOwnership(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	execution := newBlockingRegistryExecution()
+	release := registry.Register("loop_release", "run_release", "exec_release", execution)
+	release()
+
+	stopped := make(chan struct {
+		found bool
+		err   error
+	}, 1)
+	go func() {
+		found, err := registry.StopAndWait(context.Background(), "loop_release", "run_release", "exec_release", "test stop")
+		stopped <- struct {
+			found bool
+			err   error
+		}{found: found, err: err}
+	}()
+
+	select {
+	case <-execution.killed:
+	case result := <-stopped:
+		t.Fatalf("StopAndWait() returned before stopping the released live execution: found=%v err=%v", result.found, result.err)
+	case <-time.After(time.Second):
+		t.Fatal("StopAndWait() did not retain authority over the released live execution")
+	}
+	execution.finish()
+	result := <-stopped
+	if result.err != nil || !result.found {
+		t.Fatalf("StopAndWait() = (%v, %v), want (true, nil)", result.found, result.err)
+	}
+}
+
+func TestRegisterRunReleaseCannotDropLiveRunOwnership(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	runDone := make(chan struct{})
+	runCancelled := make(chan struct{})
+	var cancelOnce sync.Once
+	release, accepted := registry.RegisterRun("loop_run_release", "owner_release", func() {
+		cancelOnce.Do(func() { close(runCancelled) })
+	}, runDone)
+	if !accepted {
+		t.Fatal("RegisterRun() rejected live run before shutdown")
+	}
+	release()
+
+	stopped := make(chan struct {
+		found bool
+		err   error
+	}, 1)
+	go func() {
+		found, err := registry.StopAndWait(context.Background(), "loop_run_release", "", "", "test stop")
+		stopped <- struct {
+			found bool
+			err   error
+		}{found: found, err: err}
+	}()
+
+	select {
+	case <-runCancelled:
+	case result := <-stopped:
+		t.Fatalf("StopAndWait() returned before cancelling the released live run: found=%v err=%v", result.found, result.err)
+	case <-time.After(time.Second):
+		t.Fatal("StopAndWait() did not retain authority over the released live run")
+	}
+	close(runDone)
+	result := <-stopped
+	if result.err != nil || !result.found {
+		t.Fatalf("StopAndWait() = (%v, %v), want (true, nil)", result.found, result.err)
+	}
+}
+
+func TestFailedReapRemainsOwnedUntilForcedResolution(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	execution := newFailedReapRegistryExecution()
+	registry.Register("loop_failed_reap", "run_failed_reap", "exec_failed_reap", execution)
+	<-execution.waited
+
+	stopped := make(chan struct {
+		found bool
+		err   error
+	}, 1)
+	go func() {
+		found, err := registry.StopAndWait(context.Background(), "loop_failed_reap", "", "", "test stop")
+		stopped <- struct {
+			found bool
+			err   error
+		}{found: found, err: err}
+	}()
+	select {
+	case result := <-stopped:
+		if !result.found || !errors.Is(result.err, errRegistryReapFailed) {
+			t.Fatalf("StopAndWait() = (%v, %v), want (true, failed-reap error)", result.found, result.err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("StopAndWait() looped after the retained execution reported a failed reap")
+	}
+	if err := registry.ForceKillAndWait(context.Background()); err != nil {
+		t.Fatalf("ForceKillAndWait() error = %v", err)
+	}
+	select {
+	case <-execution.forceKilled:
+	default:
+		t.Fatal("failed reap was removed before forced process-group resolution")
+	}
+	if err := registry.ForceKillAndWait(context.Background()); err != nil {
+		t.Fatalf("second ForceKillAndWait() error = %v", err)
+	}
+}
+
+func TestRuntimeStopLogsGracefulReapFailureAfterSuccessfulForceResolution(t *testing.T) {
+	t.Parallel()
+
+	logger := &testLogger{}
+	rt := New(Options{Logger: logger, ShutdownTimeout: time.Second})
+	execution := newFailedReapRegistryExecution()
+	rt.activeExecutions.Register("loop_reap_log", "run_reap_log", "exec_reap_log", execution)
+	<-execution.waited
+
+	rt.Stop("test shutdown")
+
+	select {
+	case <-execution.forceKilled:
+	default:
+		t.Fatal("Runtime.Stop() did not force-resolve failed reap ownership")
+	}
+	if !logger.containsMessage("looperd runtime required forced active-execution reap") {
+		t.Fatal("Runtime.Stop() did not log the graceful reap failure")
+	}
+}
+
+type contextObservingRegistryStarter struct {
+	execution *contextObservingRegistryExecution
+}
+
+var errRegistryReapFailed = errors.New("process group remains signalable")
+
+type failedReapRegistryExecution struct {
+	waited      chan struct{}
+	forceKilled chan struct{}
+	waitOnce    sync.Once
+	forceOnce   sync.Once
+}
+
+func newFailedReapRegistryExecution() *failedReapRegistryExecution {
+	return &failedReapRegistryExecution{
+		waited:      make(chan struct{}),
+		forceKilled: make(chan struct{}),
+	}
+}
+
+func (e *failedReapRegistryExecution) Wait(context.Context) (agent.Result, error) {
+	e.waitOnce.Do(func() { close(e.waited) })
+	return agent.Result{Status: "killed"}, errRegistryReapFailed
+}
+
+func (e *failedReapRegistryExecution) Kill(string) error { return nil }
+
+// A nil ForceKill result is the registry contract that the live handle has
+// resolved process-group ownership, not merely that it sent a signal.
+func (e *failedReapRegistryExecution) ForceKill() error {
+	e.forceOnce.Do(func() { close(e.forceKilled) })
+	return nil
+}
+
+func (s *contextObservingRegistryStarter) Start(ctx context.Context, _ agent.RunInput) (agent.Execution, error) {
+	s.execution = &contextObservingRegistryExecution{ctx: ctx, done: make(chan struct{})}
+	return s.execution, nil
+}
+
+type contextObservingRegistryExecution struct {
+	ctx      context.Context
+	done     chan struct{}
+	doneOnce sync.Once
+}
+
+func (e *contextObservingRegistryExecution) Wait(context.Context) (agent.Result, error) {
+	<-e.ctx.Done()
+	e.doneOnce.Do(func() { close(e.done) })
+	return agent.Result{Status: "killed"}, nil
+}
+
+func (e *contextObservingRegistryExecution) Kill(string) error { return nil }

--- a/internal/runtime/active_executions.go
+++ b/internal/runtime/active_executions.go
@@ -508,18 +508,30 @@ func (r *ActiveExecutionRegistry) ForceKillAndWait(ctx context.Context) error {
 				continue
 			}
 			waitErr := execution.entry.err()
-			if execution.forceErr != nil && waitErr != nil {
-				errList = append(errList, execution.forceErr, fmt.Errorf("wait for force-killed execution reap: %w", waitErr))
+			if execution.forceErr != nil {
+				// ForceKill did not confirm process-group resolution. Keep the
+				// live handle and surface both failures.
+				if waitErr != nil {
+					errList = append(errList, execution.forceErr, fmt.Errorf("wait for force-killed execution reap: %w", waitErr))
+				} else {
+					errList = append(errList, execution.forceErr)
+				}
 				continue
 			}
-			// Either Wait confirmed the original reap or ForceKill confirmed a
-			// later probe. Only those authorities can retire the retained entry.
+			// ForceKill confirmed the process group is gone, so process ownership
+			// can be retired. Preserve a non-nil Wait error (for example a
+			// terminal persistFinal failure) so shutdown cannot treat durable
+			// status as cleanly closed while the agent_executions row remains
+			// running/cancelling.
 			r.mu.Lock()
 			if r.executions[execution.key] == execution.entry {
 				delete(r.executions, execution.key)
 				r.notifyStateChangedLocked()
 			}
 			r.mu.Unlock()
+			if waitErr != nil {
+				errList = append(errList, fmt.Errorf("wait for force-killed execution reap: %w", waitErr))
+			}
 		}
 		for _, run := range runs {
 			if err := waitForActiveDone(ctx, run.entry.done); err != nil {

--- a/internal/runtime/active_executions.go
+++ b/internal/runtime/active_executions.go
@@ -125,6 +125,18 @@ func (r *ActiveExecutionRegistry) BeginShutdown(reason string) {
 	}
 }
 
+// IsClosing reports whether BeginShutdown has closed the spawn boundary.
+// Callers that race RegisterRun against shutdown use this to decide whether
+// unstarted claimed work should be requeued for restart recovery.
+func (r *ActiveExecutionRegistry) IsClosing() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.closing
+}
+
 // StartAgentExecution acquires an ownership lease before invoking Start. The
 // lease closes the spawn-to-register gap: shutdown cannot observe an empty
 // registry while a starter may already have created a child process.

--- a/internal/runtime/active_executions.go
+++ b/internal/runtime/active_executions.go
@@ -1,51 +1,581 @@
 package runtime
 
-import "sync"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/nexu-io/looper/internal/agent"
+)
 
 type activeExecution interface {
+	Wait(context.Context) (agent.Result, error)
 	Kill(string) error
 }
 
+type forceKillingExecution interface {
+	// ForceKill returns nil only after the owned process group is confirmed no
+	// longer signalable. Implementations must not treat signal delivery alone as
+	// successful resolution.
+	ForceKill() error
+}
+
+type activeExecutionEntry struct {
+	execution activeExecution
+	done      chan struct{}
+	cleanup   func()
+
+	mu      sync.Mutex
+	waitErr error
+}
+
+func (e *activeExecutionEntry) finish(err error) {
+	e.mu.Lock()
+	e.waitErr = err
+	e.mu.Unlock()
+	close(e.done)
+}
+
+func (e *activeExecutionEntry) err() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.waitErr
+}
+
+type activeRunEntry struct {
+	cancel context.CancelFunc
+	done   <-chan struct{}
+}
+
 type ActiveExecutionRegistry struct {
-	mu         sync.Mutex
-	executions map[string]activeExecution
+	mu             sync.Mutex
+	executions     map[string]*activeExecutionEntry
+	runs           map[string]*activeRunEntry
+	pendingStarts  int
+	pendingByLoop  map[string]int
+	stoppingLoops  map[string]int
+	closing        bool
+	stopReason     string
+	shutdownCtx    context.Context
+	shutdownCancel context.CancelFunc
+	stateChanged   chan struct{}
 }
 
 func NewActiveExecutionRegistry() *ActiveExecutionRegistry {
-	return &ActiveExecutionRegistry{executions: make(map[string]activeExecution)}
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	return &ActiveExecutionRegistry{
+		executions:     make(map[string]*activeExecutionEntry),
+		runs:           make(map[string]*activeRunEntry),
+		pendingByLoop:  make(map[string]int),
+		stoppingLoops:  make(map[string]int),
+		shutdownCtx:    shutdownCtx,
+		shutdownCancel: shutdownCancel,
+		stateChanged:   make(chan struct{}),
+	}
 }
 
+// BeginLoopStop prevents new run reservations and agent starts for loopID. The
+// caller must hold the returned lease through its durable pause/terminate/
+// takeover transition so the scheduler cannot publish a replacement between
+// the final empty registry snapshot and that state change.
+func (r *ActiveExecutionRegistry) BeginLoopStop(loopID string) func() {
+	if r == nil || loopID == "" {
+		return func() {}
+	}
+	r.mu.Lock()
+	r.stoppingLoops[loopID]++
+	r.notifyStateChangedLocked()
+	r.mu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.mu.Lock()
+			if r.stoppingLoops[loopID] <= 1 {
+				delete(r.stoppingLoops, loopID)
+			} else {
+				r.stoppingLoops[loopID]--
+			}
+			r.notifyStateChangedLocked()
+			r.mu.Unlock()
+		})
+	}
+}
+
+// BeginShutdown closes the spawn boundary before scheduler cancellation. Any
+// registered-start lease already in progress remains visible as pending until
+// it either fails or atomically publishes its live handle; later starts are
+// rejected before invoking the subprocess starter.
+func (r *ActiveExecutionRegistry) BeginShutdown(reason string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.closing {
+		r.mu.Unlock()
+		return
+	}
+	r.closing = true
+	r.stopReason = reason
+	cancel := r.shutdownCancel
+	r.notifyStateChangedLocked()
+	r.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// StartAgentExecution acquires an ownership lease before invoking Start. The
+// lease closes the spawn-to-register gap: shutdown cannot observe an empty
+// registry while a starter may already have created a child process.
+func (r *ActiveExecutionRegistry) StartAgentExecution(ctx context.Context, loopID, runID, executionID string, starter agentExecutionStarter, input agent.RunInput) (agent.Execution, error) {
+	if starter == nil {
+		return nil, fmt.Errorf("agent execution starter is not configured")
+	}
+	if r == nil {
+		return starter.Start(ctx, input)
+	}
+
+	r.mu.Lock()
+	if r.closing || r.stoppingLoops[loopID] > 0 {
+		r.mu.Unlock()
+		return nil, context.Canceled
+	}
+	r.pendingStarts++
+	r.pendingByLoop[loopID]++
+	shutdownCtx := r.shutdownCtx
+	r.notifyStateChangedLocked()
+	r.mu.Unlock()
+
+	startCtx, cancelStart := context.WithCancel(ctx)
+	stopShutdownCancel := context.AfterFunc(shutdownCtx, cancelStart)
+	cleanupStartContext := func() {
+		stopShutdownCancel()
+		cancelStart()
+	}
+
+	execution, err := starter.Start(startCtx, input)
+	if err != nil {
+		cleanupStartContext()
+		r.finishPendingStart(loopID)
+		return nil, err
+	}
+	if execution == nil {
+		cleanupStartContext()
+		r.finishPendingStart(loopID)
+		return nil, fmt.Errorf("agent execution starter returned a nil execution")
+	}
+
+	key := activeExecutionKey(loopID, runID, executionID)
+	entry := &activeExecutionEntry{execution: execution, done: make(chan struct{}), cleanup: cleanupStartContext}
+	r.mu.Lock()
+	r.pendingStarts--
+	r.decrementPendingLoopLocked(loopID)
+	r.executions[key] = entry
+	closing := r.closing
+	reason := r.stopReason
+	r.notifyStateChangedLocked()
+	r.mu.Unlock()
+	r.waitForExecution(key, entry)
+	if closing {
+		_ = execution.Kill(reason)
+	}
+	return execution, nil
+}
+
+func (r *ActiveExecutionRegistry) finishPendingStart(loopID string) {
+	r.mu.Lock()
+	if r.pendingStarts > 0 {
+		r.pendingStarts--
+	}
+	r.decrementPendingLoopLocked(loopID)
+	r.notifyStateChangedLocked()
+	r.mu.Unlock()
+}
+
+func (r *ActiveExecutionRegistry) decrementPendingLoopLocked(loopID string) {
+	if r.pendingByLoop[loopID] <= 1 {
+		delete(r.pendingByLoop, loopID)
+		return
+	}
+	r.pendingByLoop[loopID]--
+}
+
+func (r *ActiveExecutionRegistry) waitForExecution(key string, entry *activeExecutionEntry) {
+	go func() {
+		_, err := entry.execution.Wait(context.Background())
+		if entry.cleanup != nil {
+			entry.cleanup()
+		}
+		entry.finish(err)
+		r.mu.Lock()
+		// A Wait error means the live handle did not confirm process-group
+		// reaping. Keep that authority registered so bounded shutdown can invoke
+		// its forced-resolution contract instead of losing the only safe handle.
+		if err == nil && r.executions[key] == entry {
+			delete(r.executions, key)
+		}
+		r.notifyStateChangedLocked()
+		r.mu.Unlock()
+	}()
+}
+
+// Register makes the live executor handle authoritative until its Wait method
+// confirms that the process has been reaped. The registry owns one background
+// waiter so callers can safely stop or shut down even after a role runner's
+// context has been cancelled. The returned release function is retained for
+// caller compatibility, but cannot revoke ownership before Wait resolves.
 func (r *ActiveExecutionRegistry) Register(loopID, runID, executionID string, execution activeExecution) func() {
 	if r == nil || execution == nil {
 		return func() {}
 	}
 	key := activeExecutionKey(loopID, runID, executionID)
+	entry := &activeExecutionEntry{execution: execution, done: make(chan struct{})}
+
 	r.mu.Lock()
-	r.executions[key] = execution
-	r.mu.Unlock()
-	return func() {
-		r.mu.Lock()
-		if r.executions[key] == execution {
-			delete(r.executions, key)
-		}
+	if r.closing || r.stoppingLoops[loopID] > 0 {
+		reason := r.stopReason
 		r.mu.Unlock()
+		// The process was spawned across the shutdown boundary. Resolve that
+		// ownership synchronously so a registration rejected after the registry
+		// became empty cannot escape as an unowned child process.
+		_ = execution.Kill(reason)
+		if force, ok := execution.(forceKillingExecution); ok {
+			_ = force.ForceKill()
+		}
+		_, _ = execution.Wait(context.Background())
+		return func() {}
+	}
+	r.executions[key] = entry
+	r.notifyStateChangedLocked()
+	r.mu.Unlock()
+	r.waitForExecution(key, entry)
+
+	return func() {}
+}
+
+// RegisterRun owns the cancellable context for the whole scheduled role run,
+// including work performed after the coding-agent process exits (for example,
+// validation commands). A loop stop therefore cannot lose ownership in the gap
+// between agent completion and runner completion. As with Register, the returned
+// release function cannot revoke ownership before done closes.
+func (r *ActiveExecutionRegistry) RegisterRun(loopID, ownerID string, cancel context.CancelFunc, done <-chan struct{}) (func(), bool) {
+	if r == nil || cancel == nil || done == nil {
+		return func() {}, false
+	}
+	key := activeRunKey(loopID, ownerID)
+	entry := &activeRunEntry{cancel: cancel, done: done}
+	r.mu.Lock()
+	if r.closing || r.stoppingLoops[loopID] > 0 {
+		r.mu.Unlock()
+		// RegisterRun is called before a scheduled role starts. Rejecting the
+		// ownership reservation by cancelling its context prevents a new process
+		// from being spawned after shutdown has crossed the empty boundary.
+		cancel()
+		return func() {}, false
+	}
+	r.runs[key] = entry
+	r.notifyStateChangedLocked()
+	r.mu.Unlock()
+	go func() {
+		<-done
+		r.mu.Lock()
+		if r.runs[key] == entry {
+			delete(r.runs, key)
+		}
+		r.notifyStateChangedLocked()
+		r.mu.Unlock()
+	}()
+	return func() {}, true
+}
+
+// StopAndWait stops every live execution, pending start, and enclosing
+// scheduled run for the loop. Callers performing a durable lifecycle
+// transition must hold BeginLoopStop's lease across this call and the state
+// change. A true result means live or pending ownership existed and resolved.
+func (r *ActiveExecutionRegistry) StopAndWait(ctx context.Context, loopID, _ string, _ string, reason string) (bool, error) {
+	if r == nil {
+		return false, nil
+	}
+	found := false
+	var errList []error
+	seenExecutions := make(map[*activeExecutionEntry]struct{})
+	seenRuns := make(map[*activeRunEntry]struct{})
+	for {
+		r.mu.Lock()
+		executions := r.executionsForLoopLocked(loopID)
+		runs := r.runsForLoopLocked(loopID)
+		pendingStarts := r.pendingByLoop[loopID]
+		stateChanged := r.stateChanged
+		r.mu.Unlock()
+
+		if len(executions) == 0 && len(runs) == 0 && pendingStarts == 0 {
+			return found, errors.Join(errList...)
+		}
+		found = true
+		for _, execution := range executions {
+			if _, seen := seenExecutions[execution]; seen {
+				continue
+			}
+			seenExecutions[execution] = struct{}{}
+			if err := execution.execution.Kill(reason); err != nil {
+				errList = append(errList, fmt.Errorf("kill active execution: %w", err))
+			}
+		}
+		for _, run := range runs {
+			if _, seen := seenRuns[run]; seen {
+				continue
+			}
+			seenRuns[run] = struct{}{}
+			run.cancel()
+		}
+		if len(errList) > 0 {
+			return true, errors.Join(errList...)
+		}
+		for _, execution := range executions {
+			if err := waitForActiveDone(ctx, execution.done); err != nil {
+				errList = append(errList, fmt.Errorf("wait for active execution reap: %w", err))
+				return true, errors.Join(errList...)
+			}
+			if err := execution.err(); err != nil {
+				errList = append(errList, fmt.Errorf("wait for active execution reap: %w", err))
+			}
+		}
+		for _, run := range runs {
+			if err := waitForActiveDone(ctx, run.done); err != nil {
+				errList = append(errList, fmt.Errorf("wait for active run completion: %w", err))
+				return true, errors.Join(errList...)
+			}
+		}
+		if len(executions) == 0 && len(runs) == 0 && pendingStarts > 0 {
+			if err := waitForActiveDone(ctx, stateChanged); err != nil {
+				errList = append(errList, fmt.Errorf("wait for pending loop execution start: %w", err))
+				return true, errors.Join(errList...)
+			}
+		}
+		if len(errList) > 0 {
+			return true, errors.Join(errList...)
+		}
 	}
 }
 
+// Kill preserves the existing non-blocking registry surface for callers that
+// only need to request cancellation. Lifecycle transitions should use
+// StopAndWait so process reaping remains part of the contract.
 func (r *ActiveExecutionRegistry) Kill(loopID, runID, executionID, reason string) (bool, error) {
 	if r == nil {
 		return false, nil
 	}
 	key := activeExecutionKey(loopID, runID, executionID)
 	r.mu.Lock()
-	execution := r.executions[key]
+	entry := r.executions[key]
 	r.mu.Unlock()
-	if execution == nil {
+	if entry == nil {
 		return false, nil
 	}
-	return true, execution.Kill(reason)
+	return true, entry.execution.Kill(reason)
+}
+
+// ShutdownAndWait prevents newly registered work from escaping shutdown,
+// requests cancellation for all current ownership records, and waits until the
+// registry is empty or ctx expires.
+func (r *ActiveExecutionRegistry) ShutdownAndWait(ctx context.Context, reason string) error {
+	if r == nil {
+		return nil
+	}
+	r.BeginShutdown(reason)
+
+	seenExecutions := make(map[*activeExecutionEntry]struct{})
+	seenRuns := make(map[*activeRunEntry]struct{})
+	var killErrs []error
+	for {
+		r.mu.Lock()
+		executions := make([]*activeExecutionEntry, 0, len(r.executions))
+		for _, entry := range r.executions {
+			executions = append(executions, entry)
+		}
+		runs := make([]*activeRunEntry, 0, len(r.runs))
+		for _, entry := range r.runs {
+			runs = append(runs, entry)
+		}
+		pendingStarts := r.pendingStarts
+		stateChanged := r.stateChanged
+		r.mu.Unlock()
+
+		if len(executions) == 0 && len(runs) == 0 && pendingStarts == 0 {
+			return nil
+		}
+		for _, entry := range executions {
+			if _, seen := seenExecutions[entry]; !seen {
+				seenExecutions[entry] = struct{}{}
+				if err := entry.execution.Kill(reason); err != nil {
+					killErrs = append(killErrs, fmt.Errorf("kill active execution during shutdown: %w", err))
+				}
+			}
+		}
+		for _, entry := range runs {
+			if _, seen := seenRuns[entry]; !seen {
+				seenRuns[entry] = struct{}{}
+				entry.cancel()
+			}
+		}
+		for _, entry := range executions {
+			if err := waitForActiveDone(ctx, entry.done); err != nil {
+				return fmt.Errorf("wait for active execution during shutdown: %w", err)
+			}
+			if err := entry.err(); err != nil {
+				return fmt.Errorf("wait for active execution during shutdown: %w", err)
+			}
+		}
+		for _, entry := range runs {
+			if err := waitForActiveDone(ctx, entry.done); err != nil {
+				return fmt.Errorf("wait for active run during shutdown: %w", err)
+			}
+		}
+		if len(executions) == 0 && len(runs) == 0 && pendingStarts > 0 {
+			if err := waitForActiveDone(ctx, stateChanged); err != nil {
+				return fmt.Errorf("wait for pending agent start during shutdown: %w", err)
+			}
+		}
+		if len(killErrs) > 0 {
+			return errors.Join(killErrs...)
+		}
+	}
+}
+
+// ForceKillAndWait is the bounded-shutdown escalation path. A nil ForceKill
+// result is the live handle's confirmation that process-group ownership has
+// resolved, not merely that a signal was sent. This lets the registry safely
+// retire a handle whose earlier Wait returned a failed-reap diagnostic.
+func (r *ActiveExecutionRegistry) ForceKillAndWait(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	type keyedExecution struct {
+		key      string
+		entry    *activeExecutionEntry
+		forceErr error
+	}
+	type keyedRun struct {
+		key   string
+		entry *activeRunEntry
+	}
+	for {
+		r.mu.Lock()
+		executions := make([]keyedExecution, 0, len(r.executions))
+		for key, entry := range r.executions {
+			executions = append(executions, keyedExecution{key: key, entry: entry})
+		}
+		runs := make([]keyedRun, 0, len(r.runs))
+		for key, entry := range r.runs {
+			runs = append(runs, keyedRun{key: key, entry: entry})
+		}
+		pendingStarts := r.pendingStarts
+		stateChanged := r.stateChanged
+		r.mu.Unlock()
+		if len(executions) == 0 && len(runs) == 0 && pendingStarts == 0 {
+			return nil
+		}
+		for index := range executions {
+			force, ok := executions[index].entry.execution.(forceKillingExecution)
+			if !ok {
+				executions[index].forceErr = fmt.Errorf("active execution does not support forced process-group termination")
+				continue
+			}
+			if err := force.ForceKill(); err != nil {
+				executions[index].forceErr = fmt.Errorf("force kill active execution: %w", err)
+			}
+		}
+		for _, run := range runs {
+			run.entry.cancel()
+		}
+		var errList []error
+		for _, execution := range executions {
+			if err := waitForActiveDone(ctx, execution.entry.done); err != nil {
+				errList = append(errList, fmt.Errorf("wait for force-killed execution reap: %w", err))
+				continue
+			}
+			waitErr := execution.entry.err()
+			if execution.forceErr != nil && waitErr != nil {
+				errList = append(errList, execution.forceErr, fmt.Errorf("wait for force-killed execution reap: %w", waitErr))
+				continue
+			}
+			// Either Wait confirmed the original reap or ForceKill confirmed a
+			// later probe. Only those authorities can retire the retained entry.
+			r.mu.Lock()
+			if r.executions[execution.key] == execution.entry {
+				delete(r.executions, execution.key)
+				r.notifyStateChangedLocked()
+			}
+			r.mu.Unlock()
+		}
+		for _, run := range runs {
+			if err := waitForActiveDone(ctx, run.entry.done); err != nil {
+				errList = append(errList, fmt.Errorf("wait for cancelled active run: %w", err))
+				continue
+			}
+			r.mu.Lock()
+			if r.runs[run.key] == run.entry {
+				delete(r.runs, run.key)
+				r.notifyStateChangedLocked()
+			}
+			r.mu.Unlock()
+		}
+		if len(executions) == 0 && len(runs) == 0 && pendingStarts > 0 {
+			if err := waitForActiveDone(ctx, stateChanged); err != nil {
+				errList = append(errList, fmt.Errorf("wait for pending agent start before force reap: %w", err))
+			}
+		}
+		if len(errList) > 0 {
+			return errors.Join(errList...)
+		}
+	}
+}
+
+func (r *ActiveExecutionRegistry) notifyStateChangedLocked() {
+	if r.stateChanged == nil {
+		r.stateChanged = make(chan struct{})
+		return
+	}
+	close(r.stateChanged)
+	r.stateChanged = make(chan struct{})
+}
+
+func (r *ActiveExecutionRegistry) runsForLoopLocked(loopID string) []*activeRunEntry {
+	prefix := loopID + "\x00"
+	runs := make([]*activeRunEntry, 0)
+	for key, entry := range r.runs {
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			runs = append(runs, entry)
+		}
+	}
+	return runs
+}
+
+func (r *ActiveExecutionRegistry) executionsForLoopLocked(loopID string) []*activeExecutionEntry {
+	prefix := loopID + "\x00"
+	executions := make([]*activeExecutionEntry, 0)
+	for key, entry := range r.executions {
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			executions = append(executions, entry)
+		}
+	}
+	return executions
+}
+
+func waitForActiveDone(ctx context.Context, done <-chan struct{}) error {
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func activeExecutionKey(loopID, runID, executionID string) string {
 	return loopID + "\x00" + runID + "\x00" + executionID
+}
+
+func activeRunKey(loopID, ownerID string) string {
+	return loopID + "\x00" + ownerID
 }

--- a/internal/runtime/active_executions_lifecycle_contract_test.go
+++ b/internal/runtime/active_executions_lifecycle_contract_test.go
@@ -1,0 +1,66 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/agent"
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestRuntimeStopForceReapsTermResistantRegisteredExecution(t *testing.T) {
+	workingDir := t.TempDir()
+	pidPath := filepath.Join(workingDir, "agent.pid")
+	executor := agent.New(agent.ExecutorOptions{Config: agent.ExecutorConfig{
+		Vendor: config.AgentVendor("custom"),
+		Params: map[string]any{
+			"command": "/bin/sh",
+			"args":    []any{"-c", `trap '' TERM; echo $$ > "$PID_FILE"; while :; do sleep 1; done`},
+		},
+	}})
+	execution, err := executor.Start(context.Background(), agent.RunInput{
+		ExecutionID:      "exec_runtime_shutdown",
+		LoopID:           "loop_runtime_shutdown",
+		RunID:            "run_runtime_shutdown",
+		WorkingDirectory: workingDir,
+		Prompt:           "ignored",
+		Timeout:          10 * time.Second,
+		GracefulShutdown: 5 * time.Second,
+		Env:              map[string]string{"PID_FILE": pidPath},
+	})
+	if err != nil {
+		t.Fatalf("executor.Start() error = %v", err)
+	}
+	waitForRecoveryContractFile(t, pidPath)
+	rawPID, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatalf("read pid file: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(rawPID)))
+	if err != nil {
+		t.Fatalf("parse pid file: %v", err)
+	}
+	t.Cleanup(func() { _ = syscall.Kill(-pid, syscall.SIGKILL) })
+
+	rt := New(Options{ShutdownTimeout: 30 * time.Millisecond})
+	rt.activeExecutions.Register("loop_runtime_shutdown", "run_runtime_shutdown", "exec_runtime_shutdown", execution)
+	rt.Stop("test shutdown")
+
+	if err := syscall.Kill(-pid, 0); err == nil || !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("Runtime.Stop returned while process group %d was still live: %v", pid, err)
+	}
+	result, err := execution.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("execution.Wait() error = %v", err)
+	}
+	if result.Status != "killed" {
+		t.Fatalf("execution status = %q, want killed", result.Status)
+	}
+}

--- a/internal/runtime/active_executions_test.go
+++ b/internal/runtime/active_executions_test.go
@@ -100,6 +100,36 @@ func TestActiveExecutionRegistryForceKillWaitsForReap(t *testing.T) {
 	}
 }
 
+func TestActiveExecutionRegistryForceKillPreservesTerminalWaitError(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	execution := newTerminalPersistFailureRegistryExecution()
+	registry.Register("loop_persist", "run_persist", "exec_persist", execution)
+	<-execution.waited
+
+	// Graceful shutdown keeps the live handle while durable terminal status
+	// remains unwritten.
+	if _, err := registry.StopAndWait(context.Background(), "loop_persist", "", "", "stop"); !errors.Is(err, errRegistryTerminalPersist) {
+		t.Fatalf("StopAndWait() error = %v, want terminal persist failure", err)
+	}
+
+	// ForceKill confirms the process group is gone and retires the handle, but
+	// must still surface the terminal Wait error so shutdown cannot treat the
+	// durable agent_executions row as cleanly closed.
+	if err := registry.ForceKillAndWait(context.Background()); !errors.Is(err, errRegistryTerminalPersist) {
+		t.Fatalf("ForceKillAndWait() error = %v, want terminal persist failure preserved", err)
+	}
+	select {
+	case <-execution.forceKilled:
+	default:
+		t.Fatal("ForceKill was not invoked")
+	}
+	if err := registry.ForceKillAndWait(context.Background()); err != nil {
+		t.Fatalf("second ForceKillAndWait() error = %v after ownership retired", err)
+	}
+}
+
 func TestActiveExecutionRegistryRejectsExecutionRegisteredAfterShutdownBoundary(t *testing.T) {
 	t.Parallel()
 
@@ -241,6 +271,36 @@ type blockingRegistryExecution struct {
 	finishOnce  sync.Once
 	killOnce    sync.Once
 	forceOnce   sync.Once
+}
+
+var errRegistryTerminalPersist = errors.New("persist terminal agent execution status")
+
+// terminalPersistFailureRegistryExecution models Wait after process reaping when
+// the durable agent_executions terminal Upsert still failed.
+type terminalPersistFailureRegistryExecution struct {
+	waited      chan struct{}
+	forceKilled chan struct{}
+	waitOnce    sync.Once
+	forceOnce   sync.Once
+}
+
+func newTerminalPersistFailureRegistryExecution() *terminalPersistFailureRegistryExecution {
+	return &terminalPersistFailureRegistryExecution{
+		waited:      make(chan struct{}),
+		forceKilled: make(chan struct{}),
+	}
+}
+
+func (e *terminalPersistFailureRegistryExecution) Wait(context.Context) (agent.Result, error) {
+	e.waitOnce.Do(func() { close(e.waited) })
+	return agent.Result{Status: "killed"}, errRegistryTerminalPersist
+}
+
+func (e *terminalPersistFailureRegistryExecution) Kill(string) error { return nil }
+
+func (e *terminalPersistFailureRegistryExecution) ForceKill() error {
+	e.forceOnce.Do(func() { close(e.forceKilled) })
+	return nil
 }
 
 type gatedRegistryStarter struct {

--- a/internal/runtime/active_executions_test.go
+++ b/internal/runtime/active_executions_test.go
@@ -1,0 +1,290 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/agent"
+)
+
+func TestActiveExecutionRegistryStopAndWaitRequiresExecutionAndRunCompletion(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	execution := newBlockingRegistryExecution()
+	registry.Register("loop_1", "run_1", "exec_1", execution)
+	runDone := make(chan struct{})
+	runCancelled := make(chan struct{})
+	var cancelOnce sync.Once
+	_, accepted := registry.RegisterRun("loop_1", "queue_1", func() {
+		cancelOnce.Do(func() { close(runCancelled) })
+	}, runDone)
+	if !accepted {
+		t.Fatal("RegisterRun rejected before shutdown")
+	}
+
+	returned := make(chan error, 1)
+	go func() {
+		_, err := registry.StopAndWait(context.Background(), "loop_1", "run_1", "exec_1", "stop test")
+		returned <- err
+	}()
+
+	select {
+	case <-execution.killed:
+	case <-time.After(time.Second):
+		t.Fatal("execution was not killed")
+	}
+	select {
+	case <-runCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("run context was not cancelled")
+	}
+	execution.finish()
+	select {
+	case err := <-returned:
+		t.Fatalf("StopAndWait returned before run completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(runDone)
+	if err := <-returned; err != nil {
+		t.Fatalf("StopAndWait() error = %v", err)
+	}
+}
+
+func TestActiveExecutionRegistryShutdownKillsLateRegistrationAndWaitsForReap(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	first := newBlockingRegistryExecution()
+	registry.Register("loop_1", "run_1", "exec_1", first)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	returned := make(chan error, 1)
+	go func() { returned <- registry.ShutdownAndWait(ctx, "shutdown") }()
+	select {
+	case <-first.killed:
+	case <-time.After(time.Second):
+		t.Fatal("first execution was not killed")
+	}
+
+	late := newBlockingRegistryExecution()
+	registry.Register("loop_2", "run_2", "exec_2", late)
+	select {
+	case <-late.killed:
+	case <-time.After(time.Second):
+		t.Fatal("late execution escaped registry shutdown")
+	}
+	first.finish()
+	late.finish()
+	if err := <-returned; err != nil {
+		t.Fatalf("ShutdownAndWait() error = %v", err)
+	}
+}
+
+func TestActiveExecutionRegistryForceKillWaitsForReap(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	execution := newBlockingRegistryExecution()
+	registry.Register("loop_1", "run_1", "exec_1", execution)
+	if err := registry.ForceKillAndWait(context.Background()); err != nil {
+		t.Fatalf("ForceKillAndWait() error = %v", err)
+	}
+	select {
+	case <-execution.forceKilled:
+	default:
+		t.Fatal("ForceKill was not invoked")
+	}
+}
+
+func TestActiveExecutionRegistryRejectsExecutionRegisteredAfterShutdownBoundary(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	if err := registry.ShutdownAndWait(context.Background(), "shutdown"); err != nil {
+		t.Fatalf("ShutdownAndWait() error = %v", err)
+	}
+
+	execution := newBlockingRegistryExecution()
+	registry.Register("loop_late", "run_late", "exec_late", execution)
+	select {
+	case <-execution.done:
+	default:
+		t.Fatal("late Register returned before the rejected execution was reaped")
+	}
+	select {
+	case <-execution.killed:
+	default:
+		t.Fatal("late execution did not receive graceful cancellation")
+	}
+	select {
+	case <-execution.forceKilled:
+	default:
+		t.Fatal("late execution did not receive forced process-group termination")
+	}
+}
+
+func TestActiveExecutionRegistryShutdownWaitsForPendingStartLease(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	starter := &gatedRegistryStarter{started: make(chan struct{}), release: make(chan struct{})}
+	startReturned := make(chan error, 1)
+	go func() {
+		_, err := registry.StartAgentExecution(context.Background(), "loop_pending", "run_pending", "exec_pending", starter, agent.RunInput{ExecutionID: "exec_pending"})
+		startReturned <- err
+	}()
+	<-starter.started
+
+	shutdownReturned := make(chan error, 1)
+	go func() { shutdownReturned <- registry.ShutdownAndWait(context.Background(), "shutdown") }()
+	select {
+	case err := <-shutdownReturned:
+		t.Fatalf("ShutdownAndWait returned across a pending start lease: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(starter.release)
+	if err := <-startReturned; !errors.Is(err, context.Canceled) {
+		t.Fatalf("StartAgentExecution() error = %v, want context canceled", err)
+	}
+	if err := <-shutdownReturned; err != nil {
+		t.Fatalf("ShutdownAndWait() error = %v", err)
+	}
+}
+
+func TestActiveExecutionRegistryRejectsRunAfterShutdownBoundary(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	registry.BeginShutdown("shutdown")
+	cancelled := make(chan struct{})
+	var once sync.Once
+	_, accepted := registry.RegisterRun("loop_late", "queue_late", func() {
+		once.Do(func() { close(cancelled) })
+	}, make(chan struct{}))
+	if accepted {
+		t.Fatal("RegisterRun accepted work after shutdown began")
+	}
+	select {
+	case <-cancelled:
+	default:
+		t.Fatal("RegisterRun did not cancel rejected work")
+	}
+}
+
+func TestActiveExecutionRegistryLoopStopLeaseRejectsReplacementUntilDurableTransition(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	execution := newBlockingRegistryExecution()
+	registry.Register("loop_stop", "run_old", "exec_old", execution)
+	releaseLoopStop := registry.BeginLoopStop("loop_stop")
+	returned := make(chan error, 1)
+	go func() {
+		_, err := registry.StopAndWait(context.Background(), "loop_stop", "run_old", "exec_old", "stop")
+		returned <- err
+	}()
+	select {
+	case <-execution.killed:
+	case <-time.After(time.Second):
+		t.Fatal("existing execution was not killed")
+	}
+
+	assertRunRejected := func(owner string) {
+		t.Helper()
+		cancelled := make(chan struct{})
+		var once sync.Once
+		_, accepted := registry.RegisterRun("loop_stop", owner, func() { once.Do(func() { close(cancelled) }) }, make(chan struct{}))
+		if accepted {
+			t.Fatalf("RegisterRun(%q) accepted while loop stop lease was held", owner)
+		}
+		select {
+		case <-cancelled:
+		default:
+			t.Fatalf("RegisterRun(%q) did not cancel rejected run", owner)
+		}
+	}
+	assertRunRejected("queue_during_reap")
+	starter := &countingRegistryStarter{}
+	if _, err := registry.StartAgentExecution(context.Background(), "loop_stop", "run_new", "exec_new", starter, agent.RunInput{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("StartAgentExecution() error = %v, want context canceled", err)
+	}
+	if starter.calls != 0 {
+		t.Fatalf("underlying starter calls = %d, want 0 while loop stop lease held", starter.calls)
+	}
+
+	execution.finish()
+	if err := <-returned; err != nil {
+		t.Fatalf("StopAndWait() error = %v", err)
+	}
+	// StopAndWait has reached an empty snapshot, but the caller has not yet made
+	// its durable transition; the lease must still close that final race.
+	assertRunRejected("queue_before_transition")
+	releaseLoopStop()
+
+	done := make(chan struct{})
+	close(done)
+	unregister, accepted := registry.RegisterRun("loop_stop", "queue_after_release", func() {}, done)
+	if !accepted {
+		t.Fatal("RegisterRun rejected after loop stop lease was released")
+	}
+	unregister()
+}
+
+type blockingRegistryExecution struct {
+	done        chan struct{}
+	killed      chan struct{}
+	forceKilled chan struct{}
+	finishOnce  sync.Once
+	killOnce    sync.Once
+	forceOnce   sync.Once
+}
+
+type gatedRegistryStarter struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+type countingRegistryStarter struct{ calls int }
+
+func (s *countingRegistryStarter) Start(context.Context, agent.RunInput) (agent.Execution, error) {
+	s.calls++
+	return newBlockingRegistryExecution(), nil
+}
+
+func (s *gatedRegistryStarter) Start(ctx context.Context, _ agent.RunInput) (agent.Execution, error) {
+	close(s.started)
+	<-s.release
+	return nil, ctx.Err()
+}
+
+func newBlockingRegistryExecution() *blockingRegistryExecution {
+	return &blockingRegistryExecution{done: make(chan struct{}), killed: make(chan struct{}), forceKilled: make(chan struct{})}
+}
+
+func (e *blockingRegistryExecution) Wait(ctx context.Context) (agent.Result, error) {
+	select {
+	case <-e.done:
+		return agent.Result{Status: "killed"}, nil
+	case <-ctx.Done():
+		return agent.Result{}, ctx.Err()
+	}
+}
+
+func (e *blockingRegistryExecution) Kill(string) error {
+	e.killOnce.Do(func() { close(e.killed) })
+	return nil
+}
+
+func (e *blockingRegistryExecution) ForceKill() error {
+	e.forceOnce.Do(func() { close(e.forceKilled) })
+	e.finish()
+	return nil
+}
+
+func (e *blockingRegistryExecution) finish() {
+	e.finishOnce.Do(func() { close(e.done) })
+}

--- a/internal/runtime/recovery_lifecycle_contract_test.go
+++ b/internal/runtime/recovery_lifecycle_contract_test.go
@@ -1,0 +1,252 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestStartupRecoveryReapsTermResistantOrphanBeforeSchedulerTick(t *testing.T) {
+	workingDir := t.TempDir()
+	script := filepath.Join(workingDir, "term-resistant-orphan.sh")
+	readyFile := filepath.Join(workingDir, "ready")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\ntrap '' TERM\n: > \"$READY_FILE\"\nwhile :; do sleep 1; done\n"), 0o755); err != nil {
+		t.Fatalf("write orphan script: %v", err)
+	}
+	cmd := exec.Command("/bin/sh", script)
+	cmd.Env = append(os.Environ(), "READY_FILE="+readyFile)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start orphan: %v", err)
+	}
+	pid := cmd.Process.Pid
+	reaped := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(reaped)
+	}()
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		select {
+		case <-reaped:
+		case <-time.After(time.Second):
+		}
+	})
+	waitForRecoveryContractFile(t, readyFile)
+
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Name: "Project", RepoPath: workingDir}}
+	now := time.Now().UTC()
+	nowISO := formatJavaScriptISOString(now.Add(-time.Hour))
+	seed := openMigratedCoordinator(t, cfg.Storage.DBPath, backupDir)
+	repos := storage.NewRepositories(seed.DB())
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Project", RepoPath: workingDir, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loopID := "loop_orphan"
+	runID := "run_orphan"
+	projectID := "project_1"
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: runID, LoopID: loopID, Status: "running", CurrentStep: stringPtr("execute"), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	commandJSON, err := json.Marshal(map[string]any{"command": "/bin/sh", "args": []string{script}})
+	if err != nil {
+		t.Fatalf("marshal command metadata: %v", err)
+	}
+	pid64 := int64(pid)
+	if err := repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "exec_orphan", ProjectID: &projectID, LoopID: &loopID, RunID: &runID, Vendor: "codex", Status: "running", PID: &pid64, CommandJSON: stringPtr(string(commandJSON)), CWD: &workingDir, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("seed coordinator close: %v", err)
+	}
+
+	ticked := make(chan struct{}, 1)
+	rt := New(Options{
+		Config: cfg,
+		Logger: &testLogger{},
+		RunSchedulerTick: func(context.Context, Services) error {
+			if recoveryProcessGroupExists(pid) {
+				t.Errorf("scheduler ticked while orphan process group %d was still live", pid)
+			}
+			select {
+			case ticked <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+	})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Runtime.Start() error = %v", err)
+	}
+	t.Cleanup(func() { rt.Stop("test cleanup") })
+	select {
+	case <-ticked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler did not start after recovery")
+	}
+	select {
+	case <-reaped:
+	default:
+		t.Fatal("recovery made scheduler visible before orphan was reaped")
+	}
+	execution, err := rt.Services().Repositories.AgentExecutions.GetByID(context.Background(), "exec_orphan")
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
+	}
+	if execution == nil || execution.Status != "killed" {
+		t.Fatalf("recovered execution = %#v, want killed", execution)
+	}
+}
+
+func TestStartupRecoveryReapsDescendantAfterLeaderExitsOnTERMBeforeSchedulerTick(t *testing.T) {
+	workingDir := t.TempDir()
+	script := filepath.Join(workingDir, "leader-exits-orphan.sh")
+	descendantPIDFile := filepath.Join(workingDir, "descendant.pid")
+	readyFile := filepath.Join(workingDir, "ready")
+	scriptBody := "#!/bin/sh\n" +
+		"/bin/sh -c 'trap \"\" TERM HUP; echo $$ > \"$DESCENDANT_PID_FILE\"; while :; do sleep 1; done' &\n" +
+		"while [ ! -s \"$DESCENDANT_PID_FILE\" ]; do sleep 0.01; done\n" +
+		": > \"$READY_FILE\"\n" +
+		"wait\n"
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatalf("write orphan script: %v", err)
+	}
+	cmd := exec.Command("/bin/sh", script)
+	cmd.Env = append(os.Environ(), "READY_FILE="+readyFile, "DESCENDANT_PID_FILE="+descendantPIDFile)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start orphan: %v", err)
+	}
+	leaderPID := cmd.Process.Pid
+	leaderReaped := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(leaderReaped)
+	}()
+	t.Cleanup(func() {
+		_ = syscall.Kill(-leaderPID, syscall.SIGKILL)
+		select {
+		case <-leaderReaped:
+		case <-time.After(time.Second):
+		}
+	})
+	waitForRecoveryContractFile(t, readyFile)
+	rawDescendantPID, err := os.ReadFile(descendantPIDFile)
+	if err != nil {
+		t.Fatalf("read descendant pid: %v", err)
+	}
+	descendantPID, err := strconv.Atoi(strings.TrimSpace(string(rawDescendantPID)))
+	if err != nil || descendantPID <= 0 {
+		t.Fatalf("parse descendant pid %q: %v", rawDescendantPID, err)
+	}
+	t.Cleanup(func() { _ = syscall.Kill(descendantPID, syscall.SIGKILL) })
+
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	cfg.Projects = []config.ProjectRefConfig{{ID: "project_descendant", Name: "Project", RepoPath: workingDir}}
+	nowISO := formatJavaScriptISOString(time.Now().UTC().Add(-time.Hour))
+	seed := openMigratedCoordinator(t, cfg.Storage.DBPath, backupDir)
+	repos := storage.NewRepositories(seed.DB())
+	projectID := "project_descendant"
+	loopID := "loop_descendant"
+	runID := "run_descendant"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Project", RepoPath: workingDir, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: runID, LoopID: loopID, Status: "running", CurrentStep: stringPtr("execute"), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	commandJSON, err := json.Marshal(map[string]any{"command": "/bin/sh", "args": []string{script}})
+	if err != nil {
+		t.Fatalf("marshal command metadata: %v", err)
+	}
+	leaderPID64 := int64(leaderPID)
+	if err := repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "exec_descendant", ProjectID: &projectID, LoopID: &loopID, RunID: &runID, Vendor: "codex", Status: "running", PID: &leaderPID64, CommandJSON: stringPtr(string(commandJSON)), CWD: &workingDir, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("seed coordinator close: %v", err)
+	}
+
+	ticked := make(chan struct{}, 1)
+	rt := New(Options{
+		Config: cfg,
+		Logger: &testLogger{},
+		RunSchedulerTick: func(context.Context, Services) error {
+			if recoveryProcessGroupExists(leaderPID) {
+				t.Errorf("scheduler ticked while orphan process group %d was still live", leaderPID)
+			}
+			if err := syscall.Kill(descendantPID, 0); err == nil || !errors.Is(err, syscall.ESRCH) {
+				t.Errorf("scheduler ticked while orphan descendant %d was still live: %v", descendantPID, err)
+			}
+			select {
+			case ticked <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+	})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Runtime.Start() error = %v", err)
+	}
+	t.Cleanup(func() { rt.Stop("test cleanup") })
+	select {
+	case <-ticked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler did not start after descendant process-group recovery")
+	}
+	select {
+	case <-leaderReaped:
+	default:
+		t.Fatal("recovery made scheduler visible before orphan leader was reaped")
+	}
+	if recoveryProcessGroupExists(leaderPID) {
+		t.Fatalf("orphan process group %d survived startup recovery", leaderPID)
+	}
+}
+
+func waitForRecoveryContractFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process readiness file %s was not written", path)
+}
+
+func recoveryProcessGroupExists(pid int) bool {
+	err := syscall.Kill(-pid, 0)
+	return err == nil || !errors.Is(err, syscall.ESRCH)
+}

--- a/internal/runtime/recovery_lifecycle_contract_test.go
+++ b/internal/runtime/recovery_lifecycle_contract_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	shellinfra "github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -249,4 +250,61 @@ func waitForRecoveryContractFile(t *testing.T, path string) {
 func recoveryProcessGroupExists(pid int) bool {
 	err := syscall.Kill(-pid, 0)
 	return err == nil || !errors.Is(err, syscall.ESRCH)
+}
+
+// TestRecoveredProcessGroupExitedTreatsZombieOnlyGroupAsExited locks the recovery
+// barrier to the non-zombie probe: after SIGKILL, kill(-pgid, 0) can still
+// succeed for unreaped zombies on Linux, but recovery must treat the group as
+// exited so orphan cleanup marks the execution killed instead of uncertain.
+func TestRecoveredProcessGroupExitedTreatsZombieOnlyGroupAsExited(t *testing.T) {
+	// Leaf process only: a shell -c "sleep …" can leave a live sleep sibling in
+	// the group after the shell is killed (dash forks), which is not the
+	// zombie-only case under test.
+	cmd := exec.Command("sleep", "30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	pgid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL process group: %v", err)
+	}
+	// Wait until the leader is no longer runnable without reaping it.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		live, err := shellinfra.ProcessRunnable(pgid)
+		if err != nil {
+			t.Fatalf("ProcessRunnable() settle error = %v", err)
+		}
+		if !live {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process %d remained runnable after SIGKILL", pgid)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// kill(0) may still succeed (or return EPERM) while the process is a zombie.
+	if err := syscall.Kill(pgid, 0); err != nil && !errors.Is(err, syscall.ESRCH) && !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("kill(%d,0) error = %v", pgid, err)
+	}
+
+	rt := New(Options{Logger: &testLogger{}})
+	startedAt := time.Now()
+	exited, err := rt.recoveredProcessGroupExited(pgid)
+	if err != nil {
+		t.Fatalf("recoveredProcessGroupExited() error = %v", err)
+	}
+	if !exited {
+		t.Fatalf("recoveredProcessGroupExited(%d) = false, want true for zombie-only group", pgid)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 100*time.Millisecond {
+		t.Fatalf("recoveredProcessGroupExited() elapsed = %s, want immediate zombie-only success", elapsed)
+	}
 }

--- a/internal/runtime/recovery_lifecycle_contract_test.go
+++ b/internal/runtime/recovery_lifecycle_contract_test.go
@@ -235,11 +235,12 @@ func TestStartupRecoveryReapsDescendantAfterLeaderExitsOnTERMBeforeSchedulerTick
 	}
 }
 
-// TestStartupRecoveryReapsDescendantWhenLeaderAlreadyExitedBeforeRestart covers the
-// restart window where the agent leader has already exited but a TERM-resistant
-// descendant still holds the executor-created process group. Recovery must reap
-// that group before the scheduler becomes visible.
-func TestStartupRecoveryReapsDescendantWhenLeaderAlreadyExitedBeforeRestart(t *testing.T) {
+// TestStartupRecoveryProtectsLeaderlessLiveProcessGroupAsUncertain covers the
+// restart window where the agent leader has already exited but a process group
+// under the persisted PGID is still live. Without a live identity-matched
+// leader, recovery must not signal the group (PGID reuse risk) and must protect
+// the run as uncertain instead of marking the execution terminal.
+func TestStartupRecoveryProtectsLeaderlessLiveProcessGroupAsUncertain(t *testing.T) {
 	workingDir := t.TempDir()
 	script := filepath.Join(workingDir, "leader-already-exited-orphan.sh")
 	descendantPIDFile := filepath.Join(workingDir, "descendant.pid")
@@ -324,17 +325,12 @@ func TestStartupRecoveryReapsDescendantWhenLeaderAlreadyExitedBeforeRestart(t *t
 		t.Fatalf("seed coordinator close: %v", err)
 	}
 
+	logger := &testLogger{}
 	ticked := make(chan struct{}, 1)
 	rt := New(Options{
 		Config: cfg,
-		Logger: &testLogger{},
+		Logger: logger,
 		RunSchedulerTick: func(context.Context, Services) error {
-			if recoveryProcessGroupExists(leaderPID) {
-				t.Errorf("scheduler ticked while orphan process group %d was still live", leaderPID)
-			}
-			if err := syscall.Kill(descendantPID, 0); err == nil || !errors.Is(err, syscall.ESRCH) {
-				t.Errorf("scheduler ticked while orphan descendant %d was still live: %v", descendantPID, err)
-			}
 			select {
 			case ticked <- struct{}{}:
 			default:
@@ -349,20 +345,41 @@ func TestStartupRecoveryReapsDescendantWhenLeaderAlreadyExitedBeforeRestart(t *t
 	select {
 	case <-ticked:
 	case <-time.After(2 * time.Second):
-		t.Fatal("scheduler did not start after leader-already-exited process-group recovery")
+		t.Fatal("scheduler did not start after leaderless uncertain recovery protection")
 	}
-	if recoveryProcessGroupExists(leaderPID) {
-		t.Fatalf("orphan process group %d survived startup recovery after leader exit", leaderPID)
+	// Must not signal a leaderless group: descendants remain live under the PGID.
+	if !recoveryProcessGroupExists(leaderPID) {
+		t.Fatalf("process group %d was reaped; want leaderless group left unsignaled", leaderPID)
 	}
-	if err := syscall.Kill(descendantPID, 0); err == nil || !errors.Is(err, syscall.ESRCH) {
-		t.Fatalf("orphan descendant %d survived startup recovery: %v", descendantPID, err)
+	if err := syscall.Kill(descendantPID, 0); err != nil {
+		t.Fatalf("descendant %d was killed during recovery: %v", descendantPID, err)
 	}
 	execution, err := rt.Services().Repositories.AgentExecutions.GetByID(context.Background(), "exec_leader_gone")
 	if err != nil {
 		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
 	}
-	if execution == nil || execution.Status != "killed" {
-		t.Fatalf("recovered execution = %#v, want killed", execution)
+	if execution == nil || execution.Status != "running" || execution.EndedAt != nil {
+		t.Fatalf("recovered execution = %#v, want still running (uncertain, not killed)", execution)
+	}
+	run, err := rt.Services().Repositories.Runs.GetByID(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID() error = %v", err)
+	}
+	if run == nil || run.Status != "running" || run.EndedAt != nil {
+		t.Fatalf("run = %#v, want preserved running run for uncertain leaderless group", run)
+	}
+	events, err := rt.Services().Repositories.Events.ListByEntity(context.Background(), "agent_execution", "exec_leader_gone")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity() error = %v", err)
+	}
+	if !containsEventType(events, "looperd.recovery.process_identity_uncertain") {
+		t.Fatalf("events = %#v, want uncertain-identity event for leaderless live group", events)
+	}
+	if recovery := rt.RecoverySummary(); recovery.OrphanAgentCleanup.CleanedCount != 0 {
+		t.Fatalf("RecoverySummary() = %#v, want cleanedCount=0 for leaderless uncertain group", recovery)
+	}
+	if !logger.containsMessage("recovery skipped due to uncertain process identity") {
+		t.Fatalf("logger entries = %#v, want uncertain process identity warning", logger.messages())
 	}
 }
 

--- a/internal/runtime/recovery_lifecycle_contract_test.go
+++ b/internal/runtime/recovery_lifecycle_contract_test.go
@@ -235,6 +235,137 @@ func TestStartupRecoveryReapsDescendantAfterLeaderExitsOnTERMBeforeSchedulerTick
 	}
 }
 
+// TestStartupRecoveryReapsDescendantWhenLeaderAlreadyExitedBeforeRestart covers the
+// restart window where the agent leader has already exited but a TERM-resistant
+// descendant still holds the executor-created process group. Recovery must reap
+// that group before the scheduler becomes visible.
+func TestStartupRecoveryReapsDescendantWhenLeaderAlreadyExitedBeforeRestart(t *testing.T) {
+	workingDir := t.TempDir()
+	script := filepath.Join(workingDir, "leader-already-exited-orphan.sh")
+	descendantPIDFile := filepath.Join(workingDir, "descendant.pid")
+	readyFile := filepath.Join(workingDir, "ready")
+	// Leader exits immediately after spawning a TERM-resistant child that keeps
+	// the process group alive under the leader's PGID.
+	scriptBody := "#!/bin/sh\n" +
+		"/bin/sh -c 'trap \"\" TERM HUP; echo $$ > \"$DESCENDANT_PID_FILE\"; : > \"$READY_FILE\"; while :; do sleep 1; done' &\n" +
+		"while [ ! -s \"$DESCENDANT_PID_FILE\" ]; do sleep 0.01; done\n" +
+		"exit 0\n"
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatalf("write orphan script: %v", err)
+	}
+	cmd := exec.Command("/bin/sh", script)
+	cmd.Env = append(os.Environ(), "READY_FILE="+readyFile, "DESCENDANT_PID_FILE="+descendantPIDFile)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start orphan: %v", err)
+	}
+	leaderPID := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("leader Wait() error = %v", err)
+	}
+	waitForRecoveryContractFile(t, readyFile)
+	rawDescendantPID, err := os.ReadFile(descendantPIDFile)
+	if err != nil {
+		t.Fatalf("read descendant pid: %v", err)
+	}
+	descendantPID, err := strconv.Atoi(strings.TrimSpace(string(rawDescendantPID)))
+	if err != nil || descendantPID <= 0 {
+		t.Fatalf("parse descendant pid %q: %v", rawDescendantPID, err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(-leaderPID, syscall.SIGKILL)
+		_ = syscall.Kill(descendantPID, syscall.SIGKILL)
+	})
+	if err := syscall.Kill(descendantPID, 0); err != nil {
+		t.Fatalf("descendant %d not live before recovery: %v", descendantPID, err)
+	}
+	if !recoveryProcessGroupExists(leaderPID) {
+		t.Fatalf("process group %d not live before recovery", leaderPID)
+	}
+	// Leader must already be gone so executionMatchesProcess reports running=false.
+	if live, err := shellinfra.ProcessRunnable(leaderPID); err != nil {
+		t.Fatalf("ProcessRunnable(leader) error = %v", err)
+	} else if live {
+		t.Fatalf("leader pid %d still runnable; test requires leader already exited", leaderPID)
+	}
+
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	cfg.Projects = []config.ProjectRefConfig{{ID: "project_leader_gone", Name: "Project", RepoPath: workingDir}}
+	nowISO := formatJavaScriptISOString(time.Now().UTC().Add(-time.Hour))
+	seed := openMigratedCoordinator(t, cfg.Storage.DBPath, backupDir)
+	repos := storage.NewRepositories(seed.DB())
+	projectID := "project_leader_gone"
+	loopID := "loop_leader_gone"
+	runID := "run_leader_gone"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Project", RepoPath: workingDir, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: runID, LoopID: loopID, Status: "running", CurrentStep: stringPtr("execute"), StartedAt: nowISO, LastHeartbeatAt: &nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	commandJSON, err := json.Marshal(map[string]any{"command": "/bin/sh", "args": []string{script}})
+	if err != nil {
+		t.Fatalf("marshal command metadata: %v", err)
+	}
+	leaderPID64 := int64(leaderPID)
+	if err := repos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{ID: "exec_leader_gone", ProjectID: &projectID, LoopID: &loopID, RunID: &runID, Vendor: "codex", Status: "running", PID: &leaderPID64, CommandJSON: stringPtr(string(commandJSON)), CWD: &workingDir, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("seed coordinator close: %v", err)
+	}
+
+	ticked := make(chan struct{}, 1)
+	rt := New(Options{
+		Config: cfg,
+		Logger: &testLogger{},
+		RunSchedulerTick: func(context.Context, Services) error {
+			if recoveryProcessGroupExists(leaderPID) {
+				t.Errorf("scheduler ticked while orphan process group %d was still live", leaderPID)
+			}
+			if err := syscall.Kill(descendantPID, 0); err == nil || !errors.Is(err, syscall.ESRCH) {
+				t.Errorf("scheduler ticked while orphan descendant %d was still live: %v", descendantPID, err)
+			}
+			select {
+			case ticked <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+	})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Runtime.Start() error = %v", err)
+	}
+	t.Cleanup(func() { rt.Stop("test cleanup") })
+	select {
+	case <-ticked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler did not start after leader-already-exited process-group recovery")
+	}
+	if recoveryProcessGroupExists(leaderPID) {
+		t.Fatalf("orphan process group %d survived startup recovery after leader exit", leaderPID)
+	}
+	if err := syscall.Kill(descendantPID, 0); err == nil || !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("orphan descendant %d survived startup recovery: %v", descendantPID, err)
+	}
+	execution, err := rt.Services().Repositories.AgentExecutions.GetByID(context.Background(), "exec_leader_gone")
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID() error = %v", err)
+	}
+	if execution == nil || execution.Status != "killed" {
+		t.Fatalf("recovered execution = %#v, want killed", execution)
+	}
+}
+
 func waitForRecoveryContractFile(t *testing.T, path string) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -261,9 +261,31 @@ func (r *Runtime) Stop(reason string) {
 			r.logger.Info("looperd runtime stopping", map[string]any{"reason": reason})
 		}
 
+		// Close the spawn boundary before cancelling scheduler producers. Starts
+		// already in flight remain pending ownership leases until they fail or
+		// publish a handle; later starts are rejected before spawning.
+		r.activeExecutions.BeginShutdown(reason)
 		r.stopDeferredReviewerRecovery()
 		r.stopWorktreeCleanupLoop()
 		r.stopSchedulerLoop()
+		reapCtx, cancelReap := context.WithTimeout(context.Background(), r.shutdownTimeout)
+		reapErr := r.activeExecutions.ShutdownAndWait(reapCtx, reason)
+		cancelReap()
+		if reapErr != nil {
+			// The configured daemon deadline bounds graceful TERM handling. At
+			// that boundary, force the executor-owned process groups down and
+			// allow a short, bounded reap before storage is closed.
+			forceCtx, cancelForce := context.WithTimeout(context.Background(), time.Second)
+			forceErr := r.activeExecutions.ForceKillAndWait(forceCtx)
+			cancelForce()
+			if r.logger != nil {
+				message := "looperd runtime required forced active-execution reap"
+				if forceErr != nil {
+					message = "looperd runtime failed while force-reaping active executions"
+				}
+				r.logger.Warn(message, map[string]any{"error": errors.Join(reapErr, forceErr).Error()})
+			}
+		}
 		r.stopWebhookRuntime()
 
 		r.mu.Lock()
@@ -1218,6 +1240,23 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 	summary.OrphanAgentCleanup.Attempted = true
 	uncertainAgentRunIDs := make(map[string]struct{})
 	uncertainExecutionIDs := make(map[string]struct{})
+	protectUncertainExecution := func(execution storage.AgentExecutionRecord, pid int, scope string) error {
+		if execution.RunID != nil && strings.TrimSpace(*execution.RunID) != "" {
+			uncertainAgentRunIDs[*execution.RunID] = struct{}{}
+		}
+		if _, protected := uncertainExecutionIDs[execution.ID]; protected {
+			return nil
+		}
+		uncertainExecutionIDs[execution.ID] = struct{}{}
+		written, err := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO)
+		if err != nil {
+			return err
+		}
+		if written {
+			eventsWritten += 1
+		}
+		return nil
+	}
 	if repositories.AgentExecutions != nil {
 		activeExecutions, err := repositories.AgentExecutions.ListActive(ctx)
 		if err != nil {
@@ -1233,42 +1272,26 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				if r.logger != nil {
 					r.logger.Warn("failed to verify orphan agent execution identity", map[string]any{"executionId": execution.ID, "pid": pid, "error": err.Error()})
 				}
+				if err := protectUncertainExecution(execution, pid, "orphan_cleanup_verifier_error"); err != nil {
+					return RecoverySummary{}, err
+				}
 				continue
 			}
 			if running && !matches {
-				if execution.RunID != nil && strings.TrimSpace(*execution.RunID) != "" {
-					uncertainAgentRunIDs[*execution.RunID] = struct{}{}
-				}
-				if _, ok := uncertainExecutionIDs[execution.ID]; !ok {
-					uncertainExecutionIDs[execution.ID] = struct{}{}
-				}
-				written, err := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, "orphan_cleanup", nowISO)
-				if err != nil {
+				if err := protectUncertainExecution(execution, pid, "orphan_cleanup"); err != nil {
 					return RecoverySummary{}, err
-				}
-				if written {
-					eventsWritten += 1
 				}
 				continue
 			}
 			if running {
-				if err := r.signalAgentProcessGroup(pid, syscall.SIGTERM); err != nil {
-					if errors.Is(err, syscall.ESRCH) {
-						running = false
-					} else {
-						if r.logger != nil {
-							r.logger.Warn("failed to cleanup orphan agent execution", map[string]any{"executionId": execution.ID, "pid": pid, "error": err.Error()})
-						}
-						continue
+				if err := r.terminateRecoveredExecution(ctx, execution, pid, 5*time.Second); err != nil {
+					if r.logger != nil {
+						r.logger.Warn("failed to cleanup orphan agent execution", map[string]any{"executionId": execution.ID, "pid": pid, "error": err.Error()})
 					}
-				}
-				if running {
-					go func(pid int) {
-						timer := time.NewTimer(5 * time.Second)
-						defer timer.Stop()
-						<-timer.C
-						_ = r.signalAgentProcessGroup(pid, syscall.SIGKILL)
-					}(pid)
+					if err := protectUncertainExecution(execution, pid, "orphan_cleanup_termination_error"); err != nil {
+						return RecoverySummary{}, err
+					}
+					continue
 				}
 			}
 			if err := r.markRecoveredExecutionTerminal(ctx, repositories, execution, pid, nowISO, "Killed during looperd recovery"); err != nil {
@@ -1347,6 +1370,15 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 			if err != nil {
 				if r.logger != nil {
 					r.logger.Warn("failed to verify active agent execution identity", map[string]any{"executionId": execution.ID, "pid": *execution.PID, "error": err.Error()})
+				}
+				if err := protectUncertainExecution(execution, pid, "active_scan_verifier_error"); err != nil {
+					return RecoverySummary{}, err
+				}
+				continue
+			}
+			if running && !matches {
+				if err := protectUncertainExecution(execution, pid, "active_scan"); err != nil {
+					return RecoverySummary{}, err
 				}
 				continue
 			}
@@ -2661,15 +2693,139 @@ func defaultSignalProcess(pid int, signal syscall.Signal) error {
 
 func (r *Runtime) signalAgentProcessGroup(pid int, signal syscall.Signal) error {
 	if r.signalProcess == nil {
-		return nil
+		return fmt.Errorf("process signal authority is not configured")
 	}
-	if err := r.signalProcess(-pid, signal); err != nil {
+	return r.signalProcess(-pid, signal)
+}
+
+func (r *Runtime) recoveredProcessGroupExited(pid int) (bool, error) {
+	if r.signalProcess == nil {
+		return false, fmt.Errorf("process signal authority is not configured")
+	}
+	err := r.signalProcess(-pid, 0)
+	switch {
+	case err == nil, errors.Is(err, syscall.EPERM):
+		return false, nil
+	case errors.Is(err, syscall.ESRCH):
+		return true, nil
+	default:
+		return false, fmt.Errorf("probe recovered process group %d: %w", pid, err)
+	}
+}
+
+func (r *Runtime) terminateRecoveredExecution(ctx context.Context, execution storage.AgentExecutionRecord, pid int, grace time.Duration) error {
+	if grace <= 0 {
+		grace = 5 * time.Second
+	}
+	// Once recovery has begun terminating an identified orphan, startup
+	// cancellation must not strand it between TERM and KILL. Give the cleanup
+	// its own bounded lifetime so an early daemon shutdown signal can still
+	// cancel the rest of startup without abandoning the process group.
+	terminationCtx, cancelTermination := context.WithTimeout(context.WithoutCancel(ctx), 2*grace+time.Second)
+	defer cancelTermination()
+	ctx = terminationCtx
+	verifyLeader := func() (bool, error) {
+		matches, running, err := r.executionMatchesProcess(ctx, execution, pid)
+		if err != nil {
+			return false, err
+		}
+		if !running {
+			return true, nil
+		}
+		if !matches {
+			return false, fmt.Errorf("execution %s pid %d identity changed while awaiting recovery cleanup", execution.ID, pid)
+		}
+		return false, nil
+	}
+	observeOwnedGroup := func() (bool, error) {
+		exited, err := r.recoveredProcessGroupExited(pid)
+		if err != nil {
+			return false, err
+		}
+		if exited {
+			leaderExited, verifyErr := verifyLeader()
+			if verifyErr != nil || leaderExited {
+				return leaderExited, verifyErr
+			}
+			return false, fmt.Errorf("execution %s leader pid %d remains live outside its recovered process group", execution.ID, pid)
+		}
+		// A leader that remains live must still match before escalation. Once a
+		// verified leader exits, the original group can remain alive through its
+		// descendants; group disappearance, not leader disappearance, is then the
+		// completion authority.
+		_, err = verifyLeader()
+		return false, err
+	}
+
+	leaderExited, err := verifyLeader()
+	if err != nil {
+		return err
+	}
+	if leaderExited {
+		groupExited, probeErr := observeOwnedGroup()
+		if probeErr != nil || groupExited {
+			return probeErr
+		}
+		return fmt.Errorf("execution %s leader pid %d exited before recovery established process-group ownership", execution.ID, pid)
+	}
+	if err := r.signalAgentProcessGroup(pid, syscall.SIGTERM); err != nil {
 		if !errors.Is(err, syscall.ESRCH) {
 			return err
 		}
-		return r.signalProcess(pid, signal)
+		groupExited, probeErr := observeOwnedGroup()
+		if probeErr != nil {
+			return probeErr
+		}
+		if groupExited {
+			return nil
+		}
+		return fmt.Errorf("execution %s process group %d rejected recovery SIGTERM but remains live", execution.ID, pid)
+	}
+	exited, err := waitForRecoveredExecutionExit(ctx, grace, observeOwnedGroup)
+	if err != nil || exited {
+		return err
+	}
+
+	// Re-probe the group and revalidate any still-live leader at the escalation
+	// boundary. If TERM removed only the leader, the verified pre-TERM ownership
+	// plus the still-live group is authoritative for its descendants.
+	exited, err = observeOwnedGroup()
+	if err != nil || exited {
+		return err
+	}
+	if err := r.signalAgentProcessGroup(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	exited, err = waitForRecoveredExecutionExit(ctx, grace, func() (bool, error) {
+		return r.recoveredProcessGroupExited(pid)
+	})
+	if err != nil {
+		return err
+	}
+	if !exited {
+		return fmt.Errorf("execution %s pid %d was not reaped after recovery SIGKILL", execution.ID, pid)
 	}
 	return nil
+}
+
+func waitForRecoveredExecutionExit(ctx context.Context, timeout time.Duration, verify func() (bool, error)) (bool, error) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-timer.C:
+			return verify()
+		case <-ticker.C:
+			exited, err := verify()
+			if err != nil || exited {
+				return exited, err
+			}
+		}
+	}
 }
 
 func createEmptyRecoverySummary() RecoverySummary {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nexu-io/looper/internal/domain"
 	gitinfra "github.com/nexu-io/looper/internal/infra/git"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	shellinfra "github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/infra/specpr"
 	"github.com/nexu-io/looper/internal/loops"
 	networkclient "github.com/nexu-io/looper/internal/network/client"
@@ -127,6 +128,7 @@ type Runtime struct {
 	customSchedulerTick    bool
 	readProcessCommand     ReadProcessCommandFunc
 	signalProcess          SignalProcessFunc
+	customSignalProcess    bool
 	shutdownTimeout        time.Duration
 	deferRecovery          bool
 
@@ -193,6 +195,7 @@ func New(options Options) *Runtime {
 	}
 
 	signalProcess := options.SignalProcess
+	customSignalProcess := signalProcess != nil
 	if signalProcess == nil {
 		signalProcess = defaultSignalProcess
 	}
@@ -217,6 +220,7 @@ func New(options Options) *Runtime {
 		customSchedulerTick:         customSchedulerTick,
 		readProcessCommand:          readProcessCommand,
 		signalProcess:               signalProcess,
+		customSignalProcess:         customSignalProcess,
 		shutdownTimeout:             shutdownTimeout,
 		worktreeCleanupInitialDelay: options.WorktreeCleanupInitialDelay,
 		deferRecovery:               options.DeferRecovery,
@@ -2701,6 +2705,19 @@ func (r *Runtime) signalAgentProcessGroup(pid int, signal syscall.Signal) error 
 func (r *Runtime) recoveredProcessGroupExited(pid int) (bool, error) {
 	if r.signalProcess == nil {
 		return false, fmt.Errorf("process signal authority is not configured")
+	}
+	// Production recovery uses the non-zombie process-group probe. kill(-pgid, 0)
+	// can keep succeeding for unreaped zombie-only groups on Linux after recovery
+	// SIGKILL; treating those as live strands orphan cleanup as
+	// orphan_cleanup_termination_error instead of marking the execution killed.
+	// Injected SignalProcess mocks keep kill(0)-only semantics so unit tests can
+	// drive the barrier without real PIDs.
+	if !r.customSignalProcess {
+		live, err := shellinfra.ProcessGroupRunnable(pid)
+		if err != nil {
+			return false, fmt.Errorf("probe recovered process group %d: %w", pid, err)
+		}
+		return !live, nil
 	}
 	err := r.signalProcess(-pid, 0)
 	switch {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1287,12 +1287,14 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				}
 				continue
 			}
-			// Reap when the leader is still live, and also when the leader has
-			// already exited but the executor-created process group still has
-			// descendants (for example TERM-ignoring grandchildren). Marking
-			// the execution terminal while the group is live would reopen the
-			// scheduler against a worktree that can still mutate.
-			needsTermination := running
+			// Only terminate when the leader PID is still live and identity-matched.
+			// A leaderless live process group is not safe to signal: the persisted
+			// PGID can be reused after the original agent group exits, and without a
+			// verified leader (or other group-member identity check) recovery cannot
+			// distinguish agent descendants from an unrelated group. Protect as
+			// uncertain so the run is not reopened while a possibly foreign group
+			// remains under that ID. When both leader and group are gone, mark the
+			// execution terminal without signaling.
 			if !running {
 				groupExited, probeErr := r.recoveredProcessGroupExited(pid)
 				if probeErr != nil {
@@ -1304,9 +1306,13 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 					}
 					continue
 				}
-				needsTermination = !groupExited
-			}
-			if needsTermination {
+				if !groupExited {
+					if err := protectUncertainExecution(execution, pid, "orphan_cleanup_leaderless_group"); err != nil {
+						return RecoverySummary{}, err
+					}
+					continue
+				}
+			} else {
 				if err := r.terminateRecoveredExecution(ctx, execution, pid, 5*time.Second); err != nil {
 					if r.logger != nil {
 						r.logger.Warn("failed to cleanup orphan agent execution", map[string]any{"executionId": execution.ID, "pid": pid, "error": err.Error()})
@@ -2068,6 +2074,39 @@ func (r *Runtime) verifyRunExecutionLiveness(ctx context.Context, repositories *
 			result.Live = true
 			continue
 		}
+		// Leader PID is gone. A still-live process group under the persisted
+		// PGID is not safe to treat as dead (or to signal): without a verified
+		// leader identity, PGID reuse can leave an unrelated group under that
+		// ID. Protect as uncertain so stale-run recovery does not mark the
+		// execution terminal while that group remains.
+		groupExited, probeErr := r.recoveredProcessGroupExited(pid)
+		if probeErr != nil {
+			if r.logger != nil {
+				r.logger.Warn("failed to probe orphan agent process group", map[string]any{"executionId": execution.ID, "pid": pid, "error": probeErr.Error(), "scope": scope})
+			}
+			nowISO := formatJavaScriptISOString(now)
+			written, appendErr := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope+"_group_probe_error", nowISO)
+			if appendErr != nil {
+				return executionLivenessResult{}, appendErr
+			}
+			result.Uncertain = true
+			if written {
+				result.EventsWritten += 1
+			}
+			continue
+		}
+		if !groupExited {
+			nowISO := formatJavaScriptISOString(now)
+			written, appendErr := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope+"_leaderless_group", nowISO)
+			if appendErr != nil {
+				return executionLivenessResult{}, appendErr
+			}
+			result.Uncertain = true
+			if written {
+				result.EventsWritten += 1
+			}
+			continue
+		}
 		result.DeadExecutions = append(result.DeadExecutions, execution)
 	}
 	return result, nil
@@ -2798,9 +2837,10 @@ func (r *Runtime) terminateRecoveredExecution(ctx context.Context, execution sto
 		return err
 	}
 	if leaderExited {
-		// Leader PID is gone: the persisted PID is still the process-group ID
-		// from Setpgid. Probe that group and, when descendants remain, escalate
-		// TERM→KILL without requiring a live matching leader first.
+		// Leader is already gone before recovery signaling. A live numeric PGID
+		// alone is not ownership: the ID may have been reused by an unrelated
+		// group after the original agent leader exited. Only treat leader+group
+		// disappearance as success; refuse to signal without identity authority.
 		groupExited, probeErr := r.recoveredProcessGroupExited(pid)
 		if probeErr != nil {
 			return probeErr
@@ -2808,6 +2848,7 @@ func (r *Runtime) terminateRecoveredExecution(ctx context.Context, execution sto
 		if groupExited {
 			return nil
 		}
+		return fmt.Errorf("execution %s leader pid %d is gone; process group %d remains live without verifiable identity", execution.ID, pid, pid)
 	}
 	if err := r.signalAgentProcessGroup(pid, syscall.SIGTERM); err != nil {
 		if !errors.Is(err, syscall.ESRCH) {
@@ -2821,11 +2862,10 @@ func (r *Runtime) terminateRecoveredExecution(ctx context.Context, execution sto
 			return nil
 		}
 		// SIGTERM returned ESRCH but the group probe still sees members (for
-		// example a race where the leader vanished mid-call). Continue to
-		// SIGKILL escalation rather than stranding descendants.
-		if !leaderExited {
-			return fmt.Errorf("execution %s process group %d rejected recovery SIGTERM but remains live", execution.ID, pid)
-		}
+		// example a race where the verified leader vanished mid-call). Continue
+		// to SIGKILL escalation rather than stranding descendants of a group we
+		// already identity-matched before the first signal.
+		return fmt.Errorf("execution %s process group %d rejected recovery SIGTERM but remains live", execution.ID, pid)
 	}
 	exited, err := waitForRecoveredExecutionExit(ctx, grace, observeOwnedGroup)
 	if err != nil || exited {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1287,7 +1287,26 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				}
 				continue
 			}
-			if running {
+			// Reap when the leader is still live, and also when the leader has
+			// already exited but the executor-created process group still has
+			// descendants (for example TERM-ignoring grandchildren). Marking
+			// the execution terminal while the group is live would reopen the
+			// scheduler against a worktree that can still mutate.
+			needsTermination := running
+			if !running {
+				groupExited, probeErr := r.recoveredProcessGroupExited(pid)
+				if probeErr != nil {
+					if r.logger != nil {
+						r.logger.Warn("failed to probe orphan agent process group", map[string]any{"executionId": execution.ID, "pid": pid, "error": probeErr.Error()})
+					}
+					if err := protectUncertainExecution(execution, pid, "orphan_cleanup_group_probe_error"); err != nil {
+						return RecoverySummary{}, err
+					}
+					continue
+				}
+				needsTermination = !groupExited
+			}
+			if needsTermination {
 				if err := r.terminateRecoveredExecution(ctx, execution, pid, 5*time.Second); err != nil {
 					if r.logger != nil {
 						r.logger.Warn("failed to cleanup orphan agent execution", map[string]any{"executionId": execution.ID, "pid": pid, "error": err.Error()})
@@ -2779,11 +2798,16 @@ func (r *Runtime) terminateRecoveredExecution(ctx context.Context, execution sto
 		return err
 	}
 	if leaderExited {
-		groupExited, probeErr := observeOwnedGroup()
-		if probeErr != nil || groupExited {
+		// Leader PID is gone: the persisted PID is still the process-group ID
+		// from Setpgid. Probe that group and, when descendants remain, escalate
+		// TERM→KILL without requiring a live matching leader first.
+		groupExited, probeErr := r.recoveredProcessGroupExited(pid)
+		if probeErr != nil {
 			return probeErr
 		}
-		return fmt.Errorf("execution %s leader pid %d exited before recovery established process-group ownership", execution.ID, pid)
+		if groupExited {
+			return nil
+		}
 	}
 	if err := r.signalAgentProcessGroup(pid, syscall.SIGTERM); err != nil {
 		if !errors.Is(err, syscall.ESRCH) {
@@ -2796,7 +2820,12 @@ func (r *Runtime) terminateRecoveredExecution(ctx context.Context, execution sto
 		if groupExited {
 			return nil
 		}
-		return fmt.Errorf("execution %s process group %d rejected recovery SIGTERM but remains live", execution.ID, pid)
+		// SIGTERM returned ESRCH but the group probe still sees members (for
+		// example a race where the leader vanished mid-call). Continue to
+		// SIGKILL escalation rather than stranding descendants.
+		if !leaderExited {
+			return fmt.Errorf("execution %s process group %d rejected recovery SIGTERM but remains live", execution.ID, pid)
+		}
 	}
 	exited, err := waitForRecoveredExecutionExit(ctx, grace, observeOwnedGroup)
 	if err != nil || exited {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1776,6 +1776,70 @@ func TestTerminateRecoveredExecutionEscalatesOnlyWhileIdentityMatchesAndAwaitsEx
 	}
 }
 
+func TestTerminateRecoveredExecutionReapsProcessGroupAfterLeaderAlreadyExited(t *testing.T) {
+	t.Parallel()
+
+	groupRunning := true
+	var signals []syscall.Signal
+	rt := New(Options{
+		ReadProcessCommand: func(context.Context, int) (string, error) {
+			// Leader PID is already gone at recovery time.
+			return "", nil
+		},
+		SignalProcess: func(pid int, signal syscall.Signal) error {
+			if pid != -4242 {
+				t.Fatalf("SignalProcess pid = %d, want -4242", pid)
+			}
+			if signal == 0 {
+				if groupRunning {
+					return nil
+				}
+				return syscall.ESRCH
+			}
+			signals = append(signals, signal)
+			if signal == syscall.SIGKILL {
+				groupRunning = false
+			}
+			return nil
+		},
+	})
+	execution := storage.AgentExecutionRecord{ID: "exec_leader_gone", CommandJSON: stringPtr(`{"command":"codex","args":["exec","test"]}`)}
+	if err := rt.terminateRecoveredExecution(context.Background(), execution, 4242, 10*time.Millisecond); err != nil {
+		t.Fatalf("terminateRecoveredExecution() error = %v", err)
+	}
+	if !slices.Equal(signals, []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}) {
+		t.Fatalf("signals = %#v, want TERM then KILL for leader-gone process group", signals)
+	}
+	if groupRunning {
+		t.Fatal("terminateRecoveredExecution returned before process group exit")
+	}
+}
+
+func TestTerminateRecoveredExecutionNoopsWhenLeaderAndProcessGroupAlreadyExited(t *testing.T) {
+	t.Parallel()
+
+	var signals []syscall.Signal
+	rt := New(Options{
+		ReadProcessCommand: func(context.Context, int) (string, error) {
+			return "", nil
+		},
+		SignalProcess: func(pid int, signal syscall.Signal) error {
+			if signal == 0 {
+				return syscall.ESRCH
+			}
+			signals = append(signals, signal)
+			return nil
+		},
+	})
+	execution := storage.AgentExecutionRecord{ID: "exec_already_gone", CommandJSON: stringPtr(`{"command":"codex","args":["exec","test"]}`)}
+	if err := rt.terminateRecoveredExecution(context.Background(), execution, 4242, 10*time.Millisecond); err != nil {
+		t.Fatalf("terminateRecoveredExecution() error = %v", err)
+	}
+	if len(signals) != 0 {
+		t.Fatalf("signals = %#v, want no termination signals when leader and group are gone", signals)
+	}
+}
+
 func TestTerminateRecoveredExecutionFinishesAfterStartupContextCancellation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1669,6 +1670,8 @@ func TestRuntimeRecoveryCleansOrphanAgentExecutions(t *testing.T) {
 		t.Fatalf("seed coordinator close error = %v", err)
 	}
 
+	processRunning := true
+	processGroupRunning := true
 	rt := New(Options{
 		Config: cfg,
 		Logger: &testLogger{},
@@ -1676,15 +1679,26 @@ func TestRuntimeRecoveryCleansOrphanAgentExecutions(t *testing.T) {
 			return startedAt
 		},
 		ReadProcessCommand: func(context.Context, int) (string, error) {
+			if !processRunning {
+				return "", nil
+			}
 			return "codex exec fix failing tests", nil
 		},
 		SignalProcess: func(gotPID int, signal syscall.Signal) error {
-			if signal == syscall.SIGKILL {
-				return nil
+			if gotPID != -int(pid) {
+				t.Fatalf("SignalProcess pid = %d, want %d", gotPID, -pid)
 			}
-			if gotPID != -int(pid) || signal != syscall.SIGTERM {
-				t.Fatalf("SignalProcess(%d, %v), want (%d, SIGTERM)", gotPID, signal, -pid)
+			if signal == 0 {
+				if processGroupRunning {
+					return nil
+				}
+				return syscall.ESRCH
 			}
+			if signal != syscall.SIGTERM {
+				t.Fatalf("SignalProcess(%d, %v), want SIGTERM or signal-0 probe", gotPID, signal)
+			}
+			processRunning = false
+			processGroupRunning = false
 			return nil
 		},
 	})
@@ -1716,6 +1730,128 @@ func TestRuntimeRecoveryCleansOrphanAgentExecutions(t *testing.T) {
 	recovery := rt.RecoverySummary()
 	if !recovery.OrphanAgentCleanup.Attempted || recovery.OrphanAgentCleanup.CleanedCount != 1 {
 		t.Fatalf("RecoverySummary().OrphanAgentCleanup = %#v, want attempted + cleanedCount=1", recovery.OrphanAgentCleanup)
+	}
+}
+
+func TestTerminateRecoveredExecutionEscalatesOnlyWhileIdentityMatchesAndAwaitsExit(t *testing.T) {
+	t.Parallel()
+
+	running := true
+	groupRunning := true
+	var signals []syscall.Signal
+	rt := New(Options{
+		ReadProcessCommand: func(context.Context, int) (string, error) {
+			if !running {
+				return "", nil
+			}
+			return "codex exec test", nil
+		},
+		SignalProcess: func(pid int, signal syscall.Signal) error {
+			if pid != -4242 {
+				t.Fatalf("SignalProcess pid = %d, want -4242", pid)
+			}
+			if signal == 0 {
+				if groupRunning {
+					return nil
+				}
+				return syscall.ESRCH
+			}
+			signals = append(signals, signal)
+			if signal == syscall.SIGKILL {
+				running = false
+				groupRunning = false
+			}
+			return nil
+		},
+	})
+	execution := storage.AgentExecutionRecord{ID: "exec_recovery", CommandJSON: stringPtr(`{"command":"codex","args":["exec","test"]}`)}
+	if err := rt.terminateRecoveredExecution(context.Background(), execution, 4242, 10*time.Millisecond); err != nil {
+		t.Fatalf("terminateRecoveredExecution() error = %v", err)
+	}
+	if !slices.Equal(signals, []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}) {
+		t.Fatalf("signals = %#v, want TERM then KILL", signals)
+	}
+	if running {
+		t.Fatal("terminateRecoveredExecution returned before verifier confirmed exit")
+	}
+}
+
+func TestTerminateRecoveredExecutionFinishesAfterStartupContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	running := true
+	groupRunning := true
+	var signals []syscall.Signal
+	rt := New(Options{
+		ReadProcessCommand: func(context.Context, int) (string, error) {
+			if !running {
+				return "", nil
+			}
+			return "codex exec test", nil
+		},
+		SignalProcess: func(pid int, signal syscall.Signal) error {
+			if pid != -4242 {
+				t.Fatalf("SignalProcess pid = %d, want -4242", pid)
+			}
+			if signal == 0 {
+				if groupRunning {
+					return nil
+				}
+				return syscall.ESRCH
+			}
+			signals = append(signals, signal)
+			if signal == syscall.SIGTERM {
+				cancel()
+			}
+			if signal == syscall.SIGKILL {
+				running = false
+				groupRunning = false
+			}
+			return nil
+		},
+	})
+	execution := storage.AgentExecutionRecord{ID: "exec_cancelled_startup", CommandJSON: stringPtr(`{"command":"codex","args":["exec","test"]}`)}
+	if err := rt.terminateRecoveredExecution(ctx, execution, 4242, 10*time.Millisecond); err != nil {
+		t.Fatalf("terminateRecoveredExecution() error = %v", err)
+	}
+	if !slices.Equal(signals, []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}) {
+		t.Fatalf("signals = %#v, want TERM then KILL after startup cancellation", signals)
+	}
+	if running {
+		t.Fatal("terminateRecoveredExecution returned before cancelled-startup orphan exited")
+	}
+}
+
+func TestTerminateRecoveredExecutionDoesNotEscalateAfterIdentityChanges(t *testing.T) {
+	t.Parallel()
+
+	reads := 0
+	var signals []syscall.Signal
+	rt := New(Options{
+		ReadProcessCommand: func(context.Context, int) (string, error) {
+			reads++
+			if reads >= 3 {
+				return "python unrelated.py", nil
+			}
+			return "codex exec test", nil
+		},
+		SignalProcess: func(_ int, signal syscall.Signal) error {
+			if signal == 0 {
+				return nil
+			}
+			signals = append(signals, signal)
+			return nil
+		},
+	})
+	execution := storage.AgentExecutionRecord{ID: "exec_reused", CommandJSON: stringPtr(`{"command":"codex","args":["exec","test"]}`)}
+	err := rt.terminateRecoveredExecution(context.Background(), execution, 4242, 20*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "identity changed") {
+		t.Fatalf("terminateRecoveredExecution() error = %v, want identity-change error", err)
+	}
+	if !slices.Equal(signals, []syscall.Signal{syscall.SIGTERM}) {
+		t.Fatalf("signals = %#v, want TERM without delayed KILL", signals)
 	}
 }
 
@@ -1829,6 +1965,8 @@ func TestRuntimeRecoveryPreservesRunWithUncertainActiveAgentExecution(t *testing
 	targetID := "pr:nexu-io/looper:186"
 	loopID := "loop_mismatched_agent_running"
 	runID := "run_mismatched_agent_running"
+	verifierErrorLoopID := "loop_verifier_error_agent_running"
+	verifierErrorRunID := "run_verifier_error_agent_running"
 	if err := seedRepos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Projects.Upsert() seed error = %v", err)
 	}
@@ -1838,7 +1976,14 @@ func TestRuntimeRecoveryPreservesRunWithUncertainActiveAgentExecution(t *testing
 	if err := seedRepos.Runs.Upsert(context.Background(), storage.RunRecord{ID: runID, LoopID: loopID, Status: "running", CurrentStep: stringPtr("execute"), StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
 		t.Fatalf("Runs.Upsert() seed error = %v", err)
 	}
+	if err := seedRepos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: verifierErrorLoopID, Seq: 187, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert(verifier error) seed error = %v", err)
+	}
+	if err := seedRepos.Runs.Upsert(context.Background(), storage.RunRecord{ID: verifierErrorRunID, LoopID: verifierErrorLoopID, Status: "running", CurrentStep: stringPtr("execute"), StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Runs.Upsert(verifier error) seed error = %v", err)
+	}
 	pid := int64(4343)
+	verifierErrorPID := int64(4344)
 	if err := seedRepos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
 		ID:             "agent_mismatched_running_run",
 		ProjectID:      stringPtr("project_1"),
@@ -1856,6 +2001,12 @@ func TestRuntimeRecoveryPreservesRunWithUncertainActiveAgentExecution(t *testing
 	}); err != nil {
 		t.Fatalf("AgentExecutions.Upsert() seed error = %v", err)
 	}
+	if err := seedRepos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
+		ID: "agent_verifier_error_running_run", ProjectID: stringPtr("project_1"), LoopID: &verifierErrorLoopID, RunID: &verifierErrorRunID,
+		Vendor: "codex", Status: "running", PID: &verifierErrorPID, CommandJSON: stringPtr(`{"command":"codex","args":["exec"]}`), CWD: stringPtr(workingDir), StartedAt: oldISO, CreatedAt: oldISO, UpdatedAt: oldISO,
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(verifier error) seed error = %v", err)
+	}
 	if err := seedCoordinator.Close(); err != nil {
 		t.Fatalf("seed coordinator close error = %v", err)
 	}
@@ -1867,7 +2018,10 @@ func TestRuntimeRecoveryPreservesRunWithUncertainActiveAgentExecution(t *testing
 		Now: func() time.Time {
 			return startedAt
 		},
-		ReadProcessCommand: func(context.Context, int) (string, error) {
+		ReadProcessCommand: func(_ context.Context, gotPID int) (string, error) {
+			if gotPID == int(verifierErrorPID) {
+				return "", errors.New("ps temporarily unavailable")
+			}
 			return "python unrelated.py", nil
 		},
 		SignalProcess: func(int, syscall.Signal) error {
@@ -1913,6 +2067,27 @@ func TestRuntimeRecoveryPreservesRunWithUncertainActiveAgentExecution(t *testing
 	}
 	if !logger.containsMessage("recovery skipped due to uncertain process identity") {
 		t.Fatalf("logger entries = %#v, want uncertain process identity warning", logger.messages())
+	}
+	verifierErrorRun, err := services.Repositories.Runs.GetByID(context.Background(), verifierErrorRunID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID(verifier error) error = %v", err)
+	}
+	if verifierErrorRun == nil || verifierErrorRun.Status != "running" || verifierErrorRun.EndedAt != nil {
+		t.Fatalf("verifier-error run = %#v, want preserved running run", verifierErrorRun)
+	}
+	verifierErrorLoop, err := services.Repositories.Loops.GetByID(context.Background(), verifierErrorLoopID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID(verifier error) error = %v", err)
+	}
+	if verifierErrorLoop == nil || verifierErrorLoop.Status != "running" {
+		t.Fatalf("verifier-error loop = %#v, want preserved running loop", verifierErrorLoop)
+	}
+	verifierEvents, err := services.Repositories.Events.ListByEntity(context.Background(), "agent_execution", "agent_verifier_error_running_run")
+	if err != nil {
+		t.Fatalf("Events.ListByEntity(verifier error) error = %v", err)
+	}
+	if !containsEventType(verifierEvents, "looperd.recovery.process_identity_uncertain") {
+		t.Fatalf("verifier-error events = %#v, want uncertain identity event", verifierEvents)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1776,7 +1776,7 @@ func TestTerminateRecoveredExecutionEscalatesOnlyWhileIdentityMatchesAndAwaitsEx
 	}
 }
 
-func TestTerminateRecoveredExecutionReapsProcessGroupAfterLeaderAlreadyExited(t *testing.T) {
+func TestTerminateRecoveredExecutionRefusesLeaderlessLiveProcessGroup(t *testing.T) {
 	t.Parallel()
 
 	groupRunning := true
@@ -1797,21 +1797,22 @@ func TestTerminateRecoveredExecutionReapsProcessGroupAfterLeaderAlreadyExited(t 
 				return syscall.ESRCH
 			}
 			signals = append(signals, signal)
-			if signal == syscall.SIGKILL {
-				groupRunning = false
-			}
 			return nil
 		},
 	})
 	execution := storage.AgentExecutionRecord{ID: "exec_leader_gone", CommandJSON: stringPtr(`{"command":"codex","args":["exec","test"]}`)}
-	if err := rt.terminateRecoveredExecution(context.Background(), execution, 4242, 10*time.Millisecond); err != nil {
-		t.Fatalf("terminateRecoveredExecution() error = %v", err)
+	err := rt.terminateRecoveredExecution(context.Background(), execution, 4242, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("terminateRecoveredExecution() error = nil, want refusal for leaderless live group")
 	}
-	if !slices.Equal(signals, []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}) {
-		t.Fatalf("signals = %#v, want TERM then KILL for leader-gone process group", signals)
+	if !strings.Contains(err.Error(), "without verifiable identity") {
+		t.Fatalf("terminateRecoveredExecution() error = %v, want verifiable-identity refusal", err)
 	}
-	if groupRunning {
-		t.Fatal("terminateRecoveredExecution returned before process group exit")
+	if len(signals) != 0 {
+		t.Fatalf("signals = %#v, want no termination signals for leaderless live group", signals)
+	}
+	if !groupRunning {
+		t.Fatal("leaderless live process group must remain unsignaled")
 	}
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -77,6 +77,25 @@ type schedulerAsyncRunner interface {
 	Go(func())
 }
 
+type agentExecutionStarter interface {
+	Start(context.Context, agent.RunInput) (agent.Execution, error)
+}
+
+type agentExecutionStarterFunc func(context.Context, agent.RunInput) (agent.Execution, error)
+
+func (f agentExecutionStarterFunc) Start(ctx context.Context, input agent.RunInput) (agent.Execution, error) {
+	return f(ctx, input)
+}
+
+type coordinatorAgentExecutorAdapter struct {
+	executor agentExecutionStarter
+	registry *ActiveExecutionRegistry
+}
+
+func (a coordinatorAgentExecutorAdapter) Start(ctx context.Context, input agent.RunInput) (agent.Execution, error) {
+	return startRegisteredAgentExecution(ctx, a.registry, input.LoopID, input.RunID, input.ExecutionID, a.executor, input)
+}
+
 type defaultSchedulerTickInput struct {
 	Repos                    *storage.Repositories
 	GitHubGateway            *githubinfra.Gateway
@@ -99,6 +118,7 @@ type defaultSchedulerTickInput struct {
 	ReviewerDiscoveryEnabled *bool
 	FixerDiscoveryEnabled    *bool
 	WorkerDiscoveryEnabled   *bool
+	ActiveExecutions         *ActiveExecutionRegistry
 	// OnHITLAnswerDelivered, when set, is called after a Feishu HITL answer is
 	// delivered to a loop, so the transport can mark the ask card resolved.
 	OnHITLAnswerDelivered func(context.Context, string, string)
@@ -982,11 +1002,15 @@ func (a plannerGitAdapter) Push(ctx context.Context, input planner.PushInput) er
 	return a.gateway.Push(ctx, gitinfra.PushInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ProtectedBranches: input.ProtectedBranches})
 }
 
-type plannerAgentExecutorAdapter struct{ executor *agent.ConfiguredExecutor }
+type plannerAgentExecutorAdapter struct {
+	executor agentExecutionStarter
+	registry *ActiveExecutionRegistry
+}
 type plannerAgentExecutionAdapter struct{ execution agent.Execution }
 
 func (a plannerAgentExecutorAdapter) Start(ctx context.Context, input planner.AgentRunInput) (planner.AgentExecution, error) {
-	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
+	runInput := agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey}
+	execution, err := startRegisteredAgentExecution(ctx, a.registry, input.LoopID, input.RunID, input.ExecutionID, a.executor, runInput)
 	if err != nil {
 		return nil, err
 	}
@@ -1642,7 +1666,8 @@ func (a reviewerGitHubAdapter) ResolveReviewThread(ctx context.Context, input re
 }
 
 type reviewerAgentExecutorAdapter struct {
-	executor   *agent.ConfiguredExecutor
+	executor   agentExecutionStarter
+	registry   *ActiveExecutionRegistry
 	realLooper string
 	trustedEnv map[string]string
 	// configPath is the daemon-loaded config file path injected as LOOPER_CONFIG
@@ -1657,6 +1682,48 @@ type reviewerAgentExecutionAdapter struct {
 	execution agent.Execution
 	cleanup   func()
 	once      sync.Once
+}
+
+// reviewerOwnedAgentExecution extends the registry's live-process authority to
+// the trusted publication proxy. A stop request cancels both mutation paths;
+// Wait does not resolve until the agent is reaped and proxy cleanup has run.
+type reviewerOwnedAgentExecution struct {
+	execution agent.Execution
+	cleanup   func()
+	once      sync.Once
+}
+
+func (e *reviewerOwnedAgentExecution) closeProxy() {
+	if e == nil {
+		return
+	}
+	e.once.Do(func() {
+		if e.cleanup != nil {
+			e.cleanup()
+		}
+	})
+}
+
+func (e *reviewerOwnedAgentExecution) Wait(ctx context.Context) (agent.Result, error) {
+	defer e.closeProxy()
+	return e.execution.Wait(ctx)
+}
+
+func (e *reviewerOwnedAgentExecution) Kill(reason string) error {
+	err := e.execution.Kill(reason)
+	e.closeProxy()
+	return err
+}
+
+func (e *reviewerOwnedAgentExecution) ForceKill() error {
+	force, ok := e.execution.(forceKillingExecution)
+	if !ok {
+		e.closeProxy()
+		return fmt.Errorf("reviewer agent execution does not support confirmed forced process-group reap")
+	}
+	err := force.ForceKill()
+	e.closeProxy()
+	return err
 }
 
 func (a *reviewerAgentExecutionAdapter) closeProxy() {
@@ -1824,7 +1891,7 @@ func (a reviewerAgentExecutorAdapter) Start(ctx context.Context, input reviewer.
 		policy = reviewerAllowedReviewPolicy(input.Metadata)
 	}
 	sock, proxyCleanup := mintTrustedReviewProxyForPR(a.realLooper, a.trustedEnv, allowedPR, allowedCwd, a.configPath, policy, a.logger)
-	execution, err := a.executor.Start(ctx, agent.RunInput{
+	runInput := agent.RunInput{
 		ExecutionID:        input.ExecutionID,
 		ProjectID:          input.ProjectID,
 		LoopID:             input.LoopID,
@@ -1837,7 +1904,15 @@ func (a reviewerAgentExecutorAdapter) Start(ctx context.Context, input reviewer.
 		Metadata:           input.Metadata,
 		IdempotencyKey:     input.IdempotencyKey,
 		Env:                reviewerTrustedReviewEnv(sock),
+	}
+	ownedStarter := agentExecutionStarterFunc(func(startCtx context.Context, registeredInput agent.RunInput) (agent.Execution, error) {
+		execution, err := a.executor.Start(startCtx, registeredInput)
+		if err != nil {
+			return nil, err
+		}
+		return &reviewerOwnedAgentExecution{execution: execution, cleanup: proxyCleanup}, nil
 	})
+	execution, err := startRegisteredAgentExecution(ctx, a.registry, input.LoopID, input.RunID, input.ExecutionID, ownedStarter, runInput)
 	if err != nil {
 		proxyCleanup()
 		return nil, err
@@ -2266,11 +2341,15 @@ func (a fixerGitAdapter) CleanupWorktree(ctx context.Context, input fixer.Cleanu
 	return a.gateway.CleanupWorktree(ctx, gitinfra.CleanupWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, ProtectedBranches: input.ProtectedBranches})
 }
 
-type fixerAgentExecutorAdapter struct{ executor *agent.ConfiguredExecutor }
+type fixerAgentExecutorAdapter struct {
+	executor agentExecutionStarter
+	registry *ActiveExecutionRegistry
+}
 type fixerAgentExecutionAdapter struct{ execution agent.Execution }
 
 func (a fixerAgentExecutorAdapter) Start(ctx context.Context, input fixer.AgentRunInput) (fixer.AgentExecution, error) {
-	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
+	runInput := agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey}
+	execution, err := startRegisteredAgentExecution(ctx, a.registry, input.LoopID, input.RunID, input.ExecutionID, a.executor, runInput)
 	if err != nil {
 		return nil, err
 	}
@@ -2719,7 +2798,7 @@ func (a workerGitAdapter) Push(ctx context.Context, input worker.PushInput) erro
 }
 
 type workerAgentExecutorAdapter struct {
-	executor *agent.ConfiguredExecutor
+	executor agentExecutionStarter
 	registry *ActiveExecutionRegistry
 }
 type workerAgentExecutionAdapter struct {
@@ -2727,19 +2806,19 @@ type workerAgentExecutionAdapter struct {
 }
 
 func (a workerAgentExecutorAdapter) Start(ctx context.Context, input worker.AgentRunInput) (worker.AgentExecution, error) {
-	execution, err := a.executor.Start(ctx, agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, NativeResumePrompt: input.NativeResumePrompt, NativeSessionID: input.NativeSessionID, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey})
+	runInput := agent.RunInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Prompt: input.Prompt, NativeResumePrompt: input.NativeResumePrompt, NativeSessionID: input.NativeSessionID, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout, Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey}
+	execution, err := startRegisteredAgentExecution(ctx, a.registry, input.LoopID, input.RunID, input.ExecutionID, a.executor, runInput)
 	if err != nil {
 		return nil, err
 	}
-	unregister := func() {}
-	if a.registry != nil {
-		unregister = a.registry.Register(input.LoopID, input.RunID, input.ExecutionID, execution)
-	}
-	go func() {
-		_, _ = execution.Wait(context.Background())
-		unregister()
-	}()
 	return workerAgentExecutionAdapter{execution: execution}, nil
+}
+
+func startRegisteredAgentExecution(ctx context.Context, registry *ActiveExecutionRegistry, loopID, runID, executionID string, starter agentExecutionStarter, input agent.RunInput) (agent.Execution, error) {
+	if registry == nil {
+		return starter.Start(ctx, input)
+	}
+	return registry.StartAgentExecution(ctx, loopID, runID, executionID, starter, input)
 }
 
 func (a workerAgentExecutionAdapter) Wait(ctx context.Context) (worker.AgentResult, error) {
@@ -2942,7 +3021,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		Repos:              repos,
 		GitHub:             plannerGitHubAdapter{gateway: githubGateway, stamper: stamper, config: &cfg},
 		Git:                plannerGitAdapter{gateway: gitGateway, stamper: stamper},
-		AgentExecutor:      plannerAgentExecutorAdapter{executor: agentExecutor},
+		AgentExecutor:      plannerAgentExecutorAdapter{executor: agentExecutor, registry: activeExecutions},
 		Logger:             logger,
 		Now:                now,
 		AllowAutoPush:      boolPtr(cfg.Defaults.AllowAutoPush),
@@ -2972,7 +3051,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		Logger:  logger,
 		Now:     now,
 		Network: coordinatorrole.NewLoopernetGateway(networkclient.DefaultStatePath(runtimeHomeDirOrEmpty())),
-		TriageLLM: coordinatorrole.NewAgentLLM(agentExecutor, now,
+		TriageLLM: coordinatorrole.NewAgentLLM(coordinatorAgentExecutorAdapter{executor: agentExecutor, registry: activeExecutions}, now,
 			time.Duration(cfg.Agent.Timeouts.PlannerMaxRuntimeSeconds)*time.Second,
 			time.Duration(cfg.Agent.Timeouts.PlannerIdleTimeoutSeconds)*time.Second,
 		),
@@ -2984,6 +3063,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		Git:    reviewerGitAdapter{gateway: gitGateway},
 		AgentExecutor: reviewerAgentExecutorAdapter{
 			executor:   agentExecutor,
+			registry:   activeExecutions,
 			realLooper: looperCLIPath,
 			trustedEnv: providerTrustedEnv(cfg),
 			configPath: strings.TrimSpace(configPath),
@@ -3029,7 +3109,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		Repos:              repos,
 		GitHub:             fixerGitHubAdapter{gateway: githubGateway, stamper: stamper, config: &cfg},
 		Git:                fixerGitAdapter{gateway: gitGateway, stamper: stamper},
-		AgentExecutor:      fixerAgentExecutorAdapter{executor: agentExecutor},
+		AgentExecutor:      fixerAgentExecutorAdapter{executor: agentExecutor, registry: activeExecutions},
 		Logger:             logger,
 		Now:                now,
 		AllowAutoCommit:    cfg.Defaults.AllowAutoCommit,
@@ -3136,6 +3216,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 			ReviewerDiscoveryEnabled: boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "reviewer")),
 			FixerDiscoveryEnabled:    boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "fixer")),
 			WorkerDiscoveryEnabled:   boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "worker")),
+			ActiveExecutions:         services.ActiveExecutions,
 			OnHITLAnswerDelivered:    notificationGateway.MarkAskAnswered,
 		}
 	}
@@ -3671,7 +3752,24 @@ func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemR
 			continue
 		}
 		item := item
-		processFn := process
+		processCtx, cancelProcess := context.WithCancel(ctx)
+		processDone := make(chan struct{})
+		unregisterRun := func() {}
+		if input.ActiveExecutions != nil && item.LoopID != nil && isAgentRoleQueueType(item.Type) {
+			var accepted bool
+			unregisterRun, accepted = input.ActiveExecutions.RegisterRun(*item.LoopID, item.ID, cancelProcess, processDone)
+			if !accepted {
+				close(processDone)
+				cancelProcess()
+				continue
+			}
+		}
+		processFn := func(context.Context) error {
+			defer unregisterRun()
+			defer close(processDone)
+			defer cancelProcess()
+			return process(processCtx)
+		}
 
 		if input.AsyncRunner != nil {
 			input.AsyncRunner.Go(func() {
@@ -3691,6 +3789,15 @@ func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemR
 		return nil
 	}
 	return errors.Join(errList...)
+}
+
+func isAgentRoleQueueType(queueType string) bool {
+	switch queueType {
+	case "planner", "reviewer", "fixer", "worker":
+		return true
+	default:
+		return false
+	}
 }
 
 func schedulerQueueProcessor(item storage.QueueItemRecord, input defaultSchedulerTickInput) (func(context.Context) error, error) {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -3759,8 +3759,21 @@ func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemR
 			var accepted bool
 			unregisterRun, accepted = input.ActiveExecutions.RegisterRun(*item.LoopID, item.ID, cancelProcess, processDone)
 			if !accepted {
+				// Claim already moved the item to running; RegisterRun rejects when
+				// BeginLoopStop/shutdown wins the race. Release the claim so the
+				// slot does not stay stranded until a later recovery pass.
 				close(processDone)
 				cancelProcess()
+				if input.Repos != nil && input.Repos.Queue != nil {
+					_ = input.Repos.Queue.Complete(ctx, item.ID, formatJavaScriptISOString(now().UTC()))
+				}
+				if input.Logger != nil {
+					loopID := ""
+					if item.LoopID != nil {
+						loopID = *item.LoopID
+					}
+					input.Logger.Info("scheduler released claimed item after rejected run registration", map[string]any{"queueItemId": item.ID, "loopId": loopID})
+				}
 				continue
 			}
 		}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -3760,19 +3760,33 @@ func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemR
 			unregisterRun, accepted = input.ActiveExecutions.RegisterRun(*item.LoopID, item.ID, cancelProcess, processDone)
 			if !accepted {
 				// Claim already moved the item to running; RegisterRun rejects when
-				// BeginLoopStop/shutdown wins the race. Release the claim so the
-				// slot does not stay stranded until a later recovery pass.
+				// BeginLoopStop/shutdown wins the race. Unstarted work must not be
+				// marked completed: shutdown requeues for restart recovery, while
+				// intentional loop-stop cancels the claim.
 				close(processDone)
 				cancelProcess()
 				if input.Repos != nil && input.Repos.Queue != nil {
-					_ = input.Repos.Queue.Complete(ctx, item.ID, formatJavaScriptISOString(now().UTC()))
-				}
-				if input.Logger != nil {
+					nowISO := formatJavaScriptISOString(now().UTC())
 					loopID := ""
 					if item.LoopID != nil {
 						loopID = *item.LoopID
 					}
-					input.Logger.Info("scheduler released claimed item after rejected run registration", map[string]any{"queueItemId": item.ID, "loopId": loopID})
+					if input.ActiveExecutions.IsClosing() {
+						if loopID != "" {
+							_, _ = input.Repos.Queue.RequeueRunningByLoop(ctx, loopID, nowISO)
+						}
+						if input.Logger != nil {
+							input.Logger.Info("scheduler requeued claimed item after shutdown rejected run registration", map[string]any{"queueItemId": item.ID, "loopId": loopID})
+						}
+					} else {
+						reason := "loop stop rejected run registration"
+						if loopID != "" {
+							_, _ = input.Repos.Queue.CancelByLoop(ctx, loopID, nowISO, &reason)
+						}
+						if input.Logger != nil {
+							input.Logger.Info("scheduler cancelled claimed item after loop stop rejected run registration", map[string]any{"queueItemId": item.ID, "loopId": loopID})
+						}
+					}
 				}
 				continue
 			}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -35,6 +35,11 @@ import (
 	"github.com/nexu-io/looper/internal/worker"
 )
 
+// registerRunReleaseTimeout bounds durable claim release after RegisterRun
+// rejects a claimed item during daemon shutdown. The scheduler context may
+// already be canceled by Runtime.Stop, so release uses a detached budget.
+const registerRunReleaseTimeout = 5 * time.Second
+
 type plannerScheduler interface {
 	DiscoverIssues(context.Context, planner.DiscoveryInput) (planner.DiscoveryResult, error)
 	ProcessNext(context.Context, string) (*planner.ProcessResult, error)
@@ -3773,7 +3778,19 @@ func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemR
 					}
 					if input.ActiveExecutions.IsClosing() {
 						if loopID != "" {
-							_, _ = input.Repos.Queue.RequeueRunningByLoop(ctx, loopID, nowISO)
+							// Scheduler ctx may already be canceled during Runtime.Stop;
+							// use a bounded background context so release can finish and
+							// surface durable failures instead of leaving the row running.
+							requeueCtx, cancelRequeue := context.WithTimeout(context.Background(), registerRunReleaseTimeout)
+							_, requeueErr := input.Repos.Queue.RequeueRunningByLoop(requeueCtx, loopID, nowISO)
+							cancelRequeue()
+							if requeueErr != nil {
+								errList = append(errList, fmt.Errorf("requeue claimed queue item %s after shutdown rejected run registration: %w", item.ID, requeueErr))
+								if input.Logger != nil {
+									input.Logger.Warn("scheduler failed to requeue claimed item after shutdown rejected run registration", map[string]any{"queueItemId": item.ID, "loopId": loopID, "error": requeueErr.Error()})
+								}
+								continue
+							}
 						}
 						if input.Logger != nil {
 							input.Logger.Info("scheduler requeued claimed item after shutdown rejected run registration", map[string]any{"queueItemId": item.ID, "loopId": loopID})

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -3798,7 +3798,19 @@ func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemR
 					} else {
 						reason := "loop stop rejected run registration"
 						if loopID != "" {
-							_, _ = input.Repos.Queue.CancelByLoop(ctx, loopID, nowISO, &reason)
+							// Scheduler ctx may already be canceled during loop stop;
+							// use a bounded background context so claim release can finish
+							// and surface durable failures instead of leaving the row running.
+							cancelCtx, cancelRelease := context.WithTimeout(context.Background(), registerRunReleaseTimeout)
+							_, cancelErr := input.Repos.Queue.CancelByLoop(cancelCtx, loopID, nowISO, &reason)
+							cancelRelease()
+							if cancelErr != nil {
+								errList = append(errList, fmt.Errorf("cancel claimed queue item %s after loop stop rejected run registration: %w", item.ID, cancelErr))
+								if input.Logger != nil {
+									input.Logger.Warn("scheduler failed to cancel claimed item after loop stop rejected run registration", map[string]any{"queueItemId": item.ID, "loopId": loopID, "error": cancelErr.Error()})
+								}
+								continue
+							}
 						}
 						if input.Logger != nil {
 							input.Logger.Info("scheduler cancelled claimed item after loop stop rejected run registration", map[string]any{"queueItemId": item.ID, "loopId": loopID})

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -348,6 +348,60 @@ func TestRunScheduledQueueItemsSurfacesRequeueFailureAfterShutdownRejectsRegiste
 	}
 }
 
+func TestRunScheduledQueueItemsSurfacesCancelFailureAfterLoopStopRejectsRegisterRun(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "register-run-loop-stop-fail.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	projectID := "project_register_loop_stop_fail"
+	loopID := "loop_register_loop_stop_fail"
+	queueID := "queue_register_loop_stop_fail"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Register loop stop fail", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	claimed := storage.QueueItemRecord{
+		ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: projectID,
+		DedupeKey: "worker:register_loop_stop_fail", Priority: storage.QueuePriorityWorker, Status: "running",
+		AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, ClaimedBy: stringPtr("scheduler"), ClaimedAt: stringPtr(nowISO),
+		StartedAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Queue.Upsert(context.Background(), claimed); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	registry := NewActiveExecutionRegistry()
+	releaseStop := registry.BeginLoopStop(loopID)
+	defer releaseStop()
+	// Close the DB so CancelByLoop fails after RegisterRun rejection.
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+
+	runner := &stubWorkerScheduler{}
+	err := runScheduledQueueItems(context.Background(), []storage.QueueItemRecord{claimed}, defaultSchedulerTickInput{
+		Repos:            repos,
+		Now:              func() time.Time { return now },
+		Worker:           runner,
+		ActiveExecutions: registry,
+	})
+	if err == nil {
+		t.Fatal("runScheduledQueueItems() error = nil, want cancel failure after loop-stop rejected registration")
+	}
+	if !strings.Contains(err.Error(), "cancel claimed queue item") {
+		t.Fatalf("error = %q, want cancel claimed queue item context", err.Error())
+	}
+	if runner.processItemCount() != 0 {
+		t.Fatalf("worker processed %d items after RegisterRun rejection, want 0", runner.processItemCount())
+	}
+}
+
 func TestCommentInfosToObjectsPreservesNestedAuthorLogin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -295,6 +295,59 @@ func TestRunScheduledQueueItemsRequeuesClaimWhenShutdownRejectsRegisterRun(t *te
 	}
 }
 
+func TestRunScheduledQueueItemsSurfacesRequeueFailureAfterShutdownRejectsRegisterRun(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "register-run-shutdown-fail.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	projectID := "project_register_shutdown_fail"
+	loopID := "loop_register_shutdown_fail"
+	queueID := "queue_register_shutdown_fail"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Register shutdown fail", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	claimed := storage.QueueItemRecord{
+		ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: projectID,
+		DedupeKey: "worker:register_shutdown_fail", Priority: storage.QueuePriorityWorker, Status: "running",
+		AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, ClaimedBy: stringPtr("scheduler"), ClaimedAt: stringPtr(nowISO),
+		StartedAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Queue.Upsert(context.Background(), claimed); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	registry := NewActiveExecutionRegistry()
+	registry.BeginShutdown("daemon shutting down")
+	// Close the DB so RequeueRunningByLoop fails after RegisterRun rejection.
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+
+	runner := &stubWorkerScheduler{}
+	err := runScheduledQueueItems(context.Background(), []storage.QueueItemRecord{claimed}, defaultSchedulerTickInput{
+		Repos:            repos,
+		Now:              func() time.Time { return now },
+		Worker:           runner,
+		ActiveExecutions: registry,
+	})
+	if err == nil {
+		t.Fatal("runScheduledQueueItems() error = nil, want requeue failure after shutdown rejected registration")
+	}
+	if !strings.Contains(err.Error(), "requeue claimed queue item") {
+		t.Fatalf("error = %q, want requeue claimed queue item context", err.Error())
+	}
+	if runner.processItemCount() != 0 {
+		t.Fatalf("worker processed %d items after RegisterRun rejection, want 0", runner.processItemCount())
+	}
+}
+
 func TestCommentInfosToObjectsPreservesNestedAuthorLogin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -187,6 +187,59 @@ func TestScheduledAgentRunRemainsOwnedAfterAgentPhase(t *testing.T) {
 	}
 }
 
+func TestRunScheduledQueueItemsReleasesClaimWhenRegisterRunRejected(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "register-run-reject.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	projectID := "project_register_reject"
+	loopID := "loop_register_reject"
+	queueID := "queue_register_reject"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Register reject", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	claimed := storage.QueueItemRecord{
+		ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: projectID,
+		DedupeKey: "worker:register_reject", Priority: storage.QueuePriorityWorker, Status: "running",
+		AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, ClaimedBy: stringPtr("scheduler"), ClaimedAt: stringPtr(nowISO),
+		StartedAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Queue.Upsert(context.Background(), claimed); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	registry := NewActiveExecutionRegistry()
+	releaseStop := registry.BeginLoopStop(loopID)
+	defer releaseStop()
+
+	runner := &stubWorkerScheduler{}
+	if err := runScheduledQueueItems(context.Background(), []storage.QueueItemRecord{claimed}, defaultSchedulerTickInput{
+		Repos:            repos,
+		Now:              func() time.Time { return now },
+		Worker:           runner,
+		ActiveExecutions: registry,
+	}); err != nil {
+		t.Fatalf("runScheduledQueueItems() error = %v", err)
+	}
+	if runner.processItemCount() != 0 {
+		t.Fatalf("worker processed %d items after RegisterRun rejection, want 0", runner.processItemCount())
+	}
+	updated, err := repos.Queue.GetByID(context.Background(), queueID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if updated == nil || updated.Status != "completed" {
+		t.Fatalf("queue item = %#v, want status completed after rejected run registration", updated)
+	}
+}
+
 func TestCommentInfosToObjectsPreservesNestedAuthorLogin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -41,6 +41,152 @@ func TestWorkerAgentExecutionAdapterPropagatesParseStatus(t *testing.T) {
 	}
 }
 
+func TestEveryRoleRegistersAgentExecutionForConfirmedStop(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		start func(agentExecutionStarter, *ActiveExecutionRegistry) error
+	}{
+		{name: "planner", start: func(starter agentExecutionStarter, registry *ActiveExecutionRegistry) error {
+			_, err := (plannerAgentExecutorAdapter{executor: starter, registry: registry}).Start(context.Background(), planner.AgentRunInput{LoopID: "loop_1", RunID: "run_1", ExecutionID: "exec_1"})
+			return err
+		}},
+		{name: "reviewer", start: func(starter agentExecutionStarter, registry *ActiveExecutionRegistry) error {
+			_, err := (reviewerAgentExecutorAdapter{executor: starter, registry: registry}).Start(context.Background(), reviewer.AgentRunInput{LoopID: "loop_1", RunID: "run_1", ExecutionID: "exec_1"})
+			return err
+		}},
+		{name: "fixer", start: func(starter agentExecutionStarter, registry *ActiveExecutionRegistry) error {
+			_, err := (fixerAgentExecutorAdapter{executor: starter, registry: registry}).Start(context.Background(), fixer.AgentRunInput{LoopID: "loop_1", RunID: "run_1", ExecutionID: "exec_1"})
+			return err
+		}},
+		{name: "worker", start: func(starter agentExecutionStarter, registry *ActiveExecutionRegistry) error {
+			_, err := (workerAgentExecutorAdapter{executor: starter, registry: registry}).Start(context.Background(), worker.AgentRunInput{LoopID: "loop_1", RunID: "run_1", ExecutionID: "exec_1"})
+			return err
+		}},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			registry := NewActiveExecutionRegistry()
+			execution := newBlockingRegistryExecution()
+			if err := tt.start(stubAgentExecutionStarter{execution: execution}, registry); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			stopped := make(chan error, 1)
+			go func() {
+				_, err := registry.StopAndWait(context.Background(), "loop_1", "run_1", "exec_1", "test stop")
+				stopped <- err
+			}()
+			select {
+			case <-execution.killed:
+			case <-time.After(time.Second):
+				t.Fatal("registered execution was not killed")
+			}
+			execution.finish()
+			if err := <-stopped; err != nil {
+				t.Fatalf("StopAndWait() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestCoordinatorAgentExecutionRegistersForDaemonShutdown(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	execution := newBlockingRegistryExecution()
+	adapter := coordinatorAgentExecutorAdapter{executor: stubAgentExecutionStarter{execution: execution}, registry: registry}
+	if _, err := adapter.Start(context.Background(), agent.RunInput{ExecutionID: "coord_exec_1", Prompt: "triage", WorkingDirectory: t.TempDir()}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	returned := make(chan error, 1)
+	go func() { returned <- registry.ShutdownAndWait(context.Background(), "test shutdown") }()
+	select {
+	case <-execution.killed:
+	case <-time.After(time.Second):
+		t.Fatal("coordinator execution was not killed during shutdown")
+	}
+	execution.finish()
+	if err := <-returned; err != nil {
+		t.Fatalf("ShutdownAndWait() error = %v", err)
+	}
+}
+
+func TestReviewerRegistryStopCancelsTrustedPublicationOwnership(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	execution := newBlockingRegistryExecution()
+	proxyCancelled := make(chan struct{})
+	owned := &reviewerOwnedAgentExecution{execution: execution, cleanup: func() { close(proxyCancelled) }}
+	registry.Register("loop_review", "run_review", "exec_review", owned)
+	returned := make(chan error, 1)
+	go func() {
+		_, err := registry.StopAndWait(context.Background(), "loop_review", "run_review", "exec_review", "stop reviewer")
+		returned <- err
+	}()
+	select {
+	case <-execution.killed:
+	case <-time.After(time.Second):
+		t.Fatal("reviewer agent was not killed")
+	}
+	select {
+	case <-proxyCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("trusted publication proxy was not cancelled with reviewer ownership")
+	}
+	execution.finish()
+	if err := <-returned; err != nil {
+		t.Fatalf("StopAndWait() error = %v", err)
+	}
+}
+
+func TestReviewerOwnedExecutionRejectsUnsupportedForcedResolution(t *testing.T) {
+	t.Parallel()
+
+	owned := &reviewerOwnedAgentExecution{execution: stubAgentExecution{}}
+	if err := owned.ForceKill(); err == nil {
+		t.Fatal("ForceKill() returned nil without an underlying confirmed-reap contract")
+	}
+}
+
+func TestScheduledAgentRunRemainsOwnedAfterAgentPhase(t *testing.T) {
+	t.Parallel()
+
+	registry := NewActiveExecutionRegistry()
+	runner := &cancellableWorkerScheduler{started: make(chan struct{}), cancelled: make(chan struct{}), release: make(chan struct{})}
+	loopID := "loop_validation"
+	if err := runScheduledQueueItems(context.Background(), []storage.QueueItemRecord{{ID: "queue_1", LoopID: &loopID, Type: "worker"}}, defaultSchedulerTickInput{Worker: runner, ActiveExecutions: registry}); err != nil {
+		t.Fatalf("runScheduledQueueItems() error = %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(time.Second):
+		t.Fatal("scheduled run did not start")
+	}
+	returned := make(chan error, 1)
+	go func() {
+		_, err := registry.StopAndWait(context.Background(), loopID, "run_1", "completed_agent", "stop validation")
+		returned <- err
+	}()
+	select {
+	case <-runner.cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("scheduled run context was not cancelled")
+	}
+	select {
+	case err := <-returned:
+		t.Fatalf("StopAndWait returned before runner cleanup: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(runner.release)
+	if err := <-returned; err != nil {
+		t.Fatalf("StopAndWait() error = %v", err)
+	}
+}
+
 func TestCommentInfosToObjectsPreservesNestedAuthorLogin(t *testing.T) {
 	t.Parallel()
 
@@ -1669,4 +1815,32 @@ func (s stubAgentExecution) Wait(context.Context) (agent.Result, error) {
 
 func (s stubAgentExecution) Kill(string) error {
 	return nil
+}
+
+type stubAgentExecutionStarter struct {
+	execution agent.Execution
+	err       error
+}
+
+func (s stubAgentExecutionStarter) Start(context.Context, agent.RunInput) (agent.Execution, error) {
+	return s.execution, s.err
+}
+
+type cancellableWorkerScheduler struct {
+	started   chan struct{}
+	cancelled chan struct{}
+	release   chan struct{}
+	once      sync.Once
+}
+
+func (s *cancellableWorkerScheduler) ProcessNext(context.Context, string) (*worker.ProcessResult, error) {
+	return nil, nil
+}
+
+func (s *cancellableWorkerScheduler) ProcessClaimedQueueItem(ctx context.Context, _ storage.QueueItemRecord) (*worker.ProcessResult, error) {
+	s.once.Do(func() { close(s.started) })
+	<-ctx.Done()
+	close(s.cancelled)
+	<-s.release
+	return nil, ctx.Err()
 }

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -187,7 +187,7 @@ func TestScheduledAgentRunRemainsOwnedAfterAgentPhase(t *testing.T) {
 	}
 }
 
-func TestRunScheduledQueueItemsReleasesClaimWhenRegisterRunRejected(t *testing.T) {
+func TestRunScheduledQueueItemsCancelsClaimWhenLoopStopRejectsRegisterRun(t *testing.T) {
 	t.Parallel()
 
 	workingDir := t.TempDir()
@@ -235,8 +235,63 @@ func TestRunScheduledQueueItemsReleasesClaimWhenRegisterRunRejected(t *testing.T
 	if err != nil {
 		t.Fatalf("Queue.GetByID() error = %v", err)
 	}
-	if updated == nil || updated.Status != "completed" {
-		t.Fatalf("queue item = %#v, want status completed after rejected run registration", updated)
+	if updated == nil || updated.Status != "cancelled" {
+		t.Fatalf("queue item = %#v, want status cancelled after loop-stop rejected run registration", updated)
+	}
+}
+
+func TestRunScheduledQueueItemsRequeuesClaimWhenShutdownRejectsRegisterRun(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "register-run-shutdown.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	projectID := "project_register_shutdown"
+	loopID := "loop_register_shutdown"
+	queueID := "queue_register_shutdown"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Register shutdown", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	claimed := storage.QueueItemRecord{
+		ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: projectID,
+		DedupeKey: "worker:register_shutdown", Priority: storage.QueuePriorityWorker, Status: "running",
+		AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, ClaimedBy: stringPtr("scheduler"), ClaimedAt: stringPtr(nowISO),
+		StartedAt: stringPtr(nowISO), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Queue.Upsert(context.Background(), claimed); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	registry := NewActiveExecutionRegistry()
+	registry.BeginShutdown("daemon shutting down")
+
+	runner := &stubWorkerScheduler{}
+	if err := runScheduledQueueItems(context.Background(), []storage.QueueItemRecord{claimed}, defaultSchedulerTickInput{
+		Repos:            repos,
+		Now:              func() time.Time { return now },
+		Worker:           runner,
+		ActiveExecutions: registry,
+	}); err != nil {
+		t.Fatalf("runScheduledQueueItems() error = %v", err)
+	}
+	if runner.processItemCount() != 0 {
+		t.Fatalf("worker processed %d items after RegisterRun rejection, want 0", runner.processItemCount())
+	}
+	updated, err := repos.Queue.GetByID(context.Background(), queueID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID() error = %v", err)
+	}
+	if updated == nil || updated.Status != "queued" {
+		t.Fatalf("queue item = %#v, want status queued after shutdown rejected run registration", updated)
+	}
+	if updated.ClaimedBy != nil || updated.ClaimedAt != nil || updated.StartedAt != nil {
+		t.Fatalf("queue item claim fields = claimedBy=%v claimedAt=%v startedAt=%v, want cleared", updated.ClaimedBy, updated.ClaimedAt, updated.StartedAt)
 	}
 }
 

--- a/internal/runtime/webhook.go
+++ b/internal/runtime/webhook.go
@@ -387,13 +387,17 @@ func (w *webhookRuntime) Stop() {
 		w.wg.Wait()
 		close(waitDone)
 	}()
-	timer := time.NewTimer(w.shutdownTimeout())
+	// runForwarder waits shutdownTimeout after SIGTERM before escalating to Kill.
+	// Budget a second equal interval so Stop does not return at the same moment
+	// Kill starts, before cmd.Wait and forwarder record cleanup finish.
+	shutdownBudget := 2 * w.shutdownTimeout()
+	timer := time.NewTimer(shutdownBudget)
 	defer timer.Stop()
 	select {
 	case <-waitDone:
 	case <-timer.C:
 		if w.logger != nil {
-			w.logger.Warn("webhook shutdown timed out", map[string]any{"timeout": w.shutdownTimeout().String()})
+			w.logger.Warn("webhook shutdown timed out", map[string]any{"timeout": shutdownBudget.String()})
 		}
 	}
 }

--- a/internal/runtime/webhook.go
+++ b/internal/runtime/webhook.go
@@ -382,7 +382,20 @@ func (w *webhookRuntime) Stop() {
 		_ = server.server.Shutdown(ctx)
 		cancel()
 	}
-	w.wg.Wait()
+	waitDone := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(waitDone)
+	}()
+	timer := time.NewTimer(w.shutdownTimeout())
+	defer timer.Stop()
+	select {
+	case <-waitDone:
+	case <-timer.C:
+		if w.logger != nil {
+			w.logger.Warn("webhook shutdown timed out", map[string]any{"timeout": w.shutdownTimeout().String()})
+		}
+	}
 }
 
 func (w *webhookRuntime) Status() WebhookStatus {
@@ -542,21 +555,27 @@ func (w *webhookRuntime) adoptionGate(record storage.WebhookForwarderRecord, com
 	return ""
 }
 
-func (w *webhookRuntime) adoptForwarder(record storage.WebhookForwarderRecord, command []string) {
+func (w *webhookRuntime) adoptForwarder(record storage.WebhookForwarderRecord, command []string) bool {
 	pid := int(record.PID)
 	spawnedAt := formatJavaScriptISOString(time.Unix(0, record.SpawnedAt).UTC())
 	stopCh := make(chan struct{})
 	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		return false
+	}
 	if w.forwarderStopCh == nil {
 		w.forwarderStopCh = map[string]chan struct{}{}
 	}
 	w.forwarderStopCh[record.Repo] = stopCh
 	w.status.Forwarders = append(w.status.Forwarders, WebhookForwarderState{Repo: record.Repo, Running: true, PID: &pid, Adopted: true, Fingerprint: record.Fingerprint, SpawnedAt: &spawnedAt, Command: append([]string{}, command...)})
+	// Add while holding the same gate Stop uses to set stopped. This guarantees
+	// no positive WaitGroup delta can race an empty Wait after shutdown begins.
+	w.wg.Add(1)
 	w.mu.Unlock()
 	if w.logger != nil {
 		w.logger.Info("webhook.forwarder.adopted", map[string]any{"repo": record.Repo, "pid": pid, "process_start": record.ProcessStart, "fingerprint": record.Fingerprint})
 	}
-	w.wg.Add(1)
 	go func() {
 		defer w.wg.Done()
 		proc := &adoptedForwarderProcess{pid: pid, processStart: record.ProcessStart, probe: w.processProbe()}
@@ -592,6 +611,7 @@ func (w *webhookRuntime) adoptForwarder(record storage.WebhookForwarderRecord, c
 			}
 		}
 	}()
+	return true
 }
 
 func (w *webhookRuntime) waitForAdoptedStop(proc *adoptedForwarderProcess, repo string) {
@@ -777,12 +797,19 @@ func (w *webhookRuntime) processProbe() processProbe {
 	return w.probe
 }
 
-func (w *webhookRuntime) launchForwarder(repo string) {
+func (w *webhookRuntime) launchForwarder(repo string) bool {
+	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		return false
+	}
 	w.wg.Add(1)
+	w.mu.Unlock()
 	go func() {
 		defer w.wg.Done()
 		w.runForwarder(repo)
 	}()
+	return true
 }
 
 func (w *webhookRuntime) isStopped() bool {
@@ -1145,21 +1172,24 @@ func (w *webhookRuntime) killAndWait(cmd *exec.Cmd) {
 }
 
 func (w *webhookRuntime) shutdownTimeout() time.Duration {
+	if w != nil && w.cfg.Daemon.ShutdownTimeoutMS > 0 {
+		return time.Duration(w.cfg.Daemon.ShutdownTimeoutMS) * time.Millisecond
+	}
 	return 5 * time.Second
 }
 
-func (w *webhookRuntime) scheduleReconcileRetry(repos *storage.Repositories) {
+func (w *webhookRuntime) scheduleReconcileRetry(repos *storage.Repositories) bool {
 	if w == nil || repos == nil {
-		return
+		return false
 	}
 	w.mu.Lock()
 	if w.stopped || w.reconcileRetry {
 		w.mu.Unlock()
-		return
+		return false
 	}
 	w.reconcileRetry = true
-	w.mu.Unlock()
 	w.wg.Add(1)
+	w.mu.Unlock()
 	go func() {
 		defer w.wg.Done()
 		timer := time.NewTimer(webhookReconcileRetryDelay)
@@ -1182,6 +1212,7 @@ func (w *webhookRuntime) scheduleReconcileRetry(repos *storage.Repositories) {
 		w.mu.Unlock()
 		w.Reconcile(repos)
 	}()
+	return true
 }
 
 func webhookBaseURL(cfg config.Config) string {

--- a/internal/runtime/webhook_runtime_test.go
+++ b/internal/runtime/webhook_runtime_test.go
@@ -7,8 +7,10 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1180,6 +1182,9 @@ func TestWebhookRuntimeForwarderHelperProcess(t *testing.T) {
 	if message := os.Getenv("LOOPER_HELPER_STDERR_EXIT"); message != "" {
 		_, _ = os.Stderr.WriteString(message + "\n")
 		os.Exit(1)
+	}
+	if os.Getenv("LOOPER_HELPER_IGNORE_TERM") == "1" {
+		signal.Ignore(syscall.SIGTERM)
 	}
 	select {}
 }

--- a/internal/runtime/webhook_shutdown_test.go
+++ b/internal/runtime/webhook_shutdown_test.go
@@ -1,0 +1,40 @@
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestWebhookStopDoesNotWaitPastShutdownDeadline(t *testing.T) {
+	cfg := config.Config{Daemon: config.DaemonConfig{ShutdownTimeoutMS: 25}}
+	runtime := newWebhookRuntime(cfg, nil, time.Now)
+	runtime.wg.Add(1) // Model a stuck webhook goroutine.
+	t.Cleanup(runtime.wg.Done)
+
+	startedAt := time.Now()
+	runtime.Stop()
+	if elapsed := time.Since(startedAt); elapsed > 500*time.Millisecond {
+		t.Fatalf("Stop() elapsed = %s, want bounded webhook shutdown", elapsed)
+	}
+}
+
+func TestWebhookStopClosesTaskSpawnGate(t *testing.T) {
+	runtime := newWebhookRuntime(config.Config{}, nil, time.Now)
+	runtime.Stop()
+
+	if runtime.launchForwarder("nexu-io/looper") {
+		t.Fatal("launchForwarder accepted a task after Stop")
+	}
+	if runtime.adoptForwarder(storage.WebhookForwarderRecord{Repo: "nexu-io/looper", PID: 42}, []string{"gh"}) {
+		t.Fatal("adoptForwarder accepted a task after Stop")
+	}
+	if runtime.scheduleReconcileRetry(&storage.Repositories{}) {
+		t.Fatal("scheduleReconcileRetry accepted a task after Stop")
+	}
+	if got := len(runtime.Status().Forwarders); got != 0 {
+		t.Fatalf("forwarders after rejected adoption = %d, want 0", got)
+	}
+}

--- a/internal/runtime/webhook_shutdown_test.go
+++ b/internal/runtime/webhook_shutdown_test.go
@@ -1,6 +1,9 @@
 package runtime
 
 import (
+	"os"
+	"os/exec"
+	"syscall"
 	"testing"
 	"time"
 
@@ -16,8 +19,84 @@ func TestWebhookStopDoesNotWaitPastShutdownDeadline(t *testing.T) {
 
 	startedAt := time.Now()
 	runtime.Stop()
+	// Stop budgets 2x shutdownTimeout (TERM grace + kill/reap), still bounded.
 	if elapsed := time.Since(startedAt); elapsed > 500*time.Millisecond {
 		t.Fatalf("Stop() elapsed = %s, want bounded webhook shutdown", elapsed)
+	}
+}
+
+func TestWebhookStopWaitsForForwarderReapAfterKillEscalation(t *testing.T) {
+	testBin, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error = %v", err)
+	}
+	startedCh := make(chan struct{})
+	originalCommand := execCommand
+	originalStartedHook := webhookForwarderStartedHook
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		cmd := exec.Command(testBin, "-test.run=TestWebhookRuntimeForwarderHelperProcess", "--")
+		cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1", "LOOPER_HELPER_IGNORE_TERM=1")
+		cmd.Args[0] = name
+		return cmd
+	}
+	webhookForwarderStartedHook = func() {
+		close(startedCh)
+	}
+	t.Cleanup(func() {
+		execCommand = originalCommand
+		webhookForwarderStartedHook = originalStartedHook
+	})
+
+	const shutdownMS = 40
+	rt := &webhookRuntime{
+		cfg: config.Config{Daemon: config.DaemonConfig{ShutdownTimeoutMS: shutdownMS}},
+		status: WebhookStatus{
+			Enabled:    true,
+			Forwarders: []WebhookForwarderState{{Repo: "nexu-io/looper", Command: []string{"gh", "webhook", "forward"}}},
+		},
+		stopCh:          make(chan struct{}),
+		forwarderStopCh: map[string]chan struct{}{"nexu-io/looper": make(chan struct{})},
+		now:             time.Now,
+	}
+	rt.launchForwarder("nexu-io/looper")
+	<-startedCh
+
+	// Wait until the forwarder publishes a live PID so we can assert reaping.
+	var pid int
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		status := rt.Status()
+		if status.Forwarders[0].Running && status.Forwarders[0].PID != nil {
+			pid = *status.Forwarders[0].PID
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("forwarder did not publish a running PID")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	startedAt := time.Now()
+	rt.Stop()
+	elapsed := time.Since(startedAt)
+	// Must outlast the TERM grace window so Kill escalation can complete, but
+	// stay within the 2x shutdown budget used by Stop.
+	if elapsed < time.Duration(shutdownMS)*time.Millisecond {
+		t.Fatalf("Stop() returned after %s, want at least one TERM grace interval for escalation", elapsed)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("Stop() elapsed = %s, want bounded 2x shutdown wait", elapsed)
+	}
+
+	if live, probeErr := (defaultProcessProbe{}).IsAlive(pid); probeErr != nil {
+		t.Fatalf("probe forwarder pid %d: %v", pid, probeErr)
+	} else if live {
+		t.Fatalf("forwarder pid %d still alive after Stop(); want reaped after Kill escalation", pid)
+	}
+	status := rt.Status()
+	if status.Forwarders[0].Running || status.Forwarders[0].PID != nil {
+		t.Fatalf("forwarder state after Stop = %#v, want not running and nil PID", status.Forwarders[0])
 	}
 }
 

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -1031,6 +1031,26 @@ func (r *AgentExecutionsRepository) Upsert(ctx context.Context, record AgentExec
 	return nil
 }
 
+// UpdateLiveProgress updates only non-authoritative side-effect fields for a live
+// execution. Full Upsert from the output path can race with ownership writes
+// (initial spawn or native-resume fallback) and restore a dead PID or stale
+// native-resume metadata after the live process group has already changed.
+func (r *AgentExecutionsRepository) UpdateLiveProgress(ctx context.Context, id string, heartbeatCount int64, heartbeatAt string, outputJSON string) error {
+	_, err := r.q.ExecContext(ctx, `
+		UPDATE agent_executions
+		SET heartbeat_count = ?,
+		    last_heartbeat_at = ?,
+		    output_json = ?,
+		    updated_at = ?
+		WHERE id = ?
+		  AND status IN ('running', 'cancelling')
+	`, heartbeatCount, heartbeatAt, outputJSON, heartbeatAt, id)
+	if err != nil {
+		return fmt.Errorf("update agent execution live progress: %w", err)
+	}
+	return nil
+}
+
 func (r *AgentExecutionsRepository) GetByID(ctx context.Context, id string) (*AgentExecutionRecord, error) {
 	row := r.q.QueryRowContext(ctx, `SELECT `+agentExecutionColumns+` FROM agent_executions WHERE id = ?`, id)
 	record, err := scanAgentExecution(row)

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -226,6 +226,46 @@ func TestRepositoriesRoundTripForProjectsLoopsRunsAndRuntimeMetadata(t *testing.
 		t.Fatalf("AgentExecutions.GetByID() = %#v, want agent_1 with heartbeat_count=2 and native session", agentExecution)
 	}
 
+	fallbackPID := int64(9756)
+	fallbackMode := "checkpoint_restart"
+	fallbackStatus := "fallback_started"
+	fallbackError := "resume failed"
+	if err := repos.AgentExecutions.Upsert(ctx, AgentExecutionRecord{
+		ID:                 "agent_1",
+		RunID:              strPtr("run_1"),
+		LoopID:             strPtr("loop_1"),
+		ProjectID:          strPtr("project_1"),
+		Vendor:             "codex",
+		Status:             "running",
+		PID:                &fallbackPID,
+		CommandJSON:        &agentCommand,
+		CWD:                &agentCWD,
+		HeartbeatCount:     0,
+		NativeResumeMode:   &fallbackMode,
+		NativeResumeStatus: &fallbackStatus,
+		NativeResumeError:  &fallbackError,
+		StartedAt:          now,
+		LastHeartbeatAt:    &now,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert(fallback ownership) error = %v", err)
+	}
+	staleOutput := `{"stdout":"","stderr":"resume failed\n"}`
+	if err := repos.AgentExecutions.UpdateLiveProgress(ctx, "agent_1", 1, now, staleOutput); err != nil {
+		t.Fatalf("AgentExecutions.UpdateLiveProgress() error = %v", err)
+	}
+	progress, err := repos.AgentExecutions.GetByID(ctx, "agent_1")
+	if err != nil {
+		t.Fatalf("AgentExecutions.GetByID(after progress) error = %v", err)
+	}
+	if progress == nil || progress.PID == nil || *progress.PID != fallbackPID || progress.HeartbeatCount != 1 || progress.OutputJSON == nil || *progress.OutputJSON != staleOutput {
+		t.Fatalf("AgentExecutions after UpdateLiveProgress = %#v, want preserved fallback PID %d with progress fields", progress, fallbackPID)
+	}
+	if progress.NativeResumeMode == nil || *progress.NativeResumeMode != fallbackMode || progress.NativeResumeStatus == nil || *progress.NativeResumeStatus != fallbackStatus || progress.NativeResumeError == nil || *progress.NativeResumeError != fallbackError {
+		t.Fatalf("AgentExecutions after UpdateLiveProgress = %#v, want preserved native-resume ownership metadata", progress)
+	}
+
 	latestExecution, err := repos.AgentExecutions.GetLatestByRunID(ctx, "run_1")
 	if err != nil {
 		t.Fatalf("AgentExecutions.GetLatestByRunID() error = %v", err)

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -53,6 +53,10 @@ const (
 	maxRetryDelay       = 300 * time.Second
 	defaultRetryMax     = 3
 	defaultIssueLimit   = 30
+	// Validation is owned by the scheduled-run context. Keep its TERM grace
+	// below the daemon's forced-shutdown reap window so a resistant validation
+	// subprocess cannot outlive looperd after that context is cancelled.
+	validationGracefulShutdown = 250 * time.Millisecond
 
 	workerBranchSlugMaxLength        = 30
 	workerBranchSlugMaxWords         = 5
@@ -2563,12 +2567,15 @@ func (r *Runner) runValidation(ctx context.Context, input ValidationInput) (Vali
 
 	outputs := make([]string, 0, len(input.Commands)*2)
 	for _, command := range input.Commands {
-		result, err := shell.Run(ctx, shell.Options{Command: "/bin/sh", Args: []string{"-c", command}, CWD: input.CWD})
+		result, err := shell.Run(ctx, shell.Options{Command: "/bin/sh", Args: []string{"-c", command}, CWD: input.CWD, Timeout: r.agentTimeout, GracefulShutdown: validationGracefulShutdown})
 		if err != nil {
 			output := "Unknown validation failure"
 			var commandErr *shell.CommandExecutionError
 			if errors.As(err, &commandErr) {
 				output = strings.TrimSpace(strings.Join([]string{commandErr.Result.Stdout, commandErr.Result.Stderr}, "\n"))
+				if output == "" {
+					output = commandErr.Error()
+				}
 			} else {
 				output = err.Error()
 			}

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -3431,6 +3431,24 @@ func TestRunValidationReturnsCommandFailureOutput(t *testing.T) {
 	}
 }
 
+func TestRunValidationUsesRunnerDeadline(t *testing.T) {
+	runner := New(Options{AgentTimeout: 50 * time.Millisecond})
+	startedAt := time.Now()
+	result, err := runner.runValidation(context.Background(), ValidationInput{
+		CWD:      t.TempDir(),
+		Commands: []string{"trap '' TERM; while :; do sleep 1; done"},
+	})
+	if err != nil {
+		t.Fatalf("runValidation() error = %v", err)
+	}
+	if result.Passed || !strings.Contains(result.Output, "timed out") {
+		t.Fatalf("result = %#v, want timed-out validation failure", result)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 2*time.Second {
+		t.Fatalf("runValidation() elapsed = %s, want bounded cancellation", elapsed)
+	}
+}
+
 func TestProcessClaimedItemExecuteResumeDoesNotRerunAgentAfterTransientInspectFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)


### PR DESCRIPTION
## Summary

- make live executor handles authoritative from successful spawn through confirmed process-group reaping for planner, reviewer, fixer, worker, and coordinator executions
- prevent stop, close, takeover, recovery, and daemon shutdown from advancing durable state while an owned process or enclosing validation run remains live
- give validation, feedback, interactive takeover, trusted review publication, and generic shell commands bounded process-group ownership
- gate mutating API requests until startup recovery succeeds and stop the daemon on post-start API serve failures
- add real TERM-resistant child/grandchild lifecycle contracts plus blocked persistence, output, startup, and shutdown regressions

## Root cause

Process ownership was fragmented across roles and subprocess launchers. Several paths treated persisted PID/argv inference or a delivered signal as proof of termination, while executor waits could return before graceful escalation, descendant cleanup, or blocked side effects completed. That allowed durable loop state, scheduler work, and human takeover to overlap a still-running process group.

## Authority

The authority for a live agent action is its in-memory execution handle and confirmed Wait/process-group disappearance, not the agent's structured output or persisted multiline argv; PID and command inspection are reserved for conservative startup-recovery drift detection.

Startup mutation readiness is authorized only by successful Runtime.CompleteStartup completion.

## Design trade-offs

- In-memory pending-start, run, shutdown, and per-loop stop leases close spawn-to-register and empty-snapshot races. They add cancellation/rescan paths, but add no persisted state; persisted PID inference cannot safely replace them because multiline prompts and native fallback make command matching ambiguous.
- Planner locks are refreshed for agent timeout plus claim TTL. This prevents live overlap, at the cost of a longer stale lock after a crash.
- Output, log, progress, and event side effects are bounded and best effort. A dependency that ignores context may lose diagnostics or retain its own goroutine, but it cannot backpressure agent pipes or retain process ownership.
- SIGKILL is sent at most once and followed by probe-only confirmation. A group that remains signalable is retained and reported rather than risking a later signal to a reused PGID.
- During recovery, safe reads remain available while mutations receive HTTP 503 until startup is authoritative.

## User and operator impact

Stop, close, takeover, and shutdown now wait for confirmed cleanup or fail loudly instead of reporting success while an agent survives. Startup may temporarily return 503 for mutations during orphan recovery. Cleanup-barrier failures are preserved alongside command timeout, cancellation, and exit diagnostics.

## Validation

- gofmt -l .
- go vet ./...
- go test ./...
- go build ./...
- git diff --check
- focused race tests for agent and runtime ownership
- five-run feedback lifecycle stress test