### PR TITLE
fix: make dashboard config vendor saves apply cleanly

### DIFF
--- a/internal/runtime/config_patch_test.go
+++ b/internal/runtime/config_patch_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/nexu-io/looper/internal/config"
@@ -218,6 +220,35 @@ func TestPatchConfigCanonicalFieldRetiresShadowingLegacyAliases(t *testing.T) {
 	}
 	if got := rt.Config().Roles.Reviewer.Behavior.ReviewEvents.Clean; got != config.ReviewerReviewEventApprove {
 		t.Fatalf("clean event after canonical unset = %q, want default APPROVE", got)
+	}
+}
+
+func TestPatchConfigVendorCompanionModelMessageIsNotRestart(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	original := []byte(`{"agent":{"vendor":"codex","model":"gpt-5"},"scheduler":{"maxConcurrentRuns":2}}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	rt := newConfigPatchRuntime(t, path, nil)
+	err := rt.PatchConfig(context.Background(), ConfigPatch{
+		Revision: testConfigRevision(t, path),
+		Set:      map[string]json.RawMessage{"agent.vendor": json.RawMessage(`"claude-code"`)},
+	})
+	var patchErr *ConfigPatchError
+	if !errors.As(err, &patchErr) {
+		t.Fatalf("PatchConfig() error = %v, want ConfigPatchError", err)
+	}
+	if patchErr.Kind != "validation" {
+		t.Fatalf("PatchConfig() kind = %q, want validation (companion, not restart)", patchErr.Kind)
+	}
+	if !strings.Contains(patchErr.Message, "companion fields") || strings.Contains(patchErr.Message, "daemon restart") {
+		t.Fatalf("PatchConfig() message = %q, want companion-field guidance without restart claim", patchErr.Message)
+	}
+	if got, want := patchErr.Paths, []string{"agent.model"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("PatchConfig() paths = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/runtime/config_reload.go
+++ b/internal/runtime/config_reload.go
@@ -86,7 +86,7 @@ func (e *ConfigReloadError) Error() string {
 		return e.Err.Error()
 	}
 	if len(e.Paths) > 0 {
-		return fmt.Sprintf("configuration changes require a daemon restart: %s", strings.Join(e.Paths, ", "))
+		return configRestartRejectionMessage(e.Paths)
 	}
 	return "configuration reload failed"
 }
@@ -350,7 +350,8 @@ func (r *Runtime) PatchConfig(ctx context.Context, patch ConfigPatch) error {
 	}
 	if rejected := config.RestartRequiredChanges(r.loadedConfig.Config, candidate.Config); len(rejected) > 0 {
 		sort.Strings(rejected)
-		return &ConfigPatchError{Kind: "unsupported", Message: fmt.Sprintf("configuration changes require a daemon restart: %s", strings.Join(rejected, ", ")), Paths: rejected}
+		kind, message := configRestartRejection(rejected)
+		return &ConfigPatchError{Kind: kind, Message: message, Paths: rejected}
 	}
 	r.configBoundary.Lock()
 	defer r.configBoundary.Unlock()
@@ -518,6 +519,39 @@ func (r *Runtime) configReloadStatusLocked() ConfigReloadStatus {
 func timePointer(value time.Time) *time.Time {
 	copy := value
 	return &copy
+}
+
+// configRestartRejection classifies RestartRequiredChanges paths for API errors.
+// Companion guards (hot-editable model/params leaves retained across a vendor
+// switch) are fixable in the same PATCH and must not claim a daemon restart is
+// required. True restart-bound paths keep the restart message.
+func configRestartRejection(paths []string) (kind string, message string) {
+	if len(paths) == 0 {
+		return "unsupported", "configuration changes require a daemon restart"
+	}
+	allHotCompanions := true
+	for _, path := range paths {
+		// agent.params is restart-bound / file-only — not a dashboard companion.
+		if path == "agent.params" || strings.HasPrefix(path, "agent.params.") {
+			allHotCompanions = false
+			break
+		}
+		if !config.IsHotEditablePath(path) {
+			allHotCompanions = false
+			break
+		}
+	}
+	if allHotCompanions {
+		return "validation", fmt.Sprintf(
+			"vendor change also requires updating or unsetting companion fields in the same save: %s",
+			strings.Join(paths, ", "),
+		)
+	}
+	return "unsupported", configRestartRejectionMessage(paths)
+}
+
+func configRestartRejectionMessage(paths []string) string {
+	return fmt.Sprintf("configuration changes require a daemon restart: %s", strings.Join(paths, ", "))
 }
 
 func cloneValueSources(source map[string]config.ValueSource) map[string]config.ValueSource {

--- a/web/dashboard/src/lib/configForm.test.ts
+++ b/web/dashboard/src/lib/configForm.test.ts
@@ -311,7 +311,7 @@ describe("config form contract", () => {
     ).toMatch(/referenced by worker/i);
   });
 
-  it("treats empty profile/role model drafts as unset inherit, not empty-string set", () => {
+  it("treats empty profile/role model drafts as explicit vendor-default suppress", () => {
     const data = fixture();
     const result = buildConfigPatch(
       data,
@@ -322,11 +322,11 @@ describe("config form contract", () => {
       [],
     );
     expect(result.errors).toEqual({});
-    expect(result.body.set).toEqual({});
-    expect(result.body.unset).toEqual([
-      "agent.profiles.fast.model",
-      "roles.worker.agent.model",
-    ]);
+    expect(result.body.set).toEqual({
+      "agent.profiles.fast.model": "",
+      "roles.worker.agent.model": "",
+    });
+    expect(result.body.unset).toEqual([]);
   });
 
   it("treats empty role profile drafts as unset when sibling vendor/model remain", () => {
@@ -431,6 +431,85 @@ describe("config form contract", () => {
     expect(
       profileLeafUnsetWouldEmpty(data, {}, [], "cheap", "vendor"),
     ).toBe(true);
+  });
+
+  it("auto-clears retained models when staging a vendor switch", () => {
+    const data = fixture();
+    data.agent = {
+      vendor: "codex",
+      model: "gpt-5",
+      envKeys: ["OPENAI_API_KEY"],
+      profiles: {
+        fast: { vendor: "codex", model: "gpt-5-mini" },
+      },
+      nativeResume: { enabled: true },
+      timeouts: { plannerIdleTimeoutSeconds: 300 },
+    };
+    data.roles = {
+      planner: {
+        triggers: { planeAssigneeId: "planner-member" },
+      },
+      worker: {
+        triggers: { planeAssigneeId: "worker-member" },
+        agent: {
+          profile: "fast",
+          vendor: "claude-code",
+          model: "haiku",
+        },
+      },
+      reviewer: {
+        behavior: {
+          reviewEvents: { clean: "COMMENT", blocking: "COMMENT" },
+          threadResolution: { enabled: true, mode: "report_only" },
+        },
+        autoMerge: { enabled: false },
+        agent: { vendor: "codex" },
+      },
+    };
+
+    const globalOnly = buildConfigPatch(
+      data,
+      { "agent.vendor": "opencode" },
+      [],
+    );
+    expect(globalOnly.errors).toEqual({});
+    expect(globalOnly.body.set).toEqual({ "agent.vendor": "opencode" });
+    expect(globalOnly.body.unset).toEqual(["agent.model"]);
+
+    const profileOnly = buildConfigPatch(
+      data,
+      { "agent.profiles.fast.vendor": "opencode" },
+      [],
+    );
+    expect(profileOnly.errors).toEqual({});
+    expect(profileOnly.body.set).toEqual({
+      "agent.profiles.fast.vendor": "opencode",
+    });
+    expect(profileOnly.body.unset).toEqual(["agent.profiles.fast.model"]);
+
+    const roleOwnedModel = buildConfigPatch(
+      data,
+      { "roles.worker.agent.vendor": "opencode" },
+      [],
+    );
+    expect(roleOwnedModel.errors).toEqual({});
+    expect(roleOwnedModel.body.set).toEqual({
+      "roles.worker.agent.vendor": "opencode",
+    });
+    expect(roleOwnedModel.body.unset).toEqual(["roles.worker.agent.model"]);
+
+    // Role vendor switch with only inherited global model: suppress via "".
+    const roleInherited = buildConfigPatch(
+      data,
+      { "roles.reviewer.agent.vendor": "opencode" },
+      [],
+    );
+    expect(roleInherited.errors).toEqual({});
+    expect(roleInherited.body.set).toEqual({
+      "roles.reviewer.agent.vendor": "opencode",
+      "roles.reviewer.agent.model": "",
+    });
+    expect(roleInherited.body.unset).toEqual([]);
   });
 
   it("confirms automatic commit only when the change can enable it", () => {

--- a/web/dashboard/src/lib/configForm.test.ts
+++ b/web/dashboard/src/lib/configForm.test.ts
@@ -510,6 +510,28 @@ describe("config form contract", () => {
       "roles.reviewer.agent.model": "",
     });
     expect(roleInherited.body.unset).toEqual([]);
+
+    // Profile vendor switch when profile model equals global model: unsetting
+    // the profile model would re-inherit that same global model under the new
+    // vendor (roles selecting the profile keep resolved model) — suppress "".
+    data.agent.profiles = {
+      fast: { vendor: "codex", model: "gpt-5" },
+    };
+    data.roles.worker = {
+      triggers: { planeAssigneeId: "worker-member" },
+      agent: { profile: "fast" },
+    };
+    const profileSameAsGlobal = buildConfigPatch(
+      data,
+      { "agent.profiles.fast.vendor": "opencode" },
+      [],
+    );
+    expect(profileSameAsGlobal.errors).toEqual({});
+    expect(profileSameAsGlobal.body.set).toEqual({
+      "agent.profiles.fast.vendor": "opencode",
+      "agent.profiles.fast.model": "",
+    });
+    expect(profileSameAsGlobal.body.unset).toEqual([]);
   });
 
   it("confirms automatic commit only when the change can enable it", () => {

--- a/web/dashboard/src/lib/configForm.test.ts
+++ b/web/dashboard/src/lib/configForm.test.ts
@@ -329,6 +329,58 @@ describe("config form contract", () => {
     expect(result.body.unset).toEqual([]);
   });
 
+  it("stages blank profile/role model drafts as suppress when the leaf is absent", () => {
+    const data = fixture();
+    data.agent = {
+      ...data.agent!,
+      model: "gpt-5",
+      profiles: {
+        cheap: { vendor: "opencode" },
+      },
+    };
+    data.roles!.planner = {
+      ...data.roles!.planner!,
+      // no agent.model leaf — inherits global
+    };
+
+    // Absent profile model + blank draft → create suppress binding.
+    const profileBlank = buildConfigPatch(
+      data,
+      { "agent.profiles.cheap.model": "" },
+      [],
+    );
+    expect(profileBlank.errors).toEqual({});
+    expect(profileBlank.body.set).toEqual({
+      "agent.profiles.cheap.model": "",
+    });
+    expect(profileBlank.body.unset).toEqual([]);
+
+    // Absent role model + blank draft → create suppress binding.
+    const roleBlank = buildConfigPatch(
+      data,
+      { "roles.planner.agent.model": "" },
+      [],
+    );
+    expect(roleBlank.errors).toEqual({});
+    expect(roleBlank.body.set).toEqual({
+      "roles.planner.agent.model": "",
+    });
+    expect(roleBlank.body.unset).toEqual([]);
+
+    // Already-suppress model blank draft is a no-op.
+    data.roles!.planner = {
+      ...data.roles!.planner!,
+      agent: { model: "" },
+    };
+    const alreadySuppress = buildConfigPatch(
+      data,
+      { "roles.planner.agent.model": "" },
+      [],
+    );
+    expect(alreadySuppress.body.set).toEqual({});
+    expect(alreadySuppress.body.unset).toEqual([]);
+  });
+
   it("treats empty role profile drafts as unset when sibling vendor/model remain", () => {
     const data = fixture();
     // Fixture worker has profile + vendor + model; clearing only profile must
@@ -358,10 +410,11 @@ describe("config form contract", () => {
     expect(
       draftStagesConfigChange(data, "agent.profiles.fast.model", ""),
     ).toBe(true);
-    // Clearing a model that is already absent is a no-op.
+    // Blank model on an absent role/profile leaf stages suppress (""), not a
+    // no-op — empty is distinct from inherit for overlay resolution.
     expect(
       draftStagesConfigChange(data, "roles.planner.agent.model", ""),
-    ).toBe(false);
+    ).toBe(true);
     // Non-empty change still stages.
     expect(
       draftStagesConfigChange(data, "roles.worker.agent.profile", "other"),
@@ -532,6 +585,93 @@ describe("config form contract", () => {
       "agent.profiles.fast.model": "",
     });
     expect(profileSameAsGlobal.body.unset).toEqual([]);
+
+    // Model-less profile vendor switch still inherits non-empty global model
+    // for roles selecting the profile — stage profile model suppress.
+    data.agent.profiles = {
+      bare: { vendor: "codex" },
+    };
+    data.roles.worker = {
+      triggers: { planeAssigneeId: "worker-member" },
+      agent: { profile: "bare" },
+    };
+    const modelLessProfile = buildConfigPatch(
+      data,
+      { "agent.profiles.bare.vendor": "opencode" },
+      [],
+    );
+    expect(modelLessProfile.errors).toEqual({});
+    expect(modelLessProfile.body.set).toEqual({
+      "agent.profiles.bare.vendor": "opencode",
+      "agent.profiles.bare.model": "",
+    });
+    expect(modelLessProfile.body.unset).toEqual([]);
+
+    // Global vendor switch: role owns model while inheriting global vendor.
+    data.agent.profiles = {
+      fast: { vendor: "codex", model: "gpt-5-mini" },
+    };
+    data.roles.worker = {
+      triggers: { planeAssigneeId: "worker-member" },
+      agent: { model: "gpt-5" },
+    };
+    data.roles.reviewer = {
+      behavior: {
+        reviewEvents: { clean: "COMMENT", blocking: "COMMENT" },
+        threadResolution: { enabled: true, mode: "report_only" },
+      },
+      autoMerge: { enabled: false },
+    };
+    const globalWithRoleModel = buildConfigPatch(
+      data,
+      { "agent.vendor": "claude-code" },
+      [],
+    );
+    expect(globalWithRoleModel.errors).toEqual({});
+    expect(globalWithRoleModel.body.set).toEqual({
+      "agent.vendor": "claude-code",
+    });
+    expect(globalWithRoleModel.body.unset.sort()).toEqual(
+      ["agent.model", "roles.worker.agent.model"].sort(),
+    );
+
+    // Global vendor switch: role selects a profile that inherits global vendor
+    // but owns a non-empty model — clear the profile model companion.
+    data.agent.profiles = {
+      shared: { model: "gpt-5-mini" },
+    };
+    data.roles.worker = {
+      triggers: { planeAssigneeId: "worker-member" },
+      agent: { profile: "shared" },
+    };
+    const globalWithProfileModel = buildConfigPatch(
+      data,
+      { "agent.vendor": "claude-code" },
+      [],
+    );
+    expect(globalWithProfileModel.errors).toEqual({});
+    expect(globalWithProfileModel.body.set).toEqual({
+      "agent.vendor": "claude-code",
+      "agent.profiles.shared.model": "",
+    });
+    expect(globalWithProfileModel.body.unset).toEqual(["agent.model"]);
+
+    // Global vendor switch leaves role/profile models alone when the role
+    // overrides vendor (resolved vendor does not inherit global).
+    data.roles.worker = {
+      triggers: { planeAssigneeId: "worker-member" },
+      agent: { vendor: "codex", model: "gpt-5" },
+    };
+    const globalWithRoleVendor = buildConfigPatch(
+      data,
+      { "agent.vendor": "claude-code" },
+      [],
+    );
+    expect(globalWithRoleVendor.errors).toEqual({});
+    expect(globalWithRoleVendor.body.set).toEqual({
+      "agent.vendor": "claude-code",
+    });
+    expect(globalWithRoleVendor.body.unset).toEqual(["agent.model"]);
   });
 
   it("confirms automatic commit only when the change can enable it", () => {

--- a/web/dashboard/src/lib/configForm.ts
+++ b/web/dashboard/src/lib/configForm.ts
@@ -561,10 +561,14 @@ export function buildConfigPatch(
  * When a vendor leaf is set or unset to a different effective vendor, clear any
  * retained non-empty model that would otherwise block the hot vendor edit.
  *
- * - Global / profile / role-owned models are unset (inherit / drop binding).
+ * - Global / profile / role-owned models are unset (inherit / drop binding)
+ *   when that does not leave the same non-empty resolved model under the new CLI.
  * - Role vendor edits that inherit a non-empty global or profile model stage an
  *   explicit empty role model (suppress) so the resolved model is not reused
  *   under the new CLI — matching daemon RestartRequiredChanges guards.
+ * - Profile vendor edits whose post-unset global inherit equals the current
+ *   profile model stage model:"" for the same reason (roles selecting the
+ *   profile would otherwise keep the global model across the vendor switch).
  */
 function stageVendorCompanionModelOps(
   data: ConfigData,
@@ -610,11 +614,19 @@ function stageVendorCompanionModelOps(
     if (!vendorChanged(vendorPath)) continue;
     if (unset.has(`agent.profiles.${id}`)) continue;
     const modelPath = agentProfilePath(id, "model");
-    if (
-      !unset.has(modelPath) &&
-      !Object.hasOwn(set, modelPath) &&
-      modelNonEmpty(getConfigValue(data, modelPath))
-    ) {
+    if (unset.has(modelPath) || Object.hasOwn(set, modelPath)) continue;
+    const profileModel = getConfigValue(data, modelPath);
+    if (!modelNonEmpty(profileModel)) continue;
+
+    // Unsetting falls through to post-patch global agent.model. When that
+    // inherits the same non-empty value, roles selecting this profile keep the
+    // resolved model across the vendor switch and RestartRequiredChanges rejects
+    // the PATCH (often reporting agent.model). Suppress with model:"" so the
+    // vendor default is used instead.
+    const inherited = resolvedPostPatchGlobalModel(data, set, unset);
+    if (modelNonEmpty(inherited) && valuesEqual(inherited, profileModel)) {
+      set[modelPath] = "";
+    } else {
       unset.add(modelPath);
     }
   }
@@ -641,6 +653,16 @@ function stageVendorCompanionModelOps(
       set[modelPath] = "";
     }
   }
+}
+
+function resolvedPostPatchGlobalModel(
+  data: ConfigData,
+  set: Record<string, ConfigValue>,
+  unset: Set<string>,
+): unknown {
+  if (Object.hasOwn(set, "agent.model")) return set["agent.model"];
+  if (unset.has("agent.model")) return undefined;
+  return getConfigValue(data, "agent.model");
 }
 
 function resolvedInheritedRoleModel(
@@ -670,9 +692,7 @@ function resolvedInheritedRoleModel(
     }
   }
 
-  if (Object.hasOwn(set, "agent.model")) return set["agent.model"];
-  if (unset.has("agent.model")) return undefined;
-  return getConfigValue(data, "agent.model");
+  return resolvedPostPatchGlobalModel(data, set, unset);
 }
 
 /**

--- a/web/dashboard/src/lib/configForm.ts
+++ b/web/dashboard/src/lib/configForm.ts
@@ -518,10 +518,14 @@ export function buildConfigPatch(
       }
       continue;
     }
-    // Model empty draft: only stage explicit vendor-default suppress (non-nil
-    // "") when a non-empty model is currently published. Absent model already
-    // means inherit — empty is a no-op. Use Unset to go from suppress/value
-    // back to inherit. Vendor-switch companion logic may still set "" itself.
+    // Model empty draft: stage explicit vendor-default suppress (non-nil "").
+    // Profile/role empty models are distinct from unset (inherit) in
+    // overlayAgentIdentity, so a blank draft stages set "" even when the leaf
+    // is currently absent — operators can create suppress without first saving
+    // a non-empty model. Global agent.model only stages "" when replacing a
+    // non-empty published value (absent already means no model). Use Unset to
+    // go from suppress/value back to inherit. Vendor-switch companion logic may
+    // still set "" itself.
     if (
       parsed.value === "" &&
       (path === "agent.model" ||
@@ -529,9 +533,18 @@ export function buildConfigPatch(
           path.endsWith(".model"))
     ) {
       const current = getConfigValue(data, path);
-      if (typeof current === "string" && current !== "") {
-        set[path] = "";
+      if (current === "") {
+        // Already an explicit suppress binding.
+        continue;
       }
+      if (path === "agent.model") {
+        if (typeof current === "string" && current !== "") {
+          set[path] = "";
+        }
+        continue;
+      }
+      // Profile / role model: create or replace with suppress even if absent.
+      set[path] = "";
       continue;
     }
     if (!valuesEqual(parsed.value, getConfigValue(data, path))) {
@@ -566,9 +579,12 @@ export function buildConfigPatch(
  * - Role vendor edits that inherit a non-empty global or profile model stage an
  *   explicit empty role model (suppress) so the resolved model is not reused
  *   under the new CLI — matching daemon RestartRequiredChanges guards.
- * - Profile vendor edits whose post-unset global inherit equals the current
- *   profile model stage model:"" for the same reason (roles selecting the
- *   profile would otherwise keep the global model across the vendor switch).
+ * - Profile vendor edits whose post-unset global inherit is non-empty stage
+ *   model:"" (including model-less profiles) so roles selecting the profile do
+ *   not keep the global model across the vendor switch.
+ * - Global vendor edits also clear role/profile model bindings for coding roles
+ *   whose resolved vendor still inherits agent.vendor (role + selected profile
+ *   lack an override vendor).
  */
 function stageVendorCompanionModelOps(
   data: ConfigData,
@@ -587,7 +603,7 @@ function stageVendorCompanionModelOps(
   const modelNonEmpty = (value: unknown): boolean =>
     value != null && String(value).trim() !== "";
 
-  // Global agent.vendor ↔ agent.model
+  // Global agent.vendor ↔ agent.model and role/profile models that inherit it
   if (vendorChanged("agent.vendor")) {
     const modelPath = "agent.model";
     if (
@@ -597,6 +613,7 @@ function stageVendorCompanionModelOps(
     ) {
       unset.add(modelPath);
     }
+    stageGlobalVendorInheritedModelCompanions(data, set, unset, modelNonEmpty);
   }
 
   // Profile vendor ↔ profile model
@@ -616,14 +633,24 @@ function stageVendorCompanionModelOps(
     const modelPath = agentProfilePath(id, "model");
     if (unset.has(modelPath) || Object.hasOwn(set, modelPath)) continue;
     const profileModel = getConfigValue(data, modelPath);
-    if (!modelNonEmpty(profileModel)) continue;
+    const inherited = resolvedPostPatchGlobalModel(data, set, unset);
+
+    if (!modelNonEmpty(profileModel)) {
+      // Model-less (or already-suppress) profile: roles selecting it still
+      // resolve the post-patch global model under the new profile vendor.
+      // Stage suppress when that inherit is non-empty so RestartRequiredChanges
+      // does not reject with agent.model.
+      if (profileModel !== "" && modelNonEmpty(inherited)) {
+        set[modelPath] = "";
+      }
+      continue;
+    }
 
     // Unsetting falls through to post-patch global agent.model. When that
     // inherits the same non-empty value, roles selecting this profile keep the
     // resolved model across the vendor switch and RestartRequiredChanges rejects
     // the PATCH (often reporting agent.model). Suppress with model:"" so the
     // vendor default is used instead.
-    const inherited = resolvedPostPatchGlobalModel(data, set, unset);
     if (modelNonEmpty(inherited) && valuesEqual(inherited, profileModel)) {
       set[modelPath] = "";
     } else {
@@ -653,6 +680,108 @@ function stageVendorCompanionModelOps(
       set[modelPath] = "";
     }
   }
+}
+
+/**
+ * When agent.vendor changes, clear non-empty role/profile model bindings for
+ * coding roles whose resolved vendor still inherits the global vendor. Those
+ * roles' resolved CLI changes with the global switch while an owned model
+ * would be retained — RestartRequiredChanges rejects the PATCH.
+ */
+function stageGlobalVendorInheritedModelCompanions(
+  data: ConfigData,
+  set: Record<string, ConfigValue>,
+  unset: Set<string>,
+  modelNonEmpty: (value: unknown) => boolean,
+): void {
+  const clearedProfiles = new Set<string>();
+  for (const role of CODING_ROLES) {
+    if (!roleResolvedVendorInheritsGlobal(data, set, unset, role)) continue;
+
+    const roleModelPath = roleAgentPath(role, "model");
+    if (unset.has(roleModelPath) || Object.hasOwn(set, roleModelPath)) {
+      continue;
+    }
+
+    const roleModel = getConfigValue(data, roleModelPath);
+    if (modelNonEmpty(roleModel)) {
+      unset.add(roleModelPath);
+      continue;
+    }
+    // Explicit suppress already breaks same-model retention.
+    if (roleModel === "") continue;
+
+    const profileId = resolvedPostPatchRoleProfileId(data, set, unset, role);
+    if (profileId == null || clearedProfiles.has(profileId)) continue;
+    if (unset.has(`agent.profiles.${profileId}`)) continue;
+
+    const profileModelPath = agentProfilePath(profileId, "model");
+    if (unset.has(profileModelPath) || Object.hasOwn(set, profileModelPath)) {
+      clearedProfiles.add(profileId);
+      continue;
+    }
+
+    const profileModel = getConfigValue(data, profileModelPath);
+    if (!modelNonEmpty(profileModel)) {
+      clearedProfiles.add(profileId);
+      continue;
+    }
+
+    // Always suppress with model:"" rather than unset. Unsetting a model-only
+    // profile promotes to whole-profile removal and would break roles that
+    // still select it; "" keeps the profile and breaks same-model retention.
+    set[profileModelPath] = "";
+    clearedProfiles.add(profileId);
+  }
+}
+
+/** True when post-patch role vendor and selected profile vendor are both absent. */
+function roleResolvedVendorInheritsGlobal(
+  data: ConfigData,
+  set: Record<string, ConfigValue>,
+  unset: Set<string>,
+  role: CodingRole,
+): boolean {
+  const roleVendorPath = roleAgentPath(role, "vendor");
+  if (Object.hasOwn(set, roleVendorPath)) {
+    const v = set[roleVendorPath];
+    if (v != null && String(v).trim() !== "") return false;
+  } else if (!unset.has(roleVendorPath)) {
+    const v = getConfigValue(data, roleVendorPath);
+    if (v != null && String(v).trim() !== "") return false;
+  }
+
+  const profileId = resolvedPostPatchRoleProfileId(data, set, unset, role);
+  if (profileId == null) return true;
+  if (unset.has(`agent.profiles.${profileId}`)) return true;
+
+  const profileVendorPath = agentProfilePath(profileId, "vendor");
+  if (Object.hasOwn(set, profileVendorPath)) {
+    const v = set[profileVendorPath];
+    if (v != null && String(v).trim() !== "") return false;
+  } else if (!unset.has(profileVendorPath)) {
+    const v = getConfigValue(data, profileVendorPath);
+    if (v != null && String(v).trim() !== "") return false;
+  }
+  return true;
+}
+
+function resolvedPostPatchRoleProfileId(
+  data: ConfigData,
+  set: Record<string, ConfigValue>,
+  unset: Set<string>,
+  role: CodingRole,
+): string | null {
+  const profilePath = roleAgentPath(role, "profile");
+  let profileId: unknown = getConfigValue(data, profilePath);
+  if (unset.has(profilePath)) {
+    profileId = undefined;
+  } else if (Object.hasOwn(set, profilePath)) {
+    profileId = set[profilePath];
+  }
+  if (typeof profileId !== "string") return null;
+  const trimmed = profileId.trim();
+  return trimmed === "" ? null : trimmed;
 }
 
 function resolvedPostPatchGlobalModel(

--- a/web/dashboard/src/lib/configForm.ts
+++ b/web/dashboard/src/lib/configForm.ts
@@ -500,11 +500,9 @@ export function buildConfigPatch(
       errors[path] = parsed.error;
       continue;
     }
-    // Profile/role identity text leaves: empty draft means inherit (omit leaf),
-    // not set "". Role .profile must unset rather than stage "" — backend
-    // validateRoleAgentBindings rejects empty profile when sibling vendor/model
-    // keeps the role agent object alive. Model empty-string suppress is not
-    // staged from the text control; use Unset or an explicit future control.
+    // Role/profile .profile: empty draft means inherit (omit leaf), not set "".
+    // Backend validateRoleAgentBindings rejects empty profile when sibling
+    // vendor/model keeps the role agent object alive.
     //
     // Callers that probe single-path drafts (Config onDraft / rebase) must treat
     // an unset-only result as a staged change via draftStagesConfigChange so
@@ -512,11 +510,27 @@ export function buildConfigPatch(
     if (
       parsed.value === "" &&
       (isAgentProfileLeafPath(path) || isRoleAgentLeafPath(path)) &&
-      (path.endsWith(".model") || path.endsWith(".profile"))
+      path.endsWith(".profile")
     ) {
       const current = getConfigValue(data, path);
       if (current != null && current !== "") {
         unset.add(path);
+      }
+      continue;
+    }
+    // Model empty draft: only stage explicit vendor-default suppress (non-nil
+    // "") when a non-empty model is currently published. Absent model already
+    // means inherit — empty is a no-op. Use Unset to go from suppress/value
+    // back to inherit. Vendor-switch companion logic may still set "" itself.
+    if (
+      parsed.value === "" &&
+      (path === "agent.model" ||
+        (isAgentProfileLeafPath(path) || isRoleAgentLeafPath(path)) &&
+          path.endsWith(".model"))
+    ) {
+      const current = getConfigValue(data, path);
+      if (typeof current === "string" && current !== "") {
+        set[path] = "";
       }
       continue;
     }
@@ -529,6 +543,11 @@ export function buildConfigPatch(
     if (!unset.has(path)) set[path] = value;
   }
 
+  // Vendor leave/switch while retaining the same non-empty model is rejected by
+  // the daemon as an unsafe companion reuse. Stage the paired model clear before
+  // empty-profile collapse so a vendor-only edit that clears the last model leaf
+  // promotes to whole-profile removal instead of agent.profiles.<id>={}.
+  stageVendorCompanionModelOps(data, set, unset);
   // Avoid agent.profiles.<id>={} which validateAgentProfiles rejects.
   collapseEmptyProfileLeafOps(data, set, unset);
 
@@ -536,6 +555,124 @@ export function buildConfigPatch(
     body: { revision: data.metadata.revision, set, unset: [...unset].sort() },
     errors,
   };
+}
+
+/**
+ * When a vendor leaf is set or unset to a different effective vendor, clear any
+ * retained non-empty model that would otherwise block the hot vendor edit.
+ *
+ * - Global / profile / role-owned models are unset (inherit / drop binding).
+ * - Role vendor edits that inherit a non-empty global or profile model stage an
+ *   explicit empty role model (suppress) so the resolved model is not reused
+ *   under the new CLI — matching daemon RestartRequiredChanges guards.
+ */
+function stageVendorCompanionModelOps(
+  data: ConfigData,
+  set: Record<string, ConfigValue>,
+  unset: Set<string>,
+): void {
+  const vendorChanged = (vendorPath: string): boolean => {
+    if (unset.has(vendorPath)) {
+      const current = getConfigValue(data, vendorPath);
+      return current != null && String(current).trim() !== "";
+    }
+    if (!Object.hasOwn(set, vendorPath)) return false;
+    return !valuesEqual(set[vendorPath], getConfigValue(data, vendorPath));
+  };
+
+  const modelNonEmpty = (value: unknown): boolean =>
+    value != null && String(value).trim() !== "";
+
+  // Global agent.vendor ↔ agent.model
+  if (vendorChanged("agent.vendor")) {
+    const modelPath = "agent.model";
+    if (
+      !unset.has(modelPath) &&
+      !Object.hasOwn(set, modelPath) &&
+      modelNonEmpty(getConfigValue(data, modelPath))
+    ) {
+      unset.add(modelPath);
+    }
+  }
+
+  // Profile vendor ↔ profile model
+  const profileVendorOps = new Set<string>();
+  for (const path of unset) {
+    const match = /^agent\.profiles\.([A-Za-z0-9_-]+)\.vendor$/.exec(path);
+    if (match) profileVendorOps.add(match[1]);
+  }
+  for (const path of Object.keys(set)) {
+    const match = /^agent\.profiles\.([A-Za-z0-9_-]+)\.vendor$/.exec(path);
+    if (match) profileVendorOps.add(match[1]);
+  }
+  for (const id of profileVendorOps) {
+    const vendorPath = agentProfilePath(id, "vendor");
+    if (!vendorChanged(vendorPath)) continue;
+    if (unset.has(`agent.profiles.${id}`)) continue;
+    const modelPath = agentProfilePath(id, "model");
+    if (
+      !unset.has(modelPath) &&
+      !Object.hasOwn(set, modelPath) &&
+      modelNonEmpty(getConfigValue(data, modelPath))
+    ) {
+      unset.add(modelPath);
+    }
+  }
+
+  // Role vendor ↔ role model (or suppress inherited model)
+  for (const role of CODING_ROLES) {
+    const vendorPath = roleAgentPath(role, "vendor");
+    if (!vendorChanged(vendorPath)) continue;
+    const modelPath = roleAgentPath(role, "model");
+    if (unset.has(modelPath) || Object.hasOwn(set, modelPath)) continue;
+
+    const roleModel = getConfigValue(data, modelPath);
+    if (modelNonEmpty(roleModel)) {
+      unset.add(modelPath);
+      continue;
+    }
+
+    // Role has no own model: resolve inherited model after this patch
+    // (profile overlay, then global) the same way the daemon does.
+    const inherited = resolvedInheritedRoleModel(data, set, unset, role);
+    if (modelNonEmpty(inherited)) {
+      // Explicit empty suppress: keeps the role agent object and breaks
+      // same-model retention across the vendor switch.
+      set[modelPath] = "";
+    }
+  }
+}
+
+function resolvedInheritedRoleModel(
+  data: ConfigData,
+  set: Record<string, ConfigValue>,
+  unset: Set<string>,
+  role: CodingRole,
+): unknown {
+  const profilePath = roleAgentPath(role, "profile");
+  let profileId: unknown = getConfigValue(data, profilePath);
+  if (unset.has(profilePath)) {
+    profileId = undefined;
+  } else if (Object.hasOwn(set, profilePath)) {
+    profileId = set[profilePath];
+  }
+
+  if (typeof profileId === "string" && profileId.trim() !== "") {
+    if (!unset.has(`agent.profiles.${profileId}`)) {
+      const profileModelPath = agentProfilePath(profileId, "model");
+      if (Object.hasOwn(set, profileModelPath)) {
+        return set[profileModelPath];
+      }
+      if (!unset.has(profileModelPath)) {
+        const profileModel = getConfigValue(data, profileModelPath);
+        if (profileModel != null) return profileModel;
+      }
+    }
+  }
+
+  if (Object.hasOwn(set, "agent.model")) return set["agent.model"];
+  if (unset.has("agent.model")) return undefined;
+  return getConfigValue(data, "agent.model");
 }
 
 /**

--- a/web/dashboard/src/pages/Config.test.tsx
+++ b/web/dashboard/src/pages/Config.test.tsx
@@ -99,6 +99,33 @@ function renderPage() {
   );
 }
 
+/** Header + sticky footer both expose Save while dirty. */
+function saveButtons(): HTMLButtonElement[] {
+  return screen.getAllByRole("button", {
+    name: "Save changes",
+  }) as HTMLButtonElement[];
+}
+
+function clickSaveChanges() {
+  fireEvent.click(saveButtons()[0]);
+}
+
+function expectSaveDisabled(disabled: boolean) {
+  for (const button of saveButtons()) {
+    expect(button.disabled).toBe(disabled);
+  }
+}
+
+function discardButtons(): HTMLButtonElement[] {
+  return screen.getAllByRole("button", {
+    name: "Discard",
+  }) as HTMLButtonElement[];
+}
+
+function clickDiscard() {
+  fireEvent.click(discardButtons()[0]);
+}
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
@@ -158,7 +185,7 @@ describe("ConfigPage", () => {
       "scheduler.slowLaneWarnThresholdMs",
     ) as HTMLInputElement;
     fireEvent.change(retry, { target: { value: "8" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
 
     await waitFor(() => {
       expect(
@@ -221,7 +248,7 @@ describe("ConfigPage", () => {
     await waitFor(() => expect(getCount).toBe(3));
 
     fireEvent.change(retry, { target: { value: "8" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     await waitFor(() => expect(retry.value).toBe("8"));
     expect(screen.queryByText("refresh failed")).toBeNull();
     expect(resolveRefresh).toBeTypeOf("function");
@@ -274,7 +301,7 @@ describe("ConfigPage", () => {
     });
     expect(retry.value).toBe("6");
 
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     await waitFor(() => {
       expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
         true,
@@ -327,26 +354,24 @@ describe("ConfigPage", () => {
       "scheduler.slowLaneWarnThresholdMs",
     )) as HTMLInputElement;
     fireEvent.change(retry, { target: { value: "6" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     const rebase = await screen.findByRole("button", {
       name: "Reload latest and keep edits",
     });
     expect(retry.value).toBe("6");
     expect(retry.disabled).toBe(true);
-    expect(
-      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement)
-        .disabled,
-    ).toBe(true);
+    expectSaveDisabled(true);
     fireEvent.click(rebase);
 
     await waitFor(() => {
       const field = container.querySelector(
         '[data-config-path="scheduler.slowLaneWarnThresholdMs"]',
       );
-      expect(field?.textContent).toContain("Published value: 8");
+      expect(field?.textContent).toMatch(/Unsaved draft/i);
+      expect(field?.textContent).toContain("8");
     });
     expect(retry.value).toBe("6");
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     await waitFor(() => expect(patchCount).toBe(2));
     const patchCalls = fetchMock.mock.calls.filter(
       ([, init]) => init?.method === "PATCH",
@@ -392,7 +417,7 @@ describe("ConfigPage", () => {
       await screen.findByLabelText("scheduler.slowLaneWarnThresholdMs"),
       { target: { value: "6" } },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     fireEvent.click(
       await screen.findByRole("button", {
         name: "Reload latest and keep edits",
@@ -409,6 +434,69 @@ describe("ConfigPage", () => {
       (screen.getByLabelText("scheduler.slowLaneWarnThresholdMs") as HTMLInputElement)
         .value,
     ).toBe("6");
+  });
+
+  it("unlocks a same-revision conflict when the daemon has no reload error", async () => {
+    // PATCH can 409 without changing the accepted content hash (identity race,
+    // cancel). Rebase must not stay locked forever when revision is unchanged
+    // but lastError is empty — OCC will re-check on the next save.
+    const initial = configFixture();
+    const sameRevision = configFixture({
+      metadata: {
+        ...initial.metadata,
+        revision: initial.metadata.revision,
+        lastError: null,
+      },
+    });
+    const applied = configFixture({
+      scheduler: { ...(initial.scheduler ?? {}), slowLaneWarnThresholdMs: 6 },
+      metadata: { ...initial.metadata, revision: "sha256:applied" },
+    });
+    let getCount = 0;
+    let patchCount = 0;
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        if (String(input) !== "/api/v1/config") {
+          return Promise.reject(new Error(`unexpected request: ${String(input)}`));
+        }
+        if (init?.method === "PATCH") {
+          patchCount += 1;
+          if (patchCount === 1) {
+            return Promise.resolve(
+              response(
+                { code: "CONFIG_CONFLICT", message: "configuration changed on disk" },
+                409,
+              ),
+            );
+          }
+          return Promise.resolve(response(applied));
+        }
+        getCount += 1;
+        return Promise.resolve(response(getCount === 1 ? initial : sameRevision));
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    fireEvent.change(
+      await screen.findByLabelText("scheduler.slowLaneWarnThresholdMs"),
+      { target: { value: "6" } },
+    );
+    clickSaveChanges();
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Reload latest and keep edits",
+      }),
+    );
+
+    await waitFor(() => {
+      expectSaveDisabled(false);
+    });
+    expect(
+      screen.queryByText(/changed config file is still rejected/i),
+    ).toBeNull();
+    clickSaveChanges();
+    await waitFor(() => expect(patchCount).toBe(2));
   });
 
   it("prunes a retained draft that already matches the rebased snapshot", async () => {
@@ -448,7 +536,7 @@ describe("ConfigPage", () => {
       "scheduler.slowLaneWarnThresholdMs",
     )) as HTMLInputElement;
     fireEvent.change(retry, { target: { value: "8" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     fireEvent.click(
       await screen.findByRole("button", {
         name: "Reload latest and keep edits",
@@ -457,14 +545,11 @@ describe("ConfigPage", () => {
 
     expect(await screen.findByText(/change now matches/i)).toBeTruthy();
     expect(retry.value).toBe("8");
-    expect(
-      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement)
-        .disabled,
-    ).toBe(true);
+    expectSaveDisabled(true);
     const field = container.querySelector(
       '[data-config-path="scheduler.slowLaneWarnThresholdMs"]',
     );
-    expect(field?.textContent).not.toContain("Published value:");
+    expect(field?.textContent).not.toMatch(/Unsaved draft/i);
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
     await waitFor(() => expect(retry.value).toBe("9"));
@@ -504,7 +589,7 @@ describe("ConfigPage", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Stage secret" }));
     fireEvent.click(screen.getByRole("button", { name: "Remove OPENAI_API_KEY" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     fireEvent.click(
       await screen.findByRole("button", {
         name: "Reload latest and keep edits",
@@ -518,10 +603,7 @@ describe("ConfigPage", () => {
     expect(
       screen.getByRole("button", { name: "Remove OPENAI_API_KEY" }),
     ).toBeTruthy();
-    expect(
-      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement)
-        .disabled,
-    ).toBe(true);
+    expectSaveDisabled(true);
   });
 
   it("tracks and discards typed but unstaged environment input", async () => {
@@ -544,18 +626,14 @@ describe("ConfigPage", () => {
     fireEvent.change(key, { target: { value: "UNSTAGED" } });
     fireEvent.change(secret, { target: { value: "not-saved" } });
 
-    const discard = screen.getByRole("button", { name: "Discard" }) as HTMLButtonElement;
-    expect(discard.disabled).toBe(false);
+    expect(discardButtons()[0].disabled).toBe(false);
     expect(
       (screen.getByRole("button", { name: "Refresh" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
-    expect(
-      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement)
-        .disabled,
-    ).toBe(true);
+    expectSaveDisabled(true);
 
-    fireEvent.click(discard);
+    clickDiscard();
     expect(
       (screen.getByLabelText("Environment variable name") as HTMLInputElement)
         .value,
@@ -660,7 +738,7 @@ describe("ConfigPage", () => {
       "scheduler.slowLaneWarnThresholdMs",
     )) as HTMLInputElement;
     fireEvent.change(retry, { target: { value: "8" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     await waitFor(() => expect(resolvePatch).toBeTypeOf("function"));
 
     expect(retry.disabled).toBe(true);
@@ -712,14 +790,14 @@ describe("ConfigPage", () => {
       "scheduler.slowLaneWarnThresholdMs",
     )) as HTMLInputElement;
     fireEvent.change(retry, { target: { value: "3.5" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     expect(await screen.findByText(/enter a whole number/i)).toBeTruthy();
     expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
       false,
     );
 
     fireEvent.change(retry, { target: { value: "0" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     expect(
       await screen.findByText(/must be -1 or greater than zero/i),
     ).toBeTruthy();
@@ -786,7 +864,7 @@ describe("ConfigPage", () => {
     expect(container.textContent).not.toContain("super-secret-value");
     expect(screen.getByText("NEW_SECRET")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Remove OPENAI_API_KEY" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
 
     await waitFor(() => {
       expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
@@ -816,7 +894,7 @@ describe("ConfigPage", () => {
       "defaults.allowAutoPush",
     )) as HTMLInputElement;
     fireEvent.click(autoPush);
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
 
     expect(
       await screen.findByRole("dialog", {
@@ -824,17 +902,13 @@ describe("ConfigPage", () => {
       }),
     ).toBeTruthy();
     expect(
-      (screen.getByRole("button", { name: "Discard" }) as HTMLButtonElement)
-        .disabled,
+      discardButtons()[0].disabled,
     ).toBe(true);
     expect(
       (screen.getByRole("button", { name: "Refresh" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
-    expect(
-      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement)
-        .disabled,
-    ).toBe(true);
+    expectSaveDisabled(true);
     expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
       false,
     );
@@ -887,7 +961,7 @@ describe("ConfigPage", () => {
     );
     // Profile shows as pending removal, not dual leaf unsets.
     expect(screen.getByText("undo remove")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
 
     // Unreferenced whole-profile remove is not high-impact; PATCH immediately.
     await waitFor(() => {
@@ -954,7 +1028,7 @@ describe("ConfigPage", () => {
       target: { value: "opencode" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Add profile" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
 
     // Vendor change is high-impact (resolved-vendor companion guard).
     fireEvent.click(
@@ -1026,7 +1100,7 @@ describe("ConfigPage", () => {
       target: { value: "opencode" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Add profile" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Apply changes" }),
@@ -1078,7 +1152,7 @@ describe("ConfigPage", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "Unset agent.profiles.fast.model" }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
 
     await waitFor(() => {
       expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
@@ -1168,7 +1242,7 @@ describe("ConfigPage", () => {
     fireEvent.change(await screen.findByLabelText("agent.profiles.fast.model"), {
       target: { value: "gpt-5" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     fireEvent.click(
       await screen.findByRole("button", {
         name: "Reload latest and keep edits",
@@ -1180,7 +1254,7 @@ describe("ConfigPage", () => {
         (screen.getByLabelText("agent.profiles.fast.model") as HTMLInputElement).value,
       ).toBe("gpt-5");
     });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     await waitFor(() => expect(patchCount).toBe(2));
     const patchCalls = fetchMock.mock.calls.filter(
       ([, init]) => init?.method === "PATCH",
@@ -1221,7 +1295,7 @@ describe("ConfigPage", () => {
     fireEvent.change(await screen.findByLabelText("roles.worker.agent.vendor"), {
       target: { value: "opencode" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
 
     expect(
       await screen.findByRole("dialog", {
@@ -1317,7 +1391,7 @@ describe("ConfigPage", () => {
     fireEvent.change(screen.getByLabelText("roles.worker.agent.profile"), {
       target: { value: "cheap" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
 
     // Profile switch is high-impact (can change resolved vendor).
     fireEvent.click(
@@ -1391,9 +1465,9 @@ describe("ConfigPage", () => {
     fireEvent.change(profileInput, { target: { value: "" } });
     // Empty draft must stick (not snap back to published "fast").
     expect(profileInput.value).toBe("");
-    expect(screen.getByText(/1\s*pending/i)).toBeTruthy();
+    expect(screen.getAllByText(/1\s*unsaved/i).length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
     // Unsetting a role profile is high-impact.
     fireEvent.click(
       await screen.findByRole("button", { name: "Apply changes" }),
@@ -1472,7 +1546,7 @@ describe("ConfigPage", () => {
       target: { value: "opencode" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Add profile" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    clickSaveChanges();
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Apply changes" }),

--- a/web/dashboard/src/pages/Config.tsx
+++ b/web/dashboard/src/pages/Config.tsx
@@ -199,12 +199,19 @@ function FieldFrame({
         </div>
         {unset ? (
           <p className="m-0 mt-1 text-[10px] text-[var(--warn)]">
-            Pending: remove the file value and use the next authority.
+            Unsaved: will remove the file value on Save (next authority wins).
           </p>
         ) : null}
         {dirty || unset ? (
-          <p className="m-0 mt-1 text-[10px] text-[var(--text-muted)]">
-            Published value: <code>{formatConfigValue(publishedValue)}</code>
+          <p className="m-0 mt-1 text-[10px] text-[var(--warn)]">
+            Unsaved draft
+            {unset ? null : (
+              <>
+                {" "}
+                (was <code>{formatConfigValue(publishedValue)}</code>)
+              </>
+            )}
+            . Click <strong>Save changes</strong> to apply.
           </p>
         ) : null}
         {error ? (
@@ -601,17 +608,11 @@ function AgentProfiles({
                         disabled={
                           !modelEditable || pendingRemoval || modelUnset
                         }
-                        placeholder="optional model (empty = inherit)"
+                        placeholder="optional (empty = vendor default; Unset = inherit)"
                         onChange={(event) => {
-                          const next = event.currentTarget.value;
-                          // Clearing the field unsets the leaf (inherit). Empty
-                          // string suppress is not staged from this control.
-                          // Last remaining leaf promotes to whole-profile remove.
-                          if (next === "" && published?.model != null) {
-                            if (!modelUnset) toggleProfileLeafUnset("model");
-                            return;
-                          }
-                          onDraft(modelPath, next);
+                          // Empty draft stages model:"" (vendor default suppress).
+                          // Use Unset for inheritance. Do not auto-unset on clear.
+                          onDraft(modelPath, event.currentTarget.value);
                         }}
                       />
                     </label>
@@ -1186,15 +1187,18 @@ export function ConfigPage() {
       setData(next);
       setLoadError(null);
       if (rebaseDrafts) {
+        // Stay locked only when the published generation is unchanged AND the
+        // daemon still reports a rejected reload. Same revision without
+        // lastError means the accepted file is back (or never left); OCC will
+        // re-check on the next PATCH, so unlock and let the operator retry.
         if (
           conflictRevisionRef.current !== null &&
-          next.metadata.revision === conflictRevisionRef.current
+          next.metadata.revision === conflictRevisionRef.current &&
+          Boolean(next.metadata.lastError)
         ) {
           setSaveConflict(true);
           setSaveError(
-            next.metadata.lastError
-              ? "The changed config file is still rejected. Repair it outside the dashboard, wait for a successful reload, then try again."
-              : "The daemon has not published the changed config file yet. Wait for the reload loop, then reload again.",
+            "The changed config file is still rejected. Repair it outside the dashboard, wait for a successful reload, then try again.",
           );
           setFieldErrors({});
           return;
@@ -1511,13 +1515,13 @@ export function ConfigPage() {
         <div>
           <h1 className="m-0 text-[15px] font-semibold">Configuration</h1>
           <p className="m-0 mt-0.5 text-[11px] text-[var(--text-muted)]">
-            Hot-safe global policy. Changes affect new runs; active runs keep their snapshot.
+            Hot-safe global policy. Edit fields, then click Save changes. Applies to new runs only.
           </p>
         </div>
         <div className="flex items-center gap-1.5">
           {formDirtyCount > 0 ? (
             <span className="mono text-[11px] text-[var(--warn)]">
-              {formDirtyCount} pending
+              {formDirtyCount} unsaved
             </span>
           ) : null}
           <Button
@@ -1541,11 +1545,34 @@ export function ConfigPage() {
             size="sm"
             disabled={editorLocked || environmentInputDirty || dirtyCount === 0}
             onClick={requestSave}
+            title={
+              environmentInputDirty
+                ? "Stage or clear the agent environment inputs first"
+                : dirtyCount === 0
+                  ? "No unsaved field changes"
+                  : "Write changes to the config file and apply to new runs"
+            }
           >
             {saving ? "Saving…" : "Save changes"}
           </Button>
         </div>
       </div>
+
+      {formDirtyCount > 0 && !saveConflict ? (
+        <div
+          className="rounded border border-[var(--warn)] bg-[color-mix(in_srgb,var(--warn)_8%,transparent)] px-3 py-2 text-[12px] text-[var(--warn)]"
+          role="status"
+          data-testid="config-unsaved-banner"
+        >
+          {formDirtyCount} unsaved{" "}
+          {formDirtyCount === 1 ? "change" : "changes"}. Nothing is written until
+          you click <strong>Save changes</strong>
+          {environmentInputDirty
+            ? " (stage or clear agent environment inputs first)"
+            : ""}
+          . A save bar stays pinned at the bottom while edits are pending.
+        </div>
+      ) : null}
 
       {environmentInputDirty ? (
         <div className="rounded border border-[var(--warn)] px-3 py-2 text-[12px] text-[var(--warn)]" role="status">
@@ -1640,6 +1667,37 @@ export function ConfigPage() {
           />
         ))}
       </div>
+
+      {formDirtyCount > 0 && !saveConflict ? (
+        <div
+          className="sticky bottom-0 z-20 -mx-0 flex flex-wrap items-center justify-between gap-2 border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2 shadow-[0_-8px_24px_rgba(0,0,0,0.35)]"
+          role="region"
+          aria-label="Unsaved configuration actions"
+        >
+          <p className="m-0 text-[12px] text-[var(--warn)]">
+            {formDirtyCount} unsaved{" "}
+            {formDirtyCount === 1 ? "change" : "changes"} — save to apply to new
+            runs.
+          </p>
+          <div className="flex items-center gap-1.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={saving || confirmBody !== null}
+              onClick={discard}
+            >
+              Discard
+            </Button>
+            <Button
+              size="sm"
+              disabled={editorLocked || environmentInputDirty || dirtyCount === 0}
+              onClick={requestSave}
+            >
+              {saving ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </div>
+      ) : null}
 
       <ConfirmDialog
         open={confirmBody !== null}


### PR DESCRIPTION
## Summary
- Dashboard auto-stages companion model clears when switching agent/profile/role vendor, so vendor-only edits no longer fail the hot-reload companion guard.
- Empty model drafts stage explicit `model: ""` (vendor default); **Unset** remains inheritance. Backend companion-only rejections report validation guidance instead of a false “daemon restart” message.
- Config 409 rebase no longer permanently locks when revision is unchanged and there is no reload `lastError`.
- Clearer unsaved UX: field hints, top banner, and sticky bottom **Save changes** bar.

## Test plan
- [x] `go test ./internal/runtime/ -run 'TestPatchConfig|ConfigReload'`
- [x] `npm test -- --run src/lib/configForm.test.ts src/pages/Config.test.tsx` (dashboard)
- [ ] Manual: open `looper dashboard` → Config → change `agent.vendor` → confirm unsaved banner/sticky save → Save → toast success; new runs use new vendor
- [ ] Manual: vendor change with existing model auto-clears/suppresses companion model in one save
- [ ] Manual: 409 with same revision and no `lastError` unlocks after “Reload latest and keep edits”