### PR TITLE
feat: prompt discard or jump on dirty worktree retry

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3867,6 +3867,11 @@ func (h *Handler) buildLoopRouteResponse(r *http.Request, path string) (any, err
 			return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
 		}
 		return h.buildLoopLogsResponse(r.Context(), loop)
+	case "worktree":
+		if r.Method != http.MethodGet {
+			return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}
+		}
+		return h.loopWorktreeStatus(r.Context(), loop)
 	case "start":
 		if r.Method != http.MethodPost {
 			return nil, apiError{code: pkgapi.ErrorCodeMethodNotAllowed, status: http.StatusMethodNotAllowed, message: fmt.Sprintf("Unsupported method for %s", path)}

--- a/internal/api/loop_retry_discard.go
+++ b/internal/api/loop_retry_discard.go
@@ -26,6 +26,27 @@ type worktreeDiscardResult struct {
 	Reason       string  `json:"reason,omitempty"`
 }
 
+// loopWorktreeStatusResponse is the read-only preflight for retry/jump UX.
+//
+// Semantics:
+//   - present: path exists on disk (after successful stat)
+//   - worktreePath/branch: resolved location hints even when missing on disk
+//   - managed: path is under a Looper-managed worktree root (discard-safe)
+//   - clean/dirty: set only when git status succeeds; omitted on status_unavailable
+//   - reason: no_worktree | worktree_missing | status_unavailable | already_clean |
+//     dirty | loop_type_without_worktree | unmanaged
+type loopWorktreeStatusResponse struct {
+	LoopID       string  `json:"loopId"`
+	Seq          int64   `json:"seq"`
+	Present      bool    `json:"present"`
+	WorktreePath *string `json:"worktreePath,omitempty"`
+	Branch       *string `json:"branch,omitempty"`
+	Managed      bool    `json:"managed"`
+	Clean        *bool   `json:"clean,omitempty"`
+	Dirty        *bool   `json:"dirty,omitempty"`
+	Reason       string  `json:"reason,omitempty"`
+}
+
 type checkpointWorktreeRef struct {
 	ID       string `json:"id,omitempty"`
 	Path     string `json:"path,omitempty"`
@@ -52,6 +73,83 @@ type checkpointWithWorktree struct {
 		HeadRefName string `json:"headRefName,omitempty"`
 		PRNumber    int64  `json:"prNumber,omitempty"`
 	} `json:"detail,omitempty"`
+}
+
+// loopWorktreeStatus resolves the managed worktree for a loop and reports
+// whether git status is clean. Used by CLI/dashboard retry preflight and jump.
+func (h *Handler) loopWorktreeStatus(ctx context.Context, loop storage.LoopRecord) (loopWorktreeStatusResponse, error) {
+	resp := loopWorktreeStatusResponse{
+		LoopID: loop.ID,
+		Seq:    loop.Seq,
+	}
+	if loop.Type != string(domain.LoopTypePlanner) && loop.Type != string(domain.LoopTypeFixer) && loop.Type != string(domain.LoopTypeReviewer) && loop.Type != string(domain.LoopTypeWorker) {
+		resp.Reason = "loop_type_without_worktree"
+		return resp, nil
+	}
+	services := h.context.Runtime.Services()
+	if services.Repositories == nil {
+		return loopWorktreeStatusResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
+	}
+	project, err := requireActiveProjectRecord(ctx, services.Repositories.Projects, loop.ProjectID)
+	if err != nil {
+		return loopWorktreeStatusResponse{}, err
+	}
+	resolved, err := resolveManagedWorktreeForLoop(ctx, services.Repositories, *project, loop)
+	if err != nil {
+		return loopWorktreeStatusResponse{}, err
+	}
+	if resolved == nil || strings.TrimSpace(resolved.Path) == "" {
+		resp.Reason = "no_worktree"
+		return resp, nil
+	}
+	path := strings.TrimSpace(resolved.Path)
+	resp.WorktreePath = stringPtrOrNil(path)
+	resp.Branch = stringPtrOrNil(strings.TrimSpace(resolved.Branch))
+	resp.Managed = resolved.Managed
+	if _, statErr := os.Stat(path); statErr != nil {
+		if os.IsNotExist(statErr) {
+			// Path resolved but not on disk — present stays false so jump refuses cd.
+			resp.Reason = "worktree_missing"
+			return resp, nil
+		}
+		return loopWorktreeStatusResponse{}, apiError{
+			code:    pkgapi.ErrorCodeInternalError,
+			status:  http.StatusInternalServerError,
+			message: fmt.Sprintf("Failed to stat worktree at %s: %v", path, statErr),
+		}
+	}
+	resp.Present = true
+	if !resolved.Managed {
+		// Still report path for inspect; discard is not offered by clients.
+		resp.Reason = "unmanaged"
+	}
+	gitPath := ""
+	if h.context.Config.Tools.GitPath != nil {
+		gitPath = strings.TrimSpace(*h.context.Config.Tools.GitPath)
+	}
+	gateway := gitinfra.New(gitinfra.Options{GitPath: gitPath, Repos: services.Repositories, Now: h.now})
+	clean, cleanErr := gateway.WorktreeClean(ctx, path)
+	if cleanErr != nil {
+		// Keep path for jump/inspect; omit clean/dirty so clients fail closed on discard.
+		if resp.Reason == "" {
+			resp.Reason = "status_unavailable"
+		}
+		return resp, nil
+	}
+	resp.Clean = &clean
+	dirty := !clean
+	resp.Dirty = &dirty
+	if !resolved.Managed {
+		// Prefer unmanaged over clean/dirty so clients do not offer discard.
+		resp.Reason = "unmanaged"
+		return resp, nil
+	}
+	if clean {
+		resp.Reason = "already_clean"
+	} else {
+		resp.Reason = "dirty"
+	}
+	return resp, nil
 }
 
 // discardLoopWorktreeChanges performs the operator opt-in dirty-worktree discard

--- a/internal/api/loop_retry_discard.go
+++ b/internal/api/loop_retry_discard.go
@@ -28,6 +28,36 @@ type worktreeDiscardResult struct {
 
 // loopWorktreeStatusResponse is the read-only preflight for retry/jump UX.
 //
+// Design trade-off (new status concept + preflight gate on retry):
+//
+// Failure prevented: operators and the dashboard used to call POST /retry while a
+// managed agent worktree was dirty. Retry re-prepares from HEAD and either fails
+// prepare-worktree or silently collides with uncommitted local edits. Without a
+// structured preflight, clients could only guess from logs after the damage.
+//
+// Cost / edge cases:
+//   - New wire fields (present/managed/clean/dirty/reason) that CLI and dashboard
+//     must interpret consistently; drift between clients is a real risk.
+//   - Extra GET before every interactive retry (latency + one more auth/path).
+//   - status_unavailable and unmanaged reasons force fail-closed discard offers
+//     while still exposing path for inspect — more branches than a pure 409.
+//   - Old daemons without /worktree must keep plain-retry fallback so upgrades
+//     are not a hard break.
+//
+// Why not simpler alternatives:
+//   - Delete the gate / trust the agent: dirty trees are operator-local state the
+//     agent did not declare; trusting retry to "just work" already caused lost
+//     edits and opaque prepare failures. Agent structured output cannot see the
+//     worktree after the run ended.
+//   - Fail loud only (hard 409 on dirty retry): blocks the legitimate "discard
+//     and retry" path and gives no jump/inspect guidance when the operator wants
+//     to keep local changes. Preflight keeps authority on the daemon's on-disk
+//     git status while letting the operator choose discard vs inspect.
+//
+// Authority: the daemon's worktree resolution + git status are the authority for
+// present/managed/dirty; the agent does not emit this after the run completes.
+// Clients may gate UX on the response but must not invent discard safety.
+//
 // Semantics:
 //   - present: path exists on disk (after successful stat)
 //   - worktreePath/branch: resolved location hints even when missing on disk

--- a/internal/api/loop_retry_discard_test.go
+++ b/internal/api/loop_retry_discard_test.go
@@ -20,6 +20,79 @@ import (
 	"github.com/nexu-io/looper/internal/storage"
 )
 
+func TestHandlerLoopWorktreeStatusDirtyAndClean(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+
+	dirty := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_wt_status_dirty",
+		LoopID:    "loop_wt_status_dirty",
+		LoopSeq:   3201,
+		LoopType:  "fixer",
+		Branch:    "feature/wt-status-dirty",
+		NowISO:    nowISO,
+		Dirty:     true,
+	})
+	clean := seedManagedWorktreeFixture(t, services.Repositories, managedWorktreeSeed{
+		ProjectID: "project_wt_status_clean",
+		LoopID:    "loop_wt_status_clean",
+		LoopSeq:   3202,
+		LoopType:  "fixer",
+		Branch:    "feature/wt-status-clean",
+		NowISO:    nowISO,
+		Dirty:     false,
+	})
+
+	reqDirty := httptest.NewRequest(http.MethodGet, "/api/v1/loops/3201/worktree", nil)
+	recDirty := httptest.NewRecorder()
+	h.ServeHTTP(recDirty, reqDirty)
+	if recDirty.Code != http.StatusOK {
+		t.Fatalf("dirty status = %d, want 200; body=%s", recDirty.Code, recDirty.Body.String())
+	}
+	dirtyData := parseJSONMap(t, recDirty.Body.Bytes())["data"].(map[string]any)
+	assertEqual(t, dirtyData["present"], true)
+	assertEqual(t, dirtyData["managed"], true)
+	assertEqual(t, dirtyData["dirty"], true)
+	assertEqual(t, dirtyData["clean"], false)
+	assertEqual(t, dirtyData["reason"], "dirty")
+	assertEqual(t, dirtyData["worktreePath"], dirty.WorktreePath)
+	assertEqual(t, dirtyData["branch"], "feature/wt-status-dirty")
+
+	reqClean := httptest.NewRequest(http.MethodGet, "/api/v1/loops/3202/worktree", nil)
+	recClean := httptest.NewRecorder()
+	h.ServeHTTP(recClean, reqClean)
+	if recClean.Code != http.StatusOK {
+		t.Fatalf("clean status = %d, want 200; body=%s", recClean.Code, recClean.Body.String())
+	}
+	cleanData := parseJSONMap(t, recClean.Body.Bytes())["data"].(map[string]any)
+	assertEqual(t, cleanData["present"], true)
+	assertEqual(t, cleanData["managed"], true)
+	assertEqual(t, cleanData["dirty"], false)
+	assertEqual(t, cleanData["clean"], true)
+	assertEqual(t, cleanData["reason"], "already_clean")
+	assertEqual(t, cleanData["worktreePath"], clean.WorktreePath)
+
+	// Missing path: present=false, path still returned for diagnostics.
+	if err := os.RemoveAll(dirty.WorktreePath); err != nil {
+		t.Fatalf("RemoveAll(dirty worktree) error = %v", err)
+	}
+	reqMissing := httptest.NewRequest(http.MethodGet, "/api/v1/loops/3201/worktree", nil)
+	recMissing := httptest.NewRecorder()
+	h.ServeHTTP(recMissing, reqMissing)
+	if recMissing.Code != http.StatusOK {
+		t.Fatalf("missing status = %d, want 200; body=%s", recMissing.Code, recMissing.Body.String())
+	}
+	missingData := parseJSONMap(t, recMissing.Body.Bytes())["data"].(map[string]any)
+	assertEqual(t, missingData["present"], false)
+	assertEqual(t, missingData["reason"], "worktree_missing")
+	assertEqual(t, missingData["worktreePath"], dirty.WorktreePath)
+	if _, ok := missingData["dirty"]; ok {
+		t.Fatalf("missing worktree should omit dirty, got %#v", missingData["dirty"])
+	}
+}
+
 func TestHandlerLoopRetryDiscardWorktreeChangesDirtyFixer(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})

