### PR TITLE
fix: execution persistence authority and degrade on mid-life failure

### DIFF
--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -1185,7 +1185,14 @@ func markExecutionCancelling(ctx context.Context, services looperdruntime.Servic
 	if updated.ErrorMessage == nil {
 		updated.ErrorMessage = &reason
 	}
-	return services.Repositories.AgentExecutions.Upsert(ctx, updated)
+	if err := services.Repositories.AgentExecutions.Upsert(ctx, updated); err != nil {
+		// Terminal already won: stop path must not invent success-over-conflict.
+		if errors.Is(err, storage.ErrAgentExecutionConflict) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func hasVersionArg(args []string) bool {

--- a/docs/adr/0015-execution-supervisor-live-ownership.md
+++ b/docs/adr/0015-execution-supervisor-live-ownership.md
@@ -119,7 +119,7 @@ to a slice while any open blocker remains.
 | R2 | #574 | Process containment handle with confirmed drain | Containment API; kill success = confirmed drain; no production removal of PID fallback yet | **Enforced** |
 | R3 | #576 | Own all in-scope agent spawns at common executor boundary | Lease before `cmd.Start`; bind handle before return; stop-kill via handle; remove agent live PID fallback only after full agent coverage | **Enforced** |
 | R4 | #577 | Migrate remaining Supervisor-owned non-agent subprocesses | Validation/shell and other in-scope non-agents on containment; no raw PID fallback inside Supervisor domain; shutdown order tested | **Deferred** |
-| R5 | #578 | Execution persistence Authority + degrade on mid-life failure | Ordered writer; terminal immutability; hard persist failure degrades; no terminal status before confirmed dead | **Deferred** |
+| R5 | #578 | Execution persistence Authority + degrade on mid-life failure | Ordered writer; terminal immutability; hard persist failure degrades; no terminal status before confirmed dead | **Enforced** |
 | R6 | #579 | Operation lease owns queue claims until durable finalize | No live `running` claim without lease; release only after durable finalize; finalize failure retains ownership + degrades | **Deferred** |
 | R7 | #580 | Full non-mutating coverage when not-ready or degraded | Exhaustive mutation surface audit; scheduler pause; HTTP 503; no dual ready Authority | **Deferred** |
 | R8 | #581 | Conservative startup recovery without PID Authority | confirmed dead / observed live / uncertain; uncertain cannot act; PID is evidence only | **Deferred** |
@@ -195,6 +195,52 @@ boundary so there is no worker-only registry escape hatch.
 | **Costs** | Every agent Start path consults the registry; stop latency includes confirmed drain; unit tests need Owner nil or a registry; native-resume fallback must rebind handles. |
 | **Why not simpler** | Post-spawn adapter Register (#572) leaves Coordinator and race windows unowned. Keeping PID fallback after full coverage reintroduces reusable-ID Authority. |
 | **Deletion attempt** | Remove registry and trust only `exec.Cmd` + SQLite — fails stop when live handle is missing and reopens dual Authority. |
+
+### Execution persistence Authority (enforced by #578)
+
+SQLite `agent_executions` is a **durable observation**, not a second live
+Authority. Each in-process execution serializes its own writes (`persistMu`);
+there is no general global writer subsystem.
+
+**Terminal immutability policy** (storage-level, `AgentExecutionsRepository.Upsert`):
+
+| From → To | Allowed? |
+|-----------|----------|
+| active (`running`, `cancelling`) → active | yes |
+| active → terminal (`completed`, `failed`, `timeout`, `killed`, legacy `success`) | yes |
+| terminal → active | **no** (conflict) |
+| terminal → different terminal | **no** (first terminal wins; conflict) |
+| terminal → same terminal (field enrichment) | yes (e.g. native-resume metadata) |
+
+Zero-row / rejected upserts return `ErrAgentExecutionConflict`, never success.
+
+**Hard persistence failure policy:**
+
+| Path | Behavior |
+|------|----------|
+| **Initial** ownership after spawn+bind | Fail `Start` loud; kill/confirmed-drain the process; do not leave unowned live process |
+| **Heartbeat / output** mid-life | Surface error; **first hard failure** closes admission (`degraded`) |
+| **Terminal** | Fail loud via `Wait` error; do not report successful completion; degrade if storage is broken |
+| Soft/transient | One retry on SQLITE_BUSY/locked; pure cancel/context death and conflict-after-terminal-won do **not** sticky-degrade |
+
+Terminal status is not published until containment is confirmed dead for owned
+handles (`Drain` when needed after leader `Wait`).
+
+**Operator recovery from degraded (persistence hard failure):**
+
+1. Inspect daemon logs for `daemon admission degraded after agent execution persistence failure` and the underlying storage error.
+2. Repair storage (disk space, permissions, SQLite integrity) under the configured runtime path (default `~/.looper/`).
+3. **Restart `looperd`** — the normal recovery path. Admission is sticky degraded until process restart (or an explicit `ClearDegraded` test/operator hook).
+4. After restart, startup recovery classifies durable observations conservatively (#581); do not manually requeue uncertain work.
+
+**Persistence concept trade-off (R5):**
+
+| | |
+|--|--|
+| **Failure prevented** | Stale live writers regressing terminal rows; silent upsert “success” when zero rows changed; split-brain observations while admission keeps accepting work; terminal status before containment confirmed dead. |
+| **Costs** | Sticky degrade stops new work until restart/clear; terminal conflict means first terminal wins even if a later writer had richer fields; per-execution serialization; hard fail paths kill on initial persist failure. |
+| **Why not simpler** | Trusting raw Upsert success leaves #579 release able to free claims on silent no-op writes. Global writer queues add complexity without fixing per-execution ordering. Soft-degrade on cancel creates sticky noise without recovery signal. |
+| **Deletion attempt** | Remove mid-life heartbeat persistence and keep only terminal — insufficient for operator progress and native-session capture while live. |
 
 ### Shutdown order (target; partial in #575, complete in #577/#580)
 

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -16,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mattn/go-sqlite3"
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/eventlog"
 	"github.com/nexu-io/looper/internal/forge"
@@ -23,6 +25,12 @@ import (
 	"github.com/nexu-io/looper/internal/processcontainment"
 	"github.com/nexu-io/looper/internal/storage"
 )
+
+// ErrExecutionPersistence is returned when a hard agent_executions observation
+// write fails (initial ownership, mid-life heartbeat/output, or terminal).
+// Soft/transient failures (cancel, conflict after terminal won, one busy retry)
+// do not produce this error alone.
+var ErrExecutionPersistence = errors.New("agent execution persistence failed")
 
 const (
 	defaultMaxOutputBytes    = 256 * 1024
@@ -105,6 +113,11 @@ type ExecutorOptions struct {
 	// returns (ADR-0015 / #576). Daemon producers must wire Owner; unit tests
 	// may leave it nil and still get containment without Supervisor lease.
 	Owner SpawnOwner
+	// OnHardPersistFailure is invoked on the first hard agent_executions write
+	// failure for an execution path (heartbeat/output or terminal storage
+	// broken). Daemon wiring must map this to sticky admission degraded
+	// (ADR-0015 R5 / #578). Soft/transient errors and pure cancel do not call it.
+	OnHardPersistFailure func(error)
 	// OnProgress, when set, is called (throttled) while an agent run streams
 	// output, so a transport can surface live progress. Vendor-agnostic: it works
 	// off the subprocess's stdout tail, whatever agent (codex/opencode/claude) runs.
@@ -175,12 +188,13 @@ type Execution interface {
 }
 
 type ConfiguredExecutor struct {
-	config     ExecutorConfig
-	repos      *storage.Repositories
-	logDir     string
-	now        func() time.Time
-	owner      SpawnOwner
-	onProgress func(context.Context, ProgressUpdate)
+	config               ExecutorConfig
+	repos                *storage.Repositories
+	logDir               string
+	now                  func() time.Time
+	owner                SpawnOwner
+	onHardPersistFailure func(error)
+	onProgress           func(context.Context, ProgressUpdate)
 }
 
 func New(options ExecutorOptions) *ConfiguredExecutor {
@@ -188,7 +202,15 @@ func New(options ExecutorOptions) *ConfiguredExecutor {
 	if now == nil {
 		now = time.Now
 	}
-	return &ConfiguredExecutor{config: options.Config, repos: options.Repos, logDir: options.LogDir, now: now, owner: options.Owner, onProgress: options.OnProgress}
+	return &ConfiguredExecutor{
+		config:               options.Config,
+		repos:                options.Repos,
+		logDir:               options.LogDir,
+		now:                  now,
+		owner:                options.Owner,
+		onHardPersistFailure: options.OnHardPersistFailure,
+		onProgress:           options.OnProgress,
+	}
 }
 
 // liveProgressInterval throttles OnProgress so a chatty agent doesn't hammer the
@@ -424,11 +446,37 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 		}
 	}
 
+	// Initial ownership observation is hard: fail Start loud and do not leave
+	// an unowned live process (#578). Persist before transferring lease so the
+	// deferred Release still drains Supervisor ownership on failure.
+	if err := x.persistStatus(ctx, "running", nil, nil, nil); err != nil {
+		if hard := x.classifyPersistError(err); hard != nil {
+			x.reportHardPersistFailure(hard)
+			killCtx, cancel := context.WithTimeout(context.Background(), grace+15*time.Second)
+			if x.handle != nil {
+				_ = x.handle.Kill(killCtx)
+			} else {
+				_ = killStartedCmd(cmd)
+			}
+			cancel()
+			return nil, errors.Join(ErrExecutionPersistence, fmt.Errorf("persist initial agent execution ownership: %w", hard))
+		}
+		// Soft (cancel/conflict): still refuse Start without a durable observation
+		// when storage rejected or cancelled, but do not sticky-degrade.
+		killCtx, cancel := context.WithTimeout(context.Background(), grace+15*time.Second)
+		if x.handle != nil {
+			_ = x.handle.Kill(killCtx)
+		} else {
+			_ = killStartedCmd(cmd)
+		}
+		cancel()
+		return nil, errors.Join(ErrExecutionPersistence, fmt.Errorf("persist initial agent execution ownership: %w", err))
+	}
+
 	// Transfer lease ownership to execution; defer must not Release on success.
 	lease = nil
 
 	resumeSessionID, resumeMode, resumeStatus, _ := x.nativeResumeSnapshot()
-	x.persistStatus("running", nil, nil, nil)
 	e.appendLifecycleEvent("agent.invoked", input, executionID, map[string]any{"command": command, "args": args, "cwd": input.WorkingDirectory, "nativeResumeMode": resumeMode, "nativeResumeStatus": resumeStatus, "nativeSessionId": resumeSessionID}, startedAtISO)
 
 	go x.run(ctx)
@@ -473,6 +521,9 @@ type execution struct {
 	lastProgressAt     time.Time
 
 	mu                      sync.Mutex
+	persistMu               sync.Mutex // one ordered writer per execution (#578)
+	terminalPersisted       bool
+	hardPersistReported     bool
 	status                  string
 	stdout                  []byte
 	stderr                  []byte
@@ -760,17 +811,40 @@ func (x *execution) run(ctx context.Context) {
 	if x.shouldFallbackNativeResume(status, stdout, stderr) {
 		// Cancellation / stop must not spawn a second process (#576).
 		if runCtx.Err() == nil && (x.lease == nil || x.lease.Context().Err() == nil) {
-			if fallbackResult, fallbackErrorMessage, ok := x.runCheckpointFallback(runCtx, errorMessage); ok {
+			if fallbackResult, fallbackErrorMessage, ok, fallbackErr := x.runCheckpointFallback(runCtx, errorMessage); ok {
 				result = fallbackResult
 				status = fallbackResult.Status
 				timeoutType = fallbackResult.TimeoutType
 				errorMessage = fallbackErrorMessage
 				endedAtISO = eventlog.FormatJavaScriptISOString(x.executor.now().UTC())
+			} else if fallbackErr != nil {
+				// Fallback ownership persist failed after process reaped.
+				x.doneCh <- execOutcome{result: result, err: fallbackErr}
+				return
 			}
 		}
 	}
 
-	x.persistFinal(status, result, errorMessage, endedAtISO)
+	// No terminal observation before containment is confirmed dead for owned
+	// executions (ties to #574/#576 / ADR-0015 R5).
+	if err := x.ensureConfirmedDeadBeforeTerminal(); err != nil {
+		x.reportHardPersistFailure(err)
+		x.doneCh <- execOutcome{
+			result: result,
+			err:    errors.Join(ErrExecutionPersistence, fmt.Errorf("containment not confirmed dead before terminal observation: %w", err)),
+		}
+		return
+	}
+
+	persistErr := x.persistFinal(status, result, errorMessage, endedAtISO)
+	if hard := x.classifyPersistError(persistErr); hard != nil {
+		x.reportHardPersistFailure(hard)
+		persistErr = errors.Join(ErrExecutionPersistence, fmt.Errorf("persist terminal agent execution: %w", hard))
+	} else if persistErr != nil {
+		// Soft terminal write issues still fail loud (do not report success).
+		persistErr = errors.Join(ErrExecutionPersistence, fmt.Errorf("persist terminal agent execution: %w", persistErr))
+	}
+
 	eventType := "agent.completed"
 	if status == "timeout" {
 		switch timeoutType {
@@ -784,19 +858,21 @@ func (x *execution) run(ctx context.Context) {
 	} else if status == "killed" {
 		eventType = "agent.killed"
 	}
-	x.executor.appendLifecycleEvent(eventType, x.input, x.executionID, map[string]any{
-		"status":                       status,
-		"timeoutType":                  timeoutType,
-		"configuredIdleTimeoutSeconds": result.ConfiguredIdleTimeoutSeconds,
-		"configuredMaxRuntimeSeconds":  result.ConfiguredMaxRuntimeSeconds,
-		"elapsedRuntimeSeconds":        result.ElapsedRuntimeSeconds,
-		"lastProgressAt":               result.LastProgressAt,
-		"parseStatus":                  result.ParseStatus,
-		"heartbeatCount":               result.HeartbeatCount,
-		"summary":                      result.Summary,
-	}, endedAtISO)
+	if persistErr == nil {
+		x.executor.appendLifecycleEvent(eventType, x.input, x.executionID, map[string]any{
+			"status":                       status,
+			"timeoutType":                  timeoutType,
+			"configuredIdleTimeoutSeconds": result.ConfiguredIdleTimeoutSeconds,
+			"configuredMaxRuntimeSeconds":  result.ConfiguredMaxRuntimeSeconds,
+			"elapsedRuntimeSeconds":        result.ElapsedRuntimeSeconds,
+			"lastProgressAt":               result.LastProgressAt,
+			"parseStatus":                  result.ParseStatus,
+			"heartbeatCount":               result.HeartbeatCount,
+			"summary":                      result.Summary,
+		}, endedAtISO)
+	}
 
-	x.doneCh <- execOutcome{result: result, err: nil}
+	x.doneCh <- execOutcome{result: result, err: persistErr}
 }
 
 func (x *execution) shouldFallbackNativeResume(status string, stdout string, stderr string) bool {
@@ -833,16 +909,16 @@ func normalizeNativeResumeErrorLine(line string) string {
 	return strings.TrimSpace(line)
 }
 
-func (x *execution) runCheckpointFallback(ctx context.Context, nativeError string) (Result, string, bool) {
+func (x *execution) runCheckpointFallback(ctx context.Context, nativeError string) (Result, string, bool, error) {
 	// Stop/cancel must not spawn a second process after the first failed attach.
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {
-			return Result{}, "", false
+			return Result{}, "", false, nil
 		}
 	}
 	if x.lease != nil {
 		if err := x.lease.Context().Err(); err != nil {
-			return Result{}, "", false
+			return Result{}, "", false, nil
 		}
 	}
 
@@ -859,7 +935,7 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 	if x.lease != nil {
 		if r, ok := x.lease.(rebindLease); ok {
 			if err := r.BeginRebind(); err != nil {
-				return Result{}, "", false
+				return Result{}, "", false, nil
 			}
 			rebind = r
 			defer func() {
@@ -893,8 +969,6 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 	x.lastHeartbeatAtISO = nowISO
 	x.lastOutputAt = now
 	x.mu.Unlock()
-	x.persistStatus("running", nil, nil, nil)
-	x.executor.appendLifecycleEvent("agent.native_resume_fallback_started", x.input, x.executionID, map[string]any{"command": command, "args": args, "nativeResumeError": nativeError}, nowISO)
 
 	if err := cmd.Start(); err != nil {
 		x.mu.Lock()
@@ -902,7 +976,7 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 		x.nativeResumeStatus = "fallback_failed"
 		x.nativeResumeError = firstNonEmpty(err.Error(), nativeError)
 		x.mu.Unlock()
-		return Result{}, "", false
+		return Result{}, "", false, nil
 	}
 
 	grace := x.gracefulShutdown
@@ -920,7 +994,7 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 		x.nativeResumeStatus = "fallback_failed"
 		x.nativeResumeError = firstNonEmpty(err.Error(), nativeError)
 		x.mu.Unlock()
-		return Result{}, "", false
+		return Result{}, "", false, nil
 	}
 	// Prior handle already Wait'd in the outer run loop; replace for stop-kill.
 	x.mu.Lock()
@@ -951,9 +1025,22 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 				ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
 				LastProgressAt:               x.lastProgressAtISO(),
 				PID:                          x.leaderPID(),
-			}, errMsg, true
+			}, errMsg, true, nil
 		}
 	}
+
+	// Ownership observation after spawn+bind: fail loud and reap if storage is broken.
+	if err := x.persistStatus(ctx, "running", nil, nil, nil); err != nil {
+		killCtx, cancel := context.WithTimeout(context.Background(), grace+15*time.Second)
+		_ = handle.Kill(killCtx)
+		cancel()
+		if hard := x.classifyPersistError(err); hard != nil {
+			x.reportHardPersistFailure(hard)
+			return Result{}, "", false, errors.Join(ErrExecutionPersistence, fmt.Errorf("persist fallback agent execution ownership: %w", hard))
+		}
+		return Result{}, "", false, errors.Join(ErrExecutionPersistence, fmt.Errorf("persist fallback agent execution ownership: %w", err))
+	}
+	x.executor.appendLifecycleEvent("agent.native_resume_fallback_started", x.input, x.executionID, map[string]any{"command": command, "args": args, "nativeResumeError": nativeError}, nowISO)
 
 	waitCh := make(chan error, 1)
 	go func() { waitCh <- handle.Wait(context.Background()) }()
@@ -1096,7 +1183,7 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 		ElapsedRuntimeSeconds:        durationSeconds(x.executor.now().UTC().Sub(x.startedAt)),
 		LastProgressAt:               x.lastProgressAtISO(),
 		PID:                          x.leaderPID(),
-	}, errorMessage, true
+	}, errorMessage, true, nil
 }
 
 func (x *execution) onOutput(stream string, chunk []byte) {
@@ -1135,7 +1222,13 @@ func (x *execution) onOutput(stream string, chunk []byte) {
 	x.mu.Unlock()
 
 	outputJSON := x.outputJSON(stdout, stderr)
-	x.persistStatus(x.currentStatus(), &heartbeatCount, &nowISO, &outputJSON)
+	if err := x.persistStatus(context.Background(), x.currentStatus(), &heartbeatCount, &nowISO, &outputJSON); err != nil {
+		if hard := x.classifyPersistError(err); hard != nil {
+			// First hard mid-life failure closes admission (degraded). Soft
+			// cancel/conflict/busy-after-retry do not sticky-degrade.
+			x.reportHardPersistFailure(hard)
+		}
+	}
 	x.bumpRunHeartbeat(nowISO)
 	x.maybeEmitProgress(now, stdout, stderr)
 }
@@ -1243,9 +1336,20 @@ func (x *execution) bumpRunHeartbeat(nowISO string) {
 	_ = x.executor.repos.Runs.Upsert(ctx, updated)
 }
 
-func (x *execution) persistStatus(status string, heartbeatCount *int64, heartbeatAt *string, outputJSON *string) {
+// persistStatus writes a live (or initial) observation. One ordered writer per
+// execution (persistMu). After a terminal observation is recorded, live writes
+// are no-ops so a stale heartbeat cannot race terminal immutability.
+func (x *execution) persistStatus(ctx context.Context, status string, heartbeatCount *int64, heartbeatAt *string, outputJSON *string) error {
+	x.persistMu.Lock()
+	defer x.persistMu.Unlock()
+	if x.terminalPersisted {
+		return nil
+	}
 	if x.executor.repos == nil || x.executor.repos.AgentExecutions == nil {
-		return
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	nativeSessionID, nativeResumeMode, nativeResumeStatus, nativeResumeError := x.nativeResumeSnapshot()
 	metadata := mustJSON(x.executionMetadata(""))
@@ -1280,12 +1384,17 @@ func (x *execution) persistStatus(status string, heartbeatCount *int64, heartbea
 	if outputJSON != nil {
 		record.OutputJSON = outputJSON
 	}
-	_ = x.executor.repos.AgentExecutions.Upsert(context.Background(), record)
+	return x.upsertAgentExecutionWithRetry(ctx, record)
 }
 
-func (x *execution) persistFinal(status string, result Result, errorMessage, endedAtISO string) {
+// persistFinal writes the terminal observation after containment is confirmed
+// dead. Failures must surface to Wait; callers degrade on hard storage errors.
+func (x *execution) persistFinal(status string, result Result, errorMessage, endedAtISO string) error {
+	x.persistMu.Lock()
+	defer x.persistMu.Unlock()
 	if x.executor.repos == nil || x.executor.repos.AgentExecutions == nil {
-		return
+		x.terminalPersisted = true
+		return nil
 	}
 	nativeSessionID, nativeResumeMode, nativeResumeStatus, nativeResumeError := x.nativeResumeSnapshot()
 	commandJSON := mustJSON(map[string]any{"command": x.command, "args": x.args})
@@ -1338,7 +1447,104 @@ func (x *execution) persistFinal(status string, result Result, errorMessage, end
 		CreatedAt:          x.startedAtISO,
 		UpdatedAt:          endedAtISO,
 	}
-	_ = x.executor.repos.AgentExecutions.Upsert(context.Background(), record)
+	err := x.upsertAgentExecutionWithRetry(context.Background(), record)
+	// Mark terminal attempted so live writers stop; conflict after another
+	// terminal observation also counts as terminal settled.
+	if err == nil || errors.Is(err, storage.ErrAgentExecutionConflict) {
+		x.terminalPersisted = true
+	}
+	if errors.Is(err, storage.ErrAgentExecutionConflict) {
+		// Another writer already recorded a terminal observation — treat as
+		// durable success for this process lifetime (no silent overwrite).
+		return nil
+	}
+	return err
+}
+
+// upsertAgentExecutionWithRetry performs one soft retry on SQLITE_BUSY /
+// locked storage. Cancel/deadline are not retried.
+func (x *execution) upsertAgentExecutionWithRetry(ctx context.Context, record storage.AgentExecutionRecord) error {
+	err := x.executor.repos.AgentExecutions.Upsert(ctx, record)
+	if err == nil || !isSQLiteBusyPersistError(err) {
+		return err
+	}
+	// Soft/transient: single retry only. Do not sticky-degrade on pure busy.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(25 * time.Millisecond):
+	}
+	return x.executor.repos.AgentExecutions.Upsert(ctx, record)
+}
+
+// classifyPersistError returns a non-nil hard error when infrastructure must
+// fail loud and/or degrade. Soft errors (cancel, deadline, conflict after
+// terminal won) return nil so callers do not sticky-degrade.
+func (x *execution) classifyPersistError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	if errors.Is(err, storage.ErrAgentExecutionConflict) {
+		return nil
+	}
+	return err
+}
+
+func isSQLiteBusyPersistError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		return sqliteErr.Code == sqlite3.ErrBusy || sqliteErr.Code == sqlite3.ErrLocked
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "database is locked") || strings.Contains(msg, "sqlite_busy")
+}
+
+func (x *execution) reportHardPersistFailure(err error) {
+	if err == nil || x == nil || x.executor == nil {
+		return
+	}
+	x.mu.Lock()
+	if x.hardPersistReported {
+		x.mu.Unlock()
+		return
+	}
+	x.hardPersistReported = true
+	fn := x.executor.onHardPersistFailure
+	x.mu.Unlock()
+	if fn != nil {
+		fn(err)
+	}
+}
+
+// ensureConfirmedDeadBeforeTerminal drains the containment handle when the
+// leader has exited but descendants may still be runnable. Terminal status is
+// not published until ConfirmedDead for owned handles (#574/#578).
+func (x *execution) ensureConfirmedDeadBeforeTerminal() error {
+	if x == nil || x.handle == nil {
+		return nil
+	}
+	if x.handle.ConfirmedDead() {
+		return nil
+	}
+	grace := x.gracefulShutdown
+	if grace <= 0 {
+		grace = 5 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), grace+15*time.Second)
+	defer cancel()
+	if err := x.handle.Drain(ctx); err != nil && !x.handle.ConfirmedDead() {
+		return err
+	}
+	if !x.handle.ConfirmedDead() {
+		return processcontainment.ErrNotConfirmedDead
+	}
+	return nil
 }
 
 func (x *execution) currentStatus() string {

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -1212,7 +1212,10 @@ func (x *execution) onOutput(stream string, chunk []byte) {
 	x.mu.Unlock()
 
 	outputJSON := x.outputJSON(stdout, stderr)
-	if err := x.persistStatus(context.Background(), x.currentStatus(), &heartbeatCount, &nowISO, &outputJSON); err != nil {
+	// Mid-life output must not publish terminal observations: timeout/kill may
+	// already be set in-memory while the process group is still draining, and
+	// terminal rows are immutable (ADR-0015 R5 / ensureConfirmedDeadBeforeTerminal).
+	if err := x.persistStatus(context.Background(), x.liveObservationStatus(), &heartbeatCount, &nowISO, &outputJSON); err != nil {
 		if hard := x.classifyPersistError(err); hard != nil {
 			// First hard mid-life failure closes admission (degraded). Soft
 			// cancel/conflict/busy-after-retry do not sticky-degrade.
@@ -1570,6 +1573,27 @@ func (x *execution) currentStatus() string {
 	x.mu.Lock()
 	defer x.mu.Unlock()
 	return x.status
+}
+
+// liveObservationStatus maps in-memory lifecycle status to a non-terminal
+// durable observation for mid-life heartbeat/output writes. Terminal values
+// stay in memory for finalStatus/persistFinal after containment is confirmed
+// dead; publishing them early would freeze the durable row while the process
+// group can still be live.
+func (x *execution) liveObservationStatus() string {
+	status := x.currentStatus()
+	if !storage.IsTerminalAgentExecutionStatus(status) {
+		if status == "" {
+			return "running"
+		}
+		return status
+	}
+	switch status {
+	case "timeout", "killed":
+		return "cancelling"
+	default:
+		return "running"
+	}
 }
 
 func (x *execution) setStatus(status string) {

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -448,29 +448,16 @@ func (e *ConfiguredExecutor) Start(ctx context.Context, input RunInput) (Executi
 
 	// Initial ownership observation is hard: fail Start loud and do not leave
 	// an unowned live process (#578). Persist before transferring lease so the
-	// deferred Release still drains Supervisor ownership on failure.
+	// deferred Release still drains Supervisor ownership when reap confirms dead.
 	if err := x.persistStatus(ctx, "running", nil, nil, nil); err != nil {
-		if hard := x.classifyPersistError(err); hard != nil {
-			x.reportHardPersistFailure(hard)
-			killCtx, cancel := context.WithTimeout(context.Background(), grace+15*time.Second)
-			if x.handle != nil {
-				_ = x.handle.Kill(killCtx)
-			} else {
-				_ = killStartedCmd(cmd)
-			}
-			cancel()
-			return nil, errors.Join(ErrExecutionPersistence, fmt.Errorf("persist initial agent execution ownership: %w", hard))
+		outErr := x.reapOnOwnershipPersistFailure(cmd, grace, err, "persist initial agent execution ownership")
+		// When Kill cannot confirm death, keep the registry handle: dropping the
+		// lease here would leave a still-live agent with neither a durable row
+		// nor an owner (Start returns no Execution).
+		if x.handle != nil && !x.handle.ConfirmedDead() {
+			lease = nil
 		}
-		// Soft (cancel/conflict): still refuse Start without a durable observation
-		// when storage rejected or cancelled, but do not sticky-degrade.
-		killCtx, cancel := context.WithTimeout(context.Background(), grace+15*time.Second)
-		if x.handle != nil {
-			_ = x.handle.Kill(killCtx)
-		} else {
-			_ = killStartedCmd(cmd)
-		}
-		cancel()
-		return nil, errors.Join(ErrExecutionPersistence, fmt.Errorf("persist initial agent execution ownership: %w", err))
+		return nil, outErr
 	}
 
 	// Transfer lease ownership to execution; defer must not Release on success.
@@ -600,6 +587,13 @@ func (x *execution) killProcessGroup() error {
 func (x *execution) releaseLease() {
 	x.mu.Lock()
 	if x.leaseReleased || x.lease == nil {
+		x.mu.Unlock()
+		return
+	}
+	// Prefer a durable registry orphan over an unowned live process: do not drop
+	// Supervisor ownership while containment may still be live (e.g. Kill timeout
+	// after failed ownership persist on native-resume fallback).
+	if x.handle != nil && !x.handle.ConfirmedDead() {
 		x.mu.Unlock()
 		return
 	}
@@ -818,7 +812,8 @@ func (x *execution) run(ctx context.Context) {
 				errorMessage = fallbackErrorMessage
 				endedAtISO = eventlog.FormatJavaScriptISOString(x.executor.now().UTC())
 			} else if fallbackErr != nil {
-				// Fallback ownership persist failed after process reaped.
+				// Fallback ownership persist failed; process reaped only when
+				// Kill confirmed dead (releaseLease keeps ownership otherwise).
 				x.doneCh <- execOutcome{result: result, err: fallbackErr}
 				return
 			}
@@ -1030,15 +1025,10 @@ func (x *execution) runCheckpointFallback(ctx context.Context, nativeError strin
 	}
 
 	// Ownership observation after spawn+bind: fail loud and reap if storage is broken.
+	// Join Kill failures and keep registry ownership unless ConfirmedDead so a
+	// deferred run releaseLease cannot drop the only live handle on drain timeout.
 	if err := x.persistStatus(ctx, "running", nil, nil, nil); err != nil {
-		killCtx, cancel := context.WithTimeout(context.Background(), grace+15*time.Second)
-		_ = handle.Kill(killCtx)
-		cancel()
-		if hard := x.classifyPersistError(err); hard != nil {
-			x.reportHardPersistFailure(hard)
-			return Result{}, "", false, errors.Join(ErrExecutionPersistence, fmt.Errorf("persist fallback agent execution ownership: %w", hard))
-		}
-		return Result{}, "", false, errors.Join(ErrExecutionPersistence, fmt.Errorf("persist fallback agent execution ownership: %w", err))
+		return Result{}, "", false, x.reapOnOwnershipPersistFailure(cmd, grace, err, "persist fallback agent execution ownership")
 	}
 	x.executor.appendLifecycleEvent("agent.native_resume_fallback_started", x.input, x.executionID, map[string]any{"command": command, "args": args, "nativeResumeError": nativeError}, nowISO)
 
@@ -1449,15 +1439,13 @@ func (x *execution) persistFinal(status string, result Result, errorMessage, end
 	}
 	err := x.upsertAgentExecutionWithRetry(context.Background(), record)
 	// Mark terminal attempted so live writers stop; conflict after another
-	// terminal observation also counts as terminal settled.
+	// terminal observation also counts as terminal settled for mid-life writes.
 	if err == nil || errors.Is(err, storage.ErrAgentExecutionConflict) {
 		x.terminalPersisted = true
 	}
-	if errors.Is(err, storage.ErrAgentExecutionConflict) {
-		// Another writer already recorded a terminal observation — treat as
-		// durable success for this process lifetime (no silent overwrite).
-		return nil
-	}
+	// Surface terminal conflicts: a competing terminal with a different status
+	// is not durable finalize success (storage contract / #578). Callers fail
+	// loud without sticky-degrade (classifyPersistError treats conflict as soft).
 	return err
 }
 
@@ -1520,6 +1508,37 @@ func (x *execution) reportHardPersistFailure(err error) {
 	if fn != nil {
 		fn(err)
 	}
+}
+
+// reapOnOwnershipPersistFailure kills the just-started process after a failed
+// initial/fallback ownership observation, joins drain errors into the return,
+// and sticky-degrades on hard storage failure. Soft persist errors still fail
+// Start/fallback loud without degrade. Callers must keep Supervisor ownership
+// when the containment handle is not ConfirmedDead after this returns.
+func (x *execution) reapOnOwnershipPersistFailure(cmd *exec.Cmd, grace time.Duration, persistErr error, msg string) error {
+	hard := x.classifyPersistError(persistErr)
+	var base error
+	if hard != nil {
+		x.reportHardPersistFailure(hard)
+		base = errors.Join(ErrExecutionPersistence, fmt.Errorf("%s: %w", msg, hard))
+	} else {
+		base = errors.Join(ErrExecutionPersistence, fmt.Errorf("%s: %w", msg, persistErr))
+	}
+	if grace <= 0 {
+		grace = 5 * time.Second
+	}
+	killCtx, cancel := context.WithTimeout(context.Background(), grace+15*time.Second)
+	defer cancel()
+	var killErr error
+	if x.handle != nil {
+		killErr = x.handle.Kill(killCtx)
+	} else if cmd != nil {
+		killErr = killStartedCmd(cmd)
+	}
+	if killErr != nil {
+		return errors.Join(base, killErr)
+	}
+	return base
 }
 
 // ensureConfirmedDeadBeforeTerminal drains the containment handle when the

--- a/internal/agent/executor_persist_ownership_test.go
+++ b/internal/agent/executor_persist_ownership_test.go
@@ -1,0 +1,235 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/processcontainment"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// trackingLease records BindHandle ownership and Release calls for Start failure paths.
+type trackingLease struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	handle   *processcontainment.Handle
+	released bool
+}
+
+func (l *trackingLease) Context() context.Context { return l.ctx }
+func (l *trackingLease) BindHandle(handle *processcontainment.Handle, _ SoftKillFunc) error {
+	l.handle = handle
+	return nil
+}
+func (l *trackingLease) Release() {
+	l.released = true
+	if l.cancel != nil {
+		l.cancel()
+	}
+}
+
+type trackingOwner struct {
+	lease *trackingLease
+}
+
+func (o *trackingOwner) AdmitSpawn(ctx context.Context, _ SpawnMeta) (SpawnLease, error) {
+	leaseCtx, cancel := context.WithCancel(ctx)
+	o.lease = &trackingLease{ctx: leaseCtx, cancel: cancel}
+	return o.lease, nil
+}
+
+// When initial ownership persist fails and Kill confirms death, Start may Release
+// the lease. When Kill cannot confirm death, Start must keep ownership.
+func TestStartOwnershipAfterInitialPersistFailure(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+
+	owner := &trackingOwner{}
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh", "args": []any{"-c", "trap '' TERM; while true; do sleep 1; done"},
+		}},
+		Repos: repos,
+		Owner: owner,
+	})
+
+	handle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID: "agent_initial_persist_keep_owner", WorkingDirectory: t.TempDir(), Prompt: "ignored",
+		Timeout: time.Second,
+	})
+	if err == nil {
+		t.Fatal("Start() error = nil, want initial persistence failure")
+	}
+	if !errors.Is(err, ErrExecutionPersistence) {
+		t.Fatalf("Start() error = %v, want ErrExecutionPersistence", err)
+	}
+	if handle != nil {
+		t.Fatalf("Start() handle = %#v, want nil", handle)
+	}
+	if owner.lease == nil || owner.lease.handle == nil {
+		t.Fatal("expected tracking lease with bound handle")
+	}
+	// Normal path: reap succeeds → ConfirmedDead and lease released.
+	if !owner.lease.handle.ConfirmedDead() {
+		t.Fatal("handle not ConfirmedDead after initial-persist failure reap")
+	}
+	if !owner.lease.released {
+		t.Fatal("lease.Release not called after ConfirmedDead reap on Start failure")
+	}
+}
+
+// releaseLease must not drop Supervisor ownership while containment is live.
+func TestReleaseLeaseSkipsWhenHandleNotConfirmedDead(t *testing.T) {
+	cmd := exec.Command("sleep", "60")
+	processcontainment.Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+	signalFail := errors.New("synthetic signal delivery failure")
+	handle, err := processcontainment.Bind(cmd, processcontainment.Options{
+		GracePeriod:  10 * time.Millisecond,
+		DrainTimeout: 100 * time.Millisecond,
+		Signal: func(pid int, sig syscall.Signal) error {
+			return signalFail
+		},
+	})
+	if err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("Bind: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	})
+
+	lease := &trackingLease{}
+	x := &execution{
+		handle: handle,
+		lease:  lease,
+	}
+	killCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	killErr := handle.Kill(killCtx)
+	cancel()
+	if killErr == nil {
+		t.Fatal("Kill() error = nil, want not-confirmed failure with injected signal")
+	}
+	if handle.ConfirmedDead() {
+		t.Fatal("ConfirmedDead() = true after failed Kill")
+	}
+
+	x.releaseLease()
+	if lease.released {
+		t.Fatal("releaseLease released ownership while handle not ConfirmedDead")
+	}
+
+	// Normal path still releases when there is no live handle.
+	x.handle = nil
+	x.releaseLease()
+	if !lease.released {
+		t.Fatal("releaseLease did not release when handle is nil")
+	}
+}
+
+// reapOnOwnershipPersistFailure must join Kill errors into the return value.
+func TestReapOnOwnershipPersistFailureJoinsKillError(t *testing.T) {
+	cmd := exec.Command("sleep", "60")
+	processcontainment.Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+	signalFail := errors.New("synthetic signal delivery failure")
+	handle, err := processcontainment.Bind(cmd, processcontainment.Options{
+		GracePeriod:  10 * time.Millisecond,
+		DrainTimeout: 50 * time.Millisecond,
+		Signal: func(pid int, sig syscall.Signal) error {
+			return signalFail
+		},
+	})
+	if err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("Bind: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	})
+
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendorCodex}})
+	x := &execution{executor: executor, handle: handle}
+	persistErr := errors.New("sqlite closed")
+	got := x.reapOnOwnershipPersistFailure(cmd, 10*time.Millisecond, persistErr, "persist initial agent execution ownership")
+	if !errors.Is(got, ErrExecutionPersistence) {
+		t.Fatalf("error = %v, want ErrExecutionPersistence", got)
+	}
+	if !errors.Is(got, persistErr) {
+		t.Fatalf("error = %v, want joined persist cause", got)
+	}
+	if !errors.Is(got, signalFail) && !errors.Is(got, processcontainment.ErrNotConfirmedDead) && !strings.Contains(got.Error(), "synthetic signal") {
+		t.Fatalf("error = %v, want joined kill/not-confirmed drain failure", got)
+	}
+	if handle.ConfirmedDead() {
+		t.Fatal("ConfirmedDead() = true after failed reap")
+	}
+}
+
+// Competing terminal status must surface ErrAgentExecutionConflict, not success.
+func TestPersistFinalSurfacesTerminalConflict(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendorCodex}, Repos: repos})
+	x := &execution{
+		executor:       executor,
+		executionID:    "agent_terminal_conflict",
+		input:          RunInput{WorkingDirectory: t.TempDir(), Prompt: "x"},
+		startedAtISO:   "2026-07-18T00:00:00.000Z",
+		maxOutputBytes: defaultMaxOutputBytes,
+		process:        exec.Command("/bin/true"),
+	}
+	if err := x.persistStatus(context.Background(), "running", nil, nil, nil); err != nil {
+		t.Fatalf("initial persistStatus error = %v", err)
+	}
+	if err := x.persistFinal("killed", Result{Status: "killed", HeartbeatCount: 1}, "stop", "2026-07-18T00:01:00.000Z"); err != nil {
+		t.Fatalf("persistFinal(killed) error = %v", err)
+	}
+	x2 := &execution{
+		executor:       executor,
+		executionID:    "agent_terminal_conflict",
+		input:          x.input,
+		startedAtISO:   x.startedAtISO,
+		maxOutputBytes: defaultMaxOutputBytes,
+		process:        exec.Command("/bin/true"),
+	}
+	err := x2.persistFinal("completed", Result{Status: "completed", HeartbeatCount: 2}, "", "2026-07-18T00:02:00.000Z")
+	if err == nil {
+		t.Fatal("persistFinal(completed over killed) error = nil, want conflict")
+	}
+	if !errors.Is(err, storage.ErrAgentExecutionConflict) {
+		t.Fatalf("persistFinal error = %v, want ErrAgentExecutionConflict", err)
+	}
+	if !x2.terminalPersisted {
+		t.Fatal("terminalPersisted = false after conflict, want true so live writers stop")
+	}
+	if hard := x2.classifyPersistError(err); hard != nil {
+		t.Fatalf("classifyPersistError(conflict) = %v, want nil (no sticky degrade)", hard)
+	}
+	got, getErr := repos.AgentExecutions.GetByID(context.Background(), x.executionID)
+	if getErr != nil {
+		t.Fatalf("GetByID error = %v", getErr)
+	}
+	if got == nil || got.Status != "killed" {
+		t.Fatalf("durable status = %#v, want killed", got)
+	}
+}

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -1515,6 +1515,61 @@ func TestPersistStatusNoOpAfterTerminalPersisted(t *testing.T) {
 	}
 }
 
+// Mid-life output after timeout/kill must keep the durable row active
+// (cancelling) until ensureConfirmedDeadBeforeTerminal + persistFinal.
+func TestOnOutputDoesNotPersistTerminalBeforeDrain(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendorCodex}, Repos: repos})
+	x := &execution{
+		executor:       executor,
+		executionID:    "agent_midlife_no_terminal",
+		input:          RunInput{WorkingDirectory: t.TempDir(), Prompt: "x"},
+		startedAt:      time.Now().UTC(),
+		startedAtISO:   "2026-07-18T00:00:00.000Z",
+		maxOutputBytes: defaultMaxOutputBytes,
+		status:         "running",
+		process:        exec.Command("/bin/true"),
+	}
+	if err := x.persistStatus(context.Background(), "running", nil, nil, nil); err != nil {
+		t.Fatalf("initial persistStatus error = %v", err)
+	}
+
+	for _, terminal := range []string{"timeout", "killed"} {
+		x.setStatus(terminal)
+		x.onOutput("stdout", []byte("final flush while draining\n"))
+
+		got, err := repos.AgentExecutions.GetByID(context.Background(), x.executionID)
+		if err != nil {
+			t.Fatalf("GetByID after %s flush error = %v", terminal, err)
+		}
+		if got == nil {
+			t.Fatalf("GetByID after %s flush = nil", terminal)
+		}
+		if got.Status != "cancelling" {
+			t.Fatalf("durable status after in-memory %s = %q, want cancelling (active until drain)", terminal, got.Status)
+		}
+		if !storage.IsActiveAgentExecutionStatus(got.Status) {
+			t.Fatalf("status %q is not active after mid-life flush under %s", got.Status, terminal)
+		}
+		if got.HeartbeatCount < 1 {
+			t.Fatalf("HeartbeatCount = %d after mid-life flush, want progress persisted", got.HeartbeatCount)
+		}
+	}
+
+	// Final path still publishes terminal after drain authority.
+	if err := x.persistFinal("killed", Result{Status: "killed", HeartbeatCount: x.heartbeatCountValue()}, "stop", "2026-07-18T00:02:00.000Z"); err != nil {
+		t.Fatalf("persistFinal error = %v", err)
+	}
+	got, err := repos.AgentExecutions.GetByID(context.Background(), x.executionID)
+	if err != nil {
+		t.Fatalf("GetByID after terminal error = %v", err)
+	}
+	if got == nil || got.Status != "killed" {
+		t.Fatalf("durable status after persistFinal = %#v, want killed", got)
+	}
+}
+
 func openAgentCoordinator(t *testing.T) *storage.SQLiteCoordinator {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "agent.sqlite")

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1339,6 +1341,177 @@ func TestExecutorExplicitKillMarksKilled(t *testing.T) {
 	}
 	if result.Status != "killed" {
 		t.Fatalf("result status = %q, want killed", result.Status)
+	}
+}
+
+func TestExecutorStartFailsAndReapsProcessWhenInitialPersistenceFails(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+	workDir := t.TempDir()
+	pidPath := filepath.Join(workDir, "agent.pid")
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+		"command": "/bin/sh", "args": []any{"-c", `echo $$ > "$PID_FILE"; trap '' TERM; while true; do sleep 1; done`},
+	}}, Repos: repos})
+
+	handle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID: "agent_initial_persist_failure", WorkingDirectory: workDir, Prompt: "ignored",
+		Timeout: time.Second, Env: map[string]string{"PID_FILE": pidPath},
+	})
+	if err == nil {
+		t.Fatal("Start() error = nil, want initial persistence failure")
+	}
+	if !errors.Is(err, ErrExecutionPersistence) {
+		t.Fatalf("Start() error = %v, want ErrExecutionPersistence", err)
+	}
+	if handle != nil {
+		t.Fatalf("Start() handle = %#v, want nil", handle)
+	}
+	if data, readErr := os.ReadFile(pidPath); readErr == nil {
+		pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+		if parseErr != nil {
+			t.Fatalf("parse pid: %v", parseErr)
+		}
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if killErr := syscall.Kill(pid, 0); killErr == syscall.ESRCH {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatalf("spawned process %d survived failed Start", pid)
+	}
+}
+
+func TestExecutorWaitSurfacesTerminalPersistenceFailure(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	var degraded []error
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh", "args": []any{"-c", "sleep 0.05; printf 'done\\n'"},
+		}},
+		Repos:                repos,
+		OnHardPersistFailure: func(err error) { degraded = append(degraded, err) },
+	})
+	handle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID: "agent_terminal_persist_failure", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+
+	_, err = handle.Wait(context.Background())
+	if err == nil || !errors.Is(err, ErrExecutionPersistence) {
+		t.Fatalf("Wait() error = %v, want ErrExecutionPersistence", err)
+	}
+	if !strings.Contains(err.Error(), "persist terminal agent execution") {
+		t.Fatalf("Wait() error = %v, want terminal persistence message", err)
+	}
+	if len(degraded) == 0 {
+		t.Fatal("OnHardPersistFailure was not called for terminal hard failure")
+	}
+}
+
+func TestExecutorMidLifeHardPersistFailureReportsDegradeHook(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	var degraded []error
+	executor := New(ExecutorOptions{
+		Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+			"command": "/bin/sh", "args": []any{"-c", `i=0; while [ $i -lt 50 ]; do printf 'tick %s\n' "$i"; i=$((i+1)); sleep 0.02; done`},
+		}},
+		Repos:                repos,
+		OnHardPersistFailure: func(err error) { degraded = append(degraded, err) },
+	})
+	handle, err := executor.Start(context.Background(), RunInput{
+		ExecutionID: "agent_midlife_persist_failure", WorkingDirectory: t.TempDir(), Prompt: "ignored", Timeout: 3 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	// Close storage after initial ownership so the first mid-life output write hard-fails.
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(degraded) == 0 {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(degraded) == 0 {
+		_ = handle.Kill("test cleanup")
+		_, _ = handle.Wait(context.Background())
+		t.Fatal("OnHardPersistFailure was not called for mid-life hard failure")
+	}
+	_ = handle.Kill("test cleanup")
+	_, _ = handle.Wait(context.Background())
+}
+
+func TestCheckpointFallbackReapsSpawnWhenOwnershipPersistenceFails(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("coordinator.Close() error = %v", err)
+	}
+	configured := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendor("custom"), Params: map[string]any{
+		"command": "/bin/sh", "args": []any{"-c", "trap '' TERM; while true; do sleep 1; done"},
+	}}, Repos: repos})
+	x := &execution{
+		executor:       configured,
+		input:          RunInput{WorkingDirectory: t.TempDir(), Prompt: "retry", Timeout: time.Second},
+		executionID:    "agent_fallback_persist_failure",
+		startedAt:      time.Now(),
+		startedAtISO:   time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+		maxOutputBytes: defaultMaxOutputBytes,
+	}
+
+	_, _, ok, err := x.runCheckpointFallback(context.Background(), "resume failed")
+	if ok {
+		t.Fatal("runCheckpointFallback() ok = true, want infrastructure failure")
+	}
+	if err == nil || !errors.Is(err, ErrExecutionPersistence) {
+		t.Fatalf("runCheckpointFallback() error = %v, want ErrExecutionPersistence", err)
+	}
+	if !strings.Contains(err.Error(), "persist fallback agent execution ownership") {
+		t.Fatalf("runCheckpointFallback() error = %v, want ownership persistence message", err)
+	}
+}
+
+func TestPersistStatusNoOpAfterTerminalPersisted(t *testing.T) {
+	coordinator := openAgentCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendorCodex}, Repos: repos})
+	x := &execution{
+		executor:       executor,
+		executionID:    "agent_persist_mu",
+		input:          RunInput{WorkingDirectory: t.TempDir(), Prompt: "x"},
+		startedAtISO:   "2026-07-18T00:00:00.000Z",
+		maxOutputBytes: defaultMaxOutputBytes,
+		process:        exec.Command("/bin/true"),
+	}
+	if err := x.persistStatus(context.Background(), "running", nil, nil, nil); err != nil {
+		t.Fatalf("initial persistStatus error = %v", err)
+	}
+	ended := "2026-07-18T00:01:00.000Z"
+	if err := x.persistFinal("completed", Result{Status: "completed", HeartbeatCount: 1}, "", ended); err != nil {
+		t.Fatalf("persistFinal error = %v", err)
+	}
+	hb := int64(99)
+	at := "2026-07-18T00:02:00.000Z"
+	if err := x.persistStatus(context.Background(), "running", &hb, &at, nil); err != nil {
+		t.Fatalf("post-terminal persistStatus error = %v", err)
+	}
+	got, err := repos.AgentExecutions.GetByID(context.Background(), x.executionID)
+	if err != nil {
+		t.Fatalf("GetByID error = %v", err)
+	}
+	if got == nil || got.Status != "completed" || got.HeartbeatCount != 1 {
+		t.Fatalf("got %#v, want completed with heartbeat 1 (no active regress)", got)
 	}
 }
 

