### PR TITLE
fix(hitl): keep awaiting loops parked on recovery

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -3719,10 +3719,11 @@ func shouldRequeueLoop(loop storage.LoopRecord, latestRun *storage.RunRecord, la
 	if terminalReviewerRecoveryMetadataStatus(loop) != "" {
 		return false
 	}
-	// paused + human_takeover are deliberately parked: a human paused it, or is
-	// driving its agent session via takeover. Recovery must NOT re-queue them (the
-	// killed run looks "interrupted", but that's expected) — only a handback does.
-	if loop.Status == "paused" || loop.Status == string(domain.LoopStatusHumanTakeover) {
+	// paused + awaiting_human + human_takeover are deliberately parked: a human
+	// paused it, the agent is waiting for an answer, or a human is driving its
+	// session via takeover. Recovery must NOT re-queue them (the killed run looks
+	// "interrupted", but that's expected) — only an explicit resume does.
+	if loop.Status == "paused" || loop.Status == string(domain.LoopStatusAwaitingHuman) || loop.Status == string(domain.LoopStatusHumanTakeover) {
 		return false
 	}
 	if loop.Status == "completed" || loop.Status == "failed" || loop.Status == "terminated" || loop.Status == "stopped" {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3976,6 +3976,16 @@ func TestShouldRequeueLoopKeepsPausedLoopsExcluded(t *testing.T) {
 	}
 }
 
+func TestShouldRequeueLoopKeepsAwaitingHumanExcluded(t *testing.T) {
+	t.Parallel()
+
+	loop := storage.LoopRecord{Status: "awaiting_human"}
+	run := &storage.RunRecord{Status: "interrupted"}
+	if shouldRequeueLoop(loop, run, false) {
+		t.Fatal("shouldRequeueLoop() = true, want false for awaiting_human loop")
+	}
+}
+
 func TestShouldAutoRecoverFailedReviewerLoopIgnoresLegacyBudgetTermination(t *testing.T) {
 	t.Parallel()
 	errorKind := "retryable_after_resume"


### PR DESCRIPTION
# Summary

- Keep `awaiting_human` loops parked during daemon startup recovery.
- Treat the interrupted run beneath a human-waiting loop as expected suspension evidence, not authorization to requeue.
- Add one focused regression test for the recovery decision.

# Testing

- [x] `go test ./...`
- [x] Additional targeted checks:
  - `go test ./internal/runtime -run '^TestShouldRequeueLoopKeeps(AwaitingHuman|PausedLoops)Excluded$'`
  - `go vet ./...`
  - `go build ./...`
  - `gofmt -l .`

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [x] Daemon boot / config / runtime path risk
- [ ] Worktree / repo isolation / lifecycle risk
- [ ] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

The affected surface is the existing startup recovery decision only. There are no provider, worktree, notification, dashboard, or answer-delivery changes.

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [ ] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- PR / issue links for regression coverage:
  - Thin HITL sequence PR2 following #612.
  - `TestShouldRequeueLoopKeepsAwaitingHumanExcluded` fails before this change because an interrupted run makes startup recovery requeue the parked loop.

# Design tradeoffs

- Concrete failure prevented: daemon restart must not resume an agent before the operator answers an existing HITL question.
- Cost: a stale `awaiting_human` loop remains parked until the existing answer, handback, pause, stop, or terminate control plane changes its status. Recovery no longer guesses that an interrupted child run means the human wait ended.
- Simpler alternative considered: failing loud or requeueing the loop cannot preserve the pending human decision. No new state or recovery layer is added; this reuses the existing `awaiting_human` status alongside the existing `paused` and `human_takeover` exclusions.
- Deletion-first result: there is no redundant layer to remove—the generic recovery predicate needs one missing existing-status exclusion.
- Authority: The Fixer’s validated structured `needs_human` result authorizes only pausing; an operator answer accepted through the existing `/respond` control plane authorizes resume and the chosen direction, subject to normal Looper safety gates; head or content fingerprints are drift signals only and never authority.
- Recovery authority sentence: the persisted `loop.status = awaiting_human`, written by the existing HITL park path, is the authority to remain parked; an interrupted run is recovery evidence only and is not resume authority.

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied

# Operational hold

- This PR carries `looper:hold`; no automatic Looper Reviewer/Fixer changes are authorized.

# Non-goals

- No Fixer `needs_human` parsing, park/resume/consume implementation, or dashboard form.
- No `.looper/ask.json`, fingerprints, generation/CAS, delivery state, provider transport, notification, poll, worker, or Forgejo changes.
- No broader startup recovery redesign.
