### PR TITLE
fix: project dependency probe issue list under shell capture cap

### DIFF
--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -1095,10 +1095,20 @@ func (g *Gateway) listDependencyIssues(ctx context.Context, input ViewIssueInput
 	return out, nil
 }
 
+// findAnyIssueNumberJQ projects each issues page down to number + PR marker only.
+// Full issue bodies easily exceed the shell capture cap on busy sandbox repos;
+// gh applies this filter before writing to the bounded stdout buffer.
+const findAnyIssueNumberJQ = `[.[] | {number, pull_request}]`
+
 func (g *Gateway) FindAnyIssueNumber(ctx context.Context, repo string, cwd string) (int64, error) {
 	hostname, repoName := splitRepoHostname(repo)
 	for page := 1; ; page++ {
-		args := []string{"api", fmt.Sprintf("repos/%s/issues?state=all&per_page=100&page=%d", repoName, page)}
+		args := []string{
+			"api",
+			fmt.Sprintf("repos/%s/issues?state=all&per_page=100&page=%d", repoName, page),
+			"--jq",
+			findAnyIssueNumberJQ,
+		}
 		if hostname != "" {
 			args = append(args, "--hostname", hostname)
 		}

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -1843,7 +1843,7 @@ func TestFindAnyIssueNumberSkipsPullRequests(t *testing.T) {
 	t.Parallel()
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
-		if got := strings.Join(options.Args, " "); got != "api repos/acme/looper/issues?state=all&per_page=100&page=1" {
+		if got := strings.Join(options.Args, " "); got != "api repos/acme/looper/issues?state=all&per_page=100&page=1 --jq "+findAnyIssueNumberJQ {
 			t.Fatalf("unexpected gh args: %q", got)
 		}
 		return shell.Result{Stdout: `[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}},{"number":7}]`}, nil
@@ -1863,9 +1863,9 @@ func TestFindAnyIssueNumberChecksLaterPages(t *testing.T) {
 	runner := &fakeGHRunner{t: t}
 	runner.respond = func(options shell.Options) (shell.Result, error) {
 		switch got := strings.Join(options.Args, " "); got {
-		case "api repos/acme/looper/issues?state=all&per_page=100&page=1":
+		case "api repos/acme/looper/issues?state=all&per_page=100&page=1 --jq " + findAnyIssueNumberJQ:
 			return shell.Result{Stdout: `[{"number":99,"pull_request":{"url":"https://example.test/pr/99"}}]`}, nil
-		case "api repos/acme/looper/issues?state=all&per_page=100&page=2":
+		case "api repos/acme/looper/issues?state=all&per_page=100&page=2 --jq " + findAnyIssueNumberJQ:
 			return shell.Result{Stdout: `[{"number":7}]`}, nil
 		default:
 			t.Fatalf("unexpected gh args: %q", got)
@@ -1882,6 +1882,28 @@ func TestFindAnyIssueNumberChecksLaterPages(t *testing.T) {
 	}
 	if len(runner.calls) != 2 {
 		t.Fatalf("FindAnyIssueNumber() calls = %d, want two paged requests", len(runner.calls))
+	}
+}
+
+func TestFindAnyIssueNumberProjectsPayloadBeforeShellCapture(t *testing.T) {
+	t.Parallel()
+	runner := &fakeGHRunner{t: t}
+	runner.respond = func(options shell.Options) (shell.Result, error) {
+		args := strings.Join(options.Args, " ")
+		if !strings.Contains(args, "--jq "+findAnyIssueNumberJQ) {
+			t.Fatalf("FindAnyIssueNumber must project issue pages with --jq before shell capture; got %q", args)
+		}
+		// Projected rows stay tiny even when the underlying page would exceed the
+		// 256 KiB shell capture cap used by runGh.
+		return shell.Result{Stdout: `[{"number":7,"pull_request":null}]`}, nil
+	}
+	gateway := New(Options{GHPath: "gh", CWD: t.TempDir(), GHRun: runner.run})
+	issueNumber, err := gateway.FindAnyIssueNumber(context.Background(), "acme/looper", "")
+	if err != nil {
+		t.Fatalf("FindAnyIssueNumber() error = %v", err)
+	}
+	if issueNumber != 7 {
+		t.Fatalf("FindAnyIssueNumber() = %d, want 7", issueNumber)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -4442,7 +4442,7 @@ func TestValidateCoordinatorDependencyGatesFailsClosedWhenAPIUnavailable(t *test
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case args == "api repos/acme/looper/issues?state=all&per_page=100&page=1":
+		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=1") && strings.Contains(args, "--jq"):
 			return shell.Result{Stdout: `[{"number":7}]`}, nil
 		case strings.Contains(args, "dependencies/blocked_by"):
 			result := shell.Result{ExitCode: 1, Stderr: "gh: HTTP 404: Not Found"}
@@ -4480,7 +4480,7 @@ func TestValidateCoordinatorDependencyGatesAllowsAvailableAPI(t *testing.T) {
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case args == "api repos/acme/looper/issues?state=all&per_page=100&page=1":
+		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=1") && strings.Contains(args, "--jq"):
 			return shell.Result{Stdout: `[{"number":7}]`}, nil
 		case strings.Contains(args, "dependencies/blocked_by"):
 			return shell.Result{Stdout: `[]`}, nil
@@ -4517,9 +4517,9 @@ func TestValidateCoordinatorDependencyGatesSkipsProbeWhenRepoHasNoIssues(t *test
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case args == "api repos/acme/looper/issues?state=all&per_page=100&page=1":
+		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=1") && strings.Contains(args, "--jq"):
 			return shell.Result{Stdout: `[{"number":12,"pull_request":{}}]`}, nil
-		case args == "api repos/acme/looper/issues?state=all&per_page=100&page=2":
+		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=2") && strings.Contains(args, "--jq"):
 			return shell.Result{Stdout: `[]`}, nil
 		case strings.Contains(args, "dependencies/blocked_by"):
 			blockedByCalls++
@@ -4559,7 +4559,7 @@ func TestValidateCoordinatorDependencyGatesReturnsInvalidJSONFromIssueProbe(t *t
 	githubGateway := githubinfra.New(githubinfra.Options{GHRun: func(ctx context.Context, options shell.Options) (shell.Result, error) {
 		args := strings.Join(options.Args, " ")
 		switch {
-		case args == "api repos/acme/looper/issues?state=all&per_page=100&page=1":
+		case strings.HasPrefix(args, "api repos/acme/looper/issues?state=all&per_page=100&page=1") && strings.Contains(args, "--jq"):
 			return shell.Result{Stdout: `not-json`}, nil
 		default:
 			t.Fatalf("unexpected gh args: %q", args)


### PR DESCRIPTION
## Summary
- GitHub sandbox E2E failed on `TestGitHubSandboxDependencyGateScenarios/looperd_startup_validation_succeeds_against_real_dependency_API` with:
  - `wait for ready: looperd exited before readiness: exit status 1`
  - `looperd: GitHub command output truncated: stdout after 262144 bytes`
- Root cause: coordinator dependency-gate startup validation calls `FindAnyIssueNumber`, which listed full issue JSON pages (`per_page=100`). Busy sandbox repos exceed the 256 KiB shell stdout cap, so `runGh` hard-fails before readiness.
- Fix: project each issues page with `gh api ... --jq '[.[] | {number, pull_request}]'` before shell capture (same pattern as PR automation comment discovery). Pagination / PR-skip semantics unchanged.

## Test plan
- [x] `go test ./internal/infra/github/ -run 'TestFindAnyIssueNumber|TestGatewayReportsTruncated'`
- [x] `go test ./internal/runtime/ -run 'TestValidateCoordinatorDependencyGates'`
- [ ] CI GitHub sandbox E2E job green on this PR

Fixes failure from https://github.com/nexu-io/looper/actions/runs/29589743905/job/87915556506