--- a/internal/runtime/active_executions.go
+++ b/internal/runtime/active_executions.go
@@ -71,6 +71,10 @@ type ActiveExecutionRegistry struct {
 	// (tests that do not wire Runtime admission).
 	allowSpawn func() error
 
+	// onHardPersistFailure maps hard agent_executions write failures into the
+	// single sticky admission degraded state (ADR-0015 R5 / #578).
+	onHardPersistFailure func(error)
+
 	// killTimeout bounds handle.Kill during stop. Zero uses defaultKillTimeout.
 	killTimeout time.Duration
 }
@@ -96,6 +100,32 @@ func (r *ActiveExecutionRegistry) SetAllowSpawn(fn func() error) {
 	r.mu.Lock()
 	r.allowSpawn = fn
 	r.mu.Unlock()
+}
+
+// SetOnHardPersistFailure wires sticky admission degrade for hard execution
+// observation write failures (initial/heartbeat/output/terminal). Soft cancel
+// and conflict after terminal won must not invoke this callback.
+func (r *ActiveExecutionRegistry) SetOnHardPersistFailure(fn func(error)) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.onHardPersistFailure = fn
+	r.mu.Unlock()
+}
+
+// ReportHardPersistFailure surfaces a hard agent_executions write failure into
+// daemon admission. Safe to call from agent executor mid-life paths.
+func (r *ActiveExecutionRegistry) ReportHardPersistFailure(err error) {
+	if r == nil || err == nil {
+		return
+	}
+	r.mu.Lock()
+	fn := r.onHardPersistFailure
+	r.mu.Unlock()
+	if fn != nil {
+		fn(err)
+	}
 }
 
 // spawnLease implements agent.SpawnLease.