--- a/internal/cliapp/app_test.go
+++ b/internal/cliapp/app_test.go
@@ -4109,11 +4109,12 @@ func TestLogsHelpIncludesFollowFlag(t *testing.T) {
 func TestJumpWithoutJSONPrintsShellChangeDir(t *testing.T) {
 	t.Parallel()
 
+	worktreePath := t.TempDir()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got, want := r.URL.Path, "/api/v1/runs/active/12"; got != want {
 			t.Fatalf("request path = %q, want %q", got, want)
 		}
-		writeEnvelope(t, w, pkgapi.Success("req_active_run", map[string]any{"seq": 12, "loopId": "loop_12", "projectId": "project_1", "worktree": map[string]any{"path": "/tmp/worktree"}}))
+		writeEnvelope(t, w, pkgapi.Success("req_active_run", map[string]any{"seq": 12, "loopId": "loop_12", "projectId": "project_1", "worktree": map[string]any{"path": worktreePath}}))
 	}))
 	defer server.Close()
 
@@ -4125,7 +4126,7 @@ func TestJumpWithoutJSONPrintsShellChangeDir(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("Run([jump 12]) stderr = %q, want empty string", stderr)
 	}
-	if got, want := stdout, "cd -- '/tmp/worktree'\n"; got != want {
+	if got, want := stdout, "cd -- "+quoteShellArg(worktreePath)+"\n"; got != want {
 		t.Fatalf("Run([jump 12]) stdout = %q, want %q", got, want)
 	}
 }
@@ -4133,11 +4134,12 @@ func TestJumpWithoutJSONPrintsShellChangeDir(t *testing.T) {
 func TestJumpWithPrintPathPrintsWorktreePath(t *testing.T) {
 	t.Parallel()
 
+	worktreePath := t.TempDir()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got, want := r.URL.Path, "/api/v1/runs/active/12"; got != want {
 			t.Fatalf("request path = %q, want %q", got, want)
 		}
-		writeEnvelope(t, w, pkgapi.Success("req_active_run", map[string]any{"seq": 12, "loopId": "loop_12", "projectId": "project_1", "worktree": map[string]any{"path": "/tmp/worktree"}}))
+		writeEnvelope(t, w, pkgapi.Success("req_active_run", map[string]any{"seq": 12, "loopId": "loop_12", "projectId": "project_1", "worktree": map[string]any{"path": worktreePath}}))
 	}))
 	defer server.Close()
 
@@ -4149,7 +4151,7 @@ func TestJumpWithPrintPathPrintsWorktreePath(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("Run([jump 12 --print-path]) stderr = %q, want empty string", stderr)
 	}
-	if got, want := stdout, "/tmp/worktree\n"; got != want {
+	if got, want := stdout, worktreePath+"\n"; got != want {
 		t.Fatalf("Run([jump 12 --print-path]) stdout = %q, want %q", got, want)
 	}
 }

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/version"
+	pkgapi "github.com/nexu-io/looper/pkg/api"
 	"github.com/spf13/cobra"
 )
 
@@ -304,19 +307,189 @@ func (r *commandRuntime) loopRetry(cmd *cobra.Command, args []string) error {
 		if selector == "" {
 			return nil, fmt.Errorf("loop retry requires <seq|loopId>")
 		}
-		if getBoolFlag(cmd, "discard-worktree-changes") && !getBoolFlag(cmd, "confirm") {
+		discard := getBoolFlag(cmd, "discard-worktree-changes")
+		if discard && !getBoolFlag(cmd, "confirm") {
 			return nil, fmt.Errorf("--discard-worktree-changes requires --confirm")
 		}
 		mode := strings.TrimSpace(getStringFlag(cmd, "mode"))
 		if mode == "" {
 			mode = "auto"
 		}
+
+		// When discard is not already opted in, preflight dirty worktree and
+		// either prompt (human) or refuse with jump guidance (scripts/json).
+		if !discard {
+			status, statusErr := r.fetchLoopWorktreeStatus(ctx, selector)
+			if statusErr != nil {
+				// Preflight is best-effort: daemon older than worktree route
+				// should still allow plain retry.
+				if !isAPINotFoundError(statusErr) {
+					return nil, statusErr
+				}
+			} else if decision := classifyRetryWorktreePreflight(status); decision != retryWorktreeOK {
+				switch decision {
+				case retryWorktreeOfferDiscard:
+					if getBoolFlag(cmd, "json") {
+						return nil, dirtyWorktreeRetryGuidanceError(selector, status)
+					}
+					discardConfirmed, promptErr := promptDiscardDirtyWorktree(cmd, selector, status)
+					if promptErr != nil {
+						return nil, promptErr
+					}
+					if !discardConfirmed {
+						return nil, dirtyWorktreeRetryGuidanceError(selector, status)
+					}
+					discard = true
+				case retryWorktreeInspectOnly:
+					return nil, dirtyWorktreeRetryGuidanceError(selector, status)
+				}
+			}
+		}
+
 		body := map[string]any{"mode": mode, "resetAttempts": true}
-		if getBoolFlag(cmd, "discard-worktree-changes") {
+		if discard {
 			body["discardWorktreeChanges"] = true
 		}
 		return r.postJSON(ctx, "/api/v1/loops/"+url.PathEscape(selector)+"/retry", body)
 	}, writeHumanLoopRetried)
+}
+
+type loopWorktreeStatusOutput struct {
+	LoopID       string  `json:"loopId"`
+	Seq          int64   `json:"seq"`
+	Present      bool    `json:"present"`
+	WorktreePath *string `json:"worktreePath"`
+	Branch       *string `json:"branch"`
+	Managed      bool    `json:"managed"`
+	Clean        *bool   `json:"clean"`
+	Dirty        *bool   `json:"dirty"`
+	Reason       string  `json:"reason"`
+}
+
+func (r *commandRuntime) fetchLoopWorktreeStatus(ctx context.Context, selector string) (*loopWorktreeStatusOutput, error) {
+	payload, err := r.getJSON(ctx, "/api/v1/loops/"+url.PathEscape(strings.TrimSpace(selector))+"/worktree")
+	if err != nil {
+		return nil, err
+	}
+	var status loopWorktreeStatusOutput
+	if err := json.Unmarshal(payload, &status); err != nil {
+		return nil, fmt.Errorf("decode loop worktree status: %w", err)
+	}
+	return &status, nil
+}
+
+func promptDiscardDirtyWorktree(cmd *cobra.Command, selector string, status *loopWorktreeStatusOutput) (bool, error) {
+	path := ""
+	if status != nil && status.WorktreePath != nil {
+		path = strings.TrimSpace(*status.WorktreePath)
+	}
+	branch := ""
+	if status != nil && status.Branch != nil {
+		branch = strings.TrimSpace(*status.Branch)
+	}
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Worktree is dirty for loop %s", strings.TrimSpace(selector))
+	if branch != "" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), " (branch %s)", branch)
+	}
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+	if path != "" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  path: %s\n", path)
+	}
+	return promptBootstrapBool(
+		bufio.NewReader(cmd.InOrStdin()),
+		cmd.ErrOrStderr(),
+		"Discard local worktree changes and retry",
+		false,
+	)
+}
+
+type retryWorktreeDecision int
+
+const (
+	retryWorktreeOK retryWorktreeDecision = iota
+	retryWorktreeOfferDiscard
+	retryWorktreeInspectOnly
+)
+
+// classifyRetryWorktreePreflight decides whether plain retry may proceed.
+// Discard is offered only for present + managed + dirty worktrees.
+func classifyRetryWorktreePreflight(status *loopWorktreeStatusOutput) retryWorktreeDecision {
+	if status == nil || !status.Present {
+		return retryWorktreeOK
+	}
+	if status.Dirty == nil || !*status.Dirty {
+		// status_unavailable leaves dirty nil — allow plain retry (fail later if needed).
+		return retryWorktreeOK
+	}
+	if status.Managed {
+		return retryWorktreeOfferDiscard
+	}
+	// Dirty but unmanaged: never offer discard; force inspect.
+	return retryWorktreeInspectOnly
+}
+
+func dirtyWorktreeRetryGuidanceError(selector string, status *loopWorktreeStatusOutput) error {
+	path := ""
+	if status != nil && status.WorktreePath != nil {
+		path = strings.TrimSpace(*status.WorktreePath)
+	}
+	branch := ""
+	if status != nil && status.Branch != nil {
+		branch = strings.TrimSpace(*status.Branch)
+	}
+	sel := strings.TrimSpace(selector)
+	managedDirty := status != nil && status.Managed && status.Present && status.Dirty != nil && *status.Dirty
+	var b strings.Builder
+	if status != nil && !status.Managed && status.Dirty != nil && *status.Dirty {
+		b.WriteString("retry cancelled: dirty worktree is not Looper-managed (discard unavailable)")
+	} else if managedDirty {
+		b.WriteString("retry cancelled: worktree is dirty")
+	} else {
+		b.WriteString("retry cancelled: worktree is dirty")
+	}
+	if branch != "" {
+		fmt.Fprintf(&b, " (branch %s)", branch)
+	}
+	if path != "" {
+		fmt.Fprintf(&b, "\n  path: %s", path)
+	}
+	if status != nil && status.Present {
+		fmt.Fprintf(&b, "\n  inspect: looper jump %s", quoteShellArg(sel))
+		if path != "" {
+			fmt.Fprintf(&b, "\n  or:     cd -- %s", quoteShellArg(path))
+		}
+	} else if path != "" {
+		fmt.Fprintf(&b, "\n  path missing on disk; inspect manually if needed")
+	}
+	// Document discard for managed dirty trees so operators can re-run non-interactively.
+	if managedDirty {
+		fmt.Fprintf(&b, "\n  discard: looper retry %s --discard-worktree-changes --confirm", quoteShellArg(sel))
+	}
+	return fmt.Errorf("%s", b.String())
+}
+
+func isAPINotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *DaemonAPIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Status == http.StatusNotFound || apiErr.Code == pkgapi.ErrorCodeRouteNotFound
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unknown route")
+}
+
+func isActiveRunNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *DaemonAPIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Code == pkgapi.ErrorCodeActiveRunNotFound ||
+			(apiErr.Status == http.StatusNotFound && strings.Contains(strings.ToLower(apiErr.Message), "active run"))
+	}
+	return false
 }
 
 func loopSeqSelector(value string) (string, error) {
@@ -482,35 +655,89 @@ func (r *commandRuntime) jump(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Usage: looper jump <id>")
 	}
 
-	payload, err := r.getJSON(cmd.Context(), "/api/v1/runs/active/"+url.PathEscape(strings.TrimSpace(args[0])))
+	selector := strings.TrimSpace(args[0])
+	path, meta, err := r.resolveJumpWorktree(cmd.Context(), selector)
 	if err != nil {
 		return err
 	}
-
-	var data activeRunDetailOutput
-	if err := json.Unmarshal(payload, &data); err != nil {
-		return fmt.Errorf("decode active run response: %w", err)
-	}
-	if data.Worktree == nil || strings.TrimSpace(data.Worktree.Path) == "" {
-		return fmt.Errorf("Loop %s has no active worktree path", strings.TrimSpace(args[0]))
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("Loop %s has no worktree path", selector)
 	}
 
 	if getBoolFlag(cmd, "json") {
-		return writeJSON(cmd.OutOrStdout(), map[string]any{
-			"seq":       data.Seq,
-			"loopId":    data.LoopID,
-			"projectId": data.ProjectID,
-			"worktree":  data.Worktree,
-		})
+		return writeJSON(cmd.OutOrStdout(), meta)
 	}
 
 	if getBoolFlag(cmd, "print-path") {
-		_, err := fmt.Fprintln(cmd.OutOrStdout(), data.Worktree.Path)
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), path)
 		return err
 	}
 
