### PR TITLE
fix: migrate remaining daemon subprocesses onto containment

### DIFF
--- a/cmd/looperd/main.go
+++ b/cmd/looperd/main.go
@@ -371,7 +371,8 @@ func stopServerWithTimeout(stop func(context.Context) error, timeout time.Durati
 
 func (d *daemonRuntime) Stop(reason string) {
 	d.stopOnce.Do(func() {
-		// Admission → HTTP ingress drain → runtime storage close (ADR-0015 / #575).
+		// Admission → HTTP ingress drain → cancel/drain producers → SQLite close
+		// (or retain storage on drain timeout) — ADR-0015 / #575 / #577.
 		if d.runtime != nil {
 			d.runtime.BeginShutdown(reason)
 		}
@@ -380,13 +381,22 @@ func (d *daemonRuntime) Stop(reason string) {
 			err := d.server.Stop(ctx)
 			cancel()
 			if err != nil {
-				// Fail loud when ingress drain is incomplete. Full producer drain
-				// is later slices; still close storage so stop cannot hang forever.
+				// Fail loud when ingress drain is incomplete; Runtime.Stop still
+				// decides storage close vs retain based on producer drain.
 				_, _ = fmt.Fprintf(os.Stderr, "looperd: HTTP ingress drain incomplete during shutdown: %v\n", err)
 			}
 		}
 		if d.runtime != nil {
 			d.runtime.Stop(reason)
+			if d.runtime.StorageRetained() {
+				// No false graceful success: undrained ownership keeps SQLite open.
+				drainErr := d.runtime.ShutdownDrainError()
+				if drainErr != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "looperd: shutdown drain incomplete; storage retained: %v\n", drainErr)
+				} else {
+					_, _ = fmt.Fprintf(os.Stderr, "looperd: shutdown drain incomplete; storage retained\n")
+				}
+			}
 		}
 	})
 }

--- a/docs/adr/0015-execution-supervisor-live-ownership.md
+++ b/docs/adr/0015-execution-supervisor-live-ownership.md
@@ -118,7 +118,7 @@ to a slice while any open blocker remains.
 | R1 | #575 | Safety floor: one admission state; stop unsafe recovery PID action | Single admission Authority; no mutation/claim before ready; recovery no-act + quarantine; drain ingress before storage close | **Enforced** |
 | R2 | #574 | Process containment handle with confirmed drain | Containment API; kill success = confirmed drain; no production removal of PID fallback yet | **Enforced** |
 | R3 | #576 | Own all in-scope agent spawns at common executor boundary | Lease before `cmd.Start`; bind handle before return; stop-kill via handle; remove agent live PID fallback only after full agent coverage | **Enforced** |
-| R4 | #577 | Migrate remaining Supervisor-owned non-agent subprocesses | Validation/shell and other in-scope non-agents on containment; no raw PID fallback inside Supervisor domain; shutdown order tested | **Deferred** |
+| R4 | #577 | Migrate remaining Supervisor-owned non-agent subprocesses | Validation/shell and other in-scope non-agents on containment; no raw PID fallback inside Supervisor domain; shutdown order tested | **Enforced** |
 | R5 | #578 | Execution persistence Authority + degrade on mid-life failure | Ordered writer; terminal immutability; hard persist failure degrades; no terminal status before confirmed dead | **Deferred** |
 | R6 | #579 | Operation lease owns queue claims until durable finalize | No live `running` claim without lease; release only after durable finalize; finalize failure retains ownership + degrades | **Deferred** |
 | R7 | #580 | Full non-mutating coverage when not-ready or degraded | Exhaustive mutation surface audit; scheduler pause; HTTP 503; no dual ready Authority | **Deferred** |
