### PR TITLE
feat: add thin Fixer HITL pause and resume

### DIFF
--- a/internal/api/handler_hitl_test.go
+++ b/internal/api/handler_hitl_test.go
@@ -20,18 +20,20 @@ func TestHandlerRespondResumesAwaitingHumanLoop(t *testing.T) {
 	nowISO := "2026-04-11T12:00:00.000Z"
 	projectID := "project_hitl"
 	loopID := "loop_hitl"
-	targetID := projectID
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
 	metadata := `{"hitl":{"question":"Which direction?","options":["continue","redirect"],"sessionId":"sess-abc","executionId":"agent-1","vendor":"codex","status":"awaiting","askedAt":"2026-04-11T11:59:00.000Z"}}`
 
 	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Projects.Upsert() error = %v", err)
 	}
-	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 71, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &targetID, Status: "awaiting_human", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 71, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "awaiting_human", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 	// A cancelled queue item (as a suspend leaves behind) so the resume requeues it.
 	cancelReason := "loop suspended awaiting human"
-	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_hitl", ProjectID: &projectID, LoopID: &loopID, Type: "worker", TargetType: "project", TargetID: targetID, DedupeKey: "worker:hitl", Priority: storage.QueuePriorityWorker, Status: "cancelled", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, LastError: &cancelReason, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_hitl", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:hitl", Priority: storage.QueuePriorityFixer, Status: "cancelled", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, LastError: &cancelReason, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
 

--- a/internal/fixer/hitl.go
+++ b/internal/fixer/hitl.go
@@ -127,6 +127,14 @@ func shouldResumeAnsweredHITLRepair(metadataJSON *string, runStatus string, fail
 	return ok && ask.Status == "answered" && strings.TrimSpace(ask.Answer) != ""
 }
 
+func hasDeliveredHITLAnswer(metadataJSON *string) bool {
+	ask, ok := loops.ReadHITLAsk(metadataJSON)
+	if !ok || strings.TrimSpace(ask.Answer) == "" {
+		return false
+	}
+	return ask.Status == "answered" || ask.Status == "consumed"
+}
+
 func (r *Runner) readFreshHITLAsk(ctx context.Context, loop *storage.LoopRecord) (loops.HITLAsk, bool) {
 	metadata := loop.MetadataJSON
 	if r.repos != nil && r.repos.Loops != nil {

--- a/internal/fixer/hitl.go
+++ b/internal/fixer/hitl.go
@@ -1,0 +1,158 @@
+package fixer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+const fixerHITLPromptInstruction = `HUMAN-IN-THE-LOOP: Decide implementation details yourself. Use "needs_human" only when a listed review request creates a genuine conflict with repository rules or the pull request's documented intent, depends on private product intent, or requires a high-stakes sign-off. Do not use it for reversible implementation choices.
+
+When human direction is truly required, set that fix item's review_thread_replies action to "needs_human", put the concrete conflict and decision needed in "explanation", and STOP. Do not push, dismiss reviews, post replies, resolve threads, or otherwise mutate remote state. Looper will pause and resume you after an operator answers through its existing control plane.`
+
+type awaitingHumanError struct {
+	question    string
+	options     []string
+	executionID string
+	vendor      string
+}
+
+func (e *awaitingHumanError) Error() string { return "fixer paused awaiting human decision" }
+
+func asAwaitingHumanError(err error) (*awaitingHumanError, bool) {
+	var typed *awaitingHumanError
+	if errors.As(err, &typed) {
+		return typed, true
+	}
+	return nil, false
+}
+
+func humanDecisionFromReplies(replies []replyExplanationEntry, executionID, vendor string) *awaitingHumanError {
+	questions := make([]string, 0)
+	for _, reply := range replies {
+		if normalizeReplyAction(reply.Action) == string(replyActionNeedsHuman) {
+			questions = append(questions, strings.TrimSpace(reply.Explanation))
+		}
+	}
+	if len(questions) == 0 {
+		return nil
+	}
+	return &awaitingHumanError{
+		question: strings.Join(questions, "\n"),
+		options: []string{
+			"Keep the repository rules and documented PR intent",
+			"Follow the reviewer request",
+			"Provide different guidance",
+		},
+		executionID: executionID,
+		vendor:      strings.TrimSpace(vendor),
+	}
+}
+
+func completionMentionsNeedsHuman(stdout, stderr string) bool {
+	payload := extractCompletionMarkerPayload(stdout + "\n" + stderr)
+	return strings.Contains(payload, `"`+string(replyActionNeedsHuman)+`"`)
+}
+
+func (r *Runner) pendingHumanAnswer(ctx context.Context, loop *storage.LoopRecord, agentVendor string) (string, string) {
+	ask, ok := r.readFreshHITLAsk(ctx, loop)
+	if !ok || ask.Status != "answered" || strings.TrimSpace(ask.Answer) == "" {
+		return "", ""
+	}
+	prompt := fmt.Sprintf("An operator answered the question you asked earlier (%q). Their decision: %s\nContinue the repair using this decision; do not ask the same question again.", ask.Question, ask.Answer)
+	if strings.TrimSpace(ask.Vendor) != strings.TrimSpace(agentVendor) {
+		return prompt + "\nThe configured agent vendor changed, so continue in a fresh session.", ""
+	}
+	return prompt, strings.TrimSpace(ask.SessionID)
+}
+
+func (r *Runner) readFreshHITLAsk(ctx context.Context, loop *storage.LoopRecord) (loops.HITLAsk, bool) {
+	metadata := loop.MetadataJSON
+	if r.repos != nil && r.repos.Loops != nil {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			metadata = fresh.MetadataJSON
+		}
+	}
+	return loops.ReadHITLAsk(metadata)
+}
+
+func (r *Runner) markHumanAnswerConsumed(ctx context.Context, loop *storage.LoopRecord) error {
+	if r.repos == nil || r.repos.Loops == nil {
+		return nil
+	}
+	fresh, err := r.repos.Loops.GetByID(ctx, loop.ID)
+	if err != nil || fresh == nil {
+		return err
+	}
+	ask, ok := loops.ReadHITLAsk(fresh.MetadataJSON)
+	if !ok || ask.Status != "answered" {
+		return nil
+	}
+	ask.Status = "consumed"
+	metadata, err := loops.WriteHITLAsk(fresh.MetadataJSON, ask)
+	if err != nil {
+		return err
+	}
+	fresh.MetadataJSON = &metadata
+	fresh.UpdatedAt = r.nowISO()
+	if err := r.repos.Loops.Upsert(ctx, *fresh); err != nil {
+		return err
+	}
+	loop.MetadataJSON = &metadata
+	return nil
+}
+
+func (r *Runner) latestAgentSession(ctx context.Context, loopID string) (string, string) {
+	if r.repos == nil || r.repos.AgentExecutions == nil {
+		return "", ""
+	}
+	execution, err := r.repos.AgentExecutions.GetLatestByLoopID(ctx, loopID)
+	if err != nil || execution == nil {
+		return "", ""
+	}
+	sessionID := ""
+	if execution.NativeSessionID != nil {
+		sessionID = strings.TrimSpace(*execution.NativeSessionID)
+	}
+	return sessionID, strings.TrimSpace(execution.Vendor)
+}
+
+func (r *Runner) suspendForHuman(ctx context.Context, input stepInput, run storage.RunRecord, checkpoint fixerCheckpoint, awaiting *awaitingHumanError) (ProcessResult, error) {
+	nowISO := r.nowISO()
+	sessionID, vendor := r.latestAgentSession(ctx, input.Loop.ID)
+	if vendor == "" {
+		vendor = awaiting.vendor
+	}
+	ask := loops.HITLAsk{
+		Question:    awaiting.question,
+		Options:     awaiting.options,
+		SessionID:   sessionID,
+		ExecutionID: awaiting.executionID,
+		Vendor:      vendor,
+		Status:      "awaiting",
+		AskedAt:     nowISO,
+	}
+	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) {
+		if metadata, writeErr := loops.WriteHITLAsk(updated.MetadataJSON, ask); writeErr == nil {
+			updated.MetadataJSON = &metadata
+		}
+		updated.Status = "awaiting_human"
+		updated.LastRunAt = stringPtr(nowISO)
+		updated.NextRunAt = nil
+	}); err != nil {
+		return ProcessResult{}, err
+	}
+	reason := "fixer suspended awaiting human decision"
+	if _, err := r.repos.Queue.CancelByLoop(ctx, input.Loop.ID, nowISO, &reason); err != nil {
+		return ProcessResult{}, err
+	}
+	summary := "Awaiting human decision: " + awaiting.question
+	if _, err := r.completeRun(ctx, run, "interrupted", summary, "", checkpoint); err != nil {
+		return ProcessResult{}, err
+	}
+	return ProcessResult{LoopID: input.Loop.ID, RunID: run.ID, QueueItemID: input.QueueItem.ID, Status: "awaiting_human", Summary: summary}, nil
+}