-	_, err = fmt.Fprintln(cmd.OutOrStdout(), "cd -- "+quoteShellArg(data.Worktree.Path))
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), "cd -- "+quoteShellArg(path))
 	return err
+}
+
+// resolveJumpWorktree prefers the active-run worktree, then falls back to the
+// loop worktree status endpoint so paused/failed dirty loops still jump.
+// Fallback only runs when active run is missing or has no path — not on 5xx.
+func (r *commandRuntime) resolveJumpWorktree(ctx context.Context, selector string) (string, map[string]any, error) {
+	payload, err := r.getJSON(ctx, "/api/v1/runs/active/"+url.PathEscape(selector))
+	if err == nil {
+		var data activeRunDetailOutput
+		if decodeErr := json.Unmarshal(payload, &data); decodeErr != nil {
+			return "", nil, fmt.Errorf("decode active run response: %w", decodeErr)
+		}
+		if data.Worktree != nil && strings.TrimSpace(data.Worktree.Path) != "" {
+			return data.Worktree.Path, map[string]any{
+				"seq":       data.Seq,
+				"loopId":    data.LoopID,
+				"projectId": data.ProjectID,
+				"worktree":  data.Worktree,
+				"source":    "active_run",
+			}, nil
+		}
+		// Active run exists but has no path — try loop worktree fallback.
+	} else if !isActiveRunNotFoundError(err) && !isAPINotFoundError(err) {
+		// Unexpected active-run failure (5xx, auth, etc.): do not mask with fallback.
+		return "", nil, err
+	}
+
+	status, statusErr := r.fetchLoopWorktreeStatus(ctx, selector)
+	if statusErr != nil {
+		if err != nil {
+			return "", nil, err
+		}
+		return "", nil, statusErr
+	}
+	if status == nil || status.WorktreePath == nil || strings.TrimSpace(*status.WorktreePath) == "" {
+		if err != nil {
+			return "", nil, fmt.Errorf("Loop %s has no active worktree path", selector)
+		}
+		return "", nil, fmt.Errorf("Loop %s has no worktree path", selector)
+	}
+	if !status.Present || status.Reason == "worktree_missing" {
+		path := strings.TrimSpace(*status.WorktreePath)
+		return "", nil, fmt.Errorf("Loop %s worktree path is missing on disk: %s", selector, path)
+	}
+	path := strings.TrimSpace(*status.WorktreePath)
+	branch := ""
+	if status.Branch != nil {
+		branch = strings.TrimSpace(*status.Branch)
+	}
+	return path, map[string]any{
+		"seq":    status.Seq,
+		"loopId": status.LoopID,
+		"worktree": map[string]any{
+			"path":   path,
+			"branch": branch,
+		},
+		"source":  "loop_worktree",
+		"dirty":   status.Dirty,
+		"clean":   status.Clean,
+		"reason":  status.Reason,
+		"managed": status.Managed,
+		"present": status.Present,
+	}, nil
 }
 
 func (r *commandRuntime) activeRuns(cmd *cobra.Command, args []string) error {

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -680,6 +680,8 @@ func (r *commandRuntime) jump(cmd *cobra.Command, args []string) error {
 // resolveJumpWorktree prefers the active-run worktree, then falls back to the
 // loop worktree status endpoint so paused/failed dirty loops still jump.
 // Fallback only runs when active run is missing or has no path — not on 5xx.
+// Both sources refuse paths that are missing on disk so jump never prints cd
+// for a directory the operator cannot enter.
 func (r *commandRuntime) resolveJumpWorktree(ctx context.Context, selector string) (string, map[string]any, error) {
 	payload, err := r.getJSON(ctx, "/api/v1/runs/active/"+url.PathEscape(selector))
 	if err == nil {
@@ -688,7 +690,11 @@ func (r *commandRuntime) resolveJumpWorktree(ctx context.Context, selector strin
 			return "", nil, fmt.Errorf("decode active run response: %w", decodeErr)
 		}
 		if data.Worktree != nil && strings.TrimSpace(data.Worktree.Path) != "" {
-			return data.Worktree.Path, map[string]any{
+			path := strings.TrimSpace(data.Worktree.Path)
+			if jumpPathMissingOnDisk(path) {
+				return "", nil, fmt.Errorf("Loop %s worktree path is missing on disk: %s", selector, path)
+			}
+			return path, map[string]any{
 				"seq":       data.Seq,
 				"loopId":    data.LoopID,
 				"projectId": data.ProjectID,
@@ -715,11 +721,10 @@ func (r *commandRuntime) resolveJumpWorktree(ctx context.Context, selector strin
 		}
 		return "", nil, fmt.Errorf("Loop %s has no worktree path", selector)
 	}
-	if !status.Present || status.Reason == "worktree_missing" {
-		path := strings.TrimSpace(*status.WorktreePath)
+	path := strings.TrimSpace(*status.WorktreePath)
+	if !status.Present || status.Reason == "worktree_missing" || jumpPathMissingOnDisk(path) {
 		return "", nil, fmt.Errorf("Loop %s worktree path is missing on disk: %s", selector, path)
 	}
-	path := strings.TrimSpace(*status.WorktreePath)
 	branch := ""
 	if status.Branch != nil {
 		branch = strings.TrimSpace(*status.Branch)
@@ -738,6 +743,16 @@ func (r *commandRuntime) resolveJumpWorktree(ctx context.Context, selector strin
 		"managed": status.Managed,
 		"present": status.Present,
 	}, nil
+}
+
+// jumpPathMissingOnDisk reports whether path is absent so jump must refuse cd.
+func jumpPathMissingOnDisk(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return true
+	}
+	_, err := os.Stat(path)
+	return err != nil && os.IsNotExist(err)
 }
 
 func (r *commandRuntime) activeRuns(cmd *cobra.Command, args []string) error {

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -764,7 +764,7 @@ func recommendedActionForManualIntervention(message string) string {
 	lower := strings.ToLower(message)
 	// Match the narrower dirty-worktree classifier used by failureclass.
 	if strings.Contains(lower, "dirty worktree") || strings.Contains(lower, "worktree is dirty") || strings.Contains(lower, "uncommitted changes") {
-		return "fix or discard local worktree changes, then looper retry <seq>"
+		return "inspect with looper jump <seq>, or discard via looper retry <seq> --discard-worktree-changes --confirm"
 	}
 	if strings.Contains(lower, "worktree is locked") {
 		return "unlock or remove the locked worktree, then looper retry <seq>"

--- a/internal/cliapp/loop_retry_discard_test.go
+++ b/internal/cliapp/loop_retry_discard_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -86,361 +87,278 @@ func TestLoopRetryDiscardWorktreeChangesWiresAPIBodyAndHumanOutput(t *testing.T)
 	}
 }
 
-func TestLoopRetryDirtyWorktreePromptYesDiscards(t *testing.T) {
-	t.Parallel()
-
-	var gotBody map[string]any
-	var sawWorktree bool
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
-			sawWorktree = true
-			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
-				"loopId": "loop_dirty", "seq": 3491, "present": true,
-				"worktreePath": "/tmp/managed/dirty-wt", "branch": "feat/dirty",
-				"managed": true, "clean": false, "dirty": true, "reason": "dirty",
-			}))
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/loops/3491/retry":
-			raw, err := io.ReadAll(r.Body)
-			if err != nil {
-				t.Fatalf("read body: %v", err)
-			}
-			if err := json.Unmarshal(raw, &gotBody); err != nil {
-				t.Fatalf("unmarshal body: %v", err)
-			}
-			writeEnvelope(t, w, pkgapi.Success("req_retry", map[string]any{
-				"loop": map[string]any{
-					"id": "loop_dirty", "seq": 3491, "projectId": "project_1",
-					"type": "fixer", "targetType": "pull_request", "status": "queued",
-				},
-				"queueItemId": "queue_new", "mode": "auto", "resetAttempts": true,
-				"discardWorktreeChanges": true,
-				"worktreeDiscard": map[string]any{
-					"worktreePath": "/tmp/managed/dirty-wt",
-					"discarded":    true, "noOp": false, "reason": "discarded",
-				},
-			}))
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	configPath := writeCLIConfig(t, server.URL, "")
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	app := New(Deps{
-		Stdin:      strings.NewReader("y\n"),
-		Stdout:     stdout,
-		Stderr:     stderr,
-		HTTPClient: server.Client(),
-	})
-	args := []string{"--config", configPath, "retry", "3491"}
-	if exitCode := app.Run(context.Background(), args); exitCode != 0 {
-		t.Fatalf("Run() exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
-	}
-	if !sawWorktree {
-		t.Fatal("expected worktree preflight GET")
-	}
-	if gotBody["discardWorktreeChanges"] != true {
-		t.Fatalf("retry body = %#v, want discardWorktreeChanges=true", gotBody)
-	}
-	if !strings.Contains(stderr.String(), "Worktree is dirty") {
-		t.Fatalf("stderr missing dirty prompt context: %q", stderr.String())
-	}
-	if !strings.Contains(stdout.String(), "Loop retry queued") {
-		t.Fatalf("stdout = %q, want retry queued", stdout.String())
-	}
+// retryPreflightCase drives CLI retry against a fake /worktree (+ optional /retry) daemon.
+type retryPreflightCase struct {
+	name           string
+	selector       string
+	stdin          string
+	jsonMode       bool
+	worktree       map[string]any
+	worktreeStatus int // 0 = success envelope; else ErrorCode via Failure
+	expectExitOK   bool
+	expectDiscard  *bool // nil = field must be absent
+	errContains    []string
+	errNotContains []string
+	stdoutContains []string
 }
 
-func TestLoopRetryDirtyWorktreePromptNoGuidesJump(t *testing.T) {
+func TestLoopRetryWorktreePreflight(t *testing.T) {
 	t.Parallel()
 
-	retryCalled := false
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
-			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
-				"loopId": "loop_dirty", "seq": 3491, "present": true,
-				"worktreePath": "/tmp/managed/dirty-wt", "branch": "feat/dirty",
-				"managed": true, "clean": false, "dirty": true, "reason": "dirty",
-			}))
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/retry"):
-			retryCalled = true
-			t.Fatalf("retry must not be called when operator declines discard")
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	configPath := writeCLIConfig(t, server.URL, "")
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	app := New(Deps{
-		Stdin:      strings.NewReader("n\n"),
-		Stdout:     stdout,
-		Stderr:     stderr,
-		HTTPClient: server.Client(),
-	})
-	args := []string{"--config", configPath, "retry", "3491"}
-	if exitCode := app.Run(context.Background(), args); exitCode == 0 {
-		t.Fatalf("Run() exit code = 0, want failure; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	trueVal, falseVal := true, false
+	dirtyManaged := map[string]any{
+		"loopId": "loop_dirty", "seq": 3491, "present": true,
+		"worktreePath": "/tmp/managed/dirty-wt", "branch": "feat/dirty",
+		"managed": true, "clean": false, "dirty": true, "reason": "dirty",
 	}
-	if retryCalled {
-		t.Fatal("retry POST was called")
-	}
-	errOut := stderr.String()
-	for _, needle := range []string{
-		"retry cancelled: worktree is dirty",
-		"looper jump '3491'",
-		"/tmp/managed/dirty-wt",
-		"--discard-worktree-changes --confirm",
-	} {
-		if !strings.Contains(errOut, needle) {
-			t.Fatalf("stderr missing %q\n%s", needle, errOut)
-		}
-	}
-}
-
-func TestLoopRetryDirtyWorktreeJSONRefusesWithoutDiscardFlag(t *testing.T) {
-	t.Parallel()
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree" {
-			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
-				"loopId": "loop_dirty", "seq": 3491, "present": true,
-				"worktreePath": "/tmp/managed/dirty-wt", "branch": "feat/dirty",
-				"managed": true, "clean": false, "dirty": true, "reason": "dirty",
-			}))
-			return
-		}
-		t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-	}))
-	defer server.Close()
-
-	configPath := writeCLIConfig(t, server.URL, "")
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
-	args := []string{"--config", configPath, "--json", "retry", "3491"}
-	if exitCode := app.Run(context.Background(), args); exitCode == 0 {
-		t.Fatalf("Run() exit code = 0, want failure; stdout=%q stderr=%q", stdout.String(), stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "retry cancelled: worktree is dirty") {
-		t.Fatalf("stderr = %q, want json dirty refusal", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "looper jump '3491'") {
-		t.Fatalf("stderr missing jump guidance: %q", stderr.String())
-	}
-}
-
-func TestLoopRetryCleanWorktreeSkipsPrompt(t *testing.T) {
-	t.Parallel()
-
-	var gotBody map[string]any
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3108/worktree":
-			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
+	cases := []retryPreflightCase{
+		{
+			name: "dirty_prompt_yes_discards", selector: "3491", stdin: "y\n",
+			worktree: dirtyManaged, expectExitOK: true, expectDiscard: &trueVal,
+			errContains:    []string{"Worktree is dirty"},
+			stdoutContains: []string{"Loop retry queued"},
+		},
+		{
+			name: "dirty_prompt_no_guides_jump", selector: "3491", stdin: "n\n",
+			worktree: dirtyManaged, expectExitOK: false,
+			errContains: []string{
+				"retry cancelled: worktree is dirty",
+				"looper jump '3491'",
+				"/tmp/managed/dirty-wt",
+				"--discard-worktree-changes --confirm",
+			},
+		},
+		{
+			name: "dirty_json_refuses_without_discard", selector: "3491", jsonMode: true,
+			worktree: dirtyManaged, expectExitOK: false,
+			errContains: []string{"retry cancelled: worktree is dirty", "looper jump '3491'"},
+		},
+		{
+			name: "clean_skips_prompt", selector: "3108",
+			worktree: map[string]any{
 				"loopId": "loop_clean", "seq": 3108, "present": true,
 				"worktreePath": "/tmp/managed/clean-wt", "branch": "feat/clean",
 				"managed": true, "clean": true, "dirty": false, "reason": "already_clean",
-			}))
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/loops/3108/retry":
-			raw, _ := io.ReadAll(r.Body)
-			_ = json.Unmarshal(raw, &gotBody)
-			writeEnvelope(t, w, pkgapi.Success("req_retry", map[string]any{
-				"loop": map[string]any{
-					"id": "loop_clean", "seq": 3108, "projectId": "project_1",
-					"type": "fixer", "targetType": "pull_request", "status": "queued",
-				},
-				"queueItemId": "queue_new", "mode": "auto", "resetAttempts": true,
-				"discardWorktreeChanges": false,
-			}))
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	configPath := writeCLIConfig(t, server.URL, "")
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
-	args := []string{"--config", configPath, "retry", "3108"}
-	if exitCode := app.Run(context.Background(), args); exitCode != 0 {
-		t.Fatalf("Run() exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
-	}
-	if _, ok := gotBody["discardWorktreeChanges"]; ok {
-		t.Fatalf("retry body = %#v, want no discardWorktreeChanges", gotBody)
-	}
-}
-
-func TestJumpFallsBackToLoopWorktreeWhenNoActiveRun(t *testing.T) {
-	t.Parallel()
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/runs/active/3491":
-			writeEnvelope(t, w, pkgapi.Failure("req_active", pkgapi.ErrorCodeActiveRunNotFound, "active run not found", nil))
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
-			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
-				"loopId": "loop_dirty", "seq": 3491, "present": true,
-				"worktreePath": "/tmp/managed/dirty-wt", "branch": "feat/dirty",
-				"managed": true, "clean": false, "dirty": true, "reason": "dirty",
-			}))
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	configPath := writeCLIConfig(t, server.URL, "")
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
-	args := []string{"--config", configPath, "jump", "3491"}
-	if exitCode := app.Run(context.Background(), args); exitCode != 0 {
-		t.Fatalf("Run() exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
-	}
-	if got := strings.TrimSpace(stdout.String()); got != "cd -- '/tmp/managed/dirty-wt'" {
-		t.Fatalf("stdout = %q, want cd to worktree", got)
-	}
-}
-
-func TestJumpRefusesMissingWorktreePath(t *testing.T) {
-	t.Parallel()
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/runs/active/3491":
-			writeEnvelope(t, w, pkgapi.Failure("req_active", pkgapi.ErrorCodeActiveRunNotFound, "active run not found", nil))
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
-			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
-				"loopId": "loop_missing", "seq": 3491, "present": false,
-				"worktreePath": "/tmp/managed/gone", "branch": "feat/gone",
-				"managed": true, "reason": "worktree_missing",
-			}))
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	configPath := writeCLIConfig(t, server.URL, "")
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
-	if exitCode := app.Run(context.Background(), []string{"--config", configPath, "jump", "3491"}); exitCode == 0 {
-		t.Fatalf("Run() exit code = 0, want failure; stdout=%q", stdout.String())
-	}
-	if !strings.Contains(stderr.String(), "missing on disk") {
-		t.Fatalf("stderr = %q, want missing-on-disk error", stderr.String())
-	}
-}
-
-func TestJumpDoesNotFallbackOnActiveRunServerError(t *testing.T) {
-	t.Parallel()
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/runs/active/3491" {
-			writeEnvelope(t, w, pkgapi.Failure("req_active", pkgapi.ErrorCodeInternalError, "database down", nil))
-			return
-		}
-		t.Fatalf("unexpected fallback request %s %s", r.Method, r.URL.Path)
-	}))
-	defer server.Close()
-
-	configPath := writeCLIConfig(t, server.URL, "")
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
-	if exitCode := app.Run(context.Background(), []string{"--config", configPath, "jump", "3491"}); exitCode == 0 {
-		t.Fatalf("Run() exit code = 0, want failure")
-	}
-	if !strings.Contains(stderr.String(), "database down") {
-		t.Fatalf("stderr = %q, want original active-run error", stderr.String())
-	}
-}
-
-func TestLoopRetryUnmanagedDirtyRefusesDiscardOffer(t *testing.T) {
-	t.Parallel()
-
-	retryCalled := false
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
-			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
+			},
+			expectExitOK: true, expectDiscard: &falseVal, // falseVal marker: field absent
+		},
+		{
+			name: "unmanaged_dirty_refuses_discard_offer", selector: "3491", stdin: "y\n",
+			worktree: map[string]any{
 				"loopId": "loop_unmanaged", "seq": 3491, "present": true,
 				"worktreePath": "/tmp/primary-repo", "branch": "main",
 				"managed": false, "clean": false, "dirty": true, "reason": "unmanaged",
-			}))
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/retry"):
-			retryCalled = true
-			t.Fatalf("retry must not run for unmanaged dirty worktree")
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
+			},
+			expectExitOK:   false,
+			errContains:    []string{"not Looper-managed"},
+			errNotContains: []string{"--discard-worktree-changes"},
+		},
+		{
+			name: "old_daemon_without_worktree_route_still_retries", selector: "3108",
+			worktreeStatus: http.StatusNotFound, expectExitOK: true, expectDiscard: &falseVal,
+		},
+	}
 
