### PR TITLE
fix: recover hollow managed worktrees instead of infinite retry

### DIFF
--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -673,6 +673,13 @@ func classifyDiagnosticMessage(message string, errorKind string) loopDiagnosis {
 	if msg == "" && kind == "" {
 		return loopDiagnosis{}
 	}
+	// Preserved unusable managed paths are stored as LastErrorKind=manual_intervention.
+	// Classify them before the generic MI branch so operators get integrity-specific
+	// cleanup guidance instead of generic manual_intervention actions.
+	if strings.Contains(lower, "unusable and not empty") || strings.Contains(lower, "unusable worktree path preserved") {
+		retryable := false
+		return loopDiagnosis{FailureClass: "managed_worktree_integrity", Retryable: &retryable, Message: msg, RecommendedAction: "inspect the managed worktree path, preserve any agent output, clear or move the leftover directory, then retry the loop"}
+	}
 	if kind == "manual_intervention" {
 		retryable := false
 		return loopDiagnosis{
@@ -705,10 +712,6 @@ func classifyDiagnosticMessage(message string, errorKind string) loopDiagnosis {
 	if strings.Contains(lower, "could not resolve to a repository") || strings.Contains(lower, "repository not found") {
 		retryable := true
 		return loopDiagnosis{FailureClass: "github_repository_access", Retryable: &retryable, Message: msg, RecommendedAction: "check the configured repo slug and GitHub access, then allow the queued retry to continue"}
-	}
-	if strings.Contains(lower, "unusable and not empty") || strings.Contains(lower, "unusable worktree path preserved") {
-		retryable := false
-		return loopDiagnosis{FailureClass: "managed_worktree_integrity", Retryable: &retryable, Message: msg, RecommendedAction: "inspect the managed worktree path, preserve any agent output, clear or move the leftover directory, then retry the loop"}
 	}
 	if strings.Contains(lower, "start command: chdir") || strings.Contains(lower, "not a git repository") || strings.Contains(lower, "not in a git directory") {
 		retryable := true

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -706,6 +706,10 @@ func classifyDiagnosticMessage(message string, errorKind string) loopDiagnosis {
 		retryable := true
 		return loopDiagnosis{FailureClass: "github_repository_access", Retryable: &retryable, Message: msg, RecommendedAction: "check the configured repo slug and GitHub access, then allow the queued retry to continue"}
 	}
+	if strings.Contains(lower, "unusable and not empty") || strings.Contains(lower, "unusable worktree path preserved") {
+		retryable := false
+		return loopDiagnosis{FailureClass: "managed_worktree_integrity", Retryable: &retryable, Message: msg, RecommendedAction: "inspect the managed worktree path, preserve any agent output, clear or move the leftover directory, then retry the loop"}
+	}
 	if strings.Contains(lower, "start command: chdir") || strings.Contains(lower, "not a git repository") || strings.Contains(lower, "not in a git directory") {
 		retryable := true
 		return loopDiagnosis{FailureClass: "project_repo_path", Retryable: &retryable, Message: msg, RecommendedAction: "fix the project repoPath or restore the local checkout, then allow the queued retry to continue"}

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -228,6 +228,19 @@ func TestClassifyDiagnosticMessageManualIntervention(t *testing.T) {
 	if !strings.Contains(locked.RecommendedAction, "unlock") {
 		t.Fatalf("RecommendedAction = %q, want unlock guidance for locked worktree", locked.RecommendedAction)
 	}
+
+	// Production stores ErrUnusableWorktreePreserved as LastErrorKind=manual_intervention;
+	// message-specific integrity class must win over the generic MI branch.
+	preserved := classifyDiagnosticMessage(
+		"worktree path /tmp/wt is unusable and not empty; manual intervention required: unusable worktree path preserved",
+		"manual_intervention",
+	)
+	if preserved.FailureClass != "managed_worktree_integrity" || preserved.Retryable == nil || *preserved.Retryable {
+		t.Fatalf("preserved diagnosis = %#v, want non-retryable managed_worktree_integrity", preserved)
+	}
+	if !strings.Contains(preserved.RecommendedAction, "preserve any agent output") {
+		t.Fatalf("RecommendedAction = %q, want managed-worktree cleanup guidance", preserved.RecommendedAction)
+	}
 }
 
 func TestDiagnoseLoopExpandsRetrySeqPlaceholder(t *testing.T) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -6237,7 +6237,7 @@ func (r *Runner) cleanupFixerWorktreeIfTerminal(ctx context.Context, project sto
 // by itself. Remote helpers can emit "fatal: not a git repository" while the
 // managed worktree remains valid; force CleanupWorktree would then destroy
 // interrupted agent dirt. When error text merely *looks* like a local integrity
-// failure, confirm with localFixerWorktreeCheckoutUsable before recreating.
+// failure, confirm with LocalCheckoutUsable before recreating.
 func isMissingOrUnusableFixerWorktree(path string, prepErr error) bool {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -6258,188 +6258,37 @@ func isMissingOrUnusableFixerWorktree(path string, prepErr error) bool {
 	if _, err := os.Stat(path); err != nil {
 		return os.IsNotExist(err)
 	}
-	msg := strings.ToLower(prepErr.Error())
-	// Integrity-looking phrases are necessary but not sufficient: remote
-	// helpers/servers can emit the same text. Do not substring-match generic
-	// existence phrases either — external dependency errors share that wording.
-	// "invalid gitfile format" is Git's distinct message for a .git file that is
-	// not a gitdir: pointer (malformed retained metadata).
-	looksLikeLocalIntegrity := strings.Contains(msg, "not a working tree") ||
-		strings.Contains(msg, "not a git repository") ||
-		strings.Contains(msg, "invalid gitfile format")
-	if !looksLikeLocalIntegrity {
+	if !worktreesafety.LooksLikeLocalIntegrityError(prepErr) {
 		return false
 	}
 	// Confirm with a non-remote local probe before force-cleaning.
-	return !localFixerWorktreeCheckoutUsable(path)
+	return !worktreesafety.LocalCheckoutUsable(path)
 }
 
-// localFixerWorktreeCheckoutUsable reports whether path has local git metadata
-// without contacting remotes. Linked worktrees use a .git file (gitdir pointer);
-// ordinary checkouts use a .git directory. Metadata presence alone is not enough:
-// ordinary repos and the linked common repository need full non-remote integrity
-// (HEAD + objects/ + refs/), and linked private gitdirs need HEAD plus a
-// resolvable usable common repo via commondir. Empty or corrupt metadata makes
-// real Git report "not a git repository", so prepare can recreate instead of
-// retrying forever.
-// A non-empty .git file that is not a gitdir: pointer is also unusable: real Git
-// reports "fatal: invalid gitfile format" and prepare must recreate rather than
-// retry forever on retained broken metadata.
+// localFixerWorktreeCheckoutUsable delegates to the shared local metadata probe.
 func localFixerWorktreeCheckoutUsable(path string) bool {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return false
-	}
-	gitMeta := filepath.Join(path, ".git")
-	info, err := os.Lstat(gitMeta)
-	if err != nil {
-		return false
-	}
-	if info.IsDir() {
-		// Ordinary checkout: require full local repository metadata.
-		return localGitRepositoryMetadataUsable(gitMeta)
-	}
-	// Linked worktree or gitfile: .git is a regular file (or symlink to one).
-	if info.Mode()&os.ModeSymlink != 0 {
-		target, err := os.Stat(gitMeta)
-		if err != nil {
-			return false
-		}
-		if target.IsDir() {
-			return localGitRepositoryMetadataUsable(gitMeta)
-		}
-	}
-	data, err := os.ReadFile(gitMeta)
-	if err != nil {
-		return false
-	}
-	line := strings.TrimSpace(string(data))
-	if line == "" {
-		return false
-	}
-	const prefix = "gitdir:"
-	if len(line) < len(prefix) || !strings.EqualFold(line[:len(prefix)], prefix) {
-		// Malformed gitfile: real Git rejects non-gitdir: content as
-		// "invalid gitfile format". Treat as unusable so prepare can recreate.
-		return false
-	}
-	gitdir := strings.TrimSpace(line[len(prefix):])
-	if gitdir == "" {
-		return false
-	}
-	if !filepath.IsAbs(gitdir) {
-		gitdir = filepath.Join(path, gitdir)
-	}
-	// Linked private gitdir must look like a real git dir (HEAD), not merely exist.
-	// An empty/corrupt gitdir still makes `git` report "not a git repository"; if
-	// we only checked existence, prepare would retry forever without recreating.
-	if _, err = os.Stat(filepath.Join(gitdir, "HEAD")); err != nil {
-		return false
-	}
-	// commondir is required for linked worktrees: without it (or when it does not
-	// resolve to a common repo with full local integrity), Git 2.43+ still fails
-	// with "fatal: not a git repository" even though private HEAD remains.
-	return linkedPrivateGitdirCommonUsable(gitdir)
+	return worktreesafety.LocalCheckoutUsable(path)
 }
 
-// localGitRepositoryMetadataUsable is a non-remote integrity probe for a Git
-// repository directory (ordinary .git or a linked worktree common repo).
-// HEAD alone is insufficient: Git 2.43+ also requires objects/ and refs/ and
-// reports "fatal: not a git repository" when either directory is missing.
-func localGitRepositoryMetadataUsable(dir string) bool {
-	dir = strings.TrimSpace(dir)
-	if dir == "" {
-		return false
-	}
-	if _, err := os.Stat(filepath.Join(dir, "HEAD")); err != nil {
-		return false
-	}
-	objects, err := os.Stat(filepath.Join(dir, "objects"))
-	if err != nil || !objects.IsDir() {
-		return false
-	}
-	refs, err := os.Stat(filepath.Join(dir, "refs"))
-	if err != nil || !refs.IsDir() {
-		return false
-	}
-	return true
-}
+// errUnusableFixerWorktreePreserved aliases the shared preserved-path sentinel
+// so existing fixer call sites and tests keep working.
+var errUnusableFixerWorktreePreserved = worktreesafety.ErrUnusableWorktreePreserved
 
-// linkedPrivateGitdirCommonUsable reports whether a linked worktree private
-// gitdir has a readable commondir that resolves to a common repository with
-// non-remote integrity (HEAD + objects/ + refs/).
-func linkedPrivateGitdirCommonUsable(gitdir string) bool {
-	data, err := os.ReadFile(filepath.Join(gitdir, "commondir"))
-	if err != nil {
-		return false
-	}
-	common := strings.TrimSpace(string(data))
-	if common == "" {
-		return false
-	}
-	if !filepath.IsAbs(common) {
-		common = filepath.Join(gitdir, common)
-	}
-	common = filepath.Clean(common)
-	return localGitRepositoryMetadataUsable(common)
-}
-
-// errUnusableFixerWorktreePreserved signals that an unusable worktree path still
-// holds content after CleanupWorktree and must not be recreated over.
-var errUnusableFixerWorktreePreserved = errors.New("unusable fixer worktree path preserved")
-
-// clearUnusableFixerWorktreePath handles filesystem leftovers after CleanupWorktree
-// on a missing/unusable checkout. Git's `worktree remove --force` only removes
-// registered worktrees; unregistered directories are left intact, which then
-// blocks CreateWorktree when the managed path already exists.
-//
-// Policy: remove empty directories (safe stale), and remove directories whose only
-// content is unusable local git metadata (corrupt/empty linked .git) so Create
-// can reuse the managed path. Preserve any other populated path for manual
-// intervention (may hold interrupted agent output even without a usable .git).
+// clearUnusableFixerWorktreePath clears empty/metadata-only leftovers after
+// CleanupWorktree. Safety bounds use the path itself as WorktreePath; callers
+// only invoke this for managed fixer checkouts under the project worktree root.
 func clearUnusableFixerWorktreePath(path string) error {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return nil
 	}
-	info, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("fixer worktree path %s is unusable and not empty; manual intervention required: %w", path, errUnusableFixerWorktreePreserved)
-	}
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return err
-	}
-	if len(entries) == 0 {
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		return nil
-	}
-	// Only corrupt/empty git metadata: safe to remove so prepare can recreate.
-	if onlyUnusableLocalGitMetadata(path, entries) {
-		if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		return nil
-	}
-	return fmt.Errorf("fixer worktree path %s is unusable and not empty; manual intervention required: %w", path, errUnusableFixerWorktreePreserved)
-}
-
-// onlyUnusableLocalGitMetadata is true when path holds nothing but a non-usable
-// .git file/dir (and optional nested empties under an ordinary .git dir). Any
-// other entry is treated as possible agent dirt and must be preserved.
-func onlyUnusableLocalGitMetadata(path string, entries []os.DirEntry) bool {
-	if len(entries) != 1 || entries[0].Name() != ".git" {
-		return false
-	}
-	return !localFixerWorktreeCheckoutUsable(path)
+	// Parent of the worktree directory is the managed root for this path.
+	// Validate requires path under WorktreeRoot and not equal to it.
+	root := filepath.Dir(path)
+	return worktreesafety.ClearUnusableManagedPath(worktreesafety.CheckInput{
+		WorktreePath: path,
+		WorktreeRoot: root,
+	}, path)
 }
 
 func queueResultIsTerminalForCleanup(queue *storage.QueueItemRecord) bool {

--- a/internal/fixer/runner_prepare_real_gateway_corrupt_test.go
+++ b/internal/fixer/runner_prepare_real_gateway_corrupt_test.go
@@ -67,7 +67,13 @@ func TestRunPrepareWorktreeStepRealGatewayRecreatesCorruptCommonRepo(t *testing.
 	t.Parallel()
 
 	f := setupRealLinkedWorktree(t, "project_real_corrupt_common", "feature/fix-42")
-	if !localGitRepositoryMetadataUsable(resolveLinkedCommonDir(t, f.gitdir)) {
+	// Common dir alone is not a checkout path; probe via a synthetic ordinary
+	// checkout whose .git is that common repository.
+	commonCheckout := t.TempDir()
+	if err := os.Symlink(resolveLinkedCommonDir(t, f.gitdir), filepath.Join(commonCheckout, ".git")); err != nil {
+		t.Fatalf("Symlink common .git: %v", err)
+	}
+	if !localFixerWorktreeCheckoutUsable(commonCheckout) {
 		t.Fatal("common repo not usable before corruption")
 	}
 	// HEAD-only common: missing objects/ (and refs/) — Git rejects as not a repo.

--- a/internal/infra/git/gateway.go
+++ b/internal/infra/git/gateway.go
@@ -241,6 +241,17 @@ func (g *Gateway) CreateWorktree(ctx context.Context, input CreateWorktreeInput)
 		return *restored, nil
 	}
 
+	// Unregistered hollow leftovers block `git worktree add`. Clear only when
+	// local metadata proves the path is not a usable checkout; preserve any
+	// other content for manual intervention.
+	if err := worktreesafety.EnsureUnusableManagedPathCleared(worktreesafety.CheckInput{
+		WorktreePath: worktreePath,
+		RepoPath:     input.RepoPath,
+		WorktreeRoot: input.WorktreeRoot,
+	}, worktreePath); err != nil {
+		return storage.WorktreeRecord{}, err
+	}
+
 	if checkoutMode == CheckoutModeDetached {
 		startPoint, err := g.resolveDetachedStartPoint(ctx, input)
 		if err != nil {
@@ -373,6 +384,16 @@ func (g *Gateway) RestoreWorktree(ctx context.Context, input RestoreWorktreeInpu
 			}
 			if !storedHealthy {
 				g.tryRemoveWorktree(ctx, input.RepoPath, stored.WorktreePath)
+				// Hollow/unregistered leftovers survive `worktree remove`. Clear
+				// empty or metadata-only paths so Create can recreate; preserve
+				// populated unusable paths as MI instead of infinite retry.
+				if err := worktreesafety.EnsureUnusableManagedPathCleared(worktreesafety.CheckInput{
+					WorktreePath: stored.WorktreePath,
+					RepoPath:     input.RepoPath,
+					WorktreeRoot: input.WorktreeRoot,
+				}, stored.WorktreePath); err != nil {
+					return nil, err
+				}
 			} else {
 				storedCheckoutMatches, err := g.matchesRestoreCheckoutMode(ctx, stored.WorktreePath, checkoutMode, input.Branch)
 				if err != nil {
@@ -445,6 +466,13 @@ func (g *Gateway) RestoreWorktree(ctx context.Context, input RestoreWorktreeInpu
 	}
 	if !healthy {
 		g.tryRemoveWorktree(ctx, input.RepoPath, match.Path)
+		if err := worktreesafety.EnsureUnusableManagedPathCleared(worktreesafety.CheckInput{
+			WorktreePath: match.Path,
+			RepoPath:     input.RepoPath,
+			WorktreeRoot: input.WorktreeRoot,
+		}, match.Path); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 
@@ -1004,6 +1032,15 @@ func (g *Gateway) isHealthyWorktree(ctx context.Context, worktreePath string) (b
 			return false, nil
 		}
 		return false, err
+	}
+
+	// Confirmed local-unusable (hollow/corrupt metadata): treat as unhealthy
+	// without propagating git status. Restore can remove + clear + recreate
+	// instead of infinite retryable_transient storms.
+	// Usable local metadata with a failing `git status` still propagates —
+	// that may be locks, permissions, or other non-hollow failures.
+	if !worktreesafety.LocalCheckoutUsable(worktreePath) {
+		return false, nil
 	}
 
 	_, err := g.runGitResult(ctx, worktreePath, nil, "status", "--porcelain", "--untracked-files=all")

--- a/internal/infra/git/gateway_test.go
+++ b/internal/infra/git/gateway_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worktreesafety"
 )
 
 func TestGatewayRejectsRepoPathAsMutationWorktree(t *testing.T) {
@@ -1231,7 +1232,7 @@ func TestGatewayDiscardWorktreeChangesRejectsUnsafePaths(t *testing.T) {
 	}
 }
 
-func TestGatewayRestoreWorktreePropagatesHealthCheckFailureForStoredWorktree(t *testing.T) {
+func TestGatewayRestoreWorktreeRecreatesHollowStoredWorktree(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -1239,6 +1240,8 @@ func TestGatewayRestoreWorktreePropagatesHealthCheckFailureForStoredWorktree(t *
 	fixture.createMainOnlyRepo(t)
 	gateway := fixture.gateway()
 
+	// Empty hollow directory with an active DB row — the production failure mode
+	// that previously infinite-retried as retryable_transient.
 	brokenWorktreePath := filepath.Join(fixture.worktreeRoot, "broken-worktree")
 	mustMkdirAll(t, brokenWorktreePath)
 	metadata := `{"recovered":false}`
@@ -1247,16 +1250,111 @@ func TestGatewayRestoreWorktreePropagatesHealthCheckFailureForStoredWorktree(t *
 		t.Fatalf("Worktrees.Upsert() error = %v", err)
 	}
 
-	_, err := gateway.RestoreWorktree(ctx, RestoreWorktreeInput{ProjectID: fixture.projectID, RepoPath: fixture.repoPath, Branch: "feature/fixer", WorktreeRoot: fixture.worktreeRoot})
+	// Restore should clear the hollow path and fall through (nil, nil) so Create can rebuild.
+	restored, err := gateway.RestoreWorktree(ctx, RestoreWorktreeInput{ProjectID: fixture.projectID, RepoPath: fixture.repoPath, Branch: "feature/fixer", WorktreeRoot: fixture.worktreeRoot})
+	if err != nil {
+		t.Fatalf("RestoreWorktree() error = %v, want nil after clearing hollow path", err)
+	}
+	if restored != nil {
+		t.Fatalf("RestoreWorktree() restored = %+v, want nil so CreateWorktree can rebuild", restored)
+	}
+	if _, err := os.Stat(brokenWorktreePath); !os.IsNotExist(err) {
+		t.Fatalf("hollow path still exists after RestoreWorktree, err=%v", err)
+	}
+
+	created, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       "feature/fixer",
+		BaseBranch:   "main",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(created.WorktreePath, ".git")); err != nil {
+		t.Fatalf("created worktree missing .git: %v", err)
+	}
+}
+
+func TestGatewayRestoreWorktreePreservesPopulatedUnusablePath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createMainOnlyRepo(t)
+	gateway := fixture.gateway()
+
+	brokenWorktreePath := filepath.Join(fixture.worktreeRoot, "populated-hollow")
+	mustMkdirAll(t, brokenWorktreePath)
+	if err := os.WriteFile(filepath.Join(brokenWorktreePath, "agent-output.txt"), []byte("keep\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	metadata := `{"recovered":false}`
+	baseBranch := "main"
+	if err := fixture.repos.Worktrees.Upsert(ctx, storage.WorktreeRecord{ID: "populated-record", ProjectID: fixture.projectID, RepoPath: fixture.repoPath, WorktreePath: brokenWorktreePath, Branch: "feature/populated", BaseBranch: &baseBranch, Status: "active", MetadataJSON: &metadata, CreatedAt: fixture.now().UTC().Format(javaScriptISOStringLayout), UpdatedAt: fixture.now().UTC().Format(javaScriptISOStringLayout)}); err != nil {
+		t.Fatalf("Worktrees.Upsert() error = %v", err)
+	}
+
+	_, err := gateway.RestoreWorktree(ctx, RestoreWorktreeInput{ProjectID: fixture.projectID, RepoPath: fixture.repoPath, Branch: "feature/populated", WorktreeRoot: fixture.worktreeRoot})
 	if err == nil {
-		t.Fatal("RestoreWorktree() error = nil, want health check failure")
+		t.Fatal("RestoreWorktree() error = nil, want preserved populated path error")
 	}
-	var commandErr *shell.CommandExecutionError
-	if !errors.As(err, &commandErr) {
-		t.Fatalf("RestoreWorktree() error = %T, want *shell.CommandExecutionError", err)
+	if !errors.Is(err, worktreesafety.ErrUnusableWorktreePreserved) {
+		t.Fatalf("RestoreWorktree() error = %v, want ErrUnusableWorktreePreserved", err)
 	}
-	if commandErr.Result.ExitCode == 1 {
-		t.Fatalf("RestoreWorktree() exit code = %d, want non-1 health check failure", commandErr.Result.ExitCode)
+	if _, err := os.Stat(filepath.Join(brokenWorktreePath, "agent-output.txt")); err != nil {
+		t.Fatalf("populated content missing: %v", err)
+	}
+}
+
+func TestGatewayIsHealthyWorktreePropagatesStatusFailureWhenLocalMetadataUsable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fixture := newFixture(t)
+	fixture.createMainOnlyRepo(t)
+	gateway := fixture.gateway()
+
+	created, err := gateway.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:    fixture.projectID,
+		RepoPath:     fixture.repoPath,
+		WorktreeRoot: fixture.worktreeRoot,
+		Branch:       "feature/status-fail",
+		BaseBranch:   "main",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+	// Make the worktree path unreadable to git status while leaving local
+	// metadata layout intact. chmod 000 on the worktree directory causes
+	// `git -C path status` to fail without removing HEAD/objects/refs.
+	// Restore perms in cleanup so TempDir removal succeeds.
+	if err := os.Chmod(created.WorktreePath, 0o000); err != nil {
+		t.Fatalf("Chmod worktree: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(created.WorktreePath, 0o755) })
+
+	// LocalCheckoutUsable may still see metadata depending on OS permission
+	// checks; if the probe itself cannot read .git, the path is treated as
+	// local-unusable (false, nil) which is also correct. Prefer the stronger
+	// assertion when metadata remains readable.
+	if worktreesafety.LocalCheckoutUsable(created.WorktreePath) {
+		healthy, healthErr := gateway.isHealthyWorktree(ctx, created.WorktreePath)
+		if healthErr == nil {
+			t.Fatal("isHealthyWorktree() error = nil, want status failure propagated when metadata usable")
+		}
+		if healthy {
+			t.Fatal("isHealthyWorktree() = true, want false")
+		}
+		return
+	}
+	healthy, healthErr := gateway.isHealthyWorktree(ctx, created.WorktreePath)
+	if healthErr != nil {
+		t.Fatalf("isHealthyWorktree() error = %v, want nil for confirmed local-unusable", healthErr)
+	}
+	if healthy {
+		t.Fatal("isHealthyWorktree() = true, want false")
 	}
 }
 

--- a/internal/loops/failureclass/failureclass.go
+++ b/internal/loops/failureclass/failureclass.go
@@ -75,11 +75,12 @@ func Classify(err error, ctx Context) Kind {
 	if githubinfra.IsTransientError(err) {
 		return RetryableTransient
 	}
-	if ctx.Boundary == BoundaryUnknown {
-		var boundaryErr *BoundaryError
-		if errors.As(err, &boundaryErr) && boundaryErr.Boundary != "" {
-			ctx.Boundary = boundaryErr.Boundary
-		}
+	// Prefer an explicit boundary attached to the error over the caller's step
+	// default. Worktree steps often default to git_remote (fetch), but local
+	// integrity failures wrap BoundaryLocalWorktree after a confirmed probe.
+	var boundaryErr *BoundaryError
+	if errors.As(err, &boundaryErr) && boundaryErr.Boundary != "" {
+		ctx.Boundary = boundaryErr.Boundary
 	}
 
 	message := strings.ToLower(githubinfra.ErrorMessage(err))

--- a/internal/loops/failureclass/failureclass_test.go
+++ b/internal/loops/failureclass/failureclass_test.go
@@ -39,6 +39,19 @@ func TestClassifyUsesWrappedBoundaryAuthority(t *testing.T) {
 	}
 }
 
+func TestClassifyWrappedLocalWorktreeOverridesStepRemoteBoundary(t *testing.T) {
+	// Reviewer worktree steps default to git_remote (fetch), but a confirmed
+	// local integrity failure must park as MI rather than infinite transient retry.
+	err := WithBoundary(
+		errors.New("worktree path /tmp/wt is unusable and not empty; manual intervention required"),
+		BoundaryLocalWorktree,
+	)
+	got := Classify(err, Context{Runner: RunnerReviewer, Boundary: BoundaryGitRemote})
+	if got != ManualIntervention {
+		t.Fatalf("Classify() = %s, want %s", got, ManualIntervention)
+	}
+}
+
 func TestClassifyRetriesGitHubGraphQLUnauthorizedAtGitHubBoundary(t *testing.T) {
 	got := Classify(errors.New(`Post "https://api.github.com/graphql": HTTP 401 Unauthorized`), Context{Runner: RunnerReviewer, Boundary: BoundaryGitHubAPI})
 	if got != RetryableTransient {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -6953,8 +6953,12 @@ func reviewerWorktreeNeedsPrepare(checkpoint reviewerCheckpoint) bool {
 	if strings.TrimSpace(worktree.Path) == "" || strings.TrimSpace(worktree.Branch) == "" || worktree.CleanedAt != "" {
 		return true
 	}
-	_, err := os.Stat(worktree.Path)
-	return err != nil
+	if _, err := os.Stat(worktree.Path); err != nil {
+		return true
+	}
+	// Hollow/corrupt checkouts must not skip CreateWorktree via PreparedAt.
+	// Local metadata is authority for usability; path existence alone is not.
+	return !worktreesafety.LocalCheckoutUsable(worktree.Path)
 }
 
 func reviewerWorktreeBranch(prNumber int64, checkpoint reviewerCheckpoint) string {

--- a/internal/reviewer/runner_owner_token_restore_failure_test.go
+++ b/internal/reviewer/runner_owner_token_restore_failure_test.go
@@ -83,6 +83,7 @@ func (f *restoreFailAfterClearGit) CreateWorktree(_ context.Context, input Creat
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return CreateWorktreeResult{}, err
 	}
+	ensureFakeUsableGitCheckout(path)
 	if err := worktreesafety.ClearFixerOwnerToken(path); err != nil {
 		return CreateWorktreeResult{}, err
 	}

--- a/internal/reviewer/runner_owner_token_thread_resolution_test.go
+++ b/internal/reviewer/runner_owner_token_thread_resolution_test.go
@@ -126,6 +126,8 @@ func TestReviewerWorktreePreparedRejectsFixerOwnedPath(t *testing.T) {
 	if err := os.MkdirAll(wtPath, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
+	// Prepared reuse requires a usable local checkout, not just path existence.
+	writeMinimalUsableGitCheckout(t, wtPath)
 	checkpoint := reviewerCheckpoint{
 		Worktree: &checkpointWorktree{Path: wtPath, Branch: "pr-42-head", PreparedAt: "2026-04-11T12:00:00.000Z"},
 	}
@@ -137,5 +139,36 @@ func TestReviewerWorktreePreparedRejectsFixerOwnedPath(t *testing.T) {
 	}
 	if reviewerWorktreePrepared(checkpoint) {
 		t.Fatal("reviewerWorktreePrepared() = true, want false when fixer marker present")
+	}
+}
+
+func TestReviewerWorktreePreparedRejectsHollowCheckout(t *testing.T) {
+	t.Parallel()
+
+	wtPath := filepath.Join(t.TempDir(), "hollow-wt")
+	if err := os.MkdirAll(filepath.Join(wtPath, ".tmp"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	checkpoint := reviewerCheckpoint{
+		Worktree: &checkpointWorktree{Path: wtPath, Branch: "pr-42-head", PreparedAt: "2026-04-11T12:00:00.000Z"},
+	}
+	if reviewerWorktreePrepared(checkpoint) {
+		t.Fatal("reviewerWorktreePrepared() = true for hollow path, want false so CreateWorktree runs")
+	}
+	if !reviewerWorktreeNeedsPrepare(checkpoint) {
+		t.Fatal("reviewerWorktreeNeedsPrepare() = false for hollow path, want true")
+	}
+}
+
+func writeMinimalUsableGitCheckout(t *testing.T, path string) {
+	t.Helper()
+	gitDir := filepath.Join(path, ".git")
+	for _, sub := range []string{"objects", "refs"} {
+		if err := os.MkdirAll(filepath.Join(gitDir, sub), 0o755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", sub, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile HEAD: %v", err)
 	}
 }

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -231,6 +231,24 @@ func TestShouldRetryQueueFailureRespectsMaxAttempts(t *testing.T) {
 	if shouldRetryQueueFailure(FailureRetryableTransient, 3, 3) {
 		t.Fatal("shouldRetryQueueFailure() = true, want false once nextAttempts reaches maxAttempts")
 	}
+	// Populated hollow worktree parks as MI and must not infinite-retry under max=-1.
+	if shouldRetryQueueFailure(FailureManualIntervention, 242, -1) {
+		t.Fatal("shouldRetryQueueFailure(MI) = true, want false so hollow storms park")
+	}
+}
+
+func TestClassifyPreservedUnusableWorktreeAsManualIntervention(t *testing.T) {
+	t.Parallel()
+
+	runner := &Runner{}
+	err := fmt.Errorf("worktree path /tmp/wt is unusable and not empty; manual intervention required: %w", worktreesafety.ErrUnusableWorktreePreserved)
+	got := runner.classifyFailureForProjectAndBoundary("project_1", err, failureclass.BoundaryGitRemote)
+	if got == nil || got.kind != FailureManualIntervention {
+		t.Fatalf("classify = %#v, want FailureManualIntervention (not transient via worktree step boundary)", got)
+	}
+	if shouldRetryQueueFailure(got.kind, 1, -1) {
+		t.Fatal("preserved unusable worktree must not requeue under unlimited maxAttempts")
+	}
 }
 
 func TestBackoffDelayCapsBeforeDurationOverflow(t *testing.T) {
@@ -6144,6 +6162,7 @@ func TestRunPrepareWorktreeStepClearsFixerOwnerTokenWhenReusingPreparedPath(t *t
 	if err := os.MkdirAll(wtPath, 0o755); err != nil {
 		t.Fatalf("MkdirAll worktree: %v", err)
 	}
+	ensureFakeUsableGitCheckout(wtPath)
 	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, Logger: fixture.logger, Now: fixture.now})
 
@@ -6184,6 +6203,7 @@ func TestRunPrepareWorktreeStepRePreparesWhenFixerMarkerPresent(t *testing.T) {
 	if err := os.MkdirAll(wtPath, 0o755); err != nil {
 		t.Fatalf("MkdirAll worktree: %v", err)
 	}
+	ensureFakeUsableGitCheckout(wtPath)
 	const token = "fixer:loop_x:run_y:must-reprepare"
 	if err := worktreesafety.WriteFixerOwnerToken(wtPath, token); err != nil {
 		t.Fatalf("WriteFixerOwnerToken: %v", err)
@@ -10314,11 +10334,25 @@ func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeI
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return CreateWorktreeResult{}, err
 	}
+	// Seed usable local git metadata so reviewerWorktreePrepared (which probes
+	// LocalCheckoutUsable) can reuse the path after Prepare sets PreparedAt.
+	// Without this, stepReview re-enters prepare and double-counts Create.
+	ensureFakeUsableGitCheckout(path)
 	// Match real gateway: any CreateWorktree claim revokes prior fixer ownership.
 	if err := worktreesafety.ClearFixerOwnerToken(path); err != nil {
 		return CreateWorktreeResult{}, err
 	}
 	return CreateWorktreeResult{WorktreePath: path, Branch: input.Branch, HeadSHA: "abc123"}, nil
+}
+
+func ensureFakeUsableGitCheckout(path string) {
+	gitDir := filepath.Join(path, ".git")
+	if worktreesafety.LocalCheckoutUsable(path) {
+		return
+	}
+	_ = os.MkdirAll(filepath.Join(gitDir, "objects"), 0o755)
+	_ = os.MkdirAll(filepath.Join(gitDir, "refs"), 0o755)
+	_ = os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644)
 }
 
 func (f *fakeGitGateway) PrepareWorktree(_ context.Context, input PrepareWorktreeInput) (PrepareWorktreeResult, error) {

--- a/internal/runtime/non_mutating_coverage_test.go
+++ b/internal/runtime/non_mutating_coverage_test.go
@@ -147,14 +147,18 @@ func TestNonMutatingCoverageDegradedPausesClaimPump(t *testing.T) {
 	rt.mu.Unlock()
 
 	rt.executeSchedulerClaimPass(context.Background())
-	if claimCalls.Load() != 1 {
-		t.Fatalf("claim calls while ready = %d, want 1", claimCalls.Load())
+	claimsWhenReady := claimCalls.Load()
+	if claimsWhenReady < 1 {
+		t.Fatalf("claim calls while ready = %d, want >= 1", claimsWhenReady)
 	}
 	if err := rt.MarkDegraded("persist failure"); err != nil {
 		t.Fatalf("MarkDegraded() error = %v", err)
 	}
+	// Snapshot after degrade so a background claim-pump tick that raced while
+	// still ready cannot fail the assertion (same pattern as safety_floor).
+	claimsAtDegrade := claimCalls.Load()
 	rt.executeSchedulerClaimPass(context.Background())
-	if claimCalls.Load() != 1 {
-		t.Fatalf("claim calls after degraded = %d, want still 1", claimCalls.Load())
+	if claimCalls.Load() != claimsAtDegrade {
+		t.Fatalf("claim calls after degraded = %d, want still %d (ready had %d)", claimCalls.Load(), claimsAtDegrade, claimsWhenReady)
 	}
 }

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1548,7 +1548,7 @@ func (r *Runner) runPrepareWorktreeStep(ctx context.Context, input stepInput) (w
 		}
 	}
 	if checkpoint.Worktree != nil {
-		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err == nil {
+		if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: checkpoint.Worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err == nil && worktreesafety.LocalCheckoutUsable(checkpoint.Worktree.Path) {
 			// Reusing an existing path skips CreateWorktree/RestoreWorktree, so
 			// revoke any fixer owner marker stamped on this checkout.
 			if err := worktreesafety.ClearFixerOwnerToken(checkpoint.Worktree.Path); err != nil {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1648,27 +1648,77 @@ func (r *Runner) recoverWorkerWorktree(ctx context.Context, input stepInput, che
 	if rootErr != nil {
 		return worktree, &loopError{message: rootErr.Error(), kind: FailureRetryableTransient}
 	}
+	baseBranch := firstNonEmpty(worktree.BaseBranch, work.BaseBranch)
 	restored, restoreErr := r.git.RestoreWorktree(ctx, RestoreWorktreeInput{ProjectID: input.Project.ID, RepoPath: input.Project.RepoPath, Branch: branch, WorktreeRoot: worktreeRoot, ExpectedWorktreePath: worktree.Path})
 	if restoreErr != nil {
+		// Production restore preserves populated unusable paths. Park as MI so
+		// unlimited retry queues cannot storm on the same preserved directory.
+		if errors.Is(restoreErr, worktreesafety.ErrUnusableWorktreePreserved) {
+			return worktree, &loopError{message: restoreErr.Error(), kind: FailureManualIntervention}
+		}
 		return worktree, &loopError{message: fmt.Sprintf("Worker worktree path %s for branch %s is stale (%s) and re-resolving registered git worktrees failed: %v", worktree.Path, branch, reason, restoreErr), kind: FailureRetryableAfterResume}
 	}
-	if restored == nil || strings.TrimSpace(restored.WorktreePath) == "" {
-		return worktree, staleWorkerWorktreeError(worktree, work, reason+" and no active git worktree is registered for that branch")
+	if restored != nil && strings.TrimSpace(restored.WorktreePath) != "" {
+		return r.applyRecoveredWorkerWorktree(ctx, input, checkpoint, worktree, work, recoveredWorkerWorktree{
+			path:       restored.WorktreePath,
+			branch:     firstNonEmpty(restored.Branch, branch),
+			baseBranch: firstNonEmpty(baseBranch, restored.BaseBranch),
+			headSHA:    firstNonEmpty(worktree.HeadSHA, restored.HeadSHA),
+			id:         firstNonEmpty(restored.WorktreeID, worktree.ID),
+		})
 	}
-	recovered := worktree
-	recovered.Path = restored.WorktreePath
-	recovered.Branch = firstNonEmpty(restored.Branch, branch)
-	recovered.BaseBranch = firstNonEmpty(worktree.BaseBranch, restored.BaseBranch, work.BaseBranch)
-	recovered.HeadSHA = firstNonEmpty(worktree.HeadSHA, restored.HeadSHA)
-	recovered.ID = firstNonEmpty(restored.WorktreeID, worktree.ID)
-	checkpoint.Worktree = &recovered
+	// Restore cleared empty/metadata-only leftovers (or found no registered
+	// healthy worktree). Recreate instead of parking as stale-worktree MI.
+	created, createErr := r.git.CreateWorktree(ctx, CreateWorktreeInput{
+		ProjectID:         input.Project.ID,
+		RepoPath:          input.Project.RepoPath,
+		WorktreeRoot:      worktreeRoot,
+		Branch:            branch,
+		BaseBranch:        baseBranch,
+		PRNumber:          work.PRNumber,
+		ProtectedBranches: compactStrings([]string{baseBranch}),
+	})
+	if createErr != nil {
+		if errors.Is(createErr, worktreesafety.ErrUnusableWorktreePreserved) {
+			return worktree, &loopError{message: createErr.Error(), kind: FailureManualIntervention}
+		}
+		return worktree, &loopError{message: fmt.Sprintf("Worker worktree path %s for branch %s is stale (%s) and recreating the worktree failed: %v", worktree.Path, branch, reason, createErr), kind: FailureRetryableAfterResume}
+	}
+	if strings.TrimSpace(created.WorktreePath) == "" {
+		return worktree, staleWorkerWorktreeError(worktree, work, reason+" and create-worktree returned an empty path")
+	}
+	return r.applyRecoveredWorkerWorktree(ctx, input, checkpoint, worktree, work, recoveredWorkerWorktree{
+		path:       created.WorktreePath,
+		branch:     firstNonEmpty(created.Branch, branch),
+		baseBranch: firstNonEmpty(baseBranch, created.BaseBranch),
+		headSHA:    firstNonEmpty(worktree.HeadSHA, created.HeadSHA),
+		id:         firstNonEmpty(created.WorktreeID, worktree.ID),
+	})
+}
+
+type recoveredWorkerWorktree struct {
+	path       string
+	branch     string
+	baseBranch string
+	headSHA    string
+	id         string
+}
+
+func (r *Runner) applyRecoveredWorkerWorktree(ctx context.Context, input stepInput, checkpoint *workerCheckpoint, worktree checkpointWorktree, work workerInput, recovered recoveredWorkerWorktree) (checkpointWorktree, error) {
+	next := worktree
+	next.Path = recovered.path
+	next.Branch = recovered.branch
+	next.BaseBranch = firstNonEmpty(recovered.baseBranch, work.BaseBranch)
+	next.HeadSHA = recovered.headSHA
+	next.ID = recovered.id
+	checkpoint.Worktree = &next
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	if input.Run.ID != "" {
 		if persistErr := r.persistCheckpoint(ctx, input.Run.ID, *checkpoint); persistErr != nil {
 			return worktree, &loopError{message: persistErr.Error(), kind: FailureRetryableAfterResume}
 		}
 	}
-	return recovered, nil
+	return next, nil
 }
 
 func workerWorktreeRoot(project storage.ProjectRecord) (string, error) {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1622,11 +1622,11 @@ func (r *Runner) ensureWorkerWorktreeUsable(ctx context.Context, input stepInput
 		if !info.IsDir() {
 			return r.recoverWorkerWorktree(ctx, input, checkpoint, work, worktree, "path exists but is not a directory")
 		}
-		if _, gitErr := os.Stat(filepath.Join(worktree.Path, ".git")); gitErr != nil {
-			if errors.Is(gitErr, os.ErrNotExist) {
-				return r.recoverWorkerWorktree(ctx, input, checkpoint, work, worktree, "path is not a usable git worktree")
-			}
-			return worktree, &loopError{message: fmt.Sprintf("Unable to inspect worker worktree git metadata at %s for branch %s: %v", worktree.Path, firstNonEmpty(worktree.Branch, work.Branch, "unknown"), gitErr), kind: FailureRetryableTransient}
+		// Resume at execute/validate/open_pr skips prepare-worktree, so apply the
+		// same shared integrity probe: any existing .git entry is not enough —
+		// malformed gitfiles and corrupt linked metadata must recover too.
+		if !worktreesafety.LocalCheckoutUsable(worktree.Path) {
+			return r.recoverWorkerWorktree(ctx, input, checkpoint, work, worktree, "path is not a usable git worktree")
 		}
 		return worktree, nil
 	}

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1615,6 +1615,12 @@ func (r *Runner) ensureWorkerWorktreeUsable(ctx context.Context, input stepInput
 		return worktree, &loopError{message: rootErr.Error(), kind: FailureRetryableTransient}
 	}
 	if err := worktreesafety.Validate(worktreesafety.CheckInput{WorktreePath: worktree.Path, RepoPath: input.Project.RepoPath, WorktreeRoot: worktreeRoot}); err != nil {
+		// A checkpoint that points at the project repo is corrupt authority, not a
+		// hollow managed worktree. Recreate-after-restore-nil would invent a fresh
+		// path and let post-execute steps succeed without the claimed work.
+		if worktreesafety.IsProjectRepoPath(worktree.Path, input.Project.RepoPath) {
+			return worktree, staleWorkerWorktreeError(worktree, work, err.Error())
+		}
 		return r.recoverWorkerWorktree(ctx, input, checkpoint, work, worktree, err.Error())
 	}
 	info, err := os.Stat(worktree.Path)

--- a/internal/worker/runner_recover_real_gateway_test.go
+++ b/internal/worker/runner_recover_real_gateway_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/nexu-io/looper/internal/worktreesafety"
 )
 
-// realWorkerGitGateway adapts infra/git.Gateway to worker.GitGateway so recovery
-// tests exercise the production Restore→Create / preserve contracts.
+// realWorkerGitGateway adapts infra/git.Gateway for worker recovery contracts.
+// Unused interface methods panic: these tests only exercise Restore→Create / preserve.
 type realWorkerGitGateway struct {
 	inner        *gitinfra.Gateway
 	restoreCalls int
@@ -26,12 +26,8 @@ type realWorkerGitGateway struct {
 func (g *realWorkerGitGateway) CreateWorktree(ctx context.Context, input CreateWorktreeInput) (CreateWorktreeResult, error) {
 	g.createCalls++
 	record, err := g.inner.CreateWorktree(ctx, gitinfra.CreateWorktreeInput{
-		ProjectID:         input.ProjectID,
-		RepoPath:          input.RepoPath,
-		WorktreeRoot:      input.WorktreeRoot,
-		Branch:            input.Branch,
-		BaseBranch:        input.BaseBranch,
-		PRNumber:          input.PRNumber,
+		ProjectID: input.ProjectID, RepoPath: input.RepoPath, WorktreeRoot: input.WorktreeRoot,
+		Branch: input.Branch, BaseBranch: input.BaseBranch, PRNumber: input.PRNumber,
 		ProtectedBranches: append([]string{}, input.ProtectedBranches...),
 		CheckoutMode:      gitinfra.CheckoutMode(input.CheckoutMode),
 	})
@@ -39,77 +35,40 @@ func (g *realWorkerGitGateway) CreateWorktree(ctx context.Context, input CreateW
 		return CreateWorktreeResult{}, err
 	}
 	return CreateWorktreeResult{
-		WorktreePath: record.WorktreePath,
-		Branch:       record.Branch,
-		BaseBranch:   strings.TrimSpace(derefString(record.BaseBranch)),
-		HeadSHA:      strings.TrimSpace(derefString(record.HeadSHA)),
-		WorktreeID:   record.ID,
+		WorktreePath: record.WorktreePath, Branch: record.Branch,
+		BaseBranch: strings.TrimSpace(derefString(record.BaseBranch)),
+		HeadSHA:    strings.TrimSpace(derefString(record.HeadSHA)), WorktreeID: record.ID,
 	}, nil
 }
 
 func (g *realWorkerGitGateway) RestoreWorktree(ctx context.Context, input RestoreWorktreeInput) (*RestoreWorktreeResult, error) {
 	g.restoreCalls++
 	record, err := g.inner.RestoreWorktree(ctx, gitinfra.RestoreWorktreeInput{
-		ProjectID:            input.ProjectID,
-		RepoPath:             input.RepoPath,
-		Branch:               input.Branch,
-		WorktreeRoot:         input.WorktreeRoot,
-		CheckoutMode:         gitinfra.CheckoutMode(input.CheckoutMode),
+		ProjectID: input.ProjectID, RepoPath: input.RepoPath, Branch: input.Branch,
+		WorktreeRoot: input.WorktreeRoot, CheckoutMode: gitinfra.CheckoutMode(input.CheckoutMode),
 		ExpectedWorktreePath: input.ExpectedWorktreePath,
 	})
 	if err != nil || record == nil {
 		return nil, err
 	}
 	return &RestoreWorktreeResult{
-		WorktreePath: record.WorktreePath,
-		Branch:       record.Branch,
-		BaseBranch:   strings.TrimSpace(derefString(record.BaseBranch)),
-		HeadSHA:      strings.TrimSpace(derefString(record.HeadSHA)),
-		WorktreeID:   record.ID,
+		WorktreePath: record.WorktreePath, Branch: record.Branch,
+		BaseBranch: strings.TrimSpace(derefString(record.BaseBranch)),
+		HeadSHA:    strings.TrimSpace(derefString(record.HeadSHA)), WorktreeID: record.ID,
 	}, nil
 }
 
-func (g *realWorkerGitGateway) PrepareWorktree(ctx context.Context, input PrepareWorktreeInput) (PrepareWorktreeResult, error) {
-	prepared, err := g.inner.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{
-		WorktreePath:    input.WorktreePath,
-		Branch:          input.Branch,
-		ExpectedHeadSHA: input.ExpectedHeadSHA,
-		Remote:          input.Remote,
-	})
-	if err != nil {
-		return PrepareWorktreeResult{}, err
-	}
-	return PrepareWorktreeResult{HeadSHA: prepared.HeadSHA, Clean: prepared.Clean}, nil
+func (g *realWorkerGitGateway) PrepareWorktree(context.Context, PrepareWorktreeInput) (PrepareWorktreeResult, error) {
+	panic("PrepareWorktree not used by recoverWorkerWorktree contract tests")
 }
-
-func (g *realWorkerGitGateway) InspectHead(ctx context.Context, input InspectHeadInput) (InspectHeadResult, error) {
-	result, err := g.inner.InspectHead(ctx, gitinfra.InspectHeadInput{WorktreePath: input.WorktreePath, BaseRef: input.BaseRef})
-	if err != nil {
-		return InspectHeadResult{}, err
-	}
-	return InspectHeadResult{
-		HeadSHA:               result.HeadSHA,
-		NewCommitSHAs:         result.NewCommitSHAs,
-		HasUncommittedChanges: result.HasUncommittedChanges,
-		ChangedFiles:          result.ChangedFiles,
-	}, nil
+func (g *realWorkerGitGateway) InspectHead(context.Context, InspectHeadInput) (InspectHeadResult, error) {
+	panic("InspectHead not used by recoverWorkerWorktree contract tests")
 }
-
-func (g *realWorkerGitGateway) Commit(ctx context.Context, input CommitInput) (CommitResult, error) {
-	result, err := g.inner.Commit(ctx, gitinfra.CommitInput{WorktreePath: input.WorktreePath, Message: input.Message})
-	if err != nil {
-		return CommitResult{}, err
-	}
-	return CommitResult{CommitSHA: result.CommitSHA}, nil
+func (g *realWorkerGitGateway) Commit(context.Context, CommitInput) (CommitResult, error) {
+	panic("Commit not used by recoverWorkerWorktree contract tests")
 }
-
-func (g *realWorkerGitGateway) Push(ctx context.Context, input PushInput) error {
-	return g.inner.Push(ctx, gitinfra.PushInput{
-		WorktreePath:      input.WorktreePath,
-		Branch:            input.Branch,
-		Remote:            input.Remote,
-		ProtectedBranches: append([]string{}, input.ProtectedBranches...),
-	})
+func (g *realWorkerGitGateway) Push(context.Context, PushInput) error {
+	panic("Push not used by recoverWorkerWorktree contract tests")
 }
 
 func setupRealWorkerRepoWithBranch(t *testing.T, branch string) (repoPath, headSHA string) {
@@ -151,19 +110,29 @@ func mustRunWorkerGit(t *testing.T, cwd string, args ...string) string {
 	return string(out)
 }
 
-// Real gateway contract: hollow (empty/metadata-only) checkpoint path is cleared
-// by Restore (nil, nil) and recoverWorkerWorktree recreates via CreateWorktree.
-func TestRunExecuteStepRealGatewayRecreatesHollowCheckpointWorktree(t *testing.T) {
-	t.Parallel()
-
+func realRecoverFixture(t *testing.T, branch string) (runner *Runner, adapter *realWorkerGitGateway, project storage.ProjectRecord, worktreeRoot, repoPath, headSHA string) {
+	t.Helper()
 	fixture := newRunnerFixture(t)
-	branch := "looper/worker-hollow"
-	repoPath, headSHA := setupRealWorkerRepoWithBranch(t, branch)
-	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	repoPath, headSHA = setupRealWorkerRepoWithBranch(t, branch)
+	worktreeRoot = filepath.Join(t.TempDir(), "worktrees")
 	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll worktreeRoot: %v", err)
 	}
-	// Managed path name matches CreateWorktree for branch-mode (sanitize branch).
+	adapter = &realWorkerGitGateway{inner: gitinfra.New(gitinfra.Options{GitPath: "git"})}
+	runner = New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: adapter,
+		Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true,
+	})
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	project = storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata}
+	return runner, adapter, project, worktreeRoot, repoPath, headSHA
+}
+
+// Real gateway: hollow (metadata-only) path → Restore clears (nil,nil) → Create.
+func TestRecoverWorkerWorktreeRealGatewayRecreatesHollow(t *testing.T) {
+	t.Parallel()
+	branch := "looper/worker-hollow"
+	runner, adapter, project, worktreeRoot, _, headSHA := realRecoverFixture(t, branch)
 	hollowPath := filepath.Join(worktreeRoot, "looper-worker-hollow")
 	if err := os.MkdirAll(hollowPath, 0o755); err != nil {
 		t.Fatalf("MkdirAll hollow: %v", err)
@@ -174,86 +143,39 @@ func TestRunExecuteStepRealGatewayRecreatesHollowCheckpointWorktree(t *testing.T
 	if worktreesafety.LocalCheckoutUsable(hollowPath) {
 		t.Fatal("LocalCheckoutUsable(hollowPath) = true, want false")
 	}
+	work := workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", Branch: branch, ExecutionMode: "create-pr"}
+	wt := checkpointWorktree{ID: "worktree_old", Path: hollowPath, Branch: branch, BaseBranch: "main", HeadSHA: headSHA}
+	checkpoint := workerCheckpoint{Work: &work, Worktree: &wt, Plan: &checkpointPlan{Summary: "plan", Items: []string{"Do it"}}}
 
-	adapter := &realWorkerGitGateway{inner: gitinfra.New(gitinfra.Options{GitPath: "git"})}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", ParseStatus: "parsed"}}}
-	runner := New(Options{
-		DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: adapter, AgentExecutor: agent,
-		Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true,
-	})
-	run := storage.RunRecord{ID: "run_real_hollow_recreate", LoopID: "loop_worker_1", Status: "running", CurrentStep: stringPtr(string(stepExecute)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
-	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
-		t.Fatalf("Runs.Upsert() error = %v", err)
-	}
-	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
-	if err != nil || loop == nil {
-		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
-	}
-	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
-
-	checkpoint, err := runner.runExecuteStep(context.Background(), stepInput{
-		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
-		Loop:    *loop,
-		Run:     run,
-		Checkpoint: workerCheckpoint{
-			Work:     &workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", Branch: branch, ExecutionMode: "create-pr"},
-			Worktree: &checkpointWorktree{ID: "worktree_old", Path: hollowPath, Branch: branch, BaseBranch: "main", HeadSHA: headSHA},
-			Plan:     &checkpointPlan{Summary: "Implement worker loop", Items: []string{"Do it"}},
-		},
-	})
+	got, err := runner.recoverWorkerWorktree(context.Background(), stepInput{Project: project}, &checkpoint, work, wt, "path is not a usable git worktree")
 	if err != nil {
-		t.Fatalf("runExecuteStep() error = %v", err)
+		t.Fatalf("recoverWorkerWorktree() error = %v", err)
 	}
-	if adapter.restoreCalls < 1 {
-		t.Fatalf("restoreCalls = %d, want >= 1", adapter.restoreCalls)
+	if adapter.restoreCalls < 1 || adapter.createCalls < 1 {
+		t.Fatalf("restoreCalls=%d createCalls=%d, want both >= 1", adapter.restoreCalls, adapter.createCalls)
 	}
-	if adapter.createCalls < 1 {
-		t.Fatalf("createCalls = %d, want >= 1 (CreateWorktree fallback after restore nil)", adapter.createCalls)
+	if strings.TrimSpace(got.Path) == "" || !worktreesafety.LocalCheckoutUsable(got.Path) {
+		t.Fatalf("recovered path %q is not a usable git worktree", got.Path)
 	}
-	if checkpoint.Worktree == nil || strings.TrimSpace(checkpoint.Worktree.Path) == "" {
-		t.Fatalf("checkpoint.Worktree = %#v, want recreated path", checkpoint.Worktree)
-	}
-	if !worktreesafety.LocalCheckoutUsable(checkpoint.Worktree.Path) {
-		t.Fatalf("recreated path %q is not a usable git worktree", checkpoint.Worktree.Path)
-	}
-	if _, err := os.Stat(filepath.Join(checkpoint.Worktree.Path, "README.md")); err != nil {
+	if _, err := os.Stat(filepath.Join(got.Path, "README.md")); err != nil {
 		t.Fatalf("recreated worktree missing README: %v", err)
-	}
-	if len(agent.starts) != 1 || agent.starts[0].WorkingDirectory != checkpoint.Worktree.Path {
-		t.Fatalf("agent starts = %#v, want recreated working directory", agent.starts)
 	}
 }
 
-// Real gateway contract: populated unusable managed path is preserved and parks
-// as FailureManualIntervention (no Create, no agent start, no infinite retry).
-func TestRunExecuteStepRealGatewayParksPreservedPopulatedWorktree(t *testing.T) {
+// Real gateway: populated unusable path → preserve + FailureManualIntervention.
+func TestRecoverWorkerWorktreeRealGatewayParksPreserved(t *testing.T) {
 	t.Parallel()
-
-	fixture := newRunnerFixture(t)
 	branch := "looper/worker-populated"
-	repoPath, headSHA := setupRealWorkerRepoWithBranch(t, branch)
-	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
-	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
-		t.Fatalf("MkdirAll worktreeRoot: %v", err)
-	}
-	// Create a real worktree, then hollow the checkout while leaving agent output.
-	gateway := gitinfra.New(gitinfra.Options{GitPath: "git"})
-	created, err := gateway.CreateWorktree(context.Background(), gitinfra.CreateWorktreeInput{
-		ProjectID:    "project_1",
-		RepoPath:     repoPath,
-		WorktreeRoot: worktreeRoot,
-		Branch:       branch,
-		BaseBranch:   "main",
+	runner, adapter, project, worktreeRoot, repoPath, headSHA := realRecoverFixture(t, branch)
+	created, err := adapter.inner.CreateWorktree(context.Background(), gitinfra.CreateWorktreeInput{
+		ProjectID: "project_1", RepoPath: repoPath, WorktreeRoot: worktreeRoot, Branch: branch, BaseBranch: "main",
 	})
 	if err != nil {
 		t.Fatalf("CreateWorktree() error = %v", err)
 	}
 	populatedPath := created.WorktreePath
-	// Corrupt .git metadata while keeping agent dirt that must be preserved.
-	if err := os.RemoveAll(filepath.Join(populatedPath, ".git")); err != nil {
-		// Linked worktrees use a .git *file*; remove that and rewrite unusable.
-		_ = os.Remove(filepath.Join(populatedPath, ".git"))
-	}
+	_ = os.RemoveAll(filepath.Join(populatedPath, ".git"))
+	_ = os.Remove(filepath.Join(populatedPath, ".git"))
 	if err := os.WriteFile(filepath.Join(populatedPath, ".git"), []byte("gitdir: /does/not/exist\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile corrupt .git: %v", err)
 	}
@@ -264,50 +186,20 @@ func TestRunExecuteStepRealGatewayParksPreservedPopulatedWorktree(t *testing.T) 
 	if worktreesafety.LocalCheckoutUsable(populatedPath) {
 		t.Fatal("LocalCheckoutUsable(populatedPath) = true, want false")
 	}
+	work := workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", Branch: branch, ExecutionMode: "create-pr"}
+	wt := checkpointWorktree{ID: "worktree_old", Path: populatedPath, Branch: branch, BaseBranch: "main", HeadSHA: headSHA}
+	checkpoint := workerCheckpoint{Work: &work, Worktree: &wt, Plan: &checkpointPlan{Summary: "plan", Items: []string{"Do it"}}}
 
-	adapter := &realWorkerGitGateway{inner: gateway}
-	agent := &fakeAgentExecutor{}
-	runner := New(Options{
-		DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: adapter, AgentExecutor: agent,
-		Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true,
-	})
-	run := storage.RunRecord{ID: "run_real_populated_mi", LoopID: "loop_worker_1", Status: "running", CurrentStep: stringPtr(string(stepExecute)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
-	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
-		t.Fatalf("Runs.Upsert() error = %v", err)
-	}
-	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
-	if err != nil || loop == nil {
-		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
-	}
-	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
-
-	_, err = runner.runExecuteStep(context.Background(), stepInput{
-		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
-		Loop:    *loop,
-		Run:     run,
-		Checkpoint: workerCheckpoint{
-			Work:     &workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", Branch: branch, ExecutionMode: "create-pr"},
-			Worktree: &checkpointWorktree{ID: "worktree_old", Path: populatedPath, Branch: branch, BaseBranch: "main", HeadSHA: headSHA},
-			Plan:     &checkpointPlan{Summary: "Implement worker loop", Items: []string{"Do it"}},
-		},
-	})
+	_, err = runner.recoverWorkerWorktree(context.Background(), stepInput{Project: project}, &checkpoint, work, wt, "path is not a usable git worktree")
 	var loopErr *loopError
-	if !errors.As(err, &loopErr) {
-		t.Fatalf("runExecuteStep() error = %v, want *loopError", err)
-	}
-	if loopErr.kind != FailureManualIntervention {
-		t.Fatalf("loopErr.kind = %v, want %v (err=%v)", loopErr.kind, FailureManualIntervention, err)
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureManualIntervention {
+		t.Fatalf("error = %v, want FailureManualIntervention", err)
 	}
 	if !strings.Contains(loopErr.message, "manual intervention required") {
 		t.Fatalf("error = %q, want preserved MI message", loopErr.message)
 	}
 	if adapter.restoreCalls < 1 {
 		t.Fatalf("restoreCalls = %d, want >= 1", adapter.restoreCalls)
-	}
-	// Create may not run when restore already returned the preserve sentinel.
-	// If restore returned nil for an unregistered path, create parks instead.
-	if len(agent.starts) != 0 {
-		t.Fatalf("agent starts = %#v, want none", agent.starts)
 	}
 	if shouldRetryQueueFailure(loopErr.kind, 242, -1) {
 		t.Fatal("preserved populated worktree must not requeue under unlimited maxAttempts")

--- a/internal/worker/runner_recover_real_gateway_test.go
+++ b/internal/worker/runner_recover_real_gateway_test.go
@@ -1,0 +1,319 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gitinfra "github.com/nexu-io/looper/internal/infra/git"
+	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worktreesafety"
+)
+
+// realWorkerGitGateway adapts infra/git.Gateway to worker.GitGateway so recovery
+// tests exercise the production Restore→Create / preserve contracts.
+type realWorkerGitGateway struct {
+	inner        *gitinfra.Gateway
+	restoreCalls int
+	createCalls  int
+}
+
+func (g *realWorkerGitGateway) CreateWorktree(ctx context.Context, input CreateWorktreeInput) (CreateWorktreeResult, error) {
+	g.createCalls++
+	record, err := g.inner.CreateWorktree(ctx, gitinfra.CreateWorktreeInput{
+		ProjectID:         input.ProjectID,
+		RepoPath:          input.RepoPath,
+		WorktreeRoot:      input.WorktreeRoot,
+		Branch:            input.Branch,
+		BaseBranch:        input.BaseBranch,
+		PRNumber:          input.PRNumber,
+		ProtectedBranches: append([]string{}, input.ProtectedBranches...),
+		CheckoutMode:      gitinfra.CheckoutMode(input.CheckoutMode),
+	})
+	if err != nil {
+		return CreateWorktreeResult{}, err
+	}
+	return CreateWorktreeResult{
+		WorktreePath: record.WorktreePath,
+		Branch:       record.Branch,
+		BaseBranch:   strings.TrimSpace(derefString(record.BaseBranch)),
+		HeadSHA:      strings.TrimSpace(derefString(record.HeadSHA)),
+		WorktreeID:   record.ID,
+	}, nil
+}
+
+func (g *realWorkerGitGateway) RestoreWorktree(ctx context.Context, input RestoreWorktreeInput) (*RestoreWorktreeResult, error) {
+	g.restoreCalls++
+	record, err := g.inner.RestoreWorktree(ctx, gitinfra.RestoreWorktreeInput{
+		ProjectID:            input.ProjectID,
+		RepoPath:             input.RepoPath,
+		Branch:               input.Branch,
+		WorktreeRoot:         input.WorktreeRoot,
+		CheckoutMode:         gitinfra.CheckoutMode(input.CheckoutMode),
+		ExpectedWorktreePath: input.ExpectedWorktreePath,
+	})
+	if err != nil || record == nil {
+		return nil, err
+	}
+	return &RestoreWorktreeResult{
+		WorktreePath: record.WorktreePath,
+		Branch:       record.Branch,
+		BaseBranch:   strings.TrimSpace(derefString(record.BaseBranch)),
+		HeadSHA:      strings.TrimSpace(derefString(record.HeadSHA)),
+		WorktreeID:   record.ID,
+	}, nil
+}
+
+func (g *realWorkerGitGateway) PrepareWorktree(ctx context.Context, input PrepareWorktreeInput) (PrepareWorktreeResult, error) {
+	prepared, err := g.inner.PrepareWorktree(ctx, gitinfra.PrepareWorktreeInput{
+		WorktreePath:    input.WorktreePath,
+		Branch:          input.Branch,
+		ExpectedHeadSHA: input.ExpectedHeadSHA,
+		Remote:          input.Remote,
+	})
+	if err != nil {
+		return PrepareWorktreeResult{}, err
+	}
+	return PrepareWorktreeResult{HeadSHA: prepared.HeadSHA, Clean: prepared.Clean}, nil
+}
+
+func (g *realWorkerGitGateway) InspectHead(ctx context.Context, input InspectHeadInput) (InspectHeadResult, error) {
+	result, err := g.inner.InspectHead(ctx, gitinfra.InspectHeadInput{WorktreePath: input.WorktreePath, BaseRef: input.BaseRef})
+	if err != nil {
+		return InspectHeadResult{}, err
+	}
+	return InspectHeadResult{
+		HeadSHA:               result.HeadSHA,
+		NewCommitSHAs:         result.NewCommitSHAs,
+		HasUncommittedChanges: result.HasUncommittedChanges,
+		ChangedFiles:          result.ChangedFiles,
+	}, nil
+}
+
+func (g *realWorkerGitGateway) Commit(ctx context.Context, input CommitInput) (CommitResult, error) {
+	result, err := g.inner.Commit(ctx, gitinfra.CommitInput{WorktreePath: input.WorktreePath, Message: input.Message})
+	if err != nil {
+		return CommitResult{}, err
+	}
+	return CommitResult{CommitSHA: result.CommitSHA}, nil
+}
+
+func (g *realWorkerGitGateway) Push(ctx context.Context, input PushInput) error {
+	return g.inner.Push(ctx, gitinfra.PushInput{
+		WorktreePath:      input.WorktreePath,
+		Branch:            input.Branch,
+		Remote:            input.Remote,
+		ProtectedBranches: append([]string{}, input.ProtectedBranches...),
+	})
+}
+
+func setupRealWorkerRepoWithBranch(t *testing.T, branch string) (repoPath, headSHA string) {
+	t.Helper()
+	root := t.TempDir()
+	remotePath := filepath.Join(root, "remote.git")
+	repoPath = filepath.Join(root, "repo")
+	mustRunWorkerGit(t, root, "init", "--bare", remotePath)
+	mustRunWorkerGit(t, root, "clone", remotePath, repoPath)
+	mustRunWorkerGit(t, repoPath, "config", "user.email", "test@example.com")
+	mustRunWorkerGit(t, repoPath, "config", "user.name", "Looper Test")
+	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile README: %v", err)
+	}
+	mustRunWorkerGit(t, repoPath, "add", "README.md")
+	mustRunWorkerGit(t, repoPath, "commit", "-m", "init")
+	mustRunWorkerGit(t, repoPath, "branch", "-M", "main")
+	mustRunWorkerGit(t, repoPath, "push", "-u", "origin", "main")
+	mustRunWorkerGit(t, repoPath, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(repoPath, "feature.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile feature.txt: %v", err)
+	}
+	mustRunWorkerGit(t, repoPath, "add", "feature.txt")
+	mustRunWorkerGit(t, repoPath, "commit", "-m", "feature")
+	mustRunWorkerGit(t, repoPath, "push", "-u", "origin", branch)
+	headSHA = strings.TrimSpace(mustRunWorkerGit(t, repoPath, "rev-parse", "HEAD"))
+	mustRunWorkerGit(t, repoPath, "checkout", "main")
+	return repoPath, headSHA
+}
+
+func mustRunWorkerGit(t *testing.T, cwd string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = cwd
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s (cwd=%s): %v\n%s", strings.Join(args, " "), cwd, err, out)
+	}
+	return string(out)
+}
+
+// Real gateway contract: hollow (empty/metadata-only) checkpoint path is cleared
+// by Restore (nil, nil) and recoverWorkerWorktree recreates via CreateWorktree.
+func TestRunExecuteStepRealGatewayRecreatesHollowCheckpointWorktree(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	branch := "looper/worker-hollow"
+	repoPath, headSHA := setupRealWorkerRepoWithBranch(t, branch)
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktreeRoot: %v", err)
+	}
+	// Managed path name matches CreateWorktree for branch-mode (sanitize branch).
+	hollowPath := filepath.Join(worktreeRoot, "looper-worker-hollow")
+	if err := os.MkdirAll(hollowPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll hollow: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hollowPath, ".git"), []byte("gitdir: /does/not/exist\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile hollow .git: %v", err)
+	}
+	if worktreesafety.LocalCheckoutUsable(hollowPath) {
+		t.Fatal("LocalCheckoutUsable(hollowPath) = true, want false")
+	}
+
+	adapter := &realWorkerGitGateway{inner: gitinfra.New(gitinfra.Options{GitPath: "git"})}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", ParseStatus: "parsed"}}}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: adapter, AgentExecutor: agent,
+		Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true,
+	})
+	run := storage.RunRecord{ID: "run_real_hollow_recreate", LoopID: "loop_worker_1", Status: "running", CurrentStep: stringPtr(string(stepExecute)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+
+	checkpoint, err := runner.runExecuteStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Loop:    *loop,
+		Run:     run,
+		Checkpoint: workerCheckpoint{
+			Work:     &workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", Branch: branch, ExecutionMode: "create-pr"},
+			Worktree: &checkpointWorktree{ID: "worktree_old", Path: hollowPath, Branch: branch, BaseBranch: "main", HeadSHA: headSHA},
+			Plan:     &checkpointPlan{Summary: "Implement worker loop", Items: []string{"Do it"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runExecuteStep() error = %v", err)
+	}
+	if adapter.restoreCalls < 1 {
+		t.Fatalf("restoreCalls = %d, want >= 1", adapter.restoreCalls)
+	}
+	if adapter.createCalls < 1 {
+		t.Fatalf("createCalls = %d, want >= 1 (CreateWorktree fallback after restore nil)", adapter.createCalls)
+	}
+	if checkpoint.Worktree == nil || strings.TrimSpace(checkpoint.Worktree.Path) == "" {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated path", checkpoint.Worktree)
+	}
+	if !worktreesafety.LocalCheckoutUsable(checkpoint.Worktree.Path) {
+		t.Fatalf("recreated path %q is not a usable git worktree", checkpoint.Worktree.Path)
+	}
+	if _, err := os.Stat(filepath.Join(checkpoint.Worktree.Path, "README.md")); err != nil {
+		t.Fatalf("recreated worktree missing README: %v", err)
+	}
+	if len(agent.starts) != 1 || agent.starts[0].WorkingDirectory != checkpoint.Worktree.Path {
+		t.Fatalf("agent starts = %#v, want recreated working directory", agent.starts)
+	}
+}
+
+// Real gateway contract: populated unusable managed path is preserved and parks
+// as FailureManualIntervention (no Create, no agent start, no infinite retry).
+func TestRunExecuteStepRealGatewayParksPreservedPopulatedWorktree(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRunnerFixture(t)
+	branch := "looper/worker-populated"
+	repoPath, headSHA := setupRealWorkerRepoWithBranch(t, branch)
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktreeRoot: %v", err)
+	}
+	// Create a real worktree, then hollow the checkout while leaving agent output.
+	gateway := gitinfra.New(gitinfra.Options{GitPath: "git"})
+	created, err := gateway.CreateWorktree(context.Background(), gitinfra.CreateWorktreeInput{
+		ProjectID:    "project_1",
+		RepoPath:     repoPath,
+		WorktreeRoot: worktreeRoot,
+		Branch:       branch,
+		BaseBranch:   "main",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+	populatedPath := created.WorktreePath
+	// Corrupt .git metadata while keeping agent dirt that must be preserved.
+	if err := os.RemoveAll(filepath.Join(populatedPath, ".git")); err != nil {
+		// Linked worktrees use a .git *file*; remove that and rewrite unusable.
+		_ = os.Remove(filepath.Join(populatedPath, ".git"))
+	}
+	if err := os.WriteFile(filepath.Join(populatedPath, ".git"), []byte("gitdir: /does/not/exist\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile corrupt .git: %v", err)
+	}
+	marker := filepath.Join(populatedPath, "agent-partial-edit.txt")
+	if err := os.WriteFile(marker, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile marker: %v", err)
+	}
+	if worktreesafety.LocalCheckoutUsable(populatedPath) {
+		t.Fatal("LocalCheckoutUsable(populatedPath) = true, want false")
+	}
+
+	adapter := &realWorkerGitGateway{inner: gateway}
+	agent := &fakeAgentExecutor{}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: adapter, AgentExecutor: agent,
+		Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true,
+	})
+	run := storage.RunRecord{ID: "run_real_populated_mi", LoopID: "loop_worker_1", Status: "running", CurrentStep: stringPtr(string(stepExecute)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+
+	_, err = runner.runExecuteStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Loop:    *loop,
+		Run:     run,
+		Checkpoint: workerCheckpoint{
+			Work:     &workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", Branch: branch, ExecutionMode: "create-pr"},
+			Worktree: &checkpointWorktree{ID: "worktree_old", Path: populatedPath, Branch: branch, BaseBranch: "main", HeadSHA: headSHA},
+			Plan:     &checkpointPlan{Summary: "Implement worker loop", Items: []string{"Do it"}},
+		},
+	})
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("runExecuteStep() error = %v, want *loopError", err)
+	}
+	if loopErr.kind != FailureManualIntervention {
+		t.Fatalf("loopErr.kind = %v, want %v (err=%v)", loopErr.kind, FailureManualIntervention, err)
+	}
+	if !strings.Contains(loopErr.message, "manual intervention required") {
+		t.Fatalf("error = %q, want preserved MI message", loopErr.message)
+	}
+	if adapter.restoreCalls < 1 {
+		t.Fatalf("restoreCalls = %d, want >= 1", adapter.restoreCalls)
+	}
+	// Create may not run when restore already returned the preserve sentinel.
+	// If restore returned nil for an unregistered path, create parks instead.
+	if len(agent.starts) != 0 {
+		t.Fatalf("agent starts = %#v, want none", agent.starts)
+	}
+	if shouldRetryQueueFailure(loopErr.kind, 242, -1) {
+		t.Fatal("preserved populated worktree must not requeue under unlimited maxAttempts")
+	}
+	got, readErr := os.ReadFile(marker)
+	if readErr != nil || string(got) != "keep me\n" {
+		t.Fatalf("marker = %q err=%v, want preserved agent output", got, readErr)
+	}
+}

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1356,6 +1356,62 @@ func TestRunExecuteStepRecoversMalformedGitCheckoutAfterPrepare(t *testing.T) {
 	}
 }
 
+// Resumed post-prepare steps must not recreate when the checkpoint worktree is
+// the project repo itself. Create-after-restore-nil is for hollow managed
+// paths under the worktree root; inventing a fresh path would let validate /
+// open_pr succeed after a corrupt "ran in user repo" checkpoint.
+func TestRunValidateStepRejectsCheckpointWorktreePathAtUserRepo(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktreeRoot: %v", err)
+	}
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	branch := "looper/bad-checkpoint"
+	git := &fakeGitGateway{
+		restoreNil:   true,
+		createResult: CreateWorktreeResult{WorktreePath: filepath.Join(worktreeRoot, "recreated"), Branch: branch, BaseBranch: "main", HeadSHA: "def456", WorktreeID: "worktree_created"},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true})
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+
+	_, err = runner.runValidateStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Loop:    *loop,
+		Run:     storage.RunRecord{ID: "run_bad_repo_checkpoint", LoopID: loop.ID},
+		Checkpoint: workerCheckpoint{
+			Work:     &workerInput{Title: "Reject unsafe worktree checkpoint", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", ExecutionMode: "create-pr"},
+			Worktree: &checkpointWorktree{ID: "worktree_bad", Path: repoPath, Branch: branch, BaseBranch: "main", HeadSHA: "abc123"},
+			Plan:     &checkpointPlan{Summary: "Reject unsafe worktree checkpoint", Items: []string{"Never use the user repo as worker cwd"}},
+			Execution: &checkpointExecution{Status: "completed", Summary: "prior execution completed", ParseStatus: "parsed"},
+		},
+	})
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("runValidateStep() error = %v, want *loopError", err)
+	}
+	if loopErr.kind != FailureManualIntervention {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureManualIntervention)
+	}
+	if !strings.Contains(loopErr.message, "Worker worktree path") {
+		t.Fatalf("error = %q, want Worker worktree path rejection", loopErr.message)
+	}
+	if !strings.Contains(loopErr.message, "must not equal project repo path") {
+		t.Fatalf("error = %q, want project-repo-path detail", loopErr.message)
+	}
+	if len(git.restoreCalls) != 0 {
+		t.Fatalf("restoreCalls = %#v, want no restore for project-repo checkpoint", git.restoreCalls)
+	}
+	if len(git.createCalls) != 0 {
+		t.Fatalf("createCalls = %#v, want no recreate for project-repo checkpoint", git.createCalls)
+	}
+}
+
 // Production RestoreWorktree clears empty/metadata-only hollow leftovers and
 // returns (nil, nil) when no healthy registered worktree remains. Recovery must
 // fall through to CreateWorktree instead of parking as stale-worktree MI.

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1385,9 +1385,9 @@ func TestRunValidateStepRejectsCheckpointWorktreePathAtUserRepo(t *testing.T) {
 		Loop:    *loop,
 		Run:     storage.RunRecord{ID: "run_bad_repo_checkpoint", LoopID: loop.ID},
 		Checkpoint: workerCheckpoint{
-			Work:     &workerInput{Title: "Reject unsafe worktree checkpoint", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", ExecutionMode: "create-pr"},
-			Worktree: &checkpointWorktree{ID: "worktree_bad", Path: repoPath, Branch: branch, BaseBranch: "main", HeadSHA: "abc123"},
-			Plan:     &checkpointPlan{Summary: "Reject unsafe worktree checkpoint", Items: []string{"Never use the user repo as worker cwd"}},
+			Work:      &workerInput{Title: "Reject unsafe worktree checkpoint", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", ExecutionMode: "create-pr"},
+			Worktree:  &checkpointWorktree{ID: "worktree_bad", Path: repoPath, Branch: branch, BaseBranch: "main", HeadSHA: "abc123"},
+			Plan:      &checkpointPlan{Summary: "Reject unsafe worktree checkpoint", Items: []string{"Never use the user repo as worker cwd"}},
 			Execution: &checkpointExecution{Status: "completed", Summary: "prior execution completed", ParseStatus: "parsed"},
 		},
 	})

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	"github.com/nexu-io/looper/internal/network/protocol"
 	"github.com/nexu-io/looper/internal/networkpolicy"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worktreesafety"
 )
 
 func TestProcessNextIgnoresOtherQueueTypes(t *testing.T) {
@@ -1274,6 +1276,83 @@ func TestRunExecuteStepRecoversWorktreeOutsideWorktreeRootBeforeAgentStart(t *te
 	}
 	if len(agent.starts) != 1 || agent.starts[0].WorkingDirectory != recoveredPath {
 		t.Fatalf("agent starts = %#v, want recovered working directory", agent.starts)
+	}
+}
+
+// Post-prepare resume at execute must share LocalCheckoutUsable with prepare:
+// a path under the managed worktree root that still has a .git entry must not
+// skip recovery when that entry is malformed or linked metadata is corrupt.
+func TestRunExecuteStepRecoversMalformedGitCheckoutAfterPrepare(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktreeRoot: %v", err)
+	}
+	// Checkpoint worktree from a prior prepare: path exists under root, and .git
+	// is present but unusable (malformed gitfile — the pre-fix existence check
+	// would have accepted this and failed later under an external step boundary).
+	corruptPath := filepath.Join(worktreeRoot, "worker-wt")
+	if err := os.MkdirAll(corruptPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll corruptPath: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(corruptPath, ".git"), []byte("not-a-valid-gitfile\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile malformed .git: %v", err)
+	}
+	if worktreesafety.LocalCheckoutUsable(corruptPath) {
+		t.Fatal("LocalCheckoutUsable(corruptPath) = true, want false for malformed gitfile")
+	}
+	recoveredPath := filepath.Join(worktreeRoot, "recovered")
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	branch := "looper/feature"
+	git := &fakeGitGateway{
+		restoreResult: &RestoreWorktreeResult{WorktreePath: recoveredPath, Branch: branch, BaseBranch: "main", HeadSHA: "def456", WorktreeID: "worktree_recovered"},
+		inspectResult: InspectHeadResult{HeadSHA: "def456"},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true})
+	run := storage.RunRecord{ID: "run_malformed_git_resume", LoopID: "loop_worker_1", Status: "running", CurrentStep: stringPtr(string(stepExecute)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+
+	checkpoint, err := runner.runExecuteStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Loop:    *loop,
+		Run:     run,
+		Checkpoint: workerCheckpoint{
+			Work:     &workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", ExecutionMode: "create-pr"},
+			Worktree: &checkpointWorktree{ID: "worktree_old", Path: corruptPath, Branch: branch, BaseBranch: "main", HeadSHA: "abc123"},
+			Plan:     &checkpointPlan{Summary: "Implement worker loop", Items: []string{"Do it"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runExecuteStep() error = %v", err)
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != recoveredPath || checkpoint.Worktree.ID != "worktree_recovered" {
+		t.Fatalf("checkpoint.Worktree = %#v, want recovered worktree after malformed .git", checkpoint.Worktree)
+	}
+	if len(git.restoreCalls) != 1 || git.restoreCalls[0].ExpectedWorktreePath != corruptPath || git.restoreCalls[0].WorktreeRoot != worktreeRoot {
+		t.Fatalf("restoreCalls = %#v, want recovery of malformed managed worktree", git.restoreCalls)
+	}
+	if len(agent.starts) != 1 || agent.starts[0].WorkingDirectory != recoveredPath {
+		t.Fatalf("agent starts = %#v, want recovered working directory", agent.starts)
+	}
+	persisted, err := fixture.repos.Runs.GetByID(context.Background(), run.ID)
+	if err != nil || persisted == nil {
+		t.Fatalf("Runs.GetByID() = (%#v, %v), want persisted run", persisted, err)
+	}
+	persistedCheckpoint, err := parseCheckpoint(persisted.CheckpointJSON)
+	if err != nil {
+		t.Fatalf("parseCheckpoint() error = %v", err)
+	}
+	if persistedCheckpoint.Worktree == nil || persistedCheckpoint.Worktree.Path != recoveredPath {
+		t.Fatalf("persisted checkpoint worktree = %#v, want recovered path", persistedCheckpoint.Worktree)
 	}
 }
 

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1356,6 +1356,145 @@ func TestRunExecuteStepRecoversMalformedGitCheckoutAfterPrepare(t *testing.T) {
 	}
 }
 
+// Production RestoreWorktree clears empty/metadata-only hollow leftovers and
+// returns (nil, nil) when no healthy registered worktree remains. Recovery must
+// fall through to CreateWorktree instead of parking as stale-worktree MI.
+func TestRunExecuteStepRecreatesAfterRestoreReturnsNil(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktreeRoot: %v", err)
+	}
+	corruptPath := filepath.Join(worktreeRoot, "hollow-wt")
+	if err := os.MkdirAll(corruptPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll corruptPath: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(corruptPath, ".git"), []byte("gitdir: /missing/gitdir\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile malformed .git: %v", err)
+	}
+	recreatedPath := filepath.Join(worktreeRoot, "recreated")
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	branch := "looper/feature"
+	git := &fakeGitGateway{
+		restoreNil:    true,
+		createResult:  CreateWorktreeResult{WorktreePath: recreatedPath, Branch: branch, BaseBranch: "main", HeadSHA: "def456", WorktreeID: "worktree_created"},
+		inspectResult: InspectHeadResult{HeadSHA: "def456"},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "done", ParseStatus: "parsed"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true})
+	run := storage.RunRecord{ID: "run_restore_nil_recreate", LoopID: "loop_worker_1", Status: "running", CurrentStep: stringPtr(string(stepExecute)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+
+	checkpoint, err := runner.runExecuteStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Loop:    *loop,
+		Run:     run,
+		Checkpoint: workerCheckpoint{
+			Work:     &workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", ExecutionMode: "create-pr"},
+			Worktree: &checkpointWorktree{ID: "worktree_old", Path: corruptPath, Branch: branch, BaseBranch: "main", HeadSHA: "abc123"},
+			Plan:     &checkpointPlan{Summary: "Implement worker loop", Items: []string{"Do it"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runExecuteStep() error = %v", err)
+	}
+	if checkpoint.Worktree == nil || checkpoint.Worktree.Path != recreatedPath || checkpoint.Worktree.ID != "worktree_created" {
+		t.Fatalf("checkpoint.Worktree = %#v, want recreated worktree after restore nil", checkpoint.Worktree)
+	}
+	if len(git.restoreCalls) != 1 {
+		t.Fatalf("restoreCalls = %#v, want 1", git.restoreCalls)
+	}
+	if len(git.createCalls) != 1 || git.createCalls[0].Branch != branch || git.createCalls[0].WorktreeRoot != worktreeRoot {
+		t.Fatalf("createCalls = %#v, want CreateWorktree fallback after restore nil", git.createCalls)
+	}
+	if len(agent.starts) != 1 || agent.starts[0].WorkingDirectory != recreatedPath {
+		t.Fatalf("agent starts = %#v, want recreated working directory", agent.starts)
+	}
+}
+
+// Production RestoreWorktree preserves populated unusable paths and returns
+// ErrUnusableWorktreePreserved. Recovery must park as FailureManualIntervention
+// so unlimited queues cannot infinite-retry.
+func TestRunExecuteStepParksPreservedUnusableWorktreeAsManualIntervention(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repoPath := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktreeRoot: %v", err)
+	}
+	corruptPath := filepath.Join(worktreeRoot, "populated-hollow")
+	if err := os.MkdirAll(corruptPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll corruptPath: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(corruptPath, ".git"), []byte("gitdir: /missing/gitdir\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile malformed .git: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(corruptPath, "agent-output.txt"), []byte("keep me\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile agent-output: %v", err)
+	}
+	metadata := fmt.Sprintf(`{"worktreeRoot":%q}`, worktreeRoot)
+	branch := "looper/feature"
+	preservedErr := fmt.Errorf("worktree path %s is unusable and not empty; manual intervention required: %w", corruptPath, worktreesafety.ErrUnusableWorktreePreserved)
+	git := &fakeGitGateway{restoreErr: preservedErr}
+	agent := &fakeAgentExecutor{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Git: git, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoCommit: true})
+	run := storage.RunRecord{ID: "run_preserve_mi", LoopID: "loop_worker_1", Status: "running", CurrentStep: stringPtr(string(stepExecute)), StartedAt: fixture.nowISO(), CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), "loop_worker_1")
+	if err != nil || loop == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v), want loop", loop, err)
+	}
+
+	_, err = runner.runExecuteStep(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: repoPath, MetadataJSON: &metadata},
+		Loop:    *loop,
+		Run:     run,
+		Checkpoint: workerCheckpoint{
+			Work:     &workerInput{Title: "Implement worker loop", Repo: "acme/looper", IssueNumber: 27, BaseBranch: "main", ExecutionMode: "create-pr"},
+			Worktree: &checkpointWorktree{ID: "worktree_old", Path: corruptPath, Branch: branch, BaseBranch: "main", HeadSHA: "abc123"},
+			Plan:     &checkpointPlan{Summary: "Implement worker loop", Items: []string{"Do it"}},
+		},
+	})
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) {
+		t.Fatalf("runExecuteStep() error = %v, want *loopError", err)
+	}
+	if loopErr.kind != FailureManualIntervention {
+		t.Fatalf("loopErr.kind = %v, want %v", loopErr.kind, FailureManualIntervention)
+	}
+	if !errors.Is(err, worktreesafety.ErrUnusableWorktreePreserved) && !strings.Contains(loopErr.message, "manual intervention required") {
+		t.Fatalf("error = %q, want preserved unusable worktree message", loopErr.message)
+	}
+	if len(git.restoreCalls) != 1 {
+		t.Fatalf("restoreCalls = %#v, want 1", git.restoreCalls)
+	}
+	if len(git.createCalls) != 0 {
+		t.Fatalf("createCalls = %#v, want 0 (must not recreate preserved path)", git.createCalls)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("agent starts = %#v, want none", agent.starts)
+	}
+	// Queue classification must park under unlimited maxAttempts.
+	if shouldRetryQueueFailure(loopErr.kind, 242, -1) {
+		t.Fatal("preserved unusable worktree must not requeue under unlimited maxAttempts")
+	}
+	got, readErr := os.ReadFile(filepath.Join(corruptPath, "agent-output.txt"))
+	if readErr != nil || string(got) != "keep me\n" {
+		t.Fatalf("agent-output = %q err=%v, want preserved", got, readErr)
+	}
+}
+
 func TestCreateRunContextCopiesPredecessorAgentSnapshotOnResume(t *testing.T) {
 	t.Parallel()
 
@@ -4633,7 +4772,10 @@ func (f *fakeGitHubGateway) AddPullRequestReviewers(_ context.Context, input Pul
 
 type fakeGitGateway struct {
 	createResult   CreateWorktreeResult
+	createErr      error
 	restoreResult  *RestoreWorktreeResult
+	restoreErr     error
+	restoreNil     bool
 	prepareResult  PrepareWorktreeResult
 	inspectResult  InspectHeadResult
 	inspectResults []InspectHeadResult
@@ -4652,6 +4794,9 @@ type fakeGitGateway struct {
 
 func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeInput) (CreateWorktreeResult, error) {
 	f.createCalls = append(f.createCalls, input)
+	if f.createErr != nil {
+		return CreateWorktreeResult{}, f.createErr
+	}
 	result := f.createResult
 	if result.WorktreePath == "" {
 		result.WorktreePath = filepath.Join(input.WorktreeRoot, "wt")
@@ -4670,6 +4815,12 @@ func (f *fakeGitGateway) CreateWorktree(_ context.Context, input CreateWorktreeI
 
 func (f *fakeGitGateway) RestoreWorktree(_ context.Context, input RestoreWorktreeInput) (*RestoreWorktreeResult, error) {
 	f.restoreCalls = append(f.restoreCalls, input)
+	if f.restoreErr != nil {
+		return nil, f.restoreErr
+	}
+	if f.restoreNil {
+		return nil, nil
+	}
 	if f.restoreResult != nil {
 		return f.restoreResult, nil
 	}

--- a/internal/worktreesafety/checkout.go
+++ b/internal/worktreesafety/checkout.go
@@ -1,0 +1,196 @@
+package worktreesafety
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrUnusableWorktreePreserved signals that an unusable managed worktree path
+// still holds content that must not be deleted automatically. Callers should
+// park the loop for manual intervention rather than retrying forever.
+var ErrUnusableWorktreePreserved = errors.New("unusable worktree path preserved")
+
+// LocalCheckoutUsable reports whether path has local git metadata without
+// contacting remotes. Linked worktrees use a .git file (gitdir pointer);
+// ordinary checkouts use a .git directory. Metadata presence alone is not
+// enough: ordinary repos and the linked common repository need full non-remote
+// integrity (HEAD + objects/ + refs/), and linked private gitdirs need HEAD
+// plus a resolvable usable common repo via commondir.
+//
+// Authority: local filesystem git metadata only. This answers "is this path a
+// usable checkout?" — not "may we delete arbitrary contents?".
+func LocalCheckoutUsable(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	gitMeta := filepath.Join(path, ".git")
+	info, err := os.Lstat(gitMeta)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		return localGitRepositoryMetadataUsable(gitMeta)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Stat(gitMeta)
+		if err != nil {
+			return false
+		}
+		if target.IsDir() {
+			return localGitRepositoryMetadataUsable(gitMeta)
+		}
+	}
+	data, err := os.ReadFile(gitMeta)
+	if err != nil {
+		return false
+	}
+	line := strings.TrimSpace(string(data))
+	if line == "" {
+		return false
+	}
+	const prefix = "gitdir:"
+	if len(line) < len(prefix) || !strings.EqualFold(line[:len(prefix)], prefix) {
+		// Malformed gitfile: real Git rejects non-gitdir: content as
+		// "invalid gitfile format".
+		return false
+	}
+	gitdir := strings.TrimSpace(line[len(prefix):])
+	if gitdir == "" {
+		return false
+	}
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(path, gitdir)
+	}
+	if _, err = os.Stat(filepath.Join(gitdir, "HEAD")); err != nil {
+		return false
+	}
+	return linkedPrivateGitdirCommonUsable(gitdir)
+}
+
+// LooksLikeLocalIntegrityError reports whether err text resembles a local
+// checkout integrity failure. Remote helpers can emit the same phrases, so
+// callers must confirm with LocalCheckoutUsable before force-cleaning.
+func LooksLikeLocalIntegrityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not a working tree") ||
+		strings.Contains(msg, "not a git repository") ||
+		strings.Contains(msg, "invalid gitfile format")
+}
+
+// ClearUnusableManagedPath removes empty or metadata-only unusable leftovers at
+// a managed worktree path so CreateWorktree can reuse it. Deletion requires:
+//   - Validate(input) succeeds (path under worktree root, not repo path)
+//   - directory is empty, OR contains only unusable local git metadata
+//
+// Any other content (including generic .tmp or agent output) is preserved and
+// returns ErrUnusableWorktreePreserved.
+func ClearUnusableManagedPath(input CheckInput, path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	// Always bind deletion to the caller's safety context.
+	check := input
+	check.WorktreePath = path
+	if err := Validate(check); err != nil {
+		return err
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("worktree path %s is unusable and not empty; manual intervention required: %w", path, ErrUnusableWorktreePreserved)
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	if onlyUnusableLocalGitMetadata(path, entries) {
+		if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("worktree path %s is unusable and not empty; manual intervention required: %w", path, ErrUnusableWorktreePreserved)
+}
+
+// EnsureUnusableManagedPathCleared clears path only when it exists and is not a
+// usable local checkout. Usable checkouts are left alone for git worktree add.
+func EnsureUnusableManagedPathCleared(input CheckInput, path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if LocalCheckoutUsable(path) {
+		return nil
+	}
+	return ClearUnusableManagedPath(input, path)
+}
+
+func localGitRepositoryMetadataUsable(dir string) bool {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(dir, "HEAD")); err != nil {
+		return false
+	}
+	objects, err := os.Stat(filepath.Join(dir, "objects"))
+	if err != nil || !objects.IsDir() {
+		return false
+	}
+	refs, err := os.Stat(filepath.Join(dir, "refs"))
+	if err != nil || !refs.IsDir() {
+		return false
+	}
+	return true
+}
+
+func linkedPrivateGitdirCommonUsable(gitdir string) bool {
+	data, err := os.ReadFile(filepath.Join(gitdir, "commondir"))
+	if err != nil {
+		return false
+	}
+	common := strings.TrimSpace(string(data))
+	if common == "" {
+		return false
+	}
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(gitdir, common)
+	}
+	common = filepath.Clean(common)
+	return localGitRepositoryMetadataUsable(common)
+}
+
+// onlyUnusableLocalGitMetadata is true when path holds nothing but a non-usable
+// .git file/dir. Any other entry is treated as possible agent dirt.
+func onlyUnusableLocalGitMetadata(path string, entries []os.DirEntry) bool {
+	if len(entries) != 1 || entries[0].Name() != ".git" {
+		return false
+	}
+	return !LocalCheckoutUsable(path)
+}

--- a/internal/worktreesafety/checkout_test.go
+++ b/internal/worktreesafety/checkout_test.go
@@ -1,0 +1,129 @@
+package worktreesafety
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeMinimalGitRepoMetadata(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "objects"), 0o755); err != nil {
+		t.Fatalf("MkdirAll objects: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "refs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll refs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile HEAD: %v", err)
+	}
+}
+
+func TestLocalCheckoutUsable(t *testing.T) {
+	t.Parallel()
+
+	hollow := t.TempDir()
+	if LocalCheckoutUsable(hollow) {
+		t.Fatal("LocalCheckoutUsable(hollow) = true, want false")
+	}
+
+	ordinary := t.TempDir()
+	writeMinimalGitRepoMetadata(t, filepath.Join(ordinary, ".git"))
+	if !LocalCheckoutUsable(ordinary) {
+		t.Fatal("LocalCheckoutUsable(ordinary) = false, want true")
+	}
+
+	malformed := t.TempDir()
+	if err := os.WriteFile(filepath.Join(malformed, ".git"), []byte("not-gitdir\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if LocalCheckoutUsable(malformed) {
+		t.Fatal("LocalCheckoutUsable(malformed) = true, want false")
+	}
+}
+
+func TestClearUnusableManagedPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_removed", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		repo := filepath.Join(t.TempDir(), "repo")
+		path := filepath.Join(root, "empty")
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := ClearUnusableManagedPath(CheckInput{WorktreePath: path, RepoPath: repo, WorktreeRoot: root}, path); err != nil {
+			t.Fatalf("ClearUnusableManagedPath() error = %v", err)
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("path still exists, err=%v", err)
+		}
+	})
+
+	t.Run("populated_preserved", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		repo := filepath.Join(t.TempDir(), "repo")
+		path := filepath.Join(root, "populated")
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		marker := filepath.Join(path, "keep.txt")
+		if err := os.WriteFile(marker, []byte("x\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		err := ClearUnusableManagedPath(CheckInput{WorktreePath: path, RepoPath: repo, WorktreeRoot: root}, path)
+		if !errors.Is(err, ErrUnusableWorktreePreserved) {
+			t.Fatalf("error = %v, want ErrUnusableWorktreePreserved", err)
+		}
+		if _, err := os.Stat(marker); err != nil {
+			t.Fatalf("marker missing: %v", err)
+		}
+	})
+
+	t.Run("only_malformed_git_removed", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		repo := filepath.Join(t.TempDir(), "repo")
+		path := filepath.Join(root, "malformed")
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(path, ".git"), []byte("garbage\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := ClearUnusableManagedPath(CheckInput{WorktreePath: path, RepoPath: repo, WorktreeRoot: root}, path); err != nil {
+			t.Fatalf("ClearUnusableManagedPath() error = %v", err)
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("path still exists, err=%v", err)
+		}
+	})
+
+	t.Run("tmp_only_preserved", func(t *testing.T) {
+		t.Parallel()
+		// Generic .tmp is unknown content — preserve for MI (oracle policy).
+		root := t.TempDir()
+		repo := filepath.Join(t.TempDir(), "repo")
+		path := filepath.Join(root, "tmp-only")
+		if err := os.MkdirAll(filepath.Join(path, ".tmp"), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		err := ClearUnusableManagedPath(CheckInput{WorktreePath: path, RepoPath: repo, WorktreeRoot: root}, path)
+		if !errors.Is(err, ErrUnusableWorktreePreserved) {
+			t.Fatalf("error = %v, want ErrUnusableWorktreePreserved for .tmp-only hollow", err)
+		}
+	})
+}
+
+func TestLooksLikeLocalIntegrityError(t *testing.T) {
+	t.Parallel()
+	if !LooksLikeLocalIntegrityError(errors.New("fatal: not a git repository")) {
+		t.Fatal("expected true")
+	}
+	if LooksLikeLocalIntegrityError(errors.New("ssh: connection refused")) {
+		t.Fatal("expected false")
+	}
+}

--- a/internal/worktreesafety/safety.go
+++ b/internal/worktreesafety/safety.go
@@ -40,6 +40,14 @@ func IsSafe(input CheckInput) bool {
 	return Validate(input) == nil
 }
 
+// IsProjectRepoPath reports whether worktreePath is the project's main
+// checkout. Managed worktrees must never equal the project repo; callers that
+// resume past prepare should hard-fail this case instead of inventing a fresh
+// worktree and continuing on a checkpoint that claimed work lived at the repo.
+func IsProjectRepoPath(worktreePath, repoPath string) bool {
+	return samePath(worktreePath, repoPath)
+}
+
 func samePath(a, b string) bool {
 	a = strings.TrimSpace(a)
 	b = strings.TrimSpace(b)

--- a/internal/worktreesafety/safety_test.go
+++ b/internal/worktreesafety/safety_test.go
@@ -55,6 +55,21 @@ func TestValidateRejectsRepoPathThroughSymlink(t *testing.T) {
 	}
 }
 
+func TestIsProjectRepoPath(t *testing.T) {
+	t.Parallel()
+
+	repoPath := t.TempDir()
+	if !IsProjectRepoPath(repoPath, repoPath) {
+		t.Fatal("IsProjectRepoPath(same) = false, want true")
+	}
+	if IsProjectRepoPath(filepath.Join(repoPath, "worktree"), repoPath) {
+		t.Fatal("IsProjectRepoPath(child) = true, want false")
+	}
+	if IsProjectRepoPath("", repoPath) || IsProjectRepoPath(repoPath, "") {
+		t.Fatal("IsProjectRepoPath(empty) = true, want false")
+	}
+}
+
 func TestValidateAllowsExistingWorktreeUnderSymlinkedRoot(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Stops reviewer/worker loops from infinite-retrying when a managed worktree directory is hollow (exists on disk without usable `.git` metadata).

**Incident:** loop #3673 hit 242 consecutive failures on `git status: fatal: not a git repository` every ~5 minutes because:
1. Gateway `isHealthyWorktree` returned `(false, err)` for hollow paths → Restore hard-failed
2. Error classified as `retryable_transient` via worktree step `BoundaryGitRemote`
3. `scheduler.retryMaxAttempts = -1` never exhausted

Fixer already recovered this class of failure; this PR lifts that authority into shared `worktreesafety` and wires gateway + reviewer + worker.

## Authority

> What is the authority for recreate vs MI, and why is it not the agent's output?

**Local filesystem git metadata** (`LocalCheckoutUsable`: `.git` dir/file + HEAD/objects/refs / linked gitdir+commondir). Confirmed local-unusable paths may be cleared only when empty or metadata-only. Any other content (including generic `.tmp` or agent output) is **preserved** and parks as manual intervention.

## Trade-off

| Prevents | Costs |
|----------|--------|
| Infinite retry storms on hollow managed worktrees | Shared probe/clear surface in `worktreesafety` |
| Reviewer/worker prepared-path bypass of Restore | Prepared reuse now requires usable checkout |
| Mislabeling managed hollowness as project repoPath (diagnostics) | Populated hollow paths need human cleanup (by design) |

**Why not simpler alternatives:**
- Cap `retryMaxAttempts` alone → still fails N times, never recreates
- Substring-match error text alone → remote helpers emit the same phrases (fixer already documented this)
- Delete any non-git directory → destroys interrupted agent dirt

**Why not delete a layer:** crashes and partial cleanup can leave hollow paths; recovery must handle leftovers even if cleanup is hardened later.

## Changes

- `worktreesafety`: `LocalCheckoutUsable`, `ClearUnusableManagedPath`, `EnsureUnusableManagedPathCleared`
- Gateway: hollow → unhealthy without error; clear empty/metadata-only; Create preflight clear
- Reviewer/worker: checkpoint reuse requires usable local checkout
- `failureclass`: prefer `WithBoundary` on the error over step default
- Diagnostics: `managed_worktree_integrity` for preserved unusable paths
- Fixer: delegates to shared helpers (behavior preserved)

## Test plan

- [x] `go test ./internal/worktreesafety/ ./internal/infra/git/ ./internal/fixer/ ./internal/reviewer/ ./internal/worker/ ./internal/loops/failureclass/ ./internal/cliapp/`
- [x] Hollow stored worktree → Restore clears → Create rebuilds
- [x] Populated hollow → preserved + MI (no infinite retry)
- [x] Reviewer prepared hollow checkpoint forces recreate
- [x] Existing fixer ownership/corrupt recovery tests green