--- a/internal/runtime/execution_persistence_degrade_test.go
+++ b/internal/runtime/execution_persistence_degrade_test.go
@@ -1,0 +1,57 @@
+package runtime
+
+import (
+	"errors"
+	"testing"
+)
+
+// Contract: hard agent_executions persistence failure closes admission via the
+// single sticky degraded state (ADR-0015 R5 / #578). Soft paths must not call
+// ReportHardPersistFailure.
+func TestHardPersistFailureDegradesAdmission(t *testing.T) {
+	rt := New(Options{})
+	if err := rt.admission.MarkReady("test ready"); err != nil {
+		t.Fatalf("MarkReady() error = %v", err)
+	}
+	if err := rt.AllowClaim(); err != nil {
+		t.Fatalf("AllowClaim() before degrade error = %v", err)
+	}
+
+	hard := errors.New("sqlite disk I/O error")
+	rt.activeExecutions.ReportHardPersistFailure(hard)
+
+	if got := rt.AdmissionState(); got != AdmissionDegraded {
+		t.Fatalf("AdmissionState() = %s, want degraded", got)
+	}
+	if err := rt.AllowClaim(); !errors.Is(err, ErrAdmissionDegraded) {
+		t.Fatalf("AllowClaim() error = %v, want ErrAdmissionDegraded", err)
+	}
+	if err := rt.AllowMutations(); !errors.Is(err, ErrAdmissionDegraded) {
+		t.Fatalf("AllowMutations() error = %v, want ErrAdmissionDegraded", err)
+	}
+
+	// Operator recovery: restart is the normal path; ClearDegraded exists for
+	// tests and explicit clear hooks.
+	if err := rt.admission.ClearDegraded("operator cleared after storage repair"); err != nil {
+		t.Fatalf("ClearDegraded() error = %v", err)
+	}
+	if err := rt.AllowClaim(); err != nil {
+		t.Fatalf("AllowClaim() after clear error = %v", err)
+	}
+}
+
+func TestHardPersistFailureIsStickyOnce(t *testing.T) {
+	rt := New(Options{})
+	if err := rt.admission.MarkReady("test ready"); err != nil {
+		t.Fatalf("MarkReady() error = %v", err)
+	}
+	rt.activeExecutions.ReportHardPersistFailure(errors.New("first hard failure"))
+	// Second report while already degraded must not panic or reopen.
+	rt.activeExecutions.ReportHardPersistFailure(errors.New("second hard failure"))
+	if got := rt.AdmissionState(); got != AdmissionDegraded {
+		t.Fatalf("AdmissionState() = %s, want degraded", got)
+	}
+	if err := rt.admission.MarkReady("illegal reopen"); err == nil {
+		t.Fatal("MarkReady() from degraded succeeded, want illegal move")
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -279,6 +279,24 @@ func New(options Options) *Runtime {
 	// Project daemon Admission onto agent spawn leases so cmd.Start is refused
 	// while starting/stopping/degraded (#576 + #575).
 	rt.activeExecutions.SetAllowSpawn(rt.AllowClaim)
+	// Hard agent_executions observation failures close admission until
+	// restart/clear (#578 / ADR-0015 R5). Prefer split-brain stop over silent continue.
+	rt.activeExecutions.SetOnHardPersistFailure(func(err error) {
+		reason := "agent execution persistence hard failure"
+		if err != nil {
+			reason = reason + ": " + err.Error()
+		}
+		if markErr := rt.MarkDegraded(reason); markErr != nil && rt.logger != nil {
+			rt.logger.Warn("failed to mark admission degraded after persistence failure", map[string]any{
+				"error":  markErr.Error(),
+				"reason": reason,
+			})
+		} else if rt.logger != nil {
+			rt.logger.Error("daemon admission degraded after agent execution persistence failure", map[string]any{
+				"reason": reason,
+			})
+		}
+	})
 	if rt.webhook != nil {
 		rt.webhook.forwarder = rt.WebhookForwarder
 		// Tunnel listener is not behind the API mutation gate; consult the same

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -3067,6 +3067,12 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		// Common executor boundary ownership for every in-scope agent role
 		// (planner/reviewer/fixer/worker/coordinator) — not post-spawn adapters (#576).
 		Owner: activeExecutions,
+		// Hard observation write failures degrade sticky admission (#578).
+		OnHardPersistFailure: func(err error) {
+			if activeExecutions != nil {
+				activeExecutions.ReportHardPersistFailure(err)
+			}
+		},
 		// Live progress → Feishu anchor card. Vendor-agnostic (works off the agent
 		// subprocess's stdout tail). Only wired when the Feishu app-bot transport is
 		// configured; a no-op otherwise.

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -12,6 +12,36 @@ import (
 
 var ErrQueueItemNotActive = errors.New("queue item not active")
 
+// ErrAgentExecutionConflict is returned when an agent_executions upsert is
+// rejected by the terminal-observation immutability guard (zero rows updated).
+// Callers must not treat this as success.
+var ErrAgentExecutionConflict = errors.New("agent execution observation conflict")
+
+// IsActiveAgentExecutionStatus reports whether status is a live (non-terminal)
+// observation. Active statuses may be updated freely; terminal rows cannot
+// regress back into these values.
+func IsActiveAgentExecutionStatus(status string) bool {
+	switch status {
+	case "running", "cancelling":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsTerminalAgentExecutionStatus reports whether status is a durable terminal
+// observation. Terminal status is immutable once written: no terminal→active
+// and no terminal→other-terminal transitions. Same-terminal field enrichment
+// (e.g. native resume metadata) is allowed; see AgentExecutionsRepository.Upsert.
+func IsTerminalAgentExecutionStatus(status string) bool {
+	switch status {
+	case "completed", "failed", "timeout", "killed", "success":
+		return true
+	default:
+		return false
+	}
+}
+
 type sqliteQuerier interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
@@ -995,8 +1025,22 @@ func (r *RunsRepository) ListByLoop(ctx context.Context, loopID string) ([]RunRe
 	return scanRuns(rows)
 }
 
+// Upsert writes a durable agent_executions observation (ADR-0015 R5 / #578).
+//
+// Terminal immutability policy (status column):
+//   - Active statuses: running, cancelling.
+//   - Terminal statuses: completed, failed, timeout, killed, success (legacy).
+//   - Active → active and active → terminal are allowed.
+//   - Terminal → active is forbidden (stale live writer cannot regress).
+//   - Terminal → different terminal is forbidden (first terminal wins).
+//   - Terminal → same terminal is allowed for non-status field enrichment
+//     (e.g. native-resume metadata) without changing the terminal outcome.
+//
+// Zero-row / rejected conflict updates return ErrAgentExecutionConflict, never
+// nil success. Callsites must surface conflict and must not treat it as durable
+// success for finalize/release paths.
 func (r *AgentExecutionsRepository) Upsert(ctx context.Context, record AgentExecutionRecord) error {
-	_, err := r.q.ExecContext(ctx, `
+	result, err := r.q.ExecContext(ctx, `
 		INSERT INTO agent_executions (id, project_id, loop_id, run_id, vendor, status, pid, command_json, cwd, summary, parse_status, completion_signal, heartbeat_count, last_heartbeat_at, output_json, error_message, native_session_id, native_resume_mode, native_resume_status, native_resume_error, started_at, ended_at, metadata_json, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
@@ -1023,9 +1067,21 @@ func (r *AgentExecutionsRepository) Upsert(ctx context.Context, record AgentExec
 			ended_at=excluded.ended_at,
 			metadata_json=excluded.metadata_json,
 			updated_at=excluded.updated_at
+		WHERE agent_executions.status IN ('running', 'cancelling')
+		   OR (
+				agent_executions.status NOT IN ('running', 'cancelling')
+				AND excluded.status = agent_executions.status
+		   )
 	`, record.ID, record.ProjectID, record.LoopID, record.RunID, record.Vendor, record.Status, record.PID, record.CommandJSON, record.CWD, record.Summary, record.ParseStatus, record.CompletionSignal, record.HeartbeatCount, record.LastHeartbeatAt, record.OutputJSON, record.ErrorMessage, record.NativeSessionID, record.NativeResumeMode, record.NativeResumeStatus, record.NativeResumeError, record.StartedAt, record.EndedAt, record.MetadataJSON, record.CreatedAt, record.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("upsert agent execution: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("upsert agent execution rows affected: %w", err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("%w: id=%s status=%s", ErrAgentExecutionConflict, record.ID, record.Status)
 	}
 
 	return nil

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -13,6 +13,151 @@ import (
 	"time"
 )
 
+func TestAgentExecutionTerminalObservationCannotRegressToActive(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	ctx := context.Background()
+	startedAt := "2026-07-16T12:00:00.000Z"
+	endedAt := "2026-07-16T12:01:00.000Z"
+	terminal := AgentExecutionRecord{
+		ID: "agent_terminal_monotonic", Vendor: "codex", Status: "completed",
+		StartedAt: startedAt, EndedAt: &endedAt, CreatedAt: startedAt, UpdatedAt: endedAt,
+	}
+	if err := repos.AgentExecutions.Upsert(ctx, terminal); err != nil {
+		t.Fatalf("Upsert(terminal) error = %v", err)
+	}
+
+	staleLive := terminal
+	staleLive.Status = "running"
+	staleLive.EndedAt = nil
+	staleLive.UpdatedAt = startedAt
+	err := repos.AgentExecutions.Upsert(ctx, staleLive)
+	if !errors.Is(err, ErrAgentExecutionConflict) {
+		t.Fatalf("Upsert(stale live) error = %v, want ErrAgentExecutionConflict", err)
+	}
+
+	got, err := repos.AgentExecutions.GetByID(ctx, terminal.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if got == nil || got.Status != "completed" || got.EndedAt == nil {
+		t.Fatalf("execution = %#v, want completed terminal observation", got)
+	}
+}
+
+func TestAgentExecutionTerminalToDifferentTerminalIsConflict(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	ctx := context.Background()
+	startedAt := "2026-07-16T12:00:00.000Z"
+	endedAt := "2026-07-16T12:01:00.000Z"
+	terminal := AgentExecutionRecord{
+		ID: "agent_terminal_to_terminal", Vendor: "codex", Status: "completed",
+		StartedAt: startedAt, EndedAt: &endedAt, CreatedAt: startedAt, UpdatedAt: endedAt,
+	}
+	if err := repos.AgentExecutions.Upsert(ctx, terminal); err != nil {
+		t.Fatalf("Upsert(completed) error = %v", err)
+	}
+
+	otherTerminal := terminal
+	otherTerminal.Status = "killed"
+	otherTerminal.UpdatedAt = "2026-07-16T12:02:00.000Z"
+	err := repos.AgentExecutions.Upsert(ctx, otherTerminal)
+	if !errors.Is(err, ErrAgentExecutionConflict) {
+		t.Fatalf("Upsert(killed over completed) error = %v, want ErrAgentExecutionConflict", err)
+	}
+
+	got, err := repos.AgentExecutions.GetByID(ctx, terminal.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if got == nil || got.Status != "completed" {
+		t.Fatalf("status = %q, want completed (first terminal wins)", got.Status)
+	}
+}
+
+func TestAgentExecutionSameTerminalFieldEnrichmentAllowed(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	ctx := context.Background()
+	startedAt := "2026-07-16T12:00:00.000Z"
+	endedAt := "2026-07-16T12:01:00.000Z"
+	terminal := AgentExecutionRecord{
+		ID: "agent_terminal_enrich", Vendor: "codex", Status: "completed",
+		StartedAt: startedAt, EndedAt: &endedAt, CreatedAt: startedAt, UpdatedAt: endedAt,
+	}
+	if err := repos.AgentExecutions.Upsert(ctx, terminal); err != nil {
+		t.Fatalf("Upsert(completed) error = %v", err)
+	}
+
+	enriched := terminal
+	resumeStatus := "failed"
+	resumeErr := "native resume unavailable"
+	enriched.NativeResumeStatus = &resumeStatus
+	enriched.NativeResumeError = &resumeErr
+	enriched.UpdatedAt = "2026-07-16T12:02:00.000Z"
+	if err := repos.AgentExecutions.Upsert(ctx, enriched); err != nil {
+		t.Fatalf("Upsert(same terminal enrichment) error = %v", err)
+	}
+
+	got, err := repos.AgentExecutions.GetByID(ctx, terminal.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if got == nil || got.Status != "completed" {
+		t.Fatalf("status = %#v, want completed", got)
+	}
+	if got.NativeResumeStatus == nil || *got.NativeResumeStatus != "failed" {
+		t.Fatalf("NativeResumeStatus = %#v, want failed", got.NativeResumeStatus)
+	}
+}
+
+func TestAgentExecutionActiveToTerminalAndCancellingAllowed(t *testing.T) {
+	t.Parallel()
+
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	ctx := context.Background()
+	startedAt := "2026-07-16T12:00:00.000Z"
+	live := AgentExecutionRecord{
+		ID: "agent_active_transitions", Vendor: "codex", Status: "running",
+		StartedAt: startedAt, CreatedAt: startedAt, UpdatedAt: startedAt,
+	}
+	if err := repos.AgentExecutions.Upsert(ctx, live); err != nil {
+		t.Fatalf("Upsert(running) error = %v", err)
+	}
+
+	cancelling := live
+	cancelling.Status = "cancelling"
+	cancelling.UpdatedAt = "2026-07-16T12:00:30.000Z"
+	if err := repos.AgentExecutions.Upsert(ctx, cancelling); err != nil {
+		t.Fatalf("Upsert(cancelling) error = %v", err)
+	}
+
+	endedAt := "2026-07-16T12:01:00.000Z"
+	killed := cancelling
+	killed.Status = "killed"
+	killed.EndedAt = &endedAt
+	killed.UpdatedAt = endedAt
+	if err := repos.AgentExecutions.Upsert(ctx, killed); err != nil {
+		t.Fatalf("Upsert(killed) error = %v", err)
+	}
+
+	got, err := repos.AgentExecutions.GetByID(ctx, live.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if got == nil || got.Status != "killed" {
+		t.Fatalf("status = %#v, want killed", got)
+	}
+}
+
 func TestRepositoriesRoundTripForProjectsLoopsRunsAndRuntimeMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/skills/looper/references/daemon.md
+++ b/skills/looper/references/daemon.md
@@ -108,3 +108,14 @@ Key daemon/runtime facts for webhook mode:
 - Webhook forwarders require a loopback daemon endpoint. Non-loopback `server.host` will degrade webhook mode.
 - If webhook runtime becomes degraded because stale remote GitHub CLI hooks already exist, prefer `looper webhook cleanup owner/repo` before restarting the daemon.
 - Restart is only the next step if status still shows degraded after cleanup or after fixing auth/path/config problems.
+
+### Admission degraded after agent execution persistence failure
+
+When SQLite cannot durable-publish `agent_executions` observations (initial ownership, mid-life heartbeat/output, or terminal), looperd closes the single sticky **admission** state (`degraded`) so new work cannot continue with split-brain observations (ADR-0015 / #578).
+
+Operator recovery:
+
+1. Read `looper daemon logs` / `looper daemon status --json` for admission `degraded` and a reason mentioning agent execution persistence.
+2. Repair storage under the runtime home (default `~/.looper/`): disk space, permissions, SQLite integrity.
+3. **Restart `looperd`** — normal recovery. Admission stays degraded until process restart (or an explicit clear hook used only in tests/ops tools).
+4. After restart, let startup recovery classify durable rows conservatively; do not force-requeue uncertain work.


### PR DESCRIPTION
## Summary

Make SQLite `agent_executions` a **durable observation** with one ordered writer per execution (not a second live Authority), and surface hard infrastructure failures into the single sticky admission/`degraded` state (ADR-0015 R5 / #578).

### Storage
- Terminal status immutability: no terminal→active and no terminal→different-terminal; same-terminal field enrichment allowed
- Zero-row / rejected upserts return `ErrAgentExecutionConflict` (never success)

### Executor / runtime
- Per-execution `persistMu` ordered write path
- **Initial** ownership persist after spawn+bind: fail `Start` loud + kill/drain (no unowned live process)
- **Heartbeat/output** mid-life: first hard failure reports `OnHardPersistFailure` → sticky admission degraded
- **Terminal**: fail loud via `Wait`; do not report successful completion; degrade if storage is broken
- Soft/transient: one SQLITE_BUSY retry; cancel/context death and conflict-after-terminal-won do not sticky-degrade
- No terminal status published before containment confirmed dead (`Drain` when needed)

### Docs
- ADR-0015 matrix R5 → **Enforced**, with policy + recovery
- Operator recovery path in `skills/looper/references/daemon.md` (restart after storage repair)

## Authority

> What is the authority for durable execution status, and why is it not the agent's structured output?

The Execution Supervisor owns live process lifecycle; SQLite `agent_executions` is observation only. Storage enforces terminal monotonicity so observations cannot regress under concurrent writers. Hard persist failure closes admission rather than continuing with split-brain state.

## Trade-off

- **Prevents:** silent no-op upserts treated as success; terminal rows overwritten by stale heartbeats; new work admitted while storage cannot publish observations; terminal status before confirmed-dead containment
- **Costs:** sticky degrade until restart/clear; first terminal wins; per-execution serialization; initial persist failure kills the process
- **Why not simpler:** trusting Upsert success would leave #579 free to release claims on silent failures; a global writer queue adds complexity without fixing per-execution ordering
- **Deletion attempt:** drop mid-life heartbeat persistence — insufficient for operator progress and live native-session capture

## Test plan

- [x] Storage contract: terminal→active conflict, terminal→different-terminal conflict, same-terminal enrichment, active→cancelling→killed
- [x] Executor: initial persist failure reaps process; terminal persist failure surfaces on Wait + degrade hook; mid-life hard failure degrades; post-terminal live write no-op
- [x] Runtime: hard persist failure → sticky admission degraded; clear/restart recovery path
- [x] `go test ./internal/storage/ ./internal/agent/ ./internal/runtime/ ./cmd/looperd/`

Closes #578

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=grok-build · An autonomous AI dev team for your GitHub repos.</sub>