@@ -196,11 +196,25 @@ boundary so there is no worker-only registry escape hatch.
 | **Why not simpler** | Post-spawn adapter Register (#572) leaves Coordinator and race windows unowned. Keeping PID fallback after full coverage reintroduces reusable-ID Authority. |
 | **Deletion attempt** | Remove registry and trust only `exec.Cmd` + SQLite — fails stop when live handle is missing and reopens dual Authority. |
 
-### Shutdown order (target; partial in #575, complete in #577/#580)
+### Shutdown order (enforced by #575 admission close + #577 drain/retain)
 
 Drain **admission → ingress → producers → handles/finalizers** before SQLite
-close. On timeout: retain storage / fail loud — never report graceful success
-with undrained ownership.
+close. On timeout or confirmed-drain failure: **retain storage** and fail loud
+— never report graceful success with undrained ownership. `Runtime.Stop` skips
+`coordinator.Close` when `ActiveExecutionRegistry.BeginShutdown` returns a drain
+error; `StorageRetained()` is the operator-visible signal. Independent infra
+(webhook forwarder, network manager) still stop — they are not Supervisor domain.
+
+### Non-agent Supervisor-owned producers (enforced by #577)
+
+| Producer | Spawn boundary | Containment |
+|----------|----------------|-------------|
+| **Worker / Fixer validation shell** | `internal/infra/shell.Run` (`Configure` + `Start` + `Bind`) | Cancel/timeout → `Handle.Kill` confirmed drain; normal exit → `Handle.Drain` |
+| **Other daemon `shell.Run` work steps** on inventory-listed role helpers | same package boundary | Same as validation; short git/gh/tea remain independently lifecycle-owned (gateway Authority) but still get group containment when they share `shell.Run` |
+| **Trusted review-submit children** | `internal/forge/trusted_review_proxy.go` | `Configure` + `Bind` after Start; cancel → `Handle.Kill`; success path `Drain` |
+
+Raw PID signal-only stop is removed at these boundaries. Agent live SQLite-PID
+fallback was already removed when the registry is present (#576).
 
 ## Process-producer inventory
 
@@ -222,9 +236,9 @@ Classification:
 | **Worker agent** | scheduler worker adapter → `agent.Executor.Start` (incl. native-resume) | **Enforced by #576** (not post-spawn adapter Register) |
 | **Coordinator agent** | `internal/coordinator/agent_llm.go` → shared `agent.Executor.Start` | **Enforced by #576**; same executor, not a separate spawn stack |
 | **Native-resume fallback** | Same `agent.Executor.Start` with `NativeResumePrompt` / session; fallback to full prompt on resume failure | **Enforced by #576**; cancellation must not spawn a second process after stop |
-| **Worker validation shell** | `internal/worker/runner.go` → `shell.Run` (`/bin/sh -c` validation commands) | #577 non-agent containment |
-| **Fixer (and other role) shell helpers** that run daemon-owned long/blocking shell for work steps | e.g. fixer `shell.Run` helpers used during run processing | #577; short tool calls may reclassify only if inventory is updated |
-| **Trusted review-submit children** | `internal/forge/trusted_review_proxy.go` spawns `looper review submit` child from daemon-bound proxy | #577; child is daemon-owned for stop/drain while proxy request is live |
+| **Worker validation shell** | `internal/worker/runner.go` → `shell.Run` (`/bin/sh -c` validation commands) | **Enforced by #577** via `shell.Run` containment spawn boundary |
+| **Fixer (and other role) shell helpers** that run daemon-owned long/blocking shell for work steps | e.g. fixer `shell.Run` helpers used during run processing | **Enforced by #577** via same `shell.Run` boundary |
+| **Trusted review-submit children** | `internal/forge/trusted_review_proxy.go` spawns `looper review submit` child from daemon-bound proxy | **Enforced by #577**; handle Bind + confirmed Kill/Drain while proxy request is live |
 | **Active agent stop / loop halt / daemon shutdown kill of owned agents** | Registry `Kill` via bound containment handle (confirmed drain); no live SQLite PID fallback when registry present | **Enforced by #576** after common-executor ownership; recovery still no raw PID action (#575) |
 
 Queue **claims** themselves are not process producers, but while the daemon is

--- a/docs/adr/0015-execution-supervisor-live-ownership.md
+++ b/docs/adr/0015-execution-supervisor-live-ownership.md
@@ -248,19 +248,24 @@ Drain **admission → ingress → producers → handles/finalizers** before SQLi
 close. On timeout or confirmed-drain failure: **retain storage** and fail loud
 — never report graceful success with undrained ownership. `Runtime.Stop` skips
 `coordinator.Close` when `ActiveExecutionRegistry.BeginShutdown` returns a drain
-error; `StorageRetained()` is the operator-visible signal. Independent infra
-(webhook forwarder, network manager) still stop — they are not Supervisor domain.
+error (agents **and** tracked Supervisor-owned non-agent handles); late
+`ReportDrainFailure` from shell/trusted-review cancel paths is re-collected
+after producer waits. `StorageRetained()` is the operator-visible signal.
+Independent infra (webhook forwarder, network manager) still stop — they are
+not Supervisor domain.
 
 ### Non-agent Supervisor-owned producers (enforced by #577)
 
 | Producer | Spawn boundary | Containment |
 |----------|----------------|-------------|
-| **Worker / Fixer validation shell** | `internal/infra/shell.Run` (`Configure` + `Start` + `Bind`) | Cancel/timeout → `Handle.Kill` confirmed drain; normal exit → `Handle.Drain` |
-| **Other daemon `shell.Run` work steps** on inventory-listed role helpers | same package boundary | Same as validation; short git/gh/tea remain independently lifecycle-owned (gateway Authority) but still get group containment when they share `shell.Run` |
-| **Trusted review-submit children** | `internal/forge/trusted_review_proxy.go` | `Configure` + `Bind` after Start; cancel → `Handle.Kill`; success path `Drain` |
+| **Worker / Fixer validation shell** | `internal/infra/shell.Run` (`Configure` + `Start` + `Bind`) + `LiveTracker` | Cancel/timeout → `Handle.Kill` confirmed drain; normal exit → `Handle.Drain`; track + `ReportDrainFailure` for retain-storage |
+| **Other daemon `shell.Run` work steps** on inventory-listed role helpers | same package boundary | Same as validation when Supervisor-owned; short git/gh/tea remain independently lifecycle-owned (gateway Authority, Tracker nil) but still get group containment when they share `shell.Run` |
+| **Trusted review-submit children** | `internal/forge/trusted_review_proxy.go` + `LiveTracker` | `Configure` + `Bind` after Start; cancel → `Handle.Kill`; success path `Drain`; track + report for retain-storage |
 
 Raw PID signal-only stop is removed at these boundaries. Agent live SQLite-PID
-fallback was already removed when the registry is present (#576).
+fallback was already removed when the registry is present (#576). Non-agent
+tracking registers only the live handle (not agent spawn leases) so short jobs
+do not grow a second full registry while still feeding shutdown retain-storage.
 
 ## Process-producer inventory
 

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -32,6 +32,7 @@ import (
 	"github.com/nexu-io/looper/internal/lifecycle"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/loops/failureclass"
+	"github.com/nexu-io/looper/internal/processcontainment"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/worktreesafety"
 )
@@ -515,18 +516,22 @@ type AgentExecutionStartedInput struct {
 type AgentExecutionStartedFunc func(context.Context, AgentExecutionStartedInput) error
 
 type Options struct {
-	DB                      *sql.DB
-	Repos                   *storage.Repositories
-	GitHub                  GitHubGateway
-	Git                     GitGateway
-	AgentExecutor           AgentExecutor
-	Logger                  bootstrap.Logger
-	Now                     func() time.Time
-	AgentTimeout            time.Duration
-	AgentIdleTimeout        time.Duration
-	ClaimTTL                time.Duration
-	ValidationCommands      []string
-	ValidationRunner        ValidationRunner
+	DB                 *sql.DB
+	Repos              *storage.Repositories
+	GitHub             GitHubGateway
+	Git                GitGateway
+	AgentExecutor      AgentExecutor
+	Logger             bootstrap.Logger
+	Now                func() time.Time
+	AgentTimeout       time.Duration
+	AgentIdleTimeout   time.Duration
+	ClaimTTL           time.Duration
+	ValidationCommands []string
+	ValidationRunner   ValidationRunner
+	// ContainmentTracker registers validation shell handles with the Execution
+	// Supervisor for shutdown drain / retain-storage (#577). Nil in tests or
+	// when the runner is not daemon-owned.
+	ContainmentTracker      processcontainment.LiveTracker
 	AllowAutoCommit         bool
 	AllowAutoPush           bool
 	AllowRiskyFixes         bool
@@ -564,6 +569,7 @@ type Runner struct {
 	claimTTL                time.Duration
 	validationCommands      []string
 	validationRunner        ValidationRunner
+	containmentTracker      processcontainment.LiveTracker
 	allowAutoCommit         bool
 	allowAutoPush           bool
 	allowRiskyFixes         bool
@@ -1274,6 +1280,7 @@ func New(options Options) *Runner {
 		claimTTL:                claimTTL,
 		validationCommands:      append([]string(nil), options.ValidationCommands...),
 		validationRunner:        options.ValidationRunner,
+		containmentTracker:      options.ContainmentTracker,
 		allowAutoCommit:         options.AllowAutoCommit,
 		allowAutoPush:           options.AllowAutoPush,
 		allowRiskyFixes:         options.AllowRiskyFixes,
@@ -5937,7 +5944,14 @@ func (r *Runner) runValidation(ctx context.Context, input ValidationInput) (Vali
 
 	outputs := make([]string, 0, len(input.Commands)*2)
 	for _, command := range input.Commands {
-		result, err := shell.Run(ctx, shell.Options{Command: "/bin/sh", Args: []string{"-c", command}, CWD: input.CWD})
+		result, err := shell.Run(ctx, shell.Options{
+			Command: "/bin/sh",
+			Args:    []string{"-c", command},
+			CWD:     input.CWD,
+			// Supervisor-owned validation: track handle so shutdown retain-storage
+			// sees Kill/Drain failures even when validation collapses them to Passed=false.
+			Tracker: r.containmentTracker,
+		})
 		if err != nil {
 			output := "Unknown validation failure"
 			var commandErr *shell.CommandExecutionError

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -13,10 +13,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/processcontainment"
 )
 
 // TrustedReviewSockEnv is the agent-facing env key for the trusted review-submit
@@ -249,7 +249,8 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 	// agent argv. Rewrite local policy flags after shape/PR validation.
 	childArgv := applyTrustedReviewProxyPolicy(req.Argv, policy)
 	cmd := exec.Command(realLooper, childArgv...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// #577: Supervisor-owned non-agent child uses processcontainment at spawn.
+	processcontainment.Configure(cmd)
 	configReader, configWriter, err := os.Pipe()
 	if err != nil {
 		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: "create trusted review config pipe: " + err.Error()})
@@ -272,6 +273,22 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: err.Error()})
 		return
 	}
+	handle, bindErr := processcontainment.Bind(cmd, processcontainment.Options{
+		GracePeriod:  2 * time.Second,
+		DrainTimeout: 20 * time.Second,
+	})
+	if bindErr != nil {
+		_ = configReader.Close()
+		_ = configWriter.Close()
+		// Bind failed after Start: force-kill the orphaned process group so it
+		// does not outlive the proxy request (same emergency path as agent bind).
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: "bind trusted review containment handle: " + bindErr.Error()})
+		return
+	}
 	_ = configReader.Close()
 	configWriteDone := make(chan error, 1)
 	go func() {
@@ -281,19 +298,42 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 		}
 		configWriteDone <- writeErr
 	}()
+	// Handle owns exactly-once Wait; do not call cmd.Wait in parallel.
 	waitDone := make(chan error, 1)
-	go func() { waitDone <- cmd.Wait() }()
+	go func() { waitDone <- handle.Wait(context.Background()) }()
 	select {
 	case err = <-waitDone:
+		// Normal exit path: confirmed-drain descendants before answering.
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		if drainErr := handle.Drain(drainCtx); drainErr != nil && err == nil {
+			err = drainErr
+		}
+		drainCancel()
 	case <-ctx.Done():
-		_ = killTrustedReviewProxyChild(cmd)
+		// Cancel: confirmed Kill, never signal-only success (#577).
+		killCtx, killCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		killErr := handle.Kill(killCtx)
+		killCancel()
 		err = <-waitDone
+		if err == nil {
+			if killErr != nil {
+				err = killErr
+			} else {
+				err = ctx.Err()
+			}
+		}
 	}
 	configWriteErr := <-configWriteDone
 	resp := trustedReviewProxyResponse{Stdout: stdout.String(), Stderr: stderr.String()}
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			resp.ExitCode = exitErr.ExitCode()
+		} else if state := handle.ProcessState(); state != nil {
+			resp.ExitCode = state.ExitCode()
+			if resp.ExitCode == 0 {
+				resp.ExitCode = 1
+				resp.Error = err.Error()
+			}
 		} else {
 			resp.ExitCode = 1
 			resp.Error = err.Error()
@@ -307,19 +347,6 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 		resp.Error = "write trusted review config snapshot: " + configWriteErr.Error()
 	}
 	_ = json.NewEncoder(conn).Encode(resp)
-}
-
-func killTrustedReviewProxyChild(cmd *exec.Cmd) error {
-	if cmd == nil || cmd.Process == nil {
-		return os.ErrProcessDone
-	}
-	pid := cmd.Process.Pid
-	if pid > 0 {
-		if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil || err == syscall.ESRCH {
-			return nil
-		}
-	}
-	return cmd.Process.Kill()
 }
 
 // trustedReviewProxyBlockedFlags are CLI overrides that must never be accepted

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -304,53 +304,95 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 	defer waitCancel()
 	waitDone := make(chan error, 1)
 	go func() { waitDone <- handle.Wait(waitCtx) }()
-	select {
-	case err = <-waitDone:
-		// Normal exit path: confirmed-drain descendants before answering.
-		drainCtx, drainCancel := context.WithTimeout(context.Background(), 20*time.Second)
-		if drainErr := handle.Drain(drainCtx); drainErr != nil {
-			// Join so non-zero child exits still surface ErrNotConfirmedDead.
-			if err == nil {
-				err = drainErr
-			} else {
-				err = errors.Join(err, drainErr)
-			}
-		}
-		drainCancel()
-	case <-ctx.Done():
-		// Cancel: confirmed Kill, never signal-only success (#577).
-		killCtx, killCancel := context.WithTimeout(context.Background(), 20*time.Second)
-		killErr := handle.Kill(killCtx)
-		killCancel()
-		// Unstick Wait if Kill timed out without reaping the leader, then
-		// bound the receive so cleanup cannot hang on an open waitDone.
-		waitCancel()
+	// Poll leader liveness: if the leader is reaped but Wait is still blocked
+	// on stdout/stderr copy (descendant holds pipes), Drain before the
+	// connection deadline — ctx is not canceled by the conn deadline alone.
+	poll := time.NewTicker(10 * time.Millisecond)
+	defer poll.Stop()
+	alreadyDrained := false
+loop:
+	for {
 		select {
 		case err = <-waitDone:
-		case <-time.After(time.Second):
-			// Wait still blocked (should not happen once waitCtx is canceled);
-			// fail loud so cleanup cannot hang in wg.Wait.
-			if killErr != nil {
-				err = killErr
-			} else {
-				err = fmt.Errorf("trusted review child wait did not complete after cancel: %w", ctx.Err())
+			if !alreadyDrained {
+				// Normal exit path: confirmed-drain descendants before answering.
+				drainCtx, drainCancel := context.WithTimeout(context.Background(), 20*time.Second)
+				if drainErr := handle.Drain(drainCtx); drainErr != nil {
+					// Join so non-zero child exits still surface ErrNotConfirmedDead.
+					if err == nil {
+						err = drainErr
+					} else {
+						err = errors.Join(err, drainErr)
+					}
+				}
+				drainCancel()
 			}
-		}
-		if err == nil {
-			if killErr != nil {
-				err = killErr
-			} else {
-				err = ctx.Err()
+			break loop
+		case <-ctx.Done():
+			// Cancel: confirmed Kill, never signal-only success (#577).
+			killCtx, killCancel := context.WithTimeout(context.Background(), 20*time.Second)
+			killErr := handle.Kill(killCtx)
+			killCancel()
+			// Unstick Wait if Kill timed out without reaping the leader, then
+			// bound the receive so cleanup cannot hang on an open waitDone.
+			waitCancel()
+			select {
+			case err = <-waitDone:
+			case <-time.After(time.Second):
+				// Wait still blocked (should not happen once waitCtx is canceled);
+				// fail loud so cleanup cannot hang in wg.Wait.
+				if killErr != nil {
+					err = killErr
+				} else {
+					err = fmt.Errorf("trusted review child wait did not complete after cancel: %w", ctx.Err())
+				}
 			}
-		} else if killErr != nil {
-			if errors.Is(err, context.Canceled) {
-				// Wait unblocked via waitCancel after Kill; surface kill outcome.
-				err = killErr
-			} else {
-				// Child already exited non-zero (or other wait error); still
-				// surface containment failure so undrained descendants are not hidden.
-				err = errors.Join(err, killErr)
+			if err == nil {
+				if killErr != nil {
+					err = killErr
+				} else {
+					err = ctx.Err()
+				}
+			} else if killErr != nil {
+				if errors.Is(err, context.Canceled) {
+					// Wait unblocked via waitCancel after Kill; surface kill outcome.
+					err = killErr
+				} else {
+					// Child already exited non-zero (or other wait error); still
+					// surface containment failure so undrained descendants are not hidden.
+					err = errors.Join(err, killErr)
+				}
 			}
+			break loop
+		case <-poll.C:
+			if alreadyDrained || !trustedReviewLeaderPIDGone(handle.PID()) {
+				continue
+			}
+			// Leader reaped; Drain kills pipe-holding descendants and unblocks Wait.
+			drainCtx, drainCancel := context.WithTimeout(context.Background(), 20*time.Second)
+			if drainErr := handle.Drain(drainCtx); drainErr != nil {
+				if err == nil {
+					err = drainErr
+				} else {
+					err = errors.Join(err, drainErr)
+				}
+			}
+			drainCancel()
+			alreadyDrained = true
+			select {
+			case waitErr := <-waitDone:
+				if err == nil {
+					err = waitErr
+				} else if waitErr != nil {
+					// Keep containment drain failure and child exit together.
+					err = errors.Join(waitErr, err)
+				}
+			case <-time.After(time.Second):
+				if err == nil {
+					err = fmt.Errorf("trusted review child wait did not complete after drain")
+				}
+			}
+			break loop
 		}
 	}
 	configWriteErr := <-configWriteDone
@@ -375,12 +417,35 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 	}
 	if stdout.Truncated() || stderr.Truncated() {
 		resp.ExitCode = 1
-		resp.Error = "trusted review proxy child output exceeds size limit"
+		// Preserve prior containment/kill/drain Error so ErrNotConfirmedDead is
+		// not replaced by truncation-only text when both apply.
+		resp.Error = mergeTrustedReviewTruncationError(resp.Error)
 	} else if configWriteErr != nil && err == nil {
 		resp.ExitCode = 1
 		resp.Error = "write trusted review config snapshot: " + configWriteErr.Error()
 	}
 	_ = json.NewEncoder(conn).Encode(resp)
+}
+
+// trustedReviewLeaderPIDGone reports whether the leader pid has been reaped.
+// Used to detect Wait stuck on pipe-copy after Process.Wait completed.
+func trustedReviewLeaderPIDGone(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return errors.Is(err, syscall.ESRCH)
+}
+
+const trustedReviewOutputTruncatedMsg = "trusted review proxy child output exceeds size limit"
+
+// mergeTrustedReviewTruncationError keeps an existing containment/kill/drain
+// error when output also exceeded the capture cap.
+func mergeTrustedReviewTruncationError(existing string) string {
+	if existing == "" {
+		return trustedReviewOutputTruncatedMsg
+	}
+	return existing + "; " + trustedReviewOutputTruncatedMsg
 }
 
 // killTrustedReviewStartedWithoutHandle is only used when Bind fails after

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -308,8 +308,13 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 	case err = <-waitDone:
 		// Normal exit path: confirmed-drain descendants before answering.
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), 20*time.Second)
-		if drainErr := handle.Drain(drainCtx); drainErr != nil && err == nil {
-			err = drainErr
+		if drainErr := handle.Drain(drainCtx); drainErr != nil {
+			// Join so non-zero child exits still surface ErrNotConfirmedDead.
+			if err == nil {
+				err = drainErr
+			} else {
+				err = errors.Join(err, drainErr)
+			}
 		}
 		drainCancel()
 	case <-ctx.Done():
@@ -337,22 +342,32 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 			} else {
 				err = ctx.Err()
 			}
-		} else if killErr != nil && errors.Is(err, context.Canceled) {
-			// Wait unblocked via waitCancel after Kill; surface kill outcome.
-			err = killErr
+		} else if killErr != nil {
+			if errors.Is(err, context.Canceled) {
+				// Wait unblocked via waitCancel after Kill; surface kill outcome.
+				err = killErr
+			} else {
+				// Child already exited non-zero (or other wait error); still
+				// surface containment failure so undrained descendants are not hidden.
+				err = errors.Join(err, killErr)
+			}
 		}
 	}
 	configWriteErr := <-configWriteDone
 	resp := trustedReviewProxyResponse{Stdout: stdout.String(), Stderr: stderr.String()}
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
+			// Pure child exit: ordinary review-submit failure, no Error text.
 			resp.ExitCode = exitErr.ExitCode()
 		} else if state := handle.ProcessState(); state != nil {
 			resp.ExitCode = state.ExitCode()
 			if resp.ExitCode == 0 {
 				resp.ExitCode = 1
-				resp.Error = err.Error()
 			}
+			// Always set Error for non-ExitError outcomes (drain/kill/cancel,
+			// including errors.Join of exit + containment failure) so callers
+			// do not treat undrained process groups as ordinary submit failures.
+			resp.Error = err.Error()
 		} else {
 			resp.ExitCode = 1
 			resp.Error = err.Error()

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
@@ -281,11 +283,8 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 		_ = configReader.Close()
 		_ = configWriter.Close()
 		// Bind failed after Start: force-kill the orphaned process group so it
-		// does not outlive the proxy request (same emergency path as agent bind).
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
-			_, _ = cmd.Process.Wait()
-		}
+		// does not outlive the proxy request (same emergency path as shell bind).
+		killTrustedReviewStartedWithoutHandle(cmd)
 		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: "bind trusted review containment handle: " + bindErr.Error()})
 		return
 	}
@@ -299,8 +298,12 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 		configWriteDone <- writeErr
 	}()
 	// Handle owns exactly-once Wait; do not call cmd.Wait in parallel.
+	// waitCtx is cancelable so post-Kill Wait cannot hang forever when an
+	// escaped descendant keeps stdio open and cmd.Wait never reaps.
+	waitCtx, waitCancel := context.WithCancel(context.Background())
+	defer waitCancel()
 	waitDone := make(chan error, 1)
-	go func() { waitDone <- handle.Wait(context.Background()) }()
+	go func() { waitDone <- handle.Wait(waitCtx) }()
 	select {
 	case err = <-waitDone:
 		// Normal exit path: confirmed-drain descendants before answering.
@@ -314,13 +317,29 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 		killCtx, killCancel := context.WithTimeout(context.Background(), 20*time.Second)
 		killErr := handle.Kill(killCtx)
 		killCancel()
-		err = <-waitDone
+		// Unstick Wait if Kill timed out without reaping the leader, then
+		// bound the receive so cleanup cannot hang on an open waitDone.
+		waitCancel()
+		select {
+		case err = <-waitDone:
+		case <-time.After(time.Second):
+			// Wait still blocked (should not happen once waitCtx is canceled);
+			// fail loud so cleanup cannot hang in wg.Wait.
+			if killErr != nil {
+				err = killErr
+			} else {
+				err = fmt.Errorf("trusted review child wait did not complete after cancel: %w", ctx.Err())
+			}
+		}
 		if err == nil {
 			if killErr != nil {
 				err = killErr
 			} else {
 				err = ctx.Err()
 			}
+		} else if killErr != nil && errors.Is(err, context.Canceled) {
+			// Wait unblocked via waitCancel after Kill; surface kill outcome.
+			err = killErr
 		}
 	}
 	configWriteErr := <-configWriteDone
@@ -347,6 +366,22 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 		resp.Error = "write trusted review config snapshot: " + configWriteErr.Error()
 	}
 	_ = json.NewEncoder(conn).Encode(resp)
