### PR TITLE
feat(fixer): allow directly coupled collateral repairs in prompt

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -332,7 +332,7 @@ Use this when you want to force a repair pass on demand before waiting for any a
 Fixer will:
 
 - read pending review comments and threads on the PR
-- create a worktree and apply each listed repair, plus the smallest directly coupled changes needed to correct the same root cause (unrelated cleanup stays out of scope)
+- create a worktree and apply each listed repair; when the link is clear, prefer a complete coherent fix of that root cause across the affected dependency chain (unrelated cleanup and speculative hardening stay out of scope)
 - run validation
 - push back to the same PR branch
 - after validation and push succeed, try to resolve only the review threads that were both verified by Looper and explicitly confirmed by the fixer agent

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -332,7 +332,7 @@ Use this when you want to force a repair pass on demand before waiting for any a
 Fixer will:
 
 - read pending review comments and threads on the PR
-- create a worktree and apply fixes
+- create a worktree and apply each listed repair, plus the smallest directly coupled changes needed to correct the same root cause (unrelated cleanup stays out of scope)
 - run validation
 - push back to the same PR branch
 - after validation and push succeed, try to resolve only the review threads that were both verified by Looper and explicitly confirmed by the fixer agent

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -7176,7 +7176,7 @@ func buildFixerPrompt(projectID string, instructionConfig config.Config, repo st
 	}
 	parts = append(parts,
 		"Fix items:\n"+strings.Join(encodedItems, "\n"),
-		"Only perform repair changes for the listed fix items.",
+		fixerRepairScopeInstruction(),
 		"If — and only if — a reviewer's requested change is genuinely unreasonable, incorrect, or would make the code worse, you may decline it: write a JSON file at `.looper/dismiss.json` in the repo root with the shape {\"dismissals\":[{\"reviewer\":\"<their github login>\",\"reason\":\"<a concise, respectful explanation>\"}]} and do NOT make that change — Looper will dismiss that review with your reason. Use this sparingly and only when confident; when in doubt, implement the requested change.",
 	)
 	if instruction := buildFixerReplyExplanationInstruction(fixItems); instruction != "" {
@@ -7204,6 +7204,18 @@ func customInstructionConfig(value *config.Config) config.Config {
 		return cfg
 	}
 	return *value
+}
+
+// fixerRepairScopeInstruction is the repair-scope fragment of the fixer agent
+// prompt. Listed fix items are the primary contract; directly coupled collateral
+// is allowed so one round can clear the same root cause instead of ping-ponging.
+func fixerRepairScopeInstruction() string {
+	return strings.Join([]string{
+		"Fully address every listed fix item. If a reviewer request should not be implemented, follow the applicable decline instructions below.",
+		"You may also make the smallest collateral changes that are directly required by a listed repair or that correct another occurrence of the same concrete root cause or invariant in its affected dependency chain. Examples: update direct consumers of a changed constant/default; update caps, backoff, cadence, or scheduling logic that relies on the same timing assumption; add focused tests for the repaired behavior.",
+		"Do not fix an independent issue merely because it is nearby, in the same file/module, or might be reported later. Do not drive-by refactor, rename, restyle, or otherwise improve unrelated code. When uncertain, omit the collateral change.",
+		"Before finishing, inspect the PR diff and direct usages/dependents of symbols, constants, defaults, and assumptions changed by the repair. Fix any remaining occurrence of the same failure mode in that dependency chain.",
+	}, "\n")
 }
 
 // buildFixerReplyExplanationInstruction returns the prompt fragment that asks
@@ -7239,6 +7251,7 @@ func buildFixerReplyExplanationInstruction(fixItems []FixItem) string {
 			"Before including an entry, re-read the relevant review thread/comment context.",
 			"Use \"fixed\" only when you can confidently confirm the current branch state actually addresses the thread; in other words, only include items you can confidently confirm are actually addressed by the current branch state. Use \"declined\" if you deliberately are not acting, including cases such as: already implemented on this branch, out of scope for this PR, reviewer request is incorrect, or you cannot safely complete it.",
 			"Do not omit any non-native comment-type fix item. Do not use vague explanations like \"looks fine\" or \"no change needed\".",
+			"Create structured `review_thread_replies` entries only for listed comment fix items, never for collateral-only changes. Briefly mention material collateral in the explanation for the listed item it supports.",
 			"Read-only GitHub fetches are allowed for that verification. Do not post replies, resolve threads, submit reviews, edit PR metadata, or perform any other mutating GitHub API action; Looper owns those remote review-state changes after validation and push. Do not invent URLs.",
 		)
 	}