-	configPath := writeCLIConfig(t, server.URL, "")
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	app := New(Deps{
-		Stdin:      strings.NewReader("y\n"),
-		Stdout:     stdout,
-		Stderr:     stderr,
-		HTTPClient: server.Client(),
-	})
-	if exitCode := app.Run(context.Background(), []string{"--config", configPath, "retry", "3491"}); exitCode == 0 {
-		t.Fatalf("Run() exit code = 0, want failure; stderr=%q", stderr.String())
-	}
-	if retryCalled {
-		t.Fatal("retry POST was called")
-	}
-	if !strings.Contains(stderr.String(), "not Looper-managed") {
-		t.Fatalf("stderr = %q, want unmanaged guidance", stderr.String())
-	}
-	if strings.Contains(stderr.String(), "--discard-worktree-changes") {
-		t.Fatalf("stderr should not offer discard for unmanaged path: %q", stderr.String())
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var gotBody map[string]any
+			retryCalled := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				wtPath := "/api/v1/loops/" + tc.selector + "/worktree"
+				retryPath := "/api/v1/loops/" + tc.selector + "/retry"
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == wtPath:
+					if tc.worktreeStatus == http.StatusNotFound {
+						writeEnvelope(t, w, pkgapi.Failure("req_wt", pkgapi.ErrorCodeRouteNotFound, "Unknown route", nil))
+						return
+					}
+					writeEnvelope(t, w, pkgapi.Success("req_wt", tc.worktree))
+				case r.Method == http.MethodPost && r.URL.Path == retryPath:
+					retryCalled = true
+					if !tc.expectExitOK {
+						t.Fatalf("retry must not be called for case %s", tc.name)
+					}
+					raw, _ := io.ReadAll(r.Body)
+					_ = json.Unmarshal(raw, &gotBody)
+					writeEnvelope(t, w, pkgapi.Success("req_retry", map[string]any{
+						"loop": map[string]any{
+							"id": "loop_" + tc.selector, "seq": 3491, "projectId": "project_1",
+							"type": "fixer", "targetType": "pull_request", "status": "queued",
+						},
+						"queueItemId": "queue_new", "mode": "auto", "resetAttempts": true,
+						"discardWorktreeChanges": gotBody["discardWorktreeChanges"] == true,
+						"worktreeDiscard": map[string]any{
+							"worktreePath": "/tmp/managed/dirty-wt",
+							"discarded":    gotBody["discardWorktreeChanges"] == true,
+							"noOp":         false, "reason": "discarded",
+						},
+					}))
+				default:
+					t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			configPath := writeCLIConfig(t, server.URL, "")
+			stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+			deps := Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()}
+			if tc.stdin != "" {
+				deps.Stdin = strings.NewReader(tc.stdin)
+			}
+			args := []string{"--config", configPath}
+			if tc.jsonMode {
+				args = append(args, "--json")
+			}
+			args = append(args, "retry", tc.selector)
+			exitCode := New(deps).Run(context.Background(), args)
+			if tc.expectExitOK && exitCode != 0 {
+				t.Fatalf("exit=%d stderr=%q", exitCode, stderr.String())
+			}
+			if !tc.expectExitOK && exitCode == 0 {
+				t.Fatalf("exit=0 want failure stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+			if tc.expectDiscard != nil {
+				if *tc.expectDiscard {
+					if gotBody["discardWorktreeChanges"] != true {
+						t.Fatalf("body=%#v want discardWorktreeChanges=true", gotBody)
+					}
+				} else if _, ok := gotBody["discardWorktreeChanges"]; ok {
+					t.Fatalf("body=%#v want no discardWorktreeChanges", gotBody)
+				}
+			} else if retryCalled {
+				t.Fatal("retry POST was called unexpectedly")
+			}
+			errOut := stderr.String()
+			for _, needle := range tc.errContains {
+				if !strings.Contains(errOut, needle) {
+					t.Fatalf("stderr missing %q\n%s", needle, errOut)
+				}
+			}
+			for _, needle := range tc.errNotContains {
+				if strings.Contains(errOut, needle) {
+					t.Fatalf("stderr must not contain %q\n%s", needle, errOut)
+				}
+			}
+			for _, needle := range tc.stdoutContains {
+				if !strings.Contains(stdout.String(), needle) {
+					t.Fatalf("stdout missing %q\n%s", needle, stdout.String())
+				}
+			}
+		})
 	}
 }
 