+}
+
+// killTrustedReviewStartedWithoutHandle is only used when Bind fails after
+// Start so the orphaned process group is not left live. Production stop paths
+// use Handle.Kill. Mirrors shell.killStartedWithoutHandle: SIGKILL the group
+// first, then fall back to Process.Kill + Wait on the leader.
+func killTrustedReviewStartedWithoutHandle(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pid := cmd.Process.Pid
+	if pid > 0 {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	}
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
 }
 
 // trustedReviewProxyBlockedFlags are CLI overrides that must never be accepted

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -808,7 +808,12 @@ func trustedReviewProxyChildEnv(trustedEnv map[string]string, configFD int) []st
 	return out
 }
 
+// trustedReviewBoundedBuffer captures child stdout/stderr under a hard cap.
+// Methods are safe for concurrent use: cmd.Stdout/Stderr copy goroutines may
+// still Write after waitCtx cancel unblocks handle.Wait (containment-failure
+// path) while the proxy handler reads String/Truncated for the response.
 type trustedReviewBoundedBuffer struct {
+	mu        sync.Mutex
 	buffer    bytes.Buffer
 	limit     int
 	truncated bool
@@ -819,6 +824,8 @@ func newTrustedReviewBoundedBuffer(limit int) *trustedReviewBoundedBuffer {
 }
 
 func (b *trustedReviewBoundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	written := len(p)
 	remaining := b.limit - b.buffer.Len()
 	if remaining > 0 {
@@ -834,9 +841,17 @@ func (b *trustedReviewBoundedBuffer) Write(p []byte) (int, error) {
 	return written, nil
 }
 
-func (b *trustedReviewBoundedBuffer) String() string { return b.buffer.String() }
+func (b *trustedReviewBoundedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.String()
+}
 
-func (b *trustedReviewBoundedBuffer) Truncated() bool { return b.truncated }
+func (b *trustedReviewBoundedBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
+}
 
 // TrustedReviewSockConfigured reports whether this process should proxy
 // `review submit` through the daemon-side trusted socket.

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -109,7 +109,11 @@ type TrustedReviewProxyPolicy struct {
 // overrides). Agent argv may still include local flags for the prompted command
 // shape, but the proxy always rewrites them to this bound authority before
 // spawning the credential-injected child.
-func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd string, configSnapshot config.Config, policy TrustedReviewProxyPolicy) (sockPath string, cleanup func(), err error) {
+//
+// tracker, when non-nil, registers each Supervisor-owned review-submit child
+// handle so daemon shutdown can wait for confirmed drain and retain storage on
+// Kill/Drain failure (ADR-0015 / #577).
+func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd string, configSnapshot config.Config, policy TrustedReviewProxyPolicy, tracker processcontainment.LiveTracker) (sockPath string, cleanup func(), err error) {
 	realLooper = strings.TrimSpace(realLooper)
 	if realLooper == "" {
 		return "", nil, fmt.Errorf("real looper path is required for trusted review proxy")
@@ -198,7 +202,7 @@ func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, al
 				defer wg.Done()
 				defer func() { <-slots }()
 				defer unregister(c)
-				handleTrustedReviewProxyConn(proxyContext, c, realLooper, trustedEnv, normalizedAllowed, boundCwd, boundConfig, boundPolicy)
+				handleTrustedReviewProxyConn(proxyContext, c, realLooper, trustedEnv, normalizedAllowed, boundCwd, boundConfig, boundPolicy, tracker)
 			}(conn)
 		}
 	}()
@@ -222,7 +226,7 @@ func StartTrustedReviewProxy(realLooper string, trustedEnv map[string]string, al
 	return sockPath, cleanup, nil
 }
 
-func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd string, configSnapshot []byte, policy TrustedReviewProxyPolicy) {
+func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd string, configSnapshot []byte, policy TrustedReviewProxyPolicy, tracker processcontainment.LiveTracker) {
 	defer func() { _ = conn.Close() }()
 	_ = conn.SetDeadline(time.Now().Add(2 * time.Minute))
 
@@ -288,6 +292,12 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: "bind trusted review containment handle: " + bindErr.Error()})
 		return
 	}
+	if tracker != nil {
+		release := tracker.Track(handle)
+		if release != nil {
+			defer release()
+		}
+	}
 	_ = configReader.Close()
 	configWriteDone := make(chan error, 1)
 	go func() {
@@ -318,6 +328,7 @@ loop:
 				// Normal exit path: confirmed-drain descendants before answering.
 				drainCtx, drainCancel := context.WithTimeout(context.Background(), 20*time.Second)
 				if drainErr := handle.Drain(drainCtx); drainErr != nil {
+					reportTrustedReviewDrainFailure(tracker, drainErr)
 					// Join so non-zero child exits still surface ErrNotConfirmedDead.
 					if err == nil {
 						err = drainErr
@@ -333,6 +344,9 @@ loop:
 			killCtx, killCancel := context.WithTimeout(context.Background(), 20*time.Second)
 			killErr := handle.Kill(killCtx)
 			killCancel()
+			if killErr != nil {
+				reportTrustedReviewDrainFailure(tracker, killErr)
+			}
 			// Unstick Wait if Kill timed out without reaping the leader, then
 			// bound the receive so cleanup cannot hang on an open waitDone.
 			waitCancel()
@@ -371,6 +385,7 @@ loop:
 			// Leader reaped; Drain kills pipe-holding descendants and unblocks Wait.
 			drainCtx, drainCancel := context.WithTimeout(context.Background(), 20*time.Second)
 			if drainErr := handle.Drain(drainCtx); drainErr != nil {
+				reportTrustedReviewDrainFailure(tracker, drainErr)
 				if err == nil {
 					err = drainErr
 				} else {
@@ -435,6 +450,13 @@ func trustedReviewLeaderPIDGone(pid int) bool {
 	}
 	err := syscall.Kill(pid, 0)
 	return errors.Is(err, syscall.ESRCH)
+}
+
+func reportTrustedReviewDrainFailure(tracker processcontainment.LiveTracker, err error) {
+	if tracker == nil || err == nil {
+		return
+	}
+	tracker.ReportDrainFailure(err)
 }
 
 const trustedReviewOutputTruncatedMsg = "trusted review proxy child output exceeds size limit"

--- a/internal/forge/trusted_review_proxy_limits_test.go
+++ b/internal/forge/trusted_review_proxy_limits_test.go
@@ -20,7 +20,7 @@ func TestTrustedReviewProxyRejectsOversizedStdinBeforeStartingChild(t *testing.T
 	if err := os.WriteFile(realLooper, []byte(trustedReviewProxyStubScript("touch \""+marker+"\"\n")), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy(), nil)
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}
@@ -54,7 +54,7 @@ exit 0
 	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy(), nil)
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}
@@ -88,7 +88,7 @@ func TestTrustedReviewProxyCleanupClosesPartialConnectionsAndKillsChildGroup(t *
 	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy(), nil)
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}

--- a/internal/forge/trusted_review_proxy_limits_test.go
+++ b/internal/forge/trusted_review_proxy_limits_test.go
@@ -39,6 +39,46 @@ func TestTrustedReviewProxyRejectsOversizedStdinBeforeStartingChild(t *testing.T
 	}
 }
 
+func TestTrustedReviewProxyDrainsBackgroundChildAfterLeaderExitsWithPipes(t *testing.T) {
+	// Child leader exits 0 after spawning a same-group background sleeper that
+	// inherits stdout. Wait would hang on pipe copy; proxy must Drain and return.
+	dir := t.TempDir()
+	realLooper := filepath.Join(dir, "real-looper")
+	childPIDPath := filepath.Join(dir, "child.pid")
+	script := trustedReviewProxyStubScript(`
+(sleep 60) &
+echo $! > "` + childPIDPath + `"
+exit 0
+`)
+	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(realLooper) error = %v", err)
+	}
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
+	if err != nil {
+		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
+	}
+	t.Cleanup(cleanup)
+	t.Setenv(TrustedReviewSockEnv, sockPath)
+	t.Setenv(trustedReviewProxySkipEnv, "")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ProxyReviewSubmit(
+			[]string{"review", "submit", "acme/looper#1", "--event", "COMMENT"},
+			nil,
+			dir,
+		)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ProxyReviewSubmit() error = %v, want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ProxyReviewSubmit hung after leader exit with background pipe-holding child")
+	}
+}
+
 func TestTrustedReviewProxyCleanupClosesPartialConnectionsAndKillsChildGroup(t *testing.T) {
 	dir := t.TempDir()
 	realLooper := filepath.Join(dir, "real-looper")
@@ -102,5 +142,20 @@ func TestTrustedReviewBoundedBufferTruncatesWithoutBackpressuringChild(t *testin
 	}
 	if got := buffer.String(); got != "abcd" || !buffer.Truncated() {
 		t.Fatalf("bounded buffer = (%q, %t), want (abcd, true)", got, buffer.Truncated())
+	}
+}
+
+func TestMergeTrustedReviewTruncationErrorPreservesContainment(t *testing.T) {
+	t.Parallel()
+	if got := mergeTrustedReviewTruncationError(""); got != trustedReviewOutputTruncatedMsg {
+		t.Fatalf("empty existing = %q, want truncation-only", got)
+	}
+	existing := "process containment: not confirmed dead"
+	got := mergeTrustedReviewTruncationError(existing)
+	if !strings.Contains(got, existing) {
+		t.Fatalf("merged = %q, want to keep containment error", got)
+	}
+	if !strings.Contains(got, trustedReviewOutputTruncatedMsg) {
+		t.Fatalf("merged = %q, want truncation message", got)
 	}
 }

--- a/internal/forge/trusted_review_proxy_limits_test.go
+++ b/internal/forge/trusted_review_proxy_limits_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -142,6 +143,44 @@ func TestTrustedReviewBoundedBufferTruncatesWithoutBackpressuringChild(t *testin
 	}
 	if got := buffer.String(); got != "abcd" || !buffer.Truncated() {
 		t.Fatalf("bounded buffer = (%q, %t), want (abcd, true)", got, buffer.Truncated())
+	}
+}
+
+// TestTrustedReviewBoundedBufferConcurrentWriteAndRead covers the proxy path
+// where waitCtx cancel unblocks handle.Wait while cmd stdout/stderr copy
+// goroutines may still Write; response assembly must read safely under race.
+func TestTrustedReviewBoundedBufferConcurrentWriteAndRead(t *testing.T) {
+	buffer := newTrustedReviewBoundedBuffer(1 << 20)
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			chunk := []byte("concurrent-write-chunk\n")
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_, _ = buffer.Write(chunk)
+				}
+			}
+		}()
+	}
+	// Interleave String/Truncated with writers the way response assembly does
+	// after early wait cancellation on the containment-failure path.
+	deadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		_ = buffer.String()
+		_ = buffer.Truncated()
+	}
+	close(stop)
+	wg.Wait()
+	// Final snapshot must be consistent (no panic / no race under -race).
+	got := buffer.String()
+	if len(got) == 0 {
+		t.Fatal("String() empty after concurrent writes")
 	}
 }
 

--- a/internal/forge/trusted_review_proxy_test.go
+++ b/internal/forge/trusted_review_proxy_test.go
@@ -128,7 +128,7 @@ func TestStartTrustedReviewProxyAllowsEmptyTrustedEnv(t *testing.T) {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
 
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy(), nil)
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}
@@ -171,7 +171,7 @@ func TestStartTrustedReviewProxyInjectsTokensIntoChild(t *testing.T) {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
 
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy(), nil)
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}
@@ -221,7 +221,7 @@ func TestStartTrustedReviewProxyRewritesPolicyFlags(t *testing.T) {
 	}
 
 	policy := TrustedReviewProxyPolicy{Clean: "APPROVE", Blocking: "REQUEST_CHANGES", ExpectedCommitID: "bound-head", ReviewerManual: true, ReviewerRunID: "run_bound"}
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, config.Config{}, policy)
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, config.Config{}, policy, nil)
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}
@@ -283,7 +283,7 @@ func TestStartTrustedReviewProxyRejectsUnboundPR(t *testing.T) {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
 
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy())
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "secret-token"}, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy(), nil)
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}
@@ -309,22 +309,22 @@ func TestStartTrustedReviewProxyRequiresAllowedPR(t *testing.T) {
 		t.Fatalf("WriteFile(realLooper) error = %v", err)
 	}
 	policy := testTrustedReviewPolicy()
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "", dir, config.Config{}, policy); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "", dir, config.Config{}, policy, nil); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with empty allowed PR = nil, want error")
 	}
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "not-a-ref", dir, config.Config{}, policy); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "not-a-ref", dir, config.Config{}, policy, nil); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with invalid allowed PR = nil, want error")
 	}
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", "", config.Config{}, policy); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", "", config.Config{}, policy, nil); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with empty allowed CWD = nil, want error")
 	}
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", "relative/path", config.Config{}, policy); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", "relative/path", config.Config{}, policy, nil); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with relative allowed CWD = nil, want error")
 	}
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", dir, config.Config{}, TrustedReviewProxyPolicy{}); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", dir, config.Config{}, TrustedReviewProxyPolicy{}, nil); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with empty policy = nil, want error")
 	}
-	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", dir, config.Config{}, TrustedReviewProxyPolicy{Clean: "APPROVE", Blocking: "APPROVE"}); err == nil {
+	if _, _, err := StartTrustedReviewProxy(realLooper, map[string]string{"FORGEJO_TOKEN": "x"}, "acme/looper#1", dir, config.Config{}, TrustedReviewProxyPolicy{Clean: "APPROVE", Blocking: "APPROVE"}, nil); err == nil {
 		t.Fatal("StartTrustedReviewProxy() with invalid blocking policy = nil, want error")
 	}
 }
@@ -491,7 +491,7 @@ func TestTrustedReviewProxyKeepsRunConfigWhenLiveFileChanges(t *testing.T) {
 		t.Fatalf("WriteFile(initial live config) error = %v", err)
 	}
 
-	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, runConfig, testTrustedReviewPolicy())
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, runConfig, testTrustedReviewPolicy(), nil)
 	if err != nil {
 		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
 	}

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -92,6 +92,7 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	waitErr := handle.Wait(waitCtx)
 	timedOut := false
 	var canceledErr error
