### PR TITLE
refactor: make execution supervisor the live authority

### DIFF
--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"slices"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -154,7 +156,12 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 			rt.TriggerSchedulerTick()
 		},
 	})
-	root := looperdapi.NewRootHandler(apiHandler, dashboard.Handler())
+	var startupReady atomic.Bool
+	supervisor := rt.Services().ActiveExecutions
+	mutationsReady := func() bool {
+		return startupReady.Load() && supervisor != nil && supervisor.Failure() == nil
+	}
+	root := mutationReadinessHandler(looperdapi.NewRootHandler(apiHandler, dashboard.Handler()), mutationsReady)
 	server := looperdapi.NewServer(deps.Config, root)
 	if err := server.Start(); err != nil {
 		if deps.Logger != nil {
@@ -176,12 +183,30 @@ func startRuntimeWithAPI(ctx context.Context, deps bootstrap.RuntimeDependencies
 		rt.WaitForShutdown()
 		return nil, err
 	}
+	startupReady.Store(true)
 
 	return &daemonRuntime{
 		runtime:         rt,
 		server:          server,
 		shutdownTimeout: shutdownTimeout,
 	}, nil
+}
+
+func mutationReadinessHandler(next http.Handler, ready func() bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			next.ServeHTTP(w, r)
+			return
+		}
+		if ready == nil || !ready() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, `{"error":{"code":"runtime_mutations_unavailable","message":"runtime is not ready to accept mutations"}}`)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func stopServerWithTimeout(stop func(context.Context) error, timeout time.Duration) error {
@@ -252,6 +277,10 @@ func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 	result := stopLoopResult{Stopped: false, LoopID: loopID, Outcome: stopOutcomePausedOnly}
 	if services.Loops == nil {
 		return nil, fmt.Errorf("loops service is not configured")
+	}
+	if services.ActiveExecutions != nil {
+		releaseStop := services.ActiveExecutions.BeginLoopStop(loopID, reason)
+		defer releaseStop()
 	}
 
 	reasonCopy := reason
@@ -331,6 +360,11 @@ func haltLoop(ctx context.Context, services looperdruntime.Services, loopID, rea
 			}
 			return complete()
 		}
