### PR TITLE
feat: show attempt count and error reason on dashboard job list and detail

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1441,6 +1441,11 @@ type loopResponse struct {
 	NextRunAt    *string `json:"nextRunAt"`
 	CreatedAt    string  `json:"createdAt"`
 	UpdatedAt    string  `json:"updatedAt"`
+	// Queue-derived diagnostics (latest queue item / run), matching looper describe / ps.
+	Attempts          *int64  `json:"attempts,omitempty"`
+	MaxAttempts       *int64  `json:"maxAttempts,omitempty"`
+	LastFailureKind   *string `json:"lastFailureKind,omitempty"`
+	LastFailureReason *string `json:"lastFailureReason,omitempty"`
 }
 
 type loopLogsResponse struct {
@@ -1543,6 +1548,8 @@ type activeRunView struct {
 	Status            string             `json:"status"`
 	LoopStatus        string             `json:"loopStatus"`
 	DisplayStatus     string             `json:"displayStatus"`
+	Attempts          *int64             `json:"attempts,omitempty"`
+	MaxAttempts       *int64             `json:"maxAttempts,omitempty"`
 	LastFailureKind   *string            `json:"lastFailureKind,omitempty"`
 	LastFailureReason *string            `json:"lastFailureReason,omitempty"`
 	ResumePolicy      *string            `json:"resumePolicy,omitempty"`
@@ -1717,9 +1724,41 @@ func (h *Handler) buildLoopsRouteResponse(r *http.Request) (any, error) {
 			return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 
+		loopIDs := make([]string, 0, len(items))
+		for _, item := range items {
+			loopIDs = append(loopIDs, item.ID)
+		}
+		latestQueueByLoopID := map[string]*storage.QueueItemRecord{}
+		latestRunByLoopID := map[string]*storage.RunRecord{}
+		if len(loopIDs) > 0 && services.Repositories.Queue != nil {
+			queues, qErr := services.Repositories.Queue.ListLatestByLoopIDs(r.Context(), loopIDs)
+			if qErr != nil {
+				return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: qErr.Error()}
+			}
+			for i := range queues {
+				item := &queues[i]
+				if item.LoopID == nil || strings.TrimSpace(*item.LoopID) == "" {
+					continue
+				}
+				latestQueueByLoopID[*item.LoopID] = item
+			}
+		}
+		if len(loopIDs) > 0 && services.Repositories.Runs != nil {
+			runs, rErr := services.Repositories.Runs.ListLatestByLoopIDs(r.Context(), loopIDs)
+			if rErr != nil {
+				return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: rErr.Error()}
+			}
+			for i := range runs {
+				run := &runs[i]
+				latestRunByLoopID[run.LoopID] = run
+			}
+		}
+
 		responseItems := make([]loopResponse, 0, len(items))
 		for _, item := range items {
-			responseItems = append(responseItems, serializeLoop(item))
+			view := serializeLoop(item)
+			decorateLoopDiagnostics(&view, latestQueueByLoopID[item.ID], latestRunByLoopID[item.ID])
+			responseItems = append(responseItems, view)
 		}
 
 		resp := loopsListResponse{
@@ -2888,6 +2927,10 @@ func decorateActiveRunView(view *activeRunView, loop storage.LoopRecord, latestQ
 	}
 	view.DisplayStatus = view.Status
 	if latestQueue != nil {
+		attempts := latestQueue.Attempts
+		maxAttempts := latestQueue.MaxAttempts
+		view.Attempts = &attempts
+		view.MaxAttempts = &maxAttempts
 		view.LastFailureKind = latestQueue.LastErrorKind
 		view.LastFailureReason = latestQueue.LastError
 	}
@@ -2914,6 +2957,31 @@ func decorateActiveRunView(view *activeRunView, loop storage.LoopRecord, latestQ
 	}
 	if view.DisplayStatus == "" {
 		view.DisplayStatus = view.Status
+	}
+}
+
+// decorateLoopDiagnostics attaches latest-queue attempt counts and failure reason
+// (with the same run fallback as active-run views) for dashboard list/detail.
+func decorateLoopDiagnostics(view *loopResponse, latestQueue *storage.QueueItemRecord, latestRun *storage.RunRecord) {
+	if view == nil {
+		return
+	}
+	if latestQueue != nil {
+		attempts := latestQueue.Attempts
+		maxAttempts := latestQueue.MaxAttempts
+		view.Attempts = &attempts
+		view.MaxAttempts = &maxAttempts
+		view.LastFailureKind = latestQueue.LastErrorKind
+		view.LastFailureReason = latestQueue.LastError
+	}
+	if view.LastFailureReason == nil || strings.TrimSpace(*view.LastFailureReason) == "" {
+		if latestRun != nil {
+			if latestRun.ErrorMessage != nil && strings.TrimSpace(*latestRun.ErrorMessage) != "" {
+				view.LastFailureReason = latestRun.ErrorMessage
+			} else if shouldUseRunSummaryAsFailureReason(latestRun) && latestRun.Summary != nil && strings.TrimSpace(*latestRun.Summary) != "" {
+				view.LastFailureReason = latestRun.Summary
+			}
+		}
 	}
 }
 
@@ -3276,7 +3344,7 @@ func (h *Handler) buildLoopRouteResponse(r *http.Request, path string) (any, err
 		if r.Method != http.MethodGet {
 			return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
 		}
-		return serializeLoop(loop), nil
+		return h.serializeLoopWithDiagnostics(r.Context(), loop)
 	}
 
 	subresource := parts[1]
@@ -5618,6 +5686,30 @@ func serializeLoop(loop storage.LoopRecord) loopResponse {
 		CreatedAt:    loop.CreatedAt,
 		UpdatedAt:    loop.UpdatedAt,
 	}
+}
+
+// serializeLoopWithDiagnostics loads latest queue/run and attaches attempt/error fields.
+func (h *Handler) serializeLoopWithDiagnostics(ctx context.Context, loop storage.LoopRecord) (loopResponse, error) {
+	view := serializeLoop(loop)
+	services := h.context.Runtime.Services()
+	var latestQueue *storage.QueueItemRecord
+	var latestRun *storage.RunRecord
+	if services.Repositories != nil && services.Repositories.Queue != nil {
+		queue, err := services.Repositories.Queue.GetLatestByLoopID(ctx, loop.ID)
+		if err != nil {
+			return loopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		latestQueue = queue
+	}
+	if services.Repositories != nil && services.Repositories.Runs != nil {
+		run, err := services.Repositories.Runs.GetLatestByLoopID(ctx, loop.ID)
+		if err != nil {
+			return loopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+		}
+		latestRun = run
+	}
+	decorateLoopDiagnostics(&view, latestQueue, latestRun)
+	return view, nil
 }
 
 func serializeRun(run storage.RunRecord) runResponse {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -428,6 +428,65 @@ func TestHandlerActiveRunsSurfacesManualInterventionStatus(t *testing.T) {
 	assertEqual(t, item["loopStatus"], "paused")
 	assertEqual(t, item["lastFailureKind"], "manual_intervention")
 	assertEqual(t, item["lastFailureReason"], "dirty worker worktree")
+	assertEqual(t, item["attempts"], float64(1))
+	assertEqual(t, item["maxAttempts"], float64(3))
+}
+
+func TestHandlerLoopDetailAndListSurfaceAttemptsAndFailureReason(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_loop_diag"
+	loopID := "loop_loop_diag"
+	targetID := projectID
+	lastErrorKind := "retryable_transient"
+	lastError := "agent idle timed out after 10m0s without observable progress"
+
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 569, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "failed", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: "queue_loop_diag", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID,
+		DedupeKey: "worker:loop_diag", Priority: storage.QueuePriorityWorker, Status: "failed", AvailableAt: nowISO,
+		Attempts: 2, MaxAttempts: -1, LastError: &lastError, LastErrorKind: &lastErrorKind, FinishedAt: &nowISO,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	detailReq := httptest.NewRequest(http.MethodGet, "/api/v1/loops/569", nil)
+	detailRec := httptest.NewRecorder()
+	h.ServeHTTP(detailRec, detailReq)
+	if detailRec.Code != http.StatusOK {
+		t.Fatalf("detail status = %d, want 200; body=%s", detailRec.Code, detailRec.Body.String())
+	}
+	detailBody := parseJSONMap(t, detailRec.Body.Bytes())
+	detail := detailBody["data"].(map[string]any)
+	assertEqual(t, detail["attempts"], float64(2))
+	assertEqual(t, detail["maxAttempts"], float64(-1))
+	assertEqual(t, detail["lastFailureKind"], "retryable_transient")
+	assertEqual(t, detail["lastFailureReason"], lastError)
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/loops?status=failed", nil)
+	listRec := httptest.NewRecorder()
+	h.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200; body=%s", listRec.Code, listRec.Body.String())
+	}
+	listBody := parseJSONMap(t, listRec.Body.Bytes())
+	items := listBody["data"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("list items len = %d, want 1: %#v", len(items), items)
+	}
+	listItem := items[0].(map[string]any)
+	assertEqual(t, listItem["attempts"], float64(2))
+	assertEqual(t, listItem["maxAttempts"], float64(-1))
+	assertEqual(t, listItem["lastFailureKind"], "retryable_transient")
+	assertEqual(t, listItem["lastFailureReason"], lastError)
 }
 
 func TestHandlerActiveRunsSurfacesResumePolicyManualIntervention(t *testing.T) {

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -638,7 +638,11 @@
               "lastRunAt": "2026-04-11T12:00:00.000Z",
               "nextRunAt": "2026-04-11T12:00:00.000Z",
               "createdAt": "2026-04-11T12:00:00.000Z",
-              "updatedAt": "2026-04-11T12:00:00.000Z"
+              "updatedAt": "2026-04-11T12:00:00.000Z",
+              "attempts": 1,
+              "maxAttempts": 3,
+              "lastFailureKind": "manual_intervention",
+              "lastFailureReason": "dirty worker worktree"
             }
           ],
           "total": 1,
