### PR TITLE
fix: conservative startup recovery classification without PID authority

### DIFF
--- a/docs/adr/0015-execution-supervisor-live-ownership.md
+++ b/docs/adr/0015-execution-supervisor-live-ownership.md
@@ -122,7 +122,7 @@ to a slice while any open blocker remains.
 | R5 | #578 | Execution persistence Authority + degrade on mid-life failure | Ordered writer; terminal immutability; hard persist failure degrades; no terminal status before confirmed dead | **Enforced** |
 | R6 | #579 | Operation lease owns queue claims until durable finalize | No live `running` claim without lease; release only after durable finalize; finalize failure retains ownership + degrades | **Enforced** |
 | R7 | #580 | Full non-mutating coverage when not-ready or degraded | Exhaustive mutation surface audit; scheduler pause; HTTP 503; no dual ready Authority | **Enforced** |
-| R8 | #581 | Conservative startup recovery without PID Authority | confirmed dead / observed live / uncertain; uncertain cannot act; PID is evidence only | **Deferred** |
+| R8 | #581 | Conservative startup recovery without PID Authority | confirmed dead / observed live / uncertain; uncertain cannot act; PID is evidence only | **Enforced** |
 
 Update the **Enforcement** column as each issue closes (move the slice from
 Deferred → Enforced). ADR Accepted only when the matrix has no deferred
@@ -274,6 +274,40 @@ record; the lease is in-memory Supervisor Authority for the live daemon only.
 | **Why not simpler** | Compensating “reservation” flags and growing claim state machines reintroduce dual Authority. Trusting runner return alone leaves stranded `running` under a released lease. Releasing before verified durable finalize reopens the unowned-claim window #578 was ordered to close first. |
 | **Deletion attempt** | Drop lease and trust process handles only — fails for the claim-before-process interval and for roles that finalize without a live agent handle. |
 