-func TestLoopRetryOldDaemonWithoutWorktreeRouteStillRetries(t *testing.T) {
+func TestJumpWorktreeResolution(t *testing.T) {
 	t.Parallel()
 
-	var gotBody map[string]any
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3108/worktree":
-			writeEnvelope(t, w, pkgapi.Failure("req_wt", pkgapi.ErrorCodeRouteNotFound, "Unknown route", nil))
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/loops/3108/retry":
-			raw, _ := io.ReadAll(r.Body)
-			_ = json.Unmarshal(raw, &gotBody)
-			writeEnvelope(t, w, pkgapi.Success("req_retry", map[string]any{
-				"loop": map[string]any{
-					"id": "loop_old", "seq": 3108, "projectId": "project_1",
-					"type": "fixer", "targetType": "pull_request", "status": "queued",
-				},
-				"queueItemId": "queue_new", "mode": "auto", "resetAttempts": true,
-				"discardWorktreeChanges": false,
-			}))
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
+	existing := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "gone")
 
-	configPath := writeCLIConfig(t, server.URL, "")
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
-	if exitCode := app.Run(context.Background(), []string{"--config", configPath, "retry", "3108"}); exitCode != 0 {
-		t.Fatalf("Run() exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	type jumpCase struct {
+		name         string
+		active       func(w http.ResponseWriter, r *http.Request)
+		worktree     map[string]any
+		allowWT      bool
+		expectExitOK bool
+		stdoutExact  string
+		errContains  []string
 	}
-	if _, ok := gotBody["discardWorktreeChanges"]; ok {
-		t.Fatalf("body = %#v, want plain retry without discard", gotBody)
+	cases := []jumpCase{
+		{
+			name: "fallback_to_loop_worktree_when_no_active_run",
+			active: func(w http.ResponseWriter, r *http.Request) {
+				writeEnvelope(t, w, pkgapi.Failure("req_active", pkgapi.ErrorCodeActiveRunNotFound, "active run not found", nil))
+			},
+			worktree: map[string]any{
+				"loopId": "loop_dirty", "seq": 3491, "present": true,
+				"worktreePath": existing, "branch": "feat/dirty",
+				"managed": true, "clean": false, "dirty": true, "reason": "dirty",
+			},
+			allowWT: true, expectExitOK: true,
+			stdoutExact: "cd -- " + quoteShellArg(existing),
+		},
+		{
+			name: "refuses_missing_loop_worktree_path",
+			active: func(w http.ResponseWriter, r *http.Request) {
+				writeEnvelope(t, w, pkgapi.Failure("req_active", pkgapi.ErrorCodeActiveRunNotFound, "active run not found", nil))
+			},
+			worktree: map[string]any{
+				"loopId": "loop_missing", "seq": 3491, "present": false,
+				"worktreePath": missing, "branch": "feat/gone",
+				"managed": true, "reason": "worktree_missing",
+			},
+			allowWT: true, expectExitOK: false, errContains: []string{"missing on disk"},
+		},
+		{
+			name: "refuses_missing_active_run_worktree_path",
+			active: func(w http.ResponseWriter, r *http.Request) {
+				writeEnvelope(t, w, pkgapi.Success("req_active", map[string]any{
+					"seq": 3491, "loopId": "loop_active", "projectId": "project_1",
+					"worktree": map[string]any{"path": missing, "branch": "feat/gone"},
+				}))
+			},
+			expectExitOK: false, errContains: []string{"missing on disk", missing},
+		},
+		{
+			name: "active_run_existing_path_jumps",
+			active: func(w http.ResponseWriter, r *http.Request) {
+				writeEnvelope(t, w, pkgapi.Success("req_active", map[string]any{
+					"seq": 3491, "loopId": "loop_active", "projectId": "project_1",
+					"worktree": map[string]any{"path": existing, "branch": "feat/ok"},
+				}))
+			},
+			expectExitOK: true, stdoutExact: "cd -- " + quoteShellArg(existing),
+		},
+		{
+			name: "does_not_fallback_on_active_run_server_error",
+			active: func(w http.ResponseWriter, r *http.Request) {
+				writeEnvelope(t, w, pkgapi.Failure("req_active", pkgapi.ErrorCodeInternalError, "database down", nil))
+			},
+			expectExitOK: false, errContains: []string{"database down"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/api/v1/runs/active/3491":
+					tc.active(w, r)
+				case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
+					if !tc.allowWT {
+						t.Fatalf("unexpected fallback request %s %s", r.Method, r.URL.Path)
+					}
+					writeEnvelope(t, w, pkgapi.Success("req_wt", tc.worktree))
+				default:
+					t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			configPath := writeCLIConfig(t, server.URL, "")
+			stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+			exitCode := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()}).
+				Run(context.Background(), []string{"--config", configPath, "jump", "3491"})
+			if tc.expectExitOK && exitCode != 0 {
+				t.Fatalf("exit=%d stderr=%q", exitCode, stderr.String())
+			}
+			if !tc.expectExitOK && exitCode == 0 {
+				t.Fatalf("exit=0 want failure stdout=%q", stdout.String())
+			}
+			if tc.stdoutExact != "" {
+				if got := strings.TrimSpace(stdout.String()); got != tc.stdoutExact {
+					t.Fatalf("stdout=%q want %q", got, tc.stdoutExact)
+				}
+			}
+			for _, needle := range tc.errContains {
+				if !strings.Contains(stderr.String(), needle) {
+					t.Fatalf("stderr missing %q\n%s", needle, stderr.String())
+				}
+			}
+		})
 	}
 }

--- a/internal/cliapp/loop_retry_discard_test.go
+++ b/internal/cliapp/loop_retry_discard_test.go
@@ -85,3 +85,362 @@ func TestLoopRetryDiscardWorktreeChangesWiresAPIBodyAndHumanOutput(t *testing.T)
 		}
 	}
 }