--- a/internal/fixer/hitl.go
+++ b/internal/fixer/hitl.go
@@ -2,6 +2,7 @@ package fixer
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -53,9 +54,57 @@ func humanDecisionFromReplies(replies []replyExplanationEntry, executionID, vend
 	}
 }
 
-func completionMentionsNeedsHuman(stdout, stderr string) bool {
+func validateNeedsHumanReplies(stdout, stderr string, fixItems []FixItem, accepted []replyExplanationEntry) error {
 	payload := extractCompletionMarkerPayload(stdout + "\n" + stderr)
-	return strings.Contains(payload, `"`+string(replyActionNeedsHuman)+`"`)
+	if strings.TrimSpace(payload) == "" {
+		return nil
+	}
+	var result struct {
+		Replies []struct {
+			FixItemID   string `json:"fixItemId"`
+			ThreadID    string `json:"threadId"`
+			Action      string `json:"action"`
+			Explanation string `json:"explanation"`
+		} `json:"review_thread_replies"`
+	}
+	if err := json.Unmarshal([]byte(payload), &result); err != nil {
+		if strings.Contains(strings.ToLower(payload), `"`+string(replyActionNeedsHuman)+`"`) {
+			return fmt.Errorf("invalid needs_human completion payload: %w", err)
+		}
+		return nil
+	}
+	items := make(map[string]FixItem, len(fixItems))
+	for _, item := range fixItems {
+		if item.Type == "comment" && item.Source != NativeReviewCommentSource && item.ID != "" {
+			items[item.ID] = item
+		}
+	}
+	acceptedCount := 0
+	for _, reply := range accepted {
+		if normalizeReplyAction(reply.Action) == string(replyActionNeedsHuman) {
+			acceptedCount++
+		}
+	}
+	rawCount := 0
+	seen := map[string]struct{}{}
+	for _, reply := range result.Replies {
+		if normalizeReplyAction(reply.Action) != string(replyActionNeedsHuman) {
+			continue
+		}
+		rawCount++
+		item, ok := items[strings.TrimSpace(reply.FixItemID)]
+		_, duplicate := seen[item.ID]
+		if !ok || duplicate || strings.TrimSpace(reply.ThreadID) == "" ||
+			strings.TrimSpace(reply.ThreadID) != item.ThreadID ||
+			sanitizeReplyExplanation(reply.Explanation) == "" {
+			return fmt.Errorf("invalid needs_human decision for fix item %q", reply.FixItemID)
+		}
+		seen[item.ID] = struct{}{}
+	}
+	if rawCount != acceptedCount {
+		return fmt.Errorf("invalid needs_human decision set")
+	}
+	return nil
 }
 
 func (r *Runner) pendingHumanAnswer(ctx context.Context, loop *storage.LoopRecord, agentVendor string) (string, string) {
@@ -68,6 +117,14 @@ func (r *Runner) pendingHumanAnswer(ctx context.Context, loop *storage.LoopRecor
 		return prompt + "\nThe configured agent vendor changed, so continue in a fresh session.", ""
 	}
 	return prompt, strings.TrimSpace(ask.SessionID)
+}
+
+func shouldResumeAnsweredHITLRepair(metadataJSON *string, runStatus string, failedStep FixerStep) bool {
+	if runStatus != "interrupted" || failedStep != stepRepair {
+		return false
+	}
+	ask, ok := loops.ReadHITLAsk(metadataJSON)
+	return ok && ask.Status == "answered" && strings.TrimSpace(ask.Answer) != ""
 }
 
 func (r *Runner) readFreshHITLAsk(ctx context.Context, loop *storage.LoopRecord) (loops.HITLAsk, bool) {

--- a/internal/fixer/hitl.go
+++ b/internal/fixer/hitl.go
@@ -11,9 +11,19 @@ import (
 	"github.com/nexu-io/looper/internal/storage"
 )
 
-const fixerHITLPromptInstruction = `HUMAN-IN-THE-LOOP: Decide implementation details yourself. Use "needs_human" only when a listed review request creates a genuine conflict with repository rules or the pull request's documented intent, depends on private product intent, or requires a high-stakes sign-off. Do not use it for reversible implementation choices.
+const fixerHITLInstruction = `HUMAN-IN-THE-LOOP: This mechanism applies only to non-native comment fix items represented in review_thread_replies. Decide implementation details yourself. Use "needs_human" only when one of those review requests creates a genuine conflict with repository rules or the pull request's documented intent, depends on private product intent, or requires a high-stakes sign-off. Do not use it for reversible implementation choices. Never use "needs_human" in Forgejo repair_results; follow that contract's fixed, declined, or deferred actions.
 
 When human direction is truly required, set that fix item's review_thread_replies action to "needs_human", put the concrete conflict and decision needed in "explanation", and STOP. Do not push, dismiss reviews, post replies, resolve threads, or otherwise mutate remote state. Looper will pause and resume you after an operator answers through its existing control plane.`
+
+func fixerHITLPromptFor(fixItems []FixItem) string {
+	for _, item := range fixItems {
+		if item.Type == "comment" && item.Source != NativeReviewCommentSource &&
+			strings.TrimSpace(item.ID) != "" && strings.TrimSpace(item.ThreadID) != "" {
+			return fixerHITLInstruction
+		}
+	}
+	return ""
+}
 
 type awaitingHumanError struct {
 	question    string
@@ -47,7 +57,6 @@ func humanDecisionFromReplies(replies []replyExplanationEntry, executionID, vend
 		options: []string{
 			"Keep the repository rules and documented PR intent",
 			"Follow the reviewer request",
-			"Provide different guidance",
 		},
 		executionID: executionID,
 		vendor:      strings.TrimSpace(vendor),

--- a/internal/fixer/hitl.go
+++ b/internal/fixer/hitl.go
@@ -2,9 +2,12 @@ package fixer
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/nexu-io/looper/internal/loops"
@@ -210,22 +213,54 @@ func (r *Runner) suspendForHuman(ctx context.Context, input stepInput, run stora
 		Status:      "awaiting",
 		AskedAt:     nowISO,
 	}
-	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) {
-		if metadata, writeErr := loops.WriteHITLAsk(updated.MetadataJSON, ask); writeErr == nil {
-			updated.MetadataJSON = &metadata
+	if checkpoint.Worktree != nil {
+		dismissPath := filepath.Join(checkpoint.Worktree.Path, ".looper", "dismiss.json")
+		if err := os.Remove(dismissPath); err != nil && !os.IsNotExist(err) {
+			return ProcessResult{}, fmt.Errorf("clear pre-answer fixer dismissal intent: %w", err)
 		}
-		updated.Status = "awaiting_human"
-		updated.LastRunAt = stringPtr(nowISO)
-		updated.NextRunAt = nil
-	}); err != nil {
-		return ProcessResult{}, err
 	}
 	reason := "fixer suspended awaiting human decision"
-	if _, err := r.repos.Queue.CancelByLoop(ctx, input.Loop.ID, nowISO, &reason); err != nil {
-		return ProcessResult{}, err
-	}
 	summary := "Awaiting human decision: " + awaiting.question
-	if _, err := r.completeRun(ctx, run, "interrupted", summary, "", checkpoint); err != nil {
+	if r.db == nil {
+		return ProcessResult{}, fmt.Errorf("fixer HITL atomic parking requires a database")
+	}
+	if err := storage.WithTransaction(ctx, r.db, nil, func(tx *sql.Tx) error {
+		repos := storage.NewRepositories(tx)
+		loop, err := repos.Loops.GetByID(ctx, input.Loop.ID)
+		if err != nil {
+			return err
+		}
+		if loop == nil {
+			return fmt.Errorf("loop not found while parking fixer HITL: %s", input.Loop.ID)
+		}
+		if loop.Status == "terminated" {
+			return fmt.Errorf("cannot park terminated fixer loop: %s", input.Loop.ID)
+		}
+		metadata, err := loops.WriteHITLAsk(loop.MetadataJSON, ask)
+		if err != nil {
+			return err
+		}
+		loop.MetadataJSON = &metadata
+		loop.Status = "awaiting_human"
+		loop.LastRunAt = stringPtr(nowISO)
+		loop.NextRunAt = nil
+		loop.UpdatedAt = nowISO
+		if err := repos.Loops.Upsert(ctx, *loop); err != nil {
+			return err
+		}
+		if _, err := repos.Queue.CancelByLoop(ctx, input.Loop.ID, nowISO, &reason); err != nil {
+			return err
+		}
+		updatedRun := run
+		updatedRun.Status = "interrupted"
+		updatedRun.Summary = stringPtr(summary)
+		checkpointJSON := mustMarshalJSON(checkpoint)
+		updatedRun.CheckpointJSON = &checkpointJSON
+		updatedRun.EndedAt = stringPtr(nowISO)
+		updatedRun.LastHeartbeatAt = stringPtr(nowISO)
+		updatedRun.UpdatedAt = nowISO
+		return repos.Runs.Upsert(ctx, updatedRun)
+	}); err != nil {
 		return ProcessResult{}, err
 	}
 	return ProcessResult{LoopID: input.Loop.ID, RunID: run.ID, QueueItemID: input.QueueItem.ID, Status: "awaiting_human", Summary: summary}, nil

--- a/internal/fixer/hitl.go
+++ b/internal/fixer/hitl.go
@@ -131,12 +131,19 @@ func (r *Runner) pendingHumanAnswer(ctx context.Context, loop *storage.LoopRecor
 	return prompt, strings.TrimSpace(ask.SessionID)
 }
 
-func shouldResumeAnsweredHITLRepair(metadataJSON *string, runStatus string, failedStep FixerStep) bool {
+func shouldResumeHITLRepair(metadataJSON *string, runStatus string, failedStep FixerStep, checkpoint fixerCheckpoint) bool {
 	if runStatus != "interrupted" || failedStep != stepRepair {
 		return false
 	}
 	ask, ok := loops.ReadHITLAsk(metadataJSON)
-	return ok && ask.Status == "answered" && strings.TrimSpace(ask.Answer) != ""
+	if !ok || strings.TrimSpace(ask.Answer) == "" {
+		return false
+	}
+	if ask.Status == "answered" {
+		return true
+	}
+	return ask.Status == "consumed" && checkpoint.Repair != nil &&
+		validateCompletedRepairCheckpoint(checkpoint.Repair) == nil
 }
 
 func hasDeliveredHITLAnswer(metadataJSON *string) bool {

--- a/internal/fixer/hitl_test.go
+++ b/internal/fixer/hitl_test.go
@@ -40,7 +40,8 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	run1 := storage.RunRecord{
 		ID: "run_fixer_hitl_1", LoopID: loopID, Status: "running",
 		CurrentStep: stringPtr(string(stepRepair)), StartedAt: fixture.nowISO(),
-		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+		LastCompletedStep: stringPtr(string(stepPrepareWorktree)),
+		CreatedAt:         fixture.nowISO(), UpdatedAt: fixture.nowISO(),
 	}
 	if err := fixture.repos.Runs.Upsert(ctx, run1); err != nil {
 		t.Fatalf("Runs.Upsert() error = %v", err)
@@ -72,9 +73,10 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 		{Status: "completed", Summary: "blocked on intent", ParseStatus: "parsed", Stdout: needsHuman},
 		{Status: "completed", Summary: "applied decision", ParseStatus: "parsed", Stdout: fixed},
 	}}
+	git := &fakeGitGateway{}
 	runner := New(Options{
 		DB: fixture.coordinator.DB(), Repos: fixture.repos,
-		GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{},
+		GitHub: &fakeGitHubGateway{}, Git: git,
 		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
 		AgentRuntime: "codex", AllowAutoPush: true, HITLEnabled: true,
 	})
@@ -120,17 +122,17 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	if err := fixture.repos.Loops.Upsert(ctx, *persistedLoop); err != nil {
 		t.Fatalf("Loops.Upsert(answer) error = %v", err)
 	}
-	run2 := storage.RunRecord{
-		ID: "run_fixer_hitl_2", LoopID: loopID, Status: "running",
-		CurrentStep: stringPtr(string(stepRepair)), StartedAt: fixture.nowISO(),
-		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	resume, err := runner.createRunContext(ctx, *persistedLoop)
+	if err != nil {
+		t.Fatalf("createRunContext(resume) error = %v", err)
 	}
-	if err := fixture.repos.Runs.Upsert(ctx, run2); err != nil {
-		t.Fatalf("Runs.Upsert(resume) error = %v", err)
+	if !resume.Resumed || resume.StartStep != stepRepair ||
+		resume.Checkpoint.Worktree == nil || resume.Checkpoint.Worktree.PreparedAt == "" {
+		t.Fatalf("resume context = %#v, want direct repair with prepared worktree preserved", resume)
 	}
 	step.Loop = *persistedLoop
-	step.Run = run2
-	step.Checkpoint = parkedCheckpoint
+	step.Run = resume.Run
+	step.Checkpoint = resume.Checkpoint
 	resumed, err := runner.runRepairStep(ctx, step)
 	if err != nil || resumed.Repair == nil {
 		t.Fatalf("resumed runRepairStep() = (%#v, %v)", resumed.Repair, err)
@@ -142,5 +144,24 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	consumed, _ := loops.ReadHITLAsk(finishedLoop.MetadataJSON)
 	if consumed.Status != "consumed" {
 		t.Fatalf("answer status = %q, want consumed", consumed.Status)
+	}
+	if len(git.prepareCalls) != 0 {
+		t.Fatalf("PrepareWorktree calls = %d, want no reset-capable prepare on HITL resume", len(git.prepareCalls))
+	}
+}
+
+func TestValidateNeedsHumanRepliesRejectsMixedValidAndUnboundEntries(t *testing.T) {
+	t.Parallel()
+	stdout := `__LOOPER_RESULT__={"review_thread_replies":[` +
+		`{"fixItemId":"c1","threadId":"t1","action":"needs_human","explanation":"Choose the intended behavior."},` +
+		`{"fixItemId":"stale","threadId":"old","action":"needs_human","explanation":"Stale question."}` +
+		`]}`
+	items := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}
+	accepted := normalizeReplyExplanationActions(parseReplyExplanations(stdout, "", items))
+	if len(accepted) != 1 {
+		t.Fatalf("accepted replies = %#v, want only the bound entry", accepted)
+	}
+	if err := validateNeedsHumanReplies(stdout, "", items, accepted); err == nil {
+		t.Fatal("validateNeedsHumanReplies() error = nil, want mixed decision set rejected")
 	}
 }

--- a/internal/fixer/hitl_test.go
+++ b/internal/fixer/hitl_test.go
@@ -1,0 +1,146 @@
+package fixer
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newRunnerFixture(t)
+	project, err := fixture.repos.Projects.GetByID(ctx, "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+	}
+	worktreeRoot := t.TempDir()
+	worktreePath := filepath.Join(worktreeRoot, "wt")
+	projectMetadata := `{"worktreeRoot":` + mustJSON(t, worktreeRoot) + `}`
+	project.MetadataJSON = &projectMetadata
+
+	repo := "acme/looper"
+	prNumber := int64(42)
+	projectID := project.ID
+	loopID := "loop_fixer_hitl"
+	targetID := buildPullRequestTargetID(repo, prNumber)
+	loop := storage.LoopRecord{
+		ID: loopID, Seq: 91, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo,
+		PRNumber: &prNumber, Status: "running",
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run1 := storage.RunRecord{
+		ID: "run_fixer_hitl_1", LoopID: loopID, Status: "running",
+		CurrentStep: stringPtr(string(stepRepair)), StartedAt: fixture.nowISO(),
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Runs.Upsert(ctx, run1); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	queue := storage.QueueItemRecord{
+		ID: "queue_fixer_hitl_1", ProjectID: &projectID, LoopID: &loopID,
+		Type: "fixer", TargetType: "pull_request", TargetID: targetID,
+		Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:hitl:test",
+		Priority: storage.QueuePriorityFixer, Status: "running",
+		AvailableAt: fixture.nowISO(), MaxAttempts: 3,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Queue.Upsert(ctx, queue); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	sessionID := "session-fixer-hitl"
+	if err := fixture.repos.AgentExecutions.Upsert(ctx, storage.AgentExecutionRecord{
+		ID: "agent_fixer_hitl_1", ProjectID: &projectID, LoopID: &loopID,
+		RunID: &run1.ID, Vendor: "codex", Status: "completed",
+		NativeSessionID: &sessionID, StartedAt: fixture.nowISO(),
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}); err != nil {
+		t.Fatalf("AgentExecutions.Upsert() error = %v", err)
+	}
+
+	needsHuman := `__LOOPER_RESULT__={"summary":"blocked on intent","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","action":"needs_human","explanation":"The reviewer request conflicts with the documented PR intent; choose which authority should win."}]}`
+	fixed := `__LOOPER_RESULT__={"summary":"applied decision","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","action":"fixed","explanation":"Kept the documented PR behavior as directed."}]}`
+	agent := &fakeAgentExecutor{results: []AgentResult{
+		{Status: "completed", Summary: "blocked on intent", ParseStatus: "parsed", Stdout: needsHuman},
+		{Status: "completed", Summary: "applied decision", ParseStatus: "parsed", Stdout: fixed},
+	}}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos,
+		GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+		AgentRuntime: "codex", AllowAutoPush: true, HITLEnabled: true,
+	})
+	checkpoint := fixerCheckpoint{
+		Detail:       &checkpointDetail{HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main"},
+		FixItems:     []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "conflicting request"}},
+		FixItemsHash: "fix-items-1",
+		Worktree:     &checkpointWorktree{Path: worktreePath, Branch: "feature/fix-42", PreparedAt: fixture.nowISO()},
+	}
+	step := stepInput{Project: *project, Loop: loop, Run: run1, QueueItem: queue, Repo: repo, PRNumber: prNumber, Checkpoint: checkpoint}
+
+	parkedCheckpoint, err := runner.runRepairStep(ctx, step)
+	awaiting, ok := asAwaitingHumanError(err)
+	if !ok {
+		t.Fatalf("runRepairStep() error = %v, want awaitingHumanError", err)
+	}
+	if !strings.Contains(agent.starts[0].Prompt, "Do not push") || agent.starts[0].NativeSessionID != "" {
+		t.Fatalf("initial agent input = %#v, want local-only fresh turn", agent.starts[0])
+	}
+	result, err := runner.suspendForHuman(ctx, step, run1, parkedCheckpoint, awaiting)
+	if err != nil || result.Status != "awaiting_human" {
+		t.Fatalf("suspendForHuman() = (%#v, %v)", result, err)
+	}
+	persistedLoop, _ := fixture.repos.Loops.GetByID(ctx, loopID)
+	ask, ok := loops.ReadHITLAsk(persistedLoop.MetadataJSON)
+	if !ok || ask.Status != "awaiting" || ask.SessionID != sessionID {
+		t.Fatalf("parked ask = %#v, found=%v", ask, ok)
+	}
+	persistedQueue, _ := fixture.repos.Queue.GetByID(ctx, queue.ID)
+	persistedRun, _ := fixture.repos.Runs.GetByID(ctx, run1.ID)
+	if persistedQueue.Status != "cancelled" || persistedRun.Status != "interrupted" {
+		t.Fatalf("parked states: queue=%s run=%s", persistedQueue.Status, persistedRun.Status)
+	}
+
+	ask.Answer = "Keep the documented PR intent."
+	ask.Status = "answered"
+	metadata, err := loops.WriteHITLAsk(persistedLoop.MetadataJSON, ask)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk() error = %v", err)
+	}
+	persistedLoop.MetadataJSON = &metadata
+	persistedLoop.Status = "running"
+	if err := fixture.repos.Loops.Upsert(ctx, *persistedLoop); err != nil {
+		t.Fatalf("Loops.Upsert(answer) error = %v", err)
+	}
+	run2 := storage.RunRecord{
+		ID: "run_fixer_hitl_2", LoopID: loopID, Status: "running",
+		CurrentStep: stringPtr(string(stepRepair)), StartedAt: fixture.nowISO(),
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Runs.Upsert(ctx, run2); err != nil {
+		t.Fatalf("Runs.Upsert(resume) error = %v", err)
+	}
+	step.Loop = *persistedLoop
+	step.Run = run2
+	step.Checkpoint = parkedCheckpoint
+	resumed, err := runner.runRepairStep(ctx, step)
+	if err != nil || resumed.Repair == nil {
+		t.Fatalf("resumed runRepairStep() = (%#v, %v)", resumed.Repair, err)
+	}
+	if agent.starts[1].NativeSessionID != sessionID || !strings.Contains(agent.starts[1].NativeResumePrompt, "Keep the documented PR intent") {
+		t.Fatalf("resume agent input = %#v", agent.starts[1])
+	}
+	finishedLoop, _ := fixture.repos.Loops.GetByID(ctx, loopID)
+	consumed, _ := loops.ReadHITLAsk(finishedLoop.MetadataJSON)
+	if consumed.Status != "consumed" {
+		t.Fatalf("answer status = %q, want consumed", consumed.Status)
+	}
+}

--- a/internal/fixer/hitl_test.go
+++ b/internal/fixer/hitl_test.go
@@ -109,6 +109,11 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	if !ok || ask.Status != "awaiting" || ask.SessionID != sessionID {
 		t.Fatalf("parked ask = %#v, found=%v", ask, ok)
 	}
+	for _, option := range ask.Options {
+		if option == "Provide different guidance" {
+			t.Fatalf("parked ask includes directly submitted custom-guidance placeholder: %#v", ask.Options)
+		}
+	}
 	persistedQueue, _ := fixture.repos.Queue.GetByID(ctx, queue.ID)
 	persistedRun, _ := fixture.repos.Runs.GetByID(ctx, run1.ID)
 	if persistedQueue.Status != "cancelled" || persistedRun.Status != "interrupted" {
@@ -171,6 +176,20 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	}
 	if len(github.dismissedReviews) != 1 {
 		t.Fatalf("dismissed reviews = %d, want replayed attempt", len(github.dismissedReviews))
+	}
+}
+
+func TestFixerHITLPromptIsLimitedToNonNativeReviewThreads(t *testing.T) {
+	t.Parallel()
+	native := []FixItem{{Type: "comment", ID: "native-1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101}}
+	if instruction := fixerHITLPromptFor(native); instruction != "" {
+		t.Fatalf("native-only HITL instruction = %q, want empty", instruction)
+	}
+	regular := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}
+	instruction := fixerHITLPromptFor(regular)
+	if !strings.Contains(instruction, "only to non-native comment fix items") ||
+		!strings.Contains(instruction, "Never use \"needs_human\" in Forgejo repair_results") {
+		t.Fatalf("regular HITL instruction missing source boundary: %q", instruction)
 	}
 }
 

--- a/internal/fixer/hitl_test.go
+++ b/internal/fixer/hitl_test.go
@@ -2,6 +2,7 @@ package fixer
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -74,9 +75,12 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 		{Status: "completed", Summary: "applied decision", ParseStatus: "parsed", Stdout: fixed},
 	}}
 	git := &fakeGitGateway{}
+	github := &fakeGitHubGateway{
+		reviews: []ReviewSummary{{ID: 10, State: "CHANGES_REQUESTED", Author: "reviewer-x"}},
+	}
 	runner := New(Options{
 		DB: fixture.coordinator.DB(), Repos: fixture.repos,
-		GitHub: &fakeGitHubGateway{}, Git: git,
+		GitHub: github, Git: git,
 		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
 		AgentRuntime: "codex", AllowAutoPush: true, HITLEnabled: true,
 	})
@@ -122,6 +126,9 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	if err := fixture.repos.Loops.Upsert(ctx, *persistedLoop); err != nil {
 		t.Fatalf("Loops.Upsert(answer) error = %v", err)
 	}
+	// Disabling HITL stops new asks, but must not revoke an already accepted
+	// operator answer or re-enable agent-side remote mutation during its resume.
+	runner.hitlEnabled = false
 	resume, err := runner.createRunContext(ctx, *persistedLoop)
 	if err != nil {
 		t.Fatalf("createRunContext(resume) error = %v", err)
@@ -137,7 +144,9 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	if err != nil || resumed.Repair == nil {
 		t.Fatalf("resumed runRepairStep() = (%#v, %v)", resumed.Repair, err)
 	}
-	if agent.starts[1].NativeSessionID != sessionID || !strings.Contains(agent.starts[1].NativeResumePrompt, "Keep the documented PR intent") {
+	if agent.starts[1].NativeSessionID != sessionID ||
+		!strings.Contains(agent.starts[1].NativeResumePrompt, "Keep the documented PR intent") ||
+		!strings.Contains(agent.starts[1].Prompt, "Do not push") {
 		t.Fatalf("resume agent input = %#v", agent.starts[1])
 	}
 	finishedLoop, _ := fixture.repos.Loops.GetByID(ctx, loopID)
@@ -147,6 +156,21 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	}
 	if len(git.prepareCalls) != 0 {
 		t.Fatalf("PrepareWorktree calls = %d, want no reset-capable prepare on HITL resume", len(git.prepareCalls))
+	}
+
+	if err := os.MkdirAll(filepath.Join(worktreePath, ".looper"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.looper) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreePath, ".looper", "dismiss.json"), []byte(`{"dismissals":[{"reviewer":"reviewer-x","reason":"conflicts with the approved direction"}]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(dismiss.json) error = %v", err)
+	}
+	step.Loop = *finishedLoop
+	step.Checkpoint = resumed
+	if _, err := runner.runRepairStep(ctx, step); err != nil {
+		t.Fatalf("runRepairStep(durable repair retry) error = %v", err)
+	}
+	if len(github.dismissedReviews) != 1 {
+		t.Fatalf("dismissed reviews = %d, want replayed attempt", len(github.dismissedReviews))
 	}
 }
 

--- a/internal/fixer/hitl_test.go
+++ b/internal/fixer/hitl_test.go
@@ -100,9 +100,30 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	if !strings.Contains(agent.starts[0].Prompt, "Do not push") || agent.starts[0].NativeSessionID != "" {
 		t.Fatalf("initial agent input = %#v, want local-only fresh turn", agent.starts[0])
 	}
+	badRun := run1
+	badRun.ID = "run_fixer_hitl_bad_fk"
+	badRun.LoopID = "missing_loop"
+	if _, err := runner.suspendForHuman(ctx, step, badRun, parkedCheckpoint, awaiting); err == nil {
+		t.Fatal("suspendForHuman(bad run) error = nil, want transaction rollback")
+	}
+	rolledBackLoop, _ := fixture.repos.Loops.GetByID(ctx, loopID)
+	rolledBackQueue, _ := fixture.repos.Queue.GetByID(ctx, queue.ID)
+	if rolledBackLoop.Status != "running" || rolledBackQueue.Status != "running" {
+		t.Fatalf("failed park leaked partial state: loop=%s queue=%s", rolledBackLoop.Status, rolledBackQueue.Status)
+	}
+	if err := os.MkdirAll(filepath.Join(worktreePath, ".looper"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.looper) error = %v", err)
+	}
+	dismissPath := filepath.Join(worktreePath, ".looper", "dismiss.json")
+	if err := os.WriteFile(dismissPath, []byte(`{"dismissals":[{"reviewer":"reviewer-x","reason":"stale pre-answer intent"}]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pre-answer dismiss.json) error = %v", err)
+	}
 	result, err := runner.suspendForHuman(ctx, step, run1, parkedCheckpoint, awaiting)
 	if err != nil || result.Status != "awaiting_human" {
 		t.Fatalf("suspendForHuman() = (%#v, %v)", result, err)
+	}
+	if _, err := os.Stat(dismissPath); !os.IsNotExist(err) {
+		t.Fatalf("pre-answer dismissal intent still present after park: %v", err)
 	}
 	persistedLoop, _ := fixture.repos.Loops.GetByID(ctx, loopID)
 	ask, ok := loops.ReadHITLAsk(persistedLoop.MetadataJSON)
@@ -163,10 +184,7 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 		t.Fatalf("PrepareWorktree calls = %d, want no reset-capable prepare on HITL resume", len(git.prepareCalls))
 	}
 
-	if err := os.MkdirAll(filepath.Join(worktreePath, ".looper"), 0o755); err != nil {
-		t.Fatalf("MkdirAll(.looper) error = %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(worktreePath, ".looper", "dismiss.json"), []byte(`{"dismissals":[{"reviewer":"reviewer-x","reason":"conflicts with the approved direction"}]}`), 0o644); err != nil {
+	if err := os.WriteFile(dismissPath, []byte(`{"dismissals":[{"reviewer":"reviewer-x","reason":"conflicts with the approved direction"}]}`), 0o644); err != nil {
 		t.Fatalf("WriteFile(dismiss.json) error = %v", err)
 	}
 	step.Loop = *finishedLoop

--- a/internal/fixer/hitl_test.go
+++ b/internal/fixer/hitl_test.go
@@ -83,11 +83,11 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 		DB: fixture.coordinator.DB(), Repos: fixture.repos,
 		GitHub: github, Git: git,
 		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
-		AgentRuntime: "codex", AllowAutoPush: true, HITLEnabled: true,
+		AgentRuntime: "codex", AllowAutoPush: true, AllowRiskyFixes: true, HITLEnabled: true,
 	})
 	checkpoint := fixerCheckpoint{
 		Detail:       &checkpointDetail{HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main"},
-		FixItems:     []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Summary: "conflicting request"}},
+		FixItems:     []FixItem{{Type: "conflict", ID: "conflict-1", Summary: "base merge conflict"}, {Type: "comment", ID: "c1", ThreadID: "t1", Summary: "conflicting request"}},
 		FixItemsHash: "fix-items-1",
 		Worktree:     &checkpointWorktree{Path: worktreePath, Branch: "feature/fix-42", PreparedAt: fixture.nowISO()},
 	}
@@ -100,6 +100,9 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	}
 	if !strings.Contains(agent.starts[0].Prompt, "Do not push") || agent.starts[0].NativeSessionID != "" {
 		t.Fatalf("initial agent input = %#v, want local-only fresh turn", agent.starts[0])
+	}
+	if len(git.mergeBaseCalls) != 1 {
+		t.Fatalf("initial base merge calls = %d, want 1", len(git.mergeBaseCalls))
 	}
 	badRun := run1
 	badRun.ID = "run_fixer_hitl_bad_fk"
@@ -183,6 +186,9 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	}
 	if len(git.prepareCalls) != 0 {
 		t.Fatalf("PrepareWorktree calls = %d, want no reset-capable prepare on HITL resume", len(git.prepareCalls))
+	}
+	if len(git.mergeBaseCalls) != 1 {
+		t.Fatalf("base merge calls after HITL resume = %d, want initial merge only", len(git.mergeBaseCalls))
 	}
 
 	// Simulate a daemon exit after the durable repair consumed the answer but

--- a/internal/fixer/hitl_test.go
+++ b/internal/fixer/hitl_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
@@ -184,11 +185,34 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 		t.Fatalf("PrepareWorktree calls = %d, want no reset-capable prepare on HITL resume", len(git.prepareCalls))
 	}
 
+	// Simulate a daemon exit after the durable repair consumed the answer but
+	// before the outer lifecycle marked stepRepair complete.
+	crashedRun := resume.Run
+	crashedRun.Status = "interrupted"
+	crashedRun.CurrentStep = stringPtr(string(stepRepair))
+	crashedRun.LastCompletedStep = stringPtr(string(stepPrepareWorktree))
+	crashedRun.StartedAt = fixture.now().Add(time.Second).UTC().Format(time.RFC3339Nano)
+	crashedCheckpointJSON := mustMarshalJSON(resumed)
+	crashedRun.CheckpointJSON = &crashedCheckpointJSON
+	crashedRun.UpdatedAt = fixture.nowISO()
+	if err := fixture.repos.Runs.Upsert(ctx, crashedRun); err != nil {
+		t.Fatalf("Runs.Upsert(crashed repair) error = %v", err)
+	}
+	recovered, err := runner.createRunContext(ctx, *finishedLoop)
+	if err != nil {
+		t.Fatalf("createRunContext(consumed repair) error = %v", err)
+	}
+	if !recovered.Resumed || recovered.StartStep != stepRepair || recovered.Checkpoint.Repair == nil ||
+		recovered.Checkpoint.Worktree == nil || recovered.Checkpoint.Worktree.PreparedAt == "" {
+		t.Fatalf("consumed repair recovery = %#v, want durable repair replay without prepare", recovered)
+	}
+
 	if err := os.WriteFile(dismissPath, []byte(`{"dismissals":[{"reviewer":"reviewer-x","reason":"conflicts with the approved direction"}]}`), 0o644); err != nil {
 		t.Fatalf("WriteFile(dismiss.json) error = %v", err)
 	}
 	step.Loop = *finishedLoop
-	step.Checkpoint = resumed
+	step.Run = recovered.Run
+	step.Checkpoint = recovered.Checkpoint
 	if _, err := runner.runRepairStep(ctx, step); err != nil {
 		t.Fatalf("runRepairStep(durable repair retry) error = %v", err)
 	}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2891,10 +2891,11 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		if err := validateCompletedRepairCheckpoint(checkpoint.Repair); err != nil {
 			return checkpoint, err
 		}
-		if r.hitlEnabled {
-			if err := r.markHumanAnswerConsumed(ctx, &input.Loop); err != nil {
-				return checkpoint, err
-			}
+		if err := r.markHumanAnswerConsumed(ctx, &input.Loop); err != nil {
+			return checkpoint, err
+		}
+		if hasDeliveredHITLAnswer(input.Loop.MetadataJSON) && checkpoint.Worktree != nil {
+			r.applyReviewDismissals(ctx, input, checkpoint.Worktree.Path)
 		}
 		return checkpoint, nil
 	}
@@ -2963,15 +2964,14 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	if err != nil {
 		return checkpoint, fmt.Errorf("resolve run agent identity: %w", err)
 	}
-	prompt, instructionBlock := buildFixerPrompt(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint.Detail, checkpoint.FixItems, r.allowAutoPush && !r.hitlEnabled, r.disclosure, agentVendor, derefString(agentModel))
-	nativeResumePrompt := ""
-	nativeSessionID := ""
+	nativeResumePrompt, nativeSessionID := r.pendingHumanAnswer(ctx, &input.Loop, agentVendor)
+	continuingHITL := nativeResumePrompt != ""
+	prompt, instructionBlock := buildFixerPrompt(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint.Detail, checkpoint.FixItems, r.allowAutoPush && !r.hitlEnabled && !continuingHITL, r.disclosure, agentVendor, derefString(agentModel))
 	if r.hitlEnabled {
 		prompt += "\n\n" + fixerHITLPromptInstruction
-		nativeResumePrompt, nativeSessionID = r.pendingHumanAnswer(ctx, &input.Loop, agentVendor)
-		if nativeResumePrompt != "" {
-			prompt += "\n\n" + nativeResumePrompt
-		}
+	}
+	if continuingHITL {
+		prompt += "\n\n" + nativeResumePrompt
 	}
 	metadata := map[string]any{"loopType": "fixer", "repo": input.Repo, "prNumber": input.PRNumber, "step": "repair"}
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
@@ -3045,7 +3045,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	if err := r.persistCheckpoint(ctx, input.Run.ID, stepRepair, checkpoint); err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
-	if r.hitlEnabled {
+	if continuingHITL {
 		if err := r.markHumanAnswerConsumed(ctx, &input.Loop); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2968,7 +2968,9 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	continuingHITL := nativeResumePrompt != ""
 	prompt, instructionBlock := buildFixerPrompt(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint.Detail, checkpoint.FixItems, r.allowAutoPush && !r.hitlEnabled && !continuingHITL, r.disclosure, agentVendor, derefString(agentModel))
 	if r.hitlEnabled {
-		prompt += "\n\n" + fixerHITLPromptInstruction
+		if instruction := fixerHITLPromptFor(checkpoint.FixItems); instruction != "" {
+			prompt += "\n\n" + instruction
+		}
 	}
 	if continuingHITL {
 		prompt += "\n\n" + nativeResumePrompt

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -3025,14 +3025,14 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		return checkpoint, &holdSkipError{summary: summary}
 	}
 	replies := normalizeReplyExplanationActions(parseReplyExplanations(result.Stdout, result.Stderr, checkpoint.FixItems))
+	if err := validateNeedsHumanReplies(result.Stdout, result.Stderr, checkpoint.FixItems, replies); err != nil {
+		return checkpoint, &loopError{message: err.Error(), kind: FailureManualIntervention}
+	}
 	if awaiting := humanDecisionFromReplies(replies, executionID, agentVendor); awaiting != nil {
 		if !r.hitlEnabled {
 			return checkpoint, &loopError{message: "Fixer requested human input while HITL is disabled", kind: FailureManualIntervention}
 		}
 		return checkpoint, awaiting
-	}
-	if completionMentionsNeedsHuman(result.Stdout, result.Stderr) {
-		return checkpoint, &loopError{message: "Fixer emitted an invalid needs_human decision", kind: FailureManualIntervention}
 	}
 	checkpoint.Repair = checkpointRepairFromAgentResult(executionID, detailHeadSHA(checkpoint.Detail), result, r.nowISO())
 	checkpoint.Repair.ReplyExplanations = replies
@@ -4694,7 +4694,8 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage))
 		pause, _ := classifyFixerPause(latestRun, checkpoint, loop.MetadataJSON)
 		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, pause, failureSummary) || loops.ShouldRestartFromDiscover(latestRun.Status, checkpoint.ResumePolicy)