+	var killErr error
 
 	if waitErr != nil && isContextError(waitErr) {
 		// Prefer the parent context error when it was the cause.
@@ -103,8 +104,10 @@ func Run(ctx context.Context, options Options) (Result, error) {
 			canceledErr = waitErr
 		}
 		// Confirmed drain is the only stop success path (#574 / #577).
+		// Propagate Kill failures (e.g. ErrNotConfirmedDead) so callers learn
+		// that process-group containment failed rather than only seeing cancel/timeout.
 		killCtx, killCancel := context.WithTimeout(context.Background(), gracefulShutdown+drainSlack)
-		_ = handle.Kill(killCtx)
+		killErr = handle.Kill(killCtx)
 		killCancel()
 	} else {
 		// Leader exited (zero or non-zero). Drain group members that outlived it.
@@ -133,9 +136,16 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	}
 
 	if timedOut {
-		return result, &CommandExecutionError{Message: "Command timed out", Result: result}
+		timeoutErr := error(&CommandExecutionError{Message: "Command timed out", Result: result})
+		if killErr != nil {
+			return result, errors.Join(timeoutErr, killErr)
+		}
+		return result, timeoutErr
 	}
 	if canceledErr != nil {
+		if killErr != nil {
+			return result, errors.Join(canceledErr, killErr)
+		}
 		return result, canceledErr
 	}
 	if result.ExitCode != 0 {

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -89,44 +89,15 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		defer timeoutCancel()
 	}
 
-	waitErr := handle.Wait(waitCtx)
-	timedOut := false
-	var canceledErr error
-	var killErr error
-	var drainErr error
+	// Wait in a goroutine so we can Drain when the leader is reaped but
+	// cmd.Wait is still blocked on stdout/stderr copy (background child still
+	// holds the writer ends). Blocking only on Wait never reaches Drain.
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- handle.Wait(waitCtx) }()
 
-	if waitErr != nil && isContextError(waitErr) {
-		// Prefer the parent context error when it was the cause.
-		if ctx.Err() != nil {
-			canceledErr = ctx.Err()
-		} else if options.Timeout > 0 && errors.Is(waitErr, context.DeadlineExceeded) {
-			timedOut = true
-		} else {
-			canceledErr = waitErr
-		}
-		// Confirmed drain is the only stop success path (#574 / #577).
-		// Propagate Kill failures (e.g. ErrNotConfirmedDead) so callers learn
-		// that process-group containment failed rather than only seeing cancel/timeout.
-		killCtx, killCancel := context.WithTimeout(context.Background(), gracefulShutdown+drainSlack)
-		killErr = handle.Kill(killCtx)
-		killCancel()
-	} else {
-		// Leader exited (zero or non-zero). Drain group members that outlived it.
-		drainCtx, drainCancel := context.WithTimeout(context.Background(), gracefulShutdown+drainSlack)
-		if err := handle.Drain(drainCtx); err != nil {
-			// Surface drain failure after a finished leader so callers do not
-			// treat Run as successful while descendants remain runnable.
-			// Keep drainErr separate so non-zero exit paths can Join it and
-			// not drop ErrNotConfirmedDead behind CommandExecutionError.
-			drainErr = err
-			if waitErr == nil {
-				waitErr = drainErr
-			} else {
-				waitErr = errors.Join(waitErr, drainErr)
-			}
-		}
-		drainCancel()
-	}
+	waitErr, timedOut, canceledErr, killErr, drainErr := awaitContainedCommand(
+		handle, waitCtx, ctx, options.Timeout > 0, gracefulShutdown, waitDone,
+	)
 
 	duration := time.Since(startedAt)
 	result := Result{
@@ -165,6 +136,110 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		return result, waitErr
 	}
 	return result, nil
