### PR TITLE
fix: reuse the trusted review config snapshot within one child

### DIFF
--- a/internal/cliapp/daemon_runtime.go
+++ b/internal/cliapp/daemon_runtime.go
@@ -745,11 +745,15 @@ func splitLogLines(content string) []string {
 }
 
 func (r *commandRuntime) loadConfig() (config.LoadedFileConfig, error) {
-	if loaded, configured, err := forge.LoadTrustedReviewConfigSnapshot(); configured {
-		if err != nil {
-			return config.LoadedFileConfig{}, err
+	if !r.trustedReviewConfig.done {
+		loaded, configured, err := forge.LoadTrustedReviewConfigSnapshot()
+		r.trustedReviewConfig = trustedReviewConfigMemo{done: true, configured: configured, loaded: loaded, err: err}
+	}
+	if r.trustedReviewConfig.configured {
+		if r.trustedReviewConfig.err != nil {
+			return config.LoadedFileConfig{}, r.trustedReviewConfig.err
 		}
-		return loaded, nil
+		return r.trustedReviewConfig.loaded, nil
 	}
 	loaded, err := config.LoadFile(config.LoadFileOptions{Args: ExtractConfigArgs(r.argv)})
 	if err != nil {

--- a/internal/cliapp/json_output.go
+++ b/internal/cliapp/json_output.go
@@ -21,11 +21,23 @@ import (
 const daemonVersionProbeTimeout = 250 * time.Millisecond
 
 type commandRuntime struct {
-	app                *App
-	argv               []string
-	startupOutputPath  string
-	skipAPIStartProbe  bool
-	emittedConfigNotes map[string]struct{}
+	app                 *App
+	argv                []string
+	startupOutputPath   string
+	skipAPIStartProbe   bool
+	emittedConfigNotes  map[string]struct{}
+	trustedReviewConfig trustedReviewConfigMemo
+}
+
+// trustedReviewConfigMemo holds the once-per-process result of consuming the
+// inherited trusted review config pipe. The descriptor carries a single
+// snapshot and is closed after the first read, so every later loadConfig call
+// in the same child must reuse this result instead of reading a closed pipe.
+type trustedReviewConfigMemo struct {
+	done       bool
+	configured bool
+	loaded     config.LoadedFileConfig
+	err        error
 }
 
 func newCommandRuntime(app *App, argv []string) *commandRuntime {

--- a/internal/cliapp/trusted_review_config_reuse_test.go
+++ b/internal/cliapp/trusted_review_config_reuse_test.go
@@ -1,0 +1,97 @@
+package cliapp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/forge"
+	"github.com/spf13/cobra"
+)
+
+// A proxy child loads config more than once per process: the root
+// PersistentPreRunE runs before the bound subcommand's RunE. The inherited
+// descriptor carries one snapshot and is closed after the first read, so the
+// second load must reuse the first result instead of reading a closed pipe.
+func TestCommandRuntimeTrustedReviewConfigSurvivesRepeatedLoads(t *testing.T) {
+	capturedGHPath := filepath.Join(t.TempDir(), "daemon-cli-gh")
+	runtime := newTrustedReviewProxyChildRuntime(t, capturedGHPath)
+
+	first, err := runtime.loadConfig()
+	if err != nil {
+		t.Fatalf("first loadConfig() error = %v", err)
+	}
+	second, err := runtime.loadConfig()
+	if err != nil {
+		t.Fatalf("second loadConfig() error = %v", err)
+	}
+
+	for label, loaded := range map[string]config.LoadedFileConfig{"first": first, "second": second} {
+		if loaded.Config.Tools.GHPath == nil || *loaded.Config.Tools.GHPath != capturedGHPath {
+			t.Fatalf("%s loadConfig().Tools.GHPath = %v, want captured daemon CLI winner %q", label, loaded.Config.Tools.GHPath, capturedGHPath)
+		}
+	}
+}
+
+// The auto-upgrade pre-run hook is the concrete second loader in a proxy
+// child. A bound review-submit child must never replace its own binary
+// mid-run, so the hook is skipped before it can reach any config load.
+func TestShouldSkipAutoUpgradeForTrustedReviewProxyChild(t *testing.T) {
+	cmd := &cobra.Command{Use: "submit"}
+	parent := &cobra.Command{Use: "review"}
+	root := &cobra.Command{Use: "looper"}
+	root.AddCommand(parent)
+	parent.AddCommand(cmd)
+
+	if shouldSkipAutoUpgrade(cmd) {
+		t.Fatal("shouldSkipAutoUpgrade(review submit) = true without proxy-child env, want false")
+	}
+
+	t.Setenv("LOOPER_TRUSTED_REVIEW_PROXY_CHILD", "1")
+	if !shouldSkipAutoUpgrade(cmd) {
+		t.Fatal("shouldSkipAutoUpgrade(review submit) = false in a proxy child, want true")
+	}
+}
+
+func newTrustedReviewProxyChildRuntime(t *testing.T, capturedGHPath string) *commandRuntime {
+	t.Helper()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Tools.GHPath = &capturedGHPath
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal(config snapshot) error = %v", err)
+	}
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error = %v", err)
+	}
+	writeDone := make(chan error, 1)
+	go func() {
+		_, writeErr := writer.Write(raw)
+		if closeErr := writer.Close(); writeErr == nil {
+			writeErr = closeErr
+		}
+		writeDone <- writeErr
+	}()
+	t.Cleanup(func() {
+		// LoadTrustedReviewConfigSnapshot owns and closes the inherited
+		// descriptor. Mark this test's wrapper closed so its finalizer cannot
+		// close an unrelated descriptor the OS reused.
+		_ = reader.Close()
+		if writeErr := <-writeDone; writeErr != nil {
+			t.Errorf("write config snapshot error = %v", writeErr)
+		}
+	})
+
+	t.Setenv("LOOPER_TRUSTED_REVIEW_PROXY_CHILD", "1")
+	t.Setenv(forge.TrustedReviewConfigFDEnv, strconv.FormatUint(uint64(reader.Fd()), 10))
+	return &commandRuntime{argv: []string{"review", "submit", "acme/looper#42"}}
+}

--- a/internal/cliapp/upgrade.go
+++ b/internal/cliapp/upgrade.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nexu-io/looper/internal/forge"
 	"github.com/nexu-io/looper/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -258,6 +259,13 @@ func (r *commandRuntime) maybeRunAutoUpgrade(cmd *cobra.Command, args []string) 
 
 func shouldSkipAutoUpgrade(cmd *cobra.Command) bool {
 	if cmd == nil {
+		return true
+	}
+	// A daemon-spawned review-submit child executes one bound action under a
+	// materialized authority. Replacing its own binary mid-run is never that
+	// action, and the attempt would consume run-scoped state the bound command
+	// still needs.
+	if forge.TrustedReviewProxyChild() {
 		return true
 	}
 	if cmd.Name() == "help" {

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -884,6 +884,14 @@ func TrustedReviewSockConfigured() bool {
 	return strings.TrimSpace(os.Getenv(TrustedReviewSockEnv)) != ""
 }
 
+// TrustedReviewProxyChild reports whether this process is the daemon-spawned
+// review-submit child. Such a child runs with a daemon-materialized authority
+// (credential env, bound policy, single-use config pipe) and must not take
+// ambient side paths that a normal operator CLI invocation may take.
+func TrustedReviewProxyChild() bool {
+	return strings.TrimSpace(os.Getenv(trustedReviewProxySkipEnv)) != ""
+}
+
 // ProxyReviewSubmit forwards a review-submit invocation to the trusted proxy.
 // On success it writes the proxy stdout/stderr to the current process streams
 // and returns a process-style exit error when the proxied command failed.


### PR DESCRIPTION
# Summary

- The daemon-side `looper review submit` child receives its config as a single-use inherited pipe. `loadConfig` read that pipe and closed it, so the **second** load in the same process read a closed descriptor and failed with `read trusted-review-config: bad file descriptor`. The submit exited 1, the review was never published, and Looper reported `Reviewer agent completed but no matching GitHub review marker was found`.
- The second load is reached through the root `PersistentPreRunE` auto-upgrade hook, which loads config on any **release-installed** binary. `detectCLIInstallSource` returns `dev` for non-stable channels, so no `go build` binary, dev run, or CI job can reach it — only real release installs.
- Memoize the snapshot on `commandRuntime` so every `loadConfig` call in one child reuses the first result, and skip auto-upgrade entirely in a trusted review proxy child.

Observed on a production node running v0.11.2: **42 of 45 parked loops** carry this signature; 52 loops and 161 runs hit it across 2026-07-21 → 07-29. Loop logs retained back to 06-02 show zero occurrences before 07-21. The reviews themselves were fully formed — body, inline comments, and the `<!-- looper:review … -->` marker are all in the agent transcripts. Only publication failed, then five identical retries parked each loop.

## Why now

`ebd339a` (#571) replaced the config **file path** with an **inherited pipe fd**, so a same-UID agent can no longer discover or rewrite the snapshot between proxy minting and review submission. That change is correct and stays. But a file is re-readable and a pipe is not, and `PersistentPreRunE = maybeRunAutoUpgrade` has loaded config before every non-exempt subcommand since #246 — two months earlier. Both sides were individually right; the collision only exists together. `ebd339a` shipped in v0.11.0 on 07-20; the first production failure is 07-21 19:36.

## Prefer deletion over another layer

The tempting deletion is to drop the pipe and go back to a snapshot path. Rejected: the pipe is the whole point of #571's threat model, and reverting it would hand the agent a rewritable authority file. The second candidate for deletion — the auto-upgrade pre-run hook — is genuinely not wanted in this context and **is** deleted here, but only for proxy children, where a bound child replacing its own binary mid-run is never the intended action.

No new concept, persisted state, gate, or validation is introduced. The memo is process-local, holds no new invariant, and adds no failure mode: a second read of a consumed pipe has no correct behavior other than returning the first result.

## Why the memo sits on `commandRuntime`

`loadConfig` has 22 call sites and all of them share one runtime instance per process, which is also how the pre-run hook and the bound `RunE` reach it. Fixing it there repairs the contract — *this snapshot is readable once per process* — rather than the one call site that happened to collide. A package-level cache in `forge` would work equally well in production but adds global mutable state and cross-test pollution that would need a test-only reset hook.

# Testing

- [x] `go test ./...`
- [x] Additional targeted checks: `gofmt -l .`, `go vet ./...`, `go build ./...`

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [x] Daemon boot / config / runtime path risk
- [ ] Worktree / repo isolation / lifecycle risk
- [x] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

Config-load path in the proxy child, and the review-publication path that reaches GitHub. No change to credential handling, bound policy, PR binding, or CWD binding.

# Regression Policy

- [ ] This is not a P0/P1 bug fix
- [x] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [ ] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

`TestCommandRuntimeTrustedReviewConfigSurvivesRepeatedLoads` fails without the memo with the exact production error string:

```
second loadConfig() error = read trusted review config snapshot: read trusted-review-config: bad file descriptor
```

`TestShouldSkipAutoUpgradeForTrustedReviewProxyChild` covers the pre-run exemption in both directions.

# Regression Mapping

- PR / issue links for regression coverage:
  - #571 (`ebd339a`) introduced the single-use config pipe this PR makes safe to read more than once
  - #246 introduced the auto-upgrade pre-run hook that became the second reader

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied

---

Note for release planning: this fix only takes effect on the production node after a release and upgrade. The 42 parked loops should be resumed **after** that upgrade — resuming them beforehand re-enters the same failure, as the 161 recorded runs already show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