-		resumeFromPrepare = shouldResumeFromPrepare(latestRun.Status, failedStep, checkpoint)
+		resumeFromPrepare = shouldResumeFromPrepare(latestRun.Status, failedStep, checkpoint) &&
+			!shouldResumeAnsweredHITLRepair(loop.MetadataJSON, latestRun.Status, failedStep)
 	}
 	startStep := stepDiscoverPR
 	resumedCheckpoint := checkpoint

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -463,16 +463,18 @@ type MergeBaseResult struct {
 }
 
 type AgentRunInput struct {
-	ExecutionID      string
-	ProjectID        string
-	LoopID           string
-	RunID            string
-	Prompt           string
-	WorkingDirectory string
-	Timeout          time.Duration
-	HeartbeatTimeout time.Duration
-	Metadata         map[string]any
-	IdempotencyKey   string
+	ExecutionID        string
+	ProjectID          string
+	LoopID             string
+	RunID              string
+	Prompt             string
+	NativeResumePrompt string
+	NativeSessionID    string
+	WorkingDirectory   string
+	Timeout            time.Duration
+	HeartbeatTimeout   time.Duration
+	Metadata           map[string]any
+	IdempotencyKey     string
 	// UseSnapshot + SnapshotVendor/Model override the executor config for this
 	// start when the run has a durable agent snapshot (execution authority).
 	UseSnapshot    bool
@@ -548,6 +550,7 @@ type Options struct {
 	AllowAutoCommit         bool
 	AllowAutoPush           bool
 	AllowRiskyFixes         bool
+	HITLEnabled             bool
 	FixAllPullRequests      bool
 	DiscoveryPolicy         DiscoveryPolicy
 	Disclosure              *config.DisclosureConfig
@@ -587,6 +590,7 @@ type Runner struct {
 	allowAutoCommit         bool
 	allowAutoPush           bool
 	allowRiskyFixes         bool
+	hitlEnabled             bool
 	fixAllPullRequests      bool
 	discoveryPolicy         DiscoveryPolicy
 	disclosure              config.DisclosureConfig
@@ -641,8 +645,9 @@ type ProcessResult struct {
 type replyAction string
 
 const (
-	replyActionFixed    replyAction = "fixed"
-	replyActionDeclined replyAction = "declined"
+	replyActionFixed      replyAction = "fixed"
+	replyActionDeclined   replyAction = "declined"
+	replyActionNeedsHuman replyAction = "needs_human"
 )
 
 type fixerFollowupReason string
@@ -1078,6 +1083,8 @@ func normalizeReplyAction(raw string) string {
 		return string(replyActionFixed)
 	case replyActionDeclined:
 		return string(replyActionDeclined)
+	case replyActionNeedsHuman:
+		return string(replyActionNeedsHuman)
 	default:
 		return ""
 	}
@@ -1312,6 +1319,7 @@ func New(options Options) *Runner {
 		allowAutoCommit:         options.AllowAutoCommit,
 		allowAutoPush:           options.AllowAutoPush,
 		allowRiskyFixes:         options.AllowRiskyFixes,
+		hitlEnabled:             options.HITLEnabled,
 		fixAllPullRequests:      options.FixAllPullRequests,
 		discoveryPolicy:         policy,
 		disclosure:              disclosureCfg,
@@ -2121,6 +2129,9 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		r.logInfo("fixer step started", map[string]any{"projectId": project.ID, "loopId": loop.ID, "runId": run.ID, "queueItemId": queueItem.ID, "currentStep": string(step)})
 		checkpoint, err = r.executeStep(ctx, step, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem, Repo: *queueItem.Repo, PRNumber: *queueItem.PRNumber, Checkpoint: checkpoint})
 		if err != nil {
+			if awaiting, ok := asAwaitingHumanError(err); ok {
+				return r.suspendForHuman(ctx, stepInput{Project: *project, Loop: *loop, Run: run, QueueItem: queueItem, Checkpoint: checkpoint}, run, checkpoint, awaiting)
+			}
 			var holdErr *holdSkipError
 			if errors.As(err, &holdErr) {
 				return r.finishHeldFixerQueueItem(ctx, *loop, &run, queueItem, checkpoint, holdErr.summary)
@@ -2880,6 +2891,11 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		if err := validateCompletedRepairCheckpoint(checkpoint.Repair); err != nil {
 			return checkpoint, err
 		}
+		if r.hitlEnabled {
+			if err := r.markHumanAnswerConsumed(ctx, &input.Loop); err != nil {
+				return checkpoint, err
+			}
+		}
 		return checkpoint, nil
 	}
 	if len(checkpoint.FixItems) == 0 {
@@ -2947,7 +2963,16 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	if err != nil {
 		return checkpoint, fmt.Errorf("resolve run agent identity: %w", err)
 	}
-	prompt, instructionBlock := buildFixerPrompt(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint.Detail, checkpoint.FixItems, r.allowAutoPush, r.disclosure, agentVendor, derefString(agentModel))
+	prompt, instructionBlock := buildFixerPrompt(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint.Detail, checkpoint.FixItems, r.allowAutoPush && !r.hitlEnabled, r.disclosure, agentVendor, derefString(agentModel))
+	nativeResumePrompt := ""
+	nativeSessionID := ""
+	if r.hitlEnabled {
+		prompt += "\n\n" + fixerHITLPromptInstruction
+		nativeResumePrompt, nativeSessionID = r.pendingHumanAnswer(ctx, &input.Loop, agentVendor)
+		if nativeResumePrompt != "" {
+			prompt += "\n\n" + nativeResumePrompt
+		}
+	}
 	metadata := map[string]any{"loopType": "fixer", "repo": input.Repo, "prNumber": input.PRNumber, "step": "repair"}
 	for key, value := range config.CustomInstructionMetadata(instructionBlock, prompt) {
 		metadata[key] = value
@@ -2960,7 +2985,8 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	useSnap, snapVendor, snapModel := agentRunSnapshotFields(agentVendor, agentModel, useSnapshot)
 	execution, err := r.agentExecutor.Start(ctx, AgentRunInput{
 		ExecutionID: executionID, ProjectID: input.Project.ID, LoopID: input.Loop.ID, RunID: input.Run.ID,
-		Prompt: prompt, WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout,
+		Prompt: prompt, NativeResumePrompt: nativeResumePrompt, NativeSessionID: nativeSessionID,
+		WorkingDirectory: worktree.Path, Timeout: r.agentTimeout, HeartbeatTimeout: r.agentIdleTimeout,
 		Metadata: metadata, IdempotencyKey: fmt.Sprintf("fixer:%s:%s:%s", input.Loop.ID, firstNonEmpty(checkpoint.FixItemsHash, "unknown"), firstNonEmpty(detailHeadSHA(checkpoint.Detail), "unknown")),
 		UseSnapshot: useSnap, SnapshotVendor: snapVendor, SnapshotModel: snapModel,
 	})
@@ -2998,17 +3024,35 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	} else if held {
 		return checkpoint, &holdSkipError{summary: summary}
 	}
-	// If the agent judged one or more CHANGES_REQUESTED reviews unreasonable it
-	// wrote a dismiss sentinel — dismiss those reviews (best-effort).
-	r.applyReviewDismissals(ctx, input, worktree.Path)
+	replies := normalizeReplyExplanationActions(parseReplyExplanations(result.Stdout, result.Stderr, checkpoint.FixItems))
+	if awaiting := humanDecisionFromReplies(replies, executionID, agentVendor); awaiting != nil {
+		if !r.hitlEnabled {
+			return checkpoint, &loopError{message: "Fixer requested human input while HITL is disabled", kind: FailureManualIntervention}
+		}
+		return checkpoint, awaiting
+	}
+	if completionMentionsNeedsHuman(result.Stdout, result.Stderr) {
+		return checkpoint, &loopError{message: "Fixer emitted an invalid needs_human decision", kind: FailureManualIntervention}
+	}
 	checkpoint.Repair = checkpointRepairFromAgentResult(executionID, detailHeadSHA(checkpoint.Detail), result, r.nowISO())
-	checkpoint.Repair.ReplyExplanations = normalizeReplyExplanationActions(parseReplyExplanations(result.Stdout, result.Stderr, checkpoint.FixItems))
+	checkpoint.Repair.ReplyExplanations = replies
 	checkpoint.Repair.ReplyExplanations = append(checkpoint.Repair.ReplyExplanations, parseNativeRepairResults(result.Stdout, result.Stderr, checkpoint.FixItems)...)
 	checkpoint.ensureLifecycle("fixer", worktree.Branch, detailBaseRefName(checkpoint.Detail), false)
 	if result.Lifecycle != nil {
 		checkpoint.Lifecycle.MergeAgent(result.Lifecycle, r.nowISO())
 	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
+	if err := r.persistCheckpoint(ctx, input.Run.ID, stepRepair, checkpoint); err != nil {
+		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if r.hitlEnabled {
+		if err := r.markHumanAnswerConsumed(ctx, &input.Loop); err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
+	}
+	// Remote review mutations happen only after the repair checkpoint is durable
+	// and any delivered human answer has been consumed.
+	r.applyReviewDismissals(ctx, input, worktree.Path)
 	return checkpoint, nil
 }
 
@@ -7248,7 +7292,7 @@ func buildFixerReplyExplanationInstruction(fixItems []FixItem) string {
 			"Each entry must be an object with these fields:",
 			`  - "fixItemId": the exact "id" of the fix item`,
 			`  - "threadId": the exact "threadId" of the same fix item`,
-			`  - "action": "fixed" or "declined"`,
+			`  - "action": "fixed" or "declined" (or "needs_human" only when a later HUMAN-IN-THE-LOOP instruction explicitly enables it)`,
 			`  - "explanation": one or two sentences (max ~500 chars). If action is "fixed", say what you changed and where. If action is "declined", give a concrete reason why you are not acting. No greetings, no @mentions, no markdown headings, no HTML, no disclosure markers.`,
 			`  - "threadCommentsObserved": sha256 of the JSON array of review-thread comments you observed in thread order, where each element is {"id","updatedAt"}. The "id" MUST be the GraphQL PullRequestReviewComment node ID. If you fetched comments with REST pulls/{number}/comments, map REST "node_id" to "id" and REST "updated_at" to "updatedAt"; do not use the REST numeric "id". Include target reviewer comments even when they contain a Looper stamp. Exclude only prior Looper fixer replies/round comments.`,
 			"Before including an entry, re-read the relevant review thread/comment context.",

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2922,6 +2922,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	if rootErr != nil {
 		return checkpoint, rootErr
 	}
+	worktreeReprepared := false
 	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
 		checkpoint.Worktree = nil
 		checkpoint.Repair = nil
@@ -2931,6 +2932,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		if err != nil {
 			return checkpoint, err
 		}
+		worktreeReprepared = true
 		worktree, err = requireWorktree(checkpoint)
 		if err != nil {
 			return checkpoint, err
@@ -2944,11 +2946,18 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	} else if held {
 		return checkpoint, &holdSkipError{summary: summary}
 	}
+	agentVendor, agentModel, _, useSnapshot, err := r.identityFromRun(input.Run)
+	if err != nil {
+		return checkpoint, fmt.Errorf("resolve run agent identity: %w", err)
+	}
+	nativeResumePrompt, nativeSessionID := r.pendingHumanAnswer(ctx, &input.Loop, agentVendor)
+	continuingHITL := nativeResumePrompt != ""
 	// Autonomous conflict resolution (risky fixes on): merge the base into the
 	// worktree so the agent has the conflict markers to resolve, instead of punting
-	// the conflict to a human. A merge that fails for a non-conflict reason falls
-	// back to manual intervention.
-	if hasConflict {
+	// the conflict to a human. An answered HITL continuation reuses the merge
+	// already started before parking unless worktree recovery replaced it. A merge
+	// that fails for a non-conflict reason falls back to manual intervention.
+	if hasConflict && (!continuingHITL || worktreeReprepared) {
 		base := strings.TrimSpace(checkpoint.Detail.BaseRefName)
 		if base == "" {
 			base = "main"
@@ -2960,12 +2969,6 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		}
 	}
 	executionID := eventlog.NewEventID("agent")
-	agentVendor, agentModel, _, useSnapshot, err := r.identityFromRun(input.Run)
-	if err != nil {
-		return checkpoint, fmt.Errorf("resolve run agent identity: %w", err)
-	}
-	nativeResumePrompt, nativeSessionID := r.pendingHumanAnswer(ctx, &input.Loop, agentVendor)
-	continuingHITL := nativeResumePrompt != ""
 	prompt, instructionBlock := buildFixerPrompt(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint.Detail, checkpoint.FixItems, r.allowAutoPush && !r.hitlEnabled && !continuingHITL, r.disclosure, agentVendor, derefString(agentModel))
 	if r.hitlEnabled {
 		if instruction := fixerHITLPromptFor(checkpoint.FixItems); instruction != "" {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -4697,7 +4697,7 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		pause, _ := classifyFixerPause(latestRun, checkpoint, loop.MetadataJSON)
 		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, pause, failureSummary) || loops.ShouldRestartFromDiscover(latestRun.Status, checkpoint.ResumePolicy)
 		resumeFromPrepare = shouldResumeFromPrepare(latestRun.Status, failedStep, checkpoint) &&
-			!shouldResumeAnsweredHITLRepair(loop.MetadataJSON, latestRun.Status, failedStep)
+			!shouldResumeHITLRepair(loop.MetadataJSON, latestRun.Status, failedStep, checkpoint)
 	}
 	startStep := stepDiscoverPR
 	resumedCheckpoint := checkpoint

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -2434,7 +2434,8 @@ type fixerAgentExecutionAdapter struct{ execution agent.Execution }
 func (a fixerAgentExecutorAdapter) Start(ctx context.Context, input fixer.AgentRunInput) (fixer.AgentExecution, error) {
 	execution, err := a.executor.Start(ctx, agent.RunInput{
 		ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID,
-		Prompt: input.Prompt, WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout,
+		Prompt: input.Prompt, NativeResumePrompt: input.NativeResumePrompt, NativeSessionID: input.NativeSessionID,
+		WorkingDirectory: input.WorkingDirectory, Timeout: input.Timeout, HeartbeatTimeout: input.HeartbeatTimeout,
 		Metadata: input.Metadata, IdempotencyKey: input.IdempotencyKey,
 		UseSnapshot: input.UseSnapshot, SnapshotVendor: input.SnapshotVendor, SnapshotModel: input.SnapshotModel,
 	})
@@ -3399,6 +3400,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 			AllowAutoCommit:    cfg.Defaults.AllowAutoCommit,
 			AllowAutoPush:      cfg.Defaults.AllowAutoPush,
 			AllowRiskyFixes:    cfg.Defaults.AllowRiskyFixes,
+			HITLEnabled:        cfg.HITL.Enabled,
 			FixAllPullRequests: cfg.Defaults.FixAllPullRequests,
 			// Validation shell is Supervisor-owned (#577): track handles for retain-storage.
 			ContainmentTracker: activeExecutions,

--- a/web/dashboard/src/lib/api.ts
+++ b/web/dashboard/src/lib/api.ts
@@ -536,6 +536,17 @@ export function pauseLoop(
   );
 }
 
+export function respondLoop(
+  selector: string,
+  answer: string,
+  signal?: AbortSignal,
+): Promise<Loop> {
+  return apiFetch<Loop>(
+    `/api/v1/loops/${encodeURIComponent(selector)}/respond`,
+    { method: "POST", body: JSON.stringify({ answer }), signal },
+  );
+}
+
 export function fetchLoopWorktree(
   selector: string,
   signal?: AbortSignal,

--- a/web/dashboard/src/pages/LoopDetail.tsx
+++ b/web/dashboard/src/pages/LoopDetail.tsx
@@ -15,6 +15,7 @@ import { Card } from "@/components/ui/card";
 import {
   fetchLoop,
   openLoopLogsStream,
+  respondLoop,
   type Loop,
   type LoopLogsChunk,
   type LoopLogsSnapshot,
@@ -62,6 +63,94 @@ function Kv({ label, value }: { label: string; value: ReactNode }) {
       <dt className="text-[var(--text-muted)]">{label}</dt>
       <dd className="m-0 break-all mono">{value}</dd>
     </div>
+  );
+}
+
+type HITLAsk = {
+  question?: string;
+  options?: string[];
+  status?: string;
+};
+
+function readHITLAsk(loop: Loop): HITLAsk | null {
+  try {
+    const metadata = JSON.parse(loop.metadataJson ?? "{}") as {
+      hitl?: HITLAsk;
+    };
+    return metadata.hitl ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function HITLDecisionCard({
+  loop,
+  onMutated,
+}: {
+  loop: Loop;
+  onMutated: () => Promise<void>;
+}) {
+  const ask = readHITLAsk(loop);
+  const [answer, setAnswer] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  if (
+    loop.status !== "awaiting_human" ||
+    ask?.status !== "awaiting" ||
+    !ask.question?.trim()
+  ) {
+    return null;
+  }
+
+  const submit = async (value: string) => {
+    if (!value.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await respondLoop(String(loop.seq), value.trim());
+      await onMutated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to send response");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Card title="Human decision required">
+      <p className="mt-0 whitespace-pre-wrap text-[13px]">{ask.question}</p>
+      <div className="mb-3 flex flex-wrap gap-2">
+        {ask.options?.map((option) => (
+          <Button
+            key={option}
+            size="sm"
+            disabled={submitting}
+            onClick={() => void submit(option)}
+          >
+            {option}
+          </Button>
+        ))}
+      </div>
+      <form
+        className="flex gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submit(answer);
+        }}
+      >
+        <input
+          className="min-w-0 flex-1 rounded border border-[var(--border)] bg-transparent px-2 text-[12px]"
+          value={answer}
+          onChange={(event) => setAnswer(event.target.value)}
+          placeholder="Or provide different guidance"
+          disabled={submitting}
+        />
+        <Button size="sm" type="submit" disabled={submitting || !answer.trim()}>
+          Respond
+        </Button>
+      </form>
+      {error ? <p className="mb-0 text-[12px] text-red-500">{error}</p> : null}
+    </Card>
   );
 }
 
@@ -455,6 +544,8 @@ export function LoopDetailPage() {
           />
         </Card>
       ) : null}
+
+      {data ? <HITLDecisionCard loop={data} onMutated={onMutated} /> : null}
 
       <Card title="Metadata">
         {error && !data ? (

--- a/web/dashboard/src/pages/LoopDetail.tsx
+++ b/web/dashboard/src/pages/LoopDetail.tsx
@@ -120,16 +120,18 @@ function HITLDecisionCard({
     <Card title="Human decision required">
       <p className="mt-0 whitespace-pre-wrap text-[13px]">{ask.question}</p>
       <div className="mb-3 flex flex-wrap gap-2">
-        {ask.options?.map((option) => (
-          <Button
-            key={option}
-            size="sm"
-            disabled={submitting}
-            onClick={() => void submit(option)}
-          >
-            {option}
-          </Button>
-        ))}
+        {ask.options
+          ?.filter((option) => option !== "Provide different guidance")
+          .map((option) => (
+            <Button
+              key={option}
+              size="sm"
+              disabled={submitting}
+              onClick={() => void submit(option)}
+            >
+              {option}
+            </Button>
+          ))}
       </div>
       <form
         className="flex gap-2"

--- a/web/dashboard/src/pages/LoopDetail.tsx
+++ b/web/dashboard/src/pages/LoopDetail.tsx
@@ -70,6 +70,7 @@ type HITLAsk = {
   question?: string;
   options?: string[];
   status?: string;
+  askedAt?: string;
 };
 
 function readHITLAsk(loop: Loop): HITLAsk | null {
@@ -94,6 +95,9 @@ function HITLDecisionCard({
   const [answer, setAnswer] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    setAnswer("");
+  }, [loop.id, ask?.askedAt, ask?.question]);
   if (
     loop.status !== "awaiting_human" ||
     ask?.status !== "awaiting" ||
@@ -108,6 +112,7 @@ function HITLDecisionCard({
     setError(null);
     try {
       await respondLoop(String(loop.seq), value.trim());
+      setAnswer("");
       await onMutated();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to send response");


### PR DESCRIPTION
## Summary

- let Fixer emit a validated `needs_human` decision through its existing `review_thread_replies` result
- park the loop with the existing `loops.HITLAsk` metadata and `awaiting_human` status, then resume through the existing `POST /loops/{seq}/respond` control plane
- resume the captured native agent session when compatible and consume the operator answer only after a durable successful repair checkpoint
- add a minimal dashboard decision card with the question, suggested answers, and free-text guidance

This is PR3 of the staged Fixer authority/HITL sequence, following #612 and #613.

## Authority

The Fixer’s validated structured `needs_human` result authorizes only pausing; an operator answer accepted through the existing `/respond` control plane authorizes resume and the chosen direction, subject to normal Looper safety gates; head or content fingerprints are drift signals only and never authority.

## Safety boundary

When HITL is enabled, the Fixer agent is given the local-only lifecycle prompt even if automatic push is normally enabled. A valid `needs_human` result is processed before review dismissal or any later push/resolve steps. Malformed or unbound `needs_human` output fails to manual intervention rather than authorizing a pause or allowing remote mutation.

The resume prompt is appended to the full checkpoint prompt and passed as the native resume prompt. If the stored vendor/session is no longer compatible, the existing executor starts fresh while retaining the operator answer in the full prompt.

## Trade-off

Concrete failure prevented: a Fixer that reaches a real repository/PR-intent conflict no longer has to guess, silently decline, or lose its local repair context while waiting for operator direction.

Costs: one additional structured reply action, a Fixer-specific park/resume path, and a local ordering constraint between repair checkpoint persistence and answer consumption. This adds retry cases around parking and consumption, but adds no schema, transport, fingerprint, CAS, delivery ledger, or Fixer ask file.

A simpler “fail loud” path is insufficient because it discards the same-session decision context and requires a manual restart. Trusting arbitrary prose is also insufficient: only a validated `needs_human` entry bound to a current fix item can pause. The implementation therefore reuses the existing HITL metadata, loop status, queue cancellation, interrupted-run resume, and `/respond` machinery instead of adding another durability layer.

Deletion/layer check: the Worker `.looper/ask.json`, GitHub/Feishu delivery transports, generation counters, fingerprints, and polling paths were deliberately not reused or expanded. No existing layer could be deleted without also removing the already-shared operator response control plane.

## Validation

- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- `go build ./...`
- `pnpm test` in `web/dashboard` (97 tests)
- `pnpm build` in `web/dashboard`

Lifecycle coverage verifies park → persisted ask/session → cancelled queue + interrupted run → answered resume prompt/native session → successful repair → consumed answer. The existing `/respond` contract test now exercises a Fixer loop and verifies requeue.
