### PR TITLE
feat: add safe config hot reload and dashboard management

### DIFF
--- a/cmd/looperd/config_api_bridge_test.go
+++ b/cmd/looperd/config_api_bridge_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	looperdapi "github.com/nexu-io/looper/internal/api"
+	"github.com/nexu-io/looper/internal/config"
+	looperdruntime "github.com/nexu-io/looper/internal/runtime"
+)
+
+func TestRuntimeConfigMetadataMarksHotOverridesReadOnly(t *testing.T) {
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	loaded := config.LoadedFileConfig{
+		Config: cfg,
+		Metadata: config.LoadFileMetadata{
+			ConfigPath:        "/tmp/config.toml",
+			ConfigFilePresent: true,
+			FieldSources: map[string]config.ValueSource{
+				"agent.vendor":                           config.ValueSourceConfigFile,
+				"agent.params.apiKey":                    config.ValueSourceConfigFile,
+				"agent.params.nested.token":              config.ValueSourceConfigFile,
+				"agent.env.OPENAI_API_KEY":               config.ValueSourceConfigFile,
+				"daemon.environment.SECRET":              config.ValueSourceConfigFile,
+				"server.localToken":                      config.ValueSourceConfigFile,
+				"agent.timeouts.workerSeconds":           config.ValueSourceConfigFile,
+				"roles.planner.triggers.planeAssigneeId": config.ValueSourceConfigFile,
+				"roles.worker.triggers.planeAssigneeId":  config.ValueSourceConfigFile,
+				"scheduler.maxConcurrentRuns":            config.ValueSourceEnv,
+				"scheduler.pollIntervalSeconds":          config.ValueSourceDefault,
+			},
+		},
+	}
+	rt := looperdruntime.New(looperdruntime.Options{Config: cfg, InitialConfig: loaded})
+	rtStatus := rt.ConfigReloadStatus()
+	rtStatus.RejectedPaths = []string{"agent.params.apiKey", "agent.params.nested.token", "daemon.environment.SECRET", "server.localToken"}
+	rtStatus.LastError = "configuration changes require a daemon restart: agent.params.apiKey, agent.params.nested.token, daemon.environment.SECRET, server.localToken"
+
+	metadata := runtimeConfigMetadataFromStatus(rtStatus)
+	if metadata.ConfigPath != "/tmp/config.toml" || metadata.Format != "toml" || !metadata.FilePresent {
+		t.Fatalf("metadata source = %#v", metadata)
+	}
+	if field := metadata.Fields["agent.vendor"]; !field.Editable || field.ApplyMode != "hot" || field.Source != "config-file" {
+		t.Fatalf("agent.vendor metadata = %#v, want editable hot config-file", field)
+	}
+	if field := metadata.Fields["scheduler.maxConcurrentRuns"]; field.Editable || field.ApplyMode != "hot" || field.Source != "env" {
+		t.Fatalf("env-owned scheduler metadata = %#v, want read-only hot env", field)
+	}
+	if field := metadata.Fields["scheduler.pollIntervalSeconds"]; field.Editable || field.ApplyMode != "restart" {
+		t.Fatalf("poll interval metadata = %#v, want read-only restart", field)
+	}
+	if field := metadata.Fields["roles.planner.triggers.planeAssigneeId"]; field.Editable || field.ApplyMode != "restart" {
+		t.Fatalf("planner Plane assignee metadata = %#v, want read-only restart", field)
+	}
+	if field := metadata.Fields["roles.worker.triggers.planeAssigneeId"]; !field.Editable || field.ApplyMode != "hot" {
+		t.Fatalf("worker Plane assignee metadata = %#v, want editable hot", field)
+	}
+	if field := metadata.Fields["agent.env.OPENAI_API_KEY"]; !field.Editable {
+		t.Fatalf("write-only agent env metadata = %#v, want editable key", field)
+	}
+	for _, path := range []string{"agent.params.apiKey", "agent.params.nested.token", "daemon.environment.SECRET", "server.localToken"} {
+		if _, exists := metadata.Fields[path]; exists {
+			t.Fatalf("metadata exposed file-only path %q: %#v", path, metadata.Fields)
+		}
+		if metadata.LastError != nil && strings.Contains(*metadata.LastError, path) {
+			t.Fatalf("metadata error exposed file-only path %q: %s", path, *metadata.LastError)
+		}
+	}
+	if _, exists := metadata.Fields["agent.timeouts.workerSeconds"]; exists {
+		t.Fatalf("metadata exposed deprecated compatibility alias: %#v", metadata.Fields["agent.timeouts.workerSeconds"])
+	}
+	if got, want := metadata.RejectedPaths, []string{"agent.params", "daemon.environment", "server.localToken"}; !slices.Equal(got, want) {
+		t.Fatalf("metadata rejected paths = %#v, want collapsed %#v", got, want)
+	}
+}
+
+func TestRuntimeConfigMetadataHidesUnstructuredDecodeErrors(t *testing.T) {
+	const secret = "SUPER_SECRET_VALUE"
+	metadata := runtimeConfigMetadataFromStatus(looperdruntime.ConfigReloadStatus{
+		LastError: "yaml: invalid map key containing " + secret,
+	})
+	if metadata.LastError == nil {
+		t.Fatal("metadata.LastError = nil, want safe diagnostic")
+	}
+	if strings.Contains(*metadata.LastError, secret) || strings.Contains(*metadata.LastError, "invalid map key") {
+		t.Fatalf("metadata.LastError = %q, exposed unstructured decode details", *metadata.LastError)
+	}
+}
+
+func TestPatchRuntimeConfigMapsValidationAndStartupOnlyErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"notifications":{"osascript":{"enabled":false}},"scheduler":{"maxConcurrentRuns":2}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	loadAt := func(selected string) (config.LoadedFileConfig, error) {
+		return config.LoadFile(config.LoadFileOptions{
+			ConfigPathOverride: selected,
+			LookupEnv:          func(string) (string, bool) { return "", false },
+		})
+	}
+	initial, err := loadAt(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	rt := looperdruntime.New(looperdruntime.Options{
+		Config:        initial.Config,
+		ConfigPath:    path,
+		InitialConfig: initial,
+		ReloadConfig:  func() (config.LoadedFileConfig, error) { return loadAt(path) },
+		LoadConfigAt:  loadAt,
+	})
+
+	tests := []struct {
+		name      string
+		path      string
+		value     json.RawMessage
+		wantKind  looperdapi.ConfigRequestErrorKind
+		wantIssue string
+	}{
+		{name: "invalid", path: "scheduler.maxConcurrentRuns", value: json.RawMessage("0"), wantKind: looperdapi.ConfigRequestErrorKindValidation, wantIssue: "invalid_value"},
+		{name: "startup only", path: "server.port", value: json.RawMessage("19000"), wantKind: looperdapi.ConfigRequestErrorKindUnsupported, wantIssue: "field_not_editable"},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := patchRuntimeConfig(context.Background(), rt, looperdapi.ConfigPatchRequest{Set: map[string]json.RawMessage{testCase.path: testCase.value}})
+			var requestError looperdapi.ConfigRequestError
+			if !errors.As(err, &requestError) {
+				t.Fatalf("error = %T %v, want ConfigRequestError", err, err)
+			}
+			if requestError.Kind != testCase.wantKind || len(requestError.Issues) == 0 || requestError.Issues[0].Code != testCase.wantIssue {
+				t.Fatalf("request error = %#v", requestError)
+			}
+		})
+	}
+}

--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -124,6 +124,9 @@ type executionMatchesProcessFunc func(context.Context, storage.AgentExecutionRec
 func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies) (bootstrap.Runtime, error) {
 	rt := looperdruntime.New(looperdruntime.Options{
 		Config:        deps.Config,
+		InitialConfig: deps.InitialConfig,
+		ReloadConfig:  deps.ReloadConfig,
+		LoadConfigAt:  deps.LoadConfigAt,
 		ConfigPath:    deps.Metadata.ConfigPath,
 		Logger:        deps.Logger,
 		DeferRecovery: true,
@@ -133,7 +136,14 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 	}
 
 	apiHandler := looperdapi.NewHandler(looperdapi.Context{
-		Config:  deps.Config,
+		Config: deps.Config,
+		ConfigSnapshot: func() (config.Config, looperdapi.ConfigMetadata) {
+			cfg, status := rt.ConfigSnapshot()
+			return cfg, runtimeConfigMetadataFromStatus(status)
+		},
+		PatchConfig: func(ctx context.Context, patch looperdapi.ConfigPatchRequest) error {
+			return patchRuntimeConfig(ctx, rt, patch)
+		},
 		Runtime: rt,
 		ReconcileStaleRuns: func(ctx context.Context) (looperdruntime.StaleRunReconcileSummary, error) {
 			return rt.ReconcileStaleRunningRuns(ctx)
@@ -182,6 +192,174 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 		server:          server,
 		shutdownTimeout: shutdownTimeout,
 	}, nil
+}
+
+func runtimeConfigMetadata(rt *looperdruntime.Runtime) looperdapi.ConfigMetadata {
+	_, status := rt.ConfigSnapshot()
+	return runtimeConfigMetadataFromStatus(status)
+}
+
+func runtimeConfigMetadataFromStatus(status looperdruntime.ConfigReloadStatus) looperdapi.ConfigMetadata {
+	rejectedPaths := publicConfigRejectedPaths(status.RejectedPaths)
+	lastError := sanitizeConfigDiagnostic(status.LastError, status.RejectedPaths)
+	metadata := looperdapi.ConfigMetadata{
+		ConfigPath:    status.ConfigPath,
+		Format:        status.Format,
+		FilePresent:   status.FilePresent,
+		Revision:      status.Revision,
+		LastAttemptAt: status.LastAttemptAt,
+		LastAppliedAt: status.LastAppliedAt,
+		RejectedPaths: rejectedPaths,
+		Fields:        make(map[string]looperdapi.ConfigFieldMetadata, len(status.FieldSources)),
+	}
+	if lastError != "" {
+		metadata.LastError = &lastError
+	}
+	for path, source := range status.FieldSources {
+		if path == "projects" || strings.HasPrefix(path, "projects.") || isSensitiveConfigMetadataPath(path) || config.IsHotReloadCompatibilityPath(path) {
+			continue
+		}
+		hot := config.IsHotEditablePath(path)
+		fieldLevel := config.IsFieldLevelConfigPath(path) || path == "agent.env"
+		editable := hot && fieldLevel && source != config.ValueSourceEnv && source != config.ValueSourceCLI
+		applyMode := "restart"
+		if hot {
+			applyMode = "hot"
+		}
+		metadata.Fields[path] = looperdapi.ConfigFieldMetadata{
+			Source:    string(source),
+			Editable:  editable,
+			ApplyMode: applyMode,
+		}
+	}
+	return metadata
+}
+
+var sensitiveConfigMetadataRoots = []string{
+	"server.localToken",
+	"agent.params",
+	"daemon.environment",
+}
+
+func isSensitiveConfigMetadataPath(path string) bool {
+	for _, root := range sensitiveConfigMetadataRoots {
+		if path == root || strings.HasPrefix(path, root+".") {
+			return true
+		}
+	}
+	return false
+}
+
+func publicConfigPath(path string) string {
+	for _, root := range sensitiveConfigMetadataRoots {
+		if path == root || strings.HasPrefix(path, root+".") {
+			return root
+		}
+	}
+	return path
+}
+
+func publicConfigRejectedPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	result := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = publicConfigPath(path)
+		if _, exists := seen[path]; exists {
+			continue
+		}
+		seen[path] = struct{}{}
+		result = append(result, path)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func sanitizeConfigDiagnostic(message string, paths []string) string {
+	if message != "" && len(paths) == 0 {
+		// Field-less parser errors can embed the rejected YAML/TOML scalar. Keep
+		// the API defensive even if a caller supplies status not produced by the
+		// runtime's own sanitized diagnostic path.
+		return "configuration reload rejected: config file could not be decoded or validated"
+	}
+	hasSensitive := false
+	for _, path := range paths {
+		if isSensitiveConfigMetadataPath(path) {
+			hasSensitive = true
+			break
+		}
+	}
+	if hasSensitive {
+		prefix := "configuration reload rejected"
+		if strings.Contains(strings.ToLower(message), "restart") {
+			prefix = "configuration changes require a daemon restart"
+		}
+		return prefix + "; sensitive field details are hidden"
+	}
+	return message
+}
+
+func patchRuntimeConfig(ctx context.Context, rt *looperdruntime.Runtime, patch looperdapi.ConfigPatchRequest) error {
+	err := rt.PatchConfig(ctx, looperdruntime.ConfigPatch{Revision: patch.Revision, Set: patch.Set, Unset: patch.Unset})
+	if err == nil {
+		return nil
+	}
+
+	requestError := looperdapi.ConfigRequestError{
+		Kind:    looperdapi.ConfigRequestErrorKindValidation,
+		Message: err.Error(),
+	}
+	var patchError *looperdruntime.ConfigPatchError
+	if errors.As(err, &patchError) {
+		switch patchError.Kind {
+		case "conflict":
+			requestError.Kind = looperdapi.ConfigRequestErrorKindConflict
+		case "unsupported":
+			requestError.Kind = looperdapi.ConfigRequestErrorKindUnsupported
+		case "validation":
+			requestError.Kind = looperdapi.ConfigRequestErrorKindValidation
+		default:
+			// Filesystem and bootstrap failures are server errors, not user input
+			// failures. Preserve the untyped error so the API returns 500.
+			return err
+		}
+		for _, path := range patchError.Paths {
+			requestError.Issues = append(requestError.Issues, looperdapi.ConfigPatchIssue{
+				Path:    path,
+				Code:    configPatchIssueCode(patchError.Kind),
+				Message: patchError.Error(),
+			})
+		}
+	}
+
+	var validationError *config.ConfigValidationError
+	if errors.As(err, &validationError) {
+		requestError.Issues = requestError.Issues[:0]
+		for _, issue := range validationError.Issues {
+			requestError.Issues = append(requestError.Issues, looperdapi.ConfigPatchIssue{
+				Path:    issue.Path,
+				Code:    "invalid_value",
+				Message: issue.Message,
+			})
+		}
+	}
+	if len(requestError.Issues) == 0 {
+		requestError.Issues = []looperdapi.ConfigPatchIssue{{
+			Code:    configPatchIssueCode(string(requestError.Kind)),
+			Message: err.Error(),
+		}}
+	}
+	return requestError
+}
+
+func configPatchIssueCode(kind string) string {
+	switch kind {
+	case "conflict":
+		return "file_changed"
+	case "unsupported":
+		return "field_not_editable"
+	default:
+		return "invalid_value"
+	}
 }
 
 func stopServerWithTimeout(stop func(context.Context) error, timeout time.Duration) error {

--- a/docs/adr/0014-config-file-is-global-runtime-policy-authority.md
+++ b/docs/adr/0014-config-file-is-global-runtime-policy-authority.md
@@ -1,0 +1,316 @@
+# ADR-0014: The layered config file is global runtime-policy authority
+
+## Context
+
+`looperd` historically loaded configuration once during bootstrap. Editing the
+selected TOML, YAML, or JSON file therefore left the running daemon on stale
+policy until it was restarted. The local dashboard also had no safe way to
+manage configuration.
+
+Some settings are policy read when work is claimed, while others own process
+resources. Agent, role, default/safety, in-app/osascript notification,
+disclosure, and selected scheduler settings can be snapshotted for new work.
+The HTTP listener, SQLite coordinator, logger, webhook/network topology, daemon
+supervision, runtime paths, provider/project bindings, and external startup
+preflights cannot be replaced safely in place.
+
+Projects have a separate existing authority: active SQLite project records, as
+defined by ADR-0012. Treating `projects[]` as another live configuration source
+would reintroduce the split-brain project model that ADR-0012 removed.
+
+## Decision
+
+The selected config file, overlaid by the daemon's captured startup environment
+and CLI flags, is authority for global runtime policy. `looperd` reparses that
+same fixed layer stack while running and publishes a candidate only when every
+changed effective field is on the explicit hot-safe allowlist. Any invalid or
+restart-bound change rejects the entire candidate and leaves the last-known-good
+snapshot active.
+
+The hot-safe allowlist contains agent vendor/model/environment and canonical
+idle/max-runtime timeouts, selected scheduler concurrency/slow-lane
+fields, in-app and osascript notifications, disclosure, selected default-policy
+fields, `instructions.enabled`, curated role policy, and the Looper/osascript
+tool paths. Deprecated timeout and default-policy aliases remain watcher-hot
+file-only compatibility representations of those canonical fields; they are
+not dashboard-editable. Durable queue scheduling inputs—including the scheduler
+retry budget/base delay, Reviewer quiet/minimum-publish timing, and Reviewer
+retry-delay cap—remain restart-bound, as do the persisted Coordinator transient
+retry budget and the materialized default base branch. The allowlist deliberately excludes
+`agent.nativeResume`, `agent.params`, notification webhooks and Feishu, HITL,
+`instructions.maxBytes`, Reviewer auto-merge, and Coordinator dependencies, in
+addition to Coordinator activation and other resource-owning settings. New
+fields are restart-bound until they are classified explicitly.
+
+Leaving a configured vendor—by switching it or clearing it—is hot-safe only
+when `agent.params` is empty and any explicit `agent.model` is changed or
+cleared in the same candidate. This prevents an old profile from being
+laundered through an intermediate nil vendor. Nil-to-vendor activation may use
+a prepared profile when no previously configured vendor is being left. Work
+that continues after a vendor transition retains durable checkpoint, worktree,
+HITL answer, and human-inbox state but does not attach the old vendor's native
+session ID to the new executable.
+
+Each active run keeps the immutable configuration snapshot it started with. A
+shared in-process publication boundary orders global config publication,
+project-catalog mutation, and claim capture. A claim refreshes from the latest
+catalog and config while holding the read side of that boundary, so every claim
+made after publication constructs its run from the newly published snapshot.
+The boundary is released before the run executes.
+
+Native GitHub and Forgejo reviewer runs also bind `looper review submit` to that
+same snapshot. The daemon sanitizes and JSON-encodes the complete materialized
+project catalog and run policy in memory, with `server.localToken`, `agent.env`,
+`agent.params`, and `daemon.environment` removed. Each trusted child receives
+those bytes through an inherited read-only pipe plus the captured credential
+environment; the agent receives only the per-run socket capability. A dedicated
+child loader decodes that exact snapshot and deliberately bypasses the ordinary
+file, environment, and CLI precedence layers. A missing, malformed, or oversized
+descriptor snapshot fails closed.
+
+The proxy replaces agent-supplied review-policy, expected-head, and manual-run
+identity flags with the daemon-selected policy, checkpoint head, persisted loop
+mode, and run ID. The review event itself remains agent-selected within the
+bound policy. Connections, request/stdin bytes, and child output are bounded.
+Cleanup closes partial connections, cancels active handlers, and kills an
+already spawned child's process group before removing the socket. If the
+snapshot or proxy cannot be installed, agent execution fails closed instead of
+falling back to the live config file.
+
+Project catalog/webhook/network snapshots publish inside that boundary after a
+SQLite mutation commits. Scheduler wakeups and webhook-forwarder reconciliation
+run afterward, outside the boundary, because reconciliation may issue multiple
+external `gh api` calls. A global-policy publication also pushes the coherent
+post-publication catalog snapshot into the long-lived network manager so its
+next heartbeat advertises current role capabilities. The follow-up observes the
+latest published snapshot.
+
+Snapshot-built Coordinator runners share one daemon-lifetime `RuntimeState`
+containing only synchronized poll timestamps and merge-watch mutexes. Policy
+and gateways remain snapshot-local. This prevents rebuilding a runner for a
+new configuration snapshot from resetting the Coordinator poll interval or
+allowing duplicate merge-watch work.
+
+Each immutable config snapshot builds its own notification gateway so active
+runs cannot observe later notification policy. A scheduler-owned gateway
+factory injects one synchronized, process-memory transport state into all of
+those snapshot-specific gateways. The state contains only the cached Feishu
+token and the message/card identifiers and live-tail data required to continue
+updating notification artifacts created earlier; it contains no mutable
+notification policy.
+
+The dashboard edits only curated, field-level settings in the file layer.
+Fields overridden by environment variables or CLI flags are read-only. Agent
+environment values are write-only: the API returns configured key names, never
+their values. Server tokens, daemon environment values, and arbitrary agent
+parameters remain file-only. Project management remains on the Projects API and
+SQLite catalog.
+
+Every configuration read reports the content revision captured with the exact
+file generation that produced its published snapshot. A dashboard patch must
+submit that revision; a mismatch with the current source returns a conflict,
+including when a newer on-disk edit has not yet been accepted by the reload
+loop. The writer validates the candidate, writes and syncs a temporary file,
+verifies source presence, regular-file identity, mode, and bytes immediately
+before atomically replacing the source. Portable filesystems do not provide a
+conditional compare-and-rename, so a manual editor racing in the tiny interval
+between that final check and rename can still be replaced. The writer retains
+unknown top-level extension sections,
+their native scalar values, and the selected file format, but serialization may
+canonicalize comments, quoting, and lexical key/table order. Ordinary permission
+bits are retained,
+but ACLs and extended filesystem metadata are not guaranteed to survive the
+atomic replacement. A symlinked config path is readable for reload but cannot
+be replaced through the dashboard.
+
+When `local-token` authentication is configured, config mutation uses that
+authentication. Without token authentication, `PATCH /api/v1/config` requires
+both a loopback peer and a literal loopback Host authority and rejects
+proxy-forwarding headers; request hostnames or a local reverse proxy alone do
+not grant mutation authority.
+
+## Trade-offs
+
+### Vendor transition compatibility
+
+- **Concrete failure prevented:** a Codex-to-Claude (or similar) switch must not
+  run the new executable with an old vendor's wrapper/arguments, silently carry
+  an old explicit model, or issue `--resume` with an incompatible native
+  session identifier.
+- **Cost:** edits that leave a configured vendor, including clearing it, are
+  rejected when `agent.params` is non-empty or an explicit model was not
+  changed. A cross-vendor
+  continuation loses native conversation attachment and starts from its durable
+  prompt/checkpoint and worktree instead. This adds no persisted state.
+- **Why a simpler alternative is insufficient:** blindly retaining the profile
+  is unsafe, auto-clearing fields would make the file stop reflecting the
+  user's edit, and making every vendor selection restart-bound would also block
+  the safe nil-to-vendor and implicit-profile cases.
+- **Authority:** the newly published config snapshot is authority for the new
+  run's vendor and profile. The runtime-authored vendor on the persisted HITL or
+  agent-execution record is authority for which executable owns a captured
+  native session; it is not inferred from the session string or agent prose.
+
+### Publication boundary
+
+- **Concrete failure prevented:** without one ordering boundary, a scheduler
+  tick could begin before config publication but claim afterward with stale
+  vendor/model/environment handlers. A project SQLite commit/catalog publish
+  could also interleave with global config publication and expose a config and
+  catalog pairing that was never validated together.
+- **Cost:** the lock adds an ordering rule, a potential deadlock if future code
+  violates that order, and brief contention among reloads, project mutations,
+  and claim creation. External webhook reconciliation is eventual and may
+  observe a newer published snapshot if another reload lands immediately after
+  release. It adds no persisted state and is not held while an agent or `gh api`
+  call runs.
+- **Why a simpler alternative is insufficient:** a file compare-and-swap only
+  orders file writers; it cannot order in-memory publication against claims or
+  SQLite/catalog publication. Refreshing immediately before a claim without a
+  boundary still leaves a race between the refresh and durable claim creation.
+
+### Trusted review-submit snapshot
+
+- **Concrete failure prevented:** an active reviewer agent can invoke the
+  Looper CLI after the global file has changed. Letting that child reread the
+  live file could publish with a different disclosure identity, project role
+  gate, review-event policy, expected head, or manual-review identity than the
+  run that authorized it. A named snapshot writable by the same UID could also
+  be replaced before a credential-bearing child read it, while unbounded or
+  partial socket requests could pin cleanup and child processes.
+- **Cost:** every native review/publish agent execution owns one Unix socket,
+  bounded connection bookkeeping, and an in-memory sanitized snapshot; every
+  submit uses an inherited pipe and a separately cancellable process group.
+  This relies on Unix descriptor/process-group semantics. Legitimate requests
+  or diagnostic output above the fixed limits are rejected or truncated, and
+  the explicit secret-clearing list must remain correct as config grows.
+  Config-only provider credentials are copied into the trusted child
+  environment, not the snapshot; this adds no persisted state or crash-leftover
+  snapshot file.
+- **Why a simpler alternative is insufficient:** binding only the two
+  review-event flags leaves disclosure, provider/project resolution, and
+  project-level publish gates live. A permission-restricted named file is still
+  mutable by the same UID, the ordinary loader would reapply ambient or
+  `agent.env` `LOOPER_*` values over the captured snapshot, and closing only the
+  listener cannot stop partial connections or spawned descendants. Passing
+  policy through an agent-visible environment variable remains forgeable.
+- **Authority:** the scheduler's catalog/config snapshot captured for the claim
+  is authority for the trusted child; the reviewer checkpoint head, persisted
+  loop manual bit, and `AgentRunInput` run ID authorize expected-head/manual
+  identity, while explicit loop review-event choices authorize the clean and
+  blocking limits. Agent argv/output cannot select those values; it selects only
+  the requested event within the bound policy.
+
+### Coordinator runtime scheduling state
+
+- **Concrete failure prevented:** rebuilding snapshot-specific Coordinator
+  runners on every scheduler tick would reset the five-minute poll timestamp
+  and per-issue merge-watch locks, causing discovery to run at scheduler cadence
+  and allowing duplicate/costly external work.
+- **Cost:** one daemon-lifetime object owns synchronized process-memory maps for
+  project timestamps and issue mutexes. Like the pre-reload long-lived runner,
+  it resets on daemon restart and retains entries for the daemon lifetime. It
+  contains no policy and adds no persisted recovery state.
+- **Why a simpler alternative is insufficient:** retaining the whole Runner
+  would pin stale configuration and gateways, while rebuilding it without shared
+  lifecycle state recreates the throttle/locking bug.
+- **Authority:** the immutable config snapshot on each Runner remains authority
+  for interval and Coordinator policy. Shared state records only when/where
+  that authorized work last ran; it cannot enable work.
+
+### File-content revision
+
+- **Concrete failure prevented:** a dashboard left open on revision A must not
+  overwrite a newer external edit B when its patch is submitted later.
+- **Cost:** each successfully loaded file generation is hashed, clients need a
+  conflict-and-refresh path, and a rejected on-disk generation cannot be edited
+  through a dashboard snapshot that still shows the last-known-good values.
+  The revision is only an equality signal. It is not persisted history, a lock,
+  or proof that the proposed values are safe. A final identity/mode/byte check
+  narrows but cannot eliminate the portable compare-to-rename race; operators
+  must avoid simultaneous manual and dashboard writes.
+- **Why a simpler alternative is insufficient:** rereading immediately before
+  rename catches an editor that writes during the patch, but it cannot detect an
+  edit made after the dashboard GET and before the PATCH begins.
+
+### Canonical alias retirement
+
+- **Concrete failure prevented:** unsetting a canonical dashboard field must not
+  reveal a deprecated file-layer alias and silently resurrect the policy the
+  user just removed.
+- **Cost:** a canonical patch performs a small, targeted lexical migration by
+  deleting only mapped alias leaves. Those deprecated spellings are not
+  preserved when their canonical field is edited; unrelated legacy fields and
+  extension sections remain intact. No new state is persisted.
+- **Why a simpler alternative is insufficient:** normalization alone keeps the
+  alias active after a canonical unset, while rejecting all legacy files would
+  turn an otherwise safe compatibility edit into an unnecessary restart/migration
+  event.
+- **Authority:** the submitted canonical field operation is explicit user
+  authority to retire only its known compatibility representations; no alias is
+  inferred from effective runtime values.
+
+### Shared notification transport state
+
+- **Concrete failure prevented:** rebuilding a notification gateway for every
+  immutable run snapshot would otherwise discard the token cache, HITL ask-card
+  identity, live-feed identity, and final live tail. A later answer, progress
+  update, or completion emitted through another snapshot could then fail to
+  update the card or thread created earlier.
+- **Cost:** the daemon owns synchronized process-memory maps and token state.
+  Loop-scoped entries use a 4,096-loop least-recently-used cap, so an extremely
+  old in-flight card may lose in-place update continuity after enough other
+  loops become active. The state is not persisted, so continuity also ends when
+  the daemon exits.
+- **Why simpler alternatives are insufficient:** one mutable notification
+  gateway would make active runs observe newly published policy and violate the
+  immutable-snapshot contract. Persisting transport state in SQLite would add
+  schema, recovery, retention, and stale-artifact failure modes—and risk keeping
+  credentials or short-lived tokens at rest—for continuity that is only needed
+  within one daemon process.
+- **Authority:** the config snapshot captured for a run remains authority for
+  whether and how that run uses notifications. Shared transport state cannot
+  enable a channel or choose policy; it only addresses and updates transport
+  artifacts that a config-authorized gateway previously created.
+
+The remaining cost is a polling/reparse loop, a last-known-good in-memory
+snapshot, an allowlist that must be maintained as configuration grows, and
+field-level mutation code. A rejected external edit may remain on disk while
+the daemon continues on the prior snapshot, so diagnostics must make the split
+visible. File-layer values may also remain shadowed by captured environment or
+CLI overrides.
+
+Reading the file ad hoc in every consumer would avoid a publication mechanism
+but permits one operation to observe incompatible versions. Restarting or
+rebuilding resource-owning subsystems would expand failure modes around
+listeners, database ownership, webhook locks, startup preflights, and active
+agents. Applying only the hot-safe portion of a mixed candidate would make the
+file cease to describe any coherent runtime state, so mixed candidates are
+rejected as a whole.
+
+## Authority
+
+The authority for global runtime policy is the selected config file after the
+captured startup environment and CLI overlays; active SQLite project records
+remain authority for project existence and binding, and the dashboard is only a
+validated editor of the global file layer.
+
+For dashboard mutation specifically, the selected config file bytes are the
+authority for what is being edited. The content revision identifies the bytes
+that produced the published values the client observed; it is neither policy
+authority nor authorization for the requested values.
+
+## Consequences
+
+- Safe external edits apply without changing the daemon PID or start time.
+- Active runs retain their original config; claims after publication use the
+  new snapshot.
+- Dashboard writes are targeted, validated, revision-checked, and atomically
+  replace a regular selected source file without materializing defaults,
+  overrides, projects, or secrets.
+- Environment/CLI-overridden fields are visible but not editable in the
+  dashboard.
+- Restart-bound or invalid edits keep running work healthy and produce a visible
+  error with rejected field paths.
+- New configuration fields must be classified explicitly before they become
+  dashboard-editable or hot-reloadable.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,31 @@ Rules:
 
 Later layers override earlier ones. Objects are merged deeply, arrays are replaced as a whole, and omitted fields keep the previous-layer value.
 
+### Dynamic reload
+
+`looperd` watches the selected config file and publishes a candidate atomically only when every changed effective field is hot-safe. A claim made after publication uses the new snapshot; an already active run keeps the snapshot it started with. Invalid candidates and candidates containing restart-bound changes leave the last-known-good snapshot active and expose diagnostics at `/dashboard/config`. Mixed candidates are rejected as a whole rather than partially applied.
+
+The hot-safe surface is an explicit allowlist:
+
+- `agent.vendor` (including adding the first vendor after daemon startup), `agent.model`, individual `agent.env` entries, and the canonical idle/max-runtime fields under `agent.timeouts.*`
+- `scheduler.maxConcurrentRuns` and `scheduler.slowLaneWarnThresholdMs`
+- `notifications.inApp` and the current `notifications.osascript.*` fields; notification webhooks and Feishu notification transport are restart-bound
+- the current `disclosure.*` fields
+- `defaults.allowAutoCommit`, `defaults.allowAutoPush`, `defaults.allowRiskyFixes`, `defaults.openPrStrategy`, and `defaults.addSnapshotMode`; `defaults.baseBranch` is restart-bound because configured project records materialize it
+- `instructions.enabled` only
+- the current Planner discovery/trigger/instruction fields except `roles.planner.triggers.planeAssigneeId`; all current Worker and Fixer discovery/trigger/instruction fields; Reviewer discovery, most behavior, and instructions; and Coordinator polling, triage, dispatch, and merge-watch policy except `mergeWatch.transientRetries`
+- `tools.looperPath` and `tools.osascriptPath`
+
+`agent.vendor` can switch from one configured vendor to another when `agent.params` is empty and no explicit model is being silently carried across vendors. If `agent.model` is set, change or unset it in the same candidate; an unchanged explicit model blocks that vendor-to-vendor switch. Clearing a configured vendor uses the same guard, so a retained profile cannot be laundered through an intermediate `null`. Configuring the first vendor may use an already prepared model/params profile. A continuation created under an old vendor starts a fresh new-vendor session while retaining its checkpoint, worktree, HITL answer, and queued human instructions—it never sends an old vendor's native session ID to the new CLI.
+
+Notably, `agent.nativeResume`, `agent.params`, `roles.planner.triggers.planeAssigneeId`, `roles.coordinator.enabled`, `instructions.maxBytes`, all `hitl.*`, all `notifications.webhook.*`, `roles.reviewer.autoMerge.*`, `roles.reviewer.behavior.loop.quietPeriodSeconds`, `roles.reviewer.behavior.loop.minPublishIntervalSeconds`, `roles.reviewer.behavior.retry.maxDelayMs`, `roles.coordinator.mergeWatch.transientRetries`, and `roles.coordinator.dependencies.*` require restart. The Planner Plane-assignee field is file-only; the supported Worker `roles.worker.triggers.planeAssigneeId` field remains hot-safe. The scheduler retry budget/base delay and these Reviewer timing fields are durable queue-scheduling inputs; Coordinator transient retries are persisted as a remaining budget, so they are also restart-bound. Listener, storage, daemon, logging, webhook/network topology, providers/projects, scheduler polling/cache, and `tools.gitPath`/`tools.ghPath` also require restart. New fields are restart-bound until explicitly classified.
+
+Deprecated file-layer aliases for `agent.timeouts.{planner,worker,reviewer,fixer}Seconds`, `defaults.allowAutoApprove`, and `defaults.fixAllPullRequests` are normalized into their canonical hot-safe fields so existing files can still reload without a restart. They remain file-only compatibility syntax: the dashboard exposes and writes only canonical paths, and a canonical dashboard edit removes the corresponding alias leaf so a later unset cannot resurrect the old value.
+
+The dashboard is a curated field-level editor, not a raw file editor. Environment- and CLI-owned fields are read-only. `agent.env` values are write-only (only key names are returned), while `server.localToken`, `daemon.environment`, and `agent.params` remain file-only. Projects remain under the Projects API and SQLite authority. When token authentication is not configured, `PATCH /api/v1/config` accepts only direct requests whose peer and Host authority are loopback and rejects proxy-forwarding headers; in `local-token` mode it requires the normal token authentication.
+
+Every dashboard read includes the revision of the exact file generation that produced its published values, and every patch must submit that revision. The revision check and a final identity/mode/byte check catch changes present before that final check, including a newer generation not yet accepted by the reload loop. The writer then uses a crash-safe atomic rename. Portable filesystems do not offer a conditional compare-and-rename, so an external editor racing in the tiny interval between the final check and rename can still be replaced; avoid simultaneous manual and dashboard writes. A successful patch preserves the selected TOML/YAML/JSON format, unknown top-level extension sections and their native scalar values, and ordinary permission bits, but serialization can canonicalize comments, quoting, key/table order, and other lexical formatting; ACLs and extended filesystem metadata are not guaranteed to survive atomic replacement. Dashboard patching refuses a symlinked config path; edit the symlink target directly instead.
+
 ## Supported formats and default path
 
 Looper accepts config files in these formats:
@@ -595,10 +620,14 @@ OPENAI_API_KEY = "replace-me"
 enabled = true
 
 [agent.timeouts]
-plannerSeconds = 1800
-workerSeconds = 3600
-reviewerSeconds = 1800
-fixerSeconds = 1800
+plannerIdleTimeoutSeconds = 600
+plannerMaxRuntimeSeconds = 3600
+workerIdleTimeoutSeconds = 900
+workerMaxRuntimeSeconds = 10800
+reviewerIdleTimeoutSeconds = 600
+reviewerMaxRuntimeSeconds = 5400
+fixerIdleTimeoutSeconds = 600
+fixerMaxRuntimeSeconds = 7200
 
 [logging]
 level = "info"
@@ -646,7 +675,6 @@ baseBranch = "main"
 allowAutoCommit = true
 allowAutoPush = true
 allowAutoApprove = true
-allowAutoMerge = false
 allowRiskyFixes = false
 openPrStrategy = "all_done"
 addSnapshotMode = "async"

--- a/internal/api/config_auth_test.go
+++ b/internal/api/config_auth_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestConfigPatchWithoutTokenRequiresDirectLoopback(t *testing.T) {
+	cfg := testConfigRouteConfig(t)
+	baseURL := "https://looper.example.test"
+	cfg.Server.BaseURL = &baseURL
+	callbackCalls := 0
+	handler := NewHandler(Context{
+		Config: cfg,
+		PatchConfig: func(context.Context, ConfigPatchRequest) error {
+			callbackCalls++
+			return nil
+		},
+	})
+	body := `{"revision":"sha256:test","set":{"scheduler.maxConcurrentRuns":4}}`
+
+	tests := []struct {
+		name      string
+		configure func(*http.Request)
+	}{
+		{
+			name: "remote client",
+			configure: func(req *http.Request) {
+				req.RemoteAddr = "203.0.113.10:54321"
+			},
+		},
+		{
+			name: "forwarded through local proxy",
+			configure: func(req *http.Request) {
+				req.Header.Set("X-Forwarded-For", "203.0.113.10")
+			},
+		},
+		{
+			name: "alternate forwarding metadata",
+			configure: func(req *http.Request) {
+				req.Header.Set("X-Forwarded-Proto", "https")
+			},
+		},
+		{
+			name: "public authority through stripped local proxy",
+			configure: func(req *http.Request) {
+				req.Host = "looper.example.test"
+				req.Header.Set("Origin", baseURL)
+			},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			req := loopbackConfigPatchRequest(strings.NewReader(body))
+			testCase.configure(req)
+			handler.ServeHTTP(recorder, req)
+			if recorder.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403; body=%s", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+	if callbackCalls != 0 {
+		t.Fatalf("PatchConfig calls = %d, want 0", callbackCalls)
+	}
+}
+
+func TestConfigPatchWithTokenAllowsAuthenticatedLocalProxy(t *testing.T) {
+	cfg := testConfigRouteConfig(t)
+	token := "local-token"
+	cfg.Server.AuthMode = config.AuthModeLocalToken
+	cfg.Server.LocalToken = &token
+	callbackCalls := 0
+	handler := NewHandler(Context{
+		Config: cfg,
+		PatchConfig: func(context.Context, ConfigPatchRequest) error {
+			callbackCalls++
+			return nil
+		},
+	})
+
+	recorder := httptest.NewRecorder()
+	req := loopbackConfigPatchRequest(strings.NewReader(`{"revision":"sha256:test","set":{"scheduler.maxConcurrentRuns":4}}`))
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	req.Header.Set("Authorization", "Bearer "+token)
+	handler.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if callbackCalls != 1 {
+		t.Fatalf("PatchConfig calls = %d, want 1", callbackCalls)
+	}
+}

--- a/internal/api/config_decode_test.go
+++ b/internal/api/config_decode_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestConfigPatchStrictDecodeAndSizeLimit(t *testing.T) {
+	cfg := testConfigRouteConfig(t)
+	tooLarge := `{"revision":"sha256:test","set":{"agent.env.BIG":"` + strings.Repeat("x", maxConfigPatchBodyBytes) + `"}}`
+	tests := []struct {
+		name, body, wantCode string
+		wantStatus           int
+	}{
+		{name: "body required", wantCode: "request_body_required", wantStatus: http.StatusBadRequest},
+		{name: "object required", body: "null", wantCode: "invalid_json", wantStatus: http.StatusBadRequest},
+		{name: "unknown field", body: `{"revision":"sha256:test","set":{"scheduler.maxConcurrentRuns":4},"extra":true}`, wantCode: "invalid_json", wantStatus: http.StatusBadRequest},
+		{name: "trailing json", body: `{"revision":"sha256:test","set":{"scheduler.maxConcurrentRuns":4}} {}`, wantCode: "trailing_json", wantStatus: http.StatusBadRequest},
+		{name: "empty patch", body: `{"revision":"sha256:test"}`, wantCode: "empty_patch", wantStatus: http.StatusBadRequest},
+		{name: "conflicting operations", body: `{"revision":"sha256:test","set":{"scheduler.maxConcurrentRuns":4},"unset":["scheduler.maxConcurrentRuns"]}`, wantCode: "conflicting_operation", wantStatus: http.StatusBadRequest},
+		{name: "duplicate json name", body: `{"revision":"sha256:test","set":{"scheduler.maxConcurrentRuns":3,"scheduler.maxConcurrentRuns":4}}`, wantCode: "duplicate_json_name", wantStatus: http.StatusBadRequest},
+		{name: "too large", body: tooLarge, wantCode: "request_too_large", wantStatus: http.StatusRequestEntityTooLarge},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callbackCalls := 0
+			handler := NewHandler(Context{Config: cfg, PatchConfig: func(context.Context, ConfigPatchRequest) error {
+				callbackCalls++
+				return nil
+			}})
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, loopbackConfigPatchRequest(strings.NewReader(tt.body)))
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", recorder.Code, tt.wantStatus, recorder.Body.String())
+			}
+			if callbackCalls != 0 {
+				t.Fatalf("PatchConfig calls = %d, want 0", callbackCalls)
+			}
+			issues := parseJSONMap(t, recorder.Body.Bytes())["error"].(map[string]any)["details"].(map[string]any)["issues"].([]any)
+			found := false
+			for _, item := range issues {
+				found = found || item.(map[string]any)["code"] == tt.wantCode
+			}
+			if !found {
+				t.Fatalf("issues = %#v, want code %q", issues, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestConfigPatchWithoutTokenRequiresLoopbackClient(t *testing.T) {
+	callbackCalls := 0
+	handler := NewHandler(Context{Config: testConfigRouteConfig(t), PatchConfig: func(context.Context, ConfigPatchRequest) error {
+		callbackCalls++
+		return nil
+	}})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/config", strings.NewReader(`{"revision":"sha256:test","set":{"scheduler.maxConcurrentRuns":4}}`))
+	req.Host = "localhost:17310"
+	req.RemoteAddr = "203.0.113.20:54321"
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if callbackCalls != 0 {
+		t.Fatalf("PatchConfig calls = %d, want 0", callbackCalls)
+	}
+}
+
+func TestConfigPatchWithoutCallbackIsUnsupported(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	req := loopbackConfigPatchRequest(strings.NewReader(`{"revision":"sha256:test","set":{"scheduler.maxConcurrentRuns":4}}`))
+	NewHandler(Context{Config: testConfigRouteConfig(t)}).ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	issue := parseJSONMap(t, recorder.Body.Bytes())["error"].(map[string]any)["details"].(map[string]any)["issues"].([]any)[0].(map[string]any)
+	assertEqual(t, issue["code"], "config_patch_unsupported")
+}
+
+func loopbackConfigPatchRequest(body io.Reader) *http.Request {
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/config", body)
+	req.RemoteAddr = "127.0.0.1:54321"
+	return req
+}

--- a/internal/api/config_projection_test.go
+++ b/internal/api/config_projection_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	looperdruntime "github.com/nexu-io/looper/internal/runtime"
+	"github.com/nexu-io/looper/internal/webhookforward"
+)
+
+func TestConfigGetRedactsSecretsAndIncludesMetadata(t *testing.T) {
+	cfg := testConfigRouteConfig(t)
+	localToken := "local-token-secret"
+	cfg.Server.LocalToken = &localToken
+	cfg.Agent.Env = map[string]string{"Z_TOKEN": "agent-env-secret", "A_TOKEN": "another-agent-secret"}
+	cfg.Agent.Params = map[string]any{"apiKey": "agent-param-secret", "nested": map[string]any{"token": "nested-param-secret"}}
+	cfg.Daemon.Environment = map[string]string{"SECOND": "daemon-env-secret", "FIRST": "another-daemon-secret"}
+
+	lastAttempt := time.Date(2026, time.July, 16, 10, 0, 0, 0, time.UTC)
+	lastApplied := lastAttempt.Add(-time.Minute)
+	lastError := "invalid scheduler value"
+	metadata := ConfigMetadata{
+		ConfigPath: "/tmp/looper/config.json", Format: "json", FilePresent: true, Revision: "sha256:test",
+		LastAttemptAt: &lastAttempt, LastAppliedAt: &lastApplied, LastError: &lastError,
+		RejectedPaths: []string{"server.port"},
+		Fields: map[string]ConfigFieldMetadata{
+			"scheduler.pollIntervalSeconds": {Source: "config-file", Editable: true, ApplyMode: "hot"},
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config", nil)
+	NewHandler(Context{Config: cfg, ConfigMetadata: func() ConfigMetadata { return metadata }}).ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	for _, secret := range []string{localToken, "agent-env-secret", "another-agent-secret", "agent-param-secret", "nested-param-secret", "daemon-env-secret", "another-daemon-secret"} {
+		if strings.Contains(recorder.Body.String(), secret) {
+			t.Fatalf("config response exposed secret %q: %s", secret, recorder.Body.String())
+		}
+	}
+
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	server := data["server"].(map[string]any)
+	if _, exists := server["localTokenConfigured"]; exists {
+		t.Fatalf("server.localTokenConfigured must be omitted: %#v", server)
+	}
+	if _, exists := server["localToken"]; exists {
+		t.Fatalf("server.localToken must be omitted: %#v", server)
+	}
+	agent := data["agent"].(map[string]any)
+	assertStringArray(t, agent["envKeys"], []string{"A_TOKEN", "Z_TOKEN"})
+	if len(agent["env"].(map[string]any)) != 0 || len(agent["params"].(map[string]any)) != 0 {
+		t.Fatalf("agent secret fields must be redacted to empty objects: %#v", agent)
+	}
+	daemon := data["daemon"].(map[string]any)
+	if len(daemon["environment"].(map[string]any)) != 0 {
+		t.Fatalf("daemon.environment must be redacted: %#v", daemon)
+	}
+
+	metadataResponse := data["metadata"].(map[string]any)
+	assertEqual(t, metadataResponse["configPath"], metadata.ConfigPath)
+	assertEqual(t, metadataResponse["format"], metadata.Format)
+	assertEqual(t, metadataResponse["filePresent"], true)
+	assertEqual(t, metadataResponse["revision"], "sha256:test")
+	assertEqual(t, metadataResponse["lastAttemptAt"], lastAttempt.Format(time.RFC3339))
+	assertEqual(t, metadataResponse["lastAppliedAt"], lastApplied.Format(time.RFC3339))
+	assertEqual(t, metadataResponse["lastError"], lastError)
+	assertStringArray(t, metadataResponse["rejectedPaths"], []string{"server.port"})
+	field := metadataResponse["fields"].(map[string]any)["scheduler.pollIntervalSeconds"].(map[string]any)
+	assertEqual(t, field["source"], "config-file")
+	assertEqual(t, field["editable"], true)
+	assertEqual(t, field["applyMode"], "hot")
+}
+
+func TestConfigGetUsesOneRuntimeSnapshotPerRequest(t *testing.T) {
+	first := testConfigRouteConfig(t)
+	first.Server.Port = 18001
+	second := first
+	second.Server.Port = 18002
+	runtime := &configRouteRuntime{configs: []config.Config{first, second}}
+	recorder := httptest.NewRecorder()
+	NewHandler(Context{Runtime: runtime}).ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/config", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if got := runtime.callCount(); got != 1 {
+		t.Fatalf("Runtime.Config() calls = %d, want 1", got)
+	}
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	assertEqual(t, data["server"].(map[string]any)["port"], float64(first.Server.Port))
+}
+
+type configRouteForwarderRuntime struct {
+	*configRouteRuntime
+	mu        sync.Mutex
+	forwarder looperdruntime.WebhookForwarder
+}
+
+func (r *configRouteForwarderRuntime) WebhookForwarder() looperdruntime.WebhookForwarder {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.forwarder
+}
+
+type recordingConfigRouteForwarder struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *recordingConfigRouteForwarder) Forward(context.Context, webhookforward.DeliveryRequest) (webhookforward.ForwardResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}, nil
+}
+
+func (f *recordingConfigRouteForwarder) Stats() webhookforward.Stats { return webhookforward.Stats{} }
+func (f *recordingConfigRouteForwarder) Close()                      {}
+func (f *recordingConfigRouteForwarder) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func TestWebhookForwardUsesCurrentRuntimeForwarder(t *testing.T) {
+	cfg := testConfigRouteConfig(t)
+	cfg.Webhook.Enabled = true
+	staleForwarder := &recordingConfigRouteForwarder{}
+	currentForwarder := &recordingConfigRouteForwarder{}
+	runtime := &configRouteForwarderRuntime{
+		configRouteRuntime: &configRouteRuntime{configs: []config.Config{cfg}},
+		forwarder:          currentForwarder,
+	}
+	handler := NewHandler(Context{Config: cfg, Runtime: runtime, WebhookForwarder: staleForwarder})
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", strings.NewReader(`{}`))
+	req.RemoteAddr = "127.0.0.1:17310"
+	handler.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if got := staleForwarder.callCount(); got != 0 {
+		t.Fatalf("constructor forwarder calls = %d, want 0", got)
+	}
+	if got := currentForwarder.callCount(); got != 1 {
+		t.Fatalf("runtime forwarder calls = %d, want 1", got)
+	}
+}

--- a/internal/api/config_routes_test.go
+++ b/internal/api/config_routes_test.go
@@ -1,0 +1,259 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	looperdruntime "github.com/nexu-io/looper/internal/runtime"
+)
+
+type configRouteRuntime struct {
+	mu      sync.Mutex
+	configs []config.Config
+	calls   int
+}
+
+// configOverrideRuntime keeps legacy handler fixtures explicit: tests that
+// intentionally alter a copied config after starting a runtime publish that
+// copy as the runtime's request snapshot while retaining all embedded runtime
+// services and optional control interfaces.
+type configOverrideRuntime struct {
+	*looperdruntime.Runtime
+	config config.Config
+}
+
+func (r *configOverrideRuntime) Config() config.Config {
+	return r.config
+}
+
+func runtimeWithConfig(r *looperdruntime.Runtime, cfg config.Config) RuntimeState {
+	return &configOverrideRuntime{Runtime: r, config: cfg}
+}
+
+func (r *configRouteRuntime) Services() looperdruntime.Services {
+	return looperdruntime.Services{}
+}
+
+func (r *configRouteRuntime) StartedAt() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (r *configRouteRuntime) Config() config.Config {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	index := r.calls
+	if index >= len(r.configs) {
+		index = len(r.configs) - 1
+	}
+	r.calls++
+	return r.configs[index]
+}
+
+func (r *configRouteRuntime) replaceConfig(cfg config.Config) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.configs = []config.Config{cfg}
+}
+
+func (r *configRouteRuntime) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func testConfigRouteConfig(t *testing.T) config.Config {
+	t.Helper()
+	cfg, err := config.DefaultConfig("")
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Server.AuthMode = config.AuthModeNone
+	return cfg
+}
+
+func TestConfigPatchPassesRawValuesAndReturnsRefreshedProjection(t *testing.T) {
+	initial := testConfigRouteConfig(t)
+	initial.Scheduler.MaxConcurrentRuns = 3
+	runtime := &configRouteRuntime{configs: []config.Config{initial}}
+	appliedAt := time.Date(2026, time.July, 16, 10, 30, 0, 0, time.UTC)
+	metadata := ConfigMetadata{ConfigPath: "/tmp/config.json", Format: "json", FilePresent: true, Revision: "sha256:test"}
+	callbackCalls := 0
+
+	handler := NewHandler(Context{
+		Config:  initial,
+		Runtime: runtime,
+		ConfigMetadata: func() ConfigMetadata {
+			return metadata
+		},
+		PatchConfig: func(_ context.Context, patch ConfigPatchRequest) error {
+			callbackCalls++
+			if got := string(patch.Set["scheduler.maxConcurrentRuns"]); got != "4" {
+				t.Fatalf("raw set value = %q, want 4", got)
+			}
+			if got := string(patch.Set["agent.env.NEW_TOKEN"]); got != `"write-only-value"` {
+				t.Fatalf("raw env value = %q, want quoted JSON string", got)
+			}
+			if len(patch.Unset) != 1 || patch.Unset[0] != "agent.env.OLD_TOKEN" {
+				t.Fatalf("unset = %#v", patch.Unset)
+			}
+			next := initial
+			next.Scheduler.MaxConcurrentRuns = 4
+			next.Agent.Env = map[string]string{"NEW_TOKEN": "write-only-value"}
+			runtime.replaceConfig(next)
+			metadata.LastAttemptAt = &appliedAt
+			metadata.LastAppliedAt = &appliedAt
+			return nil
+		},
+	})
+
+	body := `{"revision":"sha256:test","set":{"scheduler.maxConcurrentRuns":4,"agent.env.NEW_TOKEN":"write-only-value"},"unset":["agent.env.OLD_TOKEN"]}`
+	recorder := httptest.NewRecorder()
+	req := loopbackConfigPatchRequest(strings.NewReader(body))
+	req.Header.Set("content-type", "application/json")
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if callbackCalls != 1 {
+		t.Fatalf("PatchConfig calls = %d, want 1", callbackCalls)
+	}
+	if got := runtime.callCount(); got != 2 {
+		t.Fatalf("Runtime.Config() calls = %d, want initial and refreshed snapshots", got)
+	}
+	if strings.Contains(recorder.Body.String(), "write-only-value") {
+		t.Fatalf("PATCH response exposed write-only value: %s", recorder.Body.String())
+	}
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	assertEqual(t, data["scheduler"].(map[string]any)["maxConcurrentRuns"], float64(4))
+	assertStringArray(t, data["agent"].(map[string]any)["envKeys"], []string{"NEW_TOKEN"})
+	assertEqual(t, data["metadata"].(map[string]any)["lastAppliedAt"], appliedAt.Format(time.RFC3339))
+}
+
+func TestConfigPatchMapsTypedRequestErrors(t *testing.T) {
+	cfg := testConfigRouteConfig(t)
+	tests := []struct {
+		name   string
+		err    error
+		status int
+		code   string
+	}{
+		{
+			name: "validation",
+			err: &ConfigRequestError{
+				Kind:    ConfigRequestErrorKindValidation,
+				Message: "Configuration validation failed",
+				Issues:  []ConfigPatchIssue{{Path: "scheduler.pollIntervalSeconds", Code: "too_small", Message: "must be at least 10"}},
+			},
+			status: http.StatusBadRequest,
+			code:   "VALIDATION_FAILED",
+		},
+		{
+			name: "conflict",
+			err: fmt.Errorf("persist: %w", ConfigRequestError{
+				Kind:    ConfigRequestErrorKindConflict,
+				Message: "Configuration changed on disk",
+				Issues:  []ConfigPatchIssue{{Path: "scheduler.maxConcurrentRuns", Code: "file_changed", Message: "reload and retry"}},
+			}),
+			status: http.StatusConflict,
+			code:   "CONFIG_CONFLICT",
+		},
+		{
+			name: "unsupported",
+			err: ConfigRequestError{
+				Kind:    ConfigRequestErrorKindUnsupported,
+				Message: "Field is startup-only",
+				Issues:  []ConfigPatchIssue{{Path: "server.port", Code: "startup_only", Message: "restart required"}},
+			},
+			status: http.StatusBadRequest,
+			code:   "VALIDATION_FAILED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewHandler(Context{
+				Config: cfg,
+				PatchConfig: func(context.Context, ConfigPatchRequest) error {
+					return tt.err
+				},
+			})
+			recorder := httptest.NewRecorder()
+			req := loopbackConfigPatchRequest(strings.NewReader(`{"revision":"sha256:test","set":{"scheduler.maxConcurrentRuns":4}}`))
+			handler.ServeHTTP(recorder, req)
+
+			if recorder.Code != tt.status {
+				t.Fatalf("status = %d, want %d; body=%s", recorder.Code, tt.status, recorder.Body.String())
+			}
+			if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+				t.Fatalf("Cache-Control = %q, want no-store", got)
+			}
+			errorResponse := parseJSONMap(t, recorder.Body.Bytes())["error"].(map[string]any)
+			assertEqual(t, errorResponse["code"], tt.code)
+			details := errorResponse["details"].(map[string]any)
+			issue := details["issues"].([]any)[0].(map[string]any)
+			requestError, _ := asConfigRequestError(tt.err)
+			assertEqual(t, issue["path"], requestError.Issues[0].Path)
+			assertEqual(t, issue["code"], requestError.Issues[0].Code)
+			assertEqual(t, issue["message"], requestError.Issues[0].Message)
+		})
+	}
+}
+
+func TestConfigResponseNeverReturnsSecretValues(t *testing.T) {
+	cfg := testConfigRouteConfig(t)
+	localToken := "server-token-value"
+	cfg.Server.LocalToken = &localToken
+	cfg.Agent.Env = map[string]string{"OPENAI_API_KEY": "agent-secret-value"}
+	cfg.Agent.Params = map[string]any{"apiKey": "agent-param-secret"}
+	cfg.Daemon.Environment = map[string]string{"PRIVATE_TOKEN": "daemon-secret-value"}
+
+	handler := NewHandler(Context{
+		Config: cfg,
+		ConfigMetadata: func() ConfigMetadata {
+			return ConfigMetadata{Fields: map[string]ConfigFieldMetadata{
+				"agent.env.OPENAI_API_KEY": {Source: "config-file", Editable: true, ApplyMode: "hot"},
+			}}
+		},
+	})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/config", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := recorder.Body.String()
+	for _, secret := range []string{localToken, "agent-secret-value", "agent-param-secret", "daemon-secret-value"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("config response exposed secret %q: %s", secret, body)
+		}
+	}
+	data := parseJSONMap(t, recorder.Body.Bytes())["data"].(map[string]any)
+	if _, exists := data["server"].(map[string]any)["localTokenConfigured"]; exists {
+		t.Fatal("localTokenConfigured must not be returned")
+	}
+	assertStringArray(t, data["agent"].(map[string]any)["envKeys"], []string{"OPENAI_API_KEY"})
+	assertEqual(t, len(data["agent"].(map[string]any)["params"].(map[string]any)), 0)
+	assertEqual(t, len(data["daemon"].(map[string]any)["environment"].(map[string]any)), 0)
+}
+
+func assertStringArray(t *testing.T, value any, want []string) {
+	t.Helper()
+	items, ok := value.([]any)
+	if !ok {
+		t.Fatalf("value = %#v, want string array", value)
+	}
+	if len(items) != len(want) {
+		t.Fatalf("len(value) = %d, want %d: %#v", len(items), len(want), value)
+	}
+	for index, expected := range want {
+		assertEqual(t, items[index], expected)
+	}
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/subtle"
@@ -44,6 +45,7 @@ const (
 	requestIDHeaderName        = "x-request-id"
 	apiBasePath                = "/api/v1"
 	webhookForwardPath         = "/webhook/forward"
+	maxConfigPatchBodyBytes    = 1 << 20
 	javaScriptISOString        = "2006-01-02T15:04:05.000Z"
 	loopLogsFollowPollInterval = 200 * time.Millisecond
 	activeRunHeartbeatTTL      = 30 * time.Minute
@@ -62,8 +64,70 @@ type activeRunExecutionVerifier interface {
 	ExecutionMatchesProcess(context.Context, storage.AgentExecutionRecord, int) (bool, bool, error)
 }
 
+// ConfigFieldMetadata describes where an effective field came from and whether
+// the dashboard may change it without restarting looperd.
+type ConfigFieldMetadata struct {
+	Source    string `json:"source"`
+	Editable  bool   `json:"editable"`
+	ApplyMode string `json:"applyMode"`
+}
+
+// ConfigMetadata describes the effective configuration source and the most
+// recent file reload attempt. Fields is keyed by canonical dotted config path.
+type ConfigMetadata struct {
+	ConfigPath    string                         `json:"configPath"`
+	Format        string                         `json:"format"`
+	FilePresent   bool                           `json:"filePresent"`
+	Revision      string                         `json:"revision"`
+	LastAttemptAt *time.Time                     `json:"lastAttemptAt,omitempty"`
+	LastAppliedAt *time.Time                     `json:"lastAppliedAt,omitempty"`
+	LastError     *string                        `json:"lastError,omitempty"`
+	RejectedPaths []string                       `json:"rejectedPaths"`
+	Fields        map[string]ConfigFieldMetadata `json:"fields"`
+}
+
+// ConfigPatchRequest is the dashboard's field-level mutation contract. Set
+// values stay as raw JSON so the configuration authority performs all typing
+// and validation; Unset removes values from the file layer.
+type ConfigPatchRequest struct {
+	Revision string                     `json:"revision"`
+	Set      map[string]json.RawMessage `json:"set"`
+	Unset    []string                   `json:"unset"`
+}
+
+type ConfigRequestErrorKind string
+
+const (
+	ConfigRequestErrorKindValidation  ConfigRequestErrorKind = "validation"
+	ConfigRequestErrorKindConflict    ConfigRequestErrorKind = "conflict"
+	ConfigRequestErrorKindUnsupported ConfigRequestErrorKind = "unsupported"
+	ConfigRequestErrorKindTooLarge    ConfigRequestErrorKind = "too_large"
+)
+
+// ConfigPatchIssue identifies one rejected field-level mutation.
+type ConfigPatchIssue struct {
+	Path    string `json:"path,omitempty"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// ConfigRequestError lets the configuration authority report stable field
+// issues while the HTTP layer owns status codes and envelope formatting.
+type ConfigRequestError struct {
+	Kind    ConfigRequestErrorKind
+	Message string
+	Issues  []ConfigPatchIssue
+}
+
+func (e ConfigRequestError) Error() string {
+	return e.Message
+}
+
 type Context struct {
 	Config             config.Config
+	ConfigMetadata     func() ConfigMetadata
+	ConfigSnapshot     func() (config.Config, ConfigMetadata)
+	PatchConfig        func(context.Context, ConfigPatchRequest) error
 	Runtime            RuntimeState
 	WebhookForwarder   webhookforward.Forwarder
 	ProjectsService    projectService
@@ -177,10 +241,29 @@ func (h *Handler) lockLoopTargetForStatus(projectID string, loopType domain.Loop
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	requestHandler := *h
+	requestHandler.context = h.context
+	// The config endpoint needs one coherent config-and-metadata snapshot.
+	// Other routes use the current in-memory runtime config for authorization
+	// and policy without constructing dashboard metadata.
+	if normalizePath(r.URL.Path) == apiBasePath+"/config" && h.context.ConfigSnapshot != nil {
+		cfg, metadata := h.context.ConfigSnapshot()
+		requestHandler.context.Config = cfg
+		requestHandler.context.ConfigMetadata = func() ConfigMetadata { return metadata }
+	} else if runtimeConfig, ok := any(h.context.Runtime).(interface{ Config() config.Config }); ok {
+		requestHandler.context.Config = runtimeConfig.Config()
+	}
+	requestHandler.serveHTTP(w, r)
+}
+
+func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	path := normalizePath(r.URL.Path)
 	requestID := strings.TrimSpace(r.Header.Get(requestIDHeaderName))
 	if requestID == "" {
 		requestID = generateRequestID()
+	}
+	if path == apiBasePath+"/config" {
+		w.Header().Set("Cache-Control", "no-store")
 	}
 
 	if err := authorizeRequest(r, path, h.context.Config); err != nil {
@@ -249,11 +332,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.writeSuccess(w, requestID, h.buildVersionResponse())
 		return
 	case apiBasePath + "/config":
-		if !assertMethod(r.Method, http.MethodGet, path, w, requestID, h.writeError) {
-			return
-		}
-
-		h.writeSuccess(w, requestID, h.buildConfigResponse())
+		h.handleConfigRoute(w, r, requestID)
 		return
 	case apiBasePath + "/webhook/status":
 		if !assertMethod(r.Method, http.MethodGet, path, w, requestID, h.writeError) {
@@ -512,7 +591,15 @@ func (h *Handler) buildWebhookForwardResponse(r *http.Request) (webhookforward.F
 	if !isLoopbackRequest(r) {
 		return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeUnauthorized, status: http.StatusForbidden, message: "Webhook forwarding is limited to loopback callers"}
 	}
-	if h.webhookForwarder == nil {
+	forwarder := h.webhookForwarder
+	if runtimeWithForwarder, ok := any(h.context.Runtime).(interface {
+		WebhookForwarder() looperdruntime.WebhookForwarder
+	}); ok {
+		if current := runtimeWithForwarder.WebhookForwarder(); current != nil {
+			forwarder = current
+		}
+	}
+	if forwarder == nil {
 		return webhookforward.ForwardResult{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Webhook forwarding is not configured"}
 	}
 	if runtimeWithWebhook, ok := any(h.context.Runtime).(interface {
@@ -529,7 +616,7 @@ func (h *Handler) buildWebhookForwardResponse(r *http.Request) (webhookforward.F
 	}
 	deliveryID := r.Header.Get("X-GitHub-Delivery")
 	eventType := r.Header.Get("X-GitHub-Event")
-	result, err := h.webhookForwarder.Forward(r.Context(), webhookforward.DeliveryRequest{DeliveryID: deliveryID, EventType: eventType, Payload: body})
+	result, err := forwarder.Forward(r.Context(), webhookforward.DeliveryRequest{DeliveryID: deliveryID, EventType: eventType, Payload: body})
 	if err != nil {
 		status := http.StatusBadRequest
 		code := pkgapi.ErrorCodeValidationFailed
@@ -562,8 +649,12 @@ func isLoopbackRequest(r *http.Request) bool {
 }
 
 func hasForwardingProxyHeaders(headers http.Header) bool {
-	for _, name := range []string{"Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Real-Ip", "X-Real-IP"} {
-		for _, value := range headers.Values(name) {
+	for name, values := range headers {
+		normalized := strings.ToLower(strings.TrimSpace(name))
+		if normalized != "forwarded" && normalized != "x-real-ip" && !strings.HasPrefix(normalized, "x-forwarded-") {
+			continue
+		}
+		for _, value := range values {
 			if strings.TrimSpace(value) != "" {
 				return true
 			}
@@ -644,6 +735,13 @@ func authorizeRequest(r *http.Request, path string, cfg config.Config) error {
 	if err := validateBrowserRequestForPath(r, cfg, path); err != nil {
 		return err
 	}
+	if path == apiBasePath+"/config" && r.Method == http.MethodPatch && cfg.Server.AuthMode != config.AuthModeLocalToken && !isDirectLoopbackConfigMutation(r, cfg) {
+		return apiError{
+			code:    pkgapi.ErrorCodeUnauthorized,
+			status:  http.StatusForbidden,
+			message: "Configuration updates without token authentication are limited to direct loopback clients",
+		}
+	}
 
 	if cfg.Server.AuthMode != config.AuthModeLocalToken {
 		return nil
@@ -671,6 +769,17 @@ func authorizeRequest(r *http.Request, path string, cfg config.Config) error {
 	}
 
 	return nil
+}
+
+func isDirectLoopbackConfigMutation(r *http.Request, cfg config.Config) bool {
+	if r == nil || !isLoopbackRemoteAddr(r.RemoteAddr) || hasForwardingProxyHeaders(r.Header) {
+		return false
+	}
+	// RemoteAddr alone identifies a local reverse proxy, not the original
+	// caller. Requiring a literal loopback request authority closes the common
+	// stripped-forwarding-header proxy path while retaining direct CLI/browser
+	// access through localhost, 127.0.0.1, or ::1.
+	return isLoopbackAuthority(effectiveRequestHost(r, cfg))
 }
 
 func isLoopbackRemoteAddr(remoteAddr string) bool {
@@ -918,28 +1027,281 @@ type statusTools struct {
 	Osascript bool `json:"osascript"`
 }
 
+func (h *Handler) handleConfigRoute(w http.ResponseWriter, r *http.Request, requestID string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.writeSuccess(w, requestID, h.buildConfigResponse())
+	case http.MethodPatch:
+		patch, err := decodeConfigPatchRequest(w, r)
+		if err != nil {
+			h.writeError(w, requestID, configRequestAPIError(err))
+			return
+		}
+		if h.context.PatchConfig == nil {
+			h.writeError(w, requestID, configRequestAPIError(ConfigRequestError{
+				Kind:    ConfigRequestErrorKindUnsupported,
+				Message: "Dynamic configuration updates are unavailable",
+				Issues: []ConfigPatchIssue{{
+					Code:    "config_patch_unsupported",
+					Message: "This daemon does not support field-level configuration updates",
+				}},
+			}))
+			return
+		}
+		if err := h.context.PatchConfig(r.Context(), patch); err != nil {
+			h.writeError(w, requestID, configRequestAPIError(err))
+			return
+		}
+
+		// A mutation establishes a new snapshot boundary. Refresh once after the
+		// callback so the PATCH response projects the configuration just applied.
+		if h.context.ConfigSnapshot != nil {
+			cfg, metadata := h.context.ConfigSnapshot()
+			h.context.Config = cfg
+			h.context.ConfigMetadata = func() ConfigMetadata { return metadata }
+		} else if runtimeConfig, ok := any(h.context.Runtime).(interface{ Config() config.Config }); ok {
+			h.context.Config = runtimeConfig.Config()
+		}
+		h.writeSuccess(w, requestID, h.buildConfigResponse())
+	default:
+		h.writeError(w, requestID, apiError{
+			code:    pkgapi.ErrorCodeMethodNotAllowed,
+			status:  http.StatusMethodNotAllowed,
+			message: fmt.Sprintf("Unsupported method for %s", apiBasePath+"/config"),
+		})
+	}
+}
+
+func decodeConfigPatchRequest(w http.ResponseWriter, r *http.Request) (ConfigPatchRequest, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxConfigPatchBodyBytes)
+	raw, readErr := io.ReadAll(r.Body)
+	if readErr != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(readErr, &maxBytesError) {
+			return ConfigPatchRequest{}, ConfigRequestError{
+				Kind:    ConfigRequestErrorKindTooLarge,
+				Message: "Configuration patch is too large",
+				Issues:  []ConfigPatchIssue{{Code: "request_too_large", Message: fmt.Sprintf("Request body exceeds %d bytes", maxConfigPatchBodyBytes)}},
+			}
+		}
+		return ConfigPatchRequest{}, ConfigRequestError{Kind: ConfigRequestErrorKindValidation, Message: "Invalid configuration patch", Issues: []ConfigPatchIssue{{Code: "invalid_json", Message: readErr.Error()}}}
+	}
+	if len(bytes.TrimSpace(raw)) > 0 {
+		if err := config.ValidateUniqueJSONNames(raw); err != nil {
+			return ConfigPatchRequest{}, ConfigRequestError{
+				Kind:    ConfigRequestErrorKindValidation,
+				Message: "Invalid configuration patch",
+				Issues:  []ConfigPatchIssue{{Code: "duplicate_json_name", Message: err.Error()}},
+			}
+		}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+
+	var decoded *ConfigPatchRequest
+	if err := decoder.Decode(&decoded); err != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			return ConfigPatchRequest{}, ConfigRequestError{
+				Kind:    ConfigRequestErrorKindTooLarge,
+				Message: "Configuration patch is too large",
+				Issues: []ConfigPatchIssue{{
+					Code:    "request_too_large",
+					Message: fmt.Sprintf("Request body exceeds %d bytes", maxConfigPatchBodyBytes),
+				}},
+			}
+		}
+		message := "Request body must be a JSON object"
+		code := "invalid_json"
+		if errors.Is(err, io.EOF) {
+			message = "Request body is required"
+			code = "request_body_required"
+		}
+		return ConfigPatchRequest{}, ConfigRequestError{
+			Kind:    ConfigRequestErrorKindValidation,
+			Message: "Invalid configuration patch",
+			Issues:  []ConfigPatchIssue{{Code: code, Message: message}},
+		}
+	}
+	if decoded == nil {
+		return ConfigPatchRequest{}, ConfigRequestError{
+			Kind:    ConfigRequestErrorKindValidation,
+			Message: "Invalid configuration patch",
+			Issues:  []ConfigPatchIssue{{Code: "invalid_json", Message: "Request body must be a JSON object"}},
+		}
+	}
+	patch := *decoded
+	if strings.TrimSpace(patch.Revision) == "" {
+		return ConfigPatchRequest{}, ConfigRequestError{
+			Kind:    ConfigRequestErrorKindValidation,
+			Message: "Invalid configuration patch",
+			Issues:  []ConfigPatchIssue{{Path: "revision", Code: "missing_revision", Message: "revision is required; refresh configuration and try again"}},
+		}
+	}
+
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err != nil {
+			var maxBytesError *http.MaxBytesError
+			if errors.As(err, &maxBytesError) {
+				return ConfigPatchRequest{}, ConfigRequestError{
+					Kind:    ConfigRequestErrorKindTooLarge,
+					Message: "Configuration patch is too large",
+					Issues:  []ConfigPatchIssue{{Code: "request_too_large", Message: fmt.Sprintf("Request body exceeds %d bytes", maxConfigPatchBodyBytes)}},
+				}
+			}
+		}
+		return ConfigPatchRequest{}, ConfigRequestError{
+			Kind:    ConfigRequestErrorKindValidation,
+			Message: "Invalid configuration patch",
+			Issues:  []ConfigPatchIssue{{Code: "trailing_json", Message: "Request body must contain exactly one JSON object"}},
+		}
+	}
+
+	issues := validateConfigPatchRequest(patch)
+	if len(issues) > 0 {
+		return ConfigPatchRequest{}, ConfigRequestError{
+			Kind:    ConfigRequestErrorKindValidation,
+			Message: "Invalid configuration patch",
+			Issues:  issues,
+		}
+	}
+	if patch.Set == nil {
+		patch.Set = map[string]json.RawMessage{}
+	}
+	if patch.Unset == nil {
+		patch.Unset = []string{}
+	}
+	return patch, nil
+}
+
+func validateConfigPatchRequest(patch ConfigPatchRequest) []ConfigPatchIssue {
+	issues := make([]ConfigPatchIssue, 0)
+	if len(patch.Set) == 0 && len(patch.Unset) == 0 {
+		issues = append(issues, ConfigPatchIssue{Code: "empty_patch", Message: "At least one set or unset operation is required"})
+	}
+
+	setPaths := make(map[string]struct{}, len(patch.Set))
+	for path, raw := range patch.Set {
+		setPaths[path] = struct{}{}
+		if path == "" || path != strings.TrimSpace(path) {
+			issues = append(issues, ConfigPatchIssue{Path: path, Code: "invalid_path", Message: "Set paths must be non-empty and contain no surrounding whitespace"})
+		}
+		if len(raw) == 0 {
+			issues = append(issues, ConfigPatchIssue{Path: path, Code: "missing_value", Message: "Set operations require a JSON value"})
+		}
+	}
+
+	unsetPaths := make(map[string]struct{}, len(patch.Unset))
+	for _, path := range patch.Unset {
+		if path == "" || path != strings.TrimSpace(path) {
+			issues = append(issues, ConfigPatchIssue{Path: path, Code: "invalid_path", Message: "Unset paths must be non-empty and contain no surrounding whitespace"})
+		}
+		if _, exists := unsetPaths[path]; exists {
+			issues = append(issues, ConfigPatchIssue{Path: path, Code: "duplicate_unset", Message: "Unset paths must be unique"})
+		}
+		unsetPaths[path] = struct{}{}
+		if _, exists := setPaths[path]; exists {
+			issues = append(issues, ConfigPatchIssue{Path: path, Code: "conflicting_operation", Message: "A path cannot be both set and unset"})
+		}
+	}
+
+	sort.SliceStable(issues, func(i, j int) bool {
+		if issues[i].Path == issues[j].Path {
+			return issues[i].Code < issues[j].Code
+		}
+		return issues[i].Path < issues[j].Path
+	})
+	return issues
+}
+
+func configRequestAPIError(err error) apiError {
+	requestError, ok := asConfigRequestError(err)
+	if !ok {
+		return internalServerError(err)
+	}
+
+	status := http.StatusBadRequest
+	code := pkgapi.ErrorCodeValidationFailed
+	switch requestError.Kind {
+	case ConfigRequestErrorKindValidation, ConfigRequestErrorKindUnsupported:
+	case ConfigRequestErrorKindConflict:
+		status = http.StatusConflict
+		code = pkgapi.ErrorCodeConfigConflict
+	case ConfigRequestErrorKindTooLarge:
+		status = http.StatusRequestEntityTooLarge
+		code = pkgapi.ErrorCodeRequestTooLarge
+	default:
+		return internalServerError(err)
+	}
+
+	message := strings.TrimSpace(requestError.Message)
+	if message == "" {
+		message = "Configuration update failed"
+	}
+	issues := append([]ConfigPatchIssue{}, requestError.Issues...)
+	return apiError{
+		code:    code,
+		status:  status,
+		message: message,
+		details: struct {
+			Issues []ConfigPatchIssue `json:"issues"`
+		}{Issues: issues},
+	}
+}
+
+func asConfigRequestError(err error) (ConfigRequestError, bool) {
+	if err == nil {
+		return ConfigRequestError{}, false
+	}
+	var pointer *ConfigRequestError
+	if errors.As(err, &pointer) && pointer != nil {
+		return *pointer, true
+	}
+	var value ConfigRequestError
+	if errors.As(err, &value) {
+		return value, true
+	}
+	return ConfigRequestError{}, false
+}
+
 type configResponse struct {
 	Server        configServerResponse      `json:"server"`
 	Storage       config.StorageConfig      `json:"storage"`
 	Scheduler     config.SchedulerConfig    `json:"scheduler"`
 	Webhook       config.WebhookConfig      `json:"webhook"`
-	Agent         config.AgentConfig        `json:"agent"`
+	Network       config.NetworkConfig      `json:"network"`
+	Agent         configAgentResponse       `json:"agent"`
 	Logging       config.LoggingConfig      `json:"logging"`
 	Notifications config.NotificationConfig `json:"notifications"`
+	Disclosure    config.DisclosureConfig   `json:"disclosure"`
 	Tools         config.ToolPathsConfig    `json:"tools"`
 	Daemon        configDaemonResponse      `json:"daemon"`
 	Package       config.PackageConfig      `json:"package"`
 	Defaults      config.DefaultsConfig     `json:"defaults"`
+	Instructions  config.InstructionsConfig `json:"instructions"`
+	HITL          config.HITLConfig         `json:"hitl"`
 	Roles         config.RoleConfigs        `json:"roles"`
+	Providers     []config.ProviderConfig   `json:"providers"`
 	Projects      []config.ProjectRefConfig `json:"projects"`
+	Metadata      ConfigMetadata            `json:"metadata"`
 }
 
 type configServerResponse struct {
-	Host                 string          `json:"host"`
-	Port                 int             `json:"port"`
-	BaseURL              *string         `json:"baseUrl,omitempty"`
-	AuthMode             config.AuthMode `json:"authMode"`
-	LocalTokenConfigured bool            `json:"localTokenConfigured"`
+	Host     string          `json:"host"`
+	Port     int             `json:"port"`
+	BaseURL  *string         `json:"baseUrl,omitempty"`
+	AuthMode config.AuthMode `json:"authMode"`
+}
+
+type configAgentResponse struct {
+	Vendor       *config.AgentVendor            `json:"vendor,omitempty"`
+	Model        *string                        `json:"model,omitempty"`
+	Params       map[string]any                 `json:"params"`
+	Env          map[string]string              `json:"env"`
+	EnvKeys      []string                       `json:"envKeys"`
+	Timeouts     config.AgentTimeoutConfig      `json:"timeouts"`
+	NativeResume config.AgentNativeResumeConfig `json:"nativeResume"`
 }
 
 type configDaemonResponse struct {
@@ -955,24 +1317,30 @@ type configDaemonResponse struct {
 
 func (h *Handler) buildConfigResponse() configResponse {
 	cfg := h.context.Config
-	if runtimeConfig, ok := any(h.context.Runtime).(interface{ Config() config.Config }); ok {
-		cfg = runtimeConfig.Config()
-	}
 
 	return configResponse{
 		Server: configServerResponse{
-			Host:                 cfg.Server.Host,
-			Port:                 cfg.Server.Port,
-			BaseURL:              cfg.Server.BaseURL,
-			AuthMode:             cfg.Server.AuthMode,
-			LocalTokenConfigured: cfg.Server.LocalToken != nil && *cfg.Server.LocalToken != "",
+			Host:     cfg.Server.Host,
+			Port:     cfg.Server.Port,
+			BaseURL:  cfg.Server.BaseURL,
+			AuthMode: cfg.Server.AuthMode,
 		},
-		Storage:       cfg.Storage,
-		Scheduler:     cfg.Scheduler,
-		Webhook:       cfg.Webhook,
-		Agent:         cfg.Agent,
+		Storage:   cfg.Storage,
+		Scheduler: cfg.Scheduler,
+		Webhook:   cfg.Webhook,
+		Network:   cfg.Network,
+		Agent: configAgentResponse{
+			Vendor:       cfg.Agent.Vendor,
+			Model:        cfg.Agent.Model,
+			Params:       map[string]any{},
+			Env:          map[string]string{},
+			EnvKeys:      sortedMapKeys(cfg.Agent.Env),
+			Timeouts:     cfg.Agent.Timeouts,
+			NativeResume: cfg.Agent.NativeResume,
+		},
 		Logging:       cfg.Logging,
 		Notifications: cfg.Notifications,
+		Disclosure:    cfg.Disclosure,
 		Tools:         cfg.Tools,
 		Daemon: configDaemonResponse{
 			Mode:                   cfg.Daemon.Mode,
@@ -981,14 +1349,41 @@ func (h *Handler) buildConfigResponse() configResponse {
 			PlistPath:              cfg.Daemon.PlistPath,
 			LogDir:                 cfg.Daemon.LogDir,
 			WorkingDirectory:       cfg.Daemon.WorkingDirectory,
-			Environment:            cfg.Daemon.Environment,
+			Environment:            map[string]string{},
 			WorktreeCleanup:        cfg.Daemon.WorktreeCleanup,
 		},
-		Package:  cfg.Package,
-		Defaults: cfg.Defaults,
-		Roles:    cfg.Roles,
-		Projects: append([]config.ProjectRefConfig{}, cfg.Projects...),
+		Package:      cfg.Package,
+		Defaults:     cfg.Defaults,
+		Instructions: cfg.Instructions,
+		HITL:         cfg.HITL,
+		Roles:        cfg.Roles,
+		Providers:    append([]config.ProviderConfig{}, cfg.Providers...),
+		Projects:     append([]config.ProjectRefConfig{}, cfg.Projects...),
+		Metadata:     h.buildConfigMetadata(),
 	}
+}
+
+func (h *Handler) buildConfigMetadata() ConfigMetadata {
+	metadata := ConfigMetadata{}
+	if h.context.ConfigMetadata != nil {
+		metadata = h.context.ConfigMetadata()
+	}
+	metadata.RejectedPaths = append([]string{}, metadata.RejectedPaths...)
+	fields := make(map[string]ConfigFieldMetadata, len(metadata.Fields))
+	for path, field := range metadata.Fields {
+		fields[path] = field
+	}
+	metadata.Fields = fields
+	return metadata
+}
+
+func sortedMapKeys[T any](values map[string]T) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (h *Handler) buildWebhookStatusResponse() looperdruntime.WebhookStatus {

--- a/internal/api/handler_hitl_test.go
+++ b/internal/api/handler_hitl_test.go
@@ -117,7 +117,7 @@ func TestHandlerFeishuCardActionDeliversAnswer(t *testing.T) {
 	// Feishu verification token before it will deliver an answer.
 	t.Setenv("LOOPER_TEST_FEISHU_VTOKEN", "verify-tok-123")
 	cfg.Notifications.Webhook.VerificationTokenEnv = "LOOPER_TEST_FEISHU_VTOKEN"
-	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	h := NewHandler(Context{Config: cfg, Runtime: runtimeWithConfig(rt, cfg)})
 	services := rt.Services()
 	nowISO := "2026-04-11T12:00:00.000Z"
 	projectID := "project_card"
@@ -156,7 +156,7 @@ func TestHandlerFeishuCardActionDeliversAnswer(t *testing.T) {
 // handler + services for card-action security tests.
 func setupAwaitingCardLoop(t *testing.T, cfg config.Config, rt *looperdruntime.Runtime, projectID, loopID string, seq int64) *Handler {
 	t.Helper()
-	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	h := NewHandler(Context{Config: cfg, Runtime: runtimeWithConfig(rt, cfg)})
 	services := rt.Services()
 	nowISO := "2026-04-11T12:00:00.000Z"
 	targetID := projectID

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -844,7 +844,7 @@ func TestHandlerStatusSuccessContainsExpectedSections(t *testing.T) {
 	req.Header.Set("x-request-id", "fixture-request-id")
 	recorder := httptest.NewRecorder()
 
-	NewHandler(Context{Config: cfg, Runtime: rt}).ServeHTTP(recorder, req)
+	NewHandler(Context{Config: cfg, Runtime: runtimeWithConfig(rt, cfg)}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", recorder.Code)
@@ -917,7 +917,7 @@ func TestHandlerStatusIncludesRedactedForgejoProviderHealth(t *testing.T) {
 	cfg.Providers = []config.ProviderConfig{{ID: "forgejo-main", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: &tokenEnv}}
 	cfg.Projects = []config.ProjectRefConfig{{ID: "project-forgejo", Provider: "forgejo-main", Repo: "acme/looper", RepoPath: t.TempDir()}}
 	recorder := httptest.NewRecorder()
-	NewHandler(Context{Config: cfg, Runtime: rt}).ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/status", nil))
+	NewHandler(Context{Config: cfg, Runtime: runtimeWithConfig(rt, cfg)}).ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/status", nil))
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", recorder.Code)
 	}
@@ -994,7 +994,9 @@ func TestHandlerConfigSuccessContainsExpectedSections(t *testing.T) {
 	assertEqual(t, server["host"], cfg.Server.Host)
 	assertEqual(t, server["port"], float64(cfg.Server.Port))
 	assertEqual(t, server["authMode"], string(cfg.Server.AuthMode))
-	assertEqual(t, server["localTokenConfigured"], false)
+	if _, ok := server["localTokenConfigured"]; ok {
+		t.Fatalf("server.localTokenConfigured should be omitted: %#v", server)
+	}
 	assertEqual(t, storageInfo["mode"], cfg.Storage.Mode)
 	assertEqual(t, daemon["mode"], string(cfg.Daemon.Mode))
 	assertEqual(t, daemon["workingDirectory"], cfg.Daemon.WorkingDirectory)
@@ -1082,7 +1084,7 @@ func TestHandlerAuthMisconfigured(t *testing.T) {
 	req.Header.Set("x-request-id", "error-request-id")
 	recorder := httptest.NewRecorder()
 
-	NewHandler(Context{Config: cfg, Runtime: rt}).ServeHTTP(recorder, req)
+	NewHandler(Context{Config: cfg, Runtime: runtimeWithConfig(rt, cfg)}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500", recorder.Code)
@@ -1104,7 +1106,7 @@ func TestHandlerUnauthorized(t *testing.T) {
 	req.Header.Set("x-request-id", "error-request-id")
 	recorder := httptest.NewRecorder()
 
-	NewHandler(Context{Config: cfg, Runtime: rt}).ServeHTTP(recorder, req)
+	NewHandler(Context{Config: cfg, Runtime: runtimeWithConfig(rt, cfg)}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401", recorder.Code)
@@ -1121,7 +1123,7 @@ func TestHandlerWebhookForwardAcceptsLoopbackWithoutDoubleScheduling(t *testing.
 	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
 	triggered := 0
 	recorded := 0
-	runtime := webhookForwardRuntime{Runtime: fixture.runtime, status: func() looperdruntime.WebhookStatus {
+	runtime := webhookForwardRuntime{Runtime: fixture.runtime, config: &fixture.config, status: func() looperdruntime.WebhookStatus {
 		return looperdruntime.WebhookStatus{Enabled: true}
 	}, record: func(eventType, deliveryID string) {
 		recorded++
@@ -1157,7 +1159,7 @@ func TestHandlerWebhookForwardProcessesDeliveryWhenRuntimeIsDegraded(t *testing.
 	fixture := newTestFixture(t)
 	fixture.config.Webhook.Enabled = true
 	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
-	runtime := webhookForwardRuntime{Runtime: fixture.runtime, status: func() looperdruntime.WebhookStatus {
+	runtime := webhookForwardRuntime{Runtime: fixture.runtime, config: &fixture.config, status: func() looperdruntime.WebhookStatus {
 		return looperdruntime.WebhookStatus{Enabled: true, Degraded: true, DegradedReasons: []string{"another repo forwarder exited"}}
 	}}
 	h := NewHandler(Context{Config: fixture.config, Runtime: runtime, WebhookForwarder: forwarder})
@@ -1185,7 +1187,7 @@ func TestHandlerWebhookForwardRejectsNonLoopbackEvenWithBearerToken(t *testing.T
 	fixture.config.Server.LocalToken = &token
 	fixture.config.Webhook.Enabled = true
 	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
-	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, WebhookForwarder: forwarder})
+	h := NewHandler(Context{Config: fixture.config, Runtime: runtimeWithConfig(fixture.runtime, fixture.config), WebhookForwarder: forwarder})
 
 	req := httptest.NewRequest(http.MethodPost, "/webhook/forward", bytes.NewReader([]byte(`{"action":"review_requested"}`)))
 	req.RemoteAddr = "192.168.1.24:1234"
@@ -1211,7 +1213,7 @@ func TestHandlerWebhookForwardAcceptsLoopbackWithForwardedHeadersAndBearerToken(
 	fixture.config.Server.LocalToken = &token
 	fixture.config.Webhook.Enabled = true
 	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
-	runtime := webhookForwardRuntime{Runtime: fixture.runtime, status: func() looperdruntime.WebhookStatus {
+	runtime := webhookForwardRuntime{Runtime: fixture.runtime, config: &fixture.config, status: func() looperdruntime.WebhookStatus {
 		return looperdruntime.WebhookStatus{Enabled: true}
 	}}
 	h := NewHandler(Context{Config: fixture.config, Runtime: runtime, WebhookForwarder: forwarder})
@@ -1244,7 +1246,7 @@ func TestHandlerWebhookForwardRejectsLoopbackWithForwardedHeadersWithoutBearerTo
 	fixture.config.Server.LocalToken = &token
 	fixture.config.Webhook.Enabled = true
 	forwarder := &fakeWebhookForwarder{result: webhookforward.ForwardResult{Status: "accepted", WorkItems: 1}}
-	runtime := webhookForwardRuntime{Runtime: fixture.runtime, status: func() looperdruntime.WebhookStatus {
+	runtime := webhookForwardRuntime{Runtime: fixture.runtime, config: &fixture.config, status: func() looperdruntime.WebhookStatus {
 		return looperdruntime.WebhookStatus{Enabled: true}
 	}}
 	h := NewHandler(Context{Config: fixture.config, Runtime: runtime, WebhookForwarder: forwarder})
@@ -1631,7 +1633,7 @@ func TestHandlerMatchesFrozenErrorArtifactForStatusRoutes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.caseID, func(t *testing.T) {
-			h := NewHandler(Context{Config: tt.cfg, Runtime: rt})
+			h := NewHandler(Context{Config: tt.cfg, Runtime: runtimeWithConfig(rt, tt.cfg)})
 			req := httptest.NewRequest(tt.method, tt.path, nil)
 			for key, value := range tt.headers {
 				req.Header.Set(key, value)
@@ -1654,26 +1656,39 @@ func TestHandlerMatchesFrozenSuccessArtifactsForCoreRoutes(t *testing.T) {
 	seedStatusData(t, fixture.runtime)
 
 	routes := loadResponseArtifact(t)
+	requestRoutes := loadRequestArtifact(t)
 	h := NewHandler(Context{
 		Config:  fixture.config,
 		Runtime: fixture.runtime,
 		Now:     func() time.Time { return fixture.now },
+		PatchConfig: func(context.Context, ConfigPatchRequest) error {
+			return nil
+		},
 		RecoverySummary: func() any {
 			return map[string]any{"expiredLocksReleased": 1}
 		},
 	})
 
-	for _, routeID := range []string{"healthz.get", "status.get", "config.get"} {
+	for _, routeID := range []string{"healthz.get", "status.get", "config.get", "config.patch"} {
 		t.Run(routeID, func(t *testing.T) {
 			path := "/api/v1/healthz"
+			method := http.MethodGet
+			var requestBody io.Reader
 			switch routeID {
 			case "status.get":
 				path = "/api/v1/status"
 			case "config.get":
 				path = "/api/v1/config"
+			case "config.patch":
+				path = "/api/v1/config"
+				method = http.MethodPatch
+				requestBody = strings.NewReader(marshalArtifactRequestBody(t, requestRoutes, routeID))
 			}
 
-			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req := httptest.NewRequest(method, path, requestBody)
+			if routeID == "config.patch" {
+				req.RemoteAddr = "127.0.0.1:17310"
+			}
 			req.Header.Set("x-request-id", "fixture-request-id")
 			recorder := httptest.NewRecorder()
 			h.ServeHTTP(recorder, req)
@@ -2614,7 +2629,7 @@ func TestHandlerLoopStartRejectsCodingLoopsWithoutAgentConfigured(t *testing.T) 
 			req.Header.Set("x-request-id", "error-request-id")
 			recorder := httptest.NewRecorder()
 
-			NewHandler(Context{Config: configWithoutAgent, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
+			NewHandler(Context{Config: configWithoutAgent, Runtime: runtimeWithConfig(fixture.runtime, configWithoutAgent), Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
 
 			if recorder.Code != http.StatusBadRequest {
 				t.Fatalf("status = %d, want 400", recorder.Code)
@@ -3194,7 +3209,7 @@ func TestHandlerWorkerRouteErrorsMatchArtifactCases(t *testing.T) {
 			req.Header.Set("x-request-id", "error-request-id")
 			req.Header.Set("content-type", "application/json")
 			recorder := httptest.NewRecorder()
-			NewHandler(Context{Config: tt.cfg, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
+			NewHandler(Context{Config: tt.cfg, Runtime: runtimeWithConfig(fixture.runtime, tt.cfg), Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
 
 			want := findArtifactCase(t, artifact.Cases, tt.caseID)
 			if recorder.Code != want.ExpectedStatus {
@@ -3558,7 +3573,7 @@ func TestHandlerCreateManualLoopsRejectHeldTargetsWithoutForce(t *testing.T) {
 		t.Fatalf("Projects.Upsert() error = %v", err)
 	}
 	fixture.config.Tools.GHPath = stringPtr(writeFakeGHHoldValidationScript(t, []string{domain.HoldLabelGlobal}))
-	h := NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }})
+	h := NewHandler(Context{Config: fixture.config, Runtime: runtimeWithConfig(fixture.runtime, fixture.config), Now: func() time.Time { return fixture.now.Add(time.Minute) }})
 	for _, tc := range []struct{ name, path, body string }{
 		{name: "planner", path: "/api/v1/planners", body: `{"projectId":"project_1","issueNumber":77}`},
 		{name: "reviewer", path: "/api/v1/loops", body: `{"projectId":"project_1","type":"reviewer","targetType":"pull_request","repo":"acme/looper","prNumber":42}`},
@@ -3596,7 +3611,7 @@ func TestHandlerPlannerCreateForceBypassesHold(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/planners", bytes.NewReader([]byte(`{"projectId":"project_1","issueNumber":77,"force":true}`)))
 	req.Header.Set("content-type", "application/json")
 	rec := httptest.NewRecorder()
-	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(rec, req)
+	NewHandler(Context{Config: fixture.config, Runtime: runtimeWithConfig(fixture.runtime, fixture.config), Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
@@ -3617,7 +3632,7 @@ func TestHandlerWorkerCreateRejectsHeldRequestedIssueEvenWhenPlannerPRExists(t *
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/workers", bytes.NewReader([]byte(`{"projectId":"project_1","repo":"acme/looper","issueNumber":77,"baseBranch":"main"}`)))
 	req.Header.Set("content-type", "application/json")
 	rec := httptest.NewRecorder()
-	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(rec, req)
+	NewHandler(Context{Config: fixture.config, Runtime: runtimeWithConfig(fixture.runtime, fixture.config), Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
 	}
@@ -3645,7 +3660,7 @@ func TestHandlerCreateManualLoopForceBypassesHoldButStillConflicts(t *testing.T)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops", bytes.NewReader([]byte(`{"projectId":"project_1","type":"reviewer","targetType":"pull_request","repo":"acme/looper","prNumber":42,"force":true}`)))
 	req.Header.Set("content-type", "application/json")
 	rec := httptest.NewRecorder()
-	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(rec, req)
+	NewHandler(Context{Config: fixture.config, Runtime: runtimeWithConfig(fixture.runtime, fixture.config), Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(rec, req)
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409; body=%s", rec.Code, rec.Body.String())
 	}
@@ -3668,7 +3683,7 @@ func TestHandlerCreateReviewerLoopForcePersistsManualMetadata(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops", bytes.NewReader([]byte(`{"projectId":"project_1","type":"reviewer","targetType":"pull_request","repo":"acme/looper","prNumber":42,"force":true}`)))
 	req.Header.Set("content-type", "application/json")
 	rec := httptest.NewRecorder()
-	NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(rec, req)
+	NewHandler(Context{Config: fixture.config, Runtime: runtimeWithConfig(fixture.runtime, fixture.config), Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
@@ -3713,7 +3728,7 @@ func TestHandlerCreateManualHoldValidationSkipsWhenRepoPathOrGHPathMissing(t *te
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/loops", bytes.NewReader([]byte(`{"projectId":"project_1","type":"reviewer","targetType":"pull_request","repo":"acme/looper","prNumber":42}`)))
 			req.Header.Set("content-type", "application/json")
 			rec := httptest.NewRecorder()
-			NewHandler(Context{Config: fixture.config, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(rec, req)
+			NewHandler(Context{Config: fixture.config, Runtime: runtimeWithConfig(fixture.runtime, fixture.config), Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(rec, req)
 			if rec.Code != http.StatusOK {
 				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 			}
@@ -3932,7 +3947,7 @@ func TestHandlerCreateLoopRejectsWorkerAndPlannerWithoutAgentConfigured(t *testi
 			req.Header.Set("content-type", "application/json")
 			recorder := httptest.NewRecorder()
 
-			NewHandler(Context{Config: configWithoutAgent, Runtime: fixture.runtime, Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
+			NewHandler(Context{Config: configWithoutAgent, Runtime: runtimeWithConfig(fixture.runtime, configWithoutAgent), Now: func() time.Time { return fixture.now.Add(time.Minute) }}).ServeHTTP(recorder, req)
 
 			if recorder.Code != http.StatusBadRequest {
 				t.Fatalf("status = %d, want 400", recorder.Code)
@@ -6959,6 +6974,7 @@ func (r webhookReconcileRuntime) RefreshWebhookForwarders() error {
 
 type webhookForwardRuntime struct {
 	*looperdruntime.Runtime
+	config *config.Config
 	status func() looperdruntime.WebhookStatus
 	record func(string, string)
 }
@@ -6973,6 +6989,13 @@ func (r webhookForwardRuntime) WebhookStatus() looperdruntime.WebhookStatus {
 		return r.status()
 	}
 	return r.Runtime.WebhookStatus()
+}
+
+func (r webhookForwardRuntime) Config() config.Config {
+	if r.config != nil {
+		return *r.config
+	}
+	return r.Runtime.Config()
 }
 
 func (r webhookForwardRuntime) RecordWebhookDelivery(eventType, deliveryID string) {
@@ -7438,6 +7461,10 @@ func findResponseArtifactRoute(t *testing.T, routes []responseArtifactRoute, rou
 	t.Helper()
 	for _, route := range routes {
 		if route.ID == routeID {
+			if route.SameAs != "" {
+				base := findResponseArtifactRoute(t, routes, route.SameAs)
+				route.Body = base.Body
+			}
 			return route
 		}
 	}
@@ -7693,8 +7720,9 @@ type errorArtifactCase struct {
 }
 
 type responseArtifactRoute struct {
-	ID   string `json:"id"`
-	Body any    `json:"body"`
+	ID     string `json:"id"`
+	Body   any    `json:"body"`
+	SameAs string `json:"sameAs,omitempty"`
 }
 
 type requestArtifactRoute struct {

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -567,7 +567,7 @@ func TestHandlerLoopRetryWithoutDiscardDoesNotReportDiscard(t *testing.T) {
 func TestHandlerLoopRetryDiscardPreservesDirtyWorktreeWhenAgentNotConfigured(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	cfg.Agent.Vendor = nil
-	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	h := NewHandler(Context{Config: cfg, Runtime: runtimeWithConfig(rt, cfg)})
 	services := rt.Services()
 	nowISO := "2026-04-11T12:00:00.000Z"
 

--- a/internal/api/testdata/contracts/daemon-http.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.compat.json
@@ -82,6 +82,14 @@
       "routeSpecificStatuses": []
     },
     {
+      "id": "config.patch",
+      "method": "PATCH",
+      "path": "/api/v1/config",
+      "fixture": "default",
+      "expectedStatus": 200,
+      "routeSpecificStatuses": [400, 403, 409, 413]
+    },
+    {
       "id": "events.list",
       "method": "GET",
       "path": "/api/v1/events?limit=1",

--- a/internal/api/testdata/contracts/daemon-http.errors.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.errors.compat.json
@@ -46,6 +46,10 @@
       "status": 500
     },
     {
+      "code": "CONFIG_CONFLICT",
+      "status": 409
+    },
+    {
       "code": "INTERNAL_ERROR",
       "status": 500
     },
@@ -88,6 +92,10 @@
     {
       "code": "PULL_REQUEST_PROJECT_MISMATCH",
       "status": 409
+    },
+    {
+      "code": "REQUEST_TOO_LARGE",
+      "status": 413
     },
     {
       "code": "ROUTE_NOT_FOUND",

--- a/internal/api/testdata/contracts/daemon-http.requests.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.requests.compat.json
@@ -11,6 +11,23 @@
   ],
   "routes": [
     {
+      "id": "config.patch",
+      "method": "PATCH",
+      "path": "/api/v1/config",
+      "request": {
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "revision": "sha256:observed-config-revision",
+          "set": {
+            "scheduler.maxConcurrentRuns": 4
+          },
+          "unset": []
+        }
+      }
+    },
+    {
       "id": "loops.create",
       "method": "POST",
       "path": "/api/v1/loops",

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -7,7 +7,8 @@
   ],
   "notes": [
     "This artifact freezes the current /api/v1 success-envelope JSON shapes using the seeded fixture in apps/looperd/src/server/index.test.ts.",
-    "Values normalized as placeholders are environment- or runtime-generated but the surrounding JSON shape is part of the compatibility boundary."
+    "Values normalized as placeholders are environment- or runtime-generated but the surrounding JSON shape is part of the compatibility boundary.",
+    "A route with sameAs intentionally shares the complete frozen response shape of the referenced route."
   ],
   "placeholders": {
     "<tmp-root>": "Temporary fixture root directory used by the test harness.",
@@ -220,8 +221,7 @@
           "server": {
             "host": "127.0.0.1",
             "port": 17310,
-            "authMode": "none",
-            "localTokenConfigured": false
+            "authMode": "none"
           },
           "storage": {
             "mode": "sqlite",
@@ -243,8 +243,15 @@
             "publicBaseUrl": "",
             "fallbackPollIntervalSeconds": 300
           },
+          "network": {
+            "enrolled": false,
+            "loopernetBaseUrl": "",
+            "nodeName": "",
+            "githubLogin": ""
+          },
           "agent": {
             "env": {},
+            "envKeys": [],
             "nativeResume": {
               "enabled": true
             },
@@ -288,6 +295,18 @@
               "throttleWindowSeconds": 60
             }
           },
+          "disclosure": {
+            "enabled": true,
+            "includeAgent": true,
+            "includeOS": false,
+            "channels": {
+              "gitCommit": true,
+              "pullRequest": true,
+              "issueComment": true,
+              "reviewComment": true,
+              "inlineCommentVisible": true
+            }
+          },
           "tools": {
             "gitPath": "/usr/bin/git",
             "ghPath": "/usr/bin/gh",
@@ -325,6 +344,13 @@
             "fixAllPullRequests": false,
             "openPrStrategy": "all_done",
             "addSnapshotMode": "async"
+          },
+          "instructions": {
+            "enabled": true,
+            "maxBytes": 8192
+          },
+          "hitl": {
+            "enabled": false
           },
           "roles": {
             "coordinator": {
@@ -460,10 +486,24 @@
               }
             }
           },
-          "projects": []
+          "providers": [],
+          "projects": [],
+          "metadata": {
+            "configPath": "",
+            "format": "",
+            "filePresent": false,
+            "revision": "",
+            "rejectedPaths": [],
+            "fields": {}
+          }
         },
         "requestId": "fixture-request-id"
       }
+    },
+    {
+      "id": "config.patch",
+      "status": 200,
+      "sameAs": "config.get"
     },
     {
       "id": "events.list",

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -22,9 +22,12 @@ type ShutdownRuntime interface {
 }
 
 type RuntimeDependencies struct {
-	Config   config.Config
-	Metadata config.LoadFileMetadata
-	Logger   Logger
+	Config        config.Config
+	Metadata      config.LoadFileMetadata
+	InitialConfig config.LoadedFileConfig
+	ReloadConfig  func() (config.LoadedFileConfig, error)
+	LoadConfigAt  func(string) (config.LoadedFileConfig, error)
+	Logger        Logger
 }
 
 type LoadConfigFunc func(config.LoadFileOptions) (config.LoadedFileConfig, error)
@@ -63,11 +66,24 @@ func Bootstrap(ctx context.Context, options Options) (Result, error) {
 	if loadConfig == nil {
 		loadConfig = config.LoadFile
 	}
+	cwd := strings.TrimSpace(options.CWD)
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return Result{}, fmt.Errorf("determine bootstrap working directory: %w", err)
+		}
+	}
+	env := cloneEnvironment(options.Env)
+	if options.Env == nil {
+		env = currentEnvironment()
+	}
+	args := append([]string(nil), options.Args...)
 
 	loadedConfig, err := loadConfig(config.LoadFileOptions{
-		CWD:       options.CWD,
-		Args:      options.Args,
-		LookupEnv: envLookupFromMap(options.Env),
+		CWD:       cwd,
+		Args:      args,
+		LookupEnv: envLookupFromMap(env),
 	})
 	if err != nil {
 		return Result{}, err
@@ -109,10 +125,35 @@ func Bootstrap(ctx context.Context, options Options) (Result, error) {
 		return result, nil
 	}
 
+	reloadOptions := config.LoadFileOptions{
+		CWD:                cwd,
+		Args:               append([]string(nil), args...),
+		LookupEnv:          envLookupFromMap(env),
+		ConfigPathOverride: loadedConfig.Metadata.ConfigPath,
+	}
+	loadReloadCandidate := func(loadOptions config.LoadFileOptions) (config.LoadedFileConfig, error) {
+		candidate, err := loadConfig(loadOptions)
+		if err != nil {
+			return config.LoadedFileConfig{}, err
+		}
+		if err := validateConfiguredToolPaths(candidate.Config, candidate.Metadata.ToolDetection); err != nil {
+			return config.LoadedFileConfig{}, err
+		}
+		return candidate, nil
+	}
 	runtime, err := options.StartRuntime(ctx, RuntimeDependencies{
-		Config:   loadedConfig.Config,
-		Metadata: loadedConfig.Metadata,
-		Logger:   logger,
+		Config:        loadedConfig.Config,
+		Metadata:      loadedConfig.Metadata,
+		InitialConfig: loadedConfig,
+		ReloadConfig: func() (config.LoadedFileConfig, error) {
+			return loadReloadCandidate(reloadOptions)
+		},
+		LoadConfigAt: func(path string) (config.LoadedFileConfig, error) {
+			options := reloadOptions
+			options.ConfigPathOverride = path
+			return loadReloadCandidate(options)
+		},
+		Logger: logger,
 	})
 	if err != nil {
 		return Result{}, err
@@ -158,6 +199,7 @@ func validateConfiguredToolPaths(cfg config.Config, detection map[string]config.
 	}{
 		{statusKey: "gitPath", field: "tools.gitPath", path: cfg.Tools.GitPath},
 		{statusKey: "ghPath", field: "tools.ghPath", path: cfg.Tools.GHPath},
+		{statusKey: "looperPath", field: "tools.looperPath", path: cfg.Tools.LooperPath},
 		{statusKey: "osascriptPath", field: "tools.osascriptPath", path: cfg.Tools.OsascriptPath},
 	}
 	for _, check := range checks {
@@ -282,4 +324,26 @@ func envLookupFromMap(env map[string]string) config.EnvLookupFunc {
 		value, ok := env[key]
 		return value, ok
 	}
+}
+
+func cloneEnvironment(env map[string]string) map[string]string {
+	if env == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(env))
+	for key, value := range env {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func currentEnvironment() map[string]string {
+	env := make(map[string]string)
+	for _, entry := range os.Environ() {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	return env
 }

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -44,8 +44,8 @@ func TestBootstrapLoadsConfigEnsuresPathsCreatesLoggerAndStartsRuntime(t *testin
 		Args: []string{"--port", "9999"},
 		Env:  map[string]string{"LOOPER_CONFIG": "/tmp/override.json"},
 		LoadConfig: func(options config.LoadFileOptions) (config.LoadedFileConfig, error) {
-			if options.CWD != "" {
-				t.Fatalf("LoadConfigOptions.CWD = %q, want empty string", options.CWD)
+			if options.CWD == "" {
+				t.Fatal("LoadConfigOptions.CWD is empty, want frozen bootstrap working directory")
 			}
 			if got, ok := options.LookupEnv("LOOPER_CONFIG"); !ok || got != "/tmp/override.json" {
 				t.Fatalf("LookupEnv(LOOPER_CONFIG) = (%q, %t), want (/tmp/override.json, true)", got, ok)

--- a/internal/bootstrap/config_reload_dependencies_test.go
+++ b/internal/bootstrap/config_reload_dependencies_test.go
@@ -1,0 +1,133 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestBootstrapSuppliesExactValidatedReloadLoaders(t *testing.T) {
+	root := t.TempDir()
+	bootstrapCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(bootstrapCWD) })
+	loaded := config.LoadedFileConfig{
+		Config: config.Config{
+			Storage: config.StorageConfig{DBPath: filepath.Join(root, "data", "looper.sqlite")},
+			Logging: config.LoggingConfig{Level: config.LogLevelInfo, MaxSizeMB: 1, MaxFiles: 1},
+			Daemon: config.DaemonConfig{
+				LogDir:           filepath.Join(root, "logs"),
+				WorkingDirectory: root,
+			},
+		},
+		Metadata: config.LoadFileMetadata{ConfigPath: filepath.Join(root, "config.toml")},
+	}
+	wantArgs := []string{"--port", "19100"}
+	args := append([]string(nil), wantArgs...)
+	env := map[string]string{"LOOPER_MAX_CONCURRENT_RUNS": "7"}
+	loadCalls := 0
+
+	_, err = Bootstrap(context.Background(), Options{
+		Args: args,
+		Env:  env,
+		LoadConfig: func(options config.LoadFileOptions) (config.LoadedFileConfig, error) {
+			loadCalls++
+			if !reflect.DeepEqual(options.Args, wantArgs) {
+				t.Fatalf("LoadFileOptions.Args = %#v, want frozen %#v", options.Args, wantArgs)
+			}
+			if got, ok := options.LookupEnv("LOOPER_MAX_CONCURRENT_RUNS"); !ok || got != "7" {
+				t.Fatalf("LookupEnv() = (%q, %v), want frozen (7, true)", got, ok)
+			}
+			if options.CWD != bootstrapCWD {
+				t.Fatalf("LoadFileOptions.CWD = %q, want frozen %q", options.CWD, bootstrapCWD)
+			}
+			if loadCalls == 1 && options.ConfigPathOverride != "" {
+				t.Fatalf("initial ConfigPathOverride = %q, want empty", options.ConfigPathOverride)
+			}
+			if loadCalls == 2 && options.ConfigPathOverride != loaded.Metadata.ConfigPath {
+				t.Fatalf("reload ConfigPathOverride = %q, want pinned %q", options.ConfigPathOverride, loaded.Metadata.ConfigPath)
+			}
+			candidate := loaded
+			if options.ConfigPathOverride != "" && options.ConfigPathOverride != loaded.Metadata.ConfigPath {
+				candidate.Metadata.ConfigPath = options.ConfigPathOverride
+				return candidate, nil
+			}
+			if loadCalls > 1 {
+				missing := filepath.Join(root, "missing-osascript")
+				candidate.Config.Tools.OsascriptPath = &missing
+				candidate.Metadata.ToolDetection = map[string]config.ToolDetectionStatus{
+					"osascriptPath": config.ToolDetectionStatusConfigured,
+				}
+			}
+			return candidate, nil
+		},
+		CreateLogger: func(config.LoggingConfig, string, LoggerOptions) (Logger, error) {
+			return &recordingLogger{}, nil
+		},
+		StartRuntime: func(_ context.Context, deps RuntimeDependencies) (Runtime, error) {
+			if deps.ReloadConfig == nil || deps.LoadConfigAt == nil {
+				t.Fatal("dynamic config loaders were not supplied")
+			}
+			if !reflect.DeepEqual(deps.InitialConfig, loaded) {
+				t.Fatalf("InitialConfig = %#v, want %#v", deps.InitialConfig, loaded)
+			}
+			args[0] = "--host"
+			env["LOOPER_MAX_CONCURRENT_RUNS"] = "99"
+			if err := os.Chdir(t.TempDir()); err != nil {
+				t.Fatalf("Chdir() error = %v", err)
+			}
+			_, reloadErr := deps.ReloadConfig()
+			var validationErr *config.ConfigValidationError
+			if !errors.As(reloadErr, &validationErr) || len(validationErr.Issues) != 1 || validationErr.Issues[0].Path != "tools.osascriptPath" {
+				t.Fatalf("ReloadConfig() error = %#v, want tools.osascriptPath validation", reloadErr)
+			}
+			candidatePath := filepath.Join(root, "candidate.toml")
+			candidate, loadErr := deps.LoadConfigAt(candidatePath)
+			if loadErr != nil {
+				t.Fatalf("LoadConfigAt() error = %v", loadErr)
+			}
+			if candidate.Metadata.ConfigPath != candidatePath {
+				t.Fatalf("LoadConfigAt().ConfigPath = %q, want %q", candidate.Metadata.ConfigPath, candidatePath)
+			}
+			return struct{}{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+	if loadCalls != 3 {
+		t.Fatalf("LoadConfig() calls = %d, want initial, reload, and candidate", loadCalls)
+	}
+}
+
+func TestValidateConfiguredToolPathsRejectsMissingHotTool(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "missing-tool")
+	for _, testCase := range []struct {
+		name      string
+		field     string
+		statusKey string
+		configure func(*config.Config)
+	}{
+		{name: "looper", field: "tools.looperPath", statusKey: "looperPath", configure: func(cfg *config.Config) { cfg.Tools.LooperPath = &missing }},
+		{name: "osascript", field: "tools.osascriptPath", statusKey: "osascriptPath", configure: func(cfg *config.Config) { cfg.Tools.OsascriptPath = &missing }},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.Config{}
+			testCase.configure(&cfg)
+			err := validateConfiguredToolPaths(cfg, map[string]config.ToolDetectionStatus{testCase.statusKey: config.ToolDetectionStatusConfigured})
+			var validationErr *config.ConfigValidationError
+			if !errors.As(err, &validationErr) || len(validationErr.Issues) != 1 || validationErr.Issues[0].Path != testCase.field {
+				t.Fatalf("validateConfiguredToolPaths() error = %#v, want %s validation", err, testCase.field)
+			}
+		})
+	}
+}

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/forge"
 	"github.com/spf13/cobra"
 )
 
@@ -744,6 +745,12 @@ func splitLogLines(content string) []string {
 }
 
 func (r *commandRuntime) loadConfig() (config.LoadedFileConfig, error) {
+	if loaded, configured, err := forge.LoadTrustedReviewConfigSnapshot(); configured {
+		if err != nil {
+			return config.LoadedFileConfig{}, err
+		}
+		return loaded, nil
+	}
 	loaded, err := config.LoadFile(config.LoadFileOptions{Args: ExtractConfigArgs(r.argv)})
 	if err != nil {
 		return config.LoadedFileConfig{}, err

--- a/internal/cliapp/trusted_review_config_test.go
+++ b/internal/cliapp/trusted_review_config_test.go
@@ -1,0 +1,65 @@
+package cliapp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/forge"
+)
+
+func TestCommandRuntimeTrustedReviewConfigIgnoresChildPrecedenceLayers(t *testing.T) {
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	capturedGHPath := filepath.Join(t.TempDir(), "daemon-cli-gh")
+	cfg.Tools.GHPath = &capturedGHPath
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal(config snapshot) error = %v", err)
+	}
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error = %v", err)
+	}
+	writeDone := make(chan error, 1)
+	go func() {
+		_, writeErr := writer.Write(raw)
+		if closeErr := writer.Close(); writeErr == nil {
+			writeErr = closeErr
+		}
+		writeDone <- writeErr
+	}()
+
+	// In a real proxy child the conflicting LOOPER_GH_PATH may originate in
+	// daemon ambient env or captured Agent.Env; neither may re-apply over the
+	// daemon's already materialized CLI winner. Provider credentials remain
+	// ordinary child env because the selected transport still needs them.
+	t.Setenv("LOOPER_TRUSTED_REVIEW_PROXY_CHILD", "1")
+	t.Setenv(forge.TrustedReviewConfigFDEnv, strconv.FormatUint(uint64(reader.Fd()), 10))
+	t.Setenv("LOOPER_GH_PATH", filepath.Join(t.TempDir(), "agent-env-gh"))
+	t.Setenv("FORGEJO_TOKEN", "provider-credential")
+	runtime := &commandRuntime{argv: []string{"review", "submit", "acme/looper#42", "--gh-path", filepath.Join(t.TempDir(), "child-cli-gh")}}
+	loaded, err := runtime.loadConfig()
+	// LoadTrustedReviewConfigSnapshot owns and closes the inherited descriptor.
+	// Mark this test's original os.File wrapper closed immediately so its later
+	// finalizer cannot close an unrelated descriptor that the OS reused.
+	_ = reader.Close()
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if loaded.Config.Tools.GHPath == nil || *loaded.Config.Tools.GHPath != capturedGHPath {
+		t.Fatalf("loadConfig().Tools.GHPath = %v, want captured daemon CLI winner %q", loaded.Config.Tools.GHPath, capturedGHPath)
+	}
+	if got := os.Getenv("FORGEJO_TOKEN"); got != "provider-credential" {
+		t.Fatalf("FORGEJO_TOKEN after loadConfig() = %q, want provider credential preserved", got)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatalf("write config snapshot error = %v", err)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,9 @@ func TestLoadFileUsesDefaultsWhenConfigMissing(t *testing.T) {
 	if loaded.Metadata.ConfigFilePresent {
 		t.Fatal("LoadFile().Metadata.ConfigFilePresent = true, want false")
 	}
+	if got, want := loaded.Metadata.ConfigFileRevision, ConfigFileRevision(nil, false); got != want {
+		t.Fatalf("LoadFile().Metadata.ConfigFileRevision = %q, want %q", got, want)
+	}
 
 	if loaded.Config.Server.Host != "127.0.0.1" {
 		t.Fatalf("LoadFile().Config.Server.Host = %q, want default %q", loaded.Config.Server.Host, "127.0.0.1")
@@ -57,7 +60,8 @@ func TestLoadFileUsesDefaultsWhenConfigMissing(t *testing.T) {
 func TestLoadFileUsesDefaultsWhenConfigFileIsTopLevelNull(t *testing.T) {
 	cwd := t.TempDir()
 	configPath := filepath.Join(cwd, "config.json")
-	if err := os.WriteFile(configPath, []byte(`null`), 0o644); err != nil {
+	raw := []byte(`null`)
+	if err := os.WriteFile(configPath, raw, 0o644); err != nil {
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}
 
@@ -72,6 +76,9 @@ func TestLoadFileUsesDefaultsWhenConfigFileIsTopLevelNull(t *testing.T) {
 	}
 	if !loaded.Metadata.ConfigFilePresent {
 		t.Fatal("LoadFile().Metadata.ConfigFilePresent = false, want true")
+	}
+	if got, want := loaded.Metadata.ConfigFileRevision, ConfigFileRevision(raw, true); got != want {
+		t.Fatalf("LoadFile().Metadata.ConfigFileRevision = %q, want %q", got, want)
 	}
 	if loaded.Partial != (PartialConfig{}) {
 		t.Fatalf("LoadFile().Partial = %#v, want empty config", loaded.Partial)
@@ -672,6 +679,13 @@ func TestAgentTimeoutConfigOverrides(t *testing.T) {
 	got := loaded.Config.Agent.Timeouts
 	if got.PlannerSeconds != 1200 || got.PlannerMaxRuntimeSeconds != 1200 || got.WorkerSeconds != 4200 || got.WorkerMaxRuntimeSeconds != 4200 || got.ReviewerSeconds != 2100 || got.ReviewerMaxRuntimeSeconds != 2100 || got.FixerSeconds != 1800 || got.FixerMaxRuntimeSeconds != 1800 {
 		t.Fatalf("agent timeouts = %#v", got)
+	}
+	if loaded.Partial.Agent == nil || loaded.Partial.Agent.Timeouts == nil {
+		t.Fatalf("loaded raw timeout partial = %#v", loaded.Partial.Agent)
+	}
+	rawTimeouts := loaded.Partial.Agent.Timeouts
+	if rawTimeouts.PlannerMaxRuntimeSeconds != nil || rawTimeouts.WorkerMaxRuntimeSeconds != nil || rawTimeouts.ReviewerMaxRuntimeSeconds != nil || rawTimeouts.FixerMaxRuntimeSeconds != nil {
+		t.Fatalf("LoadFile mutated raw legacy timeout partial with canonical aliases: %#v", rawTimeouts)
 	}
 }
 

--- a/internal/config/field_patch.go
+++ b/internal/config/field_patch.go
@@ -1,0 +1,310 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+type fieldPatchOperation struct {
+	path string
+	kind string
+}
+
+// ApplyFieldPatch applies canonical dotted-path edits to a detached copy of
+// base. Set values are JSON fragments; unset removes an explicitly configured
+// value so normal precedence can reveal the lower layer again.
+//
+// The complete result is decoded through the regular strict config decoder.
+// Unknown fields, incompatible values, duplicate unsets, and overlapping
+// parent/child operations are rejected before the caller can persist it.
+func ApplyFieldPatch(base PartialConfig, set map[string]json.RawMessage, unset []string) (PartialConfig, error) {
+	operations, err := validateFieldPatchOperations(set, unset)
+	if err != nil {
+		return PartialConfig{}, err
+	}
+
+	root, err := partialConfigJSONMap(base)
+	if err != nil {
+		return PartialConfig{}, err
+	}
+
+	for _, operation := range operations {
+		switch operation.kind {
+		case "set":
+			value, err := decodeFieldPatchValue(set[operation.path])
+			if err != nil {
+				return PartialConfig{}, fmt.Errorf("set %q: %w", operation.path, err)
+			}
+			if err := setConfigMapPath(root, configFieldPathSegments(operation.path), value); err != nil {
+				return PartialConfig{}, fmt.Errorf("set %q: %w", operation.path, err)
+			}
+		case "unset":
+			if err := unsetConfigMapPath(root, configFieldPathSegments(operation.path)); err != nil {
+				return PartialConfig{}, fmt.Errorf("unset %q: %w", operation.path, err)
+			}
+		}
+	}
+
+	raw, err := json.Marshal(root)
+	if err != nil {
+		return PartialConfig{}, fmt.Errorf("encode patched config: %w", err)
+	}
+	patched, err := decodeJSONConfigFile(raw)
+	if err != nil {
+		return PartialConfig{}, fmt.Errorf("decode patched config: %w", err)
+	}
+	return patched, nil
+}
+
+func validateFieldPatchOperations(set map[string]json.RawMessage, unset []string) ([]fieldPatchOperation, error) {
+	setPaths := make([]string, 0, len(set))
+	for path := range set {
+		setPaths = append(setPaths, path)
+	}
+	sort.Strings(setPaths)
+
+	operations := make([]fieldPatchOperation, 0, len(set)+len(unset))
+	seen := make(map[string]string, len(set)+len(unset))
+	add := func(path string, kind string) error {
+		if err := validateFieldPatchPath(path); err != nil {
+			return fmt.Errorf("%s %q: %w", kind, path, err)
+		}
+		if previous, exists := seen[path]; exists {
+			if previous == kind {
+				return fmt.Errorf("duplicate %s path %q", kind, path)
+			}
+			return fmt.Errorf("path %q cannot be both set and unset", path)
+		}
+		seen[path] = kind
+		operations = append(operations, fieldPatchOperation{path: path, kind: kind})
+		return nil
+	}
+
+	for _, path := range setPaths {
+		if err := add(path, "set"); err != nil {
+			return nil, err
+		}
+	}
+	for _, path := range unset {
+		if err := add(path, "unset"); err != nil {
+			return nil, err
+		}
+	}
+
+	// Every ancestor must end at one of the child's dots. Looking those prefixes
+	// up in the existing operation map is linear in total path depth instead of
+	// comparing every operation pair (large agent.env patches can contain many
+	// thousands of independent keys).
+	for _, operation := range operations {
+		for index := strings.IndexByte(operation.path, '.'); index >= 0; {
+			ancestor := operation.path[:index]
+			if _, exists := seen[ancestor]; exists {
+				return nil, fmt.Errorf("conflicting patch paths %q and %q", ancestor, operation.path)
+			}
+			next := strings.IndexByte(operation.path[index+1:], '.')
+			if next < 0 {
+				break
+			}
+			index += next + 1
+		}
+	}
+
+	sort.SliceStable(operations, func(left int, right int) bool {
+		if operations[left].kind != operations[right].kind {
+			return operations[left].kind == "set"
+		}
+		return operations[left].path < operations[right].path
+	})
+	return operations, nil
+}
+
+func validateFieldPatchPath(path string) error {
+	if path == "" {
+		return fmt.Errorf("path must not be empty")
+	}
+	if path != strings.TrimSpace(path) {
+		return fmt.Errorf("path must not have surrounding whitespace")
+	}
+	segments := configFieldPathSegments(path)
+	for _, segment := range segments {
+		if segment == "" {
+			return fmt.Errorf("path contains an empty segment")
+		}
+		if segment != strings.TrimSpace(segment) {
+			return fmt.Errorf("path segment %q has surrounding whitespace", segment)
+		}
+	}
+	return validateFieldPatchPathType(reflect.TypeOf(PartialConfig{}), segments)
+}
+
+// IsFieldLevelConfigPath reports whether path identifies a scalar, a complete
+// list, or one dynamic map entry. Object and map-container replacement is too
+// broad for the curated dashboard patch contract.
+func IsFieldLevelConfigPath(path string) bool {
+	if err := validateFieldPatchPath(path); err != nil {
+		return false
+	}
+	return isFieldLevelConfigPathType(reflect.TypeOf(PartialConfig{}), configFieldPathSegments(path))
+}
+
+func isFieldLevelConfigPathType(current reflect.Type, segments []string) bool {
+	for current.Kind() == reflect.Pointer {
+		current = current.Elem()
+	}
+	if len(segments) == 0 {
+		return current.Kind() != reflect.Struct && current.Kind() != reflect.Map && current.Kind() != reflect.Interface
+	}
+
+	switch current.Kind() {
+	case reflect.Struct:
+		for index := 0; index < current.NumField(); index++ {
+			field := current.Field(index)
+			name := strings.Split(field.Tag.Get("json"), ",")[0]
+			if name == "" {
+				name = field.Name
+			}
+			if name != "-" && name == segments[0] {
+				return isFieldLevelConfigPathType(field.Type, segments[1:])
+			}
+		}
+		return false
+	case reflect.Map:
+		if current.Key().Kind() != reflect.String || len(segments) != 1 || segments[0] == "" {
+			return false
+		}
+		return isFieldLevelConfigPathType(current.Elem(), nil)
+	case reflect.Interface:
+		return false
+	default:
+		return false
+	}
+}
+
+// Config paths use unescaped dots as separators. Environment-variable names
+// are validated separately and therefore cannot contain dots.
+func configFieldPathSegments(path string) []string {
+	return strings.Split(path, ".")
+}
+
+func validateFieldPatchPathType(current reflect.Type, segments []string) error {
+	for current.Kind() == reflect.Pointer {
+		current = current.Elem()
+	}
+	if len(segments) == 0 {
+		return nil
+	}
+
+	switch current.Kind() {
+	case reflect.Struct:
+		for index := 0; index < current.NumField(); index++ {
+			field := current.Field(index)
+			name := strings.Split(field.Tag.Get("json"), ",")[0]
+			if name == "" {
+				name = field.Name
+			}
+			if name == "-" || name != segments[0] {
+				continue
+			}
+			if len(segments) == 1 {
+				return nil
+			}
+			return validateFieldPatchPathType(field.Type, segments[1:])
+		}
+		return fmt.Errorf("unknown config field %q", segments[0])
+	case reflect.Map:
+		if current.Key().Kind() != reflect.String {
+			return fmt.Errorf("config map does not use string keys")
+		}
+		if len(segments) == 1 {
+			return nil
+		}
+		return validateFieldPatchPathType(current.Elem(), segments[1:])
+	case reflect.Interface:
+		return nil
+	case reflect.Slice, reflect.Array:
+		return fmt.Errorf("cannot address inside a config list; set or unset the complete list")
+	default:
+		return fmt.Errorf("cannot address inside scalar config field")
+	}
+}
+
+func partialConfigJSONMap(partial PartialConfig) (map[string]any, error) {
+	raw, err := json.Marshal(partial)
+	if err != nil {
+		return nil, fmt.Errorf("encode config for patch: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var root map[string]any
+	if err := decoder.Decode(&root); err != nil {
+		return nil, fmt.Errorf("decode config for patch: %w", err)
+	}
+	if root == nil {
+		root = map[string]any{}
+	}
+	return root, nil
+}
+
+func decodeFieldPatchValue(raw json.RawMessage) (any, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, fmt.Errorf("value must contain one JSON value")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, fmt.Errorf("invalid JSON value: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("value must contain one JSON value")
+	}
+	return value, nil
+}
+
+func setConfigMapPath(root map[string]any, segments []string, value any) error {
+	current := root
+	for index, segment := range segments {
+		if index == len(segments)-1 {
+			current[segment] = value
+			return nil
+		}
+		child, exists := current[segment]
+		if !exists || child == nil {
+			next := map[string]any{}
+			current[segment] = next
+			current = next
+			continue
+		}
+		next, ok := child.(map[string]any)
+		if !ok {
+			return fmt.Errorf("path segment %q contains a non-object value", segment)
+		}
+		current = next
+	}
+	return nil
+}
+
+func unsetConfigMapPath(root map[string]any, segments []string) error {
+	current := root
+	for index, segment := range segments {
+		if index == len(segments)-1 {
+			delete(current, segment)
+			return nil
+		}
+		child, exists := current[segment]
+		if !exists || child == nil {
+			return nil
+		}
+		next, ok := child.(map[string]any)
+		if !ok {
+			return fmt.Errorf("path segment %q contains a non-object value", segment)
+		}
+		current = next
+	}
+	return nil
+}

--- a/internal/config/field_patch_test.go
+++ b/internal/config/field_patch_test.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestValidateFieldPatchOperationsScalesAcrossIndependentMapKeys(t *testing.T) {
+	t.Parallel()
+
+	set := make(map[string]json.RawMessage, 20_000)
+	for index := 0; index < 20_000; index++ {
+		set[fmt.Sprintf("agent.env.KEY_%05d", index)] = json.RawMessage(`"value"`)
+	}
+	operations, err := validateFieldPatchOperations(set, nil)
+	if err != nil {
+		t.Fatalf("validateFieldPatchOperations() error = %v", err)
+	}
+	if len(operations) != len(set) {
+		t.Fatalf("operations = %d, want %d", len(operations), len(set))
+	}
+}
+
+func TestApplyFieldPatchPreservesUnrelatedConfig(t *testing.T) {
+	t.Parallel()
+
+	host := "127.0.0.1"
+	port := 17310
+	allowPush := true
+	labels := []string{"old"}
+	base := PartialConfig{
+		Server:   &PartialServerConfig{Host: &host, Port: &port},
+		Defaults: &PartialDefaultsConfig{AllowAutoPush: &allowPush},
+		Agent: &PartialAgentConfig{
+			Env:    map[string]string{"TOKEN": "old", "REMOVE": "gone"},
+			Params: map[string]any{"nested": map[string]any{"value": "old"}},
+		},
+		Roles: &PartialRoleConfigs{Planner: &PartialPlannerRoleConfig{Triggers: &PartialIssueRoleTriggersConfig{Labels: &labels}}},
+	}
+
+	patched, err := ApplyFieldPatch(base, map[string]json.RawMessage{
+		"defaults.allowAutoPush":        json.RawMessage(`false`),
+		"agent.env.TOKEN":               json.RawMessage(`"new"`),
+		"agent.params.nested.value":     json.RawMessage(`"changed"`),
+		"roles.planner.triggers.labels": json.RawMessage(`["one","two"]`),
+	}, []string{"server.host", "agent.env.REMOVE"})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+
+	if patched.Server == nil || patched.Server.Host != nil || patched.Server.Port == nil || *patched.Server.Port != port {
+		t.Fatalf("patched.Server = %#v, want only host unset", patched.Server)
+	}
+	if patched.Defaults == nil || patched.Defaults.AllowAutoPush == nil || *patched.Defaults.AllowAutoPush {
+		t.Fatalf("patched.Defaults = %#v, want allowAutoPush false", patched.Defaults)
+	}
+	if patched.Agent == nil || patched.Agent.Env["TOKEN"] != "new" {
+		t.Fatalf("patched.Agent.Env = %#v, want TOKEN replaced", patched.Agent)
+	}
+	if _, exists := patched.Agent.Env["REMOVE"]; exists {
+		t.Fatalf("patched.Agent.Env = %#v, want REMOVE deleted", patched.Agent.Env)
+	}
+	nested := patched.Agent.Params["nested"].(map[string]any)
+	if nested["value"] != "changed" {
+		t.Fatalf("patched.Agent.Params = %#v, want nested patch", patched.Agent.Params)
+	}
+	if patched.Roles == nil || patched.Roles.Planner == nil || patched.Roles.Planner.Triggers == nil || patched.Roles.Planner.Triggers.Labels == nil || !reflect.DeepEqual(*patched.Roles.Planner.Triggers.Labels, []string{"one", "two"}) {
+		t.Fatalf("patched roles = %#v, want replaced labels", patched.Roles)
+	}
+
+	if base.Server.Host == nil || *base.Server.Host != host || base.Agent.Env["TOKEN"] != "old" || base.Agent.Params["nested"].(map[string]any)["value"] != "old" || !reflect.DeepEqual(*base.Roles.Planner.Triggers.Labels, []string{"old"}) {
+		t.Fatalf("ApplyFieldPatch() mutated base: %#v", base)
+	}
+}
+
+func TestApplyFieldPatchCreatesAgentEnvEntry(t *testing.T) {
+	t.Parallel()
+
+	patched, err := ApplyFieldPatch(PartialConfig{}, map[string]json.RawMessage{
+		"agent.env.NEW_TOKEN": json.RawMessage(`"secret"`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	if patched.Agent == nil || patched.Agent.Env["NEW_TOKEN"] != "secret" {
+		t.Fatalf("patched.Agent = %#v, want new environment entry", patched.Agent)
+	}
+}
+
+func TestIsFieldLevelConfigPathRejectsCompositeOperations(t *testing.T) {
+	t.Parallel()
+	for _, path := range []string{"agent.model", "agent.env.TOKEN", "agent.timeouts.workerSeconds", "roles.planner.triggers.labels"} {
+		if !IsFieldLevelConfigPath(path) {
+			t.Fatalf("IsFieldLevelConfigPath(%q) = false, want true", path)
+		}
+	}
+	for _, path := range []string{"agent", "agent.env", "agent.timeouts", "roles", "roles.planner", "roles.planner.triggers"} {
+		if IsFieldLevelConfigPath(path) {
+			t.Fatalf("IsFieldLevelConfigPath(%q) = true, want false", path)
+		}
+	}
+}
+
+func TestApplyFieldPatchRejectsInvalidOperations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		base    PartialConfig
+		set     map[string]json.RawMessage
+		unset   []string
+		message string
+	}{
+		{name: "empty path", set: map[string]json.RawMessage{"": json.RawMessage(`true`)}, message: "path must not be empty"},
+		{name: "empty segment", set: map[string]json.RawMessage{"agent..model": json.RawMessage(`"x"`)}, message: "empty segment"},
+		{name: "unknown field", set: map[string]json.RawMessage{"agent.unknown": json.RawMessage(`true`)}, message: "unknown config field"},
+		{name: "wrong case", set: map[string]json.RawMessage{"Agent.model": json.RawMessage(`"x"`)}, message: "unknown config field"},
+		{name: "inside list", set: map[string]json.RawMessage{"notifications.osascript.soundForLevels.0": json.RawMessage(`"failure"`)}, message: "complete list"},
+		{name: "inside scalar map value", set: map[string]json.RawMessage{"agent.env.TOKEN.extra": json.RawMessage(`"x"`)}, message: "scalar config field"},
+		{name: "invalid json", set: map[string]json.RawMessage{"agent.model": json.RawMessage(`{"bad"`)}, message: "invalid JSON value"},
+		{name: "trailing json", set: map[string]json.RawMessage{"agent.model": json.RawMessage(`"one" "two"`)}, message: "one JSON value"},
+		{name: "wrong value type", set: map[string]json.RawMessage{"defaults.allowAutoPush": json.RawMessage(`"yes"`)}, message: "cannot unmarshal string"},
+		{name: "duplicate unset", unset: []string{"agent.model", "agent.model"}, message: "duplicate unset path"},
+		{name: "set and unset", set: map[string]json.RawMessage{"agent.model": json.RawMessage(`"x"`)}, unset: []string{"agent.model"}, message: "both set and unset"},
+		{name: "parent child set", set: map[string]json.RawMessage{"agent.env": json.RawMessage(`{}`), "agent.env.TOKEN": json.RawMessage(`"x"`)}, message: "conflicting patch paths"},
+		{name: "parent unset child set", set: map[string]json.RawMessage{"roles.planner.autoDiscovery": json.RawMessage(`true`)}, unset: []string{"roles.planner"}, message: "conflicting patch paths"},
+		{
+			name:    "existing dynamic scalar cannot be descended",
+			base:    PartialConfig{Agent: &PartialAgentConfig{Params: map[string]any{"value": "scalar"}}},
+			set:     map[string]json.RawMessage{"agent.params.value.child": json.RawMessage(`true`)},
+			message: "non-object value",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ApplyFieldPatch(test.base, test.set, test.unset)
+			if err == nil || !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("ApplyFieldPatch() error = %v, want message containing %q", err, test.message)
+			}
+		})
+	}
+}
+
+func TestApplyFieldPatchValidUnsetMissingFieldIsNoop(t *testing.T) {
+	t.Parallel()
+
+	patched, err := ApplyFieldPatch(PartialConfig{}, nil, []string{"agent.model"})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	if !reflect.DeepEqual(patched, PartialConfig{}) {
+		t.Fatalf("ApplyFieldPatch() = %#v, want empty config", patched)
+	}
+}

--- a/internal/config/file_format.go
+++ b/internal/config/file_format.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -16,25 +17,263 @@ func ReadPartialConfigFile(path string) (PartialConfig, bool, error) {
 	return readConfigFile(path)
 }
 
-func MarshalConfigFile(path string, value any) ([]byte, error) {
+// DecodePartialConfigFile decodes exactly the supplied bytes using the normal
+// config-file rules. Callers that already captured a file revision use this to
+// avoid a second, independently racing read.
+func DecodePartialConfigFile(path string, raw []byte) (PartialConfig, error) {
+	if err := validateConfigFileSuffix(path); err != nil {
+		return PartialConfig{}, err
+	}
+	return decodeConfigFile(path, raw)
+}
+
+// MarshalPatchedConfigFile writes the patched typed sections back into the
+// original top-level document. Unknown top-level extension sections are kept;
+// the selected format is still normalized by MarshalConfigFile, so comments
+// and lexical ordering are not preserved.
+func MarshalPatchedConfigFile(path string, original []byte, originalPresent bool, patched PartialConfig, paths []string) ([]byte, error) {
+	root := map[string]any{}
+	if originalPresent {
+		decoded, err := decodeGenericConfigDocument(path, original)
+		if err != nil {
+			return nil, err
+		}
+		root = decoded
+	}
+
+	patchedRoot, err := partialConfigJSONMap(patched)
+	if err != nil {
+		return nil, err
+	}
+	sections := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		section := strings.SplitN(path, ".", 2)[0]
+		if section != "" {
+			sections[section] = struct{}{}
+		}
+	}
+	for section := range sections {
+		deleteConfigDocumentKeyFold(root, section)
+		if value, ok := patchedRoot[section]; ok {
+			// Known config sections came through a JSON-number-preserving typed
+			// patch. Normalize only those replacement values for TOML/YAML. Leave
+			// every untouched extension value in its decoder-native type so dates,
+			// times, uint64 values, and other format-specific scalars survive.
+			root[section] = normalizeJSONNumbers(value)
+		}
+	}
+	// Canonical dashboard edits also retire any deprecated file-layer aliases
+	// that could otherwise continue to win after an unset. Only the mapped leaf
+	// is removed; unrelated legacy fields and extension sections are preserved.
+	for _, path := range paths {
+		for _, alias := range configPatchLegacyAliases(path) {
+			unsetConfigDocumentPathFold(root, strings.Split(alias, "."))
+		}
+	}
+	return marshalConfigFileValue(path, root)
+}
+
+func configPatchLegacyAliases(path string) []string {
+	switch path {
+	case "agent.timeouts.plannerMaxRuntimeSeconds":
+		return []string{"agent.timeouts.plannerSeconds"}
+	case "agent.timeouts.workerMaxRuntimeSeconds":
+		return []string{"agent.timeouts.workerSeconds"}
+	case "agent.timeouts.reviewerMaxRuntimeSeconds":
+		return []string{"agent.timeouts.reviewerSeconds"}
+	case "agent.timeouts.fixerMaxRuntimeSeconds":
+		return []string{"agent.timeouts.fixerSeconds"}
+	case "roles.fixer.triggers.authorFilter":
+		return []string{"defaults.fixAllPullRequests"}
+	}
+
+	const behavior = "roles.reviewer.behavior."
+	if strings.HasPrefix(path, behavior) {
+		suffix := strings.TrimPrefix(path, behavior)
+		aliases := []string{"reviewer." + suffix}
+		if path == behavior+"reviewEvents.clean" {
+			aliases = append(aliases, "defaults.allowAutoApprove")
+		}
+		if path == behavior+"detectDuplicateFindings" {
+			aliases = append(aliases,
+				"reviewer.dedupeFindings",
+				"roles.reviewer.behavior.dedupeFindings",
+			)
+		}
+		return aliases
+	}
+
+	const discovery = "roles.reviewer.discovery."
+	if strings.HasPrefix(path, discovery) {
+		return []string{"roles.reviewer." + strings.TrimPrefix(path, discovery)}
+	}
+	return nil
+}
+
+func unsetConfigDocumentPathFold(root map[string]any, segments []string) {
+	current := root
+	for index, segment := range segments {
+		key := ""
+		for candidate := range current {
+			if strings.EqualFold(candidate, segment) {
+				key = candidate
+				break
+			}
+		}
+		if key == "" {
+			return
+		}
+		if index == len(segments)-1 {
+			delete(current, key)
+			return
+		}
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			return
+		}
+		current = next
+	}
+}
+
+func decodeGenericConfigDocument(path string, raw []byte) (map[string]any, error) {
 	if err := validateConfigFileSuffix(path); err != nil {
 		return nil, err
 	}
+	decoded := map[string]any{}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		if err := rejectDuplicateJSONNames(raw); err != nil {
+			return nil, err
+		}
+		decoder := json.NewDecoder(bytes.NewReader(raw))
+		decoder.UseNumber()
+		if err := decoder.Decode(&decoded); err != nil {
+			return nil, err
+		}
+		if err := decoder.Decode(&struct{}{}); err != io.EOF {
+			return nil, fmt.Errorf("trailing JSON value")
+		}
+	case ".yaml", ".yml":
+		if err := yaml.Unmarshal(raw, &decoded); err != nil {
+			return nil, err
+		}
+	case ".toml":
+		if err := toml.Unmarshal(raw, &decoded); err != nil {
+			return nil, err
+		}
+	}
+	if decoded == nil {
+		decoded = map[string]any{}
+	}
+	return decoded, nil
+}
 
+func rejectDuplicateJSONNames(raw []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := consumeUniqueJSONValue(decoder); err != nil {
+		return err
+	}
+	if token, err := decoder.Token(); err != io.EOF {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("trailing JSON token %v", token)
+	}
+	return nil
+}
+
+// ValidateUniqueJSONNames rejects ambiguous JSON objects before a last-key-wins
+// decoder can hide duplicate request or config fields.
+func ValidateUniqueJSONNames(raw []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	for {
+		err := consumeUniqueJSONValue(decoder)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func consumeUniqueJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, structured := token.(json.Delim)
+	if !structured {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		seen := map[string]struct{}{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("invalid JSON object key")
+			}
+			if _, exists := seen[key]; exists {
+				return fmt.Errorf("duplicate JSON object name %q", key)
+			}
+			seen[key] = struct{}{}
+			if err := consumeUniqueJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	case '[':
+		for decoder.More() {
+			if err := consumeUniqueJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+	}
+}
+
+func deleteConfigDocumentKeyFold(root map[string]any, canonical string) {
+	for key := range root {
+		if strings.EqualFold(key, canonical) {
+			delete(root, key)
+		}
+	}
+}
+
+func MarshalConfigFile(path string, value any) ([]byte, error) {
 	normalized, err := normalizeConfigEncodingValue(value)
 	if err != nil {
+		return nil, err
+	}
+	return marshalConfigFileValue(path, normalized)
+}
+
+func marshalConfigFileValue(path string, value any) ([]byte, error) {
+	if err := validateConfigFileSuffix(path); err != nil {
 		return nil, err
 	}
 
 	var (
 		raw []byte
+		err error
 	)
 	if strings.EqualFold(filepath.Ext(path), ".json") {
-		raw, err = json.MarshalIndent(normalized, "", "  ")
+		raw, err = json.MarshalIndent(value, "", "  ")
 	} else if strings.EqualFold(filepath.Ext(path), ".yaml") || strings.EqualFold(filepath.Ext(path), ".yml") {
-		raw, err = yaml.Marshal(normalized)
+		raw, err = yaml.Marshal(value)
 	} else {
-		raw, err = toml.Marshal(normalized)
+		raw, err = toml.Marshal(value)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("encode config: %w", err)

--- a/internal/config/format_roundtrip_test.go
+++ b/internal/config/format_roundtrip_test.go
@@ -66,6 +66,133 @@ func TestMarshalConfigFilePreservesIntegerTOMLNumbers(t *testing.T) {
 	}
 }
 
+func TestMarshalPatchedConfigFilePreservesUnknownNativeScalars(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		raw  string
+	}{
+		{
+			name: "json large integer",
+			path: "config.json",
+			raw:  `{"scheduler":{"maxConcurrentRuns":2},"x-extension":{"huge":18446744073709551615}}`,
+		},
+		{
+			name: "yaml timestamp and unsigned integer",
+			path: "config.yaml",
+			raw:  "scheduler:\n  maxConcurrentRuns: 2\nx-extension:\n  releasedAt: 2026-07-16T09:30:00Z\n  huge: 18446744073709551615\n",
+		},
+		{
+			name: "toml date and datetime",
+			path: "config.toml",
+			raw:  "[scheduler]\nmaxConcurrentRuns = 2\n\n[x-extension]\nreleaseDate = 2026-07-16\nreleasedAt = 2026-07-16T09:30:00Z\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			partial, err := DecodePartialConfigFile(tc.path, []byte(tc.raw))
+			if err != nil {
+				t.Fatalf("DecodePartialConfigFile() error = %v", err)
+			}
+			patched, err := ApplyFieldPatch(partial, map[string]json.RawMessage{
+				"scheduler.maxConcurrentRuns": json.RawMessage("3"),
+			}, nil)
+			if err != nil {
+				t.Fatalf("ApplyFieldPatch() error = %v", err)
+			}
+			encoded, err := MarshalPatchedConfigFile(tc.path, []byte(tc.raw), true, patched, []string{"scheduler.maxConcurrentRuns"})
+			if err != nil {
+				t.Fatalf("MarshalPatchedConfigFile() error = %v", err)
+			}
+			before, err := decodeGenericConfigDocument(tc.path, []byte(tc.raw))
+			if err != nil {
+				t.Fatalf("decode original extension error = %v", err)
+			}
+			after, err := decodeGenericConfigDocument(tc.path, encoded)
+			if err != nil {
+				t.Fatalf("decode patched extension error = %v\n%s", err, encoded)
+			}
+			if !reflect.DeepEqual(after["x-extension"], before["x-extension"]) {
+				t.Fatalf("unknown extension changed type or value\nbefore: %#v\nafter:  %#v\nencoded:\n%s", before["x-extension"], after["x-extension"], encoded)
+			}
+		})
+	}
+}
+
+func TestMarshalPatchedConfigFileRemovesOnlyShadowingLegacyAliases(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+  "agent":{"timeouts":{"workerSeconds":600}},
+  "defaults":{"allowAutoApprove":true,"fixAllPullRequests":true,"allowAutoPush":false},
+  "reviewer":{"reviewEvents":{"clean":"APPROVE","blocking":"REQUEST_CHANGES"},"dedupeFindings":true},
+  "roles":{"reviewer":{"autoDiscovery":false,"behavior":{"dedupeFindings":true}}}
+}`)
+	partial, err := DecodePartialConfigFile("config.json", raw)
+	if err != nil {
+		t.Fatalf("DecodePartialConfigFile() error = %v", err)
+	}
+	set := map[string]json.RawMessage{
+		"agent.timeouts.workerMaxRuntimeSeconds":          json.RawMessage("700"),
+		"roles.fixer.triggers.authorFilter":               json.RawMessage(`"current_user"`),
+		"roles.reviewer.discovery.autoDiscovery":          json.RawMessage("true"),
+		"roles.reviewer.behavior.reviewEvents.clean":      json.RawMessage(`"COMMENT"`),
+		"roles.reviewer.behavior.detectDuplicateFindings": json.RawMessage("false"),
+	}
+	patched, err := ApplyFieldPatch(partial, set, nil)
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	paths := make([]string, 0, len(set))
+	for path := range set {
+		paths = append(paths, path)
+	}
+	encoded, err := MarshalPatchedConfigFile("config.json", raw, true, patched, paths)
+	if err != nil {
+		t.Fatalf("MarshalPatchedConfigFile() error = %v", err)
+	}
+	root, err := decodeGenericConfigDocument("config.json", encoded)
+	if err != nil {
+		t.Fatalf("decode patched document: %v\n%s", err, encoded)
+	}
+	assertDocumentPathMissing(t, root, "agent.timeouts.workerSeconds")
+	assertDocumentPathMissing(t, root, "defaults.allowAutoApprove")
+	assertDocumentPathMissing(t, root, "defaults.fixAllPullRequests")
+	assertDocumentPathMissing(t, root, "reviewer.reviewEvents.clean")
+	assertDocumentPathMissing(t, root, "reviewer.dedupeFindings")
+	assertDocumentPathMissing(t, root, "roles.reviewer.autoDiscovery")
+	assertDocumentPathMissing(t, root, "roles.reviewer.behavior.dedupeFindings")
+	if got := root["reviewer"].(map[string]any)["reviewEvents"].(map[string]any)["blocking"]; got != "REQUEST_CHANGES" {
+		t.Fatalf("unrelated legacy reviewer blocking event = %#v", got)
+	}
+	if got := root["defaults"].(map[string]any)["allowAutoPush"]; got != false {
+		t.Fatalf("unrelated defaults.allowAutoPush = %#v", got)
+	}
+}
+
+func assertDocumentPathMissing(t *testing.T, root map[string]any, path string) {
+	t.Helper()
+	current := root
+	segments := strings.Split(path, ".")
+	for index, segment := range segments {
+		value, exists := current[segment]
+		if !exists {
+			return
+		}
+		if index == len(segments)-1 {
+			t.Fatalf("document path %q still exists with value %#v", path, value)
+		}
+		next, ok := value.(map[string]any)
+		if !ok {
+			return
+		}
+		current = next
+	}
+}
+
 func canonicalRoundTripFixtureConfig() Config {
 	baseURL := "https://looper.example.test"
 	localToken := "local-token"

--- a/internal/config/hot_reload.go
+++ b/internal/config/hot_reload.go
@@ -1,0 +1,328 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+var hotEditablePaths = map[string]struct{}{
+	"agent.vendor": {},
+	"agent.model":  {},
+	"agent.env":    {},
+	"agent.timeouts.plannerIdleTimeoutSeconds":  {},
+	"agent.timeouts.plannerMaxRuntimeSeconds":   {},
+	"agent.timeouts.workerIdleTimeoutSeconds":   {},
+	"agent.timeouts.workerMaxRuntimeSeconds":    {},
+	"agent.timeouts.reviewerIdleTimeoutSeconds": {},
+	"agent.timeouts.reviewerMaxRuntimeSeconds":  {},
+	"agent.timeouts.fixerIdleTimeoutSeconds":    {},
+	"agent.timeouts.fixerMaxRuntimeSeconds":     {},
+
+	"scheduler.maxConcurrentRuns":       {},
+	"scheduler.slowLaneWarnThresholdMs": {},
+
+	"notifications.inApp":                           {},
+	"notifications.osascript.enabled":               {},
+	"notifications.osascript.soundForLevels":        {},
+	"notifications.osascript.throttleWindowSeconds": {},
+	"disclosure.enabled":                            {},
+	"disclosure.includeAgent":                       {},
+	"disclosure.includeOS":                          {},
+	"disclosure.channels.gitCommit":                 {},
+	"disclosure.channels.pullRequest":               {},
+	"disclosure.channels.issueComment":              {},
+	"disclosure.channels.reviewComment":             {},
+	"disclosure.channels.inlineCommentVisible":      {},
+	"defaults.allowAutoCommit":                      {},
+	"defaults.allowAutoPush":                        {},
+	"defaults.allowRiskyFixes":                      {},
+	"defaults.openPrStrategy":                       {},
+	"defaults.addSnapshotMode":                      {},
+	"instructions.enabled":                          {},
+
+	"roles.planner.autoDiscovery":                                          {},
+	"roles.planner.triggers.labels":                                        {},
+	"roles.planner.triggers.labelMode":                                     {},
+	"roles.planner.triggers.requireAssigneeCurrentUser":                    {},
+	"roles.planner.instructions":                                           {},
+	"roles.worker.autoDiscovery":                                           {},
+	"roles.worker.triggers.labels":                                         {},
+	"roles.worker.triggers.labelMode":                                      {},
+	"roles.worker.triggers.requireAssigneeCurrentUser":                     {},
+	"roles.worker.triggers.planeAssigneeId":                                {},
+	"roles.worker.instructions":                                            {},
+	"roles.fixer.autoDiscovery":                                            {},
+	"roles.fixer.triggers.includeDrafts":                                   {},
+	"roles.fixer.triggers.authorFilter":                                    {},
+	"roles.fixer.triggers.labels":                                          {},
+	"roles.fixer.triggers.labelMode":                                       {},
+	"roles.fixer.instructions":                                             {},
+	"roles.reviewer.discovery.autoDiscovery":                               {},
+	"roles.reviewer.discovery.triggers.includeDrafts":                      {},
+	"roles.reviewer.discovery.triggers.requireReviewRequest":               {},
+	"roles.reviewer.discovery.triggers.enableSelfReview":                   {},
+	"roles.reviewer.discovery.triggers.labels":                             {},
+	"roles.reviewer.discovery.triggers.labelMode":                          {},
+	"roles.reviewer.discovery.specReview.includeReviewingLabel":            {},
+	"roles.reviewer.discovery.specReview.reviewingLabel":                   {},
+	"roles.reviewer.behavior.loop.enabledByDefault":                        {},
+	"roles.reviewer.behavior.loop.maxIterationsPerPR":                      {},
+	"roles.reviewer.behavior.loop.maxIterationsPerHead":                    {},
+	"roles.reviewer.behavior.loop.maxWallClockSeconds":                     {},
+	"roles.reviewer.behavior.loop.maxConsecutiveFailures":                  {},
+	"roles.reviewer.behavior.loop.maxAgentExecutionsPerPR":                 {},
+	"roles.reviewer.behavior.loop.stopOnApproved":                          {},
+	"roles.reviewer.behavior.loop.stopOnReadyLabel":                        {},
+	"roles.reviewer.behavior.loop.stopOnIdenticalOutput":                   {},
+	"roles.reviewer.behavior.retry.enhancedTransientClassification":        {},
+	"roles.reviewer.behavior.retry.extraTransientErrorPatterns":            {},
+	"roles.reviewer.behavior.retry.recoverExistingMatchedFailures":         {},
+	"roles.reviewer.behavior.retry.autoRecoveryMaxAttempts":                {},
+	"roles.reviewer.behavior.scope":                                        {},
+	"roles.reviewer.behavior.publishMode":                                  {},
+	"roles.reviewer.behavior.reviewEvents.clean":                           {},
+	"roles.reviewer.behavior.reviewEvents.blocking":                        {},
+	"roles.reviewer.behavior.detectDuplicateFindings":                      {},
+	"roles.reviewer.behavior.nativeResume.onHeadChange":                    {},
+	"roles.reviewer.behavior.nativeResume.reReviewPromptOnHeadChange":      {},
+	"roles.reviewer.behavior.threadResolution.enabled":                     {},
+	"roles.reviewer.behavior.threadResolution.mode":                        {},
+	"roles.reviewer.behavior.threadResolution.scope":                       {},
+	"roles.reviewer.behavior.threadResolution.autoResolve":                 {},
+	"roles.reviewer.behavior.threadResolution.requireAuditComment":         {},
+	"roles.reviewer.behavior.threadResolution.requireNewHeadSinceThread":   {},
+	"roles.reviewer.behavior.threadResolution.requireCurrentReviewRequest": {},
+	"roles.reviewer.behavior.threadResolution.maxThreadsPerRun":            {},
+	"roles.reviewer.instructions":                                          {},
+	"roles.coordinator.pollInterval":                                       {},
+	"roles.coordinator.triage.triagedLabel":                                {},
+	"roles.coordinator.triage.maxIssueAgeDays":                             {},
+	"roles.coordinator.triage.maxPerTick":                                  {},
+	"roles.coordinator.triage.disposition.outOfScopeLabel":                 {},
+	"roles.coordinator.triage.disposition.unclearLabel":                    {},
+	"roles.coordinator.triage.disposition.reTriageOnAuthorReply":           {},
+	"roles.coordinator.dispatch.mode":                                      {},
+	"roles.coordinator.dispatch.humanGate.slashCommands":                   {},
+	"roles.coordinator.dispatch.humanGate.allowedUsers":                    {},
+	"roles.coordinator.dispatch.autonomous.delayMinutes":                   {},
+	"roles.coordinator.dispatch.autonomous.holdLabel":                      {},
+	"roles.coordinator.dispatch.assignTo":                                  {},
+	"roles.coordinator.mergeWatch.maxIndeterminateDuration":                {},
+
+	"tools.looperPath":    {},
+	"tools.osascriptPath": {},
+}
+
+// hotReloadCompatibilityPaths are deprecated representations normalized into
+// curated hot fields. They are accepted by the file watcher so changing or
+// removing an alias alongside its canonical field does not make that safe
+// policy edit spuriously restart-bound. They remain absent from
+// IsHotEditablePath, so the dashboard/API can only write canonical names.
+var hotReloadCompatibilityPaths = map[string]struct{}{
+	"agent.timeouts.plannerSeconds":  {},
+	"agent.timeouts.workerSeconds":   {},
+	"agent.timeouts.reviewerSeconds": {},
+	"agent.timeouts.fixerSeconds":    {},
+	"defaults.allowAutoApprove":      {},
+	"defaults.fixAllPullRequests":    {},
+}
+
+// IsHotEditablePath reports whether path belongs to the deliberately small
+// configuration surface that can change without replacing process-owned
+// resources. Paths use canonical JSON field names joined with dots.
+func IsHotEditablePath(path string) bool {
+	if path == "" || path != strings.TrimSpace(path) || hasEmptyPathSegment(path) {
+		return false
+	}
+
+	if _, ok := hotEditablePaths[path]; ok {
+		return true
+	}
+	return strings.HasPrefix(path, "agent.env.") && len(strings.TrimPrefix(path, "agent.env.")) > 0
+}
+
+func isHotReloadablePath(path string) bool {
+	if IsHotEditablePath(path) {
+		return true
+	}
+	_, ok := hotReloadCompatibilityPaths[path]
+	return ok
+}
+
+// IsHotReloadCompatibilityPath reports deprecated file-only representations
+// that the watcher normalizes into canonical hot fields. They are intentionally
+// omitted from dashboard metadata; operators edit the canonical field instead.
+func IsHotReloadCompatibilityPath(path string) bool {
+	_, ok := hotReloadCompatibilityPaths[path]
+	return ok
+}
+
+func hasEmptyPathSegment(path string) bool {
+	for _, segment := range strings.Split(path, ".") {
+		if segment == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// RestartRequiredChanges returns sorted, concrete JSON paths whose effective
+// values changed outside the hot-editable surface. Collection values are
+// reported at their field path; object and map values are reported at their
+// changed leaves.
+func RestartRequiredChanges(oldConfig Config, newConfig Config) []string {
+	oldValue := configJSONValue(oldConfig)
+	newValue := configJSONValue(newConfig)
+	changed := make([]string, 0)
+	diffConfigJSON("", oldValue, newValue, &changed)
+
+	restartRequired := make([]string, 0, len(changed))
+	seen := make(map[string]struct{}, len(changed))
+	for _, path := range changed {
+		if path == "" || isHotReloadablePath(path) {
+			continue
+		}
+		if _, exists := seen[path]; exists {
+			continue
+		}
+		seen[path] = struct{}{}
+		restartRequired = append(restartRequired, path)
+	}
+	// Leaving a configured vendor is hot only when its vendor-specific companions
+	// are unambiguous. Reusing a command/args map under another executable is
+	// unsafe, and silently carrying the same explicit model is almost always
+	// accidental. A paired model edit (including clearing it) is explicit.
+	leavingConfiguredVendor := oldConfig.Agent.Vendor != nil && (newConfig.Agent.Vendor == nil || *oldConfig.Agent.Vendor != *newConfig.Agent.Vendor)
+	if leavingConfiguredVendor {
+		if len(newConfig.Agent.Params) > 0 {
+			if _, exists := seen["agent.params"]; !exists {
+				seen["agent.params"] = struct{}{}
+				restartRequired = append(restartRequired, "agent.params")
+			}
+		}
+		if newConfig.Agent.Model != nil && reflect.DeepEqual(oldConfig.Agent.Model, newConfig.Agent.Model) {
+			if _, exists := seen["agent.model"]; !exists {
+				seen["agent.model"] = struct{}{}
+				restartRequired = append(restartRequired, "agent.model")
+			}
+		}
+	}
+	sort.Strings(restartRequired)
+	return restartRequired
+}
+
+// CloneConfig returns a complete detached copy. Config is a JSON configuration
+// model, so a non-JSON-representable value in an interface field is a
+// programming error rather than a recoverable runtime condition.
+func CloneConfig(source Config) Config {
+	raw, err := json.Marshal(source)
+	if err != nil {
+		panic(fmt.Sprintf("clone config: %v", err))
+	}
+	var cloned Config
+	if err := json.Unmarshal(raw, &cloned); err != nil {
+		panic(fmt.Sprintf("clone config: %v", err))
+	}
+	return cloned
+}
+
+func configJSONValue(value Config) any {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		panic(fmt.Sprintf("compare config: %v", err))
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		panic(fmt.Sprintf("compare config: %v", err))
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		panic("compare config: unexpected trailing JSON value")
+	}
+	return decoded
+}
+
+func diffConfigJSON(path string, oldValue any, newValue any, changed *[]string) {
+	oldObject, oldIsObject := oldValue.(map[string]any)
+	newObject, newIsObject := newValue.(map[string]any)
+	if oldIsObject && newIsObject {
+		keys := make([]string, 0, len(oldObject)+len(newObject))
+		seen := make(map[string]struct{}, len(oldObject)+len(newObject))
+		for key := range oldObject {
+			seen[key] = struct{}{}
+			keys = append(keys, key)
+		}
+		for key := range newObject {
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			oldChild, oldExists := oldObject[key]
+			newChild, newExists := newObject[key]
+			childPath := joinConfigPath(path, key)
+			switch {
+			case !oldExists:
+				appendConfigLeafPaths(childPath, newChild, changed)
+			case !newExists:
+				appendConfigLeafPaths(childPath, oldChild, changed)
+			default:
+				diffConfigJSON(childPath, oldChild, newChild, changed)
+			}
+		}
+		return
+	}
+
+	if _, oldIsArray := oldValue.([]any); oldIsArray {
+		if !reflect.DeepEqual(oldValue, newValue) {
+			*changed = append(*changed, path)
+		}
+		return
+	}
+	if _, newIsArray := newValue.([]any); newIsArray {
+		if !reflect.DeepEqual(oldValue, newValue) {
+			*changed = append(*changed, path)
+		}
+		return
+	}
+	if !reflect.DeepEqual(oldValue, newValue) {
+		*changed = append(*changed, path)
+	}
+}
+
+func appendConfigLeafPaths(path string, value any, changed *[]string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		if len(typed) == 0 {
+			*changed = append(*changed, path)
+			return
+		}
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			appendConfigLeafPaths(joinConfigPath(path, key), typed[key], changed)
+		}
+	case []any:
+		*changed = append(*changed, path)
+	default:
+		*changed = append(*changed, path)
+	}
+}
+
+func joinConfigPath(parent string, child string) string {
+	if parent == "" {
+		return child
+	}
+	return parent + "." + child
+}

--- a/internal/config/hot_reload_test.go
+++ b/internal/config/hot_reload_test.go
@@ -1,0 +1,246 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIsHotEditablePathUsesExplicitAllowlist(t *testing.T) {
+	t.Parallel()
+
+	allowed := []string{
+		"agent.vendor",
+		"agent.model",
+		"agent.env",
+		"agent.env.OPENAI_API_KEY",
+		"agent.timeouts.workerMaxRuntimeSeconds",
+		"scheduler.maxConcurrentRuns",
+		"scheduler.slowLaneWarnThresholdMs",
+		"notifications.inApp",
+		"disclosure.channels.gitCommit",
+		"defaults.allowAutoPush",
+		"instructions.enabled",
+		"roles.worker.triggers.planeAssigneeId",
+		"roles.reviewer.behavior.scope",
+		"tools.looperPath",
+		"tools.osascriptPath",
+	}
+	for _, path := range allowed {
+		path := path
+		t.Run("allowed_"+path, func(t *testing.T) {
+			t.Parallel()
+			if !IsHotEditablePath(path) {
+				t.Fatalf("IsHotEditablePath(%q) = false, want true", path)
+			}
+		})
+	}
+
+	rejected := []string{
+		"",
+		" agent.model",
+		"agent",
+		"agent.params",
+		"agent.params.temperature",
+		"agent.nativeResume.enabled",
+		"agent.timeouts.workerSeconds",
+		"scheduler",
+		"scheduler.pollIntervalSeconds",
+		"scheduler.discoveryCacheTtlSeconds",
+		"scheduler.retryMaxAttempts",
+		"scheduler.retryBaseDelayMs",
+		"tools",
+		"tools.gitPath",
+		"tools.ghPath",
+		"server.port",
+		"storage.dbPath",
+		"providers",
+		"projects",
+		"logging.level",
+		"daemon.mode",
+		"package.autoUpgradeEnabled",
+		"webhook.enabled",
+		"network.enrolled",
+		"hitl.github.mentionLogins",
+		"notifications.webhook.verificationTokenEnv",
+		"roles.reviewer.autoMerge.enabled",
+		"roles.coordinator.enabled",
+		"roles.coordinator.dependencies.enabled",
+		"instructions.maxBytes",
+		"defaults.allowAutoMerge",
+		"defaults.baseBranch",
+		"roles.reviewer.behavior.loop.minPublishIntervalSeconds",
+		"roles.reviewer.behavior.loop.quietPeriodSeconds",
+		"roles.reviewer.behavior.retry.maxDelayMs",
+		"roles.planner.triggers.planeAssigneeId",
+		"roles.coordinator.mergeWatch.transientRetries",
+		"roles..planner",
+	}
+	for _, path := range rejected {
+		path := path
+		t.Run("rejected_"+path, func(t *testing.T) {
+			t.Parallel()
+			if IsHotEditablePath(path) {
+				t.Fatalf("IsHotEditablePath(%q) = true, want false", path)
+			}
+		})
+	}
+}
+
+func TestRestartRequiredChangesReturnsConcreteSortedPaths(t *testing.T) {
+	t.Parallel()
+
+	oldConfig, err := DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	newConfig := CloneConfig(oldConfig)
+	newConfig.Server.Port++
+	newConfig.Scheduler.PollIntervalSeconds++
+	newConfig.Scheduler.DiscoveryCacheTTLSeconds++
+	newConfig.Scheduler.RetryMaxAttempts++
+	newConfig.Scheduler.RetryBaseDelayMS++
+	newConfig.Scheduler.MaxConcurrentRuns++
+	newConfig.Agent.Model = stringPtr("hot-model")
+	newConfig.Agent.Params["temperature"] = 0.5
+	newConfig.Tools.GitPath = stringPtr("/restart/git")
+	newConfig.Tools.LooperPath = stringPtr("/hot/looper")
+	newConfig.Logging.Level = LogLevelDebug
+	newConfig.Daemon.Environment["NEW_VAR"] = "value"
+	newConfig.Roles.Planner.Triggers.Labels = []string{"hot-label"}
+	newConfig.Roles.Planner.Triggers.PlaneAssigneeID = "restart-bound-planner-member"
+	newConfig.Roles.Worker.Triggers.PlaneAssigneeID = "hot-worker-member"
+	newConfig.Defaults.BaseBranch = "develop"
+	newConfig.Roles.Coordinator.Enabled = !newConfig.Roles.Coordinator.Enabled
+	newConfig.Providers = append(newConfig.Providers, ProviderConfig{ID: "forgejo", Kind: ProviderKindForgejo})
+	newConfig.Projects = append(newConfig.Projects, ProjectRefConfig{ID: "import"})
+
+	want := []string{
+		"agent.params.temperature",
+		"daemon.environment.NEW_VAR",
+		"defaults.baseBranch",
+		"logging.level",
+		"projects",
+		"providers",
+		"roles.coordinator.enabled",
+		"roles.planner.triggers.planeAssigneeId",
+		"scheduler.discoveryCacheTtlSeconds",
+		"scheduler.pollIntervalSeconds",
+		"scheduler.retryBaseDelayMs",
+		"scheduler.retryMaxAttempts",
+		"server.port",
+		"tools.gitPath",
+	}
+	if got := RestartRequiredChanges(oldConfig, newConfig); !reflect.DeepEqual(got, want) {
+		t.Fatalf("RestartRequiredChanges() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRestartRequiredChangesIgnoresHotOnlyCandidate(t *testing.T) {
+	t.Parallel()
+
+	oldConfig, err := DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	newConfig := CloneConfig(oldConfig)
+	newConfig.Agent.Env["TOKEN"] = "new"
+	newConfig.Notifications.InApp = !newConfig.Notifications.InApp
+	newConfig.Defaults.AllowAutoPush = !newConfig.Defaults.AllowAutoPush
+	newConfig.Disclosure.Enabled = !newConfig.Disclosure.Enabled
+	newConfig.Tools.OsascriptPath = stringPtr("/hot/osascript")
+	newConfig.Agent.Timeouts.WorkerMaxRuntimeSeconds++
+	newConfig.Agent.Timeouts.WorkerSeconds = newConfig.Agent.Timeouts.WorkerMaxRuntimeSeconds
+	newConfig.Defaults.AllowAutoApprove = true
+	newConfig.Roles.Reviewer.Behavior.ReviewEvents.Clean = ReviewerReviewEventApprove
+	newConfig.Defaults.FixAllPullRequests = true
+	newConfig.Roles.Fixer.Triggers.AuthorFilter = FixerAuthorFilterAny
+
+	if got := RestartRequiredChanges(oldConfig, newConfig); len(got) != 0 {
+		t.Fatalf("RestartRequiredChanges() = %#v, want no restart-bound changes", got)
+	}
+}
+
+func TestRestartRequiredChangesGuardsVendorSpecificCompanions(t *testing.T) {
+	t.Parallel()
+
+	base, err := DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	oldVendor := AgentVendorCodex
+	base.Agent.Vendor = &oldVendor
+
+	t.Run("first vendor can activate a preconfigured profile", func(t *testing.T) {
+		old := CloneConfig(base)
+		old.Agent.Vendor = nil
+		old.Agent.Model = stringPtr("gpt-5")
+		old.Agent.Params["command"] = "/opt/codex-wrapper"
+		candidate := CloneConfig(old)
+		vendor := AgentVendorCodex
+		candidate.Agent.Vendor = &vendor
+		if got := RestartRequiredChanges(old, candidate); len(got) != 0 {
+			t.Fatalf("RestartRequiredChanges() = %#v, want no blockers", got)
+		}
+	})
+
+	t.Run("vendor alone is hot when model and params are implicit", func(t *testing.T) {
+		candidate := CloneConfig(base)
+		vendor := AgentVendorClaudeCode
+		candidate.Agent.Vendor = &vendor
+		if got := RestartRequiredChanges(base, candidate); len(got) != 0 {
+			t.Fatalf("RestartRequiredChanges() = %#v, want no blockers", got)
+		}
+	})
+
+	t.Run("unchanged explicit model blocks vendor-only edit", func(t *testing.T) {
+		old := CloneConfig(base)
+		old.Agent.Model = stringPtr("gpt-5")
+		candidate := CloneConfig(old)
+		vendor := AgentVendorClaudeCode
+		candidate.Agent.Vendor = &vendor
+		if got, want := RestartRequiredChanges(old, candidate), []string{"agent.model"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("RestartRequiredChanges() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("paired model edit makes the vendor choice explicit", func(t *testing.T) {
+		old := CloneConfig(base)
+		old.Agent.Model = stringPtr("gpt-5")
+		candidate := CloneConfig(old)
+		vendor := AgentVendorClaudeCode
+		candidate.Agent.Vendor = &vendor
+		candidate.Agent.Model = stringPtr("claude-sonnet")
+		if got := RestartRequiredChanges(old, candidate); len(got) != 0 {
+			t.Fatalf("RestartRequiredChanges() = %#v, want no blockers", got)
+		}
+	})
+
+	t.Run("configured command or args requires restart", func(t *testing.T) {
+		old := CloneConfig(base)
+		old.Agent.Params["command"] = "/opt/codex-wrapper"
+		candidate := CloneConfig(old)
+		vendor := AgentVendorClaudeCode
+		candidate.Agent.Vendor = &vendor
+		if got, want := RestartRequiredChanges(old, candidate), []string{"agent.params"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("RestartRequiredChanges() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("vendor cannot be cleared to launder a retained profile", func(t *testing.T) {
+		old := CloneConfig(base)
+		old.Agent.Model = stringPtr("gpt-5")
+		old.Agent.Params["command"] = "/opt/codex-wrapper"
+		disabled := CloneConfig(old)
+		disabled.Agent.Vendor = nil
+		if got, want := RestartRequiredChanges(old, disabled), []string{"agent.model", "agent.params"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("RestartRequiredChanges(codex -> nil) = %#v, want %#v", got, want)
+		}
+
+		claude := CloneConfig(disabled)
+		vendor := AgentVendorClaudeCode
+		claude.Agent.Vendor = &vendor
+		if got := RestartRequiredChanges(disabled, claude); len(got) != 0 {
+			t.Fatalf("RestartRequiredChanges(nil -> claude) = %#v, want prepared-profile activation allowed", got)
+		}
+	})
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,7 +26,12 @@ type EnvLookupFunc func(string) (string, bool)
 type LoadFileMetadata struct {
 	ConfigPath        string
 	ConfigFilePresent bool
-	ToolDetection     map[string]ToolDetectionStatus
+	// ConfigFileRevision identifies the exact file generation decoded into this
+	// LoadedFileConfig. Keeping it beside the snapshot prevents a later read from
+	// pairing old effective values with a newer, not-yet-published file hash.
+	ConfigFileRevision string
+	ToolDetection      map[string]ToolDetectionStatus
+	FieldSources       map[string]ValueSource
 }
 
 type LoadedFileConfig struct {
@@ -37,12 +43,16 @@ type LoadedFileConfig struct {
 }
 
 type LoadFileOptions struct {
-	CWD               string
-	ConfigPath        string
-	DefaultConfigPath string
-	Args              []string
-	LookupEnv         EnvLookupFunc
-	LookPath          LookPathFunc
+	CWD        string
+	ConfigPath string
+	// ConfigPathOverride force-selects a file before --config and LOOPER_CONFIG
+	// path selection while retaining their ordinary value overrides. It is used
+	// to validate a temporary dashboard edit under the daemon's startup layers.
+	ConfigPathOverride string
+	DefaultConfigPath  string
+	Args               []string
+	LookupEnv          EnvLookupFunc
+	LookPath           LookPathFunc
 }
 
 type parsedCLIArgs struct {
@@ -80,7 +90,9 @@ func LoadFile(options LoadFileOptions) (LoadedFileConfig, error) {
 	}
 
 	configPath := ""
-	if parsedCLI.hasConfigPath {
+	if options.ConfigPathOverride != "" {
+		configPath = options.ConfigPathOverride
+	} else if parsedCLI.hasConfigPath {
 		configPath = parsedCLI.configPath
 	} else if envConfigPath, ok := lookupEnv("LOOPER_CONFIG"); ok && strings.TrimSpace(envConfigPath) != "" {
 		configPath = envConfigPath
@@ -99,7 +111,7 @@ func LoadFile(options LoadFileOptions) (LoadedFileConfig, error) {
 	}
 
 	resolvedConfigPath := ResolveConfigPath(configPath, cwd)
-	partialConfig, present, err := readConfigFile(resolvedConfigPath)
+	partialConfig, present, revision, err := readConfigFileGeneration(resolvedConfigPath)
 	if err != nil {
 		return LoadedFileConfig{}, err
 	}
@@ -142,9 +154,11 @@ func LoadFile(options LoadFileOptions) (LoadedFileConfig, error) {
 		Warnings: dedupeWarnings(fileWarnings, envWarnings, cliWarnings),
 		Notices:  fileNotices,
 		Metadata: LoadFileMetadata{
-			ConfigPath:        resolvedConfigPath,
-			ConfigFilePresent: present,
-			ToolDetection:     toolDetection.Detection,
+			ConfigPath:         resolvedConfigPath,
+			ConfigFilePresent:  present,
+			ConfigFileRevision: revision,
+			ToolDetection:      toolDetection.Detection,
+			FieldSources:       discoverFieldSources(config, partialConfig, envOverrides, parsedCLI.overrides),
 		},
 	}, nil
 }
@@ -266,25 +280,45 @@ func applyGlobalReviewerEnableSelfReviewOverride(config *Config, partial Partial
 }
 
 func readConfigFile(path string) (PartialConfig, bool, error) {
+	partial, present, _, err := readConfigFileGeneration(path)
+	return partial, present, err
+}
+
+func readConfigFileGeneration(path string) (PartialConfig, bool, string, error) {
 	if err := validateConfigFileSuffix(path); err != nil {
-		return PartialConfig{}, false, err
+		return PartialConfig{}, false, "", err
 	}
 
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return PartialConfig{}, false, nil
+			return PartialConfig{}, false, ConfigFileRevision(nil, false), nil
 		}
 
-		return PartialConfig{}, false, fmt.Errorf("failed to read config file at %s: %w", path, err)
+		return PartialConfig{}, false, "", fmt.Errorf("failed to read config file at %s: %w", path, err)
 	}
+	revision := ConfigFileRevision(raw, true)
 
 	partialConfig, err := decodeConfigFile(path, raw)
 	if err != nil {
-		return PartialConfig{}, true, fmt.Errorf("failed to read config file at %s: %w", path, err)
+		return PartialConfig{}, true, revision, fmt.Errorf("failed to read config file at %s: %w", path, err)
 	}
 
-	return partialConfig, true, nil
+	return partialConfig, true, revision, nil
+}
+
+// ConfigFileRevision returns the equality token used by dashboard reads and
+// patches. File presence is part of the token, so an absent file and an empty
+// file are distinct generations.
+func ConfigFileRevision(raw []byte, present bool) string {
+	marker := "missing\x00"
+	if present {
+		marker = "present\x00"
+	}
+	hasher := sha256.New()
+	_, _ = hasher.Write([]byte(marker))
+	_, _ = hasher.Write(raw)
+	return fmt.Sprintf("sha256:%x", hasher.Sum(nil))
 }
 
 func validateConfigFileSuffix(path string) error {

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -29,6 +29,12 @@ func Normalize(cwd string, partials ...PartialConfig) (Config, error) {
 func CanonicalizePartialForMigration(partial PartialConfig) PartialConfig {
 	normalized := normalizeLayerPartial(clonePartialConfig(partial))
 	normalized.LegacyReviewer = nil
+	if normalized.Agent != nil && normalized.Agent.Timeouts != nil {
+		normalized.Agent.Timeouts.PlannerSeconds = nil
+		normalized.Agent.Timeouts.WorkerSeconds = nil
+		normalized.Agent.Timeouts.ReviewerSeconds = nil
+		normalized.Agent.Timeouts.FixerSeconds = nil
+	}
 
 	if normalized.Defaults != nil {
 		normalized.Defaults.AllowAutoApprove = nil
@@ -60,6 +66,24 @@ func CanonicalizePartialForMigration(partial PartialConfig) PartialConfig {
 
 func normalizeLayerPartial(partial PartialConfig) PartialConfig {
 	normalized := partial
+	if normalized.Agent != nil && normalized.Agent.Timeouts != nil {
+		agent := *normalized.Agent
+		timeouts := *agent.Timeouts
+		agent.Timeouts = &timeouts
+		normalized.Agent = &agent
+		if timeouts.PlannerMaxRuntimeSeconds == nil {
+			timeouts.PlannerMaxRuntimeSeconds = timeouts.PlannerSeconds
+		}
+		if timeouts.WorkerMaxRuntimeSeconds == nil {
+			timeouts.WorkerMaxRuntimeSeconds = timeouts.WorkerSeconds
+		}
+		if timeouts.ReviewerMaxRuntimeSeconds == nil {
+			timeouts.ReviewerMaxRuntimeSeconds = timeouts.ReviewerSeconds
+		}
+		if timeouts.FixerMaxRuntimeSeconds == nil {
+			timeouts.FixerMaxRuntimeSeconds = timeouts.FixerSeconds
+		}
+	}
 
 	if normalized.LegacyReviewer != nil {
 		reviewer := ensureReviewerRoleConfig(&normalized)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -7,12 +7,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
 )
 
 var networkNodeNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+var environmentNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 type ValidationIssue struct {
 	Path    string
@@ -32,12 +34,11 @@ func (err *ConfigValidationError) Error() string {
 		return "config validation failed"
 	}
 
-	if len(err.Issues) == 1 {
-		issue := err.Issues[0]
-		return fmt.Sprintf("config validation failed: %s %s", issue.Path, issue.Message)
+	details := make([]string, 0, len(err.Issues))
+	for _, issue := range err.Issues {
+		details = append(details, strings.TrimSpace(issue.Path+" "+issue.Message))
 	}
-
-	return fmt.Sprintf("config validation failed with %d issues", len(err.Issues))
+	return "config validation failed: " + strings.Join(details, "; ")
 }
 
 func Validate(config Config) error {
@@ -108,6 +109,7 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 	if config.Agent.Vendor != nil && !isValidAgentVendor(*config.Agent.Vendor) {
 		issues = append(issues, ValidationIssue{Path: "agent.vendor", Message: fmt.Sprintf("must be one of: %s, %s, %s, %s, %s", AgentVendorClaudeCode, AgentVendorCodex, AgentVendorOpenCode, AgentVendorCursorCLI, AgentVendorGrokBuild)})
 	}
+	validateEnvironmentNames(config.Agent.Env, "agent.env", &issues)
 	validateAgentTimeouts(config.Agent.Timeouts, "agent.timeouts", &issues)
 
 	if !isValidLogLevel(config.Logging.Level) {
@@ -150,9 +152,31 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 		issues = append(issues, ValidationIssue{Path: "notifications.webhook.mode", Message: "must be one of: webhook, app"})
 	}
 
+	transport := strings.ToLower(strings.TrimSpace(config.HITL.AnswerTransport))
+	switch transport {
+	case "", "github", "respond":
+	case "feishu":
+		if config.HITL.Feishu == nil {
+			issues = append(issues, ValidationIssue{Path: "hitl.feishu", Message: "is required when hitl.answerTransport is feishu"})
+		} else {
+			if !strings.EqualFold(strings.TrimSpace(config.HITL.Feishu.Inbound), "cf-inbox") {
+				issues = append(issues, ValidationIssue{Path: "hitl.feishu.inbound", Message: "must be cf-inbox when hitl.answerTransport is feishu"})
+			}
+			if strings.TrimSpace(config.HITL.Feishu.EventInboxURLEnv) == "" {
+				issues = append(issues, ValidationIssue{Path: "hitl.feishu.eventInboxUrlEnv", Message: "is required when hitl.answerTransport is feishu"})
+			}
+			if strings.TrimSpace(config.HITL.Feishu.EventInboxTokenEnv) == "" {
+				issues = append(issues, ValidationIssue{Path: "hitl.feishu.eventInboxTokenEnv", Message: "is required when hitl.answerTransport is feishu"})
+			}
+		}
+	default:
+		issues = append(issues, ValidationIssue{Path: "hitl.answerTransport", Message: "must be one of: github, feishu, respond"})
+	}
+
 	if !isValidDaemonMode(config.Daemon.Mode) {
 		issues = append(issues, ValidationIssue{Path: "daemon.mode", Message: fmt.Sprintf("must be one of: %s, %s", DaemonModeForeground, DaemonModeLaunchd)})
 	}
+	validateEnvironmentNames(config.Daemon.Environment, "daemon.environment", &issues)
 
 	if !isValidDaemonRestartPolicy(config.Daemon.RestartPolicy) {
 		issues = append(issues, ValidationIssue{Path: "daemon.restartPolicy", Message: fmt.Sprintf("must be one of: %s, %s, %s", DaemonRestartNever, DaemonRestartOnFailure, DaemonRestartAlways)})
@@ -590,6 +614,19 @@ func validateAgentTimeouts(timeouts AgentTimeoutConfig, path string, issues *[]V
 	validateAgentTimeoutSeconds(timeouts.ReviewerMaxRuntimeSeconds, path+".reviewerMaxRuntimeSeconds", issues)
 	validateAgentTimeoutSeconds(timeouts.FixerIdleTimeoutSeconds, path+".fixerIdleTimeoutSeconds", issues)
 	validateAgentTimeoutSeconds(timeouts.FixerMaxRuntimeSeconds, path+".fixerMaxRuntimeSeconds", issues)
+}
+
+func validateEnvironmentNames(values map[string]string, path string, issues *[]ValidationIssue) {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if !environmentNamePattern.MatchString(key) {
+			*issues = append(*issues, ValidationIssue{Path: path + "." + key, Message: "must be a valid environment-variable name"})
+		}
+	}
 }
 
 func validateAgentTimeoutSeconds(seconds int, path string, issues *[]ValidationIssue) {

--- a/internal/config/value_sources.go
+++ b/internal/config/value_sources.go
@@ -1,0 +1,182 @@
+package config
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// ValueSource identifies the winning configuration precedence layer for a
+// canonical field path.
+type ValueSource string
+
+const (
+	ValueSourceDefault    ValueSource = "default"
+	ValueSourceConfigFile ValueSource = "config-file"
+	ValueSourceEnv        ValueSource = "env"
+	ValueSourceCLI        ValueSource = "cli"
+)
+
+func discoverFieldSources(effective Config, file PartialConfig, env PartialConfig, cli PartialConfig) map[string]ValueSource {
+	sources := make(map[string]ValueSource)
+	mapContainers := make(map[string]struct{})
+	collectConfigSchemaPaths(reflect.TypeOf(Config{}), "", sources, mapContainers)
+	collectDynamicConfigPaths(reflect.ValueOf(effective), "", func(path string) {
+		if path != "" {
+			if _, exists := sources[path]; !exists {
+				sources[path] = ValueSourceDefault
+			}
+		}
+	})
+
+	applySource := func(partial PartialConfig, source ValueSource) {
+		normalized := normalizeLayerPartial(clonePartialConfig(partial))
+		collectDynamicConfigPaths(reflect.ValueOf(normalized), "", func(path string) {
+			if isCanonicalSourcePath(path, sources, mapContainers) {
+				sources[path] = source
+			}
+		})
+	}
+	applySource(file, ValueSourceConfigFile)
+	applySource(env, ValueSourceEnv)
+	applySource(cli, ValueSourceCLI)
+	return sources
+}
+
+func collectConfigSchemaPaths(current reflect.Type, path string, sources map[string]ValueSource, mapContainers map[string]struct{}) {
+	for current.Kind() == reflect.Pointer {
+		current = current.Elem()
+	}
+	switch current.Kind() {
+	case reflect.Struct:
+		for index := 0; index < current.NumField(); index++ {
+			field := current.Field(index)
+			name, ok := configJSONFieldName(field)
+			if !ok {
+				continue
+			}
+			collectConfigSchemaPaths(field.Type, joinConfigPath(path, name), sources, mapContainers)
+		}
+	case reflect.Map:
+		if path != "" {
+			sources[path] = ValueSourceDefault
+			mapContainers[path] = struct{}{}
+		}
+	case reflect.Slice, reflect.Array:
+		if path != "" {
+			sources[path] = ValueSourceDefault
+		}
+	default:
+		if path != "" {
+			sources[path] = ValueSourceDefault
+		}
+	}
+}
+
+func collectDynamicConfigPaths(current reflect.Value, path string, visit func(string)) {
+	if !current.IsValid() {
+		return
+	}
+	for current.Kind() == reflect.Interface || current.Kind() == reflect.Pointer {
+		if current.IsNil() {
+			return
+		}
+		current = current.Elem()
+	}
+
+	switch current.Kind() {
+	case reflect.Struct:
+		currentType := current.Type()
+		for index := 0; index < current.NumField(); index++ {
+			fieldType := currentType.Field(index)
+			name, ok := configJSONFieldName(fieldType)
+			if !ok {
+				continue
+			}
+			fieldValue := current.Field(index)
+			if (fieldValue.Kind() == reflect.Pointer || fieldValue.Kind() == reflect.Map || fieldValue.Kind() == reflect.Slice || fieldValue.Kind() == reflect.Interface) && fieldValue.IsNil() {
+				continue
+			}
+			collectDynamicConfigPaths(fieldValue, joinConfigPath(path, name), visit)
+		}
+	case reflect.Map:
+		if path != "" {
+			visit(path)
+		}
+		if current.Type().Key().Kind() != reflect.String {
+			return
+		}
+		keys := current.MapKeys()
+		sort.Slice(keys, func(left int, right int) bool {
+			return keys[left].String() < keys[right].String()
+		})
+		for _, key := range keys {
+			childPath := joinConfigPath(path, key.String())
+			child := current.MapIndex(key)
+			if !child.IsValid() {
+				continue
+			}
+			before := false
+			for value := child; value.IsValid() && (value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer); value = value.Elem() {
+				if value.IsNil() {
+					visit(childPath)
+					before = true
+					break
+				}
+			}
+			if before {
+				continue
+			}
+			kind := dynamicValueKind(child)
+			if kind == reflect.Struct || kind == reflect.Map {
+				collectDynamicConfigPaths(child, childPath, visit)
+			} else {
+				visit(childPath)
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		if path != "" {
+			visit(path)
+		}
+	default:
+		if path != "" {
+			visit(path)
+		}
+	}
+}
+
+func dynamicValueKind(value reflect.Value) reflect.Kind {
+	for value.IsValid() && (value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer) {
+		if value.IsNil() {
+			return reflect.Invalid
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() {
+		return reflect.Invalid
+	}
+	return value.Kind()
+}
+
+func configJSONFieldName(field reflect.StructField) (string, bool) {
+	name := strings.Split(field.Tag.Get("json"), ",")[0]
+	if name == "-" {
+		return "", false
+	}
+	if name == "" {
+		name = field.Name
+	}
+	return name, true
+}
+
+func isCanonicalSourcePath(path string, schema map[string]ValueSource, mapContainers map[string]struct{}) bool {
+	if _, exists := schema[path]; exists {
+		return true
+	}
+	for container := range mapContainers {
+		if strings.HasPrefix(path, container+".") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/value_sources_test.go
+++ b/internal/config/value_sources_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadFileMetadataReportsCanonicalFieldSources(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	raw := `{
+  "agent": {
+    "model": "file-model",
+    "env": {"TOKEN": "must-not-appear-in-metadata"},
+    "timeouts": {"plannerSeconds": 12}
+  },
+  "defaults": {"allowAutoPush": false},
+  "notifications": {"webhook": {"mentionOpenIds": []}}
+}`
+	if err := os.WriteFile(configPath, []byte(raw), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	loaded, err := LoadFile(LoadFileOptions{
+		CWD:        cwd,
+		ConfigPath: configPath,
+		Args:       []string{"--planner-agent-timeout-seconds=99"},
+		LookupEnv: mapEnvLookup(map[string]string{
+			"LOOPER_ALLOW_AUTO_PUSH":                "true",
+			"LOOPER_AGENT_TIMEOUTS_PLANNER_SECONDS": "88",
+		}),
+		LookPath: fakeLookPath(map[string]string{"git": "/git", "gh": "/gh", "osascript": "/osascript"}),
+	})
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+
+	want := map[string]ValueSource{
+		"agent.model":                             ValueSourceConfigFile,
+		"agent.env":                               ValueSourceConfigFile,
+		"agent.env.TOKEN":                         ValueSourceConfigFile,
+		"agent.timeouts.plannerSeconds":           ValueSourceCLI,
+		"agent.timeouts.plannerMaxRuntimeSeconds": ValueSourceCLI,
+		"defaults.allowAutoPush":                  ValueSourceEnv,
+		"notifications.webhook.mentionOpenIds":    ValueSourceConfigFile,
+		"server.port":                             ValueSourceDefault,
+		"server.localToken":                       ValueSourceDefault,
+		"agent.vendor":                            ValueSourceDefault,
+		"hitl.github.awaitingLabel":               ValueSourceDefault,
+		"roles.reviewer.discovery.autoDiscovery":  ValueSourceDefault,
+	}
+	for path, source := range want {
+		if got := loaded.Metadata.FieldSources[path]; got != source {
+			t.Errorf("FieldSources[%q] = %q, want %q", path, got, source)
+		}
+	}
+	for path := range loaded.Metadata.FieldSources {
+		if path == "must-not-appear-in-metadata" {
+			t.Fatalf("FieldSources exposed a configured value: %#v", loaded.Metadata.FieldSources)
+		}
+	}
+}
+
+func TestLoadFileMetadataCanonicalizesLegacyOverridePaths(t *testing.T) {
+	t.Parallel()
+
+	loaded, err := LoadFile(LoadFileOptions{
+		CWD:        t.TempDir(),
+		ConfigPath: filepath.Join(t.TempDir(), "missing.json"),
+		LookupEnv: mapEnvLookup(map[string]string{
+			"LOOPER_ROLES_REVIEWER_AUTO_DISCOVERY": "false",
+			"LOOPER_REVIEWER_LOOP_ENABLED":         "false",
+		}),
+		LookPath: fakeLookPath(map[string]string{"git": "/git", "gh": "/gh", "osascript": "/osascript"}),
+	})
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+
+	if got := loaded.Metadata.FieldSources["roles.reviewer.discovery.autoDiscovery"]; got != ValueSourceEnv {
+		t.Fatalf("canonical reviewer discovery source = %q, want env", got)
+	}
+	if got := loaded.Metadata.FieldSources["roles.reviewer.behavior.loop.enabledByDefault"]; got != ValueSourceEnv {
+		t.Fatalf("canonical reviewer loop source = %q, want env", got)
+	}
+	if _, exists := loaded.Metadata.FieldSources["roles.reviewer.autoDiscovery"]; exists {
+		t.Fatalf("FieldSources contains legacy reviewer path: %#v", loaded.Metadata.FieldSources)
+	}
+	if _, exists := loaded.Metadata.FieldSources["reviewer.loop.enabledByDefault"]; exists {
+		t.Fatalf("FieldSources contains legacy top-level reviewer path: %#v", loaded.Metadata.FieldSources)
+	}
+}
+
+func TestLoadFileConfigPathOverrideWinsSelectionButKeepsOverrides(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	forcedPath := filepath.Join(cwd, "forced.json")
+	cliPath := filepath.Join(cwd, "cli.json")
+	envPath := filepath.Join(cwd, "env.json")
+	optionPath := filepath.Join(cwd, "option.json")
+	files := map[string]string{
+		forcedPath: `{"server":{"host":"forced"}}`,
+		cliPath:    `{"server":{"host":"cli"}}`,
+		envPath:    `{"server":{"host":"env"}}`,
+		optionPath: `{"server":{"host":"option"}}`,
+	}
+	for path, raw := range files {
+		if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+			t.Fatalf("os.WriteFile(%q) error = %v", path, err)
+		}
+	}
+
+	loaded, err := LoadFile(LoadFileOptions{
+		CWD:                cwd,
+		ConfigPath:         optionPath,
+		ConfigPathOverride: forcedPath,
+		Args:               []string{"--config", cliPath, "--allow-auto-push=false"},
+		LookupEnv: mapEnvLookup(map[string]string{
+			"LOOPER_CONFIG":          envPath,
+			"LOOPER_PORT":            "19000",
+			"LOOPER_ALLOW_AUTO_PUSH": "true",
+		}),
+		LookPath: fakeLookPath(map[string]string{"git": "/git", "gh": "/gh", "osascript": "/osascript"}),
+	})
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if loaded.Metadata.ConfigPath != forcedPath || loaded.Config.Server.Host != "forced" {
+		t.Fatalf("LoadFile() selected (%q, %q), want forced path", loaded.Metadata.ConfigPath, loaded.Config.Server.Host)
+	}
+	if loaded.Config.Server.Port != 19000 || loaded.Config.Defaults.AllowAutoPush {
+		t.Fatalf("LoadFile() overrides = port %d, allow push %v; want env port and CLI bool", loaded.Config.Server.Port, loaded.Config.Defaults.AllowAutoPush)
+	}
+	if loaded.Metadata.FieldSources["server.host"] != ValueSourceConfigFile || loaded.Metadata.FieldSources["server.port"] != ValueSourceEnv || loaded.Metadata.FieldSources["defaults.allowAutoPush"] != ValueSourceCLI {
+		t.Fatalf("LoadFile() FieldSources = %#v, want file/env/cli precedence", loaded.Metadata.FieldSources)
+	}
+}

--- a/internal/coordinator/mergewatch_runner.go
+++ b/internal/coordinator/mergewatch_runner.go
@@ -286,12 +286,12 @@ func retriageCleanupPatterns(roles config.RoleConfigs, triagedLabel string) []st
 
 func (r *Runner) watchLock(repo string, issueNumber int64) *sync.Mutex {
 	key := fmt.Sprintf("%s#%d", repo, issueNumber)
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.watchLocks[key] == nil {
-		r.watchLocks[key] = &sync.Mutex{}
+	r.state.mu.Lock()
+	defer r.state.mu.Unlock()
+	if r.state.watchLocks[key] == nil {
+		r.state.watchLocks[key] = &sync.Mutex{}
 	}
-	return r.watchLocks[key]
+	return r.state.watchLocks[key]
 }
 
 func linkedPullRequestNumbers(timeline []map[string]any) []int64 {

--- a/internal/coordinator/runner.go
+++ b/internal/coordinator/runner.go
@@ -100,6 +100,22 @@ type Options struct {
 	Inspector  RepositoryInspector
 	Disclosure *config.DisclosureConfig
 	Network    NetworkGateway
+	State      *RuntimeState
+}
+
+// RuntimeState contains coordinator lifecycle state that must outlive one
+// immutable configuration snapshot. Snapshot-specific policy remains on Runner.
+type RuntimeState struct {
+	mu                sync.Mutex
+	lastTickByProject map[string]time.Time
+	watchLocks        map[string]*sync.Mutex
+}
+
+func NewRuntimeState() *RuntimeState {
+	return &RuntimeState{
+		lastTickByProject: map[string]time.Time{},
+		watchLocks:        map[string]*sync.Mutex{},
+	}
 }
 
 type Runner struct {
@@ -112,10 +128,7 @@ type Runner struct {
 	inspector  RepositoryInspector
 	disclosure *config.DisclosureConfig
 	network    NetworkGateway
-
-	mu                sync.Mutex
-	lastTickByProject map[string]time.Time
-	watchLocks        map[string]*sync.Mutex
+	state      *RuntimeState
 }
 
 type loadedIssue struct {
@@ -159,18 +172,21 @@ func New(options Options) *Runner {
 	if inspector == nil {
 		inspector = localRepositoryInspector{}
 	}
+	state := options.State
+	if state == nil {
+		state = NewRuntimeState()
+	}
 	return &Runner{
-		repos:             options.Repos,
-		github:            options.GitHub,
-		config:            options.Config,
-		logger:            options.Logger,
-		now:               now,
-		triageLLM:         options.TriageLLM,
-		inspector:         inspector,
-		network:           options.Network,
-		disclosure:        options.Disclosure,
-		lastTickByProject: map[string]time.Time{},
-		watchLocks:        map[string]*sync.Mutex{},
+		repos:      options.Repos,
+		github:     options.GitHub,
+		config:     options.Config,
+		logger:     options.Logger,
+		now:        now,
+		triageLLM:  options.TriageLLM,
+		inspector:  inspector,
+		network:    options.Network,
+		disclosure: options.Disclosure,
+		state:      state,
 	}
 }
 
@@ -1783,13 +1799,13 @@ func (r *Runner) shouldRunTick(projectID string) bool {
 		return true
 	}
 	now := r.now().UTC()
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	lastRun, ok := r.lastTickByProject[projectID]
+	r.state.mu.Lock()
+	defer r.state.mu.Unlock()
+	lastRun, ok := r.state.lastTickByProject[projectID]
 	if ok && now.Sub(lastRun) < interval {
 		return false
 	}
-	r.lastTickByProject[projectID] = now
+	r.state.lastTickByProject[projectID] = now
 	return true
 }
 

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -2,8 +2,10 @@ package forge
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -11,7 +13,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
+
+	"github.com/nexu-io/looper/internal/config"
 )
 
 // TrustedReviewSockEnv is the agent-facing env key for the trusted review-submit
@@ -23,6 +28,21 @@ const TrustedReviewSockEnv = "LOOPER_TRUSTED_REVIEW_SOCK"
 // trustedReviewProxySkipEnv marks a proxy-spawned looper child so it does not
 // re-enter the proxy (the child receives provider tokens directly).
 const trustedReviewProxySkipEnv = "LOOPER_TRUSTED_REVIEW_PROXY_CHILD"
+
+// TrustedReviewConfigFDEnv identifies the inherited, read-only pipe containing
+// the exact materialized config snapshot for a trusted review child. The pipe
+// replaces a named temporary file so the same-UID agent cannot discover or
+// rewrite the snapshot between proxy minting and review submission.
+const TrustedReviewConfigFDEnv = "LOOPER_TRUSTED_REVIEW_CONFIG_FD"
+
+const (
+	maxTrustedReviewProxyConnections   = 4
+	maxTrustedReviewProxyRequestBytes  = 2 << 20
+	maxTrustedReviewProxyStdinBytes    = 1 << 20
+	maxTrustedReviewProxyOutputBytes   = 256 << 10
+	maxTrustedReviewProxyResponseBytes = 4 << 20
+	maxTrustedReviewConfigSnapshotSize = 4 << 20
+)
 
 type trustedReviewProxyRequest struct {
 	Argv  []string `json:"argv"`
@@ -47,19 +67,23 @@ func FormatTrustedReviewPRRef(repo string, prNumber int64) string {
 	return fmt.Sprintf("%s#%d", repo, prNumber)
 }
 
-// TrustedReviewProxyPolicy is the daemon-selected clean/blocking review event
-// policy bound into a trusted review-submit proxy for one agent run.
-// Agent-supplied --clean-review-event / --blocking-review-event values are
-// stripped and replaced with this policy before the child runs.
+// TrustedReviewProxyPolicy is the daemon-selected review authority bound into
+// a trusted review-submit proxy for one agent run. Agent-supplied review-event,
+// expected-head, and manual-run identity flags are stripped and replaced with
+// these values before the child runs.
 type TrustedReviewProxyPolicy struct {
-	Clean    string // COMMENT or APPROVE
-	Blocking string // COMMENT or REQUEST_CHANGES
+	Clean            string // COMMENT or APPROVE
+	Blocking         string // COMMENT or REQUEST_CHANGES
+	ExpectedCommitID string
+	ReviewerManual   bool
+	ReviewerRunID    string
 }
 
 // StartTrustedReviewProxy listens on a private Unix socket and runs
-// `looper review submit` in a daemon-side child with optional provider tokens
-// injected. Agents receive only the socket path (via TrustedReviewSockEnv),
-// never a secret-bearing wrapper path or LOOPER_TRUSTED_ENV_FILE.
+// `looper review submit` in a daemon-side child with the run-captured credential
+// environment injected. Agents receive only the socket path (via
+// TrustedReviewSockEnv), never a secret-bearing wrapper path, config snapshot
+// path, or LOOPER_TRUSTED_ENV_FILE.
 //
 // trustedEnv may be empty for tea-backed Forgejo providers that have no
 // tokenEnv. The proxy still binds PR/CWD/policy/config so agents cannot retarget
@@ -73,17 +97,17 @@ type TrustedReviewProxyPolicy struct {
 // processes always use this CWD; request-supplied cwd is ignored so a
 // compromised agent cannot retarget provider-qualified project resolution.
 //
-// configPath is the daemon-loaded config file path (for example from --config).
-// When non-empty it is injected as LOOPER_CONFIG for the child so review submit
-// resolves the same provider/project/review policy as the daemon even when the
-// path was not present in the daemon process environment. Agent-supplied
-// --config remains rejected.
+// configSnapshot is the complete materialized config captured by the run. The
+// proxy sanitizes and retains its encoded bytes in memory, then supplies them
+// to each child through an inherited pipe. The agent receives neither a path
+// nor the snapshot bytes and therefore cannot rewrite the child's authority.
 //
-// policy is the daemon-selected effective review-events policy for the run
-// (including loop-metadata overrides). Agent argv may still include local
-// policy flags for the prompted command shape, but the proxy always rewrites
-// them to this bound policy before spawning the token-injected child.
-func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd, configPath string, policy TrustedReviewProxyPolicy) (sockPath string, cleanup func(), err error) {
+// policy is the daemon-selected effective review-events policy, expected PR
+// head, and manual-run identity for the run (including loop-metadata
+// overrides). Agent argv may still include local flags for the prompted command
+// shape, but the proxy always rewrites them to this bound authority before
+// spawning the credential-injected child.
+func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd string, configSnapshot config.Config, policy TrustedReviewProxyPolicy) (sockPath string, cleanup func(), err error) {
 	realLooper = strings.TrimSpace(realLooper)
 	if realLooper == "" {
 		return "", nil, fmt.Errorf("real looper path is required for trusted review proxy")
@@ -96,13 +120,16 @@ func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, al
 	if err != nil {
 		return "", nil, fmt.Errorf("trusted review proxy allowed CWD: %w", err)
 	}
-	boundConfigPath := strings.TrimSpace(configPath)
 	boundPolicy, err := normalizeTrustedReviewProxyPolicy(policy)
 	if err != nil {
 		return "", nil, fmt.Errorf("trusted review proxy review policy: %w", err)
 	}
 	if _, err := os.Stat(realLooper); err != nil {
 		return "", nil, fmt.Errorf("stat real looper path: %w", err)
+	}
+	boundConfig, err := marshalTrustedReviewConfigSnapshot(configSnapshot)
+	if err != nil {
+		return "", nil, err
 	}
 
 	dir, err := os.MkdirTemp("", "looper-trusted-review-sock-*")
@@ -123,6 +150,16 @@ func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, al
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
+	proxyContext, cancelProxy := context.WithCancel(context.Background())
+	slots := make(chan struct{}, maxTrustedReviewProxyConnections)
+	connections := map[net.Conn]struct{}{}
+	var connectionsMu sync.Mutex
+	closing := false
+	unregister := func(conn net.Conn) {
+		connectionsMu.Lock()
+		delete(connections, conn)
+		connectionsMu.Unlock()
+	}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -136,31 +173,71 @@ func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, al
 					continue
 				}
 			}
+			connectionsMu.Lock()
+			if closing {
+				connectionsMu.Unlock()
+				_ = conn.Close()
+				continue
+			}
+			connections[conn] = struct{}{}
+			connectionsMu.Unlock()
+			select {
+			case slots <- struct{}{}:
+				// continue below
+			default:
+				_ = conn.SetWriteDeadline(time.Now().Add(time.Second))
+				_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: "trusted review proxy is busy"})
+				_ = conn.Close()
+				unregister(conn)
+				continue
+			}
 			wg.Add(1)
 			go func(c net.Conn) {
 				defer wg.Done()
-				handleTrustedReviewProxyConn(c, realLooper, trustedEnv, normalizedAllowed, boundCwd, boundConfigPath, boundPolicy)
+				defer func() { <-slots }()
+				defer unregister(c)
+				handleTrustedReviewProxyConn(proxyContext, c, realLooper, trustedEnv, normalizedAllowed, boundCwd, boundConfig, boundPolicy)
 			}(conn)
 		}
 	}()
 
+	var cleanupOnce sync.Once
 	cleanup = func() {
-		close(stop)
-		_ = listener.Close()
-		wg.Wait()
-		_ = os.RemoveAll(dir)
+		cleanupOnce.Do(func() {
+			cancelProxy()
+			connectionsMu.Lock()
+			closing = true
+			for conn := range connections {
+				_ = conn.Close()
+			}
+			connectionsMu.Unlock()
+			close(stop)
+			_ = listener.Close()
+			wg.Wait()
+			_ = os.RemoveAll(dir)
+		})
 	}
 	return sockPath, cleanup, nil
 }
 
-func handleTrustedReviewProxyConn(conn net.Conn, realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd, configPath string, policy TrustedReviewProxyPolicy) {
+func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd string, configSnapshot []byte, policy TrustedReviewProxyPolicy) {
 	defer func() { _ = conn.Close() }()
 	_ = conn.SetDeadline(time.Now().Add(2 * time.Minute))
 
 	var req trustedReviewProxyRequest
-	decoder := json.NewDecoder(conn)
+	limited := &io.LimitedReader{R: conn, N: maxTrustedReviewProxyRequestBytes + 1}
+	decoder := json.NewDecoder(limited)
+	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&req); err != nil {
-		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: "decode trusted review proxy request: " + err.Error()})
+		message := "decode trusted review proxy request: " + err.Error()
+		if limited.N <= 0 {
+			message = "trusted review proxy request exceeds size limit"
+		}
+		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: message})
+		return
+	}
+	if len(req.Stdin) > maxTrustedReviewProxyStdinBytes {
+		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: "trusted review proxy stdin exceeds size limit"})
 		return
 	}
 	if err := validateTrustedReviewProxyArgv(req.Argv, allowedPRRef); err != nil {
@@ -172,16 +249,47 @@ func handleTrustedReviewProxyConn(conn net.Conn, realLooper string, trustedEnv m
 	// agent argv. Rewrite local policy flags after shape/PR validation.
 	childArgv := applyTrustedReviewProxyPolicy(req.Argv, policy)
 	cmd := exec.Command(realLooper, childArgv...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configReader, configWriter, err := os.Pipe()
+	if err != nil {
+		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: "create trusted review config pipe: " + err.Error()})
+		return
+	}
+	cmd.ExtraFiles = []*os.File{configReader}
 	// Never honor request-supplied cwd: project/provider resolution for
 	// provider-qualified same-owner/repo checkouts is CWD-sensitive. The child
 	// always runs in the daemon-selected worktree bound at proxy start.
 	cmd.Dir = allowedCwd
-	cmd.Env = trustedReviewProxyChildEnv(trustedEnv, configPath)
+	cmd.Env = trustedReviewProxyChildEnv(trustedEnv, 3)
 	cmd.Stdin = bytes.NewReader(req.Stdin)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
+	stdout := newTrustedReviewBoundedBuffer(maxTrustedReviewProxyOutputBytes)
+	stderr := newTrustedReviewBoundedBuffer(maxTrustedReviewProxyOutputBytes)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		_ = configReader.Close()
+		_ = configWriter.Close()
+		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: err.Error()})
+		return
+	}
+	_ = configReader.Close()
+	configWriteDone := make(chan error, 1)
+	go func() {
+		_, writeErr := io.Copy(configWriter, bytes.NewReader(configSnapshot))
+		if closeErr := configWriter.Close(); writeErr == nil {
+			writeErr = closeErr
+		}
+		configWriteDone <- writeErr
+	}()
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+	select {
+	case err = <-waitDone:
+	case <-ctx.Done():
+		_ = killTrustedReviewProxyChild(cmd)
+		err = <-waitDone
+	}
+	configWriteErr := <-configWriteDone
 	resp := trustedReviewProxyResponse{Stdout: stdout.String(), Stderr: stderr.String()}
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -191,7 +299,27 @@ func handleTrustedReviewProxyConn(conn net.Conn, realLooper string, trustedEnv m
 			resp.Error = err.Error()
 		}
 	}
+	if stdout.Truncated() || stderr.Truncated() {
+		resp.ExitCode = 1
+		resp.Error = "trusted review proxy child output exceeds size limit"
+	} else if configWriteErr != nil && err == nil {
+		resp.ExitCode = 1
+		resp.Error = "write trusted review config snapshot: " + configWriteErr.Error()
+	}
 	_ = json.NewEncoder(conn).Encode(resp)
+}
+
+func killTrustedReviewProxyChild(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	pid := cmd.Process.Pid
+	if pid > 0 {
+		if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil || err == syscall.ESRCH {
+			return nil
+		}
+	}
+	return cmd.Process.Kill()
 }
 
 // trustedReviewProxyBlockedFlags are CLI overrides that must never be accepted
@@ -370,6 +498,8 @@ func normalizeTrustedReviewCwd(value string) (string, error) {
 func normalizeTrustedReviewProxyPolicy(policy TrustedReviewProxyPolicy) (TrustedReviewProxyPolicy, error) {
 	clean := strings.ToUpper(strings.TrimSpace(policy.Clean))
 	blocking := strings.ToUpper(strings.TrimSpace(policy.Blocking))
+	expectedCommitID := strings.TrimSpace(policy.ExpectedCommitID)
+	reviewerRunID := strings.TrimSpace(policy.ReviewerRunID)
 	switch clean {
 	case "COMMENT", "APPROVE":
 	default:
@@ -380,7 +510,16 @@ func normalizeTrustedReviewProxyPolicy(policy TrustedReviewProxyPolicy) (Trusted
 	default:
 		return TrustedReviewProxyPolicy{}, fmt.Errorf("blocking review event must be COMMENT or REQUEST_CHANGES")
 	}
-	return TrustedReviewProxyPolicy{Clean: clean, Blocking: blocking}, nil
+	if expectedCommitID == "" {
+		return TrustedReviewProxyPolicy{}, fmt.Errorf("expected commit id is required")
+	}
+	if policy.ReviewerManual && reviewerRunID == "" {
+		return TrustedReviewProxyPolicy{}, fmt.Errorf("manual reviewer run id is required")
+	}
+	return TrustedReviewProxyPolicy{
+		Clean: clean, Blocking: blocking, ExpectedCommitID: expectedCommitID,
+		ReviewerManual: policy.ReviewerManual, ReviewerRunID: reviewerRunID,
+	}, nil
 }
 
 // applyTrustedReviewProxyPolicy strips agent-supplied local review-policy flags
@@ -388,10 +527,15 @@ func normalizeTrustedReviewProxyPolicy(policy TrustedReviewProxyPolicy) (Trusted
 // markers against daemon-selected policy only.
 func applyTrustedReviewProxyPolicy(argv []string, policy TrustedReviewProxyPolicy) []string {
 	stripped := stripTrustedReviewProxyPolicyFlags(argv)
-	return append(stripped,
+	bound := append(stripped,
 		"--clean-review-event", policy.Clean,
 		"--blocking-review-event", policy.Blocking,
+		"--commit-id", policy.ExpectedCommitID,
 	)
+	if policy.ReviewerManual {
+		bound = append(bound, "--reviewer-manual", "--reviewer-run-id", policy.ReviewerRunID)
+	}
+	return bound
 }
 
 func stripTrustedReviewProxyPolicyFlags(argv []string) []string {
@@ -402,7 +546,10 @@ func stripTrustedReviewProxyPolicyFlags(argv []string) []string {
 	for i := 0; i < len(argv); i++ {
 		arg := argv[i]
 		name := trustedReviewProxyFlagName(arg)
-		if name == "clean-review-event" || name == "blocking-review-event" {
+		switch name {
+		case "reviewer-manual":
+			continue
+		case "clean-review-event", "blocking-review-event", "commit-id", "reviewer-run-id":
 			if !strings.Contains(arg, "=") && i+1 < len(argv) && !strings.HasPrefix(argv[i+1], "-") {
 				i++
 			}
@@ -413,7 +560,78 @@ func stripTrustedReviewProxyPolicyFlags(argv []string) []string {
 	return out
 }
 
-func trustedReviewProxyChildEnv(trustedEnv map[string]string, configPath string) []string {
+func marshalTrustedReviewConfigSnapshot(source config.Config) ([]byte, error) {
+	// Review submit needs the materialized provider/project policy and the
+	// run's hot settings, but none of these process secrets. Auth mode is not
+	// consulted by review submit; clear it together with localToken so the
+	// sanitized snapshot remains valid when the daemon uses local-token auth.
+	snapshot := source
+	snapshot.Server.AuthMode = config.AuthModeNone
+	snapshot.Server.LocalToken = nil
+	snapshot.Agent.Env = nil
+	snapshot.Agent.Params = nil
+	snapshot.Daemon.Environment = nil
+
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("encode trusted review config snapshot: %w", err)
+	}
+	if len(encoded) > maxTrustedReviewConfigSnapshotSize {
+		return nil, fmt.Errorf("trusted review config snapshot exceeds %d bytes", maxTrustedReviewConfigSnapshotSize)
+	}
+	return encoded, nil
+}
+
+// LoadTrustedReviewConfigSnapshot consumes the exact materialized snapshot
+// supplied to a proxy child. It intentionally bypasses normal config file,
+// environment, and CLI precedence: those layers were already resolved by the
+// daemon when it captured the run. Provider credential variables remain in the
+// child environment for the selected transport but cannot rewrite this config.
+func LoadTrustedReviewConfigSnapshot() (config.LoadedFileConfig, bool, error) {
+	if strings.TrimSpace(os.Getenv(trustedReviewProxySkipEnv)) == "" {
+		return config.LoadedFileConfig{}, false, nil
+	}
+	rawFD := strings.TrimSpace(os.Getenv(TrustedReviewConfigFDEnv))
+	if rawFD == "" {
+		return config.LoadedFileConfig{}, true, fmt.Errorf("trusted review config descriptor is required")
+	}
+	fd, err := strconv.ParseUint(rawFD, 10, 64)
+	if err != nil || fd < 3 {
+		return config.LoadedFileConfig{}, true, fmt.Errorf("trusted review config descriptor is invalid")
+	}
+	file := os.NewFile(uintptr(fd), "trusted-review-config")
+	if file == nil {
+		return config.LoadedFileConfig{}, true, fmt.Errorf("trusted review config descriptor is unavailable")
+	}
+	defer file.Close()
+	limited := &io.LimitedReader{R: file, N: maxTrustedReviewConfigSnapshotSize + 1}
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return config.LoadedFileConfig{}, true, fmt.Errorf("read trusted review config snapshot: %w", err)
+	}
+	if len(raw) > maxTrustedReviewConfigSnapshotSize {
+		return config.LoadedFileConfig{}, true, fmt.Errorf("trusted review config snapshot exceeds size limit")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var snapshot config.Config
+	if err := decoder.Decode(&snapshot); err != nil {
+		return config.LoadedFileConfig{}, true, fmt.Errorf("decode trusted review config snapshot: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("multiple JSON values")
+		}
+		return config.LoadedFileConfig{}, true, fmt.Errorf("decode trusted review config snapshot: %w", err)
+	}
+	if err := config.Validate(snapshot); err != nil {
+		return config.LoadedFileConfig{}, true, fmt.Errorf("validate trusted review config snapshot: %w", err)
+	}
+	return config.LoadedFileConfig{Config: snapshot}, true, nil
+}
+
+func trustedReviewProxyChildEnv(trustedEnv map[string]string, configFD int) []string {
 	base := os.Environ()
 	envMap := make(map[string]string, len(base)+len(trustedEnv)+3)
 	for _, entry := range base {
@@ -423,16 +641,6 @@ func trustedReviewProxyChildEnv(trustedEnv map[string]string, configPath string)
 		}
 		envMap[key] = value
 	}
-	// Prevent proxy re-entry and never expose a trusted-env file path to the child
-	// beyond the direct token keys the daemon already holds in memory.
-	delete(envMap, TrustedReviewSockEnv)
-	delete(envMap, TrustedEnvFileEnv)
-	envMap[trustedReviewProxySkipEnv] = "1"
-	// Daemon-loaded config path wins over ambient LOOPER_CONFIG so children use
-	// the same config as looperd when it was started with --config only.
-	if path := strings.TrimSpace(configPath); path != "" {
-		envMap["LOOPER_CONFIG"] = path
-	}
 	for key, value := range trustedEnv {
 		key = strings.TrimSpace(key)
 		if key == "" {
@@ -440,12 +648,53 @@ func trustedReviewProxyChildEnv(trustedEnv map[string]string, configPath string)
 		}
 		envMap[key] = value
 	}
+	// Security controls are applied after every data-environment source. A
+	// configured Agent.Env or provider tokenEnv must not retarget the config,
+	// re-enter the proxy, or expose a trusted-env file path.
+	delete(envMap, TrustedReviewSockEnv)
+	delete(envMap, TrustedEnvFileEnv)
+	delete(envMap, TrustedReviewConfigFDEnv)
+	delete(envMap, "LOOPER_CONFIG")
+	envMap[trustedReviewProxySkipEnv] = "1"
+	if configFD >= 3 {
+		envMap[TrustedReviewConfigFDEnv] = strconv.Itoa(configFD)
+	}
 	out := make([]string, 0, len(envMap))
 	for key, value := range envMap {
 		out = append(out, key+"="+value)
 	}
 	return out
 }
+
+type trustedReviewBoundedBuffer struct {
+	buffer    bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func newTrustedReviewBoundedBuffer(limit int) *trustedReviewBoundedBuffer {
+	return &trustedReviewBoundedBuffer{limit: limit}
+}
+
+func (b *trustedReviewBoundedBuffer) Write(p []byte) (int, error) {
+	written := len(p)
+	remaining := b.limit - b.buffer.Len()
+	if remaining > 0 {
+		keep := len(p)
+		if keep > remaining {
+			keep = remaining
+		}
+		_, _ = b.buffer.Write(p[:keep])
+	}
+	if len(p) > remaining {
+		b.truncated = true
+	}
+	return written, nil
+}
+
+func (b *trustedReviewBoundedBuffer) String() string { return b.buffer.String() }
+
+func (b *trustedReviewBoundedBuffer) Truncated() bool { return b.truncated }
 
 // TrustedReviewSockConfigured reports whether this process should proxy
 // `review submit` through the daemon-side trusted socket.
@@ -485,7 +734,11 @@ func ProxyReviewSubmit(argv []string, stdin []byte, cwd string) error {
 		return fmt.Errorf("encode trusted review proxy request: %w", err)
 	}
 	var resp trustedReviewProxyResponse
-	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+	limited := &io.LimitedReader{R: conn, N: maxTrustedReviewProxyResponseBytes + 1}
+	if err := json.NewDecoder(limited).Decode(&resp); err != nil {
+		if limited.N <= 0 {
+			return fmt.Errorf("trusted review proxy response exceeds size limit")
+		}
 		return fmt.Errorf("decode trusted review proxy response: %w", err)
 	}
 	if resp.Stdout != "" {

--- a/internal/forge/trusted_review_proxy_limits_test.go
+++ b/internal/forge/trusted_review_proxy_limits_test.go
@@ -16,7 +16,7 @@ func TestTrustedReviewProxyRejectsOversizedStdinBeforeStartingChild(t *testing.T
 	dir := t.TempDir()
 	realLooper := filepath.Join(dir, "real-looper")
 	marker := filepath.Join(dir, "child-ran")
-	if err := os.WriteFile(realLooper, []byte("#!/bin/sh\ntouch \""+marker+"\"\n"), 0o755); err != nil {
+	if err := os.WriteFile(realLooper, []byte(trustedReviewProxyStubScript("touch \""+marker+"\"\n")), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
 	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
@@ -43,7 +43,7 @@ func TestTrustedReviewProxyCleanupClosesPartialConnectionsAndKillsChildGroup(t *
 	dir := t.TempDir()
 	realLooper := filepath.Join(dir, "real-looper")
 	started := filepath.Join(dir, "started")
-	script := "#!/bin/sh\ntouch \"" + started + "\"\nsleep 30\n"
+	script := trustedReviewProxyStubScript("touch \"" + started + "\"\nsleep 30\n")
 	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}

--- a/internal/forge/trusted_review_proxy_limits_test.go
+++ b/internal/forge/trusted_review_proxy_limits_test.go
@@ -1,0 +1,106 @@
+package forge
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestTrustedReviewProxyRejectsOversizedStdinBeforeStartingChild(t *testing.T) {
+	dir := t.TempDir()
+	realLooper := filepath.Join(dir, "real-looper")
+	marker := filepath.Join(dir, "child-ran")
+	if err := os.WriteFile(realLooper, []byte("#!/bin/sh\ntouch \""+marker+"\"\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(realLooper) error = %v", err)
+	}
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
+	if err != nil {
+		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
+	}
+	t.Cleanup(cleanup)
+	t.Setenv(TrustedReviewSockEnv, sockPath)
+	t.Setenv(trustedReviewProxySkipEnv, "")
+	err = ProxyReviewSubmit(
+		[]string{"review", "submit", "acme/looper#1", "--event", "COMMENT"},
+		make([]byte, maxTrustedReviewProxyStdinBytes+1),
+		dir,
+	)
+	if err == nil || !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("ProxyReviewSubmit(oversized) error = %v, want size-limit rejection", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("oversized request started child: %v", err)
+	}
+}
+
+func TestTrustedReviewProxyCleanupClosesPartialConnectionsAndKillsChildGroup(t *testing.T) {
+	dir := t.TempDir()
+	realLooper := filepath.Join(dir, "real-looper")
+	started := filepath.Join(dir, "started")
+	script := "#!/bin/sh\ntouch \"" + started + "\"\nsleep 30\n"
+	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(realLooper) error = %v", err)
+	}
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
+	if err != nil {
+		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	// One handler reaches cmd.Wait while another remains blocked on a partial
+	// request. Cleanup must cancel both instead of waiting for either deadline.
+	active, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Dial(active) error = %v", err)
+	}
+	if err := json.NewEncoder(active).Encode(trustedReviewProxyRequest{Argv: []string{"review", "submit", "acme/looper#1", "--event", "COMMENT"}}); err != nil {
+		t.Fatalf("Encode(active) error = %v", err)
+	}
+	partial, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Dial(partial) error = %v", err)
+	}
+	if _, err := partial.Write([]byte("{")); err != nil {
+		t.Fatalf("Write(partial) error = %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(started); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("trusted review child did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	done := make(chan struct{})
+	go func() {
+		cleanup()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cleanup blocked on active child or partial connection")
+	}
+	_ = active.Close()
+	_ = partial.Close()
+}
+
+func TestTrustedReviewBoundedBufferTruncatesWithoutBackpressuringChild(t *testing.T) {
+	buffer := newTrustedReviewBoundedBuffer(4)
+	written, err := buffer.Write([]byte("abcdef"))
+	if err != nil || written != 6 {
+		t.Fatalf("Write() = (%d, %v), want (6, nil)", written, err)
+	}
+	if got := buffer.String(); got != "abcd" || !buffer.Truncated() {
+		t.Fatalf("bounded buffer = (%q, %t), want (abcd, true)", got, buffer.Truncated())
+	}
+}

--- a/internal/forge/trusted_review_proxy_test.go
+++ b/internal/forge/trusted_review_proxy_test.go
@@ -98,6 +98,13 @@ func testTrustedReviewPolicy() TrustedReviewProxyPolicy {
 	return TrustedReviewProxyPolicy{Clean: "COMMENT", Blocking: "COMMENT", ExpectedCommitID: "abc123"}
 }
 
+// trustedReviewProxyStubScript builds a fake looper child that first drains the
+// inherited config snapshot pipe (fd 3). Without that drain, a fast-exiting
+// stub races the proxy's snapshot writer and can surface "broken pipe" on CI.
+func trustedReviewProxyStubScript(body string) string {
+	return "#!/bin/sh\ncat <&3 >/dev/null 2>&1 || true\n" + body
+}
+
 func TestFormatTrustedReviewPRRef(t *testing.T) {
 	t.Parallel()
 	if got := FormatTrustedReviewPRRef(" acme/looper ", 42); got != "acme/looper#42" {
@@ -116,7 +123,7 @@ func TestStartTrustedReviewProxyAllowsEmptyTrustedEnv(t *testing.T) {
 	realLooper := filepath.Join(dir, "real-looper")
 	outPath := filepath.Join(dir, "out.txt")
 	// Tea-backed providers have no tokenEnv; proxy still binds PR/CWD/config.
-	script := "#!/bin/sh\ntouch ./proxy-child-ran\nprintf 'sock=%s config=%s fd=%s\\n' \"$LOOPER_TRUSTED_REVIEW_SOCK\" \"$LOOPER_CONFIG\" \"$LOOPER_TRUSTED_REVIEW_CONFIG_FD\" > \"" + outPath + "\"\n"
+	script := trustedReviewProxyStubScript("touch ./proxy-child-ran\nprintf 'sock=%s config=%s fd=%s\\n' \"$LOOPER_TRUSTED_REVIEW_SOCK\" \"$LOOPER_CONFIG\" \"$LOOPER_TRUSTED_REVIEW_CONFIG_FD\" > \"" + outPath + "\"\n")
 	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
@@ -159,7 +166,7 @@ func TestStartTrustedReviewProxyInjectsTokensIntoChild(t *testing.T) {
 	outPath := filepath.Join(dir, "out.txt")
 	// Child records token/socket/config env and leaves a marker in its process
 	// CWD so daemon-bound workdir is observable without relying on pwd symlink form.
-	script := "#!/bin/sh\ntouch ./proxy-child-ran\nprintf 'token=%s sock=%s config=%s fd=%s\\n' \"$FORGEJO_TOKEN\" \"$LOOPER_TRUSTED_REVIEW_SOCK\" \"$LOOPER_CONFIG\" \"$LOOPER_TRUSTED_REVIEW_CONFIG_FD\" > \"" + outPath + "\"\n"
+	script := trustedReviewProxyStubScript("touch ./proxy-child-ran\nprintf 'token=%s sock=%s config=%s fd=%s\\n' \"$FORGEJO_TOKEN\" \"$LOOPER_TRUSTED_REVIEW_SOCK\" \"$LOOPER_CONFIG\" \"$LOOPER_TRUSTED_REVIEW_CONFIG_FD\" > \"" + outPath + "\"\n")
 	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
@@ -208,7 +215,7 @@ func TestStartTrustedReviewProxyRewritesPolicyFlags(t *testing.T) {
 	realLooper := filepath.Join(dir, "real-looper")
 	outPath := filepath.Join(dir, "argv.txt")
 	// Record argv so we can assert daemon-bound policy replaced agent values.
-	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"" + outPath + "\"\n"
+	script := trustedReviewProxyStubScript("printf '%s\\n' \"$@\" > \"" + outPath + "\"\n")
 	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
@@ -271,7 +278,7 @@ func TestStartTrustedReviewProxyRejectsUnboundPR(t *testing.T) {
 	dir := t.TempDir()
 	realLooper := filepath.Join(dir, "real-looper")
 	// Child should never run for a mismatched PR.
-	script := "#!/bin/sh\necho should-not-run\nexit 0\n"
+	script := trustedReviewProxyStubScript("echo should-not-run\nexit 0\n")
 	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
@@ -433,6 +440,7 @@ func TestTrustedReviewProxyKeepsRunConfigWhenLiveFileChanges(t *testing.T) {
 	realLooper := filepath.Join(dir, "real-looper")
 	capturedPath := filepath.Join(dir, "captured-config.json")
 	configPathOutput := filepath.Join(dir, "config-path.txt")
+	// This stub intentionally consumes fd 3 into a file for assertions.
 	script := "#!/bin/sh\ncat <&3 > \"" + capturedPath + "\"\nprintf '%s' \"$LOOPER_CONFIG\" > \"" + configPathOutput + "\"\n"
 	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)

--- a/internal/forge/trusted_review_proxy_test.go
+++ b/internal/forge/trusted_review_proxy_test.go
@@ -1,10 +1,13 @@
 package forge
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
 )
 
 func TestValidateTrustedReviewProxyArgv(t *testing.T) {
@@ -55,12 +58,12 @@ func TestValidateTrustedReviewProxyArgv(t *testing.T) {
 
 func TestApplyTrustedReviewProxyPolicyRewritesAgentFlags(t *testing.T) {
 	t.Parallel()
-	policy := TrustedReviewProxyPolicy{Clean: "APPROVE", Blocking: "REQUEST_CHANGES"}
+	policy := TrustedReviewProxyPolicy{Clean: "APPROVE", Blocking: "REQUEST_CHANGES", ExpectedCommitID: "bound-head", ReviewerManual: true, ReviewerRunID: "run_bound"}
 	got := applyTrustedReviewProxyPolicy(
-		[]string{"review", "submit", "acme/looper#1", "--event", "COMMENT", "--clean-review-event", "COMMENT", "--blocking-review-event=COMMENT", "--commit-id", "abc"},
+		[]string{"review", "submit", "acme/looper#1", "--event", "COMMENT", "--clean-review-event", "COMMENT", "--blocking-review-event=COMMENT", "--commit-id", "agent-head", "--reviewer-manual", "--reviewer-run-id", "run_agent"},
 		policy,
 	)
-	want := []string{"review", "submit", "acme/looper#1", "--event", "COMMENT", "--commit-id", "abc", "--clean-review-event", "APPROVE", "--blocking-review-event", "REQUEST_CHANGES"}
+	want := []string{"review", "submit", "acme/looper#1", "--event", "COMMENT", "--clean-review-event", "APPROVE", "--blocking-review-event", "REQUEST_CHANGES", "--commit-id", "bound-head", "--reviewer-manual", "--reviewer-run-id", "run_bound"}
 	if len(got) != len(want) {
 		t.Fatalf("applyTrustedReviewProxyPolicy() = %#v, want %#v", got, want)
 	}
@@ -71,7 +74,7 @@ func TestApplyTrustedReviewProxyPolicyRewritesAgentFlags(t *testing.T) {
 	}
 	// Missing agent policy flags still get daemon injection.
 	got = applyTrustedReviewProxyPolicy([]string{"review", "submit", "acme/looper#1"}, policy)
-	want = []string{"review", "submit", "acme/looper#1", "--clean-review-event", "APPROVE", "--blocking-review-event", "REQUEST_CHANGES"}
+	want = []string{"review", "submit", "acme/looper#1", "--clean-review-event", "APPROVE", "--blocking-review-event", "REQUEST_CHANGES", "--commit-id", "bound-head", "--reviewer-manual", "--reviewer-run-id", "run_bound"}
 	if len(got) != len(want) {
 		t.Fatalf("applyTrustedReviewProxyPolicy(no flags) = %#v, want %#v", got, want)
 	}
@@ -80,10 +83,19 @@ func TestApplyTrustedReviewProxyPolicyRewritesAgentFlags(t *testing.T) {
 			t.Fatalf("applyTrustedReviewProxyPolicy(no flags) = %#v, want %#v", got, want)
 		}
 	}
+
+	// An automatic run must strip an agent attempt to opt into manual bypass
+	// or substitute another run identity.
+	automatic := TrustedReviewProxyPolicy{Clean: "COMMENT", Blocking: "COMMENT", ExpectedCommitID: "automatic-head"}
+	got = applyTrustedReviewProxyPolicy([]string{"review", "submit", "acme/looper#1", "--reviewer-manual", "--reviewer-run-id=run_agent"}, automatic)
+	want = []string{"review", "submit", "acme/looper#1", "--clean-review-event", "COMMENT", "--blocking-review-event", "COMMENT", "--commit-id", "automatic-head"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("applyTrustedReviewProxyPolicy(automatic) = %#v, want %#v", got, want)
+	}
 }
 
 func testTrustedReviewPolicy() TrustedReviewProxyPolicy {
-	return TrustedReviewProxyPolicy{Clean: "COMMENT", Blocking: "COMMENT"}
+	return TrustedReviewProxyPolicy{Clean: "COMMENT", Blocking: "COMMENT", ExpectedCommitID: "abc123"}
 }
 
 func TestFormatTrustedReviewPRRef(t *testing.T) {
@@ -104,13 +116,12 @@ func TestStartTrustedReviewProxyAllowsEmptyTrustedEnv(t *testing.T) {
 	realLooper := filepath.Join(dir, "real-looper")
 	outPath := filepath.Join(dir, "out.txt")
 	// Tea-backed providers have no tokenEnv; proxy still binds PR/CWD/config.
-	script := "#!/bin/sh\ntouch ./proxy-child-ran\nprintf 'sock=%s config=%s\\n' \"$LOOPER_TRUSTED_REVIEW_SOCK\" \"$LOOPER_CONFIG\" > \"" + outPath + "\"\n"
+	script := "#!/bin/sh\ntouch ./proxy-child-ran\nprintf 'sock=%s config=%s fd=%s\\n' \"$LOOPER_TRUSTED_REVIEW_SOCK\" \"$LOOPER_CONFIG\" \"$LOOPER_TRUSTED_REVIEW_CONFIG_FD\" > \"" + outPath + "\"\n"
 	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
 
-	daemonConfig := filepath.Join(dir, "daemon-config.json")
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, daemonConfig, testTrustedReviewPolicy())
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}
@@ -131,8 +142,8 @@ func TestStartTrustedReviewProxyAllowsEmptyTrustedEnv(t *testing.T) {
 		t.Fatalf("ReadFile(out) error = %v", err)
 	}
 	got := string(out)
-	if !strings.Contains(got, "config="+daemonConfig) {
-		t.Fatalf("proxy child output = %q, want injected LOOPER_CONFIG=%s", got, daemonConfig)
+	if !strings.Contains(got, "config= fd=3") || strings.Contains(got, "ambient-config.json") {
+		t.Fatalf("proxy child output = %q, want descriptor-backed config without LOOPER_CONFIG", got)
 	}
 	if strings.Contains(got, "sock="+sockPath) || strings.Contains(got, "sock=/") {
 		t.Fatalf("proxy child output = %q, want empty LOOPER_TRUSTED_REVIEW_SOCK in child", got)
@@ -148,13 +159,12 @@ func TestStartTrustedReviewProxyInjectsTokensIntoChild(t *testing.T) {
 	outPath := filepath.Join(dir, "out.txt")
 	// Child records token/socket/config env and leaves a marker in its process
 	// CWD so daemon-bound workdir is observable without relying on pwd symlink form.
-	script := "#!/bin/sh\ntouch ./proxy-child-ran\nprintf 'token=%s sock=%s config=%s\\n' \"$FORGEJO_TOKEN\" \"$LOOPER_TRUSTED_REVIEW_SOCK\" \"$LOOPER_CONFIG\" > \"" + outPath + "\"\n"
+	script := "#!/bin/sh\ntouch ./proxy-child-ran\nprintf 'token=%s sock=%s config=%s fd=%s\\n' \"$FORGEJO_TOKEN\" \"$LOOPER_TRUSTED_REVIEW_SOCK\" \"$LOOPER_CONFIG\" \"$LOOPER_TRUSTED_REVIEW_CONFIG_FD\" > \"" + outPath + "\"\n"
 	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
 
-	daemonConfig := filepath.Join(dir, "daemon-config.json")
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, daemonConfig, testTrustedReviewPolicy())
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}
@@ -182,8 +192,8 @@ func TestStartTrustedReviewProxyInjectsTokensIntoChild(t *testing.T) {
 	if !strings.Contains(got, "token=secret-token") {
 		t.Fatalf("proxy child output = %q, want injected FORGEJO_TOKEN", got)
 	}
-	if !strings.Contains(got, "config="+daemonConfig) {
-		t.Fatalf("proxy child output = %q, want injected LOOPER_CONFIG=%s", got, daemonConfig)
+	if !strings.Contains(got, "config= fd=3") || strings.Contains(got, "ambient-config.json") {
+		t.Fatalf("proxy child output = %q, want descriptor-backed config without LOOPER_CONFIG", got)
 	}
 	if strings.Contains(got, "sock="+sockPath) || strings.Contains(got, "sock=/") {
 		t.Fatalf("proxy child output = %q, want empty LOOPER_TRUSTED_REVIEW_SOCK in child", got)
@@ -203,8 +213,8 @@ func TestStartTrustedReviewProxyRewritesPolicyFlags(t *testing.T) {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
 
-	policy := TrustedReviewProxyPolicy{Clean: "APPROVE", Blocking: "REQUEST_CHANGES"}
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, "", policy)
+	policy := TrustedReviewProxyPolicy{Clean: "APPROVE", Blocking: "REQUEST_CHANGES", ExpectedCommitID: "bound-head", ReviewerManual: true, ReviewerRunID: "run_bound"}
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, config.Config{}, policy)
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}
@@ -220,6 +230,8 @@ func TestStartTrustedReviewProxyRewritesPolicyFlags(t *testing.T) {
 		"--event", "COMMENT",
 		"--clean-review-event", "COMMENT",
 		"--blocking-review-event", "COMMENT",
+		"--commit-id", "agent-head",
+		"--reviewer-run-id", "run_agent",
 	}, []byte(`{"body":"x"}`), dir); err != nil {
 		t.Fatalf("ProxyReviewSubmit() error = %v", err)
 	}
@@ -233,6 +245,12 @@ func TestStartTrustedReviewProxyRewritesPolicyFlags(t *testing.T) {
 	}
 	if !strings.Contains(got, "--blocking-review-event\nREQUEST_CHANGES\n") {
 		t.Fatalf("child argv = %q, want bound --blocking-review-event REQUEST_CHANGES", got)
+	}
+	if !strings.Contains(got, "--commit-id\nbound-head\n") || strings.Contains(got, "agent-head") {
+		t.Fatalf("child argv = %q, want only bound commit id", got)
+	}
+	if !strings.Contains(got, "--reviewer-manual\n") || !strings.Contains(got, "--reviewer-run-id\nrun_bound\n") || strings.Contains(got, "run_agent") {
+		t.Fatalf("child argv = %q, want bound manual run identity", got)
 	}
 	// Downgraded agent values must not remain as the sole/authoritative policy.
 	if strings.Count(got, "COMMENT") > 1 {
@@ -258,7 +276,7 @@ func TestStartTrustedReviewProxyRejectsUnboundPR(t *testing.T) {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
 
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, "", testTrustedReviewPolicy())
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}
@@ -284,22 +302,22 @@ func TestStartTrustedReviewProxyRequiresAllowedPR(t *testing.T) {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
 	policy := testTrustedReviewPolicy()
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "", dir, "", policy); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "", dir, config.Config{}, policy); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with empty allowed PR = nil, want error")
 	}
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "not-a-ref", dir, "", policy); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "not-a-ref", dir, config.Config{}, policy); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with invalid allowed PR = nil, want error")
 	}
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", "", "", policy); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", "", config.Config{}, policy); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with empty allowed CWD = nil, want error")
 	}
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", "relative/path", "", policy); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", "relative/path", config.Config{}, policy); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with relative allowed CWD = nil, want error")
 	}
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", dir, "", TrustedReviewProxyPolicy{}); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", dir, config.Config{}, TrustedReviewProxyPolicy{}); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with empty policy = nil, want error")
 	}
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", dir, "", TrustedReviewProxyPolicy{Clean: "APPROVE", Blocking: "APPROVE"}); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", dir, config.Config{}, TrustedReviewProxyPolicy{Clean: "APPROVE", Blocking: "APPROVE"}); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with invalid blocking policy = nil, want error")
 	}
 }
@@ -323,8 +341,15 @@ func TestTrustedReviewSockConfigured(t *testing.T) {
 func TestTrustedReviewProxyChildEnvOmitsSocketAndFile(t *testing.T) {
 	t.Setenv(TrustedReviewSockEnv, "/tmp/should-not-propagate")
 	t.Setenv(TrustedEnvFileEnv, "/tmp/secret-file")
+	t.Setenv(trustedReviewProxySkipEnv, "")
 	t.Setenv("LOOPER_CONFIG", "/tmp/ambient.json")
-	env := trustedReviewProxyChildEnv(map[string]string{"FORGEJO_TOKEN": "secret"}, "/tmp/daemon-config.json")
+	env := trustedReviewProxyChildEnv(map[string]string{
+		"FORGEJO_TOKEN":           "secret",
+		TrustedReviewSockEnv:      "/tmp/agent-controlled-sock",
+		TrustedEnvFileEnv:         "/tmp/agent-controlled-secret-file",
+		trustedReviewProxySkipEnv: "",
+		"LOOPER_CONFIG":           "/tmp/agent-controlled-config.json",
+	}, 3)
 	joined := strings.Join(env, "\n")
 	if strings.Contains(joined, TrustedReviewSockEnv+"=") {
 		t.Fatalf("child env still has %s", TrustedReviewSockEnv)
@@ -338,16 +363,162 @@ func TestTrustedReviewProxyChildEnvOmitsSocketAndFile(t *testing.T) {
 	if !strings.Contains(joined, trustedReviewProxySkipEnv+"=1") {
 		t.Fatalf("child env missing skip marker: %s", joined)
 	}
-	if !strings.Contains(joined, "LOOPER_CONFIG=/tmp/daemon-config.json") {
-		t.Fatalf("child env missing daemon LOOPER_CONFIG: %s", joined)
+	if !strings.Contains(joined, TrustedReviewConfigFDEnv+"=3") {
+		t.Fatalf("child env missing trusted config descriptor: %s", joined)
 	}
-	if strings.Contains(joined, "LOOPER_CONFIG=/tmp/ambient.json") {
-		t.Fatalf("child env retained ambient LOOPER_CONFIG: %s", joined)
+	if strings.Contains(joined, "LOOPER_CONFIG=") {
+		t.Fatalf("child env retained a named config override: %s", joined)
 	}
-	// Empty daemon config path leaves ambient LOOPER_CONFIG alone.
-	env = trustedReviewProxyChildEnv(map[string]string{"FORGEJO_TOKEN": "secret"}, "")
+	// Missing descriptor still strips named config sources in a proxy child.
+	env = trustedReviewProxyChildEnv(map[string]string{"FORGEJO_TOKEN": "secret"}, 0)
 	joined = strings.Join(env, "\n")
-	if !strings.Contains(joined, "LOOPER_CONFIG=/tmp/ambient.json") {
-		t.Fatalf("child env without bound config path dropped ambient LOOPER_CONFIG: %s", joined)
+	if strings.Contains(joined, "LOOPER_CONFIG=") || strings.Contains(joined, TrustedReviewConfigFDEnv+"=") {
+		t.Fatalf("child env without descriptor retained config selectors: %s", joined)
+	}
+}
+
+func TestMarshalTrustedReviewConfigSnapshotSanitizesSecretsAndPreservesMaterializedPolicy(t *testing.T) {
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	token := "daemon-local-token"
+	vendor := config.AgentVendorCodex
+	model := "run-model"
+	requireReviewRequest := false
+	labels := []string{"run-policy"}
+	labelMode := config.LabelModeAny
+	cfg.Server.AuthMode = config.AuthModeLocalToken
+	cfg.Server.LocalToken = &token
+	cfg.Agent.Vendor = &vendor
+	cfg.Agent.Model = &model
+	cfg.Agent.Env = map[string]string{"AGENT_SECRET": "secret"}
+	cfg.Agent.Params = map[string]any{"api_key": "secret"}
+	cfg.Daemon.Environment = map[string]string{"DAEMON_SECRET": "secret"}
+	cfg.Disclosure = config.DisclosureConfig{Enabled: true, IncludeAgent: true, Channels: config.DisclosureChannelsConfig{ReviewComment: true}}
+	cfg.Projects = []config.ProjectRefConfig{{
+		ID: "project_1", Name: "Project", Repo: "acme/looper", RepoPath: t.TempDir(),
+		Roles: &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{Triggers: &config.PartialReviewerRoleTriggersConfig{
+			RequireReviewRequest: &requireReviewRequest,
+			Labels:               &labels,
+			LabelMode:            &labelMode,
+		}}}},
+	}}
+
+	raw, err := marshalTrustedReviewConfigSnapshot(cfg)
+	if err != nil {
+		t.Fatalf("marshalTrustedReviewConfigSnapshot() error = %v", err)
+	}
+	var snapshot config.Config
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		t.Fatalf("Unmarshal(snapshot) error = %v", err)
+	}
+	if snapshot.Server.AuthMode != config.AuthModeNone || snapshot.Server.LocalToken != nil {
+		t.Fatalf("snapshot server auth = %#v, want auth none without local token", snapshot.Server)
+	}
+	if len(snapshot.Agent.Env) != 0 || len(snapshot.Agent.Params) != 0 || len(snapshot.Daemon.Environment) != 0 {
+		t.Fatalf("snapshot retained process secrets: agentEnv=%#v agentParams=%#v daemonEnv=%#v", snapshot.Agent.Env, snapshot.Agent.Params, snapshot.Daemon.Environment)
+	}
+	if snapshot.Agent.Vendor == nil || *snapshot.Agent.Vendor != vendor || snapshot.Agent.Model == nil || *snapshot.Agent.Model != model || !snapshot.Disclosure.Enabled {
+		t.Fatalf("snapshot dropped run identity/disclosure policy: agent=%#v disclosure=%#v", snapshot.Agent, snapshot.Disclosure)
+	}
+	roles := config.ProjectRoleConfigs(snapshot, "project_1")
+	if roles.Reviewer.Discovery.Triggers.RequireReviewRequest || strings.Join(roles.Reviewer.Discovery.Triggers.Labels, ",") != "run-policy" || roles.Reviewer.Discovery.Triggers.LabelMode != config.LabelModeAny {
+		t.Fatalf("snapshot project roles = %#v, want materialized run-policy/any override", roles.Reviewer.Discovery.Triggers)
+	}
+}
+
+func TestTrustedReviewProxyKeepsRunConfigWhenLiveFileChanges(t *testing.T) {
+	dir := t.TempDir()
+	realLooper := filepath.Join(dir, "real-looper")
+	capturedPath := filepath.Join(dir, "captured-config.json")
+	configPathOutput := filepath.Join(dir, "config-path.txt")
+	script := "#!/bin/sh\ncat <&3 > \"" + capturedPath + "\"\nprintf '%s' \"$LOOPER_CONFIG\" > \"" + configPathOutput + "\"\n"
+	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(realLooper) error = %v", err)
+	}
+
+	runConfig, err := config.DefaultConfig(dir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	runVendor := config.AgentVendorCodex
+	runModel := "run-model"
+	requireReviewRequest := false
+	runLabels := []string{"run-policy"}
+	runLabelMode := config.LabelModeAny
+	runConfig.Agent.Vendor = &runVendor
+	runConfig.Agent.Model = &runModel
+	runConfig.Disclosure.Enabled = true
+	runConfig.Projects = []config.ProjectRefConfig{{
+		ID: "project_1", Name: "Project", Repo: "acme/looper", RepoPath: dir,
+		Roles: &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{Discovery: &config.PartialReviewerRoleDiscoveryConfig{Triggers: &config.PartialReviewerRoleTriggersConfig{
+			RequireReviewRequest: &requireReviewRequest,
+			Labels:               &runLabels,
+			LabelMode:            &runLabelMode,
+		}}}},
+	}}
+
+	livePath := filepath.Join(dir, "live-config.json")
+	runRaw, err := json.Marshal(runConfig)
+	if err != nil {
+		t.Fatalf("Marshal(run config) error = %v", err)
+	}
+	var liveConfig config.Config
+	if err := json.Unmarshal(runRaw, &liveConfig); err != nil {
+		t.Fatalf("Unmarshal(live config clone) error = %v", err)
+	}
+	liveVendor := config.AgentVendorOpenCode
+	liveModel := "live-model"
+	liveLabels := []string{"live-policy"}
+	liveConfig.Agent.Vendor = &liveVendor
+	liveConfig.Agent.Model = &liveModel
+	liveConfig.Disclosure.Enabled = false
+	liveConfig.Projects[0].Roles.Reviewer.Discovery.Triggers.Labels = &liveLabels
+	liveRaw, err := json.Marshal(liveConfig)
+	if err != nil {
+		t.Fatalf("Marshal(live config) error = %v", err)
+	}
+	if err := os.WriteFile(livePath, runRaw, 0o600); err != nil {
+		t.Fatalf("WriteFile(initial live config) error = %v", err)
+	}
+
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, runConfig, testTrustedReviewPolicy())
+	if err != nil {
+		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
+	}
+	t.Cleanup(cleanup)
+	t.Setenv(TrustedReviewSockEnv, sockPath)
+	t.Setenv(trustedReviewProxySkipEnv, "")
+	// Simulate the daemon's live source changing after this run's proxy exists.
+	// The trusted child must load the already-captured run snapshot instead.
+	if err := os.WriteFile(livePath, liveRaw, 0o600); err != nil {
+		t.Fatalf("WriteFile(changed live config) error = %v", err)
+	}
+	t.Setenv("LOOPER_CONFIG", livePath)
+	if err := ProxyReviewSubmit([]string{"review", "submit", "acme/looper#1", "--event", "COMMENT"}, []byte(`{"body":"x"}`), dir); err != nil {
+		t.Fatalf("ProxyReviewSubmit() error = %v", err)
+	}
+	capturedRaw, err := os.ReadFile(capturedPath)
+	if err != nil {
+		t.Fatalf("ReadFile(captured config) error = %v", err)
+	}
+	var captured config.Config
+	if err := json.Unmarshal(capturedRaw, &captured); err != nil {
+		t.Fatalf("Unmarshal(captured config) error = %v", err)
+	}
+	if captured.Agent.Vendor == nil || *captured.Agent.Vendor != runVendor || captured.Agent.Model == nil || *captured.Agent.Model != runModel || !captured.Disclosure.Enabled {
+		t.Fatalf("captured config = agent %#v disclosure %#v, want active run snapshot", captured.Agent, captured.Disclosure)
+	}
+	roles := config.ProjectRoleConfigs(captured, "project_1")
+	if strings.Join(roles.Reviewer.Discovery.Triggers.Labels, ",") != "run-policy" || roles.Reviewer.Discovery.Triggers.LabelMode != config.LabelModeAny {
+		t.Fatalf("captured project roles = %#v, want active run-policy/any", roles.Reviewer.Discovery.Triggers)
+	}
+	childConfigPath, err := os.ReadFile(configPathOutput)
+	if err != nil {
+		t.Fatalf("ReadFile(config path) error = %v", err)
+	}
+	if strings.TrimSpace(string(childConfigPath)) != "" {
+		t.Fatalf("trusted child retained named config path %q; want descriptor-only snapshot", strings.TrimSpace(string(childConfigPath)))
 	}
 }

--- a/internal/infra/notify/gateway.go
+++ b/internal/infra/notify/gateway.go
@@ -26,6 +26,7 @@ const (
 
 	feishuAPIBase           = "https://open.feishu.cn"
 	feishuTokenSafetyMargin = 60 * time.Second
+	gatewayStateLoopLimit   = 4096
 )
 
 type RunCommandFunc func(context.Context, shell.Options) (shell.Result, error)
@@ -44,10 +45,76 @@ type Options struct {
 	OsascriptPath string
 	LogFilePath   string
 	Repositories  *storage.Repositories
+	State         *GatewayState
 	Now           func() time.Time
 	RunCommand    RunCommandFunc
 	HTTPPost      HTTPPostFunc
 	FeishuAppHTTP FeishuAppHTTPFunc
+}
+
+// GatewayState retains transport continuity across immutable, config-specific
+// Gateway instances. Policy stays on each Gateway; only token/live-card state
+// needed to update an already-created notification is shared.
+type GatewayState struct {
+	feishuTokenMu  sync.Mutex
+	feishuToken    string
+	feishuTokenExp time.Time
+
+	liveMu sync.Mutex
+	// liveTails retains the most recent agent-activity snapshot per loop so the
+	// completion card can include the final live tail.
+	liveTails map[string]liveTailEntry
+	// askCards retains the message/card pair needed to patch an answered ask.
+	askCards map[string]askCardState
+	// liveFeeds retains each loop's in-thread live-progress message id.
+	liveFeeds map[string]string
+	// loopLastUsed bounds the union of loop-scoped transport entries without
+	// persisting delivery state. All access is protected by liveMu.
+	loopLastUsed  map[string]uint64
+	loopUseSerial uint64
+}
+
+func NewGatewayState() *GatewayState {
+	return &GatewayState{}
+}
+
+func (s *GatewayState) touchLoopLocked(loopID string) {
+	loopID = strings.TrimSpace(loopID)
+	if loopID == "" {
+		return
+	}
+	if s.loopLastUsed == nil {
+		s.loopLastUsed = make(map[string]uint64)
+	}
+	if _, exists := s.loopLastUsed[loopID]; !exists && len(s.loopLastUsed) >= gatewayStateLoopLimit {
+		oldestLoop := ""
+		oldestUse := ^uint64(0)
+		for candidate, lastUse := range s.loopLastUsed {
+			if lastUse < oldestUse {
+				oldestLoop = candidate
+				oldestUse = lastUse
+			}
+		}
+		delete(s.loopLastUsed, oldestLoop)
+		delete(s.liveTails, oldestLoop)
+		delete(s.askCards, oldestLoop)
+		delete(s.liveFeeds, oldestLoop)
+	}
+	s.loopUseSerial++
+	s.loopLastUsed[loopID] = s.loopUseSerial
+}
+
+func (s *GatewayState) forgetLoopIfUnusedLocked(loopID string) {
+	if _, exists := s.liveTails[loopID]; exists {
+		return
+	}
+	if _, exists := s.askCards[loopID]; exists {
+		return
+	}
+	if _, exists := s.liveFeeds[loopID]; exists {
+		return
+	}
+	delete(s.loopLastUsed, loopID)
 }
 
 type SystemNotificationPayload struct {
@@ -75,26 +142,7 @@ type Gateway struct {
 	runCommand    RunCommandFunc
 	httpPost      HTTPPostFunc
 	feishuAppHTTP FeishuAppHTTPFunc
-
-	feishuTokenMu  sync.Mutex
-	feishuToken    string
-	feishuTokenExp time.Time
-
-	// liveTails holds the most recent agent-activity snapshot per loop, kept in
-	// memory (not the loop record) so frequent progress ticks never race the
-	// scheduler's loop/run writes. Retained across the completion rebuild so the
-	// final card still shows the last activity.
-	liveMu    sync.Mutex
-	liveTails map[string]liveTailEntry
-	// askCards remembers each loop's live ask card (message id + the card it was
-	// built from) so the card can be patched to its resolved "✅ 已选:X" state when
-	// the answer arrives — keeping the full brief for review.
-	askCards map[string]askCardState
-	// liveFeeds remembers each loop's live-progress comment (a reply threaded under
-	// the anchor). The raw tool-call feed lives HERE — inside the thread — so the
-	// outer anchor card stays a human-scannable brief. Keyed by loop id → message id;
-	// posted on first activity, patched in place thereafter.
-	liveFeeds map[string]string
+	state         *GatewayState
 }
 
 type askCardState struct {
@@ -122,6 +170,10 @@ func NewGateway(options Options) *Gateway {
 	if feishuAppHTTP == nil {
 		feishuAppHTTP = defaultFeishuAppHTTP
 	}
+	state := options.State
+	if state == nil {
+		state = NewGatewayState()
+	}
 
 	return &Gateway{
 		config:        options.Config,
@@ -132,6 +184,7 @@ func NewGateway(options Options) *Gateway {
 		runCommand:    runCommand,
 		httpPost:      httpPost,
 		feishuAppHTTP: feishuAppHTTP,
+		state:         state,
 	}
 }
 
@@ -584,12 +637,13 @@ func (g *Gateway) SendHITLAsk(ctx context.Context, card HITLAskCard) error {
 	}
 	// Remember the card so MarkAskAnswered can patch it in place on delivery.
 	if strings.TrimSpace(msgID) != "" && strings.TrimSpace(card.LoopID) != "" {
-		g.liveMu.Lock()
-		if g.askCards == nil {
-			g.askCards = map[string]askCardState{}
+		g.state.liveMu.Lock()
+		if g.state.askCards == nil {
+			g.state.askCards = map[string]askCardState{}
 		}
-		g.askCards[card.LoopID] = askCardState{msgID: msgID, card: card}
-		g.liveMu.Unlock()
+		g.state.touchLoopLocked(card.LoopID)
+		g.state.askCards[card.LoopID] = askCardState{msgID: msgID, card: card}
+		g.state.liveMu.Unlock()
 	}
 	return nil
 }
@@ -606,9 +660,12 @@ func (g *Gateway) MarkAskAnswered(ctx context.Context, loopID, answer string) {
 	// Always log the decision to the loop's story (+ refresh the anchor), even if
 	// this process no longer holds the ask card to patch.
 	g.RecordMilestone(ctx, loopID, "🧑‍⚖️ 已定夺:"+answer)
-	g.liveMu.Lock()
-	st, ok := g.askCards[loopID]
-	g.liveMu.Unlock()
+	g.state.liveMu.Lock()
+	st, ok := g.state.askCards[loopID]
+	if ok {
+		g.state.touchLoopLocked(loopID)
+	}
+	g.state.liveMu.Unlock()
 	if !ok || strings.TrimSpace(st.msgID) == "" {
 		return
 	}
@@ -628,9 +685,10 @@ func (g *Gateway) MarkAskAnswered(ctx context.Context, loopID, answer string) {
 		return
 	}
 	if err := g.patchFeishuAppCard(ctx, token, st.msgID, string(cardJSON)); err == nil {
-		g.liveMu.Lock()
-		delete(g.askCards, loopID)
-		g.liveMu.Unlock()
+		g.state.liveMu.Lock()
+		delete(g.state.askCards, loopID)
+		g.state.forgetLoopIfUnusedLocked(loopID)
+		g.state.liveMu.Unlock()
 	}
 }
 
@@ -846,11 +904,11 @@ func feishuConfidenceLabel(confidence string) string {
 // fetches a fresh one from Feishu. Access is serialized so concurrent
 // notifications share one token.
 func (g *Gateway) feishuTenantToken(ctx context.Context, appID, appSecret string) (string, error) {
-	g.feishuTokenMu.Lock()
-	defer g.feishuTokenMu.Unlock()
+	g.state.feishuTokenMu.Lock()
+	defer g.state.feishuTokenMu.Unlock()
 
-	if g.feishuToken != "" && g.now().UTC().Before(g.feishuTokenExp) {
-		return g.feishuToken, nil
+	if g.state.feishuToken != "" && g.now().UTC().Before(g.state.feishuTokenExp) {
+		return g.state.feishuToken, nil
 	}
 
 	body, err := json.Marshal(map[string]string{"app_id": appID, "app_secret": appSecret})
@@ -884,9 +942,9 @@ func (g *Gateway) feishuTenantToken(ctx context.Context, appID, appSecret string
 	if ttl <= 0 {
 		ttl = 2 * time.Hour
 	}
-	g.feishuToken = parsed.TenantAccessToken
-	g.feishuTokenExp = g.now().UTC().Add(ttl - feishuTokenSafetyMargin)
-	return g.feishuToken, nil
+	g.state.feishuToken = parsed.TenantAccessToken
+	g.state.feishuTokenExp = g.now().UTC().Add(ttl - feishuTokenSafetyMargin)
+	return g.state.feishuToken, nil
 }
 
 func feishuResponseCode(body []byte) (int, string) {
@@ -1163,12 +1221,13 @@ func (g *Gateway) RefreshThreadHeader(ctx context.Context, loopID string, tail [
 		return
 	}
 	if len(tail) > 0 || elapsedSec > 0 {
-		g.liveMu.Lock()
-		if g.liveTails == nil {
-			g.liveTails = map[string]liveTailEntry{}
+		g.state.liveMu.Lock()
+		if g.state.liveTails == nil {
+			g.state.liveTails = map[string]liveTailEntry{}
 		}
-		g.liveTails[loopID] = liveTailEntry{lines: tail, elapsedSec: elapsedSec}
-		g.liveMu.Unlock()
+		g.state.touchLoopLocked(loopID)
+		g.state.liveTails[loopID] = liveTailEntry{lines: tail, elapsedSec: elapsedSec}
+		g.state.liveMu.Unlock()
 	}
 	cfg := g.config.Webhook
 	appID := strings.TrimSpace(os.Getenv(strings.TrimSpace(cfg.AppIDEnv)))
@@ -1209,12 +1268,15 @@ func (g *Gateway) updateLiveFeedComment(ctx context.Context, token, loopID strin
 	if !ok {
 		return
 	}
-	g.liveMu.Lock()
+	g.state.liveMu.Lock()
 	msgID := ""
-	if g.liveFeeds != nil {
-		msgID = g.liveFeeds[loopID]
+	if g.state.liveFeeds != nil {
+		msgID = g.state.liveFeeds[loopID]
 	}
-	g.liveMu.Unlock()
+	if msgID != "" {
+		g.state.touchLoopLocked(loopID)
+	}
+	g.state.liveMu.Unlock()
 	if msgID != "" {
 		_ = g.patchFeishuAppCard(ctx, token, msgID, cardJSON)
 		return
@@ -1227,22 +1289,26 @@ func (g *Gateway) updateLiveFeedComment(ctx context.Context, token, loopID strin
 	if err != nil || strings.TrimSpace(newID) == "" {
 		return
 	}
-	g.liveMu.Lock()
-	if g.liveFeeds == nil {
-		g.liveFeeds = map[string]string{}
+	g.state.liveMu.Lock()
+	if g.state.liveFeeds == nil {
+		g.state.liveFeeds = map[string]string{}
 	}
-	g.liveFeeds[loopID] = newID
-	g.liveMu.Unlock()
+	g.state.touchLoopLocked(loopID)
+	g.state.liveFeeds[loopID] = newID
+	g.state.liveMu.Unlock()
 }
 
 // liveTailFor returns the retained live activity snapshot for a loop.
 func (g *Gateway) liveTailFor(loopID string) ([]string, int64) {
-	g.liveMu.Lock()
-	defer g.liveMu.Unlock()
-	if g.liveTails == nil {
+	g.state.liveMu.Lock()
+	defer g.state.liveMu.Unlock()
+	if g.state.liveTails == nil {
 		return nil, 0
 	}
-	e := g.liveTails[strings.TrimSpace(loopID)]
+	e := g.state.liveTails[strings.TrimSpace(loopID)]
+	if len(e.lines) > 0 || e.elapsedSec > 0 {
+		g.state.touchLoopLocked(loopID)
+	}
 	return e.lines, e.elapsedSec
 }
 

--- a/internal/infra/notify/gateway_feishu_app_test.go
+++ b/internal/infra/notify/gateway_feishu_app_test.go
@@ -3,12 +3,13 @@ package notify
 import (
 	"context"
 	"encoding/json"
-	"github.com/nexu-io/looper/internal/loops"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -19,13 +20,17 @@ type capturedFeishuCall struct {
 	body    []byte
 }
 
-func newFeishuAppGateway(t *testing.T, cfg config.WebhookNotificationConfig, calls *[]capturedFeishuCall) *Gateway {
+func newFeishuAppGateway(t *testing.T, cfg config.WebhookNotificationConfig, calls *[]capturedFeishuCall, states ...*GatewayState) *Gateway {
 	t.Helper()
 
 	rootDir := t.TempDir()
 	coordinator := openNotifyCoordinator(t, rootDir)
 	repos := storage.NewRepositories(coordinator.DB())
 	now := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC)
+	var state *GatewayState
+	if len(states) > 0 {
+		state = states[0]
+	}
 
 	return NewGateway(Options{
 		Config: config.NotificationConfig{
@@ -34,6 +39,7 @@ func newFeishuAppGateway(t *testing.T, cfg config.WebhookNotificationConfig, cal
 			Webhook:   cfg,
 		},
 		Repositories: repos,
+		State:        state,
 		Now:          func() time.Time { return now },
 		FeishuAppHTTP: func(_ context.Context, method, url string, headers map[string]string, body []byte) (int, []byte, error) {
 			*calls = append(*calls, capturedFeishuCall{method: method, url: url, headers: headers, body: append([]byte(nil), body...)})
@@ -457,7 +463,11 @@ func TestLiveStatusHelpers(t *testing.T) {
 		}
 	}
 	// In-memory live tail store (kept off the loop record to avoid DB races).
-	g := &Gateway{liveTails: map[string]liveTailEntry{"loop_x": {lines: []string{"a", "b"}, elapsedSec: 90}}}
+	g := &Gateway{state: &GatewayState{
+		liveTails: map[string]liveTailEntry{
+			"loop_x": {lines: []string{"a", "b"}, elapsedSec: 90},
+		},
+	}}
 	lines, el := g.liveTailFor("loop_x")
 	if len(lines) != 2 || lines[0] != "a" || el != 90 {
 		t.Fatalf("liveTailFor = %v, %d", lines, el)
@@ -481,6 +491,52 @@ func TestFeishuLoopStatusStyle(t *testing.T) {
 		if gotT != want.template || !strings.Contains(gotL, want.contains) {
 			t.Fatalf("feishuLoopStatusStyle(%q) = (%q, %q); want template %q label~%q", status, gotT, gotL, want.template, want.contains)
 		}
+	}
+}
+
+func TestGatewayStateSurvivesConfigSpecificGatewaySnapshots(t *testing.T) {
+	t.Setenv("LOOPER_TEST_FEISHU_APP_ID", "cli_app_id")
+	t.Setenv("LOOPER_TEST_FEISHU_APP_SECRET", "app_secret_value")
+
+	state := NewGatewayState()
+	var firstCalls, secondCalls []capturedFeishuCall
+	first := newFeishuAppGateway(t, appModeConfig(), &firstCalls, state)
+	second := newFeishuAppGateway(t, appModeConfig(), &secondCalls, state)
+	if err := first.SendHITLAsk(context.Background(), HITLAskCard{
+		LoopID: "loop_shared", LoopSeq: 42, Question: "Redis or Postgres?", Options: []string{"redis", "postgres"},
+	}); err != nil {
+		t.Fatalf("first snapshot SendHITLAsk() error = %v", err)
+	}
+
+	second.MarkAskAnswered(context.Background(), "loop_shared", "postgres")
+	if len(secondCalls) != 1 || secondCalls[0].method != "PATCH" || !strings.Contains(secondCalls[0].url, "/messages/om_msg") || !strings.Contains(string(secondCalls[0].body), "postgres") {
+		t.Fatalf("second snapshot calls = %#v, want one answer-card PATCH", secondCalls)
+	}
+	state.liveMu.Lock()
+	_, retained := state.askCards["loop_shared"]
+	state.liveMu.Unlock()
+	if retained {
+		t.Fatal("answered ask card remained in shared state")
+	}
+}
+
+func TestGatewayStateBoundsLoopTransportEntries(t *testing.T) {
+	state := NewGatewayState()
+	state.liveMu.Lock()
+	state.liveTails = make(map[string]liveTailEntry)
+	for index := 0; index <= gatewayStateLoopLimit; index++ {
+		loopID := fmt.Sprintf("loop_%05d", index)
+		state.touchLoopLocked(loopID)
+		state.liveTails[loopID] = liveTailEntry{lines: []string{"active"}}
+	}
+	tracked := len(state.loopLastUsed)
+	tails := len(state.liveTails)
+	_, oldestRetained := state.liveTails["loop_00000"]
+	_, newestRetained := state.liveTails[fmt.Sprintf("loop_%05d", gatewayStateLoopLimit)]
+	state.liveMu.Unlock()
+
+	if tracked != gatewayStateLoopLimit || tails != gatewayStateLoopLimit || oldestRetained || !newestRetained {
+		t.Fatalf("bounded state = tracked %d tails %d oldest %v newest %v", tracked, tails, oldestRetained, newestRetained)
 	}
 }
 

--- a/internal/projects/catalog.go
+++ b/internal/projects/catalog.go
@@ -17,14 +17,14 @@ type ConfigSource interface {
 	Snapshot() config.Config
 }
 
-// Catalog owns the immutable runtime view of Projects. The non-project portion
-// of the configuration is frozen at construction; Publish atomically replaces
-// only the already-materialized Projects view.
+// Catalog owns the immutable runtime configuration view. Publish and
+// PublishGlobals update disjoint portions of that view with compare-and-swap
+// loops so concurrent database materialization and config reloads cannot undo
+// one another.
 //
 // Catalog keeps no caller-owned slices, maps, or pointers. Snapshot likewise
 // returns a detached copy so a consumer cannot mutate the published view.
 type Catalog struct {
-	global  config.Config
 	current atomic.Pointer[config.Config]
 }
 
@@ -33,9 +33,8 @@ type Catalog struct {
 // Catalog before the first database materialization is published.
 func NewCatalog(global config.Config) *Catalog {
 	frozen := cloneCatalogConfig(global)
-	catalog := &Catalog{global: frozen}
-	initial := cloneCatalogConfig(frozen)
-	catalog.current.Store(&initial)
+	catalog := &Catalog{}
+	catalog.current.Store(&frozen)
 	return catalog
 }
 
@@ -46,9 +45,40 @@ func (c *Catalog) Publish(projects []config.ProjectRefConfig) {
 	if c == nil {
 		return
 	}
-	next := cloneCatalogConfig(c.global)
-	next.Projects = cloneCatalogProjects(projects)
-	c.current.Store(&next)
+	detachedProjects := cloneCatalogProjects(projects)
+	for {
+		current := c.current.Load()
+		var next config.Config
+		if current != nil {
+			next = cloneCatalogConfig(*current)
+		}
+		next.Projects = cloneCatalogProjects(detachedProjects)
+		if c.current.CompareAndSwap(current, &next) {
+			return
+		}
+	}
+}
+
+// PublishGlobals atomically installs candidate's global configuration while
+// preserving the currently materialized SQLite Projects view. candidate's
+// Projects are import input and are deliberately ignored here.
+func (c *Catalog) PublishGlobals(candidate config.Config) {
+	if c == nil {
+		return
+	}
+	detachedCandidate := cloneCatalogConfig(candidate)
+	for {
+		current := c.current.Load()
+		next := cloneCatalogConfig(detachedCandidate)
+		if current != nil {
+			next.Projects = cloneCatalogProjects(current.Projects)
+		} else {
+			next.Projects = nil
+		}
+		if c.current.CompareAndSwap(current, &next) {
+			return
+		}
+	}
 }
 
 // Snapshot returns a coherent, detached copy of the currently published full

--- a/internal/projects/catalog_test.go
+++ b/internal/projects/catalog_test.go
@@ -32,6 +32,50 @@ func TestCatalogPublishesFullConfigAtomically(t *testing.T) {
 	}
 }
 
+func TestCatalogPublishGlobalsPreservesMaterializedProjects(t *testing.T) {
+	t.Parallel()
+
+	oldModel := "old"
+	newModel := "new"
+	catalog := NewCatalog(config.Config{
+		Agent:    config.AgentConfig{Model: &oldModel},
+		Projects: []config.ProjectRefConfig{{ID: "import-input"}},
+	})
+	catalog.Publish([]config.ProjectRefConfig{{ID: "database", Repo: "core/database"}})
+
+	candidate := config.Config{
+		Agent:    config.AgentConfig{Model: &newModel, Env: map[string]string{"TOKEN": "original"}},
+		Projects: []config.ProjectRefConfig{{ID: "new-import-input"}},
+	}
+	catalog.PublishGlobals(candidate)
+	candidate.Agent.Env["TOKEN"] = "caller-mutated"
+
+	got := catalog.Snapshot()
+	if got.Agent.Model == nil || *got.Agent.Model != newModel || got.Agent.Env["TOKEN"] != "original" {
+		t.Fatalf("Snapshot().Agent = %#v, want detached new globals", got.Agent)
+	}
+	if len(got.Projects) != 1 || got.Projects[0].ID != "database" {
+		t.Fatalf("Snapshot().Projects = %#v, want preserved database view", got.Projects)
+	}
+}
+
+func TestCatalogPublishPreservesReloadedGlobals(t *testing.T) {
+	t.Parallel()
+
+	model := "reloaded"
+	catalog := NewCatalog(config.Config{})
+	catalog.PublishGlobals(config.Config{Agent: config.AgentConfig{Model: &model}})
+	catalog.Publish([]config.ProjectRefConfig{{ID: "database"}})
+
+	got := catalog.Snapshot()
+	if got.Agent.Model == nil || *got.Agent.Model != model {
+		t.Fatalf("Snapshot().Agent.Model = %#v, want reloaded globals", got.Agent.Model)
+	}
+	if len(got.Projects) != 1 || got.Projects[0].ID != "database" {
+		t.Fatalf("Snapshot().Projects = %#v, want database view", got.Projects)
+	}
+}
+
 func TestCatalogDoesNotRetainOrReturnMutableAliases(t *testing.T) {
 	t.Parallel()
 
@@ -110,6 +154,47 @@ func TestCatalogConcurrentSnapshotsObserveWholePublications(t *testing.T) {
 		}
 	}()
 	wg.Wait()
+}
+
+func TestCatalogConcurrentGlobalAndProjectPublicationsPreserveBothAuthorities(t *testing.T) {
+	t.Parallel()
+
+	catalog := NewCatalog(config.Config{})
+	const iterations = 300
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for index := 0; index < iterations; index++ {
+			model := "global-a"
+			if index == iterations-1 {
+				model = "global-final"
+			}
+			catalog.PublishGlobals(config.Config{
+				Agent:    config.AgentConfig{Model: &model},
+				Projects: []config.ProjectRefConfig{{ID: "must-never-publish"}},
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for index := 0; index < iterations; index++ {
+			projectID := "database-a"
+			if index == iterations-1 {
+				projectID = "database-final"
+			}
+			catalog.Publish([]config.ProjectRefConfig{{ID: projectID}})
+		}
+	}()
+	wg.Wait()
+
+	got := catalog.Snapshot()
+	if got.Agent.Model == nil || *got.Agent.Model != "global-final" {
+		t.Fatalf("Snapshot().Agent.Model = %#v, want final global publication", got.Agent.Model)
+	}
+	if len(got.Projects) != 1 || got.Projects[0].ID != "database-final" {
+		t.Fatalf("Snapshot().Projects = %#v, want final database publication", got.Projects)
+	}
 }
 
 func TestMaterializeCatalogUsesRecordsAsProjectAuthority(t *testing.T) {

--- a/internal/projects/service.go
+++ b/internal/projects/service.go
@@ -77,12 +77,16 @@ type CapturePullRequestSnapshotInput struct {
 }
 
 type Service struct {
-	mutationMu                 sync.Mutex
-	DB                         *sql.DB
-	Repos                      *storage.Repositories
-	Logger                     bootstrap.Logger
-	Config                     config.Config
-	ConfigSource               ConfigSource
+	mutationMu   sync.Mutex
+	DB           *sql.DB
+	Repos        *storage.Repositories
+	Logger       bootstrap.Logger
+	Config       config.Config
+	ConfigSource ConfigSource
+	// ConfigBoundary serializes project materialization/commit/publication with
+	// global config validation/publication. It prevents a valid mutation on each
+	// side from combining into an invalid catalog snapshot.
+	ConfigBoundary             *sync.RWMutex
 	Now                        func() time.Time
 	DetectRepo                 DetectRepoFunc
 	GetRepositorySettings      GetRepositorySettingsFunc
@@ -92,6 +96,10 @@ type Service struct {
 	CapturePullRequestSnapshot CapturePullRequestSnapshotFunc
 	AsyncSnapshotQueueEnabled  func() bool
 	PublishProjects            func([]config.ProjectRefConfig)
+	// AfterPublishProjects runs after ConfigBoundary is released. Keep any
+	// external reconciliation or other potentially blocking follow-up here;
+	// PublishProjects itself is part of the atomic config/catalog publication.
+	AfterPublishProjects func()
 }
 
 type AddInput struct {
@@ -280,15 +288,28 @@ func (s *Service) AddProject(ctx context.Context, input AddInput) (AddResult, er
 	if existing != nil {
 		record.CreatedAt = existing.CreatedAt
 	}
-	nextProjects, err := s.materializeCandidate(ctx, &record, "")
+	var nextProjects []config.ProjectRefConfig
+	publishedProjects := false
+	err = s.withConfigBoundary(func() error {
+		var materializeErr error
+		nextProjects, materializeErr = s.materializeCandidate(ctx, &record, "")
+		if materializeErr != nil {
+			return ProjectValidationError{Message: materializeErr.Error()}
+		}
+		if upsertErr := s.Repos.Projects.Upsert(ctx, record); upsertErr != nil {
+			return upsertErr
+		}
+		if s.PublishProjects != nil {
+			s.PublishProjects(nextProjects)
+			publishedProjects = true
+		}
+		return nil
+	})
 	if err != nil {
-		return AddResult{}, ProjectValidationError{Message: err.Error()}
-	}
-	if err := s.Repos.Projects.Upsert(ctx, record); err != nil {
 		return AddResult{}, err
 	}
-	if s.PublishProjects != nil {
-		s.PublishProjects(nextProjects)
+	if publishedProjects && s.AfterPublishProjects != nil {
+		s.AfterPublishProjects()
 	}
 
 	discoveredWorktrees, err := s.discoverWorktrees(ctx, record, nowISO, &warnings)
@@ -363,40 +384,61 @@ func (s *Service) RemoveProject(ctx context.Context, identifier string) (storage
 
 	nowISO := currentISO(s.Now)
 	cancelReason := "project archived"
-	nextProjects, err := s.materializeCandidate(ctx, nil, project.ID)
-	if err != nil {
-		return storage.ProjectRecord{}, err
-	}
-	archived, err := storage.WithTransactionValue(ctx, s.DB, nil, func(tx *sql.Tx) (bool, error) {
-		repos := storage.NewRepositories(tx)
-		archived, err := repos.Projects.Archive(ctx, project.ID, nowISO)
-		if err != nil {
-			return false, err
+	var archived bool
+	publishedProjects := false
+	err = s.withConfigBoundary(func() error {
+		nextProjects, materializeErr := s.materializeCandidate(ctx, nil, project.ID)
+		if materializeErr != nil {
+			return materializeErr
 		}
-		if !archived {
-			return false, nil
+		var transactionErr error
+		archived, transactionErr = storage.WithTransactionValue(ctx, s.DB, nil, func(tx *sql.Tx) (bool, error) {
+			repos := storage.NewRepositories(tx)
+			archived, archiveErr := repos.Projects.Archive(ctx, project.ID, nowISO)
+			if archiveErr != nil {
+				return false, archiveErr
+			}
+			if !archived {
+				return false, nil
+			}
+			if _, terminateErr := repos.Loops.TerminateByProject(ctx, project.ID, nowISO); terminateErr != nil {
+				return false, terminateErr
+			}
+			if _, cancelErr := repos.Queue.CancelByProject(ctx, project.ID, nowISO, &cancelReason); cancelErr != nil {
+				return false, cancelErr
+			}
+			return true, nil
+		})
+		if transactionErr != nil || !archived {
+			return transactionErr
 		}
-		if _, err := repos.Loops.TerminateByProject(ctx, project.ID, nowISO); err != nil {
-			return false, err
+		if s.PublishProjects != nil {
+			s.PublishProjects(nextProjects)
+			publishedProjects = true
 		}
-		if _, err := repos.Queue.CancelByProject(ctx, project.ID, nowISO, &cancelReason); err != nil {
-			return false, err
-		}
-		return true, nil
+		return nil
 	})
 	if err != nil {
 		return storage.ProjectRecord{}, err
+	}
+	if publishedProjects && s.AfterPublishProjects != nil {
+		s.AfterPublishProjects()
 	}
 	if !archived {
 		return storage.ProjectRecord{}, ProjectNotFoundError{Identifier: trimmed}
 	}
 	project.Archived = true
 	project.UpdatedAt = nowISO
-	if s.PublishProjects != nil {
-		s.PublishProjects(nextProjects)
-	}
-
 	return *project, nil
+}
+
+func (s *Service) withConfigBoundary(action func() error) error {
+	if s.ConfigBoundary == nil {
+		return action()
+	}
+	s.ConfigBoundary.Lock()
+	defer s.ConfigBoundary.Unlock()
+	return action()
 }
 
 func (s *Service) resolveActiveProjectForRemoval(ctx context.Context, identifier string) (*storage.ProjectRecord, error) {

--- a/internal/projects/service_test.go
+++ b/internal/projects/service_test.go
@@ -158,6 +158,47 @@ func TestServiceConcurrentAddsPublishCommittedCatalog(t *testing.T) {
 	}
 }
 
+func TestServiceProjectPostPublicationRunsOutsideConfigBoundary(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openCoordinator(t)
+	ctx := context.Background()
+	repos := storage.NewRepositories(coordinator.DB())
+	boundary := &sync.RWMutex{}
+	publishCount := 0
+	afterPublishCount := 0
+	service := &Service{
+		DB:             coordinator.DB(),
+		Repos:          repos,
+		ConfigBoundary: boundary,
+		Now:            time.Now,
+		PublishProjects: func([]config.ProjectRefConfig) {
+			publishCount++
+			if boundary.TryLock() {
+				boundary.Unlock()
+				t.Fatal("PublishProjects ran without ConfigBoundary held")
+			}
+		},
+		AfterPublishProjects: func() {
+			afterPublishCount++
+			if !boundary.TryLock() {
+				t.Fatal("AfterPublishProjects ran while ConfigBoundary was held")
+			}
+			boundary.Unlock()
+		},
+	}
+
+	if _, err := service.AddProject(ctx, AddInput{ID: "looper", Name: "Looper", RepoPath: "/tmp/looper", BaseBranch: "main"}); err != nil {
+		t.Fatalf("AddProject() error = %v", err)
+	}
+	if _, err := service.RemoveProject(ctx, "looper"); err != nil {
+		t.Fatalf("RemoveProject() error = %v", err)
+	}
+	if publishCount != 2 || afterPublishCount != 2 {
+		t.Fatalf("publication callbacks = (%d, %d), want (2, 2)", publishCount, afterPublishCount)
+	}
+}
+
 func TestServiceAddProjectRejectsProjectIDWithBackslash(t *testing.T) {
 	t.Parallel()
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1627,17 +1627,22 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			}
 		}
 	}()
-	if _, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
+	updatedLoop, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
 		updated.Status = "running"
 		updated.LastRunAt = stringPtr(run.StartedAt)
 		updated.NextRunAt = nil
-		metadataJSON, metaErr := r.recordLoopRunStartMetadata(updated.MetadataJSON)
+		metadataJSON, metaErr := r.recordLoopRunStartMetadata(updated.MetadataJSON, project.ID)
 		if metaErr == nil {
 			updated.MetadataJSON = &metadataJSON
 		}
-	}); err != nil {
+	})
+	if err != nil {
 		return ProcessResult{}, err
 	}
+	// The runner is the immutable claim snapshot. Carry the just-persisted
+	// policy into every step so stale loop metadata from an earlier queued run
+	// cannot override configuration published before this claim.
+	loop = &updatedLoop
 	r.appendEvent(ctx, eventInput{eventType: "loop.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "loop", entityID: loop.ID, payload: map[string]any{"queueItemId": queueItem.ID, "resumed": resumedRun.Resumed, "startStep": string(resumedRun.StartStep)}})
 	r.appendEvent(ctx, eventInput{eventType: "run.started", projectID: loop.ProjectID, loopID: loop.ID, runID: run.ID, entityType: "run", entityID: run.ID, payload: map[string]any{"queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep)}})
 	r.logInfo("reviewer run started", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": string(resumedRun.StartStep), "resumed": resumedRun.Resumed})
@@ -1772,7 +1777,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		}
 		return ProcessResult{}, err
 	}
-	updatedLoop, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
+	updatedLoop, err = r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
 		metadataJSON, metaErr := r.recordLoopSuccessMetadata(updated.MetadataJSON, checkpoint, summary)
 		if metaErr == nil {
 			updated.MetadataJSON = &metadataJSON
@@ -2824,6 +2829,9 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		"prNumber":            input.PRNumber,
 		"cleanReviewEvent":    string(reviewEvents.Clean),
 		"blockingReviewEvent": string(reviewEvents.Blocking),
+		"expectedCommitID":    checkpoint.Snapshot.HeadSHA,
+		"reviewerManual":      isManualReviewerLoop(input.Loop),
+		"reviewerRunID":       input.Run.ID,
 	}
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 		metadata[key] = value
@@ -5970,11 +5978,22 @@ func (r *Runner) ensureLoopMetadataJSON(current *string, projectID, repo string,
 	return string(encoded), err
 }
 
-func (r *Runner) recordLoopRunStartMetadata(current *string) (string, error) {
+func (r *Runner) recordLoopRunStartMetadata(current *string, projectID string) (string, error) {
 	meta := parseJSONObject(current)
 	loopMeta := reviewerLoopMetadata(meta)
 	loopMeta["status"] = "active"
 	loopMeta["lastStatus"] = "running"
+	// Manual loops may carry explicit CLI review-event overrides and remain
+	// authoritative for that loop. Auto-discovered loop metadata is inherited
+	// policy, so refresh it from this claim's immutable runner snapshot.
+	manual, _ := meta["manual"].(bool)
+	if !manual {
+		reviewEvents := r.reviewEventsForProject(projectID)
+		meta["reviewEvents"] = map[string]any{
+			"clean":    string(reviewEvents.Clean),
+			"blocking": string(reviewEvents.Blocking),
+		}
+	}
 	meta["loop"] = loopMeta
 	encoded, err := json.Marshal(meta)
 	return string(encoded), err

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1814,6 +1814,42 @@ func TestEnsureLoopMetadataJSONUsesProjectReviewEvents(t *testing.T) {
 	}
 }
 
+func TestRecordLoopRunStartMetadataRefreshesInheritedReviewEventsForNewClaim(t *testing.T) {
+	t.Parallel()
+	runner := New(Options{ReviewEvents: config.ReviewerReviewEventsConfig{
+		Clean:    config.ReviewerReviewEventApprove,
+		Blocking: config.ReviewerReviewEventRequestChanges,
+	}})
+	queuedUnderOldConfig := `{"reviewEvents":{"clean":"COMMENT","blocking":"COMMENT"},"loop":{"status":"queued"}}`
+
+	metadataJSON, err := runner.recordLoopRunStartMetadata(&queuedUnderOldConfig, "project_1")
+	if err != nil {
+		t.Fatalf("recordLoopRunStartMetadata() error = %v", err)
+	}
+	got := runner.effectiveReviewEvents("project_1", &metadataJSON)
+	if got.Clean != config.ReviewerReviewEventApprove || got.Blocking != config.ReviewerReviewEventRequestChanges {
+		t.Fatalf("claimed review events = %#v, want current claim snapshot APPROVE/REQUEST_CHANGES", got)
+	}
+}
+
+func TestRecordLoopRunStartMetadataPreservesManualReviewEventOverrides(t *testing.T) {
+	t.Parallel()
+	runner := New(Options{ReviewEvents: config.ReviewerReviewEventsConfig{
+		Clean:    config.ReviewerReviewEventApprove,
+		Blocking: config.ReviewerReviewEventRequestChanges,
+	}})
+	manualOverride := `{"manual":true,"reviewEvents":{"clean":"COMMENT","blocking":"COMMENT"},"loop":{"status":"queued"}}`
+
+	metadataJSON, err := runner.recordLoopRunStartMetadata(&manualOverride, "project_1")
+	if err != nil {
+		t.Fatalf("recordLoopRunStartMetadata() error = %v", err)
+	}
+	got := runner.effectiveReviewEvents("project_1", &metadataJSON)
+	if got.Clean != config.ReviewerReviewEventComment || got.Blocking != config.ReviewerReviewEventComment {
+		t.Fatalf("manual review events = %#v, want explicit COMMENT/COMMENT overrides", got)
+	}
+}
+
 func reviewEventPtr(event config.ReviewerReviewEvent) *config.ReviewerReviewEvent {
 	return &event
 }
@@ -3451,6 +3487,15 @@ func TestProcessClaimedItemAllowsManualQueuedLoopWithoutReviewRequest(t *testing
 	if len(agent.starts) != 1 {
 		t.Fatalf("agent starts=%d, want agent-native review to run", len(agent.starts))
 	}
+	if got, _ := agent.starts[0].Metadata["expectedCommitID"].(string); got != "abc123" {
+		t.Fatalf("agent metadata expectedCommitID = %q, want captured head abc123", got)
+	}
+	if manual, _ := agent.starts[0].Metadata["reviewerManual"].(bool); !manual {
+		t.Fatalf("agent metadata reviewerManual = %v, want true for manual loop", agent.starts[0].Metadata["reviewerManual"])
+	}
+	if got, _ := agent.starts[0].Metadata["reviewerRunID"].(string); got != result.RunID || got != agent.starts[0].RunID {
+		t.Fatalf("agent metadata reviewerRunID = %q, want daemon-authored run %q", got, result.RunID)
+	}
 	updatedLoop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
 	if err != nil || updatedLoop == nil {
 		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", updatedLoop, err)
@@ -4133,6 +4178,18 @@ func TestProcessClaimedItemInterruptsRunningReviewerWhenHeadChanges(t *testing.T
 	}
 	if len(agent.killedReasons) != 1 || !contains(agent.killedReasons[0], "new-head") {
 		t.Fatalf("killedReasons = %#v, want one head-change kill", agent.killedReasons)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("agent starts = %d, want one reviewer start", len(agent.starts))
+	}
+	if got, _ := agent.starts[0].Metadata["expectedCommitID"].(string); got != "abc123" {
+		t.Fatalf("agent metadata expectedCommitID = %q, want active snapshot head abc123", got)
+	}
+	if manual, _ := agent.starts[0].Metadata["reviewerManual"].(bool); manual {
+		t.Fatalf("agent metadata reviewerManual = %v, want false for automatic loop", agent.starts[0].Metadata["reviewerManual"])
+	}
+	if got, _ := agent.starts[0].Metadata["reviewerRunID"].(string); got != result.RunID || got != agent.starts[0].RunID {
+		t.Fatalf("agent metadata reviewerRunID = %q, want daemon-authored run %q", got, result.RunID)
 	}
 	interruptedRun, err := fixture.repos.Runs.GetByID(ctx, result.RunID)
 	if err != nil || interruptedRun == nil {

--- a/internal/runtime/config_patch_fs_test.go
+++ b/internal/runtime/config_patch_fs_test.go
@@ -1,0 +1,148 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestPatchConfigRejectsDanglingSymlinkWithoutReplacingIt(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.Symlink("missing-target.json", path); err != nil {
+		t.Skipf("create symlink: %v", err)
+	}
+	rt := newConfigPatchRuntime(t, path, func(string) (string, bool) { return "", false })
+	err := rt.PatchConfig(context.Background(), ConfigPatch{
+		Revision: config.ConfigFileRevision(nil, false),
+		Set:      map[string]json.RawMessage{"scheduler.maxConcurrentRuns": json.RawMessage("4")},
+	})
+	var patchErr *ConfigPatchError
+	if !errors.As(err, &patchErr) || patchErr.Kind != "unsupported" {
+		t.Fatalf("PatchConfig() error = %#v, want unsupported symlink", err)
+	}
+	info, statErr := os.Lstat(path)
+	if statErr != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("config path was not preserved as symlink: info=%v err=%v", info, statErr)
+	}
+	if target, readErr := os.Readlink(path); readErr != nil || target != "missing-target.json" {
+		t.Fatalf("Readlink() = %q, %v", target, readErr)
+	}
+}
+
+func TestPatchConfigCASRejectsGenerationChangedDuringValidation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	original := []byte(`{"notifications":{"osascript":{"enabled":false}},"scheduler":{"maxConcurrentRuns":2}}`)
+	external := []byte(`{"notifications":{"osascript":{"enabled":false}},"scheduler":{"maxConcurrentRuns":7}}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	baseLoad := func(selected string) (config.LoadedFileConfig, error) {
+		return config.LoadFile(config.LoadFileOptions{ConfigPathOverride: selected, LookupEnv: func(string) (string, bool) { return "", false }})
+	}
+	initial, err := baseLoad(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	swapped := false
+	loadAt := func(selected string) (config.LoadedFileConfig, error) {
+		loaded, loadErr := baseLoad(selected)
+		if loadErr == nil && strings.HasPrefix(filepath.Base(selected), ".config-reload-") && !swapped {
+			swapped = true
+			if writeErr := os.WriteFile(path, external, 0o600); writeErr != nil {
+				t.Fatalf("external WriteFile() error = %v", writeErr)
+			}
+		}
+		return loaded, loadErr
+	}
+	rt := New(Options{
+		Config:        initial.Config,
+		ConfigPath:    path,
+		InitialConfig: initial,
+		ReloadConfig:  func() (config.LoadedFileConfig, error) { return baseLoad(path) },
+		LoadConfigAt:  loadAt,
+	})
+
+	err = rt.PatchConfig(context.Background(), ConfigPatch{
+		Revision: config.ConfigFileRevision(original, true),
+		Set:      map[string]json.RawMessage{"scheduler.maxConcurrentRuns": json.RawMessage("4")},
+	})
+	var patchErr *ConfigPatchError
+	if !errors.As(err, &patchErr) || patchErr.Kind != "conflict" {
+		t.Fatalf("PatchConfig() error = %#v, want conflict", err)
+	}
+	if got, readErr := os.ReadFile(path); readErr != nil || !bytes.Equal(got, external) {
+		t.Fatalf("external generation was not restored: got=%q err=%v", got, readErr)
+	}
+}
+
+func TestPatchConfigCASRejectsSameByteSymlinkIntroducedDuringValidation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	target := filepath.Join(dir, "operator-config.json")
+	original := []byte(`{"notifications":{"osascript":{"enabled":false}},"scheduler":{"maxConcurrentRuns":2}}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	baseLoad := func(selected string) (config.LoadedFileConfig, error) {
+		return config.LoadFile(config.LoadFileOptions{ConfigPathOverride: selected, LookupEnv: func(string) (string, bool) { return "", false }})
+	}
+	initial, err := baseLoad(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	swapped := false
+	loadAt := func(selected string) (config.LoadedFileConfig, error) {
+		loaded, loadErr := baseLoad(selected)
+		if loadErr == nil && strings.HasPrefix(filepath.Base(selected), ".config-reload-") && !swapped {
+			swapped = true
+			if removeErr := os.Remove(path); removeErr != nil {
+				t.Fatalf("remove config for external symlink: %v", removeErr)
+			}
+			if linkErr := os.Symlink(target, path); linkErr != nil {
+				t.Fatalf("create external symlink: %v", linkErr)
+			}
+		}
+		return loaded, loadErr
+	}
+	rt := New(Options{
+		Config:        initial.Config,
+		ConfigPath:    path,
+		InitialConfig: initial,
+		ReloadConfig:  func() (config.LoadedFileConfig, error) { return baseLoad(path) },
+		LoadConfigAt:  loadAt,
+	})
+
+	err = rt.PatchConfig(context.Background(), ConfigPatch{
+		Revision: config.ConfigFileRevision(original, true),
+		Set:      map[string]json.RawMessage{"scheduler.maxConcurrentRuns": json.RawMessage("4")},
+	})
+	var patchErr *ConfigPatchError
+	if !errors.As(err, &patchErr) || patchErr.Kind != "unsupported" {
+		t.Fatalf("PatchConfig() error = %#v, want unsupported symlink", err)
+	}
+	info, statErr := os.Lstat(path)
+	if statErr != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("external symlink was not preserved: info=%v err=%v", info, statErr)
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || !bytes.Equal(got, original) {
+		t.Fatalf("symlink target changed: got=%q err=%v", got, readErr)
+	}
+}

--- a/internal/runtime/config_patch_test.go
+++ b/internal/runtime/config_patch_test.go
@@ -1,0 +1,300 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestPatchConfigPersistsValidatedFieldsAndPublishesImmediately(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	original := []byte("# operator comment\nx-extension:\n  keep: true\nnotifications:\n  osascript:\n    enabled: false\nscheduler:\n  maxConcurrentRuns: 2\ndefaults:\n  allowAutoPush: false\n")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	rt := newConfigPatchRuntime(t, path, func(string) (string, bool) { return "", false })
+
+	err := rt.PatchConfig(context.Background(), ConfigPatch{Revision: testConfigRevision(t, path), Set: map[string]json.RawMessage{
+		"scheduler.maxConcurrentRuns": json.RawMessage("4"),
+		"defaults.allowAutoPush":      json.RawMessage("true"),
+		"agent.env.OPENAI_API_KEY":    json.RawMessage(`"new-secret"`),
+	}})
+	if err != nil {
+		t.Fatalf("PatchConfig() error = %v", err)
+	}
+
+	got := rt.Config()
+	if got.Scheduler.MaxConcurrentRuns != 4 || !got.Defaults.AllowAutoPush {
+		t.Fatalf("Config() did not publish patch: scheduler=%d allowAutoPush=%v", got.Scheduler.MaxConcurrentRuns, got.Defaults.AllowAutoPush)
+	}
+	if got.Agent.Env["OPENAI_API_KEY"] != "new-secret" {
+		t.Fatalf("Config().Agent.Env was not updated")
+	}
+	snapshot, status := rt.ConfigSnapshot()
+	publishedRaw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Scheduler.MaxConcurrentRuns != 4 || status.Revision != config.ConfigFileRevision(publishedRaw, true) {
+		t.Fatalf("ConfigSnapshot() = maxConcurrent %d, revision %q; want published values and file revision", snapshot.Scheduler.MaxConcurrentRuns, status.Revision)
+	}
+	partial, present, err := config.ReadPartialConfigFile(path)
+	if err != nil || !present {
+		t.Fatalf("ReadPartialConfigFile() = present %v, err %v", present, err)
+	}
+	if partial.Scheduler == nil || partial.Scheduler.MaxConcurrentRuns == nil || *partial.Scheduler.MaxConcurrentRuns != 4 {
+		t.Fatalf("persisted scheduler = %#v", partial.Scheduler)
+	}
+	if partial.Agent == nil || partial.Agent.Env["OPENAI_API_KEY"] != "new-secret" {
+		t.Fatalf("persisted agent env keys = %#v", partial.Agent)
+	}
+	if partial.Defaults == nil || partial.Defaults.AllowAutoPush == nil || !*partial.Defaults.AllowAutoPush {
+		t.Fatalf("persisted defaults = %#v", partial.Defaults)
+	}
+	persistedRaw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(persistedRaw, []byte("x-extension:")) || !bytes.Contains(persistedRaw, []byte("keep: true")) {
+		t.Fatalf("dashboard patch dropped unknown top-level extension:\n%s", persistedRaw)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("config mode = %v, want 0600", info.Mode().Perm())
+	}
+
+	if err := rt.PatchConfig(context.Background(), ConfigPatch{Revision: testConfigRevision(t, path), Unset: []string{"agent.env.OPENAI_API_KEY"}}); err != nil {
+		t.Fatalf("PatchConfig(unset env) error = %v", err)
+	}
+	if _, exists := rt.Config().Agent.Env["OPENAI_API_KEY"]; exists {
+		t.Fatal("Config().Agent.Env retained removed write-only value")
+	}
+}
+
+func TestPatchConfigRejectsStaleRevisionAndInheritedAuthority(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "config.json")
+	original := []byte(`{"notifications":{"osascript":{"enabled":false}},"agent":{"env":{"OLD":"value"}}}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := newConfigPatchRuntime(t, path, func(string) (string, bool) { return "", false })
+	staleRevision := config.ConfigFileRevision(original, true)
+	external := []byte(`{"notifications":{"osascript":{"enabled":false}},"agent":{"env":{"OLD":"external"}}}`)
+	if err := os.WriteFile(path, external, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := rt.PatchConfig(context.Background(), ConfigPatch{Revision: staleRevision, Set: map[string]json.RawMessage{"agent.model": json.RawMessage(`"gpt-5"`)}})
+	var patchErr *ConfigPatchError
+	if !errors.As(err, &patchErr) || patchErr.Kind != "conflict" {
+		t.Fatalf("stale PatchConfig() error = %#v, want conflict", err)
+	}
+	if got, _ := os.ReadFile(path); !bytes.Equal(got, external) {
+		t.Fatalf("stale patch overwrote external edit: %s", got)
+	}
+
+	rt.loadedConfig.Metadata.FieldSources["agent.env"] = config.ValueSourceEnv
+	err = rt.PatchConfig(context.Background(), ConfigPatch{Revision: config.ConfigFileRevision(external, true), Set: map[string]json.RawMessage{"agent.env.NEW": json.RawMessage(`"secret"`)}})
+	if !errors.As(err, &patchErr) || patchErr.Kind != "unsupported" {
+		t.Fatalf("inherited-authority PatchConfig() error = %#v, want unsupported", err)
+	}
+}
+
+func TestConfigSnapshotRevisionStaysBoundToPublishedGeneration(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	initial := []byte(`{"notifications":{"osascript":{"enabled":false}},"scheduler":{"maxConcurrentRuns":2}}`)
+	if err := os.WriteFile(path, initial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := newConfigPatchRuntime(t, path, func(string) (string, bool) { return "", false })
+
+	external := []byte(`{"notifications":{"osascript":{"enabled":false}},"scheduler":{"maxConcurrentRuns":7}}`)
+	if err := os.WriteFile(path, external, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, status := rt.ConfigSnapshot()
+	if snapshot.Scheduler.MaxConcurrentRuns != 2 {
+		t.Fatalf("ConfigSnapshot().MaxConcurrentRuns = %d, want last-published 2", snapshot.Scheduler.MaxConcurrentRuns)
+	}
+	if got, want := status.Revision, config.ConfigFileRevision(initial, true); got != want {
+		t.Fatalf("ConfigSnapshot().Revision = %q, want published generation %q", got, want)
+	}
+
+	err := rt.PatchConfig(context.Background(), ConfigPatch{
+		Revision: status.Revision,
+		Set:      map[string]json.RawMessage{"scheduler.maxConcurrentRuns": json.RawMessage("5")},
+	})
+	var patchErr *ConfigPatchError
+	if !errors.As(err, &patchErr) || patchErr.Kind != "conflict" {
+		t.Fatalf("PatchConfig() error = %#v, want conflict with unseen external generation", err)
+	}
+	if got, readErr := os.ReadFile(path); readErr != nil || !bytes.Equal(got, external) {
+		t.Fatalf("conflicting patch changed unseen external edit: got %q, err %v", got, readErr)
+	}
+
+	if err := rt.ReloadConfig(context.Background()); err != nil {
+		t.Fatalf("ReloadConfig() error = %v", err)
+	}
+	snapshot, status = rt.ConfigSnapshot()
+	if snapshot.Scheduler.MaxConcurrentRuns != 7 || status.Revision != config.ConfigFileRevision(external, true) {
+		t.Fatalf("published external generation = max %d revision %q", snapshot.Scheduler.MaxConcurrentRuns, status.Revision)
+	}
+}
+
+func TestPatchConfigCanonicalFieldRetiresShadowingLegacyAliases(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	raw := []byte(`{
+  "notifications":{"osascript":{"enabled":false}},
+  "agent":{"timeouts":{"workerSeconds":600}},
+  "defaults":{"allowAutoApprove":true},
+  "reviewer":{"reviewEvents":{"clean":"APPROVE","blocking":"REQUEST_CHANGES"}}
+}`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := newConfigPatchRuntime(t, path, func(string) (string, bool) { return "", false })
+	err := rt.PatchConfig(context.Background(), ConfigPatch{
+		Revision: testConfigRevision(t, path),
+		Set: map[string]json.RawMessage{
+			"agent.timeouts.workerMaxRuntimeSeconds":     json.RawMessage("700"),
+			"roles.reviewer.behavior.reviewEvents.clean": json.RawMessage(`"COMMENT"`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("PatchConfig() error = %v", err)
+	}
+	got := rt.Config()
+	if got.Agent.Timeouts.WorkerSeconds != 700 || got.Agent.Timeouts.WorkerMaxRuntimeSeconds != 700 {
+		t.Fatalf("worker timeout aliases = legacy %d canonical %d, want 700", got.Agent.Timeouts.WorkerSeconds, got.Agent.Timeouts.WorkerMaxRuntimeSeconds)
+	}
+	if got.Roles.Reviewer.Behavior.ReviewEvents.Clean != config.ReviewerReviewEventComment {
+		t.Fatalf("reviewer clean event = %q, want COMMENT", got.Roles.Reviewer.Behavior.ReviewEvents.Clean)
+	}
+	persisted, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(persisted, &document); err != nil {
+		t.Fatalf("decode persisted config: %v\n%s", err, persisted)
+	}
+	timeouts := document["agent"].(map[string]any)["timeouts"].(map[string]any)
+	if _, exists := timeouts["workerSeconds"]; exists {
+		t.Fatalf("persisted config retained workerSeconds alias:\n%s", persisted)
+	}
+	defaults := document["defaults"].(map[string]any)
+	if _, exists := defaults["allowAutoApprove"]; exists {
+		t.Fatalf("persisted config retained allowAutoApprove alias:\n%s", persisted)
+	}
+	legacyEvents := document["reviewer"].(map[string]any)["reviewEvents"].(map[string]any)
+	if _, exists := legacyEvents["clean"]; exists {
+		t.Fatalf("persisted config retained reviewer.reviewEvents.clean alias:\n%s", persisted)
+	}
+	if !bytes.Contains(persisted, []byte(`"blocking": "REQUEST_CHANGES"`)) {
+		t.Fatalf("persisted config dropped unrelated legacy field:\n%s", persisted)
+	}
+
+	if err := rt.PatchConfig(context.Background(), ConfigPatch{
+		Revision: testConfigRevision(t, path),
+		Unset:    []string{"roles.reviewer.behavior.reviewEvents.clean"},
+	}); err != nil {
+		t.Fatalf("PatchConfig(unset canonical) error = %v", err)
+	}
+	if got := rt.Config().Roles.Reviewer.Behavior.ReviewEvents.Clean; got != config.ReviewerReviewEventApprove {
+		t.Fatalf("clean event after canonical unset = %q, want default APPROVE", got)
+	}
+}
+
+func TestPatchConfigRejectsShadowedUnsupportedAndInvalidFieldsWithoutWriting(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	original := []byte(`{"notifications":{"osascript":{"enabled":false}},"defaults":{"allowAutoPush":true},"scheduler":{"maxConcurrentRuns":2}}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	lookup := func(key string) (string, bool) {
+		if key == "LOOPER_ALLOW_AUTO_PUSH" {
+			return "false", true
+		}
+		return "", false
+	}
+	rt := newConfigPatchRuntime(t, path, lookup)
+
+	tests := []struct {
+		name  string
+		patch ConfigPatch
+		kind  string
+	}{
+		{name: "env shadowed", patch: ConfigPatch{Set: map[string]json.RawMessage{"defaults.allowAutoPush": json.RawMessage("true")}}, kind: "unsupported"},
+		{name: "restart bound", patch: ConfigPatch{Set: map[string]json.RawMessage{"server.port": json.RawMessage("18000")}}, kind: "unsupported"},
+		{name: "invalid value", patch: ConfigPatch{Set: map[string]json.RawMessage{"scheduler.maxConcurrentRuns": json.RawMessage("0")}}, kind: "validation"},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("ReadFile(before) error = %v", err)
+			}
+			testCase.patch.Revision = config.ConfigFileRevision(before, true)
+			err = rt.PatchConfig(context.Background(), testCase.patch)
+			var patchErr *ConfigPatchError
+			if !errors.As(err, &patchErr) || patchErr.Kind != testCase.kind {
+				t.Fatalf("PatchConfig() error = %#v, want kind %q", err, testCase.kind)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("ReadFile(after) error = %v", err)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatalf("rejected patch changed file:\nbefore=%s\nafter=%s", before, after)
+			}
+		})
+	}
+}
+
+func testConfigRevision(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(revision) error = %v", err)
+	}
+	return config.ConfigFileRevision(raw, true)
+}
+
+func newConfigPatchRuntime(t *testing.T, path string, lookup config.EnvLookupFunc) *Runtime {
+	t.Helper()
+	loadAt := func(selected string) (config.LoadedFileConfig, error) {
+		return config.LoadFile(config.LoadFileOptions{ConfigPathOverride: selected, LookupEnv: lookup})
+	}
+	initial, err := loadAt(path)
+	if err != nil {
+		t.Fatalf("LoadFile(initial) error = %v", err)
+	}
+	return New(Options{
+		Config:        initial.Config,
+		ConfigPath:    path,
+		InitialConfig: initial,
+		ReloadConfig: func() (config.LoadedFileConfig, error) {
+			return loadAt(path)
+		},
+		LoadConfigAt: loadAt,
+	})
+}

--- a/internal/runtime/config_reload.go
+++ b/internal/runtime/config_reload.go
@@ -1,0 +1,554 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+// ConfigReloadStatus is transient diagnostic state. The config file overlaid by
+// the daemon's startup environment and CLI flags remains the authority for
+// global policy; this status only explains whether that authority was applied.
+type ConfigReloadStatus struct {
+	ConfigPath    string
+	Format        string
+	FilePresent   bool
+	Revision      string
+	LastAttemptAt *time.Time
+	LastAppliedAt *time.Time
+	LastError     string
+	RejectedPaths []string
+	FieldSources  map[string]config.ValueSource
+}
+
+// ConfigReloadError reports a rejected candidate without replacing the
+// last-known-good runtime snapshot.
+type ConfigReloadError struct {
+	Kind  string
+	Paths []string
+	Err   error
+}
+
+type ConfigPatch struct {
+	Revision string
+	Set      map[string]json.RawMessage
+	Unset    []string
+}
+
+type ConfigPatchError struct {
+	Kind    string
+	Message string
+	Paths   []string
+	Err     error
+}
+
+func (e *ConfigPatchError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "configuration update failed"
+}
+
+func (e *ConfigPatchError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *ConfigReloadError) Error() string {
+	if e == nil {
+		return ""
+	}
+	// Unstructured parser/decoder errors can quote rejected YAML/TOML scalar
+	// values. Keep the public error safe; callers that need classification can
+	// inspect Kind and use errors.Unwrap without putting the raw text in logs.
+	if e.Kind == "invalid" && e.Err != nil && len(e.Paths) == 0 {
+		return "configuration reload rejected: config file could not be decoded or validated"
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	if len(e.Paths) > 0 {
+		return fmt.Sprintf("configuration changes require a daemon restart: %s", strings.Join(e.Paths, ", "))
+	}
+	return "configuration reload failed"
+}
+
+func (e *ConfigReloadError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (r *Runtime) startConfigReloadLoop() {
+	if r == nil || r.reloadConfig == nil {
+		return
+	}
+	r.configReloadMu.Lock()
+	if r.configReloadStop != nil {
+		r.configReloadMu.Unlock()
+		return
+	}
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	r.configReloadStop = stopCh
+	r.configReloadDone = doneCh
+	r.configReloadMu.Unlock()
+
+	go func() {
+		defer close(doneCh)
+		ticker := time.NewTicker(r.configReloadInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-ticker.C:
+				_ = r.ReloadConfig(context.Background())
+			}
+		}
+	}()
+}
+
+func (r *Runtime) stopConfigReloadLoop() {
+	if r == nil {
+		return
+	}
+	r.configReloadMu.Lock()
+	stopCh := r.configReloadStop
+	doneCh := r.configReloadDone
+	r.configReloadStop = nil
+	r.configReloadDone = nil
+	r.configReloadMu.Unlock()
+	if stopCh == nil {
+		return
+	}
+	close(stopCh)
+	if doneCh != nil {
+		timeout := r.shutdownTimeout
+		if timeout <= 0 {
+			timeout = time.Second
+		}
+		select {
+		case <-doneCh:
+		case <-time.After(timeout):
+			if r.logger != nil {
+				r.logger.Warn("timed out waiting for configuration reload loop", map[string]any{"timeoutMs": timeout.Milliseconds()})
+			}
+		}
+	}
+}
+
+// ReloadConfig reparses the configured source using the exact loader captured
+// at bootstrap. A candidate is published atomically only when every changed
+// field is hot-safe; invalid and restart-bound candidates leave running work and
+// the last-known-good snapshot untouched.
+func (r *Runtime) ReloadConfig(ctx context.Context) error {
+	if r == nil || r.reloadConfig == nil {
+		return &ConfigReloadError{Kind: "unavailable", Err: fmt.Errorf("configuration reload is not configured")}
+	}
+
+	r.configReloadMu.Lock()
+	defer r.configReloadMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return &ConfigReloadError{Kind: "canceled", Err: err}
+	}
+
+	now := r.now().UTC()
+	r.configReloadStatus.LastAttemptAt = timePointer(now)
+	loaded, err := r.reloadConfig()
+	if err != nil {
+		return r.rejectConfigReloadLocked("invalid", configValidationPaths(err), err)
+	}
+	if err := ctx.Err(); err != nil {
+		return r.rejectConfigReloadLocked("canceled", nil, err)
+	}
+	return r.applyLoadedConfigLocked(loaded, now)
+}
+
+func (r *Runtime) applyLoadedConfigLocked(loaded config.LoadedFileConfig, now time.Time) error {
+	restartRequired := config.RestartRequiredChanges(r.loadedConfig.Config, loaded.Config)
+	if len(restartRequired) > 0 {
+		sort.Strings(restartRequired)
+		return r.rejectConfigReloadLocked("restart_required", restartRequired, nil)
+	}
+	r.configBoundary.Lock()
+	defer r.configBoundary.Unlock()
+	return r.applyLoadedConfigBoundaryLocked(loaded, now)
+}
+
+// applyLoadedConfigBoundaryLocked requires configBoundary's write lock. It is
+// split out so a dashboard patch can hold the same publication boundary across
+// final validation, rename, and publication.
+func (r *Runtime) applyLoadedConfigBoundaryLocked(loaded config.LoadedFileConfig, now time.Time) error {
+	runtimeCandidate := loaded.Config
+	if r.projectCatalog != nil {
+		runtimeCandidate.Projects = r.projectCatalog.Snapshot().Projects
+	}
+	if err := config.Validate(runtimeCandidate); err != nil {
+		return r.rejectConfigReloadLocked("invalid", nil, err)
+	}
+
+	changed := !reflect.DeepEqual(r.loadedConfig.Config, loaded.Config)
+	r.loadedConfig = loaded
+	r.configReloadStatus.ConfigPath = loaded.Metadata.ConfigPath
+	r.configReloadStatus.Format = strings.TrimPrefix(strings.ToLower(filepath.Ext(loaded.Metadata.ConfigPath)), ".")
+	r.configReloadStatus.FilePresent = loaded.Metadata.ConfigFilePresent
+	r.configReloadStatus.Revision = loaded.Metadata.ConfigFileRevision
+	r.configReloadStatus.FieldSources = cloneValueSources(loaded.Metadata.FieldSources)
+	r.configReloadStatus.LastError = ""
+	r.configReloadStatus.RejectedPaths = nil
+	if !changed {
+		return nil
+	}
+
+	if r.projectCatalog != nil {
+		r.projectCatalog.PublishGlobals(loaded.Config)
+		r.publishCatalogConsumers(r.projectCatalog.Snapshot())
+	}
+	r.configReloadStatus.LastAppliedAt = timePointer(now)
+	if r.logger != nil {
+		r.logger.Info("looperd configuration reloaded", map[string]any{
+			"configPath": loaded.Metadata.ConfigPath,
+		})
+	}
+	r.TriggerSchedulerTick()
+	return nil
+}
+
+// PatchConfig applies a targeted mutation to the file layer. It rereads the
+// source under the mutation lock, validates a same-directory temporary file
+// through the exact startup loader, performs a final identity/mode/byte check,
+// then atomically renames it into place. See the final-check comment below for
+// the narrow portable-filesystem race that remains.
+func (r *Runtime) PatchConfig(ctx context.Context, patch ConfigPatch) error {
+	if r == nil || r.reloadConfig == nil || r.loadConfigAt == nil {
+		return &ConfigPatchError{Kind: "unavailable", Message: "configuration updates are not available"}
+	}
+	if len(patch.Set) == 0 && len(patch.Unset) == 0 {
+		return &ConfigPatchError{Kind: "validation", Message: "configuration update must set or unset at least one field"}
+	}
+
+	r.configReloadMu.Lock()
+	defer r.configReloadMu.Unlock()
+
+	paths := make([]string, 0, len(patch.Set)+len(patch.Unset))
+	for path := range patch.Set {
+		paths = append(paths, strings.TrimSpace(path))
+	}
+	for _, path := range patch.Unset {
+		paths = append(paths, strings.TrimSpace(path))
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		if !config.IsHotEditablePath(path) {
+			return &ConfigPatchError{Kind: "unsupported", Message: fmt.Sprintf("configuration field %q is not hot-editable", path), Paths: []string{path}}
+		}
+		if !config.IsFieldLevelConfigPath(path) {
+			return &ConfigPatchError{Kind: "unsupported", Message: fmt.Sprintf("configuration field %q is not a curated field-level setting", path), Paths: []string{path}}
+		}
+		source := configValueSourceForPath(r.loadedConfig.Metadata.FieldSources, path)
+		if source == config.ValueSourceEnv || source == config.ValueSourceCLI {
+			return &ConfigPatchError{Kind: "unsupported", Message: fmt.Sprintf("configuration field %q is controlled by %s and is read-only", path, source), Paths: []string{path}}
+		}
+	}
+
+	configPath := strings.TrimSpace(r.loadedConfig.Metadata.ConfigPath)
+	if configPath == "" {
+		configPath = strings.TrimSpace(r.configPath)
+	}
+	if configPath == "" {
+		return &ConfigPatchError{Kind: "unavailable", Message: "the daemon config path is unavailable"}
+	}
+
+	originalInfo, inspectedPresent, err := inspectConfigPathForPatch(configPath)
+	if err != nil {
+		return err
+	}
+	originalRaw, originalPresent, err := readOptionalConfigFile(configPath)
+	if err != nil {
+		return &ConfigPatchError{Kind: "unavailable", Message: err.Error(), Err: err}
+	}
+	afterReadInfo, afterReadPresent, err := inspectConfigPathForPatch(configPath)
+	if err != nil {
+		return err
+	}
+	if inspectedPresent != originalPresent || afterReadPresent != originalPresent ||
+		(originalPresent && (!os.SameFile(originalInfo, afterReadInfo) || originalInfo.Mode().Perm() != afterReadInfo.Mode().Perm())) {
+		return &ConfigPatchError{Kind: "conflict", Message: "configuration changed while it was being read; refresh and try again"}
+	}
+	if strings.TrimSpace(patch.Revision) == "" {
+		return &ConfigPatchError{Kind: "validation", Message: "configuration revision is required"}
+	}
+	if currentRevision := config.ConfigFileRevision(originalRaw, originalPresent); patch.Revision != currentRevision {
+		return &ConfigPatchError{Kind: "conflict", Message: "configuration changed since it was loaded; refresh and try again"}
+	}
+	partial := config.PartialConfig{}
+	if originalPresent {
+		partial, err = config.DecodePartialConfigFile(configPath, originalRaw)
+		if err != nil {
+			return &ConfigPatchError{Kind: "validation", Message: err.Error(), Paths: paths, Err: err}
+		}
+	}
+	updated, err := config.ApplyFieldPatch(partial, patch.Set, patch.Unset)
+	if err != nil {
+		return &ConfigPatchError{Kind: "validation", Message: err.Error(), Paths: paths, Err: err}
+	}
+	raw, err := config.MarshalPatchedConfigFile(configPath, originalRaw, originalPresent, updated, paths)
+	if err != nil {
+		return &ConfigPatchError{Kind: "validation", Message: err.Error(), Paths: paths, Err: err}
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return &ConfigPatchError{Kind: "unavailable", Message: fmt.Sprintf("create config directory: %v", err), Err: err}
+	}
+	tmpPattern := ".config-reload-*" + filepath.Ext(configPath)
+	tmp, err := os.CreateTemp(filepath.Dir(configPath), tmpPattern)
+	if err != nil {
+		return &ConfigPatchError{Kind: "unavailable", Message: fmt.Sprintf("create temporary config: %v", err), Err: err}
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if originalPresent {
+		if chmodErr := tmp.Chmod(originalInfo.Mode().Perm()); chmodErr != nil {
+			_ = tmp.Close()
+			return &ConfigPatchError{Kind: "unavailable", Message: fmt.Sprintf("preserve config mode: %v", chmodErr), Err: chmodErr}
+		}
+	}
+	if _, err := tmp.Write(raw); err != nil {
+		_ = tmp.Close()
+		return &ConfigPatchError{Kind: "unavailable", Message: fmt.Sprintf("write temporary config: %v", err), Err: err}
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return &ConfigPatchError{Kind: "unavailable", Message: fmt.Sprintf("sync temporary config: %v", err), Err: err}
+	}
+	if err := tmp.Close(); err != nil {
+		return &ConfigPatchError{Kind: "unavailable", Message: fmt.Sprintf("close temporary config: %v", err), Err: err}
+	}
+
+	candidate, err := r.loadConfigAt(tmpPath)
+	if err != nil {
+		return &ConfigPatchError{Kind: "validation", Message: err.Error(), Err: err}
+	}
+	if rejected := config.RestartRequiredChanges(r.loadedConfig.Config, candidate.Config); len(rejected) > 0 {
+		sort.Strings(rejected)
+		return &ConfigPatchError{Kind: "unsupported", Message: fmt.Sprintf("configuration changes require a daemon restart: %s", strings.Join(rejected, ", ")), Paths: rejected}
+	}
+	r.configBoundary.Lock()
+	defer r.configBoundary.Unlock()
+	runtimeCandidate := candidate.Config
+	if r.projectCatalog != nil {
+		runtimeCandidate.Projects = r.projectCatalog.Snapshot().Projects
+	}
+	if err := config.Validate(runtimeCandidate); err != nil {
+		return &ConfigPatchError{Kind: "validation", Message: err.Error(), Err: err}
+	}
+	if err := ctx.Err(); err != nil {
+		return &ConfigPatchError{Kind: "conflict", Message: err.Error(), Err: err}
+	}
+	currentInfo, inspectedCurrentPresent, err := inspectConfigPathForPatch(configPath)
+	if err != nil {
+		return err
+	}
+	currentRaw, currentPresent, err := readOptionalConfigFile(configPath)
+	if err != nil {
+		return &ConfigPatchError{Kind: "unavailable", Message: err.Error(), Err: err}
+	}
+	afterCurrentInfo, afterCurrentPresent, err := inspectConfigPathForPatch(configPath)
+	if err != nil {
+		return err
+	}
+	if inspectedCurrentPresent != originalPresent || currentPresent != originalPresent || afterCurrentPresent != originalPresent ||
+		(originalPresent && (!os.SameFile(originalInfo, currentInfo) || !os.SameFile(currentInfo, afterCurrentInfo) ||
+			originalInfo.Mode().Perm() != currentInfo.Mode().Perm() || currentInfo.Mode().Perm() != afterCurrentInfo.Mode().Perm())) ||
+		!bytes.Equal(currentRaw, originalRaw) {
+		return &ConfigPatchError{Kind: "conflict", Message: "configuration changed in another editor; refresh and try again"}
+	}
+	// Rename is atomic, but portable filesystems do not provide a conditional
+	// compare-and-rename. The identity/mode/byte check immediately above is the
+	// final best-effort conflict check; an editor racing in this tiny interval
+	// can still win or be replaced.
+	if err := os.Rename(tmpPath, configPath); err != nil {
+		return &ConfigPatchError{Kind: "unavailable", Message: fmt.Sprintf("replace config: %v", err), Err: err}
+	}
+	if err := syncDirectory(filepath.Dir(configPath)); err != nil {
+		if r.logger != nil {
+			r.logger.Warn("configuration replaced but directory sync failed", map[string]any{"error": err.Error(), "configPath": configPath})
+		}
+	}
+	candidate.Metadata.ConfigPath = configPath
+	candidate.Metadata.ConfigFilePresent = true
+	now := r.now().UTC()
+	r.configReloadStatus.LastAttemptAt = timePointer(now)
+	if err := r.applyLoadedConfigBoundaryLocked(candidate, now); err != nil {
+		return &ConfigPatchError{Kind: "validation", Message: err.Error(), Err: err}
+	}
+	return nil
+}
+
+func inspectConfigPathForPatch(path string) (os.FileInfo, bool, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, &ConfigPatchError{Kind: "unavailable", Message: fmt.Sprintf("inspect config: %v", err), Err: err}
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, true, &ConfigPatchError{Kind: "unsupported", Message: "dashboard updates do not replace symlinked config files; edit the symlink target directly"}
+	}
+	if !info.Mode().IsRegular() {
+		return nil, true, &ConfigPatchError{Kind: "unsupported", Message: "dashboard updates require the config path to be a regular file"}
+	}
+	return info, true, nil
+}
+
+func configValueSourceForPath(sources map[string]config.ValueSource, path string) config.ValueSource {
+	for candidate := path; candidate != ""; {
+		if source, ok := sources[candidate]; ok {
+			return source
+		}
+		index := strings.LastIndex(candidate, ".")
+		if index < 0 {
+			break
+		}
+		candidate = candidate[:index]
+	}
+	return config.ValueSourceDefault
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}
+
+func readOptionalConfigFile(path string) ([]byte, bool, error) {
+	raw, err := os.ReadFile(path)
+	if err == nil {
+		return raw, true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	return nil, false, fmt.Errorf("read config: %w", err)
+}
+
+func (r *Runtime) rejectConfigReloadLocked(kind string, paths []string, cause error) error {
+	reloadErr := &ConfigReloadError{Kind: kind, Paths: append([]string(nil), paths...), Err: cause}
+	message := configReloadDiagnostic(reloadErr)
+	shouldLog := message != r.configReloadStatus.LastError
+	r.configReloadStatus.LastError = message
+	r.configReloadStatus.RejectedPaths = append([]string(nil), paths...)
+	if shouldLog && r.logger != nil {
+		r.logger.Warn("looperd configuration reload rejected", map[string]any{
+			"error":         message,
+			"rejectedPaths": append([]string(nil), paths...),
+		})
+	}
+	return reloadErr
+}
+
+func configReloadDiagnostic(reloadErr *ConfigReloadError) string {
+	if reloadErr == nil {
+		return ""
+	}
+	return reloadErr.Error()
+}
+
+func (r *Runtime) ConfigReloadStatus() ConfigReloadStatus {
+	if r == nil {
+		return ConfigReloadStatus{}
+	}
+	r.configReloadMu.Lock()
+	defer r.configReloadMu.Unlock()
+	return r.configReloadStatusLocked()
+}
+
+// ConfigSnapshot returns effective values and reload metadata from one
+// configReloadMu generation for API responses.
+func (r *Runtime) ConfigSnapshot() (config.Config, ConfigReloadStatus) {
+	if r == nil {
+		return config.Config{}, ConfigReloadStatus{}
+	}
+	r.configReloadMu.Lock()
+	defer r.configReloadMu.Unlock()
+	cfg := r.loadedConfig.Config
+	if r.projectCatalog != nil {
+		cfg = r.projectCatalog.Snapshot()
+	}
+	return cfg, r.configReloadStatusLocked()
+}
+
+func (r *Runtime) configReloadStatusLocked() ConfigReloadStatus {
+	status := r.configReloadStatus
+	if status.ConfigPath == "" {
+		status.ConfigPath = r.loadedConfig.Metadata.ConfigPath
+		status.Format = strings.TrimPrefix(strings.ToLower(filepath.Ext(status.ConfigPath)), ".")
+		status.FilePresent = r.loadedConfig.Metadata.ConfigFilePresent
+		status.Revision = r.loadedConfig.Metadata.ConfigFileRevision
+		status.FieldSources = cloneValueSources(r.loadedConfig.Metadata.FieldSources)
+	}
+	status.RejectedPaths = append([]string(nil), status.RejectedPaths...)
+	status.FieldSources = cloneValueSources(status.FieldSources)
+	return status
+}
+
+func timePointer(value time.Time) *time.Time {
+	copy := value
+	return &copy
+}
+
+func cloneValueSources(source map[string]config.ValueSource) map[string]config.ValueSource {
+	if len(source) == 0 {
+		return map[string]config.ValueSource{}
+	}
+	cloned := make(map[string]config.ValueSource, len(source))
+	for path, value := range source {
+		cloned[path] = value
+	}
+	return cloned
+}
+
+func configValidationPaths(err error) []string {
+	var validationErr *config.ConfigValidationError
+	if !errors.As(err, &validationErr) || validationErr == nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(validationErr.Issues))
+	paths := make([]string, 0, len(validationErr.Issues))
+	for _, issue := range validationErr.Issues {
+		path := strings.TrimSpace(issue.Path)
+		if path == "" {
+			continue
+		}
+		if _, exists := seen[path]; exists {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}

--- a/internal/runtime/config_reload_redaction_test.go
+++ b/internal/runtime/config_reload_redaction_test.go
@@ -1,0 +1,91 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestReloadConfigHidesSecretBearingUnstructuredDecodeErrors(t *testing.T) {
+	t.Parallel()
+
+	const secret = "SUPER_SECRET_VALUE"
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("notifications:\n  osascript:\n    enabled: false\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(initial) error = %v", err)
+	}
+	load := func() (config.LoadedFileConfig, error) {
+		return config.LoadFile(config.LoadFileOptions{
+			ConfigPathOverride: path,
+			LookupEnv:          func(string) (string, bool) { return "", false },
+		})
+	}
+	initial, err := load()
+	if err != nil {
+		t.Fatalf("LoadFile(initial) error = %v", err)
+	}
+	logger := &configReloadDiagnosticLogger{}
+	rt := New(Options{Config: initial.Config, InitialConfig: initial, ReloadConfig: load, Logger: logger})
+
+	// yaml.v3 includes the invalid composite key's scalar in this error. That
+	// makes the test exercise a real parser disclosure rather than a fake error.
+	malformed := "agent:\n  env:\n    ? [" + secret + "]\n    : value\n"
+	if err := os.WriteFile(path, []byte(malformed), 0o600); err != nil {
+		t.Fatalf("WriteFile(malformed) error = %v", err)
+	}
+	_, rawErr := load()
+	if rawErr == nil || !strings.Contains(rawErr.Error(), secret) {
+		t.Fatalf("LoadFile(malformed) error = %v, want secret-bearing parser error", rawErr)
+	}
+	reloadErr := rt.ReloadConfig(context.Background())
+	if reloadErr == nil {
+		t.Fatal("ReloadConfig() error = nil, want rejected candidate")
+	}
+	if strings.Contains(reloadErr.Error(), secret) || strings.Contains(reloadErr.Error(), "invalid map key") {
+		t.Fatalf("ReloadConfig() error = %q, exposed parser details", reloadErr)
+	}
+
+	status := rt.ConfigReloadStatus()
+	if strings.Contains(status.LastError, secret) || strings.Contains(status.LastError, "invalid map key") {
+		t.Fatalf("ConfigReloadStatus().LastError = %q, exposed parser details", status.LastError)
+	}
+	if got := logger.joined(); strings.Contains(got, secret) || strings.Contains(got, "invalid map key") {
+		t.Fatalf("logger output = %q, exposed parser details", got)
+	}
+}
+
+type configReloadDiagnosticLogger struct {
+	mu      sync.Mutex
+	entries []string
+}
+
+func (l *configReloadDiagnosticLogger) Debug(message string, context map[string]any) {
+	l.append(message, context)
+}
+func (l *configReloadDiagnosticLogger) Info(message string, context map[string]any) {
+	l.append(message, context)
+}
+func (l *configReloadDiagnosticLogger) Warn(message string, context map[string]any) {
+	l.append(message, context)
+}
+func (l *configReloadDiagnosticLogger) Error(message string, context map[string]any) {
+	l.append(message, context)
+}
+
+func (l *configReloadDiagnosticLogger) append(message string, context map[string]any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, message+" "+fmt.Sprint(context))
+}
+
+func (l *configReloadDiagnosticLogger) joined() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.entries, "\n")
+}

--- a/internal/runtime/config_reload_test.go
+++ b/internal/runtime/config_reload_test.go
@@ -1,0 +1,231 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	networkclient "github.com/nexu-io/looper/internal/network/client"
+)
+
+type recordingNetworkManager struct {
+	configs []config.Config
+}
+
+func (m *recordingNetworkManager) Start(context.Context) error { return nil }
+func (m *recordingNetworkManager) Stop()                       {}
+func (m *recordingNetworkManager) Status() networkclient.Status {
+	return networkclient.Status{}
+}
+func (m *recordingNetworkManager) UpdateConfig(cfg config.Config) {
+	m.configs = append(m.configs, config.CloneConfig(cfg))
+}
+
+func TestReloadConfigPublishesHotSnapshotAndKeepsMaterializedProjects(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Projects = []config.ProjectRefConfig{{ID: "import-input"}}
+	oldVendor := config.AgentVendorCodex
+	cfg.Agent.Vendor = &oldVendor
+	loaded := config.LoadedFileConfig{
+		Config: cfg,
+		Metadata: config.LoadFileMetadata{
+			ConfigPath:        "/tmp/config.toml",
+			ConfigFilePresent: true,
+		},
+	}
+	next := loaded
+	next.Config = config.CloneConfig(cfg)
+	next.Config.Scheduler.MaxConcurrentRuns++
+	next.Config.Roles.Worker.AutoDiscovery = !cfg.Roles.Worker.AutoDiscovery
+	newVendor := config.AgentVendorOpenCode
+	next.Config.Agent.Vendor = &newVendor
+	next.Config.Projects = []config.ProjectRefConfig{{ID: "import-input"}}
+
+	rt := New(Options{
+		Config:        cfg,
+		InitialConfig: loaded,
+		ReloadConfig: func() (config.LoadedFileConfig, error) {
+			return next, nil
+		},
+	})
+	networkManager := &recordingNetworkManager{}
+	rt.networkManager = networkManager
+	rt.projectCatalog.Publish([]config.ProjectRefConfig{{ID: "database-project", Name: "Database project", RepoPath: t.TempDir()}})
+	operationSnapshot := rt.Config()
+
+	if err := rt.ReloadConfig(context.Background()); err != nil {
+		t.Fatalf("ReloadConfig() error = %v", err)
+	}
+	got := rt.Config()
+	if got.Scheduler.MaxConcurrentRuns != next.Config.Scheduler.MaxConcurrentRuns {
+		t.Fatalf("Config().Scheduler.MaxConcurrentRuns = %d, want %d", got.Scheduler.MaxConcurrentRuns, next.Config.Scheduler.MaxConcurrentRuns)
+	}
+	if got.Agent.Vendor == nil || *got.Agent.Vendor != newVendor {
+		t.Fatalf("Config().Agent.Vendor = %#v, want %q", got.Agent.Vendor, newVendor)
+	}
+	if len(got.Projects) != 1 || got.Projects[0].ID != "database-project" {
+		t.Fatalf("Config().Projects = %#v, want materialized database project", got.Projects)
+	}
+	if len(networkManager.configs) != 1 {
+		t.Fatalf("network UpdateConfig calls = %d, want 1", len(networkManager.configs))
+	}
+	networkSnapshot := networkManager.configs[0]
+	if networkSnapshot.Roles.Worker.AutoDiscovery != next.Config.Roles.Worker.AutoDiscovery || len(networkSnapshot.Projects) != 1 || networkSnapshot.Projects[0].ID != "database-project" {
+		t.Fatalf("network config snapshot = %#v, want hot globals plus materialized project", networkSnapshot)
+	}
+	if operationSnapshot.Scheduler.MaxConcurrentRuns != cfg.Scheduler.MaxConcurrentRuns {
+		t.Fatalf("captured operation snapshot changed = %d, want %d", operationSnapshot.Scheduler.MaxConcurrentRuns, cfg.Scheduler.MaxConcurrentRuns)
+	}
+	if operationSnapshot.Agent.Vendor == nil || *operationSnapshot.Agent.Vendor != oldVendor {
+		t.Fatalf("captured operation vendor = %#v, want retained %q", operationSnapshot.Agent.Vendor, oldVendor)
+	}
+}
+
+func TestReloadConfigRejectsRestartBoundAndInvalidCandidates(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	oldVendor := config.AgentVendorCodex
+	model := "gpt-5"
+	cfg.Agent.Vendor = &oldVendor
+	cfg.Agent.Model = &model
+	cfg.Agent.Params["command"] = "/opt/codex-wrapper"
+	loaded := config.LoadedFileConfig{Config: cfg, Metadata: config.LoadFileMetadata{ConfigPath: "/tmp/config.toml", ConfigFilePresent: true}}
+	candidate := loaded
+	candidate.Config = config.CloneConfig(cfg)
+	candidate.Config.Server.Port++
+	loadErr := error(nil)
+	rt := New(Options{
+		Config:        cfg,
+		InitialConfig: loaded,
+		ReloadConfig: func() (config.LoadedFileConfig, error) {
+			return candidate, loadErr
+		},
+	})
+
+	err = rt.ReloadConfig(context.Background())
+	var reloadErr *ConfigReloadError
+	if !errors.As(err, &reloadErr) || reloadErr.Kind != "restart_required" || !slices.Contains(reloadErr.Paths, "server.port") {
+		t.Fatalf("ReloadConfig() error = %#v, want restart_required server.port", err)
+	}
+	if got := rt.Config().Server.Port; got != cfg.Server.Port {
+		t.Fatalf("Config().Server.Port = %d, want last-good %d", got, cfg.Server.Port)
+	}
+
+	candidate.Config = config.CloneConfig(cfg)
+	candidate.Config.Agent.Vendor = nil
+	err = rt.ReloadConfig(context.Background())
+	if !errors.As(err, &reloadErr) || reloadErr.Kind != "restart_required" || !slices.Equal(reloadErr.Paths, []string{"agent.model", "agent.params"}) {
+		t.Fatalf("ReloadConfig() vendor-disable error = %#v, want restart_required agent.model + agent.params", err)
+	}
+
+	candidate.Config = config.CloneConfig(cfg)
+	newVendor := config.AgentVendorClaudeCode
+	candidate.Config.Agent.Vendor = &newVendor
+	err = rt.ReloadConfig(context.Background())
+	if !errors.As(err, &reloadErr) || reloadErr.Kind != "restart_required" || !slices.Equal(reloadErr.Paths, []string{"agent.model", "agent.params"}) {
+		t.Fatalf("ReloadConfig() vendor-profile error = %#v, want restart_required agent.model + agent.params", err)
+	}
+	if got := rt.Config().Agent.Vendor; got == nil || *got != oldVendor {
+		t.Fatalf("Config().Agent.Vendor = %#v, want last-good %q", got, oldVendor)
+	}
+
+	loadErr = errors.New("temporary invalid syntax")
+	err = rt.ReloadConfig(context.Background())
+	if !errors.As(err, &reloadErr) || reloadErr.Kind != "invalid" {
+		t.Fatalf("ReloadConfig() invalid error = %#v, want invalid reload", err)
+	}
+	status := rt.ConfigReloadStatus()
+	if status.LastError != "configuration reload rejected: config file could not be decoded or validated" {
+		t.Fatalf("ConfigReloadStatus().LastError = %q", status.LastError)
+	}
+
+	loadErr = &config.ConfigValidationError{Issues: []config.ValidationIssue{
+		{Path: "agent.vendor", Message: "is invalid"},
+		{Path: "scheduler.maxConcurrentRuns", Message: "must be positive"},
+	}}
+	err = rt.ReloadConfig(context.Background())
+	if !errors.As(err, &reloadErr) || !slices.Equal(reloadErr.Paths, []string{"agent.vendor", "scheduler.maxConcurrentRuns"}) {
+		t.Fatalf("ReloadConfig() validation paths = %#v, want concrete sorted paths", reloadErr.Paths)
+	}
+	status = rt.ConfigReloadStatus()
+	if !slices.Equal(status.RejectedPaths, reloadErr.Paths) || !strings.Contains(status.LastError, "agent.vendor is invalid") || !strings.Contains(status.LastError, "scheduler.maxConcurrentRuns must be positive") {
+		t.Fatalf("ConfigReloadStatus() = %#v, want field-level diagnostics", status)
+	}
+}
+
+func TestConfigReloadLoopRecoversFromInvalidExternalEdit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeRuntimeReloadConfig(t, path, 2)
+	load := func() (config.LoadedFileConfig, error) {
+		return config.LoadFile(config.LoadFileOptions{
+			ConfigPathOverride: path,
+			LookupEnv:          func(string) (string, bool) { return "", false },
+		})
+	}
+	initial, err := load()
+	if err != nil {
+		t.Fatalf("LoadFile(initial) error = %v", err)
+	}
+	rt := New(Options{
+		Config:               initial.Config,
+		InitialConfig:        initial,
+		ReloadConfig:         load,
+		ConfigReloadInterval: 10 * time.Millisecond,
+	})
+	rt.startConfigReloadLoop()
+	t.Cleanup(rt.stopConfigReloadLoop)
+
+	if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+		t.Fatalf("WriteFile(invalid) error = %v", err)
+	}
+	waitForRuntimeConfig(t, 2*time.Second, func() bool {
+		return rt.ConfigReloadStatus().LastError != ""
+	})
+	if got := rt.Config().Scheduler.MaxConcurrentRuns; got != 2 {
+		t.Fatalf("invalid edit changed MaxConcurrentRuns = %d, want 2", got)
+	}
+
+	writeRuntimeReloadConfig(t, path, 5)
+	waitForRuntimeConfig(t, 2*time.Second, func() bool {
+		return rt.Config().Scheduler.MaxConcurrentRuns == 5 && rt.ConfigReloadStatus().LastError == ""
+	})
+}
+
+func writeRuntimeReloadConfig(t *testing.T, path string, maxConcurrent int) {
+	t.Helper()
+	raw := []byte(fmt.Sprintf(`{"notifications":{"osascript":{"enabled":false}},"scheduler":{"maxConcurrentRuns":%d}}`, maxConcurrent))
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+}
+
+func waitForRuntimeConfig(t *testing.T, timeout time.Duration, ready func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ready() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for config reload")
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"syscall"
@@ -82,9 +83,16 @@ type RecoveryOrphanAgentCleanup struct {
 
 type Options struct {
 	Config config.Config
-	// ConfigPath is the daemon-loaded config file path (from --config / LOOPER_CONFIG
-	// resolution). Passed into trusted review-submit proxy children as LOOPER_CONFIG
-	// so they load the same config when the daemon was started with --config only.
+	// InitialConfig and ReloadConfig are supplied by bootstrap so hot reloads
+	// replay the daemon's exact startup precedence (file, environment, and CLI).
+	// Tests and embedders that omit ReloadConfig simply run without a watcher.
+	InitialConfig        config.LoadedFileConfig
+	ReloadConfig         func() (config.LoadedFileConfig, error)
+	LoadConfigAt         func(string) (config.LoadedFileConfig, error)
+	ConfigReloadInterval time.Duration
+	// ConfigPath is the daemon-loaded config file path (from --config /
+	// LOOPER_CONFIG resolution). Runtime config management patches this source;
+	// trusted review-submit children receive a separate sanitized run snapshot.
 	ConfigPath                  string
 	Logger                      bootstrap.Logger
 	Now                         func() time.Time
@@ -118,6 +126,16 @@ type Runtime struct {
 	configPath string
 	logger     bootstrap.Logger
 	now        func() time.Time
+
+	configReloadMu       sync.Mutex
+	configBoundary       sync.RWMutex
+	loadedConfig         config.LoadedFileConfig
+	reloadConfig         func() (config.LoadedFileConfig, error)
+	loadConfigAt         func(string) (config.LoadedFileConfig, error)
+	configReloadInterval time.Duration
+	configReloadStop     chan struct{}
+	configReloadDone     chan struct{}
+	configReloadStatus   ConfigReloadStatus
 
 	openSQLiteCoordinator  OpenSQLiteCoordinatorFunc
 	syncConfiguredProjects SyncConfiguredProjectsFunc
@@ -159,11 +177,18 @@ type Runtime struct {
 	webhook                     *webhookRuntime
 	webhookDaemonLock           *daemonLock
 	webhookForwarder            WebhookForwarder
-	networkManager              *networkclient.Manager
+	networkManager              runtimeNetworkManager
 	schedulerDisabled           bool
 	startupReadyOnce            sync.Once
 	startupReadyErr             error
 	ownershipAcquired           bool
+}
+
+type runtimeNetworkManager interface {
+	Start(context.Context) error
+	Stop()
+	Status() networkclient.Status
+	UpdateConfig(config.Config)
 }
 
 const reviewerRecoveryLoginTimeout = 3 * time.Second
@@ -206,11 +231,24 @@ func New(options Options) *Runtime {
 	}
 
 	projectCatalog := projects.NewCatalog(options.Config)
+	loadedConfig := options.InitialConfig
+	if reflect.DeepEqual(loadedConfig.Config, config.Config{}) {
+		loadedConfig.Config = options.Config
+		loadedConfig.Metadata.ConfigPath = strings.TrimSpace(options.ConfigPath)
+	}
+	reloadInterval := options.ConfigReloadInterval
+	if reloadInterval <= 0 {
+		reloadInterval = time.Second
+	}
 	rt := &Runtime{
 		config:                      options.Config,
 		configPath:                  strings.TrimSpace(options.ConfigPath),
 		logger:                      options.Logger,
 		now:                         now,
+		loadedConfig:                loadedConfig,
+		reloadConfig:                options.ReloadConfig,
+		loadConfigAt:                options.LoadConfigAt,
+		configReloadInterval:        reloadInterval,
 		openSQLiteCoordinator:       openSQLiteCoordinator,
 		syncConfiguredProjects:      syncConfiguredProjects,
 		runSchedulerTick:            runSchedulerTick,
@@ -237,8 +275,11 @@ func New(options Options) *Runtime {
 
 func Start(ctx context.Context, deps bootstrap.RuntimeDependencies) (bootstrap.Runtime, error) {
 	rt := New(Options{
-		Config: deps.Config,
-		Logger: deps.Logger,
+		Config:        deps.Config,
+		InitialConfig: deps.InitialConfig,
+		ReloadConfig:  deps.ReloadConfig,
+		LoadConfigAt:  deps.LoadConfigAt,
+		Logger:        deps.Logger,
 	})
 	if err := rt.Start(ctx); err != nil {
 		return nil, err
@@ -261,6 +302,7 @@ func (r *Runtime) Stop(reason string) {
 			r.logger.Info("looperd runtime stopping", map[string]any{"reason": reason})
 		}
 
+		r.stopConfigReloadLoop()
 		r.stopDeferredReviewerRecovery()
 		r.stopWorktreeCleanupLoop()
 		r.stopSchedulerLoop()
@@ -559,12 +601,13 @@ func (r *Runtime) start(ctx context.Context) error {
 		githubGateway = githubinfra.New(githubinfra.Options{GHPath: derefString(r.config.Tools.GHPath), Now: r.now, DiscoveryCacheTTL: time.Duration(r.config.Scheduler.DiscoveryCacheTTLSeconds) * time.Second})
 	}
 	projectService := &projects.Service{
-		DB:           coordinator.DB(),
-		Repos:        repositories,
-		Logger:       r.logger,
-		Config:       r.config,
-		ConfigSource: r.projectCatalog,
-		Now:          r.now,
+		DB:             coordinator.DB(),
+		Repos:          repositories,
+		Logger:         r.logger,
+		Config:         r.config,
+		ConfigSource:   r.projectCatalog,
+		ConfigBoundary: &r.configBoundary,
+		Now:            r.now,
 		DetectRepo: func(ctx context.Context, repoPath string) (projects.DetectedRepo, error) {
 			return detectProjectRepo(ctx, gitGateway, r.projectCatalog.Snapshot(), repoPath)
 		},
@@ -612,11 +655,12 @@ func (r *Runtime) start(ctx context.Context) error {
 			return githubGateway.CapturePullRequestSnapshot(ctx, githubinfra.CapturePullRequestSnapshotInput{ProjectID: input.ProjectID, Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, CapturedAt: input.CapturedAt})
 		},
 		AsyncSnapshotQueueEnabled: func() bool {
-			return r.customSchedulerTick || r.config.Agent.Vendor != nil
+			return r.customSchedulerTick || r.Config().Agent.Vendor != nil
 		},
 		PublishProjects: func(projects []config.ProjectRefConfig) {
-			r.publishProjects(projects)
+			r.publishProjectsSnapshot(projects)
 		},
+		AfterPublishProjects: r.afterProjectsPublished,
 	}
 	loopService := &loops.Service{DB: coordinator.DB(), Repos: repositories, Now: r.now}
 	runService := &runs.Service{DB: coordinator.DB(), Repos: repositories, Loops: loopService, Now: r.now}
@@ -653,7 +697,7 @@ func (r *Runtime) start(ctx context.Context) error {
 	}
 	schedulerDisabled := false
 	if !r.customSchedulerTick {
-		handlers := buildCatalogSchedulerHandlers(r.projectCatalog, r.configPath, r.logger, coordinator, repositories, gitGateway, githubGateway, r.activeExecutions, func() schedulerAsyncRunner {
+		handlers := buildCatalogSchedulerHandlers(r.projectCatalog, &r.configBoundary, r.configPath, r.logger, coordinator, repositories, gitGateway, githubGateway, r.activeExecutions, func() schedulerAsyncRunner {
 			r.mu.RLock()
 			defer r.mu.RUnlock()
 			return r.schedulerTasks
@@ -738,15 +782,17 @@ func (r *Runtime) CompleteStartup(ctx context.Context) error {
 			}
 		}
 		if schedulerDisabled && r.logger != nil {
-			r.logger.Warn("looperd scheduler disabled", map[string]any{"reason": "config.agent.vendor is not set"})
+			r.logger.Warn("looperd scheduler waiting for agent configuration", map[string]any{"reason": "config.agent.vendor is not set"})
 		}
-		if !schedulerDisabled {
-			r.startSchedulerLoop()
-		}
+		// The scheduler's handlers snapshot the current config for each operation.
+		// Keep the loop alive even without an initial vendor so configuring one can
+		// take effect without restarting looperd.
+		r.startSchedulerLoop()
 		if r.config.Daemon.WorktreeCleanup.Enabled {
 			r.startWorktreeCleanupLoop()
 		}
 		r.startDeferredReviewerRecovery(githubGateway)
+		r.startConfigReloadLoop()
 
 		if r.logger != nil {
 			catalog := r.Config()
@@ -904,23 +950,46 @@ func (r *Runtime) reloadProjectCatalog(ctx context.Context, repos *storage.Repos
 }
 
 func (r *Runtime) publishProjects(materialized []config.ProjectRefConfig) {
+	r.publishProjectsSnapshot(materialized)
+	r.afterProjectsPublished()
+}
+
+// publishProjectsSnapshot is the atomic in-memory half of project
+// publication. Project mutations call it while holding configBoundary so a
+// concurrent config reload cannot validate or publish a mixed catalog.
+func (r *Runtime) publishProjectsSnapshot(materialized []config.ProjectRefConfig) {
 	if r == nil || r.projectCatalog == nil {
 		return
 	}
 	r.projectCatalog.Publish(materialized)
-	next := r.projectCatalog.Snapshot()
+	r.publishCatalogConsumers(r.projectCatalog.Snapshot())
+}
 
-	r.mu.Lock()
+// publishCatalogConsumers keeps long-lived consumers on the same coherent
+// globals-plus-projects snapshot used for new scheduler claims.
+func (r *Runtime) publishCatalogConsumers(next config.Config) {
+	r.mu.RLock()
 	webhook := r.webhook
 	networkManager := r.networkManager
-	started := r.startedAt != nil
-	r.mu.Unlock()
+	r.mu.RUnlock()
 	if webhook != nil {
 		webhook.updateConfig(next)
 	}
 	if networkManager != nil {
 		networkManager.UpdateConfig(next)
 	}
+}
+
+// afterProjectsPublished deliberately runs outside configBoundary. Webhook
+// reconciliation can invoke gh and other external operations; those must not
+// block config publication or new claim snapshots.
+func (r *Runtime) afterProjectsPublished() {
+	if r == nil {
+		return
+	}
+	r.mu.RLock()
+	started := r.startedAt != nil
+	r.mu.RUnlock()
 	if started {
 		r.TriggerSchedulerTick()
 		r.TriggerSchedulerClaim()
@@ -1499,7 +1568,7 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 				return RecoverySummary{}, err
 			}
 			if recoveredQueueItems == 0 {
-				if err := ensureRecoveryQueueItem(ctx, repositories, requeuedLoop, nowISO, int64(r.config.Scheduler.RetryMaxAttempts)); err != nil {
+				if err := ensureRecoveryQueueItem(ctx, repositories, requeuedLoop, nowISO, int64(r.Config().Scheduler.RetryMaxAttempts)); err != nil {
 					return RecoverySummary{}, err
 				}
 			}
@@ -2085,7 +2154,7 @@ func (r *Runtime) repairStaleRunQueueState(ctx context.Context, repositories *st
 		}
 		createdQueue := int64(0)
 		if requeuedCount == 0 {
-			if err := ensureRecoveryQueueItem(ctx, repositories, requeuedLoop, nowISO, int64(r.config.Scheduler.RetryMaxAttempts)); err != nil {
+			if err := ensureRecoveryQueueItem(ctx, repositories, requeuedLoop, nowISO, int64(r.Config().Scheduler.RetryMaxAttempts)); err != nil {
 				return staleRunQueueRepairSummary{}, err
 			}
 			activeQueue, err = repositories.Queue.FindActiveByLoopID(ctx, loop.ID)
@@ -2235,7 +2304,7 @@ func (r *Runtime) markRecoveredExecutionTerminal(ctx context.Context, repositori
 	if cleaned.ErrorMessage == nil {
 		cleaned.ErrorMessage = stringPtr(message)
 	}
-	if r.config.Agent.NativeResume.Enabled && runtimeNativeResumeSupported(cleaned.Vendor) && cleaned.NativeSessionID != nil && strings.TrimSpace(*cleaned.NativeSessionID) != "" {
+	if r.Config().Agent.NativeResume.Enabled && runtimeNativeResumeSupported(cleaned.Vendor) && cleaned.NativeSessionID != nil && strings.TrimSpace(*cleaned.NativeSessionID) != "" {
 		cleaned.NativeResumeMode = stringPtr("native_resume")
 		cleaned.NativeResumeStatus = stringPtr("pending")
 		if r.logger != nil {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -195,6 +195,19 @@ func TestRuntimeProjectMutationsAtomicallyPublishCatalog(t *testing.T) {
 
 	projectService := rt.Services().Projects
 	projectService.ListWorktrees = nil
+	if projectService.AfterPublishProjects == nil {
+		t.Fatal("Projects.AfterPublishProjects = nil, want runtime follow-up hook")
+	}
+	originalAfterPublish := projectService.AfterPublishProjects
+	afterPublishCalls := 0
+	projectService.AfterPublishProjects = func() {
+		if !rt.configBoundary.TryRLock() {
+			t.Fatal("runtime project follow-up ran while config publication boundary was held")
+		}
+		rt.configBoundary.RUnlock()
+		afterPublishCalls++
+		originalAfterPublish()
+	}
 	repo := "acme/live"
 	added, err := projectService.AddProject(context.Background(), projects.AddInput{
 		ID: "live", Name: "Live", RepoPath: workingDir, Repo: &repo, SnapshotMode: projects.SnapshotModeOff,
@@ -209,12 +222,18 @@ func TestRuntimeProjectMutationsAtomicallyPublishCatalog(t *testing.T) {
 	if len(afterAdd.Projects) != 1 || afterAdd.Projects[0].ID != "live" || afterAdd.Projects[0].Repo != repo {
 		t.Fatalf("Config().Projects after add = %#v, want live project", afterAdd.Projects)
 	}
+	if afterPublishCalls != 1 {
+		t.Fatalf("project follow-up calls after add = %d, want 1", afterPublishCalls)
+	}
 
 	if _, err := projectService.RemoveProject(context.Background(), "live"); err != nil {
 		t.Fatalf("RemoveProject() error = %v", err)
 	}
 	if got := rt.Config().Projects; len(got) != 0 {
 		t.Fatalf("Config().Projects after remove = %#v, want empty catalog", got)
+	}
+	if afterPublishCalls != 2 {
+		t.Fatalf("project follow-up calls after remove = %d, want 2", afterPublishCalls)
 	}
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -306,7 +307,15 @@ func mintTrustedReviewProxyForPR(realLooper string, trustedEnv map[string]string
 	if allowedCwd == "" {
 		return "", nil, fmt.Errorf("daemon-selected working directory is required")
 	}
-	return forge.StartTrustedReviewProxy(realLooper, trustedEnv, allowedPRRef, allowedCwd, configSnapshot, policy)
+	resolvedLooper, err := exec.LookPath(realLooper)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve trusted looper path %q: %w", realLooper, err)
+	}
+	resolvedLooper, err = filepath.Abs(resolvedLooper)
+	if err != nil {
+		return "", nil, fmt.Errorf("make trusted looper path absolute: %w", err)
+	}
+	return forge.StartTrustedReviewProxy(resolvedLooper, trustedEnv, allowedPRRef, allowedCwd, configSnapshot, policy)
 }
 
 func forgejoClientForRepo(cfg *config.Config, repo string) (*forge.ForgejoClient, bool, error) {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -84,6 +84,8 @@ type defaultSchedulerTickInput struct {
 	Now                      func() time.Time
 	MaxConcurrentRuns        int
 	ClaimMu                  *sync.Mutex
+	ClaimBoundary            *sync.RWMutex
+	RefreshForClaim          func() defaultSchedulerTickInput
 	ReconcileStaleRuns       func(context.Context) (StaleRunReconcileSummary, error)
 	AsyncRunner              schedulerAsyncRunner
 	RequestSchedulerWake     func()
@@ -99,15 +101,65 @@ type defaultSchedulerTickInput struct {
 	ReviewerDiscoveryEnabled *bool
 	FixerDiscoveryEnabled    *bool
 	WorkerDiscoveryEnabled   *bool
+	// OnHITLAsk is the exact transport callback captured by the snapshot's
+	// worker runner. Keeping it beside the answer callback makes the snapshot
+	// ownership boundary explicit and testable end to end.
+	OnHITLAsk worker.HITLNotifyFunc
 	// OnHITLAnswerDelivered, when set, is called after a Feishu HITL answer is
 	// delivered to a loop, so the transport can mark the ask card resolved.
 	OnHITLAnswerDelivered func(context.Context, string, string)
 }
 
 type defaultSchedulerHandlers struct {
-	tick    RunSchedulerTickFunc
-	claim   RunSchedulerTickFunc
-	webhook WebhookForwarder
+	tick                 RunSchedulerTickFunc
+	claim                RunSchedulerTickFunc
+	webhook              WebhookForwarder
+	reviewer             reviewerScheduler
+	fixer                fixerScheduler
+	input                func(Services) defaultSchedulerTickInput
+	snapshot             func() defaultSchedulerHandlers
+	notificationGateways *schedulerNotificationGatewayFactory
+}
+
+type catalogWebhookReviewer struct {
+	snapshot func() reviewerScheduler
+}
+
+func (r catalogWebhookReviewer) DiscoverPullRequest(ctx context.Context, input reviewer.TargetedDiscoveryInput) (reviewer.DiscoveryResult, error) {
+	if r.snapshot == nil {
+		return reviewer.DiscoveryResult{}, fmt.Errorf("reviewer is not configured")
+	}
+	reviewerRunner := r.snapshot()
+	if reviewerRunner == nil {
+		return reviewer.DiscoveryResult{}, fmt.Errorf("agent.vendor is not configured")
+	}
+	return reviewerRunner.DiscoverPullRequest(ctx, input)
+}
+
+type catalogWebhookFixer struct {
+	snapshot func() fixerScheduler
+}
+
+func (f catalogWebhookFixer) DiscoverPullRequest(ctx context.Context, input fixer.TargetedDiscoveryInput) (fixer.DiscoveryResult, error) {
+	if f.snapshot == nil {
+		return fixer.DiscoveryResult{}, fmt.Errorf("fixer is not configured")
+	}
+	fixerRunner := f.snapshot()
+	if fixerRunner == nil {
+		return fixer.DiscoveryResult{}, fmt.Errorf("agent.vendor is not configured")
+	}
+	return fixerRunner.DiscoverPullRequest(ctx, input)
+}
+
+func (f catalogWebhookFixer) DiscoverPullRequestsForBaseBranchUpdate(ctx context.Context, input fixer.BaseBranchDiscoveryInput) (fixer.DiscoveryResult, error) {
+	if f.snapshot == nil {
+		return fixer.DiscoveryResult{}, fmt.Errorf("fixer is not configured")
+	}
+	fixerRunner := f.snapshot()
+	if fixerRunner == nil {
+		return fixer.DiscoveryResult{}, fmt.Errorf("agent.vendor is not configured")
+	}
+	return fixerRunner.DiscoverPullRequestsForBaseBranchUpdate(ctx, input)
 }
 
 type schedulerTaskTracker struct{ wg sync.WaitGroup }
@@ -205,6 +257,26 @@ func providerTrustedEnv(cfg config.Config) map[string]string {
 	return env
 }
 
+// trustedReviewChildEnv captures the environment that a run-bound review-submit
+// child needs. Agent.Env is already visible to that run's agent process, so
+// forwarding the same captured values to the trusted child does not widen agent
+// access and preserves config-only GitHub auth such as GH_TOKEN. Provider token
+// values sourced from the daemon environment win on collisions and remain
+// available only to the trusted child.
+func trustedReviewChildEnv(cfg config.Config) map[string]string {
+	env := make(map[string]string, len(cfg.Agent.Env))
+	for key, value := range cfg.Agent.Env {
+		env[key] = value
+	}
+	for key, value := range providerTrustedEnv(cfg) {
+		env[key] = value
+	}
+	if len(env) == 0 {
+		return nil
+	}
+	return env
+}
+
 // resolveTrustedLooperCLIPath returns the agent-facing looper CLI path.
 // Agents always receive the real configured looper path — never a secret-bearing
 // wrapper path. Provider tokens for `looper review submit` are supplied through
@@ -214,30 +286,27 @@ func resolveTrustedLooperCLIPath(cfg config.Config) string {
 }
 
 // mintTrustedReviewProxyForPR starts a daemon-side Unix socket that runs
-// `looper review submit` with optional provider tokens, bound exclusively to
-// allowedPRRef (owner/repo#N), allowedCwd (daemon-selected worktree), configPath
-// (daemon-loaded config file for LOOPER_CONFIG injection), and the
-// daemon-selected review-events policy. Agents only receive the socket path
-// (not tokens). trustedEnv may be empty for tea-backed Forgejo providers: the
-// proxy still binds PR/CWD/policy/config so the agent cannot retarget submit.
-// cleanup stops the listener and must run when the agent execution ends.
-func mintTrustedReviewProxyForPR(realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd, configPath string, policy forge.TrustedReviewProxyPolicy, logger bootstrap.Logger) (sockPath string, cleanup func()) {
-	noop := func() {}
+// `looper review submit` with captured credentials, bound exclusively to
+// allowedPRRef (owner/repo#N), allowedCwd (daemon-selected worktree), the
+// materialized run config snapshot, and the daemon-selected review-events
+// policy. Agents only receive the socket path (not tokens or snapshot path).
+// trustedEnv may be empty when ambient credential stores suffice. Setup fails
+// closed: callers must not fall back to direct review submit. cleanup stops the
+// listener and must run when the agent execution ends.
+func mintTrustedReviewProxyForPR(realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd string, configSnapshot config.Config, policy forge.TrustedReviewProxyPolicy) (sockPath string, cleanup func(), err error) {
 	realLooper = strings.TrimSpace(realLooper)
 	allowedPRRef = strings.TrimSpace(allowedPRRef)
 	allowedCwd = strings.TrimSpace(allowedCwd)
-	configPath = strings.TrimSpace(configPath)
-	if realLooper == "" || allowedPRRef == "" || allowedCwd == "" {
-		return "", noop
+	if realLooper == "" {
+		return "", nil, fmt.Errorf("trusted looper path is required")
 	}
-	path, stop, err := forge.StartTrustedReviewProxy(realLooper, trustedEnv, allowedPRRef, allowedCwd, configPath, policy)
-	if err != nil {
-		if logger != nil {
-			logger.Warn("trusted review proxy install failed; Forgejo review submit may lack provider tokens in agent runs", map[string]any{"error": err.Error(), "allowedPR": allowedPRRef})
-		}
-		return "", noop
+	if allowedPRRef == "" {
+		return "", nil, fmt.Errorf("daemon-selected pull request is required")
 	}
-	return path, stop
+	if allowedCwd == "" {
+		return "", nil, fmt.Errorf("daemon-selected working directory is required")
+	}
+	return forge.StartTrustedReviewProxy(realLooper, trustedEnv, allowedPRRef, allowedCwd, configSnapshot, policy)
 }
 
 func forgejoClientForRepo(cfg *config.Config, repo string) (*forge.ForgejoClient, bool, error) {
@@ -1645,10 +1714,6 @@ type reviewerAgentExecutorAdapter struct {
 	executor   *agent.ConfiguredExecutor
 	realLooper string
 	trustedEnv map[string]string
-	// configPath is the daemon-loaded config file path injected as LOOPER_CONFIG
-	// into proxy children so review submit matches looperd's --config selection.
-	configPath string
-	logger     bootstrap.Logger
 	// config is used to gate trusted review-submit sockets on per-project
 	// publish mode (summary_comment must not mint a native review socket).
 	config *config.Config
@@ -1706,10 +1771,9 @@ func reviewerTrustedReviewEnv(sock string) map[string]string {
 // reviewerAllowsTrustedReviewProxy reports whether this reviewer agent start is
 // authorized to receive a live review-submit socket. Thread-resolution
 // classifiers share the reviewer adapter but must not receive publish capability.
-// Only native Forgejo review/publish runs need the socket: GitHub projects keep
-// the normal review-submit path (agent env credentials such as GH_TOKEN from
-// agent.env), and Forgejo summary_comment mode must not mint a socket because
-// Looper posts one top-level summary comment without native review submit.
+// Every native review/publish run needs the socket so its review-submit child
+// uses the immutable run config. Summary-comment mode must not mint a socket
+// because Looper posts that top-level comment outside agent review submit.
 func reviewerAllowsTrustedReviewProxy(cfg *config.Config, projectID string, metadata map[string]any) bool {
 	if metadata == nil {
 		return false
@@ -1721,13 +1785,13 @@ func reviewerAllowsTrustedReviewProxy(cfg *config.Config, projectID string, meta
 	default:
 		return false
 	}
-	return reviewerNativeForgejoNeedsTrustedProxy(cfg, projectID)
+	return reviewerProjectNeedsTrustedProxy(cfg, projectID)
 }
 
-// reviewerNativeForgejoNeedsTrustedProxy reports whether the selected project is
-// a Forgejo project that publishes native reviews (not summary_comment). Only
-// those runs should receive LOOPER_TRUSTED_REVIEW_SOCK.
-func reviewerNativeForgejoNeedsTrustedProxy(cfg *config.Config, projectID string) bool {
+// reviewerProjectNeedsTrustedProxy reports whether the selected project
+// publishes native reviews (not summary_comment). This includes GitHub, Plane's
+// GitHub code side, and native Forgejo projects.
+func reviewerProjectNeedsTrustedProxy(cfg *config.Config, projectID string) bool {
 	if cfg == nil {
 		return false
 	}
@@ -1738,9 +1802,6 @@ func reviewerNativeForgejoNeedsTrustedProxy(cfg *config.Config, projectID string
 	for _, project := range cfg.Projects {
 		if strings.TrimSpace(project.ID) != projectID {
 			continue
-		}
-		if config.ResolvedProjectProviderKind(*cfg, project) != config.ProviderKindForgejo {
-			return false
 		}
 		return config.ProjectRoleConfigs(*cfg, project.ID).Reviewer.Behavior.PublishMode != config.ReviewerPublishModeSummaryComment
 	}
@@ -1765,18 +1826,24 @@ func reviewerAllowedPRRef(metadata map[string]any) string {
 	return forge.FormatTrustedReviewPRRef(repo, prNumber)
 }
 
-// reviewerAllowedReviewPolicy extracts the daemon-selected clean/blocking
-// review-events policy from reviewer agent metadata so the trusted proxy can
-// inject those flags outside agent control.
+// reviewerAllowedReviewPolicy extracts daemon-selected review policy, head,
+// and run identity from reviewer metadata. The runner authors these fields from
+// its immutable loop/run checkpoint; agent argv is never authoritative.
 func reviewerAllowedReviewPolicy(metadata map[string]any) forge.TrustedReviewProxyPolicy {
 	if metadata == nil {
 		return forge.TrustedReviewProxyPolicy{}
 	}
 	clean, _ := metadata["cleanReviewEvent"].(string)
 	blocking, _ := metadata["blockingReviewEvent"].(string)
+	expectedCommitID, _ := metadata["expectedCommitID"].(string)
+	reviewerManual, _ := metadata["reviewerManual"].(bool)
+	reviewerRunID, _ := metadata["reviewerRunID"].(string)
 	return forge.TrustedReviewProxyPolicy{
-		Clean:    strings.TrimSpace(clean),
-		Blocking: strings.TrimSpace(blocking),
+		Clean:            strings.TrimSpace(clean),
+		Blocking:         strings.TrimSpace(blocking),
+		ExpectedCommitID: strings.TrimSpace(expectedCommitID),
+		ReviewerManual:   reviewerManual,
+		ReviewerRunID:    strings.TrimSpace(reviewerRunID),
 	}
 }
 
@@ -1815,15 +1882,21 @@ func (a reviewerAgentExecutorAdapter) Start(ctx context.Context, input reviewer.
 	// and review-events policy. Thread-resolution classifiers and summary_comment
 	// (comment-only) runs reuse this adapter but must not receive review-publish
 	// capability via LOOPER_TRUSTED_REVIEW_SOCK.
-	allowedPR := ""
-	allowedCwd := ""
-	policy := forge.TrustedReviewProxyPolicy{}
+	sock := ""
+	proxyCleanup := func() {}
 	if reviewerAllowsTrustedReviewProxy(a.config, input.ProjectID, input.Metadata) {
-		allowedPR = reviewerAllowedPRRef(input.Metadata)
-		allowedCwd = strings.TrimSpace(input.WorkingDirectory)
-		policy = reviewerAllowedReviewPolicy(input.Metadata)
+		allowedPR := reviewerAllowedPRRef(input.Metadata)
+		allowedCwd := strings.TrimSpace(input.WorkingDirectory)
+		policy := reviewerAllowedReviewPolicy(input.Metadata)
+		if policy.ReviewerManual && policy.ReviewerRunID != strings.TrimSpace(input.RunID) {
+			return nil, fmt.Errorf("install run-bound trusted review proxy: reviewer run id does not match agent run")
+		}
+		var err error
+		sock, proxyCleanup, err = mintTrustedReviewProxyForPR(a.realLooper, a.trustedEnv, allowedPR, allowedCwd, *a.config, policy)
+		if err != nil {
+			return nil, fmt.Errorf("install run-bound trusted review proxy: %w", err)
+		}
 	}
-	sock, proxyCleanup := mintTrustedReviewProxyForPR(a.realLooper, a.trustedEnv, allowedPR, allowedCwd, a.configPath, policy, a.logger)
 	execution, err := a.executor.Start(ctx, agent.RunInput{
 		ExecutionID:        input.ExecutionID,
 		ProjectID:          input.ProjectID,
@@ -2754,36 +2827,107 @@ func (a workerAgentExecutionAdapter) Kill(reason string) error {
 	return a.execution.Kill(reason)
 }
 
-func buildCatalogSchedulerHandlers(source projects.ConfigSource, configPath string, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time, reconcileStaleRuns func(context.Context) (StaleRunReconcileSummary, error)) defaultSchedulerHandlers {
+type schedulerNotificationGatewayFactory struct {
+	state         *notify.GatewayState
+	feishuAppHTTP notify.FeishuAppHTTPFunc
+}
+
+func newSchedulerNotificationGatewayFactory() *schedulerNotificationGatewayFactory {
+	return &schedulerNotificationGatewayFactory{state: notify.NewGatewayState()}
+}
+
+func (f *schedulerNotificationGatewayFactory) New(options notify.Options) *notify.Gateway {
+	if options.FeishuAppHTTP == nil {
+		options.FeishuAppHTTP = f.feishuAppHTTP
+	}
+	options.State = f.state
+	return notify.NewGateway(options)
+}
+
+func buildCatalogSchedulerHandlers(source projects.ConfigSource, claimBoundary *sync.RWMutex, configPath string, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time, reconcileStaleRuns func(context.Context) (StaleRunReconcileSummary, error)) defaultSchedulerHandlers {
 	if source == nil {
 		fail := func(context.Context, Services) error { return fmt.Errorf("project catalog is not configured") }
 		return defaultSchedulerHandlers{tick: fail, claim: fail}
 	}
 	claimMu := &sync.Mutex{}
+	notificationGateways := newSchedulerNotificationGatewayFactory()
+	coordinatorState := coordinatorrole.NewRuntimeState()
 	// Trusted review proxies are minted per reviewer agent run (bound to that
-	// run's PR). Catalog snapshots only need claim mutex + config source reuse.
-	initial := buildDefaultSchedulerHandlersWithOptions(source.Snapshot(), configPath, logger, coordinator, repos, gitGateway, githubGateway, activeExecutions, asyncRunner, requestWake, now, reconcileStaleRuns, true, claimMu, source)
+	// run's PR). Catalog snapshots reuse claim serialization and notification
+	// transport continuity while retaining config-specific policy.
 	buildSnapshot := func() defaultSchedulerHandlers {
 		cfg := source.Snapshot()
-		return buildDefaultSchedulerHandlersWithOptions(cfg, configPath, logger, coordinator, repos, gitGateway, githubGateway, activeExecutions, asyncRunner, requestWake, now, reconcileStaleRuns, false, claimMu, nil)
+		return buildDefaultSchedulerHandlersWithOptions(cfg, configPath, logger, coordinator, repos, gitGateway, githubGateway, activeExecutions, asyncRunner, requestWake, now, reconcileStaleRuns, false, claimMu, nil, notificationGateways, coordinatorState)
 	}
 	handlers := defaultSchedulerHandlers{
-		tick: func(ctx context.Context, services Services) error {
-			return buildSnapshot().tick(ctx, services)
-		},
-		claim: func(ctx context.Context, services Services) error {
-			return buildSnapshot().claim(ctx, services)
-		},
-		webhook: initial.webhook,
+		snapshot:             buildSnapshot,
+		notificationGateways: notificationGateways,
+	}
+	if coordinator != nil && repos != nil {
+		handlers.webhook = webhookforward.New(webhookforward.Options{
+			Repos:        repos,
+			Config:       source.Snapshot(),
+			ConfigSource: source,
+			Reviewer: catalogWebhookReviewer{snapshot: func() reviewerScheduler {
+				return handlers.snapshot().reviewer
+			}},
+			Fixer: catalogWebhookFixer{snapshot: func() fixerScheduler {
+				return handlers.snapshot().fixer
+			}},
+			Logger: logger,
+			Now:    now,
+		})
+	}
+	handlers.tick = func(ctx context.Context, services Services) error {
+		snapshot := handlers.snapshot()
+		if snapshot.input == nil {
+			return snapshot.tick(ctx, services)
+		}
+		input := snapshot.input(services)
+		input.ClaimBoundary = claimBoundary
+		input.RefreshForClaim = func() defaultSchedulerTickInput {
+			latestSnapshot := handlers.snapshot()
+			if latestSnapshot.input == nil {
+				stopped := input
+				stopped.MaxConcurrentRuns = 0
+				stopped.RefreshForClaim = nil
+				return stopped
+			}
+			latest := latestSnapshot.input(services)
+			latest.ClaimBoundary = claimBoundary
+			return latest
+		}
+		return runDefaultSchedulerTick(ctx, input)
+	}
+	handlers.claim = func(ctx context.Context, services Services) error {
+		snapshot := handlers.snapshot()
+		if snapshot.input == nil {
+			return snapshot.claim(ctx, services)
+		}
+		input := snapshot.input(services)
+		input.ClaimBoundary = claimBoundary
+		input.RefreshForClaim = func() defaultSchedulerTickInput {
+			latestSnapshot := handlers.snapshot()
+			if latestSnapshot.input == nil {
+				stopped := input
+				stopped.MaxConcurrentRuns = 0
+				stopped.RefreshForClaim = nil
+				return stopped
+			}
+			latest := latestSnapshot.input(services)
+			latest.ClaimBoundary = claimBoundary
+			return latest
+		}
+		return runIndependentClaimPass(ctx, input)
 	}
 	return handlers
 }
 
 func buildDefaultSchedulerHandlers(cfg config.Config, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time, reconcileStaleRuns func(context.Context) (StaleRunReconcileSummary, error)) defaultSchedulerHandlers {
-	return buildDefaultSchedulerHandlersWithOptions(cfg, "", logger, coordinator, repos, gitGateway, githubGateway, activeExecutions, asyncRunner, requestWake, now, reconcileStaleRuns, true, nil, nil)
+	return buildDefaultSchedulerHandlersWithOptions(cfg, "", logger, coordinator, repos, gitGateway, githubGateway, activeExecutions, asyncRunner, requestWake, now, reconcileStaleRuns, true, nil, nil, newSchedulerNotificationGatewayFactory(), coordinatorrole.NewRuntimeState())
 }
 
-func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath string, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time, reconcileStaleRuns func(context.Context) (StaleRunReconcileSummary, error), includeWebhook bool, claimMu *sync.Mutex, configSource projects.ConfigSource) defaultSchedulerHandlers {
+func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath string, logger bootstrap.Logger, coordinator *storage.SQLiteCoordinator, repos *storage.Repositories, gitGateway *gitinfra.Gateway, githubGateway *githubinfra.Gateway, activeExecutions *ActiveExecutionRegistry, asyncRunner func() schedulerAsyncRunner, requestWake func(), now func() time.Time, reconcileStaleRuns func(context.Context) (StaleRunReconcileSummary, error), includeWebhook bool, claimMu *sync.Mutex, configSource projects.ConfigSource, notificationGateways *schedulerNotificationGatewayFactory, coordinatorState *coordinatorrole.RuntimeState) defaultSchedulerHandlers {
 	if now == nil {
 		now = time.Now
 	}
@@ -2797,7 +2941,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		noop := func(context.Context, Services) error { return nil }
 		return defaultSchedulerHandlers{tick: noop, claim: noop}
 	}
-	notificationGateway := notify.NewGateway(notify.Options{
+	notificationGateway := notificationGateways.New(notify.Options{
 		Config:        cfg.Notifications,
 		OsascriptPath: derefString(cfg.Tools.OsascriptPath),
 		LogFilePath:   filepath.Join(cfg.Daemon.LogDir, "looperd.log"),
@@ -2971,6 +3115,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		Config:  &cfg,
 		Logger:  logger,
 		Now:     now,
+		State:   coordinatorState,
 		Network: coordinatorrole.NewLoopernetGateway(networkclient.DefaultStatePath(runtimeHomeDirOrEmpty())),
 		TriageLLM: coordinatorrole.NewAgentLLM(agentExecutor, now,
 			time.Duration(cfg.Agent.Timeouts.PlannerMaxRuntimeSeconds)*time.Second,
@@ -2985,9 +3130,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		AgentExecutor: reviewerAgentExecutorAdapter{
 			executor:   agentExecutor,
 			realLooper: looperCLIPath,
-			trustedEnv: providerTrustedEnv(cfg),
-			configPath: strings.TrimSpace(configPath),
-			logger:     logger,
+			trustedEnv: trustedReviewChildEnv(cfg),
 			config:     &cfg,
 		},
 		Logger:           logger,
@@ -3056,6 +3199,18 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 			return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Fixer", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
 		},
 	})
+	notifyHITLAsk := func(ctx context.Context, ask worker.HITLAskNotification) error {
+		return notificationGateway.SendHITLAsk(ctx, notify.HITLAskCard{
+			ProjectID: ask.ProjectID, LoopID: ask.LoopID, LoopSeq: ask.LoopSeq,
+			Repo: ask.Repo, Title: ask.Title, Question: ask.Question, Options: ask.Options,
+			SourceType: ask.SourceType, SourceRef: ask.SourceRef, SourceURL: ask.SourceURL,
+			TriggerLogin:      ask.TriggerLogin,
+			Recommendation:    ask.Recommendation,
+			RecommendedOption: ask.RecommendedOption,
+			Consequences:      ask.Consequences,
+			Confidence:        ask.Confidence,
+		})
+	}
 	workerRunner = worker.New(worker.Options{
 		DB:     coordinator.DB(),
 		Repos:  repos,
@@ -3092,18 +3247,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		HITLEnabled:         cfg.HITL.Enabled,
 		HITLAnswerTransport: cfg.HITL.AnswerTransport,
 		HITLGitHub:          hitlGitHubSettings(cfg.HITL.GitHub),
-		HITLNotify: func(ctx context.Context, ask worker.HITLAskNotification) error {
-			return notificationGateway.SendHITLAsk(ctx, notify.HITLAskCard{
-				ProjectID: ask.ProjectID, LoopID: ask.LoopID, LoopSeq: ask.LoopSeq,
-				Repo: ask.Repo, Title: ask.Title, Question: ask.Question, Options: ask.Options,
-				SourceType: ask.SourceType, SourceRef: ask.SourceRef, SourceURL: ask.SourceURL,
-				TriggerLogin:      ask.TriggerLogin,
-				Recommendation:    ask.Recommendation,
-				RecommendedOption: ask.RecommendedOption,
-				Consequences:      ask.Consequences,
-				Confidence:        ask.Confidence,
-			})
-		},
+		HITLNotify:          notifyHITLAsk,
 	})
 	if claimMu == nil {
 		claimMu = &sync.Mutex{}
@@ -3136,6 +3280,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 			ReviewerDiscoveryEnabled: boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "reviewer")),
 			FixerDiscoveryEnabled:    boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "fixer")),
 			WorkerDiscoveryEnabled:   boolPtr(config.AnyProjectRoleAutoDiscoveryEnabled(cfg, "worker")),
+			OnHITLAsk:                notifyHITLAsk,
 			OnHITLAnswerDelivered:    notificationGateway.MarkAskAnswered,
 		}
 	}
@@ -3147,6 +3292,10 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		claim: func(ctx context.Context, services Services) error {
 			return runIndependentClaimPass(ctx, inputForServices(services))
 		},
+		reviewer:             reviewerRunner,
+		fixer:                fixerRunner,
+		input:                inputForServices,
+		notificationGateways: notificationGateways,
 	}
 	if includeWebhook {
 		handlers.webhook = webhookforward.New(webhookforward.Options{
@@ -3488,6 +3637,13 @@ func executeClaimPhase(ctx context.Context, phase string, input defaultScheduler
 	if input.ClaimMu != nil {
 		input.ClaimMu.Lock()
 		defer input.ClaimMu.Unlock()
+	}
+	if input.ClaimBoundary != nil {
+		input.ClaimBoundary.RLock()
+		defer input.ClaimBoundary.RUnlock()
+	}
+	if input.RefreshForClaim != nil {
+		input = input.RefreshForClaim()
 	}
 	start := time.Now()
 	availableSlots, err := schedulerAvailableSlots(ctx, input.Repos, input.MaxConcurrentRuns)

--- a/internal/runtime/scheduler_config_reload_test.go
+++ b/internal/runtime/scheduler_config_reload_test.go
@@ -1,0 +1,217 @@
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	coordinatorrole "github.com/nexu-io/looper/internal/coordinator"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/infra/shell"
+	"github.com/nexu-io/looper/internal/projects"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestClaimPhaseRefreshesConfigAfterPublicationBoundary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(root, "claim-refresh.sqlite"), t.TempDir())
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 16, 10, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	insertSchedulerProject(t, repositories, root, nowISO)
+	item := schedulerTestQueueItem("queue_worker_after_config_publish", "worker", nowISO)
+	if err := repositories.Queue.Upsert(context.Background(), item); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	oldRunner := &stubWorkerScheduler{}
+	newRunner := &stubWorkerScheduler{}
+	latestRunner := workerScheduler(oldRunner)
+	publicationBoundary := &sync.RWMutex{}
+	publicationBoundary.Lock()
+	refreshed := make(chan struct{})
+
+	input := defaultSchedulerTickInput{
+		Repos:             repositories,
+		Now:               func() time.Time { return now },
+		MaxConcurrentRuns: 0,
+		ClaimBoundary:     publicationBoundary,
+		AsyncRunner:       immediateSchedulerRunner{},
+		Worker:            oldRunner,
+	}
+	input.RefreshForClaim = func() defaultSchedulerTickInput {
+		close(refreshed)
+		latest := input
+		latest.MaxConcurrentRuns = 1
+		latest.Worker = latestRunner
+		latest.RefreshForClaim = nil
+		return latest
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := executeClaimPhase(context.Background(), "test", input, nil, false)
+		done <- err
+	}()
+	refreshedEarly := false
+	select {
+	case <-refreshed:
+		refreshedEarly = true
+	case <-time.After(25 * time.Millisecond):
+	}
+	latestRunner = newRunner
+	publicationBoundary.Unlock()
+
+	if err := <-done; err != nil {
+		t.Fatalf("executeClaimPhase() error = %v", err)
+	}
+	if refreshedEarly {
+		t.Fatal("claim refreshed while config publication held the write boundary")
+	}
+	if oldRunner.processItemCount() != 0 || newRunner.processItemCount() != 1 {
+		t.Fatalf("processed items: old=%d new=%d, want old=0 new=1", oldRunner.processItemCount(), newRunner.processItemCount())
+	}
+}
+
+func TestCatalogSchedulerStartsUsingVendorPublishedAfterDaemonStartup(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cfg, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Agent.Vendor = nil
+	catalog := projects.NewCatalog(cfg)
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repositories := storage.NewRepositories(coordinator.DB())
+	logger := &capturingSchedulerLogger{}
+	handlers := buildCatalogSchedulerHandlers(
+		catalog,
+		nil,
+		"",
+		logger,
+		coordinator,
+		repositories,
+		nil,
+		nil,
+		NewActiveExecutionRegistry(),
+		nil,
+		nil,
+		time.Now,
+		nil,
+	)
+	if handlers.webhook != nil {
+		t.Cleanup(handlers.webhook.Close)
+	}
+
+	if err := handlers.tick(context.Background(), Services{Repositories: repositories}); err != nil {
+		t.Fatalf("tick without vendor error = %v", err)
+	}
+	if schedulerLoggerContains(logger, "scheduler tick summary") {
+		t.Fatal("scheduler executed a configured pass before agent.vendor was set")
+	}
+
+	next := config.CloneConfig(cfg)
+	vendor := config.AgentVendorCodex
+	next.Agent.Vendor = &vendor
+	catalog.PublishGlobals(next)
+	if err := handlers.tick(context.Background(), Services{Repositories: repositories}); err != nil {
+		t.Fatalf("tick after vendor publication error = %v", err)
+	}
+	if !schedulerLoggerContains(logger, "scheduler tick summary") {
+		t.Fatal("scheduler did not rebuild handlers after agent.vendor was published")
+	}
+}
+
+func TestCatalogSchedulerPreservesCoordinatorThrottleAcrossConfigSnapshots(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cfg, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	vendor := config.AgentVendorCodex
+	cfg.Agent.Vendor = &vendor
+	cfg.Roles.Coordinator.Enabled = true
+	cfg.Roles.Coordinator.PollInterval = "5m"
+	cfg.Roles.Reviewer.Discovery.AutoDiscovery = false
+	catalog := projects.NewCatalog(cfg)
+	coordinator := openMigratedCoordinator(t, filepath.Join(root, "coordinator-throttle.sqlite"), t.TempDir())
+	repositories := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 16, 10, 0, 0, 0, time.UTC)
+	insertSchedulerProject(t, repositories, root, formatJavaScriptISOString(now))
+	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(context.Context, shell.Options) (shell.Result, error) {
+		return shell.Result{Stdout: "[]"}, nil
+	}})
+	handlers := buildCatalogSchedulerHandlers(
+		catalog,
+		nil,
+		"",
+		&capturingSchedulerLogger{},
+		coordinator,
+		repositories,
+		nil,
+		githubGateway,
+		NewActiveExecutionRegistry(),
+		nil,
+		nil,
+		func() time.Time { return now },
+		nil,
+	)
+	if handlers.webhook != nil {
+		t.Cleanup(handlers.webhook.Close)
+	}
+
+	discover := func() coordinatorrole.DiscoveryResult {
+		t.Helper()
+		snapshot := handlers.snapshot()
+		if snapshot.input == nil {
+			t.Fatal("catalog scheduler snapshot has no input builder")
+		}
+		result, err := snapshot.input(Services{Repositories: repositories}).Coordinator.DiscoverIssues(context.Background(), coordinatorrole.DiscoveryInput{ProjectID: "looper", Repo: "nexu-io/looper"})
+		if err != nil {
+			t.Fatalf("DiscoverIssues() error = %v", err)
+		}
+		return result
+	}
+
+	if result := discover(); !result.Ticked || result.Skipped {
+		t.Fatalf("first discovery result = %#v, want ticked", result)
+	}
+	now = now.Add(2 * time.Minute)
+	if result := discover(); !result.Skipped || result.Ticked {
+		t.Fatalf("second discovery result = %#v, want shared 5m throttle to skip", result)
+	}
+
+	next := config.CloneConfig(cfg)
+	next.Roles.Coordinator.PollInterval = "1m"
+	catalog.PublishGlobals(next)
+	if result := discover(); !result.Ticked || result.Skipped {
+		t.Fatalf("discovery after interval reload = %#v, want latest 1m policy to tick", result)
+	}
+}
+
+func schedulerLoggerContains(logger *capturingSchedulerLogger, message string) bool {
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+	for _, entry := range logger.entries {
+		if entry.message == message {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/scheduler_forgejo_native_test.go
+++ b/internal/runtime/scheduler_forgejo_native_test.go
@@ -235,9 +235,32 @@ func TestReviewerAllowedReviewPolicy(t *testing.T) {
 	got := reviewerAllowedReviewPolicy(map[string]any{
 		"cleanReviewEvent":    " APPROVE ",
 		"blockingReviewEvent": "REQUEST_CHANGES",
+		"expectedCommitID":    " head-42 ",
+		"reviewerManual":      true,
+		"reviewerRunID":       " run_42 ",
 	})
-	if got.Clean != "APPROVE" || got.Blocking != "REQUEST_CHANGES" {
-		t.Fatalf("reviewerAllowedReviewPolicy() = %#v, want APPROVE/REQUEST_CHANGES", got)
+	if got.Clean != "APPROVE" || got.Blocking != "REQUEST_CHANGES" || got.ExpectedCommitID != "head-42" || !got.ReviewerManual || got.ReviewerRunID != "run_42" {
+		t.Fatalf("reviewerAllowedReviewPolicy() = %#v, want bound events/head/manual run", got)
+	}
+}
+
+func TestTrustedReviewChildEnvCapturesAgentAndProviderCredentials(t *testing.T) {
+	providerTokenEnv := "LOOPER_TEST_TRUSTED_REVIEW_PROVIDER_TOKEN"
+	t.Setenv(providerTokenEnv, "daemon-provider-token")
+	cfg := config.Config{
+		Agent: config.AgentConfig{Env: map[string]string{
+			"GH_TOKEN":       "config-only-github-token",
+			providerTokenEnv: "agent-value-must-not-win",
+		}},
+		Providers: []config.ProviderConfig{{TokenEnv: &providerTokenEnv}},
+	}
+
+	got := trustedReviewChildEnv(cfg)
+	if got["GH_TOKEN"] != "config-only-github-token" {
+		t.Fatalf("trusted child GH_TOKEN = %q, want captured Agent.Env value", got["GH_TOKEN"])
+	}
+	if got[providerTokenEnv] != "daemon-provider-token" {
+		t.Fatalf("trusted child provider token = %q, want daemon provider value", got[providerTokenEnv])
 	}
 }
 
@@ -252,8 +275,8 @@ func TestReviewerAllowsTrustedReviewProxy(t *testing.T) {
 	if reviewerAllowsTrustedReviewProxy(nil, "demo", map[string]any{"phase": ""}) {
 		t.Fatal("empty phase allowed, want false")
 	}
-	// Without a Forgejo project config, review/publish phases must not mint a socket
-	// (mixed installs must keep GitHub on the normal review-submit path).
+	// Without a captured project config, review/publish phases cannot bind a
+	// native review socket safely.
 	if reviewerAllowsTrustedReviewProxy(nil, "demo", map[string]any{"phase": "review"}) {
 		t.Fatal("nil config review phase allowed, want false")
 	}
@@ -285,7 +308,8 @@ func TestReviewerAllowsTrustedReviewProxy(t *testing.T) {
 	if !reviewerAllowsTrustedReviewProxy(nativeCfg, "forgejo-native", map[string]any{"phase": "REVIEW"}) {
 		t.Fatal("REVIEW phase on native Forgejo not allowed, want true")
 	}
-	// GitHub projects in a mixed install must not receive the Forgejo review proxy.
+	// GitHub projects use the same run-bound proxy so review submit cannot reload
+	// a changed live config during the active run.
 	githubCfg := &config.Config{
 		Providers: []config.ProviderConfig{
 			{ID: "gh", Kind: config.ProviderKindGitHub},
@@ -297,8 +321,8 @@ func TestReviewerAllowsTrustedReviewProxy(t *testing.T) {
 		},
 		Roles: config.RoleConfigs{Reviewer: config.ReviewerRoleConfig{Behavior: config.ReviewerConfig{PublishMode: config.ReviewerPublishModeSingleReview}}},
 	}
-	if reviewerAllowsTrustedReviewProxy(githubCfg, "github-demo", map[string]any{"phase": "review"}) {
-		t.Fatal("GitHub project allowed socket, want false")
+	if !reviewerAllowsTrustedReviewProxy(githubCfg, "github-demo", map[string]any{"phase": "review"}) {
+		t.Fatal("GitHub project did not allow run-bound socket, want true")
 	}
 	if !reviewerAllowsTrustedReviewProxy(githubCfg, "forgejo-native", map[string]any{"phase": "review"}) {
 		t.Fatal("Forgejo project in mixed install not allowed, want true")
@@ -344,6 +368,7 @@ func TestReviewerAgentExecutorAdapterInjectsTrustedReviewSock(t *testing.T) {
 	execHandle, err := adapter.Start(context.Background(), reviewer.AgentRunInput{
 		ExecutionID:      "reviewer_trusted_sock",
 		ProjectID:        "forgejo-native",
+		RunID:            "run_forgejo_auto",
 		WorkingDirectory: workDir,
 		Prompt:           "review",
 		Timeout:          5 * time.Second,
@@ -353,6 +378,9 @@ func TestReviewerAgentExecutorAdapterInjectsTrustedReviewSock(t *testing.T) {
 			"prNumber":            int64(42),
 			"cleanReviewEvent":    "APPROVE",
 			"blockingReviewEvent": "REQUEST_CHANGES",
+			"expectedCommitID":    "head-42",
+			"reviewerManual":      false,
+			"reviewerRunID":       "run_forgejo_auto",
 		},
 	})
 	if err != nil {
@@ -385,6 +413,7 @@ func TestReviewerAgentExecutorAdapterInjectsTrustedReviewSock(t *testing.T) {
 	teaHandle, err := teaAdapter.Start(context.Background(), reviewer.AgentRunInput{
 		ExecutionID:      "reviewer_tea_trusted_sock",
 		ProjectID:        "forgejo-native",
+		RunID:            "run_forgejo_manual",
 		WorkingDirectory: workDir,
 		Prompt:           "review",
 		Timeout:          5 * time.Second,
@@ -394,6 +423,9 @@ func TestReviewerAgentExecutorAdapterInjectsTrustedReviewSock(t *testing.T) {
 			"prNumber":            int64(42),
 			"cleanReviewEvent":    "APPROVE",
 			"blockingReviewEvent": "REQUEST_CHANGES",
+			"expectedCommitID":    "head-42",
+			"reviewerManual":      true,
+			"reviewerRunID":       "run_forgejo_manual",
 		},
 	})
 	if err != nil {
@@ -410,20 +442,22 @@ func TestReviewerAgentExecutorAdapterInjectsTrustedReviewSock(t *testing.T) {
 		t.Fatalf("tea child env dump = %q, want sock=set", string(data))
 	}
 
-	// GitHub projects must not receive the Forgejo review proxy socket.
+	// GitHub native review runs receive the same run-bound config socket.
 	githubCfg := &config.Config{
 		Providers: []config.ProviderConfig{{ID: "gh", Kind: config.ProviderKindGitHub}},
 		Projects:  []config.ProjectRefConfig{{ID: "github-demo", Name: "GitHub", Provider: "gh", Repo: "acme/looper", RepoPath: workDir}},
+		Agent:     config.AgentConfig{Env: map[string]string{"GH_TOKEN": "config-only-token"}},
 	}
 	githubAdapter := reviewerAgentExecutorAdapter{
 		executor:   executor,
 		realLooper: realLooper,
-		trustedEnv: map[string]string{"FORGEJO_TOKEN": "test-token"},
+		trustedEnv: trustedReviewChildEnv(*githubCfg),
 		config:     githubCfg,
 	}
 	githubHandle, err := githubAdapter.Start(context.Background(), reviewer.AgentRunInput{
-		ExecutionID:      "reviewer_github_no_sock",
+		ExecutionID:      "reviewer_github_trusted_sock",
 		ProjectID:        "github-demo",
+		RunID:            "run_github_auto",
 		WorkingDirectory: workDir,
 		Prompt:           "review",
 		Timeout:          5 * time.Second,
@@ -433,6 +467,9 @@ func TestReviewerAgentExecutorAdapterInjectsTrustedReviewSock(t *testing.T) {
 			"prNumber":            int64(42),
 			"cleanReviewEvent":    "APPROVE",
 			"blockingReviewEvent": "REQUEST_CHANGES",
+			"expectedCommitID":    "head-42",
+			"reviewerManual":      false,
+			"reviewerRunID":       "run_github_auto",
 		},
 	})
 	if err != nil {
@@ -445,8 +482,8 @@ func TestReviewerAgentExecutorAdapterInjectsTrustedReviewSock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile after github run error = %v", err)
 	}
-	if string(data) != "sock=\n" {
-		t.Fatalf("github child env dump = %q, want empty sock", string(data))
+	if string(data) != "sock=set\n" {
+		t.Fatalf("github child env dump = %q, want sock=set", string(data))
 	}
 
 	// Thread-resolution classifiers must not receive review-publish capability.
@@ -472,8 +509,9 @@ func TestReviewerAgentExecutorAdapterInjectsTrustedReviewSock(t *testing.T) {
 		t.Fatalf("thread_resolution child env dump = %q, want empty sock", string(data))
 	}
 
-	// Without daemon-selected PR metadata, no review-publish capability is injected.
-	noPRHandle, err := adapter.Start(context.Background(), reviewer.AgentRunInput{
+	// A native review run without daemon-selected PR metadata fails closed. It
+	// must not fall back to the direct live-config review-submit path.
+	_, err = adapter.Start(context.Background(), reviewer.AgentRunInput{
 		ExecutionID:      "reviewer_no_pr_meta",
 		ProjectID:        "forgejo-native",
 		WorkingDirectory: workDir,
@@ -481,18 +519,53 @@ func TestReviewerAgentExecutorAdapterInjectsTrustedReviewSock(t *testing.T) {
 		Timeout:          5 * time.Second,
 		Metadata:         map[string]any{"phase": "review"},
 	})
-	if err != nil {
-		t.Fatalf("Start(no PR) error = %v", err)
+	if err == nil || !strings.Contains(err.Error(), "daemon-selected pull request is required") {
+		t.Fatalf("Start(no PR) error = %v, want fail-closed missing PR error", err)
 	}
-	if _, err := noPRHandle.Wait(context.Background()); err != nil {
-		t.Fatalf("Wait(no PR) error = %v", err)
+
+	// Native review authority is incomplete without the daemon-authored head.
+	_, err = adapter.Start(context.Background(), reviewer.AgentRunInput{
+		ExecutionID:      "reviewer_missing_expected_head",
+		ProjectID:        "forgejo-native",
+		RunID:            "run_missing_head",
+		WorkingDirectory: workDir,
+		Prompt:           "review",
+		Timeout:          5 * time.Second,
+		Metadata: map[string]any{
+			"phase":               "review",
+			"repo":                "acme/looper",
+			"prNumber":            int64(42),
+			"cleanReviewEvent":    "APPROVE",
+			"blockingReviewEvent": "REQUEST_CHANGES",
+			"reviewerManual":      false,
+			"reviewerRunID":       "run_missing_head",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "expected commit id is required") {
+		t.Fatalf("Start(missing head) error = %v, want fail-closed expected-head error", err)
 	}
-	data, err = os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatalf("ReadFile after no-PR run error = %v", err)
-	}
-	if string(data) != "sock=\n" {
-		t.Fatalf("no-PR child env dump = %q, want empty sock", string(data))
+
+	// Manual mode must bind the exact daemon-authored run identity.
+	_, err = adapter.Start(context.Background(), reviewer.AgentRunInput{
+		ExecutionID:      "reviewer_forged_manual_run",
+		ProjectID:        "forgejo-native",
+		RunID:            "run_daemon",
+		WorkingDirectory: workDir,
+		Prompt:           "review",
+		Timeout:          5 * time.Second,
+		Metadata: map[string]any{
+			"phase":               "review",
+			"repo":                "acme/looper",
+			"prNumber":            int64(42),
+			"cleanReviewEvent":    "APPROVE",
+			"blockingReviewEvent": "REQUEST_CHANGES",
+			"expectedCommitID":    "head-42",
+			"reviewerManual":      true,
+			"reviewerRunID":       "run_forged",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "reviewer run id does not match") {
+		t.Fatalf("Start(forged manual run) error = %v, want fail-closed run binding error", err)
 	}
 
 	// summary_comment projects must not mint a review-submit socket even with full PR metadata.

--- a/internal/runtime/scheduler_notification_reload_test.go
+++ b/internal/runtime/scheduler_notification_reload_test.go
@@ -1,0 +1,104 @@
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/infra/notify"
+	"github.com/nexu-io/looper/internal/projects"
+	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worker"
+)
+
+func TestCatalogSchedulerPreservesNotificationTransportAcrossConfigSnapshots(t *testing.T) {
+	t.Setenv("LOOPER_TEST_FEISHU_APP_ID", "cli_app_id")
+	t.Setenv("LOOPER_TEST_FEISHU_APP_SECRET", "app_secret_value")
+
+	root := t.TempDir()
+	daemonConfig, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	vendor := config.AgentVendorCodex
+	daemonConfig.Agent.Vendor = &vendor
+	daemonConfig.Notifications.Webhook.Enabled = true
+	daemonConfig.Notifications.Webhook.Format = "feishu"
+	daemonConfig.Notifications.Webhook.Mode = "app"
+	daemonConfig.Notifications.Webhook.AppIDEnv = "LOOPER_TEST_FEISHU_APP_ID"
+	daemonConfig.Notifications.Webhook.AppSecretEnv = "LOOPER_TEST_FEISHU_APP_SECRET"
+	daemonConfig.Notifications.Webhook.ChatID = "oc_group_chat_123"
+	catalog := projects.NewCatalog(daemonConfig)
+	coordinator := openMigratedCoordinator(t, filepath.Join(root, "notification-snapshots.sqlite"), t.TempDir())
+	repositories := storage.NewRepositories(coordinator.DB())
+	handlers := buildCatalogSchedulerHandlers(
+		catalog,
+		nil,
+		"",
+		&capturingSchedulerLogger{},
+		coordinator,
+		repositories,
+		nil,
+		nil,
+		NewActiveExecutionRegistry(),
+		nil,
+		nil,
+		time.Now,
+		nil,
+	)
+	if handlers.webhook != nil {
+		t.Cleanup(handlers.webhook.Close)
+	}
+	if handlers.snapshot == nil {
+		t.Fatal("catalog scheduler did not retain its snapshot builder")
+	}
+	if handlers.notificationGateways == nil {
+		t.Fatal("catalog scheduler did not retain its notification gateway factory")
+	}
+	requester := func(calls *[]string) notify.FeishuAppHTTPFunc {
+		return func(_ context.Context, method, url string, _ map[string]string, _ []byte) (int, []byte, error) {
+			*calls = append(*calls, method+" "+url)
+			if strings.Contains(url, "/auth/v3/tenant_access_token/internal") {
+				return 200, []byte(`{"code":0,"msg":"ok","tenant_access_token":"t-abc123","expire":7200}`), nil
+			}
+			return 200, []byte(`{"code":0,"msg":"success","data":{"message_id":"om_ask"}}`), nil
+		}
+	}
+
+	var firstCalls, secondCalls []string
+	handlers.notificationGateways.feishuAppHTTP = requester(&firstCalls)
+	firstSnapshot := handlers.snapshot()
+	if firstSnapshot.notificationGateways != handlers.notificationGateways || firstSnapshot.input == nil {
+		t.Fatal("first catalog snapshot did not use the catalog notification factory")
+	}
+	firstInput := firstSnapshot.input(Services{Repositories: repositories})
+	if firstInput.OnHITLAsk == nil {
+		t.Fatal("first catalog snapshot did not expose its worker HITL notification path")
+	}
+	if err := firstInput.OnHITLAsk(context.Background(), worker.HITLAskNotification{
+		LoopID: "loop_shared", LoopSeq: 42, Question: "Redis or Postgres?", Options: []string{"redis", "postgres"},
+	}); err != nil {
+		t.Fatalf("first snapshot worker HITL notification error = %v", err)
+	}
+
+	next := config.CloneConfig(daemonConfig)
+	model := "gpt-5.1"
+	next.Agent.Model = &model
+	catalog.PublishGlobals(next)
+	handlers.notificationGateways.feishuAppHTTP = requester(&secondCalls)
+	secondSnapshot := handlers.snapshot()
+	if secondSnapshot.notificationGateways != handlers.notificationGateways || secondSnapshot.input == nil {
+		t.Fatal("second catalog snapshot did not reuse the catalog notification factory")
+	}
+	secondInput := secondSnapshot.input(Services{Repositories: repositories})
+	if secondInput.OnHITLAnswerDelivered == nil {
+		t.Fatal("second catalog snapshot did not expose its HITL answer notification path")
+	}
+	secondInput.OnHITLAnswerDelivered(context.Background(), "loop_shared", "postgres")
+	if len(secondCalls) != 1 || !strings.HasPrefix(secondCalls[0], "PATCH ") || !strings.Contains(secondCalls[0], "/messages/om_ask") {
+		t.Fatalf("second snapshot calls = %#v, want one answer-card PATCH through its actual scheduler callback", secondCalls)
+	}
+}

--- a/internal/runtime/scheduler_trusted_review_proxy_test.go
+++ b/internal/runtime/scheduler_trusted_review_proxy_test.go
@@ -1,0 +1,39 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/forge"
+)
+
+func TestMintTrustedReviewProxyResolvesConfiguredLooperCommandFromPATH(t *testing.T) {
+	binDir := t.TempDir()
+	looperPath := filepath.Join(binDir, "looper")
+	if err := os.WriteFile(looperPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(looperPath) error = %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	sock, cleanup, err := mintTrustedReviewProxyForPR(
+		"looper",
+		nil,
+		"acme/looper#42",
+		t.TempDir(),
+		config.Config{},
+		forge.TrustedReviewProxyPolicy{
+			Clean:            "COMMENT",
+			Blocking:         "REQUEST_CHANGES",
+			ExpectedCommitID: "head-42",
+		},
+	)
+	if err != nil {
+		t.Fatalf("mintTrustedReviewProxyForPR() error = %v", err)
+	}
+	defer cleanup()
+	if !filepath.IsAbs(sock) {
+		t.Fatalf("socket path = %q, want absolute path", sock)
+	}
+}

--- a/internal/worker/hitl.go
+++ b/internal/worker/hitl.go
@@ -118,7 +118,7 @@ func asAwaitingHumanError(err error) (*awaitingHumanError, bool) {
 // human drove during an interactive takeover that has since been handed back, so
 // the daemon's next worker run resumes THAT session and sees their turns. Empty
 // when no takeover resume is pending. Independent of hitl.enabled.
-func (r *Runner) pendingTakeoverResume(loop *storage.LoopRecord) (string, string) {
+func (r *Runner) pendingTakeoverResume(ctx context.Context, loop *storage.LoopRecord) (string, string) {
 	tr, ok := loops.ReadTakeoverResume(loop.MetadataJSON)
 	if !ok || strings.TrimSpace(tr.SessionID) == "" {
 		return "", ""
@@ -127,7 +127,18 @@ func (r *Runner) pendingTakeoverResume(loop *storage.LoopRecord) (string, string
 	if prompt == "" {
 		prompt = "A human took this task's agent session over directly and has handed it back. Review the whole conversation so far — including their turns — and continue from where they left off; do not restart from scratch."
 	}
-	return prompt, tr.SessionID
+	if r.repos == nil || r.repos.AgentExecutions == nil {
+		return takeoverCheckpointRestartPrompt(), ""
+	}
+	execution, err := r.repos.AgentExecutions.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil || execution == nil || execution.NativeSessionID == nil || strings.TrimSpace(*execution.NativeSessionID) != strings.TrimSpace(tr.SessionID) || strings.TrimSpace(execution.Vendor) != strings.TrimSpace(r.agentRuntime) {
+		return takeoverCheckpointRestartPrompt(), ""
+	}
+	return prompt, strings.TrimSpace(tr.SessionID)
+}
+
+func takeoverCheckpointRestartPrompt() string {
+	return "A human took this task over directly and has handed it back. The configured agent vendor no longer matches the captured session, so start a fresh session, inspect the current worktree and task state, and continue without trying to attach to the old conversation."
 }
 
 // latestNativeSessionID returns the loop's most recent captured agent session id,
@@ -138,7 +149,7 @@ func (r *Runner) latestNativeSessionID(ctx context.Context, loopID string) strin
 		return ""
 	}
 	execution, err := r.repos.AgentExecutions.GetLatestByLoopID(ctx, loopID)
-	if err != nil || execution == nil || execution.NativeSessionID == nil {
+	if err != nil || execution == nil || execution.NativeSessionID == nil || strings.TrimSpace(execution.Vendor) != strings.TrimSpace(r.agentRuntime) {
 		return ""
 	}
 	return strings.TrimSpace(*execution.NativeSessionID)
@@ -198,7 +209,10 @@ func (r *Runner) pendingHumanAnswer(ctx context.Context, loop *storage.LoopRecor
 		return "", ""
 	}
 	resumePrompt := fmt.Sprintf("A human answered the question you asked earlier (%q). Their decision: %s\nContinue the task using this decision; do not ask the same question again.", ask.Question, ask.Answer)
-	return resumePrompt, ask.SessionID
+	if strings.TrimSpace(ask.Vendor) != strings.TrimSpace(r.agentRuntime) {
+		return resumePrompt + "\nThe configured agent vendor changed after the question was asked, so continue in a fresh session rather than trying to attach to the prior vendor's session.", ""
+	}
+	return resumePrompt, strings.TrimSpace(ask.SessionID)
 }
 
 // markHumanAnswerConsumed flips a delivered human answer from "answered" to

--- a/internal/worker/hitl_test.go
+++ b/internal/worker/hitl_test.go
@@ -41,6 +41,72 @@ func TestConsumeAskSentinelReadsAndRemoves(t *testing.T) {
 	}
 }
 
+func TestWorkerDoesNotAttachOldVendorSessionsAfterVendorChange(t *testing.T) {
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	loop, err := fixture.repos.Loops.GetByID(ctx, "loop_worker_1")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v)", loop, err)
+	}
+
+	sessionID := "codex-session-123"
+	metadata, err := loops.WriteHITLAsk(loop.MetadataJSON, loops.HITLAsk{
+		Question:  "Which datastore?",
+		SessionID: sessionID,
+		Vendor:    "codex",
+		Answer:    "postgres",
+		Status:    "answered",
+	})
+	if err != nil {
+		t.Fatalf("WriteHITLAsk() error = %v", err)
+	}
+	metadata, err = loops.WriteTakeoverResume(&metadata, loops.TakeoverResume{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("WriteTakeoverResume() error = %v", err)
+	}
+	loop.MetadataJSON = &metadata
+	if err := fixture.repos.Loops.Upsert(ctx, *loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	projectID := loop.ProjectID
+	loopID := loop.ID
+	if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{
+		ID:              "agent_old_vendor",
+		ProjectID:       &projectID,
+		LoopID:          &loopID,
+		Vendor:          "codex",
+		Status:          "completed",
+		NativeSessionID: &sessionID,
+		StartedAt:       fixture.nowISO(),
+		CreatedAt:       fixture.nowISO(),
+		UpdatedAt:       fixture.nowISO(),
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	sameVendor := New(Options{Repos: fixture.repos, AgentRuntime: "codex"})
+	if prompt, gotSession := sameVendor.pendingHumanAnswer(ctx, loop); !strings.Contains(prompt, "postgres") || gotSession != sessionID {
+		t.Fatalf("same-vendor HITL resume = (%q, %q), want decision prompt + %q", prompt, gotSession, sessionID)
+	}
+	if prompt, gotSession := sameVendor.pendingTakeoverResume(ctx, loop); prompt == "" || gotSession != sessionID {
+		t.Fatalf("same-vendor takeover resume = (%q, %q), want prompt + %q", prompt, gotSession, sessionID)
+	}
+	if got := sameVendor.latestNativeSessionID(ctx, loop.ID); got != sessionID {
+		t.Fatalf("same-vendor mailbox session = %q, want %q", got, sessionID)
+	}
+
+	newVendor := New(Options{Repos: fixture.repos, AgentRuntime: "claude-code"})
+	if prompt, gotSession := newVendor.pendingHumanAnswer(ctx, loop); !strings.Contains(prompt, "postgres") || !strings.Contains(prompt, "vendor changed") || gotSession != "" {
+		t.Fatalf("cross-vendor HITL resume = (%q, %q), want decision prompt + fresh session", prompt, gotSession)
+	}
+	if prompt, gotSession := newVendor.pendingTakeoverResume(ctx, loop); !strings.Contains(prompt, "fresh session") || gotSession != "" {
+		t.Fatalf("cross-vendor takeover resume = (%q, %q), want checkpoint prompt + fresh session", prompt, gotSession)
+	}
+	if got := newVendor.latestNativeSessionID(ctx, loop.ID); got != "" {
+		t.Fatalf("cross-vendor mailbox session = %q, want fresh session", got)
+	}
+}
+
 func TestSuspendForHumanTransitionsAndNotifies(t *testing.T) {
 	fixture := newRunnerFixture(t)
 	ctx := context.Background()

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1723,8 +1723,9 @@ func (r *Runner) runExecuteStep(ctx context.Context, input stepInput) (workerChe
 		// Handed back from an interactive human takeover: resume the exact session
 		// the human drove (independent of HITL) so the daemon sees their turns.
 		if nativeSessionID == "" {
-			if takeoverPrompt, takeoverSession := r.pendingTakeoverResume(&input.Loop); takeoverSession != "" {
-				nativeResumePrompt, nativeSessionID = takeoverPrompt, takeoverSession
+			if takeoverPrompt, takeoverSession := r.pendingTakeoverResume(ctx, &input.Loop); takeoverPrompt != "" {
+				nativeResumePrompt = takeoverPrompt
+				nativeSessionID = takeoverSession
 				prompt += "\n\n" + takeoverPrompt
 			}
 		}

--- a/pkg/api/envelope.go
+++ b/pkg/api/envelope.go
@@ -6,6 +6,7 @@ const (
 	ErrorCodeActiveRunNotFound          ErrorCode = "ACTIVE_RUN_NOT_FOUND"
 	ErrorCodeAgentNotConfigured         ErrorCode = "AGENT_NOT_CONFIGURED"
 	ErrorCodeAuthMisconfigured          ErrorCode = "AUTH_MISCONFIGURED"
+	ErrorCodeConfigConflict             ErrorCode = "CONFIG_CONFLICT"
 	ErrorCodeInternalError              ErrorCode = "INTERNAL_ERROR"
 	ErrorCodeLoopConflict               ErrorCode = "LOOP_CONFLICT"
 	ErrorCodeLoopNotFound               ErrorCode = "LOOP_NOT_FOUND"
@@ -18,6 +19,7 @@ const (
 	ErrorCodePullRequestNotFound        ErrorCode = "PULL_REQUEST_NOT_FOUND"
 	ErrorCodePullRequestProjectMismatch ErrorCode = "PULL_REQUEST_PROJECT_MISMATCH"
 	ErrorCodeRouteNotFound              ErrorCode = "ROUTE_NOT_FOUND"
+	ErrorCodeRequestTooLarge            ErrorCode = "REQUEST_TOO_LARGE"
 	ErrorCodeRunNotFound                ErrorCode = "RUN_NOT_FOUND"
 	ErrorCodeRuntimeControlUnavailable  ErrorCode = "RUNTIME_CONTROL_UNAVAILABLE"
 	ErrorCodeUnauthorized               ErrorCode = "UNAUTHORIZED"
@@ -65,6 +67,8 @@ func (c ErrorCode) Status() int {
 		return 400
 	case ErrorCodeAuthMisconfigured:
 		return 500
+	case ErrorCodeConfigConflict:
+		return 409
 	case ErrorCodeInternalError:
 		return 500
 	case ErrorCodeLoopConflict:
@@ -89,6 +93,8 @@ func (c ErrorCode) Status() int {
 		return 409
 	case ErrorCodeRouteNotFound:
 		return 404
+	case ErrorCodeRequestTooLarge:
+		return 413
 	case ErrorCodeRunNotFound:
 		return 404
 	case ErrorCodeRuntimeControlUnavailable:
@@ -107,6 +113,7 @@ func AllErrorCodes() []ErrorCode {
 		ErrorCodeActiveRunNotFound,
 		ErrorCodeAgentNotConfigured,
 		ErrorCodeAuthMisconfigured,
+		ErrorCodeConfigConflict,
 		ErrorCodeInternalError,
 		ErrorCodeLoopConflict,
 		ErrorCodeLoopNotFound,
@@ -119,6 +126,7 @@ func AllErrorCodes() []ErrorCode {
 		ErrorCodePullRequestNotFound,
 		ErrorCodePullRequestProjectMismatch,
 		ErrorCodeRouteNotFound,
+		ErrorCodeRequestTooLarge,
 		ErrorCodeRunNotFound,
 		ErrorCodeRuntimeControlUnavailable,
 		ErrorCodeUnauthorized,

--- a/skills/looper/SKILL.md
+++ b/skills/looper/SKILL.md
@@ -9,6 +9,10 @@ Use this skill when an agent needs to install, configure, start, check, operate,
 
 It also covers the full webhook-mode lifecycle — turning it on, installing or validating the `gh webhook` extension, confirming forwarders are healthy, diagnosing a degraded runtime, clearing stale GitHub CLI hooks with `looper webhook cleanup`, and judging when a daemon restart is actually needed.
 
+`looperd` also watches its selected config source while running. Curated hot-safe policy changes—including `agent.vendor`—apply to claims made after publication without restarting the daemon; active runs keep the configuration snapshot they started with. The scheduler remains available when the daemon starts without a vendor, so configuring one later can activate an already prepared model/params profile. Leaving one configured vendor—by switching or clearing it—requires empty `agent.params` and, when a model is explicit, a paired model change or unset; cross-vendor continuations keep checkpoint/worktree state but start a fresh native session. Invalid edits and changes to process-owned settings are rejected as a whole while the daemon keeps its last-known-good snapshot. Use the Configuration page at `/dashboard/config` for supported field-level edits and reload diagnostics, and read [`references/config.md`](references/config.md) before deciding that a restart is required.
+
+Dashboard writes use the revision bound to the published values returned by the config read, then repeat an identity/mode/byte check immediately before atomic rename. This detects external generations present before the final check, including one not yet accepted by the watcher. Portable filesystems leave a tiny final-check-to-rename race, so avoid simultaneous manual and dashboard writes. Without token authentication, config PATCH requires a direct loopback peer and Host authority and rejects proxy-forwarding headers; proxied access requires `local-token` authentication. Dashboard serialization preserves the selected format and unknown top-level extension sections, but may normalize comments and lexical ordering; it also rejects symlinked config paths. Use a targeted manual edit of the symlink target when those constraints matter.
+
 **When NOT to use this skill:** developing on the Looper codebase itself (Go sources at `cmd/`, `internal/`, `pkg/`). For that, follow `AGENTS.md` and standard Go tooling.
 
 ## Looper in one paragraph
@@ -95,7 +99,7 @@ If none are installed, ask the user which one they want to install before contin
 
 After the user picks a vendor, verify it is authenticated (run the vendor's own status command, e.g. `claude --version` followed by a quick auth check, or `agent status`). If the vendor CLI exits with an auth error, surface it and ask the user to log in via the vendor's own flow before continuing.
 
-Looper inherits the vendor's own authentication (e.g. `claude login`, `agent login`, or env vars in the user's shell). For xAI Grok Build (`agent.vendor = "grok-build"`, executable `grok`), use `grok login --device-auth` or provide `XAI_API_KEY` in the daemon environment. **Do not** store agent credentials or API-key values in the Looper config file (commonly `~/.looper/config.toml`, with some existing installs still using `~/.looper/config.json`).
+Looper inherits the vendor's own authentication (e.g. `claude login`, `agent login`, or env vars in the user's shell). For xAI Grok Build (`agent.vendor = "grok-build"`, executable `grok`), use `grok login --device-auth` or provide `XAI_API_KEY` in the daemon environment. Prefer those vendor/daemon authentication mechanisms over storing credentials in Looper configuration. If the user explicitly manages a value through `agent.env`, treat it as a local secret: the dashboard/API returns only its key, never its value, and it must not be committed or copied into examples.
 
 Grok Build fresh runs default to `--always-approve` and `--sandbox off` so the agent can update Git metadata outside a linked worktree. Configured arguments override defaults: operators can select a stricter sandbox when the repository layout permits it; `--permission-mode` may prompt or fail unattended runs; non-`plain` output can prevent direct completion-marker parsing; and `-p`/`--single` replaces Looper's generated task prompt. Daemon native resume and interactive `looper resume` takeover are unsupported for Grok Build; retries use a fresh checkpoint prompt, and Looper never uses ambient `--continue`.
 
@@ -133,7 +137,7 @@ If `looper --version` fails, do not guess a new install location. The installer 
 | Existing-config state | Action |
 | --- | --- |
 | Config exists, daemon healthy, no projects yet | Run `looper project add` for the chosen path; skip bootstrap |
-| Config exists with wrong/missing `agent.vendor` | Targeted edit to `agent.vendor` after confirming with the user |
+| Config exists with wrong/missing `agent.vendor` | Targeted edit after confirmation; leaving a configured vendor (switch or clear) requires empty `agent.params` and a paired explicit model change/unset |
 | Config exists, daemon unhealthy | Triage with `looper daemon status` and `looper daemon logs --startup` first; do not re-bootstrap blindly |
 | Config exists and is correct | Skip bootstrap; go to Step 5 verification |
 
@@ -278,6 +282,8 @@ looper webhook cleanup owner/repo --confirm
 ## Safety rules
 
 - Do not overwrite or rewrite the Looper config file (`~/.looper/config.toml` on new installs; `~/.looper/config.json` on some existing installs) without explicit user confirmation. Prefer targeted edits.
+- Do not restart `looperd` merely to apply a hot-safe config change. Check `/dashboard/config` or daemon logs for the reload result; restart only for an explicitly reported restart-bound change or a separate lifecycle reason.
+- Do not assume the dashboard is a lossless text editor. It preserves format and unknown top-level sections, but may normalize comments, quoting, and key/table order; it refuses to replace a symlinked config path.
 - Do not delete runtime artifacts (`~/.looper/looper.sqlite`, `backups/`, `logs/`, `worktrees/`) unless the user explicitly asks and understands the impact.
 - Starting or restarting `looperd` can launch background automation against configured GitHub repositories — confirm intent before doing so.
 - Do not toggle `daemon.mode` (foreground ↔ launchd) without confirming; supervised mode persists across login/reboot.
@@ -289,7 +295,9 @@ looper webhook cleanup owner/repo --confirm
 ## Common mistakes
 
 - `cat ~/.looper/config.*` as a first move: use `looper config show` instead and redact secrets.
-- Restarting the daemon under pressure: check status/logs first; restart can re-trigger automation.
+- Restarting after every config edit: hot-safe policy reloads automatically for claims made after publication. Check the Configuration page or logs first; restart can re-trigger automation.
+- Assuming every valid edit was applied: a restart-bound field in the same candidate rejects the entire reload, and the last-known-good snapshot remains active until the file is corrected or the daemon is restarted with that config.
+- Submitting a stale Configuration page repeatedly: the patch revision intentionally conflicts after another editor changes the file; wait for a safe edit to publish and refresh, or resolve the displayed reload diagnostics in the file before retrying.
 - Disabling `notifications.osascript.enabled` silently: confirm the change or set an explicit `tools.osascriptPath`.
 - Rewriting the whole config for one fix: make targeted edits and preserve existing settings.
 - Treating a missing `~/.looper/` directory as permission to create or delete data: explain impact and ask first.

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -54,6 +54,44 @@ Custom config path examples:
 
 Relative config paths resolve from the working directory used to start `looperd`.
 
+## Live reload and dashboard management
+
+`looperd` watches the selected config file and reparses the complete, captured precedence stack while it runs. A valid candidate is published atomically only when every changed effective field is hot-safe. A claim made after publication uses the new snapshot; an already active run keeps the snapshot it started with.
+
+If the file is invalid, or if one changed field is restart-bound, the entire candidate is rejected. The daemon keeps running on its last-known-good snapshot and exposes the error and rejected paths on the Configuration page at `/dashboard/config`. Do not restart merely to apply a hot-safe edit. Correct a rejected file, or restart only when the change is intentionally restart-bound.
+
+Hot-safe fields are deliberately curated:
+
+- `scheduler.maxConcurrentRuns` and `scheduler.slowLaneWarnThresholdMs`
+- `agent.vendor`, `agent.model`, individual `agent.env` entries, and the canonical idle/max-runtime fields under `agent.timeouts.*`; configuring the first vendor after startup is supported
+- `notifications.inApp`, `notifications.osascript.enabled`, `notifications.osascript.soundForLevels`, and `notifications.osascript.throttleWindowSeconds`
+- every current `disclosure.*` field
+- `defaults.allowAutoCommit`, `defaults.allowAutoPush`, `defaults.allowRiskyFixes`, `defaults.openPrStrategy`, and `defaults.addSnapshotMode`; `defaults.baseBranch` is restart-bound because configured project records materialize it
+- `instructions.enabled` only
+- the current Planner `autoDiscovery`, `instructions`, and trigger fields except `roles.planner.triggers.planeAssigneeId`; all current Worker `autoDiscovery`, `triggers.*`, and `instructions` fields; the equivalent current Fixer fields; current Reviewer `discovery.*`, most `behavior.*`, and `instructions`; and current Coordinator `pollInterval`, `triage.*`, `dispatch.*`, and merge-watch policy except `mergeWatch.transientRetries`
+- `tools.looperPath` and `tools.osascriptPath`
+
+`agent.vendor` can switch from one configured vendor to another when `agent.params` is empty and an explicit `agent.model` is changed or unset in the same edit instead of being silently carried across vendors. Clearing a configured vendor uses the same guard, preventing a retained profile from passing through an intermediate `null`. Configuring the first vendor may use an already prepared model/params profile. Cross-vendor continuations keep their checkpoint, worktree, HITL answer, and human instructions but start a fresh native session.
+
+Everything else is restart-bound. Important exclusions are `agent.nativeResume.*`, arbitrary `agent.params`, `roles.planner.triggers.planeAssigneeId`, `roles.coordinator.enabled`, `notifications.webhook.*` (including its Feishu transport), all `hitl.*`, `instructions.maxBytes`, `roles.reviewer.autoMerge.*`, `roles.reviewer.behavior.loop.quietPeriodSeconds`, `roles.reviewer.behavior.loop.minPublishIntervalSeconds`, `roles.reviewer.behavior.retry.maxDelayMs`, `roles.coordinator.mergeWatch.transientRetries`, and `roles.coordinator.dependencies.*`. The Planner Plane-assignee field is file-only; Worker `roles.worker.triggers.planeAssigneeId` remains a supported hot-safe control. The scheduler retry budget/base delay and these Reviewer timing fields are durable queue-scheduling inputs; Coordinator transient retries are persisted as a remaining budget. The Reviewer-specific `roles.reviewer.behavior.nativeResume.*` fields are part of the curated Reviewer behavior surface; the global `agent.nativeResume.*` field is not. Listener/storage/runtime ownership, polling/cache topology, logger ownership, providers, projects, `tools.gitPath`, and `tools.ghPath` also require restart. New fields default to restart-bound until explicitly classified. Mixed hot-safe and restart-bound edits are rejected as one candidate; Looper never applies only the convenient half.
+
+Deprecated file-only aliases for `agent.timeouts.{planner,worker,reviewer,fixer}Seconds`, `defaults.allowAutoApprove`, and `defaults.fixAllPullRequests` are watcher-hot compatibility representations of canonical fields. They are never dashboard controls. A canonical dashboard edit retires the matching alias leaf so unsetting the canonical value later cannot reveal stale compatibility policy.
+
+The dashboard provides curated field-level controls rather than a raw config editor:
+
+- environment- or CLI-overridden fields are visible but read-only because those higher-precedence layers remain authoritative
+- `agent.env` values are write-only: the dashboard shows configured key names and supports set/replace/remove, but the API never returns values
+- `server.localToken`, `daemon.environment`, and arbitrary `agent.params` remain file-only
+- projects remain managed by the Projects API and SQLite catalog, not the generic Configuration page
+- each config read returns the revision captured with its published values; each patch submits it and repeats an identity/mode/byte check immediately before atomic rename, catching changes present before that final check
+- portable filesystems leave a tiny final-check-to-rename race, so do not combine simultaneous manual and dashboard writes
+- in `local-token` mode, PATCH uses normal token authentication; without token authentication, `PATCH /api/v1/config` requires a direct loopback peer and Host authority and rejects proxy-forwarding headers
+- dashboard writes preserve the selected TOML/YAML/JSON format, unknown top-level extension sections and their native scalar values, and ordinary permission bits, and are validated before atomic replacement; ACLs and extended filesystem metadata are not guaranteed to survive
+- serialization may canonicalize comments, quoting, key/table order, and other lexical formatting
+- a symlinked config path can be watched for external edits, but dashboard PATCH refuses to replace it; edit the symlink target directly
+
+After an external edit, use `/dashboard/config` to confirm the last attempt and last applied time. For a rejected candidate, inspect the displayed paths or daemon logs, then make a targeted correction. Do not expose config secrets while troubleshooting.
+
 ## Canonical taxonomy
 
 Looper's frozen canonical top-level config roots are:
@@ -62,6 +100,8 @@ Looper's frozen canonical top-level config roots are:
 - `daemon`
 - `storage`
 - `scheduler`
+- `webhook`
+- `network`
 - `agent`
 - `logging`
 - `notifications`
@@ -70,6 +110,7 @@ Looper's frozen canonical top-level config roots are:
 - `package`
 - `defaults`
 - `instructions`
+- `hitl`
 - `roles`
 - `providers`
 - `projects`
@@ -266,10 +307,14 @@ fallbackPollIntervalSeconds = 300
 vendor = "opencode"
 
 [agent.timeouts]
-plannerSeconds = 1800
-workerSeconds = 3600
-reviewerSeconds = 1800
-fixerSeconds = 1800
+plannerIdleTimeoutSeconds = 600
+plannerMaxRuntimeSeconds = 3600
+workerIdleTimeoutSeconds = 900
+workerMaxRuntimeSeconds = 10800
+reviewerIdleTimeoutSeconds = 600
+reviewerMaxRuntimeSeconds = 5400
+fixerIdleTimeoutSeconds = 600
+fixerMaxRuntimeSeconds = 7200
 
 [logging]
 level = "info"
@@ -477,4 +522,5 @@ looperd \
 - Ask before creating, overwriting, or deleting `~/.looper/config.toml`.
 - Never expose secrets from `agent.env`, tokens, or local environment variables.
 - Prefer targeted TOML edits over rewriting the whole config.
-- Confirm before changing configured projects, worktree roots, defaults that allow auto-push/auto-merge, reviewer approval behavior, or notification settings.
+- After a targeted edit, verify its reload result before proposing a restart. Active runs intentionally retain their original snapshot.
+- Confirm before changing configured projects, worktree roots, defaults that allow auto-push or risky fixes, reviewer approval behavior, or notification settings.

--- a/skills/looper/references/daemon.md
+++ b/skills/looper/references/daemon.md
@@ -14,6 +14,20 @@ looper daemon logs
 looper daemon logs --startup
 ```
 
+## Config reload versus restart
+
+The daemon watches its selected TOML, YAML, or JSON config while running. Hot-safe policy changes are validated and published without changing the daemon PID. Claims made after publication use the new snapshot; active runs retain the snapshot they started with.
+
+Use the Configuration page at `/dashboard/config` to see the selected path, winning source for each dashboard-managed hot field, last reload attempt, last successful application, and any rejected paths. File-only, project, and sensitive metadata families are intentionally omitted. Daemon logs also record a rejected reload. Invalid candidates and candidates containing a restart-bound change leave the last-known-good runtime configuration active.
+
+Do not restart after every config edit. The hot-safe allowlist covers `agent.vendor` (including configuring the first vendor after startup), model, individual env entries, and canonical idle/max-runtime timeouts; scheduler concurrency/slow-lane fields; in-app and osascript notifications; disclosure; auto-commit/push, risky-fix, PR-strategy, and snapshot-mode defaults; `instructions.enabled`; curated role policy; and Looper/osascript paths. Planner `roles.planner.triggers.planeAssigneeId` remains file-only and restart-bound; Worker `roles.worker.triggers.planeAssigneeId` remains hot-safe. `defaults.baseBranch` remains restart-bound because configured project records materialize it.
+
+Leaving one configured vendor—by switching or clearing it—requires empty `agent.params`; if `agent.model` is explicit, change or unset it in the same edit. Configuring the first vendor may use a prepared profile. Work continued after a cross-vendor switch uses the existing checkpoint and worktree in a fresh native session.
+
+Restart is required for process-owned settings such as the HTTP listener, storage/runtime paths, logger, webhook/network topology, providers/projects, polling/cache cadence, and `git`/`gh` tool paths. It is also required for `agent.nativeResume`, `agent.params`, notification webhooks/Feishu, HITL, `instructions.maxBytes`, scheduler retry budget/base delay, Reviewer auto-merge and queue timing, `roles.coordinator.enabled`, Coordinator merge-watch transient retries, and Coordinator dependencies. See `references/config.md` for the exact current field list.
+
+The Configuration page sends the file revision captured with its published values and performs a final identity/mode/byte check before atomic rename. A conflict normally means another editor changed the file, even if that generation has not yet passed reload validation; wait for it to publish and refresh, or fix its displayed diagnostics in the file before retrying. Portable filesystems leave a tiny final-check-to-rename race, so avoid simultaneous manual and dashboard writes. Without token authentication, config PATCH requires a direct loopback peer and Host authority and rejects forwarding headers; proxied access requires `local-token`. Dashboard writes retain unknown top-level extension sections and their native scalar values but may canonicalize comments and lexical ordering, and they reject symlinked config paths.
+
 ## Install and start
 
 Managed daemon install:

--- a/web/dashboard/src/App.tsx
+++ b/web/dashboard/src/App.tsx
@@ -9,6 +9,7 @@ import { LoopDetailPage } from "@/pages/LoopDetail";
 import { LoopsPage } from "@/pages/Loops";
 import { OverviewPage } from "@/pages/Overview";
 import { ProjectsPage } from "@/pages/Projects";
+import { ConfigPage } from "@/pages/Config";
 
 function resolveHostPort(): string {
   // Prefer the browser's authority as displayed in the address bar.
@@ -120,6 +121,7 @@ export default function App() {
                 <Route path="loops" element={<LoopsPage />} />
                 <Route path="loops/:selector" element={<LoopDetailPage />} />
                 <Route path="projects" element={<ProjectsPage />} />
+                <Route path="config" element={<ConfigPage />} />
                 <Route path="*" element={<Navigate to="/" replace />} />
               </Route>
             </Routes>

--- a/web/dashboard/src/components/layout/Shell.tsx
+++ b/web/dashboard/src/components/layout/Shell.tsx
@@ -3,10 +3,11 @@ import { Link, NavLink, Outlet } from "react-router-dom";
 import { useDashboardData } from "@/lib/DashboardDataContext";
 import { useProjectFilter } from "@/lib/ProjectFilterContext";
 
-const navItems: { to: string; label: string; end?: boolean }[] = [
+export const navItems: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "Overview", end: true },
   { to: "/loops", label: "Loops" },
   { to: "/projects", label: "Projects" },
+  { to: "/config", label: "Config" },
 ];
 
 /** Public asset under Vite base (/dashboard/). */

--- a/web/dashboard/src/lib/api.ts
+++ b/web/dashboard/src/lib/api.ts
@@ -15,16 +15,23 @@ export class ApiError extends Error {
   status: number;
   code?: string;
   requestId?: string;
+  details?: unknown;
 
   constructor(
     message: string,
-    opts: { status: number; code?: string; requestId?: string },
+    opts: {
+      status: number;
+      code?: string;
+      requestId?: string;
+      details?: unknown;
+    },
   ) {
     super(message);
     this.name = "ApiError";
     this.status = opts.status;
     this.code = opts.code;
     this.requestId = opts.requestId;
+    this.details = opts.details;
   }
 }
 
@@ -81,6 +88,7 @@ export async function apiFetch<T>(
       status: response.status,
       code: envelope?.error?.code,
       requestId: envelope?.requestId,
+      details: envelope?.error?.details,
     });
   }
 
@@ -245,6 +253,63 @@ export type ProjectsList = {
   items: Project[];
 };
 
+export type ConfigScalar = string | number | boolean | null;
+export type ConfigValue =
+  | ConfigScalar
+  | ConfigValue[]
+  | { [key: string]: ConfigValue | undefined };
+
+export type ConfigFieldMetadata = {
+  source: "default" | "config-file" | "env" | "cli" | string;
+  editable: boolean;
+  applyMode: "hot" | "restart" | string;
+};
+
+export type ConfigMetadata = {
+  configPath: string;
+  format: string;
+  filePresent: boolean;
+  revision: string;
+  lastAttemptAt?: string | null;
+  lastAppliedAt?: string | null;
+  lastError?: string | null;
+  rejectedPaths?: string[];
+  fields: Record<string, ConfigFieldMetadata>;
+};
+
+export type ConfigAgentView = {
+  vendor?: string | null;
+  model?: string | null;
+  nativeResume?: { enabled?: boolean };
+  timeouts?: Record<string, number>;
+  /** Secret-safe projection: values are never returned. */
+  envKeys?: string[];
+};
+
+/**
+ * Effective config view. The backend deliberately omits startup-only sections
+ * from dashboard editing metadata and projects remain managed by their own API.
+ */
+export type ConfigData = {
+  metadata: ConfigMetadata;
+  scheduler?: Record<string, ConfigValue | undefined>;
+  agent?: ConfigAgentView;
+  tools?: Record<string, ConfigValue | undefined>;
+  defaults?: Record<string, ConfigValue | undefined>;
+  notifications?: Record<string, ConfigValue | undefined>;
+  disclosure?: Record<string, ConfigValue | undefined>;
+  instructions?: Record<string, ConfigValue | undefined>;
+  hitl?: Record<string, ConfigValue | undefined>;
+  roles?: Record<string, ConfigValue | undefined>;
+  [key: string]: ConfigValue | ConfigAgentView | ConfigMetadata | undefined;
+};
+
+export type PatchConfigBody = {
+  revision: string;
+  set: Record<string, ConfigValue>;
+  unset: string[];
+};
+
 export type LoopLogsRun = {
   runId: string;
   status: string;
@@ -365,6 +430,21 @@ export function fetchLoop(
 
 export function fetchProjects(signal?: AbortSignal): Promise<ProjectsList> {
   return apiFetch<ProjectsList>("/api/v1/projects", { signal });
+}
+
+export function fetchConfig(signal?: AbortSignal): Promise<ConfigData> {
+  return apiFetch<ConfigData>("/api/v1/config", { signal });
+}
+
+export function patchConfig(
+  body: PatchConfigBody,
+  signal?: AbortSignal,
+): Promise<ConfigData> {
+  return apiFetch<ConfigData>("/api/v1/config", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    signal,
+  });
 }
 
 // --- Loop / run mutations (operator dashboard) ---

--- a/web/dashboard/src/lib/configForm.test.ts
+++ b/web/dashboard/src/lib/configForm.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import { ApiError, type ConfigData } from "./api";
+import {
+  buildConfigPatch,
+  CONFIG_GROUPS,
+  configFieldErrors,
+  configFieldPaths,
+  highImpactChanges,
+} from "./configForm";
+
+function fixture(): ConfigData {
+  return {
+    scheduler: {
+      pollIntervalSeconds: 30,
+      maxConcurrentRuns: 3,
+      retryMaxAttempts: 4,
+      retryBaseDelayMs: 5000,
+      slowLaneWarnThresholdMs: 5000,
+    },
+    agent: {
+      vendor: "codex",
+      envKeys: ["OPENAI_API_KEY"],
+      nativeResume: { enabled: true },
+      timeouts: { plannerIdleTimeoutSeconds: 300 },
+    },
+    tools: {
+      looperPath: "/usr/local/bin/looper",
+      osascriptPath: "/usr/bin/osascript",
+    },
+    defaults: {
+      allowAutoCommit: false,
+      allowAutoPush: false,
+      allowAutoApprove: false,
+      allowAutoMerge: false,
+      allowRiskyFixes: false,
+    },
+    roles: {
+      planner: {
+        triggers: { planeAssigneeId: "planner-member" },
+      },
+      worker: {
+        triggers: { planeAssigneeId: "worker-member" },
+      },
+      reviewer: {
+        behavior: {
+          reviewEvents: { clean: "COMMENT", blocking: "COMMENT" },
+          threadResolution: { enabled: true, mode: "report_only" },
+        },
+        autoMerge: { enabled: false },
+      },
+    },
+    metadata: {
+      configPath: "/tmp/config.toml",
+      format: "toml",
+      filePresent: true,
+      revision: "sha256:test",
+      fields: {
+        "scheduler.pollIntervalSeconds": {
+          source: "config-file",
+          editable: false,
+          applyMode: "restart",
+        },
+        "scheduler.maxConcurrentRuns": {
+          source: "config-file",
+          editable: true,
+          applyMode: "hot",
+        },
+        "scheduler.slowLaneWarnThresholdMs": {
+          source: "config-file",
+          editable: true,
+          applyMode: "hot",
+        },
+        "agent.vendor": {
+          source: "config-file",
+          editable: true,
+          applyMode: "hot",
+        },
+        "agent.env": {
+          source: "config-file",
+          editable: true,
+          applyMode: "hot",
+        },
+        "tools.looperPath": {
+          source: "config-file",
+          editable: true,
+          applyMode: "hot",
+        },
+        "tools.osascriptPath": {
+          source: "default",
+          editable: true,
+          applyMode: "hot",
+        },
+        "defaults.allowAutoPush": {
+          source: "config-file",
+          editable: true,
+          applyMode: "hot",
+        },
+        "roles.planner.triggers.planeAssigneeId": {
+          source: "config-file",
+          editable: false,
+          applyMode: "restart",
+        },
+        "roles.worker.triggers.planeAssigneeId": {
+          source: "config-file",
+          editable: true,
+          applyMode: "hot",
+        },
+      },
+    },
+  };
+}
+
+describe("config form contract", () => {
+  it("exposes only the curated scheduler fields and never secret projections", () => {
+    const data = fixture();
+    const scheduler = CONFIG_GROUPS.find((group) => group.id === "scheduler")!;
+    const agent = CONFIG_GROUPS.find((group) => group.id === "agent")!;
+    const tools = CONFIG_GROUPS.find((group) => group.id === "tools")!;
+    const roles = CONFIG_GROUPS.find((group) => group.id === "roles")!;
+
+    expect(configFieldPaths(data, scheduler)).toContain(
+      "scheduler.maxConcurrentRuns",
+    );
+    expect(configFieldPaths(data, scheduler)).not.toContain(
+      "scheduler.pollIntervalSeconds",
+    );
+    expect(configFieldPaths(data, agent)).toContain("agent.vendor");
+    expect(configFieldPaths(data, agent)).not.toContain(
+      "agent.nativeResume.enabled",
+    );
+    expect(configFieldPaths(data, agent)).not.toContain("agent.envKeys");
+    expect(configFieldPaths(data, agent)).not.toContain(
+      "agent.paramsConfigured",
+    );
+    expect(configFieldPaths(data, tools)).toEqual([
+      "tools.looperPath",
+      "tools.osascriptPath",
+    ]);
+    expect(configFieldPaths(data, roles)).not.toContain(
+      "roles.planner.triggers.planeAssigneeId",
+    );
+    expect(configFieldPaths(data, roles)).toContain(
+      "roles.worker.triggers.planeAssigneeId",
+    );
+  });
+
+  it("builds a dirty-only typed patch and validates integer controls", () => {
+    const data = fixture();
+    const valid = buildConfigPatch(
+      data,
+      {
+        "scheduler.maxConcurrentRuns": "3",
+        "scheduler.slowLaneWarnThresholdMs": "8",
+      },
+      ["agent.env.OLD_TOKEN"],
+      { "agent.env.NEW_TOKEN": "write-only-value" },
+    );
+    expect(valid.errors).toEqual({});
+    expect(valid.body).toEqual({
+      revision: "sha256:test",
+      set: {
+        "scheduler.slowLaneWarnThresholdMs": 8,
+        "agent.env.NEW_TOKEN": "write-only-value",
+      },
+      unset: ["agent.env.OLD_TOKEN"],
+    });
+
+    const invalid = buildConfigPatch(
+      data,
+      { "scheduler.maxConcurrentRuns": "3.5" },
+      [],
+    );
+    expect(invalid.body.set).toEqual({});
+    expect(invalid.errors["scheduler.maxConcurrentRuns"]).toMatch(
+      /whole number/i,
+    );
+  });
+
+  it("requires confirmation for newly enabled automation and review decisions", () => {
+    const changes = highImpactChanges(
+      fixture(),
+      {
+        "agent.vendor": "opencode",
+        "defaults.allowAutoCommit": true,
+        "defaults.allowAutoPush": true,
+        "roles.planner.autoDiscovery": true,
+        "roles.reviewer.behavior.reviewEvents.clean": "APPROVE",
+        "roles.reviewer.behavior.reviewEvents.blocking": "REQUEST_CHANGES",
+        "roles.reviewer.behavior.threadResolution.mode": "resolve_objective",
+        "roles.fixer.triggers.authorFilter": "any",
+        "roles.reviewer.behavior.threadResolution.requireAuditComment": false,
+      },
+      [
+        "agent.vendor",
+        "roles.coordinator.dispatch.mode",
+        "defaults.allowRiskyFixes",
+        "roles.reviewer.behavior.threadResolution.mode",
+        "roles.fixer.triggers.authorFilter",
+        "roles.reviewer.behavior.threadResolution.requireNewHeadSinceThread",
+      ],
+    );
+    expect(changes.map((change) => change.path)).toEqual([
+      "agent.vendor",
+      "defaults.allowAutoCommit",
+      "defaults.allowAutoPush",
+      "roles.planner.autoDiscovery",
+      "roles.reviewer.behavior.reviewEvents.clean",
+      "roles.reviewer.behavior.reviewEvents.blocking",
+      "roles.reviewer.behavior.threadResolution.mode",
+      "roles.fixer.triggers.authorFilter",
+      "roles.reviewer.behavior.threadResolution.requireAuditComment",
+      "agent.vendor",
+      "roles.coordinator.dispatch.mode",
+      "defaults.allowRiskyFixes",
+      "roles.reviewer.behavior.threadResolution.mode",
+      "roles.fixer.triggers.authorFilter",
+      "roles.reviewer.behavior.threadResolution.requireNewHeadSinceThread",
+    ]);
+  });
+
+  it("confirms automatic commit only when the change can enable it", () => {
+    const disabled = fixture();
+    expect(
+      highImpactChanges(disabled, { "defaults.allowAutoCommit": true }),
+    ).toEqual([
+      {
+        path: "defaults.allowAutoCommit",
+        label: "Allow Auto Commit",
+      },
+    ]);
+
+    const enabled = fixture();
+    enabled.defaults!.allowAutoCommit = true;
+    expect(
+      highImpactChanges(enabled, { "defaults.allowAutoCommit": false }),
+    ).toEqual([]);
+  });
+
+  it("maps backend validation details to dotted fields", () => {
+    const error = new ApiError("invalid config", {
+      status: 400,
+      details: {
+        issues: [
+          {
+            path: "scheduler.maxConcurrentRuns",
+            message: "must be greater than zero",
+          },
+        ],
+      },
+    });
+    expect(configFieldErrors(error)).toEqual({
+      "scheduler.maxConcurrentRuns": "must be greater than zero",
+    });
+  });
+});

--- a/web/dashboard/src/lib/configForm.ts
+++ b/web/dashboard/src/lib/configForm.ts
@@ -1,0 +1,511 @@
+import {
+  ApiError,
+  type ConfigData,
+  type ConfigValue,
+  type PatchConfigBody,
+} from "./api";
+
+export type ConfigFieldKind = "boolean" | "number" | "string" | "array";
+export type ConfigDraft = string | boolean;
+
+export type ConfigGroup = {
+  id: string;
+  title: string;
+  description: string;
+  accepts: (path: string) => boolean;
+};
+
+const SCHEDULER_PATHS = new Set([
+  "scheduler.maxConcurrentRuns",
+  "scheduler.slowLaneWarnThresholdMs",
+]);
+
+const agentPath = (path: string) =>
+  path === "agent.vendor" ||
+  path === "agent.model" ||
+  path.startsWith("agent.timeouts.");
+
+export const CONFIG_GROUPS: ConfigGroup[] = [
+  {
+    id: "scheduler",
+    title: "Scheduler",
+    description: "Concurrency and slow-lane diagnostics.",
+    accepts: (path) => SCHEDULER_PATHS.has(path),
+  },
+  {
+    id: "agent",
+    title: "Agent",
+    description: "Vendor, model, execution timeouts, and write-only environment values.",
+    accepts: agentPath,
+  },
+  {
+    id: "tools",
+    title: "Runtime tools",
+    description: "Hot-safe Looper and macOS notification executable paths.",
+    accepts: (path) =>
+      path === "tools.looperPath" || path === "tools.osascriptPath",
+  },
+  {
+    id: "defaults",
+    title: "Defaults & safety",
+    description: "Publishing behavior and automation guardrails.",
+    accepts: (path) => path.startsWith("defaults."),
+  },
+  {
+    id: "notifications",
+    title: "Notifications",
+    description: "In-app and macOS notification policy.",
+    accepts: (path) => path.startsWith("notifications."),
+  },
+  {
+    id: "disclosure",
+    title: "Disclosure",
+    description: "Where automated work is visibly attributed.",
+    accepts: (path) => path.startsWith("disclosure."),
+  },
+  {
+    id: "instructions",
+    title: "Instructions",
+    description: "Global instruction discovery for newly claimed runs.",
+    accepts: (path) => path.startsWith("instructions."),
+  },
+  {
+    id: "roles",
+    title: "Roles",
+    description: "Global planner, worker, reviewer, fixer, and coordinator policy.",
+    accepts: (path) => path.startsWith("roles."),
+  },
+];
+
+const ARRAY_SUFFIXES = [
+  ".labels",
+  ".levels",
+  ".soundForLevels",
+  ".mentionOpenIds",
+  ".mentionLogins",
+  ".answerAuthors",
+  ".slashCommands",
+  ".allowedUsers",
+  ".extraTransientErrorPatterns",
+];
+
+const BOOLEAN_NAMES = new Set([
+  "enabled",
+  "enabledByDefault",
+  "autoDiscovery",
+  "includeDrafts",
+  "requireReviewRequest",
+  "enableSelfReview",
+  "includeReviewingLabel",
+  "enhancedTransientClassification",
+  "recoverExistingMatchedFailures",
+  "stopOnApproved",
+  "stopOnReadyLabel",
+  "stopOnIdenticalOutput",
+  "detectDuplicateFindings",
+  "onHeadChange",
+  "reReviewPromptOnHeadChange",
+  "requireAuditComment",
+  "requireNewHeadSinceThread",
+  "requireCurrentReviewRequest",
+  "requireBranchProtection",
+  "requireAssigneeCurrentUser",
+  "reTriageOnAuthorReply",
+  "inApp",
+  "includeAgent",
+  "includeOS",
+  "gitCommit",
+  "pullRequest",
+  "issueComment",
+  "reviewComment",
+  "inlineCommentVisible",
+  "allowAutoCommit",
+  "allowAutoPush",
+  "allowAutoApprove",
+  "allowRiskyFixes",
+  "fixAllPullRequests",
+]);
+
+const SELECT_OPTIONS: Record<string, string[]> = {
+  "agent.vendor": [
+    "claude-code",
+    "codex",
+    "opencode",
+    "cursor-cli",
+    "grok-build",
+  ],
+  "defaults.openPrStrategy": ["all_done", "first_commit", "manual"],
+  "defaults.addSnapshotMode": ["async", "full", "off"],
+  "roles.coordinator.dispatch.mode": ["human-gated", "autonomous"],
+  "roles.fixer.triggers.authorFilter": ["current_user", "any"],
+  "roles.planner.triggers.labelMode": ["all", "any"],
+  "roles.worker.triggers.labelMode": ["all", "any"],
+  "roles.reviewer.discovery.triggers.labelMode": ["all", "any"],
+  "roles.fixer.triggers.labelMode": ["all", "any"],
+  "roles.reviewer.behavior.scope": [
+    "full_pr",
+    "changed_files",
+    "changed_ranges",
+  ],
+  "roles.reviewer.behavior.publishMode": [
+    "single_review",
+    "summary_comment",
+  ],
+  "roles.reviewer.behavior.reviewEvents.clean": ["COMMENT", "APPROVE"],
+  "roles.reviewer.behavior.reviewEvents.blocking": [
+    "COMMENT",
+    "REQUEST_CHANGES",
+  ],
+  "roles.reviewer.behavior.threadResolution.mode": [
+    "report_only",
+    "comment_only",
+    "suggest_resolution",
+    "resolve_objective",
+  ],
+  "roles.reviewer.behavior.threadResolution.scope": [
+    "looper_authored_only",
+  ],
+  "roles.reviewer.behavior.threadResolution.autoResolve": ["objective_only"],
+};
+
+const HIGH_IMPACT_BOOLEAN_PATHS = new Set([
+  "defaults.allowAutoCommit",
+  "defaults.allowAutoPush",
+  "defaults.allowRiskyFixes",
+  "roles.planner.autoDiscovery",
+  "roles.worker.autoDiscovery",
+  "roles.reviewer.discovery.autoDiscovery",
+  "roles.reviewer.discovery.triggers.enableSelfReview",
+  "roles.fixer.autoDiscovery",
+  "roles.coordinator.enabled",
+  "roles.reviewer.behavior.threadResolution.enabled",
+]);
+
+const HIGH_IMPACT_SAFEGUARD_PATHS = new Set([
+  "roles.reviewer.behavior.threadResolution.requireAuditComment",
+  "roles.reviewer.behavior.threadResolution.requireNewHeadSinceThread",
+  "roles.reviewer.behavior.threadResolution.requireCurrentReviewRequest",
+]);
+
+const THREAD_RESOLUTION_MODE_PATH =
+  "roles.reviewer.behavior.threadResolution.mode";
+
+function isConfigObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function getConfigValue(data: ConfigData, path: string): unknown {
+  let current: unknown = data;
+  for (const segment of path.split(".")) {
+    if (!isConfigObject(current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+function flattenLeaves(
+  value: unknown,
+  prefix: string,
+  target: Set<string>,
+): void {
+  if (Array.isArray(value) || value === null || typeof value !== "object") {
+    if (prefix) target.add(prefix);
+    return;
+  }
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (prefix === "agent" && (key === "envKeys" || key === "paramsConfigured")) {
+      continue;
+    }
+    flattenLeaves(child, prefix ? `${prefix}.${key}` : key, target);
+  }
+}
+
+export function configFieldPaths(data: ConfigData, group: ConfigGroup): string[] {
+  const paths = new Set<string>();
+  for (const path of Object.keys(data.metadata.fields ?? {})) {
+    if (group.accepts(path)) paths.add(path);
+  }
+  flattenLeaves(data[group.id], group.id, paths);
+  return [...paths]
+    .filter(group.accepts)
+    .filter((path) => data.metadata.fields[path]?.applyMode === "hot")
+    .filter((path) => !path.startsWith("agent.env") && path !== "agent.params")
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function configFieldKind(
+  path: string,
+  effectiveValue: unknown,
+): ConfigFieldKind {
+  if (Array.isArray(effectiveValue) || ARRAY_SUFFIXES.some((s) => path.endsWith(s))) {
+    return "array";
+  }
+  if (typeof effectiveValue === "boolean") return "boolean";
+  if (typeof effectiveValue === "number") return "number";
+  if (BOOLEAN_NAMES.has(path.split(".").at(-1) ?? "")) return "boolean";
+  return "string";
+}
+
+export function configSelectOptions(path: string): string[] | undefined {
+  return SELECT_OPTIONS[path];
+}
+
+export function draftFromValue(kind: ConfigFieldKind, value: unknown): ConfigDraft {
+  if (kind === "boolean") return value === true;
+  if (kind === "array") {
+    return Array.isArray(value) ? value.map(String).join("\n") : "";
+  }
+  return value == null ? "" : String(value);
+}
+
+function parseDraft(
+  kind: ConfigFieldKind,
+  draft: ConfigDraft,
+): { value?: ConfigValue; error?: string } {
+  if (kind === "boolean") return { value: draft === true };
+  const raw = String(draft);
+  if (kind === "number") {
+    if (!raw.trim()) return { error: "Enter a whole number." };
+    const value = Number(raw);
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      return { error: "Enter a whole number." };
+    }
+    return { value };
+  }
+  if (kind === "array") {
+    return {
+      value: raw
+        .split(/\n/)
+        .map((item) => item.trim())
+        .filter(Boolean),
+    };
+  }
+  return { value: raw };
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function buildConfigPatch(
+  data: ConfigData,
+  drafts: Record<string, ConfigDraft>,
+  unsetPaths: Iterable<string>,
+  secretSet: Record<string, string> = {},
+): { body: PatchConfigBody; errors: Record<string, string> } {
+  const set: Record<string, ConfigValue> = {};
+  const errors: Record<string, string> = {};
+  const unset = new Set(unsetPaths);
+
+  for (const [path, draft] of Object.entries(drafts)) {
+    if (unset.has(path)) continue;
+    const kind = configFieldKind(path, getConfigValue(data, path));
+    const parsed = parseDraft(kind, draft);
+    if (parsed.error) {
+      errors[path] = parsed.error;
+      continue;
+    }
+    if (!valuesEqual(parsed.value, getConfigValue(data, path))) {
+      set[path] = parsed.value as ConfigValue;
+    }
+  }
+
+  for (const [path, value] of Object.entries(secretSet)) {
+    if (!unset.has(path)) set[path] = value;
+  }
+
+  return {
+    body: { revision: data.metadata.revision, set, unset: [...unset].sort() },
+    errors,
+  };
+}
+
+export type HighImpactChange = { path: string; label: string };
+
+export function highImpactChanges(
+  data: ConfigData,
+  set: Record<string, ConfigValue>,
+  unset: Iterable<string> = [],
+): HighImpactChange[] {
+  const changes: HighImpactChange[] = [];
+  for (const [path, value] of Object.entries(set)) {
+    if (path === "agent.vendor" && getConfigValue(data, path) !== value) {
+      changes.push({ path, label: `Agent vendor → ${String(value)}` });
+      continue;
+    }
+    if (
+      path === "roles.coordinator.dispatch.mode" &&
+      value === "autonomous" &&
+      getConfigValue(data, path) !== value
+    ) {
+      changes.push({ path, label: "Coordinator dispatch → autonomous" });
+      continue;
+    }
+    if (
+      HIGH_IMPACT_BOOLEAN_PATHS.has(path) &&
+      value === true &&
+      getConfigValue(data, path) !== true
+    ) {
+      changes.push({ path, label: configFieldLabel(path) });
+      continue;
+    }
+    if (
+      HIGH_IMPACT_SAFEGUARD_PATHS.has(path) &&
+      value === false &&
+      getConfigValue(data, path) !== false
+    ) {
+      changes.push({
+        path,
+        label: `Disable ${configFieldLabel(path)}`,
+      });
+      continue;
+    }
+    if (
+      path === "roles.fixer.triggers.authorFilter" &&
+      value === "any" &&
+      getConfigValue(data, path) !== value
+    ) {
+      changes.push({ path, label: "Fixer author filter → any author" });
+      continue;
+    }
+    if (
+      path === "roles.reviewer.behavior.reviewEvents.clean" &&
+      value === "APPROVE" &&
+      getConfigValue(data, path) !== value
+    ) {
+      changes.push({ path, label: "Reviewer clean event → APPROVE" });
+      continue;
+    }
+    if (
+      path === "roles.reviewer.behavior.reviewEvents.blocking" &&
+      value === "REQUEST_CHANGES" &&
+      getConfigValue(data, path) !== value
+    ) {
+      changes.push({ path, label: "Reviewer blocking event → REQUEST_CHANGES" });
+      continue;
+    }
+    if (
+      path === THREAD_RESOLUTION_MODE_PATH &&
+      value === "resolve_objective" &&
+      getConfigValue(data, path) !== value
+    ) {
+      changes.push({ path, label: "Reviewer thread resolution → resolve objective" });
+    }
+  }
+  for (const path of unset) {
+    const current = getConfigValue(data, path);
+    if (path === "agent.vendor") {
+      changes.push({
+        path,
+        label: "Unset agent vendor (new work may stop until another authority supplies one)",
+      });
+      continue;
+    }
+    if (path === "roles.coordinator.dispatch.mode") {
+      changes.push({
+        path,
+        label: "Unset coordinator dispatch mode (the inherited mode will become active)",
+      });
+      continue;
+    }
+    if (HIGH_IMPACT_BOOLEAN_PATHS.has(path) && current !== true) {
+      changes.push({
+        path,
+        label: `Unset ${configFieldLabel(path)} (inherited value may enable it)`,
+      });
+      continue;
+    }
+    if (HIGH_IMPACT_SAFEGUARD_PATHS.has(path) && current !== false) {
+      changes.push({
+        path,
+        label: `Unset ${configFieldLabel(path)} (the inherited value may disable this safeguard)`,
+      });
+      continue;
+    }
+    if (path === "roles.fixer.triggers.authorFilter" && current !== "any") {
+      changes.push({
+        path,
+        label: "Unset fixer author filter (the inherited value may include any author)",
+      });
+      continue;
+    }
+    if (
+      path === "roles.reviewer.behavior.reviewEvents.clean" &&
+      current !== "APPROVE"
+    ) {
+      changes.push({
+        path,
+        label: "Unset reviewer clean event (inherited value may approve)",
+      });
+      continue;
+    }
+    if (
+      path === "roles.reviewer.behavior.reviewEvents.blocking" &&
+      current !== "REQUEST_CHANGES"
+    ) {
+      changes.push({
+        path,
+        label:
+          "Unset reviewer blocking event (inherited value may request changes)",
+      });
+      continue;
+    }
+    if (path === THREAD_RESOLUTION_MODE_PATH && current !== "resolve_objective") {
+      changes.push({
+        path,
+        label: "Unset reviewer thread resolution mode (inherited mode may resolve threads)",
+      });
+    }
+  }
+  return changes;
+}
+
+function titleWord(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export function configFieldLabel(path: string): string {
+  return path
+    .split(".")
+    .slice(1)
+    .map(titleWord)
+    .join(" · ");
+}
+
+type FieldIssue = { path?: unknown; message?: unknown };
+
+function formFieldPath(path: string): string {
+  // Config validation may identify a particular list element. The dashboard
+  // edits arrays atomically, so attach that issue to the whole array control.
+  return path.replace(/\[\d+\]/g, "");
+}
+
+function addIssues(target: Record<string, string>, value: unknown): void {
+  if (!Array.isArray(value)) return;
+  for (const issue of value as FieldIssue[]) {
+    if (typeof issue?.path === "string" && typeof issue?.message === "string") {
+      target[formFieldPath(issue.path)] = issue.message;
+    }
+  }
+}
+
+/** Accept the envelope detail shapes used by current and older API handlers. */
+export function configFieldErrors(error: unknown): Record<string, string> {
+  if (!(error instanceof ApiError) || !isConfigObject(error.details)) return {};
+  const result: Record<string, string> = {};
+  const details = error.details;
+  for (const key of ["fields", "fieldErrors"]) {
+    const value = details[key];
+    if (isConfigObject(value)) {
+      for (const [path, message] of Object.entries(value)) {
+        if (typeof message === "string") result[formFieldPath(path)] = message;
+      }
+    }
+  }
+  addIssues(result, details.issues);
+  addIssues(result, details.errors);
+  return result;
+}

--- a/web/dashboard/src/pages/Config.test.tsx
+++ b/web/dashboard/src/pages/Config.test.tsx
@@ -1,0 +1,848 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import App from "@/App";
+import { navItems } from "@/components/layout/Shell";
+import type { ConfigData } from "@/lib/api";
+import { ToastProvider } from "@/lib/toast";
+import { ConfigPage } from "./Config";
+
+function configFixture(overrides: Partial<ConfigData> = {}): ConfigData {
+  return {
+    scheduler: {
+      maxConcurrentRuns: 3,
+      retryMaxAttempts: 4,
+      retryBaseDelayMs: 5000,
+      slowLaneWarnThresholdMs: 5000,
+    },
+    agent: {
+      vendor: "codex",
+      model: "gpt-5",
+      nativeResume: { enabled: true },
+      timeouts: { plannerIdleTimeoutSeconds: 300 },
+      envKeys: ["OPENAI_API_KEY"],
+    },
+    defaults: {
+      allowAutoPush: false,
+    },
+    metadata: {
+      configPath: "/tmp/config.toml",
+      format: "toml",
+      filePresent: true,
+      revision: "sha256:test",
+      lastAppliedAt: "2026-07-16T01:00:00Z",
+      fields: {
+        "scheduler.maxConcurrentRuns": {
+          source: "env",
+          editable: false,
+          applyMode: "hot",
+        },
+        "scheduler.slowLaneWarnThresholdMs": {
+          source: "default",
+          editable: true,
+          applyMode: "hot",
+        },
+        "agent.vendor": { source: "config-file", editable: true, applyMode: "hot" },
+        "agent.model": { source: "config-file", editable: true, applyMode: "hot" },
+        "agent.nativeResume.enabled": {
+          source: "default",
+          editable: false,
+          applyMode: "restart",
+        },
+        "agent.timeouts.plannerIdleTimeoutSeconds": {
+          source: "default",
+          editable: true,
+          applyMode: "hot",
+        },
+        "agent.env": { source: "config-file", editable: true, applyMode: "hot" },
+        "agent.env.OPENAI_API_KEY": {
+          source: "config-file",
+          editable: true,
+          applyMode: "hot",
+        },
+        "defaults.allowAutoPush": {
+          source: "config-file",
+          editable: true,
+          applyMode: "hot",
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+function response(data: unknown, status = 200): Response {
+  return new Response(
+    JSON.stringify(
+      status >= 400
+        ? { ok: false, error: data }
+        : { ok: true, data, error: null },
+    ),
+    {
+      status,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <ConfigPage />
+    </ToastProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("ConfigPage", () => {
+  it("renders the /config route and its navigation item", async () => {
+    window.history.replaceState({}, "", "/dashboard/config");
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path === "/api/v1/healthz") return response({ healthy: true });
+      if (path === "/api/v1/runs/active") return response({ items: [] });
+      if (path === "/api/v1/projects") return response({ items: [] });
+      if (path === "/api/v1/config") return response(configFixture());
+      throw new Error(`unexpected request: ${path}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Configuration" })).toBeTruthy();
+    const configLink = screen.getByRole("link", { name: "Config" });
+    expect(configLink.getAttribute("href")).toBe("/dashboard/config");
+    expect(navItems).toContainEqual({ to: "/config", label: "Config" });
+  });
+
+  it("locks env/CLI winners and uses the authoritative PATCH snapshot", async () => {
+    const initial = configFixture();
+    const applied = configFixture({
+      scheduler: {
+        ...(initial.scheduler ?? {}),
+        slowLaneWarnThresholdMs: 8,
+      },
+    });
+    let getCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input);
+      if (path !== "/api/v1/config") throw new Error(`unexpected request: ${path}`);
+      if (init?.method === "PATCH") return response(applied);
+      getCount += 1;
+      return response(initial);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    const locked = (await screen.findByLabelText(
+      "scheduler.maxConcurrentRuns",
+    )) as HTMLInputElement;
+    expect(locked.disabled).toBe(true);
+    expect(screen.getByText(/ENV is the active authority/i)).toBeTruthy();
+    expect(screen.queryByLabelText("agent.nativeResume.enabled")).toBeNull();
+
+    const retry = screen.getByLabelText(
+      "scheduler.slowLaneWarnThresholdMs",
+    ) as HTMLInputElement;
+    fireEvent.change(retry, { target: { value: "8" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("scheduler.slowLaneWarnThresholdMs") as HTMLInputElement)
+          .value,
+      ).toBe("8");
+    });
+    expect(getCount).toBe(1);
+    const patchCall = fetchMock.mock.calls.find(
+      ([, init]) => init?.method === "PATCH",
+    );
+    expect(patchCall).toBeTruthy();
+    expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual({
+      revision: "sha256:test",
+      set: { "scheduler.slowLaneWarnThresholdMs": 8 },
+      unset: [],
+    });
+  });
+
+  it("does not let an older in-flight refresh overwrite a saved snapshot", async () => {
+    const initial = configFixture();
+    const applied = configFixture({
+      scheduler: {
+        ...(initial.scheduler ?? {}),
+        slowLaneWarnThresholdMs: 8,
+      },
+      metadata: {
+        ...initial.metadata,
+        revision: "sha256:applied",
+      },
+    });
+    let getCount = 0;
+    let resolveRefresh: ((value: Response) => void) | undefined;
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const path = String(input);
+        if (path !== "/api/v1/config") {
+          return Promise.reject(new Error(`unexpected request: ${path}`));
+        }
+        if (init?.method === "PATCH") return Promise.resolve(response(applied));
+        getCount += 1;
+        if (getCount === 1) return Promise.resolve(response(initial));
+        if (getCount === 2) {
+          return Promise.resolve(response({ message: "refresh failed" }, 500));
+        }
+        return new Promise((resolve) => {
+          resolveRefresh = resolve;
+        });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    const retry = (await screen.findByLabelText(
+      "scheduler.slowLaneWarnThresholdMs",
+    )) as HTMLInputElement;
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(await screen.findByText("refresh failed")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => expect(getCount).toBe(3));
+
+    fireEvent.change(retry, { target: { value: "8" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(retry.value).toBe("8"));
+    expect(screen.queryByText("refresh failed")).toBeNull();
+    expect(resolveRefresh).toBeTypeOf("function");
+
+    await act(async () => {
+      resolveRefresh?.(response(initial));
+      await Promise.resolve();
+    });
+
+    expect(retry.value).toBe("8");
+  });
+
+  it("aborts an in-flight refresh when the user starts editing", async () => {
+    const initial = configFixture();
+    const refreshed = configFixture({
+      scheduler: { ...(initial.scheduler ?? {}), slowLaneWarnThresholdMs: 8 },
+      metadata: { ...initial.metadata, revision: "sha256:external" },
+    });
+    const applied = configFixture({
+      scheduler: { ...(initial.scheduler ?? {}), slowLaneWarnThresholdMs: 6 },
+      metadata: { ...initial.metadata, revision: "sha256:applied" },
+    });
+    let getCount = 0;
+    let resolveRefresh: ((value: Response) => void) | undefined;
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        if (String(input) !== "/api/v1/config") {
+          return Promise.reject(new Error(`unexpected request: ${String(input)}`));
+        }
+        if (init?.method === "PATCH") return Promise.resolve(response(applied));
+        getCount += 1;
+        if (getCount === 1) return Promise.resolve(response(initial));
+        return new Promise((resolve) => {
+          resolveRefresh = resolve;
+        });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    const retry = (await screen.findByLabelText(
+      "scheduler.slowLaneWarnThresholdMs",
+    )) as HTMLInputElement;
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => expect(getCount).toBe(2));
+    fireEvent.change(retry, { target: { value: "6" } });
+    await act(async () => {
+      resolveRefresh?.(response(refreshed));
+      await Promise.resolve();
+    });
+    expect(retry.value).toBe("6");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
+        true,
+      );
+    });
+    const patchCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PATCH");
+    expect(JSON.parse(String(patchCall?.[1]?.body))).toMatchObject({
+      revision: "sha256:test",
+      set: { "scheduler.slowLaneWarnThresholdMs": 6 },
+    });
+  });
+
+  it("rebases retained drafts explicitly after a revision conflict", async () => {
+    const initial = configFixture();
+    const refreshed = configFixture({
+      scheduler: { ...(initial.scheduler ?? {}), slowLaneWarnThresholdMs: 8 },
+      metadata: { ...initial.metadata, revision: "sha256:external" },
+    });
+    const applied = configFixture({
+      scheduler: { ...(initial.scheduler ?? {}), slowLaneWarnThresholdMs: 6 },
+      metadata: { ...initial.metadata, revision: "sha256:applied" },
+    });
+    let getCount = 0;
+    let patchCount = 0;
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        if (String(input) !== "/api/v1/config") {
+          return Promise.reject(new Error(`unexpected request: ${String(input)}`));
+        }
+        if (init?.method === "PATCH") {
+          patchCount += 1;
+          if (patchCount === 1) {
+            return Promise.resolve(
+              response(
+                { code: "CONFIG_CONFLICT", message: "configuration changed on disk" },
+                409,
+              ),
+            );
+          }
+          return Promise.resolve(response(applied));
+        }
+        getCount += 1;
+        return Promise.resolve(response(getCount === 1 ? initial : refreshed));
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { container } = renderPage();
+
+    const retry = (await screen.findByLabelText(
+      "scheduler.slowLaneWarnThresholdMs",
+    )) as HTMLInputElement;
+    fireEvent.change(retry, { target: { value: "6" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    const rebase = await screen.findByRole("button", {
+      name: "Reload latest and keep edits",
+    });
+    expect(retry.value).toBe("6");
+    expect(retry.disabled).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    fireEvent.click(rebase);
+
+    await waitFor(() => {
+      const field = container.querySelector(
+        '[data-config-path="scheduler.slowLaneWarnThresholdMs"]',
+      );
+      expect(field?.textContent).toContain("Published value: 8");
+    });
+    expect(retry.value).toBe("6");
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(patchCount).toBe(2));
+    const patchCalls = fetchMock.mock.calls.filter(
+      ([, init]) => init?.method === "PATCH",
+    );
+    expect(JSON.parse(String(patchCalls[1]?.[1]?.body))).toMatchObject({
+      revision: "sha256:external",
+      set: { "scheduler.slowLaneWarnThresholdMs": 6 },
+    });
+  });
+
+  it("keeps a conflict open while the changed file is still rejected", async () => {
+    const initial = configFixture();
+    const rejected = configFixture({
+      metadata: {
+        ...initial.metadata,
+        revision: initial.metadata.revision,
+        lastError: "configuration reload rejected",
+        rejectedPaths: ["server.port"],
+      },
+    });
+    let getCount = 0;
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        if (String(input) !== "/api/v1/config") {
+          return Promise.reject(new Error(`unexpected request: ${String(input)}`));
+        }
+        if (init?.method === "PATCH") {
+          return Promise.resolve(
+            response(
+              { code: "CONFIG_CONFLICT", message: "configuration changed on disk" },
+              409,
+            ),
+          );
+        }
+        getCount += 1;
+        return Promise.resolve(response(getCount === 1 ? initial : rejected));
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    fireEvent.change(
+      await screen.findByLabelText("scheduler.slowLaneWarnThresholdMs"),
+      { target: { value: "6" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Reload latest and keep edits",
+      }),
+    );
+
+    expect(
+      await screen.findByText(/changed config file is still rejected/i),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Reload latest and keep edits" }),
+    ).toBeTruthy();
+    expect(
+      (screen.getByLabelText("scheduler.slowLaneWarnThresholdMs") as HTMLInputElement)
+        .value,
+    ).toBe("6");
+  });
+
+  it("prunes a retained draft that already matches the rebased snapshot", async () => {
+    const initial = configFixture();
+    const matching = configFixture({
+      scheduler: { ...(initial.scheduler ?? {}), slowLaneWarnThresholdMs: 8 },
+      metadata: { ...initial.metadata, revision: "sha256:external" },
+    });
+    const later = configFixture({
+      scheduler: { ...(initial.scheduler ?? {}), slowLaneWarnThresholdMs: 9 },
+      metadata: { ...initial.metadata, revision: "sha256:later" },
+    });
+    let getCount = 0;
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        if (String(input) !== "/api/v1/config") {
+          return Promise.reject(new Error(`unexpected request: ${String(input)}`));
+        }
+        if (init?.method === "PATCH") {
+          return Promise.resolve(
+            response(
+              { code: "CONFIG_CONFLICT", message: "configuration changed on disk" },
+              409,
+            ),
+          );
+        }
+        getCount += 1;
+        return Promise.resolve(
+          response(getCount === 1 ? initial : getCount === 2 ? matching : later),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { container } = renderPage();
+
+    const retry = (await screen.findByLabelText(
+      "scheduler.slowLaneWarnThresholdMs",
+    )) as HTMLInputElement;
+    fireEvent.change(retry, { target: { value: "8" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Reload latest and keep edits",
+      }),
+    );
+
+    expect(await screen.findByText(/change now matches/i)).toBeTruthy();
+    expect(retry.value).toBe("8");
+    expect(
+      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    const field = container.querySelector(
+      '[data-config-path="scheduler.slowLaneWarnThresholdMs"]',
+    );
+    expect(field?.textContent).not.toContain("Published value:");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => expect(retry.value).toBe("9"));
+  });
+
+  it("clears write-only operations when rebasing after a conflict", async () => {
+    const initial = configFixture();
+    const refreshed = configFixture({
+      metadata: { ...initial.metadata, revision: "sha256:external" },
+    });
+    let getCount = 0;
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        if (String(input) !== "/api/v1/config") {
+          return Promise.reject(new Error(`unexpected request: ${String(input)}`));
+        }
+        if (init?.method === "PATCH") {
+          return Promise.resolve(
+            response(
+              { code: "CONFIG_CONFLICT", message: "configuration changed on disk" },
+              409,
+            ),
+          );
+        }
+        getCount += 1;
+        return Promise.resolve(response(getCount === 1 ? initial : refreshed));
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    fireEvent.change(await screen.findByLabelText("Environment variable name"), {
+      target: { value: "NEW_SECRET" },
+    });
+    fireEvent.change(screen.getByLabelText("Environment variable secret"), {
+      target: { value: "secret-value" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Stage secret" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove OPENAI_API_KEY" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Reload latest and keep edits",
+      }),
+    );
+
+    expect(
+      await screen.findByText(/write-only agent environment changes were cleared/i),
+    ).toBeTruthy();
+    expect(screen.queryByText("NEW_SECRET")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Remove OPENAI_API_KEY" }),
+    ).toBeTruthy();
+    expect(
+      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("tracks and discards typed but unstaged environment input", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response(configFixture())),
+    );
+    renderPage();
+
+    const key = (await screen.findByLabelText(
+      "Environment variable name",
+    )) as HTMLInputElement;
+    const secret = screen.getByLabelText(
+      "Environment variable secret",
+    ) as HTMLInputElement;
+    const retry = screen.getByLabelText(
+      "scheduler.slowLaneWarnThresholdMs",
+    ) as HTMLInputElement;
+    fireEvent.change(retry, { target: { value: "6" } });
+    fireEvent.change(key, { target: { value: "UNSTAGED" } });
+    fireEvent.change(secret, { target: { value: "not-saved" } });
+
+    const discard = screen.getByRole("button", { name: "Discard" }) as HTMLButtonElement;
+    expect(discard.disabled).toBe(false);
+    expect(
+      (screen.getByRole("button", { name: "Refresh" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    fireEvent.click(discard);
+    expect(
+      (screen.getByLabelText("Environment variable name") as HTMLInputElement)
+        .value,
+    ).toBe("");
+    expect(
+      (screen.getByLabelText("Environment variable secret") as HTMLInputElement)
+        .value,
+    ).toBe("");
+    expect(
+      (screen.getByLabelText("scheduler.slowLaneWarnThresholdMs") as HTMLInputElement)
+        .value,
+    ).toBe("5000");
+  });
+
+  it("aborts an in-flight refresh synchronously when environment input is typed", async () => {
+    const initial = configFixture();
+    const refreshed = configFixture({
+      metadata: { ...initial.metadata, revision: "sha256:refreshed" },
+    });
+    let getCount = 0;
+    let resolveRefresh: ((value: Response) => void) | undefined;
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL): Promise<Response> => {
+        if (String(input) !== "/api/v1/config") {
+          return Promise.reject(new Error(`unexpected request: ${String(input)}`));
+        }
+        getCount += 1;
+        if (getCount === 1) return Promise.resolve(response(initial));
+        return new Promise((resolve) => {
+          resolveRefresh = resolve;
+        });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    const key = (await screen.findByLabelText(
+      "Environment variable name",
+    )) as HTMLInputElement;
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => expect(resolveRefresh).toBeTypeOf("function"));
+    fireEvent.change(key, { target: { value: "KEEP_ME" } });
+
+    await act(async () => {
+      resolveRefresh?.(response(refreshed));
+      await Promise.resolve();
+    });
+    expect(key.value).toBe("KEEP_ME");
+  });
+
+  it("hides a failed-refresh retry while local input is pending", async () => {
+    let getCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        getCount += 1;
+        if (getCount === 1) return response(configFixture());
+        return response({ message: "refresh failed" }, 500);
+      }),
+    );
+    renderPage();
+
+    await screen.findByLabelText("Environment variable name");
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(await screen.findByText("refresh failed")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Environment variable name"), {
+      target: { value: "KEEP_LOCAL" },
+    });
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(
+      (screen.getByRole("button", { name: "Refresh" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("locks all editors while a PATCH is in flight", async () => {
+    const initial = configFixture();
+    const applied = configFixture({
+      scheduler: { ...(initial.scheduler ?? {}), slowLaneWarnThresholdMs: 8 },
+      metadata: { ...initial.metadata, revision: "sha256:applied" },
+    });
+    let resolvePatch: ((value: Response) => void) | undefined;
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        if (String(input) !== "/api/v1/config") {
+          return Promise.reject(new Error(`unexpected request: ${String(input)}`));
+        }
+        if (init?.method === "PATCH") {
+          return new Promise((resolve) => {
+            resolvePatch = resolve;
+          });
+        }
+        return Promise.resolve(response(initial));
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    const retry = (await screen.findByLabelText(
+      "scheduler.slowLaneWarnThresholdMs",
+    )) as HTMLInputElement;
+    fireEvent.change(retry, { target: { value: "8" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(resolvePatch).toBeTypeOf("function"));
+
+    expect(retry.disabled).toBe(true);
+    expect(
+      (screen.getByLabelText("Environment variable name") as HTMLInputElement)
+        .disabled,
+    ).toBe(true);
+
+    await act(async () => {
+      resolvePatch?.(response(applied));
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText(
+          "scheduler.slowLaneWarnThresholdMs",
+        ) as HTMLInputElement).value,
+      ).toBe("8"),
+    );
+  });
+
+  it("shows client and backend field validation errors", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input);
+      if (path !== "/api/v1/config") throw new Error(`unexpected request: ${path}`);
+      if (init?.method === "PATCH") {
+        return response(
+          {
+            code: "invalid_argument",
+            message: "configuration is invalid",
+            details: {
+              issues: [
+                {
+                  path: "scheduler.slowLaneWarnThresholdMs",
+                  message: "must be -1 or greater than zero",
+                },
+              ],
+            },
+          },
+          400,
+        );
+      }
+      return response(configFixture());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    const retry = (await screen.findByLabelText(
+      "scheduler.slowLaneWarnThresholdMs",
+    )) as HTMLInputElement;
+    fireEvent.change(retry, { target: { value: "3.5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByText(/enter a whole number/i)).toBeTruthy();
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
+      false,
+    );
+
+    fireEvent.change(retry, { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(
+      await screen.findByText(/must be -1 or greater than zero/i),
+    ).toBeTruthy();
+  });
+
+  it("keeps agent env values write-only while supporting set and remove", async () => {
+    const base = configFixture();
+    const secretSafeFixture = configFixture({
+      agent: {
+        ...base.agent,
+        envKeys: ["OPENAI_API_KEY", "LOCKED_SECRET"],
+        // Defensive regression fixture: even if an older daemon returned this
+        // deprecated shape, the curated UI must never recursively render it.
+        env: { OPENAI_API_KEY: "existing-secret-value" },
+      } as ConfigData["agent"],
+      metadata: {
+        ...base.metadata,
+        fields: {
+          ...base.metadata.fields,
+          "agent.env.LOCKED_SECRET": {
+            source: "env",
+            editable: false,
+            applyMode: "hot",
+          },
+        },
+      },
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input);
+      if (path !== "/api/v1/config") throw new Error(`unexpected request: ${path}`);
+      return response(secretSafeFixture);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { container } = renderPage();
+
+    expect(await screen.findByText("OPENAI_API_KEY")).toBeTruthy();
+    expect(screen.getByText(/values are write-only/i)).toBeTruthy();
+    expect(container.textContent).not.toContain("existing-secret-value");
+    expect(container.querySelector('[name="agent.env"]')).toBeNull();
+
+    const lockedRemove = screen.getByRole("button", {
+      name: "Remove LOCKED_SECRET",
+    }) as HTMLButtonElement;
+    expect(lockedRemove.disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText("Environment variable name"), {
+      target: { value: "LOCKED_SECRET" },
+    });
+    fireEvent.change(screen.getByLabelText("Environment variable secret"), {
+      target: { value: "must-not-stage" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Stage secret" }));
+    expect(await screen.findByText(/higher-precedence authority/i)).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Environment variable name"), {
+      target: { value: "NEW_SECRET" },
+    });
+    const secretInput = screen.getByLabelText(
+      "Environment variable secret",
+    ) as HTMLInputElement;
+    fireEvent.change(secretInput, { target: { value: "super-secret-value" } });
+    fireEvent.click(screen.getByRole("button", { name: "Stage secret" }));
+
+    expect(secretInput.value).toBe("");
+    expect(container.textContent).not.toContain("super-secret-value");
+    expect(screen.getByText("NEW_SECRET")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Remove OPENAI_API_KEY" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
+        true,
+      );
+    });
+    const patchCall = fetchMock.mock.calls.find(
+      ([, init]) => init?.method === "PATCH",
+    );
+    expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual({
+      revision: "sha256:test",
+      set: { "agent.env.NEW_SECRET": "super-secret-value" },
+      unset: ["agent.env.OPENAI_API_KEY"],
+    });
+  });
+
+  it("confirms high-impact enables before sending PATCH", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path !== "/api/v1/config") throw new Error(`unexpected request: ${path}`);
+      return response(configFixture());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    const autoPush = (await screen.findByLabelText(
+      "defaults.allowAutoPush",
+    )) as HTMLInputElement;
+    fireEvent.click(autoPush);
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(
+      await screen.findByRole("dialog", {
+        name: "Confirm high-impact configuration",
+      }),
+    ).toBeTruthy();
+    expect(
+      (screen.getByRole("button", { name: "Discard" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Refresh" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
+      false,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply changes" }));
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/web/dashboard/src/pages/Config.tsx
+++ b/web/dashboard/src/pages/Config.tsx
@@ -1,0 +1,1132 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { PanelError } from "@/components/PanelError";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  ApiError,
+  fetchConfig,
+  patchConfig,
+  type ConfigData,
+  type ConfigFieldMetadata,
+  type PatchConfigBody,
+} from "@/lib/api";
+import {
+  buildConfigPatch,
+  CONFIG_GROUPS,
+  configFieldErrors,
+  configFieldKind,
+  configFieldLabel,
+  configFieldPaths,
+  configSelectOptions,
+  draftFromValue,
+  getConfigValue,
+  highImpactChanges,
+  type ConfigDraft,
+  type ConfigFieldKind,
+  type ConfigGroup,
+  type HighImpactChange,
+} from "@/lib/configForm";
+import { formatTs } from "@/lib/format";
+import { useToast } from "@/lib/toast";
+
+type ErrorMap = Record<string, string>;
+
+const controlClass =
+  "w-full rounded border border-[var(--border)] bg-[var(--bg)] px-2 py-1 text-[12px] text-[var(--text)] disabled:cursor-not-allowed disabled:opacity-60";
+
+function metaIsEditable(meta: ConfigFieldMetadata | undefined): boolean {
+  if (!meta?.editable) return false;
+  return meta.source !== "env" && meta.source !== "cli";
+}
+
+function sourceIsConfigFile(source: string | undefined): boolean {
+  return source === "config-file" || source === "file";
+}
+
+function SourceBadge({ meta }: { meta?: ConfigFieldMetadata }) {
+  const source = meta?.source ?? "unknown";
+  const applyMode = meta?.applyMode ?? "unknown";
+  return (
+    <span className="flex shrink-0 items-center gap-1 mono text-[10px] text-[var(--text-muted)]">
+      <span className="rounded border border-[var(--border)] px-1 py-px">
+        {source}
+      </span>
+      {applyMode !== "hot" ? (
+        <span className="rounded border border-[var(--warn)] px-1 py-px text-[var(--warn)]">
+          {applyMode}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function FieldFrame({
+  path,
+  meta,
+  error,
+  dirty,
+  unset,
+  publishedValue,
+  disabled,
+  onUnset,
+  children,
+}: {
+  path: string;
+  meta?: ConfigFieldMetadata;
+  error?: string;
+  dirty: boolean;
+  unset: boolean;
+  publishedValue: unknown;
+  disabled: boolean;
+  onUnset: () => void;
+  children: ReactNode;
+}) {
+  const editable = metaIsEditable(meta);
+  return (
+    <div
+      className={`grid gap-1 border-b border-[var(--border)] py-2 last:border-b-0 sm:grid-cols-[minmax(180px,0.9fr)_minmax(220px,1.1fr)] sm:gap-3 ${
+        dirty || unset ? "bg-[color-mix(in_srgb,var(--accent)_5%,transparent)]" : ""
+      }`}
+      data-config-path={path}
+    >
+      <div className="min-w-0">
+        <div className="flex items-start justify-between gap-2">
+          <label
+            htmlFor={`config-${path}`}
+            className="min-w-0 text-[12px] font-medium"
+          >
+            {configFieldLabel(path)}
+          </label>
+          <SourceBadge meta={meta} />
+        </div>
+        <code className="block break-all text-[10px] text-[var(--text-muted)]">
+          {path}
+        </code>
+        {!editable ? (
+          <p className="m-0 mt-0.5 text-[10px] text-[var(--text-muted)]">
+            {meta?.source === "env" || meta?.source === "cli"
+              ? `Read-only: ${meta.source.toUpperCase()} is the active authority.`
+              : "Read-only in the dashboard."}
+          </p>
+        ) : null}
+      </div>
+      <div className="min-w-0">
+        <div className="flex items-start gap-1.5">
+          <div className={`min-w-0 flex-1 ${unset ? "opacity-50" : ""}`}>
+            {children}
+          </div>
+          {editable && (sourceIsConfigFile(meta?.source) || unset) ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="shrink-0"
+              disabled={disabled}
+              onClick={onUnset}
+              title={
+                unset
+                  ? "Keep the current file value"
+                  : "Remove this value from the config file"
+              }
+            >
+              {unset ? "Undo" : "Unset"}
+            </Button>
+          ) : null}
+        </div>
+        {unset ? (
+          <p className="m-0 mt-1 text-[10px] text-[var(--warn)]">
+            Pending: remove the file value and use the next authority.
+          </p>
+        ) : null}
+        {dirty || unset ? (
+          <p className="m-0 mt-1 text-[10px] text-[var(--text-muted)]">
+            Published value: <code>{formatConfigValue(publishedValue)}</code>
+          </p>
+        ) : null}
+        {error ? (
+          <p className="m-0 mt-1 text-[11px] text-[var(--danger)]" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function formatConfigValue(value: unknown): string {
+  if (value === undefined) return "not configured";
+  if (typeof value === "string") return value || "(empty string)";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function ConfigControl({
+  path,
+  kind,
+  value,
+  options,
+  disabled,
+  unset,
+  onChange,
+}: {
+  path: string;
+  kind: ConfigFieldKind;
+  value: ConfigDraft;
+  options?: string[];
+  disabled: boolean;
+  unset: boolean;
+  onChange: (value: ConfigDraft) => void;
+}) {
+  const controlDisabled = disabled || unset;
+  if (kind === "boolean") {
+    return (
+      <label className="inline-flex min-h-7 items-center gap-2 text-[12px]">
+        <input
+          id={`config-${path}`}
+          aria-label={path}
+          type="checkbox"
+          checked={value === true}
+          disabled={controlDisabled}
+          onChange={(event) => onChange(event.currentTarget.checked)}
+        />
+        <span>{value === true ? "Enabled" : "Disabled"}</span>
+      </label>
+    );
+  }
+
+  if (options) {
+    return (
+      <select
+        id={`config-${path}`}
+        aria-label={path}
+        className={controlClass}
+        value={String(value)}
+        disabled={controlDisabled}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      >
+        {String(value) === "" ? (
+          <option value="" disabled>
+            Not configured
+          </option>
+        ) : null}
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  const multiline = kind === "array" || path.endsWith(".instructions");
+  if (multiline) {
+    return (
+      <textarea
+        id={`config-${path}`}
+        aria-label={path}
+        className={`${controlClass} min-h-16 resize-y mono`}
+        value={String(value)}
+        disabled={controlDisabled}
+        placeholder={kind === "array" ? "One value per line" : undefined}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
+    );
+  }
+
+  return (
+    <input
+      id={`config-${path}`}
+      aria-label={path}
+      className={`${controlClass} ${kind === "number" ? "mono" : ""}`}
+      type={kind === "number" ? "number" : "text"}
+      step={kind === "number" ? 1 : undefined}
+      value={String(value)}
+      disabled={controlDisabled}
+      onChange={(event) => onChange(event.currentTarget.value)}
+    />
+  );
+}
+
+function AgentEnvironment({
+  data,
+  secretSet,
+  unsetPaths,
+  errors,
+  onSet,
+  onRemove,
+  onUndoRemove,
+  onInputDirtyChange,
+  disabled,
+}: {
+  data: ConfigData;
+  secretSet: Record<string, string>;
+  unsetPaths: Set<string>;
+  errors: ErrorMap;
+  onSet: (key: string, value: string) => void;
+  onRemove: (key: string, existed: boolean) => void;
+  onUndoRemove: (key: string) => void;
+  onInputDirtyChange: (dirty: boolean) => void;
+  disabled: boolean;
+}) {
+  const [key, setKey] = useState("");
+  const [secret, setSecret] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
+  const envMeta = data.metadata.fields["agent.env"];
+  const editableByAuthority = metaIsEditable(envMeta);
+  const canAdd = editableByAuthority && !disabled;
+  const existingKeys = data.agent?.envKeys ?? [];
+  const stagedKeys = Object.keys(secretSet)
+    .filter((path) => path.startsWith("agent.env."))
+    .map((path) => path.slice("agent.env.".length));
+  const keys = [...new Set([...existingKeys, ...stagedKeys])].sort();
+
+  const stageSecret = () => {
+    const normalized = key.trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(normalized)) {
+      setLocalError("Use an environment-variable name such as OPENAI_API_KEY.");
+      return;
+    }
+    const path = `agent.env.${normalized}`;
+    if (
+      existingKeys.includes(normalized) &&
+      !metaIsEditable(data.metadata.fields[path] ?? envMeta)
+    ) {
+      setLocalError(`${normalized} is controlled by a higher-precedence authority and is read-only.`);
+      return;
+    }
+    if (!secret) {
+      setLocalError("Enter a secret value.");
+      return;
+    }
+    onSet(normalized, secret);
+    setKey("");
+    setSecret("");
+    onInputDirtyChange(false);
+    setLocalError(null);
+  };
+
+  return (
+    <div className="mt-2 border-t border-[var(--border)] pt-2" data-testid="agent-env">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <h3 className="m-0 text-[12px] font-medium">Agent environment</h3>
+          <p className="m-0 text-[10px] text-[var(--text-muted)]">
+            Values are write-only and are never returned by the daemon.
+          </p>
+        </div>
+        <SourceBadge meta={envMeta} />
+      </div>
+
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {keys.length === 0 ? (
+          <span className="text-[11px] text-[var(--text-muted)]">
+            No agent environment variables configured.
+          </span>
+        ) : null}
+        {keys.map((envKey) => {
+          const path = `agent.env.${envKey}`;
+          const exists = existingKeys.includes(envKey);
+          const pendingRemoval = unsetPaths.has(path);
+          const pendingSet = Object.hasOwn(secretSet, path);
+          const keyMeta = data.metadata.fields[path] ?? envMeta;
+          const editable = metaIsEditable(keyMeta);
+          return (
+            <span
+              key={envKey}
+              className="inline-flex items-center gap-1 rounded border border-[var(--border)] bg-[var(--bg)] px-1.5 py-0.5 mono text-[11px]"
+            >
+              <span className={pendingRemoval ? "line-through opacity-60" : ""}>
+                {envKey}
+              </span>
+              {pendingSet ? (
+                <span className="text-[9px] text-[var(--accent)]">pending</span>
+              ) : null}
+              {pendingRemoval ? (
+                <button
+                  type="button"
+                  className="border-0 bg-transparent p-0 text-[10px] text-[var(--accent)]"
+                  disabled={disabled}
+                  onClick={() => onUndoRemove(envKey)}
+                >
+                  undo
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  aria-label={`Remove ${envKey}`}
+                  className="border-0 bg-transparent p-0 text-[12px] text-[var(--danger)] disabled:opacity-40"
+                  disabled={disabled || !editable}
+                  onClick={() => onRemove(envKey, exists)}
+                >
+                  ×
+                </button>
+              )}
+              {errors[path] ? (
+                <span className="text-[var(--danger)]" title={errors[path]}>
+                  !
+                </span>
+              ) : null}
+            </span>
+          );
+        })}
+      </div>
+
+      <div className="mt-2 grid gap-1.5 sm:grid-cols-[minmax(150px,0.7fr)_minmax(220px,1fr)_auto]">
+        <input
+          aria-label="Environment variable name"
+          className={`${controlClass} mono`}
+          value={key}
+          disabled={!canAdd}
+          placeholder="VARIABLE_NAME"
+          autoCapitalize="characters"
+          spellCheck={false}
+          onChange={(event) => {
+            const next = event.currentTarget.value;
+            onInputDirtyChange(next.length > 0 || secret.length > 0);
+            setKey(next);
+          }}
+        />
+        <input
+          aria-label="Environment variable secret"
+          className={`${controlClass} mono`}
+          type="password"
+          value={secret}
+          disabled={!canAdd}
+          placeholder="Set or replace value"
+          autoComplete="new-password"
+          onChange={(event) => {
+            const next = event.currentTarget.value;
+            onInputDirtyChange(key.length > 0 || next.length > 0);
+            setSecret(next);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              stageSecret();
+            }
+          }}
+        />
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={!canAdd}
+          onClick={stageSecret}
+        >
+          Stage secret
+        </Button>
+      </div>
+      {!editableByAuthority ? (
+        <p className="m-0 mt-1 text-[10px] text-[var(--text-muted)]">
+          Agent environment is read-only under the active config authority.
+        </p>
+      ) : null}
+      {localError ? (
+        <p className="m-0 mt-1 text-[11px] text-[var(--danger)]" role="alert">
+          {localError}
+        </p>
+      ) : null}
+      {Object.entries(errors)
+        .filter(([path]) => path.startsWith("agent.env."))
+        .map(([path, message]) => (
+          <p
+            key={path}
+            className="m-0 mt-1 text-[11px] text-[var(--danger)]"
+            role="alert"
+          >
+            <code>{path}</code>: {message}
+          </p>
+        ))}
+    </div>
+  );
+}
+
+function ReloadWarning({ data }: { data: ConfigData }) {
+  const { lastError, rejectedPaths = [], lastAttemptAt, lastAppliedAt } =
+    data.metadata;
+  if (!lastError && rejectedPaths.length === 0) return null;
+  return (
+    <div
+      className="rounded border border-[var(--danger)] bg-[var(--bg-elevated)] px-3 py-2 text-[12px]"
+      role="alert"
+    >
+      <p className="m-0 font-semibold text-[var(--danger)]">
+        Latest config reload was rejected
+      </p>
+      <p className="m-0 mt-0.5 text-[var(--text-muted)]">
+        The daemon is still using the last-known-good configuration
+        {lastAppliedAt ? ` from ${formatTs(lastAppliedAt)}` : ""}.
+      </p>
+      {lastError ? (
+        <pre className="m-0 mt-1 whitespace-pre-wrap break-words mono text-[11px] text-[var(--danger)]">
+          {lastError}
+        </pre>
+      ) : null}
+      {rejectedPaths.length ? (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {rejectedPaths.map((path) => (
+            <code
+              key={path}
+              className="rounded border border-[var(--border)] px-1 py-px text-[10px]"
+            >
+              {path}
+            </code>
+          ))}
+        </div>
+      ) : null}
+      {lastAttemptAt ? (
+        <p className="m-0 mt-1 mono text-[10px] text-[var(--text-muted)]">
+          attempted {formatTs(lastAttemptAt)}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function ConfigGroupCard({
+  group,
+  data,
+  drafts,
+  unsetPaths,
+  errors,
+  secretSet,
+  onDraft,
+  onToggleUnset,
+  onSecretSet,
+  onSecretRemove,
+  onSecretUndoRemove,
+  environmentResetToken,
+  onEnvironmentInputDirtyChange,
+  disabled,
+}: {
+  group: ConfigGroup;
+  data: ConfigData;
+  drafts: Record<string, ConfigDraft>;
+  unsetPaths: Set<string>;
+  errors: ErrorMap;
+  secretSet: Record<string, string>;
+  onDraft: (path: string, value: ConfigDraft) => void;
+  onToggleUnset: (path: string) => void;
+  onSecretSet: (key: string, value: string) => void;
+  onSecretRemove: (key: string, existed: boolean) => void;
+  onSecretUndoRemove: (key: string) => void;
+  environmentResetToken: number;
+  onEnvironmentInputDirtyChange: (dirty: boolean) => void;
+  disabled: boolean;
+}) {
+  const paths = configFieldPaths(data, group);
+  if (paths.length === 0 && group.id !== "agent") return null;
+  return (
+    <Card
+      title={group.title}
+      data-config-group={group.id}
+      className={group.id === "roles" ? "xl:col-span-2" : ""}
+    >
+      <p className="m-0 mb-1 text-[11px] text-[var(--text-muted)]">
+        {group.description}
+      </p>
+      <div>
+        {paths.map((path) => {
+          const effective = getConfigValue(data, path);
+          const kind = configFieldKind(path, effective);
+          const value = Object.hasOwn(drafts, path)
+            ? drafts[path]
+            : draftFromValue(kind, effective);
+          const meta = data.metadata.fields[path];
+          const dirty = Object.hasOwn(drafts, path);
+          const unset = unsetPaths.has(path);
+          return (
+            <FieldFrame
+              key={path}
+              path={path}
+              meta={meta}
+              error={errors[path]}
+              dirty={dirty}
+              unset={unset}
+              publishedValue={effective}
+              disabled={disabled}
+              onUnset={() => onToggleUnset(path)}
+            >
+              <ConfigControl
+                path={path}
+                kind={kind}
+                value={value}
+                options={configSelectOptions(path)}
+                disabled={disabled || !metaIsEditable(meta)}
+                unset={unset}
+                onChange={(next) => onDraft(path, next)}
+              />
+            </FieldFrame>
+          );
+        })}
+      </div>
+      {group.id === "agent" ? (
+        <AgentEnvironment
+          key={environmentResetToken}
+          data={data}
+          secretSet={secretSet}
+          unsetPaths={unsetPaths}
+          errors={errors}
+          onSet={onSecretSet}
+          onRemove={onSecretRemove}
+          onUndoRemove={onSecretUndoRemove}
+          onInputDirtyChange={onEnvironmentInputDirtyChange}
+          disabled={disabled}
+        />
+      ) : null}
+    </Card>
+  );
+}
+
+function reconcilePendingAfterRebase(
+  next: ConfigData,
+  drafts: Record<string, ConfigDraft>,
+  secretSet: Record<string, string>,
+  unsetPaths: Set<string>,
+) {
+  const nextDrafts: Record<string, ConfigDraft> = {};
+  let matchedPublished = 0;
+  let noLongerEditable = 0;
+  for (const [path, draft] of Object.entries(drafts)) {
+    if (!metaIsEditable(next.metadata.fields[path])) {
+      noLongerEditable += 1;
+      continue;
+    }
+    const candidate = buildConfigPatch(next, { [path]: draft }, []);
+    if (
+      !Object.hasOwn(candidate.body.set, path) &&
+      !Object.hasOwn(candidate.errors, path)
+    ) {
+      matchedPublished += 1;
+      continue;
+    }
+    nextDrafts[path] = draft;
+  }
+
+  const nextUnsetPaths = new Set<string>();
+  let clearedWriteOnly = Object.keys(secretSet).length;
+  for (const path of unsetPaths) {
+    if (path.startsWith("agent.env.")) {
+      clearedWriteOnly += 1;
+      continue;
+    }
+    const meta = next.metadata.fields[path];
+    if (!metaIsEditable(meta) || !sourceIsConfigFile(meta?.source)) {
+      noLongerEditable += 1;
+      continue;
+    }
+    nextUnsetPaths.add(path);
+  }
+
+  const notices: string[] = [];
+  if (clearedWriteOnly > 0) {
+    notices.push(
+      "Write-only agent environment changes were cleared; review the current keys and restage them.",
+    );
+  }
+  if (matchedPublished > 0) {
+    notices.push(
+      `${matchedPublished} pending ${matchedPublished === 1 ? "change now matches" : "changes now match"} the published configuration and ${matchedPublished === 1 ? "was" : "were"} cleared.`,
+    );
+  }
+  if (noLongerEditable > 0) {
+    notices.push(
+      `${noLongerEditable} pending ${noLongerEditable === 1 ? "change is" : "changes are"} no longer editable and ${noLongerEditable === 1 ? "was" : "were"} cleared.`,
+    );
+  }
+
+  return {
+    drafts: nextDrafts,
+    secretSet: {} as Record<string, string>,
+    unsetPaths: nextUnsetPaths,
+    notice: notices.join(" "),
+  };
+}
+
+export function ConfigPage() {
+  const toast = useToast();
+  const [data, setData] = useState<ConfigData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveConflict, setSaveConflict] = useState(false);
+  const [rebaseNotice, setRebaseNotice] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [drafts, setDrafts] = useState<Record<string, ConfigDraft>>({});
+  const [secretSet, setSecretSet] = useState<Record<string, string>>({});
+  const [unsetPaths, setUnsetPaths] = useState<Set<string>>(new Set());
+  const [fieldErrors, setFieldErrors] = useState<ErrorMap>({});
+  const [confirmChanges, setConfirmChanges] = useState<HighImpactChange[]>([]);
+  const [confirmBody, setConfirmBody] = useState<PatchConfigBody | null>(null);
+  const [environmentInputDirty, setEnvironmentInputDirty] = useState(false);
+  const [environmentResetToken, setEnvironmentResetToken] = useState(0);
+  const loadAbort = useRef<AbortController | null>(null);
+  const dataRef = useRef<ConfigData | null>(null);
+  const draftsRef = useRef(drafts);
+  const secretSetRef = useRef(secretSet);
+  const unsetPathsRef = useRef(unsetPaths);
+  const conflictRevisionRef = useRef<string | null>(null);
+  dataRef.current = data;
+  draftsRef.current = drafts;
+  secretSetRef.current = secretSet;
+  unsetPathsRef.current = unsetPaths;
+
+  const load = useCallback(async (rebaseDrafts = false) => {
+    loadAbort.current?.abort();
+    const controller = new AbortController();
+    loadAbort.current = controller;
+    setLoading(true);
+    try {
+      const next = await fetchConfig(controller.signal);
+      if (controller.signal.aborted) return;
+      setData(next);
+      setLoadError(null);
+      if (rebaseDrafts) {
+        if (
+          conflictRevisionRef.current !== null &&
+          next.metadata.revision === conflictRevisionRef.current
+        ) {
+          setSaveConflict(true);
+          setSaveError(
+            next.metadata.lastError
+              ? "The changed config file is still rejected. Repair it outside the dashboard, wait for a successful reload, then try again."
+              : "The daemon has not published the changed config file yet. Wait for the reload loop, then reload again.",
+          );
+          setFieldErrors({});
+          return;
+        }
+        const reconciled = reconcilePendingAfterRebase(
+          next,
+          draftsRef.current,
+          secretSetRef.current,
+          unsetPathsRef.current,
+        );
+        setDrafts(reconciled.drafts);
+        setSecretSet(reconciled.secretSet);
+        setUnsetPaths(reconciled.unsetPaths);
+        setRebaseNotice(reconciled.notice || null);
+        setEnvironmentInputDirty(false);
+        setEnvironmentResetToken((current) => current + 1);
+        setSaveError(null);
+        setFieldErrors({});
+        setSaveConflict(false);
+        conflictRevisionRef.current = null;
+      } else {
+        setRebaseNotice(null);
+        setEnvironmentInputDirty(false);
+        setEnvironmentResetToken((current) => current + 1);
+      }
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      setLoadError(error instanceof Error ? error.message : String(error));
+    } finally {
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(false);
+    return () => loadAbort.current?.abort();
+  }, [load]);
+
+  const retireLoad = useCallback(() => {
+    loadAbort.current?.abort();
+    loadAbort.current = null;
+    setLoading(false);
+  }, []);
+
+  const onEnvironmentInputDirtyChange = useCallback(
+    (dirty: boolean) => {
+      if (dirty) retireLoad();
+      setEnvironmentInputDirty(dirty);
+    },
+    [retireLoad],
+  );
+
+  const patch = useMemo(
+    () =>
+      data
+        ? buildConfigPatch(data, drafts, unsetPaths, secretSet)
+        : { body: { revision: "", set: {}, unset: [] }, errors: {} },
+    [data, drafts, secretSet, unsetPaths],
+  );
+  const dirtyCount =
+    Object.keys(patch.body.set).length +
+    patch.body.unset.length +
+    Object.keys(patch.errors).length;
+  const formDirtyCount = dirtyCount + (environmentInputDirty ? 1 : 0);
+  const editorLocked = saving || confirmBody !== null || saveConflict;
+
+  const clearPathError = useCallback((path: string) => {
+    setFieldErrors((current) => {
+      if (!Object.hasOwn(current, path)) return current;
+      const next = { ...current };
+      delete next[path];
+      return next;
+    });
+    setSaveError(null);
+  }, []);
+
+  const onDraft = useCallback(
+    (path: string, value: ConfigDraft) => {
+      retireLoad();
+      setDrafts((current) => {
+        if (data) {
+          const candidate = buildConfigPatch(data, { [path]: value }, []);
+          if (
+            !Object.hasOwn(candidate.body.set, path) &&
+            !Object.hasOwn(candidate.errors, path)
+          ) {
+            if (!Object.hasOwn(current, path)) return current;
+            const next = { ...current };
+            delete next[path];
+            return next;
+          }
+        }
+        return { ...current, [path]: value };
+      });
+      setUnsetPaths((current) => {
+        if (!current.has(path)) return current;
+        const next = new Set(current);
+        next.delete(path);
+        return next;
+      });
+      clearPathError(path);
+    },
+    [clearPathError, data, retireLoad],
+  );
+
+  const onToggleUnset = useCallback(
+    (path: string) => {
+      retireLoad();
+      setDrafts((current) => {
+        if (!Object.hasOwn(current, path)) return current;
+        const next = { ...current };
+        delete next[path];
+        return next;
+      });
+      setUnsetPaths((current) => {
+        const next = new Set(current);
+        if (next.has(path)) next.delete(path);
+        else next.add(path);
+        return next;
+      });
+      clearPathError(path);
+    },
+    [clearPathError, retireLoad],
+  );
+
+  const onSecretSet = useCallback(
+    (key: string, value: string) => {
+      retireLoad();
+      const path = `agent.env.${key}`;
+      setSecretSet((current) => ({ ...current, [path]: value }));
+      setUnsetPaths((current) => {
+        if (!current.has(path)) return current;
+        const next = new Set(current);
+        next.delete(path);
+        return next;
+      });
+      clearPathError(path);
+    },
+    [clearPathError, retireLoad],
+  );
+
+  const onSecretRemove = useCallback(
+    (key: string, existed: boolean) => {
+      retireLoad();
+      const path = `agent.env.${key}`;
+      setSecretSet((current) => {
+        if (!Object.hasOwn(current, path)) return current;
+        const next = { ...current };
+        delete next[path];
+        return next;
+      });
+      if (existed) {
+        setUnsetPaths((current) => new Set(current).add(path));
+      }
+      clearPathError(path);
+    },
+    [clearPathError, retireLoad],
+  );
+
+  const onSecretUndoRemove = useCallback(
+    (key: string) => {
+      retireLoad();
+      const path = `agent.env.${key}`;
+      setUnsetPaths((current) => {
+        const next = new Set(current);
+        next.delete(path);
+        return next;
+      });
+      clearPathError(path);
+    },
+    [clearPathError, retireLoad],
+  );
+
+  const persist = useCallback(
+    async (body: PatchConfigBody) => {
+      // A refresh started while the form was still clean may still be in flight
+      // after the user edits and saves. Retire it before PATCH so its older
+      // snapshot cannot overwrite the authoritative PATCH response.
+      retireLoad();
+      setSaving(true);
+      setSaveConflict(false);
+      setSaveError(null);
+      setFieldErrors({});
+      try {
+        const applied = await patchConfig(body);
+        // PATCH returns the authoritative normalized snapshot from the same
+        // publication boundary. Using it avoids turning a later GET failure into
+        // a false "save failed" result after the file was already replaced.
+        setData(applied);
+        setLoadError(null);
+        setDrafts({});
+        setSecretSet({});
+        setUnsetPaths(new Set());
+        setConfirmBody(null);
+        setConfirmChanges([]);
+        setRebaseNotice(null);
+        setEnvironmentInputDirty(false);
+        setEnvironmentResetToken((current) => current + 1);
+        conflictRevisionRef.current = null;
+        toast.success("Configuration saved and applied to new runs.");
+      } catch (error) {
+        setConfirmBody(null);
+        setConfirmChanges([]);
+        const byField = configFieldErrors(error);
+        setFieldErrors(byField);
+        setSaveError(error instanceof Error ? error.message : String(error));
+        const conflict = error instanceof ApiError && error.status === 409;
+        setSaveConflict(conflict);
+        if (conflict) {
+          conflictRevisionRef.current = dataRef.current?.metadata.revision ?? body.revision;
+        }
+        toast.error(error instanceof Error ? error.message : String(error));
+      } finally {
+        setSaving(false);
+      }
+    },
+    [retireLoad, toast],
+  );
+
+  const requestSave = useCallback(() => {
+    if (!data) return;
+    if (saveConflict || environmentInputDirty) return;
+    if (Object.keys(patch.errors).length > 0) {
+      setFieldErrors(patch.errors);
+      setSaveError("Correct the highlighted fields before saving.");
+      return;
+    }
+    if (Object.keys(patch.body.set).length === 0 && patch.body.unset.length === 0) {
+      toast.info("No configuration changes to save.");
+      return;
+    }
+    const impact = highImpactChanges(data, patch.body.set, patch.body.unset);
+    if (impact.length > 0) {
+      setConfirmChanges(impact);
+      setConfirmBody(patch.body);
+      return;
+    }
+    void persist(patch.body);
+  }, [data, environmentInputDirty, patch, persist, saveConflict, toast]);
+
+  const discard = useCallback(() => {
+    setDrafts({});
+    setSecretSet({});
+    setUnsetPaths(new Set());
+    setFieldErrors({});
+    setSaveError(null);
+    setSaveConflict(false);
+    setRebaseNotice(null);
+    setEnvironmentInputDirty(false);
+    setEnvironmentResetToken((current) => current + 1);
+    setConfirmBody(null);
+    setConfirmChanges([]);
+    conflictRevisionRef.current = null;
+  }, []);
+
+  if (loading && !data) {
+    return <p className="m-0 text-[12px] text-[var(--text-muted)]">Loading configuration…</p>;
+  }
+  if (loadError && !data) {
+    return <PanelError message={loadError} onRetry={() => void load(false)} />;
+  }
+  if (!data) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h1 className="m-0 text-[15px] font-semibold">Configuration</h1>
+          <p className="m-0 mt-0.5 text-[11px] text-[var(--text-muted)]">
+            Hot-safe global policy. Changes affect new runs; active runs keep their snapshot.
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {formDirtyCount > 0 ? (
+            <span className="mono text-[11px] text-[var(--warn)]">
+              {formDirtyCount} pending
+            </span>
+          ) : null}
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={editorLocked || formDirtyCount > 0}
+            onClick={() => void load(false)}
+            title={formDirtyCount > 0 ? "Discard or save pending changes before refreshing" : undefined}
+          >
+            Refresh
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={saving || confirmBody !== null || formDirtyCount === 0}
+            onClick={discard}
+          >
+            Discard
+          </Button>
+          <Button
+            size="sm"
+            disabled={editorLocked || environmentInputDirty || dirtyCount === 0}
+            onClick={requestSave}
+          >
+            {saving ? "Saving…" : "Save changes"}
+          </Button>
+        </div>
+      </div>
+
+      {environmentInputDirty ? (
+        <div className="rounded border border-[var(--warn)] px-3 py-2 text-[12px] text-[var(--warn)]" role="status">
+          Stage the agent environment value or discard it before saving or refreshing.
+        </div>
+      ) : null}
+
+      <ReloadWarning data={data} />
+
+      <Card title="Source">
+        <dl className="m-0 grid gap-x-4 gap-y-1 text-[11px] sm:grid-cols-2 lg:grid-cols-4">
+          <div>
+            <dt className="text-[var(--text-muted)]">Config file</dt>
+            <dd className="m-0 break-all mono" title={data.metadata.configPath}>
+              {data.metadata.configPath || "—"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[var(--text-muted)]">Format</dt>
+            <dd className="m-0 mono">
+              {data.metadata.format || "—"} · {data.metadata.filePresent ? "present" : "not created"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[var(--text-muted)]">Last applied</dt>
+            <dd className="m-0 mono">{formatTs(data.metadata.lastAppliedAt)}</dd>
+          </div>
+          <div>
+            <dt className="text-[var(--text-muted)]">Last attempted</dt>
+            <dd className="m-0 mono">{formatTs(data.metadata.lastAttemptAt)}</dd>
+          </div>
+        </dl>
+      </Card>
+
+      {loadError ? (
+        <PanelError
+          message={loadError}
+          onRetry={
+            formDirtyCount === 0 && !editorLocked
+              ? () => void load(false)
+              : undefined
+          }
+        />
+      ) : null}
+      {saveConflict ? (
+        <div className="rounded border border-[var(--warn)] px-3 py-2 text-[12px]" role="alert">
+          <p className="m-0 text-[var(--warn)]">
+            The file changed after this form loaded. Reload the published snapshot and keep your pending edits rebased on it, then review each published value before saving again.
+          </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mt-1"
+            disabled={loading || saving || confirmBody !== null}
+            onClick={() => void load(true)}
+          >
+            Reload latest and keep edits
+          </Button>
+        </div>
+      ) : null}
+      {saveError ? (
+        <div className="rounded border border-[var(--danger)] px-3 py-2 text-[12px] text-[var(--danger)]" role="alert">
+          {saveError}
+        </div>
+      ) : null}
+      {rebaseNotice ? (
+        <div className="rounded border border-[var(--warn)] px-3 py-2 text-[12px] text-[var(--warn)]" role="status">
+          {rebaseNotice}
+        </div>
+      ) : null}
+
+      <div className="grid items-start gap-3 xl:grid-cols-2">
+        {CONFIG_GROUPS.map((group) => (
+          <ConfigGroupCard
+            key={group.id}
+            group={group}
+            data={data}
+            drafts={drafts}
+            unsetPaths={unsetPaths}
+            errors={fieldErrors}
+            secretSet={secretSet}
+            onDraft={onDraft}
+            onToggleUnset={onToggleUnset}
+            onSecretSet={onSecretSet}
+            onSecretRemove={onSecretRemove}
+            onSecretUndoRemove={onSecretUndoRemove}
+            environmentResetToken={environmentResetToken}
+            onEnvironmentInputDirtyChange={onEnvironmentInputDirtyChange}
+            disabled={editorLocked}
+          />
+        ))}
+      </div>
+
+      <ConfirmDialog
+        open={confirmBody !== null}
+        title="Confirm high-impact configuration"
+        confirmLabel="Apply changes"
+        danger
+        busy={saving}
+        onCancel={() => {
+          if (!saving) {
+            setConfirmBody(null);
+            setConfirmChanges([]);
+          }
+        }}
+        onConfirm={() => {
+          if (confirmBody) void persist(confirmBody);
+        }}
+      >
+        <p className="m-0">
+          These changes allow Looper to make or publish consequential decisions:
+        </p>
+        <ul className="m-0 mt-1 list-disc pl-4">
+          {confirmChanges.map((change) => (
+            <li key={change.path}>
+              {change.label} <code className="text-[10px] text-[var(--text-muted)]">{change.path}</code>
+            </li>
+          ))}
+        </ul>
+        <p className="m-0 mt-1 text-[var(--text-muted)]">
+          The new policy applies only to runs started after the reload.
+        </p>
+      </ConfirmDialog>
+    </div>
+  );
+}


### PR DESCRIPTION
# Summary

- Reparse the daemon’s fixed startup configuration stack and atomically publish only explicitly hot-safe field changes. Invalid, mixed, or restart-bound edits leave the last-known-good snapshot active.
- Keep active runs on their original configuration while new claims use the latest published snapshot. This includes safe `agent.vendor` activation and switching without reusing cross-vendor native sessions.
- Add a curated Configuration dashboard and GET/PATCH API with field-source metadata, write-only agent environment values, revision conflicts, mutation authorization, and atomic file replacement.
- Keep environment/CLI overrides read-only, resource-owning settings restart-bound, and project authority in SQLite.
- Carry the snapshot contract through the scheduler, project catalog, reviewer submit proxy, notification gateways, and Coordinator runtime state.
- Update configuration documentation, ADR-0014, and the bundled Looper skill.

# Design, Trade-offs, and Authority

**Authority:** Global runtime policy comes from the selected config file after the captured startup environment and CLI overlays; SQLite project rows remain authoritative for projects, and the dashboard is only a validated editor of the file layer. For native review submission, the scheduler’s claim snapshot and persisted checkpoint/manual/run metadata are authoritative—not agent arguments or prose.

- The polling loop, explicit allowlist, last-known-good snapshot, and publication boundary prevent stale or internally mixed claims. Their cost is reparsing, allowlist maintenance, brief lock contention, and rejected on-disk generations that may temporarily differ from the running snapshot. Ad hoc reads or partial application cannot provide a coherent config/catalog generation.
- Content revisions prevent a stale dashboard from overwriting a newer external edit. Their cost is conflict handling, possible serialization changes to comments/order, and a narrow portable compare-to-rename race despite the final identity and byte check. An unconditional write or immediate reread cannot detect edits made after the client’s original GET.
- The run-bound trusted reviewer proxy prevents active runs from submitting under later disclosure, role, head, or review-event policy. It costs a bounded Unix socket, inherited descriptor, process-group cleanup, and an explicit secret-clearing list. Reading the live file or passing policy through agent-visible arguments/environment would allow drift or forgery.
- Snapshot-specific gateways and Coordinator runners share only bounded daemon-lifetime transport/throttle state. This preserves notification continuity and prevents duplicate Coordinator work, at the cost of synchronized process memory that resets on restart. A mutable shared gateway would leak new policy into active runs; persisting this transient state would add unnecessary schema and recovery failure modes.
- Leaving an existing agent vendor requires empty `agent.params` and an explicit model change or clear. Cross-vendor continuations keep durable worktree/checkpoint/HITL state but start a fresh native session. This avoids silently applying one vendor’s profile or session to another executable.

Deletion-first check: no existing layer could be removed safely. Per-consumer file reads permit mixed generations, while rebuilding process-owned HTTP, SQLite, network, and webhook resources expands lifecycle failures. The new coordination remains in memory and resource-owning settings remain restart-bound.

# Testing

- [x] `go test ./...`
- [x] `go test -race ./internal/runtime ./internal/forge ./internal/cliapp -run 'TrustedReview|ReviewerAllowed|ReviewerAgentExecutor|ReloadConfig|PatchConfig|ClaimPhase|CatalogScheduler' -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `(cd web/dashboard && pnpm test)` — 60/60 tests
- [x] `(cd web/dashboard && pnpm build)`
- [x] `gofmt -l .`
- [x] `git diff --check`
- [x] `uv run --with pyyaml python /Users/mrc/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/looper`

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [x] Daemon boot / config / runtime path risk
- [x] Worktree / repo isolation / lifecycle risk
- [x] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [x] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- PR / issue links for regression coverage:
  - N/A — feature coverage is provided by daemon/API bridge, reload/claim lifecycle, reviewer proxy, and dashboard integration tests.

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied