### PR TITLE
fix: prevent trusted review config FD double-consume EBADF

### DIFF
--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -745,16 +745,10 @@ func splitLogLines(content string) []string {
 }
 
 func (r *commandRuntime) loadConfig() (config.LoadedFileConfig, error) {
-	// Trusted proxy children receive a one-shot config pipe on an inherited FD.
-	// Memoize success and failure so a second loadConfig never re-reads after
-	// the descriptor is closed (which surfaces as EBADF).
-	if r.trustedReviewConfigLoaded {
-		return r.trustedReviewConfig, r.trustedReviewConfigErr
-	}
+	// Trusted proxy children supply a one-shot snapshot FD. Auto-upgrade
+	// skips those children so review submit is the sole consumer; a second
+	// loadConfig fails loud (descriptor required / EBADF) rather than caching.
 	if loaded, configured, err := forge.LoadTrustedReviewConfigSnapshot(); configured {
-		r.trustedReviewConfigLoaded = true
-		r.trustedReviewConfig = loaded
-		r.trustedReviewConfigErr = err
 		if err != nil {
 			return config.LoadedFileConfig{}, err
 		}

--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -745,7 +745,16 @@ func splitLogLines(content string) []string {
 }
 
 func (r *commandRuntime) loadConfig() (config.LoadedFileConfig, error) {
+	// Trusted proxy children receive a one-shot config pipe on an inherited FD.
+	// Memoize success and failure so a second loadConfig never re-reads after
+	// the descriptor is closed (which surfaces as EBADF).
+	if r.trustedReviewConfigLoaded {
+		return r.trustedReviewConfig, r.trustedReviewConfigErr
+	}
 	if loaded, configured, err := forge.LoadTrustedReviewConfigSnapshot(); configured {
+		r.trustedReviewConfigLoaded = true
+		r.trustedReviewConfig = loaded
+		r.trustedReviewConfigErr = err
 		if err != nil {
 			return config.LoadedFileConfig{}, err
 		}

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -26,6 +26,12 @@ type commandRuntime struct {
 	startupOutputPath  string
 	skipAPIStartProbe  bool
 	emittedConfigNotes map[string]struct{}
+	// trustedReviewConfig* memoize the one-shot inherited snapshot FD. Auto-
+	// upgrade skips trusted children, but any second loadConfig in the same
+	// process must not re-read a closed descriptor (EBADF).
+	trustedReviewConfigLoaded bool
+	trustedReviewConfig       config.LoadedFileConfig
+	trustedReviewConfigErr    error
 }
 
 func newCommandRuntime(app *App, argv []string) *commandRuntime {

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -26,12 +26,6 @@ type commandRuntime struct {
 	startupOutputPath  string
 	skipAPIStartProbe  bool
 	emittedConfigNotes map[string]struct{}
-	// trustedReviewConfig* memoize the one-shot inherited snapshot FD. Auto-
-	// upgrade skips trusted children, but any second loadConfig in the same
-	// process must not re-read a closed descriptor (EBADF).
-	trustedReviewConfigLoaded bool
-	trustedReviewConfig       config.LoadedFileConfig
-	trustedReviewConfigErr    error
 }
 
 func newCommandRuntime(app *App, argv []string) *commandRuntime {

--- a/internal/cliapp/trusted_review_config_test.go
+++ b/internal/cliapp/trusted_review_config_test.go
@@ -1,14 +1,19 @@
 package cliapp
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/forge"
+	"github.com/spf13/cobra"
 )
 
 func TestCommandRuntimeTrustedReviewConfigIgnoresChildPrecedenceLayers(t *testing.T) {
@@ -23,33 +28,16 @@ func TestCommandRuntimeTrustedReviewConfigIgnoresChildPrecedenceLayers(t *testin
 		t.Fatalf("Marshal(config snapshot) error = %v", err)
 	}
 
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("Pipe() error = %v", err)
-	}
-	writeDone := make(chan error, 1)
-	go func() {
-		_, writeErr := writer.Write(raw)
-		if closeErr := writer.Close(); writeErr == nil {
-			writeErr = closeErr
-		}
-		writeDone <- writeErr
-	}()
-
 	// In a real proxy child the conflicting LOOPER_GH_PATH may originate in
 	// daemon ambient env or captured Agent.Env; neither may re-apply over the
 	// daemon's already materialized CLI winner. Provider credentials remain
 	// ordinary child env because the selected transport still needs them.
 	t.Setenv("LOOPER_TRUSTED_REVIEW_PROXY_CHILD", "1")
-	t.Setenv(forge.TrustedReviewConfigFDEnv, strconv.FormatUint(uint64(reader.Fd()), 10))
 	t.Setenv("LOOPER_GH_PATH", filepath.Join(t.TempDir(), "agent-env-gh"))
 	t.Setenv("FORGEJO_TOKEN", "provider-credential")
+	installTrustedReviewConfigFD(t, raw)
 	runtime := &commandRuntime{argv: []string{"review", "submit", "acme/looper#42", "--gh-path", filepath.Join(t.TempDir(), "child-cli-gh")}}
 	loaded, err := runtime.loadConfig()
-	// LoadTrustedReviewConfigSnapshot owns and closes the inherited descriptor.
-	// Mark this test's original os.File wrapper closed immediately so its later
-	// finalizer cannot close an unrelated descriptor that the OS reused.
-	_ = reader.Close()
 	if err != nil {
 		t.Fatalf("loadConfig() error = %v", err)
 	}
@@ -59,7 +47,186 @@ func TestCommandRuntimeTrustedReviewConfigIgnoresChildPrecedenceLayers(t *testin
 	if got := os.Getenv("FORGEJO_TOKEN"); got != "provider-credential" {
 		t.Fatalf("FORGEJO_TOKEN after loadConfig() = %q, want provider credential preserved", got)
 	}
-	if err := <-writeDone; err != nil {
-		t.Fatalf("write config snapshot error = %v", err)
+}
+
+func TestCommandRuntimeTrustedReviewConfigMemoizesOneShotFD(t *testing.T) {
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
 	}
+	capturedGHPath := filepath.Join(t.TempDir(), "daemon-cli-gh")
+	cfg.Tools.GHPath = &capturedGHPath
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal(config snapshot) error = %v", err)
+	}
+
+	t.Setenv("LOOPER_TRUSTED_REVIEW_PROXY_CHILD", "1")
+	installTrustedReviewConfigFD(t, raw)
+	runtime := &commandRuntime{argv: []string{"review", "submit", "acme/looper#42"}}
+
+	first, err := runtime.loadConfig()
+	if err != nil {
+		t.Fatalf("first loadConfig() error = %v", err)
+	}
+	if os.Getenv(forge.TrustedReviewConfigFDEnv) != "" {
+		t.Fatalf("TrustedReviewConfigFDEnv still set after first load; want cleared")
+	}
+	// Descriptor is closed; a second uncached LoadTrustedReviewConfigSnapshot
+	// would EBADF. Memoized loadConfig must return the same snapshot.
+	second, err := runtime.loadConfig()
+	if err != nil {
+		t.Fatalf("second loadConfig() error = %v (want memoized success, not EBADF)", err)
+	}
+	if first.Config.Tools.GHPath == nil || second.Config.Tools.GHPath == nil ||
+		*first.Config.Tools.GHPath != *second.Config.Tools.GHPath ||
+		*second.Config.Tools.GHPath != capturedGHPath {
+		t.Fatalf("memoized loadConfig mismatch: first=%v second=%v want %q", first.Config.Tools.GHPath, second.Config.Tools.GHPath, capturedGHPath)
+	}
+}
+
+func TestCommandRuntimeTrustedReviewConfigMemoizesOriginalError(t *testing.T) {
+	t.Setenv("LOOPER_TRUSTED_REVIEW_PROXY_CHILD", "1")
+	// Empty pipe (writer closed immediately) → decode/EOF, not EBADF.
+	installTrustedReviewConfigFD(t, nil)
+	runtime := &commandRuntime{argv: []string{"review", "submit", "acme/looper#42"}}
+
+	_, firstErr := runtime.loadConfig()
+	if firstErr == nil {
+		t.Fatal("first loadConfig() error = nil, want decode/EOF failure")
+	}
+
+	_, secondErr := runtime.loadConfig()
+	if secondErr == nil {
+		t.Fatal("second loadConfig() error = nil, want memoized original error")
+	}
+	if firstErr.Error() != secondErr.Error() {
+		t.Fatalf("memoized error mismatch:\n first=%v\nsecond=%v", firstErr, secondErr)
+	}
+	if strings.Contains(strings.ToLower(secondErr.Error()), "bad file descriptor") {
+		t.Fatalf("second loadConfig() = %v, want original snapshot error not EBADF", secondErr)
+	}
+}
+
+func TestMaybeRunAutoUpgradeSkipsTrustedReviewProxyChild(t *testing.T) {
+	// Leave a closed FD selector so any accidental loadConfig would EBADF.
+	t.Setenv("LOOPER_TRUSTED_REVIEW_PROXY_CHILD", "1")
+	t.Setenv(forge.TrustedReviewConfigFDEnv, "3")
+	runtime := &commandRuntime{argv: []string{"review", "submit", "acme/looper#42"}}
+	cmd := &cobra.Command{Use: "submit"}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	if err := runtime.maybeRunAutoUpgrade(cmd, nil); err != nil {
+		t.Fatalf("maybeRunAutoUpgrade() error = %v", err)
+	}
+	if runtime.trustedReviewConfigLoaded {
+		t.Fatal("maybeRunAutoUpgrade loaded trusted config; want complete skip")
+	}
+	if os.Getenv(forge.TrustedReviewConfigFDEnv) != "3" {
+		t.Fatalf("TrustedReviewConfigFDEnv = %q, want untouched when auto-upgrade skips", os.Getenv(forge.TrustedReviewConfigFDEnv))
+	}
+}
+
+func TestAppRunTrustedReviewChildDoesNotEBADFAfterAutoUpgradePreRun(t *testing.T) {
+	// Regression for release-installed review-submit children: root
+	// PersistentPreRunE (auto-upgrade) used to loadConfig() and close FD 3
+	// before review submit could read the daemon snapshot.
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	// Distinctive snapshot value proves daemon authority reached review submit
+	// after PersistentPreRun (not a live-file fallback).
+	sentinelGH := filepath.Join(t.TempDir(), "snapshot-authority-gh")
+	cfg.Tools.GHPath = &sentinelGH
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal(config snapshot) error = %v", err)
+	}
+
+	// Install-shaped path + stable channel so release classification would
+	// apply if auto-upgrade were not skipped for trusted children.
+	fakeHome := t.TempDir()
+	binDir := filepath.Join(fakeHome, ".looper", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	fakeExec := filepath.Join(binDir, "looper")
+	if err := os.WriteFile(fakeExec, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake exec) error = %v", err)
+	}
+
+	t.Setenv("LOOPER_TRUSTED_REVIEW_PROXY_CHILD", "1")
+	// Ambient override must not win over the snapshot.
+	t.Setenv("LOOPER_GH_PATH", filepath.Join(t.TempDir(), "must-not-win"))
+	installTrustedReviewConfigFD(t, raw)
+
+	var stdout, stderr bytes.Buffer
+	app := New(Deps{
+		Stdout:         &stdout,
+		Stderr:         &stderr,
+		Stdin:          bytes.NewBufferString(`{"body":"diagnostic","comments":[]}`),
+		HomeDir:        fakeHome,
+		ExecutablePath: fakeExec,
+		CLIChannel:     "stable",
+	})
+	code := app.Run(context.Background(), []string{
+		"review", "submit", "acme/looper#42",
+		"--event", "COMMENT",
+		"--commit-id", "0000000000000000000000000000000000000000",
+	})
+	if code == 0 {
+		t.Fatal("app.Run() exit = 0, want non-zero after config load (no real gh/PR)")
+	}
+	combined := strings.ToLower(stdout.String() + "\n" + stderr.String())
+	if strings.Contains(combined, "bad file descriptor") {
+		t.Fatalf("app.Run output contains EBADF:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	// Snapshot must have been readable; failure should be downstream of config
+	// (gateway/PR/auth), not trusted-review-config FD transport.
+	if strings.Contains(combined, "trusted review config") && strings.Contains(combined, "descriptor") {
+		t.Fatalf("app.Run hit trusted config descriptor failure:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+}
+
+// installTrustedReviewConfigFD writes snapshot bytes into a pipe and exposes a
+// duplicated read FD via TrustedReviewConfigFDEnv. The loader owns and closes
+// that duplicate exclusively; the original pipe ends are closed by cleanup so
+// finalizers cannot double-close a reused descriptor number.
+func installTrustedReviewConfigFD(t *testing.T, snapshot []byte) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error = %v", err)
+	}
+	writeDone := make(chan error, 1)
+	go func() {
+		var writeErr error
+		if len(snapshot) > 0 {
+			_, writeErr = writer.Write(snapshot)
+		}
+		if closeErr := writer.Close(); writeErr == nil {
+			writeErr = closeErr
+		}
+		writeDone <- writeErr
+	}()
+
+	dupFD, err := syscall.Dup(int(reader.Fd()))
+	if err != nil {
+		_ = reader.Close()
+		_ = writer.Close()
+		t.Fatalf("Dup(config reader) error = %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		_ = syscall.Close(dupFD)
+		t.Fatalf("Close(original reader) error = %v", err)
+	}
+	t.Setenv(forge.TrustedReviewConfigFDEnv, strconv.Itoa(dupFD))
+	// Loader owns dupFD exclusively and closes it. Do not close here: after the
+	// loader closes, the number may be reused and a second close would be unsafe.
+	t.Cleanup(func() {
+		if err := <-writeDone; err != nil {
+			t.Errorf("write config snapshot error = %v", err)
+		}
+	})
 }

--- a/internal/cliapp/trusted_review_config_test.go
+++ b/internal/cliapp/trusted_review_config_test.go
@@ -49,7 +49,9 @@ func TestCommandRuntimeTrustedReviewConfigIgnoresChildPrecedenceLayers(t *testin
 	}
 }
 
-func TestCommandRuntimeTrustedReviewConfigMemoizesOneShotFD(t *testing.T) {
+func TestCommandRuntimeTrustedReviewConfigClearsFDAndFailsLoudOnSecondLoad(t *testing.T) {
+	// Skip-only fix: no memoization. First load consumes the one-shot FD;
+	// a second load must fail loud so double consumers cannot mask as success.
 	cfg, err := config.DefaultConfig(t.TempDir())
 	if err != nil {
 		t.Fatalf("DefaultConfig() error = %v", err)
@@ -69,42 +71,18 @@ func TestCommandRuntimeTrustedReviewConfigMemoizesOneShotFD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first loadConfig() error = %v", err)
 	}
+	if first.Config.Tools.GHPath == nil || *first.Config.Tools.GHPath != capturedGHPath {
+		t.Fatalf("first loadConfig().Tools.GHPath = %v, want %q", first.Config.Tools.GHPath, capturedGHPath)
+	}
 	if os.Getenv(forge.TrustedReviewConfigFDEnv) != "" {
 		t.Fatalf("TrustedReviewConfigFDEnv still set after first load; want cleared")
 	}
-	// Descriptor is closed; a second uncached LoadTrustedReviewConfigSnapshot
-	// would EBADF. Memoized loadConfig must return the same snapshot.
-	second, err := runtime.loadConfig()
-	if err != nil {
-		t.Fatalf("second loadConfig() error = %v (want memoized success, not EBADF)", err)
-	}
-	if first.Config.Tools.GHPath == nil || second.Config.Tools.GHPath == nil ||
-		*first.Config.Tools.GHPath != *second.Config.Tools.GHPath ||
-		*second.Config.Tools.GHPath != capturedGHPath {
-		t.Fatalf("memoized loadConfig mismatch: first=%v second=%v want %q", first.Config.Tools.GHPath, second.Config.Tools.GHPath, capturedGHPath)
-	}
-}
-
-func TestCommandRuntimeTrustedReviewConfigMemoizesOriginalError(t *testing.T) {
-	t.Setenv("LOOPER_TRUSTED_REVIEW_PROXY_CHILD", "1")
-	// Empty pipe (writer closed immediately) → decode/EOF, not EBADF.
-	installTrustedReviewConfigFD(t, nil)
-	runtime := &commandRuntime{argv: []string{"review", "submit", "acme/looper#42"}}
-
-	_, firstErr := runtime.loadConfig()
-	if firstErr == nil {
-		t.Fatal("first loadConfig() error = nil, want decode/EOF failure")
-	}
-
 	_, secondErr := runtime.loadConfig()
 	if secondErr == nil {
-		t.Fatal("second loadConfig() error = nil, want memoized original error")
+		t.Fatal("second loadConfig() error = nil, want fail-loud after one-shot FD consumed")
 	}
-	if firstErr.Error() != secondErr.Error() {
-		t.Fatalf("memoized error mismatch:\n first=%v\nsecond=%v", firstErr, secondErr)
-	}
-	if strings.Contains(strings.ToLower(secondErr.Error()), "bad file descriptor") {
-		t.Fatalf("second loadConfig() = %v, want original snapshot error not EBADF", secondErr)
+	if !strings.Contains(strings.ToLower(secondErr.Error()), "trusted review config descriptor") {
+		t.Fatalf("second loadConfig() = %v, want missing-descriptor failure", secondErr)
 	}
 }
 
@@ -118,9 +96,6 @@ func TestMaybeRunAutoUpgradeSkipsTrustedReviewProxyChild(t *testing.T) {
 	cmd.SetErr(&stderr)
 	if err := runtime.maybeRunAutoUpgrade(cmd, nil); err != nil {
 		t.Fatalf("maybeRunAutoUpgrade() error = %v", err)
-	}
-	if runtime.trustedReviewConfigLoaded {
-		t.Fatal("maybeRunAutoUpgrade loaded trusted config; want complete skip")
 	}
 	if os.Getenv(forge.TrustedReviewConfigFDEnv) != "3" {
 		t.Fatalf("TrustedReviewConfigFDEnv = %q, want untouched when auto-upgrade skips", os.Getenv(forge.TrustedReviewConfigFDEnv))

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nexu-io/looper/internal/forge"
 	"github.com/nexu-io/looper/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -152,6 +153,13 @@ func (e *cliUpgradeRefusedError) Error() string {
 
 func (r *commandRuntime) maybeRunAutoUpgrade(cmd *cobra.Command, args []string) error {
 	_ = args
+	// Trusted review-submit children are credential-bearing and receive a
+	// one-shot config snapshot FD. Auto-upgrade must not run here: it is
+	// unrelated to publication and historically consumed the FD before
+	// `review submit` could load the daemon-bound snapshot (EBADF).
+	if forge.TrustedReviewProxyChildConfigured() {
+		return nil
+	}
 	if shouldSkipAutoUpgrade(cmd) {
 		return nil
 	}

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -37,6 +37,11 @@ const trustedReviewProxySkipEnv = "LOOPER_TRUSTED_REVIEW_PROXY_CHILD"
 // rewrite the snapshot between proxy minting and review submission.
 const TrustedReviewConfigFDEnv = "LOOPER_TRUSTED_REVIEW_CONFIG_FD"
 
+// TrustedReviewConfigChildFD is the child file descriptor for the config
+// snapshot pipe. Go's os/exec maps ExtraFiles[i] to FD 3+i, so the first
+// ExtraFile is always FD 3 (after stdin/stdout/stderr).
+const TrustedReviewConfigChildFD = 3
+
 const (
 	maxTrustedReviewProxyConnections   = 4
 	maxTrustedReviewProxyRequestBytes  = 2 << 20
@@ -267,7 +272,7 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 	// provider-qualified same-owner/repo checkouts is CWD-sensitive. The child
 	// always runs in the daemon-selected worktree bound at proxy start.
 	cmd.Dir = allowedCwd
-	cmd.Env = trustedReviewProxyChildEnv(trustedEnv, 3)
+	cmd.Env = trustedReviewProxyChildEnv(trustedEnv, TrustedReviewConfigChildFD)
 	cmd.Stdin = bytes.NewReader(req.Stdin)
 	stdout := newTrustedReviewBoundedBuffer(maxTrustedReviewProxyOutputBytes)
 	stderr := newTrustedReviewBoundedBuffer(maxTrustedReviewProxyOutputBytes)
@@ -746,13 +751,24 @@ func marshalTrustedReviewConfigSnapshot(source config.Config) ([]byte, error) {
 	return encoded, nil
 }
 
+// TrustedReviewProxyChildConfigured reports whether this process is a
+// daemon-spawned trusted review-submit child (credential-bearing, snapshot via
+// inherited FD). Callers must not run ambient CLI side effects such as
+// auto-upgrade that would consume the one-shot config descriptor.
+func TrustedReviewProxyChildConfigured() bool {
+	return strings.TrimSpace(os.Getenv(trustedReviewProxySkipEnv)) != ""
+}
+
 // LoadTrustedReviewConfigSnapshot consumes the exact materialized snapshot
 // supplied to a proxy child. It intentionally bypasses normal config file,
 // environment, and CLI precedence: those layers were already resolved by the
 // daemon when it captured the run. Provider credential variables remain in the
 // child environment for the selected transport but cannot rewrite this config.
+//
+// The descriptor is one-shot: this function closes it. Callers that may invoke
+// load more than once must memoize the result (see commandRuntime.loadConfig).
 func LoadTrustedReviewConfigSnapshot() (config.LoadedFileConfig, bool, error) {
-	if strings.TrimSpace(os.Getenv(trustedReviewProxySkipEnv)) == "" {
+	if !TrustedReviewProxyChildConfigured() {
 		return config.LoadedFileConfig{}, false, nil
 	}
 	rawFD := strings.TrimSpace(os.Getenv(TrustedReviewConfigFDEnv))
@@ -760,7 +776,7 @@ func LoadTrustedReviewConfigSnapshot() (config.LoadedFileConfig, bool, error) {
 		return config.LoadedFileConfig{}, true, fmt.Errorf("trusted review config descriptor is required")
 	}
 	fd, err := strconv.ParseUint(rawFD, 10, 64)
-	if err != nil || fd < 3 {
+	if err != nil || fd < TrustedReviewConfigChildFD {
 		return config.LoadedFileConfig{}, true, fmt.Errorf("trusted review config descriptor is invalid")
 	}
 	file := os.NewFile(uintptr(fd), "trusted-review-config")
@@ -768,6 +784,10 @@ func LoadTrustedReviewConfigSnapshot() (config.LoadedFileConfig, bool, error) {
 		return config.LoadedFileConfig{}, true, fmt.Errorf("trusted review config descriptor is unavailable")
 	}
 	defer file.Close()
+	// Drop the selector before reading so descendants cannot inherit a stale FD
+	// number after this process closes the descriptor. Child-mode env stays set
+	// so proxy re-entry remains blocked.
+	_ = os.Unsetenv(TrustedReviewConfigFDEnv)
 	limited := &io.LimitedReader{R: file, N: maxTrustedReviewConfigSnapshotSize + 1}
 	raw, err := io.ReadAll(limited)
 	if err != nil {
@@ -820,7 +840,7 @@ func trustedReviewProxyChildEnv(trustedEnv map[string]string, configFD int) []st
 	delete(envMap, TrustedReviewConfigFDEnv)
 	delete(envMap, "LOOPER_CONFIG")
 	envMap[trustedReviewProxySkipEnv] = "1"
-	if configFD >= 3 {
+	if configFD >= TrustedReviewConfigChildFD {
 		envMap[TrustedReviewConfigFDEnv] = strconv.Itoa(configFD)
 	}
 	out := make([]string, 0, len(envMap))
@@ -878,7 +898,7 @@ func (b *trustedReviewBoundedBuffer) Truncated() bool {
 // TrustedReviewSockConfigured reports whether this process should proxy
 // `review submit` through the daemon-side trusted socket.
 func TrustedReviewSockConfigured() bool {
-	if strings.TrimSpace(os.Getenv(trustedReviewProxySkipEnv)) != "" {
+	if TrustedReviewProxyChildConfigured() {
 		return false
 	}
 	return strings.TrimSpace(os.Getenv(TrustedReviewSockEnv)) != ""

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -765,8 +765,10 @@ func TrustedReviewProxyChildConfigured() bool {
 // daemon when it captured the run. Provider credential variables remain in the
 // child environment for the selected transport but cannot rewrite this config.
 //
-// The descriptor is one-shot: this function closes it. Callers that may invoke
-// load more than once must memoize the result (see commandRuntime.loadConfig).
+// The descriptor is one-shot: this function closes it and clears
+// TrustedReviewConfigFDEnv. A second call fails loud (missing descriptor or
+// EBADF). Trusted CLI entrypoints must not load config twice; auto-upgrade
+// skips trusted proxy children for that reason.
 func LoadTrustedReviewConfigSnapshot() (config.LoadedFileConfig, bool, error) {
 	if !TrustedReviewProxyChildConfigured() {
 		return config.LoadedFileConfig{}, false, nil

--- a/internal/forge/trusted_review_proxy_test.go
+++ b/internal/forge/trusted_review_proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -335,11 +336,17 @@ func TestTrustedReviewSockConfigured(t *testing.T) {
 	if TrustedReviewSockConfigured() {
 		t.Fatal("TrustedReviewSockConfigured() = true, want false when unset")
 	}
+	if TrustedReviewProxyChildConfigured() {
+		t.Fatal("TrustedReviewProxyChildConfigured() = true, want false when unset")
+	}
 	t.Setenv(TrustedReviewSockEnv, "/tmp/sock")
 	if !TrustedReviewSockConfigured() {
 		t.Fatal("TrustedReviewSockConfigured() = false, want true when sock set")
 	}
 	t.Setenv(trustedReviewProxySkipEnv, "1")
+	if !TrustedReviewProxyChildConfigured() {
+		t.Fatal("TrustedReviewProxyChildConfigured() = false, want true for proxy child")
+	}
 	if TrustedReviewSockConfigured() {
 		t.Fatal("TrustedReviewSockConfigured() = true, want false for proxy child")
 	}
@@ -356,7 +363,7 @@ func TestTrustedReviewProxyChildEnvOmitsSocketAndFile(t *testing.T) {
 		TrustedEnvFileEnv:         "/tmp/agent-controlled-secret-file",
 		trustedReviewProxySkipEnv: "",
 		"LOOPER_CONFIG":           "/tmp/agent-controlled-config.json",
-	}, 3)
+	}, TrustedReviewConfigChildFD)
 	joined := strings.Join(env, "\n")
 	if strings.Contains(joined, TrustedReviewSockEnv+"=") {
 		t.Fatalf("child env still has %s", TrustedReviewSockEnv)
@@ -370,7 +377,7 @@ func TestTrustedReviewProxyChildEnvOmitsSocketAndFile(t *testing.T) {
 	if !strings.Contains(joined, trustedReviewProxySkipEnv+"=1") {
 		t.Fatalf("child env missing skip marker: %s", joined)
 	}
-	if !strings.Contains(joined, TrustedReviewConfigFDEnv+"=3") {
+	if !strings.Contains(joined, TrustedReviewConfigFDEnv+"="+strconv.Itoa(TrustedReviewConfigChildFD)) {
 		t.Fatalf("child env missing trusted config descriptor: %s", joined)
 	}
 	if strings.Contains(joined, "LOOPER_CONFIG=") {


### PR DESCRIPTION
## Summary

- Release-installed `looper review submit` children were failing with `read trusted-review-config: bad file descriptor` because Cobra `PersistentPreRun` auto-upgrade called `loadConfig()`, which consumed and closed the one-shot inherited config snapshot FD (FD 3) before `review submit` could read it.
- Auto-upgrade swallowed the first load error; the second load surfaced as EBADF. Agents still reported completion, so Looper only saw `review_marker_missing` and burned retry attempts (e.g. open-design#6057 → manual_intervention 5/5).
- Fix: skip auto-upgrade entirely in trusted proxy children; memoize trusted snapshot load (success and error) on `commandRuntime`; clear `LOOPER_TRUSTED_REVIEW_CONFIG_FD` after consumption; centralize child FD constant + `TrustedReviewProxyChildConfigured()`.

## Root cause

1. Daemon proxy passes config snapshot via pipe → child FD 3 (`ExtraFiles`).
2. Root `PersistentPreRunE` → `maybeRunAutoUpgrade` → `loadConfig` → closes FD 3 (release binaries only).
3. `review submit` → `loadConfig` again → **EBADF**.
4. Surface symptom: no GitHub review marker → retryable marker-missing until exhausted.

## Test plan

- [x] `go test ./internal/cliapp/ -run 'TrustedReview|MaybeRunAutoUpgradeSkips'`
- [x] `go test ./internal/forge/ -run 'TrustedReview'`
- [x] `go test ./internal/cliapp/ ./internal/forge/ ./internal/runtime/`
- [x] Manual repro: double-read same FD → EBADF; fixed loader second call → not EBADF
- [ ] Deploy matching `looper` + `looperd` on affected host, restart daemon
- [ ] Isolated child diagnostic no longer reports EBADF
- [ ] Rediscover/retry affected reviewer loop; confirm marker-bearing review publishes

## Out of scope (follow-up)

- P1: surface trusted-wrapper failure from proxy outcome instead of masking as marker-missing
- P1: classify deterministic FD/snapshot failures as immediate `manual_intervention`