@@ -7247,6 +7260,7 @@ func buildFixerReplyExplanationInstruction(fixItems []FixItem) string {
 			"For EVERY Forgejo native review comment fix item (`source: \"forgejo_review_comment\"`), also include exactly one entry in a top-level `repair_results` array on the final "+agent.CompletionMarker+" JSON line.",
 			"Each `repair_results` entry for a Forgejo native review comment must include: `source` = `forgejo_review_comment`, the exact `providerCommentId`, `action` = `fixed`, `declined`, or `deferred`, a concrete `explanation`, and the exact `observedFingerprint` from the fix item.",
 			"Use Forgejo comment terminology for those entries: decide whether the individual review comment is fixed, declined, or deferred. Do not refer to Forgejo native review comments as threads in `repair_results`.",
+			"Create structured `repair_results` entries only for listed Forgejo native review comment fix items, never for collateral-only changes. Briefly mention material collateral in the explanation for the listed item it supports.",
 		)
 	}
 	return strings.Join(parts, "\n")

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -7207,14 +7207,16 @@ func customInstructionConfig(value *config.Config) config.Config {
 }
 
 // fixerRepairScopeInstruction is the repair-scope fragment of the fixer agent
-// prompt. Listed fix items are the primary contract; directly coupled collateral
-// is allowed so one round can clear the same root cause instead of ping-ponging.
+// prompt. Listed fix items are the primary contract. When the link to a listed
+// item is clear, prefer a complete coherent repair of that root cause over a
+// minimal symptom patch; do not become a free-form refactor agent.
 func fixerRepairScopeInstruction() string {
 	return strings.Join([]string{
 		"Fully address every listed fix item. If a reviewer request should not be implemented, follow the applicable decline instructions below.",
-		"You may also make the smallest collateral changes that are directly required by a listed repair or that correct another occurrence of the same concrete root cause or invariant in its affected dependency chain. Examples: update direct consumers of a changed constant/default; update caps, backoff, cadence, or scheduling logic that relies on the same timing assumption; add focused tests for the repaired behavior.",
-		"Do not fix an independent issue merely because it is nearby, in the same file/module, or might be reported later. Do not drive-by refactor, rename, restyle, or otherwise improve unrelated code. When uncertain, omit the collateral change.",
-		"Before finishing, inspect the PR diff and direct usages/dependents of symbols, constants, defaults, and assumptions changed by the repair. Fix any remaining occurrence of the same failure mode in that dependency chain.",
+		"Prefer a coherent, durable repair of the underlying concrete root cause over a narrow symptom patch. When the relationship to a listed item is clear, make the changes needed to restore the affected invariant consistently across its dependency chain; do not minimize the diff if doing so would leave inconsistent behavior, partially updated consumers, or another clearly evidenced instance of the same failure mode.",
+		"Before finishing, inspect the PR diff and the relevant producers, direct usages, consumers, callers, defaults, limits, and assumptions affected by the repair. Follow the behavior through the dependency chain only as far as needed to verify consistency, and add or update focused tests for the repaired behavior. Examples: update consumers of a changed constant/default; align caps, backoff, cadence, or scheduling logic that relies on the same timing assumption; cover affected boundary and failure cases.",
+		"You may fix an unlisted occurrence only when the code provides clear evidence that it has the same concrete root cause or violates the same specific invariant and is in the dependency chain affected by a listed repair.",
+		"Do not fix an independent issue merely because it is nearby, in the same file/module, or might be reported later. Do not perform speculative hardening, broad redesigns, or drive-by refactors, renames, or restyling. If the relationship to a listed item is uncertain, omit the collateral change; if the relationship is clear but the repair breadth is uncertain, prefer the smallest complete, coherent solution over the smallest diff.",
 	}, "\n")
 }
 

--- a/internal/fixer/runner_forgejo_native_test.go
+++ b/internal/fixer/runner_forgejo_native_test.go
@@ -57,6 +57,7 @@ func TestBuildFixerPromptAddsForgejoNativeCommentRepairResultsInstruction(t *tes
 		"`providerCommentId`",
 		"`observedFingerprint`",
 		"individual review comment is fixed, declined, or deferred",
+		"Create structured `repair_results` entries only for listed Forgejo native review comment fix items, never for collateral-only changes",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -110,13 +110,73 @@ func TestBuildFixerPromptIncludesMinimalPRSeedFetchContract(t *testing.T) {
 		"gh api repos/{owner}/{repo}/pulls/{number}/reviews --paginate",
 		"gh api repos/{owner}/{repo}/issues/{number}/comments --paginate",
 		"structured error with `type` set to one of `auth`, `network`, `rate_limit`, or `pr_drift`",
+		"Fully address every listed fix item",
+		"smallest collateral changes that are directly required",
+		"same concrete root cause or invariant",
+		"Do not drive-by refactor",
+		"When uncertain, omit the collateral change",
+		"direct usages/dependents",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
 		}
 	}