@@ -692,7 +696,11 @@
           "lastRunAt": "2026-04-11T12:00:00.000Z",
           "nextRunAt": "2026-04-11T12:00:00.000Z",
           "createdAt": "2026-04-11T12:00:00.000Z",
-          "updatedAt": "2026-04-11T12:00:00.000Z"
+          "updatedAt": "2026-04-11T12:00:00.000Z",
+          "attempts": 1,
+          "maxAttempts": 3,
+          "lastFailureKind": "manual_intervention",
+          "lastFailureReason": "dirty worker worktree"
         },
         "requestId": "fixture-request-id"
       }
@@ -1092,6 +1100,8 @@
               "status": "queued",
               "loopStatus": "queued",
               "displayStatus": "queued",
+              "attempts": 0,
+              "maxAttempts": 3,
               "currentStep": null,
               "startedAt": "<generated-timestamp>",
               "target": {

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -1440,6 +1440,54 @@ func (r *QueueRepository) GetLatestByLoopID(ctx context.Context, loopID string) 
 	return &record, nil
 }
 
+// ListLatestByLoopIDs returns the latest queue item per loop_id for the given IDs.
+// Ordering within a loop matches GetLatestByLoopID: updated_at, created_at, id DESC.
+func (r *QueueRepository) ListLatestByLoopIDs(ctx context.Context, loopIDs []string) ([]QueueItemRecord, error) {
+	if len(loopIDs) == 0 {
+		return []QueueItemRecord{}, nil
+	}
+	chunks := chunkStrings(loopIDs, sqliteMaxVariables)
+	items := make([]QueueItemRecord, 0, len(loopIDs))
+	for _, chunk := range chunks {
+		args := make([]any, 0, len(chunk))
+		for _, loopID := range chunk {
+			args = append(args, loopID)
+		}
+		rows, err := r.q.QueryContext(ctx, `
+			SELECT
+				id, project_id, loop_id, type, target_type, target_id, repo, pr_number, dedupe_key,
+				priority, status, available_at, attempts, max_attempts, claimed_by, claimed_at,
+				started_at, finished_at, lock_key, payload_json, last_error, last_error_kind,
+				created_at, updated_at
+			FROM (
+				SELECT
+					queue_items.*,
+					ROW_NUMBER() OVER (
+						PARTITION BY loop_id
+						ORDER BY updated_at DESC, created_at DESC, id DESC
+					) AS row_num
+				FROM queue_items
+				WHERE loop_id IN (`+sqlPlaceholders(len(chunk))+`)
+			)
+			WHERE row_num = 1
+			ORDER BY updated_at DESC, created_at DESC, id DESC
+		`, args...)
+		if err != nil {
+			return nil, fmt.Errorf("list latest queue items by loop ids: %w", err)
+		}
+		chunkItems, scanErr := scanQueueItems(rows)
+		closeErr := rows.Close()
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close list latest queue items by loop ids rows: %w", closeErr)
+		}
+		items = append(items, chunkItems...)
+	}
+	return items, nil
+}
+
 func (r *QueueRepository) List(ctx context.Context) ([]QueueItemRecord, error) {
 	rows, err := r.q.QueryContext(ctx, `SELECT * FROM queue_items ORDER BY created_at DESC`)
 	if err != nil {

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -1597,6 +1597,24 @@ func TestTargetedListRepositories(t *testing.T) {
 		t.Fatalf("Queue.ListLatestByLoopStatuses() ids = %#v, want %#v", latestQueueIDs, want)
 	}
 
+	latestQueueByIDs, err := repos.Queue.ListLatestByLoopIDs(ctx, []string{loopManual, loopDone, loopQueued})
+	if err != nil {
+		t.Fatalf("Queue.ListLatestByLoopIDs() error = %v", err)
+	}
+	if len(latestQueueByIDs) != 3 {
+		t.Fatalf("len(Queue.ListLatestByLoopIDs()) = %d, want 3", len(latestQueueByIDs))
+	}
+	latestByLoop := map[string]string{}
+	for _, item := range latestQueueByIDs {
+		if item.LoopID == nil {
+			t.Fatalf("Queue.ListLatestByLoopIDs() item missing loop id: %#v", item)
+		}
+		latestByLoop[*item.LoopID] = item.ID
+	}
+	if latestByLoop[loopManual] != "queue_manual" || latestByLoop[loopQueued] != "queue_queued" || latestByLoop[loopDone] != "queue_done" {
+		t.Fatalf("Queue.ListLatestByLoopIDs() by loop = %#v, want latest ids per loop", latestByLoop)
+	}
+
 	latestRuns, err := repos.Runs.ListLatestByLoopIDs(ctx, []string{loopManual, loopDone})
 	if err != nil {
 		t.Fatalf("Runs.ListLatestByLoopIDs() error = %v", err)

--- a/web/dashboard/src/lib/api.ts
+++ b/web/dashboard/src/lib/api.ts
@@ -188,6 +188,10 @@ export type ActiveRun = {
   status: string;
   loopStatus: string;
   displayStatus: string;
+  /** Current attempt count from latest queue item when present. */
+  attempts?: number | null;
+  /** Max attempts (-1 = unlimited) from latest queue item when present. */
+  maxAttempts?: number | null;
   lastFailureKind?: string | null;
   lastFailureReason?: string | null;
   resumePolicy?: string | null;
@@ -219,6 +223,12 @@ export type Loop = {
   nextRunAt?: string | null;
   createdAt: string;
   updatedAt: string;
+  /** Current attempt count from latest queue item when present. */
+  attempts?: number | null;
+  /** Max attempts (-1 = unlimited) from latest queue item when present. */
+  maxAttempts?: number | null;
+  lastFailureKind?: string | null;
+  lastFailureReason?: string | null;
 };
 
 export type LoopsList = {

--- a/web/dashboard/src/lib/format.test.ts
+++ b/web/dashboard/src/lib/format.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { formatAttempts, truncateReason } from "./format";
+
+describe("formatAttempts", () => {
+  it("formats current/max including unlimited -1", () => {
+    expect(formatAttempts(2, 5)).toBe("2/5");
+    expect(formatAttempts(1, -1)).toBe("1/-1");
+    expect(formatAttempts(0, 3)).toBe("0/3");
+  });
+
+  it("returns current only when max is missing", () => {
+    expect(formatAttempts(2, null)).toBe("2");
+    expect(formatAttempts(2, undefined)).toBe("2");
+  });
+
+  it("returns null when attempts metadata is absent", () => {
+    expect(formatAttempts(null, 3)).toBeNull();
+    expect(formatAttempts(undefined, -1)).toBeNull();
+    expect(formatAttempts(Number.NaN, 3)).toBeNull();
+  });
+});
+
+describe("truncateReason", () => {
+  it("returns null for empty/missing", () => {
+    expect(truncateReason(null)).toBeNull();
+    expect(truncateReason(undefined)).toBeNull();
+    expect(truncateReason("")).toBeNull();
+    expect(truncateReason("   \n\t  ")).toBeNull();
+  });
+
+  it("collapses whitespace and truncates with ellipsis", () => {
+    expect(truncateReason("agent idle\n timed  out", 64)).toBe(
+      "agent idle timed out",
+    );
+    const long = "x".repeat(80);
+    expect(truncateReason(long, 20)).toBe(`${"x".repeat(17)}...`);
+  });
+
+  it("does not truncate short text", () => {
+    expect(truncateReason("dirty worktree", 64)).toBe("dirty worktree");
+  });
+});

--- a/web/dashboard/src/lib/format.ts
+++ b/web/dashboard/src/lib/format.ts
@@ -31,6 +31,41 @@ export function formatTs(iso: string | null | undefined): string {
   }
 }
 
+/**
+ * Format attempt count as current/max (e.g. "2/5", "1/-1" for unlimited).
+ * Returns null when attempt metadata is absent so callers can hide clutter.
+ */
+export function formatAttempts(
+  attempts: number | null | undefined,
+  maxAttempts: number | null | undefined,
+): string | null {
+  if (attempts == null || Number.isNaN(Number(attempts))) {
+    return null;
+  }
+  const current = Math.trunc(Number(attempts));
+  if (maxAttempts == null || Number.isNaN(Number(maxAttempts))) {
+    return String(current);
+  }
+  return `${current}/${Math.trunc(Number(maxAttempts))}`;
+}
+
+/**
+ * Collapse whitespace and truncate for dense list rows. Full text stays in title/tooltip.
+ */
+export function truncateReason(
+  value: string | null | undefined,
+  max = 64,
+): string | null {
+  if (value == null) return null;
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  if (!collapsed) return null;
+  if (max <= 0) return "";
+  const runes = Array.from(collapsed);
+  if (runes.length <= max) return collapsed;
+  if (max <= 3) return runes.slice(0, max).join("");
+  return `${runes.slice(0, max - 3).join("")}...`;
+}
+
 export function statusColor(status: string | null | undefined): string {
   const s = (status ?? "").toLowerCase();
   if (

--- a/web/dashboard/src/pages/LoopDetail.tsx
+++ b/web/dashboard/src/pages/LoopDetail.tsx
@@ -20,7 +20,7 @@ import {
   type LoopLogsSnapshot,
 } from "@/lib/api";
 import { useDashboardData } from "@/lib/DashboardDataContext";
-import { formatTs } from "@/lib/format";
+import { formatAttempts, formatTs } from "@/lib/format";
 import { capLogChunk, capLogSeed, trimLogBuffer } from "@/lib/logBuffer";
 import {
   type LogsStreamPhase,
@@ -482,6 +482,32 @@ export function LoopDetailPage() {
               <Kv
                 label="PR"
                 value={data.prNumber != null ? String(data.prNumber) : "—"}
+              />
+              <Kv
+                label="Attempts"
+                value={
+                  formatAttempts(data.attempts, data.maxAttempts) ?? "—"
+                }
+              />
+              <Kv
+                label="Error kind"
+                value={
+                  data.lastFailureKind?.trim()
+                    ? data.lastFailureKind.trim()
+                    : "—"
+                }
+              />
+              <Kv
+                label="Error / reason"
+                value={
+                  data.lastFailureReason?.trim() ? (
+                    <span className="whitespace-pre-wrap break-words">
+                      {data.lastFailureReason.trim()}
+                    </span>
+                  ) : (
+                    "—"
+                  )
+                }
               />
               <Kv label="Last run" value={formatTs(data.lastRunAt)} />
               <Kv label="Next run" value={formatTs(data.nextRunAt)} />

--- a/web/dashboard/src/pages/Loops.tsx
+++ b/web/dashboard/src/pages/Loops.tsx
@@ -8,7 +8,12 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { fetchLoops, type ActiveRun, type Loop } from "@/lib/api";
 import { useDashboardData } from "@/lib/DashboardDataContext";
-import { formatAge, formatTs } from "@/lib/format";
+import {
+  formatAge,
+  formatAttempts,
+  formatTs,
+  truncateReason,
+} from "@/lib/format";
 import { useProjectFilter } from "@/lib/ProjectFilterContext";
 import { usePolling } from "@/lib/usePolling";
 
@@ -54,6 +59,25 @@ function agentLabel(run: ActiveRun | undefined): string {
   const pid = agent.pid != null ? `pid ${agent.pid}` : "no pid";
   const vendor = agent.vendor || "agent";
   return `${vendor} · ${pid}`;
+}
+
+/** Prefer loop fields; fall back to joined active-run diagnostics when present. */
+function rowAttempts(l: LoopRow): string {
+  return (
+    formatAttempts(l.attempts, l.maxAttempts) ??
+    formatAttempts(l.activeRun?.attempts, l.activeRun?.maxAttempts) ??
+    "—"
+  );
+}
+
+function rowReason(l: LoopRow): { display: string; full: string | null } {
+  const full =
+    (l.lastFailureReason && l.lastFailureReason.trim()) ||
+    (l.activeRun?.lastFailureReason &&
+      l.activeRun.lastFailureReason.trim()) ||
+    null;
+  if (!full) return { display: "—", full: null };
+  return { display: truncateReason(full, 48) ?? "—", full };
 }
 
 export function LoopsPage() {
@@ -185,6 +209,28 @@ export function LoopsPage() {
             {agentLabel(l.activeRun)}
           </span>
         ),
+      },
+      {
+        key: "attempts",
+        header: "Attempts",
+        cell: (l) => (
+          <span className="mono text-[var(--text-muted)]">{rowAttempts(l)}</span>
+        ),
+      },
+      {
+        key: "reason",
+        header: "Reason",
+        cell: (l) => {
+          const { display, full } = rowReason(l);
+          return (
+            <span
+              className="mono text-[var(--text-muted)] max-w-[14rem] truncate inline-block align-bottom"
+              title={full ?? undefined}
+            >
+              {display}
+            </span>
+          );
+        },
       },
       {
         key: "age",

--- a/web/dashboard/src/pages/Overview.tsx
+++ b/web/dashboard/src/pages/Overview.tsx
@@ -20,7 +20,11 @@ import {
   type StatusData,
 } from "@/lib/api";
 import { useDashboardData } from "@/lib/DashboardDataContext";
-import { formatAge } from "@/lib/format";
+import {
+  formatAge,
+  formatAttempts,
+  truncateReason,
+} from "@/lib/format";
 import { useProjectFilter } from "@/lib/ProjectFilterContext";
 
 const STATUS_SLOW_MS = 45_000;
@@ -262,6 +266,31 @@ export function OverviewPage({
             {activeAgentLabel(r)}
           </span>
         ),
+      },
+      {
+        key: "attempts",
+        header: "Attempts",
+        cell: (r) => (
+          <span className="mono text-[var(--text-muted)]">
+            {formatAttempts(r.attempts, r.maxAttempts) ?? "—"}
+          </span>
+        ),
+      },
+      {
+        key: "reason",
+        header: "Reason",
+        cell: (r) => {
+          const full = r.lastFailureReason?.trim() || null;
+          const display = full ? truncateReason(full, 48) ?? "—" : "—";
+          return (
+            <span
+              className="mono text-[var(--text-muted)] max-w-[14rem] truncate inline-block align-bottom"
+              title={full ?? undefined}
+            >
+              {display}
+            </span>
+          );
+        },
       },
       {
         key: "age",


### PR DESCRIPTION
## Summary

Surface **attempt count** and **error / reason** for each job on the Looper dashboard so operators can see retry/failure context without leaving the UI or running `looper describe` / `looper ps`.

Closes #569

## Changes

### API
- Add `attempts` / `maxAttempts` to active-run views (from latest queue item)
- Enrich loop list and detail responses with queue-derived `attempts`, `maxAttempts`, `lastFailureKind`, and `lastFailureReason` (same run-fallback rules as active runs / CLI)
- Add `Queue.ListLatestByLoopIDs` for efficient list enrichment

### Dashboard
- Overview running table and Loops list: **Attempts** (`2/5`, `1/-1`) and truncated **Reason** (full text in tooltip)
- Loop detail: **Attempts**, **Error kind**, and full **Error / reason** (not truncated)
- Missing values render as `—` without inventing parallel diagnostics

## Validation
- `go test ./internal/api/ ./internal/storage/`
- `pnpm test` + `pnpm run build` in `web/dashboard`
- Updated frozen HTTP response contracts for the new optional fields

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=grok-build · An autonomous AI dev team for your GitHub repos.</sub>