+### Conservative startup recovery classification (enforced by #581)
+
+After a daemon restart, pre-crash containment handles **no longer exist**. Startup
+recovery classifies each durable `agent_executions` observation as one of:
+
+| Class | Meaning | Recovery action |
+|-------|---------|-----------------|
+| **confirmed_dead** | Authority exists to treat the execution as non-runnable | Only when Authority holds (below) |
+| **observed_live** | Process probe matched the durable row | Evidence only — never adopt live ownership; quarantine |
+| **uncertain** | Everything else (PID absent, not running, mismatch, probe error, leader-exit-only) | Quarantine; no raw PID/PGID action |
+
+**Authority for `confirmed_dead` after restart:**
+
+| May authorize confirmed-dead | Must not authorize confirmed-dead |
+|------------------------------|-----------------------------------|
+| Durable terminal finalization already committed before crash | PID/PGID missing or not running |
+| A **current-daemon** owned handle that has completed confirmed drain | Probe-then-signal on raw PID/PGID |
+| | Leader exit alone without descendant/containment proof |
+
+Otherwise the row remains **uncertain** (or **observed_live**) and is parked via
+existing `manual_intervention` / `paused` states — no new quarantine ledger.
+Running claims after restart have no live operation lease; reconcile them via
+durable finalize semantics (#578/#579), never by inferring death from PID absence.
+Mutations stay closed until classification finishes (#575/#580).
+
+**Startup recovery concept trade-off (R8):**
+
+| | |
+|--|--|
+| **Failure prevented** | False cleanliness and PID-reuse kills after crash; marking terminal / requeue / overlap from leader exit or PID absence alone; treating observed-live orphans as Supervisor-owned. |
+| **Costs** | More quarantine/`manual_intervention` and less aggressive auto-clean after restart; operators must unstick parked work deliberately. |
+| **Why not simpler** | Trusting PID/PGID probes as Authority reopens reusable-ID kills. Requeueing “dead” leaders without descendant proof leaves live children and starts overlapping work. |
+| **Deletion attempt** | Drop classification and always quarantine — correct but loses the durable-terminal / current-daemon-drain paths that already have Authority; classification keeps those paths explicit and tested. |
+
 ### Full non-mutating coverage when not-ready or degraded (enforced by #580)
 
 R1 landed the admission Authority and known HTTP/claim gates. After producer
@@ -421,14 +455,19 @@ These rules apply during multi-PR rollout and are part of this contract:
 
 ## Full-program exit criteria (ADR Accepted only when all hold)
 
-- [ ] R1–R8 issues (#575–#581) closed with their acceptance criteria met
-- [ ] Enforcement matrix fully enforced (no deferred in-scope items left open)
-- [ ] Producer inventory reconciled: every in-scope path Supervisor-owned; independent/out-of-scope documented
-- [ ] No unowned in-scope agent or subprocess producer remains
-- [ ] No live stop/shutdown/recovery path uses raw PID/PGID as Authority
+- [x] R1–R8 issues (#575–#581) implementation acceptance criteria met (matrix Enforced; GitHub close is process)
+- [x] Enforcement matrix fully enforced (no deferred in-scope items left open)
+- [x] Producer inventory reconciled: every in-scope path Supervisor-owned; independent/out-of-scope documented
+- [x] No unowned in-scope agent or subprocess producer remains
+- [x] No live stop/shutdown/recovery path uses raw PID/PGID as Authority
 - [x] No running queue claim without an owned operation lease while daemon is live (#579)
-- [ ] Uncertain recovery evidence cannot signal, mark terminal, requeue, or overlap work
-- [ ] Shutdown drains admission → ingress → producers → handles/finalizers before SQLite close (or retains storage / fails loud on timeout)
+- [x] Uncertain recovery evidence cannot signal, mark terminal, requeue, or overlap work
+- [x] Shutdown drains admission → ingress → producers → handles/finalizers before SQLite close (or retains storage / fails loud on timeout)
+
+**Status note:** With R0–R8 enforced and the exit checklist above complete, this ADR
+may move to **Accepted** when the program owner closes the contract issue (#573)
+and the implementation issues. Do not flip Status in an intermediate slice PR
+without that process close-out.
 
 ## Follow-on implementation issues
 

--- a/internal/runtime/recovery_classification.go
+++ b/internal/runtime/recovery_classification.go
@@ -1,0 +1,161 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/processcontainment"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// ContainmentClass is the startup-recovery classification of durable execution
+// evidence after a daemon restart (ADR-0015 R8 / #581).
+//
+// PID/PGID inspection is drift evidence only. It never authorizes live stop,
+// terminal marking, requeue, or overlapping work, and never alone establishes
+// confirmed-dead after restart.
+type ContainmentClass string
+
+const (
+	// ContainmentConfirmedDead means Authority exists to treat the execution as
+	// non-runnable for recovery purposes.
+	//
+	// After restart, only:
+	//   - durable terminal finalization already committed before crash, or
+	//   - a current-daemon owned processcontainment.Handle that has completed
+	//     confirmed drain
+	// may authorize this class.
+	//
+	// Must not authorize confirmed-dead: PID/PGID missing or not running,
+	// probe-then-signal on raw PID/PGID, or leader exit alone without
+	// descendant/containment proof.
+	ContainmentConfirmedDead ContainmentClass = "confirmed_dead"
+
+	// ContainmentObservedLive means a process probe matched the durable row.
+	// This is evidence only — not adopted live ownership. Recovery must not
+	// signal, terminalize, requeue, or start overlapping work from this class.
+	ContainmentObservedLive ContainmentClass = "observed_live"
+
+	// ContainmentUncertain covers every other observation (PID absent, command
+	// mismatch, probe error, leader-exit-only without containment proof, etc.).
+	// Uncertain work stays quarantined without raw PID/PGID action.
+	ContainmentUncertain ContainmentClass = "uncertain"
+)
+
+// ContainmentClassification is one classified durable observation.
+type ContainmentClassification struct {
+	Class ContainmentClass
+	// Reason is a stable machine-oriented explanation (event payloads / tests).
+	Reason string
+	// PID is the durable PID when present (evidence only).
+	PID int
+}
+
+// durableTerminalExecution reports whether SQLite already holds a terminal
+// finalization for the row. Active statuses are never confirmed-dead by status.
+func durableTerminalExecution(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "completed", "failed", "timeout", "killed", "success":
+		return true
+	default:
+		return false
+	}
+}
+
+// classifyFromDurableStatusAndHandle applies confirmed-dead Authority rules that
+// do not depend on PID probes. currentDaemonHandle may be nil (always after a
+// crash — pre-crash handles do not exist).
+func classifyFromDurableStatusAndHandle(execution storage.AgentExecutionRecord, currentDaemonHandle *processcontainment.Handle) (ContainmentClassification, bool) {
+	pid := 0
+	if execution.PID != nil && *execution.PID > 0 {
+		pid = int(*execution.PID)
+	}
+	if durableTerminalExecution(execution.Status) {
+		return ContainmentClassification{
+			Class:  ContainmentConfirmedDead,
+			Reason: "durable_terminal_finalization",
+			PID:    pid,
+		}, true
+	}
+	if currentDaemonHandle != nil && currentDaemonHandle.ConfirmedDead() {
+		return ContainmentClassification{
+			Class:  ContainmentConfirmedDead,
+			Reason: "current_daemon_confirmed_drain",
+			PID:    pid,
+		}, true
+	}
+	return ContainmentClassification{}, false
+}
+
+// classifyStartupProbeEvidence maps PID probe outcomes to observed_live or
+// uncertain. Never returns confirmed_dead — PID absence / leader exit alone
+// cannot authorize that class after restart.
+func classifyStartupProbeEvidence(pid int, matches, running bool, probeErr error) ContainmentClassification {
+	if probeErr != nil {
+		return ContainmentClassification{
+			Class:  ContainmentUncertain,
+			Reason: "process_probe_error",
+			PID:    pid,
+		}
+	}
+	if pid <= 0 {
+		return ContainmentClassification{
+			Class:  ContainmentUncertain,
+			Reason: "pid_absent",
+			PID:    0,
+		}
+	}
+	if running && matches {
+		return ContainmentClassification{
+			Class:  ContainmentObservedLive,
+			Reason: "process_identity_matched",
+			PID:    pid,
+		}
+	}
+	if running && !matches {
+		return ContainmentClassification{
+			Class:  ContainmentUncertain,
+			Reason: "process_identity_mismatch",
+			PID:    pid,
+		}
+	}
+	// PID not running / empty process command. Leader exit or PID reuse absence
+	// is not confirmed-dead Authority (descendants may remain; IDs are reusable).
+	return ContainmentClassification{
+		Class:  ContainmentUncertain,
+		Reason: "pid_not_running_not_confirmed_dead",
+		PID:    pid,
+	}
+}
+
+// classifyStartupExecution classifies one durable agent_execution observation
+// for startup recovery. PID probes are evidence only.
+//
+// currentDaemonHandle is optional: after crash it is always nil. Mid-life tests
+// may inject a handle that has completed confirmed drain.
+func (r *Runtime) classifyStartupExecution(ctx context.Context, execution storage.AgentExecutionRecord, currentDaemonHandle *processcontainment.Handle) (ContainmentClassification, error) {
+	if class, ok := classifyFromDurableStatusAndHandle(execution, currentDaemonHandle); ok {
+		return class, nil
+	}
+	pid := 0
+	if execution.PID != nil && *execution.PID > 0 {
+		pid = int(*execution.PID)
+	}
+	if pid <= 0 {
+		return classifyStartupProbeEvidence(0, false, false, nil), nil
+	}
+	matches, running, err := r.executionMatchesProcess(ctx, execution, pid)
+	return classifyStartupProbeEvidence(pid, matches, running, err), nil
+}
+
+// classificationAllowsTerminalOrRequeue is true only for confirmed-dead.
+// Observed live and uncertain must not mark terminal, requeue, signal, or overlap.
+func classificationAllowsTerminalOrRequeue(class ContainmentClass) bool {
+	return class == ContainmentConfirmedDead
+}
+
+// classificationRequiresQuarantine is true when recovery must park work via
+// existing manual_intervention / paused states without PID action.
+func classificationRequiresQuarantine(class ContainmentClass) bool {
+	return class == ContainmentObservedLive || class == ContainmentUncertain
+}

--- a/internal/runtime/recovery_classification_test.go
+++ b/internal/runtime/recovery_classification_test.go
@@ -1,0 +1,90 @@
+package runtime
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/processcontainment"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestClassifyStartupProbeEvidenceNeverConfirmedDeadFromPID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		pid      int
+		matches  bool
+		running  bool
+		probeErr error
+		want     ContainmentClass
+		reason   string
+	}{
+		{name: "pid absent", pid: 0, want: ContainmentUncertain, reason: "pid_absent"},
+		{name: "pid not running", pid: 42, matches: false, running: false, want: ContainmentUncertain, reason: "pid_not_running_not_confirmed_dead"},
+		{name: "identity mismatch", pid: 42, matches: false, running: true, want: ContainmentUncertain, reason: "process_identity_mismatch"},
+		{name: "observed live", pid: 42, matches: true, running: true, want: ContainmentObservedLive, reason: "process_identity_matched"},
+		{name: "probe error", pid: 42, probeErr: context.DeadlineExceeded, want: ContainmentUncertain, reason: "process_probe_error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyStartupProbeEvidence(tc.pid, tc.matches, tc.running, tc.probeErr)
+			if got.Class != tc.want || got.Reason != tc.reason {
+				t.Fatalf("classify = %#v, want class=%s reason=%s", got, tc.want, tc.reason)
+			}
+			if classificationAllowsTerminalOrRequeue(got.Class) {
+				t.Fatalf("probe class %s must not allow terminal/requeue", got.Class)
+			}
+			if got.Class != ContainmentObservedLive && !classificationRequiresQuarantine(got.Class) {
+				t.Fatalf("non-live class %s must require quarantine", got.Class)
+			}
+		})
+	}
+}
+
+func TestClassifyConfirmedDeadOnlyFromDurableTerminalOrCurrentHandle(t *testing.T) {
+	t.Parallel()
+
+	terminal := storage.AgentExecutionRecord{ID: "e1", Status: "killed", PID: int64Ptr(99)}
+	class, ok := classifyFromDurableStatusAndHandle(terminal, nil)
+	if !ok || class.Class != ContainmentConfirmedDead || class.Reason != "durable_terminal_finalization" {
+		t.Fatalf("terminal classification = %#v ok=%v", class, ok)
+	}
+	if !classificationAllowsTerminalOrRequeue(class.Class) {
+		t.Fatal("confirmed_dead must allow terminal authority path")
+	}
+
+	active := storage.AgentExecutionRecord{ID: "e2", Status: "running", PID: int64Ptr(99)}
+	if _, ok := classifyFromDurableStatusAndHandle(active, nil); ok {
+		t.Fatal("active status without handle must not be confirmed_dead")
+	}
+
+	// Current-daemon handle that completed confirmed drain authorizes confirmed_dead.
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Skip("true binary not available")
+	}
+	cmd := exec.Command(truePath)
+	processcontainment.Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	handle, err := processcontainment.Bind(cmd, processcontainment.Options{})
+	if err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if err := handle.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if err := handle.Drain(context.Background()); err != nil {
+		t.Fatalf("Drain() error = %v", err)
+	}
+	if !handle.ConfirmedDead() {
+		t.Fatal("handle not ConfirmedDead after Drain")
+	}
+	class, ok = classifyFromDurableStatusAndHandle(active, handle)
+	if !ok || class.Class != ContainmentConfirmedDead || class.Reason != "current_daemon_confirmed_drain" {
+		t.Fatalf("drained handle classification = %#v ok=%v", class, ok)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -79,10 +79,16 @@ const (
 )
 
 type RecoveryOrphanAgentCleanup struct {
-	Attempted        bool   `json:"attempted"`
-	CleanedCount     int64  `json:"cleanedCount"`
-	QuarantinedCount int64  `json:"quarantinedCount"`
-	Warning          string `json:"warning,omitempty"`
+	Attempted        bool  `json:"attempted"`
+	CleanedCount     int64 `json:"cleanedCount"`
+	QuarantinedCount int64 `json:"quarantinedCount"`
+	// Classification counts for active execution evidence (ADR-0015 R8 / #581).
+	// ConfirmedDead requires durable terminal finalization or current-daemon drain;
+	// PID absence never increments ConfirmedDead.
+	ConfirmedDeadCount int64  `json:"confirmedDeadCount"`
+	ObservedLiveCount  int64  `json:"observedLiveCount"`
+	UncertainCount     int64  `json:"uncertainCount"`
+	Warning            string `json:"warning,omitempty"`
 }
 
 type Options struct {
@@ -1651,76 +1657,72 @@ func (r *Runtime) runRecoveryPipeline(ctx context.Context, repositories *storage
 			return RecoverySummary{}, err
 		}
 		for _, execution := range activeExecutions {
-			// Safety floor (#575): never SIGTERM/SIGKILL raw PID/PGID or mark
-			// terminal as "cleaned" without containment confirmation. Durable
-			// agent_executions rows remain evidence; quarantine affected work.
-			pid := 0
-			if execution.PID != nil && *execution.PID > 0 {
-				pid = int(*execution.PID)
+			// ADR-0015 R8 / #581: classify containment. PID/PGID is drift
+			// evidence only. Never SIGTERM/SIGKILL raw PID/PGID, never mark
+			// terminal from PID absence/leader exit, never requeue from
+			// observed_live or uncertain. Pre-crash handles do not exist after
+			// restart (currentDaemonHandle = nil).
+			classification, classErr := r.classifyStartupExecution(ctx, execution, nil)
+			if classErr != nil {
+				return RecoverySummary{}, classErr
 			}
-			scope := "orphan_cleanup"
-			if pid > 0 {
-				matches, running, err := r.executionMatchesProcess(ctx, execution, pid)
-				if err != nil {
-					if r.logger != nil {
-						r.logger.Warn("failed to verify orphan agent execution identity", map[string]any{"executionId": execution.ID, "pid": pid, "error": err.Error()})
-					}
-					if execution.RunID != nil && strings.TrimSpace(*execution.RunID) != "" {
-						uncertainAgentRunIDs[*execution.RunID] = struct{}{}
-					}
-					uncertainExecutionIDs[execution.ID] = struct{}{}
-					written, appendErr := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO)
-					if appendErr != nil {
-						return RecoverySummary{}, appendErr
-					}
-					if written {
-						eventsWritten += 1
-					}
-				} else if running && !matches {
-					if execution.RunID != nil && strings.TrimSpace(*execution.RunID) != "" {
-						uncertainAgentRunIDs[*execution.RunID] = struct{}{}
-					}
-					uncertainExecutionIDs[execution.ID] = struct{}{}
-					written, err := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO)
-					if err != nil {
-						return RecoverySummary{}, err
-					}
-					if written {
-						eventsWritten += 1
-					}
-				} else if running && matches {
-					// Observed live after restart: still not Supervisor-owned.
-					// Leave the process alone; quarantine so work cannot requeue.
-					if execution.RunID != nil && strings.TrimSpace(*execution.RunID) != "" {
-						uncertainAgentRunIDs[*execution.RunID] = struct{}{}
-					}
-					uncertainExecutionIDs[execution.ID] = struct{}{}
-				} else {
-					// PID not running or probe says dead — still not confirmed-dead
-					// Authority. Keep the row as evidence and quarantine.
-					if execution.RunID != nil && strings.TrimSpace(*execution.RunID) != "" {
-						uncertainAgentRunIDs[*execution.RunID] = struct{}{}
-					}
-					uncertainExecutionIDs[execution.ID] = struct{}{}
+			switch classification.Class {
+			case ContainmentConfirmedDead:
+				summary.OrphanAgentCleanup.ConfirmedDeadCount += 1
+			case ContainmentObservedLive:
+				summary.OrphanAgentCleanup.ObservedLiveCount += 1
+			default:
+				summary.OrphanAgentCleanup.UncertainCount += 1
+				classification.Class = ContainmentUncertain
+			}
+
+			wroteClass, classEventErr := r.appendContainmentClassificationEvent(ctx, repositories, execution, classification, "orphan_cleanup", nowISO)
+			if classEventErr != nil {
+				return RecoverySummary{}, classEventErr
+			}
+			if wroteClass {
+				eventsWritten += 1
+			}
+
+			// Legacy process-identity uncertain events for probe mismatch/error
+			// (kept for operator tooling that already keys on this event type).
+			if classification.Reason == "process_probe_error" || classification.Reason == "process_identity_mismatch" {
+				if r.logger != nil && classification.Reason == "process_probe_error" {
+					r.logger.Warn("failed to verify orphan agent execution identity", map[string]any{
+						"executionId": execution.ID, "pid": classification.PID, "class": string(classification.Class),
+					})
 				}
-			} else {
+				written, appendErr := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, classification.PID, "orphan_cleanup", nowISO)
+				if appendErr != nil {
+					return RecoverySummary{}, appendErr
+				}
+				if written {
+					eventsWritten += 1
+				}
+			}
+
+			// Active ListActive rows cannot be confirmed-dead from durable
+			// terminal status (they would not be active). After restart there is
+			// no current-daemon handle. Quarantine observed_live and uncertain.
+			if classificationRequiresQuarantine(classification.Class) || !classificationAllowsTerminalOrRequeue(classification.Class) {
 				if execution.RunID != nil && strings.TrimSpace(*execution.RunID) != "" {
 					uncertainAgentRunIDs[*execution.RunID] = struct{}{}
 				}
 				uncertainExecutionIDs[execution.ID] = struct{}{}
-			}
-			quarantined, wrote, err := r.quarantineRecoveryEvidence(ctx, repositories, execution, nowISO, "startup recovery: active execution evidence without containment confirmation")
-			if err != nil {
-				return RecoverySummary{}, err
-			}
-			if quarantined {
-				summary.OrphanAgentCleanup.QuarantinedCount += 1
-				if execution.LoopID != nil && strings.TrimSpace(*execution.LoopID) != "" {
-					quarantinedLoopIDs[*execution.LoopID] = struct{}{}
+				reason := "startup recovery: " + string(classification.Class) + " (" + classification.Reason + "); no PID Authority"
+				quarantined, wrote, err := r.quarantineRecoveryEvidence(ctx, repositories, execution, nowISO, reason)
+				if err != nil {
+					return RecoverySummary{}, err
 				}
-			}
-			if wrote {
-				eventsWritten += 1
+				if quarantined {
+					summary.OrphanAgentCleanup.QuarantinedCount += 1
+					if execution.LoopID != nil && strings.TrimSpace(*execution.LoopID) != "" {
+						quarantinedLoopIDs[*execution.LoopID] = struct{}{}
+					}
+				}
+				if wrote {
+					eventsWritten += 1
+				}
 			}
 		}
 		if summary.OrphanAgentCleanup.QuarantinedCount > 0 {
@@ -2404,8 +2406,9 @@ func (r *Runtime) evaluateStaleRunCandidate(ctx context.Context, repositories *s
 		decision.Candidate = true
 		if latestRun != nil && latestRun.ID == run.ID && len(activeExecutions) > 0 {
 			// Active execution evidence is never Authority to kill, mark terminal,
-			// or requeue as cleaned (#575). Leave durable rows; orphan cleanup
-			// quarantines the work separately.
+			// or requeue as cleaned (#575/#581). Classify for events; orphan
+			// cleanup quarantines observed_live/uncertain. Leader exit / PID
+			// absence alone cannot confirm dead or interrupt for requeue.
 			verification, err := r.verifyRunExecutionLiveness(ctx, repositories, activeExecutions, now, "startup_stale_run")
 			if err != nil {
 				return staleRunCandidateDecision{}, err
@@ -2414,7 +2417,9 @@ func (r *Runtime) evaluateStaleRunCandidate(ctx context.Context, repositories *s
 			decision.Uncertain = true
 			return decision, nil
 		}
-		// No active agent execution rows: interrupt orphan running runs only.
+		// No active agent_execution rows: no process evidence to mis-handle.
+		// Interrupt orphan running runs only; queue repair uses durable
+		// finalize/lease semantics (not PID inference).
 		decision.Interrupt = latestRun == nil || latestRun.ID != run.ID || len(activeExecutions) == 0
 		decision.Message = "Interrupted stale/orphaned running run during looperd recovery"
 		return decision, nil
@@ -2456,53 +2461,71 @@ func (r *Runtime) evaluateStaleRunCandidate(ctx context.Context, repositories *s
 }
 
 type executionLivenessResult struct {
-	Live           bool
-	Uncertain      bool
+	Live bool
+	// Uncertain is true when any execution cannot be treated as confirmed-dead
+	// Authority (including PID absent / not running after restart rules).
+	Uncertain bool
+	// DeadExecutions holds rows whose PID probe found no matching live process.
+	// These are NOT confirmed-dead Authority (#581): callers may quarantine
+	// evidence but must not mark terminal, signal, or requeue from this alone.
+	// Name retained for call-site compatibility; treat as "no live match".
 	DeadExecutions []storage.AgentExecutionRecord
 	EventsWritten  int64
 }
 
 func (r *Runtime) verifyRunExecutionLiveness(ctx context.Context, repositories *storage.Repositories, executions []storage.AgentExecutionRecord, now time.Time, scope string) (executionLivenessResult, error) {
 	result := executionLivenessResult{}
+	nowISO := formatJavaScriptISOString(now)
 	for _, execution := range executions {
-		if execution.PID == nil || *execution.PID <= 0 {
-			result.DeadExecutions = append(result.DeadExecutions, execution)
-			continue
-		}
-		pid := int(*execution.PID)
-		matches, running, err := r.executionMatchesProcess(ctx, execution, pid)
+		// Shared classification: PID/PGID is evidence only (#581). Confirmed-dead
+		// never comes from PID absence. Live reconcile still uses DeadExecutions
+		// to quarantine "no live match" rows without requeue or SIGKILL.
+		classification, err := r.classifyStartupExecution(ctx, execution, nil)
 		if err != nil {
-			if r.logger != nil {
-				r.logger.Warn("failed to verify active agent execution identity", map[string]any{"executionId": execution.ID, "pid": *execution.PID, "error": err.Error(), "scope": scope})
-			}
-			nowISO := formatJavaScriptISOString(now)
-			written, appendErr := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO)
-			if appendErr != nil {
-				return executionLivenessResult{}, appendErr
-			}
-			result.Uncertain = true
-			if written {
-				result.EventsWritten += 1
-			}
-			continue
+			return executionLivenessResult{}, err
 		}
-		if running && !matches {
-			nowISO := formatJavaScriptISOString(now)
-			written, err := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, pid, scope, nowISO)
-			if err != nil {
-				return executionLivenessResult{}, err
-			}
-			result.Uncertain = true
-			if written {
-				result.EventsWritten += 1
-			}
-			continue
+		wroteClass, classErr := r.appendContainmentClassificationEvent(ctx, repositories, execution, classification, scope, nowISO)
+		if classErr != nil {
+			return executionLivenessResult{}, classErr
 		}
-		if running && matches {
+		if wroteClass {
+			result.EventsWritten += 1
+		}
+		switch classification.Class {
+		case ContainmentConfirmedDead:
+			// Durable terminal or current-daemon drain — not expected for active
+			// ListActive rows without a handle.
+			continue
+		case ContainmentObservedLive:
 			result.Live = true
 			continue
+		default:
+			// Uncertain classes:
+			// - identity probe error / mismatch → skip automatic interrupt (ambiguous)
+			// - pid absent / not running → not confirmed-dead; still list for
+			//   quarantine-only cleanup (no signal, no agent_execution terminal)
+			if classification.Reason == "process_probe_error" || classification.Reason == "process_identity_mismatch" {
+				if r.logger != nil && classification.Reason == "process_probe_error" {
+					r.logger.Warn("failed to verify active agent execution identity", map[string]any{
+						"executionId": execution.ID, "pid": classification.PID, "error": classification.Reason, "scope": scope,
+					})
+				}
+				written, appendErr := r.appendUncertainProcessIdentityEvent(ctx, repositories, execution, classification.PID, scope, nowISO)
+				if appendErr != nil {
+					return executionLivenessResult{}, appendErr
+				}
+				if written {
+					result.EventsWritten += 1
+				}
+				result.Uncertain = true
+				continue
+			}
+			// pid_absent / pid_not_running_not_confirmed_dead / other uncertain:
+			// "no live match" evidence for quarantine paths. Do not set Uncertain
+			// alone here — that would skip quarantine in live reconcile. Callers
+			// must still treat DeadExecutions as non-Authority for terminal/requeue.
+			result.DeadExecutions = append(result.DeadExecutions, execution)
 		}
-		result.DeadExecutions = append(result.DeadExecutions, execution)
 	}
 	return result, nil
 }
@@ -2705,6 +2728,54 @@ func (r *Runtime) appendUncertainProcessIdentityEvent(ctx context.Context, repos
 	if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
 		ID:          newRuntimeEventID(),
 		EventType:   "looperd.recovery.process_identity_uncertain",
+		ProjectID:   execution.ProjectID,
+		LoopID:      execution.LoopID,
+		RunID:       execution.RunID,
+		EntityType:  stringPtr("agent_execution"),
+		EntityID:    stringPtr(execution.ID),
+		PayloadJSON: payloadJSON,
+		CreatedAt:   nowISO,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// appendContainmentClassificationEvent records confirmed_dead / observed_live /
+// uncertain for an execution observation. Dedupes identical class+reason+scope.
+func (r *Runtime) appendContainmentClassificationEvent(ctx context.Context, repositories *storage.Repositories, execution storage.AgentExecutionRecord, classification ContainmentClassification, scope, nowISO string) (bool, error) {
+	payload := map[string]any{
+		"class":  string(classification.Class),
+		"reason": classification.Reason,
+		"scope":  scope,
+	}
+	if classification.PID > 0 {
+		payload["pid"] = classification.PID
+	}
+	payloadJSON := mustMarshalJSON(payload)
+	if repositories != nil && repositories.Events != nil {
+		events, err := repositories.Events.ListByEntity(ctx, "agent_execution", execution.ID)
+		if err != nil {
+			return false, err
+		}
+		for _, event := range events {
+			if event.EventType == "looperd.recovery.containment_classified" && event.PayloadJSON == payloadJSON {
+				return false, nil
+			}
+		}
+	}
+	if r.logger != nil {
+		r.logger.Info("startup recovery classified containment evidence", map[string]any{
+			"executionId": execution.ID,
+			"class":       string(classification.Class),
+			"reason":      classification.Reason,
+			"scope":       scope,
+			"pid":         classification.PID,
+		})
+	}
+	if err := appendSystemEvent(ctx, repositories, storage.EventLogRecord{
+		ID:          newRuntimeEventID(),
+		EventType:   "looperd.recovery.containment_classified",
 		ProjectID:   execution.ProjectID,
 		LoopID:      execution.LoopID,
 		RunID:       execution.RunID,

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2885,21 +2885,29 @@ func TestRuntimeReconcileStaleRunningRunsDedupesUncertainIdentityEvents(t *testi
 	if err != nil {
 		t.Fatalf("second reconcile error = %v", err)
 	}
-	if first.SkippedUncertainRuns != 1 || first.EventsWritten != 1 {
-		t.Fatalf("first summary = %#v, want one uncertain event written", first)
+	// First pass writes containment_classified + process_identity_uncertain.
+	if first.SkippedUncertainRuns != 1 || first.EventsWritten != 2 {
+		t.Fatalf("first summary = %#v, want two events (classified + identity uncertain)", first)
 	}
 	if second.SkippedUncertainRuns != 1 || second.EventsWritten != 0 {
-		t.Fatalf("second summary = %#v, want deduped uncertain event without new writes", second)
+		t.Fatalf("second summary = %#v, want deduped events without new writes", second)
 	}
 	events, err := repos.Events.ListByEntity(context.Background(), "agent_execution", "exec_uncertain_event_dedupe")
 	if err != nil {
 		t.Fatalf("Events.ListByEntity() error = %v", err)
 	}
 	count := 0
+	classified := 0
 	for _, event := range events {
 		if event.EventType == "looperd.recovery.process_identity_uncertain" {
 			count += 1
 		}
+		if event.EventType == "looperd.recovery.containment_classified" {
+			classified += 1
+		}
+	}
+	if classified != 1 {
+		t.Fatalf("containment_classified events = %d, want 1", classified)
 	}
 	if count != 1 {
 		t.Fatalf("uncertain event count = %d, want 1; events = %#v", count, events)

--- a/internal/runtime/startup_recovery_classification_test.go
+++ b/internal/runtime/startup_recovery_classification_test.go
@@ -1,0 +1,273 @@
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// Contract: exited leader PID alone is uncertain — descendants may remain.
+// Recovery must not signal, terminalize agent_executions, requeue, or overlap.
+func TestStartupRecoveryExitedLeaderDoesNotConfirmDeadOrAct(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	startedAt := time.Date(2026, time.July, 19, 10, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(startedAt)
+	oldISO := formatJavaScriptISOString(startedAt.Add(-time.Hour))
+
+	seedCoordinator := openMigratedCoordinator(t, cfg.Storage.DBPath, backupDir)
+	seedRepos := storage.NewRepositories(seedCoordinator.DB())
+	projectID := "project_leader_exit"
+	loopID := "loop_leader_exit"
+	runID := "run_leader_exit"
+	queueID := "queue_leader_exit"
+	if err := seedRepos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Leader", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := seedRepos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := seedRepos.Runs.Upsert(context.Background(), storage.RunRecord{ID: runID, LoopID: loopID, Status: "running", CurrentStep: stringPtr("execute"), StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := seedRepos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: projectID,
+		DedupeKey: "worker:project_leader_exit:loop_leader_exit", Priority: storage.QueuePriorityWorker, Status: "running",
+		AvailableAt: oldISO, Attempts: 1, MaxAttempts: 3, ClaimedBy: stringPtr("scheduler"), ClaimedAt: stringPtr(oldISO),
+		StartedAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	// Leader PID gone (empty command = not running). Descendants may still be
+	// live under a reused or unrecorded PGID — classification must be uncertain.
+	deadLeaderPID := int64(7777)
+	if err := seedRepos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
+		ID: "agent_leader_exit", ProjectID: &projectID, LoopID: &loopID, RunID: &runID, Vendor: "codex", Status: "running",
+		PID: &deadLeaderPID, CommandJSON: stringPtr(`{"command":"codex","args":["exec"]}`), CWD: stringPtr(workingDir),
+		HeartbeatCount: 0, StartedAt: oldISO, CreatedAt: oldISO, UpdatedAt: oldISO,
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+	if err := seedCoordinator.Close(); err != nil {
+		t.Fatalf("seed close error = %v", err)
+	}
+
+	var signals []syscall.Signal
+	rt := New(Options{
+		Config: cfg,
+		Logger: &testLogger{},
+		Now:    func() time.Time { return startedAt },
+		ReadProcessCommand: func(context.Context, int) (string, error) {
+			return "", nil // leader not running
+		},
+		SignalProcess: func(_ int, sig syscall.Signal) error {
+			signals = append(signals, sig)
+			return nil
+		},
+	})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { rt.Stop("test cleanup") })
+
+	if len(signals) != 0 {
+		t.Fatalf("SignalProcess called with %v; want no raw PID/PGID action", signals)
+	}
+	services := rt.Services()
+	execution, err := services.Repositories.AgentExecutions.GetByID(context.Background(), "agent_leader_exit")
+	if err != nil {
+		t.Fatalf("GetByID error = %v", err)
+	}
+	if execution == nil || execution.Status != "running" || execution.EndedAt != nil {
+		t.Fatalf("execution = %#v, want still-running evidence (not terminal from leader exit)", execution)
+	}
+	queue, err := services.Repositories.Queue.GetByID(context.Background(), queueID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID error = %v", err)
+	}
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention quarantine", queue)
+	}
+	// Running claim must not be claimable after quarantine (no overlap).
+	if err := rt.AllowClaim(); err != nil {
+		t.Fatalf("AllowClaim() = %v", err)
+	}
+	claimed, err := services.Repositories.Queue.ClaimNext(context.Background(), nowISO, "scheduler")
+	if err != nil {
+		t.Fatalf("ClaimNext error = %v", err)
+	}
+	if claimed != nil {
+		t.Fatalf("ClaimNext = %#v, want nil (no overlapping work)", claimed)
+	}
+
+	recovery := rt.RecoverySummary()
+	if recovery.OrphanAgentCleanup.ConfirmedDeadCount != 0 {
+		t.Fatalf("ConfirmedDeadCount = %d, want 0 (leader exit is not confirmed-dead)", recovery.OrphanAgentCleanup.ConfirmedDeadCount)
+	}
+	if recovery.OrphanAgentCleanup.UncertainCount != 1 {
+		t.Fatalf("UncertainCount = %d, want 1", recovery.OrphanAgentCleanup.UncertainCount)
+	}
+	if recovery.OrphanAgentCleanup.CleanedCount != 0 || recovery.OrphanAgentCleanup.QuarantinedCount != 1 {
+		t.Fatalf("OrphanAgentCleanup = %#v, want quarantined without cleaned", recovery.OrphanAgentCleanup)
+	}
+	if recovery.LoopsRequeued != 0 {
+		t.Fatalf("LoopsRequeued = %d, want 0", recovery.LoopsRequeued)
+	}
+
+	events, err := services.Repositories.Events.ListByEntity(context.Background(), "agent_execution", "agent_leader_exit")
+	if err != nil {
+		t.Fatalf("ListByEntity error = %v", err)
+	}
+	if containsEventType(events, "agent.killed") {
+		t.Fatalf("events = %#v, want no agent.killed", events)
+	}
+	if !containsEventType(events, "looperd.recovery.containment_classified") {
+		t.Fatalf("events = %#v, want containment_classified", events)
+	}
+	if !containsEventType(events, "looperd.recovery.execution_quarantined") {
+		t.Fatalf("events = %#v, want execution_quarantined", events)
+	}
+}
+
+// Contract: observed-live (including TERM-resistant) evidence is never adopted
+// as live ownership and never receives fire-and-forget SIGTERM/SIGKILL on raw PGID.
+func TestStartupRecoveryObservedLiveNoSignalNoRequeue(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.DefaultConfig(workingDir)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = filepath.Join(workingDir, "runtime.sqlite")
+	backupDir := filepath.Join(workingDir, "backups")
+	cfg.Storage.BackupDir = &backupDir
+	startedAt := time.Date(2026, time.July, 19, 11, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(startedAt)
+	oldISO := formatJavaScriptISOString(startedAt.Add(-time.Hour))
+
+	seedCoordinator := openMigratedCoordinator(t, cfg.Storage.DBPath, backupDir)
+	seedRepos := storage.NewRepositories(seedCoordinator.DB())
+	projectID := "project_observed_live"
+	loopID := "loop_observed_live"
+	runID := "run_observed_live"
+	queueID := "queue_observed_live"
+	if err := seedRepos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Live", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := seedRepos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 2, ProjectID: projectID, Type: "worker", TargetType: "project", Status: "running", CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := seedRepos.Runs.Upsert(context.Background(), storage.RunRecord{ID: runID, LoopID: loopID, Status: "running", CurrentStep: stringPtr("execute"), StartedAt: oldISO, LastHeartbeatAt: &oldISO, CreatedAt: oldISO, UpdatedAt: oldISO}); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	if err := seedRepos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: projectID,
+		DedupeKey: "worker:project_observed_live:loop_observed_live", Priority: storage.QueuePriorityWorker, Status: "running",
+		AvailableAt: oldISO, Attempts: 1, MaxAttempts: 3, ClaimedBy: stringPtr("scheduler"), ClaimedAt: stringPtr(oldISO),
+		StartedAt: stringPtr(oldISO), CreatedAt: oldISO, UpdatedAt: oldISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	livePID := int64(8888)
+	if err := seedRepos.AgentExecutions.Upsert(context.Background(), storage.AgentExecutionRecord{
+		ID: "agent_observed_live", ProjectID: &projectID, LoopID: &loopID, RunID: &runID, Vendor: "codex", Status: "running",
+		PID: &livePID, CommandJSON: stringPtr(`{"command":"codex","args":["exec","--term-resistant"]}`), CWD: stringPtr(workingDir),
+		HeartbeatCount: 1, StartedAt: oldISO, CreatedAt: oldISO, UpdatedAt: oldISO,
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+	if err := seedCoordinator.Close(); err != nil {
+		t.Fatalf("seed close error = %v", err)
+	}
+
+	var signaled []struct {
+		pid int
+		sig syscall.Signal
+	}
+	rt := New(Options{
+		Config: cfg,
+		Logger: &testLogger{},
+		Now:    func() time.Time { return startedAt },
+		ReadProcessCommand: func(_ context.Context, pid int) (string, error) {
+			if pid != int(livePID) {
+				return "", nil
+			}
+			return "codex exec --term-resistant", nil
+		},
+		SignalProcess: func(pid int, sig syscall.Signal) error {
+			signaled = append(signaled, struct {
+				pid int
+				sig syscall.Signal
+			}{pid, sig})
+			return nil
+		},
+	})
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { rt.Stop("test cleanup") })
+
+	if len(signaled) != 0 {
+		t.Fatalf("SignalProcess called %#v; want no fire-and-forget SIGTERM/SIGKILL on raw PID/PGID", signaled)
+	}
+
+	services := rt.Services()
+	execution, err := services.Repositories.AgentExecutions.GetByID(context.Background(), "agent_observed_live")
+	if err != nil {
+		t.Fatalf("GetByID error = %v", err)
+	}
+	if execution == nil || execution.Status != "running" {
+		t.Fatalf("execution = %#v, want running evidence", execution)
+	}
+	queue, err := services.Repositories.Queue.GetByID(context.Background(), queueID)
+	if err != nil {
+		t.Fatalf("Queue.GetByID error = %v", err)
+	}
+	if queue == nil || queue.Status != "manual_intervention" {
+		t.Fatalf("queue = %#v, want manual_intervention", queue)
+	}
+	run, err := services.Repositories.Runs.GetByID(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("Runs.GetByID error = %v", err)
+	}
+	if run == nil || run.Status != "running" {
+		t.Fatalf("run = %#v, want still running (no false interrupt cleanliness)", run)
+	}
+
+	recovery := rt.RecoverySummary()
+	if recovery.OrphanAgentCleanup.ObservedLiveCount != 1 {
+		t.Fatalf("ObservedLiveCount = %d, want 1", recovery.OrphanAgentCleanup.ObservedLiveCount)
+	}
+	if recovery.OrphanAgentCleanup.ConfirmedDeadCount != 0 || recovery.OrphanAgentCleanup.CleanedCount != 0 {
+		t.Fatalf("cleanup = %#v, want no confirmed-dead / cleaned", recovery.OrphanAgentCleanup)
+	}
+	if recovery.LoopsRequeued != 0 {
+		t.Fatalf("LoopsRequeued = %d, want 0", recovery.LoopsRequeued)
+	}
+
+	// Lease/finalize semantics: quarantined running claim is not re-claimable.
+	if err := rt.AllowClaim(); err != nil {
+		t.Fatalf("AllowClaim() = %v", err)
+	}
+	claimed, err := services.Repositories.Queue.ClaimNext(context.Background(), nowISO, "scheduler")
+	if err != nil {
+		t.Fatalf("ClaimNext error = %v", err)
+	}
+	if claimed != nil {
+		t.Fatalf("ClaimNext = %#v, want nil", claimed)
+	}
+}

--- a/skills/looper/references/daemon.md
+++ b/skills/looper/references/daemon.md
@@ -120,4 +120,4 @@ Operator recovery:
 1. Read `looper daemon logs` / `looper daemon status --json` for admission `degraded` and a reason mentioning agent execution persistence or queue finalize failure.
 2. Repair storage under the runtime home (default `~/.looper/`): disk space, permissions, SQLite integrity.
 3. **Restart `looperd`** — normal recovery. Admission stays degraded until process restart (or an explicit clear hook used only in tests/ops tools).
-4. After restart, let startup recovery classify durable rows conservatively; do not force-requeue uncertain work.
+4. After restart, startup recovery classifies durable rows as **confirmed_dead** / **observed_live** / **uncertain** (ADR-0015 / #581). PID/PGID probes are evidence only — never confirmed-dead Authority. Uncertain and observed-live work is quarantined (`manual_intervention` / paused); do not force-requeue it.


### PR DESCRIPTION
## Summary

Finish startup recovery redesign so PID/PGID inspection is **drift evidence only**, never live Authority or confirmed-dead Authority after restart (ADR-0015 R8 / #581).

### Classification

After restart, each durable `agent_executions` observation is classified:

| Class | Meaning | Recovery action |
|-------|---------|-----------------|
| **confirmed_dead** | Authority exists to treat the execution as non-runnable | Only durable terminal finalization or current-daemon confirmed drain |
| **observed_live** | Process probe matched the durable row | Evidence only — never adopt ownership; quarantine |
| **uncertain** | PID absent/not running, mismatch, probe error, leader-exit-only | Quarantine; no raw PID/PGID action |

**Must not** authorize confirmed-dead: PID missing, probe-then-signal, or leader exit alone (descendants may remain).

### Runtime

- New `recovery_classification.go` with pure Authority rules + `classifyStartupExecution`
- Orphan cleanup emits `looperd.recovery.containment_classified` and quarantines via existing `manual_intervention` / `paused` (no new ledger)
- Never SIGTERM/SIGKILL raw PID/PGID; never mark agent_execution terminal from PID absence
- Running claims after restart have no live lease — park uncertain/observed-live work; no requeue/overlap
- Stale-run liveness verification shares the same classification (DeadExecutions = no live match, not confirmed-dead)

### Docs

- ADR-0015 matrix R8 → **Enforced**, with classification trade-off section
- Exit checklist updated for R8 delivery; Status remains Proposed until #573 process close-out
- Operator note in `skills/looper/references/daemon.md`

## Authority

> What is the authority for confirmed-dead after restart, and why is it not the agent's structured output?

A pre-crash containment handle no longer exists. Confirmed-dead may only come from durable terminal finalization already committed, or a **current-daemon** owned handle that completed confirmed drain. Agents do not own process lifecycle; PID/PGID probes are reusable IDs and are evidence only.

## Trade-off

- **Prevents:** false cleanliness and PID-reuse kills after crash; terminal/requeue/overlap from leader exit or PID absence alone; treating observed-live orphans as Supervisor-owned
- **Costs:** more quarantine/`manual_intervention` and less aggressive auto-clean after restart
- **Why not simpler:** trusting PID probes reopens reusable-ID kills; always-quarantine without classes loses explicit durable-terminal / current-daemon-drain Authority paths
- **Deletion attempt:** drop classification and always quarantine — correct but loses Authority-backed paths; classification keeps them explicit and tested

## Test plan

- [x] Pure classification: PID absence/not-running never confirmed_dead; durable terminal and current-daemon drain authorize confirmed_dead
- [x] Exited leader → uncertain; no signal; agent_execution stays running evidence; queue `manual_intervention`; no claim overlap
- [x] Observed live (TERM-resistant) → no fire-and-forget SIGTERM/SIGKILL; quarantine; no requeue
- [x] Existing safety-floor and stale-run quarantine regressions pass
- [x] `go test ./internal/runtime/ ./internal/processcontainment/`

Closes #581

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=grok-build · An autonomous AI dev team for your GitHub repos.</sub>