+		// A running daemon never reconstructs live ownership from a persisted
+		// PID. PID inspection is reserved for startup recovery; without a
+		// Supervisor handle, stop fails loud instead of risking a reused PID.
+		result.ProcessSkipReason = processSkipNoSignal
+		return complete()
 	}
 	if latestExecution.PID == nil || *latestExecution.PID <= 0 {
 		result.ProcessSkipReason = processSkipNoPID
@@ -798,18 +832,22 @@ func stopCandidateExecution(ctx context.Context, services looperdruntime.Service
 		runID = candidate.Run.ID
 		result.RunID = candidate.Run.ID
 	}
-	if services.ActiveExecutions != nil && runID != "" {
-		killed, err := services.ActiveExecutions.Kill(candidate.Loop.ID, runID, candidate.Execution.ID, reason)
-		if err != nil {
-			return result, err
-		}
-		if killed {
-			result.Outcome = stopOutcomeProcessSignaled
-			if err := markExecutionCancelling(ctx, services, *candidate.Execution, reason, now); err != nil {
+	if services.ActiveExecutions != nil {
+		if runID != "" {
+			killed, err := services.ActiveExecutions.Kill(candidate.Loop.ID, runID, candidate.Execution.ID, reason)
+			if err != nil {
 				return result, err
 			}
-			return result, nil
+			if killed {
+				result.Outcome = stopOutcomeProcessSignaled
+				if err := markExecutionCancelling(ctx, services, *candidate.Execution, reason, now); err != nil {
+					return result, err
+				}
+				return result, nil
+			}
 		}
+		result.ProcessSkipReason = processSkipNoSignal
+		return result, nil
 	}
 	if candidate.Execution.PID == nil || *candidate.Execution.PID <= 0 {
 		result.ProcessSkipReason = processSkipNoPID

--- a/cmd/looperd/main_test.go
+++ b/cmd/looperd/main_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -20,6 +22,48 @@ import (
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/version"
 )
+
+func TestMutationReadinessHandlerAllowsReadsAndGatesMutations(t *testing.T) {
+	ready := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	handler := mutationReadinessHandler(next, func() bool { return ready })
+
+	read := httptest.NewRecorder()
+	handler.ServeHTTP(read, httptest.NewRequest(http.MethodGet, "/api/v1/loops", nil))
+	if read.Code != http.StatusNoContent {
+		t.Fatalf("GET status = %d, want %d", read.Code, http.StatusNoContent)
+	}
+	mutation := httptest.NewRecorder()
+	handler.ServeHTTP(mutation, httptest.NewRequest(http.MethodPost, "/api/v1/loops", nil))
+	if mutation.Code != http.StatusServiceUnavailable {
+		t.Fatalf("POST before recovery status = %d, want %d", mutation.Code, http.StatusServiceUnavailable)
+	}
+	ready = true
+	accepted := httptest.NewRecorder()
+	handler.ServeHTTP(accepted, httptest.NewRequest(http.MethodPost, "/api/v1/loops", nil))
+	if accepted.Code != http.StatusNoContent {
+		t.Fatalf("POST after recovery status = %d, want %d", accepted.Code, http.StatusNoContent)
+	}
+}
+
+func TestMutationReadinessHandlerGatesMutationsAfterSupervisorFailure(t *testing.T) {
+	supervisor := looperdruntime.NewExecutionSupervisor()
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	handler := mutationReadinessHandler(next, func() bool { return supervisor.Failure() == nil })
+
+	supervisor.MarkDegraded(errors.New("terminal execution persistence failed"))
+
+	mutation := httptest.NewRecorder()
+	handler.ServeHTTP(mutation, httptest.NewRequest(http.MethodPost, "/api/v1/loops", nil))
+	if mutation.Code != http.StatusServiceUnavailable {
+		t.Fatalf("POST after supervisor failure status = %d, want %d", mutation.Code, http.StatusServiceUnavailable)
+	}
+	read := httptest.NewRecorder()
+	handler.ServeHTTP(read, httptest.NewRequest(http.MethodGet, "/api/v1/loops", nil))
+	if read.Code != http.StatusNoContent {
+		t.Fatalf("GET after supervisor failure status = %d, want %d", read.Code, http.StatusNoContent)
+	}
+}
 
 func TestRunPrintsVersionWithoutBootstrappingCommandHandling(t *testing.T) {
 	stdout := &bytes.Buffer{}
@@ -1145,6 +1189,23 @@ func TestStopAllLoopsReportsPausedOnlyWhenPIDVerificationRejectsOwnership(t *tes
 	}
 	if item := response.Items[0]; item.Result != string(stopAllResultPausedOnly) || item.Outcome != stopOutcomePausedOnly || item.ProcessSkipReason != processSkipVerifierRejectedPID {
 		t.Fatalf("stopAllLoops() item = %#v", item)
+	}
+}
+
+func TestStopCandidateDoesNotFallBackToPersistedPIDWhenSupervisorKeyIsIncomplete(t *testing.T) {
+	pid := int64(4103)
+	execution := storage.AgentExecutionRecord{ID: "exec_without_run", Status: "running", PID: &pid}
+	result, err := stopCandidateExecution(context.Background(), looperdruntime.Services{
+		ActiveExecutions: looperdruntime.NewExecutionSupervisor(),
+	}, stopAllCandidate{Loop: storage.LoopRecord{ID: "loop_without_run"}, Execution: &execution}, "stop", time.Now, func(int, syscall.Signal) error {
+		t.Fatal("signal invoked for persisted PID without complete Supervisor key")
+		return nil
+	}, nil)
+	if err != nil {
+		t.Fatalf("stopCandidateExecution() error = %v", err)
+	}
+	if result.Outcome != stopOutcomePausedOnly || result.ProcessSkipReason != processSkipNoSignal || result.PID != 0 {
+		t.Fatalf("stopCandidateExecution() result = %#v, want paused-only without PID authority", result)
 	}
 }
 

--- a/docs/adr/0014-execution-supervisor-is-live-ownership-authority.md
+++ b/docs/adr/0014-execution-supervisor-is-live-ownership-authority.md
@@ -1,0 +1,72 @@
+# ADR-0014: Execution Supervisor is live ownership Authority
+
+## Context
+
+Looper starts agent and validation processes from Planner, Reviewer, Fixer,
+Worker, Coordinator, feedback, and takeover paths. Live ownership is currently
+split between `exec.Cmd` handles, an in-memory registry, persisted
+`agent_executions` rows, and PID/process-group probes. Those representations can
+disagree during spawn, native-resume fallback, terminal persistence, loop stop,
+daemon shutdown, and startup recovery.
+
+The concrete failures are an unregistered process surviving stop or shutdown,
+a stale `running` write overwriting terminal state, a claimed queue item having
+no live owner, and a numeric process-group ID being treated as identity after it
+can be reused.
+
+## Decision
+
+The in-memory Execution Supervisor is the Authority for live execution
+ownership in a running daemon. It owns admission, the live process handle, stop
+delivery, confirmed wait, and release. Callers reserve ownership before they
+claim or start work and cannot publish a half-started execution.
+
+SQLite `agent_executions` rows are durable observations for operators and
+startup recovery. They do not authorize a running daemon to release a live
+handle or start overlapping work. Each execution serializes its durable writes;
+the terminal observation is ordered after all live observations.
+
+PID and process-group inspection is drift detection during startup recovery,
+not live Authority. A backend may release ownership only after its containment
+contract confirms that no runnable owned process remains. Backends that cannot
+make that guarantee fail loudly instead of inferring success from signal
+delivery.
+
+Queue admission is ordered before claim. A reservation owns every claim from
+the successful claim transition until the runner durably completes, cancels,
+or requeues it. Loop stop and daemon shutdown close admission before waiting for
+existing reservations.
+
+## Trade-off
+
+This prevents stop, shutdown, recovery, persistence, and Scheduler paths from
+independently inferring ownership and removes compensation code for claims that
+were created without an owner.
+
+The cost is one in-memory Supervisor lifecycle, explicit reservation release,
+serialized execution persistence, and platform-specific containment adapters.
+A daemon crash loses the in-memory Authority, so startup must conservatively
+reconcile durable observations before enabling mutations. A containment adapter
+failure can block shutdown rather than reporting success.
+
+A simpler extension of the existing registry is insufficient because it only
+registers some agent executions after spawn and does not own queue admission or
+terminal persistence. More PID/PGID validation is also insufficient because a
+numeric identifier is reusable and a probe followed by a signal is not atomic.
+
+## Authority
+
+The Authority for a live action is the Execution Supervisor reservation and its
+owned containment handle; SQLite and process inspection are recovery evidence
+only.
+
+## Consequences
+
+- Every execution-producing Role uses the same Supervisor Module.
+- Loop stop and daemon shutdown close admission before cancellation or waiting.
+- Queue claims cannot exist without a reservation that owns their finalization.
+- Execution persistence has one ordered writer and cannot regress terminal
+  state to active state.
+- Startup recovery must complete before mutating requests or Scheduler claims.
+- Tests assert ownership through the Supervisor interface and lifecycle
+  contracts rather than internal flags.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9
 	github.com/vbauerster/mpb/v8 v8.9.3
+	golang.org/x/sys v0.30.0
 	golang.org/x/term v0.29.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -19,5 +20,4 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
-	golang.org/x/sys v0.30.0 // indirect
 )

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -19,15 +20,19 @@ import (
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/eventlog"
 	"github.com/nexu-io/looper/internal/forge"
+	shellinfra "github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
 const (
-	defaultMaxOutputBytes    = 256 * 1024
-	maxPersistedLogReadBytes = 16 * 1024 * 1024
-	completionMarkerEnv      = "LOOPER_COMPLETION_MARKER"
+	defaultMaxOutputBytes     = 256 * 1024
+	maxPersistedLogReadBytes  = 16 * 1024 * 1024
+	completionMarkerEnv       = "LOOPER_COMPLETION_MARKER"
+	agentDescendantDrainGrace = 100 * time.Millisecond
 )
+
+var ErrExecutionPersistence = errors.New("agent execution persistence failed")
 
 var unsafeAgentEnvKeys = []string{
 	"OLDPWD",
@@ -287,7 +292,7 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 
 	cmd := exec.Command(command, args...)
 	cmd.Dir = input.WorkingDirectory
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	shellinfra.ConfigureProcessGroup(cmd, agentDescendantDrainGrace)
 	cmd.Env = buildCommandEnv(input.WorkingDirectory, spawnPrompt, e.config.Env, input.Env)
 
 	maxOutputBytes := input.MaxOutputBytes
@@ -329,7 +334,7 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 			command, args = ResolveSpawn(e.config, input.WorkingDirectory, input.Prompt)
 			cmd = exec.Command(command, args...)
 			cmd.Dir = input.WorkingDirectory
-			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+			shellinfra.ConfigureProcessGroup(cmd, agentDescendantDrainGrace)
 			cmd.Env = buildCommandEnv(input.WorkingDirectory, input.Prompt, e.config.Env, input.Env)
 			cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stdout", chunk) }}
 			cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stderr", chunk) }}
@@ -351,7 +356,11 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 	}
 
 	resumeSessionID, resumeMode, resumeStatus, _ := x.nativeResumeSnapshot()
-	x.persistStatus("running", nil, nil, nil)
+	if err := x.persistStatus(ctx, "running", nil, nil, nil); err != nil {
+		_ = x.killProcessGroup()
+		_ = cmd.Wait()
+		return nil, errors.Join(ErrExecutionPersistence, fmt.Errorf("persist initial agent execution ownership: %w", err))
+	}
 	e.appendLifecycleEvent("agent.invoked", input, executionID, map[string]any{"command": command, "args": args, "cwd": input.WorkingDirectory, "nativeResumeMode": resumeMode, "nativeResumeStatus": resumeStatus, "nativeSessionId": resumeSessionID}, startedAtISO)
 
 	go x.run(ctx)
@@ -381,6 +390,8 @@ type execution struct {
 	lastProgressAt     time.Time
 
 	mu                      sync.Mutex
+	persistMu               sync.Mutex
+	terminalPersisted       bool
 	status                  string
 	stdout                  []byte
 	stderr                  []byte
@@ -416,38 +427,16 @@ func (x *execution) Kill(reason string) error {
 }
 
 func (x *execution) signalProcessGroup(signal syscall.Signal) error {
-	if x.process.Process == nil {
-		return os.ErrProcessDone
-	}
-	pid := x.process.Process.Pid
-	if pid <= 0 {
-		return x.process.Process.Signal(signal)
-	}
-	if err := syscall.Kill(-pid, signal); err != nil {
-		if err == syscall.ESRCH {
-			return os.ErrProcessDone
-		}
-		return err
-	}
-	return nil
+	return shellinfra.SignalProcessGroup(x.process, signal)
 }
 
 func (x *execution) killProcessGroup() error {
-	if x.process.Process == nil {
-		return os.ErrProcessDone
-	}
-	pid := x.process.Process.Pid
-	if pid > 0 {
-		if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil || err == syscall.ESRCH {
-			return nil
-		}
-	}
-	return x.process.Process.Kill()
+	return shellinfra.KillProcessGroup(x.process)
 }
 
 func (x *execution) run(ctx context.Context) {
 	waitCh := make(chan error, 1)
-	go func() { waitCh <- x.process.Wait() }()
+	go func() { waitCh <- shellinfra.WaitProcessGroup(x.process) }()
 
 	var (
 		waitErr         error
@@ -497,6 +486,9 @@ func (x *execution) run(ctx context.Context) {
 	for waiting {
 		select {
 		case waitErr = <-waitCh:
+			if errors.Is(waitErr, exec.ErrWaitDelay) {
+				_ = x.killProcessGroup()
+			}
 			waiting = false
 		case <-timeoutTimer:
 			timeoutTimer = nil
@@ -613,8 +605,11 @@ func (x *execution) run(ctx context.Context) {
 		LastProgressAt:               lastProgressAt,
 		PID:                          pidOrZero(x.process.Process),
 	}
+	var fallbackInfrastructureErr error
 	if x.shouldFallbackNativeResume(status, stdout, stderr) {
-		if fallbackResult, fallbackErrorMessage, ok := x.runCheckpointFallback(ctx, errorMessage); ok {
+		fallbackResult, fallbackErrorMessage, ok, infrastructureErr := x.runCheckpointFallback(ctx, errorMessage)
+		fallbackInfrastructureErr = infrastructureErr
+		if ok {
 			result = fallbackResult
 			status = fallbackResult.Status
 			timeoutType = fallbackResult.TimeoutType
@@ -623,7 +618,7 @@ func (x *execution) run(ctx context.Context) {
 		}
 	}
 
-	x.persistFinal(status, result, errorMessage, endedAtISO)
+	persistErr := errors.Join(fallbackInfrastructureErr, x.persistFinal(status, result, errorMessage, endedAtISO))
 	eventType := "agent.completed"
 	if status == "timeout" {
 		switch timeoutType {
@@ -649,7 +644,10 @@ func (x *execution) run(ctx context.Context) {
 		"summary":                      result.Summary,
 	}, endedAtISO)
 
-	x.doneCh <- execOutcome{result: result, err: nil}
+	if persistErr != nil {
+		persistErr = errors.Join(ErrExecutionPersistence, fmt.Errorf("persist terminal agent execution: %w", persistErr))
+	}
+	x.doneCh <- execOutcome{result: result, err: persistErr}
 }
 
 func (x *execution) shouldFallbackNativeResume(status string, stdout string, stderr string) bool {
@@ -686,11 +684,11 @@ func normalizeNativeResumeErrorLine(line string) string {
 	return strings.TrimSpace(line)
 }
 
-func (x *execution) runCheckpointFallback(ctx context.Context, nativeError string) (Result, string, bool) {
+func (x *execution) runCheckpointFallback(ctx context.Context, nativeError string) (Result, string, bool, error) {
 	command, args := ResolveSpawn(x.executor.config, x.input.WorkingDirectory, x.input.Prompt)
 	cmd := exec.Command(command, args...)
 	cmd.Dir = x.input.WorkingDirectory
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	shellinfra.ConfigureProcessGroup(cmd, agentDescendantDrainGrace)
 	cmd.Env = buildCommandEnv(x.input.WorkingDirectory, x.input.Prompt, x.executor.config.Env, x.input.Env)
 	cmd.Stdout = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stdout", chunk) }}
 	cmd.Stderr = &streamCapture{onChunk: func(chunk []byte) { x.onOutput("stderr", chunk) }}
@@ -711,20 +709,23 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 	x.lastHeartbeatAtISO = nowISO
 	x.lastOutputAt = now
 	x.mu.Unlock()
-	x.persistStatus("running", nil, nil, nil)
-	x.executor.appendLifecycleEvent("agent.native_resume_fallback_started", x.input, x.executionID, map[string]any{"command": command, "args": args, "nativeResumeError": nativeError}, nowISO)
-
 	if err := cmd.Start(); err != nil {
 		x.mu.Lock()
 		x.status = "failed"
 		x.nativeResumeStatus = "fallback_failed"
 		x.nativeResumeError = firstNonEmpty(err.Error(), nativeError)
 		x.mu.Unlock()
-		return Result{}, "", false
+		return Result{}, "", false, nil
 	}
+	if err := x.persistStatus(ctx, "running", nil, nil, nil); err != nil {
+		_ = x.killProcessGroup()
+		_ = shellinfra.WaitProcessGroup(cmd)
+		return Result{}, "", false, errors.Join(ErrExecutionPersistence, fmt.Errorf("persist fallback agent execution ownership: %w", err))
+	}
+	x.executor.appendLifecycleEvent("agent.native_resume_fallback_started", x.input, x.executionID, map[string]any{"command": command, "args": args, "nativeResumeError": nativeError}, nowISO)
 
 	waitCh := make(chan error, 1)
-	go func() { waitCh <- cmd.Wait() }()
+	go func() { waitCh <- shellinfra.WaitProcessGroup(cmd) }()
 	var (
 		waitErr        error
 		timedOut       bool
@@ -768,6 +769,9 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 	for waiting {
 		select {
 		case waitErr = <-waitCh:
+			if errors.Is(waitErr, exec.ErrWaitDelay) {
+				_ = x.killProcessGroup()
+			}
 			waiting = false
 		case <-timeoutTimer:
 			timeoutTimer = nil
@@ -862,7 +866,7 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 		ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
 		LastProgressAt:               x.lastProgressAtISO(),
 		PID:                          pidOrZero(cmd.Process),
-	}, errorMessage, true
+	}, errorMessage, true, nil
 }
 
 func (x *execution) onOutput(stream string, chunk []byte) {
@@ -901,7 +905,7 @@ func (x *execution) onOutput(stream string, chunk []byte) {
 	x.mu.Unlock()
 
 	outputJSON := x.outputJSON(stdout, stderr)
-	x.persistStatus(x.currentStatus(), &heartbeatCount, &nowISO, &outputJSON)
+	_ = x.persistStatus(context.Background(), x.currentStatus(), &heartbeatCount, &nowISO, &outputJSON)
 	x.bumpRunHeartbeat(nowISO)
 	x.maybeEmitProgress(now, stdout, stderr)
 }
@@ -1009,9 +1013,14 @@ func (x *execution) bumpRunHeartbeat(nowISO string) {
 	_ = x.executor.repos.Runs.Upsert(ctx, updated)
 }
 
-func (x *execution) persistStatus(status string, heartbeatCount *int64, heartbeatAt *string, outputJSON *string) {
+func (x *execution) persistStatus(ctx context.Context, status string, heartbeatCount *int64, heartbeatAt *string, outputJSON *string) error {
+	x.persistMu.Lock()
+	defer x.persistMu.Unlock()
+	if x.terminalPersisted {
+		return nil
+	}
 	if x.executor.repos == nil || x.executor.repos.AgentExecutions == nil {
-		return
+		return nil
 	}
 	nativeSessionID, nativeResumeMode, nativeResumeStatus, nativeResumeError := x.nativeResumeSnapshot()
 	metadata := mustJSON(x.executionMetadata(""))
@@ -1046,12 +1055,15 @@ func (x *execution) persistStatus(status string, heartbeatCount *int64, heartbea
 	if outputJSON != nil {
 		record.OutputJSON = outputJSON
 	}
-	_ = x.executor.repos.AgentExecutions.Upsert(context.Background(), record)
+	return x.executor.repos.AgentExecutions.Upsert(ctx, record)
 }
 
-func (x *execution) persistFinal(status string, result Result, errorMessage, endedAtISO string) {
+func (x *execution) persistFinal(status string, result Result, errorMessage, endedAtISO string) error {
+	x.persistMu.Lock()
+	defer x.persistMu.Unlock()
 	if x.executor.repos == nil || x.executor.repos.AgentExecutions == nil {
-		return
+		x.terminalPersisted = true
+		return nil
 	}
 	nativeSessionID, nativeResumeMode, nativeResumeStatus, nativeResumeError := x.nativeResumeSnapshot()
 	commandJSON := mustJSON(map[string]any{"command": x.command, "args": x.args})
@@ -1104,7 +1116,9 @@ func (x *execution) persistFinal(status string, result Result, errorMessage, end
 		CreatedAt:          x.startedAtISO,
 		UpdatedAt:          endedAtISO,
 	}
-	_ = x.executor.repos.AgentExecutions.Upsert(context.Background(), record)
+	err := x.executor.repos.AgentExecutions.Upsert(context.Background(), record)
+	x.terminalPersisted = true
+	return err
 }
 
 func (x *execution) currentStatus() string {

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -1055,6 +1055,91 @@ func TestExecutorTimeoutMarksTimeout(t *testing.T) {
 	}
 }
 
+func TestExecutorStartFailsAndReapsProcessWhenInitialPersistenceFails(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+		"command": "/bin/sh", "args": []any{"-c", `echo $$ > "$PID_FILE"; trap '' TERM; while true; do sleep 1; done`},
+	}}, Repos: repos})
+
+	handle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_initial_persist_failure", WorkingDirectory: workDir, Prompt: "ignored", Timeout: time.Second, Env: map[string]string{"PID_FILE": pidPath}})
+	if err == nil {
+		t.Fatal("Start() error = nil, want initial persistence failure")
+	}
+	if handle != nil {
+		t.Fatalf("Start() handle = %#v, want nil", handle)
+	}
+	if data, readErr := os.ReadFile(pidPath); readErr == nil {
+		pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+		if parseErr != nil {
+			t.Fatalf("parse pid: %v", parseErr)
+		}
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			if killErr := syscall.Kill(pid, 0); killErr == syscall.ESRCH {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatalf("spawned process %d survived failed Start", pid)
+	}
+}
+
+func TestExecutorWaitSurfacesTerminalPersistenceFailure(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+		"command": "/bin/sh", "args": []any{"-c", "sleep 0.2; printf 'done\\n'"},
+	}}, Repos: repos})
+	handle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_terminal_persist_failure", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+
+	_, err = handle.Wait(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "persist terminal agent execution") {
+		t.Fatalf("Wait() error = %v, want terminal persistence failure", err)
+	}
+}
+
+func TestCheckpointFallbackReapsSpawnWhenOwnershipPersistenceFails(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+	configured := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+		"command": "/bin/sh", "args": []any{"-c", "trap '' TERM; while true; do sleep 1; done"},
+	}}, Repos: repos})
+	x := &execution{
+		executor:       configured,
+		input:          RunInput{WorkingDirectory: t.TempDir(), Prompt: "retry", Timeout: time.Second},
+		executionID:    "agent_fallback_persist_failure",
+		startedAt:      time.Now(),
+		startedAtISO:   time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+		maxOutputBytes: defaultMaxOutputBytes,
+	}
+
+	_, _, ok, err := x.runCheckpointFallback(context.Background(), "resume failed")
+	if ok {
+		t.Fatal("runCheckpointFallback() ok = true, want infrastructure failure")
+	}
+	if err == nil || !strings.Contains(err.Error(), "persist fallback agent execution ownership") {
+		t.Fatalf("runCheckpointFallback() error = %v, want ownership persistence failure", err)
+	}
+	if x.process == nil || x.process.ProcessState == nil {
+		t.Fatal("fallback process was not started and reaped before returning")
+	}
+}
+
 func TestExecutorKillTerminatesChildProcessGroup(t *testing.T) {
 	workDir := t.TempDir()
 	childPIDPath := filepath.Join(workDir, "child.pid")
@@ -1084,6 +1169,34 @@ func TestExecutorKillTerminatesChildProcessGroup(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("child process %d is still running after execution Kill", childPID)
+}
+
+func TestExecutorNormalLeaderExitReapsBackgroundChild(t *testing.T) {
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "background.pid")
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+		"command": "/bin/sh", "args": []any{"-c", `(trap '' TERM; while :; do sleep 1; done) >/dev/null 2>&1 & echo $! > "$PID_FILE"`},
+	}}})
+	handle, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_background_child", WorkingDirectory: workDir, Prompt: "ignored", Timeout: time.Second, Env: map[string]string{"PID_FILE": pidPath}})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	result, err := handle.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("result.Status = %q, want completed", result.Status)
+	}
+	pid := waitForPIDFile(t, pidPath)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("background child %d survived completed execution", pid)
 }
 
 func TestExecutorHeartbeatTimeoutMarksTimeout(t *testing.T) {

--- a/internal/infra/shell/process_group.go
+++ b/internal/infra/shell/process_group.go
@@ -1,0 +1,64 @@
+package shell
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// ConfigureProcessGroup gives one command an isolated Unix process group and
+// bounds Wait when descendants retain inherited output descriptors.
+func ConfigureProcessGroup(cmd *exec.Cmd, descendantDrainGrace time.Duration) {
+	if cmd == nil {
+		return
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if descendantDrainGrace > 0 {
+		cmd.WaitDelay = descendantDrainGrace
+	}
+}
+
+func SignalProcessGroup(cmd *exec.Cmd, signal syscall.Signal) error {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return os.ErrProcessDone
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, signal); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return nil
+}
+
+func KillProcessGroup(cmd *exec.Cmd) error {
+	return SignalProcessGroup(cmd, syscall.SIGKILL)
+}
+
+// WaitProcessGroup observes the group leader's exit without reaping it, kills
+// every remaining member while the zombie leader still anchors the numeric
+// PGID, and only then calls Cmd.Wait. This removes the probe/kill reuse window
+// created by reaping the leader first.
+func WaitProcessGroup(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return os.ErrProcessDone
+	}
+	if err := waitLeaderExitWithoutReap(cmd.Process.Pid); err != nil {
+		return err
+	}
+	killErr := KillProcessGroup(cmd)
+	if errors.Is(killErr, os.ErrProcessDone) {
+		killErr = nil
+	} else if errors.Is(killErr, syscall.EPERM) {
+		hasLiveDescendants, inspectErr := processGroupHasLiveDescendants(cmd.Process.Pid)
+		if inspectErr != nil {
+			killErr = errors.Join(killErr, inspectErr)
+		} else if !hasLiveDescendants {
+			killErr = nil
+		}
+	}
+	waitErr := cmd.Wait()
+	return errors.Join(waitErr, killErr)
+}

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -18,8 +18,9 @@ const (
 	defaultGracefulStop   = 5 * time.Second
 	// startAttempts covers transient Linux ETXTBSY after a binary/script is
 	// installed (common when tests write a fake tool then exec it immediately).
-	startAttempts      = 8
-	startRetryBaseWait = 5 * time.Millisecond
+	startAttempts        = 8
+	startRetryBaseWait   = 5 * time.Millisecond
+	descendantDrainGrace = 100 * time.Millisecond
 )
 
 type Result struct {
@@ -75,7 +76,7 @@ func Run(ctx context.Context, options Options) (Result, error) {
 
 	waitCh := make(chan error, 1)
 	go func() {
-		waitCh <- cmd.Wait()
+		waitCh <- WaitProcessGroup(cmd)
 	}()
 
 	var (
@@ -92,12 +93,12 @@ func Run(ctx context.Context, options Options) (Result, error) {
 			if cmd.Process == nil {
 				return
 			}
-			if err := cmd.Process.Signal(syscall.SIGTERM); err != nil && !isProcessDone(err) {
-				_ = cmd.Process.Kill()
+			if err := SignalProcessGroup(cmd, syscall.SIGTERM); err != nil && !isProcessDone(err) {
+				_ = KillProcessGroup(cmd)
 				return
 			}
 			if gracefulShutdown <= 0 {
-				_ = cmd.Process.Kill()
+				_ = KillProcessGroup(cmd)
 				return
 			}
 			killAt = time.After(gracefulShutdown)
@@ -112,6 +113,9 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	for waiting {
 		select {
 		case waitErr = <-waitCh:
+			if errors.Is(waitErr, exec.ErrWaitDelay) {
+				_ = KillProcessGroup(cmd)
+			}
 			waiting = false
 		case <-terminationStart:
 			timedOut = true
@@ -120,7 +124,7 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		case <-killAt:
 			killAt = nil
 			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
+				_ = KillProcessGroup(cmd)
 			}
 		case <-ctx.Done():
 			if canceledErr == nil {
@@ -151,6 +155,9 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		return result, &CommandExecutionError{Message: commandFailureMessage(result), Result: result}
 	}
 	if waitErr != nil {
+		if errors.Is(waitErr, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.Success() {
+			return result, nil
+		}
 		return result, waitErr
 	}
 	return result, nil
@@ -171,6 +178,7 @@ func startCommand(ctx context.Context, options Options, stdout, stderr *boundedB
 		}
 
 		cmd := exec.Command(options.Command, options.Args...)
+		ConfigureProcessGroup(cmd, descendantDrainGrace)
 		cmd.Dir = options.CWD
 		if len(options.Env) > 0 {
 			cmd.Env = envSlice(options.Env)
@@ -239,7 +247,7 @@ func exitCode(cmd *exec.Cmd) int {
 }
 
 func isProcessDone(err error) bool {
-	return err == nil || err == os.ErrProcessDone
+	return err == nil || errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
 }
 
 type boundedBuffer struct {

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -126,6 +127,68 @@ func TestRunRespectsContextCancellation(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v, want context.Canceled", err)
 	}
+}
+
+func TestRunCancellationReapsTermResistantChild(t *testing.T) {
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "child.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := Run(ctx, Options{Command: "/bin/sh", Args: []string{"-c", `(trap '' TERM; while :; do sleep 1; done) & echo $! > "$PID_FILE"; wait`}, CWD: workDir, Env: map[string]string{"PID_FILE": pidPath}, GracefulShutdown: 20 * time.Millisecond})
+		done <- err
+	}()
+	childPID := waitForShellPID(t, pidPath)
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want context.Canceled", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(childPID, 0); err == syscall.ESRCH {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("child process %d survived Run cancellation", childPID)
+}
+
+func TestRunNormalLeaderExitReapsBackgroundChild(t *testing.T) {
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "background.pid")
+	result, err := Run(context.Background(), Options{Command: "/bin/sh", Args: []string{"-c", `(trap '' TERM; while :; do sleep 1; done) >/dev/null 2>&1 & echo $! > "$PID_FILE"`}, CWD: workDir, Env: map[string]string{"PID_FILE": pidPath}, GracefulShutdown: 20 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("Run() exit = %d, want 0", result.ExitCode)
+	}
+	childPID := waitForShellPID(t, pidPath)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(childPID, 0); err == syscall.ESRCH {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("background child %d survived successful Run", childPID)
+}
+
+func waitForShellPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+			if err == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for pid file %s", path)
+	return 0
 }
 
 func TestIsTextFileBusy(t *testing.T) {

--- a/internal/infra/shell/wait_command_darwin.go
+++ b/internal/infra/shell/wait_command_darwin.go
@@ -1,0 +1,79 @@
+//go:build darwin
+
+package shell
+
+import (
+	"errors"
+	"fmt"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func waitLeaderExitWithoutReap(pid int) error {
+	const (
+		waitIDPID  = 1
+		waitNoHang = 0x00000001
+		waitExited = 0x00000004
+		waitNoWait = 0x00000020
+	)
+	// Darwin exposes waitid(2), including WNOWAIT, but x/sys/unix does not
+	// wrap it. WNOHANG avoids relying on the raw blocking syscall's interaction
+	// with Go's runtime; si_pid is non-zero only once this child is waitable.
+	started := time.Now()
+	for {
+		info := darwinSiginfo{}
+		_, _, errno := unix.Syscall6(
+			unix.SYS_WAITID,
+			waitIDPID,
+			uintptr(pid),
+			uintptr(unsafe.Pointer(&info)),
+			waitNoHang|waitExited|waitNoWait,
+			0,
+			0,
+		)
+		if errno == 0 && info.pid == int32(pid) {
+			return nil
+		}
+		if errors.Is(errno, unix.EINTR) {
+			continue
+		}
+		if errno != 0 {
+			return fmt.Errorf("wait for child exit without reaping: %w", errno)
+		}
+		pollInterval := time.Millisecond
+		if time.Since(started) >= time.Second {
+			pollInterval = 50 * time.Millisecond
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+// darwinSiginfo matches siginfo_t from <sys/signal.h>. Only pid is read.
+type darwinSiginfo struct {
+	signo  int32
+	errno  int32
+	code   int32
+	pid    int32
+	uid    uint32
+	status int32
+	addr   uintptr
+	value  uintptr
+	band   int64
+	pad    [7]uint64
+}
+
+func processGroupHasLiveDescendants(leaderPID int) (bool, error) {
+	processes, err := unix.SysctlKinfoProcSlice("kern.proc.pgrp", leaderPID)
+	if err != nil {
+		return false, fmt.Errorf("inspect process group after permission failure: %w", err)
+	}
+	const zombieProcessState = 5
+	for _, process := range processes {
+		if int(process.Proc.P_pid) != leaderPID && process.Proc.P_stat != zombieProcessState {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/infra/shell/wait_command_linux.go
+++ b/internal/infra/shell/wait_command_linux.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package shell
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func waitLeaderExitWithoutReap(pid int) error {
+	for {
+		err := unix.Waitid(unix.P_PID, pid, nil, unix.WEXITED|unix.WNOWAIT, nil)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		return err
+	}
+}
+
+func processGroupHasLiveDescendants(int) (bool, error) {
+	// Linux does not return EPERM when signaling an owned zombie-only group.
+	// Preserve EPERM as a containment failure instead of weakening the contract.
+	return true, nil
+}

--- a/internal/runtime/active_executions.go
+++ b/internal/runtime/active_executions.go
@@ -1,18 +1,259 @@
 package runtime
 
-import "sync"
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var (
+	ErrExecutionAdmissionClosed    = errors.New("execution admission is closed")
+	ErrExecutionLoopStopping       = errors.New("execution loop is stopping")
+	ErrExecutionSupervisorDegraded = errors.New("execution supervisor is degraded")
+)
 
 type activeExecution interface {
 	Kill(string) error
 }
 
-type ActiveExecutionRegistry struct {
-	mu         sync.Mutex
-	executions map[string]activeExecution
+type activeExecutionEntry struct {
+	loopID    string
+	execution activeExecution
 }
 
-func NewActiveExecutionRegistry() *ActiveExecutionRegistry {
-	return &ActiveExecutionRegistry{executions: make(map[string]activeExecution)}
+type ExecutionSupervisor struct {
+	mu              sync.Mutex
+	executions      map[string]activeExecutionEntry
+	reservations    map[uint64]*ExecutionReservation
+	stoppingLoops   map[string]int
+	nextReservation uint64
+	admissionClosed bool
+	shutdownReason  string
+	degradedErr     error
+	stateChanged    chan struct{}
+}
+
+// ActiveExecutionRegistry is retained as a source-compatible name while
+// callers migrate to the deeper ExecutionSupervisor Module.
+type ActiveExecutionRegistry = ExecutionSupervisor
+
+func NewExecutionSupervisor() *ExecutionSupervisor {
+	return &ExecutionSupervisor{
+		executions:    make(map[string]activeExecutionEntry),
+		reservations:  make(map[uint64]*ExecutionReservation),
+		stoppingLoops: make(map[string]int),
+		stateChanged:  make(chan struct{}),
+	}
+}
+
+func NewActiveExecutionRegistry() *ExecutionSupervisor { return NewExecutionSupervisor() }
+
+// ExecutionReservation is the Supervisor's ownership of work admitted for one
+// loop. Its context is cancelled before daemon shutdown waits for the work to
+// release ownership.
+type ExecutionReservation struct {
+	supervisor *ExecutionSupervisor
+	id         uint64
+	loopID     string
+	ctx        context.Context
+	cancel     context.CancelCauseFunc
+	once       sync.Once
+}
+
+func (r *ExecutionReservation) Context() context.Context {
+	if r == nil || r.ctx == nil {
+		return context.Background()
+	}
+	return r.ctx
+}
+
+// BindLoop attaches a pre-claim reservation to the loop selected by the
+// durable queue claim. A concurrent stop cannot leave the claim unowned: the
+// reservation remains its owner and is cancelled immediately.
+func (r *ExecutionReservation) BindLoop(loopID string) {
+	if r == nil || r.supervisor == nil {
+		return
+	}
+	supervisor := r.supervisor
+	supervisor.mu.Lock()
+	if supervisor.reservations[r.id] != r {
+		supervisor.mu.Unlock()
+		return
+	}
+	r.loopID = loopID
+	closing := supervisor.admissionClosed
+	stopping := supervisor.stoppingLoops[loopID] > 0
+	supervisor.notifyStateChangedLocked()
+	supervisor.mu.Unlock()
+	if closing {
+		r.cancel(ErrExecutionAdmissionClosed)
+	} else if stopping {
+		r.cancel(ErrExecutionLoopStopping)
+	}
+}
+
+func (r *ExecutionReservation) Release() {
+	if r == nil {
+		return
+	}
+	r.once.Do(func() {
+		r.cancel(nil)
+		r.supervisor.releaseReservation(r.id)
+	})
+}
+
+// Reserve admits work before it acquires durable queue ownership.
+func (r *ActiveExecutionRegistry) Reserve(loopID string) (*ExecutionReservation, error) {
+	if r == nil {
+		return nil, ErrExecutionAdmissionClosed
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.admissionClosed {
+		if r.degradedErr != nil {
+			return nil, errors.Join(ErrExecutionSupervisorDegraded, r.degradedErr)
+		}
+		return nil, ErrExecutionAdmissionClosed
+	}
+	if r.stoppingLoops[loopID] > 0 {
+		return nil, ErrExecutionLoopStopping
+	}
+	r.nextReservation++
+	ctx, cancel := context.WithCancelCause(context.Background())
+	reservation := &ExecutionReservation{supervisor: r, id: r.nextReservation, loopID: loopID, ctx: ctx, cancel: cancel}
+	r.reservations[reservation.id] = reservation
+	r.notifyStateChangedLocked()
+	return reservation, nil
+}
+
+// MarkDegraded closes admission after an infrastructure failure. Existing
+// reservations are cancelled so no new durable work can overlap storage or
+// ownership state that the daemon failed to publish.
+func (r *ExecutionSupervisor) MarkDegraded(err error) {
+	if r == nil || err == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.degradedErr == nil {
+		r.degradedErr = err
+	}
+	r.admissionClosed = true
+	reservations := make([]*ExecutionReservation, 0, len(r.reservations))
+	for _, reservation := range r.reservations {
+		reservations = append(reservations, reservation)
+	}
+	r.notifyStateChangedLocked()
+	r.mu.Unlock()
+	for _, reservation := range reservations {
+		reservation.cancel(errors.Join(ErrExecutionSupervisorDegraded, err))
+	}
+}
+
+func (r *ExecutionSupervisor) Failure() error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.degradedErr
+}
+
+// BeginLoopStop closes admission for one loop and cancels every reservation
+// already owned by that loop. The returned release function reopens admission
+// after the caller has completed the durable stop transition.
+func (r *ActiveExecutionRegistry) BeginLoopStop(loopID, reason string) func() {
+	if r == nil {
+		return func() {}
+	}
+	r.mu.Lock()
+	r.stoppingLoops[loopID]++
+	reservations := make([]*ExecutionReservation, 0)
+	for _, reservation := range r.reservations {
+		if reservation.loopID == loopID {
+			reservations = append(reservations, reservation)
+		}
+	}
+	r.notifyStateChangedLocked()
+	r.mu.Unlock()
+	for _, reservation := range reservations {
+		reservation.cancel(errors.New(reason))
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.mu.Lock()
+			if r.stoppingLoops[loopID] <= 1 {
+				delete(r.stoppingLoops, loopID)
+			} else {
+				r.stoppingLoops[loopID]--
+			}
+			r.notifyStateChangedLocked()
+			r.mu.Unlock()
+		})
+	}
+}
+
+// BeginShutdown atomically closes admission, then cancels every admitted
+// reservation and asks every registered live execution to stop.
+func (r *ActiveExecutionRegistry) BeginShutdown(reason string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.admissionClosed = true
+	r.shutdownReason = reason
+	reservations := make([]*ExecutionReservation, 0, len(r.reservations))
+	for _, reservation := range r.reservations {
+		reservations = append(reservations, reservation)
+	}
+	executions := make([]activeExecution, 0, len(r.executions))
+	for _, entry := range r.executions {
+		executions = append(executions, entry.execution)
+	}
+	r.notifyStateChangedLocked()
+	r.mu.Unlock()
+	for _, reservation := range reservations {
+		reservation.cancel(errors.New(reason))
+	}
+	for _, execution := range executions {
+		_ = execution.Kill(reason)
+	}
+}
+
+// Wait returns only after all admitted reservations and registered live
+// executions release ownership.
+func (r *ActiveExecutionRegistry) Wait(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	for {
+		r.mu.Lock()
+		if len(r.reservations) == 0 && len(r.executions) == 0 {
+			r.mu.Unlock()
+			return nil
+		}
+		changed := r.stateChanged
+		r.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-changed:
+		}
+	}
+}
+
+func (r *ActiveExecutionRegistry) releaseReservation(id uint64) {
+	r.mu.Lock()
+	if _, ok := r.reservations[id]; ok {
+		delete(r.reservations, id)
+		r.notifyStateChangedLocked()
+	}
+	r.mu.Unlock()
+}
+
+func (r *ActiveExecutionRegistry) notifyStateChangedLocked() {
+	close(r.stateChanged)
+	r.stateChanged = make(chan struct{})
 }
 
 func (r *ActiveExecutionRegistry) Register(loopID, runID, executionID string, execution activeExecution) func() {
@@ -21,12 +262,26 @@ func (r *ActiveExecutionRegistry) Register(loopID, runID, executionID string, ex
 	}
 	key := activeExecutionKey(loopID, runID, executionID)
 	r.mu.Lock()
-	r.executions[key] = execution
+	if r.admissionClosed || r.stoppingLoops[loopID] > 0 {
+		reason := r.shutdownReason
+		if reason == "" {
+			reason = "execution admission is closed"
+		}
+		if r.stoppingLoops[loopID] > 0 {
+			reason = "loop is stopping"
+		}
+		r.mu.Unlock()
+		_ = execution.Kill(reason)
+		return func() {}
+	}
+	r.executions[key] = activeExecutionEntry{loopID: loopID, execution: execution}
+	r.notifyStateChangedLocked()
 	r.mu.Unlock()
 	return func() {
 		r.mu.Lock()
-		if r.executions[key] == execution {
+		if entry, ok := r.executions[key]; ok && entry.execution == execution {
 			delete(r.executions, key)
+			r.notifyStateChangedLocked()
 		}
 		r.mu.Unlock()
 	}
@@ -38,12 +293,12 @@ func (r *ActiveExecutionRegistry) Kill(loopID, runID, executionID, reason string
 	}
 	key := activeExecutionKey(loopID, runID, executionID)
 	r.mu.Lock()
-	execution := r.executions[key]
+	entry := r.executions[key]
 	r.mu.Unlock()
-	if execution == nil {
+	if entry.execution == nil {
 		return false, nil
 	}
-	return true, execution.Kill(reason)
+	return true, entry.execution.Kill(reason)
 }
 
 func activeExecutionKey(loopID, runID, executionID string) string {

--- a/internal/runtime/execution_supervisor_test.go
+++ b/internal/runtime/execution_supervisor_test.go
@@ -1,0 +1,129 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestExecutionSupervisorShutdownOwnsAdmittedReservation(t *testing.T) {
+	supervisor := NewActiveExecutionRegistry()
+	reservation, err := supervisor.Reserve("loop-1")
+	if err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+
+	supervisor.BeginShutdown("daemon shutting down")
+
+	if _, err := supervisor.Reserve("loop-2"); !errors.Is(err, ErrExecutionAdmissionClosed) {
+		t.Fatalf("Reserve() error = %v, want ErrExecutionAdmissionClosed", err)
+	}
+	select {
+	case <-reservation.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("reservation context was not cancelled by shutdown")
+	}
+
+	reservation.Release()
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := supervisor.Wait(waitCtx); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+}
+
+func TestExecutionSupervisorLoopStopCancelsAndRejectsOnlyTargetLoop(t *testing.T) {
+	supervisor := NewActiveExecutionRegistry()
+	target, err := supervisor.Reserve("loop-target")
+	if err != nil {
+		t.Fatalf("Reserve(target) error = %v", err)
+	}
+
+	releaseStop := supervisor.BeginLoopStop("loop-target", "operator stopped loop")
+	defer releaseStop()
+
+	if _, err := supervisor.Reserve("loop-target"); !errors.Is(err, ErrExecutionLoopStopping) {
+		t.Fatalf("Reserve(target while stopping) error = %v, want ErrExecutionLoopStopping", err)
+	}
+	other, err := supervisor.Reserve("loop-other")
+	if err != nil {
+		t.Fatalf("Reserve(other) error = %v", err)
+	}
+	other.Release()
+	select {
+	case <-target.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("target reservation context was not cancelled by loop stop")
+	}
+	target.Release()
+
+	releaseStop()
+	resumed, err := supervisor.Reserve("loop-target")
+	if err != nil {
+		t.Fatalf("Reserve(target after stop) error = %v", err)
+	}
+	resumed.Release()
+}
+
+func TestExecutionSupervisorBindsUnknownClaimIntoConcurrentLoopStop(t *testing.T) {
+	supervisor := NewActiveExecutionRegistry()
+	reservation, err := supervisor.Reserve("")
+	if err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+	defer reservation.Release()
+
+	releaseStop := supervisor.BeginLoopStop("loop-target", "operator stopped loop")
+	defer releaseStop()
+	reservation.BindLoop("loop-target")
+
+	select {
+	case <-reservation.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("reservation bound during loop stop was not cancelled")
+	}
+}
+
+func TestExecutionSupervisorRejectsLateExecutionRegistration(t *testing.T) {
+	supervisor := NewActiveExecutionRegistry()
+	supervisor.BeginShutdown("daemon shutting down")
+	execution := &recordingActiveExecution{killReasons: make(chan string, 1)}
+
+	supervisor.Register("loop-1", "run-1", "execution-1", execution)
+
+	select {
+	case reason := <-execution.killReasons:
+		if reason != "daemon shutting down" {
+			t.Fatalf("kill reason = %q, want daemon shutting down", reason)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("late execution registration was not stopped")
+	}
+}
+
+func TestExecutionSupervisorInfrastructureFailureClosesAdmission(t *testing.T) {
+	supervisor := NewExecutionSupervisor()
+	reservation, err := supervisor.Reserve("loop-1")
+	if err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+	supervisor.MarkDegraded(errors.New("terminal persistence unavailable"))
+
+	if _, err := supervisor.Reserve("loop-2"); !errors.Is(err, ErrExecutionSupervisorDegraded) {
+		t.Fatalf("Reserve() error = %v, want ErrExecutionSupervisorDegraded", err)
+	}
+	select {
+	case <-reservation.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("degraded Supervisor did not cancel admitted work")
+	}
+	reservation.Release()
+}
+
+type recordingActiveExecution struct{ killReasons chan string }
+
+func (e *recordingActiveExecution) Kill(reason string) error {
+	e.killReasons <- reason
+	return nil
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -153,7 +153,7 @@ type Runtime struct {
 	worktreeCleanupStatus       WorktreeCleanupStatus
 	recoveryCancel              context.CancelFunc
 	recoveryDone                chan struct{}
-	activeExecutions            *ActiveExecutionRegistry
+	activeExecutions            *ExecutionSupervisor
 	projectCatalog              *projects.Catalog
 	githubGateway               *githubinfra.Gateway
 	webhook                     *webhookRuntime
@@ -222,7 +222,7 @@ func New(options Options) *Runtime {
 		deferRecovery:               options.DeferRecovery,
 		recovery:                    createEmptyRecoverySummary(),
 		shutdownCh:                  make(chan struct{}),
-		activeExecutions:            NewActiveExecutionRegistry(),
+		activeExecutions:            NewExecutionSupervisor(),
 		projectCatalog:              projectCatalog,
 		webhook:                     newWebhookRuntime(options.Config, options.Logger, now),
 	}
@@ -261,10 +261,20 @@ func (r *Runtime) Stop(reason string) {
 			r.logger.Info("looperd runtime stopping", map[string]any{"reason": reason})
 		}
 
+		// Close execution admission before cancelling Scheduler work. Every
+		// already-claimed item has a Supervisor reservation, so shutdown can
+		// cancel and wait without creating an unowned durable claim.
+		r.activeExecutions.BeginShutdown(reason)
 		r.stopDeferredReviewerRecovery()
 		r.stopWorktreeCleanupLoop()
 		r.stopSchedulerLoop()
 		r.stopWebhookRuntime()
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), r.shutdownTimeout)
+		ownershipWaitErr := r.activeExecutions.Wait(waitCtx)
+		if ownershipWaitErr != nil && r.logger != nil {
+			r.logger.Warn("looperd stop retained storage because execution ownership did not drain", map[string]any{"error": ownershipWaitErr.Error(), "timeoutMs": r.shutdownTimeout.Milliseconds()})
+		}
+		waitCancel()
 
 		r.mu.Lock()
 		r.stopped = true
@@ -293,7 +303,11 @@ func (r *Runtime) Stop(reason string) {
 		if networkManager != nil {
 			networkManager.Stop()
 		}
-		if coordinator != nil {
+		// Closing storage while an admitted execution still owns terminal-state
+		// publication converts a bounded shutdown into durable state corruption.
+		// On timeout the process is already leaving, so retain the coordinator and
+		// let process teardown reclaim it instead.
+		if coordinator != nil && ownershipWaitErr == nil {
 			if err := coordinator.Close(); err != nil && r.logger != nil {
 				r.logger.Warn("looperd runtime close failed", map[string]any{"error": err.Error()})
 			}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3149,6 +3149,35 @@ func TestRuntimeStopClosesCoordinatorAndUnblocksWaitForShutdown(t *testing.T) {
 	defer db.Close()
 }
 
+func TestRuntimeStopRetainsCoordinatorWhenExecutionOwnershipDoesNotDrain(t *testing.T) {
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}, ShutdownTimeout: 20 * time.Millisecond})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	coordinator := rt.Services().Coordinator
+	reservation, err := rt.activeExecutions.Reserve("loop_never_released")
+	if err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+
+	rt.Stop("test timeout")
+
+	if err := coordinator.DB().PingContext(context.Background()); err != nil {
+		t.Fatalf("coordinator was closed while execution ownership remained: %v", err)
+	}
+	reservation.Release()
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() cleanup error = %v", err)
+	}
+}
+
 func TestRuntimeStopTimesOutWaitingForSchedulerLoop(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -86,6 +86,7 @@ type defaultSchedulerTickInput struct {
 	ClaimMu                  *sync.Mutex
 	ReconcileStaleRuns       func(context.Context) (StaleRunReconcileSummary, error)
 	AsyncRunner              schedulerAsyncRunner
+	ExecutionSupervisor      *ActiveExecutionRegistry
 	RequestSchedulerWake     func()
 	Planner                  plannerScheduler
 	Coordinator              coordinatorScheduler
@@ -982,7 +983,10 @@ func (a plannerGitAdapter) Push(ctx context.Context, input planner.PushInput) er
 	return a.gateway.Push(ctx, gitinfra.PushInput{RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, Remote: input.Remote, ProtectedBranches: input.ProtectedBranches})
 }
 
-type plannerAgentExecutorAdapter struct{ executor *agent.ConfiguredExecutor }
+type plannerAgentExecutorAdapter struct {
+	executor *agent.ConfiguredExecutor
+	registry *ActiveExecutionRegistry
+}
 type plannerAgentExecutionAdapter struct{ execution agent.Execution }
 
 func (a plannerAgentExecutorAdapter) Start(ctx context.Context, input planner.AgentRunInput) (planner.AgentExecution, error) {
@@ -990,6 +994,7 @@ func (a plannerAgentExecutorAdapter) Start(ctx context.Context, input planner.Ag
 	if err != nil {
 		return nil, err
 	}
+	registerActiveAgentExecution(a.registry, input.LoopID, input.RunID, input.ExecutionID, execution)
 	return plannerAgentExecutionAdapter{execution: execution}, nil
 }
 
@@ -1643,6 +1648,7 @@ func (a reviewerGitHubAdapter) ResolveReviewThread(ctx context.Context, input re
 
 type reviewerAgentExecutorAdapter struct {
 	executor   *agent.ConfiguredExecutor
+	registry   *ActiveExecutionRegistry
 	realLooper string
 	trustedEnv map[string]string
 	// configPath is the daemon-loaded config file path injected as LOOPER_CONFIG
@@ -1842,6 +1848,7 @@ func (a reviewerAgentExecutorAdapter) Start(ctx context.Context, input reviewer.
 		proxyCleanup()
 		return nil, err
 	}
+	registerActiveAgentExecution(a.registry, input.LoopID, input.RunID, input.ExecutionID, execution)
 	return &reviewerAgentExecutionAdapter{execution: execution, cleanup: proxyCleanup}, nil
 }
 
@@ -2266,7 +2273,10 @@ func (a fixerGitAdapter) CleanupWorktree(ctx context.Context, input fixer.Cleanu
 	return a.gateway.CleanupWorktree(ctx, gitinfra.CleanupWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, ProtectedBranches: input.ProtectedBranches})
 }
 
-type fixerAgentExecutorAdapter struct{ executor *agent.ConfiguredExecutor }
+type fixerAgentExecutorAdapter struct {
+	executor *agent.ConfiguredExecutor
+	registry *ActiveExecutionRegistry
+}
 type fixerAgentExecutionAdapter struct{ execution agent.Execution }
 
 func (a fixerAgentExecutorAdapter) Start(ctx context.Context, input fixer.AgentRunInput) (fixer.AgentExecution, error) {
@@ -2274,6 +2284,7 @@ func (a fixerAgentExecutorAdapter) Start(ctx context.Context, input fixer.AgentR
 	if err != nil {
 		return nil, err
 	}
+	registerActiveAgentExecution(a.registry, input.LoopID, input.RunID, input.ExecutionID, execution)
 	return fixerAgentExecutionAdapter{execution: execution}, nil
 }
 
@@ -2731,15 +2742,22 @@ func (a workerAgentExecutorAdapter) Start(ctx context.Context, input worker.Agen
 	if err != nil {
 		return nil, err
 	}
-	unregister := func() {}
-	if a.registry != nil {
-		unregister = a.registry.Register(input.LoopID, input.RunID, input.ExecutionID, execution)
+	registerActiveAgentExecution(a.registry, input.LoopID, input.RunID, input.ExecutionID, execution)
+	return workerAgentExecutionAdapter{execution: execution}, nil
+}
+
+func registerActiveAgentExecution(registry *ActiveExecutionRegistry, loopID, runID, executionID string, execution agent.Execution) {
+	if registry == nil || execution == nil {
+		return
 	}
+	unregister := registry.Register(loopID, runID, executionID, execution)
 	go func() {
-		_, _ = execution.Wait(context.Background())
+		_, err := execution.Wait(context.Background())
+		if errors.Is(err, agent.ErrExecutionPersistence) {
+			registry.MarkDegraded(err)
+		}
 		unregister()
 	}()
-	return workerAgentExecutionAdapter{execution: execution}, nil
 }
 
 func (a workerAgentExecutionAdapter) Wait(ctx context.Context) (worker.AgentResult, error) {
@@ -2942,7 +2960,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		Repos:              repos,
 		GitHub:             plannerGitHubAdapter{gateway: githubGateway, stamper: stamper, config: &cfg},
 		Git:                plannerGitAdapter{gateway: gitGateway, stamper: stamper},
-		AgentExecutor:      plannerAgentExecutorAdapter{executor: agentExecutor},
+		AgentExecutor:      plannerAgentExecutorAdapter{executor: agentExecutor, registry: activeExecutions},
 		Logger:             logger,
 		Now:                now,
 		AllowAutoPush:      boolPtr(cfg.Defaults.AllowAutoPush),
@@ -2984,6 +3002,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		Git:    reviewerGitAdapter{gateway: gitGateway},
 		AgentExecutor: reviewerAgentExecutorAdapter{
 			executor:   agentExecutor,
+			registry:   activeExecutions,
 			realLooper: looperCLIPath,
 			trustedEnv: providerTrustedEnv(cfg),
 			configPath: strings.TrimSpace(configPath),
@@ -3029,7 +3048,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		Repos:              repos,
 		GitHub:             fixerGitHubAdapter{gateway: githubGateway, stamper: stamper, config: &cfg},
 		Git:                fixerGitAdapter{gateway: gitGateway, stamper: stamper},
-		AgentExecutor:      fixerAgentExecutorAdapter{executor: agentExecutor},
+		AgentExecutor:      fixerAgentExecutorAdapter{executor: agentExecutor, registry: activeExecutions},
 		Logger:             logger,
 		Now:                now,
 		AllowAutoCommit:    cfg.Defaults.AllowAutoCommit,
@@ -3123,6 +3142,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 			ClaimMu:                  claimMu,
 			ReconcileStaleRuns:       reconcileStaleRuns,
 			AsyncRunner:              runner,
+			ExecutionSupervisor:      services.ActiveExecutions,
 			RequestSchedulerWake:     requestWake,
 			Planner:                  plannerRunner,
 			Coordinator:              coordinatorRunner,
@@ -3585,13 +3605,50 @@ func claimAndRunScheduledQueueItems(ctx context.Context, availableSlots int, inp
 	}
 	nowISO := formatJavaScriptISOString(now().UTC())
 	queueItems := make([]storage.QueueItemRecord, 0, availableSlots)
+	reservations := make(map[string]*ExecutionReservation, availableSlots)
+	claim := func(longTerm bool) (*storage.QueueItemRecord, error) {
+		var reservation *ExecutionReservation
+		if input.ExecutionSupervisor != nil {
+			var err error
+			reservation, err = input.ExecutionSupervisor.Reserve("")
+			if err != nil {
+				return nil, err
+			}
+		}
+		var item *storage.QueueItemRecord
+		var err error
+		if longTerm {
+			item, err = input.Repos.Queue.ClaimNextLongTermRetry(ctx, nowISO, "scheduler")
+		} else {
+			item, err = input.Repos.Queue.ClaimNextNonLongTermRetry(ctx, nowISO, "scheduler")
+		}
+		if err != nil || item == nil {
+			if reservation != nil {
+				reservation.Release()
+			}
+			return item, err
+		}
+		if reservation != nil {
+			loopID := ""
+			if item.LoopID != nil {
+				loopID = *item.LoopID
+			}
+			reservation.BindLoop(loopID)
+			reservations[item.ID] = reservation
+		}
+		return item, nil
+	}
+	runClaimed := func(claimErr error) ([]storage.QueueItemRecord, error) {
+		runErr := runScheduledQueueItemsWithReservations(ctx, queueItems, reservations, input)
+		return queueItems, errors.Join(claimErr, runErr)
+	}
 	for i := 0; i < availableSlots; i++ {
 		if err := ctx.Err(); err != nil {
-			return queueItems, err
+			return runClaimed(err)
 		}
-		item, err := input.Repos.Queue.ClaimNextNonLongTermRetry(ctx, nowISO, "scheduler")
+		item, err := claim(false)
 		if err != nil {
-			return queueItems, err
+			return runClaimed(err)
 		}
 		if item == nil {
 			break
@@ -3600,18 +3657,18 @@ func claimAndRunScheduledQueueItems(ctx context.Context, availableSlots int, inp
 	}
 	for len(queueItems) < availableSlots {
 		if err := ctx.Err(); err != nil {
-			return queueItems, err
+			return runClaimed(err)
 		}
-		item, err := input.Repos.Queue.ClaimNextLongTermRetry(ctx, nowISO, "scheduler")
+		item, err := claim(true)
 		if err != nil {
-			return queueItems, err
+			return runClaimed(err)
 		}
 		if item == nil {
 			break
 		}
 		queueItems = append(queueItems, *item)
 	}
-	return queueItems, runScheduledQueueItems(ctx, queueItems, input)
+	return runClaimed(nil)
 }
 
 // schedulerLoopParked reports whether a claimed queue item's loop was parked
@@ -3634,6 +3691,10 @@ func schedulerLoopParked(ctx context.Context, item storage.QueueItemRecord, inpu
 }
 
 func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemRecord, input defaultSchedulerTickInput) error {
+	return runScheduledQueueItemsWithReservations(ctx, queueItems, nil, input)
+}
+
+func runScheduledQueueItemsWithReservations(ctx context.Context, queueItems []storage.QueueItemRecord, reservations map[string]*ExecutionReservation, input defaultSchedulerTickInput) error {
 	if len(queueItems) == 0 {
 		return nil
 	}
@@ -3643,8 +3704,14 @@ func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemR
 		now = time.Now
 	}
 	errList := make([]error, 0)
-	for _, item := range queueItems {
+	for index, item := range queueItems {
+		reservation := reservations[item.ID]
 		if err := ctx.Err(); err != nil {
+			for _, pending := range queueItems[index:] {
+				if pendingReservation := reservations[pending.ID]; pendingReservation != nil {
+					pendingReservation.Release()
+				}
+			}
 			return err
 		}
 
@@ -3652,6 +3719,9 @@ func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemR
 		// queue item survived a race with the parking and got claimed. Release the
 		// claim (so the slot frees) and skip — only an explicit handback re-arms it.
 		if schedulerLoopParked(ctx, item, input) {
+			if reservation != nil {
+				reservation.Release()
+			}
 			if input.Repos != nil && input.Repos.Queue != nil {
 				_ = input.Repos.Queue.Complete(ctx, item.ID, formatJavaScriptISOString(now().UTC()))
 			}
@@ -3667,22 +3737,44 @@ func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemR
 
 		process, err := schedulerQueueProcessor(item, input)
 		if err != nil {
+			if reservation != nil {
+				reservation.Release()
+			}
 			errList = append(errList, err)
 			continue
 		}
 		item := item
 		processFn := process
+		run := func() error {
+			runCtx := ctx
+			cancel := func(error) {}
+			stop := func() bool { return false }
+			if reservation != nil {
+				defer reservation.Release()
+				runCtx, cancel = context.WithCancelCause(ctx)
+				stop = context.AfterFunc(reservation.Context(), func() {
+					cancel(context.Cause(reservation.Context()))
+				})
+				defer stop()
+				defer cancel(nil)
+			}
+			err := processFn(runCtx)
+			if errors.Is(err, agent.ErrExecutionPersistence) && input.ExecutionSupervisor != nil {
+				input.ExecutionSupervisor.MarkDegraded(err)
+			}
+			return err
+		}
 
 		if input.AsyncRunner != nil {
 			input.AsyncRunner.Go(func() {
-				if err := processFn(ctx); err != nil && input.Logger != nil {
+				if err := run(); err != nil && input.Logger != nil {
 					input.Logger.Warn("scheduler queue item failed", map[string]any{"type": item.Type, "queueItemId": item.ID, "error": err.Error()})
 				}
 			})
 			continue
 		}
 		go func() {
-			if err := processFn(ctx); err != nil && input.Logger != nil {
+			if err := run(); err != nil && input.Logger != nil {
 				input.Logger.Warn("scheduler queue item failed", map[string]any{"type": item.Type, "queueItemId": item.ID, "error": err.Error()})
 			}
 		}()

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -701,6 +701,81 @@ func TestClaimAndRunScheduledQueueItemsUsesLongTermRetryOnlyForIdleSlots(t *test
 	}
 }
 
+func TestClaimedQueueItemRemainsOwnedUntilShutdownCancellationFinishes(t *testing.T) {
+	workingDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "owned-claim.sqlite"), t.TempDir())
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	projectID := "project-owned-claim"
+	loopID := "loop-owned-claim"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Owned claim", RepoPath: workingDir, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue-owned-claim", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: projectID, DedupeKey: "worker:owned-claim", Priority: storage.QueuePriorityWorker, Status: "queued", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	supervisor := NewActiveExecutionRegistry()
+	runner := &cancellableWorkerScheduler{started: make(chan struct{}), cancelled: make(chan struct{})}
+	claimed, err := claimAndRunScheduledQueueItems(context.Background(), 1, defaultSchedulerTickInput{
+		Repos: repos, Now: func() time.Time { return now }, Worker: runner, ExecutionSupervisor: supervisor,
+	})
+	if err != nil {
+		t.Fatalf("claimAndRunScheduledQueueItems() error = %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("claimed count = %d, want 1", len(claimed))
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(time.Second):
+		t.Fatal("claimed runner did not start")
+	}
+
+	supervisor.BeginShutdown("daemon shutting down")
+	select {
+	case <-runner.cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("claimed runner did not observe shutdown cancellation")
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := supervisor.Wait(waitCtx); err != nil {
+		t.Fatalf("supervisor.Wait() error = %v", err)
+	}
+}
+
+func TestRunScheduledQueueItemsReleasesUnstartedReservationsAfterCancellation(t *testing.T) {
+	supervisor := NewExecutionSupervisor()
+	first, err := supervisor.Reserve("loop-first")
+	if err != nil {
+		t.Fatalf("Reserve(first) error = %v", err)
+	}
+	second, err := supervisor.Reserve("loop-second")
+	if err != nil {
+		t.Fatalf("Reserve(second) error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = runScheduledQueueItemsWithReservations(ctx,
+		[]storage.QueueItemRecord{{ID: "first", Type: "worker"}, {ID: "second", Type: "worker"}},
+		map[string]*ExecutionReservation{"first": first, "second": second},
+		defaultSchedulerTickInput{Worker: &stubWorkerScheduler{}},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runScheduledQueueItemsWithReservations() error = %v, want context.Canceled", err)
+	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+	defer waitCancel()
+	if err := supervisor.Wait(waitCtx); err != nil {
+		t.Fatalf("Supervisor.Wait() error = %v, want all unstarted reservations released", err)
+	}
+}
+
 func TestRunScheduledQueueItemsRejectsUnsupportedType(t *testing.T) {
 	t.Parallel()
 
@@ -716,6 +791,23 @@ func TestRunScheduledQueueItemsErrorsWhenRunnerMissing(t *testing.T) {
 	err := runScheduledQueueItems(context.Background(), []storage.QueueItemRecord{{Type: "worker"}}, defaultSchedulerTickInput{})
 	if err == nil || !strings.Contains(err.Error(), "worker runner is not configured") {
 		t.Fatalf("runScheduledQueueItems() error = %v, want missing worker runner error", err)
+	}
+}
+
+func TestRunScheduledQueueItemsDegradesSupervisorOnExecutionPersistenceFailure(t *testing.T) {
+	supervisor := NewExecutionSupervisor()
+	runner := &stubWorkerScheduler{processErr: errors.Join(agent.ErrExecutionPersistence, errors.New("sqlite unavailable"))}
+	if err := runScheduledQueueItems(context.Background(), []storage.QueueItemRecord{{ID: "queue-persist-failure", Type: "worker"}}, defaultSchedulerTickInput{
+		Worker: runner, ExecutionSupervisor: supervisor,
+	}); err != nil {
+		t.Fatalf("runScheduledQueueItems() error = %v", err)
+	}
+	waitForSchedulerCondition(t, func() bool { return supervisor.Failure() != nil })
+	if !errors.Is(supervisor.Failure(), agent.ErrExecutionPersistence) {
+		t.Fatalf("supervisor.Failure() = %v, want ErrExecutionPersistence", supervisor.Failure())
+	}
+	if _, err := supervisor.Reserve("loop-after-persist-failure"); !errors.Is(err, ErrExecutionSupervisorDegraded) {
+		t.Fatalf("Reserve() error = %v, want ErrExecutionSupervisorDegraded", err)
 	}
 }
 
@@ -1581,6 +1673,22 @@ type blockingWorkerScheduler struct {
 	started chan struct{}
 	release chan struct{}
 	once    sync.Once
+}
+
+type cancellableWorkerScheduler struct {
+	started   chan struct{}
+	cancelled chan struct{}
+}
+
+func (s *cancellableWorkerScheduler) ProcessNext(ctx context.Context, _ string) (*worker.ProcessResult, error) {
+	close(s.started)
+	<-ctx.Done()
+	close(s.cancelled)
+	return nil, ctx.Err()
+}
+
+func (s *cancellableWorkerScheduler) ProcessClaimedQueueItem(ctx context.Context, _ storage.QueueItemRecord) (*worker.ProcessResult, error) {
+	return s.ProcessNext(ctx, "")
 }
 
 func (s *blockingWorkerScheduler) ProcessNext(_ context.Context, _ string) (*worker.ProcessResult, error) {

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -1023,6 +1023,8 @@ func (r *AgentExecutionsRepository) Upsert(ctx context.Context, record AgentExec
 			ended_at=excluded.ended_at,
 			metadata_json=excluded.metadata_json,
 			updated_at=excluded.updated_at
+		WHERE agent_executions.status IN ('running', 'cancelling')
+		   OR excluded.status NOT IN ('running', 'cancelling')
 	`, record.ID, record.ProjectID, record.LoopID, record.RunID, record.Vendor, record.Status, record.PID, record.CommandJSON, record.CWD, record.Summary, record.ParseStatus, record.CompletionSignal, record.HeartbeatCount, record.LastHeartbeatAt, record.OutputJSON, record.ErrorMessage, record.NativeSessionID, record.NativeResumeMode, record.NativeResumeStatus, record.NativeResumeError, record.StartedAt, record.EndedAt, record.MetadataJSON, record.CreatedAt, record.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("upsert agent execution: %w", err)

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -13,6 +13,33 @@ import (
 	"time"
 )
 
+func TestAgentExecutionTerminalObservationCannotRegressToRunning(t *testing.T) {
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	ctx := context.Background()
+	startedAt := "2026-07-16T12:00:00.000Z"
+	endedAt := "2026-07-16T12:01:00.000Z"
+	terminal := AgentExecutionRecord{ID: "agent_terminal_monotonic", Vendor: "codex", Status: "completed", StartedAt: startedAt, EndedAt: &endedAt, CreatedAt: startedAt, UpdatedAt: endedAt}
+	if err := repos.AgentExecutions.Upsert(ctx, terminal); err != nil {
+		t.Fatalf("Upsert(terminal) error = %v", err)
+	}
+	staleLive := terminal
+	staleLive.Status = "running"
+	staleLive.EndedAt = nil
+	staleLive.UpdatedAt = startedAt
+	if err := repos.AgentExecutions.Upsert(ctx, staleLive); err != nil {
+		t.Fatalf("Upsert(stale live) error = %v", err)
+	}
+
+	got, err := repos.AgentExecutions.GetByID(ctx, terminal.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if got == nil || got.Status != "completed" || got.EndedAt == nil {
+		t.Fatalf("execution = %#v, want completed terminal observation", got)
+	}
+}
+
 func TestRepositoriesRoundTripForProjectsLoopsRunsAndRuntimeMetadata(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

This replaces the patch stack in #568 with one ownership model: the in-memory `ExecutionSupervisor` is the authority for live work in a running daemon.

- reserve Supervisor ownership before a Scheduler queue claim, bind it to the selected loop, and hold it until the claimed runner finishes
- register Planner, Reviewer, Fixer, and Worker agent executions with the same Supervisor; Coordinator execution remains covered by the claimed-run reservation
- serialize execution persistence, surface persistence failures, and prevent terminal SQLite observations from regressing to `running` or `cancelling`
- close admission before loop stop and daemon shutdown, wait for owned work before closing storage, and retain storage if ownership cannot drain within the shutdown budget
- gate mutations during startup recovery and after a Supervisor infrastructure failure while keeping read endpoints available
- centralize Unix process-group containment, including descendant cleanup after normal leader exit and no-reap leader observation on Linux and macOS

The design and its lifecycle contracts are recorded in ADR-0014.

## Root cause

Live ownership was split across `exec.Cmd`, a partial in-memory registry, persisted `agent_executions` rows, queue state, and PID/PGID probes. Those representations could disagree during queue claim, native-resume fallback, terminal persistence, loop stop, shutdown, and startup recovery. Fixing one race at a time kept moving the gap to another lifecycle boundary.

## Authority and trade-off

The authority for a live action is the `ExecutionSupervisor` reservation and its owned containment handle; SQLite and process inspection are recovery evidence only.

This prevents unowned durable claims, late live writes after terminal state, shutdown closing SQLite under an active finalizer, and signals being sent to a reused PID/PGID.

The cost is one in-memory Supervisor lifecycle, explicit reservation release, serialized execution persistence, a mutation-readiness gate, and platform-specific containment adapters. A daemon crash still loses live in-memory authority, so startup recovery must reconcile durable observations before mutations are enabled. If containment or terminal persistence cannot be confirmed, the daemon fails loud/degrades instead of inferring success.

A smaller PID-validation patch is insufficient because numeric IDs are reusable and probe-then-signal is not atomic. Trusting SQLite as live authority is also insufficient because persistence is an observation that can lag the process. The deletion attempt was to remove runtime PID fallback entirely when a Supervisor exists; PID inspection remains only for legacy/no-Supervisor paths and startup recovery.

## Validation

- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- `go test -p 1 ./...`
- `go build ./...`
- race coverage for agent, shell containment, and Supervisor/Scheduler ownership contracts
- repeated macOS process-containment, native-resume, and worktree E2E regression runs
- Linux cross-compilation of `internal/infra/shell`

Supersedes #568.
