### PR TITLE
feat(dashboard): polish loop UX, list order, and icons

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2024,8 +2024,11 @@ type projectResponse struct {
 	BaseBranch string `json:"baseBranch"`
 	Archived   bool   `json:"archived"`
 	// Provider is the resolved provider kind for display (github, forgejo, plane).
-	Provider     string  `json:"provider"`
-	Repo         *string `json:"repo"`
+	Provider string  `json:"provider"`
+	Repo     *string `json:"repo"`
+	// RepoURL is the forge HTML URL for the repo (provider base + owner/name).
+	// Nil when repo slug or forge base cannot be resolved.
+	RepoURL      *string `json:"repoUrl"`
 	WorktreeRoot *string `json:"worktreeRoot"`
 	CreatedAt    string  `json:"createdAt"`
 	UpdatedAt    string  `json:"updatedAt"`
@@ -7494,14 +7497,30 @@ func serializeProject(project storage.ProjectRecord, cfg config.Config, defaultB
 		baseBranch = *project.BaseBranch
 	}
 
+	repo := stringMetadataPtr(metadata, "repo")
+	// Prefer config project.Repo when metadata lacks it (configured projects).
+	if repo == nil {
+		for _, configured := range cfg.Projects {
+			if configured.ID != project.ID {
+				continue
+			}
+			if trimmed := strings.TrimSpace(configured.Repo); trimmed != "" {
+				repo = &trimmed
+			}
+			break
+		}
+	}
+
+	providerKind := resolveProjectProviderKind(cfg, project.ID, metadata)
 	return projectResponse{
 		ID:           project.ID,
 		Name:         project.Name,
 		RepoPath:     project.RepoPath,
 		BaseBranch:   baseBranch,
 		Archived:     project.Archived,
-		Provider:     resolveProjectProviderKind(cfg, project.ID, metadata),
-		Repo:         stringMetadataPtr(metadata, "repo"),
+		Provider:     providerKind,
+		Repo:         repo,
+		RepoURL:      resolveProjectRepoURL(cfg, project.ID, metadata, repo),
 		WorktreeRoot: stringMetadataPtr(metadata, "worktreeRoot"),
 		CreatedAt:    project.CreatedAt,
 		UpdatedAt:    project.UpdatedAt,
@@ -7511,24 +7530,70 @@ func serializeProject(project storage.ProjectRecord, cfg config.Config, defaultB
 // resolveProjectProviderKind returns the display provider kind for a project:
 // config binding first, then API metadata provider id, else github.
 func resolveProjectProviderKind(cfg config.Config, projectID string, metadata map[string]any) string {
+	if kind, _, ok := resolveProjectProvider(cfg, projectID, metadata); ok && kind != "" {
+		return string(kind)
+	}
+	return string(config.ProviderKindGitHub)
+}
+
+// resolveProjectProvider returns kind + base URL from config project binding or
+// metadata provider id. Base URL is empty for unknown providers; GitHub defaults
+// to https://github.com when kind is github and base is unset.
+func resolveProjectProvider(cfg config.Config, projectID string, metadata map[string]any) (kind config.ProviderKind, baseURL string, ok bool) {
+	providerID := ""
 	for _, configured := range cfg.Projects {
 		if configured.ID != projectID {
 			continue
 		}
-		kind := config.ResolvedProjectProviderKind(cfg, configured)
-		if kind != "" {
-			return string(kind)
+		providerID = strings.TrimSpace(configured.Provider)
+		if providerID == "" {
+			return config.ProviderKindGitHub, "https://github.com", true
 		}
 		break
 	}
-	if providerID := strings.TrimSpace(stringMetadataValue(metadata, "provider")); providerID != "" {
-		for _, provider := range cfg.Providers {
-			if provider.ID == providerID && provider.Kind != "" {
-				return string(provider.Kind)
-			}
-		}
+	if providerID == "" {
+		providerID = strings.TrimSpace(stringMetadataValue(metadata, "provider"))
 	}
-	return string(config.ProviderKindGitHub)
+	if providerID == "" {
+		return config.ProviderKindGitHub, "https://github.com", true
+	}
+	for _, provider := range cfg.Providers {
+		if provider.ID != providerID {
+			continue
+		}
+		if provider.Kind == config.ProviderKindPlane {
+			// Plane projects still host code on GitHub in current model.
+			return config.ProviderKindGitHub, "https://github.com", true
+		}
+		base := strings.TrimRight(strings.TrimSpace(provider.BaseURL), "/")
+		if provider.Kind == config.ProviderKindGitHub && base == "" {
+			base = "https://github.com"
+		}
+		if provider.Kind == "" {
+			return config.ProviderKindGitHub, base, true
+		}
+		return provider.Kind, base, true
+	}
+	return "", "", false
+}
+
+// resolveProjectRepoURL builds the forge HTML URL for owner/repo using the
+// configured provider base (Forgejo host, github.com, …). Returns nil when the
+// slug or base cannot be resolved — callers should not invent github.com.
+func resolveProjectRepoURL(cfg config.Config, projectID string, metadata map[string]any, repo *string) *string {
+	if repo == nil {
+		return nil
+	}
+	slug := strings.TrimSpace(*repo)
+	if slug == "" || strings.Contains(slug, "://") || strings.Count(slug, "/") != 1 {
+		return nil
+	}
+	_, baseURL, ok := resolveProjectProvider(cfg, projectID, metadata)
+	if !ok || strings.TrimSpace(baseURL) == "" {
+		return nil
+	}
+	url := strings.TrimRight(baseURL, "/") + "/" + slug
+	return &url
 }
 
 func stringMetadataValue(metadata map[string]any, key string) string {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2318,8 +2318,9 @@ func (h *Handler) buildLoopsRouteResponse(r *http.Request) (any, error) {
 
 func parseLoopsListOptions(r *http.Request) (storage.ListLoopsOptions, error) {
 	opts := storage.ListLoopsOptions{
-		Status:    strings.TrimSpace(r.URL.Query().Get("status")),
-		ProjectID: strings.TrimSpace(r.URL.Query().Get("projectId")),
+		Status:            strings.TrimSpace(r.URL.Query().Get("status")),
+		ProjectID:         strings.TrimSpace(r.URL.Query().Get("projectId")),
+		OrderByStatusTier: true, // dashboard list only; repository List() stays newest-first
 	}
 
 	if limitValue := strings.TrimSpace(r.URL.Query().Get("limit")); limitValue != "" {
@@ -7562,8 +7563,8 @@ func resolveProjectProvider(cfg config.Config, projectID string, metadata map[st
 			continue
 		}
 		if provider.Kind == config.ProviderKindPlane {
-			// Plane projects still host code on GitHub in current model.
-			return config.ProviderKindGitHub, "https://github.com", true
+			// Plane remains the reported task-source provider; code hosting is GitHub.
+			return config.ProviderKindPlane, "https://github.com", true
 		}
 		base := strings.TrimRight(strings.TrimSpace(provider.BaseURL), "/")
 		if provider.Kind == config.ProviderKindGitHub && base == "" {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2038,12 +2038,15 @@ func TestResolveProjectProviderKind(t *testing.T) {
 	t.Parallel()
 
 	tokenEnv := "FORGEJO_TOKEN"
+	planeTokenEnv := "PLANE_TOKEN"
 	cfg := config.Config{
 		Providers: []config.ProviderConfig{
 			{ID: "forgejo-main", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example.com", TokenEnv: &tokenEnv},
+			{ID: "plane-main", Kind: config.ProviderKindPlane, BaseURL: "https://plane.example.com/api/v1", TokenEnv: &planeTokenEnv},
 		},
 		Projects: []config.ProjectRefConfig{
 			{ID: "configured-forgejo", Name: "Configured", Provider: "forgejo-main", Repo: "acme/fj", RepoPath: "/tmp/fj"},
+			{ID: "configured-plane", Name: "Plane", Provider: "plane-main", Repo: "acme/looper", RepoPath: "/tmp/looper"},
 		},
 	}
 
@@ -2056,18 +2059,27 @@ func TestResolveProjectProviderKind(t *testing.T) {
 	if got := resolveProjectProviderKind(cfg, "legacy-github", map[string]any{"repo": "acme/looper"}); got != "github" {
 		t.Fatalf("legacy github = %q, want github", got)
 	}
+	if got := resolveProjectProviderKind(cfg, "configured-plane", map[string]any{}); got != "plane" {
+		t.Fatalf("configured plane = %q, want plane", got)
+	}
+	if got := resolveProjectProviderKind(cfg, "api-plane", map[string]any{"provider": "plane-main", "repo": "acme/looper"}); got != "plane" {
+		t.Fatalf("metadata plane = %q, want plane", got)
+	}
 }
 
 func TestResolveProjectRepoURL(t *testing.T) {
 	t.Parallel()
 
 	tokenEnv := "FORGEJO_TOKEN"
+	planeTokenEnv := "PLANE_TOKEN"
 	cfg := config.Config{
 		Providers: []config.ProviderConfig{
 			{ID: "forgejo-main", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example.com/", TokenEnv: &tokenEnv},
+			{ID: "plane-main", Kind: config.ProviderKindPlane, BaseURL: "https://plane.example.com/api/v1", TokenEnv: &planeTokenEnv},
 		},
 		Projects: []config.ProjectRefConfig{
 			{ID: "configured-forgejo", Name: "Configured", Provider: "forgejo-main", Repo: "acme/fj", RepoPath: "/tmp/fj"},
+			{ID: "configured-plane", Name: "Plane", Provider: "plane-main", Repo: "acme/looper", RepoPath: "/tmp/looper"},
 		},
 	}
 
@@ -2084,6 +2096,12 @@ func TestResolveProjectRepoURL(t *testing.T) {
 	ghRepo := "acme/looper"
 	if got := resolveProjectRepoURL(cfg, "legacy-github", map[string]any{}, &ghRepo); got == nil || *got != "https://github.com/acme/looper" {
 		t.Fatalf("legacy github repoUrl = %v, want https://github.com/acme/looper", got)
+	}
+
+	// Plane reports provider "plane" but code links use GitHub.
+	planeRepo := "acme/looper"
+	if got := resolveProjectRepoURL(cfg, "configured-plane", map[string]any{}, &planeRepo); got == nil || *got != "https://github.com/acme/looper" {
+		t.Fatalf("configured plane repoUrl = %v, want https://github.com/acme/looper", got)
 	}
 }
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2511,6 +2511,8 @@ func TestHandlerLoopsListPaginationAndFilters(t *testing.T) {
 	})
 
 	t.Run("limit and offset page with total", func(t *testing.T) {
+		// Default list order is status tier then updated_at DESC, seq DESC:
+		// running (loop_4, loop_3, loop_1) → paused (loop_2) → failed (loop_5).
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/loops?limit=2&offset=1", nil)
 		recorder := httptest.NewRecorder()
 		h.ServeHTTP(recorder, req)
@@ -2523,8 +2525,8 @@ func TestHandlerLoopsListPaginationAndFilters(t *testing.T) {
 		if len(items) != 2 {
 			t.Fatalf("items len = %d, want 2", len(items))
 		}
-		assertEqual(t, items[0].(map[string]any)["id"], "loop_4")
-		assertEqual(t, items[1].(map[string]any)["id"], "loop_3")
+		assertEqual(t, items[0].(map[string]any)["id"], "loop_3")
+		assertEqual(t, items[1].(map[string]any)["id"], "loop_1")
 		assertEqual(t, data["total"], float64(5))
 		assertEqual(t, data["limit"], float64(2))
 		assertEqual(t, data["offset"], float64(1))
@@ -2543,9 +2545,9 @@ func TestHandlerLoopsListPaginationAndFilters(t *testing.T) {
 		if len(items) != 3 {
 			t.Fatalf("items len = %d, want 3", len(items))
 		}
-		assertEqual(t, items[0].(map[string]any)["id"], "loop_3")
+		assertEqual(t, items[0].(map[string]any)["id"], "loop_1")
 		assertEqual(t, items[1].(map[string]any)["id"], "loop_2")
-		assertEqual(t, items[2].(map[string]any)["id"], "loop_1")
+		assertEqual(t, items[2].(map[string]any)["id"], "loop_5")
 		assertEqual(t, data["total"], float64(5))
 		assertEqual(t, data["offset"], float64(2))
 		if _, ok := data["limit"]; ok {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2026,6 +2026,7 @@ func TestHandlerProjectsListRouteSuccess(t *testing.T) {
 	assertEqual(t, project["archived"], false)
 	assertEqual(t, project["provider"], "github")
 	assertEqual(t, project["repo"], "acme/looper")
+	assertEqual(t, project["repoUrl"], "https://github.com/acme/looper")
 	if project["worktreeRoot"] != nil {
 		t.Fatalf("worktreeRoot = %#v, want nil", project["worktreeRoot"])
 	}
@@ -2054,6 +2055,35 @@ func TestResolveProjectProviderKind(t *testing.T) {
 	}
 	if got := resolveProjectProviderKind(cfg, "legacy-github", map[string]any{"repo": "acme/looper"}); got != "github" {
 		t.Fatalf("legacy github = %q, want github", got)
+	}
+}
+
+func TestResolveProjectRepoURL(t *testing.T) {
+	t.Parallel()
+
+	tokenEnv := "FORGEJO_TOKEN"
+	cfg := config.Config{
+		Providers: []config.ProviderConfig{
+			{ID: "forgejo-main", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example.com/", TokenEnv: &tokenEnv},
+		},
+		Projects: []config.ProjectRefConfig{
+			{ID: "configured-forgejo", Name: "Configured", Provider: "forgejo-main", Repo: "acme/fj", RepoPath: "/tmp/fj"},
+		},
+	}
+
+	repo := "acme/fj"
+	if got := resolveProjectRepoURL(cfg, "configured-forgejo", map[string]any{}, &repo); got == nil || *got != "https://code.example.com/acme/fj" {
+		t.Fatalf("configured forgejo repoUrl = %v, want https://code.example.com/acme/fj", got)
+	}
+
+	metaRepo := "core/odcrew"
+	if got := resolveProjectRepoURL(cfg, "api-forgejo", map[string]any{"provider": "forgejo-main"}, &metaRepo); got == nil || *got != "https://code.example.com/core/odcrew" {
+		t.Fatalf("metadata forgejo repoUrl = %v, want https://code.example.com/core/odcrew", got)
+	}
+
+	ghRepo := "acme/looper"
+	if got := resolveProjectRepoURL(cfg, "legacy-github", map[string]any{}, &ghRepo); got == nil || *got != "https://github.com/acme/looper" {
+		t.Fatalf("legacy github repoUrl = %v, want https://github.com/acme/looper", got)
 	}
 }
 

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -632,11 +632,14 @@ func (r *LoopsRepository) AllocateSeq(ctx context.Context) (int64, error) {
 // ListLoopsOptions filters and paginates loop listings.
 // Empty Status/ProjectID match all. Limit 0 means no limit (full list).
 // Offset is always applied when > 0, including when Limit == 0 (SQLite LIMIT -1 OFFSET n).
+// Default order is newest-first (updated_at DESC, seq DESC). OrderByStatusTier is for
+// dashboard list UX only; generic List() and first-match scans must stay newest-first.
 type ListLoopsOptions struct {
-	Status    string
-	ProjectID string
-	Limit     int64
-	Offset    int64
+	Status            string
+	ProjectID         string
+	Limit             int64
+	Offset            int64
+	OrderByStatusTier bool
 }
 
 func (r *LoopsRepository) List(ctx context.Context) ([]LoopRecord, error) {
@@ -680,9 +683,11 @@ func buildLoopsListQuery(base string, opts ListLoopsOptions, withOrderAndLimit b
 		query += " WHERE " + strings.Join(clauses, " AND ")
 	}
 	if withOrderAndLimit {
-		// Active / attention-needed statuses first so recently completed loops
-		// (which bump updated_at) do not dominate the default list page.
-		query += ` ORDER BY CASE status
+		if opts.OrderByStatusTier {
+			// Dashboard list only: active / attention-needed statuses first so
+			// recently completed loops (which bump updated_at) do not dominate.
+			// Generic List() stays newest-first for first-match mutation scans.
+			query += ` ORDER BY CASE status
 			WHEN 'running' THEN 0
 			WHEN 'awaiting_human' THEN 0
 			WHEN 'human_takeover' THEN 0
@@ -697,6 +702,9 @@ func buildLoopsListQuery(base string, opts ListLoopsOptions, withOrderAndLimit b
 			WHEN 'terminated' THEN 4
 			ELSE 5
 		END ASC, updated_at DESC, seq DESC`
+		} else {
+			query += " ORDER BY updated_at DESC, seq DESC"
+		}
 		if opts.Limit > 0 {
 			query += " LIMIT ?"
 			args = append(args, opts.Limit)

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -680,7 +680,23 @@ func buildLoopsListQuery(base string, opts ListLoopsOptions, withOrderAndLimit b
 		query += " WHERE " + strings.Join(clauses, " AND ")
 	}
 	if withOrderAndLimit {
-		query += " ORDER BY updated_at DESC, seq DESC"
+		// Active / attention-needed statuses first so recently completed loops
+		// (which bump updated_at) do not dominate the default list page.
+		query += ` ORDER BY CASE status
+			WHEN 'running' THEN 0
+			WHEN 'awaiting_human' THEN 0
+			WHEN 'human_takeover' THEN 0
+			WHEN 'queued' THEN 1
+			WHEN 'paused' THEN 2
+			WHEN 'waiting' THEN 2
+			WHEN 'idle' THEN 2
+			WHEN 'failed' THEN 3
+			WHEN 'interrupted' THEN 3
+			WHEN 'stopped' THEN 4
+			WHEN 'completed' THEN 4
+			WHEN 'terminated' THEN 4
+			ELSE 5
+		END ASC, updated_at DESC, seq DESC`
 		if opts.Limit > 0 {
 			query += " LIMIT ?"
 			args = append(args, opts.Limit)

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -2289,7 +2289,7 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 		}
 	}
 
-	// Distinct updated_at so ORDER BY updated_at DESC, seq DESC is deterministic.
+	// Distinct updated_at; default order is status tier then updated_at DESC, seq DESC.
 	loops := []LoopRecord{
 		{ID: "loop_1", Seq: 1, ProjectID: "project_a", Type: "worker", TargetType: "project", Status: "running", CreatedAt: "2026-04-11T12:00:01.000Z", UpdatedAt: "2026-04-11T12:00:01.000Z"},
 		{ID: "loop_2", Seq: 2, ProjectID: "project_a", Type: "worker", TargetType: "project", Status: "paused", CreatedAt: "2026-04-11T12:00:02.000Z", UpdatedAt: "2026-04-11T12:00:02.000Z"},
@@ -2310,8 +2310,9 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 	if len(all) != 5 {
 		t.Fatalf("ListFiltered(unlimited) len = %d, want 5", len(all))
 	}
-	if all[0].ID != "loop_5" || all[4].ID != "loop_1" {
-		t.Fatalf("ListFiltered(unlimited) order = %v, want newest-first", loopIDs(all))
+	// running (newest first) → paused → failed; completed-like terminal does not lead.
+	if got := loopIDs(all); !reflect.DeepEqual(got, []string{"loop_4", "loop_3", "loop_1", "loop_2", "loop_5"}) {
+		t.Fatalf("ListFiltered(unlimited) order = %v, want status-tier then newest", got)
 	}
 
 	total, err := repos.Loops.CountFiltered(ctx, ListLoopsOptions{})
@@ -2326,8 +2327,8 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListFiltered(limit/offset) error = %v", err)
 	}
-	if got := loopIDs(page); !reflect.DeepEqual(got, []string{"loop_4", "loop_3"}) {
-		t.Fatalf("ListFiltered(limit=2,offset=1) = %v, want [loop_4 loop_3]", got)
+	if got := loopIDs(page); !reflect.DeepEqual(got, []string{"loop_3", "loop_1"}) {
+		t.Fatalf("ListFiltered(limit=2,offset=1) = %v, want [loop_3 loop_1]", got)
 	}
 
 	// Offset without limit must still skip rows (SQLite LIMIT -1 OFFSET n).
@@ -2335,8 +2336,8 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListFiltered(offset-only) error = %v", err)
 	}
-	if got := loopIDs(offsetOnly); !reflect.DeepEqual(got, []string{"loop_3", "loop_2", "loop_1"}) {
-		t.Fatalf("ListFiltered(offset=2) = %v, want [loop_3 loop_2 loop_1]", got)
+	if got := loopIDs(offsetOnly); !reflect.DeepEqual(got, []string{"loop_1", "loop_2", "loop_5"}) {
+		t.Fatalf("ListFiltered(offset=2) = %v, want [loop_1 loop_2 loop_5]", got)
 	}
 
 	running, err := repos.Loops.ListFiltered(ctx, ListLoopsOptions{Status: "running"})
@@ -2358,8 +2359,8 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListFiltered(projectId) error = %v", err)
 	}
-	if got := loopIDs(projectB); !reflect.DeepEqual(got, []string{"loop_5", "loop_4"}) {
-		t.Fatalf("ListFiltered(projectId=project_b) = %v, want [loop_5 loop_4]", got)
+	if got := loopIDs(projectB); !reflect.DeepEqual(got, []string{"loop_4", "loop_5"}) {
+		t.Fatalf("ListFiltered(projectId=project_b) = %v, want [loop_4 loop_5]", got)
 	}
 
 	combined, err := repos.Loops.ListFiltered(ctx, ListLoopsOptions{Status: "running", ProjectID: "project_a", Limit: 1, Offset: 0})

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -2289,7 +2289,7 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 		}
 	}
 
-	// Distinct updated_at; default order is status tier then updated_at DESC, seq DESC.
+	// Distinct updated_at; default generic order is newest-first (updated_at DESC, seq DESC).
 	loops := []LoopRecord{
 		{ID: "loop_1", Seq: 1, ProjectID: "project_a", Type: "worker", TargetType: "project", Status: "running", CreatedAt: "2026-04-11T12:00:01.000Z", UpdatedAt: "2026-04-11T12:00:01.000Z"},
 		{ID: "loop_2", Seq: 2, ProjectID: "project_a", Type: "worker", TargetType: "project", Status: "paused", CreatedAt: "2026-04-11T12:00:02.000Z", UpdatedAt: "2026-04-11T12:00:02.000Z"},
@@ -2310,9 +2310,27 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 	if len(all) != 5 {
 		t.Fatalf("ListFiltered(unlimited) len = %d, want 5", len(all))
 	}
-	// running (newest first) → paused → failed; completed-like terminal does not lead.
-	if got := loopIDs(all); !reflect.DeepEqual(got, []string{"loop_4", "loop_3", "loop_1", "loop_2", "loop_5"}) {
-		t.Fatalf("ListFiltered(unlimited) order = %v, want status-tier then newest", got)
+	if got := loopIDs(all); !reflect.DeepEqual(got, []string{"loop_5", "loop_4", "loop_3", "loop_2", "loop_1"}) {
+		t.Fatalf("ListFiltered(unlimited) order = %v, want newest-first", got)
+	}
+
+	// List() must stay newest-first so first-match scans (ensureLoop / PR grouping)
+	// pick the latest loop rather than an older higher-status-tier row.
+	listed, err := repos.Loops.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got := loopIDs(listed); !reflect.DeepEqual(got, []string{"loop_5", "loop_4", "loop_3", "loop_2", "loop_1"}) {
+		t.Fatalf("List() order = %v, want newest-first", got)
+	}
+
+	tiered, err := repos.Loops.ListFiltered(ctx, ListLoopsOptions{OrderByStatusTier: true})
+	if err != nil {
+		t.Fatalf("ListFiltered(status-tier) error = %v", err)
+	}
+	// running (newest first) → paused → failed
+	if got := loopIDs(tiered); !reflect.DeepEqual(got, []string{"loop_4", "loop_3", "loop_1", "loop_2", "loop_5"}) {
+		t.Fatalf("ListFiltered(status-tier) order = %v, want status-tier then newest", got)
 	}
 
 	total, err := repos.Loops.CountFiltered(ctx, ListLoopsOptions{})
@@ -2327,8 +2345,16 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListFiltered(limit/offset) error = %v", err)
 	}
-	if got := loopIDs(page); !reflect.DeepEqual(got, []string{"loop_3", "loop_1"}) {
-		t.Fatalf("ListFiltered(limit=2,offset=1) = %v, want [loop_3 loop_1]", got)
+	if got := loopIDs(page); !reflect.DeepEqual(got, []string{"loop_4", "loop_3"}) {
+		t.Fatalf("ListFiltered(limit=2,offset=1) = %v, want [loop_4 loop_3]", got)
+	}
+
+	tieredPage, err := repos.Loops.ListFiltered(ctx, ListLoopsOptions{OrderByStatusTier: true, Limit: 2, Offset: 1})
+	if err != nil {
+		t.Fatalf("ListFiltered(status-tier limit/offset) error = %v", err)
+	}
+	if got := loopIDs(tieredPage); !reflect.DeepEqual(got, []string{"loop_3", "loop_1"}) {
+		t.Fatalf("ListFiltered(status-tier limit=2,offset=1) = %v, want [loop_3 loop_1]", got)
 	}
 
 	// Offset without limit must still skip rows (SQLite LIMIT -1 OFFSET n).
@@ -2336,8 +2362,8 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListFiltered(offset-only) error = %v", err)
 	}
-	if got := loopIDs(offsetOnly); !reflect.DeepEqual(got, []string{"loop_1", "loop_2", "loop_5"}) {
-		t.Fatalf("ListFiltered(offset=2) = %v, want [loop_1 loop_2 loop_5]", got)
+	if got := loopIDs(offsetOnly); !reflect.DeepEqual(got, []string{"loop_3", "loop_2", "loop_1"}) {
+		t.Fatalf("ListFiltered(offset=2) = %v, want [loop_3 loop_2 loop_1]", got)
 	}
 
 	running, err := repos.Loops.ListFiltered(ctx, ListLoopsOptions{Status: "running"})
@@ -2359,8 +2385,8 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListFiltered(projectId) error = %v", err)
 	}
-	if got := loopIDs(projectB); !reflect.DeepEqual(got, []string{"loop_4", "loop_5"}) {
-		t.Fatalf("ListFiltered(projectId=project_b) = %v, want [loop_4 loop_5]", got)
+	if got := loopIDs(projectB); !reflect.DeepEqual(got, []string{"loop_5", "loop_4"}) {
+		t.Fatalf("ListFiltered(projectId=project_b) = %v, want [loop_5 loop_4]", got)
 	}
 
 	combined, err := repos.Loops.ListFiltered(ctx, ListLoopsOptions{Status: "running", ProjectID: "project_a", Limit: 1, Offset: 0})
@@ -2376,6 +2402,41 @@ func TestLoopsListFilteredAndCountFiltered(t *testing.T) {
 	}
 	if combinedTotal != 2 {
 		t.Fatalf("CountFiltered(status+project) = %d, want 2", combinedTotal)
+	}
+}
+
+func TestLoopsListNewestFirstDespiteLowerStatusTier(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{
+		ID: "project_pr", Name: "PR", RepoPath: "/tmp/pr",
+		CreatedAt: "2026-04-11T12:00:00.000Z", UpdatedAt: "2026-04-11T12:00:00.000Z",
+	}); err != nil {
+		t.Fatalf("Projects.Upsert error = %v", err)
+	}
+	// Older waiting loop vs newer completed loop for the same PR: generic List
+	// must surface the newer completed row first (status tier would invert this).
+	repo := "acme/looper"
+	pr := int64(42)
+	for _, loop := range []LoopRecord{
+		{ID: "loop_old_waiting", Seq: 1, ProjectID: "project_pr", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &pr, Status: "waiting", CreatedAt: "2026-04-11T12:00:01.000Z", UpdatedAt: "2026-04-11T12:00:01.000Z"},
+		{ID: "loop_new_completed", Seq: 2, ProjectID: "project_pr", Type: "fixer", TargetType: "pull_request", Repo: &repo, PRNumber: &pr, Status: "completed", CreatedAt: "2026-04-11T12:00:02.000Z", UpdatedAt: "2026-04-11T12:00:02.000Z"},
+	} {
+		if err := repos.Loops.Upsert(ctx, loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+
+	listed, err := repos.Loops.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got := loopIDs(listed); !reflect.DeepEqual(got, []string{"loop_new_completed", "loop_old_waiting"}) {
+		t.Fatalf("List() order = %v, want newest completed before older waiting", got)
 	}
 }
 

--- a/web/dashboard/index.html
+++ b/web/dashboard/index.html
@@ -21,20 +21,8 @@
     <link rel="apple-touch-icon" href="%BASE_URL%apple-touch-icon.png" />
     <link rel="manifest" href="%BASE_URL%site.webmanifest" />
     <meta name="theme-color" content="#0a0a0a" />
-    <script>
-      // Inline theme init: run before paint so first render matches the
-      // persisted preference. CSS falls back to the media query when no
-      // attribute is set, so failures here still produce a sensible palette.
-      (function () {
-        try {
-          var m = localStorage.getItem("looper.dashboard.theme");
-          if (m !== "light" && m !== "dark" && m !== "system") m = "system";
-          document.documentElement.setAttribute("data-theme", m);
-        } catch (_) {
-          /* localStorage unavailable — leave attribute unset, CSS media query decides. */
-        }
-      })();
-    </script>
+    <!-- External script: production CSP is script-src 'self' (no unsafe-inline). -->
+    <script src="%BASE_URL%theme-init.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/dashboard/index.html
+++ b/web/dashboard/index.html
@@ -21,6 +21,20 @@
     <link rel="apple-touch-icon" href="%BASE_URL%apple-touch-icon.png" />
     <link rel="manifest" href="%BASE_URL%site.webmanifest" />
     <meta name="theme-color" content="#0a0a0a" />
+    <script>
+      // Inline theme init: run before paint so first render matches the
+      // persisted preference. CSS falls back to the media query when no
+      // attribute is set, so failures here still produce a sensible palette.
+      (function () {
+        try {
+          var m = localStorage.getItem("looper.dashboard.theme");
+          if (m !== "light" && m !== "dark" && m !== "system") m = "system";
+          document.documentElement.setAttribute("data-theme", m);
+        } catch (_) {
+          /* localStorage unavailable — leave attribute unset, CSS media query decides. */
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/dashboard/package.json
+++ b/web/dashboard/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "lucide-react": "^1.28.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2"
@@ -29,6 +30,8 @@
     "vitest": "^3.2.4"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/web/dashboard/pnpm-lock.yaml
+++ b/web/dashboard/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      lucide-react:
+        specifier: ^1.28.0
+        version: 1.28.0(react@19.2.7)
       react:
         specifier: ^19.1.0
         version: 19.2.7
@@ -938,6 +941,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.28.0:
+    resolution: {integrity: sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -1993,6 +2001,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.28.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   lz-string@1.5.0: {}
 

--- a/web/dashboard/public/theme-init.js
+++ b/web/dashboard/public/theme-init.js
@@ -1,0 +1,12 @@
+// CSP-safe theme bootstrap (script-src 'self'). Runs before paint so the
+// first frame matches the persisted preference. CSS falls back to the
+// media query when no attribute is set, so failures still look sensible.
+(function () {
+  try {
+    var m = localStorage.getItem("looper.dashboard.theme");
+    if (m !== "light" && m !== "dark" && m !== "system") m = "system";
+    document.documentElement.setAttribute("data-theme", m);
+  } catch (_) {
+    /* localStorage unavailable — leave attribute unset, CSS media query decides. */
+  }
+})();

--- a/web/dashboard/src/App.tsx
+++ b/web/dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { Shell } from "@/components/layout/Shell";
 import { exchangeBootstrapCodeIfPresent } from "@/lib/api";
@@ -11,27 +11,11 @@ import { OverviewPage } from "@/pages/Overview";
 import { ProjectsPage } from "@/pages/Projects";
 import { ConfigPage } from "@/pages/Config";
 
-function resolveHostPort(): string {
-  // Prefer the browser's authority as displayed in the address bar.
-  if (typeof window !== "undefined" && window.location.host) {
-    return window.location.host;
-  }
-  const { hostname, port } = window.location;
-  if (port) {
-    return `${hostname}:${port}`;
-  }
-  if (hostname === "localhost" || hostname === "127.0.0.1") {
-    return `${hostname}:17310`;
-  }
-  return hostname;
-}
-
 export default function App() {
   const [bootstrapped, setBootstrapped] = useState(false);
   const [bootstrapError, setBootstrapError] = useState<string | null>(null);
   const [healthy, setHealthy] = useState<boolean | null>(null);
   const [version, setVersion] = useState<string | undefined>();
-  const hostPort = useMemo(() => resolveHostPort(), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -106,7 +90,6 @@ export default function App() {
               <Route
                 element={
                   <Shell
-                    hostPort={hostPort}
                     healthy={healthy}
                     version={version}
                     onHealthChange={onHealthChange}

--- a/web/dashboard/src/components/AttemptsCell.tsx
+++ b/web/dashboard/src/components/AttemptsCell.tsx
@@ -1,0 +1,39 @@
+import { Infinity as InfinityIcon } from "lucide-react";
+
+/**
+ * Attempts cell for dense tables. Renders `current/max` and swaps the ∞
+ * character for a real lucide Infinity glyph when max is unlimited (-1).
+ * `formatAttempts` remains the source of truth for text contexts (Summary,
+ * tests, tooltips).
+ */
+export function AttemptsCell({
+  attempts,
+  maxAttempts,
+}: {
+  attempts: number | null | undefined;
+  maxAttempts: number | null | undefined;
+}) {
+  if (attempts == null || Number.isNaN(Number(attempts))) {
+    return <span className="mono text-[var(--text-muted)]">—</span>;
+  }
+  const current = Math.trunc(Number(attempts));
+  if (maxAttempts == null || Number.isNaN(Number(maxAttempts))) {
+    return <span className="mono text-[var(--text-muted)]">{current}</span>;
+  }
+  const max = Math.trunc(Number(maxAttempts));
+  return (
+    <span className="mono inline-flex items-center gap-0.5 text-[var(--text-muted)]">
+      <span>{current}/</span>
+      {max < 0 ? (
+        <InfinityIcon
+          size={13}
+          strokeWidth={2}
+          aria-label="unlimited"
+          className="shrink-0"
+        />
+      ) : (
+        <span>{max}</span>
+      )}
+    </span>
+  );
+}

--- a/web/dashboard/src/components/DataTable.tsx
+++ b/web/dashboard/src/components/DataTable.tsx
@@ -1,13 +1,23 @@
-import type { KeyboardEvent, ReactNode } from "react";
+import type { CSSProperties, KeyboardEvent, ReactNode } from "react";
 
 export type Column<T> = {
   key: string;
   header: string;
   className?: string;
+  /**
+   * Fixed column width (CSS length). Used with table-layout:fixed so content
+   * changes don't reflow neighboring columns.
+   */
+  width?: string;
   /** When true, clicks inside this cell do not trigger onRowClick. */
   stopRowClick?: boolean;
   cell: (row: T) => ReactNode;
 };
+
+function colStyle(width?: string): CSSProperties | undefined {
+  if (!width) return undefined;
+  return { width, minWidth: width, maxWidth: width };
+}
 
 export function DataTable<T>({
   columns,
@@ -32,13 +42,19 @@ export function DataTable<T>({
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full border-collapse text-left text-[12px]">
+      <table className="w-full table-fixed border-collapse text-left text-[12px]">
+        <colgroup>
+          {columns.map((col) => (
+            <col key={col.key} style={colStyle(col.width)} />
+          ))}
+        </colgroup>
         <thead>
           <tr className="border-b border-[var(--border)] text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
             {columns.map((col) => (
               <th
                 key={col.key}
                 className={`px-2 py-1.5 align-middle font-medium ${col.className ?? ""}`}
+                style={colStyle(col.width)}
               >
                 {col.header}
               </th>
@@ -72,7 +88,8 @@ export function DataTable<T>({
               {columns.map((col) => (
                 <td
                   key={col.key}
-                  className={`px-2 py-1.5 align-middle ${col.className ?? ""}`}
+                  className={`overflow-hidden px-2 py-1.5 align-middle ${col.className ?? ""}`}
+                  style={colStyle(col.width)}
                   onClick={
                     col.stopRowClick
                       ? (e) => {
@@ -88,7 +105,9 @@ export function DataTable<T>({
                       : undefined
                   }
                 >
-                  <div className="flex min-h-7 items-center">{col.cell(row)}</div>
+                  <div className="flex min-h-7 min-w-0 items-center">
+                    {col.cell(row)}
+                  </div>
                 </td>
               ))}
             </tr>

--- a/web/dashboard/src/components/LoopActionBar.tsx
+++ b/web/dashboard/src/components/LoopActionBar.tsx
@@ -1,4 +1,13 @@
 import { useCallback, useMemo, useState } from "react";
+import {
+  Hand,
+  Pause,
+  Play,
+  RotateCcw,
+  Square,
+  Undo2,
+  type LucideIcon,
+} from "lucide-react";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { CopyButton } from "@/components/CopyButton";
 import { Button } from "@/components/ui/button";
@@ -68,6 +77,15 @@ const LABELS: Record<LoopAction, string> = {
   stop: "Stop",
   takeover: "Takeover",
   handback: "Handback",
+};
+
+const ICONS: Record<LoopAction, LucideIcon> = {
+  pause: Pause,
+  unpause: Play,
+  retry: RotateCcw,
+  stop: Square,
+  takeover: Hand,
+  handback: Undo2,
 };
 
 /** True when preflight is missing on older daemons — fall back to plain retry. */
@@ -283,6 +301,12 @@ export function LoopActionBar({
       <div className="flex flex-wrap items-center gap-1">
         {visibleActions.map((action) => {
           if (!enabled[action] && mode === "compact") return null;
+              const Icon = ICONS[action];
+          // Fill Stop/Pause so small media glyphs read solid, not empty outlines.
+          const iconProps =
+            action === "stop" || action === "pause"
+              ? { size: 10, className: "shrink-0", fill: "currentColor" }
+              : { size: 11, className: "shrink-0" };
           return (
             <Button
               key={action}
@@ -290,6 +314,7 @@ export function LoopActionBar({
                 action === "stop" || action === "takeover" ? "danger" : "ghost"
               }
               size="sm"
+              className="gap-1"
               disabled={busy || !enabled[action]}
               onClick={() => onClick(action)}
               title={
@@ -298,6 +323,7 @@ export function LoopActionBar({
                   : LABELS[action]
               }
             >
+              <Icon {...iconProps} aria-hidden />
               {pending === action ? "…" : LABELS[action]}
             </Button>
           );

--- a/web/dashboard/src/components/LoopTypeBadge.tsx
+++ b/web/dashboard/src/components/LoopTypeBadge.tsx
@@ -1,0 +1,77 @@
+// Distinct role badge for loop.type. Colors are restrained and reuse CSS
+// vars where the role maps naturally to a semantic hue; other roles get a
+// dedicated tint so they never fall back to the same neutral as unknown types.
+
+type Palette = {
+  bg: string;
+  fg: string;
+  border: string;
+};
+
+const PALETTES: Record<string, Palette> = {
+  reviewer: {
+    bg: "color-mix(in srgb, #a855f7 18%, transparent)",
+    fg: "color-mix(in srgb, #a855f7 92%, var(--text))",
+    border: "color-mix(in srgb, #a855f7 45%, var(--border))",
+  },
+  fixer: {
+    bg: "color-mix(in srgb, var(--warn) 20%, transparent)",
+    fg: "var(--warn)",
+    border: "color-mix(in srgb, var(--warn) 55%, var(--border))",
+  },
+  worker: {
+    bg: "color-mix(in srgb, var(--accent) 18%, transparent)",
+    fg: "var(--accent)",
+    border: "color-mix(in srgb, var(--accent) 50%, var(--border))",
+  },
+  planner: {
+    bg: "color-mix(in srgb, var(--ok) 18%, transparent)",
+    fg: "var(--ok)",
+    border: "color-mix(in srgb, var(--ok) 50%, var(--border))",
+  },
+  coordinator: {
+    bg: "color-mix(in srgb, #06b6d4 18%, transparent)",
+    fg: "color-mix(in srgb, #06b6d4 90%, var(--text))",
+    border: "color-mix(in srgb, #06b6d4 45%, var(--border))",
+  },
+};
+
+const NEUTRAL: Palette = {
+  bg: "var(--bg-muted)",
+  fg: "var(--text)",
+  border: "var(--border)",
+};
+
+function toLabel(raw: string): string {
+  const t = raw.trim();
+  if (!t) return "Unknown";
+  return t.charAt(0).toUpperCase() + t.slice(1).toLowerCase();
+}
+
+export function LoopTypeBadge({
+  type,
+  size = "md",
+}: {
+  type: string | null | undefined;
+  size?: "sm" | "md";
+}) {
+  const key = (type ?? "").trim().toLowerCase();
+  const palette = PALETTES[key] ?? NEUTRAL;
+  const label = toLabel(type ?? "");
+  const sizing =
+    size === "sm"
+      ? "px-1.5 py-0 text-[10px]"
+      : "px-2 py-[1px] text-[11px]";
+  return (
+    <span
+      className={`inline-flex items-center rounded border font-semibold uppercase tracking-wide leading-tight ${sizing}`}
+      style={{
+        backgroundColor: palette.bg,
+        color: palette.fg,
+        borderColor: palette.border,
+      }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/web/dashboard/src/components/PullRequestLink.test.tsx
+++ b/web/dashboard/src/components/PullRequestLink.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PullRequestLink } from "@/components/PullRequestLink";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PullRequestLink", () => {
+  it("stops click and Enter/Space keydown from bubbling to row handlers", () => {
+    const onRowClick = vi.fn();
+    const onRowKeyDown = vi.fn();
+
+    render(
+      <div
+        data-testid="row"
+        tabIndex={0}
+        onClick={onRowClick}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onRowKeyDown(e);
+          }
+        }}
+      >
+        <PullRequestLink href="https://github.com/acme/looper/pull/1">
+          #1
+        </PullRequestLink>
+      </div>,
+    );
+
+    const link = screen.getByRole("link", { name: /#1/ });
+    fireEvent.click(link);
+    expect(onRowClick).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(link, { key: "Enter" });
+    fireEvent.keyDown(link, { key: " " });
+    expect(onRowKeyDown).not.toHaveBeenCalled();
+  });
+});

--- a/web/dashboard/src/components/PullRequestLink.tsx
+++ b/web/dashboard/src/components/PullRequestLink.tsx
@@ -25,6 +25,13 @@ export function PullRequestLink({
       rel="noreferrer"
       title={title ?? href}
       onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        // DataTable rows handle Enter/Space for navigation; keep those keys on
+        // the forge link so keyboard users can activate the external href.
+        if (e.key === "Enter" || e.key === " ") {
+          e.stopPropagation();
+        }
+      }}
       className={[
         "mono group inline-flex max-w-full items-baseline gap-1",
         "text-[var(--accent)]",

--- a/web/dashboard/src/components/PullRequestLink.tsx
+++ b/web/dashboard/src/components/PullRequestLink.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+
+/**
+ * External forge link (PR, repo, …) styled for dense mono tables.
+ * - At rest reads as a link (accent color + subtle underline + external cue).
+ * - Hover/focus strengthens the affordance without breaking row density.
+ * - Callers pass a resolved `href`; render plain text upstream when none.
+ */
+export function PullRequestLink({
+  href,
+  children,
+  title,
+}: {
+  href: string;
+  children: ReactNode;
+  title?: string;
+}) {
+  // Underline lives on the label span (not the flex <a>): global `a {
+  // text-decoration: none }` plus inline-flex both suppress decoration on the
+  // anchor itself. border-b is the reliable affordance here.
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      title={title ?? href}
+      onClick={(e) => e.stopPropagation()}
+      className={[
+        "mono group inline-flex max-w-full items-baseline gap-1",
+        "text-[var(--accent)]",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)] rounded-[2px]",
+      ].join(" ")}
+    >
+      <span className="truncate border-b border-[color-mix(in_srgb,var(--accent)_40%,transparent)] transition-[border-color] group-hover:border-[var(--accent)] group-focus-visible:border-[var(--accent)]">
+        {children}
+      </span>
+      <span
+        aria-hidden="true"
+        className="shrink-0 text-[0.85em] opacity-60 transition-[opacity,transform] group-hover:opacity-100 group-hover:-translate-y-px group-focus-visible:opacity-100"
+      >
+        ↗
+      </span>
+    </a>
+  );
+}

--- a/web/dashboard/src/components/layout/Shell.tsx
+++ b/web/dashboard/src/components/layout/Shell.tsx
@@ -1,13 +1,25 @@
 import { useEffect, useMemo } from "react";
 import { Link, NavLink, Outlet } from "react-router-dom";
+import {
+  FolderGit2,
+  LayoutDashboard,
+  Repeat,
+  Settings,
+  type LucideIcon,
+} from "lucide-react";
 import { useDashboardData } from "@/lib/DashboardDataContext";
 import { useProjectFilter } from "@/lib/ProjectFilterContext";
 
-export const navItems: { to: string; label: string; end?: boolean }[] = [
-  { to: "/", label: "Overview", end: true },
-  { to: "/loops", label: "Loops" },
-  { to: "/projects", label: "Projects" },
-  { to: "/config", label: "Config" },
+export const navItems: {
+  to: string;
+  label: string;
+  end?: boolean;
+  icon: LucideIcon;
+}[] = [
+  { to: "/", label: "Overview", end: true, icon: LayoutDashboard },
+  { to: "/loops", label: "Loops", icon: Repeat },
+  { to: "/projects", label: "Projects", icon: FolderGit2 },
+  { to: "/config", label: "Config", icon: Settings },
 ];
 
 /** Public asset under Vite base (/dashboard/). */
@@ -118,31 +130,35 @@ export function Shell({
             </span>
           </div>
           <nav className="flex flex-wrap items-center gap-1">
-            {navItems.map((item) => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                end={item.end}
-                className={({ isActive }) =>
-                  [
-                    "rounded px-2 py-0.5 text-[12px] font-medium",
-                    isActive
-                      ? "bg-[var(--bg-muted)] text-[var(--text)]"
-                      : "text-[var(--text-muted)] hover:bg-[var(--bg-muted)] hover:text-[var(--text)]",
-                  ].join(" ")
-                }
-              >
-                {item.label}
-                {item.to === "/loops" &&
-                !activeRuns.error &&
-                activeRuns.data != null &&
-                activeCount > 0 ? (
-                  <span className="ml-1 mono text-[10px] text-[var(--ok)]">
-                    {activeCount}
-                  </span>
-                ) : null}
-              </NavLink>
-            ))}
+            {navItems.map((item) => {
+              const Icon = item.icon;
+              return (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  end={item.end}
+                  className={({ isActive }) =>
+                    [
+                      "inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-[12px] font-medium",
+                      isActive
+                        ? "bg-[var(--bg-muted)] text-[var(--text)]"
+                        : "text-[var(--text-muted)] hover:bg-[var(--bg-muted)] hover:text-[var(--text)]",
+                    ].join(" ")
+                  }
+                >
+                  <Icon size={14} className="shrink-0" aria-hidden />
+                  {item.label}
+                  {item.to === "/loops" &&
+                  !activeRuns.error &&
+                  activeRuns.data != null &&
+                  activeCount > 0 ? (
+                    <span className="ml-1 mono text-[10px] text-[var(--ok)]">
+                      {activeCount}
+                    </span>
+                  ) : null}
+                </NavLink>
+              );
+            })}
           </nav>
           <div className="ml-auto flex items-center gap-2">
             <label className="flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">

--- a/web/dashboard/src/components/layout/Shell.tsx
+++ b/web/dashboard/src/components/layout/Shell.tsx
@@ -14,7 +14,6 @@ export const navItems: { to: string; label: string; end?: boolean }[] = [
 const logoSrc = `${import.meta.env.BASE_URL}apple-touch-icon.png`;
 
 export type ShellProps = {
-  hostPort: string;
   healthy: boolean | null;
   version?: string;
   onHealthChange?: (healthy: boolean | null, version?: string) => void;
@@ -47,7 +46,6 @@ function HealthDot({ healthy }: { healthy: boolean | null }) {
 }
 
 export function Shell({
-  hostPort,
   healthy,
   version,
   onHealthChange,
@@ -96,9 +94,6 @@ export function Shell({
               />
               <span>Looper</span>
             </Link>
-            <span className="mono text-[12px] text-[var(--text-muted)]">
-              {hostPort}
-            </span>
             <HealthDot healthy={chromeHealthy} />
             <span
               className="inline-flex items-center gap-1 rounded border border-[var(--border)] px-1.5 py-0.5 text-[11px] text-[var(--text-muted)]"

--- a/web/dashboard/src/components/layout/Shell.tsx
+++ b/web/dashboard/src/components/layout/Shell.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useDashboardData } from "@/lib/DashboardDataContext";
 import { useProjectFilter } from "@/lib/ProjectFilterContext";
+import { ThemeToggle } from "./ThemeToggle";
 
 export const navItems: {
   to: string;
@@ -161,6 +162,7 @@ export function Shell({
             })}
           </nav>
           <div className="ml-auto flex items-center gap-2">
+            <ThemeToggle />
             <label className="flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
               <span className="uppercase tracking-wide">Project</span>
               <select

--- a/web/dashboard/src/components/layout/ThemeToggle.tsx
+++ b/web/dashboard/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,48 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useTheme, type ThemeMode } from "@/lib/theme";
+
+const OPTIONS: { mode: ThemeMode; label: string; Icon: typeof Sun }[] = [
+  { mode: "light", label: "Light", Icon: Sun },
+  { mode: "dark", label: "Dark", Icon: Moon },
+  { mode: "system", label: "System", Icon: Monitor },
+];
+
+/**
+ * Segmented tri-state theme control for the header. Matches the density of
+ * neighboring header controls (Project select). Uses `aria-pressed` to expose
+ * the active mode; label text lives in `aria-label`/`title`, icons are decorative.
+ */
+export function ThemeToggle() {
+  const { mode, setMode } = useTheme();
+  return (
+    <div
+      role="group"
+      aria-label="Theme"
+      className="inline-flex items-center rounded border border-[var(--border)] bg-[var(--bg)] p-[1px]"
+    >
+      {OPTIONS.map(({ mode: value, label, Icon }) => {
+        const active = mode === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            aria-label={label}
+            aria-pressed={active}
+            title={label}
+            onClick={() => setMode(value)}
+            className={[
+              "inline-flex h-5 w-6 items-center justify-center rounded-[3px]",
+              "transition-colors focus-visible:outline focus-visible:outline-2",
+              "focus-visible:outline-offset-1 focus-visible:outline-[var(--accent)]",
+              active
+                ? "bg-[var(--bg-muted)] text-[var(--text)]"
+                : "text-[var(--text-muted)] hover:text-[var(--text)]",
+            ].join(" ")}
+          >
+            <Icon size={13} className="shrink-0" aria-hidden />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/dashboard/src/index.css
+++ b/web/dashboard/src/index.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
 
   --bg: #f4f4f5;
   --bg-elevated: #ffffff;
@@ -20,8 +20,31 @@
     sans-serif;
 }
 
+/* Shared dark palette. Applied on explicit `data-theme="dark"` and,
+   via the media query below, whenever the theme is unset or "system"
+   and the OS reports a dark preference. Keeping the tokens in one
+   place avoids drift between explicit-dark and system-dark. */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --bg: #09090b;
+  --bg-elevated: #18181b;
+  --bg-muted: #27272a;
+  --border: #3f3f46;
+  --text: #fafafa;
+  --text-muted: #a1a1aa;
+  --accent: #3b82f6;
+  --accent-fg: #f8fafc;
+  --danger: #f87171;
+  --ok: #4ade80;
+  --warn: #facc15;
+}
+
 @media (prefers-color-scheme: dark) {
-  :root {
+  /* No data-theme set (first paint before JS) OR explicit "system" */
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
+    color-scheme: dark;
+
     --bg: #09090b;
     --bg-elevated: #18181b;
     --bg-muted: #27272a;

--- a/web/dashboard/src/lib/api.ts
+++ b/web/dashboard/src/lib/api.ts
@@ -260,6 +260,8 @@ export type Project = {
   archived: boolean;
   provider: string;
   repo?: string | null;
+  /** Forge HTML URL for the repo (provider base + owner/name). */
+  repoUrl?: string | null;
   worktreeRoot?: string | null;
   createdAt: string;
   updatedAt: string;

--- a/web/dashboard/src/lib/format.test.ts
+++ b/web/dashboard/src/lib/format.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { formatAttempts, truncateReason } from "./format";
+import {
+  formatAttempts,
+  issueUrl,
+  parseIssueTargetId,
+  pullRequestUrl,
+  repositoryUrl,
+  truncateReason,
+} from "./format";
 
 describe("formatAttempts", () => {
   it("formats current/max including unlimited -1", () => {
@@ -17,6 +24,102 @@ describe("formatAttempts", () => {
     expect(formatAttempts(null, 3)).toBeNull();
     expect(formatAttempts(undefined, -1)).toBeNull();
     expect(formatAttempts(Number.NaN, 3)).toBeNull();
+  });
+});
+
+describe("repositoryUrl", () => {
+  it("prefers server-resolved repoUrl", () => {
+    expect(
+      repositoryUrl("acme/fj", "https://code.example.com/acme/fj"),
+    ).toBe("https://code.example.com/acme/fj");
+  });
+
+  it("builds github repo urls from owner/repo as fallback", () => {
+    expect(repositoryUrl("powerformer/vela")).toBe(
+      "https://github.com/powerformer/vela",
+    );
+  });
+
+  it("returns null for incomplete or invalid inputs", () => {
+    expect(repositoryUrl(null)).toBeNull();
+    expect(repositoryUrl("")).toBeNull();
+    expect(repositoryUrl("bare")).toBeNull();
+    expect(repositoryUrl("https://github.com/o/r")).toBeNull();
+  });
+});
+
+describe("pullRequestUrl", () => {
+  it("builds github PR urls from owner/repo + number", () => {
+    expect(pullRequestUrl("powerformer/vela", 1217)).toBe(
+      "https://github.com/powerformer/vela/pull/1217",
+    );
+  });
+
+  it("uses forgejo /pulls path when provider is forgejo", () => {
+    expect(
+      pullRequestUrl("acme/fj", 42, {
+        repoUrl: "https://code.example.com/acme/fj",
+        provider: "forgejo",
+      }),
+    ).toBe("https://code.example.com/acme/fj/pulls/42");
+  });
+
+  it("uses /pull path for github repoUrl", () => {
+    expect(
+      pullRequestUrl("o/r", 7, {
+        repoUrl: "https://github.com/o/r/",
+        provider: "github",
+      }),
+    ).toBe("https://github.com/o/r/pull/7");
+  });
+
+  it("returns null for incomplete or invalid inputs", () => {
+    expect(pullRequestUrl(null, 1)).toBeNull();
+    expect(pullRequestUrl("owner/repo", null)).toBeNull();
+    expect(pullRequestUrl("owner/repo", 0)).toBeNull();
+    expect(pullRequestUrl("bare", 1)).toBeNull();
+    expect(pullRequestUrl("https://github.com/o/r", 1)).toBeNull();
+  });
+});
+
+describe("issueUrl", () => {
+  it("builds github issue urls from owner/repo + number", () => {
+    expect(issueUrl("powerformer/vela", 77)).toBe(
+      "https://github.com/powerformer/vela/issues/77",
+    );
+  });
+
+  it("uses server repoUrl when provided (forgejo self-host)", () => {
+    expect(
+      issueUrl("acme/fj", 42, {
+        repoUrl: "https://code.example.com/acme/fj/",
+      }),
+    ).toBe("https://code.example.com/acme/fj/issues/42");
+  });
+
+  it("returns null for incomplete or invalid inputs", () => {
+    expect(issueUrl(null, 1)).toBeNull();
+    expect(issueUrl("owner/repo", null)).toBeNull();
+    expect(issueUrl("owner/repo", 0)).toBeNull();
+    expect(issueUrl("bare", 1)).toBeNull();
+  });
+});
+
+describe("parseIssueTargetId", () => {
+  it("parses canonical issue target key", () => {
+    expect(parseIssueTargetId("issue:acme/looper:77")).toEqual({
+      repo: "acme/looper",
+      issueNumber: 77,
+    });
+  });
+
+  it("rejects non-issue or malformed keys", () => {
+    expect(parseIssueTargetId(null)).toBeNull();
+    expect(parseIssueTargetId("")).toBeNull();
+    expect(parseIssueTargetId("project:acme")).toBeNull();
+    expect(parseIssueTargetId("issue:acme/looper")).toBeNull();
+    expect(parseIssueTargetId("issue:barerepo:1")).toBeNull();
+    expect(parseIssueTargetId("issue:acme/looper:abc")).toBeNull();
   });
 });
 

--- a/web/dashboard/src/lib/format.test.ts
+++ b/web/dashboard/src/lib/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatAge,
   formatAttempts,
   issueUrl,
   parseIssueTargetId,
@@ -8,10 +9,29 @@ import {
   truncateReason,
 } from "./format";
 
+describe("formatAge", () => {
+  const now = Date.parse("2026-04-11T12:00:00.000Z");
+
+  it("formats compact elapsed durations", () => {
+    expect(formatAge("2026-04-11T11:59:48.000Z", now)).toBe("12s");
+    expect(formatAge("2026-04-11T11:57:00.000Z", now)).toBe("3m");
+    expect(formatAge("2026-04-11T10:00:00.000Z", now)).toBe("2h");
+    expect(formatAge("2026-04-11T09:40:00.000Z", now)).toBe("2h 20m");
+    expect(formatAge("2026-04-09T12:00:00.000Z", now)).toBe("2d");
+    expect(formatAge("2026-04-09T08:00:00.000Z", now)).toBe("2d 4h");
+  });
+
+  it("returns em dash for missing or invalid input", () => {
+    expect(formatAge(null, now)).toBe("—");
+    expect(formatAge(undefined, now)).toBe("—");
+    expect(formatAge("not-a-date", now)).toBe("—");
+  });
+});
+
 describe("formatAttempts", () => {
-  it("formats current/max including unlimited -1", () => {
+  it("formats current/max including unlimited as infinity", () => {
     expect(formatAttempts(2, 5)).toBe("2/5");
-    expect(formatAttempts(1, -1)).toBe("1/-1");
+    expect(formatAttempts(1, -1)).toBe("1/∞");
     expect(formatAttempts(0, 3)).toBe("0/3");
   });
 

--- a/web/dashboard/src/lib/format.ts
+++ b/web/dashboard/src/lib/format.ts
@@ -1,4 +1,4 @@
-/** Compact relative age from ISO timestamp (e.g. 12s, 3m, 2h, 1d). */
+/** Compact relative age from ISO timestamp (e.g. 12s, 3m, 2h 3m, 1d 4h). */
 export function formatAge(iso: string | null | undefined, nowMs = Date.now()): string {
   if (!iso) return "—";
   const t = Date.parse(iso);
@@ -8,9 +8,13 @@ export function formatAge(iso: string | null | undefined, nowMs = Date.now()): s
   const min = Math.floor(sec / 60);
   if (min < 60) return `${min}m`;
   const hr = Math.floor(min / 60);
-  if (hr < 48) return `${hr}h`;
+  if (hr < 48) {
+    const remMin = min % 60;
+    return remMin > 0 ? `${hr}h ${remMin}m` : `${hr}h`;
+  }
   const day = Math.floor(hr / 24);
-  return `${day}d`;
+  const remHr = hr % 24;
+  return remHr > 0 ? `${day}d ${remHr}h` : `${day}d`;
 }
 
 export function formatTs(iso: string | null | undefined): string {
@@ -32,7 +36,7 @@ export function formatTs(iso: string | null | undefined): string {
 }
 
 /**
- * Format attempt count as current/max (e.g. "2/5", "1/-1" for unlimited).
+ * Format attempt count as current/max (e.g. "2/5", "1/∞" for unlimited).
  * Returns null when attempt metadata is absent so callers can hide clutter.
  */
 export function formatAttempts(
@@ -46,7 +50,9 @@ export function formatAttempts(
   if (maxAttempts == null || Number.isNaN(Number(maxAttempts))) {
     return String(current);
   }
-  return `${current}/${Math.trunc(Number(maxAttempts))}`;
+  const max = Math.trunc(Number(maxAttempts));
+  // -1 means unlimited in queue/loop policy.
+  return `${current}/${max < 0 ? "∞" : max}`;
 }
 
 /**

--- a/web/dashboard/src/lib/format.ts
+++ b/web/dashboard/src/lib/format.ts
@@ -66,6 +66,109 @@ export function truncateReason(
   return `${runes.slice(0, max - 3).join("")}...`;
 }
 
+/** owner/name slug, or null when not a plain GitHub-style repo id. */
+function ownerRepoSlug(repo: string | null | undefined): string | null {
+  if (repo == null) return null;
+  const trimmed = repo.trim();
+  if (!trimmed) return null;
+  // owner/name — reject URLs or bare names
+  if (!/^[^/\s]+\/[^/\s]+$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+function normalizeForgeBase(base: string): string {
+  return base.trim().replace(/\/+$/, "");
+}
+
+/**
+ * Prefer server-resolved project.repoUrl (correct Forgejo/GitHub host).
+ * Falls back to github.com only when no server URL is available.
+ */
+export function repositoryUrl(
+  repo: string | null | undefined,
+  repoUrl?: string | null,
+): string | null {
+  const fromServer = typeof repoUrl === "string" ? repoUrl.trim() : "";
+  if (fromServer) return fromServer;
+  const slug = ownerRepoSlug(repo);
+  if (!slug) return null;
+  return `https://github.com/${slug}`;
+}
+
+/**
+ * PR HTML URL. Prefer project.repoUrl + provider kind:
+ * - github:  {repoUrl}/pull/{n}
+ * - forgejo: {repoUrl}/pulls/{n}
+ * Falls back to github.com when only owner/repo is known.
+ */
+export function pullRequestUrl(
+  repo: string | null | undefined,
+  prNumber: number | null | undefined,
+  opts?: { repoUrl?: string | null; provider?: string | null },
+): string | null {
+  if (prNumber == null || !Number.isFinite(prNumber) || prNumber <= 0) {
+    return null;
+  }
+  const n = Math.trunc(prNumber);
+  const fromServer =
+    typeof opts?.repoUrl === "string" ? normalizeForgeBase(opts.repoUrl) : "";
+  if (fromServer) {
+    const kind = (opts?.provider ?? "").toLowerCase();
+    const segment = kind === "forgejo" ? "pulls" : "pull";
+    return `${fromServer}/${segment}/${n}`;
+  }
+  const slug = ownerRepoSlug(repo);
+  if (!slug) return null;
+  return `https://github.com/${slug}/pull/${n}`;
+}
+
+/**
+ * Issue HTML URL. GitHub and Forgejo both expose `/issues/{n}`.
+ * Prefer project.repoUrl (correct host for self-hosted forges); fall back to
+ * github.com when only owner/repo is known.
+ */
+export function issueUrl(
+  repo: string | null | undefined,
+  issueNumber: number | null | undefined,
+  opts?: { repoUrl?: string | null },
+): string | null {
+  if (issueNumber == null || !Number.isFinite(issueNumber) || issueNumber <= 0) {
+    return null;
+  }
+  const n = Math.trunc(issueNumber);
+  const fromServer =
+    typeof opts?.repoUrl === "string" ? normalizeForgeBase(opts.repoUrl) : "";
+  if (fromServer) {
+    return `${fromServer}/issues/${n}`;
+  }
+  const slug = ownerRepoSlug(repo);
+  if (!slug) return null;
+  return `https://github.com/${slug}/issues/${n}`;
+}
+
+/**
+ * Parse a loop's stored issue target key. Worker loops targeting an issue
+ * persist targetId as `issue:{owner/repo}:{n}` (see requeue_guard.go).
+ * Returns null when the value is missing or not in that shape.
+ */
+export function parseIssueTargetId(
+  targetId: string | null | undefined,
+): { repo: string; issueNumber: number } | null {
+  if (!targetId) return null;
+  const trimmed = targetId.trim();
+  if (!trimmed.startsWith("issue:")) return null;
+  const rest = trimmed.slice("issue:".length);
+  // repo may contain a single "/", issue number is the last ":" segment.
+  const lastColon = rest.lastIndexOf(":");
+  if (lastColon <= 0) return null;
+  const repo = rest.slice(0, lastColon).trim();
+  const nStr = rest.slice(lastColon + 1).trim();
+  if (!repo.includes("/")) return null;
+  const n = Number(nStr);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return { repo, issueNumber: Math.trunc(n) };
+}
+
 export function statusColor(status: string | null | undefined): string {
   const s = (status ?? "").toLowerCase();
   if (

--- a/web/dashboard/src/lib/theme.test.ts
+++ b/web/dashboard/src/lib/theme.test.ts
@@ -70,6 +70,16 @@ describe("getTheme / setTheme / applyTheme", () => {
     expect(detail).toBe("light");
     window.removeEventListener("looper:theme-change", spy as EventListener);
   });
+
+  it("getTheme + applyTheme restores an explicit stored preference onto the DOM", () => {
+    // Mirrors main.tsx startup and CSP-safe theme-init.js: without this,
+    // reloading with a saved light/dark mode leaves data-theme unset and the
+    // palette follows the OS while the toggle reports the stored value.
+    window.localStorage.setItem(THEME_STORAGE_KEY, "light");
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+    applyTheme(getTheme());
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
 });
 
 describe("resolvedTheme", () => {

--- a/web/dashboard/src/lib/theme.test.ts
+++ b/web/dashboard/src/lib/theme.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyTheme,
+  getTheme,
+  normalizeThemeMode,
+  resolvedTheme,
+  setTheme,
+  THEME_STORAGE_KEY,
+} from "./theme";
+
+describe("normalizeThemeMode", () => {
+  it("accepts the three known modes verbatim", () => {
+    expect(normalizeThemeMode("light")).toBe("light");
+    expect(normalizeThemeMode("dark")).toBe("dark");
+    expect(normalizeThemeMode("system")).toBe("system");
+  });
+
+  it("falls back to system for anything else", () => {
+    expect(normalizeThemeMode(null)).toBe("system");
+    expect(normalizeThemeMode(undefined)).toBe("system");
+    expect(normalizeThemeMode("")).toBe("system");
+    expect(normalizeThemeMode("hi-contrast")).toBe("system");
+    expect(normalizeThemeMode(42)).toBe("system");
+  });
+});
+
+describe("getTheme / setTheme / applyTheme", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    delete document.documentElement.dataset.theme;
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    delete document.documentElement.dataset.theme;
+  });
+
+  it("defaults to system when nothing is stored", () => {
+    expect(getTheme()).toBe("system");
+  });
+
+  it("round-trips explicit modes through localStorage", () => {
+    setTheme("dark");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(getTheme()).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+
+    setTheme("light");
+    expect(getTheme()).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  it("normalizes bad stored values to system", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "neon");
+    expect(getTheme()).toBe("system");
+  });
+
+  it("applyTheme mutates the html dataset without touching storage", () => {
+    applyTheme("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+  });
+
+  it("setTheme dispatches a custom event with the new mode", () => {
+    const spy = vi.fn();
+    window.addEventListener("looper:theme-change", spy as EventListener);
+    setTheme("light");
+    expect(spy).toHaveBeenCalledTimes(1);
+    const detail = (spy.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail).toBe("light");
+    window.removeEventListener("looper:theme-change", spy as EventListener);
+  });
+});
+
+describe("resolvedTheme", () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("passes explicit modes through unchanged", () => {
+    expect(resolvedTheme("light")).toBe("light");
+    expect(resolvedTheme("dark")).toBe("dark");
+  });
+
+  it("uses matchMedia to resolve system mode", () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      media: "(prefers-color-scheme: dark)",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      onchange: null,
+    }) as unknown as typeof window.matchMedia;
+    expect(resolvedTheme("system")).toBe("dark");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      media: "(prefers-color-scheme: dark)",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      onchange: null,
+    }) as unknown as typeof window.matchMedia;
+    expect(resolvedTheme("system")).toBe("light");
+  });
+});

--- a/web/dashboard/src/lib/theme.ts
+++ b/web/dashboard/src/lib/theme.ts
@@ -84,7 +84,10 @@ export function useTheme(): {
     resolvedTheme(mode),
   );
 
+  // Keep data-theme aligned with React state on mount and mode changes.
+  // Required because production CSP blocks inline HTML init scripts.
   useEffect(() => {
+    applyTheme(mode);
     setResolved(resolvedTheme(mode));
   }, [mode]);
 

--- a/web/dashboard/src/lib/theme.ts
+++ b/web/dashboard/src/lib/theme.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type ThemeMode = "light" | "dark" | "system";
+
+export const THEME_STORAGE_KEY = "looper.dashboard.theme";
+export const THEME_MODES: readonly ThemeMode[] = ["light", "dark", "system"];
+
+/** Narrow arbitrary strings to a valid mode. Falls back to "system". */
+export function normalizeThemeMode(value: unknown): ThemeMode {
+  if (value === "light" || value === "dark" || value === "system") {
+    return value;
+  }
+  return "system";
+}
+
+/** Reads persisted mode; safe on SSR / private-mode / non-DOM environments. */
+export function getTheme(): ThemeMode {
+  try {
+    if (typeof window === "undefined") return "system";
+    const raw = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return normalizeThemeMode(raw);
+  } catch {
+    return "system";
+  }
+}
+
+/**
+ * Writes `data-theme` on <html>. Uses "system" (not attribute removal) so
+ * consumers can still detect an explicit user preference via the DOM.
+ * The CSS also matches "no attribute" for the initial paint fallback.
+ */
+export function applyTheme(mode: ThemeMode): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.dataset.theme = mode;
+}
+
+/** Persists and applies. Notifies subscribers via a custom event. */
+export function setTheme(mode: ThemeMode): void {
+  const next = normalizeThemeMode(mode);
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, next);
+  } catch {
+    // Ignore quota/private-mode errors; visual apply still succeeds.
+  }
+  applyTheme(next);
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent<ThemeMode>("looper:theme-change", { detail: next }),
+    );
+  }
+}
+
+/**
+ * Resolve the concrete palette a given mode currently displays as. Used only
+ * for icon hints; the actual paint is CSS-driven via data-theme + media query.
+ */
+export function resolvedTheme(mode: ThemeMode): "light" | "dark" {
+  if (mode === "light" || mode === "dark") return mode;
+  if (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function"
+  ) {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+  return "light";
+}
+
+/**
+ * React hook: current mode + setter. Keeps in sync with:
+ *  - direct setTheme() calls in this tab (custom event)
+ *  - localStorage writes from other tabs (storage event)
+ *  - OS color-scheme changes while mode="system" (matchMedia)
+ * The last one only re-renders so `resolvedTheme` icons flip; CSS handles paint.
+ */
+export function useTheme(): {
+  mode: ThemeMode;
+  resolved: "light" | "dark";
+  setMode: (mode: ThemeMode) => void;
+} {
+  const [mode, setMode] = useState<ThemeMode>(() => getTheme());
+  const [resolved, setResolved] = useState<"light" | "dark">(() =>
+    resolvedTheme(mode),
+  );
+
+  useEffect(() => {
+    setResolved(resolvedTheme(mode));
+  }, [mode]);
+
+  useEffect(() => {
+    const onCustom = (event: Event) => {
+      const detail = (event as CustomEvent<ThemeMode>).detail;
+      setMode(normalizeThemeMode(detail));
+    };
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== THEME_STORAGE_KEY) return;
+      const next = normalizeThemeMode(event.newValue);
+      applyTheme(next);
+      setMode(next);
+    };
+    window.addEventListener("looper:theme-change", onCustom);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("looper:theme-change", onCustom);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (mode !== "system") return;
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => setResolved(mql.matches ? "dark" : "light");
+    // Safari <14 uses addListener; modern browsers use addEventListener.
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, [mode]);
+
+  const update = useCallback((next: ThemeMode) => {
+    setTheme(next);
+    setMode(normalizeThemeMode(next));
+  }, []);
+
+  return { mode, resolved, setMode: update };
+}

--- a/web/dashboard/src/main.tsx
+++ b/web/dashboard/src/main.tsx
@@ -1,7 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { applyTheme, getTheme } from "./lib/theme";
 import "./index.css";
+
+// Apply persisted theme at module load so React state and data-theme agree
+// even if the pre-paint theme-init.js script is missing or blocked.
+applyTheme(getTheme());
 
 const root = document.getElementById("root");
 if (!root) {

--- a/web/dashboard/src/pages/Config.test.tsx
+++ b/web/dashboard/src/pages/Config.test.tsx
@@ -152,7 +152,11 @@ describe("ConfigPage", () => {
     expect(await screen.findByRole("heading", { name: "Configuration" })).toBeTruthy();
     const configLink = screen.getByRole("link", { name: "Config" });
     expect(configLink.getAttribute("href")).toBe("/dashboard/config");
-    expect(navItems).toContainEqual({ to: "/config", label: "Config" });
+    expect(
+      navItems.some(
+        (item) => item.to === "/config" && item.label === "Config",
+      ),
+    ).toBe(true);
   });
 
   it("locks env/CLI winners and uses the authoritative PATCH snapshot", async () => {

--- a/web/dashboard/src/pages/Config.tsx
+++ b/web/dashboard/src/pages/Config.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { RefreshCw, Settings } from "lucide-react";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { PanelError } from "@/components/PanelError";
 import { Button } from "@/components/ui/button";
@@ -1609,7 +1610,14 @@ export function ConfigPage() {
     <div className={`flex flex-col gap-3 ${dockVisible ? "pb-24" : ""}`}>
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
-          <h1 className="m-0 text-[15px] font-semibold">Configuration</h1>
+          <h1 className="m-0 inline-flex items-center gap-1.5 text-[15px] font-semibold">
+            <Settings
+              size={15}
+              className="shrink-0 text-[var(--text-muted)]"
+              aria-hidden
+            />
+            Configuration
+          </h1>
           <p className="m-0 mt-0.5 text-[11px] text-[var(--text-muted)]">
             Hot-safe global policy. Common settings are shown first; the rest
             live under Advanced. Changes apply to new runs only.
@@ -1627,6 +1635,7 @@ export function ConfigPage() {
           <Button
             variant="ghost"
             size="sm"
+            className="gap-1.5"
             disabled={editorLocked || formDirtyCount > 0}
             onClick={() => void load(false)}
             title={
@@ -1635,6 +1644,7 @@ export function ConfigPage() {
                 : undefined
             }
           >
+            <RefreshCw size={13} className="shrink-0" aria-hidden />
             Refresh
           </Button>
         </div>

--- a/web/dashboard/src/pages/LoopDetail.tsx
+++ b/web/dashboard/src/pages/LoopDetail.tsx
@@ -8,7 +8,9 @@ import {
 } from "react";
 import { Link, useParams } from "react-router-dom";
 import { LoopActionBar } from "@/components/LoopActionBar";
+import { LoopTypeBadge } from "@/components/LoopTypeBadge";
 import { PanelError } from "@/components/PanelError";
+import { PullRequestLink } from "@/components/PullRequestLink";
 import { RecoveryCard } from "@/components/RecoveryCard";
 import { StatusChip } from "@/components/StatusChip";
 import { Button } from "@/components/ui/button";
@@ -17,12 +19,21 @@ import {
   fetchLoop,
   openLoopLogsStream,
   respondLoop,
+  type ActiveRun,
   type Loop,
   type LoopLogsChunk,
   type LoopLogsSnapshot,
+  type Project,
 } from "@/lib/api";
 import { useDashboardData } from "@/lib/DashboardDataContext";
-import { formatAttempts, formatTs } from "@/lib/format";
+import {
+  formatAttempts,
+  formatTs,
+  issueUrl,
+  parseIssueTargetId,
+  pullRequestUrl,
+  repositoryUrl,
+} from "@/lib/format";
 import { capLogChunk, capLogSeed, trimLogBuffer } from "@/lib/logBuffer";
 import {
   type LogsStreamPhase,
@@ -63,6 +74,97 @@ function Kv({ label, value }: { label: string; value: ReactNode }) {
     <div className="grid grid-cols-[110px_1fr] gap-2 py-0.5 text-[12px]">
       <dt className="text-[var(--text-muted)]">{label}</dt>
       <dd className="m-0 break-all mono">{value}</dd>
+    </div>
+  );
+}
+
+type ForgeLinkPalette = "accent" | "warn";
+
+const FORGE_LINK_CLASSES: Record<ForgeLinkPalette, string> = {
+  accent:
+    "text-[var(--accent)] focus-visible:outline-[var(--accent)] [--forge-border:color-mix(in_srgb,var(--accent)_40%,transparent)] [--forge-border-hover:var(--accent)]",
+  warn: "text-[var(--warn)] focus-visible:outline-[var(--warn)] [--forge-border:color-mix(in_srgb,var(--warn)_45%,transparent)] [--forge-border-hover:var(--warn)]",
+};
+
+function ForgeLink({
+  href,
+  label,
+  children,
+  palette = "accent",
+}: {
+  href: string;
+  label: string;
+  children: ReactNode;
+  palette?: ForgeLinkPalette;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      title={href}
+      className={`group inline-flex max-w-full items-baseline gap-1 rounded-[2px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${FORGE_LINK_CLASSES[palette]}`}
+    >
+      <span className="text-[10px] font-semibold uppercase tracking-wider opacity-70 group-hover:opacity-100">
+        {label}
+      </span>
+      <span className="mono truncate border-b border-[var(--forge-border)] text-[12px] transition-[border-color] group-hover:border-[var(--forge-border-hover)] group-focus-visible:border-[var(--forge-border-hover)]">
+        {children}
+      </span>
+      <span
+        aria-hidden="true"
+        className="shrink-0 text-[0.85em] opacity-60 transition-[opacity,transform] group-hover:-translate-y-px group-hover:opacity-100"
+      >
+        ↗
+      </span>
+    </a>
+  );
+}
+
+function TargetLinks({
+  loop,
+  repoUrl,
+  provider,
+}: {
+  loop: Loop;
+  repoUrl?: string | null;
+  provider?: string | null;
+}) {
+  const prHref = pullRequestUrl(loop.repo, loop.prNumber, { repoUrl, provider });
+  const prLabel =
+    loop.repo && loop.prNumber != null
+      ? `${loop.repo}#${loop.prNumber}`
+      : prHref
+      ? `#${loop.prNumber}`
+      : null;
+
+  // Worker loops targeting an issue store targetId as `issue:{repo}:{n}`.
+  const isWorker = (loop.type ?? "").toLowerCase() === "worker";
+  const parsedIssue =
+    isWorker && loop.targetType === "issue"
+      ? parseIssueTargetId(loop.targetId)
+      : null;
+  const issueHref = parsedIssue
+    ? issueUrl(parsedIssue.repo, parsedIssue.issueNumber, { repoUrl })
+    : null;
+  const issueLabel = parsedIssue
+    ? `${parsedIssue.repo}#${parsedIssue.issueNumber}`
+    : null;
+
+  if (!prHref && !issueHref) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+      {prHref && prLabel ? (
+        <ForgeLink href={prHref} label="PR" palette="accent">
+          {prLabel}
+        </ForgeLink>
+      ) : null}
+      {issueHref && issueLabel ? (
+        <ForgeLink href={issueHref} label="Issue" palette="warn">
+          {issueLabel}
+        </ForgeLink>
+      ) : null}
     </div>
   );
 }
@@ -486,9 +588,144 @@ function LogsPane({ selector }: { selector: string }) {
   );
 }
 
+function agentLabel(run: ActiveRun): string {
+  const agent = run.agent;
+  if (!agent) return "";
+  const pid = agent.pid != null ? ` · pid ${agent.pid}` : "";
+  return `${agent.vendor || "agent"}${pid}`;
+}
+
+function targetSummaryText(loop: Loop): string {
+  if (loop.repo && loop.prNumber != null) {
+    return `${loop.repo}#${loop.prNumber}`;
+  }
+  if (loop.targetType === "issue" && loop.targetId) {
+    const parsed = parseIssueTargetId(loop.targetId);
+    if (parsed) return `${parsed.repo}#${parsed.issueNumber}`;
+  }
+  if (loop.repo) return loop.repo;
+  if (loop.targetId) return loop.targetId;
+  return loop.targetType || "—";
+}
+
+function targetSummaryHref(
+  loop: Loop,
+  project?: Project,
+): string | null {
+  const repoUrl = project?.repoUrl;
+  const provider = project?.provider;
+  const prHref = pullRequestUrl(loop.repo, loop.prNumber, { repoUrl, provider });
+  if (prHref) return prHref;
+  if (loop.targetType === "issue" && loop.targetId) {
+    const parsed = parseIssueTargetId(loop.targetId);
+    if (parsed) {
+      const href = issueUrl(parsed.repo, parsed.issueNumber, { repoUrl });
+      if (href) return href;
+    }
+  }
+  return repositoryUrl(loop.repo, repoUrl);
+}
+
+function TargetSummaryValue({
+  loop,
+  project,
+}: {
+  loop: Loop;
+  project?: Project;
+}) {
+  const label = targetSummaryText(loop);
+  const href = targetSummaryHref(loop, project);
+  if (!href) return label;
+  return <PullRequestLink href={href}>{label}</PullRequestLink>;
+}
+
+function SummaryCard({
+  loop,
+  project,
+  activeRun,
+  error,
+  onRetry,
+}: {
+  loop: Loop;
+  project?: Project;
+  activeRun?: ActiveRun;
+  error?: string | null;
+  onRetry: () => void;
+}) {
+  const attempts = formatAttempts(loop.attempts, loop.maxAttempts);
+  const failureKind = loop.lastFailureKind?.trim();
+  const failureReason = loop.lastFailureReason?.trim();
+  const resumePolicy = loop.resumePolicy?.trim();
+  const currentStep = activeRun?.currentStep?.trim();
+  const agent = activeRun ? agentLabel(activeRun) : "";
+
+  return (
+    <Card title="Summary">
+      {error ? (
+        <div className="mb-2">
+          <PanelError message={error} onRetry={onRetry} />
+        </div>
+      ) : null}
+      <dl className="m-0 columns-1 gap-x-6 md:columns-2">
+        <Kv
+          label="Project"
+          value={
+            project ? (
+              <span>
+                <span>{project.name}</span>
+                <span className="ml-1 text-[var(--text-muted)]">
+                  {loop.projectId}
+                </span>
+              </span>
+            ) : (
+              loop.projectId
+            )
+          }
+        />
+        <Kv
+          label="Target"
+          value={<TargetSummaryValue loop={loop} project={project} />}
+        />
+        <Kv label="Target type" value={loop.targetType} />
+        <Kv label="Target ID" value={loop.targetId ?? "—"} />
+        <Kv label="ID" value={loop.id} />
+        <Kv label="Attempts" value={attempts ?? "—"} />
+        {currentStep ? <Kv label="Current step" value={currentStep} /> : null}
+        {agent ? <Kv label="Agent" value={agent} /> : null}
+        <Kv label="Last run" value={formatTs(loop.lastRunAt)} />
+        <Kv label="Next run" value={formatTs(loop.nextRunAt)} />
+        <Kv label="Created" value={formatTs(loop.createdAt)} />
+        <Kv label="Updated" value={formatTs(loop.updatedAt)} />
+        {resumePolicy ? (
+          <Kv label="Resume policy" value={resumePolicy} />
+        ) : null}
+        {failureKind ? <Kv label="Failure kind" value={failureKind} /> : null}
+      </dl>
+      {failureReason ? (
+        <div className="mt-2">
+          <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+            Failure reason
+          </div>
+          <pre
+            title={failureReason}
+            className="mono m-0 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border p-2 text-[11px] leading-snug"
+            style={{
+              borderColor:
+                "color-mix(in srgb, var(--danger) 40%, var(--border))",
+              background: "var(--bg)",
+            }}
+          >
+            {failureReason}
+          </pre>
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
 export function LoopDetailPage() {
   const { selector = "" } = useParams<{ selector: string }>();
-  const { activeRuns } = useDashboardData();
+  const { activeRuns, projects } = useDashboardData();
 
   const fetcher = useCallback(
     (signal: AbortSignal) => fetchLoop(selector, signal),
@@ -504,17 +741,22 @@ export function LoopDetailPage() {
   const activeRunItems = activeRuns.data?.items;
   const forceRefreshActiveRuns = activeRuns.forceRefresh;
 
-  const hasActiveRun = useMemo(() => {
-    if (!data) return false;
+  const activeRun = useMemo(() => {
+    if (!data) return undefined;
     const items = activeRunItems ?? [];
-    return items.some(
-      (r) => r.loopId === data.id || r.seq === data.seq,
-    );
+    return items.find((r) => r.loopId === data.id || r.seq === data.seq);
   }, [activeRunItems, data]);
+
+  const hasActiveRun = Boolean(activeRun);
 
   const onMutated = useCallback(async () => {
     await Promise.all([forceRefresh(), forceRefreshActiveRuns()]);
   }, [forceRefresh, forceRefreshActiveRuns]);
+
+  const project = useMemo(() => {
+    if (!data) return undefined;
+    return projects.data?.items.find((p) => p.id === data.projectId);
+  }, [data, projects.data]);
 
   if (!selector) {
     return <PanelError message="Missing loop selector" />;
@@ -522,17 +764,26 @@ export function LoopDetailPage() {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
           <Link
             to="/loops"
             className="text-[12px] text-[var(--text-muted)] hover:text-[var(--text)]"
           >
             ← Loops
           </Link>
-          <h1 className="m-0 text-[15px] font-semibold">
-            Loop{" "}
-            <span className="mono">{data ? `#${data.seq}` : selector}</span>
+          <h1 className="m-0 flex items-center gap-2 text-[15px] font-semibold">
+            {data ? (
+              <>
+                <LoopTypeBadge type={data.type} />
+                <span className="mono">#{data.seq}</span>
+              </>
+            ) : (
+              <>
+                <span>Loop</span>
+                <span className="mono">{selector}</span>
+              </>
+            )}
           </h1>
           {data ? (
             <>
@@ -544,9 +795,15 @@ export function LoopDetailPage() {
             </>
           ) : null}
         </div>
-        <Button variant="ghost" size="sm" onClick={refresh}>
-          Refresh
-        </Button>
+        {data ? (
+          <div className="ml-auto flex flex-wrap items-center justify-end gap-x-3 gap-y-1">
+            <TargetLinks
+              loop={data}
+              repoUrl={project?.repoUrl}
+              provider={project?.provider}
+            />
+          </div>
+        ) : null}
       </div>
 
       {/* Recovery card is prominent and appears above generic actions when
@@ -561,6 +818,8 @@ export function LoopDetailPage() {
         />
       ) : null}
 
+      {data ? <HITLDecisionCard loop={data} onMutated={onMutated} /> : null}
+
       {data ? (
         <Card title="Actions">
           <LoopActionBar
@@ -574,81 +833,25 @@ export function LoopDetailPage() {
         </Card>
       ) : null}
 
-      {data ? <HITLDecisionCard loop={data} onMutated={onMutated} /> : null}
-
-      <Card title="Metadata">
-        {error && !data ? (
+      {data ? (
+        <SummaryCard
+          loop={data}
+          project={project}
+          activeRun={activeRun}
+          error={error}
+          onRetry={refresh}
+        />
+      ) : error ? (
+        <Card title="Summary">
           <PanelError message={error} onRetry={refresh} />
-        ) : loading && !data ? (
+        </Card>
+      ) : loading ? (
+        <Card title="Summary">
           <p className="m-0 text-[12px] text-[var(--text-muted)]">
             Loading loop…
           </p>
-        ) : data ? (
-          <>
-            {error ? (
-              <div className="mb-2">
-                <PanelError message={error} onRetry={refresh} />
-              </div>
-            ) : null}
-            <dl className="m-0 columns-1 gap-x-6 md:columns-2">
-              <Kv label="Seq" value={data.seq} />
-              <Kv label="ID" value={data.id} />
-              <Kv label="Type" value={data.type} />
-              <Kv label="Status" value={<StatusChip status={data.status} />} />
-              <Kv
-                label="Display"
-                value={
-                  data.displayStatus?.trim() ? (
-                    <StatusChip status={data.displayStatus} />
-                  ) : (
-                    "—"
-                  )
-                }
-              />
-              <Kv label="Project" value={data.projectId} />
-              <Kv label="Target type" value={data.targetType} />
-              <Kv label="Target ID" value={data.targetId ?? "—"} />
-              <Kv label="Repo" value={data.repo ?? "—"} />
-              <Kv
-                label="PR"
-                value={data.prNumber != null ? String(data.prNumber) : "—"}
-              />
-              <Kv
-                label="Attempts"
-                value={
-                  formatAttempts(data.attempts, data.maxAttempts) ?? "—"
-                }
-              />
-              <Kv
-                label="Error kind"
-                value={
-                  data.lastFailureKind?.trim()
-                    ? data.lastFailureKind.trim()
-                    : "—"
-                }
-              />
-              <Kv
-                label="Error / reason"
-                value={
-                  data.lastFailureReason?.trim() ? (
-                    <span className="whitespace-pre-wrap break-words">
-                      {data.lastFailureReason.trim()}
-                    </span>
-                  ) : (
-                    "—"
-                  )
-                }
-              />
-              <Kv label="Last run" value={formatTs(data.lastRunAt)} />
-              <Kv label="Next run" value={formatTs(data.nextRunAt)} />
-              <Kv label="Created" value={formatTs(data.createdAt)} />
-              <Kv label="Updated" value={formatTs(data.updatedAt)} />
-            </dl>
-          </>
-        ) : (
-          <p className="m-0 text-[12px] text-[var(--text-muted)]">No data</p>
-        )}
-      </Card>
+        </Card>
+      ) : null}
 
       {/* Remount on selector change so log buffer/stream state never leaks. */}
       <div id="loop-logs">

--- a/web/dashboard/src/pages/Loops.tsx
+++ b/web/dashboard/src/pages/Loops.tsx
@@ -2,16 +2,19 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { DataTable, type Column } from "@/components/DataTable";
 import { LoopActionBar } from "@/components/LoopActionBar";
+import { LoopTypeBadge } from "@/components/LoopTypeBadge";
 import { PanelError } from "@/components/PanelError";
+import { PullRequestLink } from "@/components/PullRequestLink";
 import { StatusChip } from "@/components/StatusChip";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { fetchLoops, type ActiveRun, type Loop } from "@/lib/api";
+import { fetchLoops, type ActiveRun, type Loop, type Project } from "@/lib/api";
 import { useDashboardData } from "@/lib/DashboardDataContext";
 import {
   formatAge,
   formatAttempts,
   formatTs,
+  pullRequestUrl,
   truncateReason,
 } from "@/lib/format";
 import { useProjectFilter } from "@/lib/ProjectFilterContext";
@@ -53,6 +56,28 @@ function targetLabel(loop: Loop): string {
   return loop.targetType || "—";
 }
 
+function TargetCell({
+  loop,
+  project,
+}: {
+  loop: Loop;
+  project?: Project;
+}) {
+  const label = targetLabel(loop);
+  const href = pullRequestUrl(loop.repo, loop.prNumber, {
+    repoUrl: project?.repoUrl,
+    provider: project?.provider,
+  });
+  if (!href) {
+    return (
+      <span className="mono" title={label}>
+        {label}
+      </span>
+    );
+  }
+  return <PullRequestLink href={href}>{label}</PullRequestLink>;
+}
+
 function agentLabel(run: ActiveRun | undefined): string {
   if (!run?.agent) return "—";
   const agent = run.agent;
@@ -83,7 +108,14 @@ function rowReason(l: LoopRow): { display: string; full: string | null } {
 export function LoopsPage() {
   const navigate = useNavigate();
   const { projectId } = useProjectFilter();
-  const { activeRuns } = useDashboardData();
+  const { activeRuns, projects } = useDashboardData();
+  const projectsById = useMemo(() => {
+    const map = new Map<string, Project>();
+    for (const p of projects.data?.items ?? []) {
+      map.set(p.id, p);
+    }
+    return map;
+  }, [projects.data]);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>(
     DEFAULT_STATUS_FILTER,
   );
@@ -162,18 +194,24 @@ export function LoopsPage() {
       {
         key: "seq",
         header: "Seq",
+        width: "4.5rem",
         cell: (l) => <span className="mono text-[var(--accent)]">{l.seq}</span>,
       },
       {
         key: "type",
         header: "Type",
-        cell: (l) => <span className="mono">{l.type}</span>,
+        width: "6.5rem",
+        cell: (l) => <LoopTypeBadge type={l.type} size="sm" />,
       },
       {
         key: "projectId",
         header: "Project",
+        width: "8rem",
         cell: (l) => (
-          <span className="mono text-[var(--text-muted)]" title={l.projectId}>
+          <span
+            className="mono block min-w-0 truncate text-[var(--text-muted)]"
+            title={l.projectId}
+          >
             {l.projectId}
           </span>
         ),
@@ -181,13 +219,18 @@ export function LoopsPage() {
       {
         key: "status",
         header: "Status",
+        width: "7.5rem",
         cell: (l) => <StatusChip status={l.status} />,
       },
       {
         key: "step",
         header: "Step",
+        width: "8rem",
         cell: (l) => (
-          <span className="mono text-[var(--text-muted)]">
+          <span
+            className="mono block min-w-0 truncate text-[var(--text-muted)]"
+            title={l.activeRun?.currentStep ?? undefined}
+          >
             {l.activeRun?.currentStep ?? "—"}
           </span>
         ),
@@ -195,17 +238,20 @@ export function LoopsPage() {
       {
         key: "target",
         header: "Target",
+        width: "14rem",
         cell: (l) => (
-          <span className="mono" title={targetLabel(l)}>
-            {targetLabel(l)}
-          </span>
+          <TargetCell loop={l} project={projectsById.get(l.projectId)} />
         ),
       },
       {
         key: "agent",
         header: "Agent / PID",
+        width: "9rem",
         cell: (l) => (
-          <span className="mono text-[var(--text-muted)]">
+          <span
+            className="mono block min-w-0 truncate text-[var(--text-muted)]"
+            title={agentLabel(l.activeRun)}
+          >
             {agentLabel(l.activeRun)}
           </span>
         ),
@@ -213,6 +259,7 @@ export function LoopsPage() {
       {
         key: "attempts",
         header: "Attempts",
+        width: "5rem",
         cell: (l) => (
           <span className="mono text-[var(--text-muted)]">{rowAttempts(l)}</span>
         ),
@@ -220,11 +267,12 @@ export function LoopsPage() {
       {
         key: "reason",
         header: "Reason",
+        width: "12rem",
         cell: (l) => {
           const { display, full } = rowReason(l);
           return (
             <span
-              className="mono text-[var(--text-muted)] max-w-[14rem] truncate inline-block align-bottom"
+              className="mono block min-w-0 truncate text-[var(--text-muted)]"
               title={full ?? undefined}
             >
               {display}
@@ -235,8 +283,9 @@ export function LoopsPage() {
       {
         key: "age",
         header: "Age",
+        width: "5.5rem",
         cell: (l) => (
-          <span className="mono text-[var(--text-muted)]">
+          <span className="mono block min-w-0 truncate text-[var(--text-muted)]">
             {l.activeRun?.startedAt
               ? formatAge(l.activeRun.startedAt)
               : formatTs(l.updatedAt)}
@@ -246,6 +295,7 @@ export function LoopsPage() {
       {
         key: "actions",
         header: "Actions",
+        width: "11rem",
         stopRowClick: true,
         cell: (l) => (
           <LoopActionBar
@@ -258,7 +308,7 @@ export function LoopsPage() {
         ),
       },
     ],
-    [onMutated],
+    [onMutated, projectsById],
   );
 
   const emptyLabel =

--- a/web/dashboard/src/pages/Loops.tsx
+++ b/web/dashboard/src/pages/Loops.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { Inbox, RefreshCw, Repeat } from "lucide-react";
+import { AttemptsCell } from "@/components/AttemptsCell";
 import { DataTable, type Column } from "@/components/DataTable";
 import { LoopActionBar } from "@/components/LoopActionBar";
 import { LoopTypeBadge } from "@/components/LoopTypeBadge";
@@ -13,7 +15,6 @@ import { useDashboardData } from "@/lib/DashboardDataContext";
 import {
   formatAge,
   formatAttempts,
-  formatTs,
   pullRequestUrl,
   truncateReason,
 } from "@/lib/format";
@@ -93,6 +94,20 @@ function rowAttempts(l: LoopRow): string {
     formatAttempts(l.activeRun?.attempts, l.activeRun?.maxAttempts) ??
     "—"
   );
+}
+
+/** Same precedence as `rowAttempts`, but returns the raw pair for AttemptsCell. */
+function rowAttemptsPair(
+  l: LoopRow,
+): { attempts: number; maxAttempts: number | null | undefined } | null {
+  if (l.attempts != null && !Number.isNaN(Number(l.attempts))) {
+    return { attempts: Number(l.attempts), maxAttempts: l.maxAttempts };
+  }
+  const r = l.activeRun;
+  if (r?.attempts != null && !Number.isNaN(Number(r.attempts))) {
+    return { attempts: Number(r.attempts), maxAttempts: r.maxAttempts };
+  }
+  return null;
 }
 
 function rowReason(l: LoopRow): { display: string; full: string | null } {
@@ -260,9 +275,20 @@ export function LoopsPage() {
         key: "attempts",
         header: "Attempts",
         width: "5rem",
-        cell: (l) => (
-          <span className="mono text-[var(--text-muted)]">{rowAttempts(l)}</span>
-        ),
+        cell: (l) => {
+          const pair = rowAttemptsPair(l);
+          if (!pair) {
+            return <span className="mono text-[var(--text-muted)]">—</span>;
+          }
+          return (
+            <span title={rowAttempts(l)}>
+              <AttemptsCell
+                attempts={pair.attempts}
+                maxAttempts={pair.maxAttempts}
+              />
+            </span>
+          );
+        },
       },
       {
         key: "reason",
@@ -284,13 +310,20 @@ export function LoopsPage() {
         key: "age",
         header: "Age",
         width: "5.5rem",
-        cell: (l) => (
-          <span className="mono block min-w-0 truncate text-[var(--text-muted)]">
-            {l.activeRun?.startedAt
-              ? formatAge(l.activeRun.startedAt)
-              : formatTs(l.updatedAt)}
-          </span>
-        ),
+        cell: (l) => {
+          // Elapsed duration, never absolute timestamps. Prefer live run start,
+          // then last run, then loop creation.
+          const since =
+            l.activeRun?.startedAt ?? l.lastRunAt ?? l.createdAt ?? null;
+          return (
+            <span
+              className="mono block min-w-0 truncate text-[var(--text-muted)]"
+              title={since ?? undefined}
+            >
+              {formatAge(since)}
+            </span>
+          );
+        },
       },
       {
         key: "actions",
@@ -316,10 +349,24 @@ export function LoopsPage() {
       ? "No loops"
       : `No loops with status=${statusFilter}`;
 
+  const emptyNode = (
+    <span className="inline-flex items-center gap-1.5 text-[var(--text-muted)]">
+      <Inbox size={14} className="shrink-0" aria-hidden />
+      {emptyLabel}
+    </span>
+  );
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h1 className="m-0 text-[15px] font-semibold">Loops</h1>
+        <h1 className="m-0 inline-flex items-center gap-1.5 text-[15px] font-semibold">
+          <Repeat
+            size={15}
+            className="shrink-0 text-[var(--text-muted)]"
+            aria-hidden
+          />
+          Loops
+        </h1>
         <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
           <label className="flex items-center gap-1.5">
             <span className="uppercase tracking-wide">Status</span>
@@ -341,7 +388,8 @@ export function LoopsPage() {
           {projectId ? (
             <span className="mono">project: {projectId}</span>
           ) : null}
-          <Button variant="ghost" size="sm" onClick={refresh}>
+          <Button variant="ghost" size="sm" className="gap-1.5" onClick={refresh}>
+            <RefreshCw size={13} className="shrink-0" aria-hidden />
             Refresh
           </Button>
         </div>
@@ -365,7 +413,7 @@ export function LoopsPage() {
               columns={columns}
               rows={rows}
               rowKey={(l) => l.id}
-              empty={emptyLabel}
+              empty={emptyNode}
               onRowClick={onRowClick}
             />
             {total != null && total > 0 && totalPages != null ? (

--- a/web/dashboard/src/pages/Overview.tsx
+++ b/web/dashboard/src/pages/Overview.tsx
@@ -7,6 +7,8 @@ import {
   type ReactNode,
 } from "react";
 import { useNavigate } from "react-router-dom";
+import { Inbox, LayoutDashboard, RefreshCw } from "lucide-react";
+import { AttemptsCell } from "@/components/AttemptsCell";
 import { DataTable, type Column } from "@/components/DataTable";
 import { LoopActionBar } from "@/components/LoopActionBar";
 import { LoopTypeBadge } from "@/components/LoopTypeBadge";
@@ -324,8 +326,8 @@ export function OverviewPage({
         header: "Attempts",
         width: "5rem",
         cell: (r) => (
-          <span className="mono text-[var(--text-muted)]">
-            {formatAttempts(r.attempts, r.maxAttempts) ?? "—"}
+          <span title={formatAttempts(r.attempts, r.maxAttempts) ?? "—"}>
+            <AttemptsCell attempts={r.attempts} maxAttempts={r.maxAttempts} />
           </span>
         ),
       },
@@ -428,14 +430,23 @@ export function OverviewPage({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-2">
-        <h1 className="m-0 text-[15px] font-semibold">Overview</h1>
+        <h1 className="m-0 inline-flex items-center gap-1.5 text-[15px] font-semibold">
+          <LayoutDashboard
+            size={15}
+            className="shrink-0 text-[var(--text-muted)]"
+            aria-hidden
+          />
+          Overview
+        </h1>
         <Button
           variant="ghost"
+          className="gap-1.5"
           onClick={() => {
             health.refresh();
             void loadStatus();
           }}
         >
+          <RefreshCw size={13} className="shrink-0" aria-hidden />
           Refresh
         </Button>
       </div>
@@ -603,9 +614,12 @@ export function OverviewPage({
               rows={runningRows}
               rowKey={(r) => r.loopId || String(r.seq)}
               empty={
-                projectId
-                  ? "No running loops for this project"
-                  : "No running loops"
+                <span className="inline-flex items-center gap-1.5 text-[var(--text-muted)]">
+                  <Inbox size={14} className="shrink-0" aria-hidden />
+                  {projectId
+                    ? "No running loops for this project"
+                    : "No running loops"}
+                </span>
               }
               onRowClick={onRunningRowClick}
             />

--- a/web/dashboard/src/pages/Overview.tsx
+++ b/web/dashboard/src/pages/Overview.tsx
@@ -9,7 +9,9 @@ import {
 import { useNavigate } from "react-router-dom";
 import { DataTable, type Column } from "@/components/DataTable";
 import { LoopActionBar } from "@/components/LoopActionBar";
+import { LoopTypeBadge } from "@/components/LoopTypeBadge";
 import { PanelError } from "@/components/PanelError";
+import { PullRequestLink } from "@/components/PullRequestLink";
 import { StatusChip } from "@/components/StatusChip";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -17,12 +19,14 @@ import {
   fetchStatus,
   type ActiveRun,
   type LoopRoleCounts,
+  type Project,
   type StatusData,
 } from "@/lib/api";
 import { useDashboardData } from "@/lib/DashboardDataContext";
 import {
   formatAge,
   formatAttempts,
+  pullRequestUrl,
   truncateReason,
 } from "@/lib/format";
 import { useProjectFilter } from "@/lib/ProjectFilterContext";
@@ -94,6 +98,28 @@ function activeTargetLabel(run: ActiveRun): string {
   return t?.type || "—";
 }
 
+function ActiveTargetCell({
+  run,
+  project,
+}: {
+  run: ActiveRun;
+  project?: Project;
+}) {
+  const label = activeTargetLabel(run);
+  const href = pullRequestUrl(run.target?.repo, run.target?.prNumber, {
+    repoUrl: project?.repoUrl,
+    provider: project?.provider,
+  });
+  if (!href) {
+    return (
+      <span className="mono" title={label}>
+        {label}
+      </span>
+    );
+  }
+  return <PullRequestLink href={href}>{label}</PullRequestLink>;
+}
+
 function activeAgentLabel(run: ActiveRun): string {
   const agent = run.agent;
   if (!agent) return "—";
@@ -109,7 +135,19 @@ export function OverviewPage({
 }) {
   const navigate = useNavigate();
   const { projectId } = useProjectFilter();
-  const { health, healthy: sharedHealthy, activeRuns } = useDashboardData();
+  const {
+    health,
+    healthy: sharedHealthy,
+    activeRuns,
+    projects,
+  } = useDashboardData();
+  const projectsById = useMemo(() => {
+    const map = new Map<string, Project>();
+    for (const p of projects.data?.items ?? []) {
+      map.set(p.id, p);
+    }
+    return map;
+  }, [projects.data]);
 
   const [status, setStatus] = useState<StatusData | null>(null);
   const [statusError, setStatusError] = useState<string | null>(null);
@@ -215,6 +253,7 @@ export function OverviewPage({
       {
         key: "seq",
         header: "Seq",
+        width: "4.5rem",
         cell: (r) => (
           <span className="mono text-[var(--accent)]">{r.seq}</span>
         ),
@@ -222,13 +261,18 @@ export function OverviewPage({
       {
         key: "type",
         header: "Type",
-        cell: (r) => <span className="mono">{r.type}</span>,
+        width: "6.5rem",
+        cell: (r) => <LoopTypeBadge type={r.type} size="sm" />,
       },
       {
         key: "projectId",
         header: "Project",
+        width: "8rem",
         cell: (r) => (
-          <span className="mono text-[var(--text-muted)]" title={r.projectId}>
+          <span
+            className="mono block min-w-0 truncate text-[var(--text-muted)]"
+            title={r.projectId}
+          >
             {r.projectId}
           </span>
         ),
@@ -236,6 +280,7 @@ export function OverviewPage({
       {
         key: "status",
         header: "Status",
+        width: "7.5rem",
         cell: (r) => (
           <StatusChip status={r.displayStatus || r.loopStatus || r.status} />
         ),
@@ -243,8 +288,12 @@ export function OverviewPage({
       {
         key: "step",
         header: "Step",
+        width: "8rem",
         cell: (r) => (
-          <span className="mono text-[var(--text-muted)]">
+          <span
+            className="mono block min-w-0 truncate text-[var(--text-muted)]"
+            title={r.currentStep ?? undefined}
+          >
             {r.currentStep ?? "—"}
           </span>
         ),
@@ -252,17 +301,20 @@ export function OverviewPage({
       {
         key: "target",
         header: "Target",
+        width: "14rem",
         cell: (r) => (
-          <span className="mono" title={activeTargetLabel(r)}>
-            {activeTargetLabel(r)}
-          </span>
+          <ActiveTargetCell run={r} project={projectsById.get(r.projectId)} />
         ),
       },
       {
         key: "agent",
         header: "Agent / PID",
+        width: "9rem",
         cell: (r) => (
-          <span className="mono text-[var(--text-muted)]">
+          <span
+            className="mono block min-w-0 truncate text-[var(--text-muted)]"
+            title={activeAgentLabel(r)}
+          >
             {activeAgentLabel(r)}
           </span>
         ),
@@ -270,6 +322,7 @@ export function OverviewPage({
       {
         key: "attempts",
         header: "Attempts",
+        width: "5rem",
         cell: (r) => (
           <span className="mono text-[var(--text-muted)]">
             {formatAttempts(r.attempts, r.maxAttempts) ?? "—"}
@@ -279,12 +332,13 @@ export function OverviewPage({
       {
         key: "reason",
         header: "Reason",
+        width: "12rem",
         cell: (r) => {
           const full = r.lastFailureReason?.trim() || null;
           const display = full ? truncateReason(full, 48) ?? "—" : "—";
           return (
             <span
-              className="mono text-[var(--text-muted)] max-w-[14rem] truncate inline-block align-bottom"
+              className="mono block min-w-0 truncate text-[var(--text-muted)]"
               title={full ?? undefined}
             >
               {display}
@@ -295,8 +349,9 @@ export function OverviewPage({
       {
         key: "age",
         header: "Age",
+        width: "5.5rem",
         cell: (r) => (
-          <span className="mono text-[var(--text-muted)]">
+          <span className="mono block min-w-0 truncate text-[var(--text-muted)]">
             {r.startedAt ? formatAge(r.startedAt) : "—"}
           </span>
         ),
@@ -304,6 +359,7 @@ export function OverviewPage({
       {
         key: "actions",
         header: "Actions",
+        width: "11rem",
         stopRowClick: true,
         cell: (r) => (
           <LoopActionBar
@@ -316,7 +372,7 @@ export function OverviewPage({
         ),
       },
     ],
-    [onRunningMutated],
+    [onRunningMutated, projectsById],
   );
 
   if (health.loading && !health.data && !health.error) {

--- a/web/dashboard/src/pages/Projects.tsx
+++ b/web/dashboard/src/pages/Projects.tsx
@@ -2,12 +2,26 @@ import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { DataTable, type Column } from "@/components/DataTable";
 import { PanelError } from "@/components/PanelError";
+import { PullRequestLink } from "@/components/PullRequestLink";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import type { Project } from "@/lib/api";
 import { useDashboardData } from "@/lib/DashboardDataContext";
-import { formatTs } from "@/lib/format";
+import { formatTs, repositoryUrl } from "@/lib/format";
 import { useProjectFilter } from "@/lib/ProjectFilterContext";
+
+function RepoCell({ project }: { project: Project }) {
+  const label = project.repo?.trim() || "—";
+  const href = repositoryUrl(project.repo, project.repoUrl);
+  if (!href) {
+    return (
+      <span className="mono" title={project.repo ?? undefined}>
+        {label}
+      </span>
+    );
+  }
+  return <PullRequestLink href={href}>{label}</PullRequestLink>;
+}
 
 export function ProjectsPage() {
   const navigate = useNavigate();
@@ -22,8 +36,9 @@ export function ProjectsPage() {
       {
         key: "name",
         header: "Name",
+        width: "10rem",
         cell: (p) => (
-          <span className="font-medium">
+          <span className="block min-w-0 truncate font-medium" title={p.name}>
             {p.name}
             {p.archived ? (
               <span className="ml-1 text-[var(--text-muted)]">(archived)</span>
@@ -34,29 +49,37 @@ export function ProjectsPage() {
       {
         key: "id",
         header: "ID",
+        width: "9rem",
         cell: (p) => (
-          <span className="mono text-[var(--text-muted)]">{p.id}</span>
+          <span
+            className="mono block min-w-0 truncate text-[var(--text-muted)]"
+            title={p.id}
+          >
+            {p.id}
+          </span>
         ),
       },
       {
         key: "provider",
         header: "Provider",
+        width: "6rem",
         cell: (p) => <span className="mono">{p.provider || "—"}</span>,
       },
       {
         key: "repo",
         header: "Repo",
-        cell: (p) => (
-          <span className="mono" title={p.repo ?? undefined}>
-            {p.repo ?? "—"}
-          </span>
-        ),
+        width: "14rem",
+        cell: (p) => <RepoCell project={p} />,
       },
       {
         key: "repoPath",
         header: "Path",
+        width: "18rem",
         cell: (p) => (
-          <span className="mono text-[var(--text-muted)]" title={p.repoPath}>
+          <span
+            className="mono block min-w-0 truncate text-[var(--text-muted)]"
+            title={p.repoPath}
+          >
             {p.repoPath}
           </span>
         ),
@@ -64,13 +87,19 @@ export function ProjectsPage() {
       {
         key: "baseBranch",
         header: "Base",
-        cell: (p) => <span className="mono">{p.baseBranch}</span>,
+        width: "6rem",
+        cell: (p) => (
+          <span className="mono block min-w-0 truncate" title={p.baseBranch}>
+            {p.baseBranch}
+          </span>
+        ),
       },
       {
         key: "updatedAt",
         header: "Updated",
+        width: "8rem",
         cell: (p) => (
-          <span className="mono text-[var(--text-muted)]">
+          <span className="mono block min-w-0 truncate text-[var(--text-muted)]">
             {formatTs(p.updatedAt)}
           </span>
         ),

--- a/web/dashboard/src/pages/Projects.tsx
+++ b/web/dashboard/src/pages/Projects.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
+import { FolderGit2, Inbox, RefreshCw } from "lucide-react";
 import { DataTable, type Column } from "@/components/DataTable";
 import { PanelError } from "@/components/PanelError";
 import { PullRequestLink } from "@/components/PullRequestLink";
@@ -117,12 +118,20 @@ export function ProjectsPage() {
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-2">
         <div>
-          <h1 className="m-0 text-[15px] font-semibold">Projects</h1>
+          <h1 className="m-0 inline-flex items-center gap-1.5 text-[15px] font-semibold">
+            <FolderGit2
+              size={15}
+              className="shrink-0 text-[var(--text-muted)]"
+              aria-hidden
+            />
+            Projects
+          </h1>
           <p className="m-0 mt-0.5 text-[11px] text-[var(--text-muted)]">
             Click a row to set the project filter and open Loops.
           </p>
         </div>
-        <Button variant="ghost" size="sm" onClick={refresh}>
+        <Button variant="ghost" size="sm" className="gap-1.5" onClick={refresh}>
+          <RefreshCw size={13} className="shrink-0" aria-hidden />
           Refresh
         </Button>
       </div>
@@ -145,7 +154,12 @@ export function ProjectsPage() {
               columns={columns}
               rows={rows}
               rowKey={(p) => p.id}
-              empty="No projects"
+              empty={
+                <span className="inline-flex items-center gap-1.5 text-[var(--text-muted)]">
+                  <Inbox size={14} className="shrink-0" aria-hidden />
+                  No projects
+                </span>
+              }
               onRowClick={onRowClick}
             />
           </>

--- a/web/dashboard/vite.config.ts
+++ b/web/dashboard/vite.config.ts
@@ -15,6 +15,7 @@ const PUBLIC_MIME: Record<string, string> = {
   ".svg": "image/svg+xml",
   ".webmanifest": "application/manifest+json",
   ".json": "application/json",
+  ".js": "text/javascript; charset=utf-8",
 };
 
 function servePublicUnderBase() {


### PR DESCRIPTION
## Summary
- Polish dashboard loop UX: forge-aware PR/repo links via `project.repoUrl`, loop type badges, fixed table columns, and a cleaner loop detail layout.
- Fix default loop list ordering so active statuses rank above recently completed work; show Age as elapsed duration instead of absolute timestamps.
- Add lucide-react icons across nav, page headers, refresh, empty states, attempts infinity, and loop action buttons (pause/stop/retry/etc.).

## Test plan
- [x] `go test ./internal/storage/ -run TestLoopsListFilteredAndCountFiltered`
- [x] `go test` coverage for API `repoUrl` (handler tests from earlier commit)
- [x] `cd web/dashboard && pnpm test` (137 tests)
- [x] `cd web/dashboard && pnpm exec tsc -b`
- [ ] Manual: open dashboard Loops — active loops first; Age shows `2h 20m` style; unlimited attempts show ∞ icon
- [ ] Manual: Pause/Stop/Refresh icons spacing; forge PR links on Forgejo projects after looperd rebuild