+
+func TestLoopRetryDirtyWorktreePromptYesDiscards(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	var sawWorktree bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
+			sawWorktree = true
+			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
+				"loopId": "loop_dirty", "seq": 3491, "present": true,
+				"worktreePath": "/tmp/managed/dirty-wt", "branch": "feat/dirty",
+				"managed": true, "clean": false, "dirty": true, "reason": "dirty",
+			}))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/loops/3491/retry":
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if err := json.Unmarshal(raw, &gotBody); err != nil {
+				t.Fatalf("unmarshal body: %v", err)
+			}
+			writeEnvelope(t, w, pkgapi.Success("req_retry", map[string]any{
+				"loop": map[string]any{
+					"id": "loop_dirty", "seq": 3491, "projectId": "project_1",
+					"type": "fixer", "targetType": "pull_request", "status": "queued",
+				},
+				"queueItemId": "queue_new", "mode": "auto", "resetAttempts": true,
+				"discardWorktreeChanges": true,
+				"worktreeDiscard": map[string]any{
+					"worktreePath": "/tmp/managed/dirty-wt",
+					"discarded":    true, "noOp": false, "reason": "discarded",
+				},
+			}))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdin:      strings.NewReader("y\n"),
+		Stdout:     stdout,
+		Stderr:     stderr,
+		HTTPClient: server.Client(),
+	})
+	args := []string{"--config", configPath, "retry", "3491"}
+	if exitCode := app.Run(context.Background(), args); exitCode != 0 {
+		t.Fatalf("Run() exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !sawWorktree {
+		t.Fatal("expected worktree preflight GET")
+	}
+	if gotBody["discardWorktreeChanges"] != true {
+		t.Fatalf("retry body = %#v, want discardWorktreeChanges=true", gotBody)
+	}
+	if !strings.Contains(stderr.String(), "Worktree is dirty") {
+		t.Fatalf("stderr missing dirty prompt context: %q", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Loop retry queued") {
+		t.Fatalf("stdout = %q, want retry queued", stdout.String())
+	}
+}
+
+func TestLoopRetryDirtyWorktreePromptNoGuidesJump(t *testing.T) {
+	t.Parallel()
+
+	retryCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
+			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
+				"loopId": "loop_dirty", "seq": 3491, "present": true,
+				"worktreePath": "/tmp/managed/dirty-wt", "branch": "feat/dirty",
+				"managed": true, "clean": false, "dirty": true, "reason": "dirty",
+			}))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/retry"):
+			retryCalled = true
+			t.Fatalf("retry must not be called when operator declines discard")
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdin:      strings.NewReader("n\n"),
+		Stdout:     stdout,
+		Stderr:     stderr,
+		HTTPClient: server.Client(),
+	})
+	args := []string{"--config", configPath, "retry", "3491"}
+	if exitCode := app.Run(context.Background(), args); exitCode == 0 {
+		t.Fatalf("Run() exit code = 0, want failure; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if retryCalled {
+		t.Fatal("retry POST was called")
+	}
+	errOut := stderr.String()
+	for _, needle := range []string{
+		"retry cancelled: worktree is dirty",
+		"looper jump '3491'",
+		"/tmp/managed/dirty-wt",
+		"--discard-worktree-changes --confirm",
+	} {
+		if !strings.Contains(errOut, needle) {
+			t.Fatalf("stderr missing %q\n%s", needle, errOut)
+		}
+	}
+}
+
+func TestLoopRetryDirtyWorktreeJSONRefusesWithoutDiscardFlag(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree" {
+			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
+				"loopId": "loop_dirty", "seq": 3491, "present": true,
+				"worktreePath": "/tmp/managed/dirty-wt", "branch": "feat/dirty",
+				"managed": true, "clean": false, "dirty": true, "reason": "dirty",
+			}))
+			return
+		}
+		t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+	args := []string{"--config", configPath, "--json", "retry", "3491"}
+	if exitCode := app.Run(context.Background(), args); exitCode == 0 {
+		t.Fatalf("Run() exit code = 0, want failure; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "retry cancelled: worktree is dirty") {
+		t.Fatalf("stderr = %q, want json dirty refusal", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "looper jump '3491'") {
+		t.Fatalf("stderr missing jump guidance: %q", stderr.String())
+	}
+}
+
+func TestLoopRetryCleanWorktreeSkipsPrompt(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3108/worktree":
+			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
+				"loopId": "loop_clean", "seq": 3108, "present": true,
+				"worktreePath": "/tmp/managed/clean-wt", "branch": "feat/clean",
+				"managed": true, "clean": true, "dirty": false, "reason": "already_clean",
+			}))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/loops/3108/retry":
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &gotBody)
+			writeEnvelope(t, w, pkgapi.Success("req_retry", map[string]any{
+				"loop": map[string]any{
+					"id": "loop_clean", "seq": 3108, "projectId": "project_1",
+					"type": "fixer", "targetType": "pull_request", "status": "queued",
+				},
+				"queueItemId": "queue_new", "mode": "auto", "resetAttempts": true,
+				"discardWorktreeChanges": false,
+			}))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+	args := []string{"--config", configPath, "retry", "3108"}
+	if exitCode := app.Run(context.Background(), args); exitCode != 0 {
+		t.Fatalf("Run() exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if _, ok := gotBody["discardWorktreeChanges"]; ok {
+		t.Fatalf("retry body = %#v, want no discardWorktreeChanges", gotBody)
+	}
+}
+
+func TestJumpFallsBackToLoopWorktreeWhenNoActiveRun(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/runs/active/3491":
+			writeEnvelope(t, w, pkgapi.Failure("req_active", pkgapi.ErrorCodeActiveRunNotFound, "active run not found", nil))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
+			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
+				"loopId": "loop_dirty", "seq": 3491, "present": true,
+				"worktreePath": "/tmp/managed/dirty-wt", "branch": "feat/dirty",
+				"managed": true, "clean": false, "dirty": true, "reason": "dirty",
+			}))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+	args := []string{"--config", configPath, "jump", "3491"}
+	if exitCode := app.Run(context.Background(), args); exitCode != 0 {
+		t.Fatalf("Run() exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "cd -- '/tmp/managed/dirty-wt'" {
+		t.Fatalf("stdout = %q, want cd to worktree", got)
+	}
+}
+
+func TestJumpRefusesMissingWorktreePath(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/runs/active/3491":
+			writeEnvelope(t, w, pkgapi.Failure("req_active", pkgapi.ErrorCodeActiveRunNotFound, "active run not found", nil))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
+			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
+				"loopId": "loop_missing", "seq": 3491, "present": false,
+				"worktreePath": "/tmp/managed/gone", "branch": "feat/gone",
+				"managed": true, "reason": "worktree_missing",
+			}))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+	if exitCode := app.Run(context.Background(), []string{"--config", configPath, "jump", "3491"}); exitCode == 0 {
+		t.Fatalf("Run() exit code = 0, want failure; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "missing on disk") {
+		t.Fatalf("stderr = %q, want missing-on-disk error", stderr.String())
+	}
+}
+
+func TestJumpDoesNotFallbackOnActiveRunServerError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/runs/active/3491" {
+			writeEnvelope(t, w, pkgapi.Failure("req_active", pkgapi.ErrorCodeInternalError, "database down", nil))
+			return
+		}
+		t.Fatalf("unexpected fallback request %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+	if exitCode := app.Run(context.Background(), []string{"--config", configPath, "jump", "3491"}); exitCode == 0 {
+		t.Fatalf("Run() exit code = 0, want failure")
+	}
+	if !strings.Contains(stderr.String(), "database down") {
+		t.Fatalf("stderr = %q, want original active-run error", stderr.String())
+	}
+}
+
+func TestLoopRetryUnmanagedDirtyRefusesDiscardOffer(t *testing.T) {
+	t.Parallel()
+
+	retryCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3491/worktree":
+			writeEnvelope(t, w, pkgapi.Success("req_wt", map[string]any{
+				"loopId": "loop_unmanaged", "seq": 3491, "present": true,
+				"worktreePath": "/tmp/primary-repo", "branch": "main",
+				"managed": false, "clean": false, "dirty": true, "reason": "unmanaged",
+			}))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/retry"):
+			retryCalled = true
+			t.Fatalf("retry must not run for unmanaged dirty worktree")
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{
+		Stdin:      strings.NewReader("y\n"),
+		Stdout:     stdout,
+		Stderr:     stderr,
+		HTTPClient: server.Client(),
+	})
+	if exitCode := app.Run(context.Background(), []string{"--config", configPath, "retry", "3491"}); exitCode == 0 {
+		t.Fatalf("Run() exit code = 0, want failure; stderr=%q", stderr.String())
+	}
+	if retryCalled {
+		t.Fatal("retry POST was called")
+	}
+	if !strings.Contains(stderr.String(), "not Looper-managed") {
+		t.Fatalf("stderr = %q, want unmanaged guidance", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "--discard-worktree-changes") {
+		t.Fatalf("stderr should not offer discard for unmanaged path: %q", stderr.String())
+	}
+}
+
+func TestLoopRetryOldDaemonWithoutWorktreeRouteStillRetries(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/loops/3108/worktree":
+			writeEnvelope(t, w, pkgapi.Failure("req_wt", pkgapi.ErrorCodeRouteNotFound, "Unknown route", nil))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/loops/3108/retry":
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &gotBody)
+			writeEnvelope(t, w, pkgapi.Success("req_retry", map[string]any{
+				"loop": map[string]any{
+					"id": "loop_old", "seq": 3108, "projectId": "project_1",
+					"type": "fixer", "targetType": "pull_request", "status": "queued",
+				},
+				"queueItemId": "queue_new", "mode": "auto", "resetAttempts": true,
+				"discardWorktreeChanges": false,
+			}))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeCLIConfig(t, server.URL, "")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := New(Deps{Stdout: stdout, Stderr: stderr, HTTPClient: server.Client()})
+	if exitCode := app.Run(context.Background(), []string{"--config", configPath, "retry", "3108"}); exitCode != 0 {
+		t.Fatalf("Run() exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if _, ok := gotBody["discardWorktreeChanges"]; ok {
+		t.Fatalf("body = %#v, want plain retry without discard", gotBody)
+	}
+}

--- a/web/dashboard/src/components/ConfirmDialog.test.ts
+++ b/web/dashboard/src/components/ConfirmDialog.test.ts
@@ -1,22 +1,48 @@
 import { describe, expect, it } from "vitest";