+}
+
+// awaitContainedCommand finishes a contained shell command without hanging on
+// cmd.Wait's pipe-copy phase. When a same-process-group descendant inherits
+// stdout/stderr and outlives the leader, Process.Wait reaps the leader (PID
+// goes ESRCH) while Wait is still blocked on copy EOF — poll that case and
+// Drain so containment can kill the descendant and unstick Wait.
+func awaitContainedCommand(
+	handle *processcontainment.Handle,
+	waitCtx, parentCtx context.Context,
+	hasTimeout bool,
+	gracefulShutdown time.Duration,
+	waitDone <-chan error,
+) (waitErr error, timedOut bool, canceledErr error, killErr error, drainErr error) {
+	poll := time.NewTicker(10 * time.Millisecond)
+	defer poll.Stop()
+
+	var alreadyDrained bool
+	for {
+		select {
+		case waitErr = <-waitDone:
+			if waitErr != nil && isContextError(waitErr) {
+				// Prefer the parent context error when it was the cause.
+				if parentCtx.Err() != nil {
+					canceledErr = parentCtx.Err()
+				} else if hasTimeout && errors.Is(waitErr, context.DeadlineExceeded) {
+					timedOut = true
+				} else {
+					canceledErr = waitErr
+				}
+				// Confirmed drain is the only stop success path (#574 / #577).
+				// Propagate Kill failures (e.g. ErrNotConfirmedDead) so callers learn
+				// that process-group containment failed rather than only seeing cancel/timeout.
+				killCtx, killCancel := context.WithTimeout(context.Background(), gracefulShutdown+drainSlack)
+				killErr = handle.Kill(killCtx)
+				killCancel()
+				return waitErr, timedOut, canceledErr, killErr, drainErr
+			}
+			if !alreadyDrained {
+				// Leader exited (zero or non-zero). Drain group members that outlived it.
+				drainCtx, drainCancel := context.WithTimeout(context.Background(), gracefulShutdown+drainSlack)
+				if err := handle.Drain(drainCtx); err != nil {
+					// Surface drain failure after a finished leader so callers do not
+					// treat Run as successful while descendants remain runnable.
+					// Keep drainErr separate so non-zero exit paths can Join it and
+					// not drop ErrNotConfirmedDead behind CommandExecutionError.
+					drainErr = err
+					if waitErr == nil {
+						waitErr = drainErr
+					} else {
+						waitErr = errors.Join(waitErr, drainErr)
+					}
+				}
+				drainCancel()
+			}
+			return waitErr, timedOut, canceledErr, killErr, drainErr
+
+		case <-poll.C:
+			if alreadyDrained || !processPIDGone(handle.PID()) {
+				continue
+			}
+			// Leader reaped by cmd.Wait's Process.Wait, but pipe copy still
+			// blocks Wait. Drain kills pipe-holding descendants and unblocks it.
+			drainCtx, drainCancel := context.WithTimeout(context.Background(), gracefulShutdown+drainSlack)
+			if err := handle.Drain(drainCtx); err != nil {
+				drainErr = err
+			}
+			drainCancel()
+			alreadyDrained = true
+			// Wait should complete once pipes close; bound the receive.
+			select {
+			case waitErr = <-waitDone:
+				if drainErr != nil {
+					if waitErr == nil {
+						waitErr = drainErr
+					} else if !isExitError(waitErr) {
+						waitErr = errors.Join(waitErr, drainErr)
+					}
+					// ExitError + drainErr: keep drainErr separate for Join below.
+				}
+				return waitErr, timedOut, canceledErr, killErr, drainErr
+			case <-time.After(gracefulShutdown + drainSlack):
+				if waitErr == nil {
+					if drainErr != nil {
+						waitErr = drainErr
+					} else {
+						waitErr = fmt.Errorf("shell wait did not complete after drain")
+					}
+				}
+				return waitErr, timedOut, canceledErr, killErr, drainErr
+			}
+		}
+	}
+}
+
+// processPIDGone reports whether pid is no longer addressable (reaped).
+// Used to detect the stuck-pipe Wait case: cmd.Wait reaped the leader via
+// Process.Wait but is still blocked on stdout/stderr copy goroutines.
+func processPIDGone(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return errors.Is(err, syscall.ESRCH)
 }
 
 func startContainedCommand(ctx context.Context, options Options, gracefulShutdown time.Duration, stdout, stderr *boundedBuffer) (*processcontainment.Handle, error) {

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"sort"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/nexu-io/looper/internal/processcontainment"
 )
 
 const (
@@ -20,6 +21,9 @@ const (
 	// installed (common when tests write a fake tool then exec it immediately).
 	startAttempts      = 8
 	startRetryBaseWait = 5 * time.Millisecond
+	// drainSlack is added to GracefulShutdown when building containment
+	// DrainTimeout so TERM grace plus descendant cleanup fit the budget.
+	drainSlack = 15 * time.Second
 )
 
 type Result struct {
@@ -50,6 +54,11 @@ type CommandExecutionError struct {
 
 func (e *CommandExecutionError) Error() string { return e.Message }
 
+// Run starts a command under process containment (ADR-0015 / #577).
+//
+// The spawn boundary is Configure + Start + Bind. Cancel and timeout use
+// Handle.Kill (confirmed drain), not raw PID signal-only success. Normal exit
+// still Drain so background process-group descendants cannot outlive Run.
 func Run(ctx context.Context, options Options) (Result, error) {
 	if strings.TrimSpace(options.Command) == "" {
 		return Result{}, fmt.Errorf("command is required")
@@ -68,71 +77,53 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	stdoutBuffer := newBoundedBuffer(maxCapturedBytes)
 	stderrBuffer := newBoundedBuffer(maxCapturedBytes)
 
-	cmd, err := startCommand(ctx, options, stdoutBuffer, stderrBuffer)
+	handle, err := startContainedCommand(ctx, options, gracefulShutdown, stdoutBuffer, stderrBuffer)
 	if err != nil {
 		return Result{}, fmt.Errorf("start command: %w", err)
 	}
 
-	waitCh := make(chan error, 1)
-	go func() {
-		waitCh <- cmd.Wait()
-	}()
-
-	var (
-		waitErr          error
-		timedOut         bool
-		canceledErr      error
-		terminationStart <-chan time.Time
-		killAt           <-chan time.Time
-		terminateOnce    sync.Once
-	)
-
-	terminate := func() {
-		terminateOnce.Do(func() {
-			if cmd.Process == nil {
-				return
-			}
-			if err := cmd.Process.Signal(syscall.SIGTERM); err != nil && !isProcessDone(err) {
-				_ = cmd.Process.Kill()
-				return
-			}
-			if gracefulShutdown <= 0 {
-				_ = cmd.Process.Kill()
-				return
-			}
-			killAt = time.After(gracefulShutdown)
-		})
-	}
-
+	waitCtx := ctx
+	var timeoutCancel context.CancelFunc
 	if options.Timeout > 0 {
-		terminationStart = time.After(options.Timeout)
+		waitCtx, timeoutCancel = context.WithTimeout(ctx, options.Timeout)
+		defer timeoutCancel()
 	}
 
-	waiting := true
-	for waiting {
-		select {
-		case waitErr = <-waitCh:
-			waiting = false
-		case <-terminationStart:
+	waitErr := handle.Wait(waitCtx)
+	timedOut := false
+	var canceledErr error
+
+	if waitErr != nil && isContextError(waitErr) {
+		// Prefer the parent context error when it was the cause.
+		if ctx.Err() != nil {
+			canceledErr = ctx.Err()
+		} else if options.Timeout > 0 && errors.Is(waitErr, context.DeadlineExceeded) {
 			timedOut = true
-			terminationStart = nil
-			terminate()
-		case <-killAt:
-			killAt = nil
-			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
-			}
-		case <-ctx.Done():
-			if canceledErr == nil {
-				canceledErr = ctx.Err()
-				terminate()
+		} else {
+			canceledErr = waitErr
+		}
+		// Confirmed drain is the only stop success path (#574 / #577).
+		killCtx, killCancel := context.WithTimeout(context.Background(), gracefulShutdown+drainSlack)
+		_ = handle.Kill(killCtx)
+		killCancel()
+	} else {
+		// Leader exited (zero or non-zero). Drain group members that outlived it.
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), gracefulShutdown+drainSlack)
+		if drainErr := handle.Drain(drainCtx); drainErr != nil {
+			// Surface drain failure after a finished leader so callers do not
+			// treat Run as successful while descendants remain runnable.
+			if waitErr == nil {
+				waitErr = drainErr
+			} else {
+				waitErr = errors.Join(waitErr, drainErr)
 			}
 		}
+		drainCancel()
 	}
 
 	duration := time.Since(startedAt)
 	result := Result{
-		ExitCode:        exitCode(cmd),
+		ExitCode:        exitCode(handle),
 		Stdout:          stdoutBuffer.String(),
 		Stderr:          stderrBuffer.String(),
 		StdoutTruncated: stdoutBuffer.Truncated(),
@@ -150,13 +141,13 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	if result.ExitCode != 0 {
 		return result, &CommandExecutionError{Message: commandFailureMessage(result), Result: result}
 	}
-	if waitErr != nil {
+	if waitErr != nil && !isExitError(waitErr) {
 		return result, waitErr
 	}
 	return result, nil
 }
 
-func startCommand(ctx context.Context, options Options, stdout, stderr *boundedBuffer) (*exec.Cmd, error) {
+func startContainedCommand(ctx context.Context, options Options, gracefulShutdown time.Duration, stdout, stderr *boundedBuffer) (*processcontainment.Handle, error) {
 	var lastErr error
 	for attempt := 0; attempt < startAttempts; attempt++ {
 		if attempt > 0 {
@@ -184,6 +175,7 @@ func startCommand(ctx context.Context, options Options, stdout, stderr *boundedB
 		stderr.reset()
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
+		processcontainment.Configure(cmd)
 
 		if err := cmd.Start(); err != nil {
 			lastErr = err
@@ -192,13 +184,44 @@ func startCommand(ctx context.Context, options Options, stdout, stderr *boundedB
 			}
 			return nil, err
 		}
-		return cmd, nil
+		handle, err := processcontainment.Bind(cmd, processcontainment.Options{
+			GracePeriod:  gracefulShutdown,
+			DrainTimeout: gracefulShutdown + drainSlack,
+		})
+		if err != nil {
+			killStartedWithoutHandle(cmd)
+			return nil, err
+		}
+		return handle, nil
 	}
 	return nil, lastErr
 }
 
+// killStartedWithoutHandle is only used when Bind fails after Start so the
+// orphaned process group is not left live. Production stop paths use Handle.Kill.
+func killStartedWithoutHandle(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pid := cmd.Process.Pid
+	if pid > 0 {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	}
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+}
+
 func isTextFileBusy(err error) bool {
 	return errors.Is(err, syscall.ETXTBSY)
+}
+
+func isContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func isExitError(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr)
 }
 
 func commandFailureMessage(result Result) string {
@@ -231,15 +254,15 @@ func envSlice(env map[string]string) []string {
 	return values
 }
 
-func exitCode(cmd *exec.Cmd) int {
-	if cmd == nil || cmd.ProcessState == nil {
+func exitCode(handle *processcontainment.Handle) int {
+	if handle == nil {
 		return -1
 	}
-	return cmd.ProcessState.ExitCode()
-}
-
-func isProcessDone(err error) bool {
-	return err == nil || err == os.ErrProcessDone
+	state := handle.ProcessState()
+	if state == nil {
+		return -1
+	}
+	return state.ExitCode()
 }
 
 type boundedBuffer struct {

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -45,6 +45,11 @@ type Options struct {
 	Timeout          time.Duration
 	GracefulShutdown time.Duration
 	MaxCapturedBytes int
+	// Tracker registers the live containment handle with the Execution
+	// Supervisor for shutdown drain / retain-storage (ADR-0015 / #577).
+	// Set only for Supervisor-owned paths (worker/fixer validation). Leave nil
+	// for independently lifecycle-owned gateways (git/gh/tea, osascript).
+	Tracker processcontainment.LiveTracker
 }
 
 type CommandExecutionError struct {
@@ -81,6 +86,12 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	if err != nil {
 		return Result{}, fmt.Errorf("start command: %w", err)
 	}
+	if options.Tracker != nil {
+		release := options.Tracker.Track(handle)
+		if release != nil {
+			defer release()
+		}
+	}
 
 	waitCtx := ctx
 	var timeoutCancel context.CancelFunc
@@ -98,6 +109,9 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	waitErr, timedOut, canceledErr, killErr, drainErr := awaitContainedCommand(
 		handle, waitCtx, ctx, options.Timeout > 0, gracefulShutdown, waitDone,
 	)
+	// Surface containment failures to the Supervisor for retain-storage even
+	// when callers (e.g. validation) collapse Run errors into a failed result.
+	reportContainmentFailure(options.Tracker, killErr, drainErr)
 
 	duration := time.Since(startedAt)
 	result := Result{
@@ -136,6 +150,17 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		return result, waitErr
 	}
 	return result, nil
+}
+
+func reportContainmentFailure(tracker processcontainment.LiveTracker, errs ...error) {
+	if tracker == nil {
+		return
+	}
+	for _, err := range errs {
+		if err != nil {
+			tracker.ReportDrainFailure(err)
+		}
+	}
 }
 
 // awaitContainedCommand finishes a contained shell command without hanging on

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -93,6 +93,7 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	timedOut := false
 	var canceledErr error
 	var killErr error
+	var drainErr error
 
 	if waitErr != nil && isContextError(waitErr) {
 		// Prefer the parent context error when it was the cause.
@@ -112,9 +113,12 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	} else {
 		// Leader exited (zero or non-zero). Drain group members that outlived it.
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), gracefulShutdown+drainSlack)
-		if drainErr := handle.Drain(drainCtx); drainErr != nil {
+		if err := handle.Drain(drainCtx); err != nil {
 			// Surface drain failure after a finished leader so callers do not
 			// treat Run as successful while descendants remain runnable.
+			// Keep drainErr separate so non-zero exit paths can Join it and
+			// not drop ErrNotConfirmedDead behind CommandExecutionError.
+			drainErr = err
 			if waitErr == nil {
 				waitErr = drainErr
 			} else {
@@ -149,7 +153,13 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		return result, canceledErr
 	}
 	if result.ExitCode != 0 {
-		return result, &CommandExecutionError{Message: commandFailureMessage(result), Result: result}
+		cmdErr := error(&CommandExecutionError{Message: commandFailureMessage(result), Result: result})
+		// Containment contract: drain failures must surface even when the
+		// leader already failed validation/tool exit.
+		if drainErr != nil {
+			return result, errors.Join(cmdErr, drainErr)
+		}
+		return result, cmdErr
 	}
 	if waitErr != nil && !isExitError(waitErr) {
 		return result, waitErr

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -158,9 +159,9 @@ func TestRunRetriesStartOnTextFileBusy(t *testing.T) {
 	}
 	// Confirm this platform produces ETXTBSY under a write hold; skip otherwise
 	// (some filesystems / kernels do not surface it for shell scripts).
-	if probe, probeErr := startCommand(context.Background(), Options{Command: script}, newBoundedBuffer(64), newBoundedBuffer(64)); probeErr == nil {
+	if probe, probeErr := startContainedCommand(context.Background(), Options{Command: script}, defaultGracefulStop, newBoundedBuffer(64), newBoundedBuffer(64)); probeErr == nil {
 		_ = holder.Close()
-		if waitErr := probe.Wait(); waitErr != nil {
+		if waitErr := probe.Wait(context.Background()); waitErr != nil {
 			t.Fatalf("probe Wait() error = %v", waitErr)
 		}
 		t.Skip("filesystem does not return ETXTBSY while script is open for write")
@@ -184,4 +185,66 @@ func TestRunRetriesStartOnTextFileBusy(t *testing.T) {
 	if result.Stdout != "ok" {
 		t.Fatalf("Stdout = %q, want ok", result.Stdout)
 	}
+}
+
+func TestRunCancelConfirmedDrainsBackgroundChild(t *testing.T) {
+	t.Parallel()
+	// Contract at the shell spawn boundary (#577): cancel must confirmed-drain
+	// process-group descendants, not treat SIGTERM delivery alone as success.
+	workDir := t.TempDir()
+	childPIDPath := filepath.Join(workDir, "child.pid")
+	script := `
+set -e
+(sleep 60) &
+echo $! > child.pid
+sleep 60
+`
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := Run(ctx, Options{
+			Command:          "/bin/sh",
+			Args:             []string{"-c", script},
+			CWD:              workDir,
+			GracefulShutdown: 50 * time.Millisecond,
+		})
+		done <- err
+	}()
+
+	// Wait for background child PID file.
+	var childPID int
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(childPIDPath)
+		if err == nil {
+			if _, scanErr := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &childPID); scanErr == nil && childPID > 0 {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if childPID <= 0 {
+		cancel()
+		t.Fatal("child pid file not written")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not return after cancel")
+	}
+
+	// Child must not remain runnable after confirmed drain.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(childPID, 0); err != nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("background child pid %d still runnable after shell cancel drain", childPID)
 }

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -190,6 +190,67 @@ func TestRunRetriesStartOnTextFileBusy(t *testing.T) {
 	}
 }
 
+func TestRunDrainsBackgroundChildAfterLeaderExitsWithPipes(t *testing.T) {
+	t.Parallel()
+	// Writer-based capture (bounded stdout/stderr) makes cmd.Wait block on copy
+	// EOF when a same-group background child inherits the pipes after the
+	// leader exits. Run must Drain that child instead of hanging in Wait.
+	workDir := t.TempDir()
+	childPIDPath := filepath.Join(workDir, "child.pid")
+	script := `
+set -e
+(sleep 60) &
+echo $! > child.pid
+exit 0
+`
+	done := make(chan struct {
+		result Result
+		err    error
+	}, 1)
+	go func() {
+		result, err := Run(context.Background(), Options{
+			Command:          "/bin/sh",
+			Args:             []string{"-c", script},
+			CWD:              workDir,
+			GracefulShutdown: 50 * time.Millisecond,
+		})
+		done <- struct {
+			result Result
+			err    error
+		}{result, err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("Run() error = %v, want nil", got.err)
+		}
+		if got.result.ExitCode != 0 {
+			t.Fatalf("ExitCode = %d, want 0", got.result.ExitCode)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() hung after leader exit with background pipe-holding child")
+	}
+
+	// Child must not remain runnable after confirmed drain.
+	data, err := os.ReadFile(childPIDPath)
+	if err != nil {
+		t.Fatalf("read child pid: %v", err)
+	}
+	var childPID int
+	if _, scanErr := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &childPID); scanErr != nil || childPID <= 0 {
+		t.Fatalf("child pid file = %q, want positive pid", data)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if processIsNonRunnable(childPID) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("background child pid %d still runnable after shell normal-exit drain", childPID)
+}
+
 func TestRunCancelConfirmedDrainsBackgroundChild(t *testing.T) {
 	t.Parallel()
 	// Contract at the shell spawn boundary (#577): cancel must confirmed-drain

--- a/internal/infra/shell/runner_test.go
+++ b/internal/infra/shell/runner_test.go
@@ -1,11 +1,14 @@
 package shell
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -239,12 +242,51 @@ sleep 60
 	}
 
 	// Child must not remain runnable after confirmed drain.
+	// Use zombie-aware liveness: on Linux kill(pid, 0) still succeeds for
+	// zombies, but containment treats zombie-only groups as non-runnable.
 	deadline = time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if err := syscall.Kill(childPID, 0); err != nil {
+		if processIsNonRunnable(childPID) {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("background child pid %d still runnable after shell cancel drain", childPID)
+}
+
+// processIsNonRunnable matches processcontainment confirmed-dead semantics:
+// ESRCH, or a Linux zombie that kill(0) still addresses.
+func processIsNonRunnable(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	if errors.Is(err, syscall.ESRCH) {
+		return true
+	}
+	if err != nil {
+		return false
+	}
+	if runtime.GOOS == "linux" {
+		if zombie, ok := linuxPIDIsZombie(pid); ok {
+			return zombie
+		}
+	}
+	return false
+}
+
+// linuxPIDIsZombie reports whether /proc/pid is a zombie (state Z).
+// ok is false when the stat file cannot be read/parsed.
+func linuxPIDIsZombie(pid int) (zombie bool, ok bool) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, true
+		}
+		return false, false
+	}
+	// Format: pid (comm) state ... — state is the first field after the final ") ".
+	i := bytes.LastIndexByte(data, ')')
+	if i < 0 || i+2 >= len(data) {
+		return false, false
+	}
+	state := data[i+2]
+	return state == 'Z' || state == 'X' || state == 'x', true
 }

--- a/internal/processcontainment/containment.go
+++ b/internal/processcontainment/containment.go
@@ -110,6 +110,12 @@ func Configure(cmd *exec.Cmd) {
 // The bound process must be its process-group leader (pgid == pid). Binding a
 // command that shares the caller's ambient group would make SignalGroup target
 // -pgid against Looper and sibling processes.
+//
+// When the leader exits between Start and Bind, getpgid may return ESRCH. If
+// Configure was used (Setpgid), the process was group leader while live, so
+// Bind assumes pgid == pid and still attaches a handle so Wait/Drain can reap
+// and confirm the group. Callers that did not Configure must not rely on this
+// path.
 func Bind(cmd *exec.Cmd, opts Options) (*Handle, error) {
 	if cmd == nil || cmd.Process == nil {
 		return nil, fmt.Errorf("process containment: started command with process is required")
@@ -120,6 +126,11 @@ func Bind(cmd *exec.Cmd, opts Options) (*Handle, error) {
 	}
 	pgid, err := syscall.Getpgid(pid)
 	if err != nil {
+		if isNoSuchProcess(err) {
+			// Fast-exit race after Configure+Start: leader is already gone.
+			// Configure sets Setpgid so the live process was group leader.
+			return newHandle(cmd, pid, pid, opts), nil
+		}
 		return nil, fmt.Errorf("process containment: getpgid(%d): %w", pid, err)
 	}
 	if pgid != pid {

--- a/internal/processcontainment/containment_bind_test.go
+++ b/internal/processcontainment/containment_bind_test.go
@@ -1,6 +1,8 @@
 package processcontainment
 
 import (
+	"context"
+	"errors"
 	"os/exec"
 	"runtime"
 	"testing"
@@ -41,5 +43,42 @@ func TestBindRejectsNonGroupLeader(t *testing.T) {
 	_, err := Bind(cmd, Options{})
 	if err == nil {
 		t.Fatal("Bind() error = nil, want error when command is not process group leader")
+	}
+}
+
+func TestBindAllowsFastExitAfterConfigure(t *testing.T) {
+	requireUnixProcessGroup(t)
+
+	// Short-lived commands can exit before Bind's getpgid. Configure guarantees
+	// the process was group leader while live, so Bind must still attach.
+	for i := 0; i < 20; i++ {
+		cmd := exec.Command("/bin/sh", "-c", "exit 7")
+		Configure(cmd)
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+		handle, err := Bind(cmd, Options{})
+		if err != nil {
+			t.Fatalf("Bind() after fast exit error = %v", err)
+		}
+		if err := handle.Wait(context.Background()); err != nil {
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("Wait() error = %v, want ExitError", err)
+			}
+		}
+		if state := handle.ProcessState(); state == nil || state.ExitCode() != 7 {
+			code := -1
+			if state != nil {
+				code = state.ExitCode()
+			}
+			t.Fatalf("ExitCode = %d, want 7", code)
+		}
+		if err := handle.Drain(context.Background()); err != nil {
+			t.Fatalf("Drain() error = %v", err)
+		}
+		if !handle.ConfirmedDead() {
+			t.Fatal("ConfirmedDead() = false after Drain of fast-exit leader")
+		}
 	}
 }

--- a/internal/processcontainment/doc.go
+++ b/internal/processcontainment/doc.go
@@ -15,6 +15,7 @@
 // they return an explicit failure/timeout.
 //
 // Agent producers migrate onto this handle via the common executor boundary
-// (#576). Non-agent daemon subprocesses remain for #577. Recovery must still
-// not treat raw PID/PGID as live Authority (#575).
+// (#576). Non-agent Supervisor-owned producers (validation/shell, trusted
+// review-submit children) migrate via their spawn boundaries (#577). Recovery
+// must still not treat raw PID/PGID as live Authority (#575).
 package processcontainment

--- a/internal/processcontainment/live_tracker.go
+++ b/internal/processcontainment/live_tracker.go
@@ -1,0 +1,18 @@
+package processcontainment
+
+// LiveTracker is the optional Supervisor hook for non-agent containment handles
+// (ADR-0015 / #577). Supervisor-owned spawn boundaries (validation/shell,
+// trusted review-submit children) register live handles so daemon shutdown can
+// wait for confirmed drain and record Kill/Drain failures for retain-storage.
+//
+// Independently lifecycle-owned shell users (git/gh/tea gateways, osascript)
+// leave Tracker nil.
+type LiveTracker interface {
+	// Track registers a live handle until release is called. release is
+	// idempotent and safe after Kill/Drain completes (success or failure).
+	Track(handle *Handle) (release func())
+	// ReportDrainFailure records a Kill/Drain failure observed on the caller's
+	// ownership path so Runtime.Stop can retain SQLite instead of reporting a
+	// clean stop with undrained ownership.
+	ReportDrainFailure(err error)
+}

--- a/internal/runtime/active_executions.go
+++ b/internal/runtime/active_executions.go
@@ -727,11 +727,20 @@ func (r *ActiveExecutionRegistry) LoopStopActive(loopID string) bool {
 	return active
 }
 
+// errShutdownDrainTimeout is returned when BeginShutdown cannot confirm that a
+// pending spawn/rebind window closed within killBudget, or a bound handle did
+// not reach confirmed-dead. Callers must retain storage and fail loud (#577).
+var errShutdownDrainTimeout = errors.New("shutdown: containment drain timed out or failed")
+
 // BeginShutdown closes spawn admission, cancels pending and bound (active)
 // leases, and confirmed-drains every bound containment handle.
-func (r *ActiveExecutionRegistry) BeginShutdown(reason string) {
+//
+// Returns a non-nil error when any handle Kill fails or a spawn/rebind wait
+// times out. ADR-0015 / #577: drain failure must not be reported as graceful
+// success; Runtime.Stop retains SQLite when this returns an error.
+func (r *ActiveExecutionRegistry) BeginShutdown(reason string) error {
 	if r == nil {
-		return
+		return nil
 	}
 	r.mu.Lock()
 	r.admissionClosed = true
@@ -769,8 +778,11 @@ func (r *ActiveExecutionRegistry) BeginShutdown(reason string) {
 	for _, lease := range toCancel {
 		lease.cancel(cause)
 	}
+	var drainErr error
 	for _, entry := range entries {
-		_ = r.killOwned(entry, reason)
+		if err := r.killOwned(entry, reason); err != nil {
+			drainErr = errors.Join(drainErr, err)
+		}
 	}
 	budget := r.killBudget()
 	waitChans := make([]<-chan struct{}, 0, len(spawnWait)+len(rebindWait))
@@ -783,6 +795,13 @@ func (r *ActiveExecutionRegistry) BeginShutdown(reason string) {
 		select {
 		case <-done:
 		case <-time.After(budget):
+			drainErr = errors.Join(drainErr, errShutdownDrainTimeout)
+		}
+	}
+	// Join refuse-path killUnowned failures published on waited leases.
+	for _, lease := range toCancel {
+		if err := lease.takeUnownedDrainErr(); err != nil {
+			drainErr = errors.Join(drainErr, err)
 		}
 	}
 	if len(waitChans) > 0 {
@@ -795,9 +814,15 @@ func (r *ActiveExecutionRegistry) BeginShutdown(reason string) {
 		}
 		r.mu.Unlock()
 		for _, entry := range second {
-			_ = r.killOwned(entry, reason)
+			if err := r.killOwned(entry, reason); err != nil {
+				drainErr = errors.Join(drainErr, err)
+			}
 		}
 	}
+	if drainErr != nil {
+		return errors.Join(errShutdownDrainTimeout, drainErr)
+	}
+	return nil
 }
 
 // Register is retained for tests and transitional paths that hold an

--- a/internal/runtime/active_executions.go
+++ b/internal/runtime/active_executions.go
@@ -29,6 +29,14 @@ type ownedExecution struct {
 	handle *processcontainment.Handle
 }
 
+// nonAgentTracked is one Supervisor-owned non-agent containment handle
+// (shell validation, trusted review child). Owners register while the handle
+// is live and release after their confirmed Kill/Drain path finishes.
+type nonAgentTracked struct {
+	handle *processcontainment.Handle
+	done   chan struct{}
+}
+
 // ActiveExecutionRegistry is the in-process Supervisor registry for live agent
 // executions (ADR-0015 R3 / #576). It owns:
 //
@@ -36,9 +44,13 @@ type ownedExecution struct {
 //   - containment handle binding after spawn
 //   - stop/shutdown race linearization (kill+confirmed drain before Start success)
 //   - Kill via bound handle for looper stop / haltLoop
+//   - non-agent handle tracking for shutdown drain / retain-storage (#577)
 //
 // This is intentionally narrower than the #572 draft ExecutionSupervisor
 // (queue reservations, persistence Authority, etc.). Those land in later slices.
+// Non-agent tracking is not a second agent lease registry: short shell/proxy
+// jobs only register the live containment handle so BeginShutdown can wait or
+// force-drain and surface failures for retain-storage.
 type ActiveExecutionRegistry struct {
 	mu sync.Mutex
 
@@ -63,6 +75,14 @@ type ActiveExecutionRegistry struct {
 	stopDrained map[string]struct{}
 	nextLeaseID uint64
 
+	// nonAgentHandles tracks Supervisor-owned non-agent containment handles
+	// registered via Track (processcontainment.LiveTracker).
+	nonAgentHandles map[uint64]*nonAgentTracked
+	nextNonAgentID  uint64
+	// nonAgentDrainErr accumulates ReportDrainFailure and force-kill failures
+	// from non-agent handles so Runtime.Stop can retain SQLite.
+	nonAgentDrainErr error
+
 	admissionClosed bool
 	shutdownReason  string
 
@@ -83,12 +103,13 @@ const defaultKillTimeout = 20 * time.Second
 
 func NewActiveExecutionRegistry() *ActiveExecutionRegistry {
 	return &ActiveExecutionRegistry{
-		executions:    make(map[string]*ownedExecution),
-		pending:       make(map[uint64]*spawnLease),
-		active:        make(map[uint64]*spawnLease),
-		stoppingLoops: make(map[string]int),
-		stopEpoch:     make(map[string]uint64),
-		stopDrained:   make(map[string]struct{}),
+		executions:      make(map[string]*ownedExecution),
+		pending:         make(map[uint64]*spawnLease),
+		active:          make(map[uint64]*spawnLease),
+		stoppingLoops:   make(map[string]int),
+		stopEpoch:       make(map[string]uint64),
+		stopDrained:     make(map[string]struct{}),
+		nonAgentHandles: make(map[uint64]*nonAgentTracked),
 	}
 }
 
@@ -762,8 +783,65 @@ func (r *ActiveExecutionRegistry) LoopStopActive(loopID string) bool {
 // not reach confirmed-dead. Callers must retain storage and fail loud (#577).
 var errShutdownDrainTimeout = errors.New("shutdown: containment drain timed out or failed")
 
+// Track implements processcontainment.LiveTracker for Supervisor-owned non-agent
+// handles (validation/shell, trusted review). release is idempotent.
+func (r *ActiveExecutionRegistry) Track(handle *processcontainment.Handle) (release func()) {
+	if r == nil || handle == nil {
+		return func() {}
+	}
+	entry := &nonAgentTracked{handle: handle, done: make(chan struct{})}
+	r.mu.Lock()
+	if r.nonAgentHandles == nil {
+		r.nonAgentHandles = make(map[uint64]*nonAgentTracked)
+	}
+	r.nextNonAgentID++
+	id := r.nextNonAgentID
+	r.nonAgentHandles[id] = entry
+	r.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.mu.Lock()
+			if _, ok := r.nonAgentHandles[id]; ok {
+				delete(r.nonAgentHandles, id)
+			}
+			r.mu.Unlock()
+			close(entry.done)
+		})
+	}
+}
+
+// ReportDrainFailure implements processcontainment.LiveTracker. Callers report
+// Kill/Drain failures from their ownership path so late cancel drains still
+// feed retain-storage even when BeginShutdown already returned.
+func (r *ActiveExecutionRegistry) ReportDrainFailure(err error) {
+	if r == nil || err == nil {
+		return
+	}
+	r.mu.Lock()
+	r.nonAgentDrainErr = errors.Join(r.nonAgentDrainErr, err)
+	r.mu.Unlock()
+}
+
+// NonAgentDrainErr returns accumulated non-agent containment drain failures.
+// Runtime.Stop re-reads this after producer waits so late shell/proxy reports
+// still retain storage.
+func (r *ActiveExecutionRegistry) NonAgentDrainErr() error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.nonAgentDrainErr
+}
+
 // BeginShutdown closes spawn admission, cancels pending and bound (active)
 // leases, and confirmed-drains every bound containment handle.
+//
+// Also waits for Supervisor-owned non-agent handles (shell/trusted-review) to
+// release after cancel, force-kills stragglers, and joins ReportDrainFailure
+// results so retain-storage covers non-agent containment failures (#577).
 //
 // Returns a non-nil error when any handle Kill fails or a spawn/rebind wait
 // times out. ADR-0015 / #577: drain failure must not be reported as graceful
@@ -849,10 +927,80 @@ func (r *ActiveExecutionRegistry) BeginShutdown(reason string) error {
 			}
 		}
 	}
+
+	// Non-agent Supervisor-owned handles: prefer owner cancel path (shell.Run /
+	// trusted-review Kill) so we do not race concurrent Kill. Wait for release,
+	// then force-kill stragglers and join reported drain failures.
+	if err := r.drainNonAgentHandles(budget); err != nil {
+		drainErr = errors.Join(drainErr, err)
+	}
+
 	if drainErr != nil {
 		return errors.Join(errShutdownDrainTimeout, drainErr)
 	}
 	return nil
+}
+
+// drainNonAgentHandles waits for tracked non-agent handles to release (owner
+// confirmed-drain path), force-kills any that outlive the budget, and joins
+// ReportDrainFailure results.
+func (r *ActiveExecutionRegistry) drainNonAgentHandles(budget time.Duration) error {
+	if r == nil {
+		return nil
+	}
+	type pendingNonAgent struct {
+		handle *processcontainment.Handle
+		done   <-chan struct{}
+	}
+	r.mu.Lock()
+	pending := make([]pendingNonAgent, 0, len(r.nonAgentHandles))
+	for _, entry := range r.nonAgentHandles {
+		if entry == nil || entry.handle == nil {
+			continue
+		}
+		pending = append(pending, pendingNonAgent{handle: entry.handle, done: entry.done})
+	}
+	r.mu.Unlock()
+
+	deadline := time.NewTimer(budget)
+	defer deadline.Stop()
+	timedOut := false
+	for _, p := range pending {
+		if timedOut {
+			break
+		}
+		select {
+		case <-p.done:
+		case <-deadline.C:
+			timedOut = true
+		}
+	}
+
+	var drainErr error
+	if timedOut {
+		drainErr = errors.Join(drainErr, errShutdownDrainTimeout)
+		r.mu.Lock()
+		stragglers := make([]*processcontainment.Handle, 0, len(r.nonAgentHandles))
+		for _, entry := range r.nonAgentHandles {
+			if entry != nil && entry.handle != nil {
+				stragglers = append(stragglers, entry.handle)
+			}
+		}
+		r.mu.Unlock()
+		for _, handle := range stragglers {
+			ctx, cancel := context.WithTimeout(context.Background(), r.killBudget())
+			if err := handle.Kill(ctx); err != nil {
+				drainErr = errors.Join(drainErr, err)
+				r.ReportDrainFailure(err)
+			}
+			cancel()
+		}
+	}
+
+	if err := r.NonAgentDrainErr(); err != nil {
+		drainErr = errors.Join(drainErr, err)
+	}
+	return drainErr
 }
 
 // Register is retained for tests and transitional paths that hold an
@@ -1025,3 +1173,6 @@ func activeExecutionKey(loopID, runID, executionID string) string {
 
 // Compile-time check: registry is the agent.SpawnOwner for daemon producers.
 var _ agent.SpawnOwner = (*ActiveExecutionRegistry)(nil)
+
+// Compile-time check: registry tracks Supervisor-owned non-agent handles (#577).
+var _ processcontainment.LiveTracker = (*ActiveExecutionRegistry)(nil)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -443,6 +443,10 @@ func (r *Runtime) Stop(reason string) {
 //
 // Shutdown order (ADR-0015 / #577): close admission → cancel producers →
 // confirmed-drain handles (agents + tracked non-agent shell/trusted-review).
+// Producer cancel must run before ActiveExecutionRegistry.BeginShutdown waits
+// on tracked non-agent handles: validation shell.Run only enters Kill after its
+// owner ctx is canceled. Waiting first would burn the full kill budget then
+// force-kill instead of cancel/drain promptly.
 // SQLite close happens only in Stop after drain succeeds; drain failure is
 // recorded for retain-storage. Non-agent Kill/Drain failures that finish after
 // this returns are re-collected in Stop via NonAgentDrainErr.
@@ -451,15 +455,9 @@ func (r *Runtime) BeginShutdown(reason string) {
 		return
 	}
 	_ = r.admission.BeginShutdown(reason)
-	// Close agent spawn admission and confirmed-drain live handles — agents and
-	// tracked Supervisor-owned non-agents (#576/#577).
-	if r.activeExecutions != nil {
-		if err := r.activeExecutions.BeginShutdown(reason); err != nil {
-			r.mu.Lock()
-			r.shutdownDrainErr = errors.Join(r.shutdownDrainErr, err)
-			r.mu.Unlock()
-		}
-	}
+	// Cancel work-producing owners before waiting on tracked non-agent handles
+	// so shell validation / trusted-review Run paths observe cancel and enter
+	// their confirmed Kill path promptly (#590 review).
 	r.mu.Lock()
 	cancel := r.schedulerCancel
 	recoveryCancel := r.recoveryCancel
@@ -473,6 +471,16 @@ func (r *Runtime) BeginShutdown(reason string) {
 	}
 	if forwarder != nil {
 		forwarder.CancelExecute()
+	}
+	// Close agent spawn admission and confirmed-drain live handles — agents and
+	// tracked Supervisor-owned non-agents (#576/#577). Agent leases cancel via
+	// registry; non-agent owners were canceled above.
+	if r.activeExecutions != nil {
+		if err := r.activeExecutions.BeginShutdown(reason); err != nil {
+			r.mu.Lock()
+			r.shutdownDrainErr = errors.Join(r.shutdownDrainErr, err)
+			r.mu.Unlock()
+		}
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -193,6 +193,13 @@ type Runtime struct {
 	// this flag is not a mutation/claim gate.
 	ownershipAcquired bool
 	admission         *Admission
+
+	// shutdownDrainErr is set by BeginShutdown when producer/handle drain fails.
+	// Stop retains SQLite when non-nil (ADR-0015 / #577).
+	shutdownDrainErr error
+	// storageRetained is true when Stop skipped coordinator.Close after a
+	// drain failure so undrained ownership is not closed under SQLite.
+	storageRetained bool
 }
 
 type runtimeNetworkManager interface {
@@ -342,6 +349,7 @@ func (r *Runtime) Stop(reason string) {
 		coordinator := r.services.Coordinator
 		repositories := r.services.Repositories
 		ownershipAcquired := r.ownershipAcquired
+		drainErr := r.shutdownDrainErr
 		r.mu.Unlock()
 
 		if ownershipAcquired && repositories != nil {
@@ -350,16 +358,35 @@ func (r *Runtime) Stop(reason string) {
 			}
 		}
 
-		r.mu.Lock()
-		r.services = Services{}
-		r.mu.Unlock()
-
+		// Independent infra (forwarder/network) still stop on drain failure;
+		// they are not Supervisor domain and must not block retain-storage.
 		if forwarder != nil {
 			forwarder.Close()
 		}
 		if networkManager != nil {
 			networkManager.Stop()
 		}
+
+		// #577: retain SQLite when containment drain failed. Never report
+		// graceful success with undrained ownership under a closed DB.
+		if drainErr != nil {
+			r.mu.Lock()
+			r.storageRetained = true
+			r.mu.Unlock()
+			close(r.shutdownCh)
+			if r.logger != nil {
+				r.logger.Error("looperd runtime stop retained storage after drain failure", map[string]any{
+					"reason": reason,
+					"error":  drainErr.Error(),
+				})
+			}
+			return
+		}
+
+		r.mu.Lock()
+		r.services = Services{}
+		r.mu.Unlock()
+
 		if coordinator != nil {
 			if err := coordinator.Close(); err != nil && r.logger != nil {
 				r.logger.Warn("looperd runtime close failed", map[string]any{"error": err.Error()})
@@ -384,14 +411,22 @@ func (r *Runtime) Stop(reason string) {
 // wait for recovery exit remains in Runtime.Stop via stopDeferredReviewerRecovery.
 // Cancels webhook-forward discovery so a worker that already passed
 // AllowExecute cannot finish CreateOrGetActiveByDedupe after admission closes.
+//
+// Shutdown order (ADR-0015 / #577): close admission → cancel producers →
+// confirmed-drain handles. SQLite close happens only in Stop after drain
+// succeeds; drain failure is recorded for retain-storage.
 func (r *Runtime) BeginShutdown(reason string) {
 	if r == nil {
 		return
 	}
 	_ = r.admission.BeginShutdown(reason)
-	// Close agent spawn admission and confirmed-drain live handles (#576).
+	// Close agent spawn admission and confirmed-drain live handles (#576/#577).
 	if r.activeExecutions != nil {
-		r.activeExecutions.BeginShutdown(reason)
+		if err := r.activeExecutions.BeginShutdown(reason); err != nil {
+			r.mu.Lock()
+			r.shutdownDrainErr = errors.Join(r.shutdownDrainErr, err)
+			r.mu.Unlock()
+		}
 	}
 	r.mu.Lock()
 	cancel := r.schedulerCancel
@@ -407,6 +442,28 @@ func (r *Runtime) BeginShutdown(reason string) {
 	if forwarder != nil {
 		forwarder.CancelExecute()
 	}
+}
+
+// StorageRetained reports whether Stop skipped SQLite close after a drain
+// failure (ADR-0015 / #577). Operators must not treat stop as graceful success.
+func (r *Runtime) StorageRetained() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.storageRetained
+}
+
+// ShutdownDrainError returns the drain failure recorded during BeginShutdown,
+// if any.
+func (r *Runtime) ShutdownDrainError() error {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.shutdownDrainErr
 }
 
 // AdmissionState returns the authoritative live admission state.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -358,6 +358,17 @@ func (r *Runtime) Stop(reason string) {
 		r.stopSchedulerLoop()
 		r.stopWebhookRuntime()
 
+		// Re-collect non-agent containment drain failures reported while
+		// producers finished after BeginShutdown (shell validation / trusted
+		// review cancel paths). Agent failures were already joined above.
+		if r.activeExecutions != nil {
+			if err := r.activeExecutions.NonAgentDrainErr(); err != nil {
+				r.mu.Lock()
+				r.shutdownDrainErr = errors.Join(r.shutdownDrainErr, err)
+				r.mu.Unlock()
+			}
+		}
+
 		r.mu.Lock()
 		r.stopped = true
 		forwarder := r.webhookForwarder
@@ -431,14 +442,17 @@ func (r *Runtime) Stop(reason string) {
 // AllowExecute cannot finish CreateOrGetActiveByDedupe after admission closes.
 //
 // Shutdown order (ADR-0015 / #577): close admission → cancel producers →
-// confirmed-drain handles. SQLite close happens only in Stop after drain
-// succeeds; drain failure is recorded for retain-storage.
+// confirmed-drain handles (agents + tracked non-agent shell/trusted-review).
+// SQLite close happens only in Stop after drain succeeds; drain failure is
+// recorded for retain-storage. Non-agent Kill/Drain failures that finish after
+// this returns are re-collected in Stop via NonAgentDrainErr.
 func (r *Runtime) BeginShutdown(reason string) {
 	if r == nil {
 		return
 	}
 	_ = r.admission.BeginShutdown(reason)
-	// Close agent spawn admission and confirmed-drain live handles (#576/#577).
+	// Close agent spawn admission and confirmed-drain live handles — agents and
+	// tracked Supervisor-owned non-agents (#576/#577).
 	if r.activeExecutions != nil {
 		if err := r.activeExecutions.BeginShutdown(reason); err != nil {
 			r.mu.Lock()

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nexu-io/looper/internal/network/protocol"
 	"github.com/nexu-io/looper/internal/networkpolicy"
 	"github.com/nexu-io/looper/internal/planner"
+	"github.com/nexu-io/looper/internal/processcontainment"
 	"github.com/nexu-io/looper/internal/projects"
 	"github.com/nexu-io/looper/internal/reviewer"
 	"github.com/nexu-io/looper/internal/storage"
@@ -298,7 +299,10 @@ func resolveTrustedLooperCLIPath(cfg config.Config) string {
 // trustedEnv may be empty when ambient credential stores suffice. Setup fails
 // closed: callers must not fall back to direct review submit. cleanup stops the
 // listener and must run when the agent execution ends.
-func mintTrustedReviewProxyForPR(realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd string, configSnapshot config.Config, policy forge.TrustedReviewProxyPolicy) (sockPath string, cleanup func(), err error) {
+//
+// tracker registers Supervisor-owned review-submit children for shutdown drain
+// / retain-storage (#577). Nil is allowed only in tests.
+func mintTrustedReviewProxyForPR(realLooper string, trustedEnv map[string]string, allowedPRRef, allowedCwd string, configSnapshot config.Config, policy forge.TrustedReviewProxyPolicy, tracker processcontainment.LiveTracker) (sockPath string, cleanup func(), err error) {
 	realLooper = strings.TrimSpace(realLooper)
 	allowedPRRef = strings.TrimSpace(allowedPRRef)
 	allowedCwd = strings.TrimSpace(allowedCwd)
@@ -319,7 +323,7 @@ func mintTrustedReviewProxyForPR(realLooper string, trustedEnv map[string]string
 	if err != nil {
 		return "", nil, fmt.Errorf("make trusted looper path absolute: %w", err)
 	}
-	return forge.StartTrustedReviewProxy(resolvedLooper, trustedEnv, allowedPRRef, allowedCwd, configSnapshot, policy)
+	return forge.StartTrustedReviewProxy(resolvedLooper, trustedEnv, allowedPRRef, allowedCwd, configSnapshot, policy, tracker)
 }
 
 func forgejoClientForRepo(cfg *config.Config, repo string) (*forge.ForgejoClient, bool, error) {
@@ -1730,6 +1734,9 @@ type reviewerAgentExecutorAdapter struct {
 	// config is used to gate trusted review-submit sockets on per-project
 	// publish mode (summary_comment must not mint a native review socket).
 	config *config.Config
+	// tracker registers Supervisor-owned review-submit children for shutdown
+	// drain / retain-storage (#577).
+	tracker processcontainment.LiveTracker
 }
 type reviewerAgentExecutionAdapter struct {
 	execution agent.Execution
@@ -1905,7 +1912,7 @@ func (a reviewerAgentExecutorAdapter) Start(ctx context.Context, input reviewer.
 			return nil, fmt.Errorf("install run-bound trusted review proxy: reviewer run id does not match agent run")
 		}
 		var err error
-		sock, proxyCleanup, err = mintTrustedReviewProxyForPR(a.realLooper, a.trustedEnv, allowedPR, allowedCwd, *a.config, policy)
+		sock, proxyCleanup, err = mintTrustedReviewProxyForPR(a.realLooper, a.trustedEnv, allowedPR, allowedCwd, *a.config, policy, a.tracker)
 		if err != nil {
 			return nil, fmt.Errorf("install run-bound trusted review proxy: %w", err)
 		}
@@ -3142,6 +3149,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 			realLooper: looperCLIPath,
 			trustedEnv: trustedReviewChildEnv(cfg),
 			config:     &cfg,
+			tracker:    activeExecutions,
 		},
 		Logger:           logger,
 		Now:              now,
@@ -3189,6 +3197,8 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		AllowAutoPush:      cfg.Defaults.AllowAutoPush,
 		AllowRiskyFixes:    cfg.Defaults.AllowRiskyFixes,
 		FixAllPullRequests: cfg.Defaults.FixAllPullRequests,
+		// Validation shell is Supervisor-owned (#577): track handles for retain-storage.
+		ContainmentTracker: activeExecutions,
 		DiscoveryPolicy: fixer.DiscoveryPolicy{
 			AutoDiscovery: cfg.Roles.Fixer.AutoDiscovery,
 			IncludeDrafts: cfg.Roles.Fixer.Triggers.IncludeDrafts,
@@ -3235,6 +3245,8 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		AllowAutoCommit: cfg.Defaults.AllowAutoCommit,
 		AllowAutoPush:   cfg.Defaults.AllowAutoPush,
 		OpenPRStrategy:  cfg.Defaults.OpenPRStrategy,
+		// Validation shell is Supervisor-owned (#577): track handles for retain-storage.
+		ContainmentTracker: activeExecutions,
 		DiscoveryPolicy: worker.DiscoveryPolicy{
 			AutoDiscovery:              cfg.Roles.Worker.AutoDiscovery,
 			Labels:                     append([]string(nil), cfg.Roles.Worker.Triggers.Labels...),

--- a/internal/runtime/scheduler_trusted_review_proxy_test.go
+++ b/internal/runtime/scheduler_trusted_review_proxy_test.go
@@ -28,6 +28,7 @@ func TestMintTrustedReviewProxyResolvesConfiguredLooperCommandFromPATH(t *testin
 			Blocking:         "REQUEST_CHANGES",
 			ExpectedCommitID: "head-42",
 		},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("mintTrustedReviewProxyForPR() error = %v", err)

--- a/internal/runtime/shutdown_order_test.go
+++ b/internal/runtime/shutdown_order_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/processcontainment"
 )
 
@@ -187,6 +188,96 @@ func TestShutdownRetainsStorageWhenNonAgentDrainFailureReported(t *testing.T) {
 	}
 	if services := rt.Services(); services.Coordinator == nil {
 		t.Fatal("Services().Coordinator = nil after Stop with non-agent drain failure, want retained storage")
+	}
+}
+
+// Contract (#590 review): BeginShutdown cancels producer contexts before
+// waiting on tracked non-agent handles. Validation shell.Run only Kill/Drains
+// after its owner ctx is canceled; waiting first would burn killBudget then
+// force-kill instead of cancel/drain promptly.
+func TestBeginShutdownCancelsProducersBeforeNonAgentDrain(t *testing.T) {
+	t.Parallel()
+
+	reg := NewActiveExecutionRegistry()
+	// Long budget makes reverse-order bugs obvious: without producer cancel
+	// first, drainNonAgentHandles waits this long before force-kill.
+	reg.killTimeout = 3 * time.Second
+
+	producerCtx, producerCancel := context.WithCancel(context.Background())
+	rt := &Runtime{
+		admission:        NewAdmission(),
+		activeExecutions: reg,
+		schedulerCancel:  producerCancel,
+		shutdownCh:       make(chan struct{}),
+	}
+	if err := rt.admission.MarkReady("test"); err != nil {
+		t.Fatalf("MarkReady: %v", err)
+	}
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		// Signal once Track has a chance after Bind: poll registry LiveTracker
+		// by starting a long sleep that only exits via cancel → Kill.
+		close(started)
+		_, err := shell.Run(producerCtx, shell.Options{
+			Command:          "/bin/sh",
+			Args:             []string{"-c", "sleep 60"},
+			GracefulShutdown: 100 * time.Millisecond,
+			Tracker:          reg,
+		})
+		done <- err
+	}()
+	<-started
+
+	// Wait until the shell handle is tracked (or fail fast).
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		reg.mu.Lock()
+		n := len(reg.nonAgentHandles)
+		reg.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			producerCancel()
+			t.Fatal("timed out waiting for non-agent handle Track")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	start := time.Now()
+	rt.BeginShutdown("test cancel-before-non-agent-drain")
+	elapsed := time.Since(start)
+
+	// Prompt path must finish well under kill budget (cancel → shell Kill → release).
+	if elapsed >= reg.killTimeout {
+		t.Fatalf("BeginShutdown took %v (>= killTimeout %v); producer cancel likely ran after non-agent wait", elapsed, reg.killTimeout)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("BeginShutdown took %v, want prompt cancel/drain well under 1s", elapsed)
+	}
+	if rt.AdmissionState() != AdmissionStopping {
+		t.Fatalf("AdmissionState() = %q, want stopping", rt.AdmissionState())
+	}
+
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			// Kill join with cancel is acceptable; plain cancel is ideal.
+			if !strings.Contains(err.Error(), context.Canceled.Error()) {
+				t.Fatalf("shell.Run error = %v, want context.Canceled (prompt cancel path)", err)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("shell.Run did not return after BeginShutdown")
+	}
+
+	reg.mu.Lock()
+	remaining := len(reg.nonAgentHandles)
+	reg.mu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("nonAgentHandles remaining = %d, want 0 after prompt drain", remaining)
 	}
 }
 

--- a/internal/runtime/shutdown_order_test.go
+++ b/internal/runtime/shutdown_order_test.go
@@ -1,0 +1,190 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/agent"
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/processcontainment"
+)
+
+// Contract (#577): shutdown order is admission → cancel/drain producers →
+// handles, then SQLite close. On drain failure, retain storage and never
+// report graceful success (StorageRetained).
+func TestShutdownRetainsStorageWhenContainmentDrainFails(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if rt.AdmissionState() != AdmissionReady {
+		t.Fatalf("AdmissionState() = %q, want ready", rt.AdmissionState())
+	}
+
+	// Bind a live Supervisor-owned process, then force softKill to fail so
+	// BeginShutdown surfaces a drain error (confirmed-drain path still runs).
+	lease, err := rt.activeExecutions.AdmitSpawn(context.Background(), agent.SpawnMeta{
+		LoopID: "loop-drain-fail", RunID: "run-drain-fail", ExecutionID: "exec-drain-fail",
+	})
+	if err != nil {
+		t.Fatalf("AdmitSpawn: %v", err)
+	}
+	cmd := exec.Command("sleep", "60")
+	processcontainment.Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+	handle, err := processcontainment.Bind(cmd, processcontainment.Options{
+		GracePeriod:  20 * time.Millisecond,
+		DrainTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("Bind: %v", err)
+	}
+	forceDrainFail := errors.New("forced soft-kill failure for retain-storage contract")
+	if err := lease.BindHandle(handle, func(string) error { return forceDrainFail }); err != nil {
+		t.Fatalf("BindHandle: %v", err)
+	}
+
+	// BeginShutdown records drain failure without closing storage.
+	rt.BeginShutdown("test drain fail")
+	if rt.AdmissionState() != AdmissionStopping {
+		t.Fatalf("AdmissionState() = %q, want stopping", rt.AdmissionState())
+	}
+	if services := rt.Services(); services.Coordinator == nil {
+		t.Fatal("Services().Coordinator = nil after BeginShutdown, want storage retained until Stop decision")
+	}
+	if err := rt.ShutdownDrainError(); err == nil {
+		t.Fatal("ShutdownDrainError() = nil after failed drain, want error")
+	} else if !errors.Is(err, errShutdownDrainTimeout) && !errors.Is(err, forceDrainFail) && !strings.Contains(err.Error(), forceDrainFail.Error()) {
+		t.Fatalf("ShutdownDrainError() = %v, want join of drain failure", err)
+	}
+
+	// Stop must retain SQLite — no false graceful close.
+	rt.Stop("test drain fail")
+	if !rt.StorageRetained() {
+		t.Fatal("StorageRetained() = false, want true after drain failure")
+	}
+	if services := rt.Services(); services.Coordinator == nil {
+		t.Fatal("Services().Coordinator = nil after Stop with drain failure, want retained storage")
+	}
+	// Process group must still have been targeted for kill even though softKill failed.
+	if !handle.ConfirmedDead() {
+		// softKill failed but handle.Kill should still have run; if not confirmed,
+		// kill may have timed — either way storage must stay retained (already asserted).
+		t.Logf("handle ConfirmedDead=%v Snapshot=%+v (storage retained regardless)", handle.ConfirmedDead(), handle.Snapshot())
+	}
+}
+
+// Contract: happy-path shutdown closes storage after successful drain.
+func TestShutdownClosesStorageWhenDrainSucceeds(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Bind a short-lived process that Kill can confirmed-drain.
+	lease, err := rt.activeExecutions.AdmitSpawn(context.Background(), agent.SpawnMeta{
+		LoopID: "loop-drain-ok", RunID: "run-drain-ok", ExecutionID: "exec-drain-ok",
+	})
+	if err != nil {
+		t.Fatalf("AdmitSpawn: %v", err)
+	}
+	cmd := exec.Command("sleep", "60")
+	processcontainment.Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+	handle, err := processcontainment.Bind(cmd, processcontainment.Options{
+		GracePeriod:  20 * time.Millisecond,
+		DrainTimeout: 3 * time.Second,
+	})
+	if err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("Bind: %v", err)
+	}
+	if err := lease.BindHandle(handle, func(string) error { return nil }); err != nil {
+		t.Fatalf("BindHandle: %v", err)
+	}
+
+	rt.Stop("test clean drain")
+	if rt.StorageRetained() {
+		t.Fatal("StorageRetained() = true after successful drain, want false")
+	}
+	if err := rt.ShutdownDrainError(); err != nil {
+		t.Fatalf("ShutdownDrainError() = %v, want nil", err)
+	}
+	if services := rt.Services(); services.Coordinator != nil {
+		t.Fatal("Services().Coordinator still set after successful Stop, want closed")
+	}
+	if !handle.ConfirmedDead() {
+		t.Fatal("handle not confirmed-dead after successful shutdown drain")
+	}
+}
+
+// Registry contract: BeginShutdown surfaces kill/drain failures (#577).
+func TestActiveExecutionRegistryBeginShutdownReturnsDrainFailure(t *testing.T) {
+	t.Parallel()
+	reg := NewActiveExecutionRegistry()
+	reg.killTimeout = 2 * time.Second
+
+	lease, err := reg.AdmitSpawn(context.Background(), agent.SpawnMeta{
+		LoopID: "loop-sd", RunID: "run-sd", ExecutionID: "exec-sd",
+	})
+	if err != nil {
+		t.Fatalf("AdmitSpawn: %v", err)
+	}
+	cmd := exec.Command("sleep", "60")
+	processcontainment.Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+	handle, err := processcontainment.Bind(cmd, processcontainment.Options{
+		GracePeriod:  20 * time.Millisecond,
+		DrainTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("Bind: %v", err)
+	}
+	force := errors.New("soft kill failed")
+	if err := lease.BindHandle(handle, func(string) error { return force }); err != nil {
+		t.Fatalf("BindHandle: %v", err)
+	}
+
+	err = reg.BeginShutdown("shutdown")
+	if err == nil {
+		t.Fatal("BeginShutdown() error = nil, want drain failure")
+	}
+	if !errors.Is(err, errShutdownDrainTimeout) && !errors.Is(err, force) && !strings.Contains(err.Error(), force.Error()) {
+		t.Fatalf("BeginShutdown() = %v, want wrapped drain failure", err)
+	}
+}

--- a/internal/runtime/shutdown_order_test.go
+++ b/internal/runtime/shutdown_order_test.go
@@ -150,6 +150,46 @@ func TestShutdownClosesStorageWhenDrainSucceeds(t *testing.T) {
 	}
 }
 
+// Contract (#577): non-agent Supervisor-owned containment failures (shell /
+// trusted-review) must feed retain-storage, not only agent-registry drains.
+func TestShutdownRetainsStorageWhenNonAgentDrainFailureReported(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+
+	rt := New(Options{Config: cfg, Logger: &testLogger{}})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Simulate validation/trusted-review reporting ErrNotConfirmedDead outside
+	// ActiveExecutionRegistry agent leases (the gap fixed for #590 review).
+	force := errors.New("non-agent shell drain not confirmed")
+	rt.activeExecutions.ReportDrainFailure(force)
+
+	rt.BeginShutdown("test non-agent drain fail")
+	if err := rt.ShutdownDrainError(); err == nil {
+		t.Fatal("ShutdownDrainError() = nil after non-agent drain failure report, want error")
+	} else if !errors.Is(err, force) && !strings.Contains(err.Error(), force.Error()) {
+		t.Fatalf("ShutdownDrainError() = %v, want non-agent failure", err)
+	}
+
+	rt.Stop("test non-agent drain fail")
+	if !rt.StorageRetained() {
+		t.Fatal("StorageRetained() = false, want true after non-agent drain failure")
+	}
+	if services := rt.Services(); services.Coordinator == nil {
+		t.Fatal("Services().Coordinator = nil after Stop with non-agent drain failure, want retained storage")
+	}
+}
+
 // Registry contract: BeginShutdown surfaces kill/drain failures (#577).
 func TestActiveExecutionRegistryBeginShutdownReturnsDrainFailure(t *testing.T) {
 	t.Parallel()

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nexu-io/looper/internal/loops/failureclass"
 	"github.com/nexu-io/looper/internal/network/protocol"
 	"github.com/nexu-io/looper/internal/networkpolicy"
+	"github.com/nexu-io/looper/internal/processcontainment"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/worktreesafety"
 )
@@ -442,20 +443,24 @@ type Options struct {
 	ClaimTTL                        time.Duration
 	ValidationCommands              []string
 	ValidationRunner                ValidationRunner
-	AllowAutoCommit                 bool
-	AllowAutoPush                   bool
-	OpenPRStrategy                  config.OpenPRStrategy
-	Disclosure                      *config.DisclosureConfig
-	AgentRuntime                    string
-	CustomInstructions              *config.Config
-	AgentModel                      *string
-	RetryBaseDelay                  time.Duration
-	RetryMaxAttempts                int64
-	OnAgentExecutionStarted         AgentExecutionStartedFunc
-	OnRunCompleted                  RunCompletedFunc
-	DiscoveryPolicy                 DiscoveryPolicy
-	OnQueueItemEnqueued             func()
-	Network                         NetworkStatusGateway
+	// ContainmentTracker registers validation shell handles with the Execution
+	// Supervisor for shutdown drain / retain-storage (#577). Nil in tests or
+	// when the runner is not daemon-owned.
+	ContainmentTracker      processcontainment.LiveTracker
+	AllowAutoCommit         bool
+	AllowAutoPush           bool
+	OpenPRStrategy          config.OpenPRStrategy
+	Disclosure              *config.DisclosureConfig
+	AgentRuntime            string
+	CustomInstructions      *config.Config
+	AgentModel              *string
+	RetryBaseDelay          time.Duration
+	RetryMaxAttempts        int64
+	OnAgentExecutionStarted AgentExecutionStartedFunc
+	OnRunCompleted          RunCompletedFunc
+	DiscoveryPolicy         DiscoveryPolicy
+	OnQueueItemEnqueued     func()
+	Network                 NetworkStatusGateway
 	// HITLEnabled gates the mid-run human-in-the-loop feature. When false (the
 	// default) none of the HITL code paths run and the worker behaves exactly as
 	// before. HITLNotify, when set, sends the ask-card to the human channel.
@@ -529,6 +534,7 @@ type Runner struct {
 	claimTTL                time.Duration
 	validationCommands      []string
 	validationRunner        ValidationRunner
+	containmentTracker      processcontainment.LiveTracker
 	allowAutoCommit         bool
 	allowAutoPush           bool
 	githubCLIAvailable      bool
@@ -800,6 +806,7 @@ func New(options Options) *Runner {
 		claimTTL:                claimTTL,
 		validationCommands:      append([]string(nil), options.ValidationCommands...),
 		validationRunner:        options.ValidationRunner,
+		containmentTracker:      options.ContainmentTracker,
 		allowAutoCommit:         options.AllowAutoCommit,
 		allowAutoPush:           options.AllowAutoPush,
 		githubCLIAvailable:      githubCLIAvailable,
@@ -2564,7 +2571,14 @@ func (r *Runner) runValidation(ctx context.Context, input ValidationInput) (Vali
 
 	outputs := make([]string, 0, len(input.Commands)*2)
 	for _, command := range input.Commands {
-		result, err := shell.Run(ctx, shell.Options{Command: "/bin/sh", Args: []string{"-c", command}, CWD: input.CWD})
+		result, err := shell.Run(ctx, shell.Options{
+			Command: "/bin/sh",
+			Args:    []string{"-c", command},
+			CWD:     input.CWD,
+			// Supervisor-owned validation: track handle so shutdown retain-storage
+			// sees Kill/Drain failures even when validation collapses them to Passed=false.
+			Tracker: r.containmentTracker,
+		})
 		if err != nil {
 			output := "Unknown validation failure"
 			var commandErr *shell.CommandExecutionError


### PR DESCRIPTION
## Summary

Migrate Supervisor-owned **non-agent** subprocess producers onto the process containment contract (#574) and finish lifecycle cutover for the Supervisor domain (#577).

- **`shell.Run` spawn boundary**: Configure + Start + Bind; cancel/timeout uses `Handle.Kill` (confirmed drain); normal exit uses `Handle.Drain` so process-group descendants cannot outlive validation/role shell jobs
- **Trusted review-submit children**: proxy uses containment Bind + confirmed Kill/Drain instead of raw PGID SIGKILL
- **Shutdown order**: admission close → ingress drain → cancel producers → confirmed-drain handles → SQLite close; on drain failure **retain storage** and fail loud (`StorageRetained`)
- **Fast-exit Bind race**: Bind tolerates leader already exited after Configure (getpgid ESRCH) so short validation commands do not fail start
- **ADR-0015**: R4 moved to **Enforced**; inventory rows for validation/shell and trusted review updated; independent infra authorities remain documented

## Authority and trade-off

**Authority:** containment handle confirmed-dead for stop/drain of Supervisor-owned non-agent producers; Supervisor registry for agent handles; independent producers (webhook, git/gh/tea gateways, CLI, ps probes) keep their documented non-Supervisor authorities.

**Prevents:** dual kill paths on shell/validation and trusted review; false graceful shutdown while undrained ownership remains; raw signal-only success for in-scope non-agents.

**Costs:** stop/cancel latency includes confirmed drain; Bind assumes Configure for fast-exit ESRCH path; retain-storage leaves SQLite open on drain failure.

**Deletion attempt:** remove raw PID signal paths at shell and trusted-review spawn boundaries rather than add a second registry for short shell jobs; short tool gateways stay independently lifecycle-owned.

## Validation

- `gofmt -l .`
- `go vet` on changed packages
- `go test ./internal/infra/shell/ ./internal/processcontainment/ ./internal/runtime/ ./internal/forge/ ./internal/agent/ ./internal/fixer/ ./cmd/looperd/ ./internal/e2e/`

## Test plan

- [x] Shell cancel confirmed-drains background process-group child
- [x] Shutdown retain-storage when containment drain fails
- [x] Shutdown closes storage when drain succeeds
- [x] Bind allows fast-exit after Configure
- [x] Happy-path shell/validation and agent packages green

Closes #577

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=grok-build · An autonomous AI dev team for your GitHub repos.</sub>