+	if strings.Contains(prompt, "Only perform repair changes for the listed fix items.") {
+		t.Fatalf("prompt still uses the old listed-items-only scope line:\n%s", prompt)
+	}
+	// Non-comment fix items must not activate provider reply protocols.
+	for _, unwanted := range []string{"review_thread_replies", "repair_results"} {
+		if strings.Contains(prompt, unwanted) {
+			t.Fatalf("non-comment prompt unexpectedly contains %q:\n%s", unwanted, prompt)
+		}
+	}
 	if strings.Contains(prompt, "gh pr diff -- <path>") {
 		t.Fatalf("prompt contains unsupported gh pr diff pathspec instruction:\n%s", prompt)
+	}
+}
+
+func TestFixerRepairScopeInstructionAllowsCollateralWithoutDriveBy(t *testing.T) {
+	t.Parallel()
+
+	got := fixerRepairScopeInstruction()
+	for _, want := range []string{
+		"Fully address every listed fix item",
+		"smallest collateral changes that are directly required",
+		"same concrete root cause or invariant",
+		"affected dependency chain",
+		"Do not drive-by refactor",
+		"When uncertain, omit the collateral change",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("scope instruction missing %q:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"Only perform repair changes for the listed fix items.",
+		"review_thread_replies",
+		"repair_results",
+		"change-class",
+		"likely force another review round",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("scope instruction contains unwanted %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestBuildFixerPromptGitHubCommentMentionsCollateralOnlyInThreadReplies(t *testing.T) {
+	t.Parallel()
+
+	detail := &checkpointDetail{State: "OPEN", HeadSHA: "abc123", BaseRefName: "main", HeadRefName: "feature/fix"}
+	prompt, _ := buildFixerPrompt("project_1", customInstructionConfig(nil), "acme/looper", 42, detail, []FixItem{{Type: "comment", ID: "c1", ThreadID: "thread-1", Summary: "repair disclosure"}}, false, config.DefaultDisclosureConfig(), "opencode", "openai/gpt-5.5")
+	if !strings.Contains(prompt, "review_thread_replies") {
+		t.Fatalf("GitHub comment prompt missing review_thread_replies:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Create structured `review_thread_replies` entries only for listed comment fix items, never for collateral-only changes") {
+		t.Fatalf("GitHub comment prompt missing collateral reporting guidance:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "repair_results") {
+		t.Fatalf("GitHub comment prompt unexpectedly contains repair_results:\n%s", prompt)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -111,11 +111,11 @@ func TestBuildFixerPromptIncludesMinimalPRSeedFetchContract(t *testing.T) {
 		"gh api repos/{owner}/{repo}/issues/{number}/comments --paginate",
 		"structured error with `type` set to one of `auth`, `network`, `rate_limit`, or `pr_drift`",
 		"Fully address every listed fix item",
-		"smallest collateral changes that are directly required",
-		"same concrete root cause or invariant",
-		"Do not drive-by refactor",
-		"When uncertain, omit the collateral change",
-		"direct usages/dependents",
+		"coherent, durable repair of the underlying concrete root cause",
+		"smallest complete, coherent solution over the smallest diff",
+		"clear evidence that it has the same concrete root cause",
+		"Do not perform speculative hardening",
+		"If the relationship to a listed item is uncertain, omit the collateral change",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
@@ -141,11 +141,12 @@ func TestFixerRepairScopeInstructionAllowsCollateralWithoutDriveBy(t *testing.T)
 	got := fixerRepairScopeInstruction()
 	for _, want := range []string{
 		"Fully address every listed fix item",
-		"smallest collateral changes that are directly required",
-		"same concrete root cause or invariant",
-		"affected dependency chain",
-		"Do not drive-by refactor",
-		"When uncertain, omit the collateral change",
+		"coherent, durable repair of the underlying concrete root cause",
+		"dependency chain",
+		"smallest complete, coherent solution over the smallest diff",
+		"clear evidence that it has the same concrete root cause",
+		"Do not perform speculative hardening",
+		"If the relationship to a listed item is uncertain, omit the collateral change",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("scope instruction missing %q:\n%s", want, got)
@@ -157,6 +158,7 @@ func TestFixerRepairScopeInstructionAllowsCollateralWithoutDriveBy(t *testing.T)
 		"repair_results",
 		"change-class",
 		"likely force another review round",
+		"smallest collateral changes that are directly required",
 	} {
 		if strings.Contains(got, unwanted) {
 			t.Fatalf("scope instruction contains unwanted %q:\n%s", unwanted, got)


### PR DESCRIPTION
# Summary

- Soften fixer agent scope: listed review items stay primary, but **directly coupled collateral** (same concrete root cause / invariant on the dependency chain) may be fixed in the same round.
- Ban drive-by refactors and proximity-only cleanup.
- Structured reply protocols (`review_thread_replies` / `repair_results`) still cover **listed items only**; collateral is mentioned in those explanations.
- Document the boundary in `docs/users-guide.md`.

**Why:** Bot reviewers often post one finding per pass. The old line `Only perform repair changes for the listed fix items` forced multi-round ping-pong for the same root cause (e.g. interval default change → backoff cap → scheduler cadence → flaky test).

# New-concept trade-off: directly coupled collateral

AGENTS.md requires an explicit cost analysis before introducing a new action-scope concept. This section is that analysis.

## Failure prevented

Strict “listed items only” scope made fixer rounds stop at the first listed surface. When a root cause spans a dependency chain (constant/default → consumers → caps/backoff/cadence → tests), bot reviewers typically open **one finding per pass**. Each round fixed only the listed line, CI or the next review reopened the next link, and Looper/agent rounds ping-ponged until the chain was exhausted. That multiplies latency, CI load, and review noise without improving correctness.

## Costs and failure modes (what the broader scope adds)

- **Scope over-expansion:** agents can mis-classify nearby or “might be related” edits as collateral and touch code outside the listed repair’s dependency chain.
- **Attribution blur:** one round’s diff can include files that are not 1:1 with a review thread; reviewers must read explanations carefully to see which edits are listed vs collateral.
- **Reporting asymmetry:** `review_thread_replies` / `repair_results` remain **listed-item only**. Collateral has no separate resolve contract—only a brief mention under the supporting listed item—so over-scope is harder to gate purely from structured output shape.
- **Prompt/docs drift:** the boundary now lives in three places (fixer prompt, users-guide, resolve/confirmation rules). Those must stay aligned; loosening one without the others reintroduces either ping-pong or drive-bys.
- **No new persisted state:** this is a prompt/contract concept only (no new DB field, lock, ledger, or status). Failure modes are behavioral (wrong diff scope), not durable state divergence.

Mitigations already in the change: smallest-change language; ban proximity-only and drive-by refactor; “when uncertain, omit”; listed items remain primary; resolve still requires listed-item confirmation.

## Why simpler alternatives are insufficient

1. **Delete the strict sentence and “trust structured agent output” alone** — Insufficient. Without a written collateral *and* ban boundary, agents either stay timid (ping-pong returns) or treat “trust” as unbounded cleanup. Structured replies describe listed items; they do not define which unlisted dependency-chain edits are allowed. Infra/git signals are for drift detection, not for inventing authority after the fact (AGENTS.md: name the authority before enforcing it). The authority here is the **fixer prompt repair-scope instruction**, which must state the boundary explicitly.

2. **Keep “listed items only” and rely on multi-round review** — Rejected. That is the failure mode this PR removes. Waiting for the next bot finding per dependency-chain link is correct only if collateral is independent work; for the same invariant it is pure process tax.

3. **Infer required collateral from repo state after the agent finishes** — Insufficient and the wrong authority. Post-hoc inference from the diff or CI would second-guess agent structure and create a parallel scope model. Prefer making the agent’s allowed scope explicit and structured rather than building an inference layer on top of infra state.

**Net:** Accept a bounded, prompt-defined expansion (same root cause / dependency chain only) with explicit anti-drive-by rules, rather than unbounded trust or multi-round ping-pong. Prefer deletion of a layer when possible; here deletion of the strict line without a replacement boundary is worse than a named, limited collateral concept.

# Testing

- [x] `go test ./internal/fixer/` — pass
- [x] Additional targeted checks: `TestBuildFixerPrompt*`, `TestFixerRepairScope*`, Forgejo native isolation
- [ ] `go test ./...` (full suite not run; change is prompt/docs + fixer unit tests only)

# E2E / Invariant Risk

- [x] No Looper E2E / invariant risk
- [ ] Daemon boot / config / runtime path risk
- [ ] Worktree / repo isolation / lifecycle risk
- [ ] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk — **prompt-only**; resolve still requires listed-item confirmation
- [ ] Real sandbox GitHub behavior risk

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [ ] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- PR / issue links for regression coverage:
  - Motivating case: open-design-evals auto-update interval PR multi-round Codex↔Looper ping-pong

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied
- [x] Oracle review: approve (after one revision for provider protocol isolation)