+import { classifyRetryWorktree } from "@/components/LoopActionBar";
 
 /**
- * Pure helper for confirm-gated actions (stop / takeover / handback).
- * UI ConfirmDialog is presentational; this freezes which actions require confirm.
+ * Confirm-gated actions for LoopActionBar.
+ * Dirty managed retry opens discard confirm; clean retry does not.
  */
 function actionRequiresConfirm(
   action: "pause" | "unpause" | "retry" | "stop" | "takeover" | "handback",
+  opts?: { worktreeDirty?: boolean; managed?: boolean },
 ): boolean {
-  return action === "stop" || action === "takeover" || action === "handback";
+  if (action === "stop" || action === "takeover" || action === "handback") {
+    return true;
+  }
+  if (action === "retry") {
+    return (
+      classifyRetryWorktree({
+        loopId: "x",
+        seq: 1,
+        present: true,
+        managed: opts?.managed ?? true,
+        dirty: opts?.worktreeDirty ?? false,
+      }) === "offer-discard"
+    );
+  }
+  return false;
 }
 
 describe("actionRequiresConfirm", () => {
-  it("requires confirm only for stop, takeover, handback", () => {
+  it("requires confirm for stop, takeover, handback", () => {
     expect(actionRequiresConfirm("pause")).toBe(false);
     expect(actionRequiresConfirm("unpause")).toBe(false);
     expect(actionRequiresConfirm("retry")).toBe(false);
     expect(actionRequiresConfirm("stop")).toBe(true);
     expect(actionRequiresConfirm("takeover")).toBe(true);
     expect(actionRequiresConfirm("handback")).toBe(true);
+  });
+
+  it("requires confirm for retry only when managed worktree is dirty", () => {
+    expect(actionRequiresConfirm("retry", { worktreeDirty: false })).toBe(
+      false,
+    );
+    expect(actionRequiresConfirm("retry", { worktreeDirty: true })).toBe(true);
+    expect(
+      actionRequiresConfirm("retry", { worktreeDirty: true, managed: false }),
+    ).toBe(false);
   });
 });

--- a/web/dashboard/src/components/LoopActionBar.test.tsx
+++ b/web/dashboard/src/components/LoopActionBar.test.tsx
@@ -1,0 +1,263 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  classifyRetryWorktree,
+  isWorktreeRouteUnavailable,
+  LoopActionBar,
+} from "@/components/LoopActionBar";
+import { ApiError } from "@/lib/api";
+import { ToastProvider } from "@/lib/toast";
+
+const fetchLoopWorktree = vi.fn();
+const retryLoop = vi.fn();
+const pauseLoop = vi.fn();
+const startLoop = vi.fn();
+const stopActiveRun = vi.fn();
+const takeoverLoop = vi.fn();
+const handbackLoop = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchLoopWorktree: (...args: unknown[]) => fetchLoopWorktree(...args),
+    retryLoop: (...args: unknown[]) => retryLoop(...args),
+    pauseLoop: (...args: unknown[]) => pauseLoop(...args),
+    startLoop: (...args: unknown[]) => startLoop(...args),
+    stopActiveRun: (...args: unknown[]) => stopActiveRun(...args),
+    takeoverLoop: (...args: unknown[]) => takeoverLoop(...args),
+    handbackLoop: (...args: unknown[]) => handbackLoop(...args),
+  };
+});
+
+function renderBar(props?: Partial<React.ComponentProps<typeof LoopActionBar>>) {
+  const onMutated = vi.fn().mockResolvedValue(undefined);
+  render(
+    <ToastProvider>
+      <LoopActionBar
+        selector="3491"
+        status="paused"
+        mode="full"
+        onMutated={onMutated}
+        {...props}
+      />
+    </ToastProvider>,
+  );
+  return { onMutated };
+}
+
+describe("classifyRetryWorktree", () => {
+  it("offers discard only for present managed dirty trees", () => {
+    expect(
+      classifyRetryWorktree({
+        loopId: "l",
+        seq: 1,
+        present: true,
+        managed: true,
+        dirty: true,
+      }),
+    ).toBe("offer-discard");
+    expect(
+      classifyRetryWorktree({
+        loopId: "l",
+        seq: 1,
+        present: true,
+        managed: false,
+        dirty: true,
+      }),
+    ).toBe("inspect-only");
+    expect(
+      classifyRetryWorktree({
+        loopId: "l",
+        seq: 1,
+        present: true,
+        managed: true,
+        dirty: false,
+      }),
+    ).toBe("ok");
+    expect(
+      classifyRetryWorktree({
+        loopId: "l",
+        seq: 1,
+        present: false,
+        managed: true,
+        dirty: true,
+      }),
+    ).toBe("ok");
+  });
+});
+
+describe("isWorktreeRouteUnavailable", () => {
+  it("detects older-daemon route missing", () => {
+    expect(
+      isWorktreeRouteUnavailable(
+        new ApiError("Unknown route", {
+          status: 404,
+          code: "ROUTE_NOT_FOUND",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isWorktreeRouteUnavailable(
+        new ApiError("boom", { status: 500, code: "INTERNAL_ERROR" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("LoopActionBar retry dirty UX", () => {
+  beforeEach(() => {
+    fetchLoopWorktree.mockReset();
+    retryLoop.mockReset();
+    pauseLoop.mockReset();
+    startLoop.mockReset();
+    stopActiveRun.mockReset();
+    takeoverLoop.mockReset();
+    handbackLoop.mockReset();
+    retryLoop.mockResolvedValue({
+      loop: { id: "loop_1", status: "queued" },
+      mode: "auto",
+      resetAttempts: true,
+      discardWorktreeChanges: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("retries immediately when worktree is clean", async () => {
+    fetchLoopWorktree.mockResolvedValue({
+      loopId: "loop_1",
+      seq: 3491,
+      present: true,
+      managed: true,
+      dirty: false,
+      clean: true,
+      worktreePath: "/tmp/wt",
+    });
+    const { onMutated } = renderBar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(retryLoop).toHaveBeenCalledWith("3491", {
+        discardWorktreeChanges: false,
+      });
+    });
+    expect(onMutated).toHaveBeenCalled();
+    expect(screen.queryByText(/Dirty worktree/i)).toBeNull();
+  });
+
+  it("confirms discard for managed dirty worktree and posts discard=true", async () => {
+    fetchLoopWorktree.mockResolvedValue({
+      loopId: "loop_1",
+      seq: 3491,
+      present: true,
+      managed: true,
+      dirty: true,
+      clean: false,
+      worktreePath: "/tmp/dirty-wt",
+      branch: "feat/x",
+    });
+    renderBar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await screen.findByText(/Dirty worktree — discard and retry/i);
+    expect(retryLoop).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Discard & retry" }));
+
+    await waitFor(() => {
+      expect(retryLoop).toHaveBeenCalledWith("3491", {
+        discardWorktreeChanges: true,
+      });
+    });
+  });
+
+  it("inspect-first cancels discard and shows jump guidance", async () => {
+    fetchLoopWorktree.mockResolvedValue({
+      loopId: "loop_1",
+      seq: 3491,
+      present: true,
+      managed: true,
+      dirty: true,
+      clean: false,
+      worktreePath: "/tmp/dirty-wt",
+      branch: "feat/x",
+    });
+    renderBar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await screen.findByText(/Dirty worktree — discard and retry/i);
+
+    fireEvent.click(screen.getByRole("button", { name: "Inspect first" }));
+
+    await screen.findByText(/Inspect dirty worktree/i);
+    expect(screen.getByText("looper jump 3491")).toBeTruthy();
+    expect(screen.getByText("/tmp/dirty-wt")).toBeTruthy();
+    expect(retryLoop).not.toHaveBeenCalled();
+  });
+
+  it("does not offer discard for unmanaged dirty worktree", async () => {
+    fetchLoopWorktree.mockResolvedValue({
+      loopId: "loop_1",
+      seq: 3491,
+      present: true,
+      managed: false,
+      dirty: true,
+      clean: false,
+      worktreePath: "/tmp/primary-repo",
+      reason: "unmanaged",
+    });
+    renderBar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await screen.findByText(/Unmanaged dirty worktree/i);
+    expect(screen.queryByText("Discard & retry")).toBeNull();
+    expect(retryLoop).not.toHaveBeenCalled();
+  });
+
+  it("falls back to plain retry when /worktree route is missing", async () => {
+    fetchLoopWorktree.mockRejectedValue(
+      new ApiError("Unknown route", {
+        status: 404,
+        code: "ROUTE_NOT_FOUND",
+      }),
+    );
+    renderBar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(retryLoop).toHaveBeenCalledWith("3491", {
+        discardWorktreeChanges: false,
+      });
+    });
+  });
+
+  it("surfaces non-404 preflight failures without retrying", async () => {
+    fetchLoopWorktree.mockRejectedValue(
+      new ApiError("git status failed", {
+        status: 500,
+        code: "INTERNAL_ERROR",
+      }),
+    );
+    renderBar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("git status failed").length).toBeGreaterThan(0);
+    });
+    expect(retryLoop).not.toHaveBeenCalled();
+  });
+});

--- a/web/dashboard/src/components/LoopActionBar.tsx
+++ b/web/dashboard/src/components/LoopActionBar.tsx
@@ -3,12 +3,15 @@ import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { CopyButton } from "@/components/CopyButton";
 import { Button } from "@/components/ui/button";
 import {
+  ApiError,
+  fetchLoopWorktree,
   handbackLoop,
   pauseLoop,
   retryLoop,
   startLoop,
   stopActiveRun,
   takeoverLoop,
+  type LoopWorktreeStatus,
   type TakeoverResult,
 } from "@/lib/api";
 import {
@@ -38,7 +41,15 @@ type PendingConfirm =
   | { action: "stop" }
   | { action: "takeover" }
   | { action: "handback" }
+  | { action: "retry-dirty"; worktree: LoopWorktreeStatus }
   | null;
+
+type InspectGuidance = {
+  worktree: LoopWorktreeStatus;
+  jumpCommand: string;
+  /** When false, hide discard CLI hint (unmanaged paths). */
+  offerDiscard: boolean;
+} | null;
 
 const LABELS: Record<LoopAction, string> = {
   pause: "Pause",
@@ -48,6 +59,30 @@ const LABELS: Record<LoopAction, string> = {
   takeover: "Takeover",
   handback: "Handback",
 };
+
+/** True when preflight is missing on older daemons — fall back to plain retry. */
+export function isWorktreeRouteUnavailable(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  if (err.code === "ROUTE_NOT_FOUND") return true;
+  if (err.status === 404) {
+    const msg = (err.message || "").toLowerCase();
+    return msg.includes("unknown route") || msg.includes("not found");
+  }
+  return false;
+}
+
+/**
+ * Classify worktree preflight for retry UX.
+ * Discard is only offered for present + managed + dirty.
+ */
+export function classifyRetryWorktree(
+  worktree: LoopWorktreeStatus,
+): "ok" | "offer-discard" | "inspect-only" {
+  if (!worktree.present) return "ok";
+  if (worktree.dirty !== true) return "ok";
+  if (worktree.managed) return "offer-discard";
+  return "inspect-only";
+}
 
 export function LoopActionBar({
   selector,
@@ -67,12 +102,27 @@ export function LoopActionBar({
   const [takeoverResult, setTakeoverResult] = useState<TakeoverResult | null>(
     null,
   );
+  const [inspectGuidance, setInspectGuidance] =
+    useState<InspectGuidance>(null);
   const [inlineError, setInlineError] = useState<string | null>(null);
 
   const busy = pending !== null;
 
+  const finishRetry = useCallback(
+    async (discardWorktreeChanges: boolean) => {
+      await retryLoop(selector, { discardWorktreeChanges });
+      toast.success(
+        discardWorktreeChanges
+          ? "Retry queued (worktree discarded)"
+          : "Retry queued",
+      );
+      await onMutated?.();
+    },
+    [selector, toast, onMutated],
+  );
+
   const runAction = useCallback(
-    async (action: LoopAction) => {
+    async (action: Exclude<LoopAction, "retry">) => {
       setPending(action);
       setInlineError(null);
       try {
@@ -84,10 +134,6 @@ export function LoopActionBar({
           case "unpause":
             await startLoop(selector);
             toast.success("Unpaused (started)");
-            break;
-          case "retry":
-            await retryLoop(selector);
-            toast.success("Retry queued");
             break;
           case "stop":
             await stopActiveRun(selector);
@@ -108,7 +154,6 @@ export function LoopActionBar({
             toast.success("Handback queued");
             break;
         }
-        // Keep buttons pending until post-mutation refresh finishes (or fails).
         await onMutated?.();
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -122,8 +167,70 @@ export function LoopActionBar({
     [selector, toast, onMutated],
   );
 
+  const onRetryClick = useCallback(async () => {
+    if (busy || !enabled.retry) return;
+    setPending("retry");
+    setInlineError(null);
+    try {
+      let worktree: LoopWorktreeStatus;
+      try {
+        worktree = await fetchLoopWorktree(selector);
+      } catch (err) {
+        if (isWorktreeRouteUnavailable(err)) {
+          // Older daemon without /worktree — keep prior plain-retry behavior.
+          await finishRetry(false);
+          return;
+        }
+        throw err;
+      }
+
+      const decision = classifyRetryWorktree(worktree);
+      if (decision === "offer-discard") {
+        setConfirm({ action: "retry-dirty", worktree });
+        return;
+      }
+      if (decision === "inspect-only") {
+        setInspectGuidance({
+          worktree,
+          jumpCommand: `looper jump ${selector}`,
+          offerDiscard: false,
+        });
+        toast.error(
+          "Dirty worktree is not Looper-managed; inspect before retrying",
+        );
+        return;
+      }
+      await finishRetry(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setInlineError(message);
+      toast.error(message);
+    } finally {
+      setPending(null);
+    }
+  }, [busy, enabled.retry, selector, toast, finishRetry]);
+
+  const onDiscardRetry = useCallback(async () => {
+    setPending("retry");
+    setInlineError(null);
+    try {
+      await finishRetry(true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setInlineError(message);
+      toast.error(message);
+    } finally {
+      setPending(null);
+      setConfirm(null);
+    }
+  }, [finishRetry, toast]);
+
   const onClick = (action: LoopAction) => {
     if (busy || !enabled[action]) return;
+    if (action === "retry") {
+      void onRetryClick();
+      return;
+    }
     if (action === "stop" || action === "takeover" || action === "handback") {
       setConfirm({ action });
       return;
@@ -159,6 +266,14 @@ export function LoopActionBar({
           body: "Re-queues the loop so the daemon resumes after your interactive session. Worktree edits are preserved (discard is not allowed on handback).",
           confirmLabel: "Handback",
           danger: false,
+        };
+      case "retry-dirty":
+        return {
+          title: "Dirty worktree — discard and retry?",
+          body: "Local uncommitted changes were found in the loop worktree. Discard them before retrying, or inspect the worktree first.",
+          confirmLabel: "Discard & retry",
+          danger: true,
+          cancelLabel: "Inspect first",
         };
     }
   })();
@@ -197,17 +312,120 @@ export function LoopActionBar({
           open
           title={confirmCopy.title}
           confirmLabel={confirmCopy.confirmLabel}
+          cancelLabel={
+            "cancelLabel" in confirmCopy ? confirmCopy.cancelLabel : undefined
+          }
           danger={confirmCopy.danger}
           busy={busy}
           onCancel={() => {
-            if (!busy) setConfirm(null);
+            if (busy) return;
+            if (confirm.action === "retry-dirty") {
+              const wt = confirm.worktree;
+              setConfirm(null);
+              setInspectGuidance({
+                worktree: wt,
+                jumpCommand: `looper jump ${selector}`,
+                offerDiscard: true,
+              });
+              return;
+            }
+            setConfirm(null);
           }}
-          onConfirm={() => void runAction(confirm.action)}
+          onConfirm={() => {
+            if (confirm.action === "retry-dirty") {
+              void onDiscardRetry();
+              return;
+            }
+            void runAction(confirm.action);
+          }}
         >
           <p className="m-0 text-[var(--text-muted)]">{confirmCopy.body}</p>
-          <p className="mt-2 mb-0 mono text-[11px] text-[var(--text-muted)]">
-            selector: {selector}
-          </p>
+          {confirm.action === "retry-dirty" ? (
+            <div className="mt-2 flex flex-col gap-2">
+              {confirm.worktree.branch ? (
+                <p className="m-0 mono text-[11px] text-[var(--text-muted)]">
+                  branch: {confirm.worktree.branch}
+                </p>
+              ) : null}
+              <div className="rounded border border-[var(--border)] bg-[var(--bg)] p-2">
+                <div className="mb-1 flex items-center justify-between gap-2">
+                  <span className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+                    Worktree
+                  </span>
+                  <CopyButton text={confirm.worktree.worktreePath ?? ""} />
+                </div>
+                <p className="m-0 break-all mono text-[11px]">
+                  {confirm.worktree.worktreePath || "—"}
+                </p>
+              </div>
+            </div>
+          ) : (
+            <p className="mt-2 mb-0 mono text-[11px] text-[var(--text-muted)]">
+              selector: {selector}
+            </p>
+          )}
+        </ConfirmDialog>
+      ) : null}
+
+      {inspectGuidance ? (
+        <ConfirmDialog
+          open
+          title={
+            inspectGuidance.offerDiscard
+              ? "Inspect dirty worktree"
+              : "Unmanaged dirty worktree"
+          }
+          confirmLabel="Close"
+          showCancel={false}
+          onCancel={() => setInspectGuidance(null)}
+          onConfirm={() => setInspectGuidance(null)}
+        >
+          <div className="flex flex-col gap-2">
+            <p className="m-0 text-[var(--text-muted)]">
+              {inspectGuidance.offerDiscard
+                ? "Review local changes in the worktree, then retry again. Use jump from a terminal on this machine."
+                : "This path is not a Looper-managed worktree, so discard is unavailable. Inspect manually, then retry only after the tree is clean or the path is fixed."}
+            </p>
+            {inspectGuidance.worktree.branch ? (
+              <p className="m-0 mono text-[11px] text-[var(--text-muted)]">
+                branch: {inspectGuidance.worktree.branch}
+              </p>
+            ) : null}
+            <div className="rounded border border-[var(--border)] bg-[var(--bg)] p-2">
+              <div className="mb-1 flex items-center justify-between gap-2">
+                <span className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+                  Worktree
+                </span>
+                <CopyButton
+                  text={inspectGuidance.worktree.worktreePath ?? ""}
+                />
+              </div>
+              <p className="m-0 break-all mono text-[11px]">
+                {inspectGuidance.worktree.worktreePath || "—"}
+              </p>
+            </div>
+            {inspectGuidance.worktree.present ? (
+              <div className="rounded border border-[var(--border)] bg-[var(--bg)] p-2">
+                <div className="mb-1 flex items-center justify-between gap-2">
+                  <span className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+                    Jump command
+                  </span>
+                  <CopyButton text={inspectGuidance.jumpCommand} />
+                </div>
+                <p className="m-0 break-all mono text-[11px]">
+                  {inspectGuidance.jumpCommand}
+                </p>
+              </div>
+            ) : null}
+            {inspectGuidance.offerDiscard ? (
+              <p className="m-0 text-[11px] text-[var(--text-muted)]">
+                After fixing or deciding to drop changes: Retry again, or run{" "}
+                <span className="mono">
+                  looper retry {selector} --discard-worktree-changes --confirm
+                </span>
+              </p>
+            ) : null}
+          </div>
         </ConfirmDialog>
       ) : null}
 

--- a/web/dashboard/src/lib/api.ts
+++ b/web/dashboard/src/lib/api.ts
@@ -482,6 +482,19 @@ export type RetryLoopResult = {
   worktreeDiscard?: unknown;
 };
 
+/** GET /loops/{sel}/worktree — retry/jump preflight. */
+export type LoopWorktreeStatus = {
+  loopId: string;
+  seq: number;
+  present: boolean;
+  worktreePath?: string | null;
+  branch?: string | null;
+  managed: boolean;
+  clean?: boolean | null;
+  dirty?: boolean | null;
+  reason?: string;
+};
+
 export type StopActiveRunResult = {
   stopped: boolean;
   loopId: string;
@@ -523,16 +536,30 @@ export function pauseLoop(
   );
 }
 
-export function retryLoop(
+export function fetchLoopWorktree(
   selector: string,
   signal?: AbortSignal,
+): Promise<LoopWorktreeStatus> {
+  return apiFetch<LoopWorktreeStatus>(
+    `/api/v1/loops/${encodeURIComponent(selector)}/worktree`,
+    { signal },
+  );
+}
+
+export function retryLoop(
+  selector: string,
+  opts?: { discardWorktreeChanges?: boolean; signal?: AbortSignal },
 ): Promise<RetryLoopResult> {
+  const body: RetryLoopBody = {
+    ...RETRY_BODY,
+    ...(opts?.discardWorktreeChanges ? { discardWorktreeChanges: true } : {}),
+  };
   return apiFetch<RetryLoopResult>(
     `/api/v1/loops/${encodeURIComponent(selector)}/retry`,
     {
       method: "POST",
-      body: JSON.stringify(RETRY_BODY),
-      signal,
+      body: JSON.stringify(body),
+      signal: opts?.signal,
     },
   );
 }


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/loops/{sel}/worktree` preflight (present/managed/dirty/path) for retry and jump UX.
- CLI `looper retry`: if managed dirty, prompt discard; on decline (or unmanaged dirty), guide `looper jump` + path + optional discard flags. Old daemons without `/worktree` still plain-retry.
- Dashboard Retry follows the same flow (discard confirm / inspect guidance / old-daemon fallback).
- `looper jump` falls back to loop worktree when no active run; refuses missing-on-disk paths; does not mask active-run 5xx.

## Oracle review
Addressed CHANGES REQUIRED from oracle review:
- discard only when `managed && present && dirty`
- dashboard old-daemon `/worktree` 404 fallback
- jump fallback only on active-run-not-found / empty path
- `present` = on-disk; missing path keeps path for diagnostics but jump refuses
- git status failure returns path with `status_unavailable` (no 500)
- real `LoopActionBar` RTL tests + CLI regression coverage

## Test plan
- [x] `go test ./internal/cliapp/ -run 'TestLoopRetry|TestJump'`
- [x] `go test ./internal/api/ -run 'TestHandlerLoopWorktreeStatus'`
- [x] `go test ./internal/cliapp/ ./internal/api/`
- [x] `cd web/dashboard && npm test -- src/components/LoopActionBar.test.tsx src/components/ConfirmDialog.test.ts`
- [ ] Manual: `looper retry <mi-seq>` on dirty managed worktree → y discards, n prints jump
- [ ] Manual: dashboard Loop detail Retry on dirty loop → Discard & retry / Inspect first