### PR TITLE
fix: scrub reserved reviewer scratch before prepare

### DIFF
--- a/internal/infra/git/reserved_review_scratch.go
+++ b/internal/infra/git/reserved_review_scratch.go
@@ -26,9 +26,14 @@ var reservedReviewerScratchBaseName = regexp.MustCompile(`^\.looper-review-[A-Za
 // managed worktree root immediately before ordinary PrepareWorktree cleanliness.
 //
 // It enumerates the worktree root directly (not via git status). Only regular
-// files matching reservedReviewerScratchBaseName that are absent from the Git
-// index are deleted. Symlinks and directories are left alone. Delete failures
+// files matching reservedReviewerScratchBaseName that are absent from both the
+// Git index and HEAD tree are deleted. Symlinks and directories are left alone.
+// Files tracked by HEAD but staged for index removal (e.g. after
+// `git rm --cached`) remain ordinary dirt and are preserved. Delete failures
 // fail closed.
+//
+// gitPath must be the configured Git executable (tools.gitPath); callers must
+// not hard-code "git" when a non-PATH binary is configured.
 func ScrubReservedReviewerScratch(ctx context.Context, gitPath, worktreePath string) error {
 	worktreePath = strings.TrimSpace(worktreePath)
 	if worktreePath == "" {
@@ -62,11 +67,11 @@ func ScrubReservedReviewerScratch(ctx context.Context, gitPath, worktreePath str
 			continue
 		}
 
-		tracked, terr := isIndexPathPresent(ctx, gitPath, worktreePath, name)
+		preserve, terr := shouldPreserveReservedScratch(ctx, gitPath, worktreePath, name)
 		if terr != nil {
 			return terr
 		}
-		if tracked {
+		if preserve {
 			continue
 		}
 		if err := os.Remove(fullPath); err != nil {
@@ -79,15 +84,39 @@ func ScrubReservedReviewerScratch(ctx context.Context, gitPath, worktreePath str
 	return nil
 }
 
-func isIndexPathPresent(ctx context.Context, gitPath, worktreePath, name string) (bool, error) {
-	// ls-files with a pathspec returns the path only when it is in the index.
+// ScrubReservedReviewerScratch removes disposable reviewer submit scratch using
+// this gateway's configured Git executable.
+func (g *Gateway) ScrubReservedReviewerScratch(ctx context.Context, worktreePath string) error {
+	return ScrubReservedReviewerScratch(ctx, g.gitPath, worktreePath)
+}
+
+// shouldPreserveReservedScratch reports whether a reserved-name file must be
+// left as ordinary dirt: present in the current index and/or the committed HEAD
+// tree. Index-only checks miss `git rm --cached` (tracked by HEAD, dropped from
+// the index while still on disk).
+func shouldPreserveReservedScratch(ctx context.Context, gitPath, worktreePath, name string) (bool, error) {
+	inIndex, err := gitListsPath(ctx, gitPath, worktreePath, name, []string{"ls-files", "--full-name", "--", name})
+	if err != nil {
+		return false, fmt.Errorf("probe index for reserved reviewer scratch %q: %w", name, err)
+	}
+	if inIndex {
+		return true, nil
+	}
+	inHead, err := gitListsPath(ctx, gitPath, worktreePath, name, []string{"ls-tree", "--name-only", "HEAD", "--", name})
+	if err != nil {
+		return false, fmt.Errorf("probe HEAD for reserved reviewer scratch %q: %w", name, err)
+	}
+	return inHead, nil
+}
+
+func gitListsPath(ctx context.Context, gitPath, worktreePath, name string, args []string) (bool, error) {
 	result, err := shell.Run(ctx, shell.Options{
 		Command: gitPath,
-		Args:    []string{"-C", worktreePath, "ls-files", "--full-name", "--", name},
+		Args:    append([]string{"-C", worktreePath}, args...),
 		CWD:     worktreePath,
 	})
 	if err != nil {
-		return false, fmt.Errorf("probe index for reserved reviewer scratch %q: %w", name, err)
+		return false, err
 	}
 	for _, line := range strings.Split(result.Stdout, "\n") {
 		if strings.TrimSpace(line) == name {

--- a/internal/infra/git/reserved_review_scratch.go
+++ b/internal/infra/git/reserved_review_scratch.go
@@ -1,0 +1,104 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/infra/shell"
+)
+
+// reservedReviewerScratchBaseName matches disposable reviewer submit scratch only.
+// Authority: the Looper reviewer contract reserves top-level, untracked regular
+// files matching this grammar in managed reviewer worktrees as disposable
+// submission scratch. That contract—not git status inference—is the authority
+// to delete them during reviewer prepare.
+//
+// Do not broaden this to staged, tracked, nested, case-folded, or preserved
+// artifacts; those remain ordinary dirt. Quarantine, generation IDs, status
+// filtering, and Commit interception are redesign requests, not incremental fixes.
+var reservedReviewerScratchBaseName = regexp.MustCompile(`^\.looper-review-[A-Za-z0-9_-]+\.json$`)
+
+// ScrubReservedReviewerScratch removes disposable reviewer submit scratch from a
+// managed worktree root immediately before ordinary PrepareWorktree cleanliness.
+//
+// It enumerates the worktree root directly (not via git status). Only regular
+// files matching reservedReviewerScratchBaseName that are absent from the Git
+// index are deleted. Symlinks and directories are left alone. Delete failures
+// fail closed.
+func ScrubReservedReviewerScratch(ctx context.Context, gitPath, worktreePath string) error {
+	worktreePath = strings.TrimSpace(worktreePath)
+	if worktreePath == "" {
+		return fmt.Errorf("worktree path is required")
+	}
+	gitPath = strings.TrimSpace(gitPath)
+	if gitPath == "" {
+		gitPath = "git"
+	}
+
+	entries, err := os.ReadDir(worktreePath)
+	if err != nil {
+		return fmt.Errorf("read worktree root for reserved reviewer scratch: %w", err)
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if !reservedReviewerScratchBaseName.MatchString(name) {
+			continue
+		}
+		// Lstat so we never follow symlinks; only plain regular files are disposable.
+		fullPath := filepath.Join(worktreePath, name)
+		info, lerr := os.Lstat(fullPath)
+		if lerr != nil {
+			if os.IsNotExist(lerr) {
+				continue
+			}
+			return fmt.Errorf("stat reserved reviewer scratch %q: %w", name, lerr)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+
+		tracked, terr := isIndexPathPresent(ctx, gitPath, worktreePath, name)
+		if terr != nil {
+			return terr
+		}
+		if tracked {
+			continue
+		}
+		if err := os.Remove(fullPath); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("remove reserved reviewer scratch %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func isIndexPathPresent(ctx context.Context, gitPath, worktreePath, name string) (bool, error) {
+	// ls-files with a pathspec returns the path only when it is in the index.
+	result, err := shell.Run(ctx, shell.Options{
+		Command: gitPath,
+		Args:    []string{"-C", worktreePath, "ls-files", "--full-name", "--", name},
+		CWD:     worktreePath,
+	})
+	if err != nil {
+		return false, fmt.Errorf("probe index for reserved reviewer scratch %q: %w", name, err)
+	}
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		if strings.TrimSpace(line) == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// IsReservedReviewerScratchBaseName reports whether name matches the disposable
+// reviewer scratch grammar (exported for focused tests).
+func IsReservedReviewerScratchBaseName(name string) bool {
+	return reservedReviewerScratchBaseName.MatchString(name)
+}

--- a/internal/infra/git/reserved_review_scratch_test.go
+++ b/internal/infra/git/reserved_review_scratch_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -80,6 +81,103 @@ func TestScrubReservedReviewerScratchDeletesUntrackedOnly(t *testing.T) {
 	if _, err := os.Lstat(filepath.Join(repo, linkName)); err != nil {
 		t.Fatalf("symlink reserved name missing: %v", err)
 	}
+}
+
+// After `git rm --cached`, ls-files no longer lists the path but HEAD still owns
+// it. Scrub must preserve the worktree file as ordinary dirt.
+func TestScrubReservedReviewerScratchPreservesHeadTrackedAfterCachedRemoval(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	mustGit(t, root, "init", repo)
+	mustGit(t, repo, "config", "user.email", "test@example.com")
+	mustGit(t, repo, "config", "user.name", "test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cached := ".looper-review-cached.json"
+	payload := []byte(`{"local":"content"}` + "\n")
+	if err := os.WriteFile(filepath.Join(repo, cached), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "add", "README.md", cached)
+	mustGit(t, repo, "commit", "-m", "init with reserved name tracked")
+	mustGit(t, repo, "rm", "--cached", cached)
+
+	// True untracked scratch still scrubbed in the same pass.
+	scratch := ".looper-review-untracked.json"
+	if err := os.WriteFile(filepath.Join(repo, scratch), []byte(`{"scratch":true}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ScrubReservedReviewerScratch(context.Background(), "git", repo); err != nil {
+		t.Fatalf("ScrubReservedReviewerScratch() error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(repo, cached))
+	if err != nil {
+		t.Fatalf("HEAD-tracked file after rm --cached missing: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("HEAD-tracked content = %q, want %q", got, payload)
+	}
+	if _, err := os.Stat(filepath.Join(repo, scratch)); !os.IsNotExist(err) {
+		t.Fatalf("untracked scratch still present: err=%v", err)
+	}
+}
+
+func TestScrubReservedReviewerScratchUsesConfiguredGitExecutable(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	mustGit(t, root, "init", repo)
+	mustGit(t, repo, "config", "user.email", "test@example.com")
+	mustGit(t, repo, "config", "user.name", "test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "add", "README.md")
+	mustGit(t, repo, "commit", "-m", "init")
+
+	scratch := ".looper-review-custom-git.json"
+	if err := os.WriteFile(filepath.Join(repo, scratch), []byte(`{"scratch":true}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrapper is the only "git" the scrub may invoke; real git is not on PATH for it.
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath git: %v", err)
+	}
+	wrapper := filepath.Join(root, "custom-git")
+	script := "#!/bin/sh\nexec " + shellQuote(realGit) + " \"$@\"\n"
+	if err := os.WriteFile(wrapper, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	gateway := New(Options{GitPath: wrapper})
+	if err := gateway.ScrubReservedReviewerScratch(context.Background(), repo); err != nil {
+		t.Fatalf("Gateway.ScrubReservedReviewerScratch() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, scratch)); !os.IsNotExist(err) {
+		t.Fatalf("scratch still present after gateway scrub via custom git: err=%v", err)
+	}
+
+	// Re-create scratch so the missing binary is actually invoked for the probe.
+	if err := os.WriteFile(filepath.Join(repo, scratch), []byte(`{"scratch":true}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Hard-fail when the configured path is unusable so recovery does not silently
+	// fall back to PATH "git".
+	if err := ScrubReservedReviewerScratch(context.Background(), filepath.Join(root, "missing-git"), repo); err == nil {
+		t.Fatal("ScrubReservedReviewerScratch with missing gitPath error = nil, want failure")
+	}
+}
+
+func shellQuote(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", `'"'"'`) + "'"
 }
 
 func mustGit(t *testing.T, cwd string, args ...string) {

--- a/internal/infra/git/reserved_review_scratch_test.go
+++ b/internal/infra/git/reserved_review_scratch_test.go
@@ -1,0 +1,93 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsReservedReviewerScratchBaseName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{".looper-review-1048.json", true},
+		{".looper-review-abc_def-1.json", true},
+		{".looper-review-.json", false},
+		{".looper-review-é.json", false},
+		{"looper-review-1.json", false},
+		{".Looper-review-1.json", false},
+		{".looper-review-1.JSON", false},
+		{"subdir/.looper-review-1.json", false},
+		{" .looper-review-1.json", false},
+	}
+	for _, tc := range cases {
+		if got := IsReservedReviewerScratchBaseName(tc.name); got != tc.want {
+			t.Errorf("IsReservedReviewerScratchBaseName(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestScrubReservedReviewerScratchDeletesUntrackedOnly(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	mustGit(t, root, "init", repo)
+	mustGit(t, repo, "config", "user.email", "test@example.com")
+	mustGit(t, repo, "config", "user.name", "test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Tracked fixture that matches the reserved grammar must not be deleted.
+	tracked := ".looper-review-fixture.json"
+	if err := os.WriteFile(filepath.Join(repo, tracked), []byte(`{"tracked":true}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "add", "README.md", tracked)
+	mustGit(t, repo, "commit", "-m", "init")
+
+	scratch := ".looper-review-3503.json"
+	if err := os.WriteFile(filepath.Join(repo, scratch), []byte(`{"scratch":true}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ordinary := "notes.txt"
+	if err := os.WriteFile(filepath.Join(repo, ordinary), []byte("keep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Symlink with reserved name must not be followed or removed as a file scrub.
+	linkName := ".looper-review-link.json"
+	if err := os.Symlink("README.md", filepath.Join(repo, linkName)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ScrubReservedReviewerScratch(context.Background(), "git", repo); err != nil {
+		t.Fatalf("ScrubReservedReviewerScratch() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(repo, scratch)); !os.IsNotExist(err) {
+		t.Fatalf("untracked scratch still present: err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, tracked)); err != nil {
+		t.Fatalf("tracked reserved-name fixture missing: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(repo, ordinary)); err != nil || string(got) != "keep\n" {
+		t.Fatalf("ordinary untracked = %q err=%v, want preserved", got, err)
+	}
+	if _, err := os.Lstat(filepath.Join(repo, linkName)); err != nil {
+		t.Fatalf("symlink reserved name missing: %v", err)
+	}
+}
+
+func mustGit(t *testing.T, cwd string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = cwd
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2346,6 +2346,16 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 			return checkpoint, err
 		}
 	}
+	// Discard disposable reviewer submit scratch before the ordinary cleanliness
+	// gate. Authority is the reviewer reserved-namespace contract (see
+	// gitinfra.ScrubReservedReviewerScratch); do not broaden beyond untracked
+	// root regular files matching that grammar.
+	if err := gitinfra.ScrubReservedReviewerScratch(ctx, "git", created.WorktreePath); err != nil {
+		if restoreErr := restoreFixerOwnerToken(created.WorktreePath, priorFixerToken); restoreErr != nil {
+			return checkpoint, fmt.Errorf("restore fixer owner token after reserved-scratch scrub failure: %w (scrub error: %v)", restoreErr, err)
+		}
+		return checkpoint, err
+	}
 	prepared, err := r.git.PrepareWorktree(ctx, PrepareWorktreeInput{RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot, WorktreePath: created.WorktreePath, Branch: branch, Ref: prRef, ExpectedHeadSHA: checkpoint.Snapshot.HeadSHA})
 	if err != nil {
 		if restoreErr := restoreFixerOwnerToken(created.WorktreePath, priorFixerToken); restoreErr != nil {
@@ -6683,6 +6693,7 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		reviewRequestInstruction,
 		"Review body style contract: the visible body must be human-authored review prose only. Never post terminal/tool output, ANSI escape sequences, file-read traces, command logs, JSON parsing artifacts, or your internal scratch work as the GitHub review body. If you have actionable findings but do not have concrete actionable prose yet, exit non-zero instead of posting logs. For a clean APPROVE review, write the required author mention, change/verification summary, and warm acknowledgement; never use an LGTM, empty, or disclosure-only clean body as a fallback.",
 		"Shell payload safety contract: never build review JSON inside a double-quoted shell string because Markdown backticks and dollar expressions can execute or expand. Serialize the payload with a JSON-aware tool or pass a literal single-quoted heredoc to the trusted review-submit wrapper.",
+		"Worktree hygiene contract: do not create review payload or scratch files inside the managed worktree (including top-level `/.looper-review-*.json`). Pipe review JSON via a literal single-quoted heredoc on stdin, or write temporary files only under an OS temp directory outside the worktree.",
 		"Content safety recovery contract: if `looper review submit` fails with an outbound content safety gate rejection, rewrite the rejected body/comments/paths in plain prose without secret-shaped env assignments, credential URLs, env dumps, or high-entropy tokens, then resubmit in the same session; do not exit non-zero solely because of that rejection, and never paste the rejected value into logs, prompts, or the next payload.",
 		"Every review body you post must include exactly one stable idempotency marker with id, head, and outcome fields: `<!-- looper:review id=... head=... outcome=clean|non_blocking|blocking -->`.",
 		reviewDisclosureInstruction(disclosureCfg, agentRuntime, agentModel),

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -396,6 +396,9 @@ type GitGateway interface {
 	CreateWorktree(context.Context, CreateWorktreeInput) (CreateWorktreeResult, error)
 	PrepareWorktree(context.Context, PrepareWorktreeInput) (PrepareWorktreeResult, error)
 	CleanupWorktree(context.Context, CleanupWorktreeInput) error
+	// ScrubReservedReviewerScratch removes disposable top-level reviewer submit
+	// scratch using the gateway's configured Git executable (tools.gitPath).
+	ScrubReservedReviewerScratch(ctx context.Context, worktreePath string) error
 }
 
 type AgentRunInput struct {
@@ -2348,9 +2351,9 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (r
 	}
 	// Discard disposable reviewer submit scratch before the ordinary cleanliness
 	// gate. Authority is the reviewer reserved-namespace contract (see
-	// gitinfra.ScrubReservedReviewerScratch); do not broaden beyond untracked
-	// root regular files matching that grammar.
-	if err := gitinfra.ScrubReservedReviewerScratch(ctx, "git", created.WorktreePath); err != nil {
+	// GitGateway.ScrubReservedReviewerScratch); use the configured Git executable
+	// via the gateway — never hard-code "git" when tools.gitPath is set.
+	if err := r.git.ScrubReservedReviewerScratch(ctx, created.WorktreePath); err != nil {
 		if restoreErr := restoreFixerOwnerToken(created.WorktreePath, priorFixerToken); restoreErr != nil {
 			return checkpoint, fmt.Errorf("restore fixer owner token after reserved-scratch scrub failure: %w (scrub error: %v)", restoreErr, err)
 		}

--- a/internal/reviewer/runner_owner_token_restore_failure_test.go
+++ b/internal/reviewer/runner_owner_token_restore_failure_test.go
@@ -101,3 +101,7 @@ func (f *restoreFailAfterClearGit) PrepareWorktree(_ context.Context, input Prep
 func (f *restoreFailAfterClearGit) CleanupWorktree(_ context.Context, _ CleanupWorktreeInput) error {
 	return nil
 }
+
+func (f *restoreFailAfterClearGit) ScrubReservedReviewerScratch(_ context.Context, _ string) error {
+	return nil
+}

--- a/internal/reviewer/runner_prepare_real_gateway_helpers_test.go
+++ b/internal/reviewer/runner_prepare_real_gateway_helpers_test.go
@@ -111,3 +111,7 @@ func (g *countingRealGitGateway) CleanupWorktree(ctx context.Context, input Clea
 		WorktreePath: input.WorktreePath, Branch: input.Branch, ProtectedBranches: input.ProtectedBranches,
 	})
 }
+
+func (g *countingRealGitGateway) ScrubReservedReviewerScratch(ctx context.Context, worktreePath string) error {
+	return g.inner.ScrubReservedReviewerScratch(ctx, worktreePath)
+}

--- a/internal/reviewer/runner_prepare_real_gateway_test.go
+++ b/internal/reviewer/runner_prepare_real_gateway_test.go
@@ -107,3 +107,109 @@ func TestRunPrepareWorktreeStepRealGatewayRemoteHeadChangedPreservesFixerDirt(t 
 		t.Fatalf("dirty marker = %q err=%v, want preserved", dirtyBytes, err)
 	}
 }
+
+// Real-gateway contract: leftover untracked reserved reviewer scratch must not
+// force manual_intervention. Ordinary untracked dirt still does.
+func TestRunPrepareWorktreeStepRealGatewayScrubsReservedReviewerScratch(t *testing.T) {
+	t.Parallel()
+
+	const prNumber int64 = 77
+	const projectID = "project_real_reviewer_scratch"
+	branch := "feature/review-77"
+	root, _, repoPath, headSHA := setupRealRepoWithPRHead(t, branch, prNumber)
+	worktreeRoot := filepath.Join(root, "worktrees")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktreeRoot: %v", err)
+	}
+
+	gateway := gitinfra.New(gitinfra.Options{GitPath: "git"})
+	created, err := gateway.CreateWorktree(context.Background(), gitinfra.CreateWorktreeInput{
+		ProjectID: projectID, RepoPath: repoPath, WorktreeRoot: worktreeRoot,
+		Branch: "pr-77-head", BaseBranch: "main", PRNumber: prNumber,
+		CheckoutMode: gitinfra.CheckoutModeDetached,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+	wtPath := created.WorktreePath
+
+	scratch := filepath.Join(wtPath, ".looper-review-3503.json")
+	if err := os.WriteFile(scratch, []byte(`{"leftover":true}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile scratch: %v", err)
+	}
+
+	adapter := &countingRealGitGateway{inner: gateway}
+	runner := New(Options{Git: adapter})
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	checkpoint, prepErr := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: projectID, RepoPath: repoPath, BaseBranch: stringPtr("main"), MetadataJSON: &metadata},
+		Repo:     "acme/looper",
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadSHA: headSHA, BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: headSHA},
+			Worktree: &checkpointWorktree{Path: wtPath, Branch: "pr-77-head", BaseBranch: "main"},
+		},
+	})
+	if prepErr != nil {
+		t.Fatalf("runPrepareWorktreeStep() error = %v, want clean prepare after scrub", prepErr)
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.PreparedAt == "" {
+		t.Fatalf("Worktree = %#v, want prepared path", checkpoint.Worktree)
+	}
+	if _, err := os.Stat(scratch); !os.IsNotExist(err) {
+		t.Fatalf("reserved scratch still present after prepare: err=%v", err)
+	}
+}
+
+func TestRunPrepareWorktreeStepRealGatewayKeepsOrdinaryUntrackedDirt(t *testing.T) {
+	t.Parallel()
+
+	const prNumber int64 = 78
+	const projectID = "project_real_reviewer_ordinary_dirt"
+	branch := "feature/review-78"
+	root, _, repoPath, headSHA := setupRealRepoWithPRHead(t, branch, prNumber)
+	worktreeRoot := filepath.Join(root, "worktrees")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktreeRoot: %v", err)
+	}
+
+	gateway := gitinfra.New(gitinfra.Options{GitPath: "git"})
+	created, err := gateway.CreateWorktree(context.Background(), gitinfra.CreateWorktreeInput{
+		ProjectID: projectID, RepoPath: repoPath, WorktreeRoot: worktreeRoot,
+		Branch: "pr-78-head", BaseBranch: "main", PRNumber: prNumber,
+		CheckoutMode: gitinfra.CheckoutModeDetached,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+	wtPath := created.WorktreePath
+
+	ordinary := filepath.Join(wtPath, "agent-notes.txt")
+	if err := os.WriteFile(ordinary, []byte("real dirt\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile ordinary: %v", err)
+	}
+
+	adapter := &countingRealGitGateway{inner: gateway}
+	runner := New(Options{Git: adapter})
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	_, prepErr := runner.runPrepareWorktreeStep(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: projectID, RepoPath: repoPath, BaseBranch: stringPtr("main"), MetadataJSON: &metadata},
+		Repo:     "acme/looper",
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadSHA: headSHA, BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: headSHA},
+			Worktree: &checkpointWorktree{Path: wtPath, Branch: "pr-78-head", BaseBranch: "main"},
+		},
+	})
+	if prepErr == nil {
+		t.Fatal("runPrepareWorktreeStep() error = nil, want manual_intervention for ordinary dirt")
+	}
+	if !contains(prepErr.Error(), "worktree is dirty") && !contains(prepErr.Error(), "manual intervention") {
+		t.Fatalf("error = %v, want dirty/manual intervention", prepErr)
+	}
+	if got, err := os.ReadFile(ordinary); err != nil || string(got) != "real dirt\n" {
+		t.Fatalf("ordinary dirt = %q err=%v, want preserved", got, err)
+	}
+}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -7897,6 +7897,8 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"Review body style contract",
 		"Never post terminal/tool output",
 		"never build review JSON inside a double-quoted shell string",
+		"Worktree hygiene contract",
+		"do not create review payload or scratch files inside the managed worktree",
 		"outbound content safety gate rejection",
 		"resubmit in the same session",
 		"ANSI escape sequences",

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -10338,6 +10338,10 @@ func (f *fakeGitGateway) CleanupWorktree(_ context.Context, input CleanupWorktre
 	return nil
 }
 
+func (f *fakeGitGateway) ScrubReservedReviewerScratch(_ context.Context, _ string) error {
+	return nil
+}
+
 type fakeAgentExecutor struct {
 	results       []AgentResult
 	starts        []AgentRunInput

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1805,6 +1805,10 @@ func (a reviewerGitAdapter) CleanupWorktree(ctx context.Context, input reviewer.
 	return a.gateway.CleanupWorktree(ctx, gitinfra.CleanupWorktreeInput{ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot, WorktreePath: input.WorktreePath, Branch: input.Branch, ProtectedBranches: input.ProtectedBranches})
 }
 
+func (a reviewerGitAdapter) ScrubReservedReviewerScratch(ctx context.Context, worktreePath string) error {
+	return a.gateway.ScrubReservedReviewerScratch(ctx, worktreePath)
+}
+
 // reviewerTrustedReviewEnv injects the trusted review-submit socket only for
 // reviewer agent runs. Planner/worker/fixer share the executor but must not
 // receive review publication capability via LOOPER_TRUSTED_REVIEW_SOCK.


### PR DESCRIPTION
## Summary

Reviewer agents leave top-level `/.looper-review-*.json` submit scratch in managed worktrees. `PrepareWorktree` treats that as real dirt and forces `manual_intervention` even when no source changed.

This is a thin replacement for #608 (closed as superseded). #608 grew into dual classifiers, Commit unstage, generation-keyed quarantine, and ~2.6k LOC defending theoretical git edges. The correct fix is reviewer hygiene only.

### Observed failure
One normal top-level untracked reviewer payload blocks retry.

### Authority
The Looper reviewer contract reserves top-level, untracked `.looper-review-<safe-id>.json` regular files in managed reviewer worktrees as disposable submission scratch; that explicit ownership contract—not repeated inference from Git porcelain—is the authority to remove them.

### What this PR does
- **Prompt hygiene:** tell the agent to pipe JSON via heredoc / OS temp outside the worktree
- **Reviewer-scoped scrub** immediately before ordinary `PrepareWorktree`: enumerate worktree root directly; delete only regular files matching `^\.looper-review-[A-Za-z0-9_-]+\.json$` that are absent from the index
- Fail closed on delete/probe errors
- Leave tracked, staged, nested, symlink, and non-matching names as ordinary dirt

### Cost
Files in the reserved namespace are deliberately disposable. Abandoned submit JSON is not trusted recovery state.

### Why not simpler / heavier alternatives
- **Prompt-only:** agents still leave historical residue
- **info/exclude only:** hides rather than cleans; imports ignore precedence
- **Ignore-as-clean in status:** residue accumulates and can be staged later
- **Quarantine / generation / Commit unstage / status classifiers (#608):** solve problems created by preservation, not the original MI bug

### Explicit non-goals
- Recovering abandoned payload contents
- Quarantine, generations, retention, markers, orphan cleanup
- Status filtering or making generic git status lie
- `Gateway.Commit` unstage / interception
- Global status capture budget changes
- Defending `.gitignore` negation, ITA, rename detection, casefold, non-ASCII lookalikes
- Preventing malicious agents from committing/pushing
- Changing worker / fixer / planner prepare behavior

### Review rule
No edge-case fix without a production reproducer that falls inside the declared filename and lifecycle contract. Quarantine / gen IDs / Commit interception / generic status changes are **redesign requests**, not incremental review fixes.

Supersedes #608.

## Test plan
- [x] `go test ./internal/infra/git/ -count=1 -run 'TestIsReservedReviewerScratchBaseName|TestScrubReservedReviewerScratch'`
- [x] `go test ./internal/reviewer/ -count=1 -run 'TestRunPrepareWorktreeStepRealGatewayScrubsReservedReviewerScratch|TestRunPrepareWorktreeStepRealGatewayKeepsOrdinaryUntrackedDirt|TestBuildReviewPromptIncludesActionableQualityContract'`
- [x] `go vet ./internal/infra/git/ ./internal/reviewer/`
- [ ] After merge: `looper retry` on a reviewer stuck only on leftover `.looper-review-*.json` should pass worktree prepare without `--discard-